### PR TITLE
Recover active jobs when daemon lease metadata is missing

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use std::path::PathBuf;
 
 use homeboy::core::daemon::{
-    self, BrokerConfig, BrokerConfigOptions, DaemonOrphanAdoptionResult, DaemonStartResult, DaemonStatus, DaemonStopResult,
+    self, BrokerConfig, BrokerConfigOptions, DaemonMissingLeaseRecoveryResult, DaemonOrphanAdoptionResult, DaemonStartResult, DaemonStatus, DaemonStopResult,
     ServiceIdentity,
 };
 use homeboy::core::http_api::{AnalysisJobRunOutput, AnalysisJobRunner};
@@ -37,6 +37,17 @@ enum DaemonCommand {
         /// Confirm the recorded PID was inspected and is dead
         #[arg(long)]
         confirm_pid_dead: bool,
+        #[arg(long, default_value = daemon::DEFAULT_ADDR)]
+        addr: String,
+    },
+    /// Explicitly recover active jobs when the daemon lease metadata is absent
+    RecoverMissingLease {
+        /// Exact state_identity reported by `homeboy daemon status`
+        #[arg(long)]
+        state_identity: String,
+        /// Confirm the endpoint is unreachable and the lease metadata is absent
+        #[arg(long)]
+        confirm_lease_missing: bool,
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
     },
@@ -92,6 +103,7 @@ pub enum DaemonOutput {
     Start(DaemonStartResult),
     EnsureRunning(DaemonStartResult),
     AdoptOrphan(DaemonOrphanAdoptionResult),
+    RecoverMissingLease(DaemonMissingLeaseRecoveryResult),
     Serve(DaemonStartResult),
     Stop(DaemonStopResult),
     Status(DaemonStatus),
@@ -123,6 +135,14 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
         )),
         DaemonCommand::AdoptOrphan { lease_id, confirm_pid_dead, addr } => Ok((
             DaemonOutput::AdoptOrphan(daemon::adopt_orphaned_lease(&lease_id, confirm_pid_dead, &addr)?),
+            0,
+        )),
+        DaemonCommand::RecoverMissingLease { state_identity, confirm_lease_missing, addr } => Ok((
+            DaemonOutput::RecoverMissingLease(daemon::recover_missing_lease_state(
+                &state_identity,
+                confirm_lease_missing,
+                &addr,
+            )?),
             0,
         )),
         DaemonCommand::Serve { addr } => serve(&addr),

