### PR TITLE
Add a hermetic Homeboy test context

### DIFF
--- a/docs/internals/test-tiers.md
+++ b/docs/internals/test-tiers.md
@@ -30,3 +30,19 @@ cargo test --lib --features slow-tests collect_refactor_sources_audit_write_uses
 ```
 
 Use the slow tier when changing audit detector orchestration, audit fixability planning, or audit-driven refactor planning. These tests remain runnable, but they are not part of the default unit gate because they scan real fixture/checkouts and dominated local suite wall-clock time.
+
+## Hermetic CLI Fixtures
+
+Ordinary Rust tests must use `homeboy::test_support::HermeticTestContext` for
+Homeboy subprocesses. It supplies owned HOME, config, data, artifact, runtime,
+temporary, daemon, and runner locations, and requires an explicit binary choice:
+`TestBinary::HomeboyFixture` for Cargo's fixture binary or
+`TestBinary::CurrentTest` for the running test executable. This prevents tests
+from reading operator configuration or resolving an installed `homeboy` through
+`PATH`.
+
+Host integration tests are opt-in: place them behind an explicit Cargo feature
+or an explicit command-line opt-in and document the required host service,
+credentials, and cleanup contract beside the test. They may use host state only
+when that contract is the behavior under test; they are excluded from the
+ordinary Rust gate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,14 @@ pub mod core;
 pub mod extensions;
 pub mod help_topics;
 
-#[cfg(test)]
-pub(crate) mod test_support;
+/// Test-only fixtures and hermetic process contexts.
+///
+/// This is public so integration tests can use the same isolation contract as
+/// unit tests. It is hidden from normal API documentation and has no role in
+/// production command execution.
+#[doc(hidden)]
+#[allow(dead_code)] // Unit-test-only helpers share this module with public CLI fixtures.
+pub mod test_support;
 
 /// Helper for `#[serde(skip_serializing_if = "is_zero")]` on `usize` fields.
 pub fn is_zero(v: &usize) -> bool {

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -8,6 +8,119 @@ use tempfile::TempDir;
 static SHARED_EMPTY_GIT_REPO_TEMPLATE: OnceLock<TempDir> = OnceLock::new();
 static SHARED_COMMITTED_GIT_REPO_TEMPLATE: OnceLock<TempDir> = OnceLock::new();
 
+/// An explicit executable selection for a hermetic test command.
+///
+/// Fixture commands never resolve `homeboy` through `PATH`: integration tests
+/// select Cargo's binary and unit tests can select their current test binary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TestBinary {
+    CurrentTest,
+    HomeboyFixture,
+}
+
+/// Isolated filesystem and process environment for one test.
+///
+/// Constructing this type does not mutate the parent process. Prefer
+/// [`HermeticTestContext::command`] for subprocess tests. `HomeGuard` exists
+/// only for legacy in-process tests whose dependencies still read environment
+/// variables directly.
+pub struct HermeticTestContext {
+    root: TempDir,
+    runtime: TempDir,
+    invocation_runtime: TempDir,
+}
+
+impl HermeticTestContext {
+    pub fn new() -> Self {
+        let context = Self {
+            root: exec_capable_tempdir(),
+            runtime: exec_capable_tempdir(),
+            invocation_runtime: short_invocation_tempdir(),
+        };
+        for path in [
+            context.root().join(".config"),
+            context.data_dir(),
+            context.artifact_dir(),
+            context.temp_dir(),
+            context.daemon_dir(),
+            context.runner_dir(),
+        ] {
+            fs::create_dir_all(path).expect("create hermetic test path");
+        }
+        context
+    }
+
+    pub fn root(&self) -> &Path {
+        self.root.path()
+    }
+
+    pub fn home(&self) -> &Path {
+        self.root()
+    }
+
+    pub fn config_dir(&self) -> PathBuf {
+        self.home().join(".config/homeboy")
+    }
+
+    pub fn data_dir(&self) -> PathBuf {
+        self.root().join("data/homeboy")
+    }
+
+    pub fn artifact_dir(&self) -> PathBuf {
+        self.root().join("artifacts")
+    }
+
+    pub fn runtime_dir(&self) -> &Path {
+        self.runtime.path()
+    }
+
+    pub fn temp_dir(&self) -> PathBuf {
+        self.root().join("tmp")
+    }
+
+    pub fn daemon_dir(&self) -> PathBuf {
+        self.config_dir().join("daemon")
+    }
+
+    pub fn runner_dir(&self) -> PathBuf {
+        self.config_dir().join("runners")
+    }
+
+    pub fn binary_path(&self, binary: TestBinary) -> PathBuf {
+        match binary {
+            TestBinary::CurrentTest => std::env::current_exe().expect("current test executable"),
+            TestBinary::HomeboyFixture => PathBuf::from(
+                std::env::var_os("CARGO_BIN_EXE_homeboy")
+                    .expect("CARGO_BIN_EXE_homeboy fixture binary"),
+            ),
+        }
+    }
+
+    /// Build a command whose Homeboy state is wholly owned by this context.
+    pub fn command(&self, binary: TestBinary) -> Command {
+        let mut command = Command::new(self.binary_path(binary));
+        command
+            .env("HOME", self.home())
+            .env("XDG_CONFIG_HOME", self.root().join(".config"))
+            .env("XDG_DATA_HOME", self.root().join("data"))
+            .env("HOMEBOY_ARTIFACT_ROOT", self.artifact_dir())
+            .env("HOMEBOY_RUNTIME_TMPDIR", self.runtime_dir())
+            .env("TMPDIR", self.temp_dir())
+            .env(
+                crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
+                self.invocation_runtime.path(),
+            )
+            .env("HOMEBOY_NO_UPDATE_CHECK", "1");
+        command
+    }
+}
+
+impl Default for HermeticTestContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub(crate) struct HomeGuard {
     prior: Option<String>,
     prior_xdg_data_home: Option<String>,
@@ -15,13 +128,7 @@ pub(crate) struct HomeGuard {
     prior_runtime_tmpdir: Option<String>,
     prior_invocation_runtime: Option<String>,
     prior_no_update_check: Option<String>,
-    dir: TempDir,
-    _runtime_dir: TempDir,
-    /// Held alongside `dir` so the short invocation runtime tempdir is
-    /// dropped only after the test completes. Distinct from `dir` so the
-    /// invocation root can live on a short path (e.g. `/tmp/hb-XXXX`)
-    /// regardless of where `$TMPDIR` lands.
-    _inv_dir: Option<TempDir>,
+    context: HermeticTestContext,
     _guard: MutexGuard<'static, ()>,
 }
 
@@ -75,8 +182,7 @@ impl AuditHomeGuard {
 impl HomeGuard {
     pub(crate) fn new() -> Self {
         let guard = home_lock().lock().unwrap_or_else(|e| e.into_inner());
-        crate::core::defaults::reset_config_cache_for_test();
-        crate::commands::utils::entity_suggest::reset_entity_suggestion_cache_for_test();
+        reset_cached_test_state();
         let prior = std::env::var("HOME").ok();
         let prior_xdg_data_home = std::env::var("XDG_DATA_HOME").ok();
         let prior_artifact_root = std::env::var("HOMEBOY_ARTIFACT_ROOT").ok();
@@ -90,23 +196,23 @@ impl HomeGuard {
         // failing every capability-script test with exit 126 (#6760). Anchor
         // it (and the runtime tmpdir, which also hosts executables) on an
         // exec-capable root.
-        let dir = exec_capable_tempdir();
-        std::env::set_var("HOME", dir.path());
-        std::env::set_var("XDG_DATA_HOME", dir.path().join(".local").join("share"));
+        let context = HermeticTestContext::new();
+        std::env::set_var("HOME", context.home());
+        // Preserve the legacy in-process defaults while the subprocess context
+        // uses explicit paths. These tests exercise fallback path resolution.
+        std::env::set_var("XDG_DATA_HOME", context.home().join(".local").join("share"));
         std::env::remove_var("HOMEBOY_ARTIFACT_ROOT");
         std::env::set_var("HOMEBOY_NO_UPDATE_CHECK", "1");
-        let runtime_dir = exec_capable_tempdir();
-        std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", runtime_dir.path());
+        std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", context.runtime_dir());
         crate::core::set_artifact_root_override(None);
         // Pin invocation runtime to a SHORT tempdir, isolated from `$TMPDIR`
         // and from the home tempdir (which itself can already live on a long
         // path on macOS, e.g. `/var/folders/<14>/T/.tmpXXXXXX/...`). Using
         // `/tmp` directly keeps tests within the platform `sockaddr_un`
         // budget regardless of host configuration.
-        let inv_dir = short_invocation_tempdir();
         std::env::set_var(
             crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
-            inv_dir.path(),
+            context.invocation_runtime.path(),
         );
         Self {
             prior,
@@ -115,9 +221,7 @@ impl HomeGuard {
             prior_runtime_tmpdir,
             prior_invocation_runtime,
             prior_no_update_check,
-            dir,
-            _runtime_dir: runtime_dir,
-            _inv_dir: Some(inv_dir),
+            context,
             _guard: guard,
         }
     }
@@ -227,7 +331,7 @@ pub(crate) fn exec_capable_tempdir() -> TempDir {
     #[cfg(unix)]
     {
         let mut roots: Vec<PathBuf> = Vec::new();
-        let mut push = |path: PathBuf, roots: &mut Vec<PathBuf>| {
+        let push = |path: PathBuf, roots: &mut Vec<PathBuf>| {
             if path.is_dir() && !roots.contains(&path) {
                 roots.push(path);
             }
@@ -286,20 +390,28 @@ impl Drop for HomeGuard {
             Some(value) => std::env::set_var("HOMEBOY_NO_UPDATE_CHECK", value),
             None => std::env::remove_var("HOMEBOY_NO_UPDATE_CHECK"),
         }
-        crate::core::defaults::reset_config_cache_for_test();
-        crate::commands::utils::entity_suggest::reset_entity_suggestion_cache_for_test();
+        reset_cached_test_state();
     }
 }
 
 pub(crate) fn with_isolated_home<R>(body: impl FnOnce(&TempDir) -> R) -> R {
     let home = HomeGuard::new();
-    body(&home.dir)
+    body(&home.context.root)
 }
 
 pub(crate) fn with_isolated_audit_home<R>(body: impl FnOnce(&TempDir) -> R) -> R {
     let guard = AuditHomeGuard::new();
-    body(&guard.home.dir)
+    body(&guard.home.context.root)
 }
+
+#[cfg(test)]
+fn reset_cached_test_state() {
+    crate::core::defaults::reset_config_cache_for_test();
+    crate::commands::utils::entity_suggest::reset_entity_suggestion_cache_for_test();
+}
+
+#[cfg(not(test))]
+fn reset_cached_test_state() {}
 
 pub(crate) fn write_source_extension(home: &std::path::Path, id: &str, file_extension: &str) {
     let extension_dir = home.join(".config/homeboy/extensions").join(id);

--- a/tests/stale_linked_rig_recovery.rs
+++ b/tests/stale_linked_rig_recovery.rs
@@ -1,18 +1,14 @@
 use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::path::Path;
+use std::process::Output;
 
-fn homeboy_bin() -> PathBuf {
-    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
-}
+use homeboy::test_support::{HermeticTestContext, TestBinary};
 
-fn run_homeboy(home: &Path, args: &[&str]) -> Output {
-    Command::new(homeboy_bin())
+fn run_homeboy(context: &HermeticTestContext, args: &[&str]) -> Output {
+    context
+        .command(TestBinary::HomeboyFixture)
         .args(["--placement", "local"])
         .args(args)
-        .env("HOME", home)
-        .env("XDG_DATA_HOME", home.join(".local/share"))
-        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
         .output()
         .expect("run homeboy")
 }
@@ -25,6 +21,53 @@ fn assert_success(output: Output, args: &[&str]) {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+#[test]
+fn hermetic_fixture_command_cannot_use_operator_paths_or_installed_homeboy() {
+    let context = HermeticTestContext::new();
+    let command = context.command(TestBinary::HomeboyFixture);
+    let configured_env = command
+        .get_envs()
+        .map(|(key, value)| {
+            (
+                key.to_string_lossy().into_owned(),
+                value
+                    .expect("hermetic context only sets values")
+                    .to_string_lossy()
+                    .into_owned(),
+            )
+        })
+        .collect::<std::collections::BTreeMap<_, _>>();
+
+    assert_eq!(
+        command.get_program(),
+        context.binary_path(TestBinary::HomeboyFixture).as_os_str(),
+        "fixture commands select Cargo's binary rather than PATH"
+    );
+    assert_eq!(configured_env["HOME"], context.home().display().to_string());
+    assert_eq!(
+        configured_env["XDG_CONFIG_HOME"],
+        context.root().join(".config").display().to_string()
+    );
+    assert_eq!(
+        configured_env["XDG_DATA_HOME"],
+        context.root().join("data").display().to_string()
+    );
+    assert_eq!(
+        configured_env["HOMEBOY_ARTIFACT_ROOT"],
+        context.artifact_dir().display().to_string()
+    );
+    assert_eq!(
+        configured_env["HOMEBOY_RUNTIME_TMPDIR"],
+        context.runtime_dir().display().to_string()
+    );
+    assert!(context.config_dir().starts_with(context.root()));
+    assert!(context.data_dir().starts_with(context.root()));
+    assert!(context.artifact_dir().starts_with(context.root()));
+    assert!(context.temp_dir().starts_with(context.root()));
+    assert!(context.daemon_dir().starts_with(context.root()));
+    assert!(context.runner_dir().starts_with(context.root()));
 }
 
 fn write_bench_extension(home: &Path) {
@@ -83,10 +126,10 @@ fn write_package_rig(package: &Path, id: &str) {
     .expect("write rig package");
 }
 
-fn install_then_remove_source_a(home: &Path, source_a: &Path) {
+fn install_then_remove_source_a(context: &HermeticTestContext, source_a: &Path) {
     let source_a_text = source_a.to_str().expect("source A path");
     assert_success(
-        run_homeboy(home, &["rig", "install", source_a_text]),
+        run_homeboy(context, &["rig", "install", source_a_text]),
         &["rig", "install", source_a_text],
     );
     fs::remove_dir_all(source_a).expect("remove source A");
@@ -94,13 +137,13 @@ fn install_then_remove_source_a(home: &Path, source_a: &Path) {
 
 #[test]
 fn bench_repairs_missing_linked_rig_source_from_path_override() {
-    let home = tempfile::tempdir().expect("home");
+    let context = HermeticTestContext::new();
     let source_a = tempfile::tempdir().expect("source A");
     let checkout_b = tempfile::tempdir().expect("checkout B");
-    write_bench_extension(home.path());
+    write_bench_extension(context.home());
     write_package_rig(source_a.path(), "stale-rig");
     write_package_rig(checkout_b.path(), "stale-rig");
-    install_then_remove_source_a(home.path(), source_a.path());
+    install_then_remove_source_a(&context, source_a.path());
 
     let checkout_b_text = checkout_b.path().to_str().expect("checkout B path");
     let args = [
@@ -112,13 +155,10 @@ fn bench_repairs_missing_linked_rig_source_from_path_override() {
         "--iterations",
         "1",
     ];
-    assert_success(run_homeboy(home.path(), &args), &args);
+    assert_success(run_homeboy(&context, &args), &args);
 
-    let metadata = fs::read_to_string(
-        home.path()
-            .join(".config/homeboy/rig-sources/stale-rig.json"),
-    )
-    .expect("refreshed source metadata");
+    let metadata = fs::read_to_string(context.config_dir().join("rig-sources/stale-rig.json"))
+        .expect("refreshed source metadata");
     let metadata: serde_json::Value = serde_json::from_str(&metadata).expect("metadata JSON");
     let expected_package_path = checkout_b.path().to_string_lossy().into_owned();
     assert_eq!(
@@ -129,22 +169,22 @@ fn bench_repairs_missing_linked_rig_source_from_path_override() {
 
 #[test]
 fn bench_recovery_preserves_conflicting_user_owned_rig() {
-    let home = tempfile::tempdir().expect("home");
+    let context = HermeticTestContext::new();
     let source_a = tempfile::tempdir().expect("source A");
     let checkout_b = tempfile::tempdir().expect("checkout B");
-    write_bench_extension(home.path());
+    write_bench_extension(context.home());
     write_package_rig(source_a.path(), "stale-rig");
     write_package_rig(checkout_b.path(), "stale-rig");
-    install_then_remove_source_a(home.path(), source_a.path());
+    install_then_remove_source_a(&context, source_a.path());
 
-    let config_path = home.path().join(".config/homeboy/rigs/stale-rig.json");
+    let config_path = context.config_dir().join("rigs/stale-rig.json");
     fs::remove_file(&config_path).expect("remove stale rig link");
     let user_owned = r#"{ "id": "other-rig", "components": {} }"#;
     fs::write(&config_path, user_owned).expect("write conflicting user rig");
 
     let checkout_b_text = checkout_b.path().to_str().expect("checkout B path");
     let output = run_homeboy(
-        home.path(),
+        &context,
         &[
             "bench",
             "--rig",


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `recovery-homeboy-8150-hermetic-rust-tests` into review-ready branch `fix/8150-hermetic-rust-tests`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:recovery-homeboy-8150-hermetic-rust-tests`
- **Homeboy run ID:** `recovery-homeboy-8150-hermetic-rust-tests`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `fix/8150-hermetic-rust-tests`

## Source refs
- https://github.com/Extra-Chill/homeboy/issues/8150

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** test-only
- **Supersedes:** none recorded
- **Depends on:** none recorded

## Runtime guardrails
- **Why this is not broader than the packet evidence:** Migrates one coherent high-failure family first; remaining ambient-state families stay listed for bounded follow-up rather than a risky repository-wide rewrite.
- **Evidence discriminators preserved:** explicit test-owned state roots and Cargo fixture binary
- **Nearby contracts preserved:** legacy HomeGuard serialized fallback, host integration remains explicit opt-in

## Attempt summary
Introduces an explicit subprocess-scoped test context for HOME/config/data/artifact/runtime/temp/daemon/runner paths and migrates the stale linked-rig integration family.

## Gate results
- hermetic-integration-parallel: passed (targeted)
- hermetic-integration-serial: passed (targeted)
- artifact-path: passed (targeted)
- format: passed (targeted)
- diff-check: passed (targeted)

## Verification capability
- `targeted_checks_run`: `cargo test --test stale_linked_rig_recovery --no-fail-fast`, `cargo test --test stale_linked_rig_recovery -- --test-threads=1`, `cargo test --lib core::paths::tests::artifact_root_defaults_under_homeboy_data`, `cargo fmt --check`, `git diff --check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- docs/internals/test-tiers.md
- src/lib.rs
- src/test_support.rs
- tests/stale_linked_rig_recovery.rs

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `fix/8150-hermetic-rust-tests`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Compared parallel and serial host-state failures, implemented the shared hermetic context and first migration slice, and verified the candidate with Chris.
