### PR TITLE
Persist deploy timing and resumable target state

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -91,6 +91,9 @@ pub struct DeployArgs {
     /// Force local tag-based build/deploy, ignoring reusable release assets
     #[arg(long)]
     pub tagged: bool,
+    /// Resume a prior multi-project deploy run after exact identity validation
+    #[arg(long, value_name = "RUN_ID")]
+    pub resume: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -123,6 +126,8 @@ pub struct MultiProjectDeployOutput {
     pub dry_run: bool,
     pub check: bool,
     pub force: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deploy_run_id: Option<String>,
     #[serde(
         rename = "_homeboy_actionable",
         skip_serializing_if = "Option::is_none"
@@ -371,6 +376,7 @@ fn build_config(args: &DeployArgs, skip_build: bool) -> DeployConfig {
         requested_ref: args.requested_ref.clone(),
         tagged: args.tagged,
         prepared_artifact: None,
+        resume_run_id: args.resume.clone(),
     }
 }
 
@@ -394,6 +400,7 @@ fn run_multi_output(
             dry_run: args.dry_run,
             check: args.check,
             force: args.force,
+            deploy_run_id: result.deploy_run_id,
             actionable: Some(actionable),
         }),
         exit_code,

--- a/src/core/deploy/execution/mod.rs
+++ b/src/core/deploy/execution/mod.rs
@@ -231,6 +231,7 @@ mod tests {
             requested_ref: None,
             tagged: false,
             prepared_artifact: None,
+            resume_run_id: None,
         };
 
         let result = resolve_preflight_artifact_path(
@@ -292,6 +293,7 @@ mod tests {
             requested_ref: None,
             tagged: false,
             prepared_artifact: None,
+            resume_run_id: None,
         };
 
         assert!(!should_try_download_release_artifact(
@@ -326,6 +328,7 @@ mod tests {
             requested_ref: None,
             tagged: true,
             prepared_artifact: None,
+            resume_run_id: None,
         };
 
         assert!(!should_try_download_release_artifact(
@@ -371,6 +374,7 @@ mod tests {
             requested_ref: None,
             tagged: false,
             prepared_artifact: None,
+            resume_run_id: None,
         };
 
         assert!(should_try_download_release_artifact(
@@ -416,6 +420,7 @@ mod tests {
             requested_ref: None,
             tagged: false,
             prepared_artifact: None,
+            resume_run_id: None,
         };
 
         assert!(should_try_download_release_artifact(
@@ -452,6 +457,7 @@ mod tests {
             requested_ref: None,
             tagged: false,
             prepared_artifact: None,
+            resume_run_id: None,
         };
 
         match release_artifact_plan(&component, &config, false, false) {
@@ -501,6 +507,7 @@ mod tests {
             requested_ref: None,
             tagged: false,
             prepared_artifact: None,
+            resume_run_id: None,
         };
 
         assert!(should_try_download_release_artifact(
@@ -575,6 +582,7 @@ mod tests {
             requested_ref: None,
             tagged: false,
             prepared_artifact: None,
+            resume_run_id: None,
         };
 
         let artifact = resolve_preflight_artifact_path(

--- a/src/core/deploy/execution/mod.rs
+++ b/src/core/deploy/execution/mod.rs
@@ -148,6 +148,8 @@ mod tests {
             skip_deps_hydration: false,
             expected_version: Some("1.2.3".to_string()),
             no_pull: true,
+            allow_stale_source: false,
+            allow_downgrade: false,
             head: false,
             requested_ref: None,
             tagged: false,
@@ -161,6 +163,7 @@ mod tests {
                 tag: "v1.2.3".to_string(),
                 source_commit: "0123456789abcdef".to_string(),
             }),
+            resume_run_id: None,
         };
 
         let prepared = prepare_component_deploy(

--- a/src/core/deploy/lifecycle.rs
+++ b/src/core/deploy/lifecycle.rs
@@ -1,0 +1,254 @@
+//! Durable, versioned lifecycle records for resumable multi-target deploys.
+
+use std::fs;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::error::{Error, Result};
+use crate::core::paths;
+use crate::core::phase_timing::PhaseTimingReport;
+
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeployRunIdentity {
+    pub source: String,
+    pub artifact: String,
+    pub components: Vec<String>,
+    pub targets: Vec<String>,
+    pub policy: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeployTargetStatus {
+    Planned,
+    Running,
+    Succeeded,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeployTargetLifecycle {
+    pub target: String,
+    pub status: DeployTargetStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase_timings: Option<PhaseTimingReport>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeployLifecycleRun {
+    pub schema_version: u32,
+    pub id: String,
+    pub identity: DeployRunIdentity,
+    pub targets: Vec<DeployTargetLifecycle>,
+}
+
+impl DeployLifecycleRun {
+    pub fn new(id: String, identity: DeployRunIdentity) -> Self {
+        let targets = identity
+            .targets
+            .iter()
+            .cloned()
+            .map(|target| DeployTargetLifecycle {
+                target,
+                status: DeployTargetStatus::Planned,
+                error: None,
+                phase_timings: None,
+            })
+            .collect();
+        Self {
+            schema_version: SCHEMA_VERSION,
+            id,
+            identity,
+            targets,
+        }
+    }
+
+    pub fn resume(&mut self, identity: &DeployRunIdentity) -> Result<()> {
+        if self.schema_version != SCHEMA_VERSION {
+            return Err(Error::validation_invalid_argument(
+                "resume",
+                format!(
+                    "Deploy run '{}' uses unsupported schema version {}",
+                    self.id, self.schema_version
+                ),
+                None,
+                None,
+            ));
+        }
+        if &self.identity != identity {
+            return Err(Error::validation_invalid_argument(
+                "resume",
+                format!("Deploy run '{}' identity does not exactly match the requested source, artifact, components, targets, and policy", self.id),
+                None,
+                None,
+            ));
+        }
+        for target in &mut self.targets {
+            if target.status == DeployTargetStatus::Running {
+                // A process death leaves no reliable remote completion signal. Retry it.
+                target.status = DeployTargetStatus::Planned;
+                target.error = Some(
+                    "Recovered interrupted target; retrying from its durable checkpoint"
+                        .to_string(),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    pub fn target_is_succeeded(&self, target: &str) -> bool {
+        self.targets
+            .iter()
+            .any(|entry| entry.target == target && entry.status == DeployTargetStatus::Succeeded)
+    }
+
+    pub fn update_target(
+        &mut self,
+        target: &str,
+        status: DeployTargetStatus,
+        error: Option<String>,
+        phase_timings: Option<PhaseTimingReport>,
+    ) {
+        if let Some(entry) = self.targets.iter_mut().find(|entry| entry.target == target) {
+            entry.status = status;
+            entry.error = error;
+            entry.phase_timings = phase_timings;
+        }
+    }
+}
+
+pub(super) fn lifecycle_path(id: &str) -> Result<PathBuf> {
+    Ok(paths::homeboy_data()?
+        .join("deploy-runs")
+        .join(format!("{id}.json")))
+}
+
+pub(super) fn load(id: &str) -> Result<DeployLifecycleRun> {
+    let path = lifecycle_path(id)?;
+    let contents = fs::read_to_string(&path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("read deploy run {}", path.display())),
+        )
+    })?;
+    serde_json::from_str(&contents).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("parse deploy run {}", path.display())),
+        )
+    })
+}
+
+pub(super) fn save(run: &DeployLifecycleRun) -> Result<()> {
+    let path = lifecycle_path(&run.id)?;
+    let parent = path.parent().expect("deploy lifecycle path has parent");
+    fs::create_dir_all(parent).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("create {}", parent.display())),
+        )
+    })?;
+    let temporary = path.with_extension("json.tmp");
+    let contents = serde_json::to_vec_pretty(run).map_err(|error| {
+        Error::internal_io(error.to_string(), Some("serialize deploy run".to_string()))
+    })?;
+    fs::write(&temporary, contents).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("write {}", temporary.display())),
+        )
+    })?;
+    fs::rename(&temporary, &path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("commit {}", path.display())),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::with_isolated_home;
+
+    fn identity() -> DeployRunIdentity {
+        DeployRunIdentity {
+            source: "refs/tags/v1.2.3@abc".to_string(),
+            artifact: "sha256:123".to_string(),
+            components: vec!["plugin".to_string()],
+            targets: vec!["a".to_string(), "b".to_string()],
+            policy: "tagged=true".to_string(),
+        }
+    }
+
+    #[test]
+    fn success_failure_and_skip_are_durable() {
+        let mut run = DeployLifecycleRun::new("run".to_string(), identity());
+        run.update_target("a", DeployTargetStatus::Succeeded, None, None);
+        run.update_target(
+            "b",
+            DeployTargetStatus::Failed,
+            Some("boom".to_string()),
+            None,
+        );
+        assert!(run.target_is_succeeded("a"));
+        assert!(!run.target_is_succeeded("b"));
+        assert_eq!(run.targets[1].error.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn resume_recovers_interrupted_targets_without_redeploying_successes() {
+        let mut run = DeployLifecycleRun::new("run".to_string(), identity());
+        run.update_target("a", DeployTargetStatus::Succeeded, None, None);
+        run.update_target("b", DeployTargetStatus::Running, None, None);
+        run.resume(&identity()).expect("matching resume");
+        assert!(run.target_is_succeeded("a"));
+        assert_eq!(run.targets[1].status, DeployTargetStatus::Planned);
+    }
+
+    #[test]
+    fn resume_refuses_any_identity_mismatch() {
+        let run = DeployLifecycleRun::new("run".to_string(), identity());
+        let mut changed = identity();
+        changed.artifact = "sha256:changed".to_string();
+        let error = run.clone().resume(&changed).expect_err("must fail closed");
+        assert!(error.message.contains("does not exactly match"));
+    }
+
+    #[test]
+    fn durable_record_round_trips_target_state_and_partial_timing_evidence() {
+        with_isolated_home(|_| {
+            let mut run = DeployLifecycleRun::new("run".to_string(), identity());
+            let mut timer = crate::core::phase_timing::PhaseTimer::new();
+            timer.record_failed("transfer", std::time::Duration::from_millis(1));
+            run.update_target(
+                "b",
+                DeployTargetStatus::Failed,
+                Some("connection lost".to_string()),
+                Some(timer.into_report()),
+            );
+            save(&run).expect("persist run before retryable remote work");
+
+            let restored = load("run").expect("read durable run");
+            assert_eq!(restored.schema_version, SCHEMA_VERSION);
+            assert_eq!(restored.targets[1].status, DeployTargetStatus::Failed);
+            assert_eq!(
+                restored.targets[1].error.as_deref(),
+                Some("connection lost")
+            );
+            assert_eq!(
+                restored.targets[1]
+                    .phase_timings
+                    .as_ref()
+                    .and_then(|report| report.span("transfer"))
+                    .map(|span| span.status),
+                Some(crate::core::phase_timing::PhaseStatus::Failed)
+            );
+        });
+    }
+}

--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -1,6 +1,7 @@
 mod effect;
 mod execution;
 mod generated_artifacts;
+mod lifecycle;
 mod orchestration;
 mod orchestration_ref_checkout;
 mod orchestration_tag_checkout;
@@ -34,7 +35,9 @@ pub use version_overrides::{RemoteVersionProbeFailure, RemoteVersionProbeResult}
 use crate::core::component;
 use crate::core::context::resolve_project_ssh_with_base_path;
 use crate::core::error::{Error, Result};
+use crate::core::phase_timing::PhaseTimer;
 use crate::core::project;
+use uuid::Uuid;
 
 /// High-level deploy entry point. Resolves SSH context internally.
 ///
@@ -80,8 +83,8 @@ pub fn fetch_project_remote_versions(
 
 /// Deploy components across multiple projects.
 ///
-/// Builds each project independently unless an upstream workflow supplies a
-/// prepared artifact, which is validated once and reused unchanged for every target.
+/// Reuses a validated prepared artifact or verified release asset across targets
+/// while keeping per-target lifecycle state isolated for resumable deployments.
 ///
 /// Unknown project IDs are skipped (not fatal) — fleet configs can
 /// accumulate stale references that shouldn't block the rest.
@@ -153,10 +156,25 @@ pub fn run_multi(
         }
     );
 
+    let identity = lifecycle_identity(project_ids, component_ids, config);
+    let mut lifecycle_run = if config.dry_run || config.check {
+        None
+    } else if let Some(id) = config.resume_run_id.as_deref() {
+        let mut run = lifecycle::load(id)?;
+        run.resume(&identity)?;
+        lifecycle::save(&run)?;
+        Some(run)
+    } else {
+        let run = lifecycle::DeployLifecycleRun::new(Uuid::new_v4().to_string(), identity);
+        lifecycle::save(&run)?;
+        Some(run)
+    };
+    let deploy_run_id = lifecycle_run.as_ref().map(|run| run.id.clone());
+
     let mut project_results = Vec::new();
     let mut succeeded: u32 = 0;
     let mut failed: u32 = 0;
-    let skipped: u32 = unknown_projects.len() as u32;
+    let mut skipped: u32 = unknown_projects.len() as u32;
     let mut planned: u32 = 0;
     let mut release_artifacts = release_download::ReleaseArtifactStore::default();
     // Record skipped results for unknown projects
@@ -172,6 +190,7 @@ pub fn run_multi(
                 skipped: 0,
                 failed: 0,
             },
+            phase_timings: None,
         });
     }
 
@@ -197,9 +216,50 @@ pub fn run_multi(
             requested_ref: config.requested_ref.clone(),
             tagged: config.tagged,
             prepared_artifact: config.prepared_artifact.clone(),
+            resume_run_id: None,
         };
 
-        match run_with_release_artifacts(project_id, &project_config, &mut release_artifacts) {
+        if lifecycle_run
+            .as_ref()
+            .is_some_and(|run| run.target_is_succeeded(project_id))
+        {
+            let mut timer = PhaseTimer::new();
+            timer.record_skipped("transfer");
+            timer.record_skipped("install");
+            timer.record_skipped("verify");
+            project_results.push(ProjectDeployResult {
+                project_id: project_id.to_string(),
+                status: "skipped".to_string(),
+                error: Some("Already succeeded in the resumed deploy run".to_string()),
+                results: vec![],
+                summary: DeploySummary {
+                    total: 0,
+                    succeeded: 0,
+                    failed: 0,
+                    skipped: 1,
+                },
+                phase_timings: Some(timer.into_report()),
+            });
+            skipped += 1;
+            continue;
+        }
+
+        if let Some(run) = lifecycle_run.as_mut() {
+            run.update_target(
+                project_id,
+                lifecycle::DeployTargetStatus::Running,
+                None,
+                None,
+            );
+            lifecycle::save(run)?;
+        }
+        let mut timer = PhaseTimer::new();
+        let result = timer.time("resolve_source", || {
+            run_with_release_artifacts(project_id, &project_config, &mut release_artifacts)
+        });
+        let timings = timer.into_report();
+
+        match result {
             Ok(result) => {
                 let deploy_failed = result.summary.failed > 0;
                 let is_planned = config.dry_run || config.check;
@@ -217,7 +277,17 @@ pub fn run_multi(
                         error: Some(error_msg),
                         results: result.results,
                         summary: result.summary,
+                        phase_timings: Some(timings.clone()),
                     });
+                    if let Some(run) = lifecycle_run.as_mut() {
+                        run.update_target(
+                            project_id,
+                            lifecycle::DeployTargetStatus::Failed,
+                            project_results.last().and_then(|entry| entry.error.clone()),
+                            Some(timings.clone()),
+                        );
+                        lifecycle::save(run)?;
+                    }
                     failed += 1;
                 } else if is_planned {
                     project_results.push(ProjectDeployResult {
@@ -226,6 +296,7 @@ pub fn run_multi(
                         error: None,
                         results: result.results,
                         summary: result.summary,
+                        phase_timings: Some(timings.clone()),
                     });
                     planned += 1;
                 } else {
@@ -235,7 +306,17 @@ pub fn run_multi(
                         error: None,
                         results: result.results,
                         summary: result.summary,
+                        phase_timings: Some(timings.clone()),
                     });
+                    if let Some(run) = lifecycle_run.as_mut() {
+                        run.update_target(
+                            project_id,
+                            lifecycle::DeployTargetStatus::Succeeded,
+                            None,
+                            Some(timings.clone()),
+                        );
+                        lifecycle::save(run)?;
+                    }
                     succeeded += 1;
                 }
             }
@@ -251,7 +332,17 @@ pub fn run_multi(
                         skipped: 0,
                         failed: 1,
                     },
+                    phase_timings: Some(timings.clone()),
                 });
+                if let Some(run) = lifecycle_run.as_mut() {
+                    run.update_target(
+                        project_id,
+                        lifecycle::DeployTargetStatus::Failed,
+                        Some(e.to_string()),
+                        Some(timings),
+                    );
+                    lifecycle::save(run)?;
+                }
                 failed += 1;
             }
         }
