### PR TITLE
Fix cook retry workspace isolation

### DIFF
--- a/src/commands/agent_task/status.rs
+++ b/src/commands/agent_task/status.rs
@@ -488,11 +488,35 @@ pub(super) fn replay_provider_boundary(args: ReplayProviderBoundaryArgs) -> CmdR
         .collect::<Vec<_>>();
 
     let candidate_count = candidates.len();
-    let selected_index = candidates
+    let Some((evidence_ref, task_id, hydrated)) = candidates
         .iter()
-        .position(|(evidence_ref, _)| !evidence_ref.uri.contains("/plan#"))
-        .unwrap_or(0);
-    let Some((evidence_ref, task_id)) = candidates.into_iter().nth(selected_index) else {
+        .filter(|(evidence_ref, _)| !evidence_ref.uri.contains("/plan#"))
+        .find_map(|(evidence_ref, task_id)| {
+            let hydrated = agent_task_service::hydrate_evidence_ref(
+                &args.run_id,
+                evidence_ref,
+                task_id.as_deref(),
+                plan.as_ref(),
+                aggregate.as_ref(),
+            );
+            (hydrated.status == "ok"
+                && !hydrated.truncated
+                && hydrated.content.get("format").and_then(Value::as_str) == Some("json"))
+            .then(|| (evidence_ref.clone(), task_id.clone(), hydrated))
+        })
+        .or_else(|| {
+            candidates.first().map(|(evidence_ref, task_id)| {
+                let hydrated = agent_task_service::hydrate_evidence_ref(
+                    &args.run_id,
+                    evidence_ref,
+                    task_id.as_deref(),
+                    plan.as_ref(),
+                    aggregate.as_ref(),
+                );
+                (evidence_ref.clone(), task_id.clone(), hydrated)
+            })
+        })
+    else {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "agent-task replay-provider-boundary",
             "no executor-input evidence was found for this run",
@@ -504,13 +528,6 @@ pub(super) fn replay_provider_boundary(args: ReplayProviderBoundaryArgs) -> CmdR
         ));
     };
 
