### PR TITLE
Fix Git-backed Lab retry primary materialization

### DIFF
--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -151,6 +151,9 @@ pub fn route_after_parse(
                 .is_some_and(|contract| contract.command.routing_policy.read_only_polling),
             local_output_file: output_file,
             durable_agent_task_plan,
+            source_path: retry_handoff
+                .as_ref()
+                .map(|handoff| handoff.primary_workspace.as_path()),
             job_overrides,
         },
         inferred_runner_id.as_deref(),
@@ -228,6 +231,7 @@ struct AgentTaskRetryHandoff {
     args: Vec<String>,
     run_id: String,
     plan: homeboy::core::agent_tasks::scheduler::AgentTaskPlan,
+    primary_workspace: PathBuf,
 }
 
 /// Retries are controller-owned because the source plan lives in the local
@@ -264,10 +268,9 @@ fn materialize_agent_task_retry_handoff(
             Error::internal_unexpected("agent-task retry argv was missing agent-task")
         })?;
     let mut args = retry_handoff_prefix(&normalized_args[..agent_task_index]);
-    // A retry executes the original task, not the controller invocation. Make
-    // its git checkout the Lab primary so the remote cwd and patch capture use
-    // the same materialized worktree.
-    args.extend(["--cwd".to_string(), primary_workspace.display().to_string()]);
+    // A retry executes the original task, not the controller invocation. Carry
+    // its checkout through the route request rather than emitting an unsupported
+    // global --cwd argument; staging makes it the git-backed Lab primary.
     args.extend([
         "agent-task".to_string(),
         "run-plan".to_string(),
@@ -281,6 +284,7 @@ fn materialize_agent_task_retry_handoff(
         args,
         run_id: record.run_id,
         plan,
+        primary_workspace,
     }))
 }
 
@@ -1908,19 +1912,29 @@ mod tests {
             .into_iter()
             .map(str::to_string)
             .collect::<Vec<_>>();
-            let cli = Cli::parse_from(&normalized);
+            let cli = Cli::parse_from([
+                "homeboy",
+                "--detach-after-handoff",
+                "agent-task",
+                "retry",
+                "failed-run",
+                "--run",
+                "--new-run-id",
+                "failed-run-retry-on-lab",
+                "--runner",
+                "homeboy-lab",
+            ]);
             let handoff = materialize_agent_task_retry_handoff(&cli, &normalized)
                 .expect("retry handoff materialized")
                 .expect("retry handoff");
 
-            let cwd_index = handoff
-                .args
-                .iter()
-                .position(|arg| arg == "--cwd")
-                .expect("canonical task cwd");
+            assert!(!handoff.args.iter().any(|arg| arg == "--cwd"));
             assert_eq!(
-                handoff.args[cwd_index + 1],
-                workspace.path().display().to_string()
+                handoff.primary_workspace,
+                workspace
+                    .path()
+                    .canonicalize()
+                    .expect("canonical workspace")
             );
             assert!(!handoff.args.iter().any(|arg| arg == "/controller/homeboy"));
             let agent_task_index = handoff
@@ -1949,6 +1963,10 @@ mod tests {
             let remote_plan: homeboy::core::agent_tasks::scheduler::AgentTaskPlan =
                 serde_json::from_str(&remote.plan).expect("serialized retry plan");
             assert_eq!(remote_plan, handoff.plan);
+            // The emitted command is accepted by the real CLI parser without
+            // inventing a global --cwd. The route carries the selected task
+            // checkout separately, and workspace staging maps it to the job cwd.
+            assert!(remote_cli.detach_after_handoff);
             let replacement = agent_task_lifecycle::status(&handoff.run_id).expect("replacement");
             assert_eq!(replacement.metadata["retry_of"], "failed-run");
 

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -44,6 +44,9 @@ pub struct LabRoutingRequest<'a> {
     /// durable agent-task run id can be persisted before long execution (#5684).
     pub local_output_file: Option<&'a str>,
     pub durable_agent_task_plan: Option<&'a crate::core::agent_task_scheduler::AgentTaskPlan>,
+    /// Controller checkout selected independently of CLI argv, such as the
+    /// logical primary workspace of a materialized retry plan.
+    pub source_path: Option<&'a std::path::Path>,
     pub job_overrides: runners::LabJobOverrides,
 }
 
@@ -69,6 +72,7 @@ pub(crate) fn route_lab_offload(
         read_only_polling: request.read_only_polling,
         local_output_file: request.local_output_file,
         durable_agent_task_plan: request.durable_agent_task_plan,
+        source_path: request.source_path,
         job_overrides: request.job_overrides,
     })
 }
