### PR TITLE
Remove release auto-refactor and isolate generated drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@
 #   2. Version bump + changelog generation from conventional commits
 #   3. Cross-platform binary builds via cargo-dist
 #   4. Publish to GitHub Releases, crates.io, and Homebrew
-#   5. Auto-refactor direct commits (post-release, never opens PRs)
 #
 # No human input needed — version is computed from commit types:
 #   fix: → patch, feat: → minor, BREAKING CHANGE → major
@@ -343,66 +342,17 @@ jobs:
           autofix: 'false'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
-  gate-refactor:
-    name: Auto-refactor
-    continue-on-error: true
-    timeout-minutes: 35
-    needs:
-      - check
-      - gate-build
-      - gate-lint
-      - gate-test
-    if: ${{ always() && inputs.release_tag == '' && needs.check.outputs.should-release == 'true' && needs.check.outputs.recovery-release != 'true' && needs.gate-build.result == 'success' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.release_tag || github.ref }}
-          fetch-depth: 0
-
-      - name: Download homeboy binary
-        uses: actions/download-artifact@v4
-        with:
-          name: homeboy-binary
-          path: .homeboy-bin
-
-      - name: Verify homeboy binary present
-        run: |
-          if [ ! -f .homeboy-bin/homeboy ]; then
-            echo "::error::Build artifact missing from upstream Build job: .homeboy-bin/homeboy was not produced/uploaded by gate-build. This is a CI artifact-handoff problem, not an autofix finding. Re-run the failed Build job or investigate the homeboy-binary upload step." >&2
-            exit 1
-          fi
-          chmod +x .homeboy-bin/homeboy
-
-      # Rust toolchain needed for cargo fmt (called by lint fixer in autofix)
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        continue-on-error: true
-        with:
-          app-id: ${{ secrets.HOMEBOY_APP_ID }}
-          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
-
-      # In Homeboy Action, autofix-open-pr gates the non-PR repair transaction.
-      # Only release-blocking commands are repaired in the release path. Audit
-      # remains tracked by gate-audit unless it is explicitly added to
-      # RELEASE_BLOCKING_COMMANDS.
-      - name: Run autofix via homeboy-action
-        uses: Extra-Chill/homeboy-action@v2
-        continue-on-error: true
-        with:
-          binary-path: .homeboy-bin/homeboy
-          commands: ${{ env.RELEASE_BLOCKING_COMMANDS }}
-          expected-commands: review audit,review lint,review test
-          autofix: 'true'
-          autofix-mode: always
-          autofix-open-pr: 'true'
-          execution-timeout-seconds: '1800'
-          app-token: ${{ steps.app-token.outputs.token }}
-
+  # ── Step 3b: Release-blocking quality policy ──
+  # Release preparation is gated by release-quality-policy, not by raw job
+  # failures or generic source auto-refactor. Generic release auto-refactor /
+  # autofix was removed (#8046): the release pipeline no longer mutates source,
+  # opens autofix branches, or creates autofix PRs. Audit baseline consumption
+  # (--changed-since against homeboy.json baselines.audit.known_fingerprints)
+  # and automated categorized issue filing (app-token) are preserved in the
+  # read-only gate jobs. Extension-declared generated-drift maintenance is
+  # preserved as a narrow allowlisted transaction in core
+  # (changes_are_only_drift / drift_file_paths), not as a release-workflow
+  # source-mutation step.
   release-quality-policy:
     name: Release Quality Policy
     needs:
@@ -824,7 +774,6 @@ jobs:
       - gate-audit
       - gate-lint
       - gate-test
-      - gate-refactor
       - release-quality-policy
       - prepare
       - plan
@@ -854,7 +803,6 @@ jobs:
       - gate-audit
       - gate-lint
       - gate-test
-      - gate-refactor
       - release-quality-policy
       - prepare
       - plan

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -49,17 +49,62 @@ fn job_section<'a>(workflow: &'a str, job: &str) -> &'a str {
 }
 
 #[test]
