### PR TITLE
Fix Lab cook phase and live-job status reporting

### DIFF
--- a/src/commands/runner/status.rs
+++ b/src/commands/runner/status.rs
@@ -918,6 +918,15 @@ pub(super) fn runner_status_operator_hints(report: &RunnerStatusReport) -> Vec<S
             "Active-job status for `{}` is unavailable: {reason}. Treat active_job_count=0 as unknown, not idle.",
             report.runner_id
         ));
+    } else if let Some(error) = report
+        .active_job_error
+        .as_ref()
+        .filter(|error| error.code == "active_job_view_inconsistent")
+    {
+        hints.push(format!(
+            "Active-job view for `{}` is inconsistent: {}",
+            report.runner_id, error.message
+        ));
     }
     if report.stale_runner_job_count > 0 {
         hints.push(format!(

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -500,6 +500,22 @@ pub(crate) fn reconcile_runner_job_snapshot(
             let metadata = reconciled.ensure_metadata_object();
             metadata.insert("runner_job_status".to_string(), json!(snapshot.job.status));
             metadata.insert("runner_job_last_seen_at".to_string(), json!(last_seen_at));
+            metadata.insert("runner_job_events".to_string(), json!(snapshot.events));
+            metadata.insert("phase".to_string(), json!("executing"));
+            metadata.insert(
+                "phase_activity".to_string(),
+                json!("provider/executor process is active"),
+            );
+            metadata.insert("provider_state".to_string(), json!("active"));
+            if let Some(provider) = metadata
+                .get("provider_rotation")
+                .and_then(|rotation| rotation.get("entries"))
+                .and_then(Value::as_array)
+                .and_then(|entries| entries.first())
+            {
+                metadata.insert("active_provider".to_string(), provider.clone());
+            }
+            merge_live_provider_handles(&mut reconciled, &snapshot.events);
             store::write_record(&reconciled)?;
         }
         crate::core::api_jobs::JobStatus::Succeeded
@@ -528,6 +544,52 @@ pub(crate) fn reconcile_runner_job_snapshot(
     }
     *record = reconciled;
     Ok(())
+}
+
+fn merge_live_provider_handles(
+    record: &mut AgentTaskRunRecord,
+    events: &[crate::core::api_jobs::JobEvent],
+) {
+    for handle in events.iter().filter_map(|event| {
+        event
+            .data
+            .as_ref()
+            .and_then(|data| {
+                data.pointer("/metadata/provider_handle")
+                    .or_else(|| data.get("provider_handle"))
+            })
+            .and_then(provider_handle_from_value)
+    }) {
+        if record
+            .provider_handles
+            .iter()
+            .any(|existing| existing.provider_run_id == handle.run_id)
+        {
+            continue;
+        }
+        record.provider_handles.push(AgentTaskRunProviderHandle {
+            kind: handle.kind,
+            task_id: handle.task_id,
+            backend: handle.backend,
+            provider_run_id: handle.run_id,
+            stream_uri: handle.stream_uri,
+            state: Some(AgentTaskState::Running),
+            metadata: handle.metadata,
+        });
+    }
+    if !record.provider_handles.is_empty() {
+        record.lifecycle.provider_runtime = record
+            .provider_handles
+            .iter()
+            .map(provider_runtime_for_handle)
+            .collect();
+        record.lifecycle.external_runtime_ids = record
+            .lifecycle
+            .provider_runtime
+            .iter()
+            .flat_map(|runtime| runtime.external_runtime_ids.clone())
+            .collect();
+    }
 }
 
 fn validate_runner_job_snapshot(
@@ -845,8 +907,9 @@ pub fn record_lab_offload_phase(
         durable_plan,
     )?;
     record.updated_at = Some(now_timestamp());
+    let phase_started_at = record.updated_at.clone().unwrap_or_else(now_timestamp);
     let metadata = record.ensure_metadata_object();
-    metadata.insert("phase".to_string(), json!(phase));
+    record_lab_offload_phase_metadata(metadata, phase, &phase_started_at);
     metadata.insert("provider_state".to_string(), json!("pending"));
     if let Some(remote_workspace) = remote_workspace {
         metadata.insert("remote_workspace".to_string(), json!(remote_workspace));
@@ -875,8 +938,9 @@ pub fn record_lab_offload_phase_executions(
         .filter(|id| !id.trim().is_empty())
         .collect();
     record.updated_at = Some(now_timestamp());
+    let phase_started_at = record.updated_at.clone().unwrap_or_else(now_timestamp);
     let metadata = record.ensure_metadata_object();
-    metadata.insert("phase".to_string(), json!(phase));
+    record_lab_offload_phase_metadata(metadata, phase, &phase_started_at);
     metadata.insert(
         "materialization_execution_ids".to_string(),
         json!(execution_ids),
@@ -887,6 +951,44 @@ pub fn record_lab_offload_phase_executions(
     );
     store::write_record(&record)?;
     Ok(record)
+}
+
+fn record_lab_offload_phase_metadata(
+    metadata: &mut serde_json::Map<String, Value>,
+    phase: &str,
+    started_at: &str,
+) {
+    let previous_phase = metadata
+        .get("phase")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    if previous_phase.as_deref() != Some(phase) {
+        if let Some(previous_phase) = previous_phase {
+            if let Some(entry) = metadata
+                .get_mut("phase_history")
+                .and_then(Value::as_array_mut)
+                .and_then(|entries| {
+                    entries.iter_mut().rev().find(|entry| {
+                        entry.get("phase").and_then(Value::as_str) == Some(previous_phase.as_str())
+                            && entry.get("ended_at").is_none()
+                    })
+                })
+            {
+                entry["ended_at"] = json!(started_at);
+            }
+        }
+        metadata
+            .entry("phase_history".to_string())
+            .or_insert_with(|| json!([]))
+            .as_array_mut()
+            .expect("phase history is an array")
+            .push(json!({ "phase": phase, "started_at": started_at }));
+    }
+    metadata.insert("phase".to_string(), json!(phase));
+    metadata.insert(
+        "phase_activity".to_string(),
+        json!(format!("Homeboy {phase}")),
+    );
 }
 
 pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentTaskRunRecord> {
@@ -1209,14 +1311,19 @@ pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRu
 }
 
 pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
-    let run_id = resolve_run_id(run_id)?;
-    let record = store::read_record(&run_id)?;
+    // Status reconciliation fetches the live daemon snapshot for a bound Lab
+    // child, making executor progress visible before the child is terminal.
+    let record = status(run_id)?;
+    let run_id = record.run_id.clone();
     let (events, artifact_refs) = match store::read_aggregate(&run_id) {
         Ok(aggregate) => {
             let refs = artifact_refs_for_outcomes(&aggregate.outcomes);
             (aggregate.events, refs)
         }
-        Err(_) => (queued_events(&record.tasks), record.artifact_refs.clone()),
+        Err(_) => (
+            runner_job_progress_events(&record).unwrap_or_else(|| queued_events(&record.tasks)),
+            record.artifact_refs.clone(),
+        ),
     };
     let normalized_events = normalize_progress_events(&run_id, &events, &artifact_refs);
     Ok(AgentTaskRunLog {
@@ -1225,6 +1332,26 @@ pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
         events,
         normalized_events,
     })
+}
+
+fn runner_job_progress_events(record: &AgentTaskRunRecord) -> Option<Vec<AgentTaskProgressEvent>> {
+    let events = record.metadata.get("runner_job_events")?.as_array()?;
+    let task_id = record
+        .tasks
+        .first()
+        .map(|task| task.task_id.clone())
+        .unwrap_or_else(|| record.run_id.clone());
+    Some(
+        events
+            .iter()
+            .map(|event| AgentTaskProgressEvent {
+                task_id: task_id.clone(),
+                state: AgentTaskState::Running,
+                attempt: 0,
+                message: serde_json::to_string(event).ok(),
+            })
+            .collect(),
+    )
 }
 
 pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -12,6 +12,7 @@ use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
     AGENT_TASK_AGGREGATE_SCHEMA,
 };
+use crate::core::api_jobs::{JobEvent, JobEventKind};
 use crate::test_support::with_isolated_home;
 
 #[test]
@@ -444,6 +445,47 @@ fn controller_proxy_records_pre_execution_phase_progress() {
         let loaded = status("agent-task-pre-execution").expect("status resolves during setup");
         assert_eq!(loaded.metadata["phase"], "hydrating");
         assert_eq!(loaded.metadata["provider_state"], "pending");
+        let phases = loaded.metadata["phase_history"]
+            .as_array()
+            .expect("phase history");
+        assert_eq!(phases.len(), 2);
+        assert_eq!(phases[0]["phase"], "materializing");
+        assert!(phases[0].get("started_at").is_some());
+        assert!(phases[0].get("ended_at").is_some());
+        assert_eq!(phases[1]["phase"], "hydrating");
+        assert!(phases[1].get("started_at").is_some());
+    });
+}
+
+#[test]
+fn logs_expose_mirrored_live_runner_events_before_terminal_aggregate() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "live-runner-events",
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-live",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        })
+        .expect("running proxy");
+        record.metadata["runner_job_events"] = json!([JobEvent {
+            sequence: 1,
+            job_id: uuid::Uuid::new_v4(),
+            kind: JobEventKind::Progress,
+            timestamp_ms: 42,
+            message: Some("provider started".to_string()),
+            data: Some(json!({"provider": "openai/gpt-5.6-terra"})),
+        }]);
+        store::write_record(&record).expect("persist mirrored event");
+
+        let log = logs("live-runner-events").expect("live logs resolve");
+
+        assert_eq!(log.events.len(), 1);
+        assert!(log.events[0]
+            .message
+            .as_deref()
+            .is_some_and(|message| message.contains("provider started")));
     });
 }
 
