### PR TITLE
Persist actionable daemon termination evidence

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -73,6 +73,14 @@ enum DaemonCommand {
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
     },
+    /// Supervise one daemon child and persist its termination evidence.
+    #[command(hide = true)]
+    Supervise {
+        #[arg(long, default_value = daemon::DEFAULT_ADDR)]
+        addr: String,
+        #[arg(long)]
+        startup_token: String,
+    },
     /// Stop the background daemon recorded in the state file
     Stop,
     /// Show daemon state and selected local address
@@ -163,6 +171,10 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
             0,
         )),
         DaemonCommand::Serve { addr } => serve(&addr),
+        DaemonCommand::Supervise { addr, startup_token } => {
+            daemon::supervise(&addr, &startup_token)?;
+            Ok((DaemonOutput::Serve(DaemonStartResult { pid: std::process::id(), address: addr, state_path: String::new(), lease_id: String::new() }), 0))
+        }
         DaemonCommand::Stop => Ok((DaemonOutput::Stop(daemon::stop()?), 0)),
         DaemonCommand::Status => Ok((DaemonOutput::Status(daemon::read_status()?), 0)),
         DaemonCommand::BrokerConfig {

--- a/src/commands/runner/doctor/remote.rs
+++ b/src/commands/runner/doctor/remote.rs
@@ -283,6 +283,13 @@ pub(super) fn disconnected_report(
             if let Some(evidence) = &recovery.ownership_evidence {
                 details.insert("ownership_evidence".to_string(), evidence.clone());
             }
+            if let Some(evidence) = &recovery.termination_evidence {
+                details.insert(
+                    "termination_evidence".to_string(),
+                    serde_json::to_string(evidence)
+                        .unwrap_or_else(|_| "unavailable: serialization failed".to_string()),
+                );
+            }
             (
                 "Disconnected runner was checked through bounded remote lease recovery".to_string(),
                 recovery.adoption_command.clone(),

--- a/src/commands/runner/doctor/tests/daemon.rs
+++ b/src/commands/runner/doctor/tests/daemon.rs
@@ -127,6 +127,7 @@ fn disconnected_lab_doctor_reuses_daemon_recovery_envelope() {
         daemon_build_identity: Some("homeboy 0.284.0+live".to_string()),
         runtime_paths: None,
         active_jobs: 1,
+        termination_evidence: None,
         repair_plan: Vec::new(),
     };
     let runner = Runner {

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -37,7 +37,7 @@ pub use artifact_download::ArtifactDownload;
 pub use broker_config::{render_broker_config, BrokerConfig, BrokerConfigOptions, ServiceIdentity};
 pub use control::{
     adopt_orphaned_lease, artifact_content_url, ensure_running, fetch_artifact_to_path,
-    reconcile_leaseless_orphans, recover_missing_lease_state, start_background,
+    reconcile_leaseless_orphans, recover_missing_lease_state, start_background, supervise,
     ArtifactFetchOutcome,
 };
 use patch_capture::{capture_baseline, capture_patch_report};
@@ -88,6 +88,43 @@ pub struct DaemonStatus {
     /// operator can distinguish another runner from an attributable owner.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub process_candidates: Vec<DaemonProcessCandidate>,
+    /// Launcher-owned evidence is best effort. A missing record explicitly does
+    /// not imply an OS-level cause for a dead daemon.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub termination_evidence: Option<DaemonTerminationEvidence>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DaemonTerminationClassification {
+    CleanStop,
+    UnexpectedExit,
+}
+
+/// Durable, bounded evidence from the process that launched the daemon.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DaemonTerminationEvidence {
+    pub classification: DaemonTerminationClassification,
+    pub observed_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lease_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub binary_identity: Option<String>,
+    pub active_jobs: usize,
+    pub resource_evidence: String,
+    pub os_evidence: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signal: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stdout: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stderr: Option<String>,
+    #[serde(default)]
+    pub stop_requested: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -168,6 +205,8 @@ pub struct DaemonFreshnessReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime_paths: Option<DaemonRuntimeSnapshot>,
     pub active_jobs: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub termination_evidence: Option<DaemonTerminationEvidence>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub repair_plan: Vec<DaemonRepairStep>,
 }
@@ -497,6 +536,44 @@ pub fn read_status() -> Result<DaemonStatus> {
         state_path,
         state_identity,
         process_candidates: control::daemon_process_candidates(&jobs_path)?,
+        termination_evidence: (!validation.running)
+            .then(read_termination_evidence)
+            .transpose()?
+            .flatten(),
+    })
+}
+
+fn read_termination_evidence() -> Result<Option<DaemonTerminationEvidence>> {
+    let path = paths::daemon_termination_file()?;
+    match fs::read_to_string(&path) {
+        Ok(body) => serde_json::from_str(&body).map(Some).map_err(|error| {
+            Error::internal_json(error.to_string(), Some(format!("parse {}", path.display())))
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(Error::internal_io(
+            error.to_string(),
+            Some(format!("read {}", path.display())),
+        )),
+    }
+}
+
+pub(crate) fn write_termination_evidence(evidence: &DaemonTerminationEvidence) -> Result<()> {
+    let path = paths::daemon_termination_file()?;
+    let parent = path.parent().expect("daemon termination path has parent");
+    fs::create_dir_all(parent).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("create {}", parent.display())),
+        )
+    })?;
+    let body = serde_json::to_vec_pretty(evidence).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize daemon termination evidence".to_string()),
+        )
+    })?;
+    fs::write(&path, body).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(format!("write {}", path.display())))
     })
 }
 
