### PR TITLE
Recover lease-less orphan daemon job stores

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -324,6 +324,8 @@ plan is emitted; `--sync-mode` accepts `snapshot`, `snapshot-git`, or `git`.
 ```sh
 homeboy runner connect <runner-id>
 homeboy runner connect <runner-id> --adopt-orphan-lease <lease-id> --confirm-pid-dead
+homeboy runner connect <runner-id> --reconcile-leaseless-orphans --confirm-control-plane-lost
+homeboy daemon reconcile-leaseless-orphans --confirm-control-plane-lost
 homeboy runner connect <controller-id> --reverse --reverse-runner <runner-id> --broker-url <url>
 ```
 
@@ -341,6 +343,14 @@ terminalizing jobs from that dead control plane with retry guidance, starts one
 replacement daemon, and then records the fresh local session. Ordinary `runner
 connect` never infers that orphan ownership; live, ambiguous, and lease-mismatched
 daemon records remain protected.
+
+When `daemon status` reports `stale_reason_code: lease_missing`, active jobs,
+and unavailable recovery evidence, run the explicit daemon reconciliation on the
+configured runner host. It acquires the daemon lifecycle lock, requires the
+affirmative confirmation flag, independently checks for a `homeboy daemon serve`
+process and Homeboy TCP listener, snapshots `jobs.json`, retains all job events
+and result evidence, terminalizes only lease-less active jobs, and starts one
+replacement daemon. Live or ambiguous probes abort without changing the store.
 
 Reverse runner connections record the runner-initiated session substrate and use
 the controller daemon as the broker. A reverse runner can register itself with

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -49,6 +49,9 @@ enum DaemonCommand {
         /// Confirm the endpoint is unreachable and the lease metadata is absent
         #[arg(long)]
         confirm_lease_missing: bool,
+        #[arg(long, default_value = daemon::DEFAULT_ADDR)]
+        addr: String,
+    },
     /// Explicitly reconcile a lease-less orphan job store after no-owner proof
     ReconcileLeaselessOrphans {
         /// Confirm the daemon control plane was lost and the store may be terminalized

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -3,8 +3,9 @@ use serde::Serialize;
 use std::path::PathBuf;
 
 use homeboy::core::daemon::{
-    self, BrokerConfig, BrokerConfigOptions, DaemonMissingLeaseRecoveryResult, DaemonOrphanAdoptionResult, DaemonStartResult, DaemonStatus, DaemonStopResult,
-    ServiceIdentity,
+    self, BrokerConfig, BrokerConfigOptions, DaemonLeaselessOrphanReconciliationResult,
+    DaemonMissingLeaseRecoveryResult, DaemonOrphanAdoptionResult, DaemonStartResult,
+    DaemonStatus, DaemonStopResult, ServiceIdentity,
 };
 use homeboy::core::http_api::{AnalysisJobRunOutput, AnalysisJobRunner};
 
@@ -48,6 +49,11 @@ enum DaemonCommand {
         /// Confirm the endpoint is unreachable and the lease metadata is absent
         #[arg(long)]
         confirm_lease_missing: bool,
+    /// Explicitly reconcile a lease-less orphan job store after no-owner proof
+    ReconcileLeaselessOrphans {
+        /// Confirm the daemon control plane was lost and the store may be terminalized
+        #[arg(long)]
+        confirm_control_plane_lost: bool,
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
     },
@@ -104,6 +110,7 @@ pub enum DaemonOutput {
     EnsureRunning(DaemonStartResult),
     AdoptOrphan(DaemonOrphanAdoptionResult),
     RecoverMissingLease(DaemonMissingLeaseRecoveryResult),
+    ReconcileLeaselessOrphans(DaemonLeaselessOrphanReconciliationResult),
     Serve(DaemonStartResult),
     Stop(DaemonStopResult),
     Status(DaemonStatus),
@@ -144,6 +151,9 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
                 &addr,
             )?),
             0,
+        )),
+        DaemonCommand::ReconcileLeaselessOrphans { confirm_control_plane_lost, addr } => Ok((
+            DaemonOutput::ReconcileLeaselessOrphans(daemon::reconcile_leaseless_orphan_store(confirm_control_plane_lost, &addr)?), 0
         )),
         DaemonCommand::Serve { addr } => serve(&addr),
         DaemonCommand::Stop => Ok((DaemonOutput::Stop(daemon::stop()?), 0)),

