### PR TITLE
Prepare Lab snapshots for committed harvest

### DIFF
--- a/src/core/agent_task_scheduler/mod.rs
+++ b/src/core/agent_task_scheduler/mod.rs
@@ -336,8 +336,8 @@ where
                     continue;
                 }
                 let task_id = request.task_id.clone();
-                let task_base_sha = match prepare_committed_harvest(&request) {
-                    Ok(base) => base,
+                let harvest_preflight = match prepare_committed_harvest(&request) {
+                    Ok(preflight) => preflight,
                     Err(error) => {
                         let outcome = committed_harvest_failure(
                             committed_harvest_preflight_outcome(task_id.clone()),
@@ -353,6 +353,7 @@ where
                         continue;
                     }
                 };
+                let task_base_sha = harvest_preflight.base_sha;
                 let source_workspace_root = request.workspace.root.clone();
                 let attempt_workspace =
                     match prepare_attempt_workspace(&mut request, task_base_sha.as_deref()) {
@@ -416,6 +417,7 @@ where
                     run_id: self.run_id.clone(),
                     artifact_nonce: uuid::Uuid::new_v4().to_string(),
                     task_base_sha,
+                    source_provenance: harvest_preflight.source_provenance,
                 });
 
                 thread::spawn(move || {
@@ -699,6 +701,8 @@ struct RunningTask {
     /// Workspace HEAD captured immediately before the executor runs. It bounds
     /// any committed patch candidate to this dispatch attempt.
     task_base_sha: Option<String>,
+    /// Verified source identity for snapshot-backed candidate artifacts.
+    source_provenance: Option<serde_json::Value>,
 }
 
 struct QuarantinedTask {
@@ -750,18 +754,109 @@ impl Drop for AttemptWorkspace {
     }
 }
 
-fn prepare_committed_harvest(request: &AgentTaskRequest) -> Result<Option<String>, HarvestError> {
+struct HarvestPreflight {
+    base_sha: Option<String>,
+    source_provenance: Option<serde_json::Value>,
+}
+
+fn prepare_committed_harvest(request: &AgentTaskRequest) -> Result<HarvestPreflight, HarvestError> {
     let Some(root) = request.workspace.root.as_deref().map(Path::new) else {
-        return Ok(None);
+        return Ok(HarvestPreflight {
+            base_sha: None,
+            source_provenance: None,
+        });
     };
-    if !git_is_repository(root)? {
-        return Ok(None);
+    let snapshot_signaled = std::env::var_os(crate::core::observation::LAB_OFFLOAD_METADATA_ENV)
+        .is_some()
+        || std::env::var_os(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV).is_some();
+    let is_repository = git_is_repository(root)?;
+    if !snapshot_signaled && !is_repository {
+        return Ok(HarvestPreflight {
+            base_sha: None,
+            source_provenance: None,
+        });
+    }
+    let source_provenance = if snapshot_signaled {
+        let provenance =
+            crate::core::runner::verify_lab_workspace_from_env(&root.display().to_string(), root)
+                .map_err(snapshot_harvest_error)?;
+        if is_repository {
+            crate::core::runner::verify_lab_workspace_git_root(root, &provenance)
+                .map_err(snapshot_harvest_error)?;
+        } else {
+            if provenance.materialization_mode == "git" {
+                return Err(snapshot_harvest_error(
+                    "verified Git materialization is missing root Git metadata".to_string(),
+                ));
+            }
+            if root.join(".git").exists() {
+                return Err(snapshot_harvest_error(
+                    "snapshot workspace unexpectedly contains root .git metadata".to_string(),
+                ));
+            }
+            if provenance.materialization_mode != "snapshot"
+                && provenance.materialization_mode != "snapshot-git"
+            {
+                return Err(snapshot_harvest_error(format!(
+                    "unsupported snapshot materialization mode `{}`",
+                    provenance.materialization_mode
+                )));
+            }
+        }
+        Some(serde_json::json!({
+            "source_revision": provenance.source_revision,
+            "workspace_snapshot_identity": provenance.workspace_identity,
+            "snapshot_hash": provenance.snapshot_hash,
+            "runner_id": provenance.runner_id,
+            "workspace_path": root.display().to_string(),
+            "materialization_mode": provenance.materialization_mode,
+        }))
+    } else {
+        None
+    };
+    if !is_repository {
+        crate::core::runner::materialize_verified_lab_snapshot_git_baseline_from_env(
+            &root.display().to_string(),
+            root,
+        )
+        .map_err(|message| HarvestError::Git {
+            command: "materialize verified Lab snapshot Git baseline".to_string(),
+            message,
+        })?;
+    }
+    let git_root = git_output(root, &["rev-parse", "--show-toplevel"])?;
+    let canonical_root = root.canonicalize().map_err(|error| HarvestError::Git {
+        command: "canonicalize workspace root".to_string(),
+        message: error.to_string(),
+    })?;
+    let canonical_git_root =
+        PathBuf::from(git_root)
+            .canonicalize()
+            .map_err(|error| HarvestError::Git {
+                command: "canonicalize Git top-level".to_string(),
+                message: error.to_string(),
+            })?;
+    if canonical_root != canonical_git_root {
+        return Err(HarvestError::Git {
+            command: "verify Git top-level ownership".to_string(),
+            message: "Git top-level does not exactly match the managed workspace root".to_string(),
+        });
     }
     let status = git_output(root, &["status", "--porcelain", "--untracked-files=all"])?;
     if !status.trim().is_empty() {
         return Err(HarvestError::DirtyWorkspace { status });
     }
-    Ok(Some(git_output(root, &["rev-parse", "HEAD"])?))
+    Ok(HarvestPreflight {
+        base_sha: Some(git_output(root, &["rev-parse", "HEAD"])?),
+        source_provenance,
+    })
+}
+
+fn snapshot_harvest_error(message: String) -> HarvestError {
+    HarvestError::Git {
+        command: "verify Lab snapshot harvest provenance".to_string(),
+        message,
+    }
 }
 
 /// Give each provider dispatch a detached checkout at the caller's clean base.
@@ -859,6 +954,7 @@ fn harvest_uncommitted_patch(
             "producer_attempt": running.attempt,
             "provider_rotation_index": running.rotation_index,
             "provider_backend": running.request.executor.backend,
+            "source_provenance": running.source_provenance,
         }),
     });
     Ok(())
@@ -873,6 +969,17 @@ fn persist_attempt_patch_artifacts(
         if !is_actionable_patch_artifact(artifact) {
             continue;
         }
+        if !artifact.metadata.is_object() {
+            artifact.metadata = serde_json::json!({});
+        }
+        artifact
+            .metadata
+            .as_object_mut()
+            .expect("patch artifact metadata object")
+            .insert(
+                "source_provenance".to_string(),
+                serde_json::json!(running.source_provenance),
+            );
         let Some(source) = artifact.path.as_deref().map(PathBuf::from) else {
             continue;
         };
@@ -984,6 +1091,7 @@ fn harvest_committed_patch_with_metadata(
         "run_id": running.run_id.as_deref(),
         "task_id": &running.task_id,
         "producer_attempt": running.attempt,
+        "source_provenance": running.source_provenance,
     });
     Ok(())
 }
@@ -1028,6 +1136,7 @@ fn committed_patch_artifact(
             "run_id": running.run_id,
             "task_id": running.task_id,
             "producer_attempt": running.attempt,
+            "source_provenance": running.source_provenance,
         }),
     }
 }
