### PR TITLE
fix: constrain portable promotion handback

### DIFF
--- a/src/core/agent_task_promotion/apply.rs
+++ b/src/core/agent_task_promotion/apply.rs
@@ -1,6 +1,8 @@
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -23,24 +25,68 @@ const PROMOTION_PROVIDER_COMMAND_ENV: &str = "HOMEBOY_AGENT_TASK_PROMOTION_COMMA
 /// report. Mirrors the bounded-capture cap used by extension self-checks so the
 /// retained evidence cannot grow without bound (#5077).
 const PROMOTION_CAPTURE_LIMIT_BYTES: usize = 65_536;
+const PROMOTION_PROVIDER_RESPONSE_LIMIT_BYTES: usize = 1_048_576;
 
-/// Bound a captured stream to a retained-byte cap, keeping the trailing bytes
-/// (most relevant tail) and returning the retained text plus truncation
-/// metadata. Mirrors the `BoundedCapture` pattern in extension self-checks.
-fn bound_captured_stream(bytes: &[u8], limit: usize) -> (String, StreamCaptureMetadata) {
-    let seen = bytes.len();
-    let retained: &[u8] = if seen > limit {
-        &bytes[seen - limit..]
-    } else {
-        bytes
-    };
-    let metadata = StreamCaptureMetadata {
-        limit_bytes: limit,
-        seen_bytes: seen,
-        retained_bytes: retained.len(),
-        truncated: seen > retained.len(),
-    };
-    (String::from_utf8_lossy(retained).to_string(), metadata)
+struct ProviderCapturedStream {
+    response: Vec<u8>,
+    retained: Vec<u8>,
+    seen: usize,
+    overflowed: bool,
+}
+
+fn capture_provider_stream(
+    mut reader: impl Read,
+    response_limit: Option<usize>,
+    overflow_signal: Option<mpsc::Sender<()>>,
+) -> std::io::Result<ProviderCapturedStream> {
+    let mut response = Vec::new();
+    let mut retained = Vec::new();
+    let mut seen = 0;
+    let mut buffer = [0_u8; 8_192];
+    loop {
+        let count = reader.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        seen += count;
+        retained.extend_from_slice(&buffer[..count]);
+        if retained.len() > PROMOTION_CAPTURE_LIMIT_BYTES {
+            let discard = retained.len() - PROMOTION_CAPTURE_LIMIT_BYTES;
+            retained.drain(..discard);
+        }
+        if let Some(limit) = response_limit {
+            if response.len() + count > limit {
+                if let Some(signal) = overflow_signal.as_ref() {
+                    let _ = signal.send(());
+                }
+                return Ok(ProviderCapturedStream {
+                    response,
+                    retained,
+                    seen,
+                    overflowed: true,
+                });
+            }
+            response.extend_from_slice(&buffer[..count]);
+        }
+    }
+    Ok(ProviderCapturedStream {
+        response,
+        retained,
+        seen,
+        overflowed: false,
+    })
+}
+
+fn captured_stream_report(stream: &ProviderCapturedStream) -> (String, StreamCaptureMetadata) {
+    (
+        String::from_utf8_lossy(&stream.retained).to_string(),
+        StreamCaptureMetadata {
+            limit_bytes: PROMOTION_CAPTURE_LIMIT_BYTES,
+            seen_bytes: stream.seen,
+            retained_bytes: stream.retained.len(),
+            truncated: stream.seen > stream.retained.len(),
+        },
+    )
 }
 
 pub(crate) const AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA: &str =
@@ -281,21 +327,91 @@ pub(crate) fn run_provider_command(
                 Some("write agent-task promotion provider request".to_string()),
             )
         })?;
