### PR TITLE
Verify canonical Lab workspace provenance

### DIFF
--- a/src/core/extension/trace/canonicality.rs
+++ b/src/core/extension/trace/canonicality.rs
@@ -5,6 +5,11 @@ use crate::core::component::Component;
 use crate::core::error::{ErrorCode, Result};
 use crate::core::extension::manifest_config::TraceToolchainProvenanceConfig;
 use crate::core::extension::ExtensionExecutionContext;
+#[cfg(test)]
+use crate::core::runner::verify_lab_workspace;
+use crate::core::runner::verify_lab_workspace_from_env;
+#[cfg(test)]
+use crate::core::source_snapshot::SourceSnapshot;
 
 use super::parsing::{
     TraceAssertion, TraceAssertionStatus, TraceCanonicalCheck, TraceEvidenceMetadata, TraceResults,
@@ -168,6 +173,7 @@ pub(crate) fn evaluate_trace_canonicality(
     checks.push(check_git_checkout(
         "component",
         Path::new(component_path),
+        Some(&component.local_path),
         checkout_provenance,
         &mut reasons,
     ));
@@ -243,6 +249,7 @@ fn check_declared_toolchain_provenance(
                 &format!("toolchain:{} ({key}, {source})", requirement.id),
                 &crate::core::git::git_probe_path(Path::new(path)),
                 None,
+                None,
                 reasons,
             )),
             _ => reasons.push(format!(
@@ -265,7 +272,7 @@ fn check_extension_checkout(
     .as_deref()
         == Some("true")
     {
-        return check_git_checkout(&target, &context.extension_path, None, reasons);
+        return check_git_checkout(&target, &context.extension_path, None, None, reasons);
     }
 
     let manifest_path = context
@@ -289,7 +296,7 @@ fn check_extension_checkout(
     }
 
     TraceCanonicalCheck {
-        target,
+        target: target.to_string(),
         path: context.extension_path.to_string_lossy().to_string(),
         status: "installed-extension".to_string(),
         sha: None,
@@ -297,6 +304,8 @@ fn check_extension_checkout(
         upstream: None,
         commits_ahead: None,
         commits_behind: None,
+        materialization_mode: None,
+        runner_id: None,
     }
 }
 
@@ -309,6 +318,7 @@ fn canonical_paths_equal(left: &str, right: &str) -> bool {
 fn check_git_checkout(
     target: &str,
     path: &Path,
+    expected_remote_component_path: Option<&str>,
     provenance: Option<&TraceCheckoutProvenance>,
     reasons: &mut Vec<String>,
 ) -> TraceCanonicalCheck {
@@ -321,6 +331,11 @@ fn check_git_checkout(
         return empty_check(target, path, "missing");
     }
     if git_output(path, &["rev-parse", "--is-inside-work-tree"]).as_deref() != Some("true") {
+        if let Some(check) =
+            check_managed_lab_snapshot(target, path, expected_remote_component_path, reasons)
+        {
+            return check;
+        }
         reasons.push(format!(
             "{} path is not a git checkout: {}",
             target,
@@ -380,6 +395,68 @@ fn check_git_checkout(
         upstream,
         commits_ahead: ahead,
         commits_behind: behind,
+        materialization_mode: None,
+        runner_id: None,
+    }
+}
+
+/// A Lab snapshot deliberately excludes `.git`; accept it only when the Lab
+/// dispatch envelope binds the remote directory to the clean controller checkout.
+fn check_managed_lab_snapshot(
+    target: &str,
+    path: &Path,
+    expected_remote_component_path: Option<&str>,
+    reasons: &mut Vec<String>,
+) -> Option<TraceCanonicalCheck> {
+    let expected_remote_component_path = expected_remote_component_path?;
+    verified_lab_snapshot_check(
+        target,
+        path,
+        verify_lab_workspace_from_env(expected_remote_component_path, path),
+        reasons,
+    )
+}
+
+#[cfg(test)]
+fn validate_managed_lab_snapshot(
+    target: &str,
+    path: &Path,
+    expected_remote_component_path: &str,
+    snapshot: SourceSnapshot,
+    lab: serde_json::Value,
+    reasons: &mut Vec<String>,
+) -> Option<TraceCanonicalCheck> {
+    verified_lab_snapshot_check(
+        target,
+        path,
+        verify_lab_workspace(expected_remote_component_path, path, snapshot, lab),
+        reasons,
+    )
+}
+
+fn verified_lab_snapshot_check(
+    target: &str,
+    path: &Path,
+    provenance: std::result::Result<crate::core::runner::VerifiedLabWorkspaceProvenance, String>,
+    reasons: &mut Vec<String>,
+) -> Option<TraceCanonicalCheck> {
+    match provenance {
+        Ok(provenance) => Some(TraceCanonicalCheck {
+            target: target.to_string(),
+            path: path.to_string_lossy().to_string(),
+            status: "managed-lab-snapshot".to_string(),
+            sha: Some(provenance.source_revision),
+            branch: None,
+            upstream: None,
+            commits_ahead: None,
+            commits_behind: None,
+            materialization_mode: Some(provenance.materialization_mode),
+            runner_id: Some(provenance.runner_id),
+        }),
+        Err(reason) => {
+            reasons.push(format!("{target} Lab materialization {reason}"));
+            None
+        }
     }
 }
 
@@ -437,6 +514,8 @@ fn empty_check(target: &str, path: &Path, status: &str) -> TraceCanonicalCheck {
         upstream: None,
         commits_ahead: None,
         commits_behind: None,
+        materialization_mode: None,
+        runner_id: None,
     }
 }
 
@@ -840,6 +919,182 @@ mod tests {
     }
 
     #[test]
+    fn canonical_trace_accepts_verified_lab_snapshot_without_git_metadata() {
+        let (_source, remote, snapshot, lab) = lab_snapshot_fixture();
+        let mut reasons = Vec::new();
+
+        let check = validate_managed_lab_snapshot(
+            "component",
+            remote.path(),
+            &remote.path().display().to_string(),
+            snapshot,
+            lab,
+            &mut reasons,
+        );
+
+        assert!(reasons.is_empty());
+        let check = check.expect("verified Lab snapshot accepted");
+        assert_eq!(check.status, "managed-lab-snapshot");
+        assert_eq!(check.materialization_mode.as_deref(), Some("snapshot"));
+        assert_eq!(check.runner_id.as_deref(), Some("homeboy-lab"));
+    }
+
+    #[test]
+    fn canonical_trace_refuses_forged_lab_snapshot_evidence() {
+        let (_source, remote, mut snapshot, lab) = lab_snapshot_fixture();
+        snapshot.git_sha = Some("forged".to_string());
+        let mut reasons = Vec::new();
+
+        let check = validate_managed_lab_snapshot(
+            "component",
+            remote.path(),
+            &remote.path().display().to_string(),
+            snapshot,
+            lab,
+            &mut reasons,
+        );
+
+        assert!(check.is_none());
+        assert!(reasons
+            .iter()
+            .any(|reason| reason.contains("invalid source revision")));
+    }
+
+    #[test]
+    fn canonical_trace_refuses_arbitrary_non_git_materialization_evidence() {
+        let (_source, remote, mut snapshot, mut lab) = lab_snapshot_fixture();
+        snapshot.sync_mode = "snapshot".to_string();
+        lab["source_snapshot"] = serde_json::to_value(&snapshot).unwrap();
+        let snapshot = serde_json::from_value(lab["source_snapshot"].clone()).unwrap();
+        let mut reasons = Vec::new();
+
+        let check = validate_managed_lab_snapshot(
+            "component",
+            remote.path(),
+            &remote.path().display().to_string(),
+            snapshot,
+            lab,
+            &mut reasons,
+        );
+
+        assert!(check.is_none());
+        assert!(reasons
+            .iter()
+            .any(|reason| reason.contains("untrusted source mode `snapshot`")));
+    }
+
+    #[test]
+    fn canonical_trace_refuses_nonmatching_lab_snapshot_workspace() {
+        let (_source, remote, mut snapshot, lab) = lab_snapshot_fixture();
+        snapshot.remote_path = Some("/not/the/materialized/workspace".to_string());
+        let mut reasons = Vec::new();
+
+        let check = validate_managed_lab_snapshot(
+            "component",
+            remote.path(),
+            &remote.path().display().to_string(),
+            snapshot,
+            lab,
+            &mut reasons,
+        );
+
+        assert!(check.is_none());
+        assert!(reasons
+            .iter()
+            .any(|reason| reason.contains("remote workspace does not match")));
+    }
+
+    #[test]
+    fn canonical_trace_refuses_self_consistent_forged_lab_env_with_changed_bytes() {
+        let (_source, remote, snapshot, lab) = lab_snapshot_fixture();
+        std::fs::write(remote.path().join("README.md"), "forged contents\n").unwrap();
+        let mut reasons = Vec::new();
+
+        let check = validate_managed_lab_snapshot(
+            "component",
+            remote.path(),
+            &remote.path().display().to_string(),
+            snapshot,
+            lab,
+            &mut reasons,
+        );
+
+        assert!(check.is_none());
+        assert!(reasons
+            .iter()
+            .any(|reason| reason.contains("content hash does not match")));
+    }
+
+    #[test]
+    fn canonical_trace_accepts_lab_dispatch_environment_for_remapped_workspace() {
+        let (_source, remote, snapshot, lab) = lab_snapshot_fixture();
+        let mut env = crate::core::runner::build_lab_offload_env(&lab);
+        env.insert(
+            "HOMEBOY_SOURCE_SNAPSHOT_JSON".to_string(),
+            serde_json::to_string(&snapshot).unwrap(),
+        );
+        let _guard = TraceEnvGuard::set(env);
+        let mut reasons = Vec::new();
+
+        let check = check_managed_lab_snapshot(
+            "component",
+            remote.path(),
+            Some(&remote.path().display().to_string()),
+            &mut reasons,
+        );
+
+        assert!(reasons.is_empty());
+        let check = check.expect("Lab dispatch environment accepted");
+        assert_eq!(check.sha, snapshot.git_sha);
+        assert_eq!(check.materialization_mode.as_deref(), Some("snapshot"));
+        assert_eq!(check.runner_id.as_deref(), Some("homeboy-lab"));
+    }
+
+    #[test]
+    fn canonical_trace_fails_closed_for_legacy_lab_metadata_without_content_hash() {
+        let (_source, remote, snapshot, mut lab) = lab_snapshot_fixture();
+        lab.as_object_mut()
+            .unwrap()
+            .remove("workspace_content_hash");
+        let mut reasons = Vec::new();
+
+        let check = validate_managed_lab_snapshot(
+            "component",
+            remote.path(),
+            &remote.path().display().to_string(),
+            snapshot,
+            lab,
+            &mut reasons,
+        );
+
+        assert!(check.is_none());
+        assert!(reasons
+            .iter()
+            .any(|reason| reason.contains("missing workspace content hash")));
+    }
+
+    #[test]
+    fn canonical_trace_refuses_dirty_lab_snapshot_evidence() {
+        let (_source, remote, mut snapshot, lab) = lab_snapshot_fixture();
+        snapshot.dirty = true;
+        let mut reasons = Vec::new();
+
+        let check = validate_managed_lab_snapshot(
+            "component",
+            remote.path(),
+            &remote.path().display().to_string(),
+            snapshot,
+            lab,
+            &mut reasons,
+        );
+
+        assert!(check.is_none());
+        assert!(reasons
+            .iter()
+            .any(|reason| reason.contains("records a dirty source checkout")));
+    }
+
+    #[test]
     fn canonical_trace_accepts_installed_extension_manifest_directory() {
         let component_dir = tempfile::tempdir().unwrap();
         let component_remote = tempfile::tempdir().unwrap();
@@ -977,6 +1232,78 @@ mod tests {
         std::fs::write(path.join("README.md"), "test\n").unwrap();
         git(path, &["add", "."]);
         git(path, &["commit", "-m", "initial"]);
+    }
+
+    fn lab_snapshot_fixture() -> (
+        tempfile::TempDir,
+        tempfile::TempDir,
+        SourceSnapshot,
+        serde_json::Value,
+    ) {
+        let source = tempfile::tempdir().unwrap();
+        let remote = tempfile::tempdir().unwrap();
+        init_git_repo(source.path());
+        std::fs::copy(
+            source.path().join("README.md"),
+            remote.path().join("README.md"),
+        )
+        .unwrap();
+        let snapshot = SourceSnapshot {
+            runner_id: "homeboy-lab".to_string(),
+            local_path: Some(source.path().display().to_string()),
+            remote_path: Some(remote.path().display().to_string()),
+            workspace_root: Some(source.path().display().to_string()),
+            git_branch: Some("main".to_string()),
+            git_sha: Some(git_stdout(source.path(), &["rev-parse", "HEAD"]).unwrap()),
+            dirty: false,
+            sync_mode: "lab_offload".to_string(),
+            workspace_snapshot_identity: Some("workspace:verified".to_string()),
+            snapshot_hash: "sha256:verified".to_string(),
+            synced_at: "2026-01-01T00:00:00Z".to_string(),
+            sync_excludes: vec![".git".to_string(), ".git/**".to_string()],
+        };
+        let workspace_content_hash =
+            crate::core::runner::workspace_content_hash(source.path(), &snapshot.sync_excludes)
+                .unwrap();
+        let lab = serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "remote_workspace": remote.path().display().to_string(),
+            "sync_mode": "snapshot",
+            "status": "offloaded",
+            "source_snapshot": snapshot,
+            "workspace_content_hash": workspace_content_hash,
+            "workspace_materialization_plan": { "identity": "workspace:verified" },
+        });
+        let snapshot = serde_json::from_value(lab["source_snapshot"].clone()).unwrap();
+        (source, remote, snapshot, lab)
+    }
+
+    struct TraceEnvGuard(Vec<(String, Option<String>)>);
+
+    impl TraceEnvGuard {
+        fn set(env: std::collections::HashMap<String, String>) -> Self {
+            let previous = env
+                .into_iter()
+                .map(|(name, value)| {
+                    let previous = std::env::var(&name).ok();
+                    unsafe { std::env::set_var(&name, value) };
+                    (name, previous)
+                })
+                .collect();
+            Self(previous)
+        }
+    }
+
+    impl Drop for TraceEnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in self.0.drain(..) {
+                if let Some(value) = value {
+                    unsafe { std::env::set_var(name, value) };
+                } else {
+                    unsafe { std::env::remove_var(name) };
+                }
+            }
+        }
     }
 
     fn init_bare_repo(path: &std::path::Path) {

--- a/src/core/extension/trace/parsing.rs
+++ b/src/core/extension/trace/parsing.rs
@@ -189,6 +189,10 @@ pub struct TraceCanonicalCheck {
     pub commits_ahead: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub commits_behind: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub materialization_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/core/extension/trace/run/workflow.rs
+++ b/src/core/extension/trace/run/workflow.rs
@@ -76,7 +76,6 @@ fn run_trace_workflow_with_component_script(
             canonicality.metadata(TraceCanonicalPolicy::Canonical),
         ));
     }
-    let evidence = canonicality.metadata(args.canonical_policy);
     let (mut toolchain, components) = trace_provenance(None, &component_path, &args)?;
     mark_non_canonical(
         &mut toolchain,
@@ -112,6 +111,10 @@ fn run_trace_workflow_with_component_script(
         cleanup_trace_overlays(&applied_overlays)?
     }
     let script_output = script_output?;
+    let final_canonicality = evaluate_trace_canonicality(None, component, &args)?;
+    let canonicality_changed =
+        args.canonical_policy.refuses_non_canonical() && !final_canonicality.is_canonical();
+    let evidence = final_canonicality.metadata(args.canonical_policy);
     let preview = finish_trace_public_preview(preview_session, run_dir)?;
     let results_path = run_dir.step_file(run_dir::files::TRACE_RESULTS);
     let mut results = if results_path.exists() {
@@ -133,17 +136,21 @@ fn run_trace_workflow_with_component_script(
         super::super::assertions::apply_temporal_assertions(parsed);
         persist_trace_results(&results_path, parsed)?;
     }
-    let status = results
-        .as_ref()
-        .map(|r| r.status.as_str().to_string())
-        .unwrap_or_else(|| {
-            if script_output.success {
-                "pass"
-            } else {
-                "error"
-            }
-            .to_string()
-        });
+    let status = if canonicality_changed {
+        "error".to_string()
+    } else {
+        results
+            .as_ref()
+            .map(|r| r.status.as_str().to_string())
+            .unwrap_or_else(|| {
+                if script_output.success {
+                    "pass"
+                } else {
+                    "error"
+                }
+                .to_string()
+            })
+    };
     let exit_code = if script_output.success {
         if status == "pass" {
             0
@@ -223,7 +230,6 @@ pub(super) fn run_trace_workflow_with_context(
             canonicality.metadata(TraceCanonicalPolicy::Canonical),
         ));
     }
-    let evidence = canonicality.metadata(args.canonical_policy);
     let (toolchain, components) = trace_provenance(execution_context, &component_path, &args)?;
     let _overlay_locks = if args.overlays.is_empty() {
         None
@@ -269,6 +275,14 @@ pub(super) fn run_trace_workflow_with_context(
         cleanup_trace_overlays(&applied_overlays)?
     }
     let preview = finish_trace_public_preview(preview_session, run_dir)?;
+    // A Lab snapshot is verified again after the workload. This is structural
+    // provenance, not a security boundary: a same-user process can construct
+    // both Git and envelope claims, while the independently recomputed bytes
+    // prevent a changed materialized workspace from retaining canonical status.
+    let final_canonicality = evaluate_trace_canonicality(execution_context, component, &args)?;
+    let canonicality_changed =
+        args.canonical_policy.refuses_non_canonical() && !final_canonicality.is_canonical();
+    let evidence = final_canonicality.metadata(args.canonical_policy);
     let results_path = run_dir.step_file(run_dir::files::TRACE_RESULTS);
     let mut results = if results_path.exists() {
         let mut parsed = parse_trace_results_file(&results_path)?;
@@ -294,17 +308,21 @@ pub(super) fn run_trace_workflow_with_context(
         persist_trace_results(&results_path, parsed)?;
     }
 
-    let status = results
-        .as_ref()
-        .map(|r| r.status.as_str().to_string())
-        .unwrap_or_else(|| {
-            if runner_output.success {
-                "pass"
-            } else {
-                "error"
-            }
-            .to_string()
-        });
+    let status = if canonicality_changed {
+        "error".to_string()
+    } else {
+        results
+            .as_ref()
+            .map(|r| r.status.as_str().to_string())
+            .unwrap_or_else(|| {
+                if runner_output.success {
+                    "pass"
+                } else {
+                    "error"
+                }
+                .to_string()
+            })
+    };
     let failure = (!runner_output.success && status != "pass")
         .then(|| failure_from_output(&args, &runner_output, Some(&artifact_dir), results.as_ref()));
     let exit_code = if status == "pass" {

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -1224,6 +1224,11 @@ pub(crate) fn run_lab_offload_inner(
     );
     lab_metadata["source_snapshot"] =
         serde_json::to_value(&source_snapshot).unwrap_or(serde_json::json!(null));
+    lab_metadata["workspace_content_hash"] =
+        serde_json::json!(crate::core::runner::workspace_content_hash(
+            Path::new(&source_snapshot.local_path.clone().unwrap_or_default()),
+            &source_snapshot.sync_excludes,
+        )?);
     lab_metadata["dependency_hydration"] =
         dependency_hydration_metadata(&dependency_hydration.record);
     lab_metadata["workspace_materialization_plan"] =

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -295,6 +295,9 @@ fn prepare_lab_offload_workspace_stage_inner(
         Some(&remote_cwd),
         "lab_offload",
     );
+    // The effective workspace filters define the bytes shipped to Lab and are
+    // carried to the runner for deterministic post-materialization verification.
+    source_snapshot.sync_excludes = synced.excludes.clone();
     source_snapshot.workspace_snapshot_identity = Some(synced.snapshot_identity.clone());
     validate_lab_source_snapshot_handoff(source_path, &synced, &source_snapshot)?;
     if contract.routing_policy.requires_extension_parity {

--- a/src/core/runner/lab_env.rs
+++ b/src/core/runner/lab_env.rs
@@ -27,7 +27,7 @@ pub(super) fn forward_release_ci_env(env: &mut HashMap<String, String>) {
     }
 }
 
-pub(super) fn build_lab_offload_env(lab_metadata: &serde_json::Value) -> HashMap<String, String> {
+pub(crate) fn build_lab_offload_env(lab_metadata: &serde_json::Value) -> HashMap<String, String> {
     HashMap::from([(
         LAB_OFFLOAD_METADATA_ENV.to_string(),
         serde_json::to_string(lab_metadata).unwrap_or_default(),

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -126,6 +126,8 @@ pub use lab::{
     execute_lab_offload, LabJobOverrides, LabOffloadCommand, LabOffloadOutcome, LabOffloadRequest,
     LabOffloadSourcePathMode, LabOffloadWorkspaceModePolicy, LabRunnerSelectionSource,
 };
+#[cfg(test)]
+pub(crate) use lab_env::build_lab_offload_env;
 pub use offload_changed_since::{
     lab_offload_changed_since_ref, preflight_lab_offload_changed_since,
     prepare_git_lab_offload_changed_since,
@@ -153,6 +155,8 @@ pub use tool_registry::{RunnerToolRegistry, RunnerToolSpec};
 pub(crate) use transport::{select_runner_transport, RunnerFileTransfer, RunnerTransport};
 pub use worker::{run_reverse_worker, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput};
 pub use workspace::reap_run_workspace;
+#[cfg(test)]
+pub(crate) use workspace::verify_lab_workspace;
 pub use workspace::{
     list_workspaces, plan_workspace_pull, prune_workspaces, pull_workspace, sync_workspace,
     workspace_snapshots, ByteFileCounts, RunnerWorkspaceCurrentSummary, RunnerWorkspaceListEntry,
@@ -163,6 +167,9 @@ pub use workspace::{
     RunnerWorkspaceSnapshotAppliedFilters, RunnerWorkspaceSnapshotEntry,
     RunnerWorkspaceSnapshotFilters, RunnerWorkspaceSnapshotsOutput, RunnerWorkspaceSyncMode,
     RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+};
+pub(crate) use workspace::{
+    verify_lab_workspace_from_env, workspace_content_hash, VerifiedLabWorkspaceProvenance,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/core/runner/workspace/mod.rs
+++ b/src/core/runner/workspace/mod.rs
@@ -9,6 +9,7 @@
 mod git;
 mod materialized;
 mod materializer;
+mod provenance;
 mod pull;
 mod snapshot;
 mod sync;
@@ -36,9 +37,12 @@ pub(crate) use materializer::{
     dependency_cache_manifest_command, dependency_cache_restore_command,
     dependency_cache_save_command,
 };
+#[cfg(test)]
+pub(crate) use provenance::verify_lab_workspace;
+pub(crate) use provenance::{verify_lab_workspace_from_env, VerifiedLabWorkspaceProvenance};
 pub(crate) use snapshot::{
     copy_snapshot_to_directory, effective_snapshot_excludes, local_snapshot_stats,
-    materialize_snapshot, materialize_snapshot_git, snapshot_identity,
+    materialize_snapshot, materialize_snapshot_git, snapshot_identity, workspace_content_hash,
 };
 pub(crate) use types::{canonical_workspace_path, DEFAULT_EXCLUDES};
 pub(crate) use util::{

--- a/src/core/runner/workspace/provenance.rs
+++ b/src/core/runner/workspace/provenance.rs
@@ -1,0 +1,153 @@
+use std::path::Path;
+
+use crate::core::observation::{LAB_OFFLOAD_METADATA_ENV, SOURCE_SNAPSHOT_METADATA_ENV};
+use crate::core::source_snapshot::SourceSnapshot;
+
+use super::workspace_content_hash;
+
+const LAB_SOURCE_SNAPSHOT_SYNC_MODE: &str = "lab_offload";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VerifiedLabWorkspaceProvenance {
+    pub source_revision: String,
+    pub materialization_mode: String,
+    pub runner_id: String,
+    pub workspace_identity: String,
+}
+
+/// Verifies a Lab-materialized workspace against the controller-produced
+/// content digest. Environment values transport the contract; the remote bytes
+/// are the authority for the content match.
+pub(crate) fn verify_lab_workspace_from_env(
+    expected_remote_component_path: &str,
+    materialized_workspace_path: &Path,
+) -> std::result::Result<VerifiedLabWorkspaceProvenance, String> {
+    let snapshot: SourceSnapshot = env_json(SOURCE_SNAPSHOT_METADATA_ENV)
+        .ok_or_else(|| "is missing source snapshot transport metadata".to_string())?;
+    let lab: serde_json::Value = env_json(LAB_OFFLOAD_METADATA_ENV)
+        .ok_or_else(|| "is missing Lab dispatch transport metadata".to_string())?;
+    verify_lab_workspace(
+        expected_remote_component_path,
+        materialized_workspace_path,
+        snapshot,
+        lab,
+    )
+}
+
+pub(crate) fn verify_lab_workspace(
+    expected_remote_component_path: &str,
+    materialized_workspace_path: &Path,
+    snapshot: SourceSnapshot,
+    lab: serde_json::Value,
+) -> std::result::Result<VerifiedLabWorkspaceProvenance, String> {
+    snapshot
+        .local_path
+        .as_deref()
+        .ok_or("is missing controller source path")?;
+    let recorded_remote_path = snapshot
+        .remote_path
+        .as_deref()
+        .ok_or("is missing remote path")?;
+    let source_revision = snapshot
+        .git_sha
+        .as_deref()
+        .ok_or("is missing source revision")?;
+    let workspace_identity = snapshot
+        .workspace_snapshot_identity
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or("is missing workspace identity")?;
+    let runner_id = lab
+        .get("runner_id")
+        .and_then(|value| value.as_str())
+        .ok_or("is missing runner identity")?;
+    let lab_remote_path = lab
+        .get("remote_workspace")
+        .and_then(|value| value.as_str())
+        .ok_or("is missing remote workspace")?;
+    let materialization_mode = lab
+        .get("sync_mode")
+        .and_then(|value| value.as_str())
+        .ok_or("is missing materialization mode")?;
+    let expected_content_hash = lab
+        .get("workspace_content_hash")
+        .and_then(|value| value.as_str())
+        .ok_or("is missing workspace content hash")?;
+    let lab_snapshot = lab
+        .get("source_snapshot")
+        .ok_or("is missing source snapshot evidence")?;
+    let plan_identity = lab
+        .get("workspace_materialization_plan")
+        .and_then(|value| value.get("identity"))
+        .and_then(|value| value.as_str())
+        .ok_or("is missing workspace materialization identity")?;
+
+    if snapshot.sync_mode != LAB_SOURCE_SNAPSHOT_SYNC_MODE {
+        return Err(format!(
+            "has untrusted source mode `{}`",
+            snapshot.sync_mode
+        ));
+    }
+    if !matches!(materialization_mode, "git" | "snapshot" | "snapshot-git") {
+        return Err(format!(
+            "has untrusted workspace materialization mode `{materialization_mode}`"
+        ));
+    }
+    if snapshot.dirty {
+        return Err("records a dirty source checkout".to_string());
+    }
+    if !is_git_revision(source_revision) {
+        return Err("has an invalid source revision".to_string());
+    }
+    if snapshot.runner_id.trim().is_empty() || snapshot.runner_id != runner_id {
+        return Err("runner identity does not match the Lab dispatch".to_string());
+    }
+    if !paths_equal(
+        expected_remote_component_path,
+        &materialized_workspace_path.to_string_lossy(),
+    ) || !paths_equal(
+        recorded_remote_path,
+        &materialized_workspace_path.to_string_lossy(),
+    ) || !paths_equal(
+        lab_remote_path,
+        &materialized_workspace_path.to_string_lossy(),
+    ) {
+        return Err("remote workspace does not match materialized path".to_string());
+    }
+    if lab.get("status").and_then(|value| value.as_str()) != Some("offloaded") {
+        return Err("dispatch status is not `offloaded`".to_string());
+    }
+    if workspace_identity != plan_identity {
+        return Err("workspace identity does not match materialization plan".to_string());
+    }
+    if serde_json::to_value(&snapshot).ok().as_ref() != Some(lab_snapshot) {
+        return Err("source snapshot does not match Lab dispatch evidence".to_string());
+    }
+    let actual_content_hash =
+        workspace_content_hash(materialized_workspace_path, &snapshot.sync_excludes)
+            .map_err(|error| format!("could not hash materialized workspace: {}", error.message))?;
+    if actual_content_hash != expected_content_hash {
+        return Err("content hash does not match the controller materialization".to_string());
+    }
+
+    Ok(VerifiedLabWorkspaceProvenance {
+        source_revision: source_revision.to_string(),
+        materialization_mode: materialization_mode.to_string(),
+        runner_id: snapshot.runner_id,
+        workspace_identity: workspace_identity.to_string(),
+    })
+}
+
+fn env_json<T: serde::de::DeserializeOwned>(name: &str) -> Option<T> {
+    std::env::var(name)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+}
+
+fn paths_equal(left: &str, right: &str) -> bool {
+    matches!((Path::new(left).canonicalize(), Path::new(right).canonicalize()), (Ok(left), Ok(right)) if left == right)
+}
+
+fn is_git_revision(value: &str) -> bool {
+    matches!(value.len(), 40 | 64) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}

--- a/src/core/runner/workspace/snapshot.rs
+++ b/src/core/runner/workspace/snapshot.rs
@@ -37,6 +37,126 @@ pub(crate) fn snapshot_identity(
     Ok(format!("snapshot:{}", hex_prefix(&hasher.finalize(), 16)))
 }
 
+/// Stable digest of the files a snapshot materializes. Unlike `snapshot_identity`,
+/// this is portable across controller and runner paths and can be recomputed after
+/// transport. The runner workspace record is transport metadata, not source.
+pub(crate) fn workspace_content_hash(path: &Path, excludes: &[String]) -> Result<String> {
+    let mut entries = Vec::new();
+    let root = path.canonicalize().map_err(|err| {
+        Error::internal_io(err.to_string(), Some("canonicalize workspace".to_string()))
+    })?;
+    collect_content_hash_entries(
+        &root,
+        &root,
+        Path::new(""),
+        excludes,
+        &mut vec![root.clone()],
+        &mut entries,
+    )?;
+    entries.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut hasher = Sha256::new();
+    hasher.update(b"homeboy-workspace-content-v1\0");
+    for (relative, kind, mode, contents) in entries {
+        hasher.update(relative.as_bytes());
+        hasher.update(kind.as_bytes());
+        hasher.update(mode.to_le_bytes());
+        hasher.update((contents.len() as u64).to_le_bytes());
+        hasher.update(contents);
+    }
+    Ok(format!("sha256:{:x}", hasher.finalize()))
+}
+
+fn collect_content_hash_entries(
+    root: &Path,
+    path: &Path,
+    logical: &Path,
+    excludes: &[String],
+    ancestors: &mut Vec<std::path::PathBuf>,
+    entries: &mut Vec<(String, &'static str, u32, Vec<u8>)>,
+) -> Result<()> {
+    let mut children = fs::read_dir(path)
+        .map_err(|err| {
+            Error::internal_io(err.to_string(), Some("read sync directory".to_string()))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some("read sync directory entry".to_string()),
+            )
+        })?;
+    children.sort_by_key(|entry| entry.path());
+    for entry in children {
+        let entry_path = entry.path();
+        let relative_path = logical.join(entry.file_name());
+        let relative = relative_path.to_string_lossy().replace('\\', "/");
+        if relative == ".homeboy/runner-workspace.json"
+            || is_excluded(root, &root.join(&relative_path), excludes, &[])
+        {
+            continue;
+        }
+        let link_metadata = fs::symlink_metadata(&entry_path).map_err(|err| {
+            Error::internal_io(err.to_string(), Some("read sync file metadata".to_string()))
+        })?;
+        let resolved = if link_metadata.file_type().is_symlink() {
+            entry_path.canonicalize().map_err(|err| {
+                Error::validation_invalid_argument(
+                    "workspace",
+                    "workspace content hash refused an unresolved symlink",
+                    Some(err.to_string()),
+                    None,
+                )
+            })?
+        } else {
+            entry_path.clone()
+        };
+        let metadata = fs::metadata(&resolved).map_err(|err| {
+            Error::internal_io(err.to_string(), Some("read sync file metadata".to_string()))
+        })?;
+        if metadata.is_dir() {
+            let canonical = resolved
+                .canonicalize()
+                .map_err(|err| Error::internal_io(err.to_string(), None))?;
+            if ancestors.contains(&canonical) {
+                return Err(Error::validation_invalid_argument(
+                    "workspace",
+                    "workspace content hash refused a symlink cycle",
+                    Some(entry_path.display().to_string()),
+                    None,
+                ));
+            }
+            entries.push((relative, "\0dir\0", mode_bits(&metadata), Vec::new()));
+            ancestors.push(canonical);
+            collect_content_hash_entries(
+                root,
+                &resolved,
+                &relative_path,
+                excludes,
+                ancestors,
+                entries,
+            )?;
+            ancestors.pop();
+        } else if metadata.is_file() {
+            let contents = fs::read(&resolved).map_err(|err| {
+                Error::internal_io(err.to_string(), Some("read sync file".to_string()))
+            })?;
+            entries.push((relative, "\0file\0", mode_bits(&metadata), contents));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn mode_bits(metadata: &fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    metadata.permissions().mode() & 0o777
+}
+
+#[cfg(not(unix))]
+fn mode_bits(_metadata: &fs::Metadata) -> u32 {
+    0
+}
+
 pub(crate) fn local_snapshot_stats(
     path: &Path,
     excludes: &[String],


### PR DESCRIPTION
## Summary
- accept Homeboy-managed Lab snapshots as canonical structural evidence only after binding controller source and remapped runner workspace metadata
- recompute full portable workspace identity before and after trace execution, including paths, directories, bytes, and executable modes
- reject dirty, mismatched, legacy-unverifiable, or mutated materializations while preserving supported dereferenced symlinks
- expose source revision, materialization mode, and runner identity in trace evidence

Fixes #8086.

## How to test
1. Check out this branch with Rust installed.
2. Run `cargo test core::extension::trace::canonicality --lib`.
3. Run `cargo test core::runner::workspace::tests --lib`.
4. Run `cargo check --lib`, `cargo fmt --check`, and `git diff --check origin/main...HEAD`.
5. Route a canonical trace from a clean Git worktree through a Lab runner and confirm the remapped managed snapshot is accepted; mutate the workspace during a test workload and confirm the trace fails canonicality.

## Contract
Canonicality remains structural reproducibility evidence, matching the local Git checkout contract; it is not same-user cryptographic attestation. Arbitrary non-Git paths without matching verified Lab materialization evidence remain rejected.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab canonicality mismatch, implemented reusable workspace provenance verification, added mutation and path-binding coverage, and independently reviewed the trust model. Chris reviewed and owns the change.