### PR TITLE
Fix dead lease recovery diagnostics

### DIFF
--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -53,6 +53,9 @@ const RUNTIME_PATH_SUFFIXES: &[&str] = &["_COMPONENT_PATH", "_PROVIDER_PATH", "_
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct DaemonState {
+    /// Older writers could omit this field. Retain the remaining identity as
+    /// stale evidence instead of losing the lease and PID during deserialization.
+    #[serde(default)]
     pub schema: String,
     pub lease_id: String,
     #[serde(default)]
@@ -425,20 +428,23 @@ fn validate_lease_file(path: &Path) -> Result<DaemonLeaseValidation> {
     };
 
     let running = pid_is_running(state.pid);
-    if state.schema != DAEMON_LEASE_SCHEMA {
-        return Ok(stale_lease(
-            state,
-            running,
-            DaemonStaleReasonCode::LeaseSchemaMismatch,
-            "unsupported daemon lease schema",
-        ));
-    }
+    // A dead owner is safe to recover even when its persisted schema was
+    // omitted. Keeping the parsed lease identity makes explicit adoption
+    // possible; a live invalid lease remains protected by schema validation.
     if !running {
         return Ok(stale_lease(
             state,
             false,
             DaemonStaleReasonCode::PidDead,
             "daemon lease pid is not running",
+        ));
+    }
+    if state.schema != DAEMON_LEASE_SCHEMA {
+        return Ok(stale_lease(
+            state,
+            true,
+            DaemonStaleReasonCode::LeaseSchemaMismatch,
+            "unsupported daemon lease schema",
         ));
     }
     let current_identity = build_identity::current();
@@ -1642,6 +1648,12 @@ fn heartbeat_lease() -> Result<DaemonState> {
 }
 
 fn write_lease(path: &Path, state: &DaemonState) -> Result<()> {
+    if state.schema != DAEMON_LEASE_SCHEMA {
+        return Err(Error::internal_unexpected(format!(
+            "refusing to write daemon lease with unsupported schema `{}`",
+            state.schema
+        )));
+    }
     let body = serde_json::to_string_pretty(&state).map_err(|e| {
         Error::internal_json(e.to_string(), Some("serialize daemon state".to_string()))
     })?;

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -1039,9 +1039,42 @@ mod remote_daemon {
     ) -> std::result::Result<RemoteDaemonConnectAction, String> {
         let healthy = status.fresh && status.reachable;
         if status.active_jobs > 0 && !healthy {
+            let lease_evidence = status
+                .daemon
+                .as_ref()
+                .map(|daemon| {
+                    format!(
+                        "lease_id={}, recorded_pid={}",
+                        daemon.lease_id.as_deref().unwrap_or("unavailable"),
+                        daemon
+                            .pid
+                            .map(|pid| pid.to_string())
+                            .as_deref()
+                            .unwrap_or("unavailable")
+                    )
+                })
+                .unwrap_or_else(|| "lease_id=unavailable, recorded_pid=unavailable".to_string());
+            let recovery = match (
+                status.stale_reason_code,
+                status
+                    .daemon
+                    .as_ref()
+                    .and_then(|daemon| daemon.lease_id.as_deref()),
+            ) {
+                (Some(DaemonStaleReasonCode::PidDead), Some(lease_id)) => format!(
+                    " The recorded PID is proven dead; recover this exact lease with `homeboy runner connect <runner-id> --adopt-orphan-lease {lease_id} --confirm-pid-dead`."
+                ),
+                _ => " Inspect `homeboy daemon status`; explicit adoption is available only after the recorded PID is proven dead.".to_string(),
+            };
             return Err(format!(
-                "remote daemon has {} active job(s) but cannot be safely reattached (fresh={}, reachable={}, reason={:?}); refusing implicit replacement. Inspect `homeboy daemon status` and recover only the exact dead lease with `homeboy runner connect <runner-id> --adopt-orphan-lease <lease-id> --confirm-pid-dead`",
-                status.active_jobs, status.fresh, status.reachable, status.stale_reason,
+                "remote daemon has {} active job(s) but cannot be safely reattached (fresh={}, reachable={}, reason={:?}, {}, active_job_count={}); refusing implicit replacement.{}",
+                status.active_jobs,
+                status.fresh,
+                status.reachable,
+                status.stale_reason,
+                lease_evidence,
+                status.active_jobs,
+                recovery,
             ));
         }
 
@@ -1619,6 +1652,10 @@ mod tests {
 
         assert!(err.contains("refusing implicit replacement"));
         assert!(err.contains("--adopt-orphan-lease"));
+        assert!(err.contains("lease_id=lease-dead"));
+        assert!(err.contains("recorded_pid=4545"));
+        assert!(err.contains("active_job_count=1"));
+        assert!(err.contains("--adopt-orphan-lease lease-dead"));
     }
 
     #[test]

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -121,6 +121,18 @@ fn write_state_establishes_daemon_session_lease_identity() {
 }
 
 #[test]
+fn lease_writer_rejects_an_unsupported_schema() {
+    let _home = HomeGuard::new();
+    let mut state = daemon_state_for_test(std::process::id(), "127.0.0.1:49152");
+    state.schema = "homeboy.daemon.session_lease.v0".to_string();
+
+    let error = write_lease(&state_path().expect("state path"), &state)
+        .expect_err("unsupported schema is not persisted");
+
+    assert!(error.message.contains("unsupported schema"));
+}
+
+#[test]
 fn health_route_refreshes_daemon_lease_heartbeat() {
     let _home = HomeGuard::new();
     let mut state = write_state("127.0.0.1:49152".parse().expect("addr")).expect("write lease");
@@ -377,6 +389,50 @@ fn test_pid_is_running_rejects_impossible_pid_and_drives_status() {
         .as_deref()
         .unwrap_or_default()
         .contains("invalid daemon lease"));
+}
+
+#[test]
+fn status_retains_dead_missing_schema_lease_identity_for_explicit_recovery() {
+    let _home = HomeGuard::new();
+    let state = daemon_state_for_test(u32::MAX, "127.0.0.1:49152");
+    let path = state_path().expect("state path");
+    let mut lease = serde_json::to_value(state).expect("serialize lease");
+    lease
+        .as_object_mut()
+        .expect("lease object")
+        .remove("schema");
+    std::fs::create_dir_all(path.parent().expect("state parent")).expect("state dir");
+    std::fs::write(&path, serde_json::to_string(&lease).expect("lease json")).expect("write state");
+
+    let status = read_status().expect("status");
+
+    assert_eq!(
+        status.freshness.stale_reason_code,
+        Some(DaemonStaleReasonCode::PidDead)
+    );
+    assert_eq!(
+        status.state.as_ref().map(|state| state.lease_id.as_str()),
+        Some("test-lease")
+    );
+    assert_eq!(status.freshness.lease_id.as_deref(), Some("test-lease"));
+    assert!(path.exists());
+}
+
+#[test]
+fn status_keeps_corrupt_lease_fail_closed_without_identity() {
+    let _home = HomeGuard::new();
+    let path = state_path().expect("state path");
+    std::fs::create_dir_all(path.parent().expect("state parent")).expect("state dir");
+    std::fs::write(&path, "{invalid json").expect("write corrupt state");
+
+    let status = read_status().expect("status");
+
+    assert_eq!(
+        status.freshness.stale_reason_code,
+        Some(DaemonStaleReasonCode::LeaseCorrupt)
+    );
+    assert!(status.state.is_none());
+    assert!(status.freshness.lease_id.is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- retain parseable lease and PID evidence when only the lease schema is missing
- reject writes that do not carry the current daemon lease schema
- include lease ID, recorded PID, active-job count, and the exact orphan-adoption arguments in dead-daemon reconnect guidance

Fixes #8026.

Related: Extra-Chill/homeboy-extensions#2240.

## How to test
1. Run `cargo test --lib lease_writer_rejects_an_unsupported_schema`.
2. Run `cargo test --lib status_retains_dead_missing_schema_lease_identity_for_explicit_recovery`.
3. Run `cargo test --lib status_keeps_corrupt_lease_fail_closed_without_identity`.
4. Run `cargo test --lib core::runner::connection::tests::`.
5. Run `cargo fmt --check` and `cargo check`.

## Behavior
A parseable dead lease without `schema` remains stale but exposes its verified lease identity for explicit adoption. Invalid JSON remains fail-closed and exposes no identity. Active-job recovery diagnostics include the recorded lease ID, PID, job count, and an adoption command only when PID death is proven.

## Backwards compatibility
This is additive diagnostic and recovery behavior; existing valid lease files and runner-connect arguments are unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Diagnosed the lease parsing and reconnect recovery failure, implemented the schema validation and recovery diagnostics, and added behavioral tests.
