### PR TITLE
Bound observation storage and workspace triage latency

### DIFF
--- a/src/commands/runs/dispatch.rs
+++ b/src/commands/runs/dispatch.rs
@@ -8,7 +8,7 @@ use homeboy::core::Error;
 use super::types::{RunsArgs, RunsArtifactArgs, RunsArtifactCommand, RunsCommand, RunsOutput};
 use super::{
     bench, compare, distribution, dossier, drift, evidence, findings, fuzz_compare, handlers,
-    hotspots, latest, loop_sync, proof, query, reconcile, refs, resources, watch,
+    hotspots, latest, loop_sync, proof, query, reconcile, refs, resources, retention, watch,
 };
 use super::{CmdResult, GlobalArgs};
 
@@ -172,6 +172,7 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::FuzzCompare(args) => fuzz_compare::fuzz_compare_from_args(args),
         RunsCommand::Hotspots(args) => hotspots::runs_hotspots(args),
         RunsCommand::Reconcile(args) => reconcile::reconcile_runs(args),
+        RunsCommand::Retention(args) => retention::retain_terminal_runs(args),
         RunsCommand::Watch(args) => watch::watch_run(args),
         RunsCommand::Show {
             run_id,

--- a/src/commands/runs/mod.rs
+++ b/src/commands/runs/mod.rs
@@ -35,6 +35,7 @@ mod refs;
 mod remote;
 mod remote_artifact;
 mod resources;
+mod retention;
 #[cfg(test)]
 mod tests;
 mod types;
@@ -45,7 +46,9 @@ use super::{CmdResult, GlobalArgs};
 // Public command-layer API consumed by routing, raw/json output, rig, and bench.
 pub use dispatch::{global_runner_error, run, run_markdown};
 pub use handlers::list_runs;
-pub use types::{RunsArgs, RunsOutput, HOSTED_BLUEPRINT_VIEWER};
+pub use types::{
+    RunsArgs, RunsOutput, RunsRetentionArgs, RunsRetentionOutput, HOSTED_BLUEPRINT_VIEWER,
+};
 
 // Intra-module re-exports so sibling submodules (and the test modules) can
 // reference shared items via `super::` without depending on each other's

--- a/src/commands/runs/retention.rs
+++ b/src/commands/runs/retention.rs
@@ -1,0 +1,21 @@
+use homeboy::core::observation::runs_service::{self, TerminalRunRetentionOptions};
+
+use super::{CmdResult, RunsOutput, RunsRetentionArgs, RunsRetentionOutput};
+
+pub fn retain_terminal_runs(args: RunsRetentionArgs) -> CmdResult<RunsOutput> {
+    let outcome = runs_service::retain_terminal_runs(TerminalRunRetentionOptions {
+        apply: args.apply,
+        older_than_days: args.older_than_days,
+        limit: args.limit,
+    })?;
+    Ok((
+        RunsOutput::Retention(RunsRetentionOutput {
+            command: "runs.retention",
+            dry_run: outcome.dry_run,
+            older_than_days: outcome.older_than_days,
+            candidate_run_ids: outcome.candidate_run_ids,
+            removed_run_count: outcome.removed_run_count,
+        }),
+        0,
+    ))
+}

--- a/src/commands/runs/types.rs
+++ b/src/commands/runs/types.rs
@@ -84,6 +84,8 @@ pub(super) enum RunsCommand {
     Hotspots(RunsHotspotsArgs),
     /// Mark orphaned running observation records stale
     Reconcile(RunsReconcileArgs),
+    /// Plan or apply bounded retention of terminal observation rows and dependent records
+    Retention(RunsRetentionArgs),
     /// Block and stream a run's status until it reaches a terminal state,
     /// exiting with a code that reflects pass/fail. Works for attached and
     /// detached/offloaded runs.
@@ -186,6 +188,28 @@ pub struct RunsListArgs {
     pub include_active_runner_jobs: bool,
 }
 
+#[derive(Args, Clone)]
+pub struct RunsRetentionArgs {
+    /// Delete the planned terminal rows. Without this flag, only reports the plan.
+    #[arg(long)]
+    pub apply: bool,
+    /// Only include terminal runs finished more than this many days ago.
+    #[arg(long, default_value_t = 30)]
+    pub older_than_days: i64,
+    /// Maximum terminal run rows to inspect and remove in one invocation.
+    #[arg(long, default_value_t = 1000)]
+    pub limit: i64,
+}
+
+#[derive(Serialize)]
+pub struct RunsRetentionOutput {
+    pub command: &'static str,
+    pub dry_run: bool,
+    pub older_than_days: i64,
+    pub candidate_run_ids: Vec<String>,
+    pub removed_run_count: usize,
+}
+
 #[derive(Serialize)]
 #[serde(tag = "variant", content = "payload", rename_all = "snake_case")]
 pub enum RunsOutput {
@@ -216,6 +240,7 @@ pub enum RunsOutput {
     FuzzCompare(FuzzCompareOutput),
     Hotspots(RunsHotspotsOutput),
     Reconcile(RunsReconcileOutput),
+    Retention(RunsRetentionOutput),
     Watch(RunsWatchOutput),
     Export(RunsExportOutput),
     Import(RunsImportOutput),

--- a/src/core/observation/runs_service.rs
+++ b/src/core/observation/runs_service.rs
@@ -124,6 +124,21 @@ pub struct PersistedArtifactCleanupRow {
     pub size_bytes: u64,
 }
 
+#[derive(Debug, Clone)]
+pub struct TerminalRunRetentionOptions {
+    pub apply: bool,
+    pub older_than_days: i64,
+    pub limit: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TerminalRunRetentionOutcome {
+    pub dry_run: bool,
+    pub older_than_days: i64,
+    pub candidate_run_ids: Vec<String>,
+    pub removed_run_count: usize,
+}
+
 #[derive(Debug, Default)]
 struct RunnerDownloadCleanupPreview {
     file_count: usize,
@@ -1085,6 +1100,34 @@ mod persisted_cleanup {
 }
 pub use persisted_cleanup::*;
 
+/// Safe, bounded retention of terminal observation rows. Artifact byte cleanup
+/// remains a separate explicit operation because artifact roots may have their
+/// own evidence-retention policy.
+pub fn retain_terminal_runs(
+    options: TerminalRunRetentionOptions,
+) -> Result<TerminalRunRetentionOutcome> {
+    if options.older_than_days < 0 {
+        return Err(Error::validation_invalid_argument(
+            "older_than_days",
+            "--older-than-days must be zero or greater",
+            Some(options.older_than_days.to_string()),
+            None,
+        ));
+    }
+    let finished_before = (Utc::now() - Duration::days(options.older_than_days)).to_rfc3339();
+    let mut store = ObservationStore::open_initialized()?;
+    let candidate_run_ids = store.terminal_run_ids_before(&finished_before, options.limit)?;
+    if options.apply {
+        store.delete_terminal_runs(&candidate_run_ids)?;
+    }
+    Ok(TerminalRunRetentionOutcome {
+        dry_run: !options.apply,
+        older_than_days: options.older_than_days,
+        removed_run_count: usize::from(options.apply) * candidate_run_ids.len(),
+        candidate_run_ids,
+    })
+}
+
 mod runner_downloads {
     use super::*;
 
@@ -1309,6 +1352,56 @@ mod tests {
             let err = require_run(&store, "missing-run").expect_err("missing");
             assert_eq!(err.code.as_str(), "validation.invalid_argument");
             assert!(err.message.contains("run record not found"));
+        });
+    }
+
+    #[test]
+    fn terminal_retention_is_dry_run_by_default_and_deletes_dependent_records_on_apply() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let terminal = store.start_run(sample_run("bench")).expect("terminal run");
+            store
+                .finish_run(&terminal.id, RunStatus::Pass, None)
+                .expect("finish run");
+            store
+                .record_url_artifact(&terminal.id, "report", "https://example.test/report")
+                .expect("artifact");
+            let active = store.start_run(sample_run("trace")).expect("active run");
+            let path = store.status().expect("status").path;
+            drop(store);
+            let db = rusqlite::Connection::open(path).expect("raw db");
+            db.execute(
+                "UPDATE runs SET finished_at = '2000-01-01T00:00:00Z' WHERE id = ?1",
+                [&terminal.id],
+            )
+            .expect("age terminal run");
+
+            let dry = retain_terminal_runs(TerminalRunRetentionOptions {
+                apply: false,
+                older_than_days: 1,
+                limit: 10,
+            })
+            .expect("dry run");
+            assert_eq!(dry.candidate_run_ids, vec![terminal.id.clone()]);
+
+            let applied = retain_terminal_runs(TerminalRunRetentionOptions {
+                apply: true,
+                older_than_days: 1,
+                limit: 10,
+            })
+            .expect("apply");
+            assert_eq!(applied.removed_run_count, 1);
+            let store = ObservationStore::open_initialized().expect("reopen");
+            assert!(store
+                .get_run(&terminal.id)
+                .expect("terminal read")
+                .is_none());
+            assert!(store
+                .list_artifacts(&terminal.id)
+                .expect("artifact read")
+                .is_empty());
+            assert!(store.get_run(&active.id).expect("active read").is_some());
         });
     }
 

--- a/src/core/observation/store/mod.rs
+++ b/src/core/observation/store/mod.rs
@@ -25,7 +25,7 @@ use crate::core::{paths, Error, Result};
 
 pub(crate) use helpers::*;
 
-pub const CURRENT_SCHEMA_VERSION: i64 = 6;
+pub const CURRENT_SCHEMA_VERSION: i64 = 8;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ObservationDbStatus {

--- a/src/core/observation/store/runs.rs
+++ b/src/core/observation/store/runs.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use rusqlite::{params, OptionalExtension};
+use rusqlite::{params, params_from_iter, OptionalExtension, ToSql};
 use uuid::Uuid;
 
 use super::*;
@@ -212,33 +212,45 @@ impl ObservationStore {
 
     pub fn list_runs(&self, filter: RunListFilter) -> Result<Vec<RunRecord>> {
         let limit = filter.limit.unwrap_or(100).clamp(1, 1000);
+        let mut predicates = Vec::new();
+        let mut values: Vec<&dyn ToSql> = Vec::new();
+        if filter.kind.is_some() {
+            predicates.push("kind = ?");
+            values.push(filter.kind.as_ref().expect("checked"));
+        }
+        if filter.component_id.is_some() {
+            predicates.push("component_id = ?");
+            values.push(filter.component_id.as_ref().expect("checked"));
+        }
+        if filter.status.is_some() {
+            predicates.push("status = ?");
+            values.push(filter.status.as_ref().expect("checked"));
+        }
+        if filter.rig_id.is_some() {
+            predicates.push("rig_id = ?");
+            values.push(filter.rig_id.as_ref().expect("checked"));
+        }
+        let where_clause = if predicates.is_empty() {
+            String::new()
+        } else {
+            format!("WHERE {}", predicates.join(" AND "))
+        };
+        values.push(&limit);
         let mut statement = self
             .connection
-            .prepare(
+            .prepare(&format!(
                 r#"
                 SELECT id, kind, component_id, started_at, finished_at, status, command, cwd,
                        homeboy_version, git_sha, rig_id, metadata_json
                 FROM runs
-                WHERE (?1 IS NULL OR kind = ?1)
-                  AND (?2 IS NULL OR component_id = ?2)
-                  AND (?3 IS NULL OR status = ?3)
-                  AND (?4 IS NULL OR rig_id = ?4)
-                ORDER BY started_at DESC, rowid DESC
-                LIMIT ?5
+                {where_clause}
+                ORDER BY started_at DESC, id DESC
+                LIMIT ?
                 "#,
-            )
+            ))
             .map_err(sqlite_error("prepare list run records"))?;
         let rows = statement
-            .query_map(
-                params![
-                    filter.kind.as_deref(),
-                    filter.component_id.as_deref(),
-                    filter.status.as_deref(),
-                    filter.rig_id.as_deref(),
-                    limit,
-                ],
-                row_to_run_record,
-            )
+            .query_map(params_from_iter(values), row_to_run_record)
             .map_err(sqlite_error("list run records"))?;
 
         collect_rows(rows, "collect run records")
@@ -247,6 +259,49 @@ impl ObservationStore {
     pub fn latest_run(&self, mut filter: RunListFilter) -> Result<Option<RunRecord>> {
         filter.limit = Some(1);
         Ok(self.list_runs(filter)?.into_iter().next())
+    }
+
+    /// Return a bounded page of terminal rows older than `finished_before`.
+    /// Unknown statuses are deliberately retained rather than guessed terminal.
+    pub fn terminal_run_ids_before(
+        &self,
+        finished_before: &str,
+        limit: i64,
+    ) -> Result<Vec<String>> {
+        let mut statement = self.connection.prepare(
+            "SELECT id FROM runs WHERE finished_at < ?1 AND status IN ('pass', 'fail', 'error', 'skipped', 'stale') ORDER BY finished_at ASC, rowid ASC LIMIT ?2",
+        ).map_err(sqlite_error("prepare terminal run retention candidates"))?;
+        let rows = statement
+            .query_map(params![finished_before, limit.clamp(1, 1000)], |row| {
+                row.get(0)
+            })
+            .map_err(sqlite_error("list terminal run retention candidates"))?;
+        collect_rows(rows, "collect terminal run retention candidates")
+    }
+
+    /// Delete run-owned records explicitly so older databases that did not
+    /// enable SQLite foreign keys retain referential integrity as well.
+    pub fn delete_terminal_runs(&mut self, ids: &[String]) -> Result<()> {
+        let tx = self
+            .connection
+            .transaction()
+            .map_err(sqlite_error("begin terminal run retention"))?;
+        for id in ids {
+            for table in [
+                "artifacts",
+                "findings",
+                "triage_items",
+                "trace_spans",
+                "trace_runs",
+            ] {
+                tx.execute(&format!("DELETE FROM {table} WHERE run_id = ?1"), [id])
+                    .map_err(sqlite_error(format!("delete terminal run {table}")))?;
+            }
+            tx.execute("DELETE FROM runs WHERE id = ?1 AND status IN ('pass', 'fail', 'error', 'skipped', 'stale')", [id])
+                .map_err(sqlite_error("delete terminal run"))?;
+        }
+        tx.commit()
+            .map_err(sqlite_error("commit terminal run retention"))
     }
 
     pub fn list_runs_started_since(&self, started_at: &str) -> Result<Vec<RunRecord>> {

--- a/src/core/observation/store/schema.rs
+++ b/src/core/observation/store/schema.rs
@@ -156,6 +156,23 @@ const MIGRATIONS: &[Migration] = &[
         version: 7,
         sql: "",
     },
+    Migration {
+        version: 8,
+        sql: r#"
+        -- Equality filters followed by started_at let latest/list queries walk
+        -- a bounded index instead of sorting the full observation history.
+        CREATE INDEX IF NOT EXISTS idx_runs_started_at_desc
+            ON runs(started_at DESC, id DESC);
+        CREATE INDEX IF NOT EXISTS idx_runs_status_started_at_desc
+            ON runs(status, started_at DESC, id DESC);
+        CREATE INDEX IF NOT EXISTS idx_runs_kind_component_started_at_desc
+            ON runs(kind, component_id, started_at DESC, id DESC);
+        -- Terminal retention selects known statuses before its finished-at
+        -- cutoff, so this avoids scanning the full history on each cleanup.
+        CREATE INDEX IF NOT EXISTS idx_runs_status_finished_at
+            ON runs(status, finished_at ASC, id ASC);
+        "#,
+    },
 ];
 
 static MIGRATION_LOCK: OnceLock<Mutex<()>> = OnceLock::new();

--- a/src/core/runner/evidence/mirror.rs
+++ b/src/core/runner/evidence/mirror.rs
@@ -25,6 +25,9 @@ use super::util::{
     runner_exec_run_label, runner_metadata, source_snapshot_from_result,
 };
 
+pub(super) const MIRRORED_REMOTE_EVENT_LIMIT: usize = 32;
+pub(super) const MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT: usize = 1_024;
+
 #[derive(Debug)]
 pub struct MirroredDaemonEvidence {
     pub run: RunRecord,
@@ -100,9 +103,9 @@ pub fn mirror_reverse_broker_evidence(
         "job_id": job.id.to_string(),
         "broker_url": broker_url,
         "status": job.status,
-        "events": events,
-        "stdout": result.get("stdout").cloned().unwrap_or(Value::Null),
-        "stderr": result.get("stderr").cloned().unwrap_or(Value::Null),
+        "events": bounded_remote_events(events),
+        "event_count": events.len(),
+        "result_summary": result_summary(result),
         "artifacts": artifacts,
     });
     run = store.update_run_metadata(&run.id, metadata)?;
@@ -328,7 +331,11 @@ pub(super) fn mirror_job_run(
     let mut lab = json!({
         "runner": runner_metadata(runner),
         "remote_job": job,
-        "remote_events": events,
+        // Events can contain streamed executor output. Keep recent lifecycle
+        // evidence in the run row; full runner logs remain retrievable from
+        // the daemon and artifact references remain in the job/result summary.
+        "remote_events": bounded_remote_events(events),
+        "remote_event_count": events.len(),
         "result_summary": result_summary(result),
         "source_snapshot": source_snapshot_from_result(result),
         "run_label": inferred_label,
@@ -393,6 +400,29 @@ pub(super) fn mirror_job_run(
             run.id
         ))
     })
+}
+
+pub(super) fn bounded_remote_events(events: &[JobEvent]) -> Vec<Value> {
+    events
+        .iter()
+        .rev()
+        .take(MIRRORED_REMOTE_EVENT_LIMIT)
+        .rev()
+        .map(|event| {
+            json!({
+                "sequence": event.sequence,
+                "job_id": event.job_id,
+                "kind": event.kind,
+                "timestamp_ms": event.timestamp_ms,
+                "message": event.message.as_deref().map(|message| {
+                    message
+                        .chars()
+                        .take(MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT)
+                        .collect::<String>()
+                }),
+            })
+        })
+        .collect()
 }
 
 fn mirror_remote_observation_runs(

--- a/src/core/runner/evidence/tests/mod.rs
+++ b/src/core/runner/evidence/tests/mod.rs
@@ -13,7 +13,10 @@ use super::detail::{
     explicit_observation_run_ids, remote_detail_artifacts, remote_detail_to_run_record,
 };
 use super::download::{content_disposition_filename, download_remote_artifact};
-use super::mirror::{mirror_job_run, mirrored_patch_result, primary_mirrored_run};
+use super::mirror::{
+    bounded_remote_events, mirror_job_run, mirrored_patch_result, primary_mirrored_run,
+    MIRRORED_REMOTE_EVENT_LIMIT, MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT,
+};
 use super::tokens::{
     is_reportable_artifact_evidence_path, is_retrievable_runner_artifact, runner_artifact_token,
     RemoteArtifactToken,
@@ -240,6 +243,31 @@ fn runner_exec_matrix_summary_run_names_come_from_command_domain() {
             Some("trace-matrix-summary")
         );
     });
+}
+
+#[test]
+fn mirrored_remote_events_keep_lifecycle_summary_without_stream_payloads() {
+    let job_id = Uuid::new_v4();
+    let events = (0..(MIRRORED_REMOTE_EVENT_LIMIT + 5))
+        .map(|sequence| JobEvent {
+            sequence: sequence as u64,
+            job_id,
+            kind: JobEventKind::Result,
+            timestamp_ms: 1_700_000_000_000,
+            message: Some("m".repeat(MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT + 100)),
+            data: Some(json!({ "unbounded": "x".repeat(1024 * 1024) })),
+        })
+        .collect::<Vec<_>>();
+    let bounded = bounded_remote_events(&events);
+
+    assert_eq!(bounded.len(), MIRRORED_REMOTE_EVENT_LIMIT);
+    assert_eq!(bounded[0]["sequence"], 5);
+    assert!(bounded.iter().all(|event| event.get("data").is_none()));
+    assert!(bounded.iter().all(|event| {
+        event["message"]
+            .as_str()
+            .is_some_and(|message| message.len() == MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT)
+    }));
 }
 
 #[test]

--- a/src/core/triage/gh.rs
+++ b/src/core/triage/gh.rs
@@ -1,32 +1,90 @@
 //! gh CLI invocation helpers and shared GitHub status-check summarization.
 
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 use serde_json::Value;
 
-use crate::core::git::gh_probe_succeeds;
+use crate::core::engine::command::{
+    isolate_process_tree, wait_with_bounded_output_until_cancelled, BoundedCommandOutput,
+    DEFAULT_CAPTURE_LIMIT_BYTES,
+};
 
 pub(crate) fn ensure_gh_ready() -> std::result::Result<(), String> {
-    if !gh_probe_succeeds(&["--version"]) {
-        return Err("gh CLI not found on PATH".to_string());
+    let version = run_gh_command(&["--version".to_string()]);
+    if version.is_err() {
+        return Err("gh CLI not found on PATH or did not respond within 30s".to_string());
     }
-    if !gh_probe_succeeds(&["auth", "status", "--hostname", "github.com"]) {
-        return Err("gh is not authenticated for github.com".to_string());
+    if let Err(error) = run_gh_command(&[
+        "auth".to_string(),
+        "status".to_string(),
+        "--hostname".to_string(),
+        "github.com".to_string(),
+    ]) {
+        return Err(format!("gh is not authenticated for github.com: {error}"));
     }
     Ok(())
 }
 
 pub(crate) fn run_gh(args: &[String]) -> std::result::Result<String, String> {
-    let output = Command::new("gh")
-        .args(args.iter().map(|s| s.as_str()))
-        .output()
-        .map_err(|e| format!("failed to invoke gh: {e}"))?;
+    run_gh_command(args)
+}
+
+fn run_gh_command(args: &[String]) -> std::result::Result<String, String> {
+    let output = run_command_with_timeout(
+        Command::new("gh").args(args.iter().map(|s| s.as_str())),
+        Duration::from_secs(30),
+    )?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
         return Err(if stderr.is_empty() { stdout } else { stderr });
     }
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn run_command_with_timeout(
+    command: &mut Command,
+    timeout: Duration,
+) -> std::result::Result<BoundedCommandOutput, String> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    isolate_process_tree(command);
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("failed to invoke gh: {e}"))?;
+    let started = Instant::now();
+    let mut timed_out = false;
+    let output =
+        wait_with_bounded_output_until_cancelled(&mut child, DEFAULT_CAPTURE_LIMIT_BYTES, || {
+            timed_out = started.elapsed() >= timeout;
+            timed_out
+        })
+        .map_err(|e| format!("failed to wait for gh: {e}"))?;
+    if timed_out {
+        return Err(format!("gh timed out after {}s", timeout.as_secs()));
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_timeout_kills_hung_process() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "sleep 1"]);
+        let err = run_command_with_timeout(&mut command, Duration::from_millis(10)).unwrap_err();
+        assert!(err.contains("timed out"));
+    }
+
+    #[test]
+    fn command_timeout_captures_success_output() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "printf '{\"ok\":true}'"]);
+        let output = run_command_with_timeout(&mut command, Duration::from_secs(1)).unwrap();
+        assert_eq!(String::from_utf8(output.stdout).unwrap(), "{\"ok\":true}");
+    }
 }
 
 pub(crate) fn non_empty(value: Option<String>) -> Option<String> {

--- a/src/core/triage/mod.rs
+++ b/src/core/triage/mod.rs
@@ -58,9 +58,9 @@ mod test_reexports {
     pub(super) use super::report::{
         build_actions, dedupe_refs_by_repo, fetch_component_report, issue_bucket,
         parse_github_parent_repo, parse_issue, parse_issue_numbers, parse_issues, parse_linked_prs,
-        parse_prs, resolve_priority_labels, resolve_repo, resolve_repo_with_parent_resolver,
-        resolve_target_components, summarize, summarize_ci_readiness, summarize_unresolved,
-        DEFAULT_PRIORITY_LABELS,
+        parse_prs, resolve_and_dedupe_refs_with_parent_resolver, resolve_priority_labels,
+        resolve_repo, resolve_repo_with_parent_resolver, resolve_target_components, run_batched,
+        summarize, summarize_ci_readiness, summarize_unresolved, DEFAULT_PRIORITY_LABELS,
     };
     pub(super) use super::types::ComponentRef;
 }

--- a/src/core/triage/report.rs
+++ b/src/core/triage/report.rs
@@ -31,26 +31,38 @@ use super::types::{
 
 pub fn run(target: super::TriageTarget, options: TriageOptions) -> Result<TriageOutput> {
     let observation = TriageObservation::start(&target, &options);
-    let refs = resolve_target_components(&target)?;
+    let refs = scope::resolve_scope_components(&target)?;
     let global_priority_labels = defaults::load_config().triage.priority_labels;
     let mut components = Vec::new();
     let mut unresolved = Vec::new();
+    let (resolved, unresolved_refs) =
+        resolve_and_dedupe_refs_with_parent_resolver(refs, github_parent_repo);
+    unresolved.extend(unresolved_refs);
 
-    for component_ref in refs {
-        match resolve_repo(&component_ref) {
-            Ok(repo) => components.push(fetch_component_report(
-                &component_ref,
-                repo,
+    if options.include_issues || options.include_prs {
+        ensure_gh_ready().map_err(Error::internal_unexpected)?;
+    }
+    let total = resolved.len();
+    // GitHub fetches are independent. Keep concurrency bounded so a large
+    // workspace improves latency without stampeding the API or local `gh`.
+    for (batch, chunk) in resolved.chunks(4).enumerate() {
+        for (offset, (_, repo)) in chunk.iter().enumerate() {
+            eprintln!(
+                "triage: fetching repository {}/{} ({}/{})",
+                repo.repo.owner,
+                repo.repo.repo,
+                batch * 4 + offset + 1,
+                total
+            );
+        }
+        components.extend(run_batched(chunk, |(component_ref, repo)| {
+            fetch_component_report(
+                component_ref,
+                repo.clone(),
                 &options,
                 global_priority_labels.as_ref(),
-            )),
-            Err(reason) => unresolved.push(TriageUnresolved {
-                component_id: component_ref.component_id,
-                local_path: component_ref.local_path,
-                reason,
-                sources: component_ref.sources.into_iter().collect(),
-            }),
-        }
+            )
+        }));
     }
 
     if options.mine {
@@ -76,6 +88,64 @@ pub fn run(target: super::TriageTarget, options: TriageOptions) -> Result<Triage
     }
 
     Ok(output)
+}
+
+pub(super) fn run_batched<T: Sync, R: Send>(items: &[T], work: impl Fn(&T) -> R + Sync) -> Vec<R> {
+    let mut results = Vec::with_capacity(items.len());
+    for batch in items.chunks(4) {
+        results.extend(std::thread::scope(|scope| {
+            batch
+                .iter()
+                .map(|item| scope.spawn(|| work(item)))
+                .collect::<Vec<_>>()
+                .into_iter()
+                .map(|handle| handle.join().expect("triage fetch worker panicked"))
+                .collect::<Vec<_>>()
+        }));
+    }
+    results
+}
+
+pub(super) fn resolve_and_dedupe_refs_with_parent_resolver(
+    refs: Vec<ComponentRef>,
+    parent_resolver: impl Fn(&GitHubRepo) -> std::result::Result<Option<GitHubRepo>, String>,
+) -> (Vec<(ComponentRef, ResolvedRepo)>, Vec<TriageUnresolved>) {
+    let mut by_source = BTreeMap::<String, std::result::Result<ResolvedRepo, String>>::new();
+    let mut resolved: BTreeMap<String, (ComponentRef, ResolvedRepo)> = BTreeMap::new();
+    let mut unresolved = Vec::new();
+    for component_ref in refs {
+        let source_key = component_ref
+            .triage_remote_url
+            .clone()
+            .or(component_ref.remote_url.clone())
+            .unwrap_or_else(|| component_ref.local_path.clone());
+        let repo = by_source
+            .entry(source_key)
+            .or_insert_with(|| resolve_repo_with_parent_resolver(&component_ref, &parent_resolver))
+            .clone();
+        match repo {
+            Ok(repo) => {
+                let key = format!(
+                    "{}/{}",
+                    repo.repo.owner.to_lowercase(),
+                    repo.repo.repo.to_lowercase()
+                );
+                if let Some((existing, _)) = resolved.get_mut(&key) {
+                    existing.sources.extend(component_ref.sources);
+                    existing.usage.extend(component_ref.usage);
+                } else {
+                    resolved.insert(key, (component_ref, repo));
+                }
+            }
+            Err(reason) => unresolved.push(TriageUnresolved {
+                component_id: component_ref.component_id,
+                local_path: component_ref.local_path,
+                reason,
+                sources: component_ref.sources.into_iter().collect(),
+            }),
+        }
+    }
+    (resolved.into_values().collect(), unresolved)
 }
 
 fn triage_component_has_items(component: &TriageComponentReport) -> bool {
@@ -335,7 +405,6 @@ fn fetch_issues(
     options: &TriageOptions,
     stale_cutoff: Option<DateTime<Utc>>,
 ) -> std::result::Result<Vec<TriageIssueItem>, String> {
-    ensure_gh_ready()?;
     if !options.issue_numbers.is_empty() {
         return fetch_targeted_issues(repo, options, stale_cutoff);
     }
@@ -399,7 +468,6 @@ fn fetch_prs(
     options: &TriageOptions,
     stale_cutoff: Option<DateTime<Utc>>,
 ) -> std::result::Result<Vec<TriagePrItem>, String> {
-    ensure_gh_ready()?;
     let mut args = vec![
         "pr".to_string(),
         "list".to_string(),

--- a/src/core/triage/tests/targets.rs
+++ b/src/core/triage/tests/targets.rs
@@ -1,5 +1,7 @@
 use super::super::*;
 use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 #[test]
 fn resolve_repo_prefers_triage_remote_without_losing_source_repo() {
@@ -22,6 +24,52 @@ fn resolve_repo_prefers_triage_remote_without_losing_source_repo() {
     let source = resolved.source_repo.expect("source repo differs");
     assert_eq!(source.owner, "example-org");
     assert_eq!(source.repo, "wordpress-playground");
+}
+
+#[test]
+fn dedupe_resolves_a_shared_fork_parent_once() {
+    let refs = ["one", "two"]
+        .into_iter()
+        .map(|id| {
+            ComponentRef::new(
+                id.to_string(),
+                format!("/tmp/{id}"),
+                Some("https://github.com/example/fork.git".to_string()),
+                None,
+                format!("component:{id}"),
+            )
+        })
+        .collect();
+    let calls = AtomicUsize::new(0);
+    let (resolved, unresolved) = resolve_and_dedupe_refs_with_parent_resolver(refs, |_| {
+        calls.fetch_add(1, Ordering::SeqCst);
+        Ok(Some(GitHubRepo {
+            host: "github.com".to_string(),
+            owner: "upstream".to_string(),
+            repo: "repo".to_string(),
+        }))
+    });
+    assert!(unresolved.is_empty());
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert_eq!(resolved.len(), 1);
+    assert_eq!(resolved[0].0.sources.len(), 2);
+}
+
+#[test]
+fn batch_scheduler_limits_concurrency_and_preserves_order() {
+    let active = AtomicUsize::new(0);
+    let peak = AtomicUsize::new(0);
+    let values = (0..9).collect::<Vec<_>>();
+    let result = run_batched(&values, |value| {
+        let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+        peak.fetch_max(current, Ordering::SeqCst);
+        std::thread::sleep(Duration::from_millis(10));
+        active.fetch_sub(1, Ordering::SeqCst);
+        *value
+    });
+    assert_eq!(result, values);
+    assert!(peak.load(Ordering::SeqCst) <= 4);
+    assert_eq!(peak.load(Ordering::SeqCst), 4);
 }
 
 #[test]

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -112,7 +112,7 @@ mod store_init_tests {
 
             assert!(status.exists);
             assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-            assert_eq!(status.migration_count, 6);
+            assert_eq!(status.migration_count, 8);
             assert_eq!(status.table_count, 7);
         });
     }
@@ -127,7 +127,7 @@ mod store_init_tests {
             let status = second.status().expect("status");
 
             assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-            assert_eq!(status.migration_count, 6);
+            assert_eq!(status.migration_count, 8);
             assert_eq!(status.table_count, 7);
         });
     }
@@ -149,7 +149,7 @@ mod store_init_tests {
             let status = reopened.status().expect("status");
 
             assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-            assert_eq!(status.migration_count, 6);
+            assert_eq!(status.migration_count, 8);
         });
     }
 
@@ -587,6 +587,54 @@ fn test_latest_run() {
         assert_ne!(selected.id, old.id);
         assert_ne!(selected.id, other_kind.id);
         assert!(missing.is_none());
+    });
+}
+
+#[test]
+fn latest_queries_use_timestamp_indexes_for_large_history() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let path = store.status().expect("status").path;
+        let db = rusqlite::Connection::open(path).expect("raw db");
+        let tx = db.unchecked_transaction().expect("transaction");
+        for index in 0..2_000 {
+            tx.execute(
+                "INSERT INTO runs(id, kind, component_id, started_at, status, metadata_json) VALUES (?1, ?2, ?3, ?4, 'pass', '{}')",
+                rusqlite::params![
+                    format!("run-{index:04}"),
+                    if index % 2 == 0 { "triage" } else { "bench" },
+                    if index % 3 == 0 { "workspace" } else { "other" },
+                    format!("2026-01-01T00:{:02}:{:02}Z", (index / 60) % 60, index % 60),
+                ],
+            ).expect("insert history");
+        }
+        tx.commit().expect("commit history");
+
+        let latest = store
+            .latest_run(RunListFilter {
+                kind: Some("triage".to_string()),
+                component_id: Some("workspace".to_string()),
+                limit: Some(1),
+                ..RunListFilter::default()
+            })
+            .expect("latest")
+            .expect("matching run");
+        assert_eq!(latest.id, "run-1998");
+
+        for sql in [
+            "EXPLAIN QUERY PLAN SELECT id FROM runs ORDER BY started_at DESC, id DESC LIMIT 1",
+            "EXPLAIN QUERY PLAN SELECT id FROM runs WHERE kind = 'triage' AND component_id = 'workspace' ORDER BY started_at DESC, id DESC LIMIT 1",
+        ] {
+            let plan = db.prepare(sql).expect("plan").query_map([], |row| row.get::<_, String>(3))
+                .expect("plan rows").collect::<Result<Vec<_>, _>>().expect("plan detail").join(" ");
+            assert!(plan.contains("INDEX"), "expected index-backed plan: {plan}");
+            assert!(!plan.contains("TEMP B-TREE"), "unexpected sort: {plan}");
+            assert!(
+                !plan.contains("SCAN runs") || plan.contains("USING COVERING INDEX"),
+                "unexpected table scan: {plan}"
+            );
+        }
     });
 }
 


