### PR TITLE
Fix detached agent task handoff timeout

### DIFF
--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -150,7 +150,7 @@ pub fn route_after_parse(
             skip_deps_hydration: cli.skip_deps_hydration,
             capture_patch: capture_mutation_patch,
             mutation_flag,
-            timeout: lab_route_dispatch_timeout(&cli.command, cli.detach_after_handoff),
+            timeout: lab_route_dispatch_timeout(&cli.command),
             active_run_id: active_run_id.as_deref(),
             detach_after_handoff: cli.detach_after_handoff,
             output_file_requested: output_file.is_some(),
@@ -256,14 +256,8 @@ fn materialize_agent_task_cook_plan(
     homeboy::core::agent_tasks::dispatch_service::build_dispatch_plan(&request).map(Some)
 }
 
-fn lab_route_dispatch_timeout(
-    command: &Commands,
-    detach_after_handoff: bool,
-) -> Option<std::time::Duration> {
+fn lab_route_dispatch_timeout(command: &Commands) -> Option<std::time::Duration> {
     if matches!(command, Commands::Trace(_)) {
-        return Some(lab_routing::lab_trace_dispatch_timeout());
-    }
-    if detach_after_handoff && is_detached_agent_task_handoff(command) {
         return Some(lab_routing::lab_trace_dispatch_timeout());
     }
     None
@@ -749,33 +743,6 @@ fn agent_task_fanout_cook_batch_dispatch_id(
             args.issues.len()
         )
     })
-}
-
-fn is_agent_task_fanout_cook_batch_run_plan(command: &Commands) -> bool {
-    matches!(
-        command,
-        Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
-            command:
-                crate::commands::agent_task::AgentTaskCommand::Fanout(
-                    crate::commands::agent_task::AgentTaskFanoutArgs {
-                        command:
-                            crate::commands::agent_task::AgentTaskFanoutCommand::CookBatch(args),
-                    },
-                ),
-        }) if args.run_plan
-    )
-}
-
-fn is_detached_agent_task_handoff(command: &Commands) -> bool {
-    is_agent_task_fanout_cook_batch_run_plan(command)
-        || matches!(
-            command,
-            Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
-                command: crate::commands::agent_task::AgentTaskCommand::Retry(
-                    crate::commands::agent_task::RetryArgs { run: true, .. },
-                ),
-            })
-        )
 }
 
 fn run_rig_source_management_on_runner(
@@ -1846,15 +1813,33 @@ mod tests {
         let lint_cli = Cli::parse_from(["homeboy", "review", "lint"]);
 
         assert_eq!(
-            lab_route_dispatch_timeout(&trace_cli.command, false),
+            lab_route_dispatch_timeout(&trace_cli.command),
             Some(lab_routing::lab_trace_dispatch_timeout())
         );
-        assert_eq!(lab_route_dispatch_timeout(&lint_cli.command, false), None);
+        assert_eq!(lab_route_dispatch_timeout(&lint_cli.command), None);
     }
 
     #[test]
-    fn detached_agent_task_fanout_cook_batch_run_plan_uses_bounded_handoff_timeout() {
-        let cli = Cli::parse_from([
+    fn detached_agent_task_handoffs_do_not_use_trace_dispatch_timeout() {
+        let cook = Cli::parse_from([
+            "homeboy",
+            "--detach-after-handoff",
+            "agent-task",
+            "cook",
+            "--repo",
+            "homeboy",
+            "--goal",
+            "Fix the detached handoff",
+            "--to-worktree",
+            "homeboy@fix-7971",
+            "--run-id",
+            "cook-7971",
+            "--runner",
+            "homeboy-lab",
+            "--placement",
+            "lab",
+        ]);
+        let batch = Cli::parse_from([
             "homeboy",
             "--detach-after-handoff",
             "agent-task",
@@ -1867,30 +1852,7 @@ mod tests {
             "--run-plan",
             "https://github.com/Extra-Chill/homeboy/issues/7167",
         ]);
-
-        assert_eq!(
-            lab_route_dispatch_timeout(&cli.command, cli.detach_after_handoff),
-            Some(lab_routing::lab_trace_dispatch_timeout())
-        );
-
-        let no_detach = Cli::parse_from([
-            "homeboy",
-            "agent-task",
-            "fanout",
-            "cook-batch",
-            "--repo",
-            "homeboy",
-            "--verify",
-            "cargo test --lib",
-            "--run-plan",
-            "https://github.com/Extra-Chill/homeboy/issues/7167",
-        ]);
-        assert_eq!(lab_route_dispatch_timeout(&no_detach.command, false), None);
-    }
-
-    #[test]
-    fn detached_agent_task_retry_uses_bounded_handoff_timeout() {
-        let cli = Cli::parse_from([
+        let retry = Cli::parse_from([
             "homeboy",
             "--detach-after-handoff",
             "agent-task",
@@ -1899,12 +1861,13 @@ mod tests {
             "--run",
             "--runner",
             "homeboy-lab",
+            "--placement",
+            "lab",
         ]);
 
-        assert_eq!(
-            lab_route_dispatch_timeout(&cli.command, cli.detach_after_handoff),
-            Some(lab_routing::lab_trace_dispatch_timeout())
-        );
+        for cli in [&cook, &batch, &retry] {
+            assert_eq!(lab_route_dispatch_timeout(&cli.command), None);
+        }
     }
 
     #[test]

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -122,40 +122,47 @@ fn active_pinned_run_blocks_controller_binary_replacement() {
 #[test]
 fn detached_lab_handoff_persists_inspectable_running_record() {
     with_isolated_home(|_| {
-        let record = record_detached_lab_run(DetachedLabRunRecord {
-            run_id: "agent-task-detached",
-            runner_id: "homeboy-lab",
-            runner_job_id: "job-123",
-            remote_workspace: "/runner/workspace/repo",
-            remote_command: &[
+        for (run_id, handoff) in [
+            ("agent-task-detached-cook", "cook"),
+            ("agent-task-detached-batch", "cook-batch"),
+            ("agent-task-detached-retry", "run-plan"),
+        ] {
+            let command = vec![
                 "homeboy".to_string(),
                 "agent-task".to_string(),
-                "cook".to_string(),
-            ],
-        })
-        .expect("detached handoff recorded");
+                handoff.to_string(),
+            ];
+            let record = record_detached_lab_run(DetachedLabRunRecord {
+                run_id,
+                runner_id: "homeboy-lab",
+                runner_job_id: "job-123",
+                remote_workspace: "/runner/workspace/repo",
+                remote_command: &command,
+            })
+            .expect("detached handoff recorded");
 
-        let loaded = status("agent-task-detached").expect("status resolves");
-        let log = logs("agent-task-detached").expect("logs resolve");
-        let artifacts = artifacts("agent-task-detached").expect("artifacts resolve");
+            let loaded = status(run_id).expect("status resolves");
+            let log = logs(run_id).expect("logs resolve");
+            let artifacts = artifacts(run_id).expect("artifacts resolve");
 
-        assert_eq!(record.run_id, "agent-task-detached");
-        assert_eq!(loaded.state, AgentTaskRunState::Running);
-        assert_eq!(loaded.tasks[0].state, AgentTaskState::Running);
-        assert_eq!(loaded.metadata["runner_id"], "homeboy-lab");
-        assert_eq!(loaded.metadata["runner_job_id"], "job-123");
-        assert!(loaded.metadata.get("stale_running").is_none());
-        assert!(loaded.lifecycle.heartbeat.is_some());
-        assert_eq!(
-            loaded
-                .lifecycle
-                .heartbeat
-                .as_ref()
-                .map(|heartbeat| heartbeat.last_seen_at.as_str()),
-            loaded.updated_at.as_deref()
-        );
-        assert_eq!(log.events.len(), 1);
-        assert!(artifacts.evidence_refs.is_empty());
+            assert_eq!(record.run_id, run_id);
+            assert_eq!(loaded.state, AgentTaskRunState::Running);
+            assert_eq!(loaded.tasks[0].state, AgentTaskState::Running);
+            assert_eq!(loaded.metadata["runner_id"], "homeboy-lab");
+            assert_eq!(loaded.metadata["runner_job_id"], "job-123");
+            assert!(loaded.metadata.get("stale_running").is_none());
+            assert!(loaded.lifecycle.heartbeat.is_some());
+            assert_eq!(
+                loaded
+                    .lifecycle
+                    .heartbeat
+                    .as_ref()
+                    .map(|heartbeat| heartbeat.last_seen_at.as_str()),
+                loaded.updated_at.as_deref()
+            );
+            assert_eq!(log.events.len(), 1);
+            assert!(artifacts.evidence_refs.is_empty());
+        }
     });
 }
 


### PR DESCRIPTION
## Summary
- limit the short Lab dispatch timeout to trace commands
- let detached cook, cook-batch, and retry handoffs wait for durable runner acceptance
- cover timeout routing and inspectable durable handoff records

Closes #7971.

## How to test
1. Run `cargo test detached_agent_task_handoffs_do_not_use_trace_dispatch_timeout`.
2. Run `cargo test detached_lab_handoff_persists_inspectable_running_record`.
3. Run `cargo fmt --check`.

## Compatibility
This removes an incorrect trace-specific timeout from detached agent-task handoffs. Trace dispatch retains its existing bounded timeout. No public schema changes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause analysis, implementation, and deterministic regression tests; Chris reviewed and owns the change.