@@ -642,6 +684,58 @@ fn reachable_running_child_clears_disconnected_liveness_and_refreshes_heartbeat(
         assert!(record.metadata.get("stale_running_reason").is_none());
         assert!(record.metadata.get("retryable").is_none());
         assert_ne!(record.lifecycle.heartbeat, disconnected_heartbeat);
+    });
+}
+
+#[test]
+fn running_child_snapshot_persists_provider_handle_and_live_log_progress() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-live-provider",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("running proxy");
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        snapshot.job.status = crate::core::api_jobs::JobStatus::Running;
+        snapshot.events = vec![crate::core::api_jobs::JobEvent {
+            sequence: 1,
+            job_id: snapshot.job.id,
+            kind: crate::core::api_jobs::JobEventKind::Progress,
+            timestamp_ms: 2,
+            message: Some("provider dispatch accepted".to_string()),
+            data: Some(json!({
+                "metadata": {
+                    "provider_handle": AgentTaskExecutionHandle {
+                        kind: crate::core::agent_task::AgentTaskExecutionHandleKind::ProviderRun,
+                        task_id: "task-a".to_string(),
+                        backend: "openai/gpt-5.6-terra".to_string(),
+                        run_id: "provider-run-live".to_string(),
+                        stream_uri: Some("provider://runs/provider-run-live/events".to_string()),
+                        metadata: json!({"progress": "accepted"}),
+                    }
+                }
+            })),
+        }];
+
+        reconcile_runner_job_snapshot(&mut record, &snapshot).expect("live reconciliation");
+
+        assert_eq!(record.metadata["phase"], "executing");
+        assert_eq!(record.metadata["provider_state"], "active");
+        assert_eq!(record.provider_handles.len(), 1);
+        assert_eq!(
+            record.provider_handles[0].provider_run_id,
+            "provider-run-live"
+        );
+        let log = logs(&record.run_id).expect("live logs");
+        assert_eq!(log.events.len(), 1);
+        assert!(log.events[0]
+            .message
+            .as_deref()
+            .is_some_and(|message| message.contains("provider dispatch accepted")));
     });
 }
 

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -719,11 +719,29 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
     let daemon_freshness = runner_daemon_freshness(&runner, session.as_ref(), connected)?
         .or_else(|| remote_daemon_recovery_freshness(runner_id, &runner));
     let active_job_source = session.as_ref().and_then(active_runner_job_source);
