### PR TITLE
Fix private Git workspace materialization fallback

### DIFF
--- a/src/core/runner/source_materialization.rs
+++ b/src/core/runner/source_materialization.rs
@@ -23,6 +23,30 @@ pub(super) fn validate_runner_git_materialization(remote_url: &str, runner_id: &
     validate_runner_git_materialization_with_policy(remote_url, runner_id, &policy)
 }
 
+/// A remote URL is restored as runner metadata after bundle materialization.
+/// Reject URL userinfo rather than risk persisting a token in that checkout.
+pub(super) fn validate_sanitized_git_remote(remote_url: &str) -> Result<()> {
+    let value = remote_url.trim();
+    let credential_bearing = ["https://", "http://"].iter().any(|scheme| {
+        value
+            .strip_prefix(scheme)
+            .and_then(|authority_and_path| authority_and_path.split('/').next())
+            .is_some_and(|authority| authority.contains('@'))
+    });
+    if !credential_bearing {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "remote.origin.url",
+        "git workspace sync refuses credential-bearing remote.origin.url",
+        None,
+        Some(vec![
+            "Configure origin with a sanitized HTTPS or SSH URL; Homeboy never transfers Git credentials to a runner.".to_string(),
+        ]),
+    ))
+}
+
 fn validate_runner_git_materialization_with_policy(
     remote_url: &str,
     runner_id: &str,
@@ -197,6 +221,16 @@ mod tests {
         assert!(err.message.contains("--mode git"));
         assert!(err.message.contains("github.example.com"));
         assert!(err.message.contains("workspace sync"));
+    }
+
+    #[test]
+    fn rejects_credential_bearing_https_remote_without_echoing_the_secret() {
+        let remote = "https://token-value@github.example.com/example/private.git";
+        let error = validate_sanitized_git_remote(remote).expect_err("credential URL is unsafe");
+
+        assert!(error.message.contains("credential-bearing"));
+        assert!(!error.message.contains("token-value"));
+        assert!(!error.details.to_string().contains("token-value"));
     }
 
     #[test]

--- a/src/core/runner/workspace/git.rs
+++ b/src/core/runner/workspace/git.rs
@@ -2,11 +2,14 @@ use std::path::Path;
 use std::process::Command;
 use std::process::Stdio;
 
+use sha2::{Digest, Sha256};
+
 use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
 
 use super::super::{Runner, RunnerKind};
 use super::materializer::{WorkspaceMaterializationOperation, WorkspaceMaterializer};
+use super::types::ControllerGitBundleProvenance;
 use super::types::GitSnapshot;
 use super::util::{git_output, run_shell_command, ssh_args, ssh_client_for_runner};
 
@@ -20,9 +23,6 @@ pub(super) fn git_snapshot(
     let branch = git_output(local_path, &["rev-parse", "--abbrev-ref", "HEAD"])
         .ok()
         .filter(|branch| branch != "HEAD");
-    if !controller_routed_git {
-        ensure_clean_git_working_tree(local_path, changed_since_base)?;
-    }
     let remote_url = git_output(local_path, &["config", "--get", "remote.origin.url"])?;
     if remote_url.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
@@ -32,18 +32,20 @@ pub(super) fn git_snapshot(
             None,
         ));
     }
+    super::super::source_materialization::validate_sanitized_git_remote(&remote_url)?;
     if controller_routed_git
         || branch.is_none()
         || super::super::source_materialization::requires_controller_routed_workspace_sync(
             &remote_url,
         )
+        // A partial controller checkout may need its selected HEAD hydrated
+        // before Git can even evaluate cleanliness.
+        || promisor_remote(local_path)?.is_some()
     {
         let refs = controller_bundle_refs(&head, changed_since_base, &git_fetch_refs);
         repair_controller_bundle_commit_closure(local_path, &refs)?;
     }
