### PR TITLE
fix: enforce embedded docs list/resolve contract (#7607)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -148,11 +148,34 @@ fn key_for_path(docs_root: &Path, path: &Path) -> String {
         key = without_ext.to_string();
     }
 
+    // Normalize every path segment the same way the resolver normalizes user
+    // input (see homeboy::core::engine::text::normalize_doc_segment). This
+    // guarantees the list/resolve contract by construction: every key emitted
+    // here — and therefore printed by `self docs list` — is reachable via
+    // `self docs <that exact string>`. Without this, an uppercase or
+    // space-bearing doc filename (e.g. CHANGELOG.md) would produce a key the
+    // resolver can never match, since it lowercases input before lookup.
+    let key = key
+        .split('/')
+        .map(normalize_doc_segment)
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join("/");
+
     if key == "index" {
         return "index".to_string();
     }
 
     key
+}
+
+/// Mirror of `homeboy::core::engine::text::normalize_doc_segment`.
+///
+/// build.rs cannot depend on the crate it builds, so this small primitive is
+/// duplicated here. Keep the two in sync — a mismatch reintroduces the
+/// list/resolve drift this normalization exists to prevent.
+fn normalize_doc_segment(input: &str) -> String {
+    input.trim().to_lowercase().replace([' ', '\t'], "-")
 }
 
 fn escape_rust_string(input: &str) -> String {

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -935,7 +935,7 @@ impl Error {
             serde_json::json!({ "topic": topic.into() }),
         )
         .with_hint("Run 'homeboy self docs list' to see available topics")
-        .with_hint("Topics use path format: 'commands/deploy', 'commands/changes'")
+        .with_hint("Topics use path format: 'commands/deploy', 'architecture/hooks'")
     }
 
     fn not_found(code: ErrorCode, message: &str, id: impl Into<String>) -> Self {

--- a/src/help_topics/mod.rs
+++ b/src/help_topics/mod.rs
@@ -157,3 +157,41 @@ fn collect_doc_topics(dir: &Path, prefix: &str, topics: &mut BTreeSet<String>) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// list/resolve contract: every embedded topic printed by `self docs list`
+    /// MUST be openable via `self docs <that exact string>`. Guards issue #7607,
+    /// where uppercase root doc keys (CHANGELOG, TESTING, ...) were listed but
+    /// unresolvable because the resolver lowercases input before lookup.
+    #[test]
+    fn every_generated_topic_resolves() {
+        for (key, _) in GENERATED_DOCS {
+            let resolved = resolve(&[key.to_string()]);
+            assert!(
+                resolved.is_ok(),
+                "topic '{key}' is listed by GENERATED_DOCS but does not resolve"
+            );
+        }
+    }
+
+    /// Generated keys must already be in normalized (resolver-facing) form, so
+    /// list output and resolver lookups share one casing. A drift here is the
+    /// exact defect issue #7607 documents.
+    #[test]
+    fn generated_keys_are_normalized() {
+        for (key, _) in GENERATED_DOCS {
+            let normalized = key
+                .split('/')
+                .map(text::normalize_doc_segment)
+                .collect::<Vec<_>>()
+                .join("/");
+            assert_eq!(
+                *key, normalized,
+                "generated doc key '{key}' is not in normalized form (expected '{normalized}')"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #7607 — `homeboy self docs list` advertised topics that `homeboy self docs <topic>` then rejected with `docs.topic_not_found`. Root cause: the build script generated doc keys from raw file paths (preserving original casing), while the resolver lowercases user input before lookup. An uppercase root doc (`CHANGELOG.md` → key `CHANGELOG`) was therefore listed but unreachable, since the resolver only ever looks up `changelog`.

The fix normalizes keys **at the source** so the list and resolver share one casing by construction.

## Changes

- **`build.rs`** — `key_for_path` now normalizes every path segment with the same rule the resolver uses (`normalize_doc_segment`: trim + lowercase + spaces/tabs → dashes). Every emitted key is now guaranteed reachable via `self docs <that exact string>`. A local mirror of `normalize_doc_segment` is added (build.rs can't depend on the crate it builds) with a keep-in-sync note.
- **`src/core/error/mod.rs`** — the `topic_not_found` hint recommended `commands/changes`, which itself does not resolve. Replaced with `architecture/hooks` (verified resolvable).
- **`src/help_topics/mod.rs`** — added contract tests:
  - `every_generated_topic_resolves` — asserts every `GENERATED_DOCS` key opens.
  - `generated_keys_are_normalized` — asserts every generated key is already in resolver-facing form, catching future drift.

## Verification

- `cargo fmt` — clean.
- `cargo check --lib` and `cargo check --lib --tests` — compile clean (pre-existing dead-code warnings unrelated to this change).
- Heavy build/test suite left to CI per this VPS's build policy.

## Notes

The specific uppercase root docs named in the issue (`CHANGELOG`, `TESTING`, …) have since been renamed/removed on `main`, so the symptom is no longer reproducible there — but the underlying list/resolve contract was still unenforced by construction. This change makes the contract structural and regression-tested.