+    let direct_daemon_active_jobs =
+        matches!(active_job_source, Some(RunnerActiveJobSource::DirectDaemon))
+            .then(|| {
+                daemon_freshness
+                    .as_ref()
+                    .map(|freshness| freshness.active_jobs)
+            })
+            .flatten();
     let (active_jobs, stale_jobs, active_job_state, active_job_error) = if connected {
         match session.as_ref() {
             Some(session) => match runner_jobs(runner_id, session) {
                 Ok((active_jobs, mut stale_jobs)) => {
-                    stale_jobs.extend(orphaned_child_run_jobs(runner_id, session, &active_jobs));
+                    // `/jobs` has a typed remote-runner subset while daemon
+                    // freshness counts every live child. Never manufacture an
+                    // orphan when that subset is incomplete.
+                    if should_infer_child_run_orphans(active_jobs.len(), direct_daemon_active_jobs)
+                    {
+                        stale_jobs.extend(orphaned_child_run_jobs(
+                            runner_id,
+                            session,
+                            &active_jobs,
+                        ));
+                    }
                     (
                         active_jobs,
                         stale_jobs,
@@ -756,7 +774,20 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
             None,
         )
     };
-    let active_job_count = active_jobs.len();
+    let active_job_count = direct_daemon_active_jobs.unwrap_or(active_jobs.len());
+    let active_job_error = match (active_job_error, direct_daemon_active_jobs) {
+        (Some(error), _) => Some(error),
+        (None, Some(authoritative_count)) if authoritative_count != active_jobs.len() => {
+            Some(RunnerActiveJobError {
+                code: "active_job_view_inconsistent".to_string(),
+                message: format!(
+                    "direct daemon freshness reports {authoritative_count} active job(s), but /jobs exposed {} typed runner job(s); freshness is authoritative and orphan recovery is suppressed until the views converge",
+                    active_jobs.len()
+                ),
+            })
+        }
+        (None, _) => None,
+    };
     let stale_runner_job_count = stale_jobs.len();
     let active_runner_jobs = active_jobs.iter().map(Into::into).collect();
     let stale_runner_jobs = stale_jobs.iter().map(Into::into).collect();
@@ -777,6 +808,13 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
         active_job_error,
         session_path: session_path.display().to_string(),
     })
+}
+
+fn should_infer_child_run_orphans(
+    typed_active_jobs: usize,
+    direct_daemon_active_jobs: Option<usize>,
+) -> bool {
+    direct_daemon_active_jobs.is_none_or(|count| typed_active_jobs >= count)
 }
 
 /// Query the daemon job store before an operation replaces its process.
