### PR TITLE
refactor: break paths<->defaults dependency cycle via resolver hook

### DIFF
--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -88,6 +88,13 @@ impl CliRuntime {
     }
 
     pub fn run_from_args(&self, args: Vec<String>) -> std::process::ExitCode {
+        // Register the config-level artifact_root resolver before any command runs
+        // so paths::artifact_root() can honor global config without paths depending
+        // on the defaults layer (breaks the paths <-> defaults dependency cycle).
+        crate::core::paths::set_config_artifact_root_resolver(|| {
+            crate::core::defaults::load_config().artifact_root
+        });
+
         if is_top_level_version_request(&args) {
             println!("{}", upgrade::current_build_version());
             return std::process::ExitCode::SUCCESS;

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -28,6 +28,41 @@ pub fn set_artifact_root_override(path: Option<PathBuf>) {
     *guard = path;
 }
 
+/// Resolver hook for the config-level `artifact_root` value.
+///
+/// `paths` is a foundation layer and must not depend on the config/`defaults`
+/// layer (that would create a paths <-> defaults dependency cycle, blocking the
+/// crate split). Instead, the config layer registers a resolver here at startup
+/// via [`set_config_artifact_root_resolver`]; `artifact_root()` calls it to
+/// honor the global config override without an inbound dependency on `defaults`.
+type ConfigArtifactRootResolver = fn() -> Option<String>;
+
+fn config_artifact_root_resolver() -> &'static Mutex<Option<ConfigArtifactRootResolver>> {
+    static RESOLVER: OnceLock<Mutex<Option<ConfigArtifactRootResolver>>> = OnceLock::new();
+    RESOLVER.get_or_init(|| Mutex::new(None))
+}
+
+/// Register the resolver that supplies the config-level `artifact_root` override.
+///
+/// Called once during startup by the config layer. Keeps `paths` free of any
+/// compile-time dependency on `defaults`.
+pub fn set_config_artifact_root_resolver(resolver: ConfigArtifactRootResolver) {
+    let mut guard = config_artifact_root_resolver()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = Some(resolver);
+}
+
+fn resolved_config_artifact_root() -> Option<String> {
+    let resolver = {
+        let guard = config_artifact_root_resolver()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *guard
+    };
+    resolver.and_then(|f| f())
+}
+
 /// Base product config directory (universal ~/.config/homeboy/ on all platforms)
 pub fn homeboy() -> Result<PathBuf> {
     #[cfg(windows)]
@@ -124,7 +159,7 @@ pub fn artifact_root() -> Result<PathBuf> {
         }
     }
 
-    if let Some(path) = crate::core::defaults::load_config().artifact_root {
+    if let Some(path) = resolved_config_artifact_root() {
         if !path.trim().is_empty() {
             return Ok(expand_tilde_path(path));
         }
@@ -443,6 +478,11 @@ mod tests {
     #[test]
     fn artifact_root_uses_configured_value() {
         with_isolated_home(|home| {
+            // Mirror production startup wiring: register the config resolver so
+            // artifact_root() can read the config-level override.
+            set_config_artifact_root_resolver(|| {
+                crate::core::defaults::load_config().artifact_root
+            });
             let configured = home.path().join("custom-artifacts");
             crate::core::defaults::save_config(&crate::core::defaults::HomeboyConfig {
                 artifact_root: Some(configured.to_string_lossy().to_string()),
@@ -457,6 +497,9 @@ mod tests {
     #[test]
     fn artifact_root_prefers_env_over_config() {
         with_isolated_home(|home| {
+            set_config_artifact_root_resolver(|| {
+                crate::core::defaults::load_config().artifact_root
+            });
             let configured = home.path().join("config-artifacts");
             let env_root = home.path().join("env-artifacts");
             crate::core::defaults::save_config(&crate::core::defaults::HomeboyConfig {


### PR DESCRIPTION
## Summary

Breaks the **`paths` ⇄ `defaults` dependency cycle** that blocks extracting `paths` (a foundation module) into its own crate. This is the first real dependency-inversion in the workspace-split effort — deferred from earlier PRs precisely because it changes config-resolution behavior and deserved isolated review.

## The cycle
- `paths::artifact_root()` called `defaults::load_config().artifact_root` to honor the config-level override.
- `defaults` depends on `paths::homeboy_json()` for the config file location (5 call sites).

Two-way = can't crate-split `paths`.

## The fix (invert the one back-edge)
`paths` is the lower foundation; `defaults` should depend on it, not vice versa. So I inverted the single `paths → defaults` runtime call:
- `paths` exposes a process-local resolver slot `set_config_artifact_root_resolver(...)`, following the **existing `set_artifact_root_override` pattern** already in the file (no new architecture).
- The config layer registers the resolver once at startup (top of `run_from_args`, before any command dispatch).
- `artifact_root()` reads the config override through the hook instead of calling `defaults` directly.

Result: **`paths` has zero runtime dependency on `defaults`** (only `#[cfg(test)]` references remain, which is fine).

## Behavior preserved
Precedence is unchanged: **CLI override > env var > config > default.** Verified by the existing `artifact_root_uses_configured_value` and `artifact_root_prefers_env_over_config` tests — which I confirmed *fail* without the resolver registered (proving the seam is real), then updated to register it mirroring production wiring.

## Verification
- `cargo check --lib` — 0 errors.
- `cargo test --lib core::paths` — 24/24 pass (incl. precedence).
- `cargo test --lib core::defaults` — 20/20 pass.
- Full build/test left to CI.

## Next
With the cycle broken, `paths` can be extracted cleanly in a follow-up PR — which in turn unblocks the `temp` → `run_dir` chain deferred from the engine-primitives work, continuing toward the big `runner` extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)