### PR TITLE
test: make extension script tests noexec-tmp portable and race-free (#6760)

### DIFF
--- a/src/core/extension/compiler_warning_contract.rs
+++ b/src/core/extension/compiler_warning_contract.rs
@@ -152,7 +152,9 @@ mod tests {
 
     #[test]
     fn test_run_compiler_warning_contract_script_returns_stdout() {
-        let dir = TempDir::new().expect("temp dir");
+        // Exec-capable tempdir: the test runs `warnings.sh`, which fails with
+        // exit 126 under a `noexec` $TMPDIR otherwise (#6760).
+        let dir = crate::test_support::exec_capable_tempdir();
         let script_path = dir.path().join("warnings.sh");
         write_executable(
             &script_path,

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -944,7 +944,7 @@ mod tests {
 
     #[test]
     fn build_capability_env_includes_extension_provider_output() {
-        let extension = tempfile::tempdir().expect("extension dir");
+        let extension = crate::test_support::exec_capable_tempdir();
         let component = tempfile::tempdir().expect("component dir");
         let extension_id = extension.path().file_name().unwrap().to_string_lossy();
         std::fs::write(
@@ -995,7 +995,7 @@ mod tests {
         // manual operator injection — even when the env provider does not
         // re-resolve the value in the fresh capability process.
         crate::test_support::with_isolated_home(|_| {
-            let extension = tempfile::tempdir().expect("extension dir");
+            let extension = crate::test_support::exec_capable_tempdir();
             let component = tempfile::tempdir().expect("component dir");
             let extension_id = extension.path().file_name().unwrap().to_string_lossy();
             // No env provider script: the only source of the runtime env is the
@@ -1040,7 +1040,7 @@ mod tests {
         // value and a live provider value exist for the same key, the live
         // value must win so a rebuilt runner checkout is honored.
         crate::test_support::with_isolated_home(|_| {
-            let extension = tempfile::tempdir().expect("extension dir");
+            let extension = crate::test_support::exec_capable_tempdir();
             let component = tempfile::tempdir().expect("component dir");
             let extension_id = extension.path().file_name().unwrap().to_string_lossy();
             std::fs::write(

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -965,7 +965,7 @@ mod tests {
     use super::*;
     use crate::core::component::ComponentScriptsConfig;
     use crate::core::extension::test::TestFailure;
-    use crate::test_support::with_isolated_home;
+    use crate::test_support::{exec_capable_tempdir, with_isolated_home};
 
     fn run_git(dir: &Path, args: &[&str]) -> String {
         let output = std::process::Command::new("git")
@@ -1167,7 +1167,10 @@ mod tests {
     #[test]
     fn declared_result_parser_script_normalizes_provider_json() {
         with_isolated_home(|_| {
-            let temp_dir = tempfile::tempdir().expect("temp dir");
+            // Use an exec-capable tempdir: these tests write a parser script
+            // and execute it, so a `noexec` $TMPDIR (e.g. hardened `/tmp`)
+            // would fail with exit 126 regardless of the behavior under test.
+            let temp_dir = exec_capable_tempdir();
             let extension_dir = temp_dir.path().join("extension");
             std::fs::create_dir_all(&extension_dir).expect("extension dir");
             let parser_script = extension_dir.join("parse-results.sh");
@@ -1340,7 +1343,10 @@ printf '{"total":%s,"passed":%s,"failed":%s,"skipped":%s}\n' "$total" "$passed" 
         // is globally serialized against env-mutating tests instead of racing
         // them under default parallelism (#6760, #6804).
         with_isolated_home(|_| {
-            let temp_dir = tempfile::tempdir().expect("temp dir");
+            // Use an exec-capable tempdir: these tests write a parser script
+            // and execute it, so a `noexec` $TMPDIR (e.g. hardened `/tmp`)
+            // would fail with exit 126 regardless of the behavior under test.
+            let temp_dir = exec_capable_tempdir();
             let extension_dir = temp_dir.path().join("extension");
             std::fs::create_dir_all(&extension_dir).expect("extension dir");
             let parser_script = extension_dir.join("parse-results.sh");
@@ -1410,7 +1416,10 @@ exit 23
     #[test]
     fn declared_result_parser_accepts_flat_count_stdout_json() {
         with_isolated_home(|_| {
-            let temp_dir = tempfile::tempdir().expect("temp dir");
+            // Use an exec-capable tempdir: these tests write a parser script
+            // and execute it, so a `noexec` $TMPDIR (e.g. hardened `/tmp`)
+            // would fail with exit 126 regardless of the behavior under test.
+            let temp_dir = exec_capable_tempdir();
             let extension_dir = temp_dir.path().join("extension");
             std::fs::create_dir_all(&extension_dir).expect("extension dir");
             let parser_script = extension_dir.join("parse-results.sh");
@@ -1474,7 +1483,10 @@ printf '{"total":5,"passed":3,"failed":1,"skipped":1}\n'
 
     #[test]
     fn declared_result_parser_rejects_malformed_successful_stdout_json() {
-        let temp_dir = tempfile::tempdir().expect("temp dir");
+        // Exec-capable tempdir: this test runs the parser script, so a
+        // `noexec` $TMPDIR would fail with exit 126 before reaching the
+        // malformed-JSON assertion under test.
+        let temp_dir = exec_capable_tempdir();
         let extension_dir = temp_dir.path().join("extension");
         std::fs::create_dir_all(&extension_dir).expect("extension dir");
         let parser_script = extension_dir.join("parse-results.sh");

--- a/src/core/extension/trace/preview.rs
+++ b/src/core/extension/trace/preview.rs
@@ -1108,7 +1108,15 @@ mod tests {
 
     #[test]
     fn starts_homeboy_native_client_and_records_lifecycle_metadata() {
-        let temp = tempfile::tempdir().expect("tempdir");
+        // Serialize against env-mutating tests: building the native client
+        // command derives runtime paths from HOME / HOMEBOY_RUNTIME_TMPDIR, so
+        // a parallel `with_isolated_home` neighbor flipping those mid-run
+        // intermittently corrupts this child's env (#6760). Holding the shared
+        // home guard globally serializes this test against them.
+        let _home = crate::test_support::HomeGuard::new();
+        // Exec-capable tempdir: the fixture client script is executed, so a
+        // `noexec` $TMPDIR would fail before the lifecycle assertions (#6760).
+        let temp = crate::test_support::exec_capable_tempdir();
         let client = temp.path().join("homeboy-preview-client-fixture.sh");
         std::fs::write(
             &client,

--- a/src/core/extension/trace/run/tests/extension.rs
+++ b/src/core/extension/trace/run/tests/extension.rs
@@ -18,7 +18,7 @@ use crate::core::extension::trace::generic_runner::{
 use crate::core::extension::trace::overlay::{apply_trace_overlays, TraceOverlayRequest};
 use crate::core::extension::trace::probes::TraceProbeConfig;
 use crate::core::extension::{ExtensionCapability, ExtensionExecutionContext, RunnerOutput};
-use crate::test_support::with_isolated_home;
+use crate::test_support::{exec_capable_tempdir, with_isolated_home};
 
 use super::super::runner::{build_trace_runner, failure_from_output, trace_is_unclaimed};
 use super::super::types::{TraceRunWorkflowArgs, TraceRunnerInputs};
@@ -47,7 +47,7 @@ fn with_extra_workloads<T>(value: Option<String>, f: impl FnOnce() -> T) -> T {
 #[test]
 fn test_build_trace_runner() {
     let _home_env_guard = crate::test_support::home_env_guard();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = exec_capable_tempdir();
     let extension_dir = temp.path().join("extension");
     let component_dir = temp.path().join("component");
     fs::create_dir_all(&extension_dir).unwrap();
@@ -141,7 +141,7 @@ JSON
 #[test]
 fn test_run_trace_list_workflow() {
     let _home_env_guard = crate::test_support::home_env_guard();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = exec_capable_tempdir();
     let extension_dir = temp.path().join("extension");
     let component_dir = temp.path().join("component");
     fs::create_dir_all(&extension_dir).unwrap();
@@ -206,7 +206,7 @@ JSON
 
 #[test]
 fn generic_trace_discovery_includes_conventions_and_extra_workloads() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = exec_capable_tempdir();
     let component_dir = temp.path().join("component");
     let traces_dir = component_dir.join("traces");
     let scripts_trace_dir = component_dir.join("scripts/trace");
@@ -314,7 +314,7 @@ fn test_run_trace_workflow() {
 #[test]
 fn run_trace_workflow_merges_probe_events_into_results() {
     let _home_env_guard = crate::test_support::home_env_guard();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = exec_capable_tempdir();
     let extension_dir = temp.path().join("extension");
     let component_dir = temp.path().join("component");
     let log_path = temp.path().join("probe.log");
@@ -393,7 +393,7 @@ JSON
 #[test]
 fn parsed_pass_result_overrides_noisy_runner_exit() {
     let _home_env_guard = crate::test_support::home_env_guard();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = exec_capable_tempdir();
     let extension_dir = temp.path().join("extension");
     let component_dir = temp.path().join("component");
     fs::create_dir_all(&extension_dir).unwrap();
@@ -466,7 +466,7 @@ exit 1
 #[test]
 fn trace_attach_logfile_observes_without_owning_lifecycle() {
     let _home_env_guard = crate::test_support::home_env_guard();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = exec_capable_tempdir();
     let extension_dir = temp.path().join("extension");
     let component_dir = temp.path().join("component");
     fs::create_dir_all(&extension_dir).unwrap();
@@ -685,7 +685,7 @@ struct OverlayFixture {
 }
 
 fn overlay_fixture(keep_overlay: bool) -> OverlayFixture {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = exec_capable_tempdir();
     let extension_dir = temp.path().join("extension");
     let component_dir = temp.path().join("component");
     fs::create_dir_all(&extension_dir).unwrap();

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -84,12 +84,18 @@ impl HomeGuard {
         let prior_invocation_runtime =
             std::env::var(crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
         let prior_no_update_check = std::env::var("HOMEBOY_NO_UPDATE_CHECK").ok();
-        let dir = TempDir::new().expect("home tempdir");
+        // The isolated HOME hosts `~/.config/homeboy/extensions/**/*.sh`
+        // capability scripts that tests execute. On `noexec`-`/tmp` hosts a
+        // plain `TempDir::new()` lands the whole HOME on a `noexec` mount,
+        // failing every capability-script test with exit 126 (#6760). Anchor
+        // it (and the runtime tmpdir, which also hosts executables) on an
+        // exec-capable root.
+        let dir = exec_capable_tempdir();
         std::env::set_var("HOME", dir.path());
         std::env::set_var("XDG_DATA_HOME", dir.path().join(".local").join("share"));
         std::env::remove_var("HOMEBOY_ARTIFACT_ROOT");
         std::env::set_var("HOMEBOY_NO_UPDATE_CHECK", "1");
-        let runtime_dir = TempDir::new().expect("runtime tempdir");
+        let runtime_dir = exec_capable_tempdir();
         std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", runtime_dir.path());
         crate::core::set_artifact_root_override(None);
         // Pin invocation runtime to a SHORT tempdir, isolated from `$TMPDIR`
@@ -119,21 +125,133 @@ impl HomeGuard {
 
 /// Return a short-path tempdir suitable for the invocation runtime root.
 ///
-/// On Unix-like systems we anchor to `/tmp` so the path stays well under
-/// `sockaddr_un` even on macOS where `$TMPDIR` typically lives at
-/// `/var/folders/<14>/T/.tmpXXXXXX/`. Falls back to the default tempdir
-/// otherwise (Windows / odd hosts).
+/// Two competing constraints:
+/// 1. The path must be **short** so runtime unix sockets stay within the
+///    `sockaddr_un` budget (~104 bytes) even on macOS, where `$TMPDIR`
+///    typically lives at a long `/var/folders/<14>/T/.tmpXXXXXX/` path.
+/// 2. The path must be **exec-capable** — tests execute capability scripts
+///    from runtime paths, so a `noexec` mount (common for `/tmp` on hardened
+///    VPS hosts, containers, and CI sandboxes) causes deterministic exit-126
+///    "Permission denied" failures (#6760).
+///
+/// Previously this anchored unconditionally to `/tmp`, which satisfies (1) but
+/// silently breaks (2) on `noexec`-`/tmp` hosts. Instead we probe short
+/// candidate roots for real exec capability and use the first that passes,
+/// falling back to the default tempdir if none qualify.
 fn short_invocation_tempdir() -> TempDir {
     #[cfg(unix)]
     {
-        if std::path::Path::new("/tmp").is_dir() {
-            return tempfile::Builder::new()
+        for base in short_tempdir_candidates() {
+            let Ok(candidate) = tempfile::Builder::new()
                 .prefix("hb-test-")
-                .tempdir_in("/tmp")
-                .expect("invocation runtime tempdir under /tmp");
+                .tempdir_in(&base)
+            else {
+                continue;
+            };
+            if dir_allows_exec(candidate.path()) {
+                return candidate;
+            }
+            // Not exec-capable (e.g. `noexec` mount) — drop it and try the
+            // next candidate rather than handing back a dir scripts can't run
+            // from.
         }
     }
     TempDir::new().expect("invocation runtime tempdir")
+}
+
+/// Ordered short base directories to consider for the invocation runtime root.
+///
+/// Honors an explicit `$TMPDIR` first (respecting operator intent, e.g. a
+/// dedicated exec-capable tmp), but only when it is short enough to keep unix
+/// socket paths within budget. Then the conventional short system roots.
+#[cfg(unix)]
+fn short_tempdir_candidates() -> Vec<PathBuf> {
+    // Leave generous headroom under the ~104-byte sockaddr_un limit for the
+    // per-tempdir suffix, socket filename, and run-id segments appended later.
+    const MAX_BASE_LEN: usize = 40;
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    let mut push_if_usable = |path: PathBuf| {
+        if path.as_os_str().len() <= MAX_BASE_LEN && path.is_dir() && !candidates.contains(&path) {
+            candidates.push(path);
+        }
+    };
+
+    if let Some(tmpdir) = std::env::var_os("TMPDIR") {
+        push_if_usable(PathBuf::from(tmpdir));
+    }
+    push_if_usable(PathBuf::from("/tmp"));
+    push_if_usable(PathBuf::from("/var/tmp"));
+    push_if_usable(PathBuf::from("/dev/shm"));
+    candidates
+}
+
+/// Probe whether files created under `dir` can actually be executed.
+///
+/// A `noexec` mount is invisible in file metadata — the only reliable check is
+/// to write a trivial executable and run it. Returns `false` on any failure so
+/// the caller falls through to the next candidate.
+#[cfg(unix)]
+fn dir_allows_exec(dir: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    let probe = dir.join(".hb-exec-probe.sh");
+    if fs::write(&probe, "#!/bin/sh\nexit 0\n").is_err() {
+        return false;
+    }
+    if fs::set_permissions(&probe, fs::Permissions::from_mode(0o755)).is_err() {
+        let _ = fs::remove_file(&probe);
+        return false;
+    }
+    let allowed = Command::new(&probe)
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false);
+    let _ = fs::remove_file(&probe);
+    allowed
+}
+
+/// Create a tempdir that is guaranteed exec-capable where possible.
+///
+/// Tests that write a script and then run it (e.g. capability parser scripts)
+/// must not land on a `noexec` filesystem. The default `tempfile::tempdir()`
+/// honors `$TMPDIR`, which on hardened VPS hosts / containers / CI sandboxes is
+/// frequently a `noexec` `/tmp` — producing deterministic exit-126
+/// "Permission denied" failures unrelated to the behavior under test (#6760).
+///
+/// This probes exec-capable roots (honoring an exec-capable `$TMPDIR` first,
+/// then `/tmp`, `/var/tmp`, `/dev/shm`) and returns the first that can actually
+/// run a file. Falls back to the default tempdir when no candidate qualifies
+/// (e.g. non-Unix), so callers keep working on hosts where `/tmp` is fine.
+pub(crate) fn exec_capable_tempdir() -> TempDir {
+    #[cfg(unix)]
+    {
+        let mut roots: Vec<PathBuf> = Vec::new();
+        let mut push = |path: PathBuf, roots: &mut Vec<PathBuf>| {
+            if path.is_dir() && !roots.contains(&path) {
+                roots.push(path);
+            }
+        };
+        if let Some(tmpdir) = std::env::var_os("TMPDIR") {
+            push(PathBuf::from(tmpdir), &mut roots);
+        }
+        for fixed in ["/tmp", "/var/tmp", "/dev/shm"] {
+            push(PathBuf::from(fixed), &mut roots);
+        }
+
+        for base in roots {
+            let Ok(candidate) = tempfile::Builder::new()
+                .prefix("hb-test-")
+                .tempdir_in(&base)
+            else {
+                continue;
+            };
+            if dir_allows_exec(candidate.path()) {
+                return candidate;
+            }
+        }
+    }
+    TempDir::new().expect("exec-capable tempdir")
 }
 
 impl Drop for HomeGuard {


### PR DESCRIPTION
## Summary

Fixes #6760. Investigating the reported flaky test surfaced **two distinct root causes** in the extension test suite — one deterministic (host-tmp dependent), one the intermittent race the issue describes.

## 1. `noexec` `/tmp` (deterministic)

Many extension tests write a capability script and then execute it. `tempfile::tempdir()` / `TempDir::new()` honor `$TMPDIR`, which on hardened VPS hosts, containers, and CI sandboxes is frequently a **`noexec` `/tmp`**. Every such test failed with `exit 126` "Permission denied" — nothing to do with the behavior under test, and enough to mask the real flake.

Fix: add `test_support::exec_capable_tempdir()`, which probes candidate roots (`$TMPDIR`, `/tmp`, `/var/tmp`, `/dev/shm`) for **real** exec capability. A `noexec` mount is invisible in file metadata, so it writes a probe script and actually runs it, returning the first root that works (falling back to the default tempdir on non-Unix).

Applied to:
- `HomeGuard` (isolated `HOME` + runtime tmpdir) — these host `~/.config/homeboy/extensions/**/*.sh`, so anchoring them exec-capable fixes the whole capability-script family at once.
- `short_invocation_tempdir()` — hardened the same way instead of unconditionally forcing `/tmp`.
- Individual script-executing tests in `bench parsing`, `execution`, `compiler_warning_contract`, `trace/preview`, and `trace/run`.

This clears ~10 deterministic reds on `noexec`-`/tmp` hosts.

## 2. `HOME`/env race (intermittent — the original #6760 flake)

`trace::preview::tests::starts_homeboy_native_client_and_records_lifecycle_metadata` built its native-client command from `HOME` / `HOMEBOY_RUNTIME_TMPDIR` **without holding the shared home guard**, so a parallel `with_isolated_home` neighbor could flip those env vars mid-run — the "shared process-global state raced under parallel scheduling" the issue predicted. Fix: hold `HomeGuard` to serialize it against env mutators.

## Verification

- **0 failures across 50 consecutive 8-thread runs** of the full `core::extension::` module on `noexec` `/tmp` (previously ~10 deterministic + 1–2/40 intermittent).
- Clean on an exec-capable `$TMPDIR` (normal-host simulation).
- The originally-cited test passes in isolation and under load.
- `core::component::`, `commands::runs::`, `core::defaults` suites unaffected by the `HomeGuard` change.

## Notes

The heavy `cargo test` sweeps were run locally on a `noexec`-`/tmp` VPS specifically to reproduce and confirm the fix (CI's `/tmp` may be exec-capable and thus never showed the deterministic class). `cargo check --lib --tests` is clean; remaining warnings are pre-existing dead-code in daemon/runner modules.