-    let output = process.wait_with_output().map_err(|error| {
+    drop(process.stdin.take());
+    let stdout = process.stdout.take().ok_or_else(|| {
         Error::internal_io(
-            error.to_string(),
-            Some("run agent-task promotion provider command".to_string()),
+            "provider command stdout was not available".to_string(),
+            Some("capture agent-task promotion provider response".to_string()),
         )
     })?;
-    let exit_code = output.status.code().unwrap_or(1);
-    // The full stdout is parsed for the provider response below, but the bytes
-    // retained in the evidence report are bounded with truncation metadata so
-    // a pathologically large stream cannot grow the report without bound.
-    let full_stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    let (retained_stdout, stdout_capture) =
-        bound_captured_stream(&output.stdout, PROMOTION_CAPTURE_LIMIT_BYTES);
-    let (retained_stderr, stderr_capture) =
-        bound_captured_stream(&output.stderr, PROMOTION_CAPTURE_LIMIT_BYTES);
+    let stderr = process.stderr.take().ok_or_else(|| {
+        Error::internal_io(
+            "provider command stderr was not available".to_string(),
+            Some("capture agent-task promotion provider diagnostics".to_string()),
+        )
+    })?;
+    let (overflow_sender, overflow_receiver) = mpsc::channel();
+    let stdout_capture_thread = std::thread::spawn(move || {
+        capture_provider_stream(
+            stdout,
+            Some(PROMOTION_PROVIDER_RESPONSE_LIMIT_BYTES),
+            Some(overflow_sender),
+        )
+    });
+    let stderr_capture_thread =
+        std::thread::spawn(move || capture_provider_stream(stderr, None, None));
+    let mut response_overflow = false;
+    let status = loop {
+        if overflow_receiver.try_recv().is_ok() {
+            response_overflow = true;
+            if let Some(status) = process.try_wait().map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("wait for oversized agent-task promotion provider response".to_string()),
+                )
+            })? {
+                break status;
+            }
+            process.kill().map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("terminate oversized agent-task promotion provider response".to_string()),
+                )
+            })?;
+            break process.wait().map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("wait for terminated agent-task promotion provider command".to_string()),
+                )
+            })?;
+        }
+        if let Some(status) = process.try_wait().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("wait for agent-task promotion provider command".to_string()),
+            )
+        })? {
+            break status;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    };
+    let stdout = stdout_capture_thread
+        .join()
+        .map_err(|_| {
+            Error::internal_unexpected("promotion provider stdout capture thread panicked")
+        })?
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("capture agent-task promotion provider response".to_string()),
+            )
+        })?;
+    let stderr = stderr_capture_thread
+        .join()
+        .map_err(|_| {
+            Error::internal_unexpected("promotion provider stderr capture thread panicked")
+        })?
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("capture agent-task promotion provider diagnostics".to_string()),
+            )
+        })?;
+    response_overflow |= stdout.overflowed;
+    let exit_code = status.code().unwrap_or(1);
+    let full_stdout = String::from_utf8_lossy(&stdout.response).to_string();
+    let (retained_stdout, stdout_capture) = captured_stream_report(&stdout);
+    let (retained_stderr, stderr_capture) = captured_stream_report(&stderr);
     let report = AgentTaskPromotionCommandReport {
         command: std::iter::once(program).chain(args).collect(),
         exit_code,
@@ -306,7 +422,27 @@ pub(crate) fn run_provider_command(
             stderr: stderr_capture,
         },
     };
