### PR TITLE
fix: adopt proven dead runner daemon leases

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -324,6 +324,7 @@ plan is emitted; `--sync-mode` accepts `snapshot`, `snapshot-git`, or `git`.
 
 ```sh
 homeboy runner connect <runner-id>
+homeboy runner connect <runner-id> --adopt-orphan-lease <lease-id> --confirm-pid-dead
 homeboy runner connect <controller-id> --reverse --reverse-runner <runner-id> --broker-url <url>
 ```
 
@@ -332,6 +333,15 @@ it. This is the preferred Lab execution path because later `runner exec` calls
 can use the daemon session instead of ad-hoc SSH command execution. The JSON
 payload uses `command: "runner.connect"` and reports connection state such as
 the runner ID, tunnel endpoint, daemon endpoint, and persisted session metadata.
+
+When a controller session was lost while a remote daemon lease is dead and its
+durable jobs remain, inspect the remote `homeboy daemon status` first. Recovery
+requires the explicit exact-lease form shown above. It verifies the recorded PID
+is dead under the remote daemon lifecycle lock, preserves job events while
+terminalizing jobs from that dead control plane with retry guidance, starts one
+replacement daemon, and then records the fresh local session. Ordinary `runner
+connect` never infers that orphan ownership; live, ambiguous, and lease-mismatched
+daemon records remain protected.
 
 Reverse runner connections record the runner-initiated session substrate and use
 the controller daemon as the broker. A reverse runner can register itself with

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use std::path::PathBuf;
 
 use homeboy::core::daemon::{
-    self, BrokerConfig, BrokerConfigOptions, DaemonStartResult, DaemonStatus, DaemonStopResult,
+    self, BrokerConfig, BrokerConfigOptions, DaemonOrphanAdoptionResult, DaemonStartResult, DaemonStatus, DaemonStopResult,
     ServiceIdentity,
 };
 use homeboy::core::http_api::{AnalysisJobRunOutput, AnalysisJobRunner};
@@ -26,6 +26,17 @@ enum DaemonCommand {
     },
     /// Return the current live daemon or start one when no live daemon exists
     EnsureRunning {
+        #[arg(long, default_value = daemon::DEFAULT_ADDR)]
+        addr: String,
+    },
+    /// Explicitly replace one proven-dead daemon lease and reconcile its durable jobs
+    AdoptOrphan {
+        /// Exact lease ID reported by `homeboy daemon status`
+        #[arg(long)]
+        lease_id: String,
+        /// Confirm the recorded PID was inspected and is dead
+        #[arg(long)]
+        confirm_pid_dead: bool,
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
     },