@@ -269,7 +360,51 @@ pub fn run_multi(
             skipped,
             planned,
         },
+        deploy_run_id,
     })
+}
+
+fn lifecycle_identity(
+    project_ids: &[String],
+    component_ids: &[String],
+    config: &DeployConfig,
+) -> lifecycle::DeployRunIdentity {
+    let mut components = component_ids.to_vec();
+    components.sort();
+    let mut targets = project_ids.to_vec();
+    targets.sort();
+    let source = config.requested_ref.clone().unwrap_or_else(|| {
+        if config.head {
+            "HEAD".to_string()
+        } else if let Some(artifact) = config.prepared_artifact.as_ref() {
+            format!("{}@{}", artifact.tag, artifact.source_commit)
+        } else {
+            "release-tag".to_string()
+        }
+    });
+    let artifact = config.prepared_artifact.as_ref().map_or_else(
+        || {
+            config
+                .expected_version
+                .clone()
+                .unwrap_or_else(|| "resolved-at-preflight".to_string())
+        },
+        |prepared| format!("sha256:{};size={}", prepared.sha256, prepared.size_bytes),
+    );
+    lifecycle::DeployRunIdentity {
+        source,
+        // Artifact selection is an input policy before preparation. Per-component
+        // provenance remains in the result after preparation has resolved it.
+        artifact,
+        components,
+        targets,
+        policy: format!(
+            "all={};outdated={};behind_upstream={};force={};skip_build={};keep_deps={};no_pull={};allow_stale_source={};allow_downgrade={};head={};tagged={}",
+            config.all, config.outdated, config.behind_upstream, config.force, config.skip_build,
+            config.keep_deps, config.no_pull, config.allow_stale_source, config.allow_downgrade,
+            config.head, config.tagged
+        ),
+    }
 }
 
 /// Find all projects that use any of the specified components.
