### PR TITLE
Isolate provider rotation attempt worktrees

### DIFF
--- a/src/core/agent_task_scheduler/mod.rs
+++ b/src/core/agent_task_scheduler/mod.rs
@@ -106,6 +106,7 @@ where
                     attempt: 1,
                     rotation_index: 0,
                     rotation_attempts: Vec::new(),
+                    candidate_artifacts: Vec::new(),
                 }
             })
             .collect();
@@ -351,6 +352,29 @@ where
                         continue;
                     }
                 };
+                let source_workspace_root = request.workspace.root.clone();
+                let attempt_workspace =
+                    match prepare_attempt_workspace(&mut request, task_base_sha.as_deref()) {
+                        Ok(workspace) => workspace,
+                        Err(error) => {
+                            let outcome = committed_harvest_failure(
+                                committed_harvest_preflight_outcome(task_id.clone()),
+                                error,
+                            );
+                            events.push(event(
+                                &task_id,
+                                AgentTaskState::Failed,
+                                scheduled.attempt,
+                                outcome.summary.clone(),
+                            ));
+                            record_completed_outcome(
+                                &mut completed_by_task,
+                                &mut outcomes,
+                                outcome,
+                            );
+                            continue;
+                        }
+                    };
                 let executor_key = executor_key(&request);
                 let executor = Arc::clone(&self.executor);
                 let plan_id = plan.plan_id.clone();
@@ -381,10 +405,18 @@ where
                     timeout_ms: Some(task_timeout_ms),
                     rotation_index: scheduled.rotation_index,
                     rotation_attempts: scheduled.rotation_attempts,
+                    candidate_artifacts: scheduled.candidate_artifacts,
+                    source_workspace_root,
+                    _attempt_workspace: attempt_workspace.clone(),
+                    run_id: self.run_id.clone(),
+                    artifact_nonce: uuid::Uuid::new_v4().to_string(),
                     task_base_sha,
                 });
 
                 thread::spawn(move || {
+                    // A scheduler timeout does not join this thread. Retain the
+                    // isolated checkout until the executor has actually stopped.
+                    let _attempt_workspace = attempt_workspace;
                     let outcome = executor.execute(request, context);
                     let _ = tx.send(SchedulerEvent::TaskResult(TaskResult {
                         task_id,
@@ -434,7 +466,9 @@ where
                         continue;
                     };
                     let mut outcome = result.outcome;
-                    if let Err(error) = harvest_committed_patch(&mut outcome, &running_task) {
+                    if let Err(error) = harvest_uncommitted_patch(&mut outcome, &running_task)
+                        .and_then(|_| harvest_committed_patch(&mut outcome, &running_task))
+                    {
                         outcome = committed_harvest_failure(outcome, error);
                     }
                     let outcome =
@@ -456,6 +490,17 @@ where
                     ) {
                         retry_budget_used += 1;
                         let mut request = running_task.request;
+                        request.workspace.root = running_task.source_workspace_root.clone();
+                        let mut candidate_artifacts = running_task.candidate_artifacts;
+                        append_unique_artifacts(
+                            &mut candidate_artifacts,
+                            outcome
+                                .artifacts
+                                .iter()
+                                .filter(|artifact| is_actionable_patch_artifact(artifact))
+                                .cloned()
+                                .collect(),
+                        );
                         request.parent_plan_id = Some(plan.plan_id.clone());
                         let next_attempt = result.attempt + 1;
                         events.push(event(
@@ -470,6 +515,7 @@ where
                             attempt: next_attempt,
                             rotation_index: running_task.rotation_index,
                             rotation_attempts: running_task.rotation_attempts,
+                            candidate_artifacts,
                         });
                         continue;
                     }
@@ -494,7 +540,18 @@ where
                                 ),
                             );
                             let entry = &policy.entries[running_task.rotation_index];
+                            let mut candidate_artifacts = running_task.candidate_artifacts;
+                            append_unique_artifacts(
+                                &mut candidate_artifacts,
+                                outcome
+                                    .artifacts
+                                    .iter()
+                                    .filter(|artifact| is_actionable_patch_artifact(artifact))
+                                    .cloned()
+                                    .collect(),
+                            );
                             let mut request = running_task.request;
+                            request.workspace.root = running_task.source_workspace_root.clone();
                             AgentTaskScheduleSupport::apply_rotation_entry(
                                 &mut request,
                                 entry,
@@ -518,11 +575,16 @@ where
                                 attempt: next_attempt,
                                 rotation_index: running_task.rotation_index + 1,
                                 rotation_attempts,
+                                candidate_artifacts,
                             });
                             continue;
                         }
                     }
                     let mut outcome = outcome;
