### PR TITLE
Prove controller-owned Lab retry handoff

### DIFF
--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -1900,6 +1900,8 @@ mod tests {
                 "retry",
                 "failed-run",
                 "--run",
+                "--new-run-id",
+                "failed-run-retry-on-lab",
                 "--runner",
                 "homeboy-lab",
             ]
@@ -1930,6 +1932,23 @@ mod tests {
             assert_eq!(handoff.args[agent_task_index + 2], "--plan");
             assert_eq!(handoff.args[agent_task_index + 4], "--record-run-id");
             assert_eq!(handoff.args[agent_task_index + 5], handoff.run_id);
+            assert_eq!(handoff.run_id, "failed-run-retry-on-lab");
+            let remote_cli = Cli::try_parse_from(&handoff.args).expect("portable run-plan argv");
+            let Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+                command: crate::commands::agent_task::AgentTaskCommand::RunPlan(remote),
+            }) = &remote_cli.command
+            else {
+                panic!(
+                    "Lab handoff must execute the materialized plan, not discover a retry record"
+                );
+            };
+            assert_eq!(
+                remote.record_run_id.as_deref(),
+                Some(handoff.run_id.as_str())
+            );
+            let remote_plan: homeboy::core::agent_tasks::scheduler::AgentTaskPlan =
+                serde_json::from_str(&remote.plan).expect("serialized retry plan");
+            assert_eq!(remote_plan, handoff.plan);
             let replacement = agent_task_lifecycle::status(&handoff.run_id).expect("replacement");
             assert_eq!(replacement.metadata["retry_of"], "failed-run");
 

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -272,11 +272,12 @@ fn failed_lab_handoff_retry_recovers_the_materialized_user_plan() {
         plan.plan_id = "materialized-cook-plan".to_string();
         plan.tasks[0].instructions = "implement the original user task".to_string();
         plan.tasks[0].workspace.root = Some("/materialized/worktree".to_string());
+        plan.rebuild_homeboy_plan();
         let record = record_lab_offload_phase(
             "failed-lab-cook",
             "homeboy-lab",
             "materializing",
-            None,
+            Some("pending"),
             None,
             None,
             Some(&plan),


### PR DESCRIPTION
## Summary

Closes #8043 by locking in the controller-owned Lab retry contract introduced in #7859 and complemented by the task-workspace selection fix in #8076.

The regression now proves that an explicit retry ID is preserved while the remote handoff parses as `agent-task run-plan`, carries the replacement ID through `--record-run-id`, and contains the exact materialized plan. The lifecycle fixture now rebuilds the plan and records the pending remote workspace before verifying retry recovery.

## Root cause

The reported failure came from a runtime path that invoked `agent-task run <retry-id>` on the Lab lifecycle store, where the controller-created retry record did not exist. Current `main` already converts that operation into a portable serialized `run-plan` handoff, but existing coverage only inspected positional arguments and did not parse or prove the remote command and durable plan contract.

## How to test

1. Check out this branch from a fresh clone.
2. Run `cargo fmt --check`.
3. Run `cargo test detached_retry_materializes_failed_plan_and_persists_bounded_preacceptance_failure`.
4. Run `cargo test failed_lab_handoff_retry_recovers_the_materialized_user_plan`.
5. Run `cargo nextest run --profile default --lib`.
6. Confirm the detached retry test parses the generated handoff as `AgentTaskCommand::RunPlan`, preserves `failed-run-retry-on-lab`, and round-trips the exact serialized plan.

## Backwards compatibility

No CLI arguments, serialized schemas, or runtime behavior change. This strengthens coverage for the existing portable retry-handoff contract and updates a test fixture to model the persisted pending Lab workspace.

## Verification

- `cargo fmt --check`: passed on Homeboy Lab.
- Both scoped retry tests: passed on Homeboy Lab before rebasing onto #8076; the conflict resolution preserved #8076 and added these assertions.
- Raw `cargo test`: compiled the suite; 7,248 tests passed and 81 unrelated live-environment/global-state tests failed.
- Canonical `cargo nextest run --profile default --lib`: unavailable on Lab because `cargo-nextest` is not installed. GitHub CI is the authoritative exact-head full gate.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** zai-coding-plan/glm-5.2
- **Used for:** Investigated existing retry ownership behavior, strengthened deterministic regression coverage, and prepared the review; Chris reviews and owns the change.
