### PR TITLE
test: verify committed harvest patch contents

### DIFF
--- a/src/core/agent_task_scheduler/mod.rs
+++ b/src/core/agent_task_scheduler/mod.rs
@@ -986,6 +986,16 @@ mod committed_harvest_tests {
         .expect_err("metadata command fails after the real patch is attached");
         let patch_path = outcome.artifacts[0].path.clone().expect("patch path");
         assert!(Path::new(&patch_path).is_file());
+        let patch = std::fs::read_to_string(&patch_path).expect("read attached patch");
+        assert!(!patch.trim().is_empty());
+        assert!(patch.contains("diff --git a/file.txt b/file.txt"));
+        assert!(patch.contains("-base\n"));
+        assert!(patch.contains("+committed change"));
+        assert_eq!(
+            outcome.artifacts[0].size_bytes,
+            Some(patch.len() as u64),
+            "artifact size must match the written patch"
+        );
         let failed = committed_harvest_failure(outcome, error);
 
         assert_eq!(failed.status, AgentTaskOutcomeStatus::Failed);


### PR DESCRIPTION
## Summary
- Assert the retained committed-work artifact contains the actual Git diff and changed content.
- Assert recorded artifact size matches the written patch bytes.

This completes the post-merge review coverage identified after #7957 and follows up #7955.

## How to test
1. Run `cargo test committed_harvest_tests --lib --no-fail-fast`.
2. Run `cargo fmt --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol/OpenCode
- **Used for:** Recovered the uncommitted regression assertion during worktree cleanup, corrected a newline-sensitive expectation, and verified the focused test; Chris reviews and owns the change.