### PR TITLE
Preserve controller provenance across Lab cook remapping

### DIFF
--- a/src/core/agent_task_scheduler/mod.rs
+++ b/src/core/agent_task_scheduler/mod.rs
@@ -1485,6 +1485,66 @@ mod committed_harvest_tests {
     }
 
     #[test]
+    fn committed_harvest_preflight_uses_runner_workspace_not_controller_provenance() {
+        let _guard = LAB_ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("Lab environment lock");
+        std::env::remove_var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV);
+        std::env::remove_var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV);
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runner_workspace = temp.path().join("runner-workspace");
+        std::fs::create_dir(&runner_workspace).expect("runner workspace");
+        git(&runner_workspace, &["init", "-b", "main"]);
+        git(
+            &runner_workspace,
+            &["config", "user.email", "test@example.com"],
+        );
+        git(&runner_workspace, &["config", "user.name", "Homeboy Test"]);
+        std::fs::write(runner_workspace.join("file.txt"), "baseline\n").expect("baseline file");
+        git(&runner_workspace, &["add", "file.txt"]);
+        git(&runner_workspace, &["commit", "-m", "baseline"]);
+        let controller_workspace = temp.path().join("missing-controller-workspace");
+        let request = AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "runner-task".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "test".to_string(),
+                selector: None,
+                runtime_selection: None,
+                required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
+                model: None,
+                config: serde_json::Value::Null,
+            },
+            instructions: String::new(),
+            inputs: serde_json::Value::Null,
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace {
+                root: Some(runner_workspace.display().to_string()),
+                ..Default::default()
+            },
+            component_contracts: Vec::new(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            artifact_declarations: Vec::new(),
+            metadata: serde_json::json!({
+                "workspace_source_provenance": {
+                    "controller_root": controller_workspace.display().to_string()
+                }
+            }),
+        };
+
+        let preflight = prepare_committed_harvest(&request).expect("runner workspace preflight");
+
+        assert!(preflight.base_sha.is_some());
+        assert!(!controller_workspace.exists());
+    }
+
+    #[test]
     fn lab_snapshot_preflight_materializes_a_provider_ready_attempt_workspace() {
         let _guard = LAB_ENV_LOCK
             .get_or_init(|| Mutex::new(()))

--- a/src/core/runner/lab_args/agent_task_specs.rs
+++ b/src/core/runner/lab_args/agent_task_specs.rs
@@ -190,13 +190,50 @@ fn remap_agent_task_plan_spec(
             None,
         )
     })?;
+    let controller_plan = value.clone();
     remap_paths_in_value(&mut value, mappings);
+    record_controller_workspace_provenance(&mut value, &controller_plan);
     serde_json::to_string(&value).map_err(|err| {
         Error::internal_json(
             err.to_string(),
             Some("serialize remapped agent-task plan".to_string()),
         )
     })
+}
+
+fn record_controller_workspace_provenance(remapped: &mut Value, controller: &Value) {
+    let Some(remapped_tasks) = remapped.get_mut("tasks").and_then(Value::as_array_mut) else {
+        return;
+    };
+    let Some(controller_tasks) = controller.get("tasks").and_then(Value::as_array) else {
+        return;
+    };
+
+    for (remapped_task, controller_task) in remapped_tasks.iter_mut().zip(controller_tasks) {
+        let Some(controller_root) = controller_task
+            .get("workspace")
+            .and_then(|workspace| workspace.get("root"))
+            .and_then(Value::as_str)
+        else {
+            continue;
+        };
+        let Some(task) = remapped_task.as_object_mut() else {
+            continue;
+        };
+        let metadata = task
+            .entry("metadata".to_string())
+            .or_insert(Value::Object(serde_json::Map::new()));
+        if metadata.is_null() {
+            *metadata = Value::Object(serde_json::Map::new());
+        }
+        let Some(metadata) = metadata.as_object_mut() else {
+            continue;
+        };
+        metadata.insert(
+            "workspace_source_provenance".to_string(),
+            serde_json::json!({ "controller_root": controller_root }),
+        );
+    }
 }
 
 fn remap_agent_task_fanout_input_spec(

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -1858,6 +1858,10 @@ mod materialize_specs_tests {
             runner.display().to_string()
         );
         assert_eq!(
+            staged["tasks"][0]["metadata"]["workspace_source_provenance"]["controller_root"],
+            controller.display().to_string()
+        );
+        assert_eq!(
             staged["tasks"][0]["executor"]["config"]["workspace"],
             runner.display().to_string()
         );
@@ -1885,10 +1889,13 @@ mod materialize_specs_tests {
             staged["component_contracts"][0]["path"],
             runner_component.display().to_string()
         );
-        assert!(
-            !std::fs::read_to_string(runner.join("agent-task-attempt-plan.json"))
+        assert_eq!(
+            std::fs::read_to_string(runner.join("agent-task-attempt-plan.json"))
                 .expect("read staged plan")
-                .contains(&controller.display().to_string())
+                .matches(&controller.display().to_string())
+                .count(),
+            1,
+            "the controller path is retained only as provenance"
         );
         assert!(std::process::Command::new("git")
             .args(["rev-parse", "--is-inside-work-tree"])


### PR DESCRIPTION
## Summary

- Preserve the controller workspace root as provenance when agent-task plans are remapped for Lab.
- Keep the remapped `workspace.root` as the only filesystem target used by committed-change harvest.
- Add regressions for distinct controller and runner paths, including a missing controller path.

Fixes https://github.com/Extra-Chill/homeboy/issues/8188.

## Root cause

Lab cook remapped executable task paths but did not retain the original controller root as explicit provenance. Committed-change harvest could therefore lose the distinction between the controller checkout and the live materialized Lab workspace and fail before provider execution.

## How to test

1. Run `cargo test --lib materialize_agent_task_specs_remaps_and_stages_cook_attempt_plan_for_runner_harvest --locked`.
2. Run `cargo test --lib core::agent_task_scheduler::committed_harvest_tests::committed_harvest_preflight_uses_runner_workspace_not_controller_provenance --locked`.
3. Run `cargo fmt --all -- --check`.
4. Run `cargo check --all-targets --locked`.
5. Run `git diff --check`.

## Compatibility

Executable paths remain remapped to the Lab workspace. The controller root is added only under task metadata provenance and is never used as a runner-local filesystem target.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab pre-dispatch failure, prepared and verified the provenance fix and regressions. Chris reviewed and owns the change.