@@ -1118,6 +1227,7 @@ fn git_output(cwd: &Path, args: &[&str]) -> Result<String, HarvestError> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+#[derive(Debug)]
 enum HarvestError {
     DirtyWorkspace { status: String },
     UnrelatedHead { base: String, head: String },
@@ -1199,6 +1309,10 @@ mod committed_harvest_tests {
         AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskWorkspace,
         AGENT_TASK_REQUEST_SCHEMA,
     };
+    use crate::core::source_snapshot::SourceSnapshot;
+    use std::sync::{Mutex, OnceLock};
+
+    static LAB_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
     fn git(cwd: &Path, args: &[&str]) -> String {
         let output = Command::new("git")
@@ -1272,6 +1386,7 @@ mod committed_harvest_tests {
             run_id: Some("committed-harvest-test".to_string()),
             artifact_nonce: "test-artifact".to_string(),
             task_base_sha: Some(base),
+            source_provenance: None,
         };
         let mut outcome = committed_harvest_preflight_outcome("task-1".to_string());
         outcome.status = AgentTaskOutcomeStatus::Succeeded;
@@ -1309,6 +1424,207 @@ mod committed_harvest_tests {
             diagnostic.class == "agent_task.committed_harvest_git_failed"
                 && diagnostic.data["command"] == "git log injected metadata failure"
         }));
