### PR TITLE
Carry Lab promotion patches through stdin

### DIFF
--- a/src/core/agent_task_promotion/apply.rs
+++ b/src/core/agent_task_promotion/apply.rs
@@ -5,6 +5,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
+use tempfile::NamedTempFile;
 
 use crate::core::agent_task_gate::{
     run_gate_command, run_gate_command_with_policy, AgentTaskGateReport, AgentTaskGateRevealPolicy,
@@ -120,11 +121,36 @@ pub fn apply_materialized_workspace_patch(workspace: &Path, request_json: &str) 
         ));
     }
     validate_provider_workspace_path(workspace)?;
+    // The provider can run in a different materialized workspace from the
+    // producer, so prefer the patch carried through the stdin request.
+    let inline_patch = request
+        .patch
+        .as_deref()
+        .map(|patch| {
+            let mut file = NamedTempFile::new().map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("create inline agent-task promotion patch".to_string()),
+                )
+            })?;
+            file.write_all(patch.as_bytes()).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("write inline agent-task promotion patch".to_string()),
+                )
+            })?;
+            Ok::<_, Error>(file)
+        })
+        .transpose()?;
+    let patch_path = inline_patch
+        .as_ref()
+        .map(|file| file.path().to_string_lossy().into_owned())
+        .unwrap_or_else(|| request.patch_path.clone());
     let mut command = Command::new("git");
     command
         .arg("-C")
         .arg(workspace)
-        .args(["apply", "--whitespace=nowarn", &request.patch_path]);
+        .args(["apply", "--whitespace=nowarn", &patch_path]);
     if request.dry_run {
         command.arg("--check");
     }
