### PR TITLE
Propagate Lab workspace verification metadata

### DIFF
--- a/src/core/extension/trace/canonicality.rs
+++ b/src/core/extension/trace/canonicality.rs
@@ -1051,11 +1051,11 @@ mod tests {
     }
 
     #[test]
-    fn canonical_trace_fails_closed_for_legacy_lab_metadata_without_content_hash() {
+    fn canonical_trace_fails_closed_for_snapshot_lab_metadata_without_workspace_verification() {
         let (_source, remote, snapshot, mut lab) = lab_snapshot_fixture();
         lab.as_object_mut()
             .unwrap()
-            .remove("workspace_content_hash");
+            .remove("workspace_verification");
         let mut reasons = Vec::new();
 
         let check = validate_managed_lab_snapshot(
@@ -1070,7 +1070,7 @@ mod tests {
         assert!(check.is_none());
         assert!(reasons
             .iter()
-            .any(|reason| reason.contains("missing workspace content hash")));
+            .any(|reason| reason.contains("missing workspace verification metadata")));
     }
 
     #[test]
@@ -1273,6 +1273,17 @@ mod tests {
             "source_snapshot": snapshot,
             "workspace_content_hash": workspace_content_hash,
             "workspace_materialization_plan": { "identity": "workspace:verified" },
+            "workspace_verification": {
+                "schema": "homeboy/lab-workspace-verification/v1",
+                "identity": "workspace:verified",
+                "content_hash": workspace_content_hash,
+                "sync_excludes": [".git", ".git/**"],
+                "source_snapshot": snapshot,
+                "primary_workspace": {
+                    "identity": "workspace:verified",
+                    "remote_path": remote.path().display().to_string(),
+                },
+            },
         });
         let snapshot = serde_json::from_value(lab["source_snapshot"].clone()).unwrap();
         (source, remote, snapshot, lab)

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -1222,17 +1222,16 @@ pub(crate) fn run_lab_offload_inner(
         None,
         Some(&workspace_mapping_metadata),
     );
-    lab_metadata["source_snapshot"] =
-        serde_json::to_value(&source_snapshot).unwrap_or(serde_json::json!(null));
-    lab_metadata["workspace_content_hash"] =
-        serde_json::json!(crate::core::runner::workspace_content_hash(
-            Path::new(&source_snapshot.local_path.clone().unwrap_or_default()),
-            &source_snapshot.sync_excludes,
-        )?);
+    attach_lab_workspace_metadata(
+        &mut lab_metadata,
+        LabWorkspaceMetadataInputs {
+            source_snapshot: &source_snapshot,
+            legacy_path_materialization_plan: &path_materialization_plan,
+            primary_synced_workspace: &synced,
+        },
+    )?;
     lab_metadata["dependency_hydration"] =
         dependency_hydration_metadata(&dependency_hydration.record);
-    lab_metadata["workspace_materialization_plan"] =
-        serde_json::to_value(&path_materialization_plan).unwrap_or(serde_json::json!(null));
     lab_metadata["workspace_resource_lifecycle"] =
         serde_json::to_value(&workspace_resource_lifecycle).unwrap_or(serde_json::json!(null));
     lab_metadata["materialization_proof"] = lab_materialization_proof_metadata(

--- a/src/core/runner/lab/offload/metadata.rs
+++ b/src/core/runner/lab/offload/metadata.rs
@@ -2,6 +2,7 @@
 //! rig component path overrides, and the stale-runner-homeboy error.
 
 use super::*;
+use crate::core::runner_execution_envelope::PathMaterializationPlan;
 #[cfg(test)]
 use crate::core::secret_env_plan::SECRET_ENV_PLAN_ENV_DELTA_SOURCE;
 use std::path::{Path, PathBuf};
@@ -569,6 +570,43 @@ pub(crate) fn lab_materialization_proof_metadata(
         "workspace_mapping": workspace_mapping,
         "rigs": synced_rigs,
     })
+}
+
+/// The two workspace plans intentionally have distinct types: the path plan is
+/// legacy dispatch metadata, while the synced workspace binds verification.
+pub(crate) struct LabWorkspaceMetadataInputs<'a> {
+    pub(crate) source_snapshot: &'a SourceSnapshot,
+    pub(crate) legacy_path_materialization_plan: &'a PathMaterializationPlan,
+    pub(crate) primary_synced_workspace: &'a RunnerWorkspaceSyncOutput,
+}
+
+/// Add verification metadata without changing the registered path-materialization
+/// metadata shape consumed by existing dispatch clients.
+pub(crate) fn attach_lab_workspace_metadata(
+    lab_metadata: &mut serde_json::Value,
+    inputs: LabWorkspaceMetadataInputs<'_>,
+) -> Result<()> {
+    let source_snapshot = inputs.source_snapshot;
+    let primary_workspace_plan = &inputs.primary_synced_workspace.materialization_plan;
+    let content_hash = crate::core::runner::workspace_content_hash(
+        Path::new(&source_snapshot.local_path.clone().unwrap_or_default()),
+        &source_snapshot.sync_excludes,
+    )?;
+    lab_metadata["source_snapshot"] =
+        serde_json::to_value(source_snapshot).unwrap_or(serde_json::json!(null));
+    lab_metadata["workspace_content_hash"] = serde_json::json!(content_hash);
+    lab_metadata["workspace_materialization_plan"] =
+        serde_json::to_value(inputs.legacy_path_materialization_plan)
+            .unwrap_or(serde_json::json!(null));
+    lab_metadata["workspace_verification"] = serde_json::json!({
+        "schema": "homeboy/lab-workspace-verification/v1",
+        "identity": primary_workspace_plan.identity,
+        "content_hash": content_hash,
+        "sync_excludes": source_snapshot.sync_excludes,
+        "source_snapshot": source_snapshot,
+        "primary_workspace": primary_workspace_plan,
+    });
+    Ok(())
 }
 
 pub(crate) fn lab_runtime_dependency_manifest_metadata(

--- a/src/core/runner/lab/offload/tests/capability_metadata.rs
+++ b/src/core/runner/lab/offload/tests/capability_metadata.rs
@@ -198,6 +198,165 @@ fn lab_offload_env_contains_workspace_mapping_metadata() {
 }
 
 #[test]
+fn lab_offload_workspace_verification_metadata_survives_process_env_hydration() {
+    let source = tempfile::tempdir().expect("source workspace");
+    let remote = tempfile::tempdir().expect("materialized workspace");
+    std::fs::write(source.path().join("README.md"), "verified contents\n").expect("source file");
+    std::fs::write(remote.path().join("README.md"), "verified contents\n").expect("remote file");
+    std::fs::write(source.path().join("excluded.txt"), "controller only\n").expect("excluded file");
+
+    let source_path = source.path().canonicalize().expect("canonical source");
+    let remote_path = remote.path().canonicalize().expect("canonical remote");
+    let snapshot = SourceSnapshot {
+        runner_id: "lab".to_string(),
+        local_path: Some(source_path.display().to_string()),
+        remote_path: Some(remote_path.display().to_string()),
+        workspace_root: Some(source_path.display().to_string()),
+        git_branch: Some("main".to_string()),
+        git_sha: Some("a".repeat(40)),
+        dirty: false,
+        sync_mode: "lab_offload".to_string(),
+        workspace_snapshot_identity: Some("snapshot:verified".to_string()),
+        snapshot_hash: "sha256:verified".to_string(),
+        synced_at: "2026-07-14T00:00:00Z".to_string(),
+        sync_excludes: vec!["excluded.txt".to_string()],
+    };
+    let synced_workspace = primary_synced_workspace(&source_path, &remote_path);
+    let path_materialization_plan = PathMaterializationPlan::new([PathMaterializationEntry::new(
+        "primary",
+        PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
+        Some(source_path.display().to_string()),
+        remote_path.display().to_string(),
+        PATH_MATERIALIZATION_MODE_SNAPSHOT,
+        PATH_MATERIALIZATION_STATUS_MATERIALIZED,
+    )]);
+    let mut plan = base_lab_plan(None);
+    plan.steps.push(
+        crate::core::plan::PlanStep::ready("lab.sync_workspace", "lab.sync_workspace")
+            .inputs(crate::core::plan::PlanValues::new().string("mode", "snapshot"))
+            .build(),
+    );
+    let mut metadata = crate::core::runner::lab_offload_metadata(
+        &plan,
+        "explicit",
+        Some("lab"),
+        Some("reverse"),
+        "offloaded",
+        Some(&remote_path.display().to_string()),
+        None,
+    );
+    attach_lab_workspace_metadata(
+        &mut metadata,
+        LabWorkspaceMetadataInputs {
+            source_snapshot: &snapshot,
+            legacy_path_materialization_plan: &path_materialization_plan,
+            primary_synced_workspace: &synced_workspace,
+        },
+    )
+    .expect("build verifier metadata");
+
+    let env = build_lab_offload_env(&metadata);
+    let prior_lab = std::env::var(LAB_OFFLOAD_METADATA_ENV).ok();
+    let prior_snapshot = std::env::var(SOURCE_SNAPSHOT_METADATA_ENV).ok();
+    std::env::set_var(
+        LAB_OFFLOAD_METADATA_ENV,
+        env.get(LAB_OFFLOAD_METADATA_ENV)
+            .expect("Lab metadata process env"),
+    );
+    std::env::set_var(
+        SOURCE_SNAPSHOT_METADATA_ENV,
+        serde_json::to_string(&snapshot).expect("source snapshot process env"),
+    );
+
+    let verified = verify_lab_workspace_from_env(&remote_path.display().to_string(), remote.path())
+        .expect("verifier accepts hydrated Lab process metadata");
+    assert_eq!(verified.workspace_identity, "snapshot:verified");
+    assert_eq!(
+        metadata["workspace_verification"]["identity"],
+        "snapshot:verified"
+    );
+    assert_eq!(
+        metadata["workspace_verification"]["sync_excludes"],
+        serde_json::json!(["excluded.txt"])
+    );
+    assert_eq!(
+        metadata["workspace_materialization_plan"],
+        serde_json::to_value(&path_materialization_plan).expect("legacy plan JSON")
+    );
+    assert_eq!(
+        metadata["workspace_verification"]["primary_workspace"],
+        serde_json::to_value(&synced_workspace.materialization_plan)
+            .expect("primary sync plan JSON")
+    );
+
+    match prior_lab {
+        Some(value) => std::env::set_var(LAB_OFFLOAD_METADATA_ENV, value),
+        None => std::env::remove_var(LAB_OFFLOAD_METADATA_ENV),
+    }
+    match prior_snapshot {
+        Some(value) => std::env::set_var(SOURCE_SNAPSHOT_METADATA_ENV, value),
+        None => std::env::remove_var(SOURCE_SNAPSHOT_METADATA_ENV),
+    }
+}
+
+fn primary_synced_workspace(
+    local_path: &std::path::Path,
+    remote_path: &std::path::Path,
+) -> RunnerWorkspaceSyncOutput {
+    let local_path = local_path.display().to_string();
+    let remote_path = remote_path.display().to_string();
+    RunnerWorkspaceSyncOutput {
+        variant: "workspace_sync",
+        command: "runner.workspace.sync",
+        runner_id: "lab".to_string(),
+        local_path: local_path.clone(),
+        remote_path: remote_path.clone(),
+        materialization_plan: RunnerWorkspaceMaterializationPlan::from_test_parts(
+            "/srv/homeboy",
+            &local_path,
+            "app",
+            &remote_path,
+            RunnerWorkspaceSyncMode::Snapshot,
+            "snapshot:verified",
+        ),
+        current_workspace: crate::core::runner::RunnerWorkspaceCurrentSummary {
+            local_path: local_path.clone(),
+            remote_path: remote_path.clone(),
+            sync_mode: RunnerWorkspaceSyncMode::Snapshot,
+            materialized: true,
+            source_commit: None,
+            source_ref: None,
+            source_dirty: None,
+            synthetic_checkout_commit: None,
+        },
+        workspace_lease: crate::core::runner::RunnerWorkspaceLease {
+            runner_id: "lab".to_string(),
+            local_path: local_path.clone(),
+            remote_path: remote_path.clone(),
+            sync_mode: "snapshot".to_string(),
+            materialized: true,
+            lifecycle_owner: crate::core::runner::RunnerLifecycleOwner::Controller,
+            source_commit: None,
+            source_ref: None,
+            source_dirty: None,
+        },
+        resource_lifecycle: crate::core::runner::workspace_resource_lifecycle(
+            "lab",
+            &remote_path,
+            None,
+            crate::core::resource_lifecycle_index::ResourceCleanupPolicy::DeleteOnSuccess,
+        ),
+        sync_mode: RunnerWorkspaceSyncMode::Snapshot,
+        snapshot_identity: "snapshot:verified".to_string(),
+        counts: crate::core::runner::ByteFileCounts::default(),
+        excludes: vec!["excluded.txt".to_string()],
+        includes: Vec::new(),
+        workspace_cleanliness: "snapshot_unique_workspace".to_string(),
+        validation_dependencies: Vec::new(),
+    }
+}
+
+#[test]
 fn materialization_proof_records_hashes_source_and_runner_identity() {
     let source_snapshot = SourceSnapshot {
         runner_id: "lab".to_string(),

--- a/src/core/runner/lab/offload/tests/mod.rs
+++ b/src/core/runner/lab/offload/tests/mod.rs
@@ -11,13 +11,18 @@ pub(super) use super::super::super::lab_workspaces::{
 };
 pub(super) use super::*;
 pub(super) use crate::core::engine::command::{CaptureMetadata, CommandCaptureMetadata};
-pub(super) use crate::core::observation::LAB_OFFLOAD_METADATA_ENV;
+pub(super) use crate::core::observation::{LAB_OFFLOAD_METADATA_ENV, SOURCE_SNAPSHOT_METADATA_ENV};
 pub(super) use crate::core::plan::PlanKind;
+pub(super) use crate::core::runner::verify_lab_workspace_from_env;
 pub(super) use crate::core::runner::{
     RunnerActiveJobSource, RunnerActiveJobState, RunnerAvailability, RunnerExecMode,
     RunnerExecOutput, RunnerRequiredTool, RunnerSession, RunnerSessionState,
     RunnerStaleDaemonWarning, RunnerTunnelMode, RunnerWorkspaceMaterializationPlan,
     RunnerWorkspaceSyncOutput,
+};
+pub(super) use crate::core::runner_execution_envelope::{
+    PathMaterializationEntry, PathMaterializationPlan, PATH_MATERIALIZATION_MODE_SNAPSHOT,
+    PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT, PATH_MATERIALIZATION_STATUS_MATERIALIZED,
 };
 
 mod capability_metadata;

--- a/src/core/runner/workspace/provenance.rs
+++ b/src/core/runner/workspace/provenance.rs
@@ -69,18 +69,9 @@ pub(crate) fn verify_lab_workspace(
         .get("sync_mode")
         .and_then(|value| value.as_str())
         .ok_or("is missing materialization mode")?;
-    let expected_content_hash = lab
-        .get("workspace_content_hash")
-        .and_then(|value| value.as_str())
-        .ok_or("is missing workspace content hash")?;
     let lab_snapshot = lab
         .get("source_snapshot")
         .ok_or("is missing source snapshot evidence")?;
-    let plan_identity = lab
-        .get("workspace_materialization_plan")
-        .and_then(|value| value.get("identity"))
-        .and_then(|value| value.as_str())
-        .ok_or("is missing workspace materialization identity")?;
 
     if snapshot.sync_mode != LAB_SOURCE_SNAPSHOT_SYNC_MODE {
         return Err(format!(
@@ -117,11 +108,66 @@ pub(crate) fn verify_lab_workspace(
     if lab.get("status").and_then(|value| value.as_str()) != Some("offloaded") {
         return Err("dispatch status is not `offloaded`".to_string());
     }
-    if workspace_identity != plan_identity {
-        return Err("workspace identity does not match materialization plan".to_string());
-    }
     if serde_json::to_value(&snapshot).ok().as_ref() != Some(lab_snapshot) {
         return Err("source snapshot does not match Lab dispatch evidence".to_string());
+    }
+    let verification = lab.get("workspace_verification");
+    let (expected_content_hash, verification_identity) = match verification {
+        Some(verification) => {
+            if verification.get("schema").and_then(|value| value.as_str())
+                != Some("homeboy/lab-workspace-verification/v1")
+            {
+                return Err("has an unsupported workspace verification schema".to_string());
+            }
+            let identity = verification
+                .get("identity")
+                .and_then(|value| value.as_str())
+                .ok_or("is missing workspace verification identity")?;
+            let content_hash = verification
+                .get("content_hash")
+                .and_then(|value| value.as_str())
+                .ok_or("is missing workspace verification content hash")?;
+            let excludes = verification
+                .get("sync_excludes")
+                .ok_or("is missing workspace verification sync excludes")?;
+            if excludes != &serde_json::json!(snapshot.sync_excludes) {
+                return Err("sync excludes do not match workspace verification".to_string());
+            }
+            if verification.get("source_snapshot") != Some(lab_snapshot) {
+                return Err("source snapshot does not match workspace verification".to_string());
+            }
+            let primary_workspace = verification
+                .get("primary_workspace")
+                .ok_or("is missing workspace verification primary workspace")?;
+            if primary_workspace
+                .get("identity")
+                .and_then(|value| value.as_str())
+                != Some(identity)
+                || primary_workspace
+                    .get("remote_path")
+                    .and_then(|value| value.as_str())
+                    != Some(recorded_remote_path)
+            {
+                return Err("primary workspace does not match workspace verification".to_string());
+            }
+            (content_hash, identity)
+        }
+        None if materialization_mode == "git" => {
+            let content_hash = lab
+                .get("workspace_content_hash")
+                .and_then(|value| value.as_str())
+                .ok_or("is missing workspace content hash")?;
+            let identity = lab
+                .get("workspace_materialization_plan")
+                .and_then(|value| value.get("identity"))
+                .and_then(|value| value.as_str())
+                .ok_or("is missing workspace materialization identity")?;
+            (content_hash, identity)
+        }
+        None => return Err("is missing workspace verification metadata".to_string()),
+    };
+    if workspace_identity != verification_identity {
+        return Err("workspace identity does not match workspace verification".to_string());
     }
     let actual_content_hash =
         workspace_content_hash(materialized_workspace_path, &snapshot.sync_excludes)


### PR DESCRIPTION
## Summary
- preserve the existing path-materialization metadata schema
- add a versioned Lab workspace verification envelope carrying the staged sync identity
- use typed production assembly inputs so path remapping and workspace verification plans cannot be swapped
- verify the final process environment through the generic canonical workspace verifier

Follow-up to #8086 and #8093.

## How to test
1. Check out this branch with Rust installed.
2. Run `cargo test lab_offload_workspace_verification_metadata_survives_process_env_hydration --lib`.
3. Run `cargo test core::extension::trace::canonicality --lib`.
4. Run `cargo test core::runner::workspace::tests --lib`.
5. Run `cargo check --lib`, `cargo fmt --check`, and `git diff --check origin/main...HEAD`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Diagnosed live Lab metadata loss, implemented typed schema-compatible propagation, added handoff regression coverage, and independently reviewed the fix. Chris reviewed and owns the change.