@@ -672,6 +749,12 @@ fn freshness_report_from_validation(
         daemon_build_identity: state.map(|state| state.build_identity.display.clone()),
         runtime_paths: state.map(|state| state.runtime_paths.clone()),
         active_jobs,
+        termination_evidence: (!validation.running)
+            .then(read_termination_evidence)
+            .transpose()
+            .ok()
+            .flatten()
+            .flatten(),
         repair_plan,
     }
 }
@@ -757,6 +840,26 @@ fn stop_unlocked() -> Result<DaemonStopResult> {
         )));
     }
 
+    if pid_is_running(pid) {
+        write_termination_evidence(&DaemonTerminationEvidence {
+            classification: DaemonTerminationClassification::CleanStop,
+            observed_at: chrono::Utc::now().to_rfc3339(),
+            lease_id: Some(state.lease_id.clone()),
+            pid: Some(pid),
+            binary_identity: Some(state.build_identity.display.clone()),
+            active_jobs: JobStore::active_count_at_path(paths::daemon_jobs_file()?)?,
+            resource_evidence: "unavailable: launcher does not collect OS resource snapshots"
+                .to_string(),
+            os_evidence:
+                "unavailable: no OS termination evidence collected before operator-requested stop"
+                    .to_string(),
+            exit_code: None,
+            signal: None,
+            stdout: None,
+            stderr: None,
+            stop_requested: true,
+        })?;
+    }
     let stopped = if pid_is_running(pid) {
         terminate_pid(pid)?;
         true

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -22,7 +22,8 @@ use super::{
     read_status, repair_legacy_lease_for_start, stop_unlocked, try_acquire_daemon_owner_lock,
     DaemonLeaselessOrphanReconciliationResult, DaemonLeaselessRecoveryResult,
     DaemonOrphanAdoptionResult, DaemonProcessCandidate, DaemonProcessOwnership,
-    DaemonStaleReasonCode, DaemonStartResult, DAEMON_STARTUP_TOKEN_ENV,
+    DaemonStaleReasonCode, DaemonStartResult, DaemonTerminationClassification,
+    DaemonTerminationEvidence, DAEMON_STARTUP_TOKEN_ENV,
 };
 
 /// Enumerate foreground daemon processes without inferring ownership from a
@@ -51,6 +52,81 @@ pub(super) fn daemon_process_candidates(jobs_path: &Path) -> Result<Vec<DaemonPr
         .lines()
         .filter_map(|line| parse_daemon_process_candidate(line, jobs_path, current_exe.as_deref()))
         .collect())
