### PR TITLE
fix: resume timed-out draft release uploads

### DIFF
--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -37,6 +37,8 @@ By default Homeboy auto-detects the bump from commit history. Use `--bump <major
 
 `--head` is for CI jobs where another step already created the release commit and tag, but Homeboy should still own the rest of the release lifecycle. It keeps the safe preflight checks, skips changelog/version/git mutation steps, populates release state from the version and tag at HEAD, then runs `release.package` (unless `--from-artifacts` is provided), `github.release`, `release.publish`, cleanup, and post-release hooks through the normal pipeline.
 
+GitHub Release asset uploads use a 30-minute timeout by default. Set `HOMEBOY_GITHUB_RELEASE_UPLOAD_TIMEOUT_SECS` to a positive number of seconds when a slower connection or larger release assets need a longer budget. When `--head` finds an existing draft release, Homeboy resumes it, verifies attached asset metadata, and publishes it only after every requested asset is present.
+
 `--package-only --tag <TAG>` is for operator recovery when the release tag already exists but its package artifact needs to be regenerated. It requires the checked-out `HEAD` to match the existing tag, runs only the extension-owned `release.package` action, copies the produced files into Homeboy's artifact root under `release-packages/<component>/<tag>/`, writes `manifest.json`, and prints both paths. It does not create tags, push, create GitHub Releases, publish registries, deploy, or clean up the component build output.
 
 Risky real release modes require explicit `--apply`: `--deploy`, `--recover`, `--retag`, `--head`, and bare `--skip-checks`. Dry-run previews never require `--apply`, and granular skips such as `--skip-checks=lint` keep the normal release flow because other quality gates remain active.

--- a/src/core/release/executor/github_release/gh_cli.rs
+++ b/src/core/release/executor/github_release/gh_cli.rs
@@ -4,6 +4,38 @@ use crate::core::component::GithubConfig;
 use crate::core::deploy::release_download::GitHubRepo;
 use crate::core::engine::shell::quote_arg;
 use crate::core::release::types::ReleaseState;
+use sha2::{Digest, Sha256};
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+pub(crate) const GITHUB_RELEASE_UPLOAD_TIMEOUT_ENV: &str =
+    "HOMEBOY_GITHUB_RELEASE_UPLOAD_TIMEOUT_SECS";
+const DEFAULT_GITHUB_RELEASE_UPLOAD_TIMEOUT_SECS: u64 = 30 * 60;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GhCommandOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: Option<i32>,
+    pub timed_out: bool,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub(crate) struct GitHubReleaseMetadata {
+    #[serde(rename = "isDraft")]
+    pub is_draft: bool,
+    #[serde(default)]
+    pub assets: Vec<GitHubReleaseAsset>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub(crate) struct GitHubReleaseAsset {
+    pub name: String,
+    pub size: u64,
+    #[serde(default)]
+    pub digest: Option<String>,
+}
 
 pub(crate) fn gh_is_available() -> bool {
     crate::core::git::gh_probe_succeeds(&["--version"])
@@ -40,6 +72,145 @@ pub(crate) fn github_release_artifact_paths(state: &ReleaseState) -> Vec<String>
                 .map(str::to_string)
         })
         .collect()
+}
+
+pub(crate) fn github_release_upload_timeout() -> Duration {
+    std::env::var(GITHUB_RELEASE_UPLOAD_TIMEOUT_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| Duration::from_secs(DEFAULT_GITHUB_RELEASE_UPLOAD_TIMEOUT_SECS))
+}
+
+pub(crate) fn gh_release_metadata(
+    github: &GitHubRepo,
+    config: &GithubConfig,
+    tag: &str,
+    repo_flag: &str,
+) -> Result<GitHubReleaseMetadata, String> {
+    let output = run_gh_command(
+        gh_command(
+            github,
+            config,
+            &[
+                "release",
+                "view",
+                tag,
+                "-R",
+                repo_flag,
+                "--json",
+                "isDraft,assets",
+            ],
+        ),
+        github_release_upload_timeout(),
+    );
+    if output.timed_out || output.exit_code != Some(0) {
+        return Err(gh_failure_detail("gh release view", &output));
+    }
+    serde_json::from_str(&output.stdout)
+        .map_err(|error| format!("gh release view returned invalid metadata: {error}"))
+}
+
+pub(crate) fn verify_release_assets(
+    artifact_paths: &[String],
+    assets: &[GitHubReleaseAsset],
+) -> Result<(), String> {
+    for path in artifact_paths {
+        let metadata = std::fs::metadata(path)
+            .map_err(|error| format!("could not read release artifact '{path}': {error}"))?;
+        let name = std::path::Path::new(path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| format!("release artifact '{path}' has no valid filename"))?;
+        let asset = assets
+            .iter()
+            .find(|asset| asset.name == name)
+            .ok_or_else(|| format!("GitHub Release is missing uploaded asset '{name}'"))?;
+        if asset.size != metadata.len() {
+            return Err(format!(
+                "GitHub Release asset '{name}' has size {}, expected {}",
+                asset.size,
+                metadata.len()
+            ));
+        }
+        if let Some(digest) = asset
+            .digest
+            .as_deref()
+            .and_then(|value| value.strip_prefix("sha256:"))
+        {
+            let mut file = std::fs::File::open(path)
+                .map_err(|error| format!("could not hash release artifact '{path}': {error}"))?;
+            let mut hasher = Sha256::new();
+            let mut buffer = [0; 8192];
+            loop {
+                let read = file.read(&mut buffer).map_err(|error| {
+                    format!("could not hash release artifact '{path}': {error}")
+                })?;
+                if read == 0 {
+                    break;
+                }
+                hasher.update(&buffer[..read]);
+            }
+            if format!("{:x}", hasher.finalize()) != digest {
+                return Err(format!(
+                    "GitHub Release asset '{name}' digest does not match uploaded artifact"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn gh_failure_detail(command: &str, output: &GhCommandOutput) -> String {
+    if output.timed_out {
+        return format!("{command} timed out");
+    }
+    match output.exit_code {
+        Some(code) => format!("{command} exited with status {code}"),
+        None => format!("{command} did not return an exit status"),
+    }
+}
+
+pub(crate) fn run_gh_command(mut command: Command, timeout: Duration) -> GhCommandOutput {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            return GhCommandOutput {
+                stdout: String::new(),
+                stderr: error.to_string(),
+                exit_code: None,
+                timed_out: false,
+            }
+        }
+    };
+    let started = Instant::now();
+    let (status, timed_out) = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break (Some(status), false),
+            Ok(None) if started.elapsed() >= timeout => {
+                let _ = child.kill();
+                break (child.wait().ok(), true);
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(25)),
+            Err(_) => break (None, false),
+        }
+    };
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    if let Some(mut stream) = child.stdout.take() {
+        let _ = stream.read_to_end(&mut stdout);
+    }
+    if let Some(mut stream) = child.stderr.take() {
+        let _ = stream.read_to_end(&mut stderr);
+    }
+    GhCommandOutput {
+        stdout: String::from_utf8_lossy(&stdout).to_string(),
+        stderr: String::from_utf8_lossy(&stderr).to_string(),
+        exit_code: status.and_then(|status| status.code()),
+        timed_out,
+    }
 }
 
 fn path_is_file(path: &str) -> bool {
@@ -143,4 +314,45 @@ pub(super) fn gh_command(
 
 pub(crate) fn github_cli_env(github: &GitHubRepo, config: &GithubConfig) -> Vec<(String, String)> {
     crate::core::git::github_cli_env(&github.host, config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_command_reports_timeout() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "sleep 1"]);
+        let output = run_gh_command(command, Duration::from_millis(10));
+        assert!(output.timed_out);
+        assert_ne!(output.exit_code, Some(0));
+    }
+
+    #[test]
+    fn bounded_command_preserves_nonzero_empty_stderr() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "exit 7"]);
+        let output = run_gh_command(command, Duration::from_secs(1));
+        assert_eq!(output.exit_code, Some(7));
+        assert!(output.stderr.is_empty());
+        assert!(!output.timed_out);
+    }
+
+    #[test]
+    fn verifies_asset_name_size_and_digest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("asset.zip");
+        std::fs::write(&path, b"asset bytes").expect("write asset");
+        let digest = format!("sha256:{:x}", Sha256::digest(b"asset bytes"));
+        verify_release_assets(
+            &[path.display().to_string()],
+            &[GitHubReleaseAsset {
+                name: "asset.zip".to_string(),
+                size: 11,
+                digest: Some(digest),
+            }],
+        )
+        .expect("verified asset");
+    }
 }

--- a/src/core/release/executor/github_release/mod.rs
+++ b/src/core/release/executor/github_release/mod.rs
@@ -21,7 +21,10 @@ pub(crate) use run::run_github_release;
 // `gh` availability/auth/existence probes are reused by the sibling `tagging`
 // step to gate tag-availability preflight, so they are part of the module's
 // non-test surface.
-pub(crate) use gh_cli::{gh_is_authenticated, gh_is_available, gh_release_exists};
+pub(crate) use gh_cli::{
+    gh_failure_detail, gh_is_authenticated, gh_is_available, gh_release_exists,
+    gh_release_metadata, github_release_upload_timeout, run_gh_command, verify_release_assets,
+};
 
 // Re-exports consumed by the in-crate test suites — both this module's own
 // `tests/` and the parent `executor` module's tests, which reference these via

--- a/src/core/release/executor/github_release/repair.rs
+++ b/src/core/release/executor/github_release/repair.rs
@@ -12,6 +12,8 @@ pub(crate) struct GitHubReleaseRepairCommands {
     pub notes_guidance: String,
     pub generate_notes_command: String,
     pub create_command: String,
+    pub upload_command: String,
+    pub publish_command: String,
     pub view_command: String,
     pub env_hint: Option<String>,
     /// True when `notes_file` is the persisted exact Homeboy release body
@@ -130,6 +132,27 @@ fn github_release_repair_commands_with_env(
     create.push("-R".to_string());
     create.push(quote_arg(&repo_flag));
 
+    let mut upload = vec![
+        format!("{}gh", env_prefix),
+        "release".to_string(),
+        "upload".to_string(),
+        quote_arg(tag),
+    ];
+    for path in artifact_paths {
+        upload.push(quote_arg(path));
+    }
+    upload.extend([
+        "--clobber".to_string(),
+        "-R".to_string(),
+        quote_arg(&repo_flag),
+    ]);
+    let publish_command = format!(
+        "{}gh release edit {} --draft=false -R {}",
+        env_prefix,
+        quote_arg(tag),
+        quote_arg(&repo_flag)
+    );
+
     let view_command = format!(
         "{}gh release view {} -R {}",
         env_prefix,
@@ -152,6 +175,8 @@ fn github_release_repair_commands_with_env(
         notes_guidance,
         generate_notes_command,
         create_command: create.join(" "),
+        upload_command: upload.join(" "),
+        publish_command,
         view_command,
         env_hint,
         exact_body_available,
@@ -183,12 +208,44 @@ pub(super) fn repair_hints(repair: &GitHubReleaseRepairCommands) -> Vec<crate::c
     hints
 }
 
+pub(super) fn existing_draft_repair_hints(
+    repair: &GitHubReleaseRepairCommands,
+) -> Vec<crate::core::error::Hint> {
+    let mut hints = Vec::new();
+    if let Some(env_hint) = repair.env_hint.as_deref() {
+        hints.push(crate::core::error::Hint {
+            message: env_hint.to_string(),
+        });
+    }
+    hints.push(crate::core::error::Hint {
+        message: format!(
+            "Resume the existing draft by uploading the built artifacts: {}",
+            repair.upload_command
+        ),
+    });
+    hints.push(crate::core::error::Hint {
+        message: format!(
+            "After verifying its assets, publish that existing draft: {}",
+            repair.publish_command
+        ),
+    });
+    hints.push(crate::core::error::Hint {
+        message: format!(
+            "Verify the release and attached assets: {}",
+            repair.view_command
+        ),
+    });
+    hints
+}
+
 pub(super) fn repair_data(repair: &GitHubReleaseRepairCommands) -> serde_json::Value {
     serde_json::json!({
         "notes_file": repair.notes_file,
         "notes_guidance": repair.notes_guidance,
         "generate_notes_command": repair.generate_notes_command,
         "create_command": repair.create_command,
+        "upload_command": repair.upload_command,
+        "publish_command": repair.publish_command,
         "view_command": repair.view_command,
         "env_hint": repair.env_hint,
         "exact_body_available": repair.exact_body_available,

--- a/src/core/release/executor/github_release/results.rs
+++ b/src/core/release/executor/github_release/results.rs
@@ -5,7 +5,9 @@ use crate::core::release::types::ReleaseStepResult;
 
 use super::super::{step_failed, step_success};
 use super::notes::GitHubReleaseBody;
-use super::repair::{repair_data, repair_hints, GitHubReleaseRepairCommands};
+use super::repair::{
+    existing_draft_repair_hints, repair_data, repair_hints, GitHubReleaseRepairCommands,
+};
 
 /// A successful but no-op result for an idempotent retry where the GitHub
 /// Release object already exists. The release exists, so this is `Success`.
@@ -121,6 +123,8 @@ pub(crate) fn upload_failed_result(
     github: &GitHubRepo,
     stdout: String,
     stderr: String,
+    exit_code: Option<i32>,
+    timed_out: bool,
     artifact_count: usize,
     repair: GitHubReleaseRepairCommands,
 ) -> ReleaseStepResult {
@@ -134,12 +138,16 @@ pub(crate) fn upload_failed_result(
         "repo": github.repo,
         "stdout": stdout,
         "stderr": stderr.clone(),
+        "exit_code": exit_code,
+        "timed_out": timed_out,
         "artifact_count": artifact_count,
         "repair": repair_data(&repair),
     });
 
     let detail = stderr.trim();
-    let error = if detail.is_empty() {
+    let error = if timed_out {
+        format!("`gh release upload` timed out for {}", tag)
+    } else if detail.is_empty() {
         format!("`gh release upload` failed for {}", tag)
     } else {
         format!("`gh release upload` failed for {}: {}", tag, detail)
@@ -150,7 +158,7 @@ pub(crate) fn upload_failed_result(
         "github.release",
         Some(data),
         Some(error),
-        repair_hints(&repair),
+        existing_draft_repair_hints(&repair),
     )
 }
 

--- a/src/core/release/executor/github_release/run.rs
+++ b/src/core/release/executor/github_release/run.rs
@@ -18,6 +18,10 @@ use super::results::{
     create_failed_result, not_created_result, skipped_result, upload_failed_result,
     upload_success_result,
 };
+use super::{
+    gh_failure_detail, gh_release_metadata, github_release_upload_timeout, run_gh_command,
+    verify_release_assets,
+};
 
 /// Create a GitHub Release for the just-pushed tag.
 ///
@@ -171,29 +175,75 @@ pub(crate) fn run_github_release(
         }
         upload_args.extend_from_slice(&["--clobber", "-R", &repo_flag]);
 
-        let upload_output = gh_command(&github, &component.github, &upload_args)
-            .output()
-            .map_err(|e| {
-                Error::internal_io(
-                    format!("Failed to invoke gh: {}", e),
-                    Some("gh release upload".to_string()),
-                )
-            })?;
+        let upload_output = run_gh_command(
+            gh_command(&github, &component.github, &upload_args),
+            github_release_upload_timeout(),
+        );
 
-        if !upload_output.status.success() {
-            let stderr = String::from_utf8_lossy(&upload_output.stderr).to_string();
-            let stdout = String::from_utf8_lossy(&upload_output.stdout).to_string();
+        if upload_output.timed_out || upload_output.exit_code != Some(0) {
+            let detail = gh_failure_detail("gh release upload", &upload_output);
+            let stderr = upload_output.stderr;
+            let stdout = upload_output.stdout;
             let repair = repair_commands(None, None);
-            log_status!("release", "✗ `gh release upload` failed: {}", stderr.trim());
+            log_status!("release", "✗ {}: {}", detail, stderr.trim());
             log_repair_commands(&repair);
             return Ok(upload_failed_result(
                 &tag,
                 &github,
                 stdout,
                 stderr,
+                upload_output.exit_code,
+                upload_output.timed_out,
                 artifact_paths.len(),
                 repair,
             ));
+        }
+
+        let metadata = match gh_release_metadata(&github, &component.github, &tag, &repo_flag) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                return Ok(upload_failed_result(
+                    &tag,
+                    &github,
+                    String::new(),
+                    error,
+                    None,
+                    false,
+                    artifact_paths.len(),
+                    repair_commands(None, None),
+                ))
+            }
+        };
+        if let Err(error) = verify_release_assets(&artifact_paths, &metadata.assets) {
+            return Ok(upload_failed_result(
+                &tag,
+                &github,
+                String::new(),
+                error,
+                None,
+                false,
+                artifact_paths.len(),
+                repair_commands(None, None),
+            ));
+        }
+        if metadata.is_draft {
+            let publish_args = ["release", "edit", &tag, "--draft=false", "-R", &repo_flag];
+            let publish_output = run_gh_command(
+                gh_command(&github, &component.github, &publish_args),
+                github_release_upload_timeout(),
+            );
+            if publish_output.timed_out || publish_output.exit_code != Some(0) {
+                return Ok(upload_failed_result(
+                    &tag,
+                    &github,
+                    publish_output.stdout,
+                    publish_output.stderr,
+                    publish_output.exit_code,
+                    publish_output.timed_out,
+                    artifact_paths.len(),
+                    repair_commands(None, None),
+                ));
+            }
         }
 
         return Ok(upload_success_result(&tag, &github, artifact_paths.len()));

--- a/src/core/release/executor/github_release/tests/repair_tests.rs
+++ b/src/core/release/executor/github_release/tests/repair_tests.rs
@@ -52,6 +52,25 @@ fn repair_commands_regenerate_notes_when_no_persisted_body() {
 }
 
 #[test]
+fn existing_draft_repair_uses_upload_then_publish_not_create() {
+    let repair = github_release_repair_commands(
+        "v0.10.6",
+        &test_repo(),
+        &GithubConfig::default(),
+        &["build/studio-web.zip".to_string()],
+        None,
+        None,
+    );
+
+    assert!(repair
+        .upload_command
+        .contains("gh release upload v0.10.6 build/studio-web.zip --clobber"));
+    assert!(repair
+        .publish_command
+        .contains("gh release edit v0.10.6 --draft=false"));
+}
+
+#[test]
 fn github_cli_env_sets_enterprise_host_and_proxy() {
     let github = GitHubRepo {
         host: "github.enterprise.test".to_string(),

--- a/src/core/release/executor/github_release/tests/result_builders.rs
+++ b/src/core/release/executor/github_release/tests/result_builders.rs
@@ -93,6 +93,8 @@ fn upload_failed_result_is_failed_but_records_release_exists() {
         &test_repo(),
         String::new(),
         "could not upload asset".to_string(),
+        Some(1),
+        false,
         1,
         test_repair(),
     );
@@ -106,4 +108,32 @@ fn upload_failed_result_is_failed_but_records_release_exists() {
         .as_deref()
         .unwrap()
         .contains("could not upload asset"));
+    assert!(result
+        .hints
+        .iter()
+        .any(|hint| hint.message.contains("Resume the existing draft")));
+}
+
+#[test]
+fn upload_timeout_is_classified_and_preserves_empty_stderr() {
+    let result = upload_failed_result(
+        "v0.10.6",
+        &test_repo(),
+        String::new(),
+        String::new(),
+        Some(124),
+        true,
+        1,
+        test_repair(),
+    );
+    assert_eq!(data_bool(&result, "timed_out"), Some(true));
+    assert_eq!(
+        result
+            .data
+            .as_ref()
+            .and_then(|data| data.get("exit_code"))
+            .and_then(|value| value.as_i64()),
+        Some(124)
+    );
+    assert!(result.error.as_deref().unwrap().contains("timed out"));
 }


### PR DESCRIPTION
## Summary
- bound GitHub Release asset uploads with a configurable 30-minute default and preserve timeout, exit-code, stdout, and stderr diagnostics
- resume existing draft releases, verify uploaded name/size/available SHA-256 digest metadata, and publish only after verification
- provide draft-specific repair commands for upload, verification, and publication; document `HOMEBOY_GITHUB_RELEASE_UPLOAD_TIMEOUT_SECS`

Closes #8024

## How to test
1. Start from a fresh checkout and run `cargo test core::release::executor::github_release --lib -- --test-threads=1`.
2. Run `cargo check`.
3. Run `cargo fmt --check`.
4. Inspect `docs/commands/release.md` for the documented `HOMEBOY_GITHUB_RELEASE_UPLOAD_TIMEOUT_SECS` override and draft-resume lifecycle.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode / openai/gpt-5.6-sol
- **Used for:** Implemented the bounded release-upload lifecycle, draft recovery behavior, diagnostics, tests, and documentation with Chris Huber's requested acceptance criteria.