@@ -524,6 +528,7 @@ fn execute_lab_offload_with_timeout(
     let read_only_polling = request.read_only_polling;
     let local_output_file = request.local_output_file.map(str::to_string);
     let durable_agent_task_plan = request.durable_agent_task_plan.cloned();
+    let source_path = request.source_path.map(std::path::Path::to_path_buf);
     let job_overrides = request.job_overrides;
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
@@ -542,6 +547,7 @@ fn execute_lab_offload_with_timeout(
             read_only_polling,
             local_output_file: local_output_file.as_deref(),
             durable_agent_task_plan: durable_agent_task_plan.as_ref(),
+            source_path: source_path.as_deref(),
             job_overrides,
         });
         let _ = tx.send(result);
@@ -729,6 +735,7 @@ mod tests {
             read_only_polling: false,
             local_output_file: None,
             durable_agent_task_plan: None,
+            source_path: None,
             job_overrides: runners::LabJobOverrides::default(),
         })
         .unwrap();
@@ -1030,6 +1037,7 @@ mod tests {
                 read_only_polling: false,
                 local_output_file: None,
                 durable_agent_task_plan: None,
+                source_path: None,
                 job_overrides: runners::LabJobOverrides::default(),
             },
             None,

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -797,9 +797,11 @@ pub(crate) fn run_lab_offload_inner(
         );
     }
 
-    let source_path =
-        rig_materialization::lab_offload_rig_component_checkout_root(request.normalized_args)?
-            .unwrap_or(lab_offload_source_path(request.normalized_args)?);
+    let source_path = request
+        .source_path
+        .map(std::path::Path::to_path_buf)
+        .or(rig_materialization::lab_offload_rig_component_checkout_root(request.normalized_args)?)
+        .unwrap_or(lab_offload_source_path(request.normalized_args)?);
     // Begin best-effort host-level telemetry capture around the offloaded run
     // boundary (#3258). The opening snapshot of the controller host + watched
     // source/artifact dir is taken now; the closing snapshot and before/after

--- a/src/core/runner/lab/offload/tests/exec_errors.rs
+++ b/src/core/runner/lab/offload/tests/exec_errors.rs
@@ -375,6 +375,7 @@ fn plan_records_skipped_auto_offload() {
         read_only_polling: false,
         local_output_file: None,
         durable_agent_task_plan: None,
+        source_path: None,
         job_overrides: LabJobOverrides::default(),
     })
     .expect("outcome");
@@ -405,6 +406,7 @@ fn lab_placement_refuses_local_execution_without_lab_contract() {
         read_only_polling: false,
         local_output_file: None,
         durable_agent_task_plan: None,
+        source_path: None,
         job_overrides: LabJobOverrides::default(),
     });
 
@@ -438,6 +440,7 @@ fn lab_placement_refuses_local_only_rig_install_with_actionable_boundary() {
         read_only_polling: false,
         local_output_file: None,
         durable_agent_task_plan: None,
+        source_path: None,
         job_overrides: LabJobOverrides::default(),
     });
 
@@ -473,6 +476,7 @@ fn build_runner_error_gives_managed_runner_replacement() {
         read_only_polling: false,
         local_output_file: None,
         durable_agent_task_plan: None,
+        source_path: None,
         job_overrides: LabJobOverrides::default(),
     });
 
@@ -517,6 +521,7 @@ fn build_lab_placement_error_gives_managed_runner_replacement() {
         read_only_polling: false,
         local_output_file: None,
         durable_agent_task_plan: None,
+        source_path: None,
         job_overrides: LabJobOverrides::default(),
     });
 
@@ -563,6 +568,7 @@ fn unsupported_runner_error_guides_tunnel_service_inspection() {
         read_only_polling: false,
         local_output_file: None,
         durable_agent_task_plan: None,
+        source_path: None,
         job_overrides: LabJobOverrides::default(),
     });
 

