### PR TITLE
Fix mixed historical daemon lease recovery

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -324,8 +324,8 @@ plan is emitted; `--sync-mode` accepts `snapshot`, `snapshot-git`, or `git`.
 ```sh
 homeboy runner connect <runner-id>
 homeboy runner connect <runner-id> --adopt-orphan-lease <lease-id> --confirm-pid-dead
-homeboy runner connect <runner-id> --reconcile-leaseless-orphans --confirm-control-plane-lost
-homeboy daemon reconcile-leaseless-orphans --confirm-control-plane-lost
+homeboy runner connect <runner-id> --reconcile-leaseless-orphans --confirm-no-daemon-owner
+homeboy daemon reconcile-leaseless-orphans --reconcile-leaseless-orphans --confirm-no-daemon-owner
 homeboy runner connect <controller-id> --reverse --reverse-runner <runner-id> --broker-url <url>
 ```
 
@@ -349,8 +349,10 @@ and unavailable recovery evidence, run the explicit daemon reconciliation on the
 configured runner host. It acquires the daemon lifecycle lock, requires the
 affirmative confirmation flag, independently checks for a `homeboy daemon serve`
 process and Homeboy TCP listener, snapshots `jobs.json`, retains all job events
-and result evidence, terminalizes only lease-less active jobs, and starts one
-replacement daemon. Live or ambiguous probes abort without changing the store.
+and artifact references, terminalizes every active job as control-plane-lost, and
+returns each original lease ID plus the affected job mapping before starting one
+replacement daemon. Historical lease IDs do not establish a current owner. Live
+or ambiguous probes abort without changing the store.
 
 Reverse runner connections record the runner-initiated session substrate and use
 the controller daemon as the broker. A reverse runner can register itself with

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -40,7 +40,7 @@ enum DaemonCommand {
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
     },