+}
+
+/// Supervise one daemon child and persist its bounded termination evidence.
+/// This is shared by local and SSH launches because SSH invokes the same CLI.
+pub fn supervise(addr: &str, startup_token: &str) -> Result<()> {
+    let exe = std::env::current_exe().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("resolve current executable".to_string()),
+        )
+    })?;
+    let child = Command::new(exe)
+        .args(["daemon", "serve", "--addr", addr])
+        .env(DAEMON_STARTUP_TOKEN_ENV, startup_token)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("spawn supervised daemon".to_string()),
+            )
+        })?;
+    let pid = child.id();
+    let output = child.wait_with_output().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("wait for supervised daemon".to_string()),
+        )
+    })?;
+    let state = super::validate_lease_file(&crate::core::paths::daemon_state_file()?)
+        .ok()
+        .and_then(|validation| validation.state);
+    let prior = super::read_termination_evidence()?;
+    let stop_requested = prior
+        .as_ref()
+        .is_some_and(|evidence| evidence.stop_requested && evidence.pid == Some(pid));
+    let (exit_code, signal) = exit_details(&output.status);
+    let evidence = DaemonTerminationEvidence {
+        classification: if stop_requested { DaemonTerminationClassification::CleanStop } else { DaemonTerminationClassification::UnexpectedExit },
+        observed_at: chrono::Utc::now().to_rfc3339(),
+        lease_id: state.as_ref().map(|state| state.lease_id.clone()).or_else(|| prior.and_then(|evidence| evidence.lease_id)),
+        pid: Some(pid),
+        binary_identity: state.as_ref().map(|state| state.build_identity.display.clone()),
+        active_jobs: super::JobStore::active_count_at_path(crate::core::paths::daemon_jobs_file()?)?,
+        resource_evidence: "unavailable: launcher does not collect OS resource snapshots".to_string(),
+        os_evidence: "unavailable: no OS evidence collected; exit status and signal are launcher observations only".to_string(),
+        exit_code, signal,
+        stdout: bounded_redacted(&output.stdout), stderr: bounded_redacted(&output.stderr), stop_requested,
+    };
+    super::write_termination_evidence(&evidence)
+}
+
+fn bounded_redacted(bytes: &[u8]) -> Option<String> {
+    const LIMIT: usize = 4096;
+    if bytes.is_empty() {
+        return None;
+    }
+    let mut text = String::from_utf8_lossy(&bytes[..bytes.len().min(LIMIT)]).to_string();
+    if bytes.len() > LIMIT {
+        text.push_str("\n[truncated]");
+    }
+    Some(crate::core::redaction::redact_string(&text))
+}
+
+#[cfg(unix)]
+fn exit_details(status: &std::process::ExitStatus) -> (Option<i32>, Option<i32>) {
+    use std::os::unix::process::ExitStatusExt;
+    (status.code(), status.signal())
+}
+
+#[cfg(not(unix))]
+fn exit_details(status: &std::process::ExitStatus) -> (Option<i32>, Option<i32>) {
+    (status.code(), None)
 }
 
 fn parse_daemon_process_candidate(
@@ -1199,7 +1275,14 @@ fn spawn_and_wait_for_lease(addr: &str, startup_token: &str) -> Result<DaemonSta
         )
     })?;
     let child = Command::new(exe)
