### PR TITLE
Fix dead runner daemon recovery

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -29,6 +29,11 @@ enum DaemonCommand {
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
     },
+    /// Reconcile interrupted jobs and replace an unreachable daemon with a dead lease PID
+    RecoverDeadLease {
+        #[arg(long, default_value = daemon::DEFAULT_ADDR)]
+        addr: String,
+    },
     /// Run the local daemon in the foreground
     Serve {
         /// Local bind address. Defaults to an OS-selected loopback port.
@@ -80,6 +85,7 @@ pub struct DaemonArtifactGetArgs {
 pub enum DaemonOutput {
     Start(DaemonStartResult),
     EnsureRunning(DaemonStartResult),
+    RecoverDeadLease(daemon::DaemonDeadLeaseRecoveryResult),
     Serve(DaemonStartResult),
     Stop(DaemonStopResult),
     Status(DaemonStatus),
@@ -107,6 +113,10 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
         }
         DaemonCommand::EnsureRunning { addr } => Ok((
             DaemonOutput::EnsureRunning(daemon::ensure_running(&addr)?),
+            0,
+        )),
+        DaemonCommand::RecoverDeadLease { addr } => Ok((
+            DaemonOutput::RecoverDeadLease(daemon::recover_dead_lease(&addr)?),
             0,
         )),
         DaemonCommand::Serve { addr } => serve(&addr),

--- a/src/commands/runner/cli.rs
+++ b/src/commands/runner/cli.rs
@@ -201,6 +201,10 @@ pub(super) enum RunnerCommand {
         /// Runner ID for direct SSH connect, or controller/broker ID when --reverse is set
         id: String,
 
+        /// Recover an unreachable daemon with a dead lease PID after recording its active jobs as retryable terminal work
+        #[arg(long)]
+        force: bool,
+
         /// Record a runner-initiated reverse tunnel session substrate
         #[arg(long)]
         reverse: bool,

--- a/src/commands/runner/dispatch.rs
+++ b/src/commands/runner/dispatch.rs
@@ -131,10 +131,11 @@ pub fn run(
         )),
         RunnerCommand::Connect {
             id,
+            force,
             reverse,
             reverse_runner,
             broker_url,
-        } => map_registry(connect(&id, reverse, reverse_runner, broker_url)),
+        } => map_registry(connect(&id, force, reverse, reverse_runner, broker_url)),
         RunnerCommand::Status { id } => map_registry(status_mod::status(id.as_deref())),
         RunnerCommand::Disconnect { id } => map_registry(registry::disconnect(&id)),
         RunnerCommand::RefreshHomeboy {

--- a/src/commands/runner/registry.rs
+++ b/src/commands/runner/registry.rs
@@ -200,11 +200,20 @@ pub(super) fn remove(id: &str) -> CmdResult<RunnerOutput> {
 
 pub(super) fn connect(
     id: &str,
+    force: bool,
     reverse: bool,
     runner_id: Option<String>,
     broker_url: Option<String>,
 ) -> CmdResult<RunnerOutput> {
     let (report, exit_code) = if reverse {
+        if force {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "force",
+                "--force recovery is only supported for direct SSH runner connections",
+                Some(id.to_string()),
+                None,
+            ));
+        }
         let runner_id = runner_id.ok_or_else(|| {
             homeboy::core::Error::validation_invalid_argument(
                 "runner",
@@ -219,7 +228,7 @@ pub(super) fn connect(
             broker_url,
         })?
     } else {
-        runner::connect(id)?
+        runner::connect_with_dead_daemon_recovery(id, force)?
     };
     Ok((
         RunnerOutput {

--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -12,7 +12,7 @@ pub use store::{JobHandle, JobRunner, JobStore};
 pub use summary::active_runner_job_run_summary;
 pub use types::{
     ActiveRunnerJobRunSummary, ActiveRunnerJobSummary, Job, JobClaimMetadata, JobEvent,
-    JobEventKind, JobStatus, RunnerJobLifecycleOwner, RunnerJobSource,
+    JobEventKind, JobStatus, RecoveredInterruptedJob, RunnerJobLifecycleOwner, RunnerJobSource,
 };
 
 #[cfg(test)]
@@ -56,6 +56,29 @@ mod tests {
             JobStatus::Running,
             "status inspection must not reconcile an in-flight daemon job"
         );
+    }
+
+    #[test]
+    fn reopening_persisted_active_job_records_terminal_retryable_recovery() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("jobs.json");
+        let store = JobStore::open(&path).expect("open store");
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start job");
+        drop(store);
+
+        let recovered = JobStore::open(&path).expect("reopen interrupted store");
+        let job = recovered.get(job.id).expect("recovered job");
+
+        assert_eq!(job.status, JobStatus::Failed);
+        assert_eq!(
+            job.stale_reason.as_deref(),
+            Some("daemon restarted before the job reached a terminal status")
+        );
+        assert!(recovered
+            .recovered_interrupted_jobs()
+            .iter()
+            .any(|recovered_job| recovered_job.job_id == job.id.to_string()));
     }
 
     #[test]

--- a/src/core/api_jobs/store.rs
+++ b/src/core/api_jobs/store.rs
@@ -14,7 +14,7 @@ use super::persistence::{
     validate_transition, write_durable_store, DEFAULT_EVENT_RETENTION_LIMIT,
 };
 use super::remote_runner;
-use super::types::{Job, JobEvent, JobEventKind, JobStatus};
+use super::types::{Job, JobEvent, JobEventKind, JobStatus, RecoveredInterruptedJob};
 use crate::core::error::{Error, Result};
 use crate::core::runner_execution_envelope::PathMaterializationPlan;
 use crate::core::source_snapshot::SourceSnapshot;
@@ -262,6 +262,36 @@ impl JobStore {
             })
             .collect();
         jobs.sort_by_key(|job| (job.updated_at_ms, job.job_id.clone()));
+        jobs
+    }
+
+    pub(crate) fn recovered_interrupted_jobs(&self) -> Vec<RecoveredInterruptedJob> {
+        let inner = self.inner.lock().expect("job store mutex poisoned");
+        let mut jobs = inner
+            .jobs
+            .values()
+            .filter(|stored| {
+                stored.job.status == JobStatus::Failed
+                    && stored.job.stale_reason.as_deref()
+                        == Some("daemon restarted before the job reached a terminal status")
+            })
+            .map(|stored| RecoveredInterruptedJob {
+                job_id: stored.job.id.to_string(),
+                durable_run_id: stored.events.iter().rev().find_map(|event| {
+                    let data = event.data.as_ref()?;
+                    [
+                        "/durable_run_id",
+                        "/metadata/durable_run_id",
+                        "/metadata/run_id",
+                        "/metadata/record_run_id",
+                    ]
+                    .iter()
+                    .find_map(|pointer| data.pointer(pointer).and_then(Value::as_str))
+                    .map(str::to_string)
+                }),
+            })
+            .collect::<Vec<_>>();
+        jobs.sort_by(|left, right| left.job_id.cmp(&right.job_id));
         jobs
     }
 

--- a/src/core/api_jobs/types.rs
+++ b/src/core/api_jobs/types.rs
@@ -143,6 +143,13 @@ pub struct ActiveRunnerJobSummary {
     pub active_cell_count: Option<u64>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RecoveredInterruptedJob {
+    pub job_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub durable_run_id: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RunnerJobSource {

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -12,7 +12,9 @@ use std::time::{Duration, Instant, UNIX_EPOCH};
 use uuid::Uuid;
 
 use crate::command_contract::RunnerWorkload;
-use crate::core::api_jobs::{JobStatus, JobStore, RunnerJobLifecycleMetadata};
+use crate::core::api_jobs::{
+    JobStatus, JobStore, RecoveredInterruptedJob, RunnerJobLifecycleMetadata,
+};
 use crate::core::build_identity;
 use crate::core::error::{Error, RemoteCommandFailedDetails, Result, TargetDetails};
 use crate::core::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnalysisJobRunner};
@@ -36,8 +38,8 @@ mod remote_runner;
 pub use artifact_download::ArtifactDownload;
 pub use broker_config::{render_broker_config, BrokerConfig, BrokerConfigOptions, ServiceIdentity};
 pub use control::{
-    artifact_content_url, ensure_running, fetch_artifact_to_path, start_background,
-    ArtifactFetchOutcome,
+    artifact_content_url, ensure_running, fetch_artifact_to_path, recover_dead_lease,
+    start_background, ArtifactFetchOutcome,
 };
 use patch_capture::{capture_baseline, capture_patch_report};
 
@@ -123,6 +125,12 @@ pub struct DaemonStartResult {
     pub address: String,
     pub state_path: String,
     pub lease_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DaemonDeadLeaseRecoveryResult {
+    pub daemon: DaemonStartResult,
+    pub recovered_jobs: Vec<RecoveredInterruptedJob>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -16,8 +16,8 @@ use crate::core::process::pid_is_running;
 
 use super::{
     acquire_daemon_operation_lock, acquire_daemon_operation_lock_for_ensure, parse_bind_addr,
-    read_status, repair_legacy_lease_for_start, stop_unlocked, DaemonStartResult,
-    DAEMON_STARTUP_TOKEN_ENV,
+    read_status, repair_legacy_lease_for_start, stop_unlocked, DaemonDeadLeaseRecoveryResult,
+    DaemonStaleReasonCode, DaemonStartResult, JobStore, DAEMON_STARTUP_TOKEN_ENV,
 };
 
 /// Outcome of a daemon byte-endpoint artifact download.
@@ -43,6 +43,37 @@ pub fn start_background(addr: &str) -> Result<DaemonStartResult> {
 /// is absent or its recorded PID is dead.
 pub fn ensure_running(addr: &str) -> Result<DaemonStartResult> {
     ensure_running_with_wait(addr, Duration::from_secs(5))
+}
+
+/// Explicitly recover an unreachable daemon whose recorded PID is dead.
+///
+/// Opening the durable store reconciles interrupted jobs before the replacement
+/// daemon can accept work, preserving retryable terminal evidence.
+pub fn recover_dead_lease(addr: &str) -> Result<DaemonDeadLeaseRecoveryResult> {
+    parse_bind_addr(addr)?;
+    let _lock = acquire_daemon_operation_lock()?;
+    let status = read_status()?;
+    if status.fresh
+        || status.reachable
+        || status.freshness.stale_reason_code != Some(DaemonStaleReasonCode::PidDead)
+    {
+        return Err(Error::validation_invalid_argument(
+            "daemon_lease",
+            format!(
+                "dead-lease recovery requires an unreachable daemon with a dead PID (fresh={}, reachable={}, reason={:?})",
+                status.fresh, status.reachable, status.freshness.stale_reason_code
+            ),
+            None,
+            Some(vec!["Run `homeboy daemon status` to inspect the recorded lease before replacing it".to_string()]),
+        ));
+    }
+    let jobs = JobStore::open(crate::core::paths::daemon_jobs_file()?)?;
+    let recovered_jobs = jobs.recovered_interrupted_jobs();
+    let daemon = start_background_unlocked(addr)?;
+    Ok(DaemonDeadLeaseRecoveryResult {
+        daemon,
+        recovered_jobs,
+    })
 }
 
 fn ensure_running_with_wait(addr: &str, wait: Duration) -> Result<DaemonStartResult> {

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -20,8 +20,8 @@ use crate::core::server::{self, Server, SshClient};
 use super::session::{
     ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource, RunnerActiveJobState,
     RunnerChangedRuntimePath, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
-    RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
-    RunnerStatusReport, RunnerTunnelMode,
+    RunnerRecoveredJob, RunnerSession, RunnerSessionRole, RunnerSessionState,
+    RunnerStaleDaemonWarning, RunnerStatusReport, RunnerTunnelMode,
 };
 use super::{broker_auth, broker_http};
 use super::{load, remote_runner_homeboy_path, Runner, RunnerKind};
@@ -46,6 +46,13 @@ struct CliEnvelope {
 }
 
 pub fn connect(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
+    connect_with_dead_daemon_recovery(runner_id, false)
+}
+
+pub fn connect_with_dead_daemon_recovery(
+    runner_id: &str,
+    force_dead_daemon_recovery: bool,
+) -> Result<(RunnerConnectReport, i32)> {
     let runner = load(runner_id)?;
     let session_path = session_path(runner_id)?;
     let homeboy = remote_runner_homeboy_path(&runner, "runner connect")?;
@@ -81,7 +88,12 @@ pub fn connect(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
     let version = identity.version.clone();
 
     let previous_session = read_session(runner_id)?;
-    let daemon = ensure_remote_daemon(&client, homeboy, previous_session.as_ref());
+    let daemon = ensure_remote_daemon(
+        &client,
+        homeboy,
+        previous_session.as_ref(),
+        force_dead_daemon_recovery,
+    );
     let Ok(daemon) = daemon else {
         return Ok(failed_connect(
             runner_id,
@@ -91,6 +103,20 @@ pub fn connect(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
         ));
     };
 
+    let (daemon, recovered_jobs) = daemon;
+    for job in &recovered_jobs {
+        eprintln!(
+            "Recovered dead daemon job {}{}; inspect {}",
+            job.job_id,
+            job.durable_run_id
+                .as_deref()
+                .map(|run_id| format!(" (durable run {run_id})"))
+                .unwrap_or_default(),
+            job.evidence_commands
+                .join(" or ")
+                .replace("<runner-id>", runner_id),
+        );
+    }
     let (local_port, tunnel_pid, local_url, daemon) = match connect_remote_daemon(
         &server,
         &client,
@@ -992,22 +1018,31 @@ mod remote_daemon {
     pub(super) enum RemoteDaemonConnectAction {
         Reattach,
         Start,
+        RecoverDeadLease,
     }
 
     pub(super) fn ensure_remote_daemon(
         client: &SshClient,
         homeboy: &str,
         previous_session: Option<&RunnerSession>,
-    ) -> std::result::Result<RemoteDaemon, String> {
+        force_dead_daemon_recovery: bool,
+    ) -> std::result::Result<(RemoteDaemon, Vec<RunnerRecoveredJob>), String> {
         let status = remote_daemon_status(client, homeboy)?;
-        match remote_daemon_connect_action(previous_session, &status)? {
+        match remote_daemon_connect_action(previous_session, &status, force_dead_daemon_recovery)? {
             RemoteDaemonConnectAction::Reattach => {
-                return status.daemon.ok_or_else(|| {
-                    "remote daemon reattach selected without a daemon lease".to_string()
-                });
+                return status
+                    .daemon
+                    .map(|daemon| (daemon, Vec::new()))
+                    .ok_or_else(|| {
+                        "remote daemon reattach selected without a daemon lease".to_string()
+                    });
             }
             RemoteDaemonConnectAction::Start => {
                 return remote_daemon_ensure_running(client, homeboy)
+                    .map(|daemon| (daemon, Vec::new()))
+            }
+            RemoteDaemonConnectAction::RecoverDeadLease => {
+                return remote_daemon_recover_dead_lease(client, homeboy)
             }
         }
     }
@@ -1015,15 +1050,19 @@ mod remote_daemon {
     pub(super) fn remote_daemon_connect_action(
         previous_session: Option<&RunnerSession>,
         status: &RemoteDaemonStatus,
+        force_dead_daemon_recovery: bool,
     ) -> std::result::Result<RemoteDaemonConnectAction, String> {
         let healthy = status.fresh && status.reachable;
-        if status.active_jobs > 0
-            && !healthy
-            && !remote_daemon_pid_dead_with_owned_lease(previous_session, status)
-        {
+        if status.active_jobs > 0 && !healthy {
+            if force_dead_daemon_recovery
+                && status.stale_reason_code == Some(DaemonStaleReasonCode::PidDead)
+                && !status.reachable
+            {
+                return Ok(RemoteDaemonConnectAction::RecoverDeadLease);
+            }
             return Err(format!(
-                "remote daemon has {} active job(s) but cannot be safely reattached (fresh={}, reachable={}, reason={:?}); refusing implicit replacement",
-                status.active_jobs, status.fresh, status.reachable, status.stale_reason
+                "remote daemon has {} active job(s) but cannot be safely reattached (fresh={}, reachable={}, reason={:?}); refusing implicit replacement. Inspect `homeboy daemon status` and the daemon job store. To recover only an unreachable daemon with a dead lease PID, run `homeboy runner connect <runner-id> --force`; recovery records affected jobs as terminal retryable evidence before replacement",
+                status.active_jobs, status.fresh, status.reachable, status.stale_reason,
             ));
         }
 
@@ -1058,35 +1097,6 @@ mod remote_daemon {
         }
 
         Ok(RemoteDaemonConnectAction::Start)
-    }
-
-    fn remote_daemon_pid_dead_with_owned_lease(
-        previous_session: Option<&RunnerSession>,
-        status: &RemoteDaemonStatus,
-    ) -> bool {
-        if status.stale_reason_code != Some(DaemonStaleReasonCode::PidDead) {
-            return false;
-        }
-        let Some(daemon) = status.daemon.as_ref() else {
-            return false;
-        };
-        let Some(lease_id) = daemon.lease_id.as_deref() else {
-            return false;
-        };
-        let Some(session) = previous_session.filter(|session| {
-            session.mode == RunnerTunnelMode::DirectSsh
-                && session.role == RunnerSessionRole::Controller
-        }) else {
-            return true;
-        };
-
-        match session.remote_daemon_lease_id.as_deref() {
-            Some(expected_lease) => expected_lease == lease_id,
-            None => {
-                session.remote_daemon_pid == daemon.pid
-                    && session.remote_daemon_address.as_deref() == Some(daemon.address.as_str())
-            }
-        }
     }
 
     pub(super) fn remote_daemon_status(
@@ -1236,6 +1246,62 @@ mod remote_daemon {
                 .and_then(Value::as_str)
                 .map(str::to_string),
         })
+    }
+
+    fn remote_daemon_recover_dead_lease(
+        client: &SshClient,
+        homeboy: &str,
+    ) -> std::result::Result<(RemoteDaemon, Vec<RunnerRecoveredJob>), String> {
+        let command = format!(
+            "{} daemon recover-dead-lease --addr 127.0.0.1:0",
+            shell::quote_arg(homeboy)
+        );
+        let output = client.execute(&command);
+        if !output.success {
+            return Err(command_failure_message(
+                "remote dead-lease recovery failed",
+                &output,
+            ));
+        }
+        let envelope = parse_envelope(&output.stdout)
+            .map_err(|err| format!("remote dead-lease recovery returned invalid JSON: {}", err))?;
+        if !envelope.success {
+            return Err(format!(
+                "remote dead-lease recovery failed: {}",
+                envelope.error.unwrap_or(Value::Null)
+            ));
+        }
+        let data = envelope
+            .data
+            .ok_or_else(|| "remote dead-lease recovery returned no data".to_string())?;
+        let daemon = data
+            .get("daemon")
+            .ok_or_else(|| "remote dead-lease recovery returned no daemon".to_string())
+            .map(remote_daemon_from_state)?;
+        let recovered_jobs = data
+            .get("recovered_jobs")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|job| {
+                let job_id = job.get("job_id")?.as_str()?.to_string();
+                let durable_run_id = job
+                    .get("durable_run_id")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                let mut evidence_commands =
+                    vec![format!("homeboy runner job logs <runner-id> {job_id}")];
+                if let Some(run_id) = durable_run_id.as_deref() {
+                    evidence_commands.push(format!("homeboy runs show {run_id}"));
+                }
+                Some(RunnerRecoveredJob {
+                    job_id,
+                    durable_run_id,
+                    evidence_commands,
+                })
+            })
+            .collect();
+        Ok((daemon, recovered_jobs))
     }
 
     pub(super) fn parse_envelope(stdout: &str) -> serde_json::Result<CliEnvelope> {
@@ -1509,7 +1575,8 @@ mod tests {
         let session = direct_ssh_session("lease-active");
         let status = remote_daemon_status_for_test(true, true, 1, "lease-active", 4242);
 
-        let action = remote_daemon_connect_action(Some(&session), &status).expect("reattach");
+        let action =
+            remote_daemon_connect_action(Some(&session), &status, false).expect("reattach");
 
         assert_eq!(action, RemoteDaemonConnectAction::Reattach);
         let daemon = status.daemon.expect("daemon");
@@ -1529,7 +1596,7 @@ mod tests {
         let status = remote_daemon_status_for_test(true, true, 0, "lease-tunnel", 4343);
 
         assert_eq!(
-            remote_daemon_connect_action(Some(&session), &status).expect("reattach"),
+            remote_daemon_connect_action(Some(&session), &status, false).expect("reattach"),
             RemoteDaemonConnectAction::Reattach
         );
     }
@@ -1539,7 +1606,7 @@ mod tests {
         let status = remote_daemon_status_for_test(false, true, 0, "lease-stale", 4444);
 
         assert_eq!(
-            remote_daemon_connect_action(None, &status).expect("replace stale daemon"),
+            remote_daemon_connect_action(None, &status, false).expect("replace stale daemon"),
             RemoteDaemonConnectAction::Start
         );
     }
@@ -1555,14 +1622,15 @@ mod tests {
             Some(DaemonStaleReasonCode::VersionMismatch),
         );
 
-        let err = remote_daemon_connect_action(None, &status).expect_err("refuse replacement");
+        let err =
+            remote_daemon_connect_action(None, &status, false).expect_err("refuse replacement");
 
         assert!(err.contains("1 active job(s)"));
         assert!(err.contains("refusing implicit replacement"));
     }
 
     #[test]
-    fn proven_dead_daemon_with_active_jobs_and_matching_lease_routes_to_startup_reconciliation() {
+    fn dead_daemon_with_active_jobs_refuses_implicit_replacement() {
         let session = direct_ssh_session("lease-dead");
         let status = remote_daemon_status_for_test_with_reason(
             false,
@@ -1573,9 +1641,26 @@ mod tests {
             Some(DaemonStaleReasonCode::PidDead),
         );
 
+        let err = remote_daemon_connect_action(Some(&session), &status, false)
+            .expect_err("refuse implicit replacement");
+        assert!(err.contains("1 active job(s)"));
+        assert!(err.contains("--force"));
+    }
+
+    #[test]
+    fn force_recovers_unreachable_dead_daemon_with_active_jobs() {
+        let status = remote_daemon_status_for_test_with_reason(
+            false,
+            false,
+            1,
+            "lease-dead",
+            4545,
+            Some(DaemonStaleReasonCode::PidDead),
+        );
+
         assert_eq!(
-            remote_daemon_connect_action(Some(&session), &status).expect("ensure start"),
-            RemoteDaemonConnectAction::Start
+            remote_daemon_connect_action(None, &status, true).expect("select recovery"),
+            RemoteDaemonConnectAction::RecoverDeadLease
         );
     }
 
@@ -1591,7 +1676,7 @@ mod tests {
             Some(DaemonStaleReasonCode::PidDead),
         );
 
-        let err = remote_daemon_connect_action(Some(&session), &status)
+        let err = remote_daemon_connect_action(Some(&session), &status, false)
             .expect_err("refuse mismatched dead lease");
 
         assert!(err.contains("1 active job(s)"));
@@ -1610,7 +1695,7 @@ mod tests {
         };
 
         assert_eq!(
-            remote_daemon_connect_action(Some(&direct_ssh_session("lease-dead")), &status)
+            remote_daemon_connect_action(Some(&direct_ssh_session("lease-dead")), &status, false)
                 .expect("ensure start"),
             RemoteDaemonConnectAction::Start
         );
@@ -1628,7 +1713,7 @@ mod tests {
         };
 
         assert_eq!(
-            remote_daemon_connect_action(None, &status).expect("ensure start"),
+            remote_daemon_connect_action(None, &status, false).expect("ensure start"),
             RemoteDaemonConnectAction::Start
         );
     }
@@ -1638,8 +1723,8 @@ mod tests {
         let session = direct_ssh_session("lease-recorded");
         let status = remote_daemon_status_for_test(true, true, 0, "lease-live", 4646);
 
-        let err =
-            remote_daemon_connect_action(Some(&session), &status).expect_err("lease mismatch");
+        let err = remote_daemon_connect_action(Some(&session), &status, false)
+            .expect_err("lease mismatch");
 
         assert!(err.contains("does not match persisted session lease"));
         assert!(err.contains("refusing to replace"));
@@ -1652,7 +1737,7 @@ mod tests {
         let status = remote_daemon_status_for_test(true, true, 1, "lease-live", 4242);
 
         assert_eq!(
-            remote_daemon_connect_action(Some(&session), &status).expect("adopt live lease"),
+            remote_daemon_connect_action(Some(&session), &status, false).expect("adopt live lease"),
             RemoteDaemonConnectAction::Reattach
         );
     }
@@ -1663,7 +1748,7 @@ mod tests {
         session.remote_daemon_lease_id = None;
         let status = remote_daemon_status_for_test(true, true, 0, "lease-live", 5555);
 
-        assert!(remote_daemon_connect_action(Some(&session), &status)
+        assert!(remote_daemon_connect_action(Some(&session), &status, false)
             .expect_err("identity mismatch")
             .contains("does not match the live daemon PID/address"));
     }

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -83,8 +83,8 @@ pub(crate) use command_path::{
     remote_shell_path_preamble,
 };
 pub use connection::{
-    connect, connect_reverse, disconnect, reverse_broker_artifact, reverse_broker_reconcile,
-    status, statuses,
+    connect, connect_reverse, connect_with_dead_daemon_recovery, disconnect,
+    reverse_broker_artifact, reverse_broker_reconcile, status, statuses,
 };
 pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
 pub use evidence::runner_artifact_store_token;

--- a/src/core/runner/session.rs
+++ b/src/core/runner/session.rs
@@ -492,6 +492,13 @@ pub struct RunnerConnectReport {
     pub failure_message: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RunnerRecoveredJob {
+    pub job_id: String,
+    pub durable_run_id: Option<String>,
+    pub evidence_commands: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct RunnerStatusReport {
     pub runner_id: String,

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -27,8 +27,9 @@
 pub use super::runner::{
     apply_change_artifact, apply_workspace_patch, broker_auth_store_path,
     broker_submit_token_for_runner, broker_token_from_env, capture_lab_offload_subprocess_metadata,
-    connect, reverse_broker_artifact, reverse_broker_reconcile, BrokerAuthGrant, BrokerAuthStore,
-    BrokerCredential, BrokerScope, MintedCredential, BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
+    connect, connect_with_dead_daemon_recovery, reverse_broker_artifact, reverse_broker_reconcile,
+    BrokerAuthGrant, BrokerAuthStore, BrokerCredential, BrokerScope, MintedCredential,
+    BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
 };
 pub use super::runner::{
     connect_reverse, disconnect, download_remote_artifact,


### PR DESCRIPTION
## Summary
- keep default runner reconnects safe when an unreachable dead daemon lease still has persisted active jobs
- add `homeboy runner connect <runner> --force` for reviewed dead-lease recovery only
- reconcile interrupted jobs into terminal retryable lifecycle records before replacement and report job/run evidence commands

Closes #8001

## Testing
1. Run `cargo test core::runner::connection::tests --lib`.
2. Run `cargo test core::api_jobs::tests --lib`.
3. Run `cargo check`.
4. Run `cargo run -- runner connect --help` and verify `--force` documents unreachable dead-lease recovery.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.6 Sol)
- **Used for:** Implemented the explicit dead-daemon recovery contract, tests, formatting, and verification under Chris direction.