### PR TITLE
Fix Lab cook attempt-plan handoff

### DIFF
--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -468,6 +468,10 @@ pub struct AgentTaskCookArgs {
     #[arg(long, hide = true)]
     pub attempt_run_id: Option<String>,
 
+    /// Controller-materialized first-attempt plan injected for Lab execution.
+    #[arg(long, hide = true)]
+    pub attempt_plan: Option<String>,
+
     /// Repo-cooking goal. Alias for the dispatch prompt when --prompt is omitted.
     #[arg(long, value_name = "TEXT")]
     pub goal: Option<String>,

--- a/src/commands/agent_task/run.rs
+++ b/src/commands/agent_task/run.rs
@@ -101,16 +101,32 @@ where
         );
     }
     dispatch_args.core.queue_only = false;
-    let (dispatch_value, _dispatch_exit) =
-        dispatch_service::run_dispatch_command(dispatch_args.into(), executor.clone())?;
-    let run_id = dispatch_value["run_id"]
-        .as_str()
-        .ok_or_else(|| {
-            homeboy::core::Error::internal_unexpected(
-                "agent-task cook dispatch step did not return a run_id".to_string(),
+    let run_id = if let Some(attempt_plan) = args.attempt_plan.as_deref() {
+        let run_id = dispatch_args.run_id.clone().ok_or_else(|| {
+            homeboy::core::Error::validation_invalid_argument(
+                "attempt_plan",
+                "agent-task cook requires --run-id when executing a controller-materialized attempt plan",
+                None,
+                None,
             )
-        })?
-        .to_string();
+        })?;
+        // Lab receives the controller's immutable plan because its lifecycle
+        // store is runner-local and cannot resolve the controller's plan path.
+        let plan = agent_task_service::read_plan(attempt_plan)?;
+        agent_task_service::run_loaded_plan(plan, Some(&run_id), executor.clone())?;
+        run_id
+    } else {
+        let (dispatch_value, _dispatch_exit) =
+            dispatch_service::run_dispatch_command(dispatch_args.into(), executor.clone())?;
+        dispatch_value["run_id"]
+            .as_str()
+            .ok_or_else(|| {
+                homeboy::core::Error::internal_unexpected(
+                    "agent-task cook dispatch step did not return a run_id".to_string(),
+                )
+            })?
+            .to_string()
+    };
     let cook_id = requested_cook_id.unwrap_or_else(|| run_id.clone());
     // Keep this cook on one runtime generation through provider work and PR finalization.
     let _runtime_generation = homeboy::core::runtime_promotion::pin_cook_generation(&cook_id)?;

--- a/src/commands/agent_task/tests/promotion_review.rs
+++ b/src/commands/agent_task/tests/promotion_review.rs
@@ -143,6 +143,7 @@ fn cook_returns_durable_id_when_promotion_provider_is_missing() {
                     },
                 },
                 attempt_run_id: Some("cook-missing-provider-attempt-1-controller".to_string()),
+                attempt_plan: None,
                 goal: Some("cook fixture".to_string()),
                 to_worktree: "homeboy@fix-agent-task-runner-cook".to_string(),
                 provider_command: None,
@@ -306,6 +307,18 @@ fn cook_applies_executor_commit_from_source_repo_to_distinct_target_repo() {
             ),
         )
         .expect("write promotion provider");
