### PR TITLE
Verify and reuse release assets across deploy targets

### DIFF
--- a/src/core/deploy/execution/mod.rs
+++ b/src/core/deploy/execution/mod.rs
@@ -10,7 +10,9 @@ mod strategies;
 pub(super) use prepare::{
     execute_preflighted_component_deploy, prepare_component_deploy, PreparedComponentDeploy,
 };
-pub(super) use release_plan::{release_artifact_plan, ReleaseArtifactPlan};
+pub(super) use release_plan::{
+    release_artifact_plan, resolve_planned_release_artifact, ReleaseArtifactPlan,
+};
 
 /// Maximum number of bytes retained when reading a version-target file out of a
 /// deploy artifact. The artifact is downloaded release content and therefore

--- a/src/core/deploy/execution/prepare.rs
+++ b/src/core/deploy/execution/prepare.rs
@@ -9,14 +9,13 @@ use super::super::generated_artifacts::GeneratedBuildArtifactCleanupGuard;
 use super::super::path_roots::{component_remote_path, resolve_effective_remote_path};
 use super::super::policy::{owner_hint_for_path, protected_path_suffixes, validate_deploy_target};
 use super::super::provenance::capture_build_provenance;
+use super::super::release_download::ReleaseArtifact;
 use super::super::types::{
     BuildProvenance, BuildSource, ComponentDeployResult, DeployArtifactSource, DeployConfig,
 };
 use super::super::version_overrides::is_self_deploy;
 use super::preflight::{resolve_preflight_artifact_path, validate_preflight_file_artifact};
