### PR TITLE
Preserve patch size metadata for local agent artifacts

### DIFF
--- a/src/core/agent_task_aggregate.rs
+++ b/src/core/agent_task_aggregate.rs
@@ -69,6 +69,7 @@ pub struct AgentTaskReconciliationItem {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentTaskReconciliationDecision {
+    NoOp,
     ApplyCandidate,
     IssueReportCandidate,
     RetryCandidate,
@@ -151,6 +152,7 @@ fn aggregate_agent_task_outcomes(outcomes: &[AgentTaskOutcome]) -> AgentTaskAggr
         };
 
         match decision {
+            AgentTaskReconciliationDecision::NoOp => {}
             AgentTaskReconciliationDecision::ApplyCandidate => {
                 report.summary.apply_candidates += 1;
                 report.apply_candidates.push(decision_ref);
@@ -275,6 +277,7 @@ impl AgentTaskOutcomeStatus {
 impl AgentTaskReconciliationDecision {
     pub fn as_str(self) -> &'static str {
         match self {
+            Self::NoOp => "no_op",
             Self::ApplyCandidate => "apply_candidate",
             Self::IssueReportCandidate => "issue_report_candidate",
             Self::RetryCandidate => "retry_candidate",
@@ -299,6 +302,13 @@ fn count_status(summary: &mut AgentTaskAggregateSummary, status: AgentTaskOutcom
 fn reconcile_outcome(
     outcome: &AgentTaskOutcome,
 ) -> (AgentTaskReconciliationDecision, String, Vec<String>) {
+    if outcome.status == AgentTaskOutcomeStatus::NoOp && has_known_empty_change_set(outcome) {
+        return (
+            AgentTaskReconciliationDecision::NoOp,
+            "known empty change artifact; provider produced no file changes".to_string(),
+            Vec::new(),
+        );
+    }
     let rejected_artifact_ids = outcome
         .artifacts
         .iter()
@@ -380,6 +390,18 @@ fn reconcile_outcome(
         },
         artifact_ids(outcome),
     )
+}
+
+fn has_known_empty_change_set(outcome: &AgentTaskOutcome) -> bool {
+    let patch_artifacts = outcome
+        .artifacts
+        .iter()
+        .filter(|artifact| is_apply_kind_artifact(artifact))
+        .collect::<Vec<_>>();
+    !patch_artifacts.is_empty()
+        && patch_artifacts
+            .iter()
+            .all(|artifact| artifact.size_bytes == Some(0))
 }
 
 fn artifact_ids(outcome: &AgentTaskOutcome) -> Vec<String> {
@@ -594,17 +616,22 @@ mod tests {
 
         let report = aggregate_agent_task_outcomes(&[outcome(
             "empty-patch",
-            AgentTaskOutcomeStatus::Succeeded,
+            AgentTaskOutcomeStatus::NoOp,
             vec![empty_patch],
         )]);
 
         assert!(report.apply_candidates.is_empty());
         assert_eq!(report.summary.apply_candidates, 0);
-        assert_eq!(report.summary.review_candidates, 1);
-        assert_eq!(report.review_candidates[0].task_id, "empty-patch");
+        assert!(report.review_candidates.is_empty());
+        assert_eq!(report.summary.review_candidates, 0);
+        assert_eq!(report.summary.no_op, 1);
         assert_eq!(
-            report.review_candidates[0].reason,
-            "patch artifact was empty (0 bytes); provider produced no file changes"
+            report.tasks[0].decision,
+            AgentTaskReconciliationDecision::NoOp
+        );
+        assert_eq!(
+            report.tasks[0].reason,
+            "known empty change artifact; provider produced no file changes"
         );
     }
 

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -87,7 +87,8 @@ use command_runner::{
 use fixtures::fixture_artifact;
 #[cfg(test)]
 use outcome_normalization::{
-    normalize_provider_outcome_roles, surface_provider_run_result_diagnostics,
+    normalize_homeboy_local_artifact_sizes, normalize_provider_outcome_roles,
+    surface_provider_run_result_diagnostics,
 };
 #[cfg(test)]
 use resolution::{

--- a/src/core/agent_task_provider/command_runner.rs
+++ b/src/core/agent_task_provider/command_runner.rs
@@ -1,4 +1,7 @@
-use super::outcome_normalization::{normalize_provider_outcome_roles, push_unique_diagnostic};
+use super::outcome_normalization::{
+    normalize_homeboy_local_artifact_sizes, normalize_provider_outcome_roles,
+    push_unique_diagnostic,
+};
 use super::runner_readiness::{
     executable_file, provider_executable_env, resolve_executable_candidate,
 };
@@ -480,6 +483,11 @@ pub(super) fn run_materialized_provider_command_once(
                 outcome.schema = AGENT_TASK_OUTCOME_SCHEMA.to_string();
             }
             normalize_provider_outcome_roles(&mut outcome, provider);
+            normalize_homeboy_local_artifact_sizes(
+                &mut outcome,
+                &request.artifacts_path,
+                &request.artifacts_path_provenance,
+            );
             surface_provider_process_failure(
                 &mut outcome,
                 request,

--- a/src/core/agent_task_provider/outcome_normalization.rs
+++ b/src/core/agent_task_provider/outcome_normalization.rs
@@ -13,6 +13,86 @@ pub(super) fn normalize_provider_outcome_roles(
     }
 }
 
+/// Records the actual size of regular files that Homeboy materialized for this
+/// executor. Provider-supplied paths are otherwise treated as untrusted.
+pub(super) fn normalize_homeboy_local_artifact_sizes(
+    outcome: &mut AgentTaskOutcome,
+    artifact_root: &std::path::Path,
+    provenance: &AgentTaskArtifactsPathProvenance,
+) {
+    if provenance.owner != "homeboy" || provenance.locality != "runner" {
+        return;
+    }
+
+    let Ok(artifact_root) = artifact_root.canonicalize() else {
+        return;
+    };
+
+    for artifact in &mut outcome.artifacts {
+        measure_homeboy_local_artifact(artifact, &artifact_root);
+    }
+    for typed_artifact in &mut outcome.typed_artifacts {
+        if let Some(artifact) = &mut typed_artifact.artifact {
+            measure_homeboy_local_artifact(artifact, &artifact_root);
+            if let Some(size_bytes) = artifact.size_bytes {
+                if let Some(payload) = typed_artifact.payload.as_object_mut() {
+                    payload.insert("size_bytes".to_string(), Value::from(size_bytes));
+                }
+            }
+        }
+    }
+
+    if outcome.status == AgentTaskOutcomeStatus::Succeeded && has_known_empty_change_set(outcome) {
+        outcome.status = AgentTaskOutcomeStatus::NoOp;
+        outcome.summary = Some("provider produced an empty change artifact".to_string());
+    }
+}
+
+fn measure_homeboy_local_artifact(
+    artifact: &mut AgentTaskArtifact,
+    artifact_root: &std::path::Path,
+) {
+    let Some(path) = artifact.path.as_deref() else {
+        return;
+    };
+    let path = std::path::Path::new(path);
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        artifact_root.join(path)
+    };
+    let Ok(path) = path.canonicalize() else {
+        return;
+    };
+    if !path.starts_with(artifact_root) {
+        return;
+    }
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return;
+    };
+    if metadata.is_file() {
+        artifact.size_bytes = Some(metadata.len());
+    }
+}
+
+fn has_known_empty_change_set(outcome: &AgentTaskOutcome) -> bool {
+    let changes = outcome
+        .artifacts
+        .iter()
+        .filter(|artifact| {
+            matches!(
+                artifact.kind.as_str(),
+                "patch" | "diff" | "change_artifact" | "workspace_patch" | "artifact"
+            )
+        })
+        .collect::<Vec<_>>();
+
+    !changes.is_empty()
+        && changes
+            .iter()
+            .all(|artifact| artifact.size_bytes == Some(0))
+}
+
 fn normalize_provider_result_contract(
     outcome: &mut AgentTaskOutcome,
     provider: &AgentTaskExecutorProvider,

--- a/src/core/agent_task_provider/tests/outcome_tests.rs
+++ b/src/core/agent_task_provider/tests/outcome_tests.rs
@@ -238,6 +238,78 @@ fn provider_outcome_roles_normalize_from_declared_aliases() {
 }
 
 #[test]
+fn homeboy_local_artifact_normalization_measures_empty_nonempty_and_unavailable_files() {
+    let root = tempfile::tempdir().expect("artifact root");
+    let empty_path = root.path().join("empty.patch");
+    let nonempty_path = root.path().join("nonempty.patch");
+    fs::write(&empty_path, "").expect("empty patch");
+    fs::write(&nonempty_path, "diff --git a/a b/a\n").expect("nonempty patch");
+    let provenance = AgentTaskArtifactsPathProvenance {
+        owner: "homeboy".to_string(),
+        locality: "runner".to_string(),
+        plan_id: "plan".to_string(),
+        run_id: None,
+        task_id: "opencode-no-op".to_string(),
+        attempt: 1,
+    };
+    let mut empty = fixture_artifact("empty", "patch", &empty_path, Some("text/x-patch"));
+    empty.size_bytes = None;
+    let mut nonempty = fixture_artifact("nonempty", "patch", &nonempty_path, Some("text/x-patch"));
+    nonempty.size_bytes = None;
+    let mut unavailable = fixture_artifact(
+        "foreign",
+        "patch",
+        &std::env::temp_dir().join("homeboy-unavailable.patch"),
+        Some("text/x-patch"),
+    );
+    unavailable.size_bytes = None;
+
+    let mut empty_outcome = failed_outcome_with_run_result(Value::Null);
+    empty_outcome.status = AgentTaskOutcomeStatus::Succeeded;
+    empty_outcome.failure_classification = None;
+    empty_outcome.artifacts = vec![empty.clone()];
+    empty_outcome.typed_artifacts = vec![AgentTaskTypedArtifact {
+        name: "patch".to_string(),
+        artifact_type: Some("patch".to_string()),
+        artifact_schema: None,
+        payload: json!({ "path": empty_path, "size_bytes": null }),
+        artifact: Some(empty),
+        metadata: Value::Null,
+    }];
+    normalize_homeboy_local_artifact_sizes(&mut empty_outcome, root.path(), &provenance);
+
+    assert_eq!(empty_outcome.status, AgentTaskOutcomeStatus::NoOp);
+    assert_eq!(empty_outcome.artifacts[0].size_bytes, Some(0));
+    assert_eq!(
+        empty_outcome.typed_artifacts[0]
+            .artifact
+            .as_ref()
+            .and_then(|artifact| artifact.size_bytes),
+        Some(0)
+    );
+    assert_eq!(empty_outcome.typed_artifacts[0].payload["size_bytes"], 0);
+
+    let mut nonempty_outcome = failed_outcome_with_run_result(Value::Null);
+    nonempty_outcome.status = AgentTaskOutcomeStatus::Succeeded;
+    nonempty_outcome.failure_classification = None;
+    nonempty_outcome.artifacts = vec![nonempty];
+    normalize_homeboy_local_artifact_sizes(&mut nonempty_outcome, root.path(), &provenance);
+    assert_eq!(nonempty_outcome.status, AgentTaskOutcomeStatus::Succeeded);
+    assert!(nonempty_outcome.artifacts[0].size_bytes.unwrap_or_default() > 0);
+
+    let mut unavailable_outcome = failed_outcome_with_run_result(Value::Null);
+    unavailable_outcome.status = AgentTaskOutcomeStatus::Succeeded;
+    unavailable_outcome.failure_classification = None;
+    unavailable_outcome.artifacts = vec![unavailable];
+    normalize_homeboy_local_artifact_sizes(&mut unavailable_outcome, root.path(), &provenance);
+    assert_eq!(
+        unavailable_outcome.status,
+        AgentTaskOutcomeStatus::Succeeded
+    );
+    assert_eq!(unavailable_outcome.artifacts[0].size_bytes, None);
+}
+
+#[test]
 fn declared_sandbox_result_contract_rejects_private_runtime_result_shape() {
     let (_, mut provider) = request("task-sandbox-private", "node provider.js".to_string());
     provider.backend = "runtime-provider".to_string();


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `recovery-homeboy-8118-empty-patch-size` into review-ready branch `fix/8118-opencode-empty-patch-size`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:recovery-homeboy-8118-empty-patch-size`
- **Homeboy run ID:** `recovery-homeboy-8118-empty-patch-size`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `fix/8118-opencode-empty-patch-size`

## Source refs
- https://github.com/Extra-Chill/homeboy/issues/8118

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** runtime-fix
- **Supersedes:** none recorded
- **Depends on:** none recorded

## Runtime guardrails
- **Why this is not broader than the packet evidence:** Only canonical regular files under the Homeboy-owned artifact root are measured; foreign, inaccessible, directory, and escaping paths remain unknown.
- **Evidence discriminators preserved:** canonical Homeboy artifact root ownership
- **Nearby contracts preserved:** unknown foreign artifact paths remain review-only

## Attempt summary
Homeboy-owned local artifact files are measured before aggregation; zero-byte patches become no-op while inaccessible artifacts remain conservatively unknown.

## Gate results
- artifact-normalization: passed (targeted)
- agent-task-aggregate: passed (targeted)
- agent-task-provider: passed (targeted)
- format: passed (targeted)
- diff-check: passed (targeted)

## Verification capability
- `targeted_checks_run`: `cargo test --lib homeboy_local_artifact_normalization_measures_empty_nonempty_and_unavailable_files`, `cargo test --lib core::agent_task_aggregate::tests -- --test-threads=1`, `cargo test --lib core::agent_task_provider::tests -- --test-threads=1`, `cargo fmt --check`, `git diff --check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- src/core/agent_task_aggregate.rs
- src/core/agent_task_provider.rs
- src/core/agent_task_provider/command_runner.rs
- src/core/agent_task_provider/outcome_normalization.rs
- src/core/agent_task_provider/tests/outcome_tests.rs

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `fix/8118-opencode-empty-patch-size`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Reproduced the artifact metadata regression, implemented the generic normalization boundary and tests, and verified the candidate with Chris.
