### PR TITLE
Recover linked agent-task results after daemon loss

### DIFF
--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -24,6 +24,7 @@ mod tests {
     use serde_json::json;
 
     use super::persistence::recovered_terminal_from_result;
+    use super::store::RecoveredTerminalJob;
     use super::*;
     use crate::core::secret_env_plan::SecretEnvPlan;
     use crate::core::source_snapshot::SourceSnapshot;
@@ -652,6 +653,97 @@ mod tests {
         assert!(diagnostics.protected_job_ids.is_empty());
         assert_eq!(diagnostics.terminalized_count(), 1);
         assert_eq!(store.get(job.id).expect("job").status, JobStatus::Failed);
+    }
+
+    #[test]
+    fn dead_child_recovers_linked_terminal_result_and_artifacts() {
+        let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start job");
+        store
+            .append_event(
+                job.id,
+                JobEventKind::Progress,
+                None,
+                Some(json!({ "process": { "root_pid": 4242 } })),
+            )
+            .expect("heartbeat");
+        store
+            .reconcile_dead_daemon_lease_jobs_with_child_liveness_and_terminal_result(
+                "lease-dead",
+                |_| false,
+                |_| {
+                    Some(RecoveredTerminalJob::test_result(
+                        JobStatus::Succeeded,
+                        "run-success",
+                        json!({ "aggregate": { "status": "succeeded" } }),
+                        vec![JobArtifactMetadata {
+                            id: "artifact-1".to_string(),
+                            name: None,
+                            path: None,
+                            url: Some("artifact://1".to_string()),
+                            mime: None,
+                            size_bytes: None,
+                            sha256: None,
+                            content_base64: None,
+                            metadata: None,
+                        }],
+                    ))
+                },
+            )
+            .expect("reconcile");
+        let recovered = store.get(job.id).expect("job");
+        assert_eq!(recovered.status, JobStatus::Succeeded);
+        assert_eq!(recovered.artifacts[0].id, "artifact-1");
+        assert!(store
+            .events(job.id)
+            .expect("events")
+            .iter()
+            .any(|event| event
+                .data
+                .as_ref()
+                .is_some_and(
+                    |data| data["child_terminal_result"]["aggregate"]["status"] == "succeeded"
+                )));
+    }
+
+    #[test]
+    fn dead_child_recovers_linked_terminal_failure_and_live_child_skips_resolver() {
+        let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start job");
+        store
+            .append_event(
+                job.id,
+                JobEventKind::Progress,
+                None,
+                Some(json!({ "process": { "root_pid": 4242 } })),
+            )
+            .expect("heartbeat");
+        store
+            .reconcile_dead_daemon_lease_jobs_with_child_liveness_and_terminal_result(
+                "lease-dead",
+                |_| true,
+                |_| panic!("live child must win"),
+            )
+            .expect("live child deferred");
+        assert_eq!(store.get(job.id).expect("job").status, JobStatus::Running);
+        store
+            .reconcile_dead_daemon_lease_jobs_with_child_liveness_and_terminal_result(
+                "lease-dead",
+                |_| false,
+                |_| {
+                    Some(RecoveredTerminalJob::test_result(
+                        JobStatus::Failed,
+                        "run-failure",
+                        json!({ "provider": "failed" }),
+                        Vec::new(),
+                    ))
+                },
+            )
+            .expect("reconcile failure");
+        assert_eq!(store.get(job.id).expect("job").status, JobStatus::Failed);
+        assert!(store.get(job.id).expect("job").stale_reason.is_none());
     }
 
     #[test]

--- a/src/core/api_jobs/persistence.rs
+++ b/src/core/api_jobs/persistence.rs
@@ -218,6 +218,13 @@ pub(super) fn stale_after_restart_classification(stored: &StoredJob) -> Value {
         .iter()
         .map(|artifact| artifact.id.clone())
         .collect::<Vec<_>>();
+    let linked_agent_task_run_id = stored
+        .remote_runner
+        .as_ref()
+        .and_then(|remote_runner| remote_runner.request.runner_workload.as_ref())
+        .and_then(|workload| workload.agent_task.as_ref())
+        .map(|agent_task| agent_task.run_id.trim())
+        .filter(|run_id| !run_id.is_empty());
 
     serde_json::json!({
         "kind": "orphaned_after_control_plane_loss",
@@ -235,6 +242,11 @@ pub(super) fn stale_after_restart_classification(stored: &StoredJob) -> Value {
             "terminal_result_recorded": false,
             "last_known_event": last_child_event.map(last_known_child_event),
             "output_observed": last_child_event.is_some(),
+            "linked_durable_run": linked_agent_task_run_id.map(|run_id| serde_json::json!({
+                "kind": "agent_task",
+                "run_id": run_id,
+                "terminal_result_observed": false,
+            })),
         },
         "remote_runner": stored.remote_runner.as_ref().map(|remote_runner| serde_json::json!({
             "runner_id": remote_runner.request.runner_id.clone(),

--- a/src/core/api_jobs/store.rs
+++ b/src/core/api_jobs/store.rs
@@ -17,10 +17,13 @@ use super::persistence::{
 #[cfg(test)]
 use super::persistence::{read_durable_store, reconcile_stale_jobs};
 use super::remote_runner;
+use super::remote_runner::JobArtifactMetadata;
 use super::types::{
     DaemonLeaseJobDiagnostics, Job, JobEvent, JobEventKind, JobStatus, LeaselessOrphanAffectedJob,
     LeaselessOrphanJobDiagnostics,
 };
+use crate::core::agent_task_scheduler::AgentTaskAggregateStatus;
+use crate::core::agent_task_service;
 use crate::core::error::{Error, Result};
 use crate::core::process::pid_is_running;
 use crate::core::runner_execution_envelope::PathMaterializationPlan;
@@ -329,6 +332,19 @@ impl JobStore {
         expected_lease_id: &str,
         pid_is_alive: impl Fn(u32) -> bool,
     ) -> Result<DaemonLeaseJobDiagnostics> {
+        self.reconcile_dead_daemon_lease_jobs_with_child_liveness_and_terminal_result(
+            expected_lease_id,
+            pid_is_alive,
+            recovered_terminal_agent_task_result,
+        )
+    }
+
+    pub(super) fn reconcile_dead_daemon_lease_jobs_with_child_liveness_and_terminal_result(
+        &self,
+        expected_lease_id: &str,
+        pid_is_alive: impl Fn(u32) -> bool,
+        terminal_child_result: impl Fn(&StoredJob) -> Option<RecoveredTerminalJob>,
+    ) -> Result<DaemonLeaseJobDiagnostics> {
         let diagnostics = self.daemon_lease_job_diagnostics(expected_lease_id);
         if diagnostics.unowned_count() > 0 {
             return Err(Error::validation_invalid_argument(
@@ -351,11 +367,13 @@ impl JobStore {
             let stored = inner.jobs.get(job_id).expect("diagnosed job exists");
             let disposition =
                 if let Some((status, exit_code)) = recovered_terminal_from_result(&stored.events) {
-                    DeadLeaseJobDisposition::RecoveredTerminal(status, exit_code)
+                    DeadLeaseJobDisposition::RecoveredOuterResult(status, exit_code)
                 } else if let Some(pid) = last_progress_child_pid(&stored.events) {
                     if pid_is_alive(pid) {
                         diagnostics.protected_job_ids.push(*job_id);
                         DeadLeaseJobDisposition::ProtectedLive
+                    } else if let Some(recovered) = terminal_child_result(stored) {
+                        DeadLeaseJobDisposition::RecoveredLinkedRun(recovered)
                     } else {
                         DeadLeaseJobDisposition::TerminalizeDead
                     }
@@ -380,7 +398,7 @@ impl JobStore {
         let now = timestamp_ms();
         for (job_id, disposition) in dispositions {
             let stored = inner.jobs.get_mut(&job_id).expect("diagnosed job exists");
-            if let DeadLeaseJobDisposition::RecoveredTerminal(status, exit_code) = disposition {
+            if let DeadLeaseJobDisposition::RecoveredOuterResult(status, exit_code) = disposition {
                 stored.job.status = status;
                 stored.job.updated_at_ms = now;
                 stored.job.finished_at_ms = Some(now);
@@ -406,7 +424,43 @@ impl JobStore {
                 stored.job.event_count = stored.events.len();
                 continue;
             }
-            if disposition == DeadLeaseJobDisposition::ProtectedLive {
+            if let DeadLeaseJobDisposition::RecoveredLinkedRun(recovered) = disposition {
+                stored.job.status = recovered.status;
+                stored.job.updated_at_ms = now;
+                stored.job.finished_at_ms = Some(now);
+                stored.job.stale_reason = None;
+                for artifact in recovered.artifacts {
+                    if !stored
+                        .job
+                        .artifacts
+                        .iter()
+                        .any(|existing| existing.id == artifact.id)
+                    {
+                        stored.job.artifacts.push(artifact);
+                    }
+                }
+                let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+                stored.events.push(JobEvent {
+                    sequence,
+                    job_id,
+                    kind: JobEventKind::Status,
+                    timestamp_ms: now,
+                    message: Some(format!(
+                        "job terminal status recovered from linked durable run `{}` after dead daemon lease",
+                        recovered.run_id
+                    )),
+                    data: Some(serde_json::json!({
+                        "status": recovered.status,
+                        "reason": "recovered_after_dead_daemon_lease",
+                        "daemon_lease_id": expected_lease_id,
+                        "child_terminal_result": recovered.terminal_result,
+                    })),
+                });
+                apply_event_retention(&mut stored.events, self.event_retention_limit());
+                stored.job.event_count = stored.events.len();
+                continue;
+            }
+            if matches!(disposition, DeadLeaseJobDisposition::ProtectedLive) {
                 continue;
             }
             let reason = "daemon lease owner process was not running".to_string();
@@ -819,11 +873,94 @@ impl JobStore {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
 enum DeadLeaseJobDisposition {
-    RecoveredTerminal(JobStatus, i64),
+    RecoveredOuterResult(JobStatus, i64),
+    RecoveredLinkedRun(RecoveredTerminalJob),
     ProtectedLive,
     TerminalizeDead,
+}
+
+pub(super) struct RecoveredTerminalJob {
+    status: JobStatus,
+    terminal_result: Value,
+    run_id: String,
+    artifacts: Vec<JobArtifactMetadata>,
+}
+
+#[cfg(test)]
+impl RecoveredTerminalJob {
+    pub(super) fn test_result(
+        status: JobStatus,
+        run_id: &str,
+        terminal_result: Value,
+        artifacts: Vec<JobArtifactMetadata>,
+    ) -> Self {
+        Self {
+            status,
+            terminal_result,
+            run_id: run_id.to_string(),
+            artifacts,
+        }
+    }
+}
+
+/// A remote runner workload records its agent-task run ID in a typed execution
+/// envelope. That durable run is authoritative after the runner child exits.
+fn recovered_terminal_agent_task_result(stored: &StoredJob) -> Option<RecoveredTerminalJob> {
+    let run_id = stored
+        .remote_runner
+        .as_ref()?
+        .request
+        .runner_workload
+        .as_ref()?
+        .agent_task
+        .as_ref()?
+        .run_id
+        .trim()
+        .to_string();
+    if run_id.is_empty() {
+        return None;
+    }
+
+    let result = agent_task_service::terminal_run_result(&run_id).ok()??;
+    let status = match result.value.status {
+        AgentTaskAggregateStatus::Succeeded => JobStatus::Succeeded,
+        AgentTaskAggregateStatus::Cancelled => JobStatus::Cancelled,
+        AgentTaskAggregateStatus::PartialFailure | AgentTaskAggregateStatus::Failed => {
+            JobStatus::Failed
+        }
+    };
+    let artifacts = result
+        .value
+        .artifact_bindings
+        .iter()
+        .map(|binding| JobArtifactMetadata {
+            id: binding.artifact_id.clone(),
+            name: binding.name.clone(),
+            path: binding.path.clone(),
+            url: binding.url.clone(),
+            mime: None,
+            size_bytes: None,
+            sha256: binding.sha256.clone(),
+            content_base64: None,
+            metadata: Some(serde_json::json!({
+                "kind": binding.kind,
+                "task_id": binding.task_id,
+                "durable_run_id": run_id,
+            })),
+        })
+        .collect();
+    Some(RecoveredTerminalJob {
+        status,
+        terminal_result: serde_json::json!({
+            "kind": "agent_task_aggregate",
+            "run_id": &run_id,
+            "exit_code": result.exit_code,
+            "aggregate": result.value,
+        }),
+        run_id,
+        artifacts,
+    })
 }
 
 /// The reverse runner records the executing child in periodic progress


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `recovery-homeboy-8119-linked-terminal-run` into review-ready branch `fix/8119-reconcile-completed-child-result`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:recovery-homeboy-8119-linked-terminal-run`
- **Homeboy run ID:** `recovery-homeboy-8119-linked-terminal-run`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `fix/8119-reconcile-completed-child-result`

## Source refs
- https://github.com/Extra-Chill/homeboy/issues/8119
- https://github.com/Extra-Chill/homeboy/pull/8120

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** runtime-fix
- **Supersedes:** none recorded
- **Depends on:** none recorded

## Runtime guardrails
- **Why this is not broader than the packet evidence:** Runs only after #8120 finds no outer Result event and the recorded child PID is confirmed dead; resolution uses the typed runner_workload.agent_task.run_id linkage.
- **Evidence discriminators preserved:** typed linked durable agent-task run ID
- **Nearby contracts preserved:** outer terminal Result remains first priority, live child PID remains protected, missing or incomplete linked run fails closed

## Attempt summary
Extends the merged outer-Result recovery from #8120 with a typed linked durable agent-task fallback after the recorded child exits.

## Gate results
- api-jobs: passed (targeted)
- daemon-adoption: passed (targeted)
- format: passed (targeted)
- diff-check: passed (targeted)

## Verification capability
- `targeted_checks_run`: `cargo test core::api_jobs --lib -- --test-threads=1`, `cargo test dead_matching_lease_reconciles_jobs_before_starting_replacement --lib -- --test-threads=1`, `cargo fmt --check`, `git diff --check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- src/core/api_jobs/mod.rs
- src/core/api_jobs/persistence.rs
- src/core/api_jobs/store.rs

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `fix/8119-reconcile-completed-child-result`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Recovered two dead Lab leases, identified the linked durable-result seam beyond #8120, implemented the typed fallback and deterministic tests, and verified the candidate with Chris.
