### PR TITLE
Recover stale linked rigs from active checkout paths

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -645,7 +645,7 @@ pub fn run(mut args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> 
         ));
     }
     if let Some(profile) = &run_args.profile {
-        matrix::validate_profile_available_for_rigs(&run_args.rig, profile)?;
+        matrix::validate_profile_available_for_rigs(run_args, profile)?;
     }
 
     let ordered_rigs = ordered_rig_ids(run_args);

--- a/src/commands/bench/default_baseline.rs
+++ b/src/commands/bench/default_baseline.rs
@@ -116,7 +116,8 @@ pub(super) fn maybe_expand_default_baseline(
     }
 
     let candidate = &args.rig[0];
-    let candidate_spec = rig::load(candidate)?;
+    let candidate_spec =
+        rig::RigSourceContext::load_for_invocation_at(candidate, args.comp.path.as_deref())?.spec;
     if args.comp.id().is_none()
         && candidate_spec
             .bench

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -40,7 +40,8 @@ fn prepare_rig_bench_context(
     rig_id: &str,
     args: &BenchRunArgs,
 ) -> homeboy::core::Result<RigBenchContext> {
-    let mut source = rig::RigSourceContext::load_for_invocation(rig_id)?;
+    let mut source =
+        rig::RigSourceContext::load_for_invocation_at(rig_id, args.comp.path.as_deref())?;
     report_rig_source(&source);
     let mut spec = source.spec.clone();
     let declared_spec = spec.clone();
@@ -147,14 +148,15 @@ fn rig_bench_components(spec: &RigSpec) -> Vec<String> {
 }
 
 pub(super) fn validate_profile_available_for_rigs(
-    rig_ids: &[String],
+    args: &BenchRunArgs,
     profile: &str,
 ) -> homeboy::core::Result<()> {
     let mut missing = Vec::new();
     let mut available_by_rig = Vec::new();
 
-    for rig_id in rig_ids {
-        let spec = rig::RigSourceContext::load_for_invocation(rig_id)?.spec;
+    for rig_id in &args.rig {
+        let spec =
+            rig::RigSourceContext::load_for_invocation_at(rig_id, args.comp.path.as_deref())?.spec;
         if !spec.bench_profiles.contains_key(profile) {
             missing.push(rig_id.clone());
         }

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -622,6 +622,29 @@ impl RigSourceContext {
         }
         Self::load(id)
     }
+
+    /// Load a rig for an invocation with an explicit component checkout.
+    ///
+    /// A linked rig source can disappear when its managed worktree is cleaned
+    /// up. When the active checkout contains the same rig declaration, refresh
+    /// the installed link through the normal install ownership checks.
+    pub fn load_for_invocation_at(id: &str, component_path: Option<&str>) -> Result<Self> {
+        let Some(component_path) = component_path else {
+            return Self::load_for_invocation(id);
+        };
+        let Some(metadata) = read_source_metadata(id) else {
+            return Self::load_for_invocation(id);
+        };
+        if !metadata.linked || Path::new(&metadata.package_path).is_dir() {
+            return Self::load_for_invocation(id);
+        }
+
+        // Confirm the active checkout declares this rig before refreshing its
+        // global registration. `install` then enforces existing ID ownership.
+        load_local_source(component_path, Some(id))?;
+        install(component_path, Some(id), false)?;
+        Self::load(id)
+    }
 }
 
 fn enclosing_local_package_for_rig(id: &str) -> Result<Option<PathBuf>> {

--- a/tests/core/rig/bench_rig_path_override_test.rs
+++ b/tests/core/rig/bench_rig_path_override_test.rs
@@ -9,6 +9,28 @@
 
 use super::*;
 
+fn write_package_rig(package: &std::path::Path, id: &str) {
+    let rig_dir = package.join("rigs").join(id);
+    std::fs::create_dir_all(&rig_dir).expect("create rig package");
+    std::fs::write(
+        rig_dir.join("rig.json"),
+        format!(
+            r#"{{
+                "id": "{id}",
+                "components": {{
+                    "studio": {{
+                        "path": "{}",
+                        "extensions": {{ "fixture-bench": {{}} }}
+                    }}
+                }},
+                "bench": {{ "default_component": "studio" }}
+            }}"#,
+            package.display()
+        ),
+    )
+    .expect("write rig package");
+}
+
 #[test]
 fn rig_pinned_bench_with_path_override_records_effective_component_path() {
     with_isolated_home(|home| {
@@ -85,5 +107,70 @@ fn rig_pinned_bench_without_path_override_keeps_rig_declared_path() {
             }
             _ => panic!("expected single output"),
         }
+    });
+}
+
+#[test]
+fn rig_pinned_bench_repairs_missing_linked_source_from_path_override() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let source_a = tempfile::TempDir::new().expect("source A");
+        let checkout_b = tempfile::TempDir::new().expect("checkout B");
+        write_package_rig(source_a.path(), "stale-rig");
+        write_package_rig(checkout_b.path(), "stale-rig");
+        homeboy::core::rig::install(
+            source_a.path().to_str().expect("source A path"),
+            None,
+            false,
+        )
+        .expect("install linked rig from source A");
+        std::fs::remove_dir_all(source_a.path()).expect("remove source A");
+
+        let mut args = run_args(
+            None,
+            vec!["stale-rig".to_string()],
+            vec!["rig-slow".to_string()],
+        );
+        args.run.comp.path = Some(checkout_b.path().to_string_lossy().into_owned());
+
+        let (_, exit_code) = run(args, &GlobalArgs {}).expect("bench recovers linked rig source");
+
+        assert_eq!(exit_code, 0);
+        let metadata = homeboy::core::rig::read_source_metadata("stale-rig")
+            .expect("refreshed source metadata");
+        assert_eq!(metadata.package_path, checkout_b.path().to_string_lossy());
+    });
+}
+
+#[test]
+fn missing_linked_source_recovery_preserves_conflicting_user_owned_rig() {
+    with_isolated_home(|home| {
+        let source_a = tempfile::TempDir::new().expect("source A");
+        let checkout_b = tempfile::TempDir::new().expect("checkout B");
+        write_package_rig(source_a.path(), "stale-rig");
+        write_package_rig(checkout_b.path(), "stale-rig");
+        homeboy::core::rig::install(
+            source_a.path().to_str().expect("source A path"),
+            None,
+            false,
+        )
+        .expect("install linked rig from source A");
+        std::fs::remove_dir_all(source_a.path()).expect("remove source A");
+
+        let config_path = home.path().join(".config/homeboy/rigs/stale-rig.json");
+        let user_owned = r#"{ "id": "other-rig", "components": {} }"#;
+        std::fs::write(&config_path, user_owned).expect("write conflicting user rig");
+
+        let error = homeboy::core::rig::RigSourceContext::load_for_invocation_at(
+            "stale-rig",
+            Some(checkout_b.path().to_str().expect("checkout B path")),
+        )
+        .expect_err("conflicting user rig must remain protected");
+
+        assert!(error.message.contains("refusing to replace"));
+        assert_eq!(
+            std::fs::read_to_string(config_path).expect("read user rig"),
+            user_owned
+        );
     });
 }

