### PR TITLE
Version portable snapshot content identity

### DIFF
--- a/src/core/agent_task_scheduler/mod.rs
+++ b/src/core/agent_task_scheduler/mod.rs
@@ -1510,11 +1510,17 @@ mod committed_harvest_tests {
         let content_hash =
             crate::core::runner::workspace_content_hash(workspace.path(), &snapshot.sync_excludes)
                 .expect("content hash");
+        let content_hash_algorithm = crate::core::runner::workspace_content_hash_algorithm(
+            crate::core::runner::WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+        )
+        .expect("default content hash algorithm");
         let lab = serde_json::json!({
             "runner_id": "lab", "remote_workspace": path, "sync_mode": "snapshot", "status": "offloaded",
             "source_snapshot": snapshot,
             "workspace_verification": {
-                "schema": "homeboy/lab-workspace-verification/v1", "identity": "snapshot:provider-ready",
+                "schema": "homeboy/lab-workspace-verification/v2", "identity": "snapshot:provider-ready",
+                "content_hash_algorithm": content_hash_algorithm,
+                "permission_policy": crate::core::runner::WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
                 "content_hash": content_hash, "sync_excludes": snapshot.sync_excludes,
                 "source_snapshot": snapshot,
                 "primary_workspace": { "identity": "snapshot:provider-ready", "remote_path": workspace.path().display().to_string() }

--- a/src/core/extension/trace/canonicality.rs
+++ b/src/core/extension/trace/canonicality.rs
@@ -1265,6 +1265,10 @@ mod tests {
         let workspace_content_hash =
             crate::core::runner::workspace_content_hash(source.path(), &snapshot.sync_excludes)
                 .unwrap();
+        let content_hash_algorithm = crate::core::runner::workspace_content_hash_algorithm(
+            crate::core::runner::WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+        )
+        .unwrap();
         let lab = serde_json::json!({
             "runner_id": "homeboy-lab",
             "remote_workspace": remote.path().display().to_string(),
@@ -1274,8 +1278,10 @@ mod tests {
             "workspace_content_hash": workspace_content_hash,
             "workspace_materialization_plan": { "identity": "workspace:verified" },
             "workspace_verification": {
-                "schema": "homeboy/lab-workspace-verification/v1",
+                "schema": "homeboy/lab-workspace-verification/v2",
                 "identity": "workspace:verified",
+                "content_hash_algorithm": content_hash_algorithm,
+                "permission_policy": crate::core::runner::WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
                 "content_hash": workspace_content_hash,
                 "sync_excludes": [".git", ".git/**"],
                 "source_snapshot": snapshot,

--- a/src/core/runner/lab/offload/metadata.rs
+++ b/src/core/runner/lab/offload/metadata.rs
@@ -588,10 +588,14 @@ pub(crate) fn attach_lab_workspace_metadata(
 ) -> Result<()> {
     let source_snapshot = inputs.source_snapshot;
     let primary_workspace_plan = &inputs.primary_synced_workspace.materialization_plan;
+    let permission_policy = crate::core::runner::WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY;
     let content_hash = crate::core::runner::workspace_content_hash(
         Path::new(&source_snapshot.local_path.clone().unwrap_or_default()),
         &source_snapshot.sync_excludes,
     )?;
+    let content_hash_algorithm =
+        crate::core::runner::workspace_content_hash_algorithm(permission_policy)
+            .expect("default workspace content permission policy is supported");
     lab_metadata["source_snapshot"] =
         serde_json::to_value(source_snapshot).unwrap_or(serde_json::json!(null));
     lab_metadata["workspace_content_hash"] = serde_json::json!(content_hash);
@@ -599,8 +603,10 @@ pub(crate) fn attach_lab_workspace_metadata(
         serde_json::to_value(inputs.legacy_path_materialization_plan)
             .unwrap_or(serde_json::json!(null));
     lab_metadata["workspace_verification"] = serde_json::json!({
-        "schema": "homeboy/lab-workspace-verification/v1",
+        "schema": "homeboy/lab-workspace-verification/v2",
         "identity": primary_workspace_plan.identity,
+        "content_hash_algorithm": content_hash_algorithm,
+        "permission_policy": permission_policy,
         "content_hash": content_hash,
         "sync_excludes": source_snapshot.sync_excludes,
         "source_snapshot": source_snapshot,

--- a/src/core/runner/lab/offload/tests/capability_metadata.rs
+++ b/src/core/runner/lab/offload/tests/capability_metadata.rs
@@ -288,6 +288,37 @@ fn lab_offload_workspace_verification_metadata_survives_process_env_hydration() 
         serde_json::to_value(&synced_workspace.materialization_plan)
             .expect("primary sync plan JSON")
     );
+    assert_eq!(
+        metadata["workspace_verification"]["schema"],
+        "homeboy/lab-workspace-verification/v2"
+    );
+    assert_eq!(
+        metadata["workspace_verification"]["content_hash_algorithm"],
+        crate::core::runner::workspace_content_hash_algorithm(
+            crate::core::runner::WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+        )
+        .expect("default content hash algorithm")
+    );
+    assert_eq!(
+        metadata["workspace_verification"]["permission_policy"],
+        crate::core::runner::WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY
+    );
+    assert!(metadata["workspace_verification"]
+        .get("content_manifest")
+        .is_none());
+    assert!(metadata["workspace_verification"].get("entries").is_none());
+    let serialized_metadata = serde_json::to_string(&metadata).expect("metadata JSON");
+    assert!(!serialized_metadata.contains("README.md"));
+    assert!(!serialized_metadata.contains("verified contents"));
+
+    std::fs::write(remote.path().join("README.md"), "changed contents\n")
+        .expect("change remote file");
+    let error = verify_lab_workspace_from_env(&remote_path.display().to_string(), remote.path())
+        .expect_err("changed remote content must fail verification");
+    assert!(error.contains("homeboy-workspace-content-v2+"));
+    assert!(error.contains("expected sha256:"));
+    assert!(error.contains("got sha256:"));
+    assert!(error.contains("homeboy runner workspace sync --mode snapshot"));
 
     match prior_lab {
         Some(value) => std::env::set_var(LAB_OFFLOAD_METADATA_ENV, value),

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -171,7 +171,8 @@ pub use workspace::{
 };
 pub(crate) use workspace::{
     verify_lab_workspace_from_env, verify_lab_workspace_git_root, workspace_content_hash,
-    VerifiedLabWorkspaceProvenance,
+    workspace_content_hash_algorithm, VerifiedLabWorkspaceProvenance,
+    WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/core/runner/workspace/mod.rs
+++ b/src/core/runner/workspace/mod.rs
@@ -46,6 +46,7 @@ pub(crate) use provenance::{
 pub(crate) use snapshot::{
     copy_snapshot_to_directory, effective_snapshot_excludes, local_snapshot_stats,
     materialize_snapshot, materialize_snapshot_git, snapshot_identity, workspace_content_hash,
+    workspace_content_hash_algorithm, WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
 };
 pub(crate) use types::{canonical_workspace_path, DEFAULT_EXCLUDES};
 pub(crate) use util::{

--- a/src/core/runner/workspace/provenance.rs
+++ b/src/core/runner/workspace/provenance.rs
@@ -1,10 +1,12 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::core::engine::shell;
 use crate::core::observation::{LAB_OFFLOAD_METADATA_ENV, SOURCE_SNAPSHOT_METADATA_ENV};
 use crate::core::source_snapshot::SourceSnapshot;
 
-use super::workspace_content_hash;
+use super::snapshot::{workspace_content_hash_for_policy, workspace_content_hash_v1};
+use super::workspace_content_hash_algorithm;
 
 const LAB_SOURCE_SNAPSHOT_SYNC_MODE: &str = "lab_offload";
 
@@ -233,68 +235,138 @@ pub(crate) fn verify_lab_workspace(
         return Err("source snapshot does not match Lab dispatch evidence".to_string());
     }
     let verification = lab.get("workspace_verification");
-    let (expected_content_hash, verification_identity) = match verification {
-        Some(verification) => {
-            if verification.get("schema").and_then(|value| value.as_str())
-                != Some("homeboy/lab-workspace-verification/v1")
-            {
-                return Err("has an unsupported workspace verification schema".to_string());
-            }
-            let identity = verification
-                .get("identity")
-                .and_then(|value| value.as_str())
-                .ok_or("is missing workspace verification identity")?;
-            let content_hash = verification
-                .get("content_hash")
-                .and_then(|value| value.as_str())
-                .ok_or("is missing workspace verification content hash")?;
-            let excludes = verification
-                .get("sync_excludes")
-                .ok_or("is missing workspace verification sync excludes")?;
-            if excludes != &serde_json::json!(snapshot.sync_excludes) {
-                return Err("sync excludes do not match workspace verification".to_string());
-            }
-            if verification.get("source_snapshot") != Some(lab_snapshot) {
-                return Err("source snapshot does not match workspace verification".to_string());
-            }
-            let primary_workspace = verification
-                .get("primary_workspace")
-                .ok_or("is missing workspace verification primary workspace")?;
-            if primary_workspace
-                .get("identity")
-                .and_then(|value| value.as_str())
-                != Some(identity)
-                || primary_workspace
-                    .get("remote_path")
+    let (expected_content_hash, verification_identity, content_hash_algorithm, permission_policy) =
+        match verification {
+            Some(verification) => {
+                let schema = verification.get("schema").and_then(|value| value.as_str());
+                let content_hash_algorithm = match schema {
+                    Some("homeboy/lab-workspace-verification/v1") => {
+                        "homeboy-workspace-content-v1".to_string()
+                    }
+                    Some("homeboy/lab-workspace-verification/v2") => {
+                        let policy = verification
+                            .get("permission_policy")
+                            .and_then(|value| value.as_str())
+                            .ok_or("is missing v2 workspace content permission policy")?;
+                        let algorithm = workspace_content_hash_algorithm(policy).ok_or_else(|| {
+                        format!("has an unsupported v2 workspace content permission policy `{policy}` on this platform")
+                    })?;
+                        if verification
+                            .get("content_hash_algorithm")
+                            .and_then(|value| value.as_str())
+                            != Some(algorithm.as_str())
+                        {
+                            return Err("v2 workspace content hash algorithm does not bind its permission policy".to_string());
+                        }
+                        algorithm
+                    }
+                    Some(schema) => {
+                        return Err(format!(
+                            "has an unsupported workspace verification schema `{schema}`"
+                        ))
+                    }
+                    None => return Err("is missing workspace verification schema".to_string()),
+                };
+                let identity = verification
+                    .get("identity")
                     .and_then(|value| value.as_str())
-                    != Some(recorded_remote_path)
-            {
-                return Err("primary workspace does not match workspace verification".to_string());
+                    .ok_or("is missing workspace verification identity")?;
+                let content_hash = verification
+                    .get("content_hash")
+                    .and_then(|value| value.as_str())
+                    .ok_or("is missing workspace verification content hash")?;
+                let excludes = verification
+                    .get("sync_excludes")
+                    .ok_or("is missing workspace verification sync excludes")?;
+                if excludes != &serde_json::json!(snapshot.sync_excludes) {
+                    return Err("sync excludes do not match workspace verification".to_string());
+                }
+                if verification.get("source_snapshot") != Some(lab_snapshot) {
+                    return Err("source snapshot does not match workspace verification".to_string());
+                }
+                let primary_workspace = verification
+                    .get("primary_workspace")
+                    .ok_or("is missing workspace verification primary workspace")?;
+                if primary_workspace
+                    .get("identity")
+                    .and_then(|value| value.as_str())
+                    != Some(identity)
+                    || primary_workspace
+                        .get("remote_path")
+                        .and_then(|value| value.as_str())
+                        != Some(recorded_remote_path)
+                {
+                    return Err(
+                        "primary workspace does not match workspace verification".to_string()
+                    );
+                }
+                (
+                    content_hash,
+                    identity,
+                    content_hash_algorithm,
+                    verification
+                        .get("permission_policy")
+                        .and_then(|value| value.as_str()),
+                )
             }
-            (content_hash, identity)
-        }
-        None if materialization_mode == "git" => {
-            let content_hash = lab
-                .get("workspace_content_hash")
-                .and_then(|value| value.as_str())
-                .ok_or("is missing workspace content hash")?;
-            let identity = lab
-                .get("workspace_materialization_plan")
-                .and_then(|value| value.get("identity"))
-                .and_then(|value| value.as_str())
-                .ok_or("is missing workspace materialization identity")?;
-            (content_hash, identity)
-        }
-        None => return Err("is missing workspace verification metadata".to_string()),
-    };
+            None if materialization_mode == "git" => {
+                let content_hash = lab
+                    .get("workspace_content_hash")
+                    .and_then(|value| value.as_str())
+                    .ok_or("is missing workspace content hash")?;
+                let identity = lab
+                    .get("workspace_materialization_plan")
+                    .and_then(|value| value.get("identity"))
+                    .and_then(|value| value.as_str())
+                    .ok_or("is missing workspace materialization identity")?;
+                (
+                    content_hash,
+                    identity,
+                    "homeboy-workspace-content-v1".to_string(),
+                    None,
+                )
+            }
+            None => return Err("is missing workspace verification metadata".to_string()),
+        };
     if workspace_identity != verification_identity {
         return Err("workspace identity does not match workspace verification".to_string());
     }
-    let actual_content_hash =
-        workspace_content_hash(materialized_workspace_path, &snapshot.sync_excludes)
-            .map_err(|error| format!("could not hash materialized workspace: {}", error.message))?;
+    let actual_content_hash = match content_hash_algorithm.as_str() {
+        "homeboy-workspace-content-v1" => {
+            workspace_content_hash_v1(materialized_workspace_path, &snapshot.sync_excludes)
+        }
+        algorithm if algorithm.starts_with("homeboy-workspace-content-v2+") => {
+            workspace_content_hash_for_policy(
+                materialized_workspace_path,
+                &snapshot.sync_excludes,
+                permission_policy.expect("v2 policy validated above"),
+            )
+        }
+        _ => unreachable!("workspace verification algorithm was validated above"),
+    }
+    .map_err(|error| format!("could not hash materialized workspace: {}", error.message))?;
     if actual_content_hash != expected_content_hash {
-        return Err("content hash does not match the controller materialization".to_string());
+        let diagnostic = match materialization_mode {
+            "git" | "snapshot-git" => format!(
+                "homeboy runner exec {} --cwd {} -- git status --short",
+                shell::quote_arg(runner_id),
+                shell::quote_arg(recorded_remote_path),
+            ),
+            "snapshot" => format!(
+                "homeboy runner workspace sync --mode snapshot --path {} {}",
+                shell::quote_arg(
+                    snapshot
+                        .local_path
+                        .as_deref()
+                        .expect("source path validated above")
+                ),
+                shell::quote_arg(runner_id),
+            ),
+            _ => unreachable!("materialization mode was validated above"),
+        };
+        return Err(format!(
+            "workspace content hash does not match the controller materialization using {content_hash_algorithm} (expected {expected_content_hash}, got {actual_content_hash}); operator diagnostic: `{diagnostic}`"
+        ));
     }
 
     Ok(VerifiedLabWorkspaceProvenance {
@@ -373,6 +445,9 @@ fn is_git_revision(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::super::snapshot::{
+        WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY, WORKSPACE_CONTENT_PERMISSION_PORTABLE,
+    };
     use super::*;
 
     fn snapshot(path: &Path) -> SourceSnapshot {
@@ -393,8 +468,8 @@ mod tests {
     }
 
     fn lab(path: &Path, snapshot: &SourceSnapshot) -> serde_json::Value {
-        let content_hash =
-            workspace_content_hash(path, &snapshot.sync_excludes).expect("snapshot content hash");
+        let content_hash = workspace_content_hash_v1(path, &snapshot.sync_excludes)
+            .expect("legacy snapshot content hash");
         serde_json::json!({
             "runner_id": "lab",
             "remote_workspace": path.display().to_string(),
@@ -482,5 +557,119 @@ mod tests {
 
         assert!(error.contains("invalid source revision"));
         assert!(!workspace.path().join(".git").exists());
+    }
+
+    #[test]
+    fn verifier_accepts_legacy_v1_and_current_v2_content_hashes() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");
+        let snapshot = snapshot(workspace.path());
+
+        verify_lab_workspace(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot.clone(),
+            lab(workspace.path(), &snapshot),
+        )
+        .expect("legacy v1 metadata remains valid");
+
+        let content_hash =
+            super::super::workspace_content_hash(workspace.path(), &snapshot.sync_excludes)
+                .expect("v2 content hash");
+        let mut v2 = lab(workspace.path(), &snapshot);
+        v2["workspace_verification"]["schema"] =
+            serde_json::json!("homeboy/lab-workspace-verification/v2");
+        v2["workspace_verification"]["permission_policy"] =
+            serde_json::json!(WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY);
+        v2["workspace_verification"]["content_hash_algorithm"] = serde_json::json!(
+            workspace_content_hash_algorithm(WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY)
+                .expect("default content hash algorithm")
+        );
+        v2["workspace_verification"]["content_hash"] = serde_json::json!(content_hash);
+        verify_lab_workspace(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot.clone(),
+            v2,
+        )
+        .expect("v2 metadata verifies with v2 algorithm");
+    }
+
+    #[test]
+    fn verifier_rejects_unknown_or_incomplete_verification_versions_clearly() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");
+        let snapshot = snapshot(workspace.path());
+        let mut newer = lab(workspace.path(), &snapshot);
+        newer["workspace_verification"]["schema"] =
+            serde_json::json!("homeboy/lab-workspace-verification/v3");
+        let error = verify_lab_workspace(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot.clone(),
+            newer,
+        )
+        .expect_err("older verifier must reject newer schema");
+        assert!(error.contains(
+            "unsupported workspace verification schema `homeboy/lab-workspace-verification/v3`"
+        ));
+
+        let mut incomplete = lab(workspace.path(), &snapshot);
+        incomplete["workspace_verification"]["schema"] =
+            serde_json::json!("homeboy/lab-workspace-verification/v2");
+        let error = verify_lab_workspace(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot.clone(),
+            incomplete,
+        )
+        .expect_err("v2 requires explicit algorithm");
+        assert!(error.contains("missing v2 workspace content permission policy"));
+
+        let mut policy_mismatch = lab(workspace.path(), &snapshot);
+        policy_mismatch["workspace_verification"]["schema"] =
+            serde_json::json!("homeboy/lab-workspace-verification/v2");
+        policy_mismatch["workspace_verification"]["permission_policy"] =
+            serde_json::json!(WORKSPACE_CONTENT_PERMISSION_PORTABLE);
+        policy_mismatch["workspace_verification"]["content_hash_algorithm"] =
+            serde_json::json!("homeboy-workspace-content-v2+unix-executable");
+        let error = verify_lab_workspace(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot,
+            policy_mismatch,
+        )
+        .expect_err("v2 algorithm must bind the declared policy");
+        assert!(error.contains("does not bind its permission policy"));
+    }
+
+    #[test]
+    fn mismatch_diagnostic_uses_git_status_only_for_git_materializations() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");
+        let snapshot = snapshot(workspace.path());
+        let mut git_materialized = lab(workspace.path(), &snapshot);
+        let snapshot_materialized = lab(workspace.path(), &snapshot);
+        git_materialized["sync_mode"] = serde_json::json!("snapshot-git");
+        std::fs::write(workspace.path().join("file.txt"), "changed\n").expect("change file");
+        let error = verify_lab_workspace(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot.clone(),
+            git_materialized,
+        )
+        .expect_err("changed snapshot-git workspace must fail");
+        assert!(error.contains("runner exec lab"));
+        assert!(error.contains("git status --short"));
+
+        let error = verify_lab_workspace(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot,
+            snapshot_materialized,
+        )
+        .expect_err("changed snapshot workspace must fail");
+        assert!(error.contains("runner workspace sync --mode snapshot"));
+        assert!(!error.contains("git status --short"));
     }
 }

--- a/src/core/runner/workspace/snapshot.rs
+++ b/src/core/runner/workspace/snapshot.rs
@@ -16,6 +16,15 @@ use super::util::{
 };
 
 const RUNNER_WORKSPACE_METADATA_FILE: &str = ".homeboy/runner-workspace.json";
+pub(crate) const WORKSPACE_CONTENT_PERMISSION_PORTABLE: &str = "portable-content-only";
+pub(crate) const WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE: &str = "unix-executable";
+
+#[cfg(unix)]
+pub(crate) const WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY: &str =
+    WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE;
+#[cfg(not(unix))]
+pub(crate) const WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY: &str =
+    WORKSPACE_CONTENT_PERMISSION_PORTABLE;
 
 pub(crate) fn snapshot_identity(
     local_path: &Path,
@@ -39,15 +48,61 @@ pub(crate) fn snapshot_identity(
     Ok(format!("snapshot:{}", hex_prefix(&hasher.finalize(), 16)))
 }
 
-/// Stable digest of the files a snapshot materializes. Unlike `snapshot_identity`,
-/// this is portable across controller and runner paths and can be recomputed after
-/// transport. The runner workspace record is transport metadata, not source.
+/// Stable v2 digest of the files a snapshot materializes. Unlike
+/// `snapshot_identity`, this is portable across controller and runner paths.
+/// The declared permission policy is part of the algorithm marker so a digest
+/// cannot be interpreted under a different platform capability contract.
 pub(crate) fn workspace_content_hash(path: &Path, excludes: &[String]) -> Result<String> {
-    let mut entries = Vec::new();
-    let root = path.canonicalize().map_err(|err| {
-        Error::internal_io(err.to_string(), Some("canonicalize workspace".to_string()))
+    workspace_content_hash_for_policy(path, excludes, WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY)
+}
+
+pub(crate) fn workspace_content_hash_algorithm(policy: &str) -> Option<String> {
+    match policy {
+        WORKSPACE_CONTENT_PERMISSION_PORTABLE => {
+            Some("homeboy-workspace-content-v2+portable-content-only".to_string())
+        }
+        WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE if cfg!(unix) => {
+            Some("homeboy-workspace-content-v2+unix-executable".to_string())
+        }
+        _ => None,
+    }
+}
+
+pub(crate) fn workspace_content_hash_for_policy(
+    path: &Path,
+    excludes: &[String],
+    policy: &str,
+) -> Result<String> {
+    let algorithm = workspace_content_hash_algorithm(policy).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "permission_policy",
+            "workspace content hash policy is unsupported on this platform",
+            Some(policy.to_string()),
+            None,
+        )
     })?;
-    collect_content_hash_entries(
+    let mut hasher = Sha256::new();
+    hasher.update(algorithm.as_bytes());
+    hasher.update(b"\0");
+    let root = content_hash_root(path)?;
+    collect_content_hash_entries_v2(
+        &root,
+        &root,
+        Path::new(""),
+        excludes,
+        &mut vec![root.clone()],
+        &mut hasher,
+        policy == WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
+    )?;
+    Ok(format!("sha256:{:x}", hasher.finalize()))
+}
+
+/// Exact historical v1 algorithm for controllers that emitted
+/// `homeboy/lab-workspace-verification/v1` metadata.
+pub(crate) fn workspace_content_hash_v1(path: &Path, excludes: &[String]) -> Result<String> {
+    let mut entries = Vec::new();
+    let root = content_hash_root(path)?;
+    collect_content_hash_entries_v1(
         &root,
         &root,
         Path::new(""),
@@ -68,7 +123,131 @@ pub(crate) fn workspace_content_hash(path: &Path, excludes: &[String]) -> Result
     Ok(format!("sha256:{:x}", hasher.finalize()))
 }
 
-fn collect_content_hash_entries(
+fn content_hash_root(path: &Path) -> Result<std::path::PathBuf> {
+    path.canonicalize().map_err(|err| {
+        Error::internal_io(err.to_string(), Some("canonicalize workspace".to_string()))
+    })
+}
+
+fn collect_content_hash_entries_v2(
+    root: &Path,
+    path: &Path,
+    logical: &Path,
+    excludes: &[String],
+    ancestors: &mut Vec<std::path::PathBuf>,
+    hasher: &mut Sha256,
+    include_executable_bit: bool,
+) -> Result<()> {
+    let mut children = fs::read_dir(path)
+        .map_err(|err| {
+            Error::internal_io(err.to_string(), Some("read sync directory".to_string()))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some("read sync directory entry".to_string()),
+            )
+        })?;
+    children.sort_by_key(|entry| entry.path());
+    for entry in children {
+        let entry_path = entry.path();
+        let relative_path = logical.join(entry.file_name());
+        let relative = relative_path.to_string_lossy().replace('\\', "/");
+        let is_runner_metadata_directory = relative == ".homeboy";
+        if relative == ".git"
+            || is_excluded(root, &root.join(&relative_path), excludes, &[])
+            || relative == RUNNER_WORKSPACE_METADATA_FILE
+        {
+            continue;
+        }
+        let link_metadata = fs::symlink_metadata(&entry_path).map_err(|err| {
+            Error::internal_io(err.to_string(), Some("read sync file metadata".to_string()))
+        })?;
+        let resolved = if link_metadata.file_type().is_symlink() {
+            entry_path.canonicalize().map_err(|err| {
+                Error::validation_invalid_argument(
+                    "workspace",
+                    "workspace content hash refused an unresolved symlink",
+                    Some(err.to_string()),
+                    None,
+                )
+            })?
+        } else {
+            entry_path.clone()
+        };
+        let metadata = fs::metadata(&resolved).map_err(|err| {
+            Error::internal_io(err.to_string(), Some("read sync file metadata".to_string()))
+        })?;
+        if metadata.is_dir() {
+            let canonical = resolved
+                .canonicalize()
+                .map_err(|err| Error::internal_io(err.to_string(), None))?;
+            if ancestors.contains(&canonical) {
+                return Err(Error::validation_invalid_argument(
+                    "workspace",
+                    "workspace content hash refused a symlink cycle",
+                    Some(entry_path.display().to_string()),
+                    None,
+                ));
+            }
+            // The runner adds `.homeboy/runner-workspace.json` after transport.
+            // Recurse through the directory so user-owned children remain bound,
+            // but omit the transport-owned container entry and record itself.
+            if !is_runner_metadata_directory {
+                hasher.update(relative.as_bytes());
+                hasher.update(b"\0dir\0");
+            }
+            ancestors.push(canonical);
+            collect_content_hash_entries_v2(
+                root,
+                &resolved,
+                &relative_path,
+                excludes,
+                ancestors,
+                hasher,
+                include_executable_bit,
+            )?;
+            ancestors.pop();
+        } else if metadata.is_file() {
+            let contents = fs::read(&resolved).map_err(|err| {
+                Error::internal_io(err.to_string(), Some("read sync file".to_string()))
+            })?;
+            hasher.update(relative.as_bytes());
+            hasher.update(b"\0file\0");
+            if include_executable_bit {
+                hasher.update([file_is_executable(&metadata) as u8]);
+            }
+            hasher.update((contents.len() as u64).to_le_bytes());
+            hasher.update(contents);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn file_is_executable(metadata: &fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    metadata.permissions().mode() & 0o111 != 0
+}
+
+#[cfg(not(unix))]
+fn file_is_executable(_metadata: &fs::Metadata) -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn mode_bits(metadata: &fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    metadata.permissions().mode() & 0o777
+}
+
+#[cfg(not(unix))]
+fn mode_bits(_metadata: &fs::Metadata) -> u32 {
+    0
+}
+
+fn collect_content_hash_entries_v1(
     root: &Path,
     path: &Path,
     logical: &Path,
@@ -129,14 +308,11 @@ fn collect_content_hash_entries(
                     None,
                 ));
             }
-            // The runner adds `.homeboy/runner-workspace.json` after transport.
-            // Recurse through the directory so user-owned children remain bound,
-            // but omit the transport-owned container entry and record itself.
             if !is_runner_metadata_directory {
                 entries.push((relative, "\0dir\0", mode_bits(&metadata), Vec::new()));
             }
             ancestors.push(canonical);
-            collect_content_hash_entries(
+            collect_content_hash_entries_v1(
                 root,
                 &resolved,
                 &relative_path,
@@ -153,17 +329,6 @@ fn collect_content_hash_entries(
         }
     }
     Ok(())
-}
-
-#[cfg(unix)]
-fn mode_bits(metadata: &fs::Metadata) -> u32 {
-    use std::os::unix::fs::PermissionsExt;
-    metadata.permissions().mode() & 0o777
-}
-
-#[cfg(not(unix))]
-fn mode_bits(_metadata: &fs::Metadata) -> u32 {
-    0
 }
 
 pub(crate) fn local_snapshot_stats(

--- a/src/core/runner/workspace/tests/snapshot.rs
+++ b/src/core/runner/workspace/tests/snapshot.rs
@@ -5,7 +5,8 @@ use std::path::Path;
 
 use crate::core::runner::workspace::snapshot::{
     copy_snapshot_to_directory, snapshot_archive_command, snapshot_install_command,
-    workspace_content_hash,
+    workspace_content_hash, workspace_content_hash_for_policy,
+    WORKSPACE_CONTENT_PERMISSION_PORTABLE, WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
 };
 use crate::core::runner::workspace::sync::{list_workspaces, sync_workspace};
 use crate::core::runner::workspace::types::{
@@ -691,6 +692,132 @@ fn snapshot_content_hash_matches_materialized_workspace_after_runner_metadata_in
         expected,
         "the controller hash must describe the bytes and structure that the runner verifies"
     );
+}
+
+#[test]
+#[cfg(unix)]
+fn workspace_content_hash_normalizes_git_materialization_umask_modes() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let controller = tempfile::tempdir().expect("controller");
+    let runner = tempfile::tempdir().expect("runner");
+    for root in [controller.path(), runner.path()] {
+        fs::create_dir_all(root.join("src")).expect("source directory");
+        fs::write(root.join("src/library.rs"), "pub fn fixture() {}\n").expect("source file");
+        fs::write(root.join("src/run.sh"), "#!/bin/sh\n").expect("executable file");
+    }
+    fs::set_permissions(
+        controller.path().join("src"),
+        fs::Permissions::from_mode(0o755),
+    )
+    .expect("controller directory mode");
+    fs::set_permissions(runner.path().join("src"), fs::Permissions::from_mode(0o775))
+        .expect("runner directory mode");
+    fs::set_permissions(
+        controller.path().join("src/library.rs"),
+        fs::Permissions::from_mode(0o644),
+    )
+    .expect("controller file mode");
+    fs::set_permissions(
+        runner.path().join("src/library.rs"),
+        fs::Permissions::from_mode(0o664),
+    )
+    .expect("runner file mode");
+    fs::set_permissions(
+        controller.path().join("src/run.sh"),
+        fs::Permissions::from_mode(0o755),
+    )
+    .expect("controller executable mode");
+    fs::set_permissions(
+        runner.path().join("src/run.sh"),
+        fs::Permissions::from_mode(0o775),
+    )
+    .expect("runner executable mode");
+
+    assert_eq!(
+        workspace_content_hash(controller.path(), &[]).expect("controller hash"),
+        workspace_content_hash(runner.path(), &[]).expect("runner hash"),
+        "Git checkout umask differences must not change materialized content identity"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn workspace_content_hash_portable_policy_is_platform_mode_independent() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let workspace = tempfile::tempdir().expect("workspace");
+    let file = workspace.path().join("file.txt");
+    fs::write(&file, "portable bytes\n").expect("source file");
+    fs::set_permissions(&file, fs::Permissions::from_mode(0o644)).expect("non-executable mode");
+    let non_executable = workspace_content_hash_for_policy(
+        workspace.path(),
+        &[],
+        WORKSPACE_CONTENT_PERMISSION_PORTABLE,
+    )
+    .expect("non-executable hash");
+    fs::set_permissions(&file, fs::Permissions::from_mode(0o755)).expect("executable mode");
+    assert_eq!(
+        workspace_content_hash_for_policy(
+            workspace.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_PORTABLE,
+        )
+        .expect("executable hash"),
+        non_executable,
+        "portable v2 identity must not bind platform-specific permission bits"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn workspace_content_hash_unix_policy_binds_executable_bit_without_umask_bits() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let workspace = tempfile::tempdir().expect("workspace");
+    let file = workspace.path().join("file.txt");
+    fs::write(&file, "portable bytes\n").expect("source file");
+    fs::set_permissions(&file, fs::Permissions::from_mode(0o644)).expect("non-executable mode");
+    let non_executable = workspace_content_hash_for_policy(
+        workspace.path(),
+        &[],
+        WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
+    )
+    .expect("non-executable hash");
+    fs::set_permissions(&file, fs::Permissions::from_mode(0o664)).expect("umask variant");
+    assert_eq!(
+        workspace_content_hash_for_policy(
+            workspace.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
+        )
+        .expect("umask variant hash"),
+        non_executable
+    );
+    fs::set_permissions(&file, fs::Permissions::from_mode(0o755)).expect("executable mode");
+    assert_ne!(
+        workspace_content_hash_for_policy(
+            workspace.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
+        )
+        .expect("executable hash"),
+        non_executable
+    );
+}
+
+#[test]
+#[cfg(not(unix))]
+fn workspace_content_hash_non_unix_rejects_unix_executable_policy() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    fs::write(workspace.path().join("file.txt"), "portable bytes\n").expect("source file");
+    let error = workspace_content_hash_for_policy(
+        workspace.path(),
+        &[],
+        WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
+    )
+    .expect_err("non-Unix cannot verify Unix executable policy");
+    assert!(error.message.contains("unsupported on this platform"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- introduce a versioned v2 workspace-content identity contract while preserving exact v1 verification compatibility
- bind Unix executable state without binding materializer-owned group/other permission bits
- provide an explicit content-only policy for non-Unix controllers and reject unsupported policy weakening
- keep verification metadata bounded and private, without per-file manifests
- emit materialization-specific, shell-safe mismatch guidance

Follow-up to #8129 and #8193. Real Lab evidence showed identical paths/kinds/content with only macOS/Linux umask differences: 212 directories `0755` vs `0775`, 697 files `0644` vs `0664`, and 212 executables `0755` vs `0775`.

## How to test
1. Run the focused v1/v2 verifier and policy/hash tests.
2. Run the snapshot umask and executable mutation tests.
3. Run the Lab metadata hydration and canonical trace tests.
4. Run `cargo check`, `cargo fmt --check`, and `git diff --check origin/main...HEAD`.
5. Route a nested Lab cook from macOS to Linux and confirm provenance verification reaches provider execution.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Compared controller/runner manifests, designed the versioned portable identity policy, added compatibility/integrity tests, and independently reviewed diagnostics and privacy. Chris reviewed and owns the change.