### PR TITLE
test: repair stale git-sync and rig-lint conflict fixtures

### DIFF
--- a/src/core/runner/workspace/tests/mod.rs
+++ b/src/core/runner/workspace/tests/mod.rs
@@ -30,6 +30,19 @@ fn dirty_git_repo() -> tempfile::TempDir {
     git(source.path(), &["init"]);
     git(source.path(), &["config", "user.email", "test@example.com"]);
     git(source.path(), &["config", "user.name", "Test User"]);
+    // git_snapshot requires remote.origin.url before it evaluates working-tree
+    // cleanliness, so the dirty-working-tree tests must configure a remote or
+    // they trip the earlier remote-url guard instead of the dirty check they
+    // assert. A placeholder URL is enough — these tests never fetch.
+    git(
+        source.path(),
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://example.test/dirty-fixture.git",
+        ],
+    );
     std::fs::write(source.path().join("file.txt"), "base\n").expect("write base");
     git(source.path(), &["add", "."]);
     git(source.path(), &["commit", "-m", "base"]);

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -324,8 +324,11 @@ mod install_flows {
         let _home = HomeGuard::new();
         let package = tempfile::tempdir().expect("package");
         write_rig(package.path(), "lint-fixture", &minimal_rig("lint-fixture"));
-        fs::write(package.path().join("conflicted.txt"), "<<<<<<< ours\n")
-            .expect("conflict fixture");
+        fs::write(
+            package.path().join("conflicted.txt"),
+            "<<<<<<< ours\n=======\n>>>>>>> theirs\n",
+        )
+        .expect("conflict fixture");
 
         install(package.path().to_str().unwrap(), None, false).expect("install");
         let rig = load("lint-fixture").expect("load rig");
@@ -667,8 +670,11 @@ mod install_flows {
             "lint-conflict",
             &minimal_rig("lint-conflict"),
         );
-        fs::write(package.path().join("conflicted.txt"), "<<<<<<< ours\n")
-            .expect("conflict fixture");
+        fs::write(
+            package.path().join("conflicted.txt"),
+            "<<<<<<< ours\n=======\n>>>>>>> theirs\n",
+        )
+        .expect("conflict fixture");
 
         install(package.path().to_str().unwrap(), None, false).expect("install");
         let rig = load("lint-conflict").expect("load rig");


### PR DESCRIPTION
## Summary

Two more deterministic Test-gate reds on `main`, both **stale test fixtures** that no longer satisfy the current (correct) production behavior. (Follow-up to #8179, which repaired the test-build so these could actually be observed.)

### 1. Workspace git dirty-sync fixtures

`git_snapshot` validates `remote.origin.url` **before** it evaluates working-tree cleanliness. The `dirty_git_repo` fixture configured no remote, so it tripped the earlier remote-url guard and never reached the clean-working-tree error the tests assert. Added a placeholder `origin` remote to the fixture (the tests never fetch).

Fixes `dirty_git_sync_without_changed_since_reports_supported_remediation`, `dirty_changed_since_git_sync_explains_snapshot_is_unavailable`.

### 2. Rig-lint conflict-marker fixtures

#7626 tightened conflict-marker detection to require a full Start/Separator/End block — fixing false positives on lone `<<<<<<<` lines in legitimate content (e.g. docs about conflict markers). But the fixtures still wrote only `<<<<<<< ours`, which the stricter detector correctly ignores, so the tests' "conflict should fail lint" assertion no longer held. Write a complete conflict block (`<<<<<<< ours` / `=======` / `>>>>>>> theirs`) so the fixtures exercise real conflict detection.

Fixes `run_lint_reports_package_conflict_markers`, `installed_rig_check_reports_package_lint_failures`.

## Verification

- `core::rig::install` — all pass.
- The two workspace `dirty_*` git tests pass.
- `cargo fmt` clean.

## Remaining red-main (deeper, separate)

Not in this PR — these need real logic investigation, not fixture tweaks:
- `changed_since_retry_route_materializes_private_unavailable_origin_from_bundle` — changed-since base resolution from a controller bundle (related to #8139).
- `commands::trace` variant tests — `rig check` rejects the variant fixture rig.
- `runner_workload_validation_rejects_dispatch_drift` — `homeboy test` has no Lab route contract, so `test`↔`trace` command-identity canonicalization anticipated by #7972 was never wired.
- Daemon lease/pid, observation-store concurrency, and remaining parallel-order flakes.