+    }
+
+    #[test]
+    fn lab_snapshot_preflight_materializes_a_provider_ready_attempt_workspace() {
+        let _guard = LAB_ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("Lab environment lock");
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source");
+        let path = workspace.path().display().to_string();
+        let snapshot = SourceSnapshot {
+            runner_id: "lab".to_string(),
+            local_path: Some("/controller/source".to_string()),
+            remote_path: Some(path.clone()),
+            workspace_root: None,
+            git_branch: Some("main".to_string()),
+            git_sha: Some("a".repeat(40)),
+            dirty: false,
+            sync_mode: "lab_offload".to_string(),
+            workspace_snapshot_identity: Some("snapshot:provider-ready".to_string()),
+            snapshot_hash: "sha256:provider-ready".to_string(),
+            synced_at: "2026-01-01T00:00:00Z".to_string(),
+            sync_excludes: vec![".git".to_string(), ".git/**".to_string()],
+        };
+        let content_hash =
+            crate::core::runner::workspace_content_hash(workspace.path(), &snapshot.sync_excludes)
+                .expect("content hash");
+        let lab = serde_json::json!({
+            "runner_id": "lab", "remote_workspace": path, "sync_mode": "snapshot", "status": "offloaded",
+            "source_snapshot": snapshot,
+            "workspace_verification": {
+                "schema": "homeboy/lab-workspace-verification/v1", "identity": "snapshot:provider-ready",
+                "content_hash": content_hash, "sync_excludes": snapshot.sync_excludes,
+                "source_snapshot": snapshot,
+                "primary_workspace": { "identity": "snapshot:provider-ready", "remote_path": workspace.path().display().to_string() }
+            }
+        });
+        std::env::set_var(
+            crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV,
+            serde_json::to_string(&snapshot).expect("snapshot JSON"),
+        );
+        std::env::set_var(
+            crate::core::observation::LAB_OFFLOAD_METADATA_ENV,
+            serde_json::to_string(&lab).expect("Lab JSON"),
+        );
+        let mut request = AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "snapshot-task".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "test".to_string(),
+                selector: None,
+                runtime_selection: None,
+                required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
+                model: None,
+                config: serde_json::Value::Null,
+            },
+            instructions: String::new(),
+            inputs: serde_json::Value::Null,
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace {
+                root: Some(workspace.path().display().to_string()),
+                ..Default::default()
+            },
+            component_contracts: Vec::new(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            artifact_declarations: Vec::new(),
+            metadata: serde_json::Value::Null,
+        };
+        let preflight = prepare_committed_harvest(&request).expect("snapshot preflight");
+        let baseline = preflight.base_sha.expect("synthetic baseline");
+        let source_provenance = preflight.source_provenance.expect("source provenance");
+        assert!(workspace.path().join(".git").is_dir());
+        assert_eq!(source_provenance["source_revision"], "a".repeat(40));
+        let attempt = prepare_attempt_workspace(&mut request, Some(&baseline))
+            .expect("provider-ready attempt")
+            .expect("attempt workspace");
+        assert_ne!(
+            request.workspace.root.as_deref(),
+            Some(workspace.path().to_str().unwrap())
+        );
+        assert!(git_is_repository(Path::new(request.workspace.root.as_deref().unwrap())).unwrap());
+        let external_patch = workspace.path().join("external.patch");
+        std::fs::write(&external_patch, "external patch").expect("external patch");
+        let mut outcome = committed_harvest_preflight_outcome("snapshot-task".to_string());
+        outcome.artifacts = vec![
+            AgentTaskArtifact {
+                schema: crate::core::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                id: "external".to_string(),
+                kind: "patch".to_string(),
+                name: None,
+                label: None,
+                role: None,
+                semantic_key: None,
+                path: Some(external_patch.display().to_string()),
+                url: None,
+                mime: None,
+                size_bytes: None,
+                sha256: None,
+                metadata: serde_json::json!({"kept": true}),
+            },
+            AgentTaskArtifact {
+                schema: crate::core::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                id: "url-only".to_string(),
+                kind: "patch".to_string(),
+                name: None,
+                label: None,
+                role: None,
+                semantic_key: None,
+                path: None,
+                url: Some("https://example.test/candidate.patch".to_string()),
+                mime: None,
+                size_bytes: None,
+                sha256: None,
+                metadata: serde_json::Value::Null,
+            },
+        ];
+        let running = RunningTask {
+            task_id: "snapshot-task".to_string(),
+            request: request.clone(),
+            workspace_key: None,
+            executor_key: "test".to_string(),
+            model_key: None,
+            resource_units: 1,
+            attempt: 1,
+            started_at: Instant::now(),
+            timeout_ms: None,
+            rotation_index: 0,
+            rotation_attempts: Vec::new(),
+            candidate_artifacts: Vec::new(),
+            retry_attempts: Vec::new(),
+            source_workspace_root: None,
+            _attempt_workspace: None,
+            run_id: None,
+            artifact_nonce: "test".to_string(),
+            task_base_sha: Some(baseline),
+            source_provenance: Some(source_provenance.clone()),
+        };
+        persist_attempt_patch_artifacts(
+            &mut outcome,
+            &running,
+            Path::new(request.workspace.root.as_deref().unwrap()),
+        )
+        .expect("external patch provenance");
+        for artifact in &outcome.artifacts {
+            assert_eq!(artifact.metadata["source_provenance"], source_provenance);
+        }
+        assert_eq!(outcome.artifacts[0].metadata["kept"], true);
+        drop(attempt);
+        std::env::remove_var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV);
+        std::env::remove_var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV);
+    }
+
+    #[test]
+    fn local_non_git_workspace_skips_harvest_preflight_without_lab_transport() {
+        let _guard = LAB_ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("Lab environment lock");
+        std::env::remove_var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV);
+        std::env::remove_var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV);
+        let workspace = tempfile::tempdir().expect("workspace");
+        let request = AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "local-task".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "test".to_string(),
+                selector: None,
+                runtime_selection: None,
+                required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
+                model: None,
+                config: serde_json::Value::Null,
+            },
+            instructions: String::new(),
+            inputs: serde_json::Value::Null,
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace {
+                root: Some(workspace.path().display().to_string()),
+                ..Default::default()
+            },
+            component_contracts: Vec::new(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            artifact_declarations: Vec::new(),
+            metadata: serde_json::Value::Null,
+        };
+
+        let preflight = prepare_committed_harvest(&request).expect("local non-Git no-op");
+
+        assert!(preflight.base_sha.is_none());
+        assert!(preflight.source_provenance.is_none());
+        assert!(!workspace.path().join(".git").exists());
     }
 }
 

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -63,6 +63,7 @@ mod worker;
 pub(crate) mod workload;
 mod workspace;
 pub(crate) use workspace::copy_snapshot_to_directory;