--- a/src/commands/runner/cli.rs
+++ b/src/commands/runner/cli.rs
@@ -220,6 +220,14 @@ pub(super) enum RunnerCommand {
         /// Confirm the recorded PID for --adopt-orphan-lease is dead
         #[arg(long)]
         confirm_pid_dead: bool,
+
+        /// Explicitly recover the exact missing-lease daemon state reported by daemon status
+        #[arg(long)]
+        recover_missing_lease_state: Option<String>,
+
+        /// Confirm the missing-lease state was inspected and its endpoint is unreachable
+        #[arg(long)]
+        confirm_lease_missing: bool,
     },
     /// Show persisted runner tunnel status
     Status {

--- a/src/commands/runner/dispatch.rs
+++ b/src/commands/runner/dispatch.rs
@@ -136,6 +136,8 @@ pub fn run(
             broker_url,
             adopt_orphan_lease,
             confirm_pid_dead,
+            recover_missing_lease_state,
+            confirm_lease_missing,
         } => map_registry(connect(
             &id,
             reverse,
@@ -143,6 +145,8 @@ pub fn run(
             broker_url,
             adopt_orphan_lease,
             confirm_pid_dead,
+            recover_missing_lease_state,
+            confirm_lease_missing,
         )),
         RunnerCommand::Status { id } => map_registry(status_mod::status(id.as_deref())),
         RunnerCommand::Disconnect { id } => map_registry(registry::disconnect(&id)),

--- a/src/commands/runner/registry.rs
+++ b/src/commands/runner/registry.rs
@@ -205,6 +205,8 @@ pub(super) fn connect(
     broker_url: Option<String>,
     adopt_orphan_lease: Option<String>,
     confirm_pid_dead: bool,
+    recover_missing_lease_state: Option<String>,
+    confirm_lease_missing: bool,
 ) -> CmdResult<RunnerOutput> {
     if adopt_orphan_lease.is_some() && !confirm_pid_dead {
         return Err(homeboy::core::Error::validation_invalid_argument(
@@ -212,6 +214,25 @@ pub(super) fn connect(
             "--adopt-orphan-lease requires --confirm-pid-dead",
             None,
             Some(vec!["Inspect `homeboy daemon status` on the runner before adopting its exact dead lease.".to_string()]),
+        ));
+    }
+    if recover_missing_lease_state.is_some() && !confirm_lease_missing {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "confirm_lease_missing",
+            "--recover-missing-lease-state requires --confirm-lease-missing",
+            None,
+            Some(vec![
+                "Inspect `homeboy daemon status` on the runner and use its exact state_identity."
+                    .to_string(),
+            ]),
+        ));
+    }
+    if adopt_orphan_lease.is_some() && recover_missing_lease_state.is_some() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "recover_missing_lease_state",
+            "choose either exact lease adoption or missing-lease recovery",
+            None,
+            None,
         ));
     }
     if reverse && adopt_orphan_lease.is_some() {
@@ -237,7 +258,11 @@ pub(super) fn connect(
             broker_url,
         })?
     } else {
-        runner::connect_with_orphan_adoption(id, adopt_orphan_lease.as_deref())?
+        runner::connect_with_recovery(
+            id,
+            adopt_orphan_lease.as_deref(),
+            recover_missing_lease_state.as_deref(),
+        )?
     };
     Ok((
         RunnerOutput {

--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -11,8 +11,9 @@ pub use remote_runner::{
 pub use store::{JobHandle, JobRunner, JobStore};
 pub use summary::active_runner_job_run_summary;
 pub use types::{
-    ActiveRunnerJobRunSummary, ActiveRunnerJobSummary, DaemonLeaseJobDiagnostics, Job,
-    JobClaimMetadata, JobEvent, JobEventKind, JobStatus, RunnerJobLifecycleOwner, RunnerJobSource,
+    ActiveRunnerJobRunSummary, ActiveRunnerJobSummary, DaemonLeaseJobDiagnostics,
+    DaemonMissingLeaseJobDiagnostics, Job, JobClaimMetadata, JobEvent, JobEventKind, JobStatus,
+    RunnerJobLifecycleOwner, RunnerJobSource,
 };
 
 #[cfg(test)]
@@ -582,6 +583,41 @@ mod tests {
             store.get(legacy_job.id).expect("legacy job").status,
             JobStatus::Running
         );
+    }
+
+    #[test]
+    fn missing_lease_recovery_terminalizes_unowned_active_jobs_with_retryable_evidence() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("jobs.json");
+        let store = JobStore::open_without_reconciliation(&path).expect("open store");
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start job");
+
+        let recovered = JobStore::open_without_reconciliation(&path)
+            .expect("open recovery store")
+            .reconcile_missing_daemon_lease_jobs("sha256:inspected-state")
+            .expect("recover missing lease");
+
+        assert_eq!(recovered.terminalized_job_ids, vec![job.id]);
+        let reopened = JobStore::open_without_reconciliation(&path).expect("reopen store");
+        let terminal = reopened.get(job.id).expect("terminal job");
+        assert_eq!(terminal.status, JobStatus::Failed);
+        assert!(
+            terminal.stale_reason.is_some(),
+            "failed job remains retryable"
+        );
+        assert!(reopened
+            .events(job.id)
+            .expect("events")
+            .iter()
+            .any(|event| {
+                event.kind == JobEventKind::Error
+                    && event.data.as_ref().is_some_and(|data| {
+                        data["reason"] == json!("missing_daemon_lease")
+                            && data["state_identity"] == json!("sha256:inspected-state")
+                            && data["retryable"] == json!(true)
+                    })
+            }));
     }
 
     #[test]

--- a/src/core/api_jobs/store.rs
+++ b/src/core/api_jobs/store.rs
@@ -17,7 +17,10 @@ use super::persistence::{
     DEFAULT_EVENT_RETENTION_LIMIT,
 };
 use super::remote_runner;
-use super::types::{DaemonLeaseJobDiagnostics, Job, JobEvent, JobEventKind, JobStatus};
+use super::types::{
+    DaemonLeaseJobDiagnostics, DaemonMissingLeaseJobDiagnostics, Job, JobEvent, JobEventKind,
+    JobStatus,
+};
 use crate::core::error::{Error, Result};
 use crate::core::runner_execution_envelope::PathMaterializationPlan;
 use crate::core::source_snapshot::SourceSnapshot;
@@ -378,6 +381,119 @@ impl JobStore {
             apply_event_retention(&mut stored.events, self.event_retention_limit());
             stored.job.event_count = stored.events.len();
         }
+        drop(inner);
+        self.persist()?;
+        Ok(diagnostics)
+    }
+
+    /// Explicitly terminalize legacy unowned jobs only after a missing-lease
+    /// recovery has pinned the exact state and durable queue snapshot.
+    pub fn reconcile_missing_daemon_lease_jobs(
+        &self,
+        state_identity: &str,
+    ) -> Result<DaemonMissingLeaseJobDiagnostics> {
+        let mut diagnostics = DaemonMissingLeaseJobDiagnostics::default();
+        let now = timestamp_ms();
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        for stored in inner.jobs.values() {
+            if matches!(stored.job.status, JobStatus::Queued | JobStatus::Running)
+                && stored.job.daemon_lease_id.is_some()
+            {
+                diagnostics.owned_job_ids.push(stored.job.id);
+            }
+        }
+        diagnostics.owned_job_ids.sort();
+        if !diagnostics.owned_job_ids.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "state-identity",
+                format!(
+                    "refusing missing-lease recovery: active jobs still name daemon lease(s): {}",
+                    diagnostics
+                        .owned_job_ids
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+                Some(state_identity.to_string()),
+                None,
+            ));
+        }
+
+        for stored in inner.jobs.values_mut() {
+            if !matches!(stored.job.status, JobStatus::Queued | JobStatus::Running) {
+                continue;
+            }
+            diagnostics.terminalized_job_ids.push(stored.job.id);
+            if let Some(request) = stored.remote_runner.as_ref().map(|remote| &remote.request) {
+                let durable_run_id = request
+                    .lifecycle
+                    .as_ref()
+                    .and_then(|lifecycle| lifecycle.durable_run_id.clone())
+                    .or_else(|| {
+                        request
+                            .metadata
+                            .as_ref()
+                            .and_then(|metadata| metadata.get("durable_run_id"))
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                    })
+                    .or_else(|| {
+                        request
+                            .metadata
+                            .as_ref()
+                            .and_then(|metadata| metadata.get("run_id"))
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                    });
+                if let Some(durable_run_id) = durable_run_id {
+                    diagnostics.durable_run_ids.push(durable_run_id);
+                }
+            }
+            let reason = "daemon lease metadata was missing after control-plane loss".to_string();
+            stored.job.status = JobStatus::Failed;
+            stored.job.updated_at_ms = now;
+            stored.job.finished_at_ms = Some(now);
+            stored.job.stale_reason = Some(reason.clone());
+            let classification = stale_after_restart_classification(stored);
+            for (kind, message, data) in [
+                (
+                    JobEventKind::Error,
+                    reason,
+                    serde_json::json!({
+                        "reason": "missing_daemon_lease",
+                        "classification": classification,
+                        "state_identity": state_identity,
+                        "retryable": true,
+                    }),
+                ),
+                (
+                    JobEventKind::Status,
+                    "job marked failed after missing daemon lease".to_string(),
+                    serde_json::json!({
+                        "status": JobStatus::Failed,
+                        "reason": "missing_daemon_lease",
+                        "state_identity": state_identity,
+                        "retryable": true,
+                    }),
+                ),
+            ] {
+                let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+                stored.events.push(JobEvent {
+                    sequence,
+                    job_id: stored.job.id,
+                    kind,
+                    timestamp_ms: now,
+                    message: Some(message),
+                    data: Some(data),
+                });
+            }
+            apply_event_retention(&mut stored.events, self.event_retention_limit());
+            stored.job.event_count = stored.events.len();
+        }
+        diagnostics.terminalized_job_ids.sort();
+        diagnostics.durable_run_ids.sort();
+        diagnostics.durable_run_ids.dedup();
         drop(inner);
         self.persist()?;
         Ok(diagnostics)

