### PR TITLE
Harden agent-task plan files and redaction

### DIFF
--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -79,6 +79,31 @@ fn submit_plan_persists_queued_status() {
     });
 }
 
+#[cfg(unix)]
+#[test]
+fn submit_plan_persists_owner_only_plan_file_before_observation() {
+    use std::os::unix::fs::PermissionsExt;
+
+    with_isolated_home(|_| {
+        let record = submit_plan(&test_plan(), Some("private-plan")).expect("submitted");
+
+        assert_eq!(
+            std::fs::metadata(&record.plan_path)
+                .expect("plan metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        assert_eq!(
+            status(&record.run_id)
+                .expect("observation record")
+                .plan_path,
+            record.plan_path
+        );
+    });
+}
+
 #[test]
 fn active_pinned_run_blocks_controller_binary_replacement() {
     with_isolated_home(|_| {

--- a/src/core/engine/local_files.rs
+++ b/src/core/engine/local_files.rs
@@ -131,6 +131,15 @@ pub fn write_file(path: &Path, content: &str, operation: &str) -> Result<()> {
 
 /// Write content to file atomically (write to .tmp, then rename).
 pub fn write_file_atomic(path: &Path, content: &str, operation: &str) -> Result<()> {
+    write_file_atomic_with_owner_only(path, content, operation, false)
+}
+
+fn write_file_atomic_with_owner_only(
+    path: &Path,
+    content: &str,
+    operation: &str,
+    owner_only: bool,
+) -> Result<()> {
     let parent = path.parent().ok_or_else(|| {
         Error::internal_io(
             format!("Invalid path: {}", path.display()),
@@ -147,9 +156,13 @@ pub fn write_file_atomic(path: &Path, content: &str, operation: &str) -> Result<
 
     let tmp_path = unique_temp_path(parent, filename.to_string_lossy().as_ref());
 
-    fs::write(&tmp_path, content).map_err(|e| {
-        Error::internal_io(e.to_string(), Some(format!("{} (write temp)", operation)))
-    })?;
+    if owner_only {
+        write_file_owner_only(&tmp_path, content, &format!("{} (write temp)", operation))?;
+    } else {
+        fs::write(&tmp_path, content).map_err(|e| {
+            Error::internal_io(e.to_string(), Some(format!("{} (write temp)", operation)))
+        })?;
+    }
 
     fs::rename(&tmp_path, path)
         .map_err(|e| Error::internal_io(e.to_string(), Some(format!("{} (rename)", operation))))?;
@@ -159,6 +172,19 @@ pub fn write_file_atomic(path: &Path, content: &str, operation: &str) -> Result<
 
 /// Create parent directories and atomically persist pretty-printed JSON.
 pub(crate) fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    write_json_file_with_owner_only(path, value, false)
+}
+
+/// Create parent directories and atomically persist owner-only JSON on Unix.
+pub(crate) fn write_json_file_owner_only<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    write_json_file_with_owner_only(path, value, true)
+}
+
+fn write_json_file_with_owner_only<T: Serialize>(
+    path: &Path,
+    value: &T,
+    owner_only: bool,
+) -> Result<()> {
     let parent = path.parent().ok_or_else(|| {
         Error::internal_unexpected(format!("path has no parent: {}", path.display()))
     })?;
@@ -168,7 +194,35 @@ pub(crate) fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<()
     let json = serde_json::to_string_pretty(value).map_err(|error| {
         Error::internal_json(error.to_string(), Some(path.display().to_string()))
     })?;
-    write_file_atomic(path, &format!("{json}\n"), &path.display().to_string())
+    write_file_atomic_with_owner_only(
+        path,
+        &format!("{json}\n"),
+        &path.display().to_string(),
+        owner_only,
+    )
+}
+
+/// Create a file owner-only on Unix before writing its contents.
+pub(crate) fn write_file_owner_only(path: &Path, content: &str, operation: &str) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(path)
+            .map_err(|error| Error::internal_io(error.to_string(), Some(operation.to_string())))?;
+        file.write_all(content.as_bytes())
+            .map_err(|error| Error::internal_io(error.to_string(), Some(operation.to_string())))
+    }
+
+    #[cfg(not(unix))]
+    {
+        write_file(path, content, operation)
+    }
 }
 
 fn unique_temp_path(parent: &Path, filename: &str) -> PathBuf {

--- a/src/core/lifecycle_store.rs
+++ b/src/core/lifecycle_store.rs
@@ -11,7 +11,9 @@ use super::{
     AgentTaskRunState,
 };
 use crate::core::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
-use crate::core::engine::local_files::write_json_file as write_json;
+use crate::core::engine::local_files::{
+    write_json_file as write_json, write_json_file_owner_only as write_private_json,
+};
 use crate::core::observation::{ObservationStore, RunListFilter, RunRecord, RunStatus};
 use crate::core::{paths, Error, ErrorCode, Result};
 
@@ -22,7 +24,7 @@ static INTERRUPT_AFTER_TERMINAL_COMMIT: AtomicBool = AtomicBool::new(false);
 
 pub(super) fn write_plan(run_id: &str, plan: &AgentTaskPlan) -> Result<PathBuf> {
     let path = run_dir(run_id)?.join("plan.json");
-    write_json(&path, plan)?;
+    write_private_json(&path, plan)?;
     Ok(path)
 }
 

--- a/src/core/redaction.rs
+++ b/src/core/redaction.rs
@@ -271,6 +271,7 @@ fn sensitive_whole_value_flag(flag: &str) -> bool {
             | "access_token"
             | "refresh_token"
             | "api_key"
+            | "attempt_plan"
             | "password"
             | "token"
     )
@@ -447,6 +448,9 @@ mod tests {
             "--secret-env=ANTHROPIC_API_KEY=sk-ant".to_string(),
             "--provider-auth-token".to_string(),
             "provider-token".to_string(),
+            "--attempt-plan".to_string(),
+            r#"{"plan_id":"private-plan"}"#.to_string(),
+            "--attempt-plan=@/private/attempt-plan.json".to_string(),
             "--url=https://example.test/?token=query-token&ok=1".to_string(),
         ];
 
@@ -469,6 +473,9 @@ mod tests {
                 "--secret-env=[REDACTED]".to_string(),
                 "--provider-auth-token".to_string(),
                 "[REDACTED]".to_string(),
+                "--attempt-plan".to_string(),
+                "[REDACTED]".to_string(),
+                "--attempt-plan=[REDACTED]".to_string(),
                 "--url=https://example.test/?token=[REDACTED]&ok=1".to_string(),
             ]
         );

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -30,6 +30,7 @@ use crate::core::api_jobs::JobEvent;
 #[cfg(test)]
 use crate::core::api_jobs::JobEventKind;
 use crate::core::artifact_manifest::ArtifactManifest;
+use crate::core::engine::local_files::write_file_owner_only;
 use crate::core::notification_route::NotificationRoute;
 use crate::core::runner::agent_task_lifecycle_event::{
     agent_task_run_plan_lifecycle_event_from_job_events, is_agent_task_run_plan_envelope,
@@ -85,12 +86,16 @@ pub(super) fn sync_inline_agent_task_file(
         )
     })?;
     let plan_file = temp.path().join(spec.filename);
-    fs::write(&plan_file, spec.spec).map_err(|err| {
-        Error::internal_io(
-            err.to_string(),
-            Some("write remapped agent-task plan".to_string()),
-        )
-    })?;
+    if spec.role == "agent_task_attempt_plan_remapped" {
+        write_private_remapped_agent_task_plan(&plan_file, spec.spec)?;
+    } else {
+        fs::write(&plan_file, spec.spec).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some("write remapped agent-task plan".to_string()),
+            )
+        })?;
+    }
     let synced = sync_workspace(
         runner_id,
         RunnerWorkspaceSyncOptions {
@@ -112,6 +117,10 @@ pub(super) fn sync_inline_agent_task_file(
     );
     let entry = workspace_mapping_entry(spec.role, &synced);
     Ok(Some((remote_spec, entry)))
+}
+
+fn write_private_remapped_agent_task_plan(path: &std::path::Path, contents: &str) -> Result<()> {
+    write_file_owner_only(path, contents, "write remapped agent-task plan")
 }
 
 pub(super) fn mirror_agent_task_run_plan_lifecycle(
@@ -1586,6 +1595,27 @@ mod tests {
         );
         assert!(!rewritten.join(" ").contains(prompt));
         assert_eq!(entry.expect("mapping entry").remote_path(), "/remote/input");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remapped_agent_task_plan_is_owner_only_before_snapshot_sync() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let plan_file = temp.path().join("agent-task-attempt-plan.json");
+
+        write_private_remapped_agent_task_plan(&plan_file, r#"{"plan_id":"private"}"#)
+            .expect("write private plan");
+
+        assert_eq!(
+            std::fs::metadata(&plan_file)
+                .expect("plan metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `homeboy-8123-plan-file-hardening` into review-ready branch `harden/agent-task-plan-files`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:homeboy-8123-plan-file-hardening`
- **Homeboy run ID:** `homeboy-8123-plan-file-hardening`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `harden/agent-task-plan-files`

## Source refs
- https://github.com/Extra-Chill/homeboy/issues/8123

## Attempt summary
green deterministic gates completed

## Gate results
- format: passed (targeted)
- compile: passed (targeted)
- permissions: passed (targeted)
- redaction: passed (targeted)
- handoff-regression: passed (targeted)

## Verification capability
- `targeted_checks_run`: `cargo fmt --check`, `cargo check --all-targets`, `cargo test --lib redacts_sensitive_argv_split_and_equals_forms`, `cargo test --lib submit_plan_persists_owner_only_plan_file_before_observation`, `cargo test --lib remapped_agent_task_plan_is_owner_only_before_snapshot_sync`, `cargo test --lib materialize_agent_task_specs_syncs_controller_attempt_plan_before_cook_handoff`, `cargo test --lib missing_lab_attempt_plan_is_recovered_before_handoff_or_terminalized`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- src/core/agent_task_lifecycle/tests.rs
- src/core/engine/local_files.rs
- src/core/lifecycle_store.rs
- src/core/redaction.rs
- src/core/runner/lab/agent_task_bridge.rs

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `harden/agent-task-plan-files`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode orchestrated by Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Extracted unique security hardening from superseded #8107, implemented atomic owner-only plan creation and argv redaction, and verified #8102 behavior with Chris.
