### PR TITLE
refactor: source version-guard language tokens from extension defaults (#6759)

### DIFF
--- a/src/core/code_audit/conventions/mod.rs
+++ b/src/core/code_audit/conventions/mod.rs
@@ -91,16 +91,6 @@ impl Language {
         &["rs", "php", "ts", "js", "go"]
     }
 
-    /// The ecosystem tokens whose builtin version-compare guard defaults ship
-    /// with Homeboy. Version-compatibility guard syntax (`version_compare(...)`)
-    /// is ecosystem-specific, so the concrete token set lives here in the
-    /// agnostic conventions home rather than hardcoded inside a detector under
-    /// `code_audit::detectors`. Components that opt into builtin defaults
-    /// inherit these; others declare their own via config.
-    pub fn builtin_version_guard_tokens() -> &'static [&'static str] {
-        &["php"]
-    }
-
     /// Extension tokens whose source files embed unit tests inline in the same
     /// file (e.g. Rust's `#[cfg(test)] mod tests { ... }`). Detectors that parse
     /// production structure must strip these inline test modules first so test

--- a/src/core/code_audit/detectors/upstream_workaround.rs
+++ b/src/core/code_audit/detectors/upstream_workaround.rs
@@ -87,11 +87,11 @@ const DEFAULT_MARKER_REGEXES: &[&str] = &[
 // Tier B — version-compare guard catalogue
 // ============================================================================
 
-// Recognized version-constant names and guard regexes are ecosystem-specific
-// (constant naming + comparison syntax), so core ships none of them as Rust
-// literals. Component or external defaults configuration supplies those values
-// when needed (#2240). Version-guard language gating likewise lives in the
-// agnostic conventions home (`builtin_version_guard_tokens`).
+// Recognized version-constant names, guard regexes, and the language tokens
+// eligible for version-compare scanning are all ecosystem-specific (constant
+// naming, comparison syntax, and which languages use it), so core ships none of
+// them as Rust literals. Component or external defaults configuration supplies
+// those values when needed (#2240 / #6759).
 const DEFAULT_VENDORED_PATH_MARKERS: &[&str] =
     &["/vendor/", "vendor/", "/node_modules/", "node_modules/"];
 
@@ -268,17 +268,16 @@ impl EffectiveDetectorProfile {
                 DetectorRegexKind::TrackerReference,
             );
             profile.extend_strings(
-                Language::builtin_version_guard_tokens(),
-                DetectorProfileField::VersionGuardLanguage,
-            );
-            profile.extend_strings(
                 DEFAULT_VENDORED_PATH_MARKERS,
                 DetectorProfileField::VendoredPathMarker,
             );
 
             // The bundled defaults asset is intentionally empty for these fields;
             // external defaults can still extend builtin profiles without adding
-            // framework literals to core source (#2240).
+            // framework literals to core source (#2240). The version-guard
+            // language token set (`version_compare(...)` is PHP-specific) is
+            // sourced from here too, so no ecosystem token remains in core
+            // (#6759).
             let ext = crate::core::defaults::extension_provided_detector_profile();
             profile.extend_owned_strings(
                 &ext.version_guard_constants,
@@ -286,6 +285,10 @@ impl EffectiveDetectorProfile {
             );
             profile
                 .extend_owned_regexes(&ext.version_guard_regexes, DetectorRegexKind::VersionGuard);
+            profile.extend_owned_strings(
+                &ext.version_guard_languages,
+                DetectorProfileField::VersionGuardLanguage,
+            );
             profile.extend_owned_regexes(
                 &ext.tracker_reference_regexes,
                 DetectorRegexKind::TrackerReference,
@@ -630,6 +633,9 @@ mod tests {
 
         assert!(profile.version_guard_constants.is_empty());
         assert!(profile.version_guard_regexes.is_empty());
+        // The version-guard language gate no longer bakes an ecosystem token
+        // (e.g. "php") into core; it is extension-provided (#2240 / #6759).
+        assert!(profile.version_guard_languages.is_empty());
         assert!(profile
             .tracker_reference_regexes
             .iter()

--- a/src/core/defaults/builtins.rs
+++ b/src/core/defaults/builtins.rs
@@ -29,6 +29,12 @@ pub(crate) struct DetectorProfileDefaults {
     pub version_guard_constants: Vec<String>,
     #[serde(default)]
     pub version_guard_regexes: Vec<String>,
+    /// Language tokens whose files are eligible for version-compare guard
+    /// scanning. `version_compare(...)` syntax is ecosystem-specific (e.g.
+    /// PHP), so the concrete token set is extension-provided rather than baked
+    /// into core (#2240 / #6759).
+    #[serde(default)]
+    pub version_guard_languages: Vec<String>,
     #[serde(default)]
     pub tracker_reference_regexes: Vec<String>,
 }
@@ -204,6 +210,9 @@ mod tests {
 
         assert!(profile.version_guard_constants.is_empty());
         assert!(profile.version_guard_regexes.is_empty());
+        // No ecosystem language token (e.g. "php") baked into core — the
+        // version-guard language set is extension-provided (#2240 / #6759).
+        assert!(profile.version_guard_languages.is_empty());
         assert!(profile.tracker_reference_regexes.is_empty());
     }
 


### PR DESCRIPTION
## Summary

Fixes #6759 — follow-up to #6758 (de-hardcode WP/Automattic literals from core, #2240). That PR moved the WP version-guard constants, the `version_compare(...)` guard regex, and the WP tracker regex out of core Rust into the extension-provided-defaults asset. **One residual framework literal remained:** `Language::builtin_version_guard_tokens()` returned `["php"]` — the language gate the upstream-workaround detector uses to decide whether to run version-compare scanning. `version_compare(...)` is PHP-specific syntax, so that token is a framework assumption baked into core.

## Changes

- **`defaults/builtins.rs`** — add `version_guard_languages: Vec<String>` to `DetectorProfileDefaults` (`#[serde(default)]`), so external defaults can supply the token set. The bundled asset stays empty.
- **`code_audit/detectors/upstream_workaround.rs`** — `EffectiveDetectorProfile::from_config` now sources `version_guard_languages` from `extension_provided_detector_profile()` (mirroring how `version_guard_constants` / `version_guard_regexes` already flow), instead of the core builtin token.
- **`code_audit/conventions/mod.rs`** — remove the now-unused `builtin_version_guard_tokens()`.

Core's built-in detector profile now carries **no ecosystem language token**, fully satisfying #2240 for this detector.

## Behavior preservation

This mirrors the exact pattern #6758 established: core ships generic defaults, and downstream WP consumers supply the PHP set via the external defaults override (`HOMEBOY_EXTENSION_DEFAULTS_PATH`). 

⚠️ **Migration note:** downstream external defaults files that rely on PHP version-guard scanning must add `"version_guard_languages": ["php"]` to their `detector_profile` section (alongside the `version_guard_constants` / `version_guard_regexes` they already supply post-#6758). Without it, core no longer assumes `php` eligibility.

## Verification

- Added regression assertions: `builtin_profile_does_not_bundle_framework_version_guards` and `core_detector_profile_fallback_is_empty` now assert `version_guard_languages.is_empty()` in the builtin/core profile.
- Existing custom-profile tests (`test_custom_profile_adds_non_php_version_guard`, `test_configured_version_guard_emits_finding`) already drive the token set via explicit config and pass unchanged.
- **All 754 `core::code_audit::` tests pass.** (`cargo check --lib --tests` clean.)