### PR TITLE
fix: repair three deterministic Test-gate reds on main

### DIFF
--- a/src/core/cleanup.rs
+++ b/src/core/cleanup.rs
@@ -659,7 +659,13 @@ fn path_size(path: &Path) -> Result<u64> {
         return Ok(metadata.len());
     }
 
-    let mut total = metadata.len();
+    // Sum only the reclaimable file/symlink content. A directory's own
+    // `metadata.len()` is the inode/directory-entry size (typically a 4 KiB
+    // block on ext4/tmpfs), not reclaimable payload — counting it made size
+    // sorting reflect directory nesting depth rather than actual artifact
+    // weight (e.g. a 5-byte file under two nested dirs outranking a 256-byte
+    // file under one). Recurse over children and count their bytes only.
+    let mut total = 0;
     for entry in fs::read_dir(path).map_err(|e| {
         Error::internal_io(
             e.to_string(),

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -534,9 +534,19 @@ impl DefaultLabRunnerCandidate {
     }
 
     fn readiness(&self) -> DefaultLabRunnerReadiness {
+        // Eligibility for *default* selection is looser than
+        // `availability().accepts_jobs`: a disconnected direct-SSH runner is
+        // still a valid default target because auto-offload connects it on
+        // demand. So gate on the hard, non-connectivity reasons only
+        // (capabilities, a failed/absent active-job poll, and capacity), and
+        // score connectivity below rather than excluding it. The one
+        // connectivity gate that IS hard is a disconnected reverse tunnel,
+        // which cannot be woken on demand — handled explicitly below.
+        let at_capacity = matches!(self.capacity, Some(capacity) if self.active_jobs >= capacity);
         if !self.capabilities_ready
             || !self.active_jobs_available
-            || !self.availability().accepts_jobs
+            || self.stale_daemon
+            || at_capacity
         {
             return DefaultLabRunnerReadiness {
                 eligible: false,


### PR DESCRIPTION
## Summary

Three independent **deterministic** Test-gate failures on `main` (surfaced while landing #6384 — main is currently red). Each is a resolver/contract returning a wrong-but-deterministic result; all fixed and verified serially.

### 1. Cleanup artifact size sort (`core::cleanup`)

`path_size` added a directory's own `metadata.len()` (the ~4 KiB inode/dir-entry block on ext4/tmpfs) to its recursive total. That is not reclaimable payload, and it made `--sort size` reflect **directory nesting depth** rather than real artifact weight: a 5-byte file under two nested dirs (`target/debug/app`) outranked a 256-byte file under one (`dist/bundle.js`). Fix: count only file/symlink bytes when recursing.

Fixes `dry_run_can_sort_artifact_candidates_by_size_descending`, `limit_applies_after_size_sort_and_removes_only_selected_artifacts`.

### 2. Default lab-runner eligibility (`core::runner`)

`DefaultLabRunnerCandidate::readiness` gated on `availability().accepts_jobs`, which treats a **disconnected** runner as non-accepting. But default selection is looser than accepts-a-job-right-now: a disconnected direct-SSH runner is a valid default because auto-offload connects it on demand. That made a lone configured-but-disconnected SSH runner resolve to `None`. Fix: gate on the hard, non-connectivity reasons only (capabilities, active-job poll, stale daemon, capacity); connectivity is scored, and the one hard connectivity gate (a disconnected reverse tunnel that cannot be woken) stays explicit.

Fixes `default_lab_runner_selects_single_runner_when_unconfigured`, `_uses_available_preferred_runner`, `_uses_readiness_when_connected_state_is_not_unique`.

### 3. Stale fanout Lab-portability assertions (`commands::infra::route`)

#8045 made agent-task fanout coordination (run-plan and non-dry-run cook-batch) **controller-local** so durable batch state/worktree ownership/recovery stay available, but two tests still asserted the old `is_portable()` contract. Updated them to assert the current local-only contract (still exposes a Lab contract, but not portable, no default offload/extension-parity, carries the controller-owned coordinator reason).

Fixes `agent_task_fanout_run_plan_*` and `agent_task_fanout_cook_batch_run_plan_*`.

## Verification

- `core::cleanup::tests` (34), `core::runner::tests` (39), and the two fanout tests all pass.
- `cargo fmt` + `cargo check --lib` clean.

## Remaining red-main work (separate)

Not in this PR — these are **parallel-order / non-hermetic** flakes, a distinct root cause needing careful test-isolation work:
- `commands::infra::route` Review-contract tests (`lab_command_preserves_portable_contract_shape`, `changed_scope_lint_is_lab_portable`, etc.) resolve the ambient component/extension config via `review_lab_extension_ids` → `execution_context::resolve`, so they're HOME-dependent and race `with_isolated_home` neighbors (get `ComponentNotFound`/`ExtensionNotFound`).
- Daemon lease/pid tests, workspace-git remediation tests, rig-check, trace-variant, and the runner-workload `test`↔`trace` command-identity canonicalization (incomplete #7972).