### PR TITLE
Fix lease-less daemon process attribution

### DIFF
--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -84,6 +84,32 @@ pub struct DaemonStatus {
     pub state_path: String,
     /// Identity of the lease and durable queue observed by status callers.
     pub state_identity: String,
+    /// Process-level evidence is retained even when the lease is absent so an
+    /// operator can distinguish another runner from an attributable owner.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub process_candidates: Vec<DaemonProcessCandidate>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DaemonProcessCandidate {
+    pub pid: u32,
+    pub executable: String,
+    pub cmdline: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bind_endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub durable_store_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_identity: Option<String>,
+    pub ownership: DaemonProcessOwnership,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DaemonProcessOwnership {
+    Owning,
+    Unrelated,
+    Ambiguous,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
@@ -460,6 +486,7 @@ pub fn read_status() -> Result<DaemonStatus> {
     let validation = validate_lease_file(&path)?;
     let active_jobs = JobStore::active_count_at_path(paths::daemon_jobs_file()?)?;
 
+    let jobs_path = paths::daemon_jobs_file()?;
     Ok(DaemonStatus {
         running: validation.running && validation.fresh && validation.reachable,
         fresh: validation.fresh,
@@ -469,6 +496,7 @@ pub fn read_status() -> Result<DaemonStatus> {
         state: validation.state,
         state_path,
         state_identity,
+        process_candidates: control::daemon_process_candidates(&jobs_path)?,
     })
 }
 

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -21,8 +21,82 @@ use super::{
     acquire_daemon_operation_lock, acquire_daemon_operation_lock_for_ensure, parse_bind_addr,
     read_status, repair_legacy_lease_for_start, stop_unlocked, try_acquire_daemon_owner_lock,
     DaemonLeaselessOrphanReconciliationResult, DaemonLeaselessRecoveryResult,
-    DaemonOrphanAdoptionResult, DaemonStaleReasonCode, DaemonStartResult, DAEMON_STARTUP_TOKEN_ENV,
+    DaemonOrphanAdoptionResult, DaemonProcessCandidate, DaemonProcessOwnership,
+    DaemonStaleReasonCode, DaemonStartResult, DAEMON_STARTUP_TOKEN_ENV,
 };
+
+/// Enumerate foreground daemon processes without inferring ownership from a
+/// command substring. A candidate is an owner only when its explicit HOME
+/// environment resolves to this durable store and its executable is the active
+/// binary; absent evidence remains ambiguous.
+pub(super) fn daemon_process_candidates(jobs_path: &Path) -> Result<Vec<DaemonProcessCandidate>> {
+    let output = Command::new("ps")
+        .args(["-axeww", "-o", "pid=", "-o", "comm=", "-o", "command="])
+        .output()
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("inspect daemon processes".to_string()),
+            )
+        })?;
+    if !output.status.success() {
+        return Err(Error::internal_unexpected(
+            "unable to inspect daemon processes",
+        ));
+    }
+    let current_exe = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.canonicalize().ok());
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| parse_daemon_process_candidate(line, jobs_path, current_exe.as_deref()))
+        .collect())
+}
+
+fn parse_daemon_process_candidate(
+    line: &str,
+    jobs_path: &Path,
+    current_exe: Option<&Path>,
+) -> Option<DaemonProcessCandidate> {
+    let mut fields = line.split_whitespace();
+    let pid = fields.next()?.parse().ok()?;
+    let executable = fields.next()?.to_string();
+    let cmdline = fields.collect::<Vec<_>>().join(" ");
+    if !cmdline.contains("daemon serve") {
+        return None;
+    }
+    let bind_endpoint = cmdline
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .windows(2)
+        .find_map(|pair| (pair[0] == "--addr").then(|| pair[1].to_string()));
+    let home = cmdline
+        .split_whitespace()
+        .find_map(|part| part.strip_prefix("HOME="));
+    let durable_store_path =
+        home.map(|home| Path::new(home).join(".config/homeboy/daemon/jobs.json"));
+    let executable_matches = current_exe.is_some_and(|current| {
+        Path::new(&executable).canonicalize().ok().as_deref() == Some(current)
+    });
+    let ownership = match durable_store_path.as_deref() {
+        Some(store) if store != jobs_path => DaemonProcessOwnership::Unrelated,
+        Some(_) if executable_matches => DaemonProcessOwnership::Owning,
+        _ => DaemonProcessOwnership::Ambiguous,
+    };
+    Some(DaemonProcessCandidate {
+        pid,
+        executable: executable.clone(),
+        cmdline: normalize_cmdline(&cmdline),
+        bind_endpoint,
+        durable_store_path: durable_store_path.map(|path| path.display().to_string()),
+        build_identity: executable_matches.then_some("current_executable".to_string()),
+        ownership,
+    })
+}
+
+fn normalize_cmdline(cmdline: &str) -> String {
+    cmdline.split_whitespace().collect::<Vec<_>>().join(" ")
+}
 
 /// Outcome of a daemon byte-endpoint artifact download.
 #[derive(Debug, Clone)]