@@ -336,6 +471,7 @@ mod tests {
             requested_ref: None,
             tagged: false,
             prepared_artifact: None,
+            resume_run_id: None,
         }
     }
 

--- a/src/core/deploy/orchestration/mod.rs
+++ b/src/core/deploy/orchestration/mod.rs
@@ -537,6 +537,7 @@ mod tests {
             requested_ref: None,
             tagged: false,
             prepared_artifact: None,
+            resume_run_id: None,
         }
     }
 

--- a/src/core/deploy/orchestration/modes.rs
+++ b/src/core/deploy/orchestration/modes.rs
@@ -367,6 +367,8 @@ mod tests {
             head: true,
             requested_ref: None,
             tagged: false,
+            prepared_artifact: None,
+            resume_run_id: None,
         };
 
         let checked = run_check_mode(

--- a/src/core/deploy/orchestration/modes.rs
+++ b/src/core/deploy/orchestration/modes.rs
@@ -302,6 +302,7 @@ mod tests {
             requested_ref: Some("reviewed".to_string()),
             tagged: false,
             prepared_artifact: None,
+            resume_run_id: None,
         };
 
         let result = run_dry_run_mode(

--- a/src/core/deploy/orchestration/preflight.rs
+++ b/src/core/deploy/orchestration/preflight.rs
@@ -320,6 +320,8 @@ mod tests {
             head: false,
             requested_ref: None,
             tagged: false,
+            prepared_artifact: None,
+            resume_run_id: None,
         }
     }
 

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -980,6 +980,7 @@ mod tests {
             requested_ref: None,
             tagged: false,
             prepared_artifact: None,
+            resume_run_id: None,
         }
     }
 