@@ -3557,6 +3595,17 @@ esac
         );
         assert_eq!(job.lifecycle_state.as_deref(), Some("recoverable_orphan"));
         assert_eq!(job.retryable, Some(true));
+    }
+
+    #[test]
+    fn direct_daemon_fresh_live_job_suppresses_false_orphan_inference() {
+        assert!(should_infer_child_run_orphans(0, Some(0)));
+        assert!(should_infer_child_run_orphans(1, Some(1)));
+        assert!(should_infer_child_run_orphans(0, None));
+        assert!(
+            !should_infer_child_run_orphans(0, Some(1)),
+            "a fresh daemon heartbeat for an untyped child is authoritative live evidence"
+        );
     }
 
     #[test]

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -315,6 +315,17 @@ pub(crate) fn exec_lab_context(
     secret_env_names.dedup();
 
     let pre_dispatch_started = std::time::Instant::now();
+    if let Some(run_id) = context.agent_task_run_id.as_deref() {
+        agent_task_lifecycle::record_lab_offload_phase(
+            run_id,
+            runner_id,
+            "executor_preflight",
+            Some(&remote_cwd),
+            None,
+            None,
+            request.durable_agent_task_plan,
+        )?;
+    }
     preflight_lab_secret_env_handoff(runner_id, context.runner, &env, &context.secret_env_handoff)?;
     if let Some(runner) = context.runner {
         preflight_agent_task_runner_secret_env_plan(
@@ -330,6 +341,17 @@ pub(crate) fn exec_lab_context(
         context.runner,
         context.source_snapshot.as_ref(),
     ) {
+        if let Some(run_id) = context.agent_task_run_id.as_deref() {
+            agent_task_lifecycle::record_lab_offload_phase(
+                run_id,
+                runner_id,
+                "provider_preflight",
+                Some(&remote_cwd),
+                None,
+                None,
+                request.durable_agent_task_plan,
+            )?;
+        }
         preflight_agent_task_provider_on_runner(
             runner_id,
             &provider.command_prefix_argv,
@@ -369,6 +391,15 @@ pub(crate) fn exec_lab_context(
                 remote_command: &context.remote_command,
                 durable_plan: request.durable_agent_task_plan,
             },
+        )?;
+        agent_task_lifecycle::record_lab_offload_phase(
+            run_id,
+            runner_id,
+            "provider_dispatch",
+            Some(&remote_cwd),
+            None,
+            None,
+            request.durable_agent_task_plan,
         )?;
     }
 
@@ -883,6 +914,15 @@ pub(crate) fn run_lab_offload_inner(
         serde_json::to_value(crate::core::defaults::load_config().agent_task.rotation)
             .unwrap_or(serde_json::Value::Null);
     if let Some(run_id) = pre_acceptance_run_id.as_deref() {
+        agent_task_lifecycle::record_lab_offload_phase(
+            run_id,
+            runner_id,
+            "validation",
+            None,
+            Some(&source_checkout),
+            Some(&provider_rotation),
+            request.durable_agent_task_plan,
+        )?;
         agent_task_lifecycle::record_lab_offload_phase(
             run_id,
             runner_id,


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `recovery-homeboy-8126-20260714` into review-ready branch `fix/8126-lab-cook-status`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:recovery-homeboy-8126-20260714`
- **Homeboy run ID:** `recovery-homeboy-8126-20260714`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `fix/8126-lab-cook-status`

## Source refs
- https://github.com/Extra-Chill/homeboy/issues/8126
- https://github.com/Extra-Chill/homeboy/issues/7891
- https://github.com/Extra-Chill/homeboy/issues/4387

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** runtime-fix
- **Supersedes:** none recorded
- **Depends on:** none recorded

## Runtime guardrails
- **Why this is not broader than the packet evidence:** The change is bounded to Lab agent-task phase/event reconciliation and direct-daemon active-job consistency observed in #8126.
- **Evidence discriminators preserved:** direct-daemon freshness active count differs from the typed /jobs subset, Lab child is running before a terminal agent-task aggregate exists
- **Nearby contracts preserved:** Genuine orphan recovery remains enabled when no untyped live daemon child accounts for the run.

## Attempt summary
Reproduced the live status contradiction, repaired phase/provider event reconciliation and direct-daemon active-job authority, then verified focused regressions on current main.

## Gate results
- phase-history: passed (targeted)
- live-provider-progress: passed (targeted)
- live-job-classification: passed (targeted)
- cargo-check: passed (targeted)
- candidate-format: passed (targeted)
- diff-check: passed (targeted)

## Verification capability
- `targeted_checks_run`: `cargo test --lib controller_proxy_records_pre_execution_phase_progress`, `cargo test --lib running_child_snapshot_persists_provider_handle_and_live_log_progress`, `cargo test --lib direct_daemon_fresh_live_job_suppresses_false_orphan_inference`, `cargo check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: `cargo test --all-targets`
- `manual_reviewer_check`: Run a detached Lab cook and confirm pre-provider phases, live provider progress, and active-job counts remain consistent.

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- src/commands/runner/status.rs
- src/core/agent_task_lifecycle/lifecycle_ops.rs
- src/core/agent_task_lifecycle/tests.rs
- src/core/runner/connection.rs
- src/core/runner/lab/offload/inner.rs

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `fix/8126-lab-cook-status`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the live runner lifecycle regression, implemented the fix and deterministic tests, and finalized the verified candidate with Chris.