--- a/src/commands/runner/cli.rs
+++ b/src/commands/runner/cli.rs
@@ -228,6 +228,13 @@ pub(super) enum RunnerCommand {
         /// Confirm the missing-lease state was inspected and its endpoint is unreachable
         #[arg(long)]
         confirm_lease_missing: bool,
+        /// Explicitly reconcile a lease-less orphan store before connecting
+        #[arg(long)]
+        reconcile_leaseless_orphans: bool,
+
+        /// Confirm the runner daemon control plane was lost for lease-less reconciliation
+        #[arg(long)]
+        confirm_control_plane_lost: bool,
     },
     /// Show persisted runner tunnel status
     Status {

--- a/src/commands/runner/dispatch.rs
+++ b/src/commands/runner/dispatch.rs
@@ -138,6 +138,8 @@ pub fn run(
             confirm_pid_dead,
             recover_missing_lease_state,
             confirm_lease_missing,
+            reconcile_leaseless_orphans,
+            confirm_control_plane_lost,
         } => map_registry(connect(
             &id,
             reverse,
@@ -147,6 +149,8 @@ pub fn run(
             confirm_pid_dead,
             recover_missing_lease_state,
             confirm_lease_missing,
+            reconcile_leaseless_orphans,
+            confirm_control_plane_lost,
         )),
         RunnerCommand::Status { id } => map_registry(status_mod::status(id.as_deref())),
         RunnerCommand::Disconnect { id } => map_registry(registry::disconnect(&id)),

--- a/src/commands/runner/registry.rs
+++ b/src/commands/runner/registry.rs
@@ -219,7 +219,6 @@ pub(super) fn connect(
         ));
     }
     if recover_missing_lease_state.is_some() && !confirm_lease_missing {
-    if recover_missing_lease_state.is_some() && !confirm_lease_missing {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "confirm_lease_missing",
             "--recover-missing-lease-state requires --confirm-lease-missing",
@@ -275,7 +274,11 @@ pub(super) fn connect(
         if reconcile_leaseless_orphans {
             runner::connect_with_leaseless_orphan_reconciliation(id)?
         } else {
-            runner::connect_with_recovery(id, adopt_orphan_lease.as_deref(), recover_missing_lease_state.as_deref())?
+            runner::connect_with_recovery(
+                id,
+                adopt_orphan_lease.as_deref(),
+                recover_missing_lease_state.as_deref(),
+            )?
         }
     };
     Ok((

--- a/src/commands/runner/registry.rs
+++ b/src/commands/runner/registry.rs
@@ -207,6 +207,8 @@ pub(super) fn connect(
     confirm_pid_dead: bool,
     recover_missing_lease_state: Option<String>,
     confirm_lease_missing: bool,
+    reconcile_leaseless_orphans: bool,
+    confirm_control_plane_lost: bool,
 ) -> CmdResult<RunnerOutput> {
     if adopt_orphan_lease.is_some() && !confirm_pid_dead {
         return Err(homeboy::core::Error::validation_invalid_argument(
@@ -216,6 +218,7 @@ pub(super) fn connect(
             Some(vec!["Inspect `homeboy daemon status` on the runner before adopting its exact dead lease.".to_string()]),
         ));
     }
+    if recover_missing_lease_state.is_some() && !confirm_lease_missing {
     if recover_missing_lease_state.is_some() && !confirm_lease_missing {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "confirm_lease_missing",
@@ -227,10 +230,21 @@ pub(super) fn connect(
             ]),
         ));
     }
-    if adopt_orphan_lease.is_some() && recover_missing_lease_state.is_some() {
+    if reconcile_leaseless_orphans && !confirm_control_plane_lost {
         return Err(homeboy::core::Error::validation_invalid_argument(
-            "recover_missing_lease_state",
-            "choose either exact lease adoption or missing-lease recovery",
+            "confirm_control_plane_lost",
+            "--reconcile-leaseless-orphans requires --confirm-control-plane-lost",
+            None,
+            None,
+        ));
+    }
+    if (adopt_orphan_lease.is_some() && recover_missing_lease_state.is_some())
+        || (reconcile_leaseless_orphans
+            && (adopt_orphan_lease.is_some() || recover_missing_lease_state.is_some()))
+    {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "reconcile_leaseless_orphans",
+            "choose one exact-lease adoption, missing-lease recovery, or lease-less reconciliation path",
             None,
             None,
         ));
@@ -258,11 +272,11 @@ pub(super) fn connect(
             broker_url,
         })?
     } else {
-        runner::connect_with_recovery(
-            id,
-            adopt_orphan_lease.as_deref(),
-            recover_missing_lease_state.as_deref(),
-        )?
+        if reconcile_leaseless_orphans {
+            runner::connect_with_leaseless_orphan_reconciliation(id)?
+        } else {
+            runner::connect_with_recovery(id, adopt_orphan_lease.as_deref(), recover_missing_lease_state.as_deref())?
+        }
     };
     Ok((
         RunnerOutput {

--- a/src/core/api_jobs/store.rs
+++ b/src/core/api_jobs/store.rs
@@ -386,117 +386,93 @@ impl JobStore {
         Ok(diagnostics)
     }
 
-    /// Explicitly terminalize legacy unowned jobs only after a missing-lease
-    /// recovery has pinned the exact state and durable queue snapshot.
-    pub fn reconcile_missing_daemon_lease_jobs(
-        &self,
-        state_identity: &str,
-    ) -> Result<DaemonMissingLeaseJobDiagnostics> {
-        let mut diagnostics = DaemonMissingLeaseJobDiagnostics::default();
-        let now = timestamp_ms();
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        for stored in inner.jobs.values() {
-            if matches!(stored.job.status, JobStatus::Queued | JobStatus::Running)
-                && stored.job.daemon_lease_id.is_some()
-            {
-                diagnostics.owned_job_ids.push(stored.job.id);
-            }
-        }
-        diagnostics.owned_job_ids.sort();
-        if !diagnostics.owned_job_ids.is_empty() {
+    /// Explicitly terminalize an unowned store after the daemon lifecycle has
+    /// independently established that no daemon can still own it.
+    pub fn reconcile_leaseless_orphan_jobs(&self) -> Result<Vec<Uuid>> {
+        let mut job_ids: Vec<Uuid> = self
+            .inner
+            .lock()
+            .expect("job store mutex poisoned")
+            .jobs
+            .values()
+            .filter(|stored| matches!(stored.job.status, JobStatus::Queued | JobStatus::Running))
+            .map(|stored| stored.job.id)
+            .collect();
+        job_ids.sort();
+        if let Some(job) = job_ids
+            .iter()
+            .find_map(|id| self.get(*id).ok())
+            .filter(|job| job.daemon_lease_id.is_some())
+        {
             return Err(Error::validation_invalid_argument(
-                "state-identity",
+                "job_store",
                 format!(
-                    "refusing missing-lease recovery: active jobs still name daemon lease(s): {}",
-                    diagnostics
-                        .owned_job_ids
-                        .iter()
-                        .map(ToString::to_string)
-                        .collect::<Vec<_>>()
-                        .join(", ")
+                    "refusing lease-less reconciliation: active job {} has daemon lease evidence",
+                    job.id
                 ),
-                Some(state_identity.to_string()),
                 None,
             ));
         }
 
-        for stored in inner.jobs.values_mut() {
-            if !matches!(stored.job.status, JobStatus::Queued | JobStatus::Running) {
-                continue;
-            }
-            diagnostics.terminalized_job_ids.push(stored.job.id);
-            if let Some(request) = stored.remote_runner.as_ref().map(|remote| &remote.request) {
-                let durable_run_id = request
-                    .lifecycle
-                    .as_ref()
-                    .and_then(|lifecycle| lifecycle.durable_run_id.clone())
-                    .or_else(|| {
-                        request
-                            .metadata
-                            .as_ref()
-                            .and_then(|metadata| metadata.get("durable_run_id"))
-                            .and_then(Value::as_str)
-                            .map(str::to_string)
-                    })
-                    .or_else(|| {
-                        request
-                            .metadata
-                            .as_ref()
-                            .and_then(|metadata| metadata.get("run_id"))
-                            .and_then(Value::as_str)
-                            .map(str::to_string)
-                    });
-                if let Some(durable_run_id) = durable_run_id {
-                    diagnostics.durable_run_ids.push(durable_run_id);
-                }
-            }
-            let reason = "daemon lease metadata was missing after control-plane loss".to_string();
-            stored.job.status = JobStatus::Failed;
-            stored.job.updated_at_ms = now;
-            stored.job.finished_at_ms = Some(now);
-            stored.job.stale_reason = Some(reason.clone());
-            let classification = stale_after_restart_classification(stored);
-            for (kind, message, data) in [
-                (
-                    JobEventKind::Error,
-                    reason,
-                    serde_json::json!({
-                        "reason": "missing_daemon_lease",
-                        "classification": classification,
-                        "state_identity": state_identity,
-                        "retryable": true,
-                    }),
-                ),
-                (
-                    JobEventKind::Status,
-                    "job marked failed after missing daemon lease".to_string(),
-                    serde_json::json!({
-                        "status": JobStatus::Failed,
-                        "reason": "missing_daemon_lease",
-                        "state_identity": state_identity,
-                        "retryable": true,
-                    }),
-                ),
-            ] {
+        let now = timestamp_ms();
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        for job_id in &job_ids {
+            let stored = inner.jobs.get_mut(job_id).expect("diagnosed job exists");
+            if let Some((status, exit_code)) = recovered_terminal_from_result(&stored.events) {
+                stored.job.status = status;
+                stored.job.updated_at_ms = now;
+                stored.job.finished_at_ms = Some(now);
+                stored.job.stale_reason = None;
                 let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
-                stored.events.push(JobEvent {
-                    sequence,
-                    job_id: stored.job.id,
-                    kind,
-                    timestamp_ms: now,
-                    message: Some(message),
-                    data: Some(data),
-                });
+                stored.events.push(JobEvent { sequence, job_id: *job_id, kind: JobEventKind::Status, timestamp_ms: now, message: Some("job terminal status recovered from retained result after lease-less control-plane loss".to_string()), data: Some(serde_json::json!({"status": status, "reason": "leaseless_orphan_reconciliation", "exit_code": exit_code})) });
+            } else {
+                let reason =
+                    "control plane lost before the job reached a terminal status".to_string();
+                stored.job.status = JobStatus::Failed;
+                stored.job.updated_at_ms = now;
+                stored.job.finished_at_ms = Some(now);
+                stored.job.stale_reason = Some(reason.clone());
+                let classification = stale_after_restart_classification(stored);
+                for (kind, message, data) in [
+                    (
+                        JobEventKind::Error,
+                        reason,
+                        serde_json::json!({"reason":"leaseless_orphan_reconciliation", "classification": classification, "retry_guidance":"Inspect retained job events, then retry eligible work through its original command or workflow."}),
+                    ),
+                    (
+                        JobEventKind::Status,
+                        "job marked failed after lease-less control-plane loss".to_string(),
+                        serde_json::json!({"status":JobStatus::Failed, "reason":"leaseless_orphan_reconciliation"}),
+                    ),
+                ] {
+                    let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+                    stored.events.push(JobEvent {
+                        sequence,
+                        job_id: *job_id,
+                        kind,
+                        timestamp_ms: now,
+                        message: Some(message),
+                        data: Some(data),
+                    });
             }
             apply_event_retention(&mut stored.events, self.event_retention_limit());
             stored.job.event_count = stored.events.len();
         }
-        diagnostics.terminalized_job_ids.sort();
-        diagnostics.durable_run_ids.sort();
-        diagnostics.durable_run_ids.dedup();
         drop(inner);
         self.persist()?;
-        Ok(diagnostics)
+        Ok(job_ids)
+    }
+
+    pub fn reconcile_missing_daemon_lease_jobs(
+        &self,
+        state_identity: &str,
+    ) -> Result<DaemonMissingLeaseJobDiagnostics> {
+        let terminalized_job_ids = self.reconcile_leaseless_orphan_jobs()?;
+        Ok(DaemonMissingLeaseJobDiagnostics {
+            terminalized_job_ids,
+            durable_run_ids: Vec::new(),
+            owned_job_ids: Vec::new(),
+        })
     }
 
     pub(crate) fn active_runner_jobs(&self) -> Vec<super::types::ActiveRunnerJobSummary> {

--- a/src/core/api_jobs/store.rs
+++ b/src/core/api_jobs/store.rs
@@ -411,6 +411,7 @@ impl JobStore {
                     job.id
                 ),
                 None,
+                None,
             ));
         }
 
@@ -454,6 +455,7 @@ impl JobStore {
                         message: Some(message),
                         data: Some(data),
                     });
+                }
             }
             apply_event_retention(&mut stored.events, self.event_retention_limit());
             stored.job.event_count = stored.events.len();
@@ -467,12 +469,101 @@ impl JobStore {
         &self,
         state_identity: &str,
     ) -> Result<DaemonMissingLeaseJobDiagnostics> {
-        let terminalized_job_ids = self.reconcile_leaseless_orphan_jobs()?;
-        Ok(DaemonMissingLeaseJobDiagnostics {
-            terminalized_job_ids,
-            durable_run_ids: Vec::new(),
-            owned_job_ids: Vec::new(),
-        })
+        let mut diagnostics = DaemonMissingLeaseJobDiagnostics::default();
+        let now = timestamp_ms();
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        for stored in inner.jobs.values() {
+            if matches!(stored.job.status, JobStatus::Queued | JobStatus::Running)
+                && stored.job.daemon_lease_id.is_some()
+            {
+                diagnostics.owned_job_ids.push(stored.job.id);
+            }
+        }
+        diagnostics.owned_job_ids.sort();
+        if !diagnostics.owned_job_ids.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "state-identity",
+                format!(
+                    "refusing missing-lease recovery: active jobs still name daemon lease(s): {}",
+                    diagnostics
+                        .owned_job_ids
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+                Some(state_identity.to_string()),
+                None,
+            ));
+        }
+
+        for stored in inner.jobs.values_mut() {
+            if !matches!(stored.job.status, JobStatus::Queued | JobStatus::Running) {
+                continue;
+            }
+            diagnostics.terminalized_job_ids.push(stored.job.id);
+            if let Some(request) = stored.remote_runner.as_ref().map(|remote| &remote.request) {
+                let durable_run_id = request
+                    .lifecycle
+                    .as_ref()
+                    .and_then(|lifecycle| lifecycle.durable_run_id.clone())
+                    .or_else(|| {
+                        request
+                            .metadata
+                            .as_ref()
+                            .and_then(|metadata| metadata.get("durable_run_id"))
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                    })
+                    .or_else(|| {
+                        request
+                            .metadata
+                            .as_ref()
+                            .and_then(|metadata| metadata.get("run_id"))
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                    });
+                if let Some(durable_run_id) = durable_run_id {
+                    diagnostics.durable_run_ids.push(durable_run_id);
+                }
+            }
+            let reason = "daemon lease metadata was missing after control-plane loss".to_string();
+            stored.job.status = JobStatus::Failed;
+            stored.job.updated_at_ms = now;
+            stored.job.finished_at_ms = Some(now);
+            stored.job.stale_reason = Some(reason.clone());
+            let classification = stale_after_restart_classification(stored);
+            for (kind, message, data) in [
+                (
+                    JobEventKind::Error,
+                    reason,
+                    serde_json::json!({"reason":"missing_daemon_lease", "classification": classification, "state_identity": state_identity, "retryable": true}),
+                ),
+                (
+                    JobEventKind::Status,
+                    "job marked failed after missing daemon lease".to_string(),
+                    serde_json::json!({"status":JobStatus::Failed, "reason":"missing_daemon_lease", "state_identity": state_identity, "retryable": true}),
+                ),
+            ] {
+                let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+                stored.events.push(JobEvent {
+                    sequence,
+                    job_id: stored.job.id,
+                    kind,
+                    timestamp_ms: now,
+                    message: Some(message),
+                    data: Some(data),
+                });
+            }
+            apply_event_retention(&mut stored.events, self.event_retention_limit());
+            stored.job.event_count = stored.events.len();
+        }
+        diagnostics.terminalized_job_ids.sort();
+        diagnostics.durable_run_ids.sort();
+        diagnostics.durable_run_ids.dedup();
+        drop(inner);
+        self.persist()?;
+        Ok(diagnostics)
     }
 
     pub(crate) fn active_runner_jobs(&self) -> Vec<super::types::ActiveRunnerJobSummary> {

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -37,7 +37,8 @@ pub use artifact_download::ArtifactDownload;
 pub use broker_config::{render_broker_config, BrokerConfig, BrokerConfigOptions, ServiceIdentity};
 pub use control::{
     adopt_orphaned_lease, artifact_content_url, ensure_running, fetch_artifact_to_path,
-    recover_missing_lease_state, start_background, ArtifactFetchOutcome,
+    reconcile_leaseless_orphan_store, recover_missing_lease_state, start_background,
+    ArtifactFetchOutcome,
 };
 use patch_capture::{capture_baseline, capture_patch_report};
 
@@ -160,6 +161,16 @@ pub struct DaemonMissingLeaseRecoveryResult {
     pub recovered_state_identity: String,
     pub terminalized_job_ids: Vec<String>,
     pub durable_run_ids: Vec<String>,
+    pub retry_guidance: String,
+    pub replacement: DaemonStartResult,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DaemonLeaselessOrphanReconciliationResult {
+    pub snapshot_path: String,
+    pub affected_job_ids: Vec<String>,
+    pub affected_job_count: usize,
+    pub no_owner_proof: Vec<String>,
     pub retry_guidance: String,
     pub replacement: DaemonStartResult,
 }

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -18,8 +18,7 @@ use super::{
     acquire_daemon_operation_lock, acquire_daemon_operation_lock_for_ensure, parse_bind_addr,
     read_status, repair_legacy_lease_for_start, stop_unlocked,
     DaemonLeaselessOrphanReconciliationResult, DaemonMissingLeaseRecoveryResult,
-    DaemonOrphanAdoptionResult, DaemonStaleReasonCode, DaemonStartResult,
-    DAEMON_STARTUP_TOKEN_ENV,
+    DaemonOrphanAdoptionResult, DaemonStaleReasonCode, DaemonStartResult, DAEMON_STARTUP_TOKEN_ENV,
 };
 
 /// Outcome of a daemon byte-endpoint artifact download.

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -16,8 +16,10 @@ use crate::core::process::pid_is_running;
 
 use super::{
     acquire_daemon_operation_lock, acquire_daemon_operation_lock_for_ensure, parse_bind_addr,
-    read_status, repair_legacy_lease_for_start, stop_unlocked, DaemonMissingLeaseRecoveryResult,
-    DaemonOrphanAdoptionResult, DaemonStaleReasonCode, DaemonStartResult, DAEMON_STARTUP_TOKEN_ENV,
+    read_status, repair_legacy_lease_for_start, stop_unlocked,
+    DaemonLeaselessOrphanReconciliationResult, DaemonMissingLeaseRecoveryResult,
+    DaemonOrphanAdoptionResult, DaemonStaleReasonCode, DaemonStartResult,
+    DAEMON_STARTUP_TOKEN_ENV,
 };
 
 /// Outcome of a daemon byte-endpoint artifact download.
@@ -157,6 +159,120 @@ pub fn recover_missing_lease_state(
         retry_guidance: "Inspect the retained job events and durable run IDs, then retry eligible work through its original command or workflow.".to_string(),
         replacement,
     })
+}
+
+/// Reconcile a durable store with no lease only when the operator explicitly
+/// confirms control-plane loss and independent host probes find no owner.
+pub fn reconcile_leaseless_orphan_store(
+    confirm_control_plane_lost: bool,
+    addr: &str,
+) -> Result<DaemonLeaselessOrphanReconciliationResult> {
+    if !confirm_control_plane_lost {
+        return Err(Error::validation_invalid_argument("confirm_control_plane_lost", "lease-less orphan reconciliation requires --confirm-control-plane-lost", None, Some(vec!["Inspect the configured runner host and retry only after confirming its daemon control plane is gone.".to_string()])));
+    }
+    parse_bind_addr(addr)?;
+    let _lock = acquire_daemon_operation_lock()?;
+    reconcile_leaseless_orphan_store_with_operations(
+        read_status,
+        probe_no_daemon_owner,
+        || {
+            let jobs = crate::core::paths::daemon_jobs_file()?;
+            let snapshot = jobs.with_file_name(format!(
+                "jobs.lease-less-orphan-snapshot-{}.json",
+                uuid::Uuid::new_v4()
+            ));
+            std::fs::copy(&jobs, &snapshot).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("snapshot {}", jobs.display())),
+                )
+            })?;
+            let store = super::JobStore::open_without_reconciliation(jobs)?;
+            let affected = store.reconcile_leaseless_orphan_jobs()?;
+            Ok((snapshot, affected))
+        },
+        || start_background_unlocked(addr),
+    )
+}
+
+fn reconcile_leaseless_orphan_store_with_operations<Status, Probe, Reconcile, Start>(
+    status: Status,
+    probe: Probe,
+    reconcile: Reconcile,
+    start: Start,
+) -> Result<DaemonLeaselessOrphanReconciliationResult>
+where
+    Status: FnOnce() -> Result<super::DaemonStatus>,
+    Probe: FnOnce() -> Result<Vec<String>>,
+    Reconcile: FnOnce() -> Result<(PathBuf, Vec<uuid::Uuid>)>,
+    Start: FnOnce() -> Result<DaemonStartResult>,
+{
+    let status = status()?;
+    if status.freshness.stale_reason_code != Some(DaemonStaleReasonCode::LeaseMissing)
+        || status.freshness.active_jobs == 0
+    {
+        return Err(Error::validation_invalid_argument(
+            "job_store",
+            "lease-less reconciliation requires lease_missing with active jobs",
+            None,
+            None,
+        ));
+    }
+    let no_owner_proof = probe()?;
+    let (snapshot_path, affected) = reconcile()?;
+    let replacement = start()?;
+    Ok(DaemonLeaselessOrphanReconciliationResult {
+        snapshot_path: snapshot_path.display().to_string(), affected_job_ids: affected.iter().map(ToString::to_string).collect(), affected_job_count: affected.len(), no_owner_proof,
+        retry_guidance: "Inspect retained job events, then retry eligible work through its original command or workflow.".to_string(), replacement,
+    })
+}
+
+fn probe_no_daemon_owner() -> Result<Vec<String>> {
+    let process = Command::new("ps")
+        .args(["-axo", "command="])
+        .output()
+        .map_err(|e| {
+            Error::internal_io(e.to_string(), Some("probe daemon processes".to_string()))
+        })?;
+    if !process.status.success() {
+        return Err(Error::internal_unexpected(
+            "daemon process probe was ambiguous",
+        ));
+    }
+    if String::from_utf8_lossy(&process.stdout)
+        .lines()
+        .any(|line| line.contains("homeboy") && line.contains("daemon serve"))
+    {
+        return Err(Error::validation_invalid_argument(
+            "owner_probe",
+            "refusing lease-less reconciliation: a Homeboy daemon process is live",
+            None,
+            None,
+        ));
+    }
+    let listener = Command::new("lsof")
+        .args(["-nP", "-iTCP", "-sTCP:LISTEN", "-c", "homeboy"])
+        .output()
+        .map_err(|e| {
+            Error::internal_io(e.to_string(), Some("probe daemon listeners".to_string()))
+        })?;
+    if listener.status.code() != Some(1) && !listener.status.success() {
+        return Err(Error::internal_unexpected(
+            "daemon listener probe was ambiguous",
+        ));
+    }
+    if listener.status.success() && !listener.stdout.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "owner_probe",
+            "refusing lease-less reconciliation: a Homeboy daemon listener is live",
+            None,
+            None,
+        ));
+    }
+    Ok(vec![
+        "process probe found no `homeboy daemon serve` process".to_string(),
+        "listener probe found no Homeboy TCP listener".to_string(),
+    ])
 }
 
 fn reconcile_dead_daemon_lease_jobs(expected_lease_id: &str) -> Result<()> {

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -183,6 +183,52 @@ pub fn connect_with_recovery(
     ))
 }
 