+                    append_unique_artifacts(
+                        &mut outcome.artifacts,
+                        running_task.candidate_artifacts,
+                    );
                     if !running_task.rotation_attempts.is_empty() {
                         let mut rotation_attempts = running_task.rotation_attempts.clone();
                         rotation_attempts.push(AgentTaskScheduleSupport::rotation_attempt_record(
@@ -585,6 +647,8 @@ struct ScheduledTask {
     rotation_index: usize,
     /// Ordered evidence for prior dispatch attempts under a rotation policy.
     rotation_attempts: Vec<AgentTaskProviderRotationAttempt>,
+    /// Patch candidates produced by earlier retry or rotation attempts.
+    candidate_artifacts: Vec<AgentTaskArtifact>,
 }
 
 #[derive(Debug, Clone)]
@@ -602,6 +666,15 @@ struct RunningTask {
     rotation_index: usize,
     /// Ordered evidence for prior dispatch attempts under a rotation policy.
     rotation_attempts: Vec<AgentTaskProviderRotationAttempt>,
+    candidate_artifacts: Vec<AgentTaskArtifact>,
+    /// The caller-managed workspace used for preflight and as the clean base
+    /// for each isolated provider dispatch.
+    source_workspace_root: Option<String>,
+    /// Dropping the final owner removes this detached checkout. The executor
+    /// thread holds a clone so timeout finalization cannot race provider I/O.
+    _attempt_workspace: Option<Arc<AttemptWorkspace>>,
+    run_id: Option<String>,
+    artifact_nonce: String,
     /// Workspace HEAD captured immediately before the executor runs. It bounds
     /// any committed patch candidate to this dispatch attempt.
     task_base_sha: Option<String>,
@@ -622,6 +695,28 @@ enum SchedulerEvent {
     Cancellation,
 }
 
+#[derive(Debug)]
+struct AttemptWorkspace {
+    source_root: PathBuf,
+    root: PathBuf,
+}
+
+impl Drop for AttemptWorkspace {
+    fn drop(&mut self) {
+        // This is a scheduler-created detached checkout, never the caller's
+        // managed task workspace. Drop runs after the executor thread exits.
+        let _ = Command::new("git")
+            .args(["worktree", "remove", "--force"])
+            .arg(&self.root)
+            .current_dir(&self.source_root)
+            .status();
+        let _ = Command::new("git")
+            .args(["worktree", "prune"])
+            .current_dir(&self.source_root)
+            .status();
+    }
+}
+
 fn prepare_committed_harvest(request: &AgentTaskRequest) -> Result<Option<String>, HarvestError> {
     let Some(root) = request.workspace.root.as_deref().map(Path::new) else {
         return Ok(None);
@@ -636,11 +731,153 @@ fn prepare_committed_harvest(request: &AgentTaskRequest) -> Result<Option<String
     Ok(Some(git_output(root, &["rev-parse", "HEAD"])?))
 }
 
+/// Give each provider dispatch a detached checkout at the caller's clean base.
+/// The managed task worktree remains a preflight-only source of truth, so a
+/// timed-out provider cannot contaminate a later provider rotation.
+fn prepare_attempt_workspace(
+    request: &mut AgentTaskRequest,
+    base: Option<&str>,
+) -> Result<Option<Arc<AttemptWorkspace>>, HarvestError> {
+    let Some(root) = request.workspace.root.as_deref().map(PathBuf::from) else {
+        return Ok(None);
+    };
+    let Some(base) = base else {
+        return Ok(None);
+    };
+    let parent = std::env::temp_dir().join("homeboy-agent-task-attempts");
+    std::fs::create_dir_all(&parent).map_err(|error| HarvestError::ArtifactDirectory {
+        path: parent.clone(),
+        message: error.to_string(),
+    })?;
+    let attempt_root = parent.join(format!("attempt-{}", uuid::Uuid::new_v4()));
+    let attempt_root_string = attempt_root.display().to_string();
+    git_output(
+        &root,
+        &["worktree", "add", "--detach", &attempt_root_string, base],
+    )?;
+    request.workspace.root = Some(attempt_root.display().to_string());
+    Ok(Some(Arc::new(AttemptWorkspace {
+        source_root: root,
+        root: attempt_root,
+    })))
+}
+
 fn harvest_committed_patch(
     outcome: &mut AgentTaskOutcome,
     running: &RunningTask,
 ) -> Result<(), HarvestError> {
     harvest_committed_patch_with_metadata(outcome, running, committed_change_metadata_for_range)
+}
+
+fn harvest_uncommitted_patch(
+    outcome: &mut AgentTaskOutcome,
+    running: &RunningTask,
+) -> Result<(), HarvestError> {
+    let Some(base) = running.task_base_sha.as_deref() else {
+        return Ok(());
+    };
+    let Some(root) = running.request.workspace.root.as_deref().map(Path::new) else {
+        return Ok(());
+    };
+    persist_attempt_patch_artifacts(outcome, running, root)?;
+    if outcome.artifacts.iter().any(is_actionable_patch_artifact) {
+        return Ok(());
+    }
+    // This checkout belongs solely to this dispatch. Staging all changes makes
+    // Git's binary patch generation include tracked, staged, and untracked files.
+    git_output(root, &["add", "--all"])?;
+    let patch = git_output(
+        root,
+        &[
+            "diff",
+            "--cached",
+            "--binary",
+            "--full-index",
+            "--find-renames",
+            "HEAD",
+        ],
+    )?;
+    if patch.trim().is_empty() {
+        return Ok(());
+    }
+    let path = attempt_patch_path(running, "uncommitted")?;
+    std::fs::write(&path, patch.as_bytes()).map_err(|error| HarvestError::ArtifactWrite {
+        path: path.clone(),
+        message: error.to_string(),
+    })?;
+    outcome.artifacts.push(AgentTaskArtifact {
+        schema: crate::core::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+        id: attempt_patch_id(running, "uncommitted-changes"),
+        kind: "patch".to_string(),
+        name: Some("uncommitted-changes.patch".to_string()),
+        label: Some("executor uncommitted changes".to_string()),
+        role: Some("patch".to_string()),
+        semantic_key: None,
+        path: Some(path.display().to_string()),
+        url: None,
+        mime: Some("text/x-patch".to_string()),
+        size_bytes: Some(patch.len() as u64),
+        sha256: None,
+        metadata: serde_json::json!({
+            "change_source": "uncommitted_attempt_workspace",
+            "base_ref": base,
+            "run_id": running.run_id.as_deref(),
+            "task_id": &running.task_id,
+            "producer_attempt": running.attempt,
+            "provider_rotation_index": running.rotation_index,
+            "provider_backend": running.request.executor.backend,
+        }),
+    });
+    Ok(())
+}
+
+fn persist_attempt_patch_artifacts(
+    outcome: &mut AgentTaskOutcome,
+    running: &RunningTask,
+    attempt_root: &Path,
+) -> Result<(), HarvestError> {
+    for (index, artifact) in outcome.artifacts.iter_mut().enumerate() {
+        if !is_actionable_patch_artifact(artifact) {
+            continue;
+        }
+        let Some(source) = artifact.path.as_deref().map(PathBuf::from) else {
+            continue;
+        };
+        if !source.starts_with(attempt_root) {
+            continue;
+        }
+        let contents = std::fs::read(&source).map_err(|error| HarvestError::ArtifactWrite {
+            path: source.clone(),
+            message: error.to_string(),
+        })?;
+        let path = attempt_patch_path(running, &format!("provider-{index}"))?;
+        std::fs::write(&path, &contents).map_err(|error| HarvestError::ArtifactWrite {
+            path: path.clone(),
+            message: error.to_string(),
+        })?;
+        artifact.path = Some(path.display().to_string());
+        artifact.size_bytes = Some(contents.len() as u64);
+        if !artifact.metadata.is_object() {
+            artifact.metadata = serde_json::json!({});
+        }
+        artifact
+            .metadata
+            .as_object_mut()
+            .expect("patch artifact metadata object")
+            .extend(serde_json::Map::from_iter([
+                ("run_id".to_string(), serde_json::json!(running.run_id)),
+                ("task_id".to_string(), serde_json::json!(running.task_id)),
+                (
+                    "producer_attempt".to_string(),
+                    serde_json::json!(running.attempt),
+                ),
+                (
+                    "change_source".to_string(),
+                    serde_json::json!("attempt_workspace_artifact"),
+                ),
+            ]));
+    }
+    Ok(())
 }
 
 fn harvest_committed_patch_with_metadata(
@@ -685,7 +922,7 @@ fn harvest_committed_patch_with_metadata(
     if patch.trim().is_empty() {
         return Ok(());
     }
-    let path = committed_patch_path(root, base, &head)?;
+    let path = attempt_patch_path(running, &format!("committed-{head}"))?;
     std::fs::write(&path, patch.as_bytes()).map_err(|error| HarvestError::ArtifactWrite {
         path: path.clone(),
         message: error.to_string(),
@@ -694,6 +931,7 @@ fn harvest_committed_patch_with_metadata(
     // Retain the patch before collecting optional commit metadata so a later
     // Git failure cannot strand the recoverable artifact.
     outcome.artifacts.push(committed_patch_artifact(
+        running,
         &path,
         &patch,
         base,
@@ -710,6 +948,9 @@ fn harvest_committed_patch_with_metadata(
         "base_ref": base,
         "commit_range": range,
         "commits": commits,
+        "run_id": running.run_id.as_deref(),
+        "task_id": &running.task_id,
+        "producer_attempt": running.attempt,
     });
     Ok(())
 }
@@ -726,6 +967,7 @@ fn committed_change_metadata_for_range(
 }
 
 fn committed_patch_artifact(
+    running: &RunningTask,
     path: &Path,
     patch: &str,
     base: &str,
@@ -734,7 +976,7 @@ fn committed_patch_artifact(
 ) -> AgentTaskArtifact {
     AgentTaskArtifact {
         schema: crate::core::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-        id: "committed-changes".to_string(),
+        id: attempt_patch_id(running, "committed-changes"),
         kind: "patch".to_string(),
         name: Some("committed-changes.patch".to_string()),
         label: Some("executor committed changes".to_string()),
@@ -750,24 +992,40 @@ fn committed_patch_artifact(
             "base_ref": base,
             "commit_range": range,
             "commits": commits,
+            "run_id": running.run_id,
+            "task_id": running.task_id,
+            "producer_attempt": running.attempt,
         }),
     }
 }
 
-fn committed_patch_path(root: &Path, base: &str, head: &str) -> Result<PathBuf, HarvestError> {
-    let git_dir = git_output(root, &["rev-parse", "--git-dir"])?;
-    let git_dir = PathBuf::from(git_dir);
-    let git_dir = if git_dir.is_absolute() {
-        git_dir
-    } else {
-        root.join(git_dir)
-    };
-    let dir = git_dir.join("homeboy-agent-task");
+fn attempt_patch_path(running: &RunningTask, kind: &str) -> Result<PathBuf, HarvestError> {
+    let run_id = running.run_id.as_deref().unwrap_or("unrecorded-run");
+    let dir = crate::core::artifacts::root()
+        .map_err(|error| HarvestError::ArtifactDirectory {
+            path: PathBuf::from("<artifact-root>"),
+            message: error.message,
+        })?
+        .join("agent-task")
+        .join("attempt-patches")
+        .join(crate::core::paths::sanitize_path_segment(run_id))
+        .join(crate::core::paths::sanitize_path_segment(&running.task_id));
     std::fs::create_dir_all(&dir).map_err(|error| HarvestError::ArtifactDirectory {
         path: dir.clone(),
         message: error.to_string(),
     })?;
-    Ok(dir.join(format!("committed-changes-{base}-{head}.patch")))
+    Ok(dir.join(format!(
+        "attempt-{}-{}-{}.patch",
+        running.attempt, kind, running.artifact_nonce
+    )))
+}
+
+fn attempt_patch_id(running: &RunningTask, kind: &str) -> String {
+    format!(
+        "{}-attempt-{}-{kind}",
+        crate::core::paths::sanitize_path_segment(&running.task_id),
+        running.attempt
+    )
 }
 
 fn committed_change_metadata(output: &str) -> Vec<serde_json::Value> {
@@ -921,6 +1179,7 @@ mod committed_harvest_tests {
 
     #[test]
     fn git_metadata_failure_after_patch_creation_preserves_the_patch_artifact() {
+        let _home = crate::test_support::HomeGuard::new();
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace = temp.path().join("workspace");
         std::fs::create_dir(&workspace).expect("workspace");
@@ -973,6 +1232,11 @@ mod committed_harvest_tests {
             timeout_ms: None,
             rotation_index: 0,
             rotation_attempts: Vec::new(),
+            candidate_artifacts: Vec::new(),
+            source_workspace_root: None,
+            _attempt_workspace: None,
+            run_id: Some("committed-harvest-test".to_string()),
+            artifact_nonce: "test-artifact".to_string(),
             task_base_sha: Some(base),
         };
         let mut outcome = committed_harvest_preflight_outcome("task-1".to_string());
@@ -999,7 +1263,7 @@ mod committed_harvest_tests {
         let failed = committed_harvest_failure(outcome, error);
 
         assert_eq!(failed.status, AgentTaskOutcomeStatus::Failed);
-        assert_eq!(failed.artifacts[0].id, "committed-changes");
+        assert_eq!(failed.artifacts[0].id, "task-1-attempt-1-committed-changes");
         assert_eq!(
             failed.artifacts[0].path.as_deref(),
             Some(patch_path.as_str())

--- a/src/core/agent_task_scheduler/scheduling.rs
+++ b/src/core/agent_task_scheduler/scheduling.rs
@@ -590,12 +590,15 @@ impl AgentTaskScheduleSupport {
 
             let task = running.remove(index);
             executor.cancel(&task.task_id);
-            let outcome = Self::timeout_outcome(
+            let mut outcome = Self::timeout_outcome(
                 task.task_id.clone(),
                 task.timeout_ms.unwrap_or_default(),
                 Some(&task.request),
                 "scheduler_timeout",
             );
+            if let Err(error) = super::harvest_uncommitted_patch(&mut outcome, &task) {
+                outcome = super::committed_harvest_failure(outcome, error);
+            }
             events.push(event(
                 &task.task_id,
                 Self::state_for_outcome(&outcome),

--- a/src/core/agent_task_scheduler/tests/scheduling_tests.rs
+++ b/src/core/agent_task_scheduler/tests/scheduling_tests.rs
@@ -157,7 +157,7 @@ mod adaptive_concurrency_tests {
 mod concurrency_tests {
     use super::*;
 
-    fn init_git_workspace(path: &std::path::Path) {
+    pub(super) fn init_git_workspace(path: &std::path::Path) {
         fs::create_dir(path).expect("workspace directory");
         for args in [
             ["init", "-b", "main"].as_slice(),
@@ -357,9 +357,9 @@ mod concurrency_tests {
 
     #[derive(Clone)]
     struct LateMutatingExecutor {
-        workspace: std::path::PathBuf,
         events: Arc<Mutex<Vec<String>>>,
         finished: Arc<AtomicBool>,
+        attempt_roots: Arc<Mutex<Vec<std::path::PathBuf>>>,
     }
 
     impl AgentTaskExecutorAdapter for LateMutatingExecutor {
@@ -373,18 +373,28 @@ mod concurrency_tests {
                 .expect("events")
                 .push(format!("{}-started", request.task_id));
             if request.task_id == "task-1" {
+                let workspace = request
+                    .workspace
+                    .root
+                    .as_deref()
+                    .map(std::path::PathBuf::from)
+                    .expect("attempt workspace");
+                self.attempt_roots
+                    .lock()
+                    .expect("attempt roots")
+                    .push(workspace.clone());
                 std::thread::sleep(Duration::from_millis(3_000));
-                fs::write(self.workspace.join("late-change.txt"), "late\n")
+                fs::write(workspace.join("late-change.txt"), "late\n")
                     .expect("late workspace mutation");
                 assert!(Command::new("git")
                     .args(["add", "late-change.txt"])
-                    .current_dir(&self.workspace)
+                    .current_dir(&workspace)
                     .status()
                     .expect("stage late mutation")
                     .success());
                 assert!(Command::new("git")
                     .args(["commit", "-m", "late mutation"])
-                    .current_dir(&self.workspace)
+                    .current_dir(&workspace)
                     .status()
                     .expect("commit late mutation")
                     .success());
@@ -409,10 +419,11 @@ mod concurrency_tests {
         init_git_workspace(&unrelated);
         let events = Arc::new(Mutex::new(Vec::new()));
         let finished = Arc::new(AtomicBool::new(false));
+        let attempt_roots = Arc::new(Mutex::new(Vec::new()));
         let scheduler = AgentTaskScheduler::new(LateMutatingExecutor {
-            workspace: workspace.clone(),
             events: Arc::clone(&events),
             finished: Arc::clone(&finished),
+            attempt_roots: Arc::clone(&attempt_roots),
         });
         let mut plan = plan_with_tasks(3);
         plan.options.max_concurrency = 3;
@@ -427,6 +438,15 @@ mod concurrency_tests {
         while !finished.load(Ordering::SeqCst) {
             std::thread::sleep(Duration::from_millis(2));
         }
+        let attempt_root = attempt_roots.lock().expect("attempt roots")[0].clone();
+        let cleanup_deadline = Instant::now() + Duration::from_secs(1);
+        while attempt_root.exists() && Instant::now() < cleanup_deadline {
+            std::thread::sleep(Duration::from_millis(2));
+        }
+        assert!(
+            !attempt_root.exists(),
+            "timed-out attempt checkout is retired"
+        );
         let events = events.lock().expect("events");
 
         assert!(events.iter().any(|event| event == "task-3-started"));
@@ -443,10 +463,14 @@ mod concurrency_tests {
                         && diagnostic.message.contains("workspace remains quarantined")
                 })
         }));
+        assert!(
+            !workspace.join("late-change.txt").exists(),
+            "the late provider mutation must stay out of the caller workspace"
+        );
     }
 
     #[test]
-    fn rejects_dirty_workspace_before_executor_can_commit_user_changes() {
+    fn rejects_preexisting_caller_dirt_before_attempt_checkout_or_provider_dispatch() {
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace = temp.path().join("workspace");
         init_git_workspace(&workspace);
@@ -565,6 +589,42 @@ mod resource_budget_tests {
 mod provider_rotation_tests {
     use super::*;
 
+    struct DirtyCandidateThenSuccessExecutor {
+        observed_roots: Arc<Mutex<Vec<std::path::PathBuf>>>,
+        calls: AtomicUsize,
+    }
+
+    impl AgentTaskExecutorAdapter for DirtyCandidateThenSuccessExecutor {
+        fn execute(
+            &self,
+            request: AgentTaskRequest,
+            _context: AgentTaskExecutionContext,
+        ) -> AgentTaskOutcome {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            let root = request
+                .workspace
+                .root
+                .as_deref()
+                .map(std::path::PathBuf::from)
+                .expect("attempt workspace");
+            self.observed_roots
+                .lock()
+                .expect("observed roots")
+                .push(root.clone());
+            if call == 0 {
+                fs::write(root.join("candidate.txt"), "candidate\n").expect("candidate edit");
+                let mut outcome = outcome(request.task_id, AgentTaskOutcomeStatus::Timeout);
+                outcome.failure_classification = Some(AgentTaskFailureClassification::Timeout);
+                return outcome;
+            }
+            assert!(
+                !root.join("candidate.txt").exists(),
+                "the rotated provider must receive a clean attempt checkout"
+            );
+            outcome(request.task_id, AgentTaskOutcomeStatus::Succeeded)
+        }
+    }
+
     fn rotation_policy(
         entries: Vec<AgentTaskProviderRotationEntry>,
     ) -> AgentTaskProviderRotationPolicy {
@@ -657,6 +717,62 @@ mod provider_rotation_tests {
         assert!(aggregate.events.iter().any(|event| {
             event.message.as_deref() == Some("provider rotation queued: entry 1 of 2")
         }));
+    }
+
+    #[test]
+    fn rotation_preserves_uncommitted_candidate_and_dispatches_next_provider_from_clean_baseline() {
+        let _home = crate::test_support::HomeGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        super::concurrency_tests::init_git_workspace(&workspace);
+        let observed_roots = Arc::new(Mutex::new(Vec::new()));
+        let scheduler = AgentTaskScheduler::new(DirtyCandidateThenSuccessExecutor {
+            observed_roots: Arc::clone(&observed_roots),
+            calls: AtomicUsize::new(0),
+        })
+        .with_run_id("run-8081");
+        let mut plan = plan_with_tasks(1);
+        plan.tasks[0].workspace.root = Some(workspace.display().to_string());
+        plan.options.rotation = Some(rotation_policy(vec![entry("fallback-backend-a")]));
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(
+            aggregate.status,
+            AgentTaskAggregateStatus::Succeeded,
+            "{aggregate:#?}"
+        );
+        assert!(
+            !workspace.join("candidate.txt").exists(),
+            "the managed task worktree must remain untouched"
+        );
+        let roots = observed_roots.lock().expect("observed roots");
+        assert_eq!(roots.len(), 2);
+        assert_ne!(roots[0], workspace);
+        assert_ne!(roots[1], workspace);
+        assert_ne!(roots[0], roots[1]);
+        let candidate = aggregate.outcomes[0]
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.id == "task-1-attempt-1-uncommitted-changes")
+            .expect("failed attempt patch candidate is retained for promotion");
+        assert_eq!(candidate.kind, "patch");
+        assert_eq!(candidate.metadata["producer_attempt"], 1);
+        assert_eq!(candidate.metadata["provider_rotation_index"], 0);
+        assert_eq!(candidate.metadata["provider_backend"], "test");
+        assert_eq!(candidate.metadata["run_id"], "run-8081");
+        assert_eq!(candidate.metadata["task_id"], "task-1");
+        let patch = fs::read_to_string(candidate.path.as_deref().expect("candidate path"))
+            .expect("candidate patch remains available");
+        assert!(patch.contains("diff --git a/candidate.txt b/candidate.txt"));
+        assert!(candidate
+            .path
+            .as_deref()
+            .is_some_and(|path| path.contains("agent-task/attempt-patches/run-8081/task-1")));
+        assert!(
+            !roots[0].exists() && !roots[1].exists(),
+            "attempt checkouts are retired after their executor threads stop"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #8081 by isolating every Git-backed provider attempt in its own detached checkout. A timed-out or failed provider can no longer contaminate the workspace used by the next retry or rotation.

Before retiring an attempt checkout, Homeboy captures tracked, staged, and untracked changes as a binary patch in stable artifact storage. Candidate metadata identifies the run, task, producing attempt, provider rotation index, and provider backend. Prior-attempt candidates carry into the terminal outcome for normal promotion and verification.

## Safety contract

- The caller-managed worktree remains preflight-only and is never staged, reset, cleaned, or removed.
- Pre-existing caller dirt still fails before provider dispatch.
- Only scheduler-created detached attempt worktrees are force-removed.
- Scheduler timeout ownership keeps the attempt checkout alive until the executor thread actually exits, preventing cleanup from racing late provider writes.
- Provider-declared patch artifacts inside a disposable checkout are copied to stable artifact storage before cleanup.

## How to test

1. Check out this branch from a fresh clone.
2. Run `cargo fmt --check`.
3. Run `cargo check`.
4. Run `cargo test agent_task_scheduler::tests::scheduling_tests::provider_rotation_tests --lib`.
5. Confirm all 9 rotation tests pass, including the regression where attempt 1 leaves an unstaged file and attempt 2 starts from a distinct clean checkout while retaining attempt 1's readable patch.
6. Run `cargo test agent_task_scheduler::tests::scheduling_tests::concurrency_tests --lib`.
7. Confirm all 10 concurrency tests pass, including pre-existing caller-dirt rejection and timeout cleanup after a late executor mutation.
8. Run `cargo test agent_task_scheduler::committed_harvest_tests --lib`.
9. Confirm committed patch evidence remains available when later metadata collection fails.

## Backwards compatibility

The public CLI and serialized schemas are unchanged. Provider execution now receives an isolated checkout path instead of the caller-managed worktree path; providers already consume the declared workspace root, and user-authored dirty-workspace rejection remains unchanged. Patch artifact IDs now include task and attempt identity to prevent collisions across rotations.

## Verification

Exact rebased head verified on `homeboy-lab`:

- `cargo fmt --check`: passed
- `cargo check`: passed
- Provider rotation tests: 9 passed
- Concurrency/timeout tests: 10 passed
- Committed-harvest tests: 1 passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode recovery agent via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Implemented provider-attempt isolation, candidate preservation, cleanup ownership, regression tests, and deterministic Lab verification; Chris reviews and owns the change.
