### PR TITLE
fix: align extension dev-run workspace dispatch

### DIFF
--- a/src/core/extension/dev_run.rs
+++ b/src/core/extension/dev_run.rs
@@ -234,14 +234,14 @@ pub(crate) fn run_extension_dev_run_with(
         &plan,
         "install",
         "extension refresh",
-        &remote_install_source,
+        &synced.remote_path,
         Vec::new(),
     );
 
     let (install, _) = exec(
         &plan.runner_id,
         RunnerExecOptions {
-            cwd: None,
+            cwd: Some(synced.remote_path.clone()),
             project_id: None,
             allow_diagnostic_ssh: false,
             command: plan.install_command.clone(),
@@ -303,7 +303,7 @@ pub(crate) fn run_extension_dev_run_with(
     let (command_output, command_exit_code) = exec(
         &plan.runner_id,
         RunnerExecOptions {
-            cwd: None,
+            cwd: Some(synced.remote_path.clone()),
             project_id: None,
             allow_diagnostic_ssh: false,
             command: plan.command.clone(),
@@ -834,6 +834,42 @@ mod tests {
                 .status,
             "succeeded"
         );
+    }
+
+    #[test]
+    fn dev_run_stages_dispatch_from_the_workload_remote_workspace() {
+        let stages = RefCell::new(Vec::new());
+        let command = vec![
+            "homeboy".to_string(),
+            "extension".to_string(),
+            "show".to_string(),
+            "demo".to_string(),
+        ];
+
+        run_extension_dev_run_with(
+            "demo",
+            "lab",
+            "/local/demo",
+            &command,
+            |_runner_id, _options| Ok((sync_output(), 0)),
+            |runner_id, options| {
+                if let Some(workload) = options.runner_workload.clone() {
+                    stages.borrow_mut().push((options.cwd.clone(), workload));
+                }
+                Ok((exec_output(runner_id, options.command, 0), 0))
+            },
+        )
+        .expect("dev run");
+
+        assert_eq!(stages.borrow().len(), 2);
+        for (cwd, workload) in stages.borrow().iter() {
+            assert_eq!(cwd.as_deref(), Some("/remote/demo"));
+            assert_eq!(
+                workload.state.remote_workspace.as_deref(),
+                cwd.as_deref(),
+                "each controller-owned stage must dispatch from its declared remote workspace"
+            );
+        }
     }
 
     #[test]

--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -961,6 +961,29 @@ mod tests {
     }
 
     #[test]
+    fn runner_workload_validation_rejects_remote_workspace_mismatch() {
+        let workload = workload();
+
+        let err = validate_runner_workload_dispatch(
+            Some(&workload),
+            "lab-a",
+            Some("/srv/homeboy/other-workspace"),
+            &["homeboy".to_string(), "trace".to_string()],
+            &SecretEnvPlan::default(),
+            true,
+        )
+        .expect_err("mismatched remote workspace must fail");
+
+        assert_eq!(
+            err.details["field"],
+            "runner_workload.state.remote_workspace"
+        );
+        assert!(err
+            .to_string()
+            .contains("remote workspace does not match dispatch cwd"));
+    }
+
+    #[test]
     fn runner_workload_validation_rejects_blank_result_refs_plan_id() {
         let mut workload = workload();
         workload.result_refs.plan_id = " ".to_string();


### PR DESCRIPTION
## Summary

Fixes #8003.

Controller-owned `extension dev-run` stages built workload state from the synced remote workspace but dispatched without a cwd. The runner workload guard correctly rejected that divergence once #7987 began carrying the controller-owned stage workload.

This change makes the synced remote workspace the canonical execution coordinate for both `extension refresh` and the requested command. The extension refresh source argument still targets its extension subdirectory when required. The strict workload-versus-dispatch mismatch validation remains unchanged.

## Testing

1. Run `cargo test dev_run_stages_dispatch_from_the_workload_remote_workspace --lib`.
2. Run `cargo test runner_workload_validation_rejects_remote_workspace_mismatch --lib`.
3. Run `cargo fmt --check`.
4. Run `cargo check`.

## Rollout

Deploy this Homeboy controller build, then rerun:

```sh
homeboy extension dev-run --source /Users/chubes/.config/homeboy/extensions/wordpress --runner homeboy-lab wordpress homeboy extension show wordpress
```

No runner daemon upgrade or data migration is required. The controller now sends the synced remote workspace as the dispatch cwd for both runner stages.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Investigated the controller-owned workspace contract, implemented the generic repair and behavioral tests, and ran focused verification with Chris responsible for review and merge.