-    let hydrated = agent_task_service::hydrate_evidence_ref(
-        &args.run_id,
-        &evidence_ref,
-        task_id.as_deref(),
-        plan.as_ref(),
-        aggregate.as_ref(),
-    );
     let input = hydrated_executor_input_value(&hydrated)?;
     let boundary = provider_boundary_projection(&input);
     let report = json!({

--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -474,7 +474,13 @@ fn diagnose_hydrates_executor_result_evidence_root_cause() {
 fn replay_provider_boundary_projects_latest_executor_input() {
     with_temp_home(|| {
         let evidence_dir = tempfile::tempdir().expect("evidence dir");
+        let stale_evidence_path = evidence_dir.path().join("stale-executor-input.txt");
         let evidence_path = evidence_dir.path().join("executor-input.json");
+        std::fs::write(
+            &stale_evidence_path,
+            "permission denied before JSON capture",
+        )
+        .expect("write stale evidence");
         std::fs::write(
             &evidence_path,
             serde_json::to_string(&json!({
@@ -515,7 +521,10 @@ fn replay_provider_boundary_projects_latest_executor_input() {
             test_plan(),
             Some("run-cli-provider-boundary-replay"),
             ExecutorInputEvidenceExecutor {
-                evidence_uri: format!("file://{}", evidence_path.display()),
+                evidence_uris: vec![
+                    format!("file://{}", stale_evidence_path.display()),
+                    format!("file://{}", evidence_path.display()),
+                ],
             },
         )
         .expect("run completed");
@@ -552,6 +561,52 @@ fn replay_provider_boundary_projects_latest_executor_input() {
             "runtime-package"
         );
         assert_eq!(value["typed_evidence"]["kind"], "provider-boundary-replay");
+        assert_eq!(
+            value["selected_evidence"]["uri"],
+            format!("file://{}", evidence_path.display())
+        );
+    });
+}
+
+#[test]
+fn replay_provider_boundary_hydrates_persisted_plan_executor_input() {
+    with_temp_home(|| {
+        let run_id = "run-cli-provider-boundary-plan-replay";
+        let mut plan = test_plan();
+        plan.tasks[0].executor.config = json!({
+            "workspace": { "root": "/candidate/workspace" },
+            "workspace_root": "/candidate/workspace"
+        });
+        run_loaded_plan(
+            plan,
+            Some(run_id),
+            ExecutorInputEvidenceExecutor {
+                evidence_uris: vec![format!(
+                    "homeboy://agent-task/run/{run_id}/plan#task=task-a"
+                )],
+            },
+        )
+        .expect("run completed");
+
+        let (value, exit_code) = replay_provider_boundary(ReplayProviderBoundaryArgs {
+            run_id: run_id.to_string(),
+            task: Some("task-a".to_string()),
+        })
+        .expect("replay persisted plan input");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(
+            value["selected_evidence"]["uri"],
+            format!("homeboy://agent-task/run/{run_id}/plan#task=task-a")
+        );
+        assert_eq!(
+            value["normalized_provider_boundary"]["provider_config"]["workspace"]["root"],
+            "/candidate/workspace"
+        );
+        assert_eq!(
+            value["normalized_provider_boundary"]["provider_config"]["workspace_root"],
+            "/candidate/workspace"
+        );
     });
 }
 
@@ -1088,10 +1143,28 @@ fn run_plan_maps_resolved_component_worktree_before_provider_dispatch() {
             observed.workspace.mode,
             homeboy::core::agent_tasks::AgentTaskWorkspaceMode::Existing
         );
-        assert_eq!(
-            observed.workspace.root.as_deref(),
-            Some(workspace_root.as_str())
+        let executor_workspace = std::path::PathBuf::from(
+            observed
+                .workspace
+                .root
+                .as_deref()
+                .expect("executor workspace"),
         );
+        assert_ne!(executor_workspace, workspace.path());
+        assert!(executor_workspace.is_dir());
+        let source_head = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(workspace.path())
+            .output()
+            .expect("source revision");
+        let executor_head = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&executor_workspace)
+            .output()
+            .expect("executor revision");
+        assert!(source_head.status.success());
+        assert!(executor_head.status.success());
+        assert_eq!(source_head.stdout, executor_head.stdout);
         assert_eq!(
             observed.workspace.slug.as_deref(),
             Some("sample-agent-runtime")

--- a/src/commands/agent_task/tests/promotion_review.rs
+++ b/src/commands/agent_task/tests/promotion_review.rs
@@ -197,17 +197,28 @@ impl AgentTaskExecutorAdapter for CommittingExecutor {
         request: AgentTaskRequest,
         _context: AgentTaskExecutionContext,
     ) -> AgentTaskOutcome {
-        std::fs::write(self.workspace.join("agent-change.txt"), "committed work\n")
+        let workspace = std::path::PathBuf::from(
+            request
+                .workspace
+                .root
+                .as_deref()
+                .expect("isolated workspace"),
+        );
+        assert_ne!(
+            workspace, self.workspace,
+            "executor must not receive the source workspace"
+        );
+        std::fs::write(workspace.join("agent-change.txt"), "committed work\n")
             .expect("write executor change");
         let status = Command::new("git")
             .args(["add", "agent-change.txt"])
-            .current_dir(&self.workspace)
+            .current_dir(&workspace)
             .status()
             .expect("stage executor change");
         assert!(status.success());
         let status = Command::new("git")
             .args(["commit", "-m", "agent: make committed change"])
-            .current_dir(&self.workspace)
+            .current_dir(&workspace)
             .status()
             .expect("commit executor change");
         assert!(status.success());
@@ -227,7 +238,7 @@ impl AgentTaskExecutorAdapter for CommittingExecutor {
                     label: None,
                     role: None,
                     semantic_key: None,
-                    path: Some(self.workspace.join("plugin.php").display().to_string()),
+                    path: Some(workspace.join("plugin.php").display().to_string()),
                     url: None,
                     mime: Some("application/json".to_string()),
                     size_bytes: None,
@@ -242,7 +253,7 @@ impl AgentTaskExecutorAdapter for CommittingExecutor {
                     label: None,
                     role: None,
                     semantic_key: None,
-                    path: Some(self.workspace.join("plugin.php").display().to_string()),
+                    path: Some(workspace.join("plugin.php").display().to_string()),
                     url: None,
                     mime: Some("text/plain".to_string()),
                     size_bytes: None,

--- a/src/commands/agent_task/tests/support.rs
+++ b/src/commands/agent_task/tests/support.rs
@@ -251,7 +251,7 @@ impl AgentTaskExecutorAdapter for ExecutorResultEvidenceFailureExecutor {
 }
 
 pub(crate) struct ExecutorInputEvidenceExecutor {
-    pub(crate) evidence_uri: String,
+    pub(crate) evidence_uris: Vec<String>,
 }
 
 impl AgentTaskExecutorAdapter for ExecutorInputEvidenceExecutor {
@@ -268,11 +268,15 @@ impl AgentTaskExecutorAdapter for ExecutorInputEvidenceExecutor {
             failure_classification: None,
             artifacts: Vec::new(),
             typed_artifacts: Vec::new(),
-            evidence_refs: vec![AgentTaskEvidenceRef {
-                kind: "executor-input".to_string(),
-                uri: self.evidence_uri.clone(),
-                label: Some("latest raw executor input".to_string()),
-            }],
+            evidence_refs: self
+                .evidence_uris
+                .iter()
+                .map(|uri| AgentTaskEvidenceRef {
+                    kind: "executor-input".to_string(),
+                    uri: uri.clone(),
+                    label: Some("latest raw executor input".to_string()),
+                })
+                .collect(),
             diagnostics: Vec::new(),
             outputs: Value::Null,
             workflow: None,

--- a/src/core/agent_task/executor.rs
+++ b/src/core/agent_task/executor.rs
@@ -35,6 +35,29 @@ pub struct AgentTaskRuntimeSelection {
 }
 
 impl AgentTaskExecutor {
+    /// Remap the explicitly supported provider workspace configuration fields.
+    ///
+    /// Providers receive the task workspace as the authoritative root. Providers
+    /// that retain a workspace root in their config must use one of these
+    /// declared shapes rather than relying on ambient config key matching.
+    pub fn remap_workspace_root(&mut self, root: &str) {
+        let Some(config) = self.config.as_object_mut() else {
+            return;
+        };
+
+        if let Some(workspace) = config.get_mut("workspace").and_then(Value::as_object_mut) {
+            if workspace.contains_key("root") {
+                workspace.insert("root".to_string(), Value::String(root.to_string()));
+            }
+        }
+        if config.contains_key("workspace_root") {
+            config.insert(
+                "workspace_root".to_string(),
+                Value::String(root.to_string()),
+            );
+        }
+    }
+
     pub fn runtime_selection(&self) -> AgentTaskRuntimeSelection {
         let explicit = self.runtime_selection.clone().unwrap_or_default();
         AgentTaskRuntimeSelection {
@@ -78,6 +101,35 @@ impl AgentTaskExecutor {
             .as_ref()
             .and_then(|selection| selection.model.as_deref())
             .or(self.model.as_deref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn remaps_only_declared_provider_workspace_fields() {
+        let mut executor = AgentTaskExecutor {
+            backend: "test".to_string(),
+            selector: None,
+            runtime_selection: None,
+            required_capabilities: Vec::new(),
+            secret_env: Vec::new(),
+            model: None,
+            config: json!({
+                "workspace": { "root": "/original", "label": "keep" },
+                "workspace_root": "/original",
+                "unrelated_root": "/original"
+            }),
+        };
+
+        executor.remap_workspace_root("/candidate");
+
+        assert_eq!(executor.config["workspace"]["root"], "/candidate");
+        assert_eq!(executor.config["workspace_root"], "/candidate");
+        assert_eq!(executor.config["unrelated_root"], "/original");
     }
 }
 

--- a/src/core/agent_task_provider/command_runner.rs
+++ b/src/core/agent_task_provider/command_runner.rs
@@ -228,7 +228,7 @@ pub(super) fn run_materialized_provider_command_once(
     provider: &AgentTaskExecutorProvider,
 ) -> AgentTaskOutcome {
     let command = render_provider_command_display(provider);
-    let Some((program, args, cwd)) = provider_command_parts(provider) else {
+    let Some((program, args, provider_cwd)) = provider_command_parts(provider) else {
         return failure_outcome(
             request,
             AgentTaskOutcomeStatus::ProviderError,
@@ -238,6 +238,17 @@ pub(super) fn run_materialized_provider_command_once(
             json!({ "provider": provider.id }),
         );
     };
+
+    // The scheduler may replace a task workspace with an isolated attempt
+    // worktree. That task root is the execution cwd; a manifest cwd is only a
+    // fallback for requests without a workspace.
+    let cwd = request
+        .request
+        .workspace
+        .root
+        .as_deref()
+        .map(PathBuf::from)
+        .or(provider_cwd);
 
     if let Some(preflight) = provider_preflight_failure(request, provider, &program, &cwd, &command)
     {

--- a/src/core/agent_task_provider/tests/manifest_tests.rs
+++ b/src/core/agent_task_provider/tests/manifest_tests.rs
@@ -220,6 +220,75 @@ fn provider_command_parts_uses_argv() {
 }
 
 #[test]
+fn opencode_provider_boundary_uses_task_workspace_for_cwd_and_config() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let original = temp.path().join("promotion-target");
+    let candidate = temp.path().join("attempt-candidate");
+    std::fs::create_dir_all(&original).expect("original workspace");
+    std::fs::create_dir_all(&candidate).expect("candidate workspace");
+    let script = script(
+        r#"const fs = require('fs');
+let input = '';
+process.stdin.on('data', (chunk) => input += chunk);
+process.stdin.on('end', () => {
+  const request = JSON.parse(input);
+  fs.writeFileSync('provider-observation.json', JSON.stringify({
+    cwd: process.cwd(),
+    workspace: request.workspace.root,
+    config_workspace: request.executor.config.workspace.root,
+    config_workspace_root: request.executor.config.workspace_root
+  }));
+  process.stderr.write('permission denied');
+});"#,
+    );
+    let (mut request, mut provider) = request("opencode-boundary", format!("node {script}"));
+    provider.id = "opencode.agent-task-executor".to_string();
+    provider.backend = "opencode".to_string();
+    request.executor.backend = "opencode".to_string();
+    request.workspace.root = Some(candidate.display().to_string());
+    request.executor.config = json!({
+        "workspace": { "root": candidate.display().to_string() },
+        "workspace_root": candidate.display().to_string(),
+    });
+
+    let outcome = run_provider_command_once(&request, &provider);
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::ProviderError);
+    assert_eq!(
+        outcome.diagnostics[0].class, "agent_task.provider_empty_stdout",
+        "{:?}",
+        outcome.diagnostics
+    );
+    assert!(
+        candidate.join("provider-observation.json").is_file(),
+        "candidate missing provider observation; original exists: {}; diagnostics: {:?}",
+        original.join("provider-observation.json").is_file(),
+        outcome.diagnostics
+    );
+    let observation: Value = serde_json::from_slice(
+        &std::fs::read(candidate.join("provider-observation.json")).expect("provider observation"),
+    )
+    .expect("observation json");
+
+    assert_eq!(
+        observation["cwd"],
+        std::fs::canonicalize(&candidate)
+            .expect("canonical candidate")
+            .display()
+            .to_string()
+    );
+    assert_eq!(observation["workspace"], candidate.display().to_string());
+    assert_eq!(
+        observation["config_workspace"],
+        candidate.display().to_string()
+    );
+    assert_eq!(
+        observation["config_workspace_root"],
+        candidate.display().to_string()
+    );
+    assert!(!original.join("provider-observation.json").exists());
+}
+
+#[test]
 fn provider_manifest_rejects_deprecated_string_command() {
     let error = serde_json::from_value::<AgentTaskExecutorProvider>(json!({
         "id": "legacy.provider",

--- a/src/core/agent_task_scheduler/mod.rs
+++ b/src/core/agent_task_scheduler/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, VecDeque};
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{mpsc, Arc};
@@ -106,6 +107,7 @@ where
                     attempt: 1,
                     rotation_index: 0,
                     rotation_attempts: Vec::new(),
+                    retry_attempts: Vec::new(),
                 }
             })
             .collect();
@@ -351,6 +353,36 @@ where
                         continue;
                     }
                 };
+                let candidate_workspace = match materialize_attempt_workspace(
+                    &request,
+                    task_base_sha.as_deref(),
+                    self.run_id.as_deref(),
+                    scheduled.attempt,
+                ) {
+                    Ok(candidate_workspace) => candidate_workspace,
+                    Err(error) => {
+                        let outcome = committed_harvest_failure(
+                            committed_harvest_preflight_outcome(task_id.clone()),
+                            error,
+                        );
+                        events.push(event(
+                            &task_id,
+                            AgentTaskState::Failed,
+                            scheduled.attempt,
+                            outcome.summary.clone(),
+                        ));
+                        record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
+                        continue;
+                    }
+                };
+                let mut executor_request = request.clone();
+                if let Some(candidate_workspace) = candidate_workspace.as_ref() {
+                    let candidate_root = candidate_workspace.display().to_string();
+                    executor_request.workspace.root = Some(candidate_root.clone());
+                    executor_request
+                        .executor
+                        .remap_workspace_root(&candidate_root);
+                }
                 let executor_key = executor_key(&request);
                 let executor = Arc::clone(&self.executor);
                 let plan_id = plan.plan_id.clone();
@@ -381,11 +413,13 @@ where
                     timeout_ms: Some(task_timeout_ms),
                     rotation_index: scheduled.rotation_index,
                     rotation_attempts: scheduled.rotation_attempts,
+                    retry_attempts: scheduled.retry_attempts,
                     task_base_sha,
+                    candidate_workspace,
                 });
 
                 thread::spawn(move || {
-                    let outcome = executor.execute(request, context);
+                    let outcome = executor.execute(executor_request, context);
                     let _ = tx.send(SchedulerEvent::TaskResult(TaskResult {
                         task_id,
                         attempt,
@@ -434,7 +468,7 @@ where
                         continue;
                     };
                     let mut outcome = result.outcome;
-                    if let Err(error) = harvest_committed_patch(&mut outcome, &running_task) {
+                    if let Err(error) = harvest_workspace_patch(&mut outcome, &running_task) {
                         outcome = committed_harvest_failure(outcome, error);
                     }
                     let outcome =
@@ -455,6 +489,9 @@ where
                         &plan.options.retry.retryable_failure_classifications,
                     ) {
                         retry_budget_used += 1;
+                        let retry_evidence = retry_attempt_evidence(&outcome, &running_task);
+                        let mut retry_attempts = running_task.retry_attempts;
+                        retry_attempts.push(retry_evidence);
                         let mut request = running_task.request;
                         request.parent_plan_id = Some(plan.plan_id.clone());
                         let next_attempt = result.attempt + 1;
@@ -470,6 +507,7 @@ where
                             attempt: next_attempt,
                             rotation_index: running_task.rotation_index,
                             rotation_attempts: running_task.rotation_attempts,
+                            retry_attempts,
                         });
                         continue;
                     }
@@ -518,11 +556,19 @@ where
                                 attempt: next_attempt,
                                 rotation_index: running_task.rotation_index + 1,
                                 rotation_attempts,
+                                retry_attempts: running_task.retry_attempts,
                             });
                             continue;
                         }
                     }
                     let mut outcome = outcome;
+                    for retry_attempt in &running_task.retry_attempts {
+                        outcome.diagnostics.push(AgentTaskDiagnostic {
+                            class: "agent_task.retry_attempt".to_string(),
+                            message: "previous retry attempt failed; its diagnostics and isolated workspace are retained".to_string(),
+                            data: retry_attempt.clone(),
+                        });
+                    }
                     if !running_task.rotation_attempts.is_empty() {
                         let mut rotation_attempts = running_task.rotation_attempts.clone();
                         rotation_attempts.push(AgentTaskScheduleSupport::rotation_attempt_record(
@@ -585,6 +631,8 @@ struct ScheduledTask {
     rotation_index: usize,
     /// Ordered evidence for prior dispatch attempts under a rotation policy.
     rotation_attempts: Vec<AgentTaskProviderRotationAttempt>,
+    /// Structured evidence retained from failed retries before the final outcome.
+    retry_attempts: Vec<serde_json::Value>,
 }
 
 #[derive(Debug, Clone)]
@@ -602,9 +650,13 @@ struct RunningTask {
     rotation_index: usize,
     /// Ordered evidence for prior dispatch attempts under a rotation policy.
     rotation_attempts: Vec<AgentTaskProviderRotationAttempt>,
+    retry_attempts: Vec<serde_json::Value>,
     /// Workspace HEAD captured immediately before the executor runs. It bounds
     /// any committed patch candidate to this dispatch attempt.
     task_base_sha: Option<String>,
+    /// Git worktree materialized for this executor attempt. The original source
+    /// workspace stays clean so retries begin from the recorded base state.
+    candidate_workspace: Option<PathBuf>,
 }
 
 struct QuarantinedTask {
@@ -636,42 +688,134 @@ fn prepare_committed_harvest(request: &AgentTaskRequest) -> Result<Option<String
     Ok(Some(git_output(root, &["rev-parse", "HEAD"])?))
 }
 
-fn harvest_committed_patch(
+fn retry_attempt_evidence(outcome: &AgentTaskOutcome, running: &RunningTask) -> serde_json::Value {
+    serde_json::json!({
+        "attempt": running.attempt,
+        "status": outcome.status,
+        "failure_classification": outcome.failure_classification,
+        "summary": outcome.summary,
+        "diagnostics": outcome.diagnostics,
+        "artifacts": outcome.artifacts,
+        "evidence_refs": outcome.evidence_refs,
+        "candidate_workspace": running.candidate_workspace,
+    })
+}
+
+fn materialize_attempt_workspace(
+    request: &AgentTaskRequest,
+    base: Option<&str>,
+    run_id: Option<&str>,
+    attempt: u32,
+) -> Result<Option<PathBuf>, HarvestError> {
+    let (Some(source), Some(base)) = (request.workspace.root.as_deref(), base) else {
+        return Ok(None);
+    };
+    let root = crate::core::artifacts::root()
+        .map_err(|error| HarvestError::CandidateWorkspace {
+            message: error.to_string(),
+        })?
+        .join("agent-task")
+        .join("attempt-workspaces")
+        .join(sanitize_workspace_segment(
+            run_id.unwrap_or("unrecorded-run"),
+        ))
+        .join(workspace_identity_segment(source))
+        .join(sanitize_workspace_segment(&request.task_id))
+        .join(attempt.to_string());
+    if let Some(parent) = root.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| HarvestError::CandidateWorkspace {
+            message: error.to_string(),
+        })?;
+    }
+    let output = Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "--detach",
+            root.to_string_lossy().as_ref(),
+            base,
+        ])
+        .current_dir(source)
+        .output()
+        .map_err(|error| HarvestError::CandidateWorkspace {
+            message: error.to_string(),
+        })?;
+    if !output.status.success() {
+        return Err(HarvestError::CandidateWorkspace {
+            message: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+    let source_relative_path = git_output(Path::new(source), &["rev-parse", "--show-prefix"])?;
+    let candidate_workspace = root.join(source_relative_path);
+    std::fs::create_dir_all(&candidate_workspace).map_err(|error| {
+        HarvestError::CandidateWorkspace {
+            message: error.to_string(),
+        }
+    })?;
+    Ok(Some(candidate_workspace))
+}
+
+fn sanitize_workspace_segment(value: &str) -> String {
+    let value: String = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || character == '-' || character == '_' {
+                character
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if value.is_empty() {
+        "unknown".to_string()
+    } else {
+        value
+    }
+}
+
+fn workspace_identity_segment(path: &str) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    path.hash(&mut hasher);
+    format!("workspace-{:x}", hasher.finish())
+}
+
+fn harvest_workspace_patch(
     outcome: &mut AgentTaskOutcome,
     running: &RunningTask,
 ) -> Result<(), HarvestError> {
-    harvest_committed_patch_with_metadata(outcome, running, committed_change_metadata_for_range)
+    harvest_workspace_patch_with_metadata(outcome, running, committed_change_metadata_for_range)
 }
 
-fn harvest_committed_patch_with_metadata(
+fn harvest_workspace_patch_with_metadata(
     outcome: &mut AgentTaskOutcome,
     running: &RunningTask,
     collect_metadata: impl FnOnce(&Path, &str) -> Result<Vec<serde_json::Value>, HarvestError>,
 ) -> Result<(), HarvestError> {
-    if outcome.status != AgentTaskOutcomeStatus::Succeeded
-        || outcome.artifacts.iter().any(|artifact| {
-            is_actionable_patch_artifact(artifact) || is_empty_patch_artifact(artifact)
-        })
+    if outcome
+        .artifacts
+        .iter()
+        .any(|artifact| is_actionable_patch_artifact(artifact) || is_empty_patch_artifact(artifact))
     {
         return Ok(());
     }
     let Some(base) = running.task_base_sha.as_deref() else {
         return Ok(());
     };
-    let Some(root) = running.request.workspace.root.as_deref().map(Path::new) else {
+    let root = running
+        .candidate_workspace
+        .as_deref()
+        .or_else(|| running.request.workspace.root.as_deref().map(Path::new));
+    let Some(root) = root else {
         return Ok(());
     };
     let head = git_output(root, &["rev-parse", "HEAD"])?;
-    if head == base {
-        return Ok(());
-    }
-    if !git_is_ancestor(root, base, "HEAD")? {
+    if head != base && !git_is_ancestor(root, base, "HEAD")? {
         return Err(HarvestError::UnrelatedHead {
             base: base.to_string(),
             head,
         });
     }
-    let patch = git_output(
+    let committed_patch = git_output(
         root,
         &[
             "diff",
@@ -682,6 +826,15 @@ fn harvest_committed_patch_with_metadata(
             "HEAD",
         ],
     )?;
+    // The attempt worktree is Homeboy-owned, so intent-to-add safely includes
+    // untracked provider edits in the recoverable patch without touching the
+    // source or promotion worktree.
+    git_output(root, &["add", "--intent-to-add", "--", "."])?;
+    let working_patch = git_output(
+        root,
+        &["diff", "--binary", "--full-index", "--find-renames", "HEAD"],
+    )?;
+    let patch = format!("{committed_patch}{working_patch}");
     if patch.trim().is_empty() {
         return Ok(());
     }
@@ -691,6 +844,7 @@ fn harvest_committed_patch_with_metadata(
         message: error.to_string(),
     })?;
     let range = format!("{base}..HEAD");
+    let committed_changes = head != base;
     // Retain the patch before collecting optional commit metadata so a later
     // Git failure cannot strand the recoverable artifact.
     outcome.artifacts.push(committed_patch_artifact(
@@ -699,14 +853,19 @@ fn harvest_committed_patch_with_metadata(
         base,
         &range,
         Vec::new(),
+        committed_changes,
     ));
-    let commits = collect_metadata(root, &range)?;
+    let commits = if committed_changes {
+        collect_metadata(root, &range)?
+    } else {
+        Vec::new()
+    };
     outcome
         .artifacts
         .last_mut()
         .expect("committed patch artifact was attached")
         .metadata = serde_json::json!({
-        "change_source": "local_commits",
+        "change_source": if committed_changes { "local_commits" } else { "isolated_workspace" },
         "base_ref": base,
         "commit_range": range,
         "commits": commits,
@@ -731,13 +890,33 @@ fn committed_patch_artifact(
     base: &str,
     range: &str,
     commits: Vec<serde_json::Value>,
+    committed_changes: bool,
 ) -> AgentTaskArtifact {
     AgentTaskArtifact {
         schema: crate::core::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-        id: "committed-changes".to_string(),
+        id: if committed_changes {
+            "committed-changes"
+        } else {
+            "attempt-workspace-changes"
+        }
+        .to_string(),
         kind: "patch".to_string(),
-        name: Some("committed-changes.patch".to_string()),
-        label: Some("executor committed changes".to_string()),
+        name: Some(
+            if committed_changes {
+                "committed-changes.patch"
+            } else {
+                "attempt-workspace-changes.patch"
+            }
+            .to_string(),
+        ),
+        label: Some(
+            if committed_changes {
+                "executor committed changes"
+            } else {
+                "isolated executor workspace changes"
+            }
+            .to_string(),
+        ),
         role: Some("patch".to_string()),
         semantic_key: None,
         path: Some(path.display().to_string()),
@@ -746,7 +925,7 @@ fn committed_patch_artifact(
         size_bytes: Some(patch.len() as u64),
         sha256: None,
         metadata: serde_json::json!({
-            "change_source": "local_commits",
+            "change_source": if committed_changes { "local_commits" } else { "isolated_workspace" },
             "base_ref": base,
             "commit_range": range,
             "commits": commits,
@@ -833,6 +1012,7 @@ enum HarvestError {
     Git { command: String, message: String },
     ArtifactDirectory { path: PathBuf, message: String },
     ArtifactWrite { path: PathBuf, message: String },
+    CandidateWorkspace { message: String },
 }
 
 fn committed_harvest_preflight_outcome(task_id: String) -> AgentTaskOutcome {
@@ -888,6 +1068,11 @@ fn committed_harvest_failure(
             "agent_task.committed_harvest_artifact_failed",
             format!("committed-change harvest could not write patch artifact {}: {message}", path.display()),
             serde_json::json!({ "path": path, "operation": "write", "error": message }),
+        ),
+        HarvestError::CandidateWorkspace { message } => (
+            "agent_task.attempt_workspace_materialization_failed",
+            format!("could not create isolated executor attempt workspace: {message}"),
+            serde_json::json!({ "error": message }),
         ),
     };
     outcome.status = AgentTaskOutcomeStatus::Failed;
@@ -973,11 +1158,13 @@ mod committed_harvest_tests {
             timeout_ms: None,
             rotation_index: 0,
             rotation_attempts: Vec::new(),
+            retry_attempts: Vec::new(),
             task_base_sha: Some(base),
+            candidate_workspace: None,
         };
         let mut outcome = committed_harvest_preflight_outcome("task-1".to_string());
         outcome.status = AgentTaskOutcomeStatus::Succeeded;
-        let error = harvest_committed_patch_with_metadata(&mut outcome, &running, |_, _| {
+        let error = harvest_workspace_patch_with_metadata(&mut outcome, &running, |_, _| {
             Err(HarvestError::Git {
                 command: "git log injected metadata failure".to_string(),
                 message: "injected failure".to_string(),

--- a/src/core/agent_task_scheduler/tests/scheduling_tests.rs
+++ b/src/core/agent_task_scheduler/tests/scheduling_tests.rs
@@ -473,6 +473,157 @@ mod concurrency_tests {
         );
     }
 
+    #[derive(Clone)]
+    struct PermissionDeniedThenCommitExecutor {
+        attempts: Arc<AtomicUsize>,
+        workspaces: Arc<Mutex<Vec<std::path::PathBuf>>>,
+    }
+
+    impl AgentTaskExecutorAdapter for PermissionDeniedThenCommitExecutor {
+        fn execute(
+            &self,
+            request: AgentTaskRequest,
+            _context: AgentTaskExecutionContext,
+        ) -> AgentTaskOutcome {
+            let workspace = std::path::PathBuf::from(
+                request
+                    .workspace
+                    .root
+                    .as_deref()
+                    .expect("isolated workspace"),
+            );
+            self.workspaces
+                .lock()
+                .expect("workspaces")
+                .push(workspace.clone());
+            assert_eq!(
+                request.executor.config["workspace"]["root"],
+                workspace.display().to_string()
+            );
+            assert_eq!(
+                request.executor.config["workspace_root"],
+                workspace.display().to_string()
+            );
+            let attempt = self.attempts.fetch_add(1, Ordering::SeqCst) + 1;
+            std::fs::write(
+                workspace.join("agent-change.txt"),
+                format!("attempt {attempt}\n"),
+            )
+            .expect("write agent change");
+            if attempt == 1 {
+                return AgentTaskOutcome {
+                    schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                    task_id: request.task_id,
+                    status: AgentTaskOutcomeStatus::Failed,
+                    summary: Some("permission denied".to_string()),
+                    failure_classification: Some(AgentTaskFailureClassification::Transient),
+                    artifacts: Vec::new(),
+                    typed_artifacts: Vec::new(),
+                    evidence_refs: Vec::new(),
+                    diagnostics: vec![AgentTaskDiagnostic {
+                        class: "provider.permission_denied".to_string(),
+                        message: "executor was denied the requested operation".to_string(),
+                        data: json!({ "operation": "write_file" }),
+                    }],
+                    outputs: Value::Null,
+                    workflow: None,
+                    follow_up: None,
+                    metadata: Value::Null,
+                };
+            }
+            assert!(Command::new("git")
+                .args(["add", "agent-change.txt"])
+                .current_dir(&workspace)
+                .status()
+                .expect("stage change")
+                .success());
+            assert!(Command::new("git")
+                .args(["commit", "-m", "agent change"])
+                .current_dir(&workspace)
+                .status()
+                .expect("commit change")
+                .success());
+            outcome(request.task_id, AgentTaskOutcomeStatus::Succeeded)
+        }
+    }
+
+    #[test]
+    fn retry_uses_clean_isolated_workspace_after_permission_denial() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let source = temp.path().join("source");
+        let target = temp.path().join("target");
+        init_git_workspace(&source);
+        assert!(Command::new("git")
+            .args([
+                "clone",
+                source.to_str().expect("source path"),
+                target.to_str().expect("target path")
+            ])
+            .status()
+            .expect("clone target")
+            .success());
+        let executor = PermissionDeniedThenCommitExecutor {
+            attempts: Arc::new(AtomicUsize::new(0)),
+            workspaces: Arc::new(Mutex::new(Vec::new())),
+        };
+        let attempts = Arc::clone(&executor.attempts);
+        let workspaces = Arc::clone(&executor.workspaces);
+        let scheduler = AgentTaskScheduler::new(executor).with_run_id("retry-isolation");
+        let mut plan = plan_with_tasks(1);
+        plan.tasks[0].workspace.root = Some(source.display().to_string());
+        plan.tasks[0].executor.config = json!({
+            "workspace": { "root": source.display().to_string() },
+            "workspace_root": source.display().to_string(),
+        });
+        plan.options.retry.max_attempts = 2;
+        plan.options.retry.retryable_failure_classifications =
+            vec![AgentTaskFailureClassification::Transient];
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        let workspaces = workspaces.lock().expect("workspaces");
+        assert_eq!(workspaces.len(), 2);
+        assert_ne!(workspaces[0], workspaces[1]);
+        assert!(workspaces.iter().all(|workspace| workspace != &source));
+        assert!(workspaces.iter().all(|workspace| workspace.is_dir()));
+        assert!(Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(&source)
+            .output()
+            .expect("source status")
+            .stdout
+            .is_empty());
+        assert!(!target.join("agent-change.txt").exists());
+        assert!(aggregate.outcomes[0]
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.id == "committed-changes"));
+        let retry = aggregate.outcomes[0]
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.class == "agent_task.retry_attempt")
+            .expect("failed retry evidence");
+        assert_eq!(
+            retry.data["diagnostics"][0]["class"],
+            "provider.permission_denied"
+        );
+        assert_eq!(
+            retry.data["diagnostics"][0]["data"]["operation"],
+            "write_file"
+        );
+        assert_eq!(
+            retry.data["artifacts"][0]["id"],
+            "attempt-workspace-changes"
+        );
+        assert_eq!(
+            retry.data["artifacts"][0]["metadata"]["change_source"],
+            "isolated_workspace"
+        );
+        assert_eq!(retry.data["candidate_workspace"], json!(workspaces[0]));
+    }
+
     #[test]
     fn clean_workspace_without_executor_commits_remains_a_no_patch_success() {
         let temp = tempfile::tempdir().expect("tempdir");

--- a/src/core/agent_task_service/status_support.rs
+++ b/src/core/agent_task_service/status_support.rs
@@ -269,6 +269,12 @@ fn hydrate_homeboy_evidence_ref(
         }),
     };
 
+    let content = if parsed.section == "plan" {
+        json!({ "format": "json", "value": content })
+    } else {
+        content
+    };
+
     Ok(HydratedContent {
         source: "homeboy".to_string(),
         truncated: false,


### PR DESCRIPTION
## Summary

- Run every agent-task executor attempt in a detached worktree at the recorded clean source revision.
- Explicitly remap the task workspace and the two declared provider workspace configuration fields to that isolated attempt workspace.
- Preserve committed and uncommitted failed-attempt changes, diagnostics, and workspace evidence for retries.
- Hydrate persisted plan evidence correctly for `replay-provider-boundary`.

Fixes #8050.

## Root cause

Homeboy recorded a clean source SHA before dispatch but still launched the real OpenCode provider from workspace paths retained in executor configuration and provider `cwd`. A failed attempt could therefore edit the source or promotion target. The next attempt then classified Homeboy's own changes as pre-existing user dirt and refused to continue.

The earlier scheduler-only isolation did not cover those real provider inputs. This change makes the task workspace authoritative at the provider boundary and keeps promotion as a separate verified transaction.

## Compatibility

This changes executor workspace behavior intentionally: providers now run inside Homeboy's isolated attempt worktree when a task workspace is present. Provider manifests that declare a fallback `cwd` continue to use it only when the task has no workspace.

The explicit provider configuration extension points are `workspace.root` and `workspace_root`. Unrelated keys are not rewritten. Dirty source workspaces remain rejected before dispatch.

## How to test

1. Check out this PR branch.
2. Run `cargo test retry_uses_clean_isolated_workspace_after_permission_denial --lib`.
3. Run `cargo test opencode_provider_boundary_uses_task_workspace_for_cwd_and_config --lib`.
4. Run `cargo test replay_provider_boundary_hydrates_persisted_plan_executor_input --lib`.
5. Run `cargo test cook_applies_executor_commit_from_source_repo_to_distinct_target_repo --lib`.
6. Run `cargo fmt --check`.
7. Confirm the four targeted tests pass and formatting is clean.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** OpenAI GPT-5.6 Terra and GPT-5.6 Sol
- **Used for:** Diagnosing the live cook failure, implementing and reviewing attempt isolation and provider workspace remapping, repairing replay hydration, and adding deterministic regression coverage with Chris.
