### PR TITLE
Fix changed-since Lab retries with private origins

### DIFF
--- a/src/core/runner/offload_changed_since.rs
+++ b/src/core/runner/offload_changed_since.rs
@@ -3,7 +3,6 @@ use std::process::Command;
 
 use crate::core::error::{Error, Result};
 
-use super::origin_refs::{advertised_origin_refs_for_commit, best_advertised_ref};
 use super::RunnerWorkspaceSyncMode;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -64,15 +63,14 @@ pub fn prepare_git_lab_offload_changed_since(
 
     let resolved_base = resolve_changed_since_base(source_path, &git_ref)?;
     ensure_local_merge_base(source_path, &git_ref)?;
-    let git_fetch_refs = advertised_origin_ref_for_commit(source_path, &resolved_base)?
-        .into_iter()
-        .collect();
-
     Ok(LabOffloadChangedSincePreflight {
         args: rewrite_changed_since_ref(args, &resolved_base),
         requested_ref: Some(git_ref),
         resolved_base: Some(resolved_base),
-        git_fetch_refs,
+        // The final Git materialization verifies this exact commit. Do not
+        // probe origin here: controller bundles carry it when Lab cannot read
+        // a private remote.
+        git_fetch_refs: Vec::new(),
     })
 }
 
@@ -150,18 +148,6 @@ fn resolve_changed_since_base(path: &Path, git_ref: &str) -> Result<String> {
         path,
         &["rev-parse", "--verify", &format!("{git_ref}^{{commit}}")],
     )
