### PR TITLE
fix: don't offer local bypass as primary rerun to non-interactive agents (#6384)

### DIFF
--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -615,6 +615,7 @@ fn preflight_hot_command(cli: &Cli, output_file: Option<&str>) -> Option<i32> {
                         default_lab_runner.as_deref(),
                     ),
                     default_lab_runner.as_deref(),
+                    hot_command,
                 ) {
                     output_runtime::emit_json_result(Err(err), output_file, 2);
                     return Some(2);

--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -310,6 +310,7 @@ pub fn non_interactive_preflight_error(
     interactive: bool,
     local_hot_rerun_command: Option<String>,
     default_runner: Option<&str>,
+    command: HotCommand,
 ) -> Option<crate::core::Error> {
     if local_override || interactive || is_runner_hosted_exec() {
         return None;
@@ -321,7 +322,7 @@ pub fn non_interactive_preflight_error(
     let mut error = crate::core::Error::validation_invalid_argument(
         "resource-policy",
         format!(
-            "Refusing to start `{}` on a {} machine from a non-interactive shell. {} Use a safe Lab/offload path once this command supports it, or rerun later when `homeboy self doctor` reports ok.",
+            "Refusing to start `{}` on a {} machine from a non-interactive shell. {} Rerun later when `homeboy self doctor` reports ok.",
             warning.command,
             severity_str(warning.recommendation),
             primary_action(warning, default_runner),
@@ -329,9 +330,32 @@ pub fn non_interactive_preflight_error(
         None,
         None,
     );
-    if let Some(command) = local_hot_rerun_command {
-        error.details["rerun_command"] = serde_json::Value::String(command);
+
+    if command.lab_offload_supported {
+        // Portable command: the safe rerun (Lab `--runner`, or explicit local
+        // placement when the operator wants it) is the primary path.
+        if let Some(rerun) = local_hot_rerun_command {
+            error.details["rerun_command"] = serde_json::Value::String(rerun);
+        }
+    } else {
+        // Non-portable command: do NOT surface a local `--placement local`
+        // rerun as the primary path — for a non-interactive agent that turns a
+        // safety refusal into a copy-paste local bypass (#6384). Instead record
+        // the Lab-portability gap and file/fix guidance, and demote the local
+        // rerun to a clearly operator-only override that agents must not take by
+        // default.
+        error.details["lab_portability_gap"] = serde_json::Value::String(format!(
+            "`{}` has no portable Lab offload contract yet: {} A non-interactive agent should stop here and open/track a Lab-portability issue for this command rather than run it locally.",
+            warning.command,
+            command.lab_offload_unsupported_reason.unwrap_or(
+                "this resource-pressure command is currently local-only under resource policy.",
+            ),
+        ));
+        if let Some(rerun) = local_hot_rerun_command {
+            error.details["operator_only_local_override"] = serde_json::Value::String(rerun);
+        }
     }
+
     Some(error)
 }
 
@@ -422,7 +446,7 @@ fn primary_action(warning: &ResourcePolicyWarning, default_runner: Option<&str>)
     if warning.message.contains("--runner") {
         "Pass --runner <id> when Lab offload supports this mode.".to_string()
     } else {
-        "Lab routing is not offered because this command is currently local-only under resource policy.".to_string()
+        "Lab routing is not offered because this command has no portable Lab offload contract yet; it needs Lab-portability work (see the lab_portability_gap detail). The local override is operator-only and is not a safe automated rerun.".to_string()
     }
 }
 
@@ -684,10 +708,15 @@ mod tests {
                 reason: "default_lab_runner".to_string(),
             }
         );
-        assert!(
-            non_interactive_preflight_error(&warning, false, false, None, Some("homeboy-lab"))
-                .is_none()
-        );
+        assert!(non_interactive_preflight_error(
+            &warning,
+            false,
+            false,
+            None,
+            Some("homeboy-lab"),
+            lab_supported_hot("agent-task cook/run-plan/retry --run"),
+        )
+        .is_none());
     }
 
     #[test]
@@ -709,8 +738,15 @@ mod tests {
         )
         .expect("hot machines warn");
 
-        let error = non_interactive_preflight_error(&warning, false, false, None, None)
-            .expect("non-interactive hot runs should fail fast");
+        let error = non_interactive_preflight_error(
+            &warning,
+            false,
+            false,
+            None,
+            None,
+            lab_supported_hot("audit"),
+        )
+        .expect("non-interactive hot runs should fail fast");
 
         assert_eq!(error.code.as_str(), "validation.invalid_argument");
         assert!(error.message.contains("Refusing to start `audit`"));
@@ -730,14 +766,19 @@ mod tests {
         )
         .expect("hot machines warn");
 
-        assert!(
-            non_interactive_preflight_error(&warning, false, false, None, Some("homeboy-lab"))
-                .is_none()
-        );
+        assert!(non_interactive_preflight_error(
+            &warning,
+            false,
+            false,
+            None,
+            Some("homeboy-lab"),
+            lab_supported_hot("agent-task providers"),
+        )
+        .is_none());
     }
 
     #[test]
-    fn non_interactive_local_only_refusal_includes_local_hot_rerun_command() {
+    fn non_interactive_local_only_refusal_demotes_local_override_and_flags_portability_gap() {
         let _lock = env_lock();
         let _guard = EnvVarGuard::remove(crate::core::runner::RUNNER_HOSTED_EXEC_ENV);
         let command = local_only_hot(
@@ -758,14 +799,28 @@ mod tests {
             None,
         );
 
-        let error = non_interactive_preflight_error(&warning, false, false, rerun, None)
+        let error = non_interactive_preflight_error(&warning, false, false, rerun, None, command)
             .expect("non-interactive local-only hot runs should fail fast");
 
+        // The local `--placement local` command must NOT be the primary rerun
+        // path handed to a non-interactive agent (#6384). It is demoted to an
+        // explicitly operator-only field, and the refusal records the
+        // Lab-portability gap the agent should stop and track instead.
+        assert!(
+            error.details.get("rerun_command").is_none(),
+            "non-portable refusal must not offer a local rerun as the primary path"
+        );
         assert_eq!(
-            error.details["rerun_command"].as_str(),
+            error.details["operator_only_local_override"].as_str(),
             Some("homeboy --placement local review lint --changed-since origin/main")
         );
-        assert!(error.message.contains("Lab routing is not offered"));
+        let gap = error.details["lab_portability_gap"]
+            .as_str()
+            .expect("portability gap recorded");
+        assert!(gap.contains("no portable Lab offload contract yet"));
+        assert!(gap.contains("open/track a Lab-portability issue"));
+        assert!(error.message.contains("needs Lab-portability work"));
+        assert!(error.message.contains("operator-only"));
     }
 
     #[test]
@@ -801,13 +856,24 @@ mod tests {
             &["homeboy".to_string(), "audit".to_string()],
             None,
         );
-        let error = non_interactive_preflight_error(&warning, false, false, rerun, None)
-            .expect("non-interactive hot runs should fail fast");
+        let error = non_interactive_preflight_error(
+            &warning,
+            false,
+            false,
+            rerun,
+            None,
+            lab_supported_hot("audit"),
+        )
+        .expect("non-interactive hot runs should fail fast");
 
+        // Portable command with no connected runner: the explicit local rerun
+        // stays the (last-resort) primary path — it is Lab-portable, the runner
+        // is simply not connected. No portability-gap footgun here.
         assert_eq!(
             error.details["rerun_command"].as_str(),
             Some("homeboy --placement local audit")
         );
+        assert!(error.details.get("lab_portability_gap").is_none());
         assert!(error
             .message
             .contains("No eligible Homeboy Lab runner was found"));
@@ -823,7 +889,15 @@ mod tests {
         )
         .expect("hot machines warn");
 
-        assert!(non_interactive_preflight_error(&warning, false, false, None, None).is_none());
+        assert!(non_interactive_preflight_error(
+            &warning,
+            false,
+            false,
+            None,
+            None,
+            lab_supported_hot("agent-task cook/run-plan"),
+        )
+        .is_none());
     }
 
     #[test]
@@ -836,8 +910,24 @@ mod tests {
         )
         .expect("hot machines warn");
 
-        assert!(non_interactive_preflight_error(&warning, false, true, None, None).is_none());
-        assert!(non_interactive_preflight_error(&warning, true, false, None, None).is_none());
+        assert!(non_interactive_preflight_error(
+            &warning,
+            false,
+            true,
+            None,
+            None,
+            lab_supported_hot("audit"),
+        )
+        .is_none());
+        assert!(non_interactive_preflight_error(
+            &warning,
+            true,
+            false,
+            None,
+            None,
+            lab_supported_hot("audit"),
+        )
+        .is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #6384. A non-interactive resource-policy refusal for a **non-Lab-portable** command surfaced a local `--placement local` rerun as `details.rerun_command`. For an agent workflow that turns a safety refusal into a copy-paste local execution path — the exact footgun that contributed to a local-execution bypass during PR #6369 verification.

(The old `--force-hot --allow-local-hot` phrasing named in the issue is already gone from current source — replaced by `--placement local` — but the underlying "local bypass as the primary rerun" footgun remained for non-portable commands.)

## Change

`non_interactive_preflight_error` now takes the matched `HotCommand` and splits behavior by portability:

- **Lab-portable commands** keep the safe rerun as the primary path (Lab `--runner`, or explicit local placement when the runner is simply not connected — it's portable, the runner just isn't up).
- **Non-portable commands** no longer expose a `rerun_command`. Instead:
  - `details.operator_only_local_override` — the `--placement local` command, clearly labeled operator-only and not for agents.
  - `details.lab_portability_gap` — explains the command has no portable Lab offload contract yet, includes the specific reason, and directs a non-interactive agent to stop and open/track a Lab-portability issue rather than run locally.
  - Message wording updated to say the command needs Lab-portability work and that the local override is operator-only, not a safe automated rerun.

## Acceptance criteria

- [x] Non-interactive hot refusal does not offer a local bypass as the primary rerun path.
- [x] Error details distinguish operator-only local override (`operator_only_local_override`) from safe automated verification (`rerun_command`, portable only).
- [x] Non-Lab-portable commands say they need Lab-portability work and carry enough context to file an issue (`lab_portability_gap`).
- [x] Remaining local override wording makes clear it is an intentional controller-local bypass, not suitable for agents by default.

## Verification

- Rewrote the footgun test (`non_interactive_local_only_refusal_*`) to assert the new contract: no primary `rerun_command`, `operator_only_local_override` + `lab_portability_gap` present, message flags the gap.
- Added assertion that portable-without-runner refusals keep the primary rerun and carry no `lab_portability_gap`.
- **All 20 `resource_policy` + 45 `commands::utils` tests pass.** `cargo check --lib --tests` clean.