### PR TITLE
Ignore runner metadata in snapshot identity

### DIFF
--- a/src/core/runner/lab_args/agent_task_specs.rs
+++ b/src/core/runner/lab_args/agent_task_specs.rs
@@ -139,19 +139,21 @@ pub(in crate::core::runner) fn remap_agent_task_plan_in_args(
     let ordered = order_mappings_by_specificity(mappings);
 
     try_rewrite_flag_value_args(args, |arg, iter, out| {
-        if arg == "--plan" {
-            out.push(arg.to_string());
-            if let Some(spec) = iter.next() {
-                out.push(remap_agent_task_plan_spec(spec, &ordered, source_path)?);
+        for flag in ["--plan", "--attempt-plan"] {
+            if arg == flag {
+                out.push(arg.to_string());
+                if let Some(spec) = iter.next() {
+                    out.push(remap_agent_task_plan_spec(spec, &ordered, source_path)?);
+                }
+                return Ok(());
             }
-            return Ok(());
-        }
-        if let Some(spec) = arg.strip_prefix("--plan=") {
-            out.push(format!(
-                "--plan={}",
-                remap_agent_task_plan_spec(spec, &ordered, source_path)?
-            ));
-            return Ok(());
+            if let Some(spec) = arg.strip_prefix(&format!("{flag}=")) {
+                out.push(format!(
+                    "{flag}={}",
+                    remap_agent_task_plan_spec(spec, &ordered, source_path)?
+                ));
+                return Ok(());
+            }
         }
         out.push(arg.to_string());
         Ok(())

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -1747,6 +1747,162 @@ mod materialize_specs_tests {
     }
 
     #[test]
+    fn materialize_agent_task_specs_remaps_and_stages_cook_attempt_plan_for_runner_harvest() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let controller = temp.path().join("controller/worktree");
+        let runner = temp.path().join("runner/worktree");
+        let controller_plugin = temp.path().join("controller/provider-plugin");
+        let runner_plugin = temp.path().join("runner/provider-plugin");
+        let controller_overlay = temp.path().join("controller/runtime-overlay");
+        let runner_overlay = temp.path().join("runner/runtime-overlay");
+        let controller_component = temp.path().join("controller/component");
+        let runner_component = temp.path().join("runner/component");
+        for path in [
+            &controller,
+            &controller_plugin,
+            &controller_overlay,
+            &controller_component,
+            &runner_plugin,
+            &runner_overlay,
+            &runner_component,
+        ] {
+            std::fs::create_dir_all(path).expect("workspace directory");
+        }
+        std::fs::create_dir_all(&runner).expect("runner checkout");
+        std::fs::write(runner.join("README.md"), "runner checkout\n").expect("checkout file");
+        for args in [
+            vec!["init".to_string(), "-b".to_string(), "main".to_string()],
+            vec!["add".to_string(), ".".to_string()],
+            vec![
+                "-c".to_string(),
+                "user.name=Homeboy Test".to_string(),
+                "-c".to_string(),
+                "user.email=homeboy@example.test".to_string(),
+                "commit".to_string(),
+                "-m".to_string(),
+                "runner checkout".to_string(),
+            ],
+        ] {
+            assert!(std::process::Command::new("git")
+                .args(args)
+                .current_dir(&runner)
+                .status()
+                .expect("run git")
+                .success());
+        }
+
+        let mappings = vec![
+            LabPathRemap {
+                local: controller.display().to_string(),
+                remote: runner.display().to_string(),
+            },
+            LabPathRemap {
+                local: controller_plugin.display().to_string(),
+                remote: runner_plugin.display().to_string(),
+            },
+            LabPathRemap {
+                local: controller_overlay.display().to_string(),
+                remote: runner_overlay.display().to_string(),
+            },
+            LabPathRemap {
+                local: controller_component.display().to_string(),
+                remote: runner_component.display().to_string(),
+            },
+        ];
+        let plan = serde_json::json!({
+            "schema": "homeboy/agent-task-plan/v1",
+            "plan_id": "controller-plan",
+            "component_contracts": [{ "slug": "component", "path": controller_component }],
+            "tasks": [{
+                "task_id": "task-1",
+                "workspace": { "root": controller },
+                "executor": { "config": {
+                    "workspace": controller,
+                    "workspace_root": controller,
+                    "provider_plugin_paths": [controller_plugin],
+                    "runtime_overlay": { "sources": [controller_overlay] }
+                }},
+                "metadata": { "workspace": controller, "workspace_root": controller }
+            }]
+        })
+        .to_string();
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--attempt-plan".to_string(),
+            plan,
+        ];
+
+        let out = materialize_agent_task_specs_in_args(&args, &mappings, temp.path(), |spec| {
+            assert_eq!(spec.filename, "agent-task-attempt-plan.json");
+            std::fs::write(runner.join(spec.filename), spec.spec).expect("stage runner plan");
+            Ok(Some((
+                format!("@{}", runner.join(spec.filename).display()),
+                (),
+            )))
+        })
+        .expect("remap and stage attempt plan");
+        let staged: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(runner.join("agent-task-attempt-plan.json"))
+                .expect("read staged plan"),
+        )
+        .expect("parse staged plan");
+
+        assert_eq!(
+            out.argv[4],
+            format!("@{}", runner.join("agent-task-attempt-plan.json").display())
+        );
+        assert_eq!(
+            staged["tasks"][0]["workspace"]["root"],
+            runner.display().to_string()
+        );
+        assert_eq!(
+            staged["tasks"][0]["executor"]["config"]["workspace"],
+            runner.display().to_string()
+        );
+        assert_eq!(
+            staged["tasks"][0]["executor"]["config"]["workspace_root"],
+            runner.display().to_string()
+        );
+        assert_eq!(
+            staged["tasks"][0]["metadata"]["workspace"],
+            runner.display().to_string()
+        );
+        assert_eq!(
+            staged["tasks"][0]["metadata"]["workspace_root"],
+            runner.display().to_string()
+        );
+        assert_eq!(
+            staged["tasks"][0]["executor"]["config"]["provider_plugin_paths"][0],
+            runner_plugin.display().to_string()
+        );
+        assert_eq!(
+            staged["tasks"][0]["executor"]["config"]["runtime_overlay"]["sources"][0],
+            runner_overlay.display().to_string()
+        );
+        assert_eq!(
+            staged["component_contracts"][0]["path"],
+            runner_component.display().to_string()
+        );
+        assert!(
+            !std::fs::read_to_string(runner.join("agent-task-attempt-plan.json"))
+                .expect("read staged plan")
+                .contains(&controller.display().to_string())
+        );
+        assert!(std::process::Command::new("git")
+            .args(["rev-parse", "--is-inside-work-tree"])
+            .current_dir(
+                staged["tasks"][0]["workspace"]["root"]
+                    .as_str()
+                    .expect("runner root")
+            )
+            .status()
+            .expect("run runner git harvest preflight")
+            .success());
+    }
+
+    #[test]
     fn materialize_agent_task_specs_rewrites_fanout_child_cwd_to_runner_path() {
         let temp = tempfile::tempdir().expect("tempdir");
         let controller = temp.path().join("homeboy@cook-one");

--- a/src/core/runner/workspace/snapshot.rs
+++ b/src/core/runner/workspace/snapshot.rs
@@ -15,6 +15,8 @@ use super::util::{
     tar_exclude_args,
 };
 
+const RUNNER_WORKSPACE_METADATA_FILE: &str = ".homeboy/runner-workspace.json";
+
 pub(crate) fn snapshot_identity(
     local_path: &Path,
     excludes: &[String],
@@ -90,9 +92,10 @@ fn collect_content_hash_entries(
         let entry_path = entry.path();
         let relative_path = logical.join(entry.file_name());
         let relative = relative_path.to_string_lossy().replace('\\', "/");
+        let is_runner_metadata_directory = relative == ".homeboy";
         if relative == ".git"
-            || relative == ".homeboy/runner-workspace.json"
             || is_excluded(root, &root.join(&relative_path), excludes, &[])
+            || relative == RUNNER_WORKSPACE_METADATA_FILE
         {
             continue;
         }
@@ -126,7 +129,12 @@ fn collect_content_hash_entries(
                     None,
                 ));
             }
-            entries.push((relative, "\0dir\0", mode_bits(&metadata), Vec::new()));
+            // The runner adds `.homeboy/runner-workspace.json` after transport.
+            // Recurse through the directory so user-owned children remain bound,
+            // but omit the transport-owned container entry and record itself.
+            if !is_runner_metadata_directory {
+                entries.push((relative, "\0dir\0", mode_bits(&metadata), Vec::new()));
+            }
             ancestors.push(canonical);
             collect_content_hash_entries(
                 root,
@@ -267,7 +275,12 @@ pub(super) fn is_excluded(
         return false;
     }
     excludes.iter().any(|pattern| {
-        pattern == rel || pattern == name || glob_match(pattern, rel) || glob_match(pattern, name)
+        let directory_pattern = pattern.trim_end_matches('/');
+        pattern == rel
+            || pattern == name
+            || directory_pattern == rel
+            || glob_match(pattern, rel)
+            || glob_match(pattern, name)
     })
 }
 
@@ -461,6 +474,25 @@ pub(crate) fn copy_snapshot_to_directory(
         excludes,
         "prepare local workspace snapshot",
     )
+}
+
+pub(crate) fn ensure_no_runner_workspace_metadata_collision(local_path: &Path) -> Result<()> {
+    let metadata_path = local_path.join(RUNNER_WORKSPACE_METADATA_FILE);
+    match fs::symlink_metadata(&metadata_path) {
+        Ok(_) => Err(Error::validation_invalid_argument(
+            "workspace",
+            "source workspace contains the reserved runner metadata path `.homeboy/runner-workspace.json`; remove or rename it before syncing",
+            Some(metadata_path.display().to_string()),
+            Some(vec![
+                "Remove or rename the source file before syncing; Homeboy writes this path only after runner materialization.".to_string(),
+            ]),
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(Error::internal_io(
+            error.to_string(),
+            Some("inspect reserved runner metadata path".to_string()),
+        )),
+    }
 }
 
 fn materialize_snapshot_piped(

--- a/src/core/runner/workspace/sync.rs
+++ b/src/core/runner/workspace/sync.rs
@@ -19,8 +19,8 @@ use super::super::{
 };
 use super::git::{git_snapshot, materialize_git, materialize_git_from_controller_bundle};
 use super::snapshot::{
-    effective_snapshot_excludes, local_snapshot_stats, materialize_snapshot,
-    materialize_snapshot_git, snapshot_identity,
+    effective_snapshot_excludes, ensure_no_runner_workspace_metadata_collision,
+    local_snapshot_stats, materialize_snapshot, materialize_snapshot_git, snapshot_identity,
 };
 use super::types::{
     canonical_workspace_path, ByteFileCounts, LocalGitState, RunnerWorkspaceCurrentSummary,
@@ -85,6 +85,7 @@ pub fn sync_workspace(
 
     match options.mode {
         RunnerWorkspaceSyncMode::Snapshot | RunnerWorkspaceSyncMode::SnapshotGit => {
+            ensure_no_runner_workspace_metadata_collision(&local_path)?;
             let snapshot = snapshot_identity(&local_path, &excludes, &includes)?;
             let remote_path = temp::unique_name(
                 &deterministic_remote_path(

--- a/src/core/runner/workspace/tests/snapshot.rs
+++ b/src/core/runner/workspace/tests/snapshot.rs
@@ -4,7 +4,8 @@ use std::fs;
 use std::path::Path;
 
 use crate::core::runner::workspace::snapshot::{
-    snapshot_archive_command, snapshot_install_command,
+    copy_snapshot_to_directory, snapshot_archive_command, snapshot_install_command,
+    workspace_content_hash,
 };
 use crate::core::runner::workspace::sync::{list_workspaces, sync_workspace};
 use crate::core::runner::workspace::types::{
@@ -106,6 +107,74 @@ fn runner_snapshot_excludes_extend_default_snapshot_policy() {
             .exists());
         assert!(!Path::new(&output.remote_path).join("local.state").exists());
     });
+}
+
+#[test]
+fn runner_snapshot_rejects_source_runner_workspace_metadata_collision() {
+    crate::test_support::with_isolated_home(|_| {
+        let source = tempfile::tempdir().expect("source tempdir");
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        fs::create_dir_all(source.path().join(".homeboy")).expect("metadata directory");
+        fs::write(
+            source.path().join(".homeboy/runner-workspace.json"),
+            "user-owned collision\n",
+        )
+        .expect("metadata collision");
+        crate::core::runner::create(
+            &format!(
+                r#"{{"id":"lab-local-collision","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+
+        let error = sync_workspace(
+            "lab-local-collision",
+            RunnerWorkspaceSyncOptions {
+                path: source.path().display().to_string(),
+                mode: RunnerWorkspaceSyncMode::Snapshot,
+                controller_routed_git: false,
+                changed_since_base: None,
+                git_fetch_refs: Vec::new(),
+                snapshot_includes: Vec::new(),
+                allow_dirty_lab_workspace: false,
+                run_isolation_token: None,
+            },
+        )
+        .expect_err("reserved runner metadata must reject staging");
+
+        assert!(error.message.contains("reserved runner metadata path"));
+        assert!(error.message.contains("remove or rename"));
+        assert_eq!(
+            fs::read_dir(runner_root.path())
+                .expect("runner root entries")
+                .count(),
+            0,
+            "collision must fail before creating a materialized workspace"
+        );
+    });
+}
+
+#[test]
+fn generic_snapshot_copy_allows_source_owned_runner_workspace_path() {
+    let source = tempfile::tempdir().expect("source tempdir");
+    let destination = tempfile::tempdir().expect("destination tempdir");
+    fs::create_dir_all(source.path().join(".homeboy")).expect("metadata directory");
+    fs::write(
+        source.path().join(".homeboy/runner-workspace.json"),
+        "source-owned generic snapshot content\n",
+    )
+    .expect("source metadata");
+
+    copy_snapshot_to_directory(source.path(), destination.path(), &[])
+        .expect("generic snapshot copy");
+
+    assert_eq!(
+        fs::read_to_string(destination.path().join(".homeboy/runner-workspace.json"))
+            .expect("copied metadata"),
+        "source-owned generic snapshot content\n"
+    );
 }
 
 #[test]
@@ -567,6 +636,177 @@ fn snapshot_archive_command_dereferences_symlinked_dependencies() {
         command.contains("tar --no-xattrs -h "),
         "snapshot tar must dereference symlinks: {command}"
     );
+}
+
+#[test]
+fn snapshot_content_hash_matches_materialized_workspace_after_runner_metadata_injection() {
+    // This mirrors a Lab snapshot of a repository such as homeboy-extensions:
+    // the runner creates its metadata directory after extracting a source that
+    // has no `.homeboy` directory of its own.
+    let controller = tempfile::tempdir().expect("controller");
+    let source = controller.path().join("homeboy-extensions@fixture");
+    let dependency = controller.path().join("dependency");
+    let destination = controller.path().join("materialized");
+    let excludes = vec![
+        ".git/".to_string(),
+        "generated-state".to_string(),
+        "generated-state/**".to_string(),
+    ];
+
+    fs::create_dir_all(source.join("packages/runtime")).expect("source package directory");
+    fs::create_dir_all(source.join("generated-state")).expect("generated state directory");
+    fs::write(
+        source.join("packages/runtime/runner.sh"),
+        "#!/bin/sh\nexit 0\n",
+    )
+    .expect("runner script");
+    fs::write(source.join("generated-state/cache.bin"), "excluded\n").expect("generated state");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let script = source.join("packages/runtime/runner.sh");
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).expect("executable mode");
+        fs::create_dir_all(dependency.join("dist")).expect("dependency directory");
+        fs::write(dependency.join("dist/index.js"), "export default {};\n")
+            .expect("dependency file");
+        symlink(&dependency, source.join("packages/runtime/dependency"))
+            .expect("dependency symlink");
+    }
+
+    let expected = workspace_content_hash(&source, &excludes).expect("controller hash");
+    copy_snapshot_to_directory(&source, &destination, &excludes).expect("materialize snapshot");
+    fs::create_dir_all(destination.join(".homeboy")).expect("runner metadata directory");
+    fs::write(
+        destination.join(".homeboy/runner-workspace.json"),
+        r#"{"schema":"homeboy/runner-workspace/v1"}"#,
+    )
+    .expect("runner metadata");
+
+    assert!(destination.join("packages/runtime/runner.sh").is_file());
+    assert!(!destination.join("generated-state").exists());
+    assert_eq!(
+        workspace_content_hash(&destination, &excludes).expect("materialized hash"),
+        expected,
+        "the controller hash must describe the bytes and structure that the runner verifies"
+    );
+}
+
+#[test]
+fn snapshot_content_hash_binds_user_owned_homeboy_files_but_ignores_runner_metadata() {
+    let controller = tempfile::tempdir().expect("controller");
+    let source = controller.path().join("homeboy-extensions@fixture");
+    let destination = controller.path().join("materialized");
+    let excludes = vec![".git/".to_string()];
+    fs::create_dir_all(source.join(".homeboy")).expect("user metadata directory");
+    fs::create_dir_all(source.join("src")).expect("source directory");
+    fs::write(
+        source.join(".homeboy/user-settings.json"),
+        "{\"enabled\":true}\n",
+    )
+    .expect("user metadata");
+    fs::write(source.join("src/lib.rs"), "pub fn fixture() {}\n").expect("source file");
+
+    let expected = workspace_content_hash(&source, &excludes).expect("controller hash");
+    copy_snapshot_to_directory(&source, &destination, &excludes).expect("materialize snapshot");
+    fs::write(
+        destination.join(".homeboy/runner-workspace.json"),
+        r#"{"schema":"homeboy/runner-workspace/v1"}"#,
+    )
+    .expect("runner metadata");
+
+    assert_eq!(
+        workspace_content_hash(&destination, &excludes).expect("materialized hash"),
+        expected,
+        "runner metadata must not change the controller identity"
+    );
+
+    fs::write(
+        destination.join(".homeboy/runner-workspace.json"),
+        r#"{"schema":"homeboy/runner-workspace/v2","changed":true}"#,
+    )
+    .expect("changed runner metadata");
+    assert_eq!(
+        workspace_content_hash(&destination, &excludes).expect("metadata-insensitive hash"),
+        expected,
+        "runner metadata bytes and mode are transport state"
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::set_permissions(
+            destination.join(".homeboy/runner-workspace.json"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .expect("changed runner metadata mode");
+        assert_eq!(
+            workspace_content_hash(&destination, &excludes).expect("mode-insensitive hash"),
+            expected,
+            "runner metadata mode is transport state"
+        );
+    }
+
+    fs::write(
+        destination.join(".homeboy/user-settings.json"),
+        "{\"enabled\":false}\n",
+    )
+    .expect("changed user metadata");
+    assert_ne!(
+        workspace_content_hash(&destination, &excludes).expect("mutated hash"),
+        expected,
+        "user-owned `.homeboy` children must remain fail-closed"
+    );
+
+    fs::write(
+        destination.join(".homeboy/user-settings.json"),
+        "{\"enabled\":true}\n",
+    )
+    .expect("restore user metadata");
+    assert_eq!(
+        workspace_content_hash(&destination, &excludes).expect("restored hash"),
+        expected,
+        "restoring user metadata restores the materialized identity"
+    );
+    fs::write(destination.join("src/lib.rs"), "pub fn changed() {}\n")
+        .expect("changed source file");
+    assert_ne!(
+        workspace_content_hash(&destination, &excludes).expect("changed source hash"),
+        expected,
+        "ordinary workspace files must remain bound by the identity"
+    );
+}
+
+#[test]
+fn snapshot_content_hash_matches_tar_when_homeboy_is_excluded() {
+    for pattern in [".homeboy", ".homeboy/", ".homeboy/**"] {
+        let controller = tempfile::tempdir().expect("controller");
+        let source = controller.path().join("source");
+        let destination = controller.path().join("materialized");
+        let excludes = vec![pattern.to_string()];
+        fs::create_dir_all(source.join(".homeboy")).expect("user metadata directory");
+        fs::create_dir_all(source.join("src")).expect("source directory");
+        fs::write(source.join(".homeboy/user-settings.json"), "user-owned\n")
+            .expect("user metadata");
+        fs::write(source.join("src/lib.rs"), "pub fn fixture() {}\n").expect("source file");
+
+        let expected = workspace_content_hash(&source, &excludes).expect("controller hash");
+        copy_snapshot_to_directory(&source, &destination, &excludes).expect("materialize snapshot");
+        fs::create_dir_all(destination.join(".homeboy")).expect("runner metadata directory");
+        fs::write(
+            destination.join(".homeboy/runner-workspace.json"),
+            "transport metadata\n",
+        )
+        .expect("runner metadata");
+
+        assert_eq!(
+            workspace_content_hash(&destination, &excludes).expect("materialized hash"),
+            expected,
+            "exclude pattern `{pattern}` must hash the same tree tar materializes"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- exclude runner-injected workspace metadata records from portable snapshot identity while retaining user-owned `.homeboy` content
- reject source collisions with the reserved runner metadata path before runner workspace creation
- align directory exclusion matching with tar materialization semantics
- preserve generic snapshot helper behavior outside runner workspace sync

Follow-up acceptance fix for #8129 after the real Lab cook advanced through #8175 and exposed content-hash drift.

## How to test
1. Run `cargo test --lib snapshot_content_hash`.
2. Run `cargo test --lib runner_snapshot_rejects_source_runner_workspace_metadata_collision`.
3. Run `cargo test --lib verified_snapshot_baseline_supports_committed_and_uncommitted_candidate_harvesting`.
4. Run `cargo test --lib canonical_trace_accepts_verified_lab_snapshot_without_git_metadata`.
5. Run `cargo check`, `cargo fmt --check`, and `git diff --check origin/main...HEAD`.
6. Route a nested Lab cook from a clean snapshot and confirm committed-harvest provenance verification reaches provider execution after runner metadata injection.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Compared preserved controller/runner materializations, fixed transport-aware identity semantics, added collision/exclusion coverage, and independently reviewed the trust boundary. Chris reviewed and owns the change.