@@ -80,6 +91,7 @@ pub struct DaemonArtifactGetArgs {
 pub enum DaemonOutput {
     Start(DaemonStartResult),
     EnsureRunning(DaemonStartResult),
+    AdoptOrphan(DaemonOrphanAdoptionResult),
     Serve(DaemonStartResult),
     Stop(DaemonStopResult),
     Status(DaemonStatus),
@@ -107,6 +119,10 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
         }
         DaemonCommand::EnsureRunning { addr } => Ok((
             DaemonOutput::EnsureRunning(daemon::ensure_running(&addr)?),
+            0,
+        )),
+        DaemonCommand::AdoptOrphan { lease_id, confirm_pid_dead, addr } => Ok((
+            DaemonOutput::AdoptOrphan(daemon::adopt_orphaned_lease(&lease_id, confirm_pid_dead, &addr)?),
             0,
         )),
         DaemonCommand::Serve { addr } => serve(&addr),

--- a/src/commands/runner/cli.rs
+++ b/src/commands/runner/cli.rs
@@ -212,6 +212,14 @@ pub(super) enum RunnerCommand {
         /// Broker/controller URL observed by the reverse runner
         #[arg(long)]
         broker_url: Option<String>,
+
+        /// Explicitly adopt this exact remote daemon lease after confirming its PID is dead
+        #[arg(long)]
+        adopt_orphan_lease: Option<String>,
+
+        /// Confirm the recorded PID for --adopt-orphan-lease is dead
+        #[arg(long)]
+        confirm_pid_dead: bool,
     },
     /// Show persisted runner tunnel status
     Status {

--- a/src/commands/runner/dispatch.rs
+++ b/src/commands/runner/dispatch.rs
@@ -134,7 +134,16 @@ pub fn run(
             reverse,
             reverse_runner,
             broker_url,
-        } => map_registry(connect(&id, reverse, reverse_runner, broker_url)),
+            adopt_orphan_lease,
+            confirm_pid_dead,
+        } => map_registry(connect(
+            &id,
+            reverse,
+            reverse_runner,
+            broker_url,
+            adopt_orphan_lease,
+            confirm_pid_dead,
+        )),
         RunnerCommand::Status { id } => map_registry(status_mod::status(id.as_deref())),
         RunnerCommand::Disconnect { id } => map_registry(registry::disconnect(&id)),
         RunnerCommand::RefreshHomeboy {

--- a/src/commands/runner/registry.rs
+++ b/src/commands/runner/registry.rs
@@ -203,7 +203,25 @@ pub(super) fn connect(
     reverse: bool,
     runner_id: Option<String>,
     broker_url: Option<String>,
+    adopt_orphan_lease: Option<String>,
+    confirm_pid_dead: bool,
 ) -> CmdResult<RunnerOutput> {
+    if adopt_orphan_lease.is_some() && !confirm_pid_dead {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "confirm_pid_dead",
+            "--adopt-orphan-lease requires --confirm-pid-dead",
+            None,
+            Some(vec!["Inspect `homeboy daemon status` on the runner before adopting its exact dead lease.".to_string()]),
+        ));
+    }
+    if reverse && adopt_orphan_lease.is_some() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "adopt_orphan_lease",
+            "orphan daemon adoption only applies to direct SSH runner connections",
+            None,
+            None,
+        ));
+    }
     let (report, exit_code) = if reverse {
         let runner_id = runner_id.ok_or_else(|| {
             homeboy::core::Error::validation_invalid_argument(
@@ -219,7 +237,7 @@ pub(super) fn connect(
             broker_url,
         })?
     } else {
-        runner::connect(id)?
+        runner::connect_with_orphan_adoption(id, adopt_orphan_lease.as_deref())?
     };
     Ok((
         RunnerOutput {

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -36,8 +36,8 @@ mod remote_runner;
 pub use artifact_download::ArtifactDownload;
 pub use broker_config::{render_broker_config, BrokerConfig, BrokerConfigOptions, ServiceIdentity};
 pub use control::{
-    artifact_content_url, ensure_running, fetch_artifact_to_path, start_background,
-    ArtifactFetchOutcome,
+    adopt_orphaned_lease, artifact_content_url, ensure_running, fetch_artifact_to_path,
+    start_background, ArtifactFetchOutcome,
 };
 use patch_capture::{capture_baseline, capture_patch_report};
 
@@ -123,6 +123,15 @@ pub struct DaemonStartResult {
     pub address: String,
     pub state_path: String,
     pub lease_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DaemonOrphanAdoptionResult {
+    pub adopted_lease_id: String,
+    pub dead_pid: u32,
+    pub active_jobs_terminalized: usize,
+    pub retry_guidance: String,
+    pub replacement: DaemonStartResult,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -16,8 +16,8 @@ use crate::core::process::pid_is_running;
 
 use super::{
     acquire_daemon_operation_lock, acquire_daemon_operation_lock_for_ensure, parse_bind_addr,
-    read_status, repair_legacy_lease_for_start, stop_unlocked, DaemonStartResult,
-    DAEMON_STARTUP_TOKEN_ENV,
+    read_status, repair_legacy_lease_for_start, stop_unlocked, DaemonOrphanAdoptionResult,
+    DaemonStaleReasonCode, DaemonStartResult, DAEMON_STARTUP_TOKEN_ENV,
 };
 
 /// Outcome of a daemon byte-endpoint artifact download.
@@ -43,6 +43,69 @@ pub fn start_background(addr: &str) -> Result<DaemonStartResult> {
 /// is absent or its recorded PID is dead.
 pub fn ensure_running(addr: &str) -> Result<DaemonStartResult> {
     ensure_running_with_wait(addr, Duration::from_secs(5))
+}
+
+/// Replace one explicitly identified, provably dead daemon lease. The operation
+/// lock covers validation, durable-job reconciliation, and replacement startup.
+pub fn adopt_orphaned_lease(
+    lease_id: &str,
+    confirm_pid_dead: bool,
+    addr: &str,
+) -> Result<DaemonOrphanAdoptionResult> {
+    if !confirm_pid_dead {
+        return Err(Error::validation_invalid_argument(
+            "confirm_pid_dead",
+            "orphan adoption requires explicit confirmation that the recorded daemon PID is dead",
+            None,
+            Some(vec!["Inspect `homeboy daemon status` and retry with --confirm-pid-dead only for the reported dead lease.".to_string()]),
+        ));
+    }
+    parse_bind_addr(addr)?;
+    let _lock = acquire_daemon_operation_lock()?;
+    let status = read_status()?;
+    let state = status.state.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "lease_id",
+            "orphan adoption requires a persisted daemon lease",
+            Some(lease_id.to_string()),
+            None,
+        )
+    })?;
+    if state.lease_id != lease_id {
+        return Err(Error::validation_invalid_argument(
+            "lease_id",
+            format!(
+                "recorded daemon lease `{}` does not match requested orphan lease `{lease_id}`",
+                state.lease_id
+            ),
+            Some(lease_id.to_string()),
+            Some(vec![
+                "Run `homeboy daemon status` and adopt only its exact dead lease.".to_string(),
+            ]),
+        ));
+    }
+    if status.freshness.stale_reason_code != Some(DaemonStaleReasonCode::PidDead) {
+        return Err(Error::validation_invalid_argument(
+            "lease_id",
+            format!("daemon lease `{lease_id}` is not proven dead"),
+            Some(lease_id.to_string()),
+            Some(vec!["Live or ambiguous daemon ownership is protected; inspect `homeboy daemon status` before retrying.".to_string()]),
+        ));
+    }
+
+    let active_jobs =
+        super::JobStore::active_count_at_path(crate::core::paths::daemon_jobs_file()?)?;
+    // Opening the durable store records terminal failure/retry evidence for jobs
+    // owned by this dead daemon before the replacement can accept new work.
+    let _reconciled = super::JobStore::open(crate::core::paths::daemon_jobs_file()?)?;
+    let replacement = start_background_unlocked(addr)?;
+    Ok(DaemonOrphanAdoptionResult {
+        adopted_lease_id: lease_id.to_string(),
+        dead_pid: state.pid,
+        active_jobs_terminalized: active_jobs,
+        retry_guidance: "Inspect the retained job events, then retry eligible work through its original command or workflow.".to_string(),
+        replacement,
+    })
 }
 
 fn ensure_running_with_wait(addr: &str, wait: Duration) -> Result<DaemonStartResult> {

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -46,6 +46,15 @@ struct CliEnvelope {
 }
 
 pub fn connect(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
+    connect_with_orphan_adoption(runner_id, None)
+}
+
+/// Connect while explicitly adopting one recorded dead remote lease. This is an
+/// operator recovery path; ordinary reconnects never infer orphan ownership.
+pub fn connect_with_orphan_adoption(
+    runner_id: &str,
+    orphan_lease_id: Option<&str>,
+) -> Result<(RunnerConnectReport, i32)> {
     let runner = load(runner_id)?;
     let session_path = session_path(runner_id)?;
     let homeboy = remote_runner_homeboy_path(&runner, "runner connect")?;
@@ -81,7 +90,7 @@ pub fn connect(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
     let version = identity.version.clone();
 
     let previous_session = read_session(runner_id)?;
-    let daemon = ensure_remote_daemon(&client, homeboy, previous_session.as_ref());
+    let daemon = ensure_remote_daemon(&client, homeboy, previous_session.as_ref(), orphan_lease_id);
     let Ok(daemon) = daemon else {
         return Ok(failed_connect(
             runner_id,
@@ -998,8 +1007,20 @@ mod remote_daemon {
         client: &SshClient,
         homeboy: &str,
         previous_session: Option<&RunnerSession>,
+        orphan_lease_id: Option<&str>,
     ) -> std::result::Result<RemoteDaemon, String> {
         let status = remote_daemon_status(client, homeboy)?;
+        if let Some(lease_id) = orphan_lease_id {
+            if status.stale_reason_code == Some(DaemonStaleReasonCode::PidDead)
+                && status
+                    .daemon
+                    .as_ref()
+                    .and_then(|daemon| daemon.lease_id.as_deref())
+                    == Some(lease_id)
+            {
+                return remote_daemon_adopt_orphan(client, homeboy, lease_id);
+            }
+        }
         match remote_daemon_connect_action(previous_session, &status)? {
             RemoteDaemonConnectAction::Reattach => {
                 return status.daemon.ok_or_else(|| {
@@ -1077,7 +1098,7 @@ mod remote_daemon {
             session.mode == RunnerTunnelMode::DirectSsh
                 && session.role == RunnerSessionRole::Controller
         }) else {
-            return true;
+            return false;
         };
 
         match session.remote_daemon_lease_id.as_deref() {
@@ -1236,6 +1257,58 @@ mod remote_daemon {
                 .and_then(Value::as_str)
                 .map(str::to_string),
         })
+    }
+
+    fn remote_daemon_adopt_orphan(
+        client: &SshClient,
+        homeboy: &str,
+        lease_id: &str,
+    ) -> std::result::Result<RemoteDaemon, String> {
+        let command = remote_daemon_adopt_orphan_command(homeboy, lease_id);
+        let output = client.execute(&command);
+        if !output.success {
+            return Err(command_failure_message(
+                "remote daemon orphan adoption failed",
+                &output,
+            ));
+        }
+        let envelope = parse_envelope(&output.stdout)
+            .map_err(|err| format!("remote daemon orphan adoption returned invalid JSON: {err}"))?;
+        if !envelope.success {
+            return Err(format!(
+                "remote daemon orphan adoption failed: {}",
+                envelope.error.unwrap_or(Value::Null)
+            ));
+        }
+        let data = envelope
+            .data
+            .ok_or_else(|| "remote daemon orphan adoption returned no data".to_string())?;
+        let replacement = data.get("replacement").ok_or_else(|| {
+            "remote daemon orphan adoption returned no replacement lease".to_string()
+        })?;
+        Ok(RemoteDaemon {
+            address: replacement
+                .get("address")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            pid: replacement
+                .get("pid")
+                .and_then(Value::as_u64)
+                .and_then(|pid| u32::try_from(pid).ok()),
+            lease_id: replacement
+                .get("lease_id")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        })
+    }
+
+    pub(super) fn remote_daemon_adopt_orphan_command(homeboy: &str, lease_id: &str) -> String {
+        format!(
+            "{} daemon adopt-orphan --lease-id {} --confirm-pid-dead --addr 127.0.0.1:0",
+            shell::quote_arg(homeboy),
+            shell::quote_arg(lease_id),
+        )
     }
 
     pub(super) fn parse_envelope(stdout: &str) -> serde_json::Result<CliEnvelope> {
@@ -1577,6 +1650,32 @@ mod tests {
             remote_daemon_connect_action(Some(&session), &status).expect("ensure start"),
             RemoteDaemonConnectAction::Start
         );
+    }
+
+    #[test]
+    fn lost_local_session_refuses_dead_daemon_with_active_jobs_without_explicit_adoption() {
+        let status = remote_daemon_status_for_test_with_reason(
+            false,
+            false,
+            1,
+            "lease-dead",
+            4545,
+            Some(DaemonStaleReasonCode::PidDead),
+        );
+
+        let err = remote_daemon_connect_action(None, &status)
+            .expect_err("lost session must not imply orphan ownership");
+
+        assert!(err.contains("refusing implicit replacement"));
+    }
+
+    #[test]
+    fn orphan_adoption_command_carries_exact_lease_and_dead_pid_confirmation() {
+        let command = remote_daemon_adopt_orphan_command("/opt/homeboy", "lease dead");
+
+        assert!(command.contains("daemon adopt-orphan"));
+        assert!(command.contains("--lease-id 'lease dead'"));
+        assert!(command.contains("--confirm-pid-dead"));
     }
 
     #[test]

--- a/src/core/runner/homeboy_refresh.rs
+++ b/src/core/runner/homeboy_refresh.rs
@@ -14,8 +14,8 @@ use crate::core::output::MergeOutput;
 
 use super::connection::active_jobs_before_daemon_replacement;
 use super::{
-    connect, disconnect, exec, load, materialize_runner_extension_with_env, merge,
-    normalize_runner_command_env_for_homeboy_path, plan_controller_snapshot_extension,
+    connect_with_orphan_adoption, disconnect, exec, load, materialize_runner_extension_with_env,
+    merge, normalize_runner_command_env_for_homeboy_path, plan_controller_snapshot_extension,
     RunnerCapabilityPreflight, RunnerExecOptions, RunnerExecOutput,
     RunnerExtensionMaterializationRequest, RunnerExtensionMaterializationSource,
     RunnerFileTransfer, RunnerKind,
@@ -231,6 +231,18 @@ pub fn refresh_homeboy_binary(
     options: HomeboyBinaryRefreshOptions,
 ) -> Result<(HomeboyBinaryRefreshOutput, i32)> {
     let plan = plan_homeboy_binary_refresh(&options)?;
+    // A refresh owns the lease it observed before changing the runner binary.
+    // If its local session disappears during that transition, reconnect can
+    // explicitly reconcile only that exact proven-dead lease.
+    let refresh_owned_lease = options
+        .reconnect
+        .then(|| {
+            super::status(&plan.runner_id)
+                .ok()
+                .and_then(|report| report.session)
+                .and_then(refresh_owned_lease)
+        })
+        .flatten();
     if options.dry_run {
         return Ok((
             HomeboyBinaryRefreshOutput {
@@ -310,7 +322,8 @@ pub fn refresh_homeboy_binary(
             options.force,
         )?;
         let _ = disconnect(&plan.runner_id);
-        let (_report, connect_exit_code) = connect(&plan.runner_id)?;
+        let (_report, connect_exit_code) =
+            connect_with_orphan_adoption(&plan.runner_id, refresh_owned_lease.as_deref())?;
         daemon_refreshed = connect_exit_code == 0;
     } else {
         interrupted_job_ids = Vec::new();
@@ -334,6 +347,13 @@ pub fn refresh_homeboy_binary(
         },
         0,
     ))
+}
+
+fn refresh_owned_lease(session: super::RunnerSession) -> Option<String> {
+    (session.mode == super::RunnerTunnelMode::DirectSsh
+        && session.role == super::RunnerSessionRole::Controller)
+        .then_some(session.remote_daemon_lease_id)
+        .flatten()
 }
 
 fn refresh_failure(
@@ -1023,6 +1043,7 @@ fn shell_arg(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::runner::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};
     use crate::test_support;
 
     #[test]
@@ -1057,6 +1078,35 @@ mod tests {
         assert_eq!(
             interrupted,
             vec!["0b77251a-b6a7-42a6-91a3-e49ff5f57c16".to_string()]
+        );
+    }
+
+    #[test]
+    fn refresh_preserves_only_its_direct_controller_lease_for_orphan_recovery() {
+        let session = RunnerSession {
+            runner_id: "lab".to_string(),
+            mode: RunnerTunnelMode::DirectSsh,
+            role: RunnerSessionRole::Controller,
+            server_id: Some("lab".to_string()),
+            controller_id: None,
+            broker_url: None,
+            remote_daemon_address: Some("127.0.0.1:7421".to_string()),
+            local_port: Some(7421),
+            local_url: Some("http://127.0.0.1:7421".to_string()),
+            tunnel_pid: Some(1),
+            remote_daemon_pid: Some(2),
+            remote_daemon_lease_id: Some("lease-refresh".to_string()),
+            homeboy_version: "test".to_string(),
+            homeboy_build_identity: None,
+            connected_at: "2026-01-01T00:00:00Z".to_string(),
+            worker_identity: None,
+            worker_pid: None,
+            last_seen_at: None,
+        };
+
+        assert_eq!(
+            refresh_owned_lease(session),
+            Some("lease-refresh".to_string())
         );
     }
 

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -83,8 +83,8 @@ pub(crate) use command_path::{
     remote_shell_path_preamble,
 };
 pub use connection::{
-    connect, connect_reverse, disconnect, reverse_broker_artifact, reverse_broker_reconcile,
-    status, statuses,
+    connect, connect_reverse, connect_with_orphan_adoption, disconnect, reverse_broker_artifact,
+    reverse_broker_reconcile, status, statuses,
 };
 pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
 pub use evidence::runner_artifact_store_token;

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -27,8 +27,9 @@
 pub use super::runner::{
     apply_change_artifact, apply_workspace_patch, broker_auth_store_path,
     broker_submit_token_for_runner, broker_token_from_env, capture_lab_offload_subprocess_metadata,
-    connect, reverse_broker_artifact, reverse_broker_reconcile, BrokerAuthGrant, BrokerAuthStore,
-    BrokerCredential, BrokerScope, MintedCredential, BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
+    connect, connect_with_orphan_adoption, reverse_broker_artifact, reverse_broker_reconcile,
+    BrokerAuthGrant, BrokerAuthStore, BrokerCredential, BrokerScope, MintedCredential,
+    BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
 };
 pub use super::runner::{
     connect_reverse, disconnect, download_remote_artifact,
@@ -96,11 +97,12 @@ pub mod registry {
 /// Connect/disconnect/status helpers for runner sessions.
 pub mod connection {
     pub use super::super::runner::{
-        connect, connect_reverse, disconnect, run_reverse_worker, status, statuses,
-        ReverseRunnerConnectOptions, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput,
-        RunnerAvailability, RunnerChangedRuntimePath, RunnerConnectReport, RunnerDisconnectReport,
-        RunnerFailureKind, RunnerSession, RunnerSessionRole, RunnerSessionState,
-        RunnerStaleDaemonWarning, RunnerStaleRuntimePath, RunnerStatusReport, RunnerTunnelMode,
+        connect, connect_reverse, connect_with_orphan_adoption, disconnect, run_reverse_worker,
+        status, statuses, ReverseRunnerConnectOptions, ReverseRunnerWorkerOptions,
+        ReverseRunnerWorkerOutput, RunnerAvailability, RunnerChangedRuntimePath,
+        RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind, RunnerSession,
+        RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning, RunnerStaleRuntimePath,
+        RunnerStatusReport, RunnerTunnelMode,
     };
 }
 


### PR DESCRIPTION
Fixes #7994.

## Summary
- add exact-lease orphan adoption for a provably dead direct-SSH daemon, retaining durable job evidence and retry guidance before replacement
- keep ordinary reconnect conservative when its controller session is missing, live, ambiguous, or lease-mismatched
- let refresh retain its observed direct controller lease and use the same adoption primitive only for its own transition

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test lost_local_session_refuses_dead_daemon_with_active_jobs_without_explicit_adoption --lib`.
3. Run `cargo test refresh_preserves_only_its_direct_controller_lease_for_orphan_recovery --lib`.
4. Run `cargo test refuses_to_replace_non_dead_stale_daemon_with_active_jobs --lib`.
5. Run `cargo test refuses_to_replace_proven_dead_daemon_with_active_jobs_when_lease_mismatches --lib`.
6. Run `cargo test ensure_running_concurrent_callers_converge_on_same_daemon --lib`.
7. Run `cargo check`.

## Backwards compatibility
Existing `homeboy runner connect <runner-id>` behavior remains conservative. Recovery requires the new explicit `--adopt-orphan-lease <lease-id> --confirm-pid-dead` intent and only applies to the exact remote `PidDead` lease.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Implemented the lease-scoped recovery contract, tests, documentation, and verification with Chris'