-fn release_refactor_gate_enables_non_pr_repair_path() {
-    let gate_refactor = job_section(release_workflow(), "gate-refactor");
+fn release_workflow_has_no_generic_source_autofix() {
+    let workflow = release_workflow();
 
-    assert!(gate_refactor.contains("commands: ${{ env.RELEASE_BLOCKING_COMMANDS }}"));
-    assert!(gate_refactor.contains("autofix: 'true'"));
-    assert!(gate_refactor.contains("autofix-mode: always"));
-    assert!(gate_refactor.contains("Only release-blocking commands are repaired"));
-    assert!(gate_refactor.contains("autofix-open-pr: 'true'"));
-    assert!(gate_refactor.contains("continue-on-error: true"));
-    assert!(gate_refactor.contains("timeout-minutes: 35"));
-    assert!(gate_refactor.contains("execution-timeout-seconds: '1800'"));
+    // Generic release auto-refactor / autofix was removed (#8046). The release
+    // pipeline must not mutate source, open autofix branches, or create
+    // autofix PRs. The gate-refactor job, the autofix action inputs, and the
+    // `refactor --from all` broad source-sweep command must all be absent.
+    assert!(
+        !workflow.contains("gate-refactor"),
+        "release workflow must not contain a gate-refactor job"
+    );
+    assert!(
+        !workflow.contains("autofix: 'true'"),
+        "release workflow must not enable generic source autofix"
+    );
+    assert!(
+        !workflow.contains("autofix-mode: always"),
+        "release workflow must not run autofix in always mode"
+    );
+    assert!(
+        !workflow.contains("autofix-open-pr: 'true'"),
+        "release workflow must not create autofix PRs"
+    );
+    assert!(
+        !workflow.contains("refactor --from all"),
+        "release workflow must not run a broad refactor --from all sweep"
+    );
+}
+
+#[test]
+fn release_workflow_declared_drift_maintenance_is_narrow_not_generic() {
+    let workflow = release_workflow();
+
+    // The only code path that can push generated drift to the base branch is
+    // the narrow allowlisted transaction in core
+    // (changes_are_only_drift / drift_file_paths), which gates on
+    // extension-declared lockfile_paths + the audit baseline (homeboy.json).
+    // The release workflow must not widen this into generic source mutation:
+    // every quality gate must run read-only (autofix disabled) so that no
+    // authored source fix is produced for the transaction to route.
+    for job in ["gate-audit", "gate-lint", "gate-test"] {
+        let section = job_section(workflow, job);
+        assert!(
+            section.contains("autofix: 'false'"),
+            "{job} must run read-only (autofix disabled) so only declared generated drift can be maintained"
+        );
+    }
+
+    // The release workflow has no other writable action invocation. Generated
+    // drift remains owned by the core allowlist, rather than a workflow-level
+    // repair action that could stage authored source files.
+    assert_eq!(
+        workflow.matches("autofix:").count(),
+        3,
+        "only the three read-only quality gates may declare autofix behavior"
+    );
 }
 
 #[test]
@@ -128,6 +173,23 @@ fn release_audit_is_advisory_without_losing_raw_failure_outcome() {
 }
 
 #[test]
+fn release_audit_preserves_changed_since_baseline_consumption() {
+    let gate_audit = job_section(release_workflow(), "gate-audit");
+
+    // Audit baseline consumption is preserved (#8046): the changed-since
+    // comparison reads homeboy.json baselines.audit.known_fingerprints from
+    // the merge-base so only newly-introduced audit findings are reported.
+    assert!(
+        gate_audit.contains("--changed-since"),
+        "gate-audit must consume the audit baseline via --changed-since"
+    );
+    assert!(
+        gate_audit.contains("app-token"),
+        "gate-audit must retain app-token for automated categorized issue filing"
+    );
+}
+
+#[test]
 fn release_ci_disables_homeboy_update_checks() {
     assert!(release_workflow().contains("HOMEBOY_NO_UPDATE_CHECK: '1'"));
 }
@@ -153,21 +215,14 @@ fn release_planning_skips_quality_gates_already_owned_by_gate_jobs() {
 }
 
 #[test]
-fn release_prepare_waits_for_command_policy_not_raw_audit_or_refactor() {
-    let gate_refactor = job_section(release_workflow(), "gate-refactor");
+fn release_prepare_waits_for_command_policy_not_raw_gates() {
     let prepare = job_section(release_workflow(), "prepare");
 
+    // gate-refactor was removed (#8046); prepare must never reference it.
     assert!(
-        !gate_refactor.contains("- gate-audit"),
-        "gate-refactor should not wait on tracked-only audit by default"
+        !prepare.contains("- gate-refactor"),
+        "prepare must not wait on the removed gate-refactor job"
     );
-
-    for gate in ["gate-lint", "gate-test"] {
-        assert!(
-            gate_refactor.contains(&format!("- {gate}")),
-            "gate-refactor should inspect the read-only {gate} result for advisory repair"
-        );
-    }
 
     for gate in ["gate-audit", "gate-lint", "gate-test"] {
         assert!(
@@ -177,7 +232,6 @@ fn release_prepare_waits_for_command_policy_not_raw_audit_or_refactor() {
     }
 
     assert!(prepare.contains("- release-quality-policy"));
-    assert!(!prepare.contains("- gate-refactor"));
     assert!(prepare.contains("needs.release-quality-policy.result == 'success'"));
     assert!(prepare.contains("inputs.release_tag != ''"));
 }


### PR DESCRIPTION
Fixes #8046.

## Summary
- Remove the post-quality-gate `gate-refactor` job and all generic release autofix/PR inputs.
- Keep audit, lint, and test gates read-only while preserving release-quality policy and categorized issue filing.
- Preserve existing audit-baseline consumption and extension-declared generated-drift allowlists without adding a broad release source-mutation step.
- Replace tests that required auto-refactor with behavioral coverage proving generic mutation is absent and read-only quality gates remain bounded.

Related action cleanup is tracked separately in Extra-Chill/homeboy-action#279.

## How to test
1. Check out this branch from a fresh clone.
2. Run `cargo test --test release_workflow_test` and confirm all 16 tests pass.
3. Run `cargo fmt --check`.
4. Run `cargo check`; existing dead-code warnings are acceptable.
5. Run `git diff --check`.
6. Inspect `.github/workflows/release.yml` and confirm `gate-refactor`, `autofix: true`, `autofix-mode: always`, `autofix-open-pr: true`, and `refactor --from all` are absent while `gate-audit`, `gate-lint`, `gate-test`, and `release-quality-policy` remain.

## Backward compatibility
- Release behavior intentionally changes: Homeboy releases no longer attempt generic source autofix or create autofix branches/PRs after quality gates.
- Existing audit baseline comparison, categorized issue reporting, release-quality policy, and extension-declared generated-drift contracts remain available.
- No Homeboy CLI or persisted-data format changes are introduced.
- Public `homeboy-action` autofix inputs are unchanged by this PR; compatibility decisions for those inputs belong to Extra-Chill/homeboy-action#279.

## Verification
- `cargo test --test release_workflow_test`: 16 passed
- `cargo fmt --check`: passed
- `cargo check`: passed with existing dead-code warnings
- `git diff --check`: passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode orchestrated by Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Audited release mutation behavior with Chris, removed generic release auto-refactor while preserving narrow generated-drift and baseline contracts, and added deterministic workflow coverage.