-}
-
-fn advertised_origin_ref_for_commit(path: &Path, commit: &str) -> Result<Option<String>> {
-    let refs = advertised_origin_refs_for_commit(
-        path,
-        commit,
-        "changed_since",
-        "Lab offload could not inspect origin refs for changed-since base materialization",
-        commit.to_string(),
-        vec!["Run with --placement local to execute the changed-since command locally while investigating remote ref availability.".to_string()],
-    )?;
-    Ok(best_advertised_ref(refs))
 }
 
 fn ensure_local_merge_base(path: &Path, git_ref: &str) -> Result<()> {
@@ -360,7 +346,7 @@ mod tests {
 
         assert_eq!(preflight.resolved_base.as_deref(), Some(base_sha.as_str()));
         assert_eq!(preflight.requested_ref.as_deref(), Some("base"));
-        assert_eq!(preflight.git_fetch_refs, vec!["refs/heads/base"]);
+        assert!(preflight.git_fetch_refs.is_empty());
         assert_eq!(
             preflight.args,
             vec![

--- a/src/core/runner/workspace/git.rs
+++ b/src/core/runner/workspace/git.rs
@@ -186,6 +186,7 @@ pub(super) fn materialize_git_from_controller_bundle(
         head,
         branch,
         remote_url,
+        changed_since_base,
         &sha256,
         allow_dirty_lab_workspace,
     );
@@ -450,6 +451,7 @@ pub(crate) fn git_bundle_install_command(
     head: &str,
     branch: Option<&str>,
     remote_url: &str,
+    changed_since_base: Option<&str>,
     expected_sha256: &str,
     allow_dirty_lab_workspace: bool,
 ) -> String {
@@ -483,6 +485,7 @@ pub(crate) fn git_bundle_install_command(
         .op(WorkspaceMaterializationOperation::VerifyGitBaseline {
             remote_url: remote_url.to_string(),
             head: head.to_string(),
+            changed_since_base: changed_since_base.map(str::to_string),
         })
         .restore_owner()
         .command()
@@ -511,6 +514,7 @@ pub(super) fn materialize_git_command(
         .op(WorkspaceMaterializationOperation::VerifyGitBaseline {
             remote_url: remote_url.to_string(),
             head: head.to_string(),
+            changed_since_base: changed_since_base.map(str::to_string),
         })
         .restore_owner()
         .command()

--- a/src/core/runner/workspace/materializer.rs
+++ b/src/core/runner/workspace/materializer.rs
@@ -27,6 +27,7 @@ pub(super) enum WorkspaceMaterializationOperation {
     VerifyGitBaseline {
         remote_url: String,
         head: String,
+        changed_since_base: Option<String>,
     },
     SyncGitCheckout {
         remote_url: String,
@@ -157,9 +158,16 @@ impl WorkspaceMaterializationOperation {
             Self::GuardCleanGitWorkspace { allow_dirty } => {
                 dirty_git_workspace_guard("$dest", *allow_dirty)
             }
-            Self::VerifyGitBaseline { remote_url, head } => {
-                verify_git_baseline_command("$dest", remote_url, head)
-            }
+            Self::VerifyGitBaseline {
+                remote_url,
+                head,
+                changed_since_base,
+            } => verify_git_baseline_command(
+                "$dest",
+                remote_url,
+                head,
+                changed_since_base.as_deref(),
+            ),
             Self::SyncGitCheckout {
                 remote_url,
                 head,
@@ -205,16 +213,28 @@ impl WorkspaceMaterializationOperation {
     }
 }
 
-fn verify_git_baseline_command(dest: &str, remote_url: &str, head: &str) -> String {
+fn verify_git_baseline_command(
+    dest: &str,
+    remote_url: &str,
+    head: &str,
+    changed_since_base: Option<&str>,
+) -> String {
     let status = format!(
         "git -C {dest} status --porcelain=v1 2>/dev/null | while IFS= read -r line; do path=${{line#???}}; if [ \"$path\" = .homeboy ] || [ \"${{path#.homeboy/}}\" != \"$path\" ]; then :; else printf '%s\\n' \"$line\"; fi; done || true",
         dest = dest,
     );
+    let changed_since = changed_since_base.map_or_else(String::new, |base| {
+        format!(
+            " && git -C {dest} rev-parse --verify -q {base}^{{commit}} >/dev/null && test \"$(git -C {dest} merge-base {base} HEAD)\" = {base}",
+            base = shell::quote_arg(base),
+        )
+    });
     format!(
-        "test -d {dest}/.git && test \"$(git -C {dest} rev-parse HEAD)\" = {head} && test \"$(git -C {dest} config --get remote.origin.url)\" = {remote_url} && test -z \"$({status})\"",
+        "test -d {dest}/.git && test \"$(git -C {dest} rev-parse HEAD)\" = {head} && test \"$(git -C {dest} config --get remote.origin.url)\" = {remote_url}{changed_since} && test -z \"$({status})\"",
         dest = dest,
         head = shell::quote_arg(head),
         remote_url = shell::quote_arg(remote_url),
+        changed_since = changed_since,
         status = status,
     )
 }

--- a/src/core/runner/workspace/tests/git.rs
+++ b/src/core/runner/workspace/tests/git.rs
@@ -12,7 +12,7 @@ use crate::core::runner::workspace::types::{RunnerWorkspaceSyncMode, RunnerWorks
 use crate::core::runner::workspace::util::git_output;
 
 #[test]
-fn controller_routed_git_sync_materializes_private_unavailable_remote_with_changed_since_base() {
+fn changed_since_retry_route_materializes_private_unavailable_origin_from_bundle() {
     crate::test_support::with_isolated_home(|_| {
         let origin = tempfile::tempdir().expect("origin tempdir");
         let author = tempfile::tempdir().expect("author tempdir");
@@ -96,6 +96,28 @@ fn controller_routed_git_sync_materializes_private_unavailable_remote_with_chang
                 .exists(),
             "the fixture must retain a commit graph after its objects are removed"
         );
+        crate::core::runner::create(
+            &format!(
+                r#"{{"id":"lab-local-git-bundle","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "retry".to_string(),
+            "--changed-since".to_string(),
+            base.clone(),
+        ];
+        let changed_since =
+            crate::core::runner::prepare_git_lab_offload_changed_since(&args, source.path())
+                .expect("preflight must resolve the local base without probing private origin");
+        assert_eq!(changed_since.resolved_base.as_deref(), Some(base.as_str()));
+        assert!(changed_since.git_fetch_refs.is_empty());
+
         remove_local_packs(source.path());
         assert!(
             git_without_lazy_fetch(
@@ -113,14 +135,6 @@ fn controller_routed_git_sync_materializes_private_unavailable_remote_with_chang
             .is_err(),
             "the fixture must leave unrelated promisor objects absent locally"
         );
-        crate::core::runner::create(
-            &format!(
-                r#"{{"id":"lab-local-git-bundle","kind":"local","workspace_root":"{}"}}"#,
-                runner_root.path().display()
-            ),
-            false,
-        )
-        .expect("create runner");
 
         let sync_result = sync_workspace(
             "lab-local-git-bundle",
@@ -130,7 +144,7 @@ fn controller_routed_git_sync_materializes_private_unavailable_remote_with_chang
                 // The runner first attempts its normal clone. The inaccessible
                 // origin then exercises the controller bundle fallback.
                 controller_routed_git: false,
-                changed_since_base: Some(base.clone()),
+                changed_since_base: changed_since.resolved_base,
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
@@ -189,6 +203,10 @@ fn controller_routed_git_sync_materializes_private_unavailable_remote_with_chang
             git_output(remote, &["merge-base", &base, "HEAD"]).unwrap(),
             base
         );
+        assert_eq!(git_output(remote, &["rev-parse", "HEAD"]).unwrap(), head);
+        assert!(git_output(remote, &["status", "--porcelain=v1"])
+            .expect("read final checkout status")
+            .is_empty());
         assert!(
             !git_output(
                 source.path(),
@@ -599,6 +617,7 @@ fn git_bundle_materialization_disables_lazy_fetches() {
         "abc123",
         None,
         "https://github.example.invalid/example-org/private-source.git",
+        Some("def456"),
         "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         false,
     );
@@ -606,6 +625,8 @@ fn git_bundle_materialization_disables_lazy_fetches() {
     assert!(command.contains("export GIT_NO_LAZY_FETCH=1"));
     assert!(command.contains("shasum -a 256"));
     assert!(command.contains("trap 'rm -rf"));
+    assert!(command.contains("rev-parse --verify -q def456^{commit}"));
+    assert!(command.contains("merge-base def456 HEAD"));
 }
 
 #[test]
@@ -616,6 +637,7 @@ fn git_bundle_materialization_rejects_digest_mismatch_before_clone() {
         "abc123",
         None,
         "https://github.example.invalid/example-org/private-source.git",
+        None,
         "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         false,
     );

--- a/src/core/runner/workspace/tests/materializer.rs
+++ b/src/core/runner/workspace/tests/materializer.rs
@@ -53,6 +53,7 @@ fn workspace_materializer_builds_git_bundle_checkout_command() {
         .op(WorkspaceMaterializationOperation::VerifyGitBaseline {
             remote_url: "https://github.com/Extra-Chill/homeboy.git".to_string(),
             head: "abc123".to_string(),
+            changed_since_base: None,
         })
         .restore_owner()
         .command();
@@ -87,6 +88,7 @@ fn workspace_materializer_builds_direct_git_checkout_command() {
         .op(WorkspaceMaterializationOperation::VerifyGitBaseline {
             remote_url: "https://github.com/Extra-Chill/homeboy.git".to_string(),
             head: "abc123".to_string(),
+            changed_since_base: Some("origin/main".to_string()),
         })
         .restore_owner()
         .command();


### PR DESCRIPTION
Fixes #8122

## Summary
- Resolve `--changed-since` to the controller-local exact SHA without probing `origin` during preflight.
- Carry the SHA through the existing controller Git bundle fallback and verify base reachability, merge-base ancestry, clean state, and exact HEAD in the final checkout.
- Cover the retry-shaped route with an inaccessible origin and a partial controller checkout.

## Compatibility
- No public CLI or configuration changes. Lab Git workspaces now require the same resolved changed-since base verification after both direct and bundle materialization.

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test changed_since_retry_route_materializes_private_unavailable_origin_from_bundle --lib`.
3. Run `cargo test rewrites_changed_since_to_resolved_commit_for_git_lab_offload --lib`.
4. Run `cargo test git_bundle_materialization --lib`.
5. Run `cargo check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode / openai-gpt-5.6-sol
- **Used for:** Traced the changed-since preflight and Git materialization path, implemented the minimal shared verification, and added deterministic coverage with Chris.