--- a/src/core/runner/lab/offload/types.rs
+++ b/src/core/runner/lab/offload/types.rs
@@ -31,6 +31,10 @@ pub struct LabOffloadRequest<'a> {
     /// The controller-materialized task plan to retain if this offload creates
     /// a durable agent-task record before the runner accepts its child job.
     pub durable_agent_task_plan: Option<&'a crate::core::agent_task_scheduler::AgentTaskPlan>,
+    /// Controller checkout selected independently of the remote command argv.
+    /// This keeps process cwd in the runner job while retaining an exact local
+    /// source for Git materialization and path remapping.
+    pub source_path: Option<&'a std::path::Path>,
     pub job_overrides: LabJobOverrides,
 }
 

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -2133,6 +2133,7 @@ mod tests {
                 read_only_polling: false,
                 local_output_file: None,
                 durable_agent_task_plan: None,
+                source_path: None,
                 job_overrides: LabJobOverrides::default(),
             };
             let contract = LabOffloadCommand {
@@ -2209,6 +2210,15 @@ mod tests {
             .expect("write fixture manifest");
             git(repository.path(), &["add", "."]);
             git(repository.path(), &["commit", "-m", "base"]);
+            git(
+                repository.path(),
+                &[
+                    "remote",
+                    "add",
+                    "origin",
+                    repository.path().to_str().expect("repo path"),
+                ],
+            );
             let source = worktree_parent.path().join("homeboy-fix-8009");
             git(
                 repository.path(),
@@ -2260,9 +2270,10 @@ mod tests {
                 read_only_polling: false,
                 local_output_file: None,
                 durable_agent_task_plan: None,
+                source_path: Some(source.as_path()),
                 job_overrides: LabJobOverrides::default(),
             };
-            let contract = LabOffloadCommand {
+            let mut contract = LabOffloadCommand {
                 command: crate::command_contract::LabCommandContract::portable(
                     "agent-task",
                     None,
@@ -2273,6 +2284,7 @@ mod tests {
                 required_capabilities: Vec::new(),
                 workload: None,
             };
+            contract.command.workspace_mode_policy = LabOffloadWorkspaceModePolicy::Git;
             let runner_workspace_root = runner_root.path().display().to_string();
             let stage = prepare_lab_offload_workspace_stage(
                 &request,
@@ -2295,6 +2307,21 @@ mod tests {
             );
             assert!(stage.remapped_args.contains(&"cook-8009".to_string()));
             assert!(stage.remapped_args.contains(&canonical_attempt_id));
+            assert_eq!(stage.sync_mode, RunnerWorkspaceSyncMode::Git);
+            assert_eq!(
+                git_output(
+                    Path::new(&stage.remote_cwd),
+                    &["rev-parse", "--is-inside-work-tree"]
+                ),
+                "true"
+            );
+            std::fs::write(Path::new(&stage.remote_cwd).join("captured.txt"), "patch\n")
+                .expect("write remote mutation");
+            git(Path::new(&stage.remote_cwd), &["add", "-N", "captured.txt"]);
+            assert!(
+                git_output(Path::new(&stage.remote_cwd), &["diff", "--binary"])
+                    .contains("captured.txt")
+            );
 
             crate::core::agent_task_lifecycle::record_lab_offload_phase(
                 &canonical_attempt_id,


### PR DESCRIPTION
## Summary
- carry the selected retry task checkout through Lab routing instead of emitting an unsupported global `--cwd` argument
- stage that checkout as the primary Git workspace, then keep the remote checkout as the runner workload and job cwd for plan/config remapping and patch capture
- retain fail-closed multi-workspace retry selection, detached handoff, and provider rotation behavior

Closes #8088

## Testing
1. `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo fmt --check`
2. `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo check`
3. `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo test detached_retry_materializes_failed_plan_and_persists_bounded_preacceptance_failure --lib`
4. `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo test managed_worktree_staging_preserves_cook_attempt_identity_through_daemon_acceptance --lib`
5. `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo test workspace_materializer --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode, openai-gpt-5.6-sol
- **Used for:** Implemented and verified the retry-routing and Git materialization fix with Chris'