### PR TITLE
Pin controller runtime across dispatch and recovery

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -612,6 +612,8 @@ const AGENT_TASK_COOK_MISSING_VERIFY_GATE_REASON: &str =
     "agent-task cook requires at least one deterministic --verify or --private-verify gate";
 const AGENT_TASK_FANOUT_COOK_BATCH_DRY_RUN_CONTROLLER_REASON: &str =
     "agent-task fanout cook-batch --dry-run is controller-local planning; it does not execute cooks and should not offload or materialize the controller cwd";
+const AGENT_TASK_FANOUT_COORDINATOR_CONTROLLER_REASON: &str =
+    "agent-task fanout coordination is controller-owned so durable batch state, worktree ownership, and recovery remain available; generated independent cooks may use their own Lab placement";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LabRunnerSupportSummary {
@@ -751,13 +753,10 @@ impl Commands {
                     agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
                         command: agent_task::AgentTaskFanoutCommand::RunPlan(_),
                     }),
-            }) => LabCommandContract::portable(
+            }) => LabCommandContract::local_only(
                 AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL,
-                None,
-                true,
-                LAB_NO_EXTRA_CAPABILITIES,
-            )
-            .with_secret_env_sources(LAB_AGENT_TASK_SECRET_ENV_SOURCES),
+                AGENT_TASK_FANOUT_COORDINATOR_CONTROLLER_REASON,
+            ),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
@@ -778,13 +777,10 @@ impl Commands {
                                 agent_task::AgentTaskFanoutCookBatchArgs { dry_run: false, .. },
                             ),
                     }),
-            }) => LabCommandContract::portable(
+            }) => LabCommandContract::local_only(
                 AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL,
-                None,
-                true,
-                LAB_NO_EXTRA_CAPABILITIES,
-            )
-            .with_secret_env_sources(LAB_AGENT_TASK_SECRET_ENV_SOURCES),
+                AGENT_TASK_FANOUT_COORDINATOR_CONTROLLER_REASON,
+            ),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
@@ -1412,6 +1408,42 @@ mod low_noise_polling_tests {
             .expect("no-finalize cook should remain portable");
 
         assert_eq!(contract.portability, LabCommandPortability::Portable);
+    }
+
+    #[test]
+    fn fanout_coordinator_stays_controller_local_while_child_cooks_remain_portable() {
+        let coordinator = parsed_command(&[
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "run-plan",
+            "--input",
+            "fanout.json",
+        ]);
+        let coordinator_contract = coordinator.lab_contract().expect("fanout contract");
+        assert_eq!(
+            coordinator_contract.portability,
+            LabCommandPortability::LocalOnly(AGENT_TASK_FANOUT_COORDINATOR_CONTROLLER_REASON)
+        );
+
+        let child = parsed_command(&[
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the assigned task",
+            "--to-worktree",
+            "homeboy@child-cook",
+            "--verify",
+            "cargo test --lib",
+        ]);
+        assert_eq!(
+            child
+                .lab_contract()
+                .expect("child cook contract")
+                .portability,
+            LabCommandPortability::Portable
+        );
     }
 
     #[test]

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -38,6 +38,9 @@ enum DaemonCommand {
         /// Confirm the recorded PID was inspected and is dead
         #[arg(long)]
         confirm_pid_dead: bool,
+        /// Recorded daemon PID for controller-evidence recovery when the remote lease file is gone
+        #[arg(long)]
+        expected_pid: Option<u32>,
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
     },
@@ -143,8 +146,8 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
             DaemonOutput::EnsureRunning(daemon::ensure_running(&addr)?),
             0,
         )),