-use super::release_plan::{
-    release_artifact_plan, try_download_release_artifact, ReleaseArtifactPlan,
-};
+use super::release_plan::{release_artifact_plan, ReleaseArtifactPlan};
 use super::strategies::{execute_artifact_deploy, execute_file_deploy, execute_git_deploy};
 
 pub(crate) struct PreparedComponentDeploy {
@@ -40,6 +39,7 @@ pub(crate) fn prepare_component_deploy(
     project: &Project,
     local_version: Option<String>,
     remote_version: Option<String>,
+    release_artifact: Option<ReleaseArtifact>,
 ) -> std::result::Result<PreparedComponentDeploy, ComponentDeployResult> {
     let is_git_deploy = component.deploy_strategy.as_deref() == Some("git");
     let is_file_deploy = component.deploy_strategy.as_deref() == Some("file");
@@ -48,22 +48,13 @@ pub(crate) fn prepare_component_deploy(
     // This is the preferred path when the component has remote_url set.
     let release_artifact: Option<PathBuf> =
         match release_artifact_plan(component, config, is_git_deploy, is_file_deploy) {
-            ReleaseArtifactPlan::Reuse { tag, .. } => {
-                match try_download_release_artifact(component, &tag) {
-                    Ok(path) => path,
-                    Err(error) => {
-                        return Err(failed_component_deploy_result(
-                            component,
-                            base_path,
-                            local_version,
-                            remote_version,
-                            None,
-                            error,
-                        )
-                        .with_artifact_source(DeployArtifactSource::ReleaseAsset));
-                    }
-                }
-            }
+            ReleaseArtifactPlan::Reuse { tag, .. } => match release_artifact {
+                Some(artifact) => Some(artifact.path),
+                None => return Err(failed_component_deploy_result(
+                    component, base_path, local_version, remote_version, None,
+                    format!("artifact source release_asset failed for '{}' tag {tag}: verified run-scoped artifact is unavailable. Refusing to fall back to local_build", component.id),
+                ).with_artifact_source(DeployArtifactSource::ReleaseAsset)),
+            },
             ReleaseArtifactPlan::LocalBuild { reason } => {
                 if config.dry_run {
                     log_status!(

--- a/src/core/deploy/execution/release_plan.rs
+++ b/src/core/deploy/execution/release_plan.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use crate::core::component::Component;
 use crate::core::release;
 
@@ -76,34 +74,21 @@ pub(super) fn should_try_download_release_artifact(
     )
 }
 
-/// Try to download a release artifact from GitHub for the selected deploy tag.
-///
-/// Returns `Ok(Some(path))` only when the planned release asset was downloaded.
-/// Once deploy has selected the release asset path, any download miss fails closed
-/// instead of silently rebuilding from the local checkout.
-pub(super) fn try_download_release_artifact(
+pub(crate) fn resolve_planned_release_artifact(
     component: &Component,
     tag: &str,
-) -> std::result::Result<Option<PathBuf>, String> {
-    let Some(remote_url) = component.remote_url.as_ref() else {
-        return Ok(None);
-    };
-    let Some(github) = release_download::parse_github_url(remote_url) else {
-        return Ok(None);
-    };
-    let Some(artifact_name) = release_download::resolve_artifact_name(component) else {
-        return Ok(None);
-    };
-
-    log_status!(
-        "deploy",
-        "Attempting to download release artifact for '{}' tag {} from GitHub...",
-        component.id,
-        tag
-    );
-
-    release_download::download_release_artifact(&github, &component.github, tag, &artifact_name)
-        .map(Some)
+    store: &mut release_download::ReleaseArtifactStore,
+) -> std::result::Result<release_download::ReleaseArtifact, String> {
+    let remote_url = component
+        .remote_url
+        .as_deref()
+        .ok_or_else(|| "component has no remote_url".to_string())?;
+    let github = release_download::parse_github_url(remote_url)
+        .ok_or_else(|| "component remote_url is not a GitHub repository URL".to_string())?;
+    let artifact_name = release_download::resolve_artifact_name(component)
+        .ok_or_else(|| "component has no build_artifact filename".to_string())?;
+    store
+        .resolve(&github, &component.github, tag, &artifact_name)
         .map_err(|error| release_asset_download_error(component, tag, &artifact_name, error))
 }
 

--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -39,10 +39,24 @@ use crate::core::project;
 /// This is the preferred entry point for callers - it handles project loading
 /// and SSH context resolution, keeping those details encapsulated.
 pub fn run(project_id: &str, config: &DeployConfig) -> Result<DeployOrchestrationResult> {
+    let mut release_artifacts = release_download::ReleaseArtifactStore::default();
+    run_with_release_artifacts(project_id, config, &mut release_artifacts)
+}
+
+fn run_with_release_artifacts(
+    project_id: &str,
+    config: &DeployConfig,
+    release_artifacts: &mut release_download::ReleaseArtifactStore,
+) -> Result<DeployOrchestrationResult> {
     let project = project::load(project_id)?;
-    project::validate_deploy_component_local_paths(&project, &config.component_ids)?;
+    // A version-pinned release asset is resolved remotely before orchestration;
+    // requiring its configured checkout to exist would reintroduce a mutable
+    // source gate. Other modes retain the existing early local-path validation.
+    if config.expected_version.is_none() {
+        project::validate_deploy_component_local_paths(&project, &config.component_ids)?;
+    }
     let (ctx, base_path) = resolve_project_ssh_with_base_path(project_id)?;
-    orchestration::deploy_components(config, &project, &ctx, &base_path)
+    orchestration::deploy_components(config, &project, &ctx, &base_path, release_artifacts)
 }
 
 /// Read deployed component versions without running deploy planning or git
@@ -137,6 +151,7 @@ pub fn run_multi(
     let mut failed: u32 = 0;
     let skipped: u32 = unknown_projects.len() as u32;
     let mut planned: u32 = 0;
+    let mut release_artifacts = release_download::ReleaseArtifactStore::default();
     // Record skipped results for unknown projects
     for pid in &unknown_projects {
         project_results.push(ProjectDeployResult {
@@ -174,7 +189,7 @@ pub fn run_multi(
             tagged: config.tagged,
         };
 
-        match run(project_id, &project_config) {
+        match run_with_release_artifacts(project_id, &project_config, &mut release_artifacts) {
             Ok(result) => {
                 let deploy_failed = result.summary.failed > 0;
                 let is_planned = config.dry_run || config.check;

--- a/src/core/deploy/orchestration/mod.rs
+++ b/src/core/deploy/orchestration/mod.rs
@@ -7,12 +7,14 @@ use crate::core::project::Project;
 use crate::core::release::version;
 
 use super::execution::{
-    execute_preflighted_component_deploy, prepare_component_deploy, PreparedComponentDeploy,
+    execute_preflighted_component_deploy, prepare_component_deploy, release_artifact_plan,
+    resolve_planned_release_artifact, PreparedComponentDeploy, ReleaseArtifactPlan,
 };
 use super::orchestration_ref_checkout::{ExactRefCheckout, ExactRefIdentity};
 use super::orchestration_tag_checkout::{checkout_deploy_tags, restore_branches};
 use super::path_roots::{project_with_detected_path_roots, resolve_effective_remote_path};
 use super::planning::{load_project_components, plan_components};
+use super::release_download::{ReleaseArtifact, ReleaseArtifactStore};
 use super::types::{ComponentDeployResult, DeployConfig, DeployOrchestrationResult, DeploySummary};
 use super::version_overrides::fetch_remote_versions_for_project;
 
@@ -34,6 +36,7 @@ pub(super) fn deploy_components(
     project: &Project,
     ctx: &RemoteProjectContext,
     base_path: &str,
+    release_artifacts: &mut ReleaseArtifactStore,
 ) -> Result<DeployOrchestrationResult> {
     let loaded = load_project_components(project, &config.component_ids, config.check)?;
     validate_supported_build_configs(&loaded.deployable)?;
@@ -105,6 +108,31 @@ pub(super) fn deploy_components(
 
     validate_effective_remote_paths(&components, &project, base_path)?;
 
+    // Release assets are immutable remote inputs. Resolve and verify them before
+    // touching any configured checkout, then reuse the same run-scoped bytes for
+    // every target/project that requests this component.
+    let mut resolved_release_artifacts: HashMap<String, ReleaseArtifact> = HashMap::new();
+    for component in &components {
+        if let ReleaseArtifactPlan::Reuse { tag, .. } =
+            release_artifact_plan(component, config, false, false)
+        {
+            let artifact = resolve_planned_release_artifact(component, &tag, release_artifacts)
+                .map_err(|error| {
+                    Error::validation_invalid_argument("releaseArtifact", error, None, None)
+                })?;
+            log_status!(
+                "deploy",
+                "Verified release asset: tag={} name={} size={} sha256={} source={}",
+                artifact.tag,
+                artifact.name,
+                artifact.size,
+                artifact.sha256,
+                artifact.url
+            );
+            resolved_release_artifacts.insert(component.id.clone(), artifact);
+        }
+    }
+
     // Resolve first, then materialize immutable detached worktrees for real deploys.
     // Dry-run resolves in `run_dry_run_mode` and never creates a worktree.
     let exact_ref_checkouts = if !config.dry_run {
@@ -172,35 +200,43 @@ pub(super) fn deploy_components(
         )?);
     }
 
+    // Only local builds require mutable checkout safety checks. Release assets are
+    // resolved and verified above and must not read or alter a source checkout.
+    let local_build_components: Vec<Component> = components
+        .iter()
+        .filter(|component| !resolved_release_artifacts.contains_key(&component.id))
+        .cloned()
+        .collect();
+
     // Sync: pull latest changes before deploying (unless --no-pull or --skip-build)
     if config.requested_ref.is_none() && !config.no_pull && !config.skip_build {
-        sync_components(&components)?;
+        sync_components(&local_build_components)?;
     }
 
     // Warn when --head deploys from a non-default branch (safety guardrail)
     if config.head && !config.skip_build {
-        warn_non_default_branch(&components, config)?;
+        warn_non_default_branch(&local_build_components, config)?;
     }
 
     if config.requested_ref.is_none() && !config.force {
-        check_uncommitted_changes(&components)?;
+        check_uncommitted_changes(&local_build_components)?;
     }
 
     // Check for HEAD-vs-tag gap before the tag checkout.
     if config.requested_ref.is_none() && !config.head && !config.skip_build {
-        check_unreleased_commits(&components, config)?;
+        check_unreleased_commits(&local_build_components, config)?;
     }
 
     // Checkout the deploy tag for each component (unless --head or --skip-build).
     let tag_checkouts = if config.requested_ref.is_none() && !config.head && !config.skip_build {
-        checkout_deploy_tags(&components, config.expected_version.as_deref())?
+        checkout_deploy_tags(&local_build_components, config.expected_version.as_deref())?
     } else {
         Vec::new()
     };
 
     // Verify expected version if --version was specified
     if let Some(ref expected) = config.expected_version {
-        if let Err(err) = verify_expected_version(&components, expected) {
+        if let Err(err) = verify_expected_version(&local_build_components, expected) {
             if !tag_checkouts.is_empty() {
                 restore_branches(&tag_checkouts);
             }
@@ -221,6 +257,7 @@ pub(super) fn deploy_components(
         base_path,
         &local_versions,
         &remote_versions,
+        &resolved_release_artifacts,
     ) {
         Ok(prepared) => prepared,
         Err(failures) => {
@@ -255,6 +292,11 @@ pub(super) fn deploy_components(
         let exact_ref_identity = exact_ref_identities.get(&component.id);
         let deployed_ref = if let Some(identity) = exact_ref_identity {
             Some(identity.requested_ref.clone())
+        } else if let Some(artifact) = resolved_release_artifacts.get(&component.id) {
+            Some(match artifact.commit.as_deref() {
+                Some(commit) => format!("{} ({commit})", artifact.tag),
+                None => artifact.tag.clone(),
+            })
         } else if let Some(checkout) = tag_checkouts
             .iter()
             .find(|c| c.component_id == component.id)
@@ -289,6 +331,8 @@ pub(super) fn deploy_components(
         build_provenance.built_from_ref = deployed_ref;
         if let Some(identity) = exact_ref_identity {
             build_provenance.built_from_commit = Some(identity.resolved_sha.clone());
+        } else if let Some(artifact) = resolved_release_artifacts.get(&component.id) {
+            build_provenance.built_from_commit = artifact.commit.clone();
         }
         result = result.with_build_provenance(build_provenance);
 
@@ -353,6 +397,7 @@ fn prepare_component_deployments(
     base_path: &str,
     local_versions: &HashMap<String, String>,
     remote_versions: &HashMap<String, String>,
+    release_artifacts: &HashMap<String, ReleaseArtifact>,
 ) -> std::result::Result<Vec<PreparedComponentDeploy>, Vec<ComponentDeployResult>> {
     let mut prepared_deployments = Vec::new();
     let mut failures = Vec::new();
@@ -374,6 +419,7 @@ fn prepare_component_deployments(
             project,
             local_versions.get(&component.id).cloned(),
             remote_versions.get(&component.id).cloned(),
+            release_artifacts.get(&component.id).cloned(),
         ) {
             Ok(prepared) => prepared_deployments.push(prepared),
             Err(result) => failures.push(result),
@@ -1206,6 +1252,7 @@ mod tests {
             "/srv/site",
             &HashMap::new(),
             &HashMap::new(),
+            &HashMap::new(),
         ) {
             Ok(_) => panic!("a later missing artifact must abort the whole deploy batch"),
             Err(failures) => failures,
@@ -1338,6 +1385,7 @@ mod tests {
             &config,
             &Project::default(),
             "/srv/site",
+            &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
         )
@@ -1476,6 +1524,7 @@ mod tests {
                 &config,
                 &project,
                 "/srv/site",
+                &HashMap::new(),
                 &HashMap::new(),
                 &HashMap::new(),
             ) {

--- a/src/core/deploy/release_download.rs
+++ b/src/core/deploy/release_download.rs
@@ -10,6 +10,7 @@
 //!
 //! See: https://github.com/Extra-Chill/homeboy/issues/784
 
+use std::collections::HashMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -17,6 +18,7 @@ use crate::core::component::{Component, GithubConfig};
 use crate::core::error::{Error, Result};
 use crate::core::git::github_cli_env;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 const PACKAGE_DEPENDENCY_FIELDS: &[&str] = &[
     "dependencies",
@@ -38,6 +40,82 @@ const MUTABLE_DEPENDENCY_PREFIXES: &[&str] = &[
 ];
 
 const ZIP_MAGIC_PREFIX: &[u8] = b"PK";
+
+/// Immutable release-asset identity verified before it is made available to deploy targets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseArtifact {
+    pub path: PathBuf,
+    pub tag: String,
+    pub commit: Option<String>,
+    pub url: String,
+    pub name: String,
+    pub size: u64,
+    pub sha256: String,
+}
+
+/// Command-scoped immutable artifact cache. A multi-target deploy resolves and
+/// verifies a release asset once, then fans out the same local bytes.
+#[derive(Default)]
+pub struct ReleaseArtifactStore {
+    artifacts: HashMap<String, ReleaseArtifact>,
+}
+
+impl ReleaseArtifactStore {
+    pub fn resolve(
+        &mut self,
+        github: &GitHubRepo,
+        github_config: &GithubConfig,
+        tag: &str,
+        artifact_name: &str,
+    ) -> Result<ReleaseArtifact> {
+        self.get_or_insert_with(github, tag, artifact_name, || {
+            resolve_and_download_release_artifact(github, github_config, tag, artifact_name)
+        })
+    }
+
+    pub fn get(
+        &self,
+        github: &GitHubRepo,
+        tag: &str,
+        artifact_name: &str,
+    ) -> Option<ReleaseArtifact> {
+        self.artifacts
+            .get(&format!(
+                "{}/{}/{}:{tag}:{artifact_name}",
+                github.host, github.owner, github.repo
+            ))
+            .cloned()
+    }
+
+    fn get_or_insert_with(
+        &mut self,
+        github: &GitHubRepo,
+        tag: &str,
+        artifact_name: &str,
+        resolve: impl FnOnce() -> Result<ReleaseArtifact>,
+    ) -> Result<ReleaseArtifact> {
+        let key = format!(
+            "{}/{}/{}:{tag}:{artifact_name}",
+            github.host, github.owner, github.repo
+        );
+        if let Some(artifact) = self.artifacts.get(&key) {
+            return Ok(artifact.clone());
+        }
+        let artifact = resolve()?;
+        self.artifacts.insert(key, artifact.clone());
+        Ok(artifact)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ReleaseAssetMetadata {
+    url: String,
+    name: String,
+    size: u64,
+    digest: Option<String>,
+    tag: String,
+    commit: Option<String>,
+}
 
 /// Parsed GitHub owner/repo from a remote URL.
 #[derive(Debug, Clone)]
@@ -156,14 +234,36 @@ pub fn download_release_artifact(
     tag: &str,
     artifact_name: &str,
 ) -> Result<PathBuf> {
-    let auth_token = github_auth_token(github, github_config);
-    let url = match auth_token.as_deref() {
-        Some(token) => {
-            resolve_release_asset_api_url(github, github_config, tag, artifact_name, token)?
-                .unwrap_or_else(|| github.release_artifact_url(tag, artifact_name))
-        }
-        None => github.release_artifact_url(tag, artifact_name),
-    };
+    Ok(resolve_and_download_release_artifact(github, github_config, tag, artifact_name)?.path)
+}
+
+/// Resolve authenticated GitHub Release metadata and download one verified asset.
+///
+/// Metadata is mandatory: direct release-download URLs cannot prove which asset was
+/// selected, its expected size, or the release/tag identity.
+pub fn resolve_and_download_release_artifact(
+    github: &GitHubRepo,
+    github_config: &GithubConfig,
+    tag: &str,
+    artifact_name: &str,
+) -> Result<ReleaseArtifact> {
+    let auth_token = github_auth_token(github, github_config).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "github",
+            format!(
+                "No GitHub authentication token is available for {}",
+                github.host
+            ),
+            None,
+            Some(vec![
+                "Authenticate gh for the configured GitHub host before deploying a release asset."
+                    .to_string(),
+            ]),
+        )
+    })?;
+    let release_asset =
+        resolve_release_asset_metadata(github, github_config, tag, artifact_name, &auth_token)?;
+    let url = release_asset.url.clone();
 
     // Create temp directory for the download
     let tmp_dir = crate::core::engine::temp::runtime_temp_dir("deploy-download")?;
@@ -174,7 +274,7 @@ pub fn download_release_artifact(
     let curl_command = curl_release_artifact_command(
         &url,
         dest_path.to_str().unwrap_or("artifact"),
-        auth_token.as_deref(),
+        Some(&auth_token),
         github_command_env(github, github_config),
     );
 
@@ -231,43 +331,82 @@ pub fn download_release_artifact(
         ));
     }
 
-    // Verify the file exists and has content
-    let metadata = std::fs::metadata(&dest_path).map_err(|e| {
-        Error::internal_io(
-            format!("Downloaded artifact not found: {}", e),
-            Some(dest_path.display().to_string()),
-        )
-    })?;
-
-    if metadata.len() == 0 {
-        return Err(Error::internal_io(
-            format!(
-                "Downloaded artifact is empty — check that tag '{}' has a release with artifact '{}'",
-                tag, artifact_name
-            ),
-            Some(url),
-        ));
-    }
-
-    validate_downloaded_artifact(&dest_path, artifact_name, &url)?;
+    let sha256 = verify_downloaded_release_artifact(&dest_path, &release_asset, &url)?;
 
     log_status!(
         "deploy",
         "Downloaded {} ({} bytes)",
-        artifact_name,
-        metadata.len()
+        release_asset.name,
+        release_asset.size
     );
 
-    Ok(dest_path)
+    Ok(ReleaseArtifact {
+        path: dest_path,
+        tag: release_asset.tag,
+        commit: release_asset.commit,
+        url,
+        name: release_asset.name,
+        size: release_asset.size,
+        sha256,
+    })
 }
 
-fn resolve_release_asset_api_url(
+fn verify_downloaded_release_artifact(
+    path: &Path,
+    release_asset: &ReleaseAssetMetadata,
+    url: &str,
+) -> Result<String> {
+    let file_metadata = std::fs::metadata(path).map_err(|error| {
+        Error::internal_io(
+            format!("Downloaded artifact not found: {error}"),
+            Some(path.display().to_string()),
+        )
+    })?;
+    if file_metadata.len() == 0 {
+        return Err(Error::validation_invalid_argument(
+            "releaseArtifact",
+            format!(
+                "Downloaded release artifact '{}' is empty",
+                release_asset.name
+            ),
+            Some(url.to_string()),
+            None,
+        ));
+    }
+    if file_metadata.len() != release_asset.size {
+        return Err(Error::validation_invalid_argument(
+            "releaseArtifact",
+            format!("Downloaded release artifact '{}' has size {}, expected {} from GitHub Release metadata", release_asset.name, file_metadata.len(), release_asset.size),
+            Some(url.to_string()),
+            None,
+        ));
+    }
+    validate_downloaded_artifact(path, &release_asset.name, url)?;
+    let sha256 = sha256_file(path)?;
+    if let Some(expected) = release_asset
+        .digest
+        .as_deref()
+        .and_then(|digest| digest.strip_prefix("sha256:"))
+    {
+        if !expected.eq_ignore_ascii_case(&sha256) {
+            return Err(Error::validation_invalid_argument(
+                "releaseArtifact",
+                format!("Downloaded release artifact '{}' SHA-256 digest does not match GitHub Release metadata", release_asset.name),
+                Some(url.to_string()),
+                None,
+            ));
+        }
+    }
+    Ok(sha256)
+}
+
+fn resolve_release_asset_metadata(
     github: &GitHubRepo,
     github_config: &GithubConfig,
     tag: &str,
     artifact_name: &str,
     auth_token: &str,
-) -> Result<Option<String>> {
+) -> Result<ReleaseAssetMetadata> {
     let url = github.release_by_tag_api_url(tag);
     let curl_command =
         curl_release_asset_api_command(&url, auth_token, github_command_env(github, github_config));
@@ -328,17 +467,106 @@ fn resolve_release_asset_api_url(
         )
     })?;
 
-    let Some(assets) = release.get("assets").and_then(Value::as_array) else {
-        return Ok(None);
-    };
+    let assets = release
+        .get("assets")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            Error::internal_json(
+                "GitHub Release metadata has no assets array".to_string(),
+                Some(url.clone()),
+            )
+        })?;
+    let asset = assets
+        .iter()
+        .find(|asset| {
+            asset
+                .get("name")
+                .and_then(Value::as_str)
+                .is_some_and(|name| release_asset_name_matches(name, artifact_name))
+        })
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "releaseArtifact",
+                format!(
+                    "GitHub Release tag '{}' is missing asset '{}'",
+                    tag, artifact_name
+                ),
+                Some(url.clone()),
+                None,
+            )
+        })?;
+    let name = asset.get("name").and_then(Value::as_str).ok_or_else(|| {
+        Error::internal_json(
+            "GitHub Release asset has no name".to_string(),
+            Some(url.clone()),
+        )
+    })?;
+    let asset_url = asset.get("url").and_then(Value::as_str).ok_or_else(|| {
+        Error::internal_json(
+            "GitHub Release asset has no API URL".to_string(),
+            Some(url.clone()),
+        )
+    })?;
+    let size = asset.get("size").and_then(Value::as_u64).ok_or_else(|| {
+        Error::internal_json(
+            "GitHub Release asset has no size".to_string(),
+            Some(url.clone()),
+        )
+    })?;
+    let release_tag = release
+        .get("tag_name")
+        .and_then(Value::as_str)
+        .unwrap_or(tag);
+    if release_tag != tag {
+        return Err(Error::validation_invalid_argument(
+            "releaseTag",
+            format!(
+                "GitHub Release metadata returned tag '{}' for requested tag '{}'",
+                release_tag, tag
+            ),
+            Some(url),
+            None,
+        ));
+    }
+    Ok(ReleaseAssetMetadata {
+        url: asset_url.to_string(),
+        name: name.to_string(),
+        size,
+        digest: asset
+            .get("digest")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        tag: release_tag.to_string(),
+        commit: release
+            .get("target_commitish")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+    })
+}
 
-    Ok(assets.iter().find_map(|asset| {
-        let name = asset.get("name")?.as_str()?;
-        if !release_asset_name_matches(name, artifact_name) {
-            return None;
+fn sha256_file(path: &Path) -> Result<String> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path).map_err(|error| {
+        Error::internal_io(
+            format!("Failed to hash downloaded artifact: {error}"),
+            Some(path.display().to_string()),
+        )
+    })?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0; 8192];
+    loop {
+        let count = file.read(&mut buffer).map_err(|error| {
+            Error::internal_io(
+                format!("Failed to hash downloaded artifact: {error}"),
+                Some(path.display().to_string()),
+            )
+        })?;
+        if count == 0 {
+            break;
         }
-        asset.get("url")?.as_str().map(ToString::to_string)
-    }))
+        hasher.update(&buffer[..count]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 fn release_asset_name_matches(asset_name: &str, artifact_name: &str) -> bool {
@@ -940,6 +1168,100 @@ mod tests {
             "theme-01-studio-native-theme.zip",
             "studio-native-theme.zip"
         ));
+    }
+
+    #[test]
+    fn release_artifact_store_resolves_once_for_multiple_targets() {
+        let github = GitHubRepo {
+            host: "github.example.test".to_string(),
+            owner: "example".to_string(),
+            repo: "plugin".to_string(),
+        };
+        let mut store = ReleaseArtifactStore::default();
+        let calls = std::cell::Cell::new(0);
+        let artifact = || ReleaseArtifact {
+            path: PathBuf::from("/tmp/plugin.zip"),
+            tag: "v1.2.3".to_string(),
+            commit: Some("abc123".to_string()),
+            url: "https://github.example.test/api/v3/assets/1".to_string(),
+            name: "plugin.zip".to_string(),
+            size: 7,
+            sha256: "abc".to_string(),
+        };
+        store
+            .get_or_insert_with(&github, "v1.2.3", "plugin.zip", || {
+                calls.set(calls.get() + 1);
+                Ok(artifact())
+            })
+            .expect("first target resolves asset");
+        store
+            .get_or_insert_with(&github, "v1.2.3", "plugin.zip", || {
+                calls.set(calls.get() + 1);
+                Ok(artifact())
+            })
+            .expect("second target reuses asset");
+        assert_eq!(calls.get(), 1, "one metadata lookup/download per run");
+    }
+
+    #[test]
+    fn sha256_file_reports_downloaded_content_identity() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("plugin.zip");
+        std::fs::write(&path, b"verified bytes").expect("write artifact");
+        assert_eq!(
+            sha256_file(&path).expect("hash artifact"),
+            format!("{:x}", Sha256::digest(b"verified bytes"))
+        );
+    }
+
+    #[test]
+    fn verification_failure_does_not_store_an_artifact_for_target_mutation() {
+        let github = GitHubRepo {
+            host: "github.example.test".to_string(),
+            owner: "example".to_string(),
+            repo: "plugin".to_string(),
+        };
+        let mut store = ReleaseArtifactStore::default();
+
+        let error = store
+            .get_or_insert_with(&github, "v1.2.3", "plugin.zip", || {
+                Err(Error::validation_invalid_argument(
+                    "releaseArtifact",
+                    "Downloaded release artifact 'plugin.zip' SHA-256 digest does not match GitHub Release metadata".to_string(),
+                    None,
+                    None,
+                ))
+            })
+            .expect_err("digest mismatch must fail release preflight");
+
+        assert!(error.to_string().contains("SHA-256 digest does not match"));
+        assert!(
+            store.get(&github, "v1.2.3", "plugin.zip").is_none(),
+            "a failed verification must not make bytes available to deploy targets"
+        );
+    }
+
+    #[test]
+    fn digest_mismatch_fails_before_an_artifact_can_be_fanned_out() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("plugin.zip");
+        std::fs::write(&path, b"PK\x03\x04fixture").expect("write artifact");
+        let metadata = ReleaseAssetMetadata {
+            url: "https://github.example.test/api/v3/assets/1".to_string(),
+            name: "plugin.zip".to_string(),
+            size: 11,
+            digest: Some(
+                "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                    .to_string(),
+            ),
+            tag: "v1.2.3".to_string(),
+            commit: Some("abc123".to_string()),
+        };
+
+        let error = verify_downloaded_release_artifact(&path, &metadata, &metadata.url)
+            .expect_err("metadata digest mismatch must fail before target preparation");
+
+        assert!(error.to_string().contains("SHA-256 digest does not match"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Resolve, verify, and download an immutable release asset once per command, then reuse it across deployment targets.

## What changed
- Release metadata and authenticated asset bytes are resolved once into command-scoped storage.
- Asset name, size, ZIP structure, SHA-256 digest, tag, and target commit identity are validated before target mutation.
- Release-asset mode bypasses mutable local checkout gates while explicit local-build modes retain them.

## How to test
1. Run `cargo test core::deploy::release_download --lib`; expect 29 tests pass.
2. Run `cargo test core::deploy::execution --lib`; expect 23 tests pass.
3. Run `cargo test predeploy_artifact --lib`; expect 4 tests pass.
4. Run `cargo test core::deploy::orchestration --lib`; expect 45 tests pass.

## Compatibility
Release-asset deployment now fails closed on missing or unverifiable assets; local-build freshness and GitHub Enterprise authentication behavior remain intact.

## Evidence
- CI expected: cargo test --all-targets
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8108
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8111
- cargo-check-tests: Passed
- diff-check: Passed
- execution: Passed
- format: Passed
- orchestration: Passed
- predeploy-artifact: Passed
- release-download: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Traced release download and deploy orchestration, rebuilt a contamination-free implementation with deterministic tests, and finalized the reviewed candidate with Chris.

## Source relationships
- Closes Extra-Chill/homeboy#8111
- Relates to Extra-Chill/homeboy#8108