--- a/tests/core/rig/bench_rig_path_override_test.rs
+++ b/tests/core/rig/bench_rig_path_override_test.rs
@@ -9,28 +9,6 @@
 
 use super::*;
 
-fn write_package_rig(package: &std::path::Path, id: &str) {
-    let rig_dir = package.join("rigs").join(id);
-    std::fs::create_dir_all(&rig_dir).expect("create rig package");
-    std::fs::write(
-        rig_dir.join("rig.json"),
-        format!(
-            r#"{{
-                "id": "{id}",
-                "components": {{
-                    "studio": {{
-                        "path": "{}",
-                        "extensions": {{ "fixture-bench": {{}} }}
-                    }}
-                }},
-                "bench": {{ "default_component": "studio" }}
-            }}"#,
-            package.display()
-        ),
-    )
-    .expect("write rig package");
-}
-
 #[test]
 fn rig_pinned_bench_with_path_override_records_effective_component_path() {
     with_isolated_home(|home| {
@@ -107,70 +85,5 @@ fn rig_pinned_bench_without_path_override_keeps_rig_declared_path() {
             }
             _ => panic!("expected single output"),
         }
-    });
-}
-
-#[test]
-fn rig_pinned_bench_repairs_missing_linked_source_from_path_override() {
-    with_isolated_home(|home| {
-        write_bench_extension(home);
-        let source_a = tempfile::TempDir::new().expect("source A");
-        let checkout_b = tempfile::TempDir::new().expect("checkout B");
-        write_package_rig(source_a.path(), "stale-rig");
-        write_package_rig(checkout_b.path(), "stale-rig");
-        homeboy::core::rig::install(
-            source_a.path().to_str().expect("source A path"),
-            None,
-            false,
-        )
-        .expect("install linked rig from source A");
-        std::fs::remove_dir_all(source_a.path()).expect("remove source A");
-
-        let mut args = run_args(
-            None,
-            vec!["stale-rig".to_string()],
-            vec!["rig-slow".to_string()],
-        );
-        args.run.comp.path = Some(checkout_b.path().to_string_lossy().into_owned());
-
-        let (_, exit_code) = run(args, &GlobalArgs {}).expect("bench recovers linked rig source");
-
-        assert_eq!(exit_code, 0);
-        let metadata = homeboy::core::rig::read_source_metadata("stale-rig")
-            .expect("refreshed source metadata");
-        assert_eq!(metadata.package_path, checkout_b.path().to_string_lossy());
-    });
-}
-
-#[test]
-fn missing_linked_source_recovery_preserves_conflicting_user_owned_rig() {
-    with_isolated_home(|home| {
-        let source_a = tempfile::TempDir::new().expect("source A");
-        let checkout_b = tempfile::TempDir::new().expect("checkout B");
-        write_package_rig(source_a.path(), "stale-rig");
-        write_package_rig(checkout_b.path(), "stale-rig");
-        homeboy::core::rig::install(
-            source_a.path().to_str().expect("source A path"),
-            None,
-            false,
-        )
-        .expect("install linked rig from source A");
-        std::fs::remove_dir_all(source_a.path()).expect("remove source A");
-
-        let config_path = home.path().join(".config/homeboy/rigs/stale-rig.json");
-        let user_owned = r#"{ "id": "other-rig", "components": {} }"#;
-        std::fs::write(&config_path, user_owned).expect("write conflicting user rig");
-
-        let error = homeboy::core::rig::RigSourceContext::load_for_invocation_at(
-            "stale-rig",
-            Some(checkout_b.path().to_str().expect("checkout B path")),
-        )
-        .expect_err("conflicting user rig must remain protected");
-
-        assert!(error.message.contains("refusing to replace"));
-        assert_eq!(
-            std::fs::read_to_string(config_path).expect("read user rig"),
-            user_owned
-        );
     });
 }

