### PR TITLE
fix: align bench/build diagnostic assertions with actionable contract (#7975)

### DIFF
--- a/src/core/extension/bench/parsing/mod.rs
+++ b/src/core/extension/bench/parsing/mod.rs
@@ -1379,17 +1379,33 @@ mod tests {
             .and_then(|v| v.as_str())
             .unwrap_or("");
 
+        // The duplicate is surfaced by `resolve_duplicate_scenario_ids`, which
+        // emits the structured `duplicate_scenario_id` diagnostic naming the
+        // conflicting id, both discovered source paths, and the actionable
+        // `--path` / `--rig` remediation.
         assert!(
-            problem.contains("duplicate bench scenario id `heavy`"),
+            problem.contains("duplicate bench scenario id(s) discovered"),
             "expected duplicate-id problem, got: {}",
             problem
         );
+        assert!(
+            problem.contains("`heavy`"),
+            "problem should name the id: {problem}"
+        );
         assert!(problem.contains("tests/bench/reads/heavy.php"));
         assert!(problem.contains("tests/bench/writes/heavy.php"));
-        assert!(problem.contains("workload paths relative to the bench root"));
+        assert!(
+            problem.contains("homeboy bench --path <workspace>"),
+            "problem should offer the --path remediation: {problem}"
+        );
+        assert!(
+            problem.contains("--rig <id>"),
+            "problem should offer the --rig remediation: {problem}"
+        );
+        // `id` carries the diagnostic code, not the scenario id.
         assert_eq!(
             err.details.get("id").and_then(|v| v.as_str()),
-            Some("heavy")
+            Some("duplicate_scenario_id")
         );
     }
 
@@ -1459,7 +1475,14 @@ mod tests {
             .and_then(|v| v.as_str())
             .unwrap_or("");
 
-        assert!(problem.contains("duplicate bench scenario id `target`"));
+        assert!(
+            problem.contains("duplicate bench scenario id(s) discovered"),
+            "expected duplicate-id problem, got: {problem}"
+        );
+        assert!(
+            problem.contains("`target`"),
+            "problem should name the id: {problem}"
+        );
     }
 
     #[test]

--- a/src/core/extension/capability.rs
+++ b/src/core/extension/capability.rs
@@ -232,8 +232,23 @@ pub(crate) fn extension_guidance_hints(
         ),
     };
 
+    // Point at the component-owned escape hatch too: a component can supply its
+    // own command via a `scripts.<capability>` entry without linking an
+    // extension at all. Named after the capability so the hint is actionable
+    // (e.g. `scripts.build`) and independently regression-covered.
+    let scripts_hint = match capability {
+        Some(capability) => format!(
+            "Use `scripts.{}` for component-owned {} commands (no extension required): set it in the component config.",
+            capability.label().to_lowercase(),
+            capability.label().to_lowercase()
+        ),
+        None => "Use `scripts.<command>` for component-owned commands (no extension required): set it in the component config."
+            .to_string(),
+    };
+
     vec![
         link_hint,
+        scripts_hint,
         "List installed extensions: homeboy extension list".to_string(),
         format!(
             "Component config lives at ~/.config/homeboy/components/{}.json or in a portable homeboy.json discovered from the component path.",


### PR DESCRIPTION
## Summary

Fixes #7975 — library tests asserted obsolete diagnostic wording and blocked the Rust test gate, even though the exercised behavior already returns the intended, more actionable diagnostics. Aligns the assertions (and restores one dropped hint) with the current contract.

## Duplicate bench scenario diagnostics

The tests expected the old `validate.rs` phrasing (`duplicate bench scenario id \`x\``, `workload paths relative to the bench root`) and `details.id == "<scenario>"`. The active `resolve_duplicate_scenario_ids` path now emits the structured `duplicate_scenario_id` diagnostic that:
- names the conflicting id and **both** discovered source paths, and
- offers actionable `homeboy bench --path <workspace>` / `--rig <id>` remediation, with the diagnostic **code** in `details.id`.

Updated assertions to validate that contract in:
- `rejects_duplicate_scenario_ids_from_same_basename_subdirs` (listed in issue)
- `selected_parse_still_rejects_selected_duplicate_scenario_ids` (same stale wording, same module — surfaced when running the module)

## Build guidance hint

`resolve_build_command_guides_unconfigured_components` (listed in issue) and `extension_guidance_hints_point_to_supported_paths` both assert a `scripts.build` component-owned-command hint that `extension_guidance_hints` no longer emitted. Rather than delete two assertions, I **restored the `scripts.<capability>` hint** — it makes the unconfigured-component diagnostic genuinely more actionable (points at the no-extension-required escape hatch) and is what both tests already document.

## Verification

- Both reproduction commands from the issue now pass.
- `cargo test --lib core::extension::bench::parsing::tests` — **45 passed**.
- `cargo test --lib core::extension::tests::` — **29 passed**.
- Named build/guidance tests pass.

## Out of scope

Other `core::extension::*` tests (trace, phpunit/component_script, compiler-warning-contract, execution/lifecycle) fail on this environment **on the clean baseline too** (verified via `git stash`) — they require external PHP/WordPress/trace tooling and are unrelated to this diagnostic-assertion regression.