### PR TITLE
Recover Lab runners with corrupt lease metadata

### DIFF
--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -612,12 +612,14 @@ where
     Start: FnOnce() -> Result<super::DaemonStartResult>,
 {
     let status = status()?;
-    if status.freshness.stale_reason_code != Some(DaemonStaleReasonCode::LeaseMissing)
-        || status.freshness.active_jobs == 0
+    if !matches!(
+        status.freshness.stale_reason_code,
+        Some(DaemonStaleReasonCode::LeaseMissing | DaemonStaleReasonCode::LeaseCorrupt)
+    ) || status.freshness.active_jobs == 0
     {
         return Err(Error::validation_invalid_argument(
             "job_store",
-            "lease-less reconciliation requires lease_missing with active jobs",
+            "lease-less reconciliation requires missing or corrupt lease metadata with active jobs",
             None,
             None,
         ));
@@ -731,8 +733,8 @@ pub fn adopt_orphaned_lease(
 }
 
 /// Explicitly recover legacy unowned durable jobs when the daemon lease is
-/// missing. Process and configured-listener probes are fail-closed because no
-/// lease identity exists to adopt.
+/// missing or unreadable. Process and configured-listener probes are fail-closed
+/// because no trustworthy lease identity exists to adopt.
 pub fn reconcile_leaseless_orphans(
     confirm_no_daemon_owner: bool,
     addr: &str,
@@ -748,10 +750,13 @@ pub fn reconcile_leaseless_orphans(
     parse_bind_addr(addr)?;
     let _lock = acquire_daemon_operation_lock()?;
     let status = read_status()?;
-    if status.freshness.stale_reason_code != Some(DaemonStaleReasonCode::LeaseMissing) {
+    if !matches!(
+        status.freshness.stale_reason_code,
+        Some(DaemonStaleReasonCode::LeaseMissing | DaemonStaleReasonCode::LeaseCorrupt)
+    ) {
         return Err(Error::validation_invalid_argument(
             "reconcile_leaseless_orphans",
-            "lease-less recovery requires a missing daemon lease; use exact lease recovery for recorded leases",
+            "lease-less recovery requires missing or corrupt daemon lease metadata; use exact lease recovery for recorded leases",
             None,
             None,
         ));

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -1492,12 +1492,19 @@ mod remote_daemon {
         let proven_dead = status.stale_reason_code == Some(DaemonStaleReasonCode::PidDead)
             && lease_id.is_some()
             && pid.is_some();
+        let leaseless_reconciliation_available = status.active_jobs > 0
+            && matches!(
+                status.stale_reason_code,
+                Some(DaemonStaleReasonCode::LeaseMissing | DaemonStaleReasonCode::LeaseCorrupt)
+            );
         let mut ownership_evidence = if proven_dead {
             Some(format!(
                 "remote daemon status over SSH proved PID {} is dead for lease `{}`",
                 pid.expect("proven dead PID"),
                 lease_id.as_deref().expect("proven dead lease")
             ))
+        } else if leaseless_reconciliation_available {
+            Some("active durable jobs have missing or corrupt daemon lease metadata; explicit reconciliation will verify the owner lock, process list, and configured listener before terminalizing them".to_string())
         } else {
             Some("remote daemon lease evidence is unavailable; active jobs are protected from implicit replacement".to_string())
         };
@@ -1513,13 +1520,20 @@ mod remote_daemon {
                 ownership_evidence.unwrap_or_default()
             ));
         }
-        let adoption_command = proven_dead.then(|| {
-            format!(
+        let adoption_command = if proven_dead {
+            Some(format!(
                 "homeboy runner connect {} --adopt-orphan-lease {} --confirm-pid-dead",
                 shell::quote_arg(runner_id),
                 shell::quote_arg(lease_id.as_deref().expect("proven dead lease"))
-            )
-        });
+            ))
+        } else if leaseless_reconciliation_available {
+            Some(format!(
+                "homeboy runner connect {} --reconcile-leaseless-orphans --confirm-no-daemon-owner",
+                shell::quote_arg(runner_id),
+            ))
+        } else {
+            None
+        };
         DaemonFreshnessReport {
             fresh: status.fresh,
             stale_reason_code: status.stale_reason_code,
@@ -2439,6 +2453,43 @@ mod tests {
             Some(crate::core::daemon::DaemonRecoveryEvidence::Unavailable)
         );
         assert!(recovery.adoption_command.is_none());
+    }
+
+    #[test]
+    fn remote_missing_or_corrupt_lease_with_active_jobs_exposes_bounded_reconciliation() {
+        for reason in [
+            DaemonStaleReasonCode::LeaseMissing,
+            DaemonStaleReasonCode::LeaseCorrupt,
+        ] {
+            let mut status = remote_daemon_status_for_test_with_reason(
+                false,
+                false,
+                1,
+                "legacy-lease",
+                4545,
+                Some(reason),
+            );
+            status.daemon = None;
+
+            let recovery = remote_daemon_recovery_freshness_from_status("homeboy-lab", &status);
+
+            assert_eq!(recovery.active_jobs, 1, "{reason:?}");
+            assert_eq!(
+                recovery.recovery_evidence,
+                Some(crate::core::daemon::DaemonRecoveryEvidence::Unavailable),
+                "recovery remains explicit until remote ownership probes pass ({reason:?})"
+            );
+            assert_eq!(
+                recovery.adoption_command.as_deref(),
+                Some("homeboy runner connect homeboy-lab --reconcile-leaseless-orphans --confirm-no-daemon-owner"),
+                "{reason:?}"
+            );
+            assert!(recovery
+                .ownership_evidence
+                .as_deref()
+                .expect("recovery guidance")
+                .contains("explicit reconciliation"));
+        }
     }
 
     #[test]

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -66,6 +66,48 @@ fn leaseless_store_requires_missing_lease_and_no_owner_then_preserves_evidence()
 }
 
 #[test]
+fn corrupt_lease_reconciliation_terminalizes_queued_durable_agent_task_after_proof() {
+    with_isolated_home(|_| {
+        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let store = JobStore::open_without_reconciliation(&path).expect("store");
+        let job = store.create("agent-task.cook");
+
+        let result = reconcile_leaseless_orphan_store_with_operations(
+            || Ok(corrupt_leaseless_status(1)),
+            || {
+                Ok(vec![
+                    "owner lock acquired".to_string(),
+                    "no process".to_string(),
+                ])
+            },
+            || {
+                let snapshot = path.with_extension("corrupt-lease.snapshot.json");
+                std::fs::copy(&path, &snapshot).expect("snapshot");
+                let store = JobStore::open_without_reconciliation(&path).expect("recovery store");
+                Ok((snapshot, store.reconcile_leaseless_orphan_jobs()?))
+            },
+            || Ok(fake_daemon(4343, "fresh-lease")),
+        )
+        .expect("reconcile corrupt lease");
+
+        assert_eq!(result.affected_job_ids, vec![job.id.to_string()]);
+        let recovered = JobStore::open_without_reconciliation(&path).expect("recovered");
+        assert_eq!(
+            recovered.get(job.id).expect("job").status,
+            JobStatus::Failed
+        );
+        assert!(recovered
+            .events(job.id)
+            .expect("events")
+            .iter()
+            .any(|event| event
+                .data
+                .as_ref()
+                .is_some_and(|data| { data["reason"] == "leaseless_orphan_reconciliation" })));
+    });
+}
+
+#[test]
 fn leaseless_store_aborts_on_ambiguous_or_live_owner_probe() {
     for probe in [
         || {
@@ -304,6 +346,13 @@ fn leaseless_status(active_jobs: usize) -> DaemonStatus {
         state_identity: "lease-missing-test-state".to_string(),
         process_candidates: Vec::new(),
     }
+}
+
+fn corrupt_leaseless_status(active_jobs: usize) -> DaemonStatus {
+    let mut status = leaseless_status(active_jobs);
+    status.freshness.stale_reason_code = Some(DaemonStaleReasonCode::LeaseCorrupt);
+    status.stale_reason = Some("invalid daemon lease".to_string());
+    status
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `recovery-homeboy-8080` into review-ready branch `fix/8080-runner-leaseless-recovery`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:recovery-homeboy-8080`
- **Homeboy run ID:** `recovery-homeboy-8080`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `fix/8080-runner-leaseless-recovery`

## Source refs
- https://github.com/Extra-Chill/homeboy/issues/8080

## Attempt summary
Recovery candidate passed focused daemon and runner tests; full all-targets compilation exposed unrelated pre-existing Lab route failures.

## Gate results
- fmt: passed (targeted)
- runner_recovery_test: passed (targeted)
- daemon_reconciliation_test: passed (targeted)
- diff_check: passed (targeted)

## Verification capability
- `targeted_checks_run`: `cargo fmt --check`, `cargo test remote_missing_or_corrupt_lease_with_active_jobs_exposes_bounded_reconciliation`, `cargo test corrupt_lease_reconciliation_terminalizes_queued_durable_agent_task_after_proof`, `git diff --check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- src/core/daemon/control.rs
- src/core/runner/connection.rs
- tests/core/daemon/control_test.rs

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `fix/8080-runner-leaseless-recovery`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode orchestrated by Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab runner lease deadlock, prepared bounded recovery semantics and regression tests, and verified the repair with Chris.