+        let mut attempt_plan = test_plan();
+        attempt_plan.plan_id = "controller-materialized-cook-attempt".to_string();
+        attempt_plan.tasks[0].instructions = "commit a change".to_string();
+        attempt_plan.tasks[0].workspace.root = Some(source.display().to_string());
+        attempt_plan.rebuild_homeboy_plan();
+        let attempt_plan_file = temp.path().join("controller-attempt-plan.json");
+        std::fs::write(
+            &attempt_plan_file,
+            serde_json::to_string(&attempt_plan).expect("serialize attempt plan"),
+        )
+        .expect("write controller attempt plan");
+        let attempt_run_id = "cook-committed-work-attempt-1-controller";
 
         let (value, exit_code) = run_cook_with_executor(
             AgentTaskCookArgs {
@@ -333,7 +346,8 @@ fn cook_applies_executor_commit_from_source_repo_to_distinct_target_repo() {
                         resolved_provider_policy: None,
                     },
                 },
-                attempt_run_id: None,
+                attempt_run_id: Some(attempt_run_id.to_string()),
+                attempt_plan: Some(format!("@{}", attempt_plan_file.display())),
                 goal: None,
                 to_worktree: "fixture-component@promoted".to_string(),
                 provider_command: Some(format!("sh {}", provider.display())),
@@ -362,8 +376,18 @@ fn cook_applies_executor_commit_from_source_repo_to_distinct_target_repo() {
         assert_eq!(exit_code, 0, "{value:#}");
         assert_eq!(value["status"], "green_no_finalize");
         assert_eq!(
+            agent_task_lifecycle::load_plan(attempt_run_id).expect("attempt plan"),
+            attempt_plan
+        );
+        assert_eq!(
             value["attempts"][0]["promotion"]["patch_artifact"]["id"],
-            "cook-fixture-component-attempt-1-committed-changes"
+            "task-a-attempt-1-committed-changes"
+        );
+        assert_eq!(
+            lifecycle_status(attempt_run_id)
+                .expect("attempt status")
+                .state,
+            AgentTaskRunState::Succeeded
         );
         assert_eq!(
             value["attempts"][0]["promotion"]["changed_files"],

--- a/src/core/lifecycle_store.rs
+++ b/src/core/lifecycle_store.rs
@@ -23,6 +23,19 @@ static INTERRUPT_AFTER_TERMINAL_COMMIT: AtomicBool = AtomicBool::new(false);
 pub(super) fn write_plan(run_id: &str, plan: &AgentTaskPlan) -> Result<PathBuf> {
     let path = run_dir(run_id)?.join("plan.json");
     write_json(&path, plan)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "restrict agent-task plan permissions {}",
+                    path.display()
+                )),
+            )
+        })?;
+    }
     Ok(path)
 }
 

