### PR TITLE
Format engine primitive re-export

### DIFF
--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -5,9 +5,7 @@
 // Leaf execution primitives moved to the internal `homeboy-engine-primitives`
 // crate. Re-exported here so existing `crate::core::engine::{shell,command,...}`
 // call sites keep working unchanged.
-pub use homeboy_engine_primitives::{
-    command, identifier, output_parse, shell, template, text,
-};
+pub use homeboy_engine_primitives::{command, identifier, output_parse, shell, template, text};
 
 pub mod baseline;
 pub mod cli_tool;


### PR DESCRIPTION
## Summary
- Apply rustfmt to the engine-primitives re-export introduced by #8160/#8161.
- Restore a clean `cargo fmt --check` so stable Homeboy release preflight can proceed.

Related to #6860.

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo check --lib`.

## Compatibility
- Formatting only; runtime behavior and public contracts are unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Isolated and corrected rustfmt drift blocking the stable Homeboy release; Chris reviews and owns the change.