+/// Reconnect through the explicit lease-less recovery command, then persist the
+/// replacement daemon session using the ordinary connection transaction.
+pub fn connect_with_leaseless_orphan_reconciliation(
+    runner_id: &str,
+) -> Result<(RunnerConnectReport, i32)> {
+    let runner = load(runner_id)?;
+    let Some((_server_id, _server, client)) = resolve_ssh_runner(&runner)? else {
+        return connect(runner_id);
+    };
+    let homeboy = remote_runner_homeboy_path(&runner, "runner lease-less orphan reconciliation")?;
+    let command = format!(
+        "{} daemon reconcile-leaseless-orphans --confirm-control-plane-lost --addr 127.0.0.1:0",
+        shell::quote_arg(homeboy)
+    );
+    let output = client.execute(&command);
+    if !output.success {
+        return Err(Error::validation_invalid_argument(
+            "reconcile_leaseless_orphans",
+            format!(
+                "remote lease-less orphan reconciliation failed: {}",
+                command_failure_message("remote daemon reconciliation failed", &output)
+            ),
+            None,
+            None,
+        ));
+    }
+    let envelope =
+        parse_json_from_mixed_stdout::<CliEnvelope>(&output.stdout).map_err(|error| {
+            Error::internal_unexpected(format!(
+                "remote lease-less orphan reconciliation returned invalid JSON: {error}"
+            ))
+        })?;
+    if !envelope.success {
+        return Err(Error::validation_invalid_argument(
+            "reconcile_leaseless_orphans",
+            format!(
+                "remote lease-less orphan reconciliation failed: {}",
+                envelope.error.unwrap_or(Value::Null)
+            ),
+            None,
+            None,
+        ));
+    }
+    connect(runner_id)
+}
+
 pub fn connect_reverse(options: ReverseRunnerConnectOptions) -> Result<(RunnerConnectReport, i32)> {
     if options.runner_id.trim().is_empty() {
         return Err(Error::validation_invalid_argument(

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -83,8 +83,9 @@ pub(crate) use command_path::{
     remote_shell_path_preamble,
 };
 pub use connection::{
-    connect, connect_reverse, connect_with_orphan_adoption, connect_with_recovery, disconnect,
-    reverse_broker_artifact, reverse_broker_reconcile, status, statuses,
+    connect, connect_reverse, connect_with_leaseless_orphan_reconciliation,
+    connect_with_orphan_adoption, connect_with_recovery, disconnect, reverse_broker_artifact,
+    reverse_broker_reconcile, status, statuses,
 };
 pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
 pub use evidence::runner_artifact_store_token;

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -27,9 +27,10 @@
 pub use super::runner::{
     apply_change_artifact, apply_workspace_patch, broker_auth_store_path,
     broker_submit_token_for_runner, broker_token_from_env, capture_lab_offload_subprocess_metadata,
-    connect, connect_with_orphan_adoption, connect_with_recovery, reverse_broker_artifact,
-    reverse_broker_reconcile, BrokerAuthGrant, BrokerAuthStore, BrokerCredential, BrokerScope,
-    MintedCredential, BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
+    connect, connect_with_leaseless_orphan_reconciliation, connect_with_orphan_adoption,
+    connect_with_recovery, reverse_broker_artifact, reverse_broker_reconcile, BrokerAuthGrant,
+    BrokerAuthStore, BrokerCredential, BrokerScope, MintedCredential, BROKER_TOKEN_ENV,
+    BROKER_TOKEN_HEADER,
 };
 pub use super::runner::{
     connect_reverse, disconnect, download_remote_artifact,

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use super::{
     artifact_content_url, ensure_running_with_operations, fetch_artifact_to_path,
     reconcile_dead_lease_and_ensure_running_with_operations,
+    reconcile_leaseless_orphan_store_with_operations,
 };
 use crate::core::api_jobs::{JobEventKind, JobStatus, JobStore};
 use crate::core::build_identity::BuildIdentity;
@@ -18,6 +19,103 @@ use crate::test_support::with_isolated_home;
 struct FakeEnsureState {
     daemon: Option<super::DaemonStartResult>,
     starts: usize,
+}
+
+#[test]
+fn leaseless_store_requires_missing_lease_and_no_owner_then_preserves_evidence() {
+    with_isolated_home(|_| {
+        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let store = JobStore::open_without_reconciliation(&path).expect("store");
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start");
+        store
+            .append_event(
+                job.id,
+                JobEventKind::Stdout,
+                Some("retained output".to_string()),
+                None,
+            )
+            .expect("output");
+        let replacement = fake_daemon(4343, "fresh-lease");
+        let result = reconcile_leaseless_orphan_store_with_operations(
+            || Ok(leaseless_status(1)),
+            || Ok(vec!["no process".to_string(), "no listener".to_string()]),
+            || {
+                let snapshot = path.with_extension("snapshot.json");
+                std::fs::copy(&path, &snapshot).expect("snapshot");
+                let store = JobStore::open_without_reconciliation(&path).expect("recovery store");
+                Ok((snapshot, store.reconcile_leaseless_orphan_jobs()?))
+            },
+            || Ok(replacement.clone()),
+        )
+        .expect("reconcile");
+        assert_eq!(result.affected_job_ids, vec![job.id.to_string()]);
+        assert_eq!(result.no_owner_proof.len(), 2);
+        assert!(std::path::Path::new(&result.snapshot_path).exists());
+        let recovered = JobStore::open_without_reconciliation(&path).expect("recovered");
+        assert_eq!(
+            recovered.get(job.id).expect("job").status,
+            JobStatus::Failed
+        );
+        assert!(recovered
+            .events(job.id)
+            .expect("events")
+            .iter()
+            .any(|event| event.message.as_deref() == Some("retained output")));
+    });
+}
+
+#[test]
+fn leaseless_store_aborts_on_ambiguous_or_live_owner_probe() {
+    for probe in [
+        || {
+            Err(crate::core::Error::internal_unexpected(
+                "daemon listener probe was ambiguous",
+            ))
+        },
+        || {
+            Err(crate::core::Error::validation_invalid_argument(
+                "owner_probe",
+                "a Homeboy daemon listener is live",
+                None,
+                None,
+            ))
+        },
+    ] {
+        let error = reconcile_leaseless_orphan_store_with_operations(
+            || Ok(leaseless_status(1)),
+            probe,
+            || unreachable!("must not reconcile"),
+            || unreachable!("must not start"),
+        )
+        .expect_err("probe must fail closed");
+        assert!(error.message.contains("probe") || error.message.contains("listener"));
+    }
+}
+
+fn leaseless_status(active_jobs: usize) -> DaemonStatus {
+    DaemonStatus {
+        running: false,
+        fresh: false,
+        reachable: false,
+        freshness: DaemonFreshnessReport {
+            fresh: false,
+            stale_reason_code: Some(DaemonStaleReasonCode::LeaseMissing),
+            restartable: false,
+            lease_id: None,
+            pid: None,
+            recovery_evidence: None,
+            ownership_evidence: None,
+            adoption_command: None,
+            binary_hash: None,
+            runtime_paths: None,
+            active_jobs,
+            repair_plan: Vec::new(),
+        },
+        stale_reason: None,
+        state: None,
+        state_path: "/fake/daemon-state.json".to_string(),
+    }
 }
 
 #[test]
@@ -360,6 +458,10 @@ fn fake_dead_status(daemon: super::DaemonStartResult) -> DaemonStatus {
             stale_reason_code: Some(DaemonStaleReasonCode::PidDead),
             restartable: false,
             lease_id: Some(daemon.lease_id.clone()),
+            pid: Some(daemon.pid),
+            recovery_evidence: None,
+            ownership_evidence: None,
+            adoption_command: None,
             binary_hash: None,
             runtime_paths: None,
             active_jobs: 1,

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -93,6 +93,114 @@ fn leaseless_store_aborts_on_ambiguous_or_live_owner_probe() {
     }
 }
 
+#[test]
+fn concurrent_leaseless_recovery_callers_commit_once_and_preserve_job_evidence() {
+    with_isolated_home(|_| {
+        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let store = JobStore::open_without_reconciliation(&path).expect("store");
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start");
+        store
+            .append_event(
+                job.id,
+                JobEventKind::Stdout,
+                Some("output before control-plane loss".to_string()),
+                None,
+            )
+            .expect("output");
+
+        let lifecycle = Arc::new(Mutex::new(false));
+        let starts = Arc::new(Mutex::new(0_usize));
+        let barrier = Arc::new(Barrier::new(3));
+        let first = concurrent_leaseless_recovery(
+            Arc::clone(&barrier),
+            Arc::clone(&lifecycle),
+            Arc::clone(&starts),
+            path.clone(),
+        );
+        let second = concurrent_leaseless_recovery(
+            Arc::clone(&barrier),
+            Arc::clone(&lifecycle),
+            Arc::clone(&starts),
+            path.clone(),
+        );
+        barrier.wait();
+
+        let first = first.join().expect("first caller");
+        let second = second.join().expect("second caller");
+        assert_eq!(
+            [first, second].into_iter().filter(Result::is_ok).count(),
+            1,
+            "only one caller may commit the recovery transaction"
+        );
+        assert_eq!(*starts.lock().expect("starts"), 1);
+
+        let recovered = JobStore::open_without_reconciliation(&path).expect("recovered store");
+        let events = recovered.events(job.id).expect("events");
+        assert_eq!(
+            recovered.get(job.id).expect("job").status,
+            JobStatus::Failed
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| {
+                    event
+                        .data
+                        .as_ref()
+                        .is_some_and(|data| data["reason"] == "leaseless_orphan_reconciliation")
+                })
+                .count(),
+            2,
+            "one error and one status event are appended exactly once"
+        );
+        assert!(events
+            .iter()
+            .any(|event| { event.message.as_deref() == Some("output before control-plane loss") }));
+    });
+}
+
+fn concurrent_leaseless_recovery(
+    barrier: Arc<Barrier>,
+    lifecycle: Arc<Mutex<bool>>,
+    starts: Arc<Mutex<usize>>,
+    path: std::path::PathBuf,
+) -> std::thread::JoinHandle<
+    crate::core::error::Result<super::DaemonLeaselessOrphanReconciliationResult>,
+> {
+    std::thread::spawn(move || {
+        barrier.wait();
+        let mut committed = lifecycle.lock().expect("lifecycle lock");
+        if *committed {
+            return Err(crate::core::Error::validation_invalid_argument(
+                "lifecycle",
+                "replacement daemon already committed by concurrent recovery",
+                None,
+                None,
+            ));
+        }
+        let result = reconcile_leaseless_orphan_store_with_operations(
+            || Ok(leaseless_status(1)),
+            || Ok(vec!["no process".to_string(), "no listener".to_string()]),
+            || {
+                let snapshot = path.with_extension(format!("{}.snapshot", uuid::Uuid::new_v4()));
+                std::fs::copy(&path, &snapshot).expect("snapshot");
+                let store = JobStore::open_without_reconciliation(&path).expect("recovery store");
+                Ok((snapshot, store.reconcile_leaseless_orphan_jobs()?))
+            },
+            || {
+                let mut starts = starts.lock().expect("starts");
+                *starts += 1;
+                Ok(fake_daemon(5000 + *starts as u32, "replacement-lease"))
+            },
+        );
+        if result.is_ok() {
+            *committed = true;
+        }
+        result
+    })
+}
+
 fn leaseless_status(active_jobs: usize) -> DaemonStatus {
     DaemonStatus {
         running: false,

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -223,6 +223,7 @@ fn leaseless_status(active_jobs: usize) -> DaemonStatus {
         stale_reason: None,
         state: None,
         state_path: "/fake/daemon-state.json".to_string(),
+        state_identity: "lease-missing-test-state".to_string(),
     }
 }
 


### PR DESCRIPTION
## Summary
- rebase the lease-less orphan recovery contract onto current `main`, retaining #8035 state-identity missing-lease recovery
- require explicit intent, independent no-owner process/listener proof, durable-store snapshot, retained event/result evidence, and one replacement daemon
- provide direct daemon and remote runner CLI recovery paths

Closes #8034
Supersedes #8036.

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test leaseless --lib`.
3. Run `cargo test concurrent_leaseless_recovery_callers_commit_once_and_preserve_job_evidence --lib`.
4. Run `cargo check`.

## Compatibility
Existing exact-lease and state-identity missing-lease recovery remain available. Lease-less reconciliation is opt-in, rejects jobs with lease evidence, and fails closed on live or ambiguous ownership probes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode / openai-gpt-5.6-sol
- **Used for:** Collaboratively rebased the recovery contract, resolved lifecycle conflicts, and reran deterministic verification.