-    if controller_routed_git {
-        ensure_clean_git_working_tree(local_path, changed_since_base)?;
-    }
+    ensure_clean_git_working_tree(local_path, changed_since_base)?;
 
     Ok(GitSnapshot {
         remote_url,
@@ -145,7 +147,7 @@ pub(super) fn materialize_git_from_controller_bundle(
     changed_since_base: Option<&str>,
     git_fetch_refs: &[String],
     allow_dirty_lab_workspace: bool,
-) -> Result<()> {
+) -> Result<ControllerGitBundleProvenance> {
     validate_controller_git_bundle_source(local_path)?;
 
     let bundle_dir = tempfile::tempdir().map_err(|err| {
@@ -156,6 +158,8 @@ pub(super) fn materialize_git_from_controller_bundle(
     })?;
     let bundle_path = bundle_dir.path().join("workspace.bundle");
 
+    // `HEAD` preserves the complete selected ancestry in a bundle. The exact
+    // resolved SHA is recorded separately in provenance and verified on Lab.
     let refs = controller_bundle_refs("HEAD", changed_since_base, git_fetch_refs);
     hydrate_controller_bundle_objects(local_path, &refs)?;
 
@@ -175,12 +179,14 @@ pub(super) fn materialize_git_from_controller_bundle(
             String::from_utf8_lossy(&output.stderr)
         )));
     }
+    let sha256 = sha256_file(&bundle_path)?;
 
     let install_command = git_bundle_install_command(
         remote_path,
         head,
         branch,
         remote_url,
+        &sha256,
         allow_dirty_lab_workspace,
     );
     let result = match runner.kind {
@@ -214,7 +220,26 @@ pub(super) fn materialize_git_from_controller_bundle(
         }
     };
 
-    result
+    result?;
+    Ok(ControllerGitBundleProvenance {
+        provenance: "controller_git_bundle",
+        source_sha: head.to_string(),
+        source_refs: refs,
+        sha256,
+        cleanup_owner: "controller",
+        // The controller tempdir is removed as soon as the transfer finishes.
+        cleanup_ttl: "PT0S",
+    })
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let bytes = std::fs::read(path).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some("read git bundle for digest".to_string()),
+        )
+    })?;
+    Ok(format!("{:x}", Sha256::digest(bytes)))
 }
 
 /// Resolve the exact object closure locally before `git bundle` can invoke a
@@ -425,6 +450,7 @@ pub(crate) fn git_bundle_install_command(
     head: &str,
     branch: Option<&str>,
     remote_url: &str,
+    expected_sha256: &str,
     allow_dirty_lab_workspace: bool,
 ) -> String {
     WorkspaceMaterializer::new(remote_path)
@@ -436,6 +462,9 @@ pub(crate) fn git_bundle_install_command(
             "\"$bundle\"".to_string(),
         ]))
         .op(WorkspaceMaterializationOperation::WriteStdinToBundle)
