### PR TITLE
Recover lease-less orphan daemon job stores

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -324,6 +324,8 @@ plan is emitted; `--sync-mode` accepts `snapshot`, `snapshot-git`, or `git`.
 ```sh
 homeboy runner connect <runner-id>
 homeboy runner connect <runner-id> --adopt-orphan-lease <lease-id> --confirm-pid-dead
+homeboy runner connect <runner-id> --reconcile-leaseless-orphans --confirm-control-plane-lost
+homeboy daemon reconcile-leaseless-orphans --confirm-control-plane-lost
 homeboy runner connect <controller-id> --reverse --reverse-runner <runner-id> --broker-url <url>
 ```
 
@@ -341,6 +343,14 @@ terminalizing jobs from that dead control plane with retry guidance, starts one
 replacement daemon, and then records the fresh local session. Ordinary `runner
 connect` never infers that orphan ownership; live, ambiguous, and lease-mismatched
 daemon records remain protected.
+
+When `daemon status` reports `stale_reason_code: lease_missing`, active jobs,
+and unavailable recovery evidence, run the explicit daemon reconciliation on the
+configured runner host. It acquires the daemon lifecycle lock, requires the
+affirmative confirmation flag, independently checks for a `homeboy daemon serve`
+process and Homeboy TCP listener, snapshots `jobs.json`, retains all job events
+and result evidence, terminalizes only lease-less active jobs, and starts one
+replacement daemon. Live or ambiguous probes abort without changing the store.
 
 Reverse runner connections record the runner-initiated session substrate and use
 the controller daemon as the broker. A reverse runner can register itself with

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use std::path::PathBuf;
 
 use homeboy::core::daemon::{
-    self, BrokerConfig, BrokerConfigOptions, DaemonOrphanAdoptionResult, DaemonStartResult, DaemonStatus, DaemonStopResult,
+    self, BrokerConfig, BrokerConfigOptions, DaemonLeaselessOrphanReconciliationResult, DaemonOrphanAdoptionResult, DaemonStartResult, DaemonStatus, DaemonStopResult,
     ServiceIdentity,
 };
 use homeboy::core::http_api::{AnalysisJobRunOutput, AnalysisJobRunner};
@@ -37,6 +37,14 @@ enum DaemonCommand {
         /// Confirm the recorded PID was inspected and is dead
         #[arg(long)]
         confirm_pid_dead: bool,
+        #[arg(long, default_value = daemon::DEFAULT_ADDR)]
+        addr: String,
+    },
+    /// Explicitly reconcile a lease-less orphan job store after no-owner proof
+    ReconcileLeaselessOrphans {
+        /// Confirm the daemon control plane was lost and the store may be terminalized
+        #[arg(long)]
+        confirm_control_plane_lost: bool,
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
     },