+pub(crate) use workspace::materialize_verified_lab_snapshot_git_baseline_from_env;
 #[cfg(test)]
 pub(crate) use workspace::workspace_resource_lifecycle;
 pub(crate) use workspace::{MaterializedWorkspace, WorkspaceCleanupPolicy};
@@ -169,7 +170,8 @@ pub use workspace::{
     RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 pub(crate) use workspace::{
-    verify_lab_workspace_from_env, workspace_content_hash, VerifiedLabWorkspaceProvenance,
+    verify_lab_workspace_from_env, verify_lab_workspace_git_root, workspace_content_hash,
+    VerifiedLabWorkspaceProvenance,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/core/runner/workspace/mod.rs
+++ b/src/core/runner/workspace/mod.rs
@@ -39,7 +39,10 @@ pub(crate) use materializer::{
 };
 #[cfg(test)]
 pub(crate) use provenance::verify_lab_workspace;
-pub(crate) use provenance::{verify_lab_workspace_from_env, VerifiedLabWorkspaceProvenance};
+pub(crate) use provenance::{
+    materialize_verified_lab_snapshot_git_baseline_from_env, verify_lab_workspace_from_env,
+    verify_lab_workspace_git_root, VerifiedLabWorkspaceProvenance,
+};
 pub(crate) use snapshot::{
     copy_snapshot_to_directory, effective_snapshot_excludes, local_snapshot_stats,
     materialize_snapshot, materialize_snapshot_git, snapshot_identity, workspace_content_hash,

--- a/src/core/runner/workspace/provenance.rs
+++ b/src/core/runner/workspace/provenance.rs
@@ -1,4 +1,5 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use crate::core::observation::{LAB_OFFLOAD_METADATA_ENV, SOURCE_SNAPSHOT_METADATA_ENV};
 use crate::core::source_snapshot::SourceSnapshot;
@@ -13,6 +14,118 @@ pub(crate) struct VerifiedLabWorkspaceProvenance {
     pub materialization_mode: String,
     pub runner_id: String,
     pub workspace_identity: String,
+    pub snapshot_hash: String,
+}
+
+/// Creates a deterministic Git root for a verified Lab snapshot so generic
+/// candidate harvesting can use the same commit and diff paths as Git syncs.
+pub(crate) fn materialize_verified_lab_snapshot_git_baseline_from_env(
+    expected_remote_component_path: &str,
+    materialized_workspace_path: &Path,
+) -> std::result::Result<String, String> {
+    let snapshot: SourceSnapshot = env_json(SOURCE_SNAPSHOT_METADATA_ENV)
+        .ok_or_else(|| "is missing source snapshot transport metadata".to_string())?;
+    let lab: serde_json::Value = env_json(LAB_OFFLOAD_METADATA_ENV)
+        .ok_or_else(|| "is missing Lab dispatch transport metadata".to_string())?;
+    materialize_verified_lab_snapshot_git_baseline(
+        expected_remote_component_path,
+        materialized_workspace_path,
+        snapshot,
+        lab,
+    )
+}
+
+pub(crate) fn materialize_verified_lab_snapshot_git_baseline(
+    expected_remote_component_path: &str,
+    materialized_workspace_path: &Path,
+    snapshot: SourceSnapshot,
+    lab: serde_json::Value,
+) -> std::result::Result<String, String> {
+    let provenance = verify_lab_workspace(
+        expected_remote_component_path,
+        materialized_workspace_path,
+        snapshot,
+        lab,
+    )?;
+    if provenance.materialization_mode == "git" {
+        return Err(
+            "does not require a synthetic Git baseline for git materialization".to_string(),
+        );
+    }
+    if materialized_workspace_path.join(".git").exists() {
+        return Err("snapshot workspace unexpectedly contains root .git metadata".to_string());
+    }
+    if let Some(path) = nested_git_metadata(materialized_workspace_path)? {
+        return Err(format!(
+            "snapshot workspace contains nested Git metadata at {}",
+            path.display()
+        ));
+    }
+
+    git(
+        materialized_workspace_path,
+        &[
+            "init",
+            "--quiet",
+            "--initial-branch=homeboy-snapshot-baseline",
+        ],
+    )?;
+    git(materialized_workspace_path, &["add", "--all"])?;
+    let tree = git(materialized_workspace_path, &["write-tree"])?;
+    let message = format!(
+        "homeboy snapshot baseline\n\nsource-revision: {}\nworkspace-identity: {}\nsnapshot-hash: {}",
+        provenance.source_revision, provenance.workspace_identity, provenance.snapshot_hash,
+    );
+    let commit = git_with_env(
+        materialized_workspace_path,
+        &["commit-tree", &tree, "-m", &message],
+        &[
+            ("GIT_AUTHOR_NAME", "Homeboy Snapshot"),
+            ("GIT_AUTHOR_EMAIL", "snapshot@homeboy.invalid"),
+            ("GIT_COMMITTER_NAME", "Homeboy Snapshot"),
+            ("GIT_COMMITTER_EMAIL", "snapshot@homeboy.invalid"),
+            ("GIT_AUTHOR_DATE", "1970-01-01T00:00:00Z"),
+            ("GIT_COMMITTER_DATE", "1970-01-01T00:00:00Z"),
+        ],
+    )?;
+    git(
+        materialized_workspace_path,
+        &[
+            "update-ref",
+            "refs/heads/homeboy-snapshot-baseline",
+            &commit,
+        ],
+    )?;
+    Ok(commit)
+}
+
+/// Verifies that a Lab Git materialization owns exactly the requested root and
+/// remains at the source revision carried by the verified snapshot contract.
+pub(crate) fn verify_lab_workspace_git_root(
+    workspace: &Path,
+    provenance: &VerifiedLabWorkspaceProvenance,
+) -> std::result::Result<(), String> {
+    if provenance.materialization_mode != "git" {
+        return Err(format!(
+            "snapshot materialization mode `{}` must be gitless",
+            provenance.materialization_mode
+        ));
+    }
+    let root = workspace
+        .canonicalize()
+        .map_err(|error| format!("could not canonicalize workspace: {error}"))?;
+    let git_root = git(workspace, &["rev-parse", "--show-toplevel"])?;
+    let git_root = PathBuf::from(git_root)
+        .canonicalize()
+        .map_err(|error| format!("could not canonicalize Git root: {error}"))?;
+    if root != git_root {
+        return Err("Git top-level does not exactly match the managed workspace root".to_string());
+    }
+    let head = git(workspace, &["rev-parse", "HEAD"])?;
+    if head != provenance.source_revision {
+        return Err("Git HEAD does not match the verified source revision".to_string());
+    }
+    Ok(())
 }
 
 /// Verifies a Lab-materialized workspace against the controller-produced
@@ -189,7 +302,59 @@ pub(crate) fn verify_lab_workspace(
         materialization_mode: materialization_mode.to_string(),
         runner_id: snapshot.runner_id,
         workspace_identity: workspace_identity.to_string(),
+        snapshot_hash: snapshot.snapshot_hash,
     })
+}
+
+fn git(cwd: &Path, args: &[&str]) -> std::result::Result<String, String> {
+    git_with_env(cwd, args, &[])
+}
+
+fn git_with_env(
+    cwd: &Path,
+    args: &[&str],
+    env: &[(&str, &str)],
+) -> std::result::Result<String, String> {
+    let output = Command::new("git")
+        .args(args)
+        .envs(env.iter().copied())
+        .current_dir(cwd)
+        .output()
+        .map_err(|error| format!("could not run git {}: {error}", args.join(" ")))?;
+    if !output.status.success() {
+        return Err(format!(
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn nested_git_metadata(workspace: &Path) -> std::result::Result<Option<PathBuf>, String> {
+    fn visit(root: &Path, path: &Path) -> std::result::Result<Option<PathBuf>, String> {
+        for entry in std::fs::read_dir(path)
+            .map_err(|error| format!("could not inspect snapshot workspace: {error}"))?
+        {
+            let entry =
+                entry.map_err(|error| format!("could not inspect snapshot entry: {error}"))?;
+            let path = entry.path();
+            if path.file_name().is_some_and(|name| name == ".git") && path != root.join(".git") {
+                return Ok(Some(path));
+            }
+            if entry
+                .file_type()
+                .map_err(|error| format!("could not inspect snapshot entry type: {error}"))?
+                .is_dir()
+            {
+                if let Some(found) = visit(root, &path)? {
+                    return Ok(Some(found));
+                }
+            }
+        }
+        Ok(None)
+    }
+    visit(workspace, workspace)
 }
 
 fn env_json<T: serde::de::DeserializeOwned>(name: &str) -> Option<T> {
@@ -204,4 +369,118 @@ fn paths_equal(left: &str, right: &str) -> bool {
 
 fn is_git_revision(value: &str) -> bool {
     matches!(value.len(), 40 | 64) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot(path: &Path) -> SourceSnapshot {
+        SourceSnapshot {
+            runner_id: "lab".to_string(),
+            local_path: Some("/controller/source".to_string()),
+            remote_path: Some(path.display().to_string()),
+            workspace_root: None,
+            git_branch: Some("main".to_string()),
+            git_sha: Some("a".repeat(40)),
+            dirty: false,
+            sync_mode: LAB_SOURCE_SNAPSHOT_SYNC_MODE.to_string(),
+            workspace_snapshot_identity: Some("snapshot:verified-content".to_string()),
+            snapshot_hash: "sha256:verified-source".to_string(),
+            synced_at: "2026-01-01T00:00:00Z".to_string(),
+            sync_excludes: vec![".git".to_string(), ".git/**".to_string()],
+        }
+    }
+
+    fn lab(path: &Path, snapshot: &SourceSnapshot) -> serde_json::Value {
+        let content_hash =
+            workspace_content_hash(path, &snapshot.sync_excludes).expect("snapshot content hash");
+        serde_json::json!({
+            "runner_id": "lab",
+            "remote_workspace": path.display().to_string(),
+            "sync_mode": "snapshot",
+            "status": "offloaded",
+            "source_snapshot": snapshot,
+            "workspace_verification": {
+                "schema": "homeboy/lab-workspace-verification/v1",
+                "identity": "snapshot:verified-content",
+                "content_hash": content_hash,
+                "sync_excludes": snapshot.sync_excludes,
+                "source_snapshot": snapshot,
+                "primary_workspace": {
+                    "identity": "snapshot:verified-content",
+                    "remote_path": path.display().to_string(),
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn verified_snapshot_baseline_supports_committed_and_uncommitted_candidate_harvesting() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");
+        let snapshot = snapshot(workspace.path());
+        let baseline = materialize_verified_lab_snapshot_git_baseline(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot.clone(),
+            lab(workspace.path(), &snapshot),
+        )
+        .expect("verified snapshot baseline");
+
+        assert_eq!(
+            git(workspace.path(), &["rev-parse", "HEAD"]).unwrap(),
+            baseline
+        );
+        let message = git(workspace.path(), &["log", "-1", "--format=%B"]).unwrap();
+        assert!(message.contains("source-revision: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+        assert!(message.contains("workspace-identity: snapshot:verified-content"));
+        assert!(message.contains("snapshot-hash: sha256:verified-source"));
+        std::fs::write(workspace.path().join("file.txt"), "candidate\n").expect("candidate");
+        git(workspace.path(), &["add", "--all"]).expect("stage candidate");
+        git(
+            workspace.path(),
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=test@homeboy.invalid",
+                "commit",
+                "-m",
+                "provider candidate",
+            ],
+        )
+        .expect("commit candidate");
+        let committed_patch = git(workspace.path(), &["diff", "--binary", &baseline, "HEAD"])
+            .expect("committed candidate patch");
+        assert!(committed_patch.contains("-baseline"));
+        assert!(committed_patch.contains("+candidate"));
+
+        std::fs::write(workspace.path().join("file.txt"), "uncommitted candidate\n")
+            .expect("uncommitted candidate");
+        git(workspace.path(), &["add", "--all"]).expect("stage uncommitted candidate");
+        let uncommitted_patch = git(workspace.path(), &["diff", "--cached", "--binary", "HEAD"])
+            .expect("candidate patch");
+        assert!(uncommitted_patch.contains("-candidate"));
+        assert!(uncommitted_patch.contains("+uncommitted candidate"));
+    }
+
+    #[test]
+    fn snapshot_baseline_rejects_invalid_provenance_before_creating_git_metadata() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");
+        let mut snapshot = snapshot(workspace.path());
+        snapshot.git_sha = Some("invalid".to_string());
+
+        let error = materialize_verified_lab_snapshot_git_baseline(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot.clone(),
+            lab(workspace.path(), &snapshot),
+        )
+        .expect_err("invalid provenance must fail closed");
+
+        assert!(error.contains("invalid source revision"));
+        assert!(!workspace.path().join(".git").exists());
+    }
 }


### PR DESCRIPTION
## Summary
- verify managed Lab snapshot provenance before committed-change harvest
- create a deterministic synthetic Git baseline so existing committed and uncommitted harvest paths work in gitless Lab snapshots
- reject ancestor, injected root, and nested Git ownership
- preserve controller source revision and snapshot identity as structured patch provenance, separate from the synthetic diff baseline
- retain existing local Git and local non-Git behavior

Fixes #8129.

## How to test
1. Run `cargo test committed_harvest_tests:: --lib --no-fail-fast`.
2. Run `cargo test runner::workspace::provenance::tests:: --lib --no-fail-fast`.
3. Run `cargo check --lib`, `cargo fmt --check`, and `git diff --check origin/main...HEAD`.
4. Route `homeboy agent-task cook` through Lab from a clean snapshot and confirm provider execution begins instead of failing at committed-harvest preflight.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab snapshot harvest failure, implemented provenance-bound baseline materialization, added safety coverage, and independently reviewed artifact provenance. Chris reviewed and owns the change.