### PR TITLE
fix: bundle retry workspaces before runner clone

### DIFF
--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -163,6 +163,7 @@ pub fn route_after_parse(
             source_path: retry_handoff
                 .as_ref()
                 .map(|handoff| handoff.primary_workspace.as_path()),
+            require_controller_git_bundle: retry_handoff.is_some(),
             job_overrides,
         },
         inferred_runner_id.as_deref(),

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -47,6 +47,9 @@ pub struct LabRoutingRequest<'a> {
     /// Controller checkout selected independently of CLI argv, such as the
     /// logical primary workspace of a materialized retry plan.
     pub source_path: Option<&'a std::path::Path>,
+    /// Require controller bundle materialization for the selected source
+    /// checkout before any runner-side Git transport is attempted.
+    pub require_controller_git_bundle: bool,
     pub job_overrides: runners::LabJobOverrides,
 }
 
@@ -73,6 +76,7 @@ pub(crate) fn route_lab_offload(
         local_output_file: request.local_output_file,
         durable_agent_task_plan: request.durable_agent_task_plan,
         source_path: request.source_path,
+        require_controller_git_bundle: request.require_controller_git_bundle,
         job_overrides: request.job_overrides,
     })
 }
@@ -529,6 +533,7 @@ fn execute_lab_offload_with_timeout(
     let local_output_file = request.local_output_file.map(str::to_string);
     let durable_agent_task_plan = request.durable_agent_task_plan.cloned();
     let source_path = request.source_path.map(std::path::Path::to_path_buf);
+    let require_controller_git_bundle = request.require_controller_git_bundle;
     let job_overrides = request.job_overrides;
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
@@ -548,6 +553,7 @@ fn execute_lab_offload_with_timeout(
             local_output_file: local_output_file.as_deref(),
             durable_agent_task_plan: durable_agent_task_plan.as_ref(),
             source_path: source_path.as_deref(),
+            require_controller_git_bundle,
             job_overrides,
         });
         let _ = tx.send(result);
@@ -736,6 +742,7 @@ mod tests {
             local_output_file: None,
             durable_agent_task_plan: None,
             source_path: None,
+            require_controller_git_bundle: false,
             job_overrides: runners::LabJobOverrides::default(),
         })
         .unwrap();
@@ -1038,6 +1045,7 @@ mod tests {
                 local_output_file: None,
                 durable_agent_task_plan: None,
                 source_path: None,
+                require_controller_git_bundle: false,
                 job_overrides: runners::LabJobOverrides::default(),
             },
             None,

--- a/src/core/runner/lab/offload/tests/exec_errors.rs
+++ b/src/core/runner/lab/offload/tests/exec_errors.rs
@@ -376,6 +376,7 @@ fn plan_records_skipped_auto_offload() {
         local_output_file: None,
         durable_agent_task_plan: None,
         source_path: None,
+        require_controller_git_bundle: false,
         job_overrides: LabJobOverrides::default(),
     })
     .expect("outcome");
@@ -407,6 +408,7 @@ fn lab_placement_refuses_local_execution_without_lab_contract() {
         local_output_file: None,
         durable_agent_task_plan: None,
         source_path: None,
+        require_controller_git_bundle: false,
         job_overrides: LabJobOverrides::default(),
     });
 
@@ -441,6 +443,7 @@ fn lab_placement_refuses_local_only_rig_install_with_actionable_boundary() {
         local_output_file: None,
         durable_agent_task_plan: None,
         source_path: None,
+        require_controller_git_bundle: false,
         job_overrides: LabJobOverrides::default(),
     });
 
@@ -477,6 +480,7 @@ fn build_runner_error_gives_managed_runner_replacement() {
         local_output_file: None,
         durable_agent_task_plan: None,
         source_path: None,
+        require_controller_git_bundle: false,
         job_overrides: LabJobOverrides::default(),
     });
 
@@ -522,6 +526,7 @@ fn build_lab_placement_error_gives_managed_runner_replacement() {
         local_output_file: None,
         durable_agent_task_plan: None,
         source_path: None,
+        require_controller_git_bundle: false,
         job_overrides: LabJobOverrides::default(),
     });
 
@@ -569,6 +574,7 @@ fn unsupported_runner_error_guides_tunnel_service_inspection() {
         local_output_file: None,
         durable_agent_task_plan: None,
         source_path: None,
+        require_controller_git_bundle: false,
         job_overrides: LabJobOverrides::default(),
     });
 