@@ -163,6 +189,10 @@ pub fn apply_materialized_workspace_patch(workspace: &Path, request_json: &str) 
 pub(crate) struct AgentTaskPromotionApplyRequest {
     pub(crate) schema: String,
     pub(crate) to_workspace: String,
+    /// Inline patch payload for providers that do not share artifact storage
+    /// with the producer. `patch_path` remains provenance and a legacy fallback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) patch: Option<String>,
     pub(crate) patch_path: String,
     pub(crate) changed_files: Vec<String>,
     #[serde(default)]

--- a/src/core/agent_task_promotion/promote.rs
+++ b/src/core/agent_task_promotion/promote.rs
@@ -153,6 +153,7 @@ pub(crate) fn promote_with_provider(
         let target = provider.apply_patch(AgentTaskPromotionApplyRequest {
             schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
             to_workspace: options.to_worktree.clone(),
+            patch: Some(normalized_patch.content.clone()),
             patch_path: provider_patch_path,
             changed_files: changed_files.clone(),
             dry_run: options.dry_run,
@@ -231,6 +232,7 @@ fn promote_committed_changes(
     let target = provider.apply_patch(AgentTaskPromotionApplyRequest {
         schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
         to_workspace: options.to_worktree.clone(),
+        patch: Some(normalized_patch.content.clone()),
         patch_path: committed_patch.patch_path.display().to_string(),
         changed_files: normalized_patch.changed_files.clone(),
         dry_run: options.dry_run,

--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -175,7 +175,7 @@ fn git(cwd: &Path, args: &[&str]) {
 }
 
 #[test]
-fn materialized_workspace_promotion_adapter_applies_patch_and_returns_workspace() {
+fn materialized_workspace_promotion_adapter_applies_inline_patch_when_artifact_is_remote() {
     let temp = tempfile::tempdir().expect("tempdir");
     let workspace = temp.path().join("workspace");
     std::fs::create_dir(&workspace).expect("create workspace");
@@ -185,19 +185,16 @@ fn materialized_workspace_promotion_adapter_applies_patch_and_returns_workspace(
     std::fs::write(workspace.join("src.txt"), "old\n").expect("write source");
     git(&workspace, &["add", "src.txt"]);
     git(&workspace, &["commit", "-m", "initial"]);
-    let patch = temp.path().join("changes.patch");
-    std::fs::write(
-        &patch,
-        "diff --git a/src.txt b/src.txt\n--- a/src.txt\n+++ b/src.txt\n@@ -1 +1 @@\n-old\n+new\n",
-    )
-    .expect("write patch");
+    let patch =
+        "diff --git a/src.txt b/src.txt\n--- a/src.txt\n+++ b/src.txt\n@@ -1 +1 @@\n-old\n+new\n";
 
     let response = super::apply_materialized_workspace_patch(
         &workspace,
         &serde_json::json!({
             "schema": AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA,
             "to_workspace": "homeboy@fix-7913",
-            "patch_path": patch,
+            "patch": patch,
+            "patch_path": "runner-artifact://homeboy-lab/run-1/changes.patch",
             "changed_files": ["src.txt"]
         })
         .to_string(),
@@ -691,6 +688,7 @@ fn promote_dry_run_validates_provider_request_without_applying() {
     assert_eq!(report.patch_artifact.id, "patch");
     assert_eq!(report.changed_files, vec!["src/lib.rs"]);
     assert_eq!(provider.apply_calls.len(), 1);
+    assert_eq!(provider.apply_calls[0].patch.as_deref(), Some(VALID_PATCH));
     assert!(provider.apply_calls[0].dry_run);
     assert_eq!(report.command_evidence.len(), 1);
     assert!(report.deterministic_gates.is_empty());
@@ -1136,6 +1134,7 @@ fn provider_command_response_supplies_workspace_and_evidence() {
     let request = AgentTaskPromotionApplyRequest {
         schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
         to_workspace: "target-workspace".to_string(),
+        patch: None,
         patch_path: temp.path().join("changes.patch").display().to_string(),
         changed_files: vec!["src/lib.rs".to_string()],
         dry_run: false,
@@ -1161,6 +1160,7 @@ fn provider_failure_surfaces_bounded_stdout_and_stderr_evidence() {
     let request = AgentTaskPromotionApplyRequest {
         schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
         to_workspace: "target-workspace".to_string(),
+        patch: None,
         patch_path: "changes.patch".to_string(),
         changed_files: vec!["src/lib.rs".to_string()],
         dry_run: false,
@@ -1195,6 +1195,7 @@ fn provider_response_overflow_is_terminated_with_bounded_evidence() {
     let request = AgentTaskPromotionApplyRequest {
         schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
         to_workspace: "target-workspace".to_string(),
+        patch: None,
         patch_path: "changes.patch".to_string(),
         changed_files: vec!["src/lib.rs".to_string()],
         dry_run: false,


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `recovery-homeboy-8090` into review-ready branch `fix/8090-lab-promotion-patch-input`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:recovery-homeboy-8090`
- **Homeboy run ID:** `recovery-homeboy-8090`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `fix/8090-lab-promotion-patch-input`

## Source refs
- https://github.com/Extra-Chill/homeboy/issues/8090

## Attempt summary
Lab promotion now carries normalized patch content in the existing stdin request while retaining artifact paths as provenance and legacy fallback.

## Gate results
- promotion_tests: passed (targeted)
- lab_workspace_tests: passed (targeted)
- promotion_provider_integration: passed (targeted)
- no_patch_classification: passed (targeted)
- fmt: passed (targeted)
- diff_check: passed (targeted)

## Verification capability
- `targeted_checks_run`: `cargo fmt --check`, `cargo test core::agent_task_promotion::tests --lib`, `cargo test core::runner::lab::offload::workspace_stage::tests --lib`, `cargo test --test agent_task_promotion_provider`, `cargo test aggregate_outcomes_reports_no_patch_produced_when_all_cells_empty --lib`, `cargo test cook_summary_reports_no_patch_produced_when_all_cells_are_empty --lib`, `git diff --check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- src/core/agent_task_promotion/apply.rs
- src/core/agent_task_promotion/promote.rs
- src/core/agent_task_promotion/tests.rs

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `fix/8090-lab-promotion-patch-input`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode orchestrated by Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed runner-resident patch loss, implemented inline promotion transport with compatibility fallback, and verified the owning contracts with Chris.
