### PR TITLE
Fix Lab cook timeout and provider rotation propagation

### DIFF
--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -318,6 +318,7 @@ mod tests {
             selector: Some("controller-selector".to_string()),
             model: Some("controller-model".to_string()),
             rotation: None,
+            rotation_starts_with_first_entry: false,
             retry: Default::default(),
             liveness_timeout_ms: None,
         });

--- a/src/core/agent_task_dispatch_plan.rs
+++ b/src/core/agent_task_dispatch_plan.rs
@@ -84,24 +84,44 @@ pub fn build_dispatch_plan_with_provider_requirements(
     let client_context = dispatch_client_context(request)?;
     let mut provider_config =
         dispatch_provider_config(request, &repo, workspace_target.as_ref(), &client_context)?;
-    let policy_backend = request
+    let mut policy_backend = request
         .core
         .resolved_provider_policy
         .as_ref()
         .map(|policy| policy.backend.clone())
         .unwrap_or_else(|| request.backend.clone());
-    let policy_selector = request
+    let mut policy_selector = request
         .core
         .resolved_provider_policy
         .as_ref()
         .and_then(|policy| policy.selector.clone())
         .or_else(|| request.selector.clone());
-    let policy_model = request
+    let mut policy_model = request
         .core
         .resolved_provider_policy
         .as_ref()
         .and_then(|policy| policy.model.clone())
         .or_else(|| request.model.clone());
+    let mut resolved_rotation = request
+        .core
+        .resolved_provider_policy
+        .as_ref()
+        .and_then(|policy| policy.rotation.clone());
+    if request
+        .core
+        .resolved_provider_policy
+        .as_ref()
+        .is_some_and(|policy| policy.rotation_starts_with_first_entry)
+    {
+        if let Some(rotation) = resolved_rotation.as_mut() {
+            if !rotation.entries.is_empty() {
+                let first = rotation.entries.remove(0);
+                policy_backend = first.backend.unwrap_or(policy_backend);
+                policy_selector = first.selector.or(policy_selector);
+                policy_model = first.model.or(policy_model);
+            }
+        }
+    }
     let component_contracts = dispatch_component_contracts(&provider_config, &client_context)?;
     // Resolve + materialize the declared runtime dependency graph at known refs
     // and preflight-fail before dispatch when a required runtime dependency is
@@ -240,7 +260,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
     // A submitted controller policy is authoritative, including an explicitly
     // absent rotation. Per-task `metadata.provider_rotation` still overrides it.
     plan.options.rotation = match &request.core.resolved_provider_policy {
-        Some(policy) => policy.rotation.clone(),
+        Some(_) => resolved_rotation,
         None => defaults::load_config().agent_task.rotation,
     };
     if let Some(policy) = &request.core.resolved_provider_policy {
@@ -1040,6 +1060,7 @@ mod tests {
                                     liveness_timeout_ms: Some(45_000),
                                 },
                             ),
+                            rotation_starts_with_first_entry: false,
                             retry: AgentTaskRetryPolicy {
                                 max_attempts: 2,
                                 ..Default::default()
@@ -1124,6 +1145,7 @@ mod tests {
                             selector: None,
                             model: None,
                             rotation: None,
+                            rotation_starts_with_first_entry: false,
                             retry: AgentTaskRetryPolicy {
                                 max_attempts: 1,
                                 ..Default::default()
@@ -1139,6 +1161,58 @@ mod tests {
 
             assert!(plan.options.rotation.is_none());
         });
+    }
+
+    #[test]
+    fn resolved_rotation_can_define_the_initial_provider_attempt() {
+        let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
+            prompt: Some("Cook with the resolved rotation.".to_string()),
+            core: DispatchCoreInputs {
+                timeout_ms: Some(2_700_000),
+                resolved_provider_policy: Some(
+                    crate::core::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy {
+                        backend: "opencode".to_string(),
+                        selector: None,
+                        model: None,
+                        rotation: Some(
+                            crate::core::agent_task_scheduler::AgentTaskProviderRotationPolicy {
+                                entries: ["model-one", "model-two", "model-three"]
+                                    .into_iter()
+                                    .map(|model| crate::core::agent_task_scheduler::AgentTaskProviderRotationEntry {
+                                        model: Some(model.to_string()),
+                                        ..Default::default()
+                                    })
+                                    .collect(),
+                                ..Default::default()
+                            },
+                        ),
+                        rotation_starts_with_first_entry: true,
+                        retry: AgentTaskRetryPolicy {
+                            max_attempts: 3,
+                            ..Default::default()
+                        },
+                        liveness_timeout_ms: None,
+                    },
+                ),
+                ..DispatchCoreInputs::default()
+            },
+            ..DispatchRequestOverrides::default()
+        }))
+        .expect("dispatch plan");
+
+        assert_eq!(plan.options.timeout_ms, Some(2_700_000));
+        assert_eq!(plan.tasks[0].executor.model.as_deref(), Some("model-one"));
+        assert_eq!(
+            plan.options
+                .rotation
+                .as_ref()
+                .expect("remaining rotation")
+                .entries
+                .iter()
+                .filter_map(|entry| entry.model.as_deref())
+                .collect::<Vec<_>>(),
+            ["model-two", "model-three"]
+        );
     }
 
     #[test]

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -40,6 +40,10 @@ pub struct ResolvedAgentTaskProviderPolicy {
     pub model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rotation: Option<AgentTaskProviderRotationPolicy>,
+    /// Whether the resolved rotation's first entry is the initial provider
+    /// attempt, rather than a fallback after the request's executor.
+    #[serde(default)]
+    pub rotation_starts_with_first_entry: bool,
     pub retry: AgentTaskRetryPolicy,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub liveness_timeout_ms: Option<u64>,

--- a/src/core/agent_task_schedule.rs
+++ b/src/core/agent_task_schedule.rs
@@ -132,6 +132,11 @@ mod plan {
         }
 
         pub fn canonicalize(mut self) -> Self {
+            for task in &mut self.tasks {
+                if task.limits.timeout_ms.is_none() {
+                    task.limits.timeout_ms = self.options.timeout_ms;
+                }
+            }
             self.rebuild_homeboy_plan();
             Self::from_homeboy_plan(self.homeboy_plan)
         }

--- a/src/core/agent_task_scheduler/tests/mod.rs
+++ b/src/core/agent_task_scheduler/tests/mod.rs
@@ -8,3 +8,4 @@
 mod fixtures;
 mod outcome_tests;
 mod scheduling_tests;
+mod timeout_propagation_tests;

--- a/src/core/agent_task_scheduler/tests/timeout_propagation_tests.rs
+++ b/src/core/agent_task_scheduler/tests/timeout_propagation_tests.rs
@@ -1,0 +1,39 @@
+use super::fixtures::{plan_with_tasks, RotationScriptedExecutor};
+use crate::core::agent_task::{AgentTaskFailureClassification, AgentTaskOutcomeStatus};
+use crate::core::agent_task_scheduler::{
+    AgentTaskProviderRotationEntry, AgentTaskProviderRotationPolicy, AgentTaskScheduler,
+};
+use std::sync::Arc;
+
+#[test]
+fn plan_timeout_reaches_each_rotated_provider_attempt() {
+    let executor = RotationScriptedExecutor::new(vec![(
+        AgentTaskOutcomeStatus::ProviderError,
+        Some(AgentTaskFailureClassification::Provider),
+    )]);
+    let observed = Arc::clone(&executor.observed);
+    let scheduler = AgentTaskScheduler::new(executor);
+    let mut plan = plan_with_tasks(1);
+    plan.options.timeout_ms = Some(2_700_000);
+    plan.options.rotation = Some(AgentTaskProviderRotationPolicy {
+        entries: vec![
+            AgentTaskProviderRotationEntry {
+                backend: Some("fallback-a".to_string()),
+                ..Default::default()
+            },
+            AgentTaskProviderRotationEntry {
+                backend: Some("fallback-b".to_string()),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    });
+
+    scheduler.run(plan);
+
+    assert!(observed
+        .lock()
+        .expect("observed requests")
+        .iter()
+        .all(|request| request.limits.timeout_ms == Some(2_700_000)));
+}

--- a/src/core/runner/lab_args/mod.rs
+++ b/src/core/runner/lab_args/mod.rs
@@ -20,6 +20,8 @@ mod provider_config;
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod workspace_contract_tests;
 
 /// Sentinel inserted to mark an explicit user-provided passthrough boundary so
 /// Lab offload rewriting can distinguish it from synthesized passthrough args.

--- a/src/core/runner/lab_args/offload.rs
+++ b/src/core/runner/lab_args/offload.rs
@@ -31,6 +31,17 @@ pub(in crate::core::runner) fn lab_offload_source_path(args: &[String]) -> Resul
             })?;
             return Ok(PathBuf::from(shellexpand::tilde(value).to_string()));
         }
