### PR TITLE
Preserve live child jobs during daemon lease recovery

### DIFF
--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -586,6 +586,58 @@ mod tests {
     }
 
     #[test]
+    fn dead_lease_reconciliation_preserves_a_job_with_a_live_recorded_child() {
+        let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start job");
+        store
+            .append_event(
+                job.id,
+                JobEventKind::Progress,
+                None,
+                Some(json!({ "phase": "heartbeat", "process": { "root_pid": 4242 } })),
+            )
+            .expect("record child heartbeat");
+
+        let diagnostics = store
+            .reconcile_dead_daemon_lease_jobs_with_child_liveness("lease-dead", |pid| pid == 4242)
+            .expect("reconcile dead lease");
+
+        assert_eq!(diagnostics.protected_job_ids, vec![job.id]);
+        assert_eq!(diagnostics.terminalized_count(), 0);
+        assert_eq!(store.get(job.id).expect("job").status, JobStatus::Running);
+        assert!(store.events(job.id).expect("events").iter().all(|event| {
+            event
+                .data
+                .as_ref()
+                .is_none_or(|data| data["reason"] != json!("dead_daemon_lease"))
+        }));
+    }
+
+    #[test]
+    fn dead_lease_reconciliation_terminalizes_a_job_with_a_dead_recorded_child() {
+        let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start job");
+        store
+            .append_event(
+                job.id,
+                JobEventKind::Progress,
+                None,
+                Some(json!({ "phase": "heartbeat", "process": { "root_pid": 4242 } })),
+            )
+            .expect("record child heartbeat");
+
+        let diagnostics = store
+            .reconcile_dead_daemon_lease_jobs_with_child_liveness("lease-dead", |_| false)
+            .expect("reconcile dead lease");
+
+        assert!(diagnostics.protected_job_ids.is_empty());
+        assert_eq!(diagnostics.terminalized_count(), 1);
+        assert_eq!(store.get(job.id).expect("job").status, JobStatus::Failed);
+    }
+
+    #[test]
     fn leaseless_recovery_terminalizes_one_historical_lease_and_retains_evidence() {
         let temp = tempfile::tempdir().expect("temp dir");
         let path = temp.path().join("jobs.json");

--- a/src/core/api_jobs/store.rs
+++ b/src/core/api_jobs/store.rs
@@ -22,6 +22,7 @@ use super::types::{
     LeaselessOrphanJobDiagnostics,
 };
 use crate::core::error::{Error, Result};
+use crate::core::process::pid_is_running;
 use crate::core::runner_execution_envelope::PathMaterializationPlan;
 use crate::core::source_snapshot::SourceSnapshot;
 
@@ -320,6 +321,14 @@ impl JobStore {
         &self,
         expected_lease_id: &str,
     ) -> Result<DaemonLeaseJobDiagnostics> {
+        self.reconcile_dead_daemon_lease_jobs_with_child_liveness(expected_lease_id, pid_is_running)
+    }
+
+    pub(super) fn reconcile_dead_daemon_lease_jobs_with_child_liveness(
+        &self,
+        expected_lease_id: &str,
+        pid_is_alive: impl Fn(u32) -> bool,
+    ) -> Result<DaemonLeaseJobDiagnostics> {
         let diagnostics = self.daemon_lease_job_diagnostics(expected_lease_id);
         if diagnostics.unowned_count() > 0 {
             return Err(Error::validation_invalid_argument(
@@ -336,8 +345,13 @@ impl JobStore {
 
         let now = timestamp_ms();
         let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let mut diagnostics = diagnostics;
         for job_id in &diagnostics.matching_job_ids {
             let stored = inner.jobs.get_mut(job_id).expect("diagnosed job exists");
+            if last_progress_child_pid(&stored.events).is_some_and(&pid_is_alive) {
+                diagnostics.protected_job_ids.push(*job_id);
+                continue;
+            }
             if let Some((status, exit_code)) = recovered_terminal_from_result(&stored.events) {
                 stored.job.status = status;
                 stored.job.updated_at_ms = now;
@@ -403,6 +417,7 @@ impl JobStore {
             apply_event_retention(&mut stored.events, self.event_retention_limit());
             stored.job.event_count = stored.events.len();
         }
+        diagnostics.protected_job_ids.sort();
         drop(inner);
         self.persist()?;
         Ok(diagnostics)
@@ -412,11 +427,22 @@ impl JobStore {
     /// owns a store whose current daemon lease is missing. Historical job leases
     /// remain evidence; they cannot prove a current owner or be adopted as one.
     pub fn reconcile_leaseless_orphan_jobs(&self) -> Result<LeaselessOrphanJobDiagnostics> {
+        self.reconcile_leaseless_orphan_jobs_with_child_liveness(pid_is_running)
+    }
+
+    fn reconcile_leaseless_orphan_jobs_with_child_liveness(
+        &self,
+        pid_is_alive: impl Fn(u32) -> bool,
+    ) -> Result<LeaselessOrphanJobDiagnostics> {
         let mut diagnostics = LeaselessOrphanJobDiagnostics::default();
         {
             let inner = self.inner.lock().expect("job store mutex poisoned");
             for stored in inner.jobs.values() {
                 if !matches!(stored.job.status, JobStatus::Queued | JobStatus::Running) {
+                    continue;
+                }
+                if last_progress_child_pid(&stored.events).is_some_and(&pid_is_alive) {
+                    diagnostics.protected_job_ids.push(stored.job.id);
                     continue;
                 }
                 let original_daemon_lease_id = stored.job.daemon_lease_id.clone();
@@ -434,6 +460,7 @@ impl JobStore {
         diagnostics.affected_jobs.sort_by_key(|job| job.job_id);
         diagnostics.historical_lease_ids.sort();
         diagnostics.historical_lease_ids.dedup();
+        diagnostics.protected_job_ids.sort();
 
         let now = timestamp_ms();
         let mut inner = self.inner.lock().expect("job store mutex poisoned");
@@ -759,6 +786,22 @@ impl JobStore {
 
         write_durable_store(&persistence.path, &durable)
     }
+}
+
+/// The reverse runner records the executing child in periodic progress
+/// heartbeats. A live child is still authoritative even after its daemon lease
+/// owner exits, so reconciliation must leave its durable run files intact.
+fn last_progress_child_pid(events: &[JobEvent]) -> Option<u32> {
+    events
+        .iter()
+        .rev()
+        .find(|event| event.kind == JobEventKind::Progress)
+        .and_then(|event| event.data.as_ref())
+        .and_then(|data| data.get("process"))
+        .and_then(|process| process.get("root_pid"))
+        .and_then(Value::as_u64)
+        .and_then(|pid| u32::try_from(pid).ok())
+        .filter(|pid| *pid > 0)
 }
 
 impl JobHandle {

--- a/src/core/api_jobs/types.rs
+++ b/src/core/api_jobs/types.rs
@@ -232,6 +232,8 @@ pub struct DaemonLeaseJobDiagnostics {
     pub matching_job_ids: Vec<Uuid>,
     pub other_lease_job_ids: Vec<Uuid>,
     pub unowned_job_ids: Vec<Uuid>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub protected_job_ids: Vec<Uuid>,
 }
 
 /// An active durable job terminalized after the daemon lease disappeared.
@@ -248,6 +250,8 @@ pub struct LeaselessOrphanJobDiagnostics {
     pub reconciled_job_ids: Vec<Uuid>,
     pub affected_jobs: Vec<LeaselessOrphanAffectedJob>,
     pub historical_lease_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub protected_job_ids: Vec<Uuid>,
 }
 
 impl LeaselessOrphanJobDiagnostics {
@@ -265,5 +269,13 @@ impl DaemonLeaseJobDiagnostics {
     }
     pub fn unowned_count(&self) -> usize {
         self.unowned_job_ids.len()
+    }
+
+    pub fn protected_count(&self) -> usize {
+        self.protected_job_ids.len()
+    }
+
+    pub fn terminalized_count(&self) -> usize {
+        self.matching_count().saturating_sub(self.protected_count())
     }
 }

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -136,7 +136,20 @@ pub fn recover_missing_lease_state(
             replacement: None,
         };
         write_state_loss_receipt(&receipt_path, &receipt)?;
-        store.reconcile_dead_daemon_lease_jobs(lease_id)?;
+        let reconciled = store.reconcile_dead_daemon_lease_jobs(lease_id)?;
+        if reconciled.protected_count() > 0 {
+            let _ = std::fs::remove_file(&receipt_path);
+            return Err(Error::validation_invalid_argument(
+                "lease_id",
+                format!(
+                    "deferred missing-lease recovery because {} active child process(es) are still running: {}",
+                    reconciled.protected_count(),
+                    reconciled.protected_job_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(", "),
+                ),
+                Some(lease_id.to_string()),
+                Some(vec!["Wait for the recorded child process to finish, then retry recovery.".to_string()]),
+            ));
+        }
         receipt.phase = StateLossRecoveryPhase::Reconciled;
         write_state_loss_receipt(&receipt_path, &receipt)?;
         drop(owner_lock);
@@ -364,6 +377,18 @@ where
         )
     })?;
     let (snapshot_path, reconciled) = reconcile()?;
+    if reconciled.protected_count() > 0 {
+        return Err(Error::validation_invalid_argument(
+            "lease_id",
+            format!(
+                "deferred missing-lease recovery because {} active child process(es) are still running: {}",
+                reconciled.protected_count(),
+                reconciled.protected_job_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(", "),
+            ),
+            Some(lease_id.to_string()),
+            Some(vec!["Wait for the recorded child process to finish, then retry recovery.".to_string()]),
+        ));
+    }
     if reconciled.matching_count() == 0 {
         return Err(Error::validation_invalid_argument(
             "lease_id",
@@ -455,6 +480,18 @@ where
     }
     let no_owner_proof = probe()?;
     let (snapshot_path, reconciled) = reconcile()?;
+    if !reconciled.protected_job_ids.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "job_store",
+            format!(
+                "deferred lease-less recovery because {} active child process(es) are still running: {}",
+                reconciled.protected_job_ids.len(),
+                reconciled.protected_job_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(", "),
+            ),
+            None,
+            Some(vec!["Wait for the recorded child process to finish, then retry recovery.".to_string()]),
+        ));
+    }
     let affected_job_count = reconciled.reconciled_count();
     let replacement = start()?;
     Ok(DaemonLeaselessOrphanReconciliationResult {
@@ -540,12 +577,24 @@ pub fn adopt_orphaned_lease(
     let store =
         super::JobStore::open_without_reconciliation(crate::core::paths::daemon_jobs_file()?)?;
     let reconciled = store.reconcile_dead_daemon_lease_jobs(lease_id)?;
+    if reconciled.protected_count() > 0 {
+        return Err(Error::validation_invalid_argument(
+            "lease_id",
+            format!(
+                "deferred exact dead-lease adoption because {} active child process(es) are still running: {}",
+                reconciled.protected_count(),
+                reconciled.protected_job_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(", "),
+            ),
+            Some(lease_id.to_string()),
+            Some(vec!["Wait for the recorded child process to finish, then retry adoption.".to_string()]),
+        ));
+    }
     drop(owner_lock);
     let replacement = start_or_return_live_unlocked(addr)?;
     Ok(DaemonOrphanAdoptionResult {
         adopted_lease_id: lease_id.to_string(),
         dead_pid: state.pid,
-        active_jobs_terminalized: reconciled.matching_count(),
+        active_jobs_terminalized: reconciled.terminalized_count(),
         retry_guidance: "Inspect the retained job events, then retry eligible work through its original command or workflow.".to_string(),
         replacement,
     })
@@ -591,6 +640,18 @@ pub fn reconcile_leaseless_orphans(
     let snapshot_path = snapshot_job_store(&jobs_path, &raw_store)?;
     let store = super::JobStore::open_without_reconciliation_from_bytes(&jobs_path, &raw_store)?;
     let reconciled = store.reconcile_leaseless_orphan_jobs()?;
+    if !reconciled.protected_job_ids.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "reconcile_leaseless_orphans",
+            format!(
+                "deferred lease-less recovery because {} active child process(es) are still running: {}",
+                reconciled.protected_job_ids.len(),
+                reconciled.protected_job_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(", "),
+            ),
+            None,
+            Some(vec!["Wait for the recorded child process to finish, then retry recovery.".to_string()]),
+        ));
+    }
     let affected_job_count = reconciled.reconciled_count();
     drop(owner_lock);
     let replacement = start_or_return_live_unlocked(addr)?;


### PR DESCRIPTION
## Summary

- preserve active durable jobs when daemon lease recovery finds their recorded child process still running
- defer exact-lease and lease-less orphan recovery until protected children exit
- retain existing terminalization for dead children and terminal result evidence

Fixes #8084.

## Root cause

Daemon lease reconciliation treated loss of the daemon owner as proof that every matching job was terminal. A Lab-offloaded `agent-task` child can outlive that daemon, so reconciliation could mark a live job failed and remove its durable run files while the child was still using them.

## How to test

1. Run `cargo test core::api_jobs::tests --lib` and confirm all 55 focused API-job tests pass.
2. Run `cargo fmt --check` and confirm it exits successfully.
3. Run `cargo check --all-targets` and confirm it exits successfully; existing dead-code warnings are expected.
4. Inspect `dead_lease_reconciliation_preserves_a_job_with_a_live_recorded_child` and confirm a live recorded child leaves the job running.
5. Inspect `dead_lease_reconciliation_terminalizes_a_job_with_a_dead_recorded_child` and confirm existing dead-child terminalization remains intact.

## Compatibility

This changes recovery behavior only for active jobs whose latest progress event records a currently live child PID. Recovery now defers instead of terminalizing those jobs. Dead-child, terminal-result, exact-lease ownership, and lease-less ownership behavior remains unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Chris and the agent diagnosed the daemon/child ownership race, implemented the liveness guard and regression tests, and verified the recovery contracts.
