### PR TITLE
refactor: move shared resource-policy context into core

### DIFF
--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -1,5 +1,3 @@
-use std::sync::RwLock;
-
 use serde::{Deserialize, Serialize};
 
 use crate::cli_surface::Commands;
@@ -7,6 +5,18 @@ use crate::command_contract::LabCommandPortability;
 use crate::commands::agent_task;
 
 use crate::commands::resources::{DoctorOutput, ResourceRecommendation};
+
+// The captured resource-policy context type, its process-wide store, and the
+// runner-placement environment probes moved to `core::resource_policy_context`
+// so `core::runner` can read them without a core -> commands dependency edge.
+// Re-exported here to keep existing `resource_policy::*` call sites working.
+#[cfg(test)]
+pub use crate::core::resource_policy_context::reset_captured_context_for_test;
+pub use crate::core::resource_policy_context::{
+    capture_context, captured_context, clear_managed_runner_placement_context,
+    clear_runner_hosted_exec, is_managed_runner_placement_context, is_runner_hosted_exec,
+    ResourcePolicyContext, ResourcePolicyHostSnapshot, ResourcePolicyRunnerSelection,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HotCommand {
@@ -38,80 +48,6 @@ pub struct ResourcePolicyWarning {
     pub command: &'static str,
     pub recommendation: ResourceRecommendation,
     pub message: String,
-}
-
-/// Persisted, host-pressure context captured at preflight time for any
-/// observation run that originates from a "hot" command (`bench`, `rig up`,
-/// `lint`, `test`, `audit`, etc.).
-///
-/// Generic across components and rigs. Persisted into observation run
-/// `metadata_json` under the `resource_policy` key so later readers can
-/// distinguish noisy timings caused by host pressure from regressions in the
-/// system under test.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ResourcePolicyContext {
-    /// Hot command label (e.g. `bench`, `lint`).
-    pub command: String,
-    /// Overall severity: `ok`, `warm`, or `hot`.
-    pub severity: String,
-    /// Requested controller placement. This records an intentional local
-    /// override without preserving deprecated CLI terminology.
-    pub local_override: bool,
-    /// Whether a warning was emitted (or would have been) for this run.
-    pub warned: bool,
-    /// Human-readable warning message produced by the policy, if any.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub message: Option<String>,
-    /// Controller-side routing decision available at resource-policy preflight.
-    pub runner_selection: ResourcePolicyRunnerSelection,
-    /// Structured host snapshot used to derive the severity.
-    pub host: ResourcePolicyHostSnapshot,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ResourcePolicyRunnerSelection {
-    /// Runner selected before command execution, when known.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub runner_id: Option<String>,
-    /// Why this command is expected to run locally or through Lab.
-    pub reason: String,
-}
-
-/// Subset of the doctor resource report that explains why the resource policy
-/// fired. Stored as plain numbers/strings so it round-trips cleanly through
-/// JSON without depending on internal `DoctorOutput` types.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ResourcePolicyHostSnapshot {
-    /// Severity of the load average alone.
-    pub load_severity: String,
-    /// 1-minute load average if available.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub load_one: Option<f64>,
-    /// 5-minute load average if available.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub load_five: Option<f64>,
-    /// 15-minute load average if available.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub load_fifteen: Option<f64>,
-    /// CPU count reported by the host.
-    pub cpu_count: usize,
-    /// Memory severity if memory data was collected.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub memory_severity: Option<String>,
-    /// Memory used percent if memory data was collected.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub memory_used_percent: Option<f64>,
-    /// Memory available in MB if memory data was collected.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub memory_available_mb: Option<u64>,
-    /// Number of Homeboy-adjacent processes already active.
-    pub relevant_process_count: usize,
-    /// Severity classification of the active process set.
-    pub process_severity: String,
-    /// Number of active rig run leases.
-    pub active_rig_lease_count: usize,
-    /// Severity classification of the active rig lease set.
-    pub rig_lease_severity: String,
 }
 
 impl ResourcePolicyContext {
@@ -202,46 +138,6 @@ fn severity_str(recommendation: ResourceRecommendation) -> &'static str {
         ResourceRecommendation::Ok => "ok",
         ResourceRecommendation::Warm => "warm",
         ResourceRecommendation::Hot => "hot",
-    }
-}
-
-/// Process-wide capture of the preflight resource policy decision so that
-/// observation runs started later in the command can include it in their
-/// metadata without re-querying the host (which would re-introduce flakiness
-/// and double-count Homeboy as a relevant process).
-fn captured_storage() -> &'static RwLock<Option<ResourcePolicyContext>> {
-    static STORAGE: std::sync::OnceLock<RwLock<Option<ResourcePolicyContext>>> =
-        std::sync::OnceLock::new();
-    STORAGE.get_or_init(|| RwLock::new(None))
-}
-
-/// Capture the resource policy context for the current process. Idempotent
-/// against later overwrites in production: once a context is recorded, repeat
-/// captures are dropped so the preflight decision wins. Tests can override
-/// this by calling [`reset_captured_context_for_test`] first.
-pub fn capture_context(context: ResourcePolicyContext) {
-    let mut slot = match captured_storage().write() {
-        Ok(slot) => slot,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-    if slot.is_none() {
-        *slot = Some(context);
-    }
-}
-
-/// Return a clone of the resource policy context captured at preflight time,
-/// if any.
-pub fn captured_context() -> Option<ResourcePolicyContext> {
-    captured_storage().read().ok().and_then(|slot| slot.clone())
-}
-
-/// Clear the captured context. Test-only: production code never resets the
-/// preflight decision so that the persisted observation matches the warning
-/// the user actually saw on stderr.
-#[cfg(test)]
-pub fn reset_captured_context_for_test() {
-    if let Ok(mut slot) = captured_storage().write() {
-        *slot = None;
     }
 }
 
@@ -395,41 +291,6 @@ fn append_local_placement(rerun: &mut Vec<String>, args: &[String]) {
         rerun.push("--placement".to_string());
         rerun.push("local".to_string());
     }
-}
-
-pub fn is_runner_hosted_exec() -> bool {
-    std::env::var(crate::core::runner::RUNNER_HOSTED_EXEC_ENV)
-        .ok()
-        .is_some_and(|value| value == "1")
-}
-
-/// True for the complete environment prepared by a managed remote runner exec.
-///
-/// Environment variables are not cryptographic provenance: a process with
-/// arbitrary environment control can forge them. They are an internal runner
-/// transport boundary, so require all three values emitted by RunnerExecOptions
-/// and daemon job preparation rather than trusting the resolved marker alone.
-pub fn is_managed_runner_placement_context() -> bool {
-    is_runner_hosted_exec()
-        && std::env::var(crate::core::runner::RUNNER_PLACEMENT_RESOLVED_ENV)
-            .ok()
-            .is_some_and(|value| value == "1")
-        && std::env::var(crate::core::runner::RUNNER_ID_ENV)
-            .ok()
-            .is_some_and(|value| !value.trim().is_empty())
-}
-
-pub fn clear_runner_hosted_exec() {
-    std::env::remove_var(crate::core::runner::RUNNER_HOSTED_EXEC_ENV);
-}
-
-/// Remove the private runner-placement transport context after CLI routing.
-/// Child workloads and persisted artifacts must not inherit controller routing
-/// markers once their single placement decision has been consumed.
-pub fn clear_managed_runner_placement_context() {
-    std::env::remove_var(crate::core::runner::RUNNER_HOSTED_EXEC_ENV);
-    std::env::remove_var(crate::core::runner::RUNNER_PLACEMENT_RESOLVED_ENV);
-    std::env::remove_var(crate::core::runner::RUNNER_ID_ENV);
 }
 
 fn primary_action(warning: &ResourcePolicyWarning, default_runner: Option<&str>) -> String {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -143,6 +143,7 @@ pub mod report_compare;
 pub(crate) mod report_compare_render;
 pub mod resource_cleanup_intent;
 pub mod resource_lifecycle_index;
+pub mod resource_policy_context;
 pub mod resources;
 pub mod review;
 pub mod rig;

--- a/src/core/resource_policy_context.rs
+++ b/src/core/resource_policy_context.rs
@@ -1,0 +1,153 @@
+//! Shared resource-policy context: the process-captured resource snapshot and
+//! the runner-placement environment probes.
+//!
+//! This lives in `core` rather than `commands` because both the CLI layer
+//! (which captures the context during preflight) and `core::runner` (which
+//! reads the captured severity and placement markers when routing lab offload)
+//! depend on it. Keeping it here avoids a `core -> commands` dependency edge,
+//! which would block extracting `commands` into its own crate.
+//!
+//! The CLI-specific evaluation logic that *builds* a [`ResourcePolicyContext`]
+//! from a `DoctorOutput` remains in `commands::utils::resource_policy`.
+
+use std::sync::{OnceLock, RwLock};
+
+use serde::{Deserialize, Serialize};
+
+/// Structured, serde-friendly snapshot of the resource-policy decision captured
+/// once per process at preflight time.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResourcePolicyContext {
+    /// Hot command label (e.g. `bench`, `lint`).
+    pub command: String,
+    /// Overall severity: `ok`, `warm`, or `hot`.
+    pub severity: String,
+    /// Requested controller placement. This records an intentional local
+    /// override without preserving deprecated CLI terminology.
+    pub local_override: bool,
+    /// Whether a warning was emitted (or would have been) for this run.
+    pub warned: bool,
+    /// Human-readable warning message produced by the policy, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    /// Controller-side routing decision available at resource-policy preflight.
+    pub runner_selection: ResourcePolicyRunnerSelection,
+    /// Structured host snapshot used to derive the severity.
+    pub host: ResourcePolicyHostSnapshot,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResourcePolicyRunnerSelection {
+    /// Runner selected before command execution, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_id: Option<String>,
+    /// Why this command is expected to run locally or through Lab.
+    pub reason: String,
+}
+
+/// Subset of the doctor resource report that explains why the resource policy
+/// fired. Stored as plain numbers/strings so it round-trips cleanly through
+/// JSON without depending on internal `DoctorOutput` types.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResourcePolicyHostSnapshot {
+    /// Severity of the load average alone.
+    pub load_severity: String,
+    /// 1-minute load average if available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_one: Option<f64>,
+    /// 5-minute load average if available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_five: Option<f64>,
+    /// 15-minute load average if available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_fifteen: Option<f64>,
+    /// CPU count reported by the host.
+    pub cpu_count: usize,
+    /// Memory severity if memory data was collected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_severity: Option<String>,
+    /// Memory used percent if memory data was collected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_used_percent: Option<f64>,
+    /// Memory available in MB if memory data was collected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_available_mb: Option<u64>,
+    /// Number of Homeboy-adjacent processes already active.
+    pub relevant_process_count: usize,
+    /// Severity classification of the active process set.
+    pub process_severity: String,
+    /// Number of active rig run leases.
+    pub active_rig_lease_count: usize,
+    /// Severity classification of the active rig lease set.
+    pub rig_lease_severity: String,
+}
+
+fn captured_storage() -> &'static RwLock<Option<ResourcePolicyContext>> {
+    static STORAGE: OnceLock<RwLock<Option<ResourcePolicyContext>>> = OnceLock::new();
+    STORAGE.get_or_init(|| RwLock::new(None))
+}
+
+/// Capture the resource policy context for the current process. Idempotent
+/// against later overwrites in production: once a context is recorded, repeat
+/// captures are dropped so the preflight decision wins. Tests can override
+/// this by calling [`reset_captured_context_for_test`] first.
+pub fn capture_context(context: ResourcePolicyContext) {
+    let mut slot = match captured_storage().write() {
+        Ok(slot) => slot,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if slot.is_none() {
+        *slot = Some(context);
+    }
+}
+
+/// Return a clone of the resource policy context captured at preflight time,
+/// if any.
+pub fn captured_context() -> Option<ResourcePolicyContext> {
+    captured_storage().read().ok().and_then(|slot| slot.clone())
+}
+
+/// Clear the captured context. Test-only: production code never resets the
+/// preflight decision so that the persisted observation matches the warning
+/// the user actually saw on stderr.
+#[cfg(test)]
+pub fn reset_captured_context_for_test() {
+    if let Ok(mut slot) = captured_storage().write() {
+        *slot = None;
+    }
+}
+
+pub fn is_runner_hosted_exec() -> bool {
+    std::env::var(crate::core::runner::RUNNER_HOSTED_EXEC_ENV)
+        .ok()
+        .is_some_and(|value| value == "1")
+}
+
+/// True for the complete environment prepared by a managed remote runner exec.
+///
+/// Environment variables are not cryptographic provenance: a process with
+/// arbitrary environment control can forge them. They are an internal runner
+/// transport boundary, so require all three values emitted by RunnerExecOptions
+/// and daemon job preparation rather than trusting the resolved marker alone.
+pub fn is_managed_runner_placement_context() -> bool {
+    is_runner_hosted_exec()
+        && std::env::var(crate::core::runner::RUNNER_PLACEMENT_RESOLVED_ENV)
+            .ok()
+            .is_some_and(|value| value == "1")
+        && std::env::var(crate::core::runner::RUNNER_ID_ENV)
+            .ok()
+            .is_some_and(|value| !value.trim().is_empty())
+}
+
+pub fn clear_runner_hosted_exec() {
+    std::env::remove_var(crate::core::runner::RUNNER_HOSTED_EXEC_ENV);
+}
+
+/// Remove the private runner-placement transport context after CLI routing.
+/// Child workloads and persisted artifacts must not inherit controller routing
+/// markers once their single placement decision has been consumed.
+pub fn clear_managed_runner_placement_context() {
+    std::env::remove_var(crate::core::runner::RUNNER_HOSTED_EXEC_ENV);
+    std::env::remove_var(crate::core::runner::RUNNER_PLACEMENT_RESOLVED_ENV);
+    std::env::remove_var(crate::core::runner::RUNNER_ID_ENV);
+}

--- a/src/core/runner/lab/offload/execute.rs
+++ b/src/core/runner/lab/offload/execute.rs
@@ -25,7 +25,7 @@ pub(crate) fn record_synced_remapped_workspace_entry(
 
 pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadOutcome> {
     if request.placement == crate::cli_surface::Placement::Auto
-        && crate::commands::utils::resource_policy::is_managed_runner_placement_context()
+        && crate::core::resource_policy_context::is_managed_runner_placement_context()
     {
         return Ok(LabOffloadOutcome::RunLocal {
             plan: disabled_select_runner_plan(
@@ -97,7 +97,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     if !contract.routing_policy.default_lab_offload
         && request.placement == crate::cli_surface::Placement::Auto
         && contract.source_path_mode != crate::command_contract::LabSourcePathMode::RunnerResident
-        && crate::commands::utils::resource_policy::captured_context()
+        && crate::core::resource_policy_context::captured_context()
             .is_some_and(|context| context.severity != "ok")
     {
         contract.routing_policy.default_lab_offload = true;


### PR DESCRIPTION
## Summary

Groundwork for extracting `commands` into a `homeboy-cli` crate. Removes **two of the three real `core -> commands` dependency edges** by moving shared resource-policy state down into `core` where it belongs.

## The problem
`core::runner` (lab offload routing) read two things from `commands::utils::resource_policy`:
- `captured_context()` — the process-captured resource-policy snapshot (checked its `severity`).
- `is_managed_runner_placement_context()` — a runner-placement env-var probe.

That's a `core -> commands` edge, and `commands -> core` is the correct direction — so this back-edge blocks putting `commands` in its own crate.

## The fix
These are shared runtime state, not CLI logic. Moved into a new `core::resource_policy_context` module:
- `ResourcePolicyContext` + `ResourcePolicyRunnerSelection` + `ResourcePolicyHostSnapshot` — plain serde data types (explicitly designed to not depend on `DoctorOutput`).
- The process-wide capture store (`capture_context` / `captured_context` / test reset).
- The runner-placement env probes (`is_managed_runner_placement_context`, `is_runner_hosted_exec`, clear helpers) — which already read `core::runner::RUNNER_*_ENV` constants, so they're more at home in core anyway.

The CLI-specific evaluation logic (`evaluate`, `hot_command`, building a context from a `DoctorOutput`, warning/rerun formatting) **stays in `commands`**. `commands::utils::resource_policy` re-exports the moved items so its call sites are unchanged; `runner` now reads directly from `core`.

## Result
`core -> commands` real edges: **3 → 1**. The remaining edge is an `AgentTaskCommand` CLI-parse inside `runner`, which turns out to be tied to a bigger question — `cli_surface` (the clap arg-definition layer) itself depends on `commands`, and `core` uses `cli_surface::Placement` in ~45 places. That layering decision is a separate follow-up before the `commands` extraction proper.

## Verification
- `cargo check --lib` — 0 errors.
- `cargo check --lib --tests` — 0 errors.
- `cargo fmt` clean.
- Full test run left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)