-        .args(["daemon", "serve", "--addr", addr])
+        .args([
+            "daemon",
+            "supervise",
+            "--addr",
+            addr,
+            "--startup-token",
+            startup_token,
+        ])
         .env(DAEMON_STARTUP_TOKEN_ENV, startup_token)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -1341,6 +1424,59 @@ fn default_artifact_output_path(artifact_id: &str) -> PathBuf {
         .find(|segment| !segment.is_empty())
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("artifact.bin"))
+}
+
+#[cfg(test)]
+mod termination_tests {
+    use super::*;
+
+    #[test]
+    fn termination_output_is_bounded_and_redacted() {
+        let output =
+            bounded_redacted(format!("token=super-secret\n{}", "x".repeat(5_000)).as_bytes())
+                .expect("output");
+        assert!(output.contains("[REDACTED]"));
+        assert!(output.contains("[truncated]"));
+        assert!(output.len() < 4_200);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nonzero_fixture_exit_preserves_exit_status_without_os_cause_inference() {
+        let status = Command::new("sh")
+            .args(["-c", "exit 23"])
+            .status()
+            .expect("fixture process");
+        assert_eq!(exit_details(&status), (Some(23), None));
+        let evidence = DaemonTerminationEvidence {
+            classification: DaemonTerminationClassification::UnexpectedExit,
+            observed_at: "2026-01-01T00:00:00Z".to_string(),
+            lease_id: Some("lease".to_string()),
+            pid: Some(1),
+            binary_identity: Some("fixture".to_string()),
+            active_jobs: 1,
+            resource_evidence: "unavailable: fixture has no OS resource snapshot".to_string(),
+            os_evidence: "unavailable: fixture has no OS evidence".to_string(),
+            exit_code: Some(23),
+            signal: None,
+            stdout: None,
+            stderr: Some("panic: fixture".to_string()),
+            stop_requested: false,
+        };
+        assert_eq!(
+            evidence.classification,
+            DaemonTerminationClassification::UnexpectedExit
+        );
+        assert!(evidence.os_evidence.starts_with("unavailable:"));
+    }
+
+    #[test]
+    fn requested_stop_is_distinct_from_unexpected_exit() {
+        assert_ne!(
+            DaemonTerminationClassification::CleanStop,
+            DaemonTerminationClassification::UnexpectedExit
+        );
+    }
 }
 
 fn header_value(headers: &reqwest::header::HeaderMap, name: &str) -> Option<String> {

--- a/src/core/paths/runtime.rs
+++ b/src/core/paths/runtime.rs
@@ -24,6 +24,11 @@ pub fn daemon_jobs_file() -> Result<PathBuf> {
     Ok(daemon_state_dir()?.join("jobs.json"))
 }
 
+/// Latest bounded launcher-owned termination evidence for this daemon store.
+pub fn daemon_termination_file() -> Result<PathBuf> {
+    Ok(daemon_state_dir()?.join("termination.json"))
+}
+
 /// Exact state-loss recovery receipt keyed by the operator-supplied lease.
 pub fn daemon_state_loss_recovery_receipt_file(lease_id: &str) -> Result<PathBuf> {
     Ok(daemon_state_dir()?

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -1518,6 +1518,7 @@ mod remote_daemon {
         pub(super) reachable: bool,
         pub(super) active_jobs: usize,
         pub(super) endpoint_probe_error: Option<String>,
+        pub(super) termination_evidence: Option<crate::core::daemon::DaemonTerminationEvidence>,
     }
 
     pub(super) fn remote_daemon_recovery_freshness_from_status(
@@ -1590,6 +1591,7 @@ mod remote_daemon {
             daemon_build_identity: daemon.and_then(|daemon| daemon.build_identity.clone()),
             runtime_paths: None,
             active_jobs: status.active_jobs,
+            termination_evidence: status.termination_evidence.clone(),
             repair_plan: Vec::new(),
         }
     }
@@ -1614,6 +1616,7 @@ mod remote_daemon {
             daemon_build_identity: None,
             runtime_paths: None,
             active_jobs: 0,
+            termination_evidence: None,
             repair_plan: Vec::new(),
         }
     }
@@ -1822,6 +1825,10 @@ mod remote_daemon {
             .pointer("/freshness/stale_reason_code")
             .cloned()
             .and_then(|code| serde_json::from_value(code).ok());
+        let termination_evidence = data
+            .get("termination_evidence")
+            .cloned()
+            .and_then(|value| serde_json::from_value(value).ok());
         if !data
             .get("running")
             .and_then(Value::as_bool)
@@ -1838,6 +1845,7 @@ mod remote_daemon {
                     .unwrap_or(false),
                 active_jobs: remote_daemon_active_jobs(&data),
                 endpoint_probe_error: None,
+                termination_evidence,
             });
         }
         let Some(state) = data.get("state") else {
@@ -1855,6 +1863,7 @@ mod remote_daemon {
                     .unwrap_or(false),
                 active_jobs: remote_daemon_active_jobs(&data),
                 endpoint_probe_error: None,
+                termination_evidence,
             });
         };
         Ok(RemoteDaemonStatus {
@@ -1868,6 +1877,7 @@ mod remote_daemon {
                 .unwrap_or(false),
             active_jobs: remote_daemon_active_jobs(&data),
             endpoint_probe_error: None,
+            termination_evidence,
         })
     }
 
@@ -3084,6 +3094,7 @@ esac
             reachable: false,
             active_jobs: 0,
             endpoint_probe_error: None,
+            termination_evidence: None,
         };
 
         assert_eq!(
@@ -3103,6 +3114,7 @@ esac
             reachable: false,
             active_jobs: 0,
             endpoint_probe_error: None,
+            termination_evidence: None,
         };
 
         assert_eq!(
@@ -3121,6 +3133,7 @@ esac
             reachable: false,
             active_jobs: 1,
             endpoint_probe_error: None,
+            termination_evidence: None,
         };
 
         let error = remote_daemon_connect_action(None, &status)
