### PR TITLE
Fix terminal child reconciliation during lease adoption

### DIFF
--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -466,6 +466,14 @@ mod tests {
                 Some(json!({ "exit_code": 0 })),
             )
             .expect("record successful result");
+        matching
+            .append_event(
+                succeeded_job.id,
+                JobEventKind::Progress,
+                None,
+                Some(json!({ "phase": "heartbeat", "process": { "root_pid": 4242 } })),
+            )
+            .expect("record stale child heartbeat after result");
         let failed_result_job = matching.create("runner.exec");
         matching
             .start(failed_result_job.id)
@@ -494,6 +502,14 @@ mod tests {
         matching
             .start(unfinished_job.id)
             .expect("start unfinished job");
+        matching
+            .append_event(
+                unfinished_job.id,
+                JobEventKind::Progress,
+                None,
+                Some(json!({ "phase": "heartbeat", "process": { "root_pid": u32::MAX } })),
+            )
+            .expect("record dead child heartbeat");
 
         let other = JobStore::open_without_reconciliation(&path)
             .expect("open other")
@@ -503,7 +519,7 @@ mod tests {
 
         let store = JobStore::open_without_reconciliation(&path).expect("open recovery store");
         let diagnostics = store
-            .reconcile_dead_daemon_lease_jobs("lease-dead")
+            .reconcile_dead_daemon_lease_jobs_with_child_liveness("lease-dead", |pid| pid == 4242)
             .expect("reconcile matching lease");
 
         assert_eq!(
@@ -521,6 +537,7 @@ mod tests {
         );
         assert_eq!(diagnostics.other_lease_job_ids, vec![other_job.id]);
         assert!(diagnostics.unowned_job_ids.is_empty());
+        assert!(diagnostics.protected_job_ids.is_empty());
         assert_eq!(
             store.get(succeeded_job.id).expect("succeeded job").status,
             JobStatus::Succeeded
@@ -635,6 +652,53 @@ mod tests {
         assert!(diagnostics.protected_job_ids.is_empty());
         assert_eq!(diagnostics.terminalized_count(), 1);
         assert_eq!(store.get(job.id).expect("job").status, JobStatus::Failed);
+    }
+
+    #[test]
+    fn dead_lease_reconciliation_refuses_ambiguous_child_state_without_mutation() {
+        let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start job");
+        let event_count = store.events(job.id).expect("events").len();
+
+        let error = store
+            .reconcile_dead_daemon_lease_jobs_with_child_liveness("lease-dead", |_| false)
+            .expect_err("missing child evidence must fail closed");
+
+        assert!(error.message.contains(&job.id.to_string()));
+        assert!(error
+            .message
+            .contains("authoritative terminal result or recorded child PID"));
+        assert_eq!(store.get(job.id).expect("job").status, JobStatus::Running);
+        assert_eq!(store.events(job.id).expect("events").len(), event_count);
+    }
+
+    #[test]
+    fn dead_lease_reconciliation_is_idempotent_after_terminalizing_a_dead_child() {
+        let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start job");
+        store
+            .append_event(
+                job.id,
+                JobEventKind::Progress,
+                None,
+                Some(json!({ "phase": "heartbeat", "process": { "root_pid": 4242 } })),
+            )
+            .expect("record child heartbeat");
+
+        let first = store
+            .reconcile_dead_daemon_lease_jobs_with_child_liveness("lease-dead", |_| false)
+            .expect("first reconciliation");
+        let event_count = store.events(job.id).expect("events").len();
+        let second = store
+            .reconcile_dead_daemon_lease_jobs_with_child_liveness("lease-dead", |_| false)
+            .expect("repeated reconciliation");
+
+        assert_eq!(first.terminalized_count(), 1);
+        assert_eq!(second.matching_count(), 0);
+        assert_eq!(second.terminalized_count(), 0);
+        assert_eq!(store.events(job.id).expect("events").len(), event_count);
     }
 
     #[test]

--- a/src/core/api_jobs/store.rs
+++ b/src/core/api_jobs/store.rs
@@ -343,16 +343,44 @@ impl JobStore {
             ));
         }
 
-        let now = timestamp_ms();
         let mut inner = self.inner.lock().expect("job store mutex poisoned");
         let mut diagnostics = diagnostics;
+        let mut dispositions = Vec::with_capacity(diagnostics.matching_job_ids.len());
+        let mut ambiguous_job_ids = Vec::new();
         for job_id in &diagnostics.matching_job_ids {
-            let stored = inner.jobs.get_mut(job_id).expect("diagnosed job exists");
-            if last_progress_child_pid(&stored.events).is_some_and(&pid_is_alive) {
-                diagnostics.protected_job_ids.push(*job_id);
-                continue;
-            }
-            if let Some((status, exit_code)) = recovered_terminal_from_result(&stored.events) {
+            let stored = inner.jobs.get(job_id).expect("diagnosed job exists");
+            let disposition =
+                if let Some((status, exit_code)) = recovered_terminal_from_result(&stored.events) {
+                    DeadLeaseJobDisposition::RecoveredTerminal(status, exit_code)
+                } else if let Some(pid) = last_progress_child_pid(&stored.events) {
+                    if pid_is_alive(pid) {
+                        diagnostics.protected_job_ids.push(*job_id);
+                        DeadLeaseJobDisposition::ProtectedLive
+                    } else {
+                        DeadLeaseJobDisposition::TerminalizeDead
+                    }
+                } else {
+                    ambiguous_job_ids.push(*job_id);
+                    continue;
+                };
+            dispositions.push((*job_id, disposition));
+        }
+        if !ambiguous_job_ids.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "expected-lease-id",
+                format!(
+                    "refusing automatic dead-daemon recovery: active job(s) {} have no authoritative terminal result or recorded child PID; inspect durable lifecycle/process evidence with `homeboy daemon status` before retrying",
+                    ambiguous_job_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(", "),
+                ),
+                Some(expected_lease_id.to_string()),
+                None,
+            ));
+        }
+
+        let now = timestamp_ms();
+        for (job_id, disposition) in dispositions {
+            let stored = inner.jobs.get_mut(&job_id).expect("diagnosed job exists");
+            if let DeadLeaseJobDisposition::RecoveredTerminal(status, exit_code) = disposition {
                 stored.job.status = status;
                 stored.job.updated_at_ms = now;
                 stored.job.finished_at_ms = Some(now);
@@ -360,7 +388,7 @@ impl JobStore {
                 let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
                 stored.events.push(JobEvent {
                     sequence,
-                    job_id: *job_id,
+                    job_id,
                     kind: JobEventKind::Status,
                     timestamp_ms: now,
                     message: Some(
@@ -376,6 +404,9 @@ impl JobStore {
                 });
                 apply_event_retention(&mut stored.events, self.event_retention_limit());
                 stored.job.event_count = stored.events.len();
+                continue;
+            }
+            if disposition == DeadLeaseJobDisposition::ProtectedLive {
                 continue;
             }
             let reason = "daemon lease owner process was not running".to_string();
@@ -407,7 +438,7 @@ impl JobStore {
                 let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
                 stored.events.push(JobEvent {
                     sequence,
-                    job_id: *job_id,
+                    job_id,
                     kind,
                     timestamp_ms: now,
                     message: Some(message),
@@ -786,6 +817,13 @@ impl JobStore {
 
         write_durable_store(&persistence.path, &durable)
     }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DeadLeaseJobDisposition {
+    RecoveredTerminal(JobStatus, i64),
+    ProtectedLive,
+    TerminalizeDead,
 }
 
 /// The reverse runner records the executing child in periodic progress

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -706,7 +706,44 @@ pub fn adopt_orphaned_lease(
     }
     parse_bind_addr(addr)?;
     let _lock = acquire_daemon_operation_lock()?;
-    let status = read_status()?;
+    adopt_orphaned_lease_with_operations(
+        lease_id,
+        read_status,
+        pid_is_running,
+        try_acquire_daemon_owner_lock,
+        || {
+            let store = super::JobStore::open_without_reconciliation(
+                crate::core::paths::daemon_jobs_file()?,
+            )?;
+            store.reconcile_dead_daemon_lease_jobs(lease_id)
+        },
+        || start_or_return_live_unlocked(addr),
+    )
+}
+
+fn adopt_orphaned_lease_with_operations<
+    Status,
+    PidIsRunning,
+    AcquireOwner,
+    OwnerLock,
+    Reconcile,
+    Start,
+>(
+    lease_id: &str,
+    status: Status,
+    pid_is_running: PidIsRunning,
+    acquire_owner: AcquireOwner,
+    reconcile: Reconcile,
+    start: Start,
+) -> Result<DaemonOrphanAdoptionResult>
+where
+    Status: FnOnce() -> Result<super::DaemonStatus>,
+    PidIsRunning: Fn(u32) -> bool,
+    AcquireOwner: FnOnce() -> Result<Option<OwnerLock>>,
+    Reconcile: FnOnce() -> Result<crate::core::api_jobs::DaemonLeaseJobDiagnostics>,
+    Start: FnOnce() -> Result<super::DaemonStartResult>,
+{
+    let status = status()?;
     let state = status.state.ok_or_else(|| {
         Error::validation_invalid_argument(
             "lease_id",
@@ -737,7 +774,7 @@ pub fn adopt_orphaned_lease(
         ));
     }
 
-    let owner_lock = try_acquire_daemon_owner_lock()?.ok_or_else(|| {
+    let owner_lock = acquire_owner()?.ok_or_else(|| {
         Error::validation_invalid_argument(
             "lease_id",
             "daemon owner lock is held; refusing exact dead-lease adoption",
@@ -747,7 +784,7 @@ pub fn adopt_orphaned_lease(
     })?;
     // Revalidate after taking the lifecycle-critical lock: a PID can be reused
     // between status inspection and exact orphan adoption.
-    if !pid_is_proven_dead(state.pid, pid_is_running) {
+    if !pid_is_proven_dead(state.pid, &pid_is_running) {
         return Err(Error::validation_invalid_argument(
             "lease_id",
             format!("recorded daemon PID {} is live or has been reused", state.pid),
@@ -755,9 +792,7 @@ pub fn adopt_orphaned_lease(
             Some(vec!["Refusing adoption until the exact recorded PID is proven dead under the lifecycle lock.".to_string()]),
         ));
     }
-    let store =
-        super::JobStore::open_without_reconciliation(crate::core::paths::daemon_jobs_file()?)?;
-    let reconciled = store.reconcile_dead_daemon_lease_jobs(lease_id)?;
+    let reconciled = reconcile()?;
     if reconciled.protected_count() > 0 {
         return Err(Error::validation_invalid_argument(
             "lease_id",
@@ -771,7 +806,7 @@ pub fn adopt_orphaned_lease(
         ));
     }
     drop(owner_lock);
-    let replacement = start_or_return_live_unlocked(addr)?;
+    let replacement = start()?;
     Ok(DaemonOrphanAdoptionResult {
         adopted_lease_id: lease_id.to_string(),
         dead_pid: state.pid,

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -413,6 +413,54 @@ fn exact_lease_adoption_refuses_owner_lock_and_preserves_store() {
 }
 
 #[test]
+fn exact_lease_adoption_reconciles_terminal_children_idempotently() {
+    with_isolated_home(|_| {
+        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let store = JobStore::open_without_reconciliation(&path)
+            .expect("store")
+            .with_daemon_lease("lease-dead".to_string());
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start job");
+        store
+            .append_event(
+                job.id,
+                JobEventKind::Result,
+                None,
+                Some(serde_json::json!({ "exit_code": 0, "output": "retained" })),
+            )
+            .expect("record terminal result");
+
+        let adopt = || {
+            super::adopt_orphaned_lease_with_operations(
+                "lease-dead",
+                || Ok(fake_dead_status(fake_daemon(4242, "lease-dead"))),
+                |_| false,
+                || Ok(Some(())),
+                || {
+                    JobStore::open_without_reconciliation(&path)?
+                        .reconcile_dead_daemon_lease_jobs("lease-dead")
+                },
+                || Ok(fake_daemon(4343, "lease-replacement")),
+            )
+        };
+
+        let first = adopt().expect("terminal child permits adoption");
+        let recovered = JobStore::open_without_reconciliation(&path).expect("reopen store");
+        let event_count = recovered.events(job.id).expect("events").len();
+        let second = adopt().expect("repeat adoption is a no-op for terminal child");
+        let recovered = JobStore::open_without_reconciliation(&path).expect("reopen store");
+
+        assert_eq!(first.active_jobs_terminalized, 1);
+        assert_eq!(second.active_jobs_terminalized, 0);
+        assert_eq!(
+            recovered.get(job.id).expect("job").status,
+            JobStatus::Succeeded
+        );
+        assert_eq!(recovered.events(job.id).expect("events").len(), event_count);
+    });
+}
+
+#[test]
 fn fetch_artifact_to_path_downloads_daemon_byte_alias() {
     with_isolated_home(|home| {
         let listener = TcpListener::bind("127.0.0.1:0").expect("listener");

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -555,6 +555,14 @@ fn dead_matching_lease_reconciles_jobs_before_starting_replacement() {
             .with_daemon_lease("lease-dead".to_string());
         let job = store.create("runner.exec");
         store.start(job.id).expect("job starts");
+        store
+            .append_event(
+                job.id,
+                JobEventKind::Progress,
+                None,
+                Some(serde_json::json!({ "phase": "heartbeat", "process": { "root_pid": u32::MAX } })),
+            )
+            .expect("record dead child heartbeat");
         let daemon = fake_daemon(4343, "lease-replacement");
 
         let started = reconcile_dead_lease_and_ensure_running_with_operations(
@@ -633,6 +641,14 @@ fn state_loss_exact_lease_recovery_terminalizes_only_matching_jobs_and_starts_on
             .with_daemon_lease("exact-lease".to_string());
         let job = store.create("runner.exec");
         store.start(job.id).expect("start");
+        store
+            .append_event(
+                job.id,
+                JobEventKind::Progress,
+                None,
+                Some(serde_json::json!({ "phase": "heartbeat", "process": { "root_pid": u32::MAX } })),
+            )
+            .expect("record dead child heartbeat");
         let starts = Arc::new(Mutex::new(0));
         let start_count = Arc::clone(&starts);
         let result = super::recover_missing_lease_state_with_operations(

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -993,32 +993,34 @@ fn replacement_starting_replay_adopts_only_the_persisted_startup_token() {
 
 #[test]
 fn dead_lease_reconciliation_reattaches_live_or_refuses_mismatched_daemon() {
-    let live_daemon = fake_daemon(4242, "lease-dead");
-    let live = reconcile_dead_lease_and_ensure_running_with_operations(
-        Duration::from_millis(50),
-        super::super::acquire_daemon_operation_lock_for_ensure,
-        "lease-dead",
-        || Ok(fake_dead_status(live_daemon.clone())),
-        |_| true,
-        || unreachable!("live daemon must not reconcile"),
-        || unreachable!("live daemon must not start replacement"),
-    )
-    .expect("live replacement from a concurrent reconnect is reattached");
-    assert_eq!(live, live_daemon);
+    with_isolated_home(|_| {
+        let live_daemon = fake_daemon(4242, "lease-dead");
+        let live = reconcile_dead_lease_and_ensure_running_with_operations(
+            Duration::from_millis(50),
+            super::super::acquire_daemon_operation_lock_for_ensure,
+            "lease-dead",
+            || Ok(fake_dead_status(live_daemon.clone())),
+            |_| true,
+            || unreachable!("live daemon must not reconcile"),
+            || unreachable!("live daemon must not start replacement"),
+        )
+        .expect("live replacement from a concurrent reconnect is reattached");
+        assert_eq!(live, live_daemon);
 
-    let mismatched = reconcile_dead_lease_and_ensure_running_with_operations(
-        Duration::from_millis(50),
-        super::super::acquire_daemon_operation_lock_for_ensure,
-        "lease-expected",
-        || Ok(fake_dead_status(fake_daemon(4242, "lease-other"))),
-        |_| false,
-        || unreachable!("mismatched lease must not reconcile"),
-        || unreachable!("mismatched lease must not start replacement"),
-    )
-    .expect_err("mismatched lease must fail closed");
-    assert!(mismatched
-        .message
-        .contains("does not match expected stale lease"));
+        let mismatched = reconcile_dead_lease_and_ensure_running_with_operations(
+            Duration::from_millis(50),
+            super::super::acquire_daemon_operation_lock_for_ensure,
+            "lease-expected",
+            || Ok(fake_dead_status(fake_daemon(4242, "lease-other"))),
+            |_| false,
+            || unreachable!("mismatched lease must not reconcile"),
+            || unreachable!("mismatched lease must not start replacement"),
+        )
+        .expect_err("mismatched lease must fail closed");
+        assert!(mismatched
+            .message
+            .contains("does not match expected stale lease"));
+    });
 }
 
 fn ensure_with_fake_operations(


### PR DESCRIPTION
## Summary

- reconcile dead-daemon child jobs from authoritative terminal result evidence before considering recorded PID liveness
- preserve genuinely live children and fail closed when child state is ambiguous
- make exact dead-lease adoption idempotent while retaining existing lease, owner-lock, and confirmed-dead PID guards

Fixes #8106.

## How to test

1. From a fresh checkout, run `cargo test --lib core::api_jobs`.
2. Run `cargo test --lib core::daemon::control`.
3. Run `cargo fmt --check`.
4. Run `git diff --check origin/main...HEAD`.
5. Confirm terminal-result jobs permit repeated exact lease adoption, live child PIDs remain protected, and jobs without terminal or child evidence fail closed.

## Verification

- `cargo test --lib core::api_jobs`: 57 passed
- `cargo test --lib core::daemon::control`: 26 passed
- `cargo fmt --check`: passed
- `git diff --check`: passed

## Compatibility

No command or persisted-data format changes. This narrows recovery behavior only when authoritative terminal evidence already exists; live and ambiguous child processes retain fail-closed protection.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Diagnosed the dead-lease reconciliation ordering, drafted the implementation and deterministic tests, and verified the recovery behavior with Chris.