@@ -92,6 +100,7 @@ pub enum DaemonOutput {
     Start(DaemonStartResult),
     EnsureRunning(DaemonStartResult),
     AdoptOrphan(DaemonOrphanAdoptionResult),
+    ReconcileLeaselessOrphans(DaemonLeaselessOrphanReconciliationResult),
     Serve(DaemonStartResult),
     Stop(DaemonStopResult),
     Status(DaemonStatus),
@@ -124,6 +133,9 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
         DaemonCommand::AdoptOrphan { lease_id, confirm_pid_dead, addr } => Ok((
             DaemonOutput::AdoptOrphan(daemon::adopt_orphaned_lease(&lease_id, confirm_pid_dead, &addr)?),
             0,
+        )),
+        DaemonCommand::ReconcileLeaselessOrphans { confirm_control_plane_lost, addr } => Ok((
+            DaemonOutput::ReconcileLeaselessOrphans(daemon::reconcile_leaseless_orphan_store(confirm_control_plane_lost, &addr)?), 0
         )),
         DaemonCommand::Serve { addr } => serve(&addr),
         DaemonCommand::Stop => Ok((DaemonOutput::Stop(daemon::stop()?), 0)),

--- a/src/commands/runner/cli.rs
+++ b/src/commands/runner/cli.rs
@@ -220,6 +220,14 @@ pub(super) enum RunnerCommand {
         /// Confirm the recorded PID for --adopt-orphan-lease is dead
         #[arg(long)]
         confirm_pid_dead: bool,
+
+        /// Explicitly reconcile a lease-less orphan store before connecting
+        #[arg(long)]
+        reconcile_leaseless_orphans: bool,
+
+        /// Confirm the runner daemon control plane was lost for lease-less reconciliation
+        #[arg(long)]
+        confirm_control_plane_lost: bool,
     },
     /// Show persisted runner tunnel status
     Status {

--- a/src/commands/runner/dispatch.rs
+++ b/src/commands/runner/dispatch.rs
@@ -136,6 +136,8 @@ pub fn run(
             broker_url,
             adopt_orphan_lease,
             confirm_pid_dead,
+            reconcile_leaseless_orphans,
+            confirm_control_plane_lost,
         } => map_registry(connect(
             &id,
             reverse,
@@ -143,6 +145,8 @@ pub fn run(
             broker_url,
             adopt_orphan_lease,
             confirm_pid_dead,
+            reconcile_leaseless_orphans,
+            confirm_control_plane_lost,
         )),
         RunnerCommand::Status { id } => map_registry(status_mod::status(id.as_deref())),
         RunnerCommand::Disconnect { id } => map_registry(registry::disconnect(&id)),

--- a/src/commands/runner/registry.rs
+++ b/src/commands/runner/registry.rs
@@ -205,6 +205,8 @@ pub(super) fn connect(
     broker_url: Option<String>,
     adopt_orphan_lease: Option<String>,
     confirm_pid_dead: bool,
+    reconcile_leaseless_orphans: bool,
+    confirm_control_plane_lost: bool,
 ) -> CmdResult<RunnerOutput> {
     if adopt_orphan_lease.is_some() && !confirm_pid_dead {
         return Err(homeboy::core::Error::validation_invalid_argument(
@@ -212,6 +214,22 @@ pub(super) fn connect(
             "--adopt-orphan-lease requires --confirm-pid-dead",
             None,
             Some(vec!["Inspect `homeboy daemon status` on the runner before adopting its exact dead lease.".to_string()]),
+        ));
+    }
+    if reconcile_leaseless_orphans && !confirm_control_plane_lost {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "confirm_control_plane_lost",
+            "--reconcile-leaseless-orphans requires --confirm-control-plane-lost",
+            None,
+            None,
+        ));
+    }
+    if reconcile_leaseless_orphans && adopt_orphan_lease.is_some() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "reconcile_leaseless_orphans",
+            "lease-less reconciliation and exact-lease adoption are mutually exclusive",
+            None,
+            None,
         ));
     }
     if reverse && adopt_orphan_lease.is_some() {
@@ -237,7 +255,11 @@ pub(super) fn connect(
             broker_url,
         })?
     } else {
-        runner::connect_with_orphan_adoption(id, adopt_orphan_lease.as_deref())?
+        if reconcile_leaseless_orphans {
+            runner::connect_with_leaseless_orphan_reconciliation(id)?
+        } else {
+            runner::connect_with_orphan_adoption(id, adopt_orphan_lease.as_deref())?
+        }
     };
     Ok((
         RunnerOutput {

--- a/src/core/api_jobs/store.rs
+++ b/src/core/api_jobs/store.rs
@@ -383,6 +383,85 @@ impl JobStore {
         Ok(diagnostics)
     }
 
+    /// Explicitly terminalize an unowned store after the daemon lifecycle has
+    /// independently established that no daemon can still own it.
+    pub fn reconcile_leaseless_orphan_jobs(&self) -> Result<Vec<Uuid>> {
+        let mut job_ids: Vec<Uuid> = self
+            .inner
+            .lock()
+            .expect("job store mutex poisoned")
+            .jobs
+            .values()
+            .filter(|stored| matches!(stored.job.status, JobStatus::Queued | JobStatus::Running))
+            .map(|stored| stored.job.id)
+            .collect();
+        job_ids.sort();
+        if let Some(job) = job_ids
+            .iter()
+            .find_map(|id| self.get(*id).ok())
+            .filter(|job| job.daemon_lease_id.is_some())
+        {
+            return Err(Error::validation_invalid_argument(
+                "job_store",
+                format!(
+                    "refusing lease-less reconciliation: active job {} has daemon lease evidence",
+                    job.id
+                ),
+                None,
+                None,
+            ));
+        }
+
+        let now = timestamp_ms();
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        for job_id in &job_ids {
+            let stored = inner.jobs.get_mut(job_id).expect("diagnosed job exists");
+            if let Some((status, exit_code)) = recovered_terminal_from_result(&stored.events) {
+                stored.job.status = status;
+                stored.job.updated_at_ms = now;
+                stored.job.finished_at_ms = Some(now);
+                stored.job.stale_reason = None;
+                let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+                stored.events.push(JobEvent { sequence, job_id: *job_id, kind: JobEventKind::Status, timestamp_ms: now, message: Some("job terminal status recovered from retained result after lease-less control-plane loss".to_string()), data: Some(serde_json::json!({"status": status, "reason": "leaseless_orphan_reconciliation", "exit_code": exit_code})) });
+            } else {
+                let reason =
+                    "control plane lost before the job reached a terminal status".to_string();
+                stored.job.status = JobStatus::Failed;
+                stored.job.updated_at_ms = now;
+                stored.job.finished_at_ms = Some(now);
+                stored.job.stale_reason = Some(reason.clone());
+                let classification = stale_after_restart_classification(stored);
+                for (kind, message, data) in [
+                    (
+                        JobEventKind::Error,
+                        reason,
+                        serde_json::json!({"reason":"leaseless_orphan_reconciliation", "classification": classification, "retry_guidance":"Inspect retained job events, then retry eligible work through its original command or workflow."}),
+                    ),
+                    (
+                        JobEventKind::Status,
+                        "job marked failed after lease-less control-plane loss".to_string(),
+                        serde_json::json!({"status":JobStatus::Failed, "reason":"leaseless_orphan_reconciliation"}),
+                    ),
+                ] {
+                    let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+                    stored.events.push(JobEvent {
+                        sequence,
+                        job_id: *job_id,
+                        kind,
+                        timestamp_ms: now,
+                        message: Some(message),
+                        data: Some(data),
+                    });
+                }
+            }
+            apply_event_retention(&mut stored.events, self.event_retention_limit());
+            stored.job.event_count = stored.events.len();
+        }
+        drop(inner);
+        self.persist()?;
+        Ok(job_ids)
+    }
+
     pub(crate) fn active_runner_jobs(&self) -> Vec<super::types::ActiveRunnerJobSummary> {
         let now = timestamp_ms();
         let inner = self.inner.lock().expect("job store mutex poisoned");

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -37,7 +37,7 @@ pub use artifact_download::ArtifactDownload;
 pub use broker_config::{render_broker_config, BrokerConfig, BrokerConfigOptions, ServiceIdentity};
 pub use control::{
     adopt_orphaned_lease, artifact_content_url, ensure_running, fetch_artifact_to_path,
-    start_background, ArtifactFetchOutcome,
+    reconcile_leaseless_orphan_store, start_background, ArtifactFetchOutcome,
 };
 use patch_capture::{capture_baseline, capture_patch_report};
 
@@ -149,6 +149,16 @@ pub struct DaemonOrphanAdoptionResult {
     pub adopted_lease_id: String,
     pub dead_pid: u32,
     pub active_jobs_terminalized: usize,
+    pub retry_guidance: String,
+    pub replacement: DaemonStartResult,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DaemonLeaselessOrphanReconciliationResult {
+    pub snapshot_path: String,
+    pub affected_job_ids: Vec<String>,
+    pub affected_job_count: usize,
+    pub no_owner_proof: Vec<String>,
     pub retry_guidance: String,
     pub replacement: DaemonStartResult,
 }

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -16,8 +16,9 @@ use crate::core::process::pid_is_running;
 
 use super::{
     acquire_daemon_operation_lock, acquire_daemon_operation_lock_for_ensure, parse_bind_addr,
-    read_status, repair_legacy_lease_for_start, stop_unlocked, DaemonOrphanAdoptionResult,
-    DaemonStaleReasonCode, DaemonStartResult, DAEMON_STARTUP_TOKEN_ENV,
+    read_status, repair_legacy_lease_for_start, stop_unlocked,
+    DaemonLeaselessOrphanReconciliationResult, DaemonOrphanAdoptionResult, DaemonStaleReasonCode,
+    DaemonStartResult, DAEMON_STARTUP_TOKEN_ENV,
 };
 
 /// Outcome of a daemon byte-endpoint artifact download.
@@ -104,6 +105,120 @@ pub fn adopt_orphaned_lease(
         retry_guidance: "Inspect the retained job events, then retry eligible work through its original command or workflow.".to_string(),
         replacement,
     })
+}
+
+/// Reconcile a durable store with no lease only when the operator explicitly
+/// confirms control-plane loss and independent host probes find no owner.
+pub fn reconcile_leaseless_orphan_store(
+    confirm_control_plane_lost: bool,
+    addr: &str,
+) -> Result<DaemonLeaselessOrphanReconciliationResult> {
+    if !confirm_control_plane_lost {
+        return Err(Error::validation_invalid_argument("confirm_control_plane_lost", "lease-less orphan reconciliation requires --confirm-control-plane-lost", None, Some(vec!["Inspect the configured runner host and retry only after confirming its daemon control plane is gone.".to_string()])));
+    }
+    parse_bind_addr(addr)?;
+    let _lock = acquire_daemon_operation_lock()?;
+    reconcile_leaseless_orphan_store_with_operations(
+        read_status,
+        probe_no_daemon_owner,
+        || {
+            let jobs = crate::core::paths::daemon_jobs_file()?;
+            let snapshot = jobs.with_file_name(format!(
+                "jobs.lease-less-orphan-snapshot-{}.json",
+                uuid::Uuid::new_v4()
+            ));
+            std::fs::copy(&jobs, &snapshot).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("snapshot {}", jobs.display())),
+                )
+            })?;
+            let store = super::JobStore::open_without_reconciliation(jobs)?;
+            let affected = store.reconcile_leaseless_orphan_jobs()?;
+            Ok((snapshot, affected))
+        },
+        || start_background_unlocked(addr),
+    )
+}
+
+fn reconcile_leaseless_orphan_store_with_operations<Status, Probe, Reconcile, Start>(
+    status: Status,
+    probe: Probe,
+    reconcile: Reconcile,
+    start: Start,
+) -> Result<DaemonLeaselessOrphanReconciliationResult>
+where
+    Status: FnOnce() -> Result<super::DaemonStatus>,
+    Probe: FnOnce() -> Result<Vec<String>>,
+    Reconcile: FnOnce() -> Result<(PathBuf, Vec<uuid::Uuid>)>,
+    Start: FnOnce() -> Result<DaemonStartResult>,
+{
+    let status = status()?;
+    if status.freshness.stale_reason_code != Some(DaemonStaleReasonCode::LeaseMissing)
+        || status.freshness.active_jobs == 0
+    {
+        return Err(Error::validation_invalid_argument(
+            "job_store",
+            "lease-less reconciliation requires lease_missing with active jobs",
+            None,
+            None,
+        ));
+    }
+    let no_owner_proof = probe()?;
+    let (snapshot_path, affected) = reconcile()?;
+    let replacement = start()?;
+    Ok(DaemonLeaselessOrphanReconciliationResult {
+        snapshot_path: snapshot_path.display().to_string(), affected_job_ids: affected.iter().map(ToString::to_string).collect(), affected_job_count: affected.len(), no_owner_proof,
+        retry_guidance: "Inspect retained job events, then retry eligible work through its original command or workflow.".to_string(), replacement,
+    })
+}
+
+fn probe_no_daemon_owner() -> Result<Vec<String>> {
+    let process = Command::new("ps")
+        .args(["-axo", "command="])
+        .output()
+        .map_err(|e| {
+            Error::internal_io(e.to_string(), Some("probe daemon processes".to_string()))
+        })?;
+    if !process.status.success() {
+        return Err(Error::internal_unexpected(
+            "daemon process probe was ambiguous",
+        ));
+    }
+    if String::from_utf8_lossy(&process.stdout)
+        .lines()
+        .any(|line| line.contains("homeboy") && line.contains("daemon serve"))
+    {
+        return Err(Error::validation_invalid_argument(
+            "owner_probe",
+            "refusing lease-less reconciliation: a Homeboy daemon process is live",
+            None,
+            None,
+        ));
+    }
+    let listener = Command::new("lsof")
+        .args(["-nP", "-iTCP", "-sTCP:LISTEN", "-c", "homeboy"])
+        .output()
+        .map_err(|e| {
+            Error::internal_io(e.to_string(), Some("probe daemon listeners".to_string()))
+        })?;
+    if listener.status.code() != Some(1) && !listener.status.success() {
+        return Err(Error::internal_unexpected(
+            "daemon listener probe was ambiguous",
+        ));
+    }
+    if listener.status.success() && !listener.stdout.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "owner_probe",
+            "refusing lease-less reconciliation: a Homeboy daemon listener is live",
+            None,
+            None,
+        ));
+    }
+    Ok(vec![
+        "process probe found no `homeboy daemon serve` process".to_string(),
+        "listener probe found no Homeboy TCP listener".to_string(),
+    ])
 }
 
 fn reconcile_dead_daemon_lease_jobs(expected_lease_id: &str) -> Result<()> {

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -166,6 +166,52 @@ pub fn connect_with_orphan_adoption(
     ))
 }
 