--- a/src/core/api_jobs/types.rs
+++ b/src/core/api_jobs/types.rs
@@ -234,6 +234,13 @@ pub struct DaemonLeaseJobDiagnostics {
     pub unowned_job_ids: Vec<Uuid>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+pub struct DaemonMissingLeaseJobDiagnostics {
+    pub terminalized_job_ids: Vec<Uuid>,
+    pub durable_run_ids: Vec<String>,
+    pub owned_job_ids: Vec<Uuid>,
+}
+
 impl DaemonLeaseJobDiagnostics {
     pub fn matching_count(&self) -> usize {
         self.matching_job_ids.len()

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -37,7 +37,7 @@ pub use artifact_download::ArtifactDownload;
 pub use broker_config::{render_broker_config, BrokerConfig, BrokerConfigOptions, ServiceIdentity};
 pub use control::{
     adopt_orphaned_lease, artifact_content_url, ensure_running, fetch_artifact_to_path,
-    start_background, ArtifactFetchOutcome,
+    recover_missing_lease_state, start_background, ArtifactFetchOutcome,
 };
 use patch_capture::{capture_baseline, capture_patch_report};
 
@@ -78,6 +78,8 @@ pub struct DaemonStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<DaemonState>,
     pub state_path: String,
+    /// Snapshot identity for explicit recovery when the daemon lease is absent.
+    pub state_identity: String,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
@@ -130,6 +132,15 @@ pub struct DaemonOrphanAdoptionResult {
     pub adopted_lease_id: String,
     pub dead_pid: u32,
     pub active_jobs_terminalized: usize,
+    pub retry_guidance: String,
+    pub replacement: DaemonStartResult,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DaemonMissingLeaseRecoveryResult {
+    pub recovered_state_identity: String,
+    pub terminalized_job_ids: Vec<String>,
+    pub durable_run_ids: Vec<String>,
     pub retry_guidance: String,
     pub replacement: DaemonStartResult,
 }
@@ -377,6 +388,7 @@ fn legacy_lease_repair_error(path: &Path, problem: impl Into<String>) -> Error {
 pub fn read_status() -> Result<DaemonStatus> {
     let path = state_path()?;
     let state_path = path.display().to_string();
+    let state_identity = daemon_state_identity(&path, &paths::daemon_jobs_file()?)?;
     let validation = validate_lease_file(&path)?;
     let active_jobs = JobStore::active_count_at_path(paths::daemon_jobs_file()?)?;
 
@@ -388,7 +400,37 @@ pub fn read_status() -> Result<DaemonStatus> {
         stale_reason: validation.stale_reason,
         state: validation.state,
         state_path,
+        state_identity,
     })
+}
+
+/// Identifies the lease file and durable queue observed by `daemon status`.
+/// The recovery command recomputes it under the lifecycle lock before mutating.
+fn daemon_state_identity(state_path: &Path, jobs_path: &Path) -> Result<String> {
+    fn update_file(hasher: &mut Sha256, label: &[u8], path: &Path) -> Result<()> {
+        hasher.update(label);
+        hasher.update(path.as_os_str().as_encoded_bytes());
+        match fs::read(path) {
+            Ok(bytes) => {
+                hasher.update([1]);
+                hasher.update((bytes.len() as u64).to_le_bytes());
+                hasher.update(bytes);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => hasher.update([0]),
+            Err(error) => {
+                return Err(Error::internal_io(
+                    error.to_string(),
+                    Some(format!("read {}", path.display())),
+                ))
+            }
+        }
+        Ok(())
+    }
+
+    let mut hasher = Sha256::new();
+    update_file(&mut hasher, b"daemon-state\0", state_path)?;
+    update_file(&mut hasher, b"daemon-jobs\0", jobs_path)?;
+    Ok(format!("sha256:{:x}", hasher.finalize()))
 }
 
 fn validate_lease_file(path: &Path) -> Result<DaemonLeaseValidation> {

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -16,8 +16,8 @@ use crate::core::process::pid_is_running;
 
 use super::{
     acquire_daemon_operation_lock, acquire_daemon_operation_lock_for_ensure, parse_bind_addr,
-    read_status, repair_legacy_lease_for_start, stop_unlocked, DaemonOrphanAdoptionResult,
-    DaemonStaleReasonCode, DaemonStartResult, DAEMON_STARTUP_TOKEN_ENV,
+    read_status, repair_legacy_lease_for_start, stop_unlocked, DaemonMissingLeaseRecoveryResult,
+    DaemonOrphanAdoptionResult, DaemonStaleReasonCode, DaemonStartResult, DAEMON_STARTUP_TOKEN_ENV,
 };
 
 /// Outcome of a daemon byte-endpoint artifact download.
@@ -102,6 +102,59 @@ pub fn adopt_orphaned_lease(
         dead_pid: state.pid,
         active_jobs_terminalized: reconciled.matching_count(),
         retry_guidance: "Inspect the retained job events, then retry eligible work through its original command or workflow.".to_string(),
+        replacement,
+    })
+}
+
+/// Recover an active durable queue only when the daemon lease is absent and the
+/// operator supplies the exact status snapshot identity they inspected.
+pub fn recover_missing_lease_state(
+    state_identity: &str,
+    confirm_lease_missing: bool,
+    addr: &str,
+) -> Result<DaemonMissingLeaseRecoveryResult> {
+    if !confirm_lease_missing {
+        return Err(Error::validation_invalid_argument(
+            "confirm_lease_missing",
+            "missing-lease recovery requires --confirm-lease-missing",
+            None,
+            Some(vec!["Inspect `homeboy daemon status` and use its exact state_identity before terminalizing retryable jobs.".to_string()]),
+        ));
+    }
+    parse_bind_addr(addr)?;
+    let _lock = acquire_daemon_operation_lock()?;
+    let status = read_status()?;
+    if status.state_identity != state_identity {
+        return Err(Error::validation_invalid_argument(
+            "state-identity",
+            "daemon state changed since inspection; refusing missing-lease recovery",
+            Some(state_identity.to_string()),
+            Some(vec![
+                "Run `homeboy daemon status` again and use its current state_identity.".to_string(),
+            ]),
+        ));
+    }
+    if status.freshness.stale_reason_code != Some(DaemonStaleReasonCode::LeaseMissing)
+        || status.state.is_some()
+        || status.reachable
+        || status.freshness.active_jobs == 0
+    {
+        return Err(Error::validation_invalid_argument(
+            "state-identity",
+            "missing-lease recovery requires an unreachable daemon with absent lease metadata and active jobs",
+            Some(state_identity.to_string()),
+            None,
+        ));
+    }
+    let store =
+        super::JobStore::open_without_reconciliation(crate::core::paths::daemon_jobs_file()?)?;
+    let reconciled = store.reconcile_missing_daemon_lease_jobs(state_identity)?;
+    let replacement = start_background_unlocked(addr)?;
+    Ok(DaemonMissingLeaseRecoveryResult {
+        recovered_state_identity: state_identity.to_string(),
+        terminalized_job_ids: reconciled.terminalized_job_ids.into_iter().map(|id| id.to_string()).collect(),
+        durable_run_ids: reconciled.durable_run_ids,
+        retry_guidance: "Inspect the retained job events and durable run IDs, then retry eligible work through its original command or workflow.".to_string(),
         replacement,
     })
 }

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -55,6 +55,16 @@ pub fn connect_with_orphan_adoption(
     runner_id: &str,
     orphan_lease_id: Option<&str>,
 ) -> Result<(RunnerConnectReport, i32)> {
+    connect_with_recovery(runner_id, orphan_lease_id, None)
+}
+
+/// Connect while explicitly selecting either an exact dead lease or an exact
+/// missing-lease status snapshot. Ordinary reconnects supply neither selector.
+pub fn connect_with_recovery(
+    runner_id: &str,
+    orphan_lease_id: Option<&str>,
+    missing_lease_state_identity: Option<&str>,
+) -> Result<(RunnerConnectReport, i32)> {
     // Reconnect replaces daemon runtime state. It shares the promotion lease
     // with binary selection so a second session cannot reconnect against a
     // different configured executable halfway through the transaction.
@@ -96,7 +106,14 @@ pub fn connect_with_orphan_adoption(
     let version = identity.version.clone();
 
     let previous_session = read_session(runner_id)?;
-    let daemon = ensure_remote_daemon(&client, homeboy, previous_session.as_ref(), orphan_lease_id);
+    let daemon = ensure_remote_daemon(
+        &client,
+        homeboy,
+        previous_session.as_ref(),
+        orphan_lease_id,
+        missing_lease_state_identity,
+        runner_id,
+    );
     let Ok(daemon) = daemon else {
         return Ok(failed_connect(
             runner_id,
@@ -1001,6 +1018,7 @@ mod remote_daemon {
         pub(super) fresh: bool,
         pub(super) reachable: bool,
         pub(super) active_jobs: usize,
+        pub(super) state_identity: Option<String>,
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1014,6 +1032,8 @@ mod remote_daemon {
         homeboy: &str,
         previous_session: Option<&RunnerSession>,
         orphan_lease_id: Option<&str>,
+        missing_lease_state_identity: Option<&str>,
+        runner_id: &str,
     ) -> std::result::Result<RemoteDaemon, String> {
         let status = remote_daemon_status(client, homeboy)?;
         if let Some(lease_id) = orphan_lease_id {
@@ -1026,6 +1046,27 @@ mod remote_daemon {
             {
                 return remote_daemon_adopt_orphan(client, homeboy, lease_id);
             }
+        }
+        if let Some(state_identity) = missing_lease_state_identity {
+            if status.stale_reason_code == Some(DaemonStaleReasonCode::LeaseMissing)
+                && status.daemon.is_none()
+                && !status.reachable
+                && status.active_jobs > 0
+                && status.state_identity.as_deref() == Some(state_identity)
+            {
+                return remote_daemon_recover_missing_lease(client, homeboy, state_identity);
+            }
+        }
+        if status.stale_reason_code == Some(DaemonStaleReasonCode::LeaseMissing)
+            && status.daemon.is_none()
+            && !status.reachable
+            && status.active_jobs > 0
+        {
+            return Err(missing_lease_recovery_guidance(
+                runner_id,
+                status.active_jobs,
+                status.state_identity.as_deref().unwrap_or("<unavailable>"),
+            ));
         }
         match remote_daemon_connect_action(previous_session, &status)? {
             RemoteDaemonConnectAction::Reattach => {
@@ -1130,6 +1171,10 @@ mod remote_daemon {
                     .and_then(Value::as_bool)
                     .unwrap_or(false),
                 active_jobs: remote_daemon_active_jobs(&data),
+                state_identity: data
+                    .get("state_identity")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
             });
         }
         let Some(state) = data.get("state") else {
@@ -1146,6 +1191,10 @@ mod remote_daemon {
                     .and_then(Value::as_bool)
                     .unwrap_or(false),
                 active_jobs: remote_daemon_active_jobs(&data),
+                state_identity: data
+                    .get("state_identity")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
             });
         };
         Ok(RemoteDaemonStatus {
@@ -1158,6 +1207,10 @@ mod remote_daemon {
                 .and_then(Value::as_bool)
                 .unwrap_or(false),
             active_jobs: remote_daemon_active_jobs(&data),
+            state_identity: data
+                .get("state_identity")
+                .and_then(Value::as_str)
+                .map(str::to_string),
         })
     }
 
@@ -1275,6 +1328,53 @@ mod remote_daemon {
                 .and_then(Value::as_str)
                 .map(str::to_string),
         })
+    }
+
+    fn remote_daemon_recover_missing_lease(
+        client: &SshClient,
+        homeboy: &str,
+        state_identity: &str,
+    ) -> std::result::Result<RemoteDaemon, String> {
+        let command = format!(
+            "{} daemon recover-missing-lease --state-identity {} --confirm-lease-missing --addr 127.0.0.1:0",
+            shell::quote_arg(homeboy),
+            shell::quote_arg(state_identity),
+        );
+        let output = client.execute(&command);
+        if !output.success {
+            return Err(command_failure_message(
+                "remote daemon missing-lease recovery failed",
+                &output,
+            ));
+        }
+        let envelope = parse_envelope(&output.stdout).map_err(|err| {
+            format!("remote daemon missing-lease recovery returned invalid JSON: {err}")
+        })?;
+        if !envelope.success {
+            return Err(format!(
+                "remote daemon missing-lease recovery failed: {}",
+                envelope.error.unwrap_or(Value::Null)
+            ));
+        }
+        let data = envelope
+            .data
+            .ok_or_else(|| "remote daemon missing-lease recovery returned no data".to_string())?;
+        let replacement = data.get("replacement").ok_or_else(|| {
+            "remote daemon missing-lease recovery returned no replacement lease".to_string()
+        })?;
+        Ok(remote_daemon_from_state(replacement))
+    }
+
+    pub(super) fn missing_lease_recovery_guidance(
+        runner_id: &str,
+        active_jobs: usize,
+        state_identity: &str,
+    ) -> String {
+        format!(
+            "remote daemon has {active_jobs} active job(s) with missing lease metadata; refusing implicit replacement. Recover only the inspected state with `homeboy runner connect {} --recover-missing-lease-state {} --confirm-lease-missing`",
+            shell::quote_arg(runner_id),
+            shell::quote_arg(state_identity),
+        )
     }
 
     pub(super) fn remote_daemon_adopt_orphan_command(homeboy: &str, lease_id: &str) -> String {
@@ -1628,6 +1728,28 @@ mod tests {
     }
 
     #[test]
+    fn missing_lease_with_active_jobs_prescribes_exact_recovery_command() {
+        let status = RemoteDaemonStatus {
+            daemon: None,
+            stale_reason: Some("daemon lease is missing".to_string()),
+            stale_reason_code: Some(DaemonStaleReasonCode::LeaseMissing),
+            fresh: false,
+            reachable: false,
+            active_jobs: 1,
+            state_identity: Some("sha256:inspected-state".to_string()),
+        };
+
+        let error = remote_daemon_connect_action(None, &status)
+            .expect_err("default path must still refuse missing lease recovery");
+        assert!(error.contains("refusing implicit replacement"));
+
+        let guidance = missing_lease_recovery_guidance("runner-1", 1, "sha256:inspected-state");
+        assert!(guidance.contains("homeboy runner connect runner-1"));
+        assert!(guidance.contains("--recover-missing-lease-state sha256:inspected-state"));
+        assert!(guidance.contains("--confirm-lease-missing"));
+    }
+
+    #[test]
     fn lost_local_session_refuses_dead_daemon_with_active_jobs_without_explicit_adoption() {
         let status = remote_daemon_status_for_test_with_reason(
             false,
@@ -1681,6 +1803,7 @@ mod tests {
             fresh: false,
             reachable: false,
             active_jobs: 0,
+            state_identity: None,
         };
 
         assert_eq!(
@@ -1699,6 +1822,7 @@ mod tests {
             fresh: false,
             reachable: false,
             active_jobs: 0,
+            state_identity: None,
         };
 
         assert_eq!(
@@ -2346,6 +2470,7 @@ mod tests {
             fresh,
             reachable,
             active_jobs,
+            state_identity: None,
         }
     }
 }

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -83,8 +83,8 @@ pub(crate) use command_path::{
     remote_shell_path_preamble,
 };
 pub use connection::{
-    connect, connect_reverse, connect_with_orphan_adoption, disconnect, reverse_broker_artifact,
-    reverse_broker_reconcile, status, statuses,
+    connect, connect_reverse, connect_with_orphan_adoption, connect_with_recovery, disconnect,
+    reverse_broker_artifact, reverse_broker_reconcile, status, statuses,
 };
 pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
 pub use evidence::runner_artifact_store_token;

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -27,9 +27,9 @@
 pub use super::runner::{
     apply_change_artifact, apply_workspace_patch, broker_auth_store_path,
     broker_submit_token_for_runner, broker_token_from_env, capture_lab_offload_subprocess_metadata,
-    connect, connect_with_orphan_adoption, reverse_broker_artifact, reverse_broker_reconcile,
-    BrokerAuthGrant, BrokerAuthStore, BrokerCredential, BrokerScope, MintedCredential,
-    BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
+    connect, connect_with_orphan_adoption, connect_with_recovery, reverse_broker_artifact,
+    reverse_broker_reconcile, BrokerAuthGrant, BrokerAuthStore, BrokerCredential, BrokerScope,
+    MintedCredential, BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
 };
 pub use super::runner::{
     connect_reverse, disconnect, download_remote_artifact,
@@ -97,12 +97,12 @@ pub mod registry {
 /// Connect/disconnect/status helpers for runner sessions.
 pub mod connection {
     pub use super::super::runner::{
-        connect, connect_reverse, connect_with_orphan_adoption, disconnect, run_reverse_worker,
-        status, statuses, ReverseRunnerConnectOptions, ReverseRunnerWorkerOptions,
-        ReverseRunnerWorkerOutput, RunnerAvailability, RunnerChangedRuntimePath,
-        RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind, RunnerSession,
-        RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning, RunnerStaleRuntimePath,
-        RunnerStatusReport, RunnerTunnelMode,
+        connect, connect_reverse, connect_with_orphan_adoption, connect_with_recovery, disconnect,
+        run_reverse_worker, status, statuses, ReverseRunnerConnectOptions,
+        ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput, RunnerAvailability,
+        RunnerChangedRuntimePath, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
+        RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
+        RunnerStaleRuntimePath, RunnerStatusReport, RunnerTunnelMode,
     };
 }
 

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -226,6 +226,35 @@ fn legacy_unowned_job_blocks_replacement_start() {
 }
 
 #[test]
+fn missing_lease_recovery_rejects_changed_active_job_state() {
+    with_isolated_home(|_| {
+        let before = crate::core::daemon::read_status().expect("missing lease status");
+        assert_eq!(
+            before.freshness.stale_reason_code,
+            Some(DaemonStaleReasonCode::LeaseMissing)
+        );
+        let path = crate::core::paths::daemon_jobs_file().expect("daemon jobs path");
+        let store = JobStore::open_without_reconciliation(&path).expect("open durable store");
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start job");
+
+        let error = super::recover_missing_lease_state(&before.state_identity, true, "127.0.0.1:0")
+            .expect_err("changed durable queue must reject recovery");
+
+        assert!(error.message.contains("state changed since inspection"));
+        assert_eq!(
+            JobStore::open_without_reconciliation(&path)
+                .expect("reopen durable store")
+                .get(job.id)
+                .expect("job remains")
+                .status,
+            JobStatus::Running,
+            "TOCTOU rejection must leave the job untouched"
+        );
+    });
+}
+
+#[test]
 fn dead_lease_reconciliation_reattaches_live_or_refuses_mismatched_daemon() {
     let live_daemon = fake_daemon(4242, "lease-dead");
     let live = reconcile_dead_lease_and_ensure_running_with_operations(
@@ -313,6 +342,7 @@ fn fake_status(daemon: Option<super::DaemonStartResult>, fresh: bool) -> DaemonS
         stale_reason: (!fresh).then(|| "simulated stale daemon".to_string()),
         state: daemon.map(fake_daemon_state),
         state_path: "/fake/daemon-state.json".to_string(),
+        state_identity: "sha256:fake".to_string(),
     }
 }
 
@@ -334,6 +364,7 @@ fn fake_dead_status(daemon: super::DaemonStartResult) -> DaemonStatus {
         stale_reason: Some("daemon lease pid is not running".to_string()),
         state: Some(fake_daemon_state(daemon)),
         state_path: "/fake/daemon-state.json".to_string(),
+        state_identity: "sha256:fake".to_string(),
     }
 }
 


### PR DESCRIPTION
## Summary
- add explicit missing-lease recovery gated by the exact `daemon status` state identity
- terminalize only unowned active jobs with retained retryable evidence before daemon replacement
- preserve exact dead-lease adoption and print the executable recovery command when lease metadata is absent

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test --lib core::runner::connection::tests`.
3. Run `cargo test --lib core::api_jobs::tests`.
4. Run `cargo test --lib core::daemon::control::control_test`.
5. Run `cargo test --lib core::runtime_promotion`.
6. Run `cargo check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.6 Sol)
- **Used for:** Implemented the explicit missing-lease recovery flow, added deterministic coverage, and ran the listed verification commands with Chris's requirements.