### PR TITLE
fix: mark local runner execs as placement-resolved (#8115)

### DIFF
--- a/src/core/runner/execution/process.rs
+++ b/src/core/runner/execution/process.rs
@@ -222,6 +222,16 @@ pub(crate) fn prepare_runner_process(
         runner.env = runner_env.clone();
         env = runner_env;
         env.extend(request_env.clone());
+        // Stamp the dispatch-only runner-placement markers for local execs too.
+        // These are kept out of argv so nested Homeboy commands (parity preflight
+        // `extension show`, extension materialization, ready_check chains) do not
+        // re-enter routing and dispatch themselves a second time. Without them a
+        // local runner exec that carries an explicit `--placement` recursively
+        // spawns `homeboy component show` / `extension show` and the extension
+        // ready_check, saturating the host (#8115).
+        env.insert(RUNNER_HOSTED_EXEC_ENV.to_string(), "1".to_string());
+        env.insert(RUNNER_PLACEMENT_RESOLVED_ENV.to_string(), "1".to_string());
+        env.insert(RUNNER_ID_ENV.to_string(), runner.id.clone());
         env.extend(resolve_runner_secret_env_for_plan(
             &runner.secret_env,
             &secret_env_plan,

--- a/src/core/runner/execution/tests/prepare.rs
+++ b/src/core/runner/execution/tests/prepare.rs
@@ -211,7 +211,15 @@ fn ssh_runner_prep_marks_remote_placement_as_resolved() {
 }
 
 #[test]
-fn local_runner_prep_does_not_mark_commands_as_runner_hosted() {
+fn local_runner_prep_marks_placement_as_resolved() {
+    // Regression for #8115: a local runner exec must stamp the dispatch-only
+    // placement-resolved markers so nested Homeboy subprocesses (parity
+    // preflight `extension show`, extension materialization, ready_check
+    // chains) recognize that placement is already resolved and short-circuit
+    // routing instead of re-dispatching. Without these markers a local exec
+    // carrying an explicit `--placement` recursively spawns
+    // `homeboy component show` / `extension show` plus the extension
+    // ready_check and saturates the host.
     crate::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace = temp.path().join("project");
@@ -238,9 +246,20 @@ fn local_runner_prep_does_not_mark_commands_as_runner_hosted() {
         })
         .expect("prepare local runner process");
 
-        assert!(!plan.env.contains_key(RUNNER_HOSTED_EXEC_ENV));
-        assert!(!plan.env.contains_key(RUNNER_PLACEMENT_RESOLVED_ENV));
-        assert!(!plan.env.contains_key(RUNNER_ID_ENV));
+        assert_eq!(
+            plan.env.get(RUNNER_HOSTED_EXEC_ENV).map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            plan.env
+                .get(RUNNER_PLACEMENT_RESOLVED_ENV)
+                .map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            plan.env.get(RUNNER_ID_ENV).map(String::as_str),
+            Some("local")
+        );
     });
 }
 


### PR DESCRIPTION
## Summary
- Fixes the recursive process-spawn storm when inspecting/checking the `wp-codebox` component (#8115), where `homeboy component show` / `extension show` and `check-wp-codebox-runtime-core.mjs` spawn each other unbounded and saturate the host.
- Root cause: `prepare_runner_process` only stamped the dispatch-only placement markers (`HOMEBOY_RUNNER_HOSTED_EXEC`, `HOMEBOY_RUNNER_PLACEMENT_RESOLVED`, `HOMEBOY_RUNNER_ID`) for non-local runners (`runner.kind != RunnerKind::Local`). #7998 introduced the placement-resolved marker + explicit `--placement` but left the local gap.
- Consequence: nested Homeboy subprocesses spawned during a local exec (extension parity preflight `extension show`, extension materialization, and the WP Codebox ready_check) never saw that placement was already resolved. Carrying an explicit `--placement`, they re-entered `route_after_parse` and re-dispatched — recursively spawning component/extension inspection plus the ready_check.

## Fix
- Stamp the three placement markers in the local branch of `prepare_runner_process`, matching the already-correct daemon-local path (which documents the same "keep out of argv so nested Homeboy commands do not route themselves a second time" intent). Nested commands now detect the resolved placement via `is_managed_runner_placement_context()` and short-circuit routing instead of recursing.

## Investigation notes
- Confirmed the extension side is clean: `check-wp-codebox-runtime-core.mjs` is a pure `import()` and the only `homeboy component show` call in homeboy-extensions (`validation-dependencies.sh`) is cycle-guarded and only reached from lint/audit/test/bench — never the ready_check or `component show`.
- Bounded local repro (forced-failing ready_check) showed the plain `runner exec` path already fails fast without looping; the loop requires the explicit-`--placement` + missing-local-marker combination introduced by #7998.

## Testing
- `cargo fmt --check` clean.
- Updated `local_runner_prep_marks_placement_as_resolved` (formerly `local_runner_prep_does_not_mark_commands_as_runner_hosted`, which encoded the buggy behavior) to assert the markers are now present. Heavier `cargo build`/`cargo test` deferred to CI per repo build policy.

Closes #8115