### PR TITLE
Fix release quality policy checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,6 +414,11 @@ jobs:
     if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.check.outputs.recovery-release != 'true' && needs.gate-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout workflow event commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
       - name: Enforce release-blocking commands
         env:
           BLOCKING_COMMANDS: ${{ env.RELEASE_BLOCKING_COMMANDS }}

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -83,6 +83,28 @@ fn release_quality_policy_defaults_to_lint_and_test_blocking() {
 }
 
 #[test]
+fn release_quality_policy_checks_out_event_commit_before_running_script() {
+    let policy = job_section(release_workflow(), "release-quality-policy");
+
+    let checkout_index = policy.find("actions/checkout@v4").expect(
+        "release-quality-policy must check out the repository before running the policy script",
+    );
+    let script_index = policy
+        .find("bash .github/release-quality-policy.sh")
+        .expect("release-quality-policy must invoke the policy script");
+
+    assert!(
+        checkout_index < script_index,
+        "release-quality-policy checkout must precede the policy script invocation"
+    );
+
+    assert!(
+        policy.contains("ref: ${{ github.sha }}"),
+        "release-quality-policy must check out the exact workflow/event commit (github.sha)"
+    );
+}
+
+#[test]
 fn release_quality_policy_blocks_review_test_failures_and_allows_passing_gates() {
     let failed = release_quality_policy("review lint,review test", "failure", "success", "failure");
 


### PR DESCRIPTION
Closes #7963.

## Summary
- Check out the exact workflow event commit before the release quality policy invokes `.github/release-quality-policy.sh`.
- Add regression coverage that requires checkout to precede policy execution and pin to `github.sha`.

## Why
The `release-quality-policy` job ran the repository script without first checking out the repository, so the release workflow failed before evaluating its quality gates.

## How to test
1. From a fresh checkout of this branch, run `cargo test --test release_workflow_test`.
2. Confirm all 14 tests pass, including `release_quality_policy_checks_out_event_commit_before_running_script`.
3. Inspect `.github/workflows/release.yml` and confirm `release-quality-policy` checks out `${{ github.sha }}` before invoking `.github/release-quality-policy.sh`.

## Compatibility
- No public API, CLI, persisted-data, or extension-path behavior changes.
- This only changes GitHub Actions release orchestration by making the policy job's existing repository dependency explicit.

## Verification
- `cargo test --test release_workflow_test`: 14 passed, 0 failed on Homeboy Lab.
- Full CI is running on this PR: Audit, Lint, and Test.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the release failure, drafted the workflow fix and regression test, and shepherded deterministic Lab promotion; Chris reviews and owns the change.