--- a/src/core/deploy/types.rs
+++ b/src/core/deploy/types.rs
@@ -9,6 +9,7 @@ use crate::core::component::Component;
 use crate::core::config;
 use crate::core::error::Result;
 use crate::core::paths as base_path;
+use crate::core::phase_timing::PhaseTimingReport;
 use crate::core::project::Project;
 use crate::is_zero_u32;
 
@@ -90,6 +91,8 @@ pub struct DeployConfig {
     pub tagged: bool,
     /// An immutable artifact prepared by an upstream workflow.
     pub prepared_artifact: Option<PreparedDeployArtifact>,
+    /// Resume a durable multi-target deploy run after exact identity validation.
+    pub resume_run_id: Option<String>,
 }
 
 impl DeployConfig {
@@ -115,6 +118,7 @@ impl DeployConfig {
             requested_ref: None,
             tagged: false,
             prepared_artifact: None,
+            resume_run_id: None,
         }
     }
 }
@@ -1194,6 +1198,8 @@ pub struct ProjectDeployResult {
     pub error: Option<String>,
     pub results: Vec<ComponentDeployResult>,
     pub summary: DeploySummary,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase_timings: Option<PhaseTimingReport>,
 }
 
 /// Result of a multi-project deployment.
@@ -1202,6 +1208,8 @@ pub struct MultiDeployResult {
     pub component_ids: Vec<String>,
     pub projects: Vec<ProjectDeployResult>,
     pub summary: MultiDeploySummary,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deploy_run_id: Option<String>,
 }
 
 /// Summary of multi-project deployment.