-    if !output.status.success() {
+    if response_overflow {
+        return Err(Error::validation_invalid_argument_with_evidence(
+            "promotion_provider.response",
+            format!(
+                "promotion provider response exceeded {} bytes and was terminated",
+                PROMOTION_PROVIDER_RESPONSE_LIMIT_BYTES
+            ),
+            None,
+            None,
+            Some(crate::core::error::CommandEvidence {
+                command: display,
+                cwd: invocation.cwd.clone(),
+                location: Some("local".to_string()),
+                exit_code,
+                stdout: report.stdout.clone(),
+                stderr: report.stderr.clone(),
+                truncated: true,
+            }),
+        ));
+    }
+    if !status.success() {
         return Err(Error::validation_invalid_argument_with_evidence(
             "command",
             format!(

--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -1189,3 +1189,37 @@ fn provider_failure_surfaces_bounded_stdout_and_stderr_evidence() {
         "provider-stderr"
     );
 }
+
+#[test]
+fn provider_response_overflow_is_terminated_with_bounded_evidence() {
+    let request = AgentTaskPromotionApplyRequest {
+        schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
+        to_workspace: "target-workspace".to_string(),
+        patch_path: "changes.patch".to_string(),
+        changed_files: vec!["src/lib.rs".to_string()],
+        dry_run: false,
+    };
+
+    let error = run_provider_command(
+        &CommandInvocation {
+            argv: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "yes response | head -c 1048577".to_string(),
+            ],
+            ..Default::default()
+        },
+        &request,
+    )
+    .expect_err("oversized provider response rejected");
+
+    assert!(error.message.contains("response exceeded"));
+    assert_eq!(
+        error.details["command_evidence"]["stdout"]
+            .as_str()
+            .expect("bounded stdout")
+            .len(),
+        65_536
+    );
+    assert_eq!(error.details["command_evidence"]["truncated"], true);
+}

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -541,8 +541,12 @@ pub(crate) fn exec_lab_context(
 
     let output_parse_started = std::time::Instant::now();
     let mut applied_mutation_files = Vec::new();
-    if request.capture_patch && exit_code == 0 {
-        let apply_output = apply_lab_offload_patch(&exec_output)?;
+    let promotion_intent = promotion_handoff_intent(request.normalized_args, &exec_output.stdout)?;
+    if request.capture_patch && (exit_code == 0 || promotion_intent.is_some()) {
+        let apply_output = match promotion_intent.as_ref() {
+            Some(intent) => apply_lab_promotion_patch(&exec_output, intent)?,
+            None => apply_lab_offload_patch(&exec_output)?,
+        };
         let Some(apply_output) = apply_output else {
             return Err(missing_mutation_patch_error(
                 request.normalized_args,
@@ -678,6 +682,51 @@ pub(crate) fn exec_lab_context(
         exit_code,
         output_file_content,
     })
+}
+
+fn promotion_handoff_intent(args: &[String], stdout: &str) -> Result<Option<PromotionPatchIntent>> {
+    if !args
+        .windows(2)
+        .any(|args| args == ["agent-task", "promote"])
+    {
+        return Ok(None);
+    }
+    let value: serde_json::Value = serde_json::from_str(stdout).map_err(|error| {
+        Error::validation_invalid_json(
+            error,
+            Some("portable promotion result".to_string()),
+            Some(stdout.to_string()),
+        )
+    })?;
+    let report = value.get("data").unwrap_or(&value);
+    let status = report.get("status").and_then(|value| value.as_str());
+    if !matches!(status, Some("applied" | "gate_failed")) {
+        return Ok(None);
+    }
+    let changed_files = report
+        .get("changed_files")
+        .and_then(|files| files.as_array())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "promotion_handoff.changed_files",
+                "portable promotion result did not declare changed files for safe controller handback",
+                None,
+                None,
+            )
+        })?
+        .iter()
+        .map(|file| {
+            file.as_str().map(str::to_string).ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "promotion_handoff.changed_files",
+                    "portable promotion result contains a non-string changed file",
+                    None,
+                    None,
+                )
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(Some(PromotionPatchIntent { changed_files }))
 }
 
 pub(crate) fn run_lab_offload_inner(

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -63,7 +63,9 @@ use super::super::execution::{
     runner_exec_failure_context_from_output, runner_exec_failure_context_remediation_hint,
     DaemonJobHandoffState,
 };
-use super::super::lab_apply::apply_lab_offload_patch;
+use super::super::lab_apply::{
+    apply_lab_offload_patch, apply_lab_promotion_patch, PromotionPatchIntent,
+};
 use super::super::lab_args::{
     inject_agent_task_default_provider_config_in_args,
     inject_agent_task_resolved_provider_policy_in_args, lab_at_file_specs, lab_offload_source_path,

--- a/src/core/runner/lab_apply.rs
+++ b/src/core/runner/lab_apply.rs
@@ -10,6 +10,13 @@ use super::{
     RunnerExecOutput, RunnerWorkspaceApplyOutput,
 };
 
+/// The narrow mutation contract for a portable promotion handback. Runner
+/// capture observes a whole workspace, so promotion only accepts the files the
+/// provider declared in its promotion report.
+pub(super) struct PromotionPatchIntent {
+    pub(super) changed_files: Vec<String>,
+}
+
 pub(super) fn apply_lab_offload_patch(
     exec_output: &RunnerExecOutput,
 ) -> Result<Option<RunnerWorkspaceApplyOutput>> {
@@ -58,6 +65,42 @@ pub(super) fn apply_lab_offload_patch(
     };
 
     apply_change_artifact(artifact, false).map(Some)
+}
+
+pub(super) fn apply_lab_promotion_patch(
+    exec_output: &RunnerExecOutput,
+    intent: &PromotionPatchIntent,
+) -> Result<Option<RunnerWorkspaceApplyOutput>> {
+    let captured_files = exec_output
+        .patch
+        .as_ref()
+        .and_then(|patch| patch.get("modified_files"))
+        .and_then(|files| files.as_array())
+        .map(|files| {
+            files
+                .iter()
+                .filter_map(|file| file.as_str().map(str::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let mut expected = intent.changed_files.clone();
+    let mut captured = captured_files;
+    expected.sort();
+    captured.sort();
+    if captured != expected {
+        return Err(Error::validation_invalid_argument(
+            "promotion_handoff.patch",
+            format!(
+                "runner capture modified files outside the promotion intent; expected {:?}, captured {:?}",
+                expected, captured
+            ),
+            None,
+            Some(vec![
+                "Promotion handback refuses dependency hydration, verification, or other side effects outside the declared patch files.".to_string(),
+            ]),
+        ));
+    }
+    apply_lab_offload_patch(exec_output)
 }
 
 fn read_lab_patch_artifact(path: &str) -> Result<String> {
@@ -223,6 +266,132 @@ mod tests {
             std::fs::read_to_string(repo.path().join("homeboy.json")).expect("manifest"),
             "{\"id\":\"demo\",\"baselines\":{\"audit\":{\"known_fingerprints\":[\"abc\"]}}}\n"
         );
+    }
+
+    #[test]
+    fn promotion_handoff_applies_only_the_declared_target_delta() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        git(repo.path(), &["init"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(repo.path().join("promoted.txt"), "before\n").expect("seed promoted");
+        std::fs::write(repo.path().join("verify-side-effect.txt"), "before\n")
+            .expect("seed side effect");
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "base"]);
+        let snapshot =
+            SourceSnapshot::collect_local("lab", repo.path(), Some("/runner/workspace"), "lab");
+        let artifact_dir = tempfile::tempdir().expect("artifact tempdir");
+        let patch_path = artifact_dir.path().join("patch.diff");
+        std::fs::write(
+            &patch_path,
+            "diff --git a/promoted.txt b/promoted.txt\n--- a/promoted.txt\n+++ b/promoted.txt\n@@ -1 +1 @@\n-before\n+after\n",
+        )
+        .expect("patch");
+        let exec_output = RunnerExecOutput {
+            variant: "exec",
+            command: "runner.exec",
+            runner_id: "lab".to_string(),
+            dry_run: false,
+            mode: super::super::RunnerExecMode::Daemon,
+            argv: vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "promote".to_string(),
+            ],
+            remote_cwd: "/runner/workspace".to_string(),
+            exit_code: 1,
+            stdout: "{\"data\":{\"status\":\"gate_failed\"}}".to_string(),
+            stderr: String::new(),
+            source_snapshot: Some(snapshot),
+            job: None,
+            runner_job: None,
+            job_id: None,
+            job_events: None,
+            mirror_run_id: None,
+            patch: Some(serde_json::json!({
+                "modified_files": ["promoted.txt"],
+                "patch_artifact_path": patch_path.display().to_string(),
+            })),
+            mutation_artifacts: None,
+            artifacts: Vec::new(),
+            promoted_outputs: Vec::new(),
+            structured_summaries: Vec::new(),
+            metrics: None,
+            capture: None,
+            execution_record: None,
+            runner_result: None,
+            handoff: None,
+            diagnostics: None,
+        };
+
+        apply_lab_promotion_patch(
+            &exec_output,
+            &PromotionPatchIntent {
+                changed_files: vec!["promoted.txt".to_string()],
+            },
+        )
+        .expect("gate-failed promotion handback")
+        .expect("patch applied");
+        assert_eq!(
+            std::fs::read_to_string(repo.path().join("promoted.txt")).unwrap(),
+            "after\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(repo.path().join("verify-side-effect.txt")).unwrap(),
+            "before\n"
+        );
+    }
+
+    #[test]
+    fn promotion_handoff_refuses_verification_or_dependency_side_effects() {
+        let exec_output = RunnerExecOutput {
+            patch: Some(serde_json::json!({
+                "modified_files": ["promoted.txt", "dependency-side-effect.txt"],
+            })),
+            ..runner_exec_output_fixture()
+        };
+
+        let error = apply_lab_promotion_patch(
+            &exec_output,
+            &PromotionPatchIntent {
+                changed_files: vec!["promoted.txt".to_string()],
+            },
+        )
+        .expect_err("extra runner changes rejected");
+        assert!(error.message.contains("outside the promotion intent"));
+    }
+
+    fn runner_exec_output_fixture() -> RunnerExecOutput {
+        RunnerExecOutput {
+            variant: "exec",
+            command: "runner.exec",
+            runner_id: "lab".to_string(),
+            dry_run: false,
+            mode: super::super::RunnerExecMode::Daemon,
+            argv: Vec::new(),
+            remote_cwd: "/runner/workspace".to_string(),
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+            source_snapshot: None,
+            job: None,
+            runner_job: None,
+            job_id: None,
+            job_events: None,
+            mirror_run_id: None,
+            patch: None,
+            mutation_artifacts: None,
+            artifacts: Vec::new(),
+            promoted_outputs: Vec::new(),
+            structured_summaries: Vec::new(),
+            metrics: None,
+            capture: None,
+            execution_record: None,
+            runner_result: None,
+            handoff: None,
+            diagnostics: None,
+        }
     }
 
     fn git(path: &Path, args: &[&str]) {


### PR DESCRIPTION
Follow-up to #7993 and #7986.

## Summary
- Return applied promotion patches to the controller after recoverable gate failures while retaining failed gate status and evidence.
- Refuse runner captures that include files outside the promotion report's declared changed files.
- Bound provider response parsing to 1 MiB and terminate oversized providers with bounded diagnostics.

## How to test
1. Run `cargo test promotion_handoff --lib --no-fail-fast`.
2. Run `cargo test provider_failure_surfaces_bounded_stdout_and_stderr_evidence --lib --no-fail-fast`.
3. Run `cargo test provider_response_overflow_is_terminated_with_bounded_evidence --lib --no-fail-fast`.
4. Run `cargo test agent_task_promote --lib --no-fail-fast`.
5. Run `cargo test portable_promotion_target_materialization_plan_requires_git --lib --no-fail-fast`.
6. Run `cargo test promote_verification_failure_keeps_the_applied_target_recoverable --lib --no-fail-fast`.
7. Run `cargo test --test agent_task_promotion_provider --no-fail-fast`.
8. Run `cargo check`.
9. Run `cargo fmt --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol/OpenCode
- **Used for:** Drafted the implementation and regression tests; Chris reviews and owns the change.