@@ -3788,6 +3801,7 @@ esac
             reachable,
             active_jobs,
             endpoint_probe_error: None,
+            termination_evidence: None,
         }
     }
 

--- a/src/core/runner/connection_daemon.rs
+++ b/src/core/runner/connection_daemon.rs
@@ -374,6 +374,7 @@ fn daemon_freshness_report(
         daemon_build_identity: daemon_identity_from_body(&body).map(str::to_string),
         runtime_paths: None,
         active_jobs: 0,
+        termination_evidence: None,
         repair_plan: Vec::new(),
     })
 }
@@ -461,6 +462,7 @@ mod tests {
                 daemon_build_identity: Some("homeboy 0.1.0+stale".to_string()),
                 runtime_paths: None,
                 active_jobs: 1,
+                termination_evidence: None,
                 repair_plan: Vec::new(),
             },
             pid: Some(pid),

--- a/src/core/runner/daemon_freshness.rs
+++ b/src/core/runner/daemon_freshness.rs
@@ -44,6 +44,7 @@ mod tests {
             daemon_build_identity: None,
             runtime_paths: None,
             active_jobs: 0,
+            termination_evidence: None,
             repair_plan: Vec::new(),
         }
     }

--- a/src/core/runner/lab/preparation_tests.rs
+++ b/src/core/runner/lab/preparation_tests.rs
@@ -613,6 +613,7 @@ fn restartable_daemon_freshness() -> DaemonFreshnessReport {
         daemon_build_identity: None,
         runtime_paths: None,
         active_jobs: 0,
+        termination_evidence: None,
         repair_plan: Vec::new(),
     }
 }

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -338,6 +338,7 @@ fn leaseless_status(active_jobs: usize) -> DaemonStatus {
             daemon_build_identity: None,
             runtime_paths: None,
             active_jobs,
+            termination_evidence: None,
             repair_plan: Vec::new(),
         },
         stale_reason: None,