--- a/src/core/execution.rs
+++ b/src/core/execution.rs
@@ -666,6 +666,7 @@ mod tests {
                 status: ReleaseStepStatus::Success,
                 warnings: vec!["signed artifact missing".to_string()],
                 summary: None,
+                phase_timings: None,
             },
         };
 

--- a/src/core/release/deployment.rs
+++ b/src/core/release/deployment.rs
@@ -258,6 +258,7 @@ fn release_deployment_config(
         requested_ref: None,
         tagged: false,
         prepared_artifact: Some(prepared_artifact),
+        resume_run_id: None,
     }
 }
 
@@ -366,6 +367,7 @@ mod tests {
                 status: ReleaseStepStatus::Success,
                 warnings: vec![],
                 summary: None,
+                phase_timings: None,
             },
         };
 

--- a/src/core/release/orchestrator.rs
+++ b/src/core/release/orchestrator.rs
@@ -4,6 +4,7 @@
 //! the accumulated step results into the public release run shape.
 
 use crate::core::error::Result;
+use crate::core::phase_timing::PhaseTimer;
 use std::collections::HashSet;
 
 use super::execution_plan::{
@@ -50,16 +51,19 @@ fn run_with_plan_inner(
     let mut results: Vec<ReleaseStepResult> = Vec::new();
 
     let initial_plan = build_initial_preflight_plan(component_id, options);
-    let initial_stop = execute_plan_steps(
-        &initial_plan.plan.steps,
-        component_id,
-        options,
-        &mut results,
-        &HashSet::new(),
-    )?;
+    let mut timer = PhaseTimer::new();
+    let initial_stop = timer.time("package_preflight", || {
+        execute_plan_steps(
+            &initial_plan.plan.steps,
+            component_id,
+            options,
+            &mut results,
+            &HashSet::new(),
+        )
+    })?;
 
     if initial_stop {
-        let run = finalize(component_id, results);
+        let run = finalize(component_id, results, timer.into_report());
         restore_checkout_after_failed_run(checkout_guard, &run)?;
         return Ok((initial_plan, run));
     }
@@ -72,15 +76,17 @@ fn run_with_plan_inner(
     let completed_preflights: HashSet<&'static str> =
         initial_executable_preflight_ids().iter().copied().collect();
 
-    execute_plan_steps(
-        &release_plan.plan.steps,
-        component_id,
-        options,
-        &mut results,
-        &completed_preflights,
-    )?;
+    timer.time("package", || {
+        execute_plan_steps(
+            &release_plan.plan.steps,
+            component_id,
+            options,
+            &mut results,
+            &completed_preflights,
+        )
+    })?;
 
-    let run = finalize(component_id, results);
+    let run = finalize(component_id, results, timer.into_report());
     restore_checkout_after_failed_run(checkout_guard, &run)?;
 
     Ok((release_plan, run))
@@ -88,7 +94,11 @@ fn run_with_plan_inner(
 
 /// Wrap the accumulated step results into a `ReleaseRun` with an overall
 /// status and a human-friendly summary.
-fn finalize(component_id: &str, results: Vec<ReleaseStepResult>) -> ReleaseRun {
+fn finalize(
+    component_id: &str,
+    results: Vec<ReleaseStepResult>,
+    phase_timings: crate::core::phase_timing::PhaseTimingReport,
+) -> ReleaseRun {
     let status = derive_overall_status(&results);
     let summary = build_summary(component_id, &results, &status);
 
@@ -100,6 +110,7 @@ fn finalize(component_id: &str, results: Vec<ReleaseStepResult>) -> ReleaseRun {
             status,
             warnings: Vec::new(),
             summary: Some(summary),
+            phase_timings: Some(phase_timings),
         },
     }
 }

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -2,6 +2,7 @@ use serde::ser::Error as SerializeError;
 use serde::{Deserialize, Serialize, Serializer};
 use std::collections::HashMap;
 
+use crate::core::phase_timing::PhaseTimingReport;
 use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus};
 use crate::is_zero_u32;
 
@@ -169,6 +170,8 @@ pub struct ReleaseRunResult {
     pub warnings: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<ReleaseRunSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase_timings: Option<PhaseTimingReport>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -446,6 +446,7 @@ fn run_dry_run_preflights(
                 status: ReleaseStepStatus::Failed,
                 warnings: Vec::new(),
                 summary: None,
+                phase_timings: None,
             },
         }));
     }