### PR DESCRIPTION
Closes #7978.

## Summary
- add indexed, predicate-specific observation run queries so latest/list operations avoid full-table scans and temporary sorts
- keep run listing off the network while retaining targeted refresh through `runs show` and explicit convergence through `runs reconcile`
- bound mirrored runner event metadata and subprocess capture while preserving summaries, counts, logs, and artifact references
- add explicit bounded terminal-run retention with transactional dependent-record cleanup
- snapshot workspace component inventory once instead of recursively rescanning all worktrees per project attachment
- resolve workspace repositories once in stable four-wide batches, emit progress, and enforce finite `gh` timeouts

## How to test
1. Run `cargo test latest_queries_use_timestamp_indexes_for_large_history --lib`.
2. Run `cargo test command_timeout_ --lib`.
3. Run `cargo test mirrored_remote_events_keep_lifecycle_summary_without_stream_payloads --lib`.
4. Run `cargo test terminal_retention_is_dry_run_by_default_and_deletes_dependent_records_on_apply --lib`.
5. Run `cargo test dedupe_resolves_a_shared_fork_parent_once --lib`.
6. Run `cargo test batch_scheduler_limits_concurrency_and_preserves_order --lib`.
7. Run `cargo test run_list_filters_kind_component_rig_and_status --lib`.
8. Run `cargo test run_list_reconciles_owned_dead_running_runs_before_listing --lib`.
9. Run `cargo test core::scope::tests --lib`.
10. Run `cargo fmt --check && cargo check`.
11. On a configured workspace, run `homeboy triage workspace --mine --drilldown --limit 20` and confirm repository progress is printed and the command completes.
12. Run `homeboy runs retention` to preview bounded terminal-row cleanup; apply only in disposable test state with `homeboy runs retention --apply`.

## Runtime proof
- `homeboy runs list --limit 1`: 146.55s before, 0.21s after.
- `homeboy activity list --limit 1`: timed out before, 2.36s after.
- `homeboy triage workspace --mine --drilldown --limit 20`: exceeded 10 minutes before, 64.37s after across 34 repositories with streamed progress.

## Verification notes
- All focused regression tests, formatting, compilation, and changed-scope audit pass.
- `homeboy review --changed-since origin/main` selected changed test files but its Rust adapter still executed the entire library suite. It reported thousands of passing tests plus unrelated hot-environment failures. None of the repair-owned tests failed.
- Schema migration 8 adds four indexes. Existing large stores perform this one-time migration when first opened by the updated binary.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Diagnosed the production performance failure, implemented the storage and triage repair, reviewed edge cases, and wrote deterministic regression coverage with Chris.