+        if arg == "--workspace" {
+            let value = iter.next().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "workspace",
+                    "--workspace requires a value before Lab offload can sync the workspace",
+                    None,
+                    None,
+                )
+            })?;
+            return resolve_workspace_source_path(value);
+        }
         if arg == "--to-worktree" {
             let value = iter.next().ok_or_else(|| {
                 Error::validation_invalid_argument(
@@ -48,6 +59,9 @@ pub(in crate::core::runner) fn lab_offload_source_path(args: &[String]) -> Resul
         if let Some(value) = arg.strip_prefix("--cwd=") {
             return Ok(PathBuf::from(shellexpand::tilde(value).to_string()));
         }
+        if let Some(value) = arg.strip_prefix("--workspace=") {
+            return resolve_workspace_source_path(value);
+        }
         if let Some(value) = arg.strip_prefix("--to-worktree=") {
             return resolve_to_worktree_source_path(value);
         }
@@ -63,6 +77,14 @@ fn resolve_to_worktree_source_path(value: &str) -> Result<PathBuf> {
         None => worktree_providers::resolve_worktree_provider_handle(value)
             .map(|worktree| PathBuf::from(worktree.path)),
     }
+}
+
+fn resolve_workspace_source_path(value: &str) -> Result<PathBuf> {
+    let path = PathBuf::from(shellexpand::tilde(value).to_string());
+    if path.exists() {
+        return Ok(path);
+    }
+    resolve_to_worktree_source_path(value)
 }
 
 fn extension_refresh_local_source_path(args: &[String]) -> Option<PathBuf> {
@@ -148,6 +170,12 @@ pub(in crate::core::runner) fn rewrite_lab_offload_args(
             let rewritten =
                 remap_local_path(value, &ordered).unwrap_or_else(|| remote_path.to_string());
             stripped.push(format!("--cwd={rewritten}"));
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("--workspace=") {
+            let rewritten =
+                remap_local_path(value, &ordered).unwrap_or_else(|| remote_path.to_string());
+            stripped.push(format!("--workspace={rewritten}"));
             continue;
         }
         if arg == "--runner" {

--- a/src/core/runner/lab_args/provider_config.rs
+++ b/src/core/runner/lab_args/provider_config.rs
@@ -234,6 +234,7 @@ pub(in crate::core::runner) fn inject_agent_task_resolved_provider_policy_in_arg
             .as_ref()
             .and_then(|policy| policy.liveness_timeout_ms),
         rotation,
+        rotation_starts_with_first_entry: true,
     };
     let encoded = serde_json::to_string(&policy).map_err(|error| {
         Error::internal_json(

--- a/src/core/runner/lab_args/workspace_contract_tests.rs
+++ b/src/core/runner/lab_args/workspace_contract_tests.rs
@@ -1,0 +1,52 @@
+use super::{lab_offload_source_path, rewrite_lab_offload_args, LabPathRemap};
+
+#[test]
+fn lab_source_path_uses_agent_task_dispatch_workspace() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "dispatch".to_string(),
+        "--workspace".to_string(),
+        workspace.path().display().to_string(),
+        "--prompt".to_string(),
+        "cook".to_string(),
+    ];
+
+    assert_eq!(
+        lab_offload_source_path(&args).expect("source path"),
+        workspace.path()
+    );
+}
+
+#[test]
+fn rewrite_remaps_agent_task_workspace_path() {
+    let input = [
+        "homeboy",
+        "agent-task",
+        "cook",
+        "--workspace",
+        "/Users/user/project",
+        "--workspace=/Users/user/project/nested",
+    ]
+    .map(str::to_string)
+    .to_vec();
+    let mappings = vec![LabPathRemap {
+        local: "/Users/user/project".to_string(),
+        remote: "/runner/project".to_string(),
+    }];
+
+    assert_eq!(
+        rewrite_lab_offload_args(&input, "/runner/project", &mappings, None),
+        [
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--workspace",
+            "/runner/project",
+            "--workspace=/runner/project/nested",
+        ]
+        .map(str::to_string)
+        .to_vec()
+    );
+}


### PR DESCRIPTION
## Summary
Honor the declared timeout, provider rotation, and workspace mapping contract for Lab-offloaded agent-task cooks.

## What changed
- Propagate the plan timeout into every provider request, including rotated attempts.
- Treat the first controller-resolved Lab rotation entry as the initial provider instead of adding an implicit default attempt.
- Resolve and remap both documented workspace input forms during Lab materialization.

## How to test
1. Run `cargo test --locked plan_timeout_reaches_each_rotated_provider_attempt --lib`; expect passes.
2. Run `cargo test --locked resolved_rotation_can_define_the_initial_provider_attempt --lib`; expect passes.
3. Run `cargo test --locked lab_source_path_uses_agent_task_dispatch_workspace --lib`; expect passes.
4. Run `cargo test --locked rewrite_remaps_agent_task_workspace_path --lib`; expect passes.
5. Run `cargo test --locked timeout_mirrors_remote_job_without_cancelling --lib`; expect passes.
6. Run `cargo check --locked --all-targets`; expect passes.

## Compatibility
Legacy non-Lab rotations remain fallback-based. Lab controller-resolved policies now execute the exact declared entries, and both --cwd and --workspace retain their documented behavior.

## Evidence
- CI expected: CI
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8140
- all-target-check: Passed
- differential-audit: Passed
- focused-tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode direct recovery
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab control-plane contract failure, implemented deterministic fixes and tests, and prepared the recovery candidate; Chris reviewed and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8140
