### PR TITLE
build: drop redundant native-tls stack from reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,21 +497,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,22 +789,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -1178,23 +1147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 3.7.0",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,49 +1209,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "openssl"
-version = "0.10.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.115"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -1560,12 +1469,10 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1576,7 +1483,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -1681,15 +1587,6 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "security-framework"
@@ -2103,16 +2000,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,11 @@ zip = "0.6"
 keyring = { version = "3.6", features = ["apple-native"] }
 core-foundation-sys = "0.8"
 security-framework-sys = "2.17"
-reqwest = { version = "0.12", features = ["json", "blocking", "rustls-tls", "socks"] }
+# default-features disabled to drop reqwest's `default-tls` (native-tls/openssl),
+# which pulled a second, redundant TLS stack alongside the rustls-tls we actually use.
+# Kept features cover current usage (blocking JSON client, socks proxy, http2, charset,
+# system proxy).
+reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls", "socks", "http2", "charset", "system-proxy"] }
 chrono = "0.4"
 ctrlc = "3.4"
 semver = "1.0"


### PR DESCRIPTION
## Summary

`reqwest` was configured with `rustls-tls` but left `default-features` on, so its
`default-tls` feature transitively pulled in a **second, complete TLS stack** —
`native-tls` → `openssl`/`openssl-sys` (which builds native C via a build script),
plus `hyper-tls` and `tokio-native-tls`. All HTTP in homeboy already runs over
rustls, so this second stack was pure waste: extra crates, extra compile time, and
extra peak build memory.

This sets `default-features = false` and explicitly enables only the features
actually in use.

## What changed
- `Cargo.toml`: `reqwest` → `default-features = false`, features = `json`, `blocking`, `rustls-tls`, `socks`, `http2`, `charset`, `system-proxy`.
- `Cargo.lock`: **10 crates removed, pure deletions, zero unrelated version churn** — `openssl`, `openssl-sys`, `openssl-macros`, `openssl-probe`, `native-tls`, `hyper-tls`, `tokio-native-tls`, `schannel`, `foreign-types`, `foreign-types-shared`.

Now a single TLS stack remains (`rustls` + `ring`).

## Why (context)
First of a series of build-cost / RAM-reduction changes. homeboy is a single 612k-LOC crate that's heavy to compile; this is the cheapest isolated win. The structural fix (splitting fat subsystems like `runner` into their own crates) is separate follow-up work.

## Feature audit
Verified against actual reqwest usage in `src/` — blocking JSON client, URL parsing, redirect policy, socks proxy, custom headers (incl. RANGE). No gzip/brotli/multipart/streaming used. Kept `http2`/`charset`/`system-proxy` (cheap, no second TLS stack) to avoid behavioral surprises.

## Verification
- `cargo check --lib` passes (only pre-existing dead-code warnings, unrelated).
- Full build/test intentionally left to CI (local VPS is RAM-constrained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)