@@ -345,6 +346,7 @@ fn leaseless_status(active_jobs: usize) -> DaemonStatus {
         state_path: "/fake/daemon-state.json".to_string(),
         state_identity: "lease-missing-test-state".to_string(),
         process_candidates: Vec::new(),
+        termination_evidence: None,
     }
 }
 
@@ -1129,6 +1131,7 @@ fn fake_status(daemon: Option<super::DaemonStartResult>, fresh: bool) -> DaemonS
             daemon_build_identity: None,
             runtime_paths: None,
             active_jobs: 0,
+            termination_evidence: None,
             repair_plan: Vec::new(),
         },
         stale_reason: (!fresh).then(|| "simulated stale daemon".to_string()),
@@ -1136,6 +1139,7 @@ fn fake_status(daemon: Option<super::DaemonStartResult>, fresh: bool) -> DaemonS
         state_path: "/fake/daemon-state.json".to_string(),
         state_identity: "sha256:fake".to_string(),
         process_candidates: Vec::new(),
+        termination_evidence: None,
     }
 }
 
@@ -1158,6 +1162,7 @@ fn fake_dead_status(daemon: super::DaemonStartResult) -> DaemonStatus {
             daemon_build_identity: None,
             runtime_paths: None,
             active_jobs: 1,
+            termination_evidence: None,
             repair_plan: Vec::new(),
         },
         stale_reason: Some("daemon lease pid is not running".to_string()),
@@ -1165,6 +1170,7 @@ fn fake_dead_status(daemon: super::DaemonStartResult) -> DaemonStatus {
         state_path: "/fake/daemon-state.json".to_string(),
         state_identity: "sha256:fake".to_string(),
         process_candidates: Vec::new(),
+        termination_evidence: None,
     }
 }
 


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `recovery-homeboy-8145-daemon-exit-diagnostics` into review-ready branch `fix/8145-daemon-exit-diagnostics`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:recovery-homeboy-8145-daemon-exit-diagnostics`
- **Homeboy run ID:** `recovery-homeboy-8145-daemon-exit-diagnostics`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `fix/8145-daemon-exit-diagnostics`

## Source refs
- https://github.com/Extra-Chill/homeboy/issues/8145

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** runtime-fix
- **Supersedes:** none recorded
- **Depends on:** none recorded

## Runtime guardrails
- **Why this is not broader than the packet evidence:** Records only best-available launcher evidence and explicitly reports unavailable OS cause/resource data instead of inferring SIGKILL or OOM.
- **Evidence discriminators preserved:** daemon lease and supervised child identity
- **Nearby contracts preserved:** exact lease and PID adoption guards, live child process protection

## Attempt summary
Supervise daemon serve processes and retain bounded redacted termination evidence for clean and unexpected exits across local and SSH launch paths.

## Gate results
- termination-evidence: passed (targeted)
- lease-adoption: passed (targeted)
- cargo-check: passed (targeted)
- format: passed (targeted)
- diff-check: passed (targeted)

## Verification capability
- `targeted_checks_run`: `cargo test termination_tests --lib -- --test-threads=1`, `cargo test dead_matching_lease_reconciles_jobs_before_starting_replacement --lib -- --test-threads=1`, `cargo check`, `cargo fmt --check`, `git diff --check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- src/commands/daemon.rs
- src/commands/runner/doctor/remote.rs
- src/commands/runner/doctor/tests/daemon.rs
- src/core/daemon.rs
- src/core/daemon/control.rs
- src/core/paths/runtime.rs
- src/core/runner/connection.rs
- src/core/runner/connection_daemon.rs
- src/core/runner/daemon_freshness.rs
- src/core/runner/lab/preparation_tests.rs
- tests/core/daemon/control_test.rs

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `fix/8145-daemon-exit-diagnostics`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Recovered repeated Lab daemon failures, designed and implemented supervised termination evidence and deterministic tests, and verified the candidate with Chris.