+        .op(WorkspaceMaterializationOperation::VerifyBundleDigest(
+            expected_sha256.to_string(),
+        ))
         .op(WorkspaceMaterializationOperation::CloneBundleToTemp)
         .op(WorkspaceMaterializationOperation::SetGitOrigin(
             remote_url.to_string(),

--- a/src/core/runner/workspace/materializer.rs
+++ b/src/core/runner/workspace/materializer.rs
@@ -11,6 +11,7 @@ pub(super) enum WorkspaceMaterializationOperation {
     RecreateTempDir,
     ExtractTarStdinToTemp,
     WriteStdinToBundle,
+    VerifyBundleDigest(String),
     CloneBundleToTemp,
     SetGitOrigin(String),
     CheckoutGitRef {
@@ -139,6 +140,10 @@ impl WorkspaceMaterializationOperation {
             Self::WriteStdinToBundle => {
                 "rm -rf \"$tmp\" \"$bundle\" && cat > \"$bundle\"".to_string()
             }
+            Self::VerifyBundleDigest(expected) => format!(
+                "test \"$(shasum -a 256 \"$bundle\" | awk '{{print $1}}')\" = {expected}",
+                expected = shell::quote_arg(expected)
+            ),
             Self::CloneBundleToTemp => "git clone \"$bundle\" \"$tmp\"".to_string(),
             Self::SetGitOrigin(remote_url) => format!(
                 "git -C \"$tmp\" remote set-url origin {remote_url}",

--- a/src/core/runner/workspace/sync.rs
+++ b/src/core/runner/workspace/sync.rs
@@ -196,7 +196,7 @@ pub fn sync_workspace(
             } else {
                 "clean_remote_required"
             };
-            let materialization_plan = workspace_materialization_plan(
+            let mut materialization_plan = workspace_materialization_plan(
                 workspace_root,
                 &local_path,
                 &remote_path,
@@ -211,17 +211,18 @@ pub fn sync_workspace(
                     &git.remote_url,
                 )
             {
-                materialize_git_from_controller_bundle(
-                    &runner,
-                    &local_path,
-                    &remote_path,
-                    &git.head,
-                    git.branch.as_deref(),
-                    &git.remote_url,
-                    git.changed_since_base.as_deref(),
-                    &git.git_fetch_refs,
-                    options.allow_dirty_lab_workspace,
-                )?;
+                materialization_plan.controller_git_bundle =
+                    Some(materialize_git_from_controller_bundle(
+                        &runner,
+                        &local_path,
+                        &remote_path,
+                        &git.head,
+                        git.branch.as_deref(),
+                        &git.remote_url,
+                        git.changed_since_base.as_deref(),
+                        &git.git_fetch_refs,
+                        options.allow_dirty_lab_workspace,
+                    )?);
             } else {
                 if runner.kind != RunnerKind::Local {
                     source_materialization::validate_runner_git_materialization(
@@ -229,7 +230,7 @@ pub fn sync_workspace(
                         &runner.id,
                     )?;
                 }
-                materialize_git(
+                if let Err(error) = materialize_git(
                     &runner,
                     &remote_path,
                     &git.remote_url,
@@ -238,7 +239,23 @@ pub fn sync_workspace(
                     git.changed_since_base.as_deref(),
                     &git.git_fetch_refs,
                     options.allow_dirty_lab_workspace,
-                )?;
+                ) {
+                    if !is_runner_git_auth_or_network_failure(&error) {
+                        return Err(error);
+                    }
+                    materialization_plan.controller_git_bundle =
+                        Some(materialize_git_from_controller_bundle(
+                            &runner,
+                            &local_path,
+                            &remote_path,
+                            &git.head,
+                            git.branch.as_deref(),
+                            &git.remote_url,
+                            git.changed_since_base.as_deref(),
+                            &git.git_fetch_refs,
+                            options.allow_dirty_lab_workspace,
+                        )?);
+                }
             }
             let metadata = workspace_metadata(
                 &runner.id,
@@ -301,6 +318,24 @@ pub fn sync_workspace(
             ))
         }
     }
+}
+
+fn is_runner_git_auth_or_network_failure(error: &Error) -> bool {
+    let message = error.message.to_ascii_lowercase();
+    [
+        "authentication failed",
+        "permission denied",
+        "could not read from remote repository",
+        "repository not found",
+        "failed to connect",
+        "could not resolve host",
+        "network is unreachable",
+        "connection timed out",
+        "connection refused",
+        "proxy",
+    ]
+    .iter()
+    .any(|needle| message.contains(needle))
 }
 
 pub(crate) fn workspace_materialization_plan(

--- a/src/core/runner/workspace/tests/git.rs
+++ b/src/core/runner/workspace/tests/git.rs
@@ -1,6 +1,7 @@
 use std::fs;
+use std::io::Write;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use super::git;
 use crate::core::runner::workspace::git::{
@@ -84,7 +85,7 @@ fn controller_routed_git_sync_materializes_private_unavailable_remote_with_chang
                 "remote",
                 "add",
                 "origin",
-                "https://github.example.invalid/example-org/private-source.git",
+                "https://127.0.0.1:1/example-org/private-source.git",
             ],
         );
         git(source.path(), &["commit-graph", "write", "--reachable"]);
@@ -126,7 +127,9 @@ fn controller_routed_git_sync_materializes_private_unavailable_remote_with_chang
             RunnerWorkspaceSyncOptions {
                 path: source.path().display().to_string(),
                 mode: RunnerWorkspaceSyncMode::Git,
-                controller_routed_git: true,
+                // The runner first attempts its normal clone. The inaccessible
+                // origin then exercises the controller bundle fallback.
+                controller_routed_git: false,
                 changed_since_base: Some(base.clone()),
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
@@ -151,6 +154,16 @@ fn controller_routed_git_sync_materializes_private_unavailable_remote_with_chang
             Some(output.snapshot_identity.clone())
         );
         assert_eq!(output.current_workspace.source_dirty, Some(false));
+        let provenance = output
+            .materialization_plan
+            .controller_git_bundle
+            .as_ref()
+            .expect("inaccessible origin falls back to a controller bundle");
+        assert_eq!(provenance.provenance, "controller_git_bundle");
+        assert_eq!(provenance.source_sha, head);
+        assert_eq!(provenance.cleanup_owner, "controller");
+        assert_eq!(provenance.cleanup_ttl, "PT0S");
+        assert_eq!(provenance.sha256.len(), 64);
         let remote = Path::new(&output.remote_path);
         assert_eq!(
             git_output(remote, &["rev-parse", "--is-inside-work-tree"]).unwrap(),
@@ -161,7 +174,7 @@ fn controller_routed_git_sync_materializes_private_unavailable_remote_with_chang
         // proves materialization did not fall back to a network clone.
         assert_eq!(
             git_output(remote, &["config", "--get", "remote.origin.url"]).unwrap(),
-            "https://github.example.invalid/example-org/private-source.git"
+            "https://127.0.0.1:1/example-org/private-source.git"
         );
         assert_eq!(
             fs::read_to_string(remote.join("file.txt")).expect("read synced file"),
@@ -200,6 +213,11 @@ fn controller_routed_git_sync_materializes_private_unavailable_remote_with_chang
             )
             .is_err(),
             "the runner bundle must not include unrelated refs"
+        );
+        fs::write(remote.join("file.txt"), "patched\n").expect("write tracked patch");
+        assert_eq!(
+            git_output(remote, &["status", "--porcelain=v1"]).unwrap(),
+            "M file.txt"
         );
     });
 }
@@ -581,10 +599,43 @@ fn git_bundle_materialization_disables_lazy_fetches() {
         "abc123",
         None,
         "https://github.example.invalid/example-org/private-source.git",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         false,
     );
 
     assert!(command.contains("export GIT_NO_LAZY_FETCH=1"));
+    assert!(command.contains("shasum -a 256"));
+    assert!(command.contains("trap 'rm -rf"));
+}
+
+#[test]
+fn git_bundle_materialization_rejects_digest_mismatch_before_clone() {
+    let root = tempfile::tempdir().expect("runner root");
+    let command = git_bundle_install_command(
+        &root.path().join("workspace").display().to_string(),
+        "abc123",
+        None,
+        "https://github.example.invalid/example-org/private-source.git",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        false,
+    );
+    let mut child = Command::new("sh")
+        .args(["-c", &command])
+        .stdin(Stdio::piped())
+        .spawn()
+        .expect("start bundle materialization");
+    child
+        .stdin
+        .take()
+        .expect("bundle stdin")
+        .write_all(b"not a bundle")
+        .expect("write malformed bundle");
+
+    assert!(
+        !child.wait().expect("wait for materialization").success(),
+        "a digest mismatch must fail before Git can clone the transfer"
+    );
+    assert!(!root.path().join("workspace.bundle").exists());
 }
 
 #[test]

--- a/src/core/runner/workspace/types.rs
+++ b/src/core/runner/workspace/types.rs
@@ -103,6 +103,18 @@ pub struct RunnerWorkspaceMaterializationContract {
     pub source_provenance: RunnerWorkspaceSourceProvenance,
     pub dirty_policy: RunnerWorkspaceDirtyPolicy,
     pub output_paths: RunnerWorkspaceOutputPaths,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub controller_git_bundle: Option<ControllerGitBundleProvenance>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ControllerGitBundleProvenance {
+    pub provenance: &'static str,
+    pub source_sha: String,
+    pub source_refs: Vec<String>,
+    pub sha256: String,
+    pub cleanup_owner: &'static str,
+    pub cleanup_ttl: &'static str,
 }
 
 pub type RunnerWorkspaceMaterializationPlan = RunnerWorkspaceMaterializationContract;
@@ -203,6 +215,7 @@ impl RunnerWorkspaceMaterializationContract {
                 workspace_cleanliness: workspace_cleanliness.to_string(),
             },
             output_paths: RunnerWorkspaceOutputPaths::for_remote_path(&workspace_root, remote_path),
+            controller_git_bundle: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- Attempt runner-side Git materialization first, then transfer a controller-created bundle only after authentication or network failures.
- Verify the bundle SHA-256 on Lab before checkout, restore only a sanitized origin URL without fetching it, and record `controller_git_bundle` source SHA, refs, digest, controller cleanup owner, and immediate cleanup TTL.
- Reject credential-bearing HTTP(S) origin URLs before any runner handoff.

Closes #8122

## How to test
1. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo test controller_routed_git_sync_materializes_private_unavailable_remote_with_changed_since_base --lib`.
2. Confirm the inaccessible origin falls back to a controller bundle, Lab has the exact recorded HEAD and sanitized origin, and one tracked-file change is the only patch.
3. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo test rejects_credential_bearing_https_remote_without_echoing_the_secret --lib`.
4. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo test git_bundle_materialization_rejects_digest_mismatch --lib`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode / openai-gpt-5.6-sol
- **Used for:** Implemented the generic Git-bundle fallback, tests, verification, and PR draft with Chris's requested requirements.