--- a/src/core/runner/lab/offload/types.rs
+++ b/src/core/runner/lab/offload/types.rs
@@ -35,6 +35,8 @@ pub struct LabOffloadRequest<'a> {
     /// This keeps process cwd in the runner job while retaining an exact local
     /// source for Git materialization and path remapping.
     pub source_path: Option<&'a std::path::Path>,
+    /// Select controller-bundle materialization before runner-side Git transport.
+    pub require_controller_git_bundle: bool,
     pub job_overrides: LabJobOverrides,
 }
 

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -149,12 +149,14 @@ fn prepare_lab_offload_workspace_stage_inner(
         RunnerWorkspaceSyncOptions {
             path: source_path.display().to_string(),
             mode: sync_mode,
-            // Patch-producing retry primaries must materialize their recorded
-            // remote baseline. Other Git workloads retain controller-routed
-            // bundles for remotes unavailable from the runner.
+            // Retry handoffs must stage the controller checkout before the
+            // runner attempts Git transport: private origins are intentionally
+            // unavailable to the runner, and changed-since must resolve from
+            // the staged bundle.
             controller_routed_git: sync_mode == RunnerWorkspaceSyncMode::Git
-                && contract.workspace_mode_policy
-                    != LabOffloadWorkspaceModePolicy::GitCheckoutRequired,
+                && (request.require_controller_git_bundle
+                    || contract.workspace_mode_policy
+                        != LabOffloadWorkspaceModePolicy::GitCheckoutRequired),
             changed_since_base: changed_since_preflight.resolved_base.clone(),
             git_fetch_refs: git_fetch_refs.clone(),
             snapshot_includes: Vec::new(),
@@ -2077,7 +2079,7 @@ mod tests {
     }
 
     #[test]
-    fn stage_routes_changed_since_private_source_through_controller_bundle() {
+    fn retry_stage_routes_changed_since_private_source_through_controller_bundle() {
         crate::test_support::with_isolated_home(|_| {
             let source = tempfile::tempdir().expect("source checkout");
             let runner_root = tempfile::tempdir().expect("runner workspace root");
@@ -2147,15 +2149,19 @@ mod tests {
                 local_output_file: None,
                 durable_agent_task_plan: None,
                 source_path: None,
+                require_controller_git_bundle: true,
                 job_overrides: LabJobOverrides::default(),
             };
             let contract = LabOffloadCommand {
-                command: crate::command_contract::LabCommandContract::portable(
-                    "audit",
-                    None,
-                    false,
-                    &[],
-                ),
+                command: crate::command_contract::LabCommandContract {
+                    workspace_mode_policy: LabOffloadWorkspaceModePolicy::GitCheckoutRequired,
+                    ..crate::command_contract::LabCommandContract::portable(
+                        "audit",
+                        None,
+                        false,
+                        &[],
+                    )
+                },
                 required_extensions: Vec::new(),
                 required_capabilities: Vec::new(),
                 workload: None,
@@ -2197,9 +2203,20 @@ mod tests {
                 Some(base.as_str())
             );
             assert!(stage.remapped_args.contains(&base));
+            let provenance = stage
+                .synced
+                .materialization_plan
+                .controller_git_bundle
+                .as_ref()
+                .expect("retry stage must emit controller bundle provenance");
+            assert_eq!(provenance.provenance, "controller_git_bundle");
             assert_eq!(
                 git_output(Path::new(&stage.remote_cwd), &["rev-parse", &base]),
                 base
+            );
+            assert_eq!(
+                git_output(Path::new(&stage.remote_cwd), &["rev-parse", "HEAD"]),
+                git_output(source.path(), &["rev-parse", "HEAD"])
             );
         });
     }
@@ -2284,6 +2301,7 @@ mod tests {
                 local_output_file: None,
                 durable_agent_task_plan: None,
                 source_path: Some(source.as_path()),
+                require_controller_git_bundle: false,
                 job_overrides: LabJobOverrides::default(),
             };
             let mut contract = LabOffloadCommand {


### PR DESCRIPTION
## Summary
- route `agent-task retry --run --runner` through a controller Git bundle before runner-side Git transport
- preserve direct Git materialization for non-retry `GitCheckoutRequired` commands
- prove the retry staging path accepts an inaccessible origin, emits `controller_git_bundle` provenance, and retains both changed-since base and HEAD

Closes #8122

## How to test
1. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo fmt --check`.
2. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo check --tests`.
3. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-8054-mixed-lease-orphan-recovery/target cargo test --lib core::runner::lab::offload::workspace_stage::tests::retry_stage_routes_changed_since_private_source_through_controller_bundle --no-fail-fast`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode / openai-gpt-5.6-sol
- **Used for:** Investigated the retry command dispatch and workspace staging call graph, then drafted the routing fix and regression coverage.