### PR TITLE
Fix staged Lab cook lifecycle identity

### DIFF
--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -627,6 +627,7 @@ pub(super) fn ensure_agent_task_dispatch_run_id_with(
 pub(super) fn ensure_agent_task_lifecycle_identity_with(
     args: &[String],
     preferred: Option<&str>,
+    preferred_attempt_run_id: Option<&str>,
 ) -> Option<(Vec<String>, String)> {
     let (args, run_id) = ensure_agent_task_dispatch_run_id_with(args, preferred)?;
     let invocation = CommandInvocation::for_subcommand(&args, "agent-task")?;
@@ -638,7 +639,10 @@ pub(super) fn ensure_agent_task_lifecycle_identity_with(
         return Some((args, attempt_run_id));
     }
 
-    let attempt_run_id = cook_attempt_run_id(&run_id, 1);
+    let attempt_run_id = preferred_attempt_run_id
+        .filter(|id| !id.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| cook_attempt_run_id(&run_id, 1));
     let args = ArgEditor::new(&args)
         .insert_after(
             action_index,
@@ -1402,13 +1406,36 @@ mod tests {
         ];
 
         let (out, lifecycle_run_id) =
-            ensure_agent_task_lifecycle_identity_with(&args, None).expect("cook identity");
+            ensure_agent_task_lifecycle_identity_with(&args, None, None).expect("cook identity");
 
         assert_eq!(out[3], "--attempt-run-id");
         assert_eq!(out[4], lifecycle_run_id);
         assert_eq!(out[5], "--run-id");
         assert_eq!(out[6], "cook-7970");
         assert!(lifecycle_run_id.starts_with("cook-7970-attempt-1-"));
+    }
+
+    #[test]
+    fn lab_cook_preserves_explicit_attempt_identity_for_drift_detection() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--attempt-run-id".to_string(),
+            "unexpected-attempt".to_string(),
+            "--run-id".to_string(),
+            "cook-8009".to_string(),
+        ];
+
+        let (out, lifecycle_run_id) = ensure_agent_task_lifecycle_identity_with(
+            &args,
+            Some("cook-8009"),
+            Some("cook-8009-attempt-1-canonical"),
+        )
+        .expect("cook identity");
+
+        assert_eq!(out, args);
+        assert_eq!(lifecycle_run_id, "unexpected-attempt");
     }
 
     #[test]

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -871,6 +871,7 @@ pub(crate) fn run_lab_offload_inner(
     let pre_acceptance_run_id = ensure_agent_task_lifecycle_identity_with(
         request.normalized_args,
         run_isolation_token.as_deref(),
+        None,
     )
     .map(|(_, run_id)| run_id);
     let provider_rotation =
@@ -1062,6 +1063,7 @@ pub(crate) fn run_lab_offload_inner(
         &command_prefix.argv,
         Some(&runner_workspace_root),
         run_isolation_token,
+        pre_acceptance_run_id.as_deref(),
     ) {
         Ok(stage) => stage,
         Err(error) => {

--- a/src/core/runner/lab/offload/resident.rs
+++ b/src/core/runner/lab/offload/resident.rs
@@ -72,9 +72,12 @@ pub(crate) fn run_runner_resident_lab_offload(
     );
     let remapped_args = inject_agent_task_resolved_provider_policy_in_args(&remapped_args)?;
     let run_isolation_token = agent_task_dispatch_run_isolation_token(request.normalized_args);
-    let (remapped_args, agent_task_run_id) =
-        ensure_agent_task_lifecycle_identity_with(&remapped_args, run_isolation_token.as_deref())
-            .map_or((remapped_args, None), |(args, run_id)| (args, Some(run_id)));
+    let (remapped_args, agent_task_run_id) = ensure_agent_task_lifecycle_identity_with(
+        &remapped_args,
+        run_isolation_token.as_deref(),
+        None,
+    )
+    .map_or((remapped_args, None), |(args, run_id)| (args, Some(run_id)));
     let mut command = vec![homeboy_path.to_string()];
     if remote_output_file.is_some() && !args_contain_output_file(request.normalized_args) {
         command.push("--output".to_string());

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -45,6 +45,7 @@ pub(crate) fn prepare_lab_offload_workspace_stage(
     command_prefix_argv: &[String],
     runner_workspace_root: Option<&str>,
     run_isolation_token: Option<String>,
+    preferred_attempt_run_id: Option<&str>,
 ) -> Result<LabOffloadWorkspaceStage> {
     // Capture the orchestration facts known *before* staging so any
     // Lab-cannot-proceed error bubbling out of the pre-execution/dispatch path
@@ -68,6 +69,7 @@ pub(crate) fn prepare_lab_offload_workspace_stage(
         command_prefix_argv,
         runner_workspace_root,
         run_isolation_token,
+        preferred_attempt_run_id,
     )
     .map_err(|error| enrich_lab_cannot_proceed_error(error, &context))
 }
@@ -83,6 +85,7 @@ fn prepare_lab_offload_workspace_stage_inner(
     command_prefix_argv: &[String],
     runner_workspace_root: Option<&str>,
     run_isolation_token: Option<String>,
+    preferred_attempt_run_id: Option<&str>,
 ) -> Result<LabOffloadWorkspaceStage> {
     let sync_mode = lab_workspace_sync_mode(
         contract.workspace_mode_policy,
@@ -418,9 +421,12 @@ fn prepare_lab_offload_workspace_stage_inner(
         command_prefix_argv.first().map(String::as_str),
         &remote_cwd,
     );
-    let (remapped_args, agent_task_run_id) =
-        ensure_agent_task_lifecycle_identity_with(&remapped_args, run_isolation_token.as_deref())
-            .map_or((remapped_args, None), |(args, run_id)| (args, Some(run_id)));
+    let (remapped_args, agent_task_run_id) = ensure_agent_task_lifecycle_identity_with(
+        &remapped_args,
+        run_isolation_token.as_deref(),
+        preferred_attempt_run_id,
+    )
+    .map_or((remapped_args, None), |(args, run_id)| (args, Some(run_id)));
 
     let remote_output_file = request
         .output_file_requested
@@ -2144,6 +2150,7 @@ mod tests {
                 &["homeboy".to_string()],
                 Some(&runner_workspace_root),
                 None,
+                None,
             );
             std::env::set_var("PATH", prior_path);
             match prior_real_git {
@@ -2172,6 +2179,136 @@ mod tests {
                 git_output(Path::new(&stage.remote_cwd), &["rev-parse", &base]),
                 base
             );
+        });
+    }
+
+    #[test]
+    fn managed_worktree_staging_preserves_cook_attempt_identity_through_daemon_acceptance() {
+        crate::test_support::with_isolated_home(|_| {
+            let repository = tempfile::tempdir().expect("repository");
+            let worktree_parent = tempfile::tempdir().expect("worktree parent");
+            let runner_root = tempfile::tempdir().expect("runner workspace root");
+            git(repository.path(), &["init"]);
+            git(
+                repository.path(),
+                &["config", "user.email", "test@example.com"],
+            );
+            git(repository.path(), &["config", "user.name", "Test User"]);
+            std::fs::write(
+                repository.path().join("Cargo.toml"),
+                "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+            )
+            .expect("write fixture manifest");
+            git(repository.path(), &["add", "."]);
+            git(repository.path(), &["commit", "-m", "base"]);
+            let source = worktree_parent.path().join("homeboy-fix-8009");
+            git(
+                repository.path(),
+                &[
+                    "worktree",
+                    "add",
+                    "-b",
+                    "fix/8009-staging-lifecycle-identity",
+                    source.to_str().expect("source path"),
+                ],
+            );
+
+            crate::core::runner::create(
+                &format!(
+                    r#"{{"id":"lab-managed-worktree-stage","kind":"local","workspace_root":"{}"}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+            let args = vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                "--run-id".to_string(),
+                "cook-8009".to_string(),
+                "--backend".to_string(),
+                "opencode".to_string(),
+                "--to-worktree".to_string(),
+                "homeboy@fix-8009-staging-lifecycle-identity".to_string(),
+                "--verify".to_string(),
+                "cargo check".to_string(),
+            ];
+            let (_, canonical_attempt_id) =
+                ensure_agent_task_lifecycle_identity_with(&args, Some("cook-8009"), None)
+                    .expect("canonical cook attempt id");
+            let request = LabOffloadRequest {
+                command: None,
+                normalized_args: &args,
+                explicit_runner: Some("lab-managed-worktree-stage"),
+                placement: crate::cli_surface::Placement::Lab,
+                allow_local_fallback: false,
+                allow_dirty_lab_workspace: false,
+                skip_deps_hydration: false,
+                capture_patch: false,
+                mutation_flag: None,
+                detach_after_handoff: true,
+                output_file_requested: false,
+                read_only_polling: false,
+                local_output_file: None,
+                durable_agent_task_plan: None,
+                job_overrides: LabJobOverrides::default(),
+            };
+            let contract = LabOffloadCommand {
+                command: crate::command_contract::LabCommandContract::portable(
+                    "agent-task",
+                    None,
+                    true,
+                    &[],
+                ),
+                required_extensions: Vec::new(),
+                required_capabilities: Vec::new(),
+                workload: None,
+            };
+            let runner_workspace_root = runner_root.path().display().to_string();
+            let stage = prepare_lab_offload_workspace_stage(
+                &request,
+                &contract,
+                crate::core::runner::lab_plan::base_lab_plan(Some(&contract)),
+                "lab-managed-worktree-stage",
+                &source,
+                "homeboy",
+                &["homeboy".to_string()],
+                Some(&runner_workspace_root),
+                Some("cook-8009".to_string()),
+                Some(&canonical_attempt_id),
+            )
+            .expect("managed worktree stage");
+
+            assert_eq!(
+                stage.agent_task_run_id.as_deref(),
+                Some(canonical_attempt_id.as_str())
+            );
+            assert!(stage.remapped_args.contains(&"cook-8009".to_string()));
+            assert!(stage.remapped_args.contains(&canonical_attempt_id));
+
+            crate::core::agent_task_lifecycle::record_lab_offload_phase(
+                &canonical_attempt_id,
+                "lab-managed-worktree-stage",
+                "materializing",
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("pre-acceptance lifecycle record");
+            let accepted = crate::core::agent_task_lifecycle::record_detached_lab_run(
+                crate::core::agent_task_lifecycle::DetachedLabRunRecord {
+                    run_id: &canonical_attempt_id,
+                    runner_id: "lab-managed-worktree-stage",
+                    runner_job_id: "job-8009",
+                    remote_workspace: &stage.remote_cwd,
+                    remote_command: &stage.remote_command,
+                },
+            )
+            .expect("daemon acceptance");
+            assert_eq!(accepted.run_id, canonical_attempt_id);
+            assert_eq!(accepted.metadata["runner_job_id"], "job-8009");
         });
     }
 


### PR DESCRIPTION
## Summary
- Preserve the precomputed canonical first-attempt lifecycle ID while a detached Lab cook crosses controller proxy and workspace staging.
- Keep the public cook-series ID in the rewritten command while daemon acceptance and runner workload use the canonical attempt ID.
- Cover real Git worktree staging through detached daemon acceptance, plus explicit-attempt drift detection.

Closes #8009

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo check`.
3. Run `cargo test core::runner::lab::offload::workspace_stage::tests --lib`.
4. Run `cargo test core::agent_task_lifecycle::tests::detached_cook --lib`.
5. Run `cargo test core::runner::lab::agent_task_bridge::tests::lab_cook_uses_one_first_attempt_identity_across_the_handoff --lib`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Traced the controller-to-Lab lifecycle handoff, implemented the canonical attempt-ID propagation, and drafted deterministic coverage and verification commands.