-    /// Explicitly reconcile legacy unowned jobs after proving no daemon owns the store
+    /// Explicitly reconcile active jobs after proving a missing-lease store has no daemon owner
     ReconcileLeaselessOrphans {
         #[arg(long)]
         reconcile_leaseless_orphans: bool,

--- a/src/commands/runner/cli.rs
+++ b/src/commands/runner/cli.rs
@@ -221,7 +221,7 @@ pub(super) enum RunnerCommand {
         #[arg(long)]
         confirm_pid_dead: bool,
 
-        /// Explicitly reconcile legacy unowned active jobs after proving no daemon owns the remote store
+        /// Explicitly reconcile active jobs after proving the missing-lease remote store has no daemon owner
         #[arg(long)]
         reconcile_leaseless_orphans: bool,
 

--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -12,8 +12,8 @@ pub use store::{JobHandle, JobRunner, JobStore};
 pub use summary::active_runner_job_run_summary;
 pub use types::{
     ActiveRunnerJobRunSummary, ActiveRunnerJobSummary, DaemonLeaseJobDiagnostics, Job,
-    JobClaimMetadata, JobEvent, JobEventKind, JobStatus, LeaselessOrphanJobDiagnostics,
-    RunnerJobLifecycleOwner, RunnerJobSource,
+    JobClaimMetadata, JobEvent, JobEventKind, JobStatus, LeaselessOrphanAffectedJob,
+    LeaselessOrphanJobDiagnostics, RunnerJobLifecycleOwner, RunnerJobSource,
 };
 
 #[cfg(test)]
@@ -586,7 +586,7 @@ mod tests {
     }
 
     #[test]
-    fn leaseless_recovery_retains_recorded_outcomes_and_refuses_lease_owned_jobs() {
+    fn leaseless_recovery_terminalizes_one_historical_lease_and_retains_evidence() {
         let temp = tempfile::tempdir().expect("temp dir");
         let path = temp.path().join("jobs.json");
         let legacy = JobStore::open_without_reconciliation(&path).expect("open legacy store");
@@ -612,7 +612,7 @@ mod tests {
         assert!(diagnostics.reconciled_job_ids.contains(&unfinished.id));
         assert_eq!(
             recovery.get(succeeded.id).expect("succeeded").status,
-            JobStatus::Succeeded
+            JobStatus::Failed
         );
         assert_eq!(
             recovery.get(unfinished.id).expect("unfinished").status,
@@ -632,15 +632,79 @@ mod tests {
             .with_daemon_lease("lease-owned".to_string());
         let leased_job = leased.create("runner.exec");
         leased.start(leased_job.id).expect("start leased job");
-        let error = JobStore::open_without_reconciliation(&path)
+        let diagnostics = JobStore::open_without_reconciliation(&path)
             .expect("open refusing recovery")
             .reconcile_leaseless_orphan_jobs()
-            .expect_err("lease-owned job must fail closed");
-        assert!(error.message.contains("have daemon leases"));
+            .expect("historical lease has no current owner");
+        assert_eq!(diagnostics.historical_lease_ids, vec!["lease-owned"]);
+        assert_eq!(diagnostics.affected_jobs.len(), 1);
         assert_eq!(
-            leased.get(leased_job.id).expect("leased job").status,
-            JobStatus::Running
+            diagnostics.affected_jobs[0]
+                .original_daemon_lease_id
+                .as_deref(),
+            Some("lease-owned")
         );
+        let recovered = JobStore::open_without_reconciliation(&path).expect("reopen recovered");
+        assert_eq!(
+            recovered.get(leased_job.id).expect("leased job").status,
+            JobStatus::Failed
+        );
+        assert!(recovered
+            .events(leased_job.id)
+            .expect("events")
+            .iter()
+            .any(|event| event
+                .data
+                .as_ref()
+                .is_some_and(|data| data["original_daemon_lease_id"] == json!("lease-owned"))));
+    }
+
+    #[test]
+    fn leaseless_recovery_enumerates_and_terminalizes_multiple_historical_leases() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("jobs.json");
+        let first = JobStore::open_without_reconciliation(&path)
+            .expect("open first")
+            .with_daemon_lease("lease-first".to_string());
+        let first_job = first.create("runner.exec");
+        first.start(first_job.id).expect("start first");
+        first
+            .append_event(
+                first_job.id,
+                JobEventKind::Stdout,
+                Some("first output".to_string()),
+                None,
+            )
+            .expect("first output");
+        let second = JobStore::open_without_reconciliation(&path)
+            .expect("open second")
+            .with_daemon_lease("lease-second".to_string());
+        let second_job = second.create("runner.exec");
+        second.start(second_job.id).expect("start second");
+
+        let recovery = JobStore::open_without_reconciliation(&path).expect("open recovery");
+        let diagnostics = recovery
+            .reconcile_leaseless_orphan_jobs()
+            .expect("reconcile");
+
+        assert_eq!(
+            diagnostics.historical_lease_ids,
+            vec!["lease-first", "lease-second"]
+        );
+        assert_eq!(diagnostics.affected_jobs.len(), 2);
+        assert_eq!(
+            recovery.get(first_job.id).expect("first job").status,
+            JobStatus::Failed
+        );
+        assert_eq!(
+            recovery.get(second_job.id).expect("second job").status,
+            JobStatus::Failed
+        );
+        assert!(recovery
+            .events(first_job.id)
+            .expect("first events")
+            .iter()
+            .any(|event| event.message.as_deref() == Some("first output")));
     }
 
     #[test]

--- a/src/core/api_jobs/store.rs
+++ b/src/core/api_jobs/store.rs
@@ -18,7 +18,7 @@ use super::persistence::{
 use super::persistence::{read_durable_store, reconcile_stale_jobs};
 use super::remote_runner;
 use super::types::{
-    DaemonLeaseJobDiagnostics, Job, JobEvent, JobEventKind, JobStatus,
+    DaemonLeaseJobDiagnostics, Job, JobEvent, JobEventKind, JobStatus, LeaselessOrphanAffectedJob,
     LeaselessOrphanJobDiagnostics,
 };
 use crate::core::error::{Error, Result};
@@ -408,8 +408,9 @@ impl JobStore {
         Ok(diagnostics)
     }
 
-    /// Terminalize only legacy active jobs after an operator has proved that no
-    /// daemon owns this store. Lease-owned jobs are intentionally fail-closed.
+    /// Terminalize all active jobs after an operator has proved that no daemon
+    /// owns a store whose current daemon lease is missing. Historical job leases
+    /// remain evidence; they cannot prove a current owner or be adopted as one.
     pub fn reconcile_leaseless_orphan_jobs(&self) -> Result<LeaselessOrphanJobDiagnostics> {
         let mut diagnostics = LeaselessOrphanJobDiagnostics::default();
         {
@@ -418,80 +419,53 @@ impl JobStore {
                 if !matches!(stored.job.status, JobStatus::Queued | JobStatus::Running) {
                     continue;
                 }
-                if stored.job.daemon_lease_id.is_some() {
-                    diagnostics.lease_owned_job_ids.push(stored.job.id);
-                } else {
-                    diagnostics.reconciled_job_ids.push(stored.job.id);
+                let original_daemon_lease_id = stored.job.daemon_lease_id.clone();
+                if let Some(lease_id) = &original_daemon_lease_id {
+                    diagnostics.historical_lease_ids.push(lease_id.clone());
                 }
+                diagnostics.reconciled_job_ids.push(stored.job.id);
+                diagnostics.affected_jobs.push(LeaselessOrphanAffectedJob {
+                    job_id: stored.job.id,
+                    original_daemon_lease_id,
+                });
             }
         }
         diagnostics.reconciled_job_ids.sort();
-        diagnostics.lease_owned_job_ids.sort();
-        if diagnostics.lease_owned_count() > 0 {
-            return Err(Error::validation_invalid_argument(
-                "reconcile_leaseless_orphans",
-                format!(
-                    "refusing lease-less recovery: {} active job(s) have daemon leases: {}",
-                    diagnostics.lease_owned_count(),
-                    diagnostics
-                        .lease_owned_job_ids
-                        .iter()
-                        .map(ToString::to_string)
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                ),
-                None,
-                Some(vec![
-                    "Lease-owned jobs require exact lease recovery; leave them untouched."
-                        .to_string(),
-                ]),
-            ));
-        }
+        diagnostics.affected_jobs.sort_by_key(|job| job.job_id);
+        diagnostics.historical_lease_ids.sort();
+        diagnostics.historical_lease_ids.dedup();
 
         let now = timestamp_ms();
         let mut inner = self.inner.lock().expect("job store mutex poisoned");
         for job_id in &diagnostics.reconciled_job_ids {
             let stored = inner.jobs.get_mut(job_id).expect("diagnosed job exists");
-            if let Some((status, exit_code)) = recovered_terminal_from_result(&stored.events) {
-                stored.job.status = status;
-                stored.job.updated_at_ms = now;
-                stored.job.finished_at_ms = Some(now);
-                stored.job.stale_reason = None;
+            let original_daemon_lease_id = stored.job.daemon_lease_id.clone();
+            stored.job.status = JobStatus::Failed;
+            stored.job.updated_at_ms = now;
+            stored.job.finished_at_ms = Some(now);
+            stored.job.stale_reason = Some("control plane lost before job completion".to_string());
+            let classification = stale_after_restart_classification(stored);
+            for (kind, message, data) in [
+                (
+                    JobEventKind::Error,
+                    "job marked failed after missing-lease control-plane loss; retry through its original command".to_string(),
+                    serde_json::json!({"reason": "leaseless_orphan_reconciliation", "classification": classification, "original_daemon_lease_id": original_daemon_lease_id, "retry_guidance": "Retry eligible work through its original command or workflow."}),
+                ),
+                (
+                    JobEventKind::Status,
+                    "job marked failed after missing-lease control-plane loss".to_string(),
+                    serde_json::json!({"status": JobStatus::Failed, "reason": "leaseless_orphan_reconciliation", "original_daemon_lease_id": original_daemon_lease_id}),
+                ),
+            ] {
                 let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
                 stored.events.push(JobEvent {
-                    sequence, job_id: *job_id, kind: JobEventKind::Status, timestamp_ms: now,
-                    message: Some("job terminal status retained from recorded result during lease-less recovery".to_string()),
-                    data: Some(serde_json::json!({"status": status, "reason": "retained_recorded_outcome", "exit_code": exit_code})),
+                    sequence,
+                    job_id: *job_id,
+                    kind,
+                    timestamp_ms: now,
+                    message: Some(message),
+                    data: Some(data),
                 });
-            } else {
-                stored.job.status = JobStatus::Failed;
-                stored.job.updated_at_ms = now;
-                stored.job.finished_at_ms = Some(now);
-                stored.job.stale_reason =
-                    Some("control plane lost before job completion".to_string());
-                let classification = stale_after_restart_classification(stored);
-                for (kind, message, data) in [
-                    (
-                        JobEventKind::Error,
-                        "job marked failed after lease-less control-plane loss; retry through its original command".to_string(),
-                        serde_json::json!({"reason": "leaseless_orphan_reconciliation", "classification": classification, "retry_guidance": "Retry eligible work through its original command or workflow."}),
-                    ),
-                    (
-                        JobEventKind::Status,
-                        "job marked failed after lease-less control-plane loss".to_string(),
-                        serde_json::json!({"status": JobStatus::Failed, "reason": "leaseless_orphan_reconciliation"}),
-                    ),
-                ] {
-                    let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
-                    stored.events.push(JobEvent {
-                        sequence,
-                        job_id: *job_id,
-                        kind,
-                        timestamp_ms: now,
-                        message: Some(message),
-                        data: Some(data),
-                    });
-                }
             }
             apply_event_retention(&mut stored.events, self.event_retention_limit());
             stored.job.event_count = stored.events.len();

--- a/src/core/api_jobs/types.rs
+++ b/src/core/api_jobs/types.rs
@@ -234,20 +234,25 @@ pub struct DaemonLeaseJobDiagnostics {
     pub unowned_job_ids: Vec<Uuid>,
 }
 
-/// Active durable jobs selected by the explicit lease-less recovery operation.
+/// An active durable job terminalized after the daemon lease disappeared.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LeaselessOrphanAffectedJob {
+    pub job_id: Uuid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original_daemon_lease_id: Option<String>,
+}
+
+/// Active durable jobs selected by the explicit missing-lease recovery operation.
 #[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
 pub struct LeaselessOrphanJobDiagnostics {
     pub reconciled_job_ids: Vec<Uuid>,
-    pub lease_owned_job_ids: Vec<Uuid>,
+    pub affected_jobs: Vec<LeaselessOrphanAffectedJob>,
+    pub historical_lease_ids: Vec<String>,
 }
 
 impl LeaselessOrphanJobDiagnostics {
     pub fn reconciled_count(&self) -> usize {
         self.reconciled_job_ids.len()
-    }
-
-    pub fn lease_owned_count(&self) -> usize {
-        self.lease_owned_job_ids.len()
     }
 }
 

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -166,6 +166,10 @@ pub struct DaemonOrphanAdoptionResult {
 pub struct DaemonLeaselessRecoveryResult {
     pub affected_job_ids: Vec<Uuid>,
     pub affected_job_count: usize,
+    #[serde(default)]
+    pub affected_jobs: Vec<crate::core::api_jobs::LeaselessOrphanAffectedJob>,
+    #[serde(default)]
+    pub historical_lease_ids: Vec<String>,
     pub evidence_snapshot_path: String,
     pub ownership_proof: Vec<String>,
     pub retry_guidance: String,

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -235,17 +235,18 @@ pub fn reconcile_leaseless_orphans(
     Ok(DaemonLeaselessRecoveryResult {
         affected_job_ids: reconciled.reconciled_job_ids,
         affected_job_count,
+        affected_jobs: reconciled.affected_jobs,
+        historical_lease_ids: reconciled.historical_lease_ids,
         evidence_snapshot_path: snapshot_path.display().to_string(),
         ownership_proof,
-        retry_guidance: "Recorded outcomes were retained. Retry unfinished eligible work through its original command or workflow.".to_string(),
+        retry_guidance: "Recorded job output and artifacts were retained. Retry eligible work through its original command or workflow.".to_string(),
         replacement,
     })
 }
 
 fn prove_no_daemon_owner(addr: &str) -> Result<Vec<String>> {
-    // The owner lock is the authoritative proof. These probes are retained as
-    // diagnostics only: port 0 and process command lines cannot establish
-    // durable ownership of the job store.
+    // The owner lock proves no serving daemon owns this store. Refuse any
+    // matching process or configured listener as additional ambiguous ownership.
     let output = Command::new("ps")
         .args(["-ax", "-o", "command="])
         .output()
@@ -259,17 +260,34 @@ fn prove_no_daemon_owner(addr: &str) -> Result<Vec<String>> {
                 .lines()
                 .any(|line| line.contains("homeboy daemon serve"));
             if matched {
-                "supplemental process probe found a matching command; owner lock remained available"
+                return Err(Error::validation_invalid_argument(
+                    "owner_probe",
+                    "a Homeboy daemon serve process is present; refusing ambiguous missing-lease recovery",
+                    None,
+                    None,
+                ));
             } else {
                 "supplemental process probe found no matching command"
             }
         }
-        _ => "supplemental process probe unavailable; owner lock is authoritative",
+        _ => {
+            return Err(Error::validation_invalid_argument(
+                "owner_probe",
+                "unable to inspect Homeboy daemon processes; refusing ambiguous missing-lease recovery",
+                None,
+                None,
+            ));
+        }
     };
     let listener = if parsed.port() == 0 {
-        format!("supplemental listener probe skipped for dynamic address {addr}")
+        format!("listener probe has no fixed address for dynamic bind {addr}")
     } else if TcpStream::connect_timeout(&parsed, Duration::from_millis(200)).is_ok() {
-        format!("supplemental listener probe reached {addr}; owner lock remained available")
+        return Err(Error::validation_invalid_argument(
+            "owner_probe",
+            format!("a daemon listener is reachable at {addr}; refusing missing-lease recovery"),
+            None,
+            None,
+        ));
     } else {
         format!("supplemental listener probe found no listener at {addr}")
     };


### PR DESCRIPTION
Closes #8054

## Summary
- Extend explicit missing-lease reconciliation to terminalize all active jobs, including jobs with distinct historical daemon leases.
- Fail closed when owner process/listener evidence is live or ambiguous, and return affected-job/original-lease plus deduplicated historical-lease evidence.
- Preserve durable output and artifact references, snapshot the exact store bytes, and retain lifecycle-lock convergence.

## How to test
1. From a fresh checkout, run `cargo fmt --check`.
2. Run `cargo check`.
3. Run `cargo test --lib leaseless_recovery`.
4. Run `cargo test --lib daemon::control::control_test`.

## Backwards compatibility
- The existing `daemon reconcile-leaseless-orphans` and `runner connect --reconcile-leaseless-orphans` commands retain their affirmative flags. Their JSON result adds `affected_jobs` and `historical_lease_ids`. The operation now intentionally reconciles historical lease-owned active jobs only after the existing missing-lease, lifecycle-lock, owner-lock, process, and listener checks succeed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode / openai-gpt-5.6-sol
- **Used for:** Implemented the guarded mixed historical-lease recovery path, deterministic tests, verification, and PR drafting with Chris's requested requirements.