@@ -1084,6 +1085,7 @@ mod tests {
                 status: ReleaseStepStatus::Success,
                 warnings: vec![],
                 summary: None,
+                phase_timings: None,
             },
         };
 
@@ -1109,6 +1111,7 @@ mod tests {
                 status: ReleaseStepStatus::PartialSuccess,
                 warnings: vec![],
                 summary: None,
+                phase_timings: None,
             },
         };
 
@@ -1188,6 +1191,7 @@ mod tests {
                 status: ReleaseStepStatus::Success,
                 warnings: vec![],
                 summary: None,
+                phase_timings: None,
             },
         };
 

--- a/tests/commands/deploy_test.rs
+++ b/tests/commands/deploy_test.rs
@@ -102,6 +102,27 @@ fn deploy_parser_accepts_exact_ref() {
 }
 
 #[test]
+fn deploy_resume_run_id_propagates_to_multi_target_config() {
+    let cli = Cli::try_parse_from([
+        "homeboy",
+        "deploy",
+        "component-a",
+        "--projects",
+        "project-a,project-b",
+        "--resume",
+        "run-123",
+    ])
+    .expect("--resume should parse");
+
+    let Commands::Deploy(args) = cli.command else {
+        panic!("expected deploy command");
+    };
+    let (_, config) = resolve_multi_args(&args).expect("deploy config should resolve");
+
+    assert_eq!(config.resume_run_id.as_deref(), Some("run-123"));
+}
+
+#[test]
 fn skip_deps_hydration_cli_flag_propagates_to_deploy_config() {
     let cli = Cli::try_parse_from([
         "homeboy",
@@ -294,6 +315,7 @@ fn deploy_args(mut customize: impl FnMut(&mut DeployArgs)) -> DeployArgs {
         head: false,
         requested_ref: None,
         tagged: false,
+        resume: None,
     };
     customize(&mut args);
     args


### PR DESCRIPTION
## Summary
Expose release/deploy phase timing and resume multi-target deploys from durable target lifecycle state.

## What changed
- Deploy runs persist versioned target identity and planned/running/succeeded/failed lifecycle state atomically.
- \--resume validates exact identity, recovers interrupted targets, and skips already successful targets.
- Release and deploy results expose additive phase timing without changing existing result fields.

## How to test
1. Run `cargo test core::deploy::lifecycle::tests --lib`; expect 4 tests pass.
2. Run `cargo test core::phase_timing::tests --lib`; expect 8 tests pass.
3. Run `cargo test core::release:: --lib`; expect 324 tests pass.
4. Run `cargo test --lib deploy_test`; expect 13 tests pass.

## Compatibility
Output fields and --resume are additive; normal deploy behavior is unchanged when no resume id is supplied.

## Evidence
- CI expected: cargo test --all-targets
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8108
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8109
- cargo-check-tests: Passed
- deploy-cli: Passed
- diff-check: Passed
- format: Passed
- lifecycle: Passed
- phase-timing: Passed
- release-regression: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Traced deploy/release lifecycle ownership, implemented durable timing and resume state with tests, resolved current-main integration, and finalized the reviewed candidate with Chris.

## Source relationships
- Closes Extra-Chill/homeboy#8109
- Relates to Extra-Chill/homeboy#8108