--- a/tests/stale_linked_rig_recovery.rs
+++ b/tests/stale_linked_rig_recovery.rs
@@ -1,0 +1,165 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}
+
+fn run_homeboy(home: &Path, args: &[&str]) -> Output {
+    Command::new(homeboy_bin())
+        .args(["--placement", "local"])
+        .args(args)
+        .env("HOME", home)
+        .env("XDG_DATA_HOME", home.join(".local/share"))
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("run homeboy")
+}
+
+fn assert_success(output: Output, args: &[&str]) {
+    assert!(
+        output.status.success(),
+        "homeboy {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn write_bench_extension(home: &Path) {
+    let extension_dir = home.join(".config/homeboy/extensions/fixture-bench");
+    fs::create_dir_all(&extension_dir).expect("create extension directory");
+    fs::write(
+        extension_dir.join("fixture-bench.json"),
+        r#"{
+            "name": "Fixture Bench",
+            "version": "0.0.0",
+            "bench": { "extension_script": "bench-runner.sh" }
+        }"#,
+    )
+    .expect("write extension manifest");
+    let script = extension_dir.join("bench-runner.sh");
+    fs::write(
+        &script,
+        r#"#!/bin/sh
+cat > "$HOMEBOY_BENCH_RESULTS_FILE" <<JSON
+{"component_id":"$HOMEBOY_COMPONENT_ID","iterations":${HOMEBOY_BENCH_ITERATIONS:-0},"scenarios":[{"id":"recovery","iterations":${HOMEBOY_BENCH_ITERATIONS:-0},"metrics":{"p95_ms":1.0}}],"metric_policies":{"p95_ms":{"direction":"lower_is_better"}}}
+JSON
+"#,
+    )
+    .expect("write bench runner");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(&script)
+            .expect("script metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).expect("make bench runner executable");
+    }
+}
+
+fn write_package_rig(package: &Path, id: &str) {
+    let rig_dir = package.join("rigs").join(id);
+    fs::create_dir_all(&rig_dir).expect("create rig package");
+    fs::write(
+        rig_dir.join("rig.json"),
+        format!(
+            r#"{{
+                "id": "{id}",
+                "components": {{
+                    "studio": {{
+                        "path": "{}",
+                        "extensions": {{ "fixture-bench": {{}} }}
+                    }}
+                }},
+                "bench": {{ "default_component": "studio" }}
+            }}"#,
+            package.display()
+        ),
+    )
+    .expect("write rig package");
+}
+
+fn install_then_remove_source_a(home: &Path, source_a: &Path) {
+    let source_a_text = source_a.to_str().expect("source A path");
+    assert_success(
+        run_homeboy(home, &["rig", "install", source_a_text]),
+        &["rig", "install", source_a_text],
+    );
+    fs::remove_dir_all(source_a).expect("remove source A");
+}
+
+#[test]
+fn bench_repairs_missing_linked_rig_source_from_path_override() {
+    let home = tempfile::tempdir().expect("home");
+    let source_a = tempfile::tempdir().expect("source A");
+    let checkout_b = tempfile::tempdir().expect("checkout B");
+    write_bench_extension(home.path());
+    write_package_rig(source_a.path(), "stale-rig");
+    write_package_rig(checkout_b.path(), "stale-rig");
+    install_then_remove_source_a(home.path(), source_a.path());
+
+    let checkout_b_text = checkout_b.path().to_str().expect("checkout B path");
+    let args = [
+        "bench",
+        "--rig",
+        "stale-rig",
+        "--path",
+        checkout_b_text,
+        "--iterations",
+        "1",
+    ];
+    assert_success(run_homeboy(home.path(), &args), &args);
+
+    let metadata = fs::read_to_string(
+        home.path()
+            .join(".config/homeboy/rig-sources/stale-rig.json"),
+    )
+    .expect("refreshed source metadata");
+    let metadata: serde_json::Value = serde_json::from_str(&metadata).expect("metadata JSON");
+    let expected_package_path = checkout_b.path().to_string_lossy().into_owned();
+    assert_eq!(
+        metadata["package_path"].as_str(),
+        Some(expected_package_path.as_str())
+    );
+}
+
+#[test]
+fn bench_recovery_preserves_conflicting_user_owned_rig() {
+    let home = tempfile::tempdir().expect("home");
+    let source_a = tempfile::tempdir().expect("source A");
+    let checkout_b = tempfile::tempdir().expect("checkout B");
+    write_bench_extension(home.path());
+    write_package_rig(source_a.path(), "stale-rig");
+    write_package_rig(checkout_b.path(), "stale-rig");
+    install_then_remove_source_a(home.path(), source_a.path());
+
+    let config_path = home.path().join(".config/homeboy/rigs/stale-rig.json");
+    fs::remove_file(&config_path).expect("remove stale rig link");
+    let user_owned = r#"{ "id": "other-rig", "components": {} }"#;
+    fs::write(&config_path, user_owned).expect("write conflicting user rig");
+
+    let checkout_b_text = checkout_b.path().to_str().expect("checkout B path");
+    let output = run_homeboy(
+        home.path(),
+        &[
+            "bench",
+            "--rig",
+            "stale-rig",
+            "--path",
+            checkout_b_text,
+            "--iterations",
+            "1",
+        ],
+    );
+
+    assert!(!output.status.success(), "conflicting rig must fail");
+    assert!(String::from_utf8_lossy(&output.stdout).contains("refusing to replace"));
+    assert_eq!(
+        fs::read_to_string(config_path).expect("read user rig"),
+        user_owned
+    );
+}


### PR DESCRIPTION
## Summary
- recover a missing linked rig source from an explicit active checkout path
- route bench, matrix, profile, and default-baseline resolution through the same path-aware contract
- preserve user-owned rig conflict protection

Closes #8039

## How to test
1. Run `cargo test --test stale_linked_rig_recovery`.
2. Run `cargo fmt --check`.
3. Run `cargo check --lib`.
4. Confirm the standalone test installs a rig from checkout A, removes A, runs the rig against checkout B, and rejects a conflicting user-owned rig ID.

## Verification
- `cargo test --test stale_linked_rig_recovery`
- `cargo fmt --check`
- `cargo check --lib`

The broader monolithic test harness currently has an unrelated pre-existing `DaemonFreshnessReport` fixture compilation failure; the new behavior is covered by an independently executable integration target.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode and Homeboy
- **Used for:** Root-cause analysis, implementation, and deterministic test coverage. Chris reviewed and owns the change.