--- a/src/core/redaction.rs
+++ b/src/core/redaction.rs
@@ -262,7 +262,8 @@ fn redact_split_flag_value(flag: &str, value: &str, policy: &RedactionPolicy) ->
 fn sensitive_whole_value_flag(flag: &str) -> bool {
     matches!(
         normalize_flag(flag).as_str(),
-        "secret_env"
+        "attempt_plan"
+            | "secret_env"
             | "provider_auth"
             | "provider_auth_json"
             | "provider_auth_token"
@@ -434,6 +435,10 @@ mod tests {
             "homeboy".to_string(),
             "agent-task".to_string(),
             "cook".to_string(),
+            "--attempt-plan".to_string(),
+            r#"{"tasks":[{"executor":{"config":{"api_key":"attempt-secret"}}]}"#.to_string(),
+            r#"--attempt-plan={"tasks":[{"executor":{"config":{"api_key":"attempt-secret"}}]}"#
+                .to_string(),
             "--setting".to_string(),
             "api_token=abc123".to_string(),
             "--setting=password=hunter2".to_string(),
@@ -456,6 +461,9 @@ mod tests {
                 "homeboy".to_string(),
                 "agent-task".to_string(),
                 "cook".to_string(),
+                "--attempt-plan".to_string(),
+                "[REDACTED]".to_string(),
+                "--attempt-plan=[REDACTED]".to_string(),
                 "--setting".to_string(),
                 "api_token=[REDACTED]".to_string(),
                 "--setting=password=[REDACTED]".to_string(),

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -88,6 +88,16 @@ pub(super) fn sync_inline_agent_task_file(
             Some("write remapped agent-task plan".to_string()),
         )
     })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&plan_file, fs::Permissions::from_mode(0o600)).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some("restrict remapped agent-task plan permissions".to_string()),
+            )
+        })?;
+    }
     let synced = sync_workspace(
         runner_id,
         RunnerWorkspaceSyncOptions {
@@ -652,6 +662,44 @@ pub(super) fn ensure_agent_task_lifecycle_identity_with(
     Some((args, attempt_run_id))
 }
 
+/// Carry the controller-materialized first attempt through Lab. The runner has
+/// its own lifecycle store, so an attempt id alone cannot resolve the
+/// controller-side plan file.
+pub(super) fn inject_agent_task_cook_attempt_plan(
+    args: &[String],
+    attempt_run_id: &str,
+) -> Result<Vec<String>> {
+    let invocation = match CommandInvocation::for_subcommand(args, "agent-task") {
+        Some(invocation) => invocation,
+        None => return Ok(args.to_vec()),
+    };
+    let Some(action_index) = invocation.child_index_matching(&["cook"]) else {
+        return Ok(args.to_vec());
+    };
+    if invocation
+        .option_value_after(action_index, "--attempt-plan")
+        .is_some()
+    {
+        return Ok(args.to_vec());
+    }
+    let record = agent_task_lifecycle::status(attempt_run_id)?;
+    let plan_path = std::path::PathBuf::from(&record.plan_path);
+    if !plan_path.is_file() {
+        return Err(Error::validation_invalid_argument(
+            "attempt_plan",
+            "Lab cook handoff cannot stage the controller attempt plan because its durable plan file does not exist",
+            Some(record.plan_path),
+            None,
+        ));
+    }
+    Ok(ArgEditor::new(args)
+        .insert_after(
+            action_index,
+            [format!("--attempt-plan=@{}", plan_path.display())],
+        )
+        .into_args())
+}
+
 /// Resolves the stable per-run isolation token for an agent-task cook offload:
 /// the explicit `--run-id` when provided, otherwise a freshly generated run id.
 /// Returns `None` for other invocations, which already use unique snapshot
@@ -780,6 +828,90 @@ fn first_quoted_dependency_path(output: &str, path_contains: &str) -> Option<Str
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cook_handoff_references_controller_attempt_plan_file_without_exposing_contents() {
+        crate::test_support::with_isolated_home(|_| {
+            let plan = crate::core::agent_task_scheduler::AgentTaskPlan::new(
+                "controller-plan",
+                vec![serde_json::from_value(serde_json::json!({
+                    "task_id": "exact-controller-task",
+                    "executor": { "backend": "fixture", "config": { "api_key": "attempt-secret" } },
+                    "instructions": "execute the controller plan",
+                    "workspace": { "root": "/controller/worktree" }
+                }))
+                .expect("task")],
+            );
+            let args = vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                "--run-id".to_string(),
+                "cook-8101".to_string(),
+            ];
+
+            let record = agent_task_lifecycle::submit_plan(&plan, Some("cook-8101-attempt-1"))
+                .expect("controller attempt plan");
+            let injected = inject_agent_task_cook_attempt_plan(&args, &record.run_id)
+                .expect("controller plan reference injected");
+            let spec = injected
+                .iter()
+                .find_map(|arg| arg.strip_prefix("--attempt-plan="))
+                .expect("attempt plan argv");
+            let staged_path = spec.strip_prefix('@').expect("file-backed plan reference");
+
+            assert_eq!(staged_path, record.plan_path);
+            assert!(!injected.iter().any(|arg| arg.contains("attempt-secret")));
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                assert_eq!(
+                    std::fs::metadata(staged_path)
+                        .expect("attempt plan metadata")
+                        .permissions()
+                        .mode()
+                        & 0o777,
+                    0o600
+                );
+            }
+            assert_eq!(
+                injected
+                    .iter()
+                    .filter(|arg| arg.starts_with("--attempt-plan="))
+                    .count(),
+                1
+            );
+        });
+    }
+
+    #[test]
+    fn cook_handoff_reports_missing_controller_attempt_plan_deterministically() {
+        crate::test_support::with_isolated_home(|_| {
+            let plan = crate::core::agent_task_scheduler::AgentTaskPlan::new(
+                "missing-controller-plan",
+                vec![serde_json::from_value(serde_json::json!({
+                    "task_id": "task",
+                    "executor": { "backend": "fixture" },
+                    "instructions": "test"
+                }))
+                .expect("task")],
+            );
+            let record = agent_task_lifecycle::submit_plan(&plan, Some("cook-missing-plan"))
+                .expect("attempt record");
+            std::fs::remove_file(&record.plan_path).expect("remove isolated plan file");
+            let args = vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+            ];
+
+            let error = inject_agent_task_cook_attempt_plan(&args, &record.run_id)
+                .expect_err("missing plan must fail before runner handoff");
+
+            assert_eq!(error.details["field"], "attempt_plan");
+            assert!(error.message.contains("durable plan file does not exist"));
+        });
+    }
 
     #[test]
     fn legacy_offloaded_run_plan_envelope_parser_tolerates_extension_stdout_chatter() {

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -114,6 +114,7 @@ use super::super::{
     RunnerWorkspaceOutputPaths, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
     RunnerWorkspaceSyncOutput, WorkspaceCleanupPolicy,
 };
+use super::agent_task_bridge::inject_agent_task_cook_attempt_plan;
 
 use super::super::workload::{
     build_runner_workload_for_dispatched_command, runner_workload_agent_task_from_command,

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -123,6 +123,12 @@ fn prepare_lab_offload_workspace_stage_inner(
     let offload_args =
         inject_agent_task_default_provider_config_in_args(&changed_since_preflight.args)?;
     let offload_args = inject_agent_task_resolved_provider_policy_in_args(&offload_args)?;
+    let offload_args = request
+        .durable_agent_task_plan
+        .zip(preferred_attempt_run_id)
+        .map(|(_, run_id)| inject_agent_task_cook_attempt_plan(&offload_args, run_id))
+        .transpose()?
+        .unwrap_or(offload_args);
     let runner = load(runner_id)?;
     preflight_agent_task_secret_env_before_workspace_stage(
         contract,

--- a/src/core/runner/lab_args/agent_task_specs.rs
+++ b/src/core/runner/lab_args/agent_task_specs.rs
@@ -113,8 +113,21 @@ pub(in crate::core::runner) fn materialize_inline_agent_task_json_specs_in_args<
         "lab.sync_remapped_agent_task_plan",
         |spec| sync_inline_json(spec),
     )?;
+    let (args, attempt_plan_entry) = materialize_inline_json_option(
+        &args,
+        agent_task_subcommand_is(&args, &["cook"]),
+        "--attempt-plan",
+        "agent-task-attempt-plan.json",
+        "agent_task_attempt_plan_remapped",
+        "lab.sync_remapped_agent_task_attempt_plan",
+        |spec| sync_inline_json(spec),
+    )?;
 
-    let workspace_entries = task_entry.into_iter().chain(plan_entry).collect();
+    let workspace_entries = task_entry
+        .into_iter()
+        .chain(plan_entry)
+        .chain(attempt_plan_entry)
+        .collect();
     Ok((args, workspace_entries))
 }
 
@@ -126,16 +139,24 @@ pub(in crate::core::runner) fn remap_agent_task_plan_in_args(
     let ordered = order_mappings_by_specificity(mappings);
 
     try_rewrite_flag_value_args(args, |arg, iter, out| {
-        if arg == "--plan" {
+        if arg == "--plan" || arg == "--attempt-plan" {
             out.push(arg.to_string());
             if let Some(spec) = iter.next() {
                 out.push(remap_agent_task_plan_spec(spec, &ordered, source_path)?);
             }
             return Ok(());
         }
-        if let Some(spec) = arg.strip_prefix("--plan=") {
+        if let Some(spec) = arg
+            .strip_prefix("--plan=")
+            .or_else(|| arg.strip_prefix("--attempt-plan="))
+        {
+            let flag = if arg.starts_with("--attempt-plan=") {
+                "--attempt-plan="
+            } else {
+                "--plan="
+            };
             out.push(format!(
-                "--plan={}",
+                "{flag}{}",
                 remap_agent_task_plan_spec(spec, &ordered, source_path)?
             ));
             return Ok(());

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -1638,6 +1638,54 @@ mod materialize_specs_tests {
     use super::*;
 
     #[test]
+    fn materialize_agent_task_specs_remaps_cook_attempt_plan() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--attempt-plan={\"tasks\":[{\"workspace\":{\"root\":\"/controller/worktree\"},\"executor\":{\"config\":{\"api_key\":\"attempt-secret\"}}}]}"
+                .to_string(),
+        ];
+        let mappings = vec![LabPathRemap {
+            local: "/controller/worktree".to_string(),
+            remote: "/runner/worktree".to_string(),
+        }];
+
+        let out = materialize_agent_task_specs_in_args(&args, &mappings, temp.path(), |spec| {
+            assert_eq!(spec.filename, "agent-task-attempt-plan.json");
+            assert_eq!(spec.role, "agent_task_attempt_plan_remapped");
+            let staged: serde_json::Value =
+                serde_json::from_str(spec.spec).expect("staged plan JSON");
+            assert_eq!(staged["tasks"][0]["workspace"]["root"], "/runner/worktree");
+            assert_eq!(
+                staged["tasks"][0]["executor"]["config"]["api_key"],
+                "attempt-secret"
+            );
+            Ok::<Option<(String, String)>, _>(Some((
+                "@/runner/staged/agent-task-attempt-plan.json".to_string(),
+                spec.role.to_string(),
+            )))
+        })
+        .expect("attempt plan remapped");
+
+        let spec = out.argv[3]
+            .strip_prefix("--attempt-plan=")
+            .expect("attempt plan flag");
+        assert_eq!(spec, "@/runner/staged/agent-task-attempt-plan.json");
+        assert!(!out
+            .argv
+            .iter()
+            .any(|arg| arg.contains("/controller/worktree")));
+        assert!(!out.argv.iter().any(|arg| arg.contains("attempt-secret")));
+        assert_eq!(out.workspace_entries.len(), 1);
+        assert_eq!(
+            out.workspace_entries[0].step_id,
+            "lab.sync_remapped_agent_task_attempt_plan"
+        );
+    }
+
+    #[test]
     fn materialize_agent_task_specs_syncs_inline_and_file_plan_json() {
         let temp = tempfile::tempdir().expect("tempdir");
         let plan = serde_json::json!({


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `homeboy-8101-recovery-candidate` into review-ready branch `fix/8101-lab-cook-plan`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:homeboy-8101-recovery-candidate`
- **Homeboy run ID:** `homeboy-8101-recovery-candidate`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `fix/8101-lab-cook-plan`

## Source refs
- https://github.com/Extra-Chill/homeboy/issues/8101

## Attempt summary
green deterministic gates completed

## Gate results
- format: passed (targeted)
- compile: passed (targeted)
- promotion-review: passed (targeted)

## Verification capability
- `targeted_checks_run`: `cargo fmt --check`, `cargo check --all-targets`, `cargo test --lib commands::agent_task::tests::promotion_review --no-fail-fast`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: Run an agent-task cook through a connected Lab runner and confirm provider execution starts without a missing plan.json error.

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- src/commands/agent_task/args/mod.rs
- src/commands/agent_task/run.rs
- src/commands/agent_task/tests/promotion_review.rs
- src/core/lifecycle_store.rs
- src/core/redaction.rs
- src/core/runner/lab/agent_task_bridge.rs
- src/core/runner/lab/offload/mod.rs
- src/core/runner/lab/offload/workspace_stage.rs
- src/core/runner/lab_args/agent_task_specs.rs
- src/core/runner/lab_args/tests.rs

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `fix/8101-lab-cook-plan`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab plan-materialization failure, implemented secure run-scoped attempt-plan staging, and added deterministic coverage with Chris.