+/// Reconnect through the explicit lease-less recovery command, then persist the
+/// replacement daemon session using the ordinary connection transaction.
+pub fn connect_with_leaseless_orphan_reconciliation(
+    runner_id: &str,
+) -> Result<(RunnerConnectReport, i32)> {
+    let runner = load(runner_id)?;
+    let Some((_server_id, _server, client)) = resolve_ssh_runner(&runner)? else {
+        return connect(runner_id);
+    };
+    let homeboy = remote_runner_homeboy_path(&runner, "runner lease-less orphan reconciliation")?;
+    let command = format!(
+        "{} daemon reconcile-leaseless-orphans --confirm-control-plane-lost --addr 127.0.0.1:0",
+        shell::quote_arg(homeboy)
+    );
+    let output = client.execute(&command);
+    if !output.success {
+        return Err(Error::validation_invalid_argument(
+            "reconcile_leaseless_orphans",
+            format!(
+                "remote lease-less orphan reconciliation failed: {}",
+                command_failure_message("remote daemon reconciliation failed", &output)
+            ),
+            None,
+            None,
+        ));
+    }
+    let envelope =
+        parse_json_from_mixed_stdout::<CliEnvelope>(&output.stdout).map_err(|error| {
+            Error::internal_unexpected(format!(
+                "remote lease-less orphan reconciliation returned invalid JSON: {error}"
+            ))
+        })?;
+    if !envelope.success {
+        return Err(Error::validation_invalid_argument(
+            "reconcile_leaseless_orphans",
+            format!(
+                "remote lease-less orphan reconciliation failed: {}",
+                envelope.error.unwrap_or(Value::Null)
+            ),
+            None,
+            None,
+        ));
+    }
+    connect(runner_id)
+}
+
 pub fn connect_reverse(options: ReverseRunnerConnectOptions) -> Result<(RunnerConnectReport, i32)> {
     if options.runner_id.trim().is_empty() {
         return Err(Error::validation_invalid_argument(

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -83,8 +83,9 @@ pub(crate) use command_path::{
     remote_shell_path_preamble,
 };
 pub use connection::{
-    connect, connect_reverse, connect_with_orphan_adoption, disconnect, reverse_broker_artifact,
-    reverse_broker_reconcile, status, statuses,
+    connect, connect_reverse, connect_with_leaseless_orphan_reconciliation,
+    connect_with_orphan_adoption, disconnect, reverse_broker_artifact, reverse_broker_reconcile,
+    status, statuses,
 };
 pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
 pub use evidence::runner_artifact_store_token;

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -27,9 +27,9 @@
 pub use super::runner::{
     apply_change_artifact, apply_workspace_patch, broker_auth_store_path,
     broker_submit_token_for_runner, broker_token_from_env, capture_lab_offload_subprocess_metadata,
-    connect, connect_with_orphan_adoption, reverse_broker_artifact, reverse_broker_reconcile,
-    BrokerAuthGrant, BrokerAuthStore, BrokerCredential, BrokerScope, MintedCredential,
-    BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
+    connect, connect_with_leaseless_orphan_reconciliation, connect_with_orphan_adoption,
+    reverse_broker_artifact, reverse_broker_reconcile, BrokerAuthGrant, BrokerAuthStore,
+    BrokerCredential, BrokerScope, MintedCredential, BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
 };
 pub use super::runner::{
     connect_reverse, disconnect, download_remote_artifact,

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -93,6 +93,114 @@ fn leaseless_store_aborts_on_ambiguous_or_live_owner_probe() {
     }
 }
 
+#[test]
+fn concurrent_leaseless_recovery_callers_commit_once_and_preserve_job_evidence() {
+    with_isolated_home(|_| {
+        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let store = JobStore::open_without_reconciliation(&path).expect("store");
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start");
+        store
+            .append_event(
+                job.id,
+                JobEventKind::Stdout,
+                Some("output before control-plane loss".to_string()),
+                None,
+            )
+            .expect("output");
+
+        let lifecycle = Arc::new(Mutex::new(false));
+        let starts = Arc::new(Mutex::new(0_usize));
+        let barrier = Arc::new(Barrier::new(3));
+        let first = concurrent_leaseless_recovery(
+            Arc::clone(&barrier),
+            Arc::clone(&lifecycle),
+            Arc::clone(&starts),
+            path.clone(),
+        );
+        let second = concurrent_leaseless_recovery(
+            Arc::clone(&barrier),
+            Arc::clone(&lifecycle),
+            Arc::clone(&starts),
+            path.clone(),
+        );
+        barrier.wait();
+
+        let first = first.join().expect("first caller");
+        let second = second.join().expect("second caller");
+        assert_eq!(
+            [first, second].into_iter().filter(Result::is_ok).count(),
+            1,
+            "only one caller may commit the recovery transaction"
+        );
+        assert_eq!(*starts.lock().expect("starts"), 1);
+
+        let recovered = JobStore::open_without_reconciliation(&path).expect("recovered store");
+        let events = recovered.events(job.id).expect("events");
+        assert_eq!(
+            recovered.get(job.id).expect("job").status,
+            JobStatus::Failed
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| {
+                    event
+                        .data
+                        .as_ref()
+                        .is_some_and(|data| data["reason"] == "leaseless_orphan_reconciliation")
+                })
+                .count(),
+            2,
+            "one error and one status event are appended exactly once"
+        );
+        assert!(events
+            .iter()
+            .any(|event| { event.message.as_deref() == Some("output before control-plane loss") }));
+    });
+}
+
+fn concurrent_leaseless_recovery(
+    barrier: Arc<Barrier>,
+    lifecycle: Arc<Mutex<bool>>,
+    starts: Arc<Mutex<usize>>,
+    path: std::path::PathBuf,
+) -> std::thread::JoinHandle<
+    crate::core::error::Result<super::DaemonLeaselessOrphanReconciliationResult>,
+> {
+    std::thread::spawn(move || {
+        barrier.wait();
+        let mut committed = lifecycle.lock().expect("lifecycle lock");
+        if *committed {
+            return Err(crate::core::Error::validation_invalid_argument(
+                "lifecycle",
+                "replacement daemon already committed by concurrent recovery",
+                None,
+                None,
+            ));
+        }
+        let result = reconcile_leaseless_orphan_store_with_operations(
+            || Ok(leaseless_status(1)),
+            || Ok(vec!["no process".to_string(), "no listener".to_string()]),
+            || {
+                let snapshot = path.with_extension(format!("{}.snapshot", uuid::Uuid::new_v4()));
+                std::fs::copy(&path, &snapshot).expect("snapshot");
+                let store = JobStore::open_without_reconciliation(&path).expect("recovery store");
+                Ok((snapshot, store.reconcile_leaseless_orphan_jobs()?))
+            },
+            || {
+                let mut starts = starts.lock().expect("starts");
+                *starts += 1;
+                Ok(fake_daemon(5000 + *starts as u32, "replacement-lease"))
+            },
+        );
+        if result.is_ok() {
+            *committed = true;
+        }
+        result
+    })
+}
+
 fn leaseless_status(active_jobs: usize) -> DaemonStatus {
     DaemonStatus {
         running: false,

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use super::{
     artifact_content_url, ensure_running_with_operations, fetch_artifact_to_path,
     reconcile_dead_lease_and_ensure_running_with_operations,
+    reconcile_leaseless_orphan_store_with_operations,
 };
 use crate::core::api_jobs::{JobEventKind, JobStatus, JobStore};
 use crate::core::build_identity::BuildIdentity;
@@ -18,6 +19,103 @@ use crate::test_support::with_isolated_home;
 struct FakeEnsureState {
     daemon: Option<super::DaemonStartResult>,
     starts: usize,
+}
+
+#[test]
+fn leaseless_store_requires_missing_lease_and_no_owner_then_preserves_evidence() {
+    with_isolated_home(|_| {
+        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let store = JobStore::open_without_reconciliation(&path).expect("store");
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start");
+        store
+            .append_event(
+                job.id,
+                JobEventKind::Stdout,
+                Some("retained output".to_string()),
+                None,
+            )
+            .expect("output");
+        let replacement = fake_daemon(4343, "fresh-lease");
+        let result = reconcile_leaseless_orphan_store_with_operations(
+            || Ok(leaseless_status(1)),
+            || Ok(vec!["no process".to_string(), "no listener".to_string()]),
+            || {
+                let snapshot = path.with_extension("snapshot.json");
+                std::fs::copy(&path, &snapshot).expect("snapshot");
+                let store = JobStore::open_without_reconciliation(&path).expect("recovery store");
+                Ok((snapshot, store.reconcile_leaseless_orphan_jobs()?))
+            },
+            || Ok(replacement.clone()),
+        )
+        .expect("reconcile");
+        assert_eq!(result.affected_job_ids, vec![job.id.to_string()]);
+        assert_eq!(result.no_owner_proof.len(), 2);
+        assert!(std::path::Path::new(&result.snapshot_path).exists());
+        let recovered = JobStore::open_without_reconciliation(&path).expect("recovered");
+        assert_eq!(
+            recovered.get(job.id).expect("job").status,
+            JobStatus::Failed
+        );
+        assert!(recovered
+            .events(job.id)
+            .expect("events")
+            .iter()
+            .any(|event| event.message.as_deref() == Some("retained output")));
+    });
+}
+
+#[test]
+fn leaseless_store_aborts_on_ambiguous_or_live_owner_probe() {
+    for probe in [
+        || {
+            Err(crate::core::Error::internal_unexpected(
+                "daemon listener probe was ambiguous",
+            ))
+        },
+        || {
+            Err(crate::core::Error::validation_invalid_argument(
+                "owner_probe",
+                "a Homeboy daemon listener is live",
+                None,
+                None,
+            ))
+        },
+    ] {
+        let error = reconcile_leaseless_orphan_store_with_operations(
+            || Ok(leaseless_status(1)),
+            probe,
+            || unreachable!("must not reconcile"),
+            || unreachable!("must not start"),
+        )
+        .expect_err("probe must fail closed");
+        assert!(error.message.contains("probe") || error.message.contains("listener"));
+    }
+}
+
+fn leaseless_status(active_jobs: usize) -> DaemonStatus {
+    DaemonStatus {
+        running: false,
+        fresh: false,
+        reachable: false,
+        freshness: DaemonFreshnessReport {
+            fresh: false,
+            stale_reason_code: Some(DaemonStaleReasonCode::LeaseMissing),
+            restartable: false,
+            lease_id: None,
+            pid: None,
+            recovery_evidence: None,
+            ownership_evidence: None,
+            adoption_command: None,
+            binary_hash: None,
+            runtime_paths: None,
+            active_jobs,
+            repair_plan: Vec::new(),
+        },
+        stale_reason: None,
+        state: None,
+        state_path: "/fake/daemon-state.json".to_string(),
+    }
 }
 
 #[test]
@@ -330,6 +428,10 @@ fn fake_dead_status(daemon: super::DaemonStartResult) -> DaemonStatus {
             stale_reason_code: Some(DaemonStaleReasonCode::PidDead),
             restartable: false,
             lease_id: Some(daemon.lease_id.clone()),
+            pid: Some(daemon.pid),
+            recovery_evidence: None,
+            ownership_evidence: None,
+            adoption_command: None,
             binary_hash: None,
             runtime_paths: None,
             active_jobs: 1,


### PR DESCRIPTION
## Summary
- add a confirmation-gated lease-less orphan reconciliation command for daemon stores with active unowned jobs
- prove no owner with independent process and listener probes under the daemon lifecycle lock, snapshot the durable store, retain terminal/result evidence, and start one replacement daemon
- expose remote runner recovery through `runner connect --reconcile-leaseless-orphans --confirm-control-plane-lost`, which records the fresh connection session

Closes #8034

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test leaseless --lib`.
3. Run `cargo check`.
4. Run `cargo run -- daemon reconcile-leaseless-orphans --help` and confirm the affirmative `--confirm-control-plane-lost` gate is present.
5. Run `cargo run -- runner connect --help` and confirm the explicit lease-less recovery flags are present.

## Compatibility
No existing recovery behavior changes. The new path is opt-in, rejects active jobs carrying lease evidence, and fails closed on live or ambiguous owner probes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode / openai-gpt-5.6-sol
- **Used for:** Collaboratively implemented the explicit lease-less recovery contract, focused deterministic tests, CLI wiring, and documentation.