-        DaemonCommand::AdoptOrphan { lease_id, confirm_pid_dead, addr } => Ok((
-            DaemonOutput::AdoptOrphan(daemon::adopt_orphaned_lease(&lease_id, confirm_pid_dead, &addr)?),
+        DaemonCommand::AdoptOrphan { lease_id, confirm_pid_dead, expected_pid, addr } => Ok((
+            DaemonOutput::AdoptOrphan(daemon::adopt_orphaned_lease(&lease_id, confirm_pid_dead, expected_pid, &addr)?),
             0,
         )),
         DaemonCommand::RecoverMissingLease { state_identity, confirm_lease_missing, addr } => Ok((

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -16,6 +16,8 @@ pub fn submit_plan(
         "lifecycle_schema": RUN_LIFECYCLE_RECORD_SCHEMA,
         "note": "submitted tasks are durable; provider run ids are recorded after an executor returns them as generic artifacts or evidence refs"
     });
+    metadata[crate::core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
+        crate::core::controller_runtime::pin_current()?;
     if let Ok(runner_id) = std::env::var(crate::core::runner::RUNNER_ID_ENV) {
         if !runner_id.trim().is_empty() {
             metadata["runner_id"] = json!(runner_id);
@@ -72,6 +74,10 @@ pub fn load_plan(run_id: &str) -> Result<AgentTaskPlan> {
 
 pub fn mark_running(run_id: &str) -> Result<AgentTaskRunRecord> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    crate::core::controller_runtime::validate_for_mutation(
+        &record.metadata,
+        &crate::core::build_identity::current().display,
+    )?;
     if record.state == AgentTaskRunState::Running && record.owner_process_is_running() {
         return Err(Error::validation_invalid_argument(
             "run_id",
@@ -290,6 +296,10 @@ impl TransportProxyRecovery {
 /// record. `None` means the run is a normal scheduler-owned plan.
 pub fn recover_transport_proxy(run_id: &str) -> Result<Option<TransportProxyRecovery>> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    crate::core::controller_runtime::validate_for_mutation(
+        &record.metadata,
+        &crate::core::build_identity::current().display,
+    )?;
     if !is_transport_proxy(&record) {
         return Ok(None);
     }

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -60,11 +60,37 @@ fn submit_plan_persists_queued_status() {
 
         assert_eq!(record.run_id, "run_a");
         assert_eq!(loaded.state, AgentTaskRunState::Queued);
+        assert_eq!(
+            loaded.metadata[crate::core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
+                ["requested"],
+            crate::core::build_identity::current().display
+        );
+        assert!(
+            loaded.metadata[crate::core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
+                ["originating"]["pinned_executable"]
+                .as_str()
+                .is_some()
+        );
         assert_eq!(loaded.tasks[0].task_id, "task-a");
         assert_eq!(
             loaded.tasks[0].provider_ref.as_deref(),
             Some("test:fixture")
         );
+    });
+}
+
+#[test]
+fn active_pinned_run_blocks_controller_binary_replacement() {
+    with_isolated_home(|_| {
+        submit_plan(&test_plan(), Some("active-pinned-runtime")).expect("submitted");
+
+        let error = crate::core::upgrade::refuse_upgrade_while_durable_runs_are_active()
+            .expect_err("active durable run must hold its controller runtime");
+
+        assert!(error.message.contains("active-pinned-runtime"));
+        assert!(error
+            .message
+            .contains("refusing to replace the controller binary"));
     });
 }
 

--- a/src/core/controller_runtime.rs
+++ b/src/core/controller_runtime.rs
@@ -1,0 +1,105 @@
+//! Immutable controller executable provenance for durable orchestration work.
+
+use serde_json::{json, Value};
+use std::path::PathBuf;
+
+use crate::core::{build_identity, paths, Error, Result};
+
+pub(crate) const CONTROLLER_RUNTIME_METADATA_KEY: &str = "controller_runtime";
+
+pub(crate) fn pin_current() -> Result<Value> {
+    let identity = build_identity::current();
+    let executable = std::env::current_exe().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("resolve controller executable".to_string()),
+        )
+    })?;
+    let pinned_path = pinned_path(&identity.display)?;
+    if !pinned_path.exists() {
+        let parent = pinned_path.parent().expect("pinned runtime has parent");
+        std::fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("create controller runtime pin".to_string()),
+            )
+        })?;
+        std::fs::copy(&executable, &pinned_path).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("pin controller executable".to_string()),
+            )
+        })?;
+    }
+
+    Ok(json!({
+        "schema": "homeboy/controller-runtime-pin/v1",
+        "requested": identity.display,
+        "originating": {
+            "build_identity": identity.display,
+            "executable": executable,
+            "pinned_executable": pinned_path,
+        },
+        "current": identity.display,
+        "executed": identity.display,
+    }))
+}
+
+pub(crate) fn validate_for_mutation(metadata: &Value, current_identity: &str) -> Result<()> {
+    let Some(runtime) = metadata.get(CONTROLLER_RUNTIME_METADATA_KEY) else {
+        return Ok(());
+    };
+    let originating = runtime
+        .pointer("/originating/build_identity")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if originating.is_empty() || originating == current_identity {
+        return Ok(());
+    }
+    let pinned = runtime
+        .pointer("/originating/pinned_executable")
+        .and_then(Value::as_str)
+        .unwrap_or("<pinned-controller-runtime>");
+    Err(Error::validation_invalid_argument(
+        "controller_runtime",
+        format!(
+            "durable run was created by controller runtime `{originating}`, but this command is `{current_identity}`"
+        ),
+        Some(current_identity.to_string()),
+        Some(vec![format!(
+            "Run the lifecycle mutation through the pinned compatible runtime: {pinned} <original homeboy arguments>"
+        )]),
+    ))
+}
+
+fn pinned_path(identity: &str) -> Result<PathBuf> {
+    Ok(paths::homeboy_data()?
+        .join("controller-runtimes")
+        .join(paths::sanitize_path_segment(identity))
+        .join("homeboy"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_mismatch_returns_pinned_runtime_recovery_command() {
+        let metadata = json!({
+            "controller_runtime": {
+                "originating": {
+                    "build_identity": "homeboy 1.0.0+origin",
+                    "pinned_executable": "/tmp/homeboy-origin",
+                }
+            }
+        });
+
+        let error = validate_for_mutation(&metadata, "homeboy 1.0.0+replacement")
+            .expect_err("replacement runtime must not mutate the originating lifecycle");
+
+        assert!(error.message.contains("homeboy 1.0.0+origin"));
+        assert!(error.details["tried"][0]
+            .as_str()
+            .is_some_and(|command| command.contains("/tmp/homeboy-origin")));
+    }
+}

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -51,6 +51,7 @@ pub fn ensure_running(addr: &str) -> Result<DaemonStartResult> {
 pub fn adopt_orphaned_lease(
     lease_id: &str,
     confirm_pid_dead: bool,
+    expected_pid: Option<u32>,
     addr: &str,
 ) -> Result<DaemonOrphanAdoptionResult> {
     if !confirm_pid_dead {
@@ -64,43 +65,65 @@ pub fn adopt_orphaned_lease(
     parse_bind_addr(addr)?;
     let _lock = acquire_daemon_operation_lock()?;
     let status = read_status()?;
-    let state = status.state.ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "lease_id",
-            "orphan adoption requires a persisted daemon lease",
-            Some(lease_id.to_string()),
-            None,
-        )
-    })?;
-    if state.lease_id != lease_id {
-        return Err(Error::validation_invalid_argument(
-            "lease_id",
-            format!(
-                "recorded daemon lease `{}` does not match requested orphan lease `{lease_id}`",
-                state.lease_id
-            ),
-            Some(lease_id.to_string()),
-            Some(vec![
-                "Run `homeboy daemon status` and adopt only its exact dead lease.".to_string(),
-            ]),
-        ));
-    }
-    if status.freshness.stale_reason_code != Some(DaemonStaleReasonCode::PidDead) {
-        return Err(Error::validation_invalid_argument(
-            "lease_id",
-            format!("daemon lease `{lease_id}` is not proven dead"),
-            Some(lease_id.to_string()),
-            Some(vec!["Live or ambiguous daemon ownership is protected; inspect `homeboy daemon status` before retrying.".to_string()]),
-        ));
-    }
-
     let store =
         super::JobStore::open_without_reconciliation(crate::core::paths::daemon_jobs_file()?)?;
+    let dead_pid = if let Some(state) = status.state {
+        if state.lease_id != lease_id {
+            return Err(Error::validation_invalid_argument(
+                "lease_id",
+                format!(
+                    "recorded daemon lease `{}` does not match requested orphan lease `{lease_id}`",
+                    state.lease_id
+                ),
+                Some(lease_id.to_string()),
+                None,
+            ));
+        }
+        if status.freshness.stale_reason_code != Some(DaemonStaleReasonCode::PidDead) {
+            return Err(Error::validation_invalid_argument(
+                "lease_id",
+                format!("daemon lease `{lease_id}` is not proven dead"),
+                Some(lease_id.to_string()),
+                None,
+            ));
+        }
+        state.pid
+    } else {
+        let pid = expected_pid.ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "expected_pid",
+                "orphan adoption without a remote lease requires controller-recorded PID evidence",
+                Some(lease_id.to_string()),
+                None,
+            )
+        })?;
+        if pid_is_running(pid) {
+            return Err(Error::validation_invalid_argument(
+                "expected_pid",
+                format!("recorded daemon PID `{pid}` is still running"),
+                Some(lease_id.to_string()),
+                None,
+            ));
+        }
+        if store
+            .daemon_lease_job_diagnostics(lease_id)
+            .matching_count()
+            == 0
+        {
+            return Err(Error::validation_invalid_argument(
+                "lease_id",
+                "no active durable job is owned by the requested lease",
+                Some(lease_id.to_string()),
+                None,
+            ));
+        }
+        pid
+    };
     let reconciled = store.reconcile_dead_daemon_lease_jobs(lease_id)?;
     let replacement = start_background_unlocked(addr)?;
     Ok(DaemonOrphanAdoptionResult {
         adopted_lease_id: lease_id.to_string(),
-        dead_pid: state.pid,
+        dead_pid,
         active_jobs_terminalized: reconciled.matching_count(),
         retry_guidance: "Inspect the retained job events, then retry eligible work through its original command or workflow.".to_string(),
         replacement,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -71,6 +71,7 @@ pub mod command_execution_plan;
 pub mod command_invocation;
 pub mod component;
 pub mod context;
+pub(crate) mod controller_runtime;
 pub mod controller_scratch;
 pub mod daemon;
 pub mod db;

--- a/src/core/paths/runtime.rs
+++ b/src/core/paths/runtime.rs
@@ -34,6 +34,15 @@ pub fn runner_session_file(id: &str) -> Result<PathBuf> {
     Ok(runner_sessions_dir()?.join(format!("{}.json", id)))
 }
 
+/// Controller-owned lease evidence retained after an ephemeral runner session
+/// or remote daemon state file disappears.
+pub(crate) fn runner_lease_evidence_file(runner_id: &str, lease_id: &str) -> Result<PathBuf> {
+    Ok(homeboy()?
+        .join("runner-lease-evidence")
+        .join(sanitize_path_segment(runner_id))
+        .join(format!("{}.json", sanitize_path_segment(lease_id))))
+}
+
 /// Managed service tunnel runtime state directory (~/.local/share/homeboy/service-tunnels/{id}/).
 pub fn service_tunnel_runtime_dir(id: &str) -> Result<PathBuf> {
     Ok(homeboy_data()?

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 use reqwest::blocking::Client;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::core::api_jobs::{ActiveRunnerJobSummary, JobClaimMetadata, JobStatus, RunnerJobSource};
@@ -43,6 +43,15 @@ struct CliEnvelope {
     success: bool,
     data: Option<Value>,
     error: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct RunnerLeaseEvidence {
+    schema: String,
+    runner_id: String,
+    lease_id: String,
+    pid: u32,
+    observed_at: String,
 }
 
 pub fn connect(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
@@ -1180,6 +1189,7 @@ mod remote_daemon {
         runner_id: &str,
     ) -> std::result::Result<RemoteDaemon, String> {
         let status = remote_daemon_status(client, homeboy)?;
+        persist_runner_lease_evidence(runner_id, &status).map_err(|error| error.message)?;
         if let Some(lease_id) = orphan_lease_id {
             if status.stale_reason_code == Some(DaemonStaleReasonCode::PidDead)
                 && status
@@ -1189,6 +1199,19 @@ mod remote_daemon {
                     == Some(lease_id)
             {
                 return remote_daemon_adopt_orphan(client, homeboy, lease_id);
+            }
+            let evidence = read_runner_lease_evidence(runner_id, lease_id)
+                .map_err(|error| error.message)?
+                .or_else(|| runner_session_lease_evidence(previous_session, runner_id, lease_id));
+            if let Some(evidence) = evidence {
+                if let Some(pid) = durable_evidence_pid_for_adoption(&status, &evidence, lease_id) {
+                    if !remote_pid_is_dead(client, pid)? {
+                        return Err(format!(
+                            "controller-recorded daemon PID `{pid}` is not proven dead; refusing orphan adoption"
+                        ));
+                    }
+                    return remote_daemon_adopt_orphan_with_pid(client, homeboy, lease_id, pid);
+                }
             }
         }
         if let Some(state_identity) = missing_lease_state_identity {
@@ -1468,7 +1491,25 @@ mod remote_daemon {
         homeboy: &str,
         lease_id: &str,
     ) -> std::result::Result<RemoteDaemon, String> {
-        let command = remote_daemon_adopt_orphan_command(homeboy, lease_id);
+        remote_daemon_adopt_orphan_with_pid_option(client, homeboy, lease_id, None)
+    }
+
+    fn remote_daemon_adopt_orphan_with_pid(
+        client: &SshClient,
+        homeboy: &str,
+        lease_id: &str,
+        expected_pid: u32,
+    ) -> std::result::Result<RemoteDaemon, String> {
+        remote_daemon_adopt_orphan_with_pid_option(client, homeboy, lease_id, Some(expected_pid))
+    }
+
+    fn remote_daemon_adopt_orphan_with_pid_option(
+        client: &SshClient,
+        homeboy: &str,
+        lease_id: &str,
+        expected_pid: Option<u32>,
+    ) -> std::result::Result<RemoteDaemon, String> {
+        let command = remote_daemon_adopt_orphan_command(homeboy, lease_id, expected_pid);
         let output = client.execute(&command);
         if !output.success {
             return Err(command_failure_message(
@@ -1554,12 +1595,115 @@ mod remote_daemon {
         )
     }
 
-    pub(super) fn remote_daemon_adopt_orphan_command(homeboy: &str, lease_id: &str) -> String {
+    pub(super) fn remote_daemon_adopt_orphan_command(
+        homeboy: &str,
+        lease_id: &str,
+        expected_pid: Option<u32>,
+    ) -> String {
+        let expected_pid = expected_pid
+            .map(|pid| format!(" --expected-pid {pid}"))
+            .unwrap_or_default();
         format!(
-            "{} daemon adopt-orphan --lease-id {} --confirm-pid-dead --addr 127.0.0.1:0",
+            "{} daemon adopt-orphan --lease-id {} --confirm-pid-dead{} --addr 127.0.0.1:0",
             shell::quote_arg(homeboy),
             shell::quote_arg(lease_id),
+            expected_pid,
         )
+    }
+
+    fn remote_pid_is_dead(client: &SshClient, pid: u32) -> std::result::Result<bool, String> {
+        let command = format!(
+            "if kill -0 {pid} 2>/dev/null; then exit 1; fi; observed=$(ps -p {pid} -o pid= 2>/dev/null | tr -d '[:space:]'); case \"$observed\" in *[0-9]*) exit 2;; esac; exit 0"
+        );
+        let output = client.execute(&format!("sh -c {}", shell::quote_arg(&command)));
+        match output.exit_code {
+            0 => Ok(true),
+            1 => Ok(false),
+            _ => Err("remote PID liveness probe was inconclusive".to_string()),
+        }
+    }
+
+    pub(super) fn persist_runner_lease_evidence(
+        runner_id: &str,
+        status: &RemoteDaemonStatus,
+    ) -> Result<()> {
+        let Some(daemon) = status.daemon.as_ref() else {
+            return Ok(());
+        };
+        let (Some(lease_id), Some(pid)) = (daemon.lease_id.as_deref(), daemon.pid) else {
+            return Ok(());
+        };
+        let path = paths::runner_lease_evidence_file(runner_id, lease_id)?;
+        let parent = path.parent().expect("lease evidence has parent");
+        std::fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("create runner lease evidence".to_string()),
+            )
+        })?;
+        let evidence = RunnerLeaseEvidence {
+            schema: "homeboy/runner-lease-evidence/v1".to_string(),
+            runner_id: runner_id.to_string(),
+            lease_id: lease_id.to_string(),
+            pid,
+            observed_at: Utc::now().to_rfc3339(),
+        };
+        let body = serde_json::to_vec_pretty(&evidence)
+            .map_err(|error| Error::internal_json(error.to_string(), None))?;
+        std::fs::write(path, body).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("write runner lease evidence".to_string()),
+            )
+        })
+    }
+
+    pub(super) fn read_runner_lease_evidence(
+        runner_id: &str,
+        lease_id: &str,
+    ) -> Result<Option<RunnerLeaseEvidence>> {
+        let path = paths::runner_lease_evidence_file(runner_id, lease_id)?;
+        let Ok(body) = std::fs::read_to_string(path) else {
+            return Ok(None);
+        };
+        let evidence = serde_json::from_str::<RunnerLeaseEvidence>(&body).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("read runner lease evidence".to_string()),
+            )
+        })?;
+        Ok((evidence.runner_id == runner_id && evidence.lease_id == lease_id).then_some(evidence))
+    }
+
+    pub(super) fn durable_evidence_pid_for_adoption(
+        status: &RemoteDaemonStatus,
+        evidence: &RunnerLeaseEvidence,
+        requested_lease_id: &str,
+    ) -> Option<u32> {
+        (status.daemon.is_none()
+            && status.active_jobs > 0
+            && evidence.lease_id == requested_lease_id)
+            .then_some(evidence.pid)
+    }
+
+    fn runner_session_lease_evidence(
+        session: Option<&RunnerSession>,
+        runner_id: &str,
+        lease_id: &str,
+    ) -> Option<RunnerLeaseEvidence> {
+        let session = session.filter(|session| {
+            session.mode == RunnerTunnelMode::DirectSsh
+                && session.role == RunnerSessionRole::Controller
+                && session.runner_id == runner_id
+                && session.remote_daemon_lease_id.as_deref() == Some(lease_id)
+        })?;
+        Some(RunnerLeaseEvidence {
+            schema: "homeboy/runner-lease-evidence/v1".to_string(),
+            runner_id: runner_id.to_string(),
+            lease_id: lease_id.to_string(),
+            pid: session.remote_daemon_pid?,
+            observed_at: session.connected_at.clone(),
+        })
     }
 
     pub(super) fn parse_envelope(stdout: &str) -> serde_json::Result<CliEnvelope> {
@@ -1829,6 +1973,43 @@ mod tests {
     }
 
     #[test]
+    fn durable_lease_evidence_survives_remote_state_loss_for_exact_adoption_only() {
+        test_support::with_isolated_home(|_| {
+            let observed = remote_daemon_status_for_test_with_reason(
+                false,
+                false,
+                1,
+                "lease-observed",
+                846_192,
+                Some(DaemonStaleReasonCode::PidDead),
+            );
+            persist_runner_lease_evidence("homeboy-lab", &observed)
+                .expect("persist controller-owned evidence");
+            let evidence = read_runner_lease_evidence("homeboy-lab", "lease-observed")
+                .expect("read evidence")
+                .expect("exact lease evidence retained");
+            let unavailable = RemoteDaemonStatus {
+                daemon: None,
+                stale_reason: Some("remote state unavailable".to_string()),
+                stale_reason_code: None,
+                fresh: false,
+                reachable: false,
+                active_jobs: 1,
+                state_identity: None,
+            };
+
+            assert_eq!(
+                durable_evidence_pid_for_adoption(&unavailable, &evidence, "lease-observed"),
+                Some(846_192)
+            );
+            assert_eq!(
+                durable_evidence_pid_for_adoption(&unavailable, &evidence, "lease-other"),
+                None
+            );
+        });
+    }
+
+    #[test]
     fn reattaches_active_daemon_without_changing_lease_or_pid() {
         let session = direct_ssh_session("lease-active");
         let status = remote_daemon_status_for_test(true, true, 1, "lease-active", 4242);
@@ -2016,7 +2197,7 @@ mod tests {
 
     #[test]
     fn orphan_adoption_command_carries_exact_lease_and_dead_pid_confirmation() {
-        let command = remote_daemon_adopt_orphan_command("/opt/homeboy", "lease dead");
+        let command = remote_daemon_adopt_orphan_command("/opt/homeboy", "lease dead", None);
 
         assert!(command.contains("daemon adopt-orphan"));
         assert!(command.contains("--lease-id 'lease dead'"));

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -165,6 +165,7 @@ pub fn run_upgrade_with_method(
     runner_targets: &[String],
     source_path: Option<&Path>,
 ) -> Result<UpgradeResult> {
+    refuse_upgrade_while_durable_runs_are_active()?;
     let promotion_lease = crate::core::runtime_promotion::acquire(
         "controller upgrade",
         source_path
@@ -335,6 +336,39 @@ pub fn run_upgrade_with_method(
         services_restarted,
         services_pending_restart,
     })
+}
+
+pub(crate) fn refuse_upgrade_while_durable_runs_are_active() -> Result<()> {
+    let active = crate::core::agent_task_lifecycle::list_records()?
+        .into_iter()
+        .filter(|record| {
+            matches!(
+                record.state,
+                crate::core::agent_task_lifecycle::AgentTaskRunState::Queued
+                    | crate::core::agent_task_lifecycle::AgentTaskRunState::Running
+            )
+        })
+        .filter_map(|record| {
+            record
+                .metadata
+                .get(crate::core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY)
+                .and_then(|runtime| runtime.pointer("/originating/build_identity"))
+                .and_then(serde_json::Value::as_str)
+                .map(|identity| format!("{} ({identity})", record.run_id))
+        })
+        .collect::<Vec<_>>();
+    if active.is_empty() {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "upgrade",
+        format!(
+            "refusing to replace the controller binary while durable orchestration run(s) are active: {}",
+            active.join(", ")
+        ),
+        None,
+        Some(vec!["Wait for the listed runs to become terminal, or recover them through their pinned controller runtime before upgrading.".to_string()]),
+    ))
 }
 
 // Upgrade output must remain visible when a controller captures stdout/stderr.

--- a/src/core/upgrade/mod.rs
+++ b/src/core/upgrade/mod.rs
@@ -9,6 +9,8 @@ pub mod update_check;
 mod validation;
 
 pub(crate) use constants::VERSION;
+#[cfg(test)]
+pub(crate) use helpers::refuse_upgrade_while_durable_runs_are_active;
 pub use helpers::{
     current_build_version, current_version, detect_install_method, fetch_latest_version,
     run_upgrade_with_method,


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `homeboy-8025-recovery-final` into review-ready branch `fix/8025-pinned-controller-runtime-final-v2`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:homeboy-8025-recovery-final`
- **Homeboy run ID:** `homeboy-8025-recovery-final`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `fix/8025-pinned-controller-runtime-final-v2`

## Source refs
- https://github.com/Extra-Chill/homeboy/issues/8025

## Attempt summary
Promoted recovery candidate and passed five focused regressions, formatting, all-target check, and diff validation

## Gate results
- focused-tests: passed (targeted)
- format: passed (targeted)
- all-target-check: passed (targeted)
- diff-check: passed (targeted)

## Verification capability
- `targeted_checks_run`: `cargo test --locked controller_runtime`, `cargo test --locked active_pinned_run_blocks_controller_binary_replacement`, `cargo test --locked fanout_coordinator_stays_controller_local_while_child_cooks_remain_portable`, `cargo test --locked orphan_adoption_command_carries_exact_lease_and_dead_pid_confirmation`, `cargo test --locked durable_lease_evidence_survives_remote_state_loss_for_exact_adoption_only`, `cargo fmt --check`, `cargo check --locked --all-targets`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: `CI`
- `manual_reviewer_check`: Confirm the runtime pinning and exact dead-lease fallback remain generic and fail closed.

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- src/command_contract/lab.rs
- src/commands/daemon.rs
- src/core/agent_task_lifecycle/lifecycle_ops.rs
- src/core/agent_task_lifecycle/tests.rs
- src/core/controller_runtime.rs
- src/core/daemon/control.rs
- src/core/mod.rs
- src/core/paths/runtime.rs
- src/core/runner/connection.rs
- src/core/upgrade/helpers.rs
- src/core/upgrade/mod.rs

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `fix/8025-pinned-controller-runtime-final-v2`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol and openai/gpt-5.6-terra
- **Used for:** Diagnosed the live failure, prepared and rebased the recovery patch, validated exact dead-lease adoption, and promoted the verified candidate; Chris reviewed and owns the change.
