### PR TITLE
Fix retry Git baseline materialization

### DIFF
--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -77,7 +77,7 @@ pub fn route_after_parse(
         }
     }
 
-    let lab_command = lab_offload_command(&cli.command)?;
+    let mut lab_command = lab_offload_command(&cli.command)?;
 
     let inferred_runner_id = if lab_command.is_some() {
         cli.runner
@@ -92,6 +92,14 @@ pub fn route_after_parse(
     } else {
         None
     };
+    if retry_handoff.is_some() {
+        if let Some(command) = lab_command.as_mut() {
+            // A retry's task primary must be a real checkout so the provider can
+            // capture a bounded git diff instead of receiving a source snapshot.
+            command.command.workspace_mode_policy =
+                homeboy::command_contract::LabWorkspaceModePolicy::GitCheckoutRequired;
+        }
+    }
     let normalized_args = retry_handoff
         .as_ref()
         .map(|handoff| handoff.args.as_slice())

--- a/src/core/daemon/patch_capture.rs
+++ b/src/core/daemon/patch_capture.rs
@@ -386,4 +386,102 @@ mod tests {
         assert!(patch_body.contains("-before"));
         assert!(patch_body.contains("+after"));
     }
+
+    #[test]
+    fn git_baseline_materialization_is_clean_and_patch_capture_is_bounded() {
+        crate::test_support::with_isolated_home(|_| {
+            let origin = tempfile::tempdir().expect("origin");
+            let author = tempfile::tempdir().expect("author");
+            let source_parent = tempfile::tempdir().expect("source parent");
+            let runner_root = tempfile::tempdir().expect("runner root");
+            let source = source_parent.path().join("source");
+            git_test_command(origin.path(), &["init", "--bare"]);
+            git_test_command(author.path(), &["init", "-b", "main"]);
+            git_test_command(author.path(), &["config", "user.email", "test@example.com"]);
+            git_test_command(author.path(), &["config", "user.name", "Test User"]);
+            fs::write(author.path().join("tracked.txt"), "before\n").expect("tracked file");
+            git_test_command(author.path(), &["add", "tracked.txt"]);
+            git_test_command(author.path(), &["commit", "-m", "base"]);
+            let head = git_output(author.path(), &["rev-parse", "HEAD"]).expect("head");
+            let remote_url = format!("file://{}", origin.path().display());
+            git_test_command(author.path(), &["remote", "add", "origin", &remote_url]);
+            git_test_command(author.path(), &["push", "origin", "main"]);
+            git_test_command(origin.path(), &["symbolic-ref", "HEAD", "refs/heads/main"]);
+            git_test_command(source_parent.path(), &["clone", &remote_url, "source"]);
+
+            crate::core::runner::create(
+                &format!(
+                    r#"{{"id":"patch-baseline","kind":"local","workspace_root":"{}"}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+            let (sync, exit_code) = crate::core::runner::sync_workspace(
+                "patch-baseline",
+                crate::core::runner::RunnerWorkspaceSyncOptions {
+                    path: source.display().to_string(),
+                    mode: crate::core::runner::RunnerWorkspaceSyncMode::Git,
+                    controller_routed_git: false,
+                    ..Default::default()
+                },
+            )
+            .expect("materialize git baseline");
+            let remote = Path::new(&sync.remote_path);
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(sync.sync_mode.label(), "git");
+            assert!(remote.join(".git").is_dir());
+            assert_eq!(git_output(remote, &["rev-parse", "HEAD"]), Some(head));
+            assert_eq!(
+                git_output(remote, &["config", "--get", "remote.origin.url"]),
+                Some(remote_url)
+            );
+            assert_eq!(
+                git_output(remote, &["status", "--porcelain=v1"]),
+                Some(String::new())
+            );
+
+            let baseline = capture_baseline(&sync.remote_path).expect("capture baseline");
+            fs::write(remote.join("tracked.txt"), "after\n").expect("modify tracked file");
+            let report = capture_patch_report(
+                uuid::Uuid::new_v4(),
+                "patch-baseline",
+                &sync.remote_path,
+                &["true".to_string()],
+                None,
+                &baseline,
+                0,
+            )
+            .expect("capture patch");
+
+            assert_eq!(report.modified_files, vec!["tracked.txt".to_string()]);
+        });
+    }
+
+    fn git_test_command(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_output(path: &Path, args: &[&str]) -> Option<String> {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .ok()?;
+        output
+            .status
+            .success()
+            .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
 }

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -149,9 +149,12 @@ fn prepare_lab_offload_workspace_stage_inner(
         RunnerWorkspaceSyncOptions {
             path: source_path.display().to_string(),
             mode: sync_mode,
-            // Lab already has the authenticated controller checkout. Ship its
-            // refs instead of requiring the runner to clone or fetch the source.
-            controller_routed_git: sync_mode == RunnerWorkspaceSyncMode::Git,
+            // Patch-producing retry primaries must materialize their recorded
+            // remote baseline. Other Git workloads retain controller-routed
+            // bundles for remotes unavailable from the runner.
+            controller_routed_git: sync_mode == RunnerWorkspaceSyncMode::Git
+                && contract.workspace_mode_policy
+                    != LabOffloadWorkspaceModePolicy::GitCheckoutRequired,
             changed_since_base: changed_since_preflight.resolved_base.clone(),
             git_fetch_refs: git_fetch_refs.clone(),
             snapshot_includes: Vec::new(),
@@ -298,6 +301,13 @@ fn prepare_lab_offload_workspace_stage_inner(
     // The effective workspace filters define the bytes shipped to Lab and are
     // carried to the runner for deterministic post-materialization verification.
     source_snapshot.sync_excludes = synced.excludes.clone();
+    if sync_mode == RunnerWorkspaceSyncMode::Git {
+        // Git materialization retains repository metadata. It is not source
+        // snapshot state, and it must not be reported as excluded evidence.
+        source_snapshot
+            .sync_excludes
+            .retain(|exclude| exclude != ".git" && exclude != ".git/**");
+    }
     source_snapshot.workspace_snapshot_identity = Some(synced.snapshot_identity.clone());
     validate_lab_source_snapshot_handoff(source_path, &synced, &source_snapshot)?;
     if contract.routing_policy.requires_extension_parity {
@@ -2287,7 +2297,8 @@ mod tests {
                 required_capabilities: Vec::new(),
                 workload: None,
             };
-            contract.command.workspace_mode_policy = LabOffloadWorkspaceModePolicy::Git;
+            contract.command.workspace_mode_policy =
+                LabOffloadWorkspaceModePolicy::GitCheckoutRequired;
             let runner_workspace_root = runner_root.path().display().to_string();
             let stage = prepare_lab_offload_workspace_stage(
                 &request,
@@ -2311,6 +2322,18 @@ mod tests {
             assert!(stage.remapped_args.contains(&"cook-8009".to_string()));
             assert!(stage.remapped_args.contains(&canonical_attempt_id));
             assert_eq!(stage.sync_mode, RunnerWorkspaceSyncMode::Git);
+            assert_eq!(
+                stage.path_materialization_plan.entries[0].materialization_mode,
+                "git"
+            );
+            assert!(
+                !stage
+                    .source_snapshot
+                    .sync_excludes
+                    .iter()
+                    .any(|exclude| exclude == ".git" || exclude == ".git/**"),
+                "a .git-excluded snapshot cannot claim git materialization"
+            );
             assert_eq!(
                 git_output(
                     Path::new(&stage.remote_cwd),

--- a/src/core/runner/workspace/git.rs
+++ b/src/core/runner/workspace/git.rs
@@ -97,6 +97,7 @@ pub(super) fn materialize_git(
     remote_path: &str,
     remote_url: &str,
     head: &str,
+    branch: Option<&str>,
     changed_since_base: Option<&str>,
     git_fetch_refs: &[String],
     allow_dirty_lab_workspace: bool,
@@ -105,6 +106,7 @@ pub(super) fn materialize_git(
         remote_path,
         remote_url,
         head,
+        branch,
         changed_since_base,
         git_fetch_refs,
         allow_dirty_lab_workspace,
@@ -449,6 +451,10 @@ pub(crate) fn git_bundle_install_command(
             allow_dirty: allow_dirty_lab_workspace,
         })
         .op(WorkspaceMaterializationOperation::AtomicReplaceTemp)
+        .op(WorkspaceMaterializationOperation::VerifyGitBaseline {
+            remote_url: remote_url.to_string(),
+            head: head.to_string(),
+        })
         .restore_owner()
         .command()
 }
@@ -457,6 +463,7 @@ pub(super) fn materialize_git_command(
     remote_path: &str,
     remote_url: &str,
     head: &str,
+    branch: Option<&str>,
     changed_since_base: Option<&str>,
     git_fetch_refs: &[String],
     allow_dirty_lab_workspace: bool,
@@ -467,9 +474,14 @@ pub(super) fn materialize_git_command(
         .op(WorkspaceMaterializationOperation::SyncGitCheckout {
             remote_url: remote_url.to_string(),
             head: head.to_string(),
+            branch: branch.map(str::to_string),
             changed_since_base: changed_since_base.map(str::to_string),
             fetch_refs: git_fetch_refs.to_vec(),
             allow_dirty: allow_dirty_lab_workspace,
+        })
+        .op(WorkspaceMaterializationOperation::VerifyGitBaseline {
+            remote_url: remote_url.to_string(),
+            head: head.to_string(),
         })
         .restore_owner()
         .command()

--- a/src/core/runner/workspace/materializer.rs
+++ b/src/core/runner/workspace/materializer.rs
@@ -23,9 +23,14 @@ pub(super) enum WorkspaceMaterializationOperation {
     GuardCleanGitWorkspace {
         allow_dirty: bool,
     },
+    VerifyGitBaseline {
+        remote_url: String,
+        head: String,
+    },
     SyncGitCheckout {
         remote_url: String,
         head: String,
+        branch: Option<String>,
         changed_since_base: Option<String>,
         fetch_refs: Vec<String>,
         allow_dirty: bool,
@@ -147,15 +152,20 @@ impl WorkspaceMaterializationOperation {
             Self::GuardCleanGitWorkspace { allow_dirty } => {
                 dirty_git_workspace_guard("$dest", *allow_dirty)
             }
+            Self::VerifyGitBaseline { remote_url, head } => {
+                verify_git_baseline_command("$dest", remote_url, head)
+            }
             Self::SyncGitCheckout {
                 remote_url,
                 head,
+                branch,
                 changed_since_base,
                 fetch_refs,
                 allow_dirty,
             } => sync_git_checkout_command(
                 remote_url,
                 head,
+                branch.as_deref(),
                 changed_since_base.as_deref(),
                 fetch_refs,
                 *allow_dirty,
@@ -188,6 +198,20 @@ impl WorkspaceMaterializationOperation {
             Self::AtomicReplaceTemp => "rm -rf \"$dest\" && mv \"$tmp\" \"$dest\"".to_string(),
         }
     }
+}
+
+fn verify_git_baseline_command(dest: &str, remote_url: &str, head: &str) -> String {
+    let status = format!(
+        "git -C {dest} status --porcelain=v1 2>/dev/null | while IFS= read -r line; do path=${{line#???}}; if [ \"$path\" = .homeboy ] || [ \"${{path#.homeboy/}}\" != \"$path\" ]; then :; else printf '%s\\n' \"$line\"; fi; done || true",
+        dest = dest,
+    );
+    format!(
+        "test -d {dest}/.git && test \"$(git -C {dest} rev-parse HEAD)\" = {head} && test \"$(git -C {dest} config --get remote.origin.url)\" = {remote_url} && test -z \"$({status})\"",
+        dest = dest,
+        head = shell::quote_arg(head),
+        remote_url = shell::quote_arg(remote_url),
+        status = status,
+    )
 }
 
 pub(crate) fn dependency_cache_restore_command(
@@ -276,6 +300,7 @@ pub(super) fn dirty_git_workspace_guard(dest: &str, allow_dirty: bool) -> String
 fn sync_git_checkout_command(
     remote_url: &str,
     head: &str,
+    branch: Option<&str>,
     changed_since_base: Option<&str>,
     fetch_refs: &[String],
     allow_dirty: bool,
@@ -300,9 +325,25 @@ fn sync_git_checkout_command(
         .collect::<String>();
     let dirty_guard = dirty_git_workspace_guard("$dest", allow_dirty);
 
+    let checkout = branch.map_or_else(
+        || {
+            format!(
+                "git -C \"$dest\" checkout --detach {head}",
+                head = shell::quote_arg(head)
+            )
+        },
+        |branch| {
+            format!(
+                "git -C \"$dest\" checkout -B {branch} {head}",
+                branch = shell::quote_arg(branch),
+                head = shell::quote_arg(head),
+            )
+        },
+    );
     format!(
-        "if [ -d \"$dest\"/.git ]; then {dirty_guard} && git -C \"$dest\" reset --hard && git -C \"$dest\" clean -ffdqx && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf \"$dest\" && git clone {remote_url} \"$dest\" && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; fi{fetch_extra_refs}{fetch_changed_since} && git -C \"$dest\" checkout --detach {head} && git -C \"$dest\" reset --hard {head} && git -C \"$dest\" clean -ffdqx",
+        "if [ -d \"$dest\"/.git ]; then {dirty_guard} && git -C \"$dest\" reset --hard && git -C \"$dest\" clean -ffdqx && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf \"$dest\" && git clone {remote_url} \"$dest\" && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; fi{fetch_extra_refs}{fetch_changed_since} && {checkout} && git -C \"$dest\" reset --hard {head} && git -C \"$dest\" clean -ffdqx",
         remote_url = shell::quote_arg(remote_url),
         head = shell::quote_arg(head),
+        checkout = checkout,
     )
 }

--- a/src/core/runner/workspace/provenance.rs
+++ b/src/core/runner/workspace/provenance.rs
@@ -93,6 +93,14 @@ pub(crate) fn verify_lab_workspace(
             "has untrusted workspace materialization mode `{materialization_mode}`"
         ));
     }
+    if materialization_mode == "git"
+        && snapshot
+            .sync_excludes
+            .iter()
+            .any(|exclude| exclude == ".git" || exclude == ".git/")
+    {
+        return Err("claims git materialization while excluding .git metadata".to_string());
+    }
     if snapshot.dirty {
         return Err("records a dirty source checkout".to_string());
     }

--- a/src/core/runner/workspace/snapshot.rs
+++ b/src/core/runner/workspace/snapshot.rs
@@ -90,7 +90,8 @@ fn collect_content_hash_entries(
         let entry_path = entry.path();
         let relative_path = logical.join(entry.file_name());
         let relative = relative_path.to_string_lossy().replace('\\', "/");
-        if relative == ".homeboy/runner-workspace.json"
+        if relative == ".git"
+            || relative == ".homeboy/runner-workspace.json"
             || is_excluded(root, &root.join(&relative_path), excludes, &[])
         {
             continue;

--- a/src/core/runner/workspace/sync.rs
+++ b/src/core/runner/workspace/sync.rs
@@ -234,6 +234,7 @@ pub fn sync_workspace(
                     &remote_path,
                     &git.remote_url,
                     &git.head,
+                    git.branch.as_deref(),
                     git.changed_since_base.as_deref(),
                     &git.git_fetch_refs,
                     options.allow_dirty_lab_workspace,

--- a/src/core/runner/workspace/tests/git.rs
+++ b/src/core/runner/workspace/tests/git.rs
@@ -560,6 +560,7 @@ fn git_materialization_fetches_changed_since_base_before_checkout() {
         "/srv/homeboy/_lab_workspaces/homeboy-abc",
         "https://github.com/Extra-Chill/homeboy.git",
         "abc123",
+        None,
         Some("def456"),
         &[],
         false,
@@ -593,6 +594,7 @@ fn git_materialization_restores_workspace_owner_after_root_run() {
         "https://github.com/Extra-Chill/homeboy.git",
         "abc123",
         None,
+        None,
         &[],
         false,
     );
@@ -613,6 +615,7 @@ fn git_materialization_fetches_extra_refs_before_checkout() {
         "https://github.com/Extra-Chill/homeboy.git",
         "abc123",
         None,
+        None,
         &["refs/pull/5530/head".to_string()],
         false,
     );
@@ -627,6 +630,7 @@ fn git_materialization_fetches_extra_refs_before_changed_since_sha() {
         "/srv/homeboy/_lab_workspaces/homeboy-abc",
         "https://github.com/Extra-Chill/homeboy.git",
         "abc123",
+        None,
         Some("def456"),
         &["refs/heads/main".to_string()],
         false,
@@ -649,6 +653,7 @@ fn git_materialization_refuses_dirty_remote_workspace_by_default() {
         "https://github.com/Extra-Chill/homeboy.git",
         "abc123",
         None,
+        None,
         &[],
         false,
     );
@@ -666,6 +671,7 @@ fn git_materialization_override_is_noisy_but_allows_reset() {
         "/srv/homeboy/_lab_workspaces/homeboy-abc",
         "https://github.com/Extra-Chill/homeboy.git",
         "abc123",
+        None,
         None,
         &[],
         true,

--- a/src/core/runner/workspace/tests/materializer.rs
+++ b/src/core/runner/workspace/tests/materializer.rs
@@ -50,6 +50,10 @@ fn workspace_materializer_builds_git_bundle_checkout_command() {
         })
         .op(WorkspaceMaterializationOperation::GuardCleanGitWorkspace { allow_dirty: false })
         .op(WorkspaceMaterializationOperation::AtomicReplaceTemp)
+        .op(WorkspaceMaterializationOperation::VerifyGitBaseline {
+            remote_url: "https://github.com/Extra-Chill/homeboy.git".to_string(),
+            head: "abc123".to_string(),
+        })
         .restore_owner()
         .command();
 
@@ -61,6 +65,8 @@ fn workspace_materializer_builds_git_bundle_checkout_command() {
     assert!(!command.contains("config branch.main.remote origin"));
     assert!(!command.contains("config branch.main.merge refs/heads/main"));
     assert!(command.contains("git -C \"$tmp\" reset --hard abc123"));
+    assert!(command.contains("test -d $dest/.git"));
+    assert!(command.contains("rev-parse HEAD)\" = abc123"));
     assert!(command.contains("Homeboy Lab refused to overwrite a dirty runner workspace"));
     assert!(command.contains("exit 97"));
 }
@@ -73,9 +79,14 @@ fn workspace_materializer_builds_direct_git_checkout_command() {
         .op(WorkspaceMaterializationOperation::SyncGitCheckout {
             remote_url: "https://github.com/Extra-Chill/homeboy.git".to_string(),
             head: "abc123".to_string(),
+            branch: None,
             changed_since_base: Some("origin/main".to_string()),
             fetch_refs: vec!["refs/pull/123/head:refs/remotes/pull/123".to_string()],
             allow_dirty: false,
+        })
+        .op(WorkspaceMaterializationOperation::VerifyGitBaseline {
+            remote_url: "https://github.com/Extra-Chill/homeboy.git".to_string(),
+            head: "abc123".to_string(),
         })
         .restore_owner()
         .command();
@@ -91,6 +102,8 @@ fn workspace_materializer_builds_direct_git_checkout_command() {
     assert!(command.contains("rev-parse --verify -q 'origin/main^{commit}'"));
     assert!(command.contains("checkout --detach abc123"));
     assert!(command.contains("git -C \"$dest\" clean -ffdqx"));
+    assert!(command.contains("test -d $dest/.git"));
+    assert!(command.contains("config --get remote.origin.url"));
     assert!(command.contains("chown -R \"$owner\" $dest"));
 }
 


### PR DESCRIPTION
## Summary
- materialize retry primaries from their recorded remote branch and SHA before provider work
- verify the materialized checkout has `.git`, the expected HEAD, origin URL, and a clean status before it is reported as Git materialization
- keep snapshot evidence from claiming Git when `.git` is excluded, and cover clean baseline plus bounded patch capture against a real temporary remote

Closes #8088

## How to test
1. Run `CARGO_TARGET_DIR=target cargo fmt --check`.
2. Run `CARGO_TARGET_DIR=target cargo test core::runner::workspace::tests::git --lib`.
3. Run `CARGO_TARGET_DIR=target cargo test core::daemon::patch_capture::tests::git_baseline_materialization_is_clean_and_patch_capture_is_bounded --lib`.
4. Run `CARGO_TARGET_DIR=target cargo test core::runner::lab::offload::workspace_stage --lib`.
5. Run `CARGO_TARGET_DIR=target cargo check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode / openai-gpt-5.6-sol
- **Used for:** Implemented the git-baseline materialization contract and regression coverage with Chris
