### PR TITLE
Remap Lab cook attempt plan paths

### DIFF
--- a/src/core/runner/lab_args/agent_task_specs.rs
+++ b/src/core/runner/lab_args/agent_task_specs.rs
@@ -139,19 +139,21 @@ pub(in crate::core::runner) fn remap_agent_task_plan_in_args(
     let ordered = order_mappings_by_specificity(mappings);
 
     try_rewrite_flag_value_args(args, |arg, iter, out| {
-        if arg == "--plan" {
-            out.push(arg.to_string());
-            if let Some(spec) = iter.next() {
-                out.push(remap_agent_task_plan_spec(spec, &ordered, source_path)?);
+        for flag in ["--plan", "--attempt-plan"] {
+            if arg == flag {
+                out.push(arg.to_string());
+                if let Some(spec) = iter.next() {
+                    out.push(remap_agent_task_plan_spec(spec, &ordered, source_path)?);
+                }
+                return Ok(());
             }
-            return Ok(());
-        }
-        if let Some(spec) = arg.strip_prefix("--plan=") {
-            out.push(format!(
-                "--plan={}",
-                remap_agent_task_plan_spec(spec, &ordered, source_path)?
-            ));
-            return Ok(());
+            if let Some(spec) = arg.strip_prefix(&format!("{flag}=")) {
+                out.push(format!(
+                    "{flag}={}",
+                    remap_agent_task_plan_spec(spec, &ordered, source_path)?
+                ));
+                return Ok(());
+            }
         }
         out.push(arg.to_string());
         Ok(())

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -1747,6 +1747,162 @@ mod materialize_specs_tests {
     }
 
     #[test]
+    fn materialize_agent_task_specs_remaps_and_stages_cook_attempt_plan_for_runner_harvest() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let controller = temp.path().join("controller/worktree");
+        let runner = temp.path().join("runner/worktree");
+        let controller_plugin = temp.path().join("controller/provider-plugin");
+        let runner_plugin = temp.path().join("runner/provider-plugin");
+        let controller_overlay = temp.path().join("controller/runtime-overlay");
+        let runner_overlay = temp.path().join("runner/runtime-overlay");
+        let controller_component = temp.path().join("controller/component");
+        let runner_component = temp.path().join("runner/component");
+        for path in [
+            &controller,
+            &controller_plugin,
+            &controller_overlay,
+            &controller_component,
+            &runner_plugin,
+            &runner_overlay,
+            &runner_component,
+        ] {
+            std::fs::create_dir_all(path).expect("workspace directory");
+        }
+        std::fs::create_dir_all(&runner).expect("runner checkout");
+        std::fs::write(runner.join("README.md"), "runner checkout\n").expect("checkout file");
+        for args in [
+            vec!["init".to_string(), "-b".to_string(), "main".to_string()],
+            vec!["add".to_string(), ".".to_string()],
+            vec![
+                "-c".to_string(),
+                "user.name=Homeboy Test".to_string(),
+                "-c".to_string(),
+                "user.email=homeboy@example.test".to_string(),
+                "commit".to_string(),
+                "-m".to_string(),
+                "runner checkout".to_string(),
+            ],
+        ] {
+            assert!(std::process::Command::new("git")
+                .args(args)
+                .current_dir(&runner)
+                .status()
+                .expect("run git")
+                .success());
+        }
+
+        let mappings = vec![
+            LabPathRemap {
+                local: controller.display().to_string(),
+                remote: runner.display().to_string(),
+            },
+            LabPathRemap {
+                local: controller_plugin.display().to_string(),
+                remote: runner_plugin.display().to_string(),
+            },
+            LabPathRemap {
+                local: controller_overlay.display().to_string(),
+                remote: runner_overlay.display().to_string(),
+            },
+            LabPathRemap {
+                local: controller_component.display().to_string(),
+                remote: runner_component.display().to_string(),
+            },
+        ];
+        let plan = serde_json::json!({
+            "schema": "homeboy/agent-task-plan/v1",
+            "plan_id": "controller-plan",
+            "component_contracts": [{ "slug": "component", "path": controller_component }],
+            "tasks": [{
+                "task_id": "task-1",
+                "workspace": { "root": controller },
+                "executor": { "config": {
+                    "workspace": controller,
+                    "workspace_root": controller,
+                    "provider_plugin_paths": [controller_plugin],
+                    "runtime_overlay": { "sources": [controller_overlay] }
+                }},
+                "metadata": { "workspace": controller, "workspace_root": controller }
+            }]
+        })
+        .to_string();
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--attempt-plan".to_string(),
+            plan,
+        ];
+
+        let out = materialize_agent_task_specs_in_args(&args, &mappings, temp.path(), |spec| {
+            assert_eq!(spec.filename, "agent-task-attempt-plan.json");
+            std::fs::write(runner.join(spec.filename), spec.spec).expect("stage runner plan");
+            Ok(Some((
+                format!("@{}", runner.join(spec.filename).display()),
+                (),
+            )))
+        })
+        .expect("remap and stage attempt plan");
+        let staged: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(runner.join("agent-task-attempt-plan.json"))
+                .expect("read staged plan"),
+        )
+        .expect("parse staged plan");
+
+        assert_eq!(
+            out.argv[4],
+            format!("@{}", runner.join("agent-task-attempt-plan.json").display())
+        );
+        assert_eq!(
+            staged["tasks"][0]["workspace"]["root"],
+            runner.display().to_string()
+        );
+        assert_eq!(
+            staged["tasks"][0]["executor"]["config"]["workspace"],
+            runner.display().to_string()
+        );
+        assert_eq!(
+            staged["tasks"][0]["executor"]["config"]["workspace_root"],
+            runner.display().to_string()
+        );
+        assert_eq!(
+            staged["tasks"][0]["metadata"]["workspace"],
+            runner.display().to_string()
+        );
+        assert_eq!(
+            staged["tasks"][0]["metadata"]["workspace_root"],
+            runner.display().to_string()
+        );
+        assert_eq!(
+            staged["tasks"][0]["executor"]["config"]["provider_plugin_paths"][0],
+            runner_plugin.display().to_string()
+        );
+        assert_eq!(
+            staged["tasks"][0]["executor"]["config"]["runtime_overlay"]["sources"][0],
+            runner_overlay.display().to_string()
+        );
+        assert_eq!(
+            staged["component_contracts"][0]["path"],
+            runner_component.display().to_string()
+        );
+        assert!(
+            !std::fs::read_to_string(runner.join("agent-task-attempt-plan.json"))
+                .expect("read staged plan")
+                .contains(&controller.display().to_string())
+        );
+        assert!(std::process::Command::new("git")
+            .args(["rev-parse", "--is-inside-work-tree"])
+            .current_dir(
+                staged["tasks"][0]["workspace"]["root"]
+                    .as_str()
+                    .expect("runner root")
+            )
+            .status()
+            .expect("run runner git harvest preflight")
+            .success());
+    }
+
+    #[test]
     fn materialize_agent_task_specs_rewrites_fanout_child_cwd_to_runner_path() {
         let temp = tempfile::tempdir().expect("tempdir");
         let controller = temp.path().join("homeboy@cook-one");


### PR DESCRIPTION
## Summary
Remap embedded controller paths in staged Lab cook attempt plans before runner execution.

## What changed
- Apply the existing typed agent-task plan path remapping contract to both --plan and --attempt-plan inputs.
- Cover workspace, provider, runtime overlay, metadata, and component contract paths with a native runner-harvest regression test.

## How to test
1. Run `cargo test materialize_agent_task_specs_remaps_and_stages_cook_attempt_plan_for_runner_harvest --lib`; expect passes.
2. Run `cargo fmt --check`; expect passes.

## Compatibility
No backwards-compatibility impact; this corrects runner-side path materialization for Lab cook attempts.

## Evidence
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8132
- focused-test: Passed
- format: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab path-remapping failure, prepared the implementation and regression coverage, and verified the candidate under Chris's direction.

## Source relationships
- Closes #8132