@@ -537,6 +611,16 @@ pub fn adopt_orphaned_lease(
             None,
         )
     })?;
+    // Revalidate after taking the lifecycle-critical lock: a PID can be reused
+    // between status inspection and exact orphan adoption.
+    if !pid_is_proven_dead(state.pid, pid_is_running) {
+        return Err(Error::validation_invalid_argument(
+            "lease_id",
+            format!("recorded daemon PID {} is live or has been reused", state.pid),
+            Some(lease_id.to_string()),
+            Some(vec!["Refusing adoption until the exact recorded PID is proven dead under the lifecycle lock.".to_string()]),
+        ));
+    }
     let store =
         super::JobStore::open_without_reconciliation(crate::core::paths::daemon_jobs_file()?)?;
     let reconciled = store.reconcile_dead_daemon_lease_jobs(lease_id)?;
@@ -609,37 +693,22 @@ pub fn reconcile_leaseless_orphans(
 fn prove_no_daemon_owner(addr: &str) -> Result<Vec<String>> {
     // The owner lock proves no serving daemon owns this store. Refuse any
     // matching process or configured listener as additional ambiguous ownership.
-    let output = Command::new("ps")
-        .args(["-ax", "-o", "command="])
-        .output()
-        .ok();
+    let candidates = daemon_process_candidates(&crate::core::paths::daemon_jobs_file()?)?;
     let parsed: SocketAddr = addr.parse().map_err(|_| {
         Error::validation_invalid_argument("addr", "invalid daemon address", None, None)
     })?;
-    let process = match output {
-        Some(output) if output.status.success() => {
-            let matched = String::from_utf8_lossy(&output.stdout)
-                .lines()
-                .any(|line| line.contains("homeboy daemon serve"));
-            if matched {
-                return Err(Error::validation_invalid_argument(
-                    "owner_probe",
-                    "a Homeboy daemon serve process is present; refusing ambiguous missing-lease recovery",
-                    None,
-                    None,
-                ));
-            } else {
-                "supplemental process probe found no matching command"
-            }
-        }
-        _ => {
-            return Err(Error::validation_invalid_argument(
-                "owner_probe",
-                "unable to inspect Homeboy daemon processes; refusing ambiguous missing-lease recovery",
-                None,
-                None,
-            ));
-        }
+    if !candidates_prove_no_owner(&candidates) {
+        return Err(Error::validation_invalid_argument(
+            "owner_probe",
+            "a daemon serve process may own the configured durable store; refusing missing-lease recovery",
+            None,
+            Some(candidates.iter().map(|candidate| format!("pid {}: {:?} ({})", candidate.pid, candidate.ownership, candidate.cmdline)).collect()),
+        ));
+    }
+    let process = if candidates.is_empty() {
+        "supplemental process probe found no daemon serve candidates".to_string()
+    } else {
+        format!("supplemental process probe proved {} daemon candidate(s) unrelated to the configured durable store", candidates.len())
     };
     let listener = if parsed.port() == 0 {
         format!("listener probe has no fixed address for dynamic bind {addr}")
@@ -655,9 +724,19 @@ fn prove_no_daemon_owner(addr: &str) -> Result<Vec<String>> {
     };
     Ok(vec![
         "daemon owner lock acquired non-destructively".to_string(),
-        process.to_string(),
+        process,
         listener,
     ])
+}
+
+fn candidates_prove_no_owner(candidates: &[DaemonProcessCandidate]) -> bool {
+    candidates
+        .iter()
+        .all(|candidate| candidate.ownership == DaemonProcessOwnership::Unrelated)
+}
+
+fn pid_is_proven_dead(pid: u32, is_running: impl FnOnce(u32) -> bool) -> bool {
+    !is_running(pid)
 }
 
 fn read_job_store_bytes(path: &Path) -> Result<Vec<u8>> {
@@ -804,12 +883,73 @@ where
 /// for lease publication without a parent/child startup deadlock.
 fn start_or_return_live_unlocked(addr: &str) -> Result<DaemonStartResult> {
     let _repaired_legacy_lease = repair_legacy_lease_for_start()?;
+    reattach_exact_live_owner()?;
     start_or_return_live_with_operations(
         read_status,
         try_acquire_daemon_owner_lock,
         || stop_unlocked().map(|_| ()),
         || spawn_and_wait_for_lease(addr),
     )
+}
+
+/// Restore the lease only for one process whose executable and explicit HOME
+/// environment prove it owns this conventional durable store. The listener is
+/// checked before writing anything; all other candidates remain fail-closed.
+fn reattach_exact_live_owner() -> Result<()> {
+    let state_path = crate::core::paths::daemon_state_file()?;
+    if state_path.exists() {
+        return Ok(());
+    }
+    let candidates = daemon_process_candidates(&crate::core::paths::daemon_jobs_file()?)?;
+    let owners: Vec<_> = candidates
+        .into_iter()
+        .filter(|candidate| candidate.ownership == DaemonProcessOwnership::Owning)
+        .collect();
+    if owners.len() != 1 {
+        return Ok(());
+    }
+    let owner = &owners[0];
+    let Some(endpoint) = owner.bind_endpoint.as_deref() else {
+        return Ok(());
+    };
+    let Ok(address) = endpoint.parse::<SocketAddr>() else {
+        return Ok(());
+    };
+    if address.port() == 0
+        || TcpStream::connect_timeout(&address, Duration::from_millis(200)).is_err()
+    {
+        return Ok(());
+    }
+    if !pid_is_running(owner.pid) {
+        return Ok(());
+    }
+    // Re-read the exact candidate immediately before persisting a lease so PID
+    // reuse cannot turn a previously attributable process into an owner.
+    let revalidated = daemon_process_candidates(&crate::core::paths::daemon_jobs_file()?)?
+        .into_iter()
+        .any(|candidate| {
+            candidate.pid == owner.pid
+                && candidate.ownership == DaemonProcessOwnership::Owning
+                && candidate.cmdline == owner.cmdline
+        });
+    if !revalidated {
+        return Ok(());
+    }
+    let now = chrono::Utc::now().to_rfc3339();
+    let state = super::DaemonState {
+        schema: super::DAEMON_LEASE_SCHEMA.to_string(),
+        lease_id: uuid::Uuid::new_v4().to_string(),
+        startup_token: "reattached".to_string(),
+        address: endpoint.to_string(),
+        pid: owner.pid,
+        state_path: state_path.display().to_string(),
+        started_at: now.clone(),
+        last_seen_at: now,
+        build_identity: crate::core::build_identity::current(),
+        binary_sha256: super::current_binary_sha256()?,
+        runtime_paths: super::capture_daemon_runtime_snapshot(),
+    };
+    super::write_lease(&state_path, &state)
 }
 
 fn start_or_return_live_with_operations<OwnerLock, ReadStatus, AcquireOwner, Cleanup, Spawn>(

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -94,6 +94,82 @@ fn leaseless_store_aborts_on_ambiguous_or_live_owner_probe() {
 }
 
 #[test]
+fn daemon_process_attribution_matches_only_explicit_store_and_binary_identity() {
+    let home = tempfile::tempdir().expect("home");
+    let jobs = home.path().join(".config/homeboy/daemon/jobs.json");
+    let executable = std::env::current_exe().expect("current executable");
+    let line = format!(
+        "4242 {} HOME={} {} daemon serve --addr 127.0.0.1:7421",
+        executable.display(),
+        home.path().display(),
+        executable.display()
+    );
+
+    let candidate =
+        super::parse_daemon_process_candidate(&line, &jobs, Some(&executable)).expect("candidate");
+    assert_eq!(
+        candidate.ownership,
+        super::super::DaemonProcessOwnership::Owning
+    );
+    assert_eq!(candidate.bind_endpoint.as_deref(), Some("127.0.0.1:7421"));
+    assert_eq!(candidate.durable_store_path.as_deref(), jobs.to_str());
+}
+
+#[test]
+fn daemon_process_attribution_proves_unrelated_and_fails_closed_when_ambiguous() {
+    let home = tempfile::tempdir().expect("home");
+    let other_home = tempfile::tempdir().expect("other home");
+    let jobs = home.path().join(".config/homeboy/daemon/jobs.json");
+    let executable = std::env::current_exe().expect("current executable");
+    let unrelated = format!(
+        "4243 {} HOME={} {} daemon serve --addr 127.0.0.1:7421",
+        executable.display(),
+        other_home.path().display(),
+        executable.display()
+    );
+    let ambiguous = format!(
+        "4244 {} {} daemon serve --addr 127.0.0.1:7421",
+        executable.display(),
+        executable.display()
+    );
+
+    assert_eq!(
+        super::parse_daemon_process_candidate(&unrelated, &jobs, Some(&executable))
+            .expect("unrelated")
+            .ownership,
+        super::super::DaemonProcessOwnership::Unrelated
+    );
+    assert_eq!(
+        super::parse_daemon_process_candidate(&ambiguous, &jobs, Some(&executable))
+            .expect("ambiguous")
+            .ownership,
+        super::super::DaemonProcessOwnership::Ambiguous
+    );
+}
+
+#[test]
+fn multiple_ambiguous_candidates_block_recovery_and_pid_reuse_blocks_adoption() {
+    let ambiguous = super::super::DaemonProcessCandidate {
+        pid: 71,
+        executable: "/tmp/homeboy".to_string(),
+        cmdline: "homeboy daemon serve --addr 127.0.0.1:0".to_string(),
+        bind_endpoint: Some("127.0.0.1:0".to_string()),
+        durable_store_path: None,
+        build_identity: None,
+        ownership: super::super::DaemonProcessOwnership::Ambiguous,
+    };
+    assert!(!super::candidates_prove_no_owner(&[
+        ambiguous.clone(),
+        ambiguous
+    ]));
+    assert!(super::pid_is_proven_dead(71, |_| false));
+    assert!(
+        !super::pid_is_proven_dead(71, |_| true),
+        "a reused PID remains live under the lifecycle lock"
+    );
+}
+
+#[test]
 fn concurrent_leaseless_recovery_callers_commit_once_and_preserve_job_evidence() {
     with_isolated_home(|_| {
         let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
@@ -226,6 +302,7 @@ fn leaseless_status(active_jobs: usize) -> DaemonStatus {
         state: None,
         state_path: "/fake/daemon-state.json".to_string(),
         state_identity: "lease-missing-test-state".to_string(),
+        process_candidates: Vec::new(),
     }
 }
 
@@ -886,6 +963,7 @@ fn fake_status(daemon: Option<super::DaemonStartResult>, fresh: bool) -> DaemonS
         state: daemon.map(fake_daemon_state),
         state_path: "/fake/daemon-state.json".to_string(),
         state_identity: "sha256:fake".to_string(),
+        process_candidates: Vec::new(),
     }
 }
 
@@ -914,6 +992,7 @@ fn fake_dead_status(daemon: super::DaemonStartResult) -> DaemonStatus {
         state: Some(fake_daemon_state(daemon)),
         state_path: "/fake/daemon-state.json".to_string(),
         state_identity: "sha256:fake".to_string(),
+        process_candidates: Vec::new(),
     }
 }
 


### PR DESCRIPTION
## Summary
- enumerate `daemon serve` candidates with PID, executable/build evidence, normalized command line, bind endpoint, durable store, and ownership classification
- reattach exactly one reachable, same-store current-binary owner under the lifecycle lock; leave ambiguous candidates fail-closed
- permit lease-less reconciliation only when all candidates are proven unrelated, and revalidate exact dead PIDs before orphan adoption

Closes #8079

## How to test
1. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo fmt --check`.
2. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo check`.
3. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo test --lib daemon_process --no-fail-fast`.
4. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo test --lib leaseless_store --no-fail-fast`.
5. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo test --lib concurrent_leaseless --no-fail-fast`.
6. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo test --lib multiple_ambiguous --no-fail-fast`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode / openai-gpt-5.6-terra
- **Used for:** Implemented typed daemon-process attribution, recovery guards, and deterministic tests under Chris Huber's direction.