### PR TITLE
Fix executable lease-less reconciliation command

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -43,8 +43,6 @@ enum DaemonCommand {
     /// Explicitly reconcile active jobs after proving a missing-lease store has no daemon owner
     ReconcileLeaselessOrphans {
         #[arg(long)]
-        reconcile_leaseless_orphans: bool,
-        #[arg(long)]
         confirm_no_daemon_owner: bool,
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
@@ -135,8 +133,8 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
             DaemonOutput::AdoptOrphan(daemon::adopt_orphaned_lease(&lease_id, confirm_pid_dead, &addr)?),
             0,
         )),
-        DaemonCommand::ReconcileLeaselessOrphans { reconcile_leaseless_orphans, confirm_no_daemon_owner, addr } => Ok((
-            DaemonOutput::ReconcileLeaselessOrphans(daemon::reconcile_leaseless_orphans(reconcile_leaseless_orphans, confirm_no_daemon_owner, &addr)?),
+        DaemonCommand::ReconcileLeaselessOrphans { confirm_no_daemon_owner, addr } => Ok((
+            DaemonOutput::ReconcileLeaselessOrphans(daemon::reconcile_leaseless_orphans(confirm_no_daemon_owner, &addr)?),
             0,
         )),
         DaemonCommand::Serve { addr } => serve(&addr),
@@ -233,12 +231,35 @@ impl AnalysisJobRunner for CommandAnalysisJobRunner {
 
 #[cfg(test)]
 mod tests {
+    use clap::Parser;
     use std::io::{Read, Write};
     use std::net::TcpListener;
 
     use homeboy::test_support::with_isolated_home;
 
     use super::*;
+    use crate::cli_surface::{Cli, Commands};
+
+    #[test]
+    fn leaseless_recovery_subcommand_reaches_address_validation() {
+        let cli = Cli::try_parse_from([
+            "homeboy",
+            "daemon",
+            "reconcile-leaseless-orphans",
+            "--confirm-no-daemon-owner",
+            "--addr",
+            "not-an-address",
+        ])
+        .expect("the recovery subcommand and its required confirmation should parse");
+        let Commands::Daemon(args) = cli.command else {
+            panic!("expected daemon command");
+        };
+
+        let error = run(args, &crate::commands::GlobalArgs {})
+            .expect_err("invalid daemon address should reach handler validation");
+
+        assert!(error.message.contains("Invalid daemon bind address"));
+    }
 
     #[test]
     fn artifact_get_downloads_daemon_byte_alias() {

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -192,14 +192,13 @@ pub fn adopt_orphaned_lease(
 /// missing. Process and configured-listener probes are fail-closed because no
 /// lease identity exists to adopt.
 pub fn reconcile_leaseless_orphans(
-    reconcile_leaseless_orphans: bool,
     confirm_no_daemon_owner: bool,
     addr: &str,
 ) -> Result<DaemonLeaselessRecoveryResult> {
-    if !reconcile_leaseless_orphans || !confirm_no_daemon_owner {
+    if !confirm_no_daemon_owner {
         return Err(Error::validation_invalid_argument(
-            "reconcile_leaseless_orphans",
-            "lease-less recovery requires --reconcile-leaseless-orphans and --confirm-no-daemon-owner",
+            "confirm_no_daemon_owner",
+            "lease-less recovery requires --confirm-no-daemon-owner",
             None,
             None,
         ));


### PR DESCRIPTION
Closes #8064

The `daemon reconcile-leaseless-orphans` subcommand now inherently selects lease-less reconciliation. The handler retains the required `--confirm-no-daemon-owner` affirmation, and the existing runner argv remains selector-free.

## How to test
1. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo fmt --check`.
2. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo check`.
3. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo test leaseless_recovery_subcommand_reaches_address_validation`.
4. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo test runner_connect_dispatches_compatible_leaseless_recovery_argv`.
5. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo test leaseless_recovery_`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode / openai-gpt-5.6-sol
- **Used for:** Implemented the parser-to-handler reconciliation-intent fix, added the focused CLI integration test, and ran verification commands.