### PR TITLE
Preserve argv-safe promotion provider requests

### DIFF
--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -779,6 +779,15 @@ pub struct ReviewArgs {
     /// External workspace provider command to include in generated promotion commands.
     #[arg(long, value_name = "COMMAND")]
     pub provider_command: Option<String>,
+
+    /// One argument for an argv-safe external workspace provider invocation.
+    /// Repeat this option in provider argv order.
+    #[arg(
+        long = "provider-argv",
+        value_name = "ARG",
+        conflicts_with = "provider_command"
+    )]
+    pub provider_argv: Vec<String>,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -154,6 +154,7 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
                 promotion_source,
                 args.to_worktree.as_deref(),
                 args.provider_command.as_deref(),
+                &args.provider_argv,
                 review,
             )
         })
@@ -464,6 +465,7 @@ fn promotion_candidates(
     source: &str,
     to_worktree: Option<&str>,
     provider_command: Option<&str>,
+    provider_argv: &[String],
     review: &AgentTaskAggregateReport,
 ) -> Vec<Value> {
     review
@@ -489,6 +491,11 @@ fn promotion_candidates(
                     command.push("--provider-command".to_string());
                     command.push(provider_command.to_string());
                 }
+                command.extend(
+                    provider_argv
+                        .iter()
+                        .map(|argument| format!("--provider-argv={argument}")),
+                );
 
                 serde_json::json!({
                     "task_id": candidate.task_id,
@@ -672,7 +679,62 @@ mod tests {
         AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandReport,
         AgentTaskPromotionNotification, AgentTaskPromotionSource, AgentTaskPromotionTarget,
     };
-    use homeboy::core::agent_tasks::AgentTaskAggregateSummary;
+    use homeboy::core::agent_tasks::{
+        AgentTaskAggregateSummary, AgentTaskDecisionRef, AgentTaskReconciliationDecision,
+    };
+
+    #[test]
+    fn promotion_candidates_preserve_provider_argv() {
+        let review = AgentTaskAggregateReport {
+            schema: "homeboy/agent-task-aggregate-report/v1".to_string(),
+            summary: AgentTaskAggregateSummary::default(),
+            tasks: Vec::new(),
+            artifact_inventory: Vec::new(),
+            apply_candidates: vec![AgentTaskDecisionRef {
+                task_id: "task-1".to_string(),
+                decision: AgentTaskReconciliationDecision::ApplyCandidate,
+                reason: "patch available".to_string(),
+                artifact_ids: vec!["patch-1".to_string()],
+            }],
+            issue_report_candidates: Vec::new(),
+            retry_plan: Vec::new(),
+            review_candidates: Vec::new(),
+            matrix: Vec::new(),
+        };
+
+        let candidates = promotion_candidates(
+            "aggregate.json",
+            Some("fixture@target"),
+            None,
+            &[
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "promotion-provider".to_string(),
+                "--workspace=/tmp/target".to_string(),
+            ],
+            &review,
+        );
+
+        assert_eq!(
+            candidates[0]["command"],
+            serde_json::json!([
+                "homeboy",
+                "agent-task",
+                "promote",
+                "aggregate.json",
+                "--task-id",
+                "task-1",
+                "--artifact-id",
+                "patch-1",
+                "--to-worktree",
+                "fixture@target",
+                "--provider-argv=homeboy",
+                "--provider-argv=agent-task",
+                "--provider-argv=promotion-provider",
+                "--provider-argv=--workspace=/tmp/target",
+            ])
+        );
+    }
 
     #[test]
     fn review_next_actions_include_retry_and_lab_run_plan_commands() {

--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -323,6 +323,7 @@ fn failed_run_status_logs_and_review_include_outcome_diagnostic_summary() {
             run_id: run_id.to_string(),
             to_worktree: None,
             provider_command: None,
+            provider_argv: Vec::new(),
         })
         .expect("review loaded");
 

--- a/src/commands/agent_task/tests/promotion_review.rs
+++ b/src/commands/agent_task/tests/promotion_review.rs
@@ -48,6 +48,7 @@ fn review_reports_queued_run_without_chat_state() {
             run_id: "run-review-queued".to_string(),
             to_worktree: None,
             provider_command: None,
+            provider_argv: Vec::new(),
         })
         .expect("review loaded");
 
@@ -79,6 +80,7 @@ fn review_reports_completed_aggregate_and_promotion_hints() {
             run_id: "run-review-completed".to_string(),
             to_worktree: Some("homeboy@fix-review-flow".to_string()),
             provider_command: None,
+            provider_argv: Vec::new(),
         })
         .expect("review loaded");
 
@@ -291,6 +293,7 @@ fn cook_applies_executor_commit_from_source_repo_to_distinct_target_repo() {
             .expect("clone target");
         assert!(status.success());
         let expected_patch = temp.path().join("expected.patch");
+        let promotion_request = temp.path().join("promotion-request.json");
         std::fs::write(
             &expected_patch,
             "diff --git a/agent-change.txt b/agent-change.txt\nnew file mode 100644\nindex 0000000..f3f8b32\n--- /dev/null\n+++ b/agent-change.txt\n@@ -0,0 +1 @@\n+committed work\n",
@@ -300,7 +303,8 @@ fn cook_applies_executor_commit_from_source_repo_to_distinct_target_repo() {
         std::fs::write(
             &provider,
             format!(
-                "#!/bin/sh\nset -eu\ncat >/dev/null\ngit -C {} apply {}\nprintf '%s\\n' '{{\"schema\":\"homeboy/agent-task-promotion-apply-response/v1\",\"workspace_path\":\"{}\"}}'\n",
+                "#!/bin/sh\nset -eu\ncat > {}\ngit -C {} apply {}\nprintf '%s\\n' '{{\"schema\":\"homeboy/agent-task-promotion-apply-response/v1\",\"workspace_path\":\"{}\"}}'\n",
+                promotion_request.display(),
                 target.display(),
                 expected_patch.display(),
                 target.display(),
@@ -338,8 +342,8 @@ fn cook_applies_executor_commit_from_source_repo_to_distinct_target_repo() {
                 attempt_plan: None,
                 goal: None,
                 to_worktree: "fixture-component@promoted".to_string(),
-                provider_command: Some(format!("sh {}", provider.display())),
-                provider_argv: Vec::new(),
+                provider_command: None,
+                provider_argv: vec!["sh".to_string(), provider.display().to_string()],
                 gates: VerifyGateArgs {
                     verify: vec!["true".to_string()],
                     private_verify: Vec::new(),
@@ -391,5 +395,19 @@ fn cook_applies_executor_commit_from_source_repo_to_distinct_target_repo() {
             std::fs::read_to_string(target.join("agent-change.txt")).expect("target patch applied"),
             "committed work\n"
         );
+        let request: Value = serde_json::from_str(
+            &std::fs::read_to_string(&promotion_request).expect("read promotion request"),
+        )
+        .expect("typed promotion request");
+        assert_eq!(
+            request["schema"],
+            "homeboy/agent-task-promotion-apply-request/v1"
+        );
+        assert_eq!(request["to_workspace"], "fixture-component@promoted");
+        assert_eq!(request["changed_files"], json!(["agent-change.txt"]));
+        assert!(request["patch"]
+            .as_str()
+            .expect("inline selected patch")
+            .contains("committed work"));
     });
 }

--- a/tests/agent_task_promotion_provider.rs
+++ b/tests/agent_task_promotion_provider.rs
@@ -7,9 +7,9 @@ const PATCH: &str =
     "diff --git a/src.txt b/src.txt\n--- a/src.txt\n+++ b/src.txt\n@@ -1 +1 @@\n-old\n+new\n";
 
 #[test]
-fn promotion_provider_validates_git_workspace_and_applies_patch() {
+fn promotion_provider_applies_a_typed_patch_request() {
     let temp = tempfile::tempdir().expect("tempdir");
-    let workspace = temp.path().join("workspace with spaces");
+    let workspace = temp.path().join("materialized managed target");
     std::fs::create_dir(&workspace).expect("workspace");
     git(&workspace, &["init"]);
     git(&workspace, &["config", "user.email", "test@example.com"]);
@@ -43,7 +43,13 @@ fn promotion_provider_validates_git_workspace_and_applies_patch() {
     );
 
     let applied = promotion_provider(&workspace, &patch, false);
-    assert_eq!(applied.status.code(), Some(0));
+    assert_eq!(
+        applied.status.code(),
+        Some(0),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&applied.stdout),
+        String::from_utf8_lossy(&applied.stderr)
+    );
     let applied = output(&applied);
     assert_eq!(applied["workspace_path"], workspace.display().to_string());
     assert_eq!(


### PR DESCRIPTION
## Summary
- Preserve repeated argv-safe promotion provider arguments in `agent-task review` generated promotion commands.
- Exercise the automatic cook path with a real typed promotion request on stdin and prove the selected patch reaches the managed target.
- Complete the production fix already introduced by #7982 with end-to-end regression coverage and a replayable review handoff.

Fixes #7977.

## How to test
1. Run `cargo test --lib promotion_candidates_preserve_provider_argv`.
2. Run `cargo test --lib review_reports_completed_aggregate_and_promotion_hints`.
3. Run `cargo test --lib cook_applies_executor_commit_from_source_repo_to_distinct_target_repo`.
4. Run `cargo test --test agent_task_promotion_provider`.
5. Run `cargo fmt --check`.

## Compatibility
- Adds repeatable `--provider-argv` support to `agent-task review`; existing string-provider and review behavior remains available.
- Generated promotion commands now retain argv values beginning with `--` instead of silently dropping the provider invocation.
- No product, framework, or extension-specific behavior is added to Homeboy core.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Implemented and reviewed typed promotion request regression coverage and argv-safe review handoff; Chris reviews and owns the change.