### PR TITLE
Persist runner child identity for orphan recovery

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -37,6 +37,9 @@ enum DaemonCommand {
         /// Confirm the recorded PID was inspected and is dead
         #[arg(long)]
         confirm_pid_dead: bool,
+        /// Explicitly terminalize legacy active jobs missing a persisted child identity
+        #[arg(long)]
+        recover_missing_child_identity: bool,
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
     },
@@ -158,8 +161,8 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
             DaemonOutput::EnsureRunning(daemon::ensure_running(&addr)?),
             0,
         )),
-        DaemonCommand::AdoptOrphan { lease_id, confirm_pid_dead, addr } => Ok((
-            DaemonOutput::AdoptOrphan(daemon::adopt_orphaned_lease(&lease_id, confirm_pid_dead, &addr)?),
+        DaemonCommand::AdoptOrphan { lease_id, confirm_pid_dead, recover_missing_child_identity, addr } => Ok((
+            DaemonOutput::AdoptOrphan(daemon::adopt_orphaned_lease(&lease_id, confirm_pid_dead, recover_missing_child_identity, &addr)?),
             0,
         )),
         DaemonCommand::ReconcileLeaselessOrphans { confirm_no_daemon_owner, addr } => Ok((

--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -656,6 +656,60 @@ mod tests {
     }
 
     #[test]
+    fn child_identity_is_durable_before_a_job_becomes_running() {
+        let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
+        let job = store.create("runner.exec");
+        store
+            .start_with_child_identity(job.id, 4242, "fixture-start".to_string())
+            .expect("record child before running");
+
+        let running = store.get(job.id).expect("running job");
+        assert_eq!(running.status, JobStatus::Running);
+        assert!(store.events(job.id).expect("events").iter().any(|event| {
+            event.kind == JobEventKind::Progress
+                && event.data.as_ref().is_some_and(|data| {
+                    data["process"]["root_pid"] == 4242
+                        && data["process"]["started_at"] == "fixture-start"
+                })
+        }));
+    }
+
+    #[test]
+    fn explicit_legacy_recovery_terminalizes_missing_child_identity() {
+        let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start legacy job");
+
+        store
+            .reconcile_dead_daemon_lease_jobs_allow_missing_child_identity("lease-dead")
+            .expect("explicit legacy recovery");
+
+        assert_eq!(store.get(job.id).expect("job").status, JobStatus::Failed);
+    }
+
+    #[test]
+    fn reused_pid_with_a_different_start_identity_is_terminalized() {
+        let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start job");
+        store
+            .append_event(
+                job.id,
+                JobEventKind::Progress,
+                None,
+                Some(json!({ "process": { "root_pid": std::process::id(), "started_at": "not-this-process" } })),
+            )
+            .expect("record reused identity");
+
+        let diagnostics = store
+            .reconcile_dead_daemon_lease_jobs_with_child_liveness("lease-dead", |_| true)
+            .expect("reconcile reused PID");
+
+        assert!(diagnostics.protected_job_ids.is_empty());
+        assert_eq!(store.get(job.id).expect("job").status, JobStatus::Failed);
+    }
+
+    #[test]
     fn dead_child_recovers_linked_terminal_result_and_artifacts() {
         let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
         let job = store.create("runner.exec");

--- a/src/core/api_jobs/store.rs
+++ b/src/core/api_jobs/store.rs
@@ -327,6 +327,20 @@ impl JobStore {
         self.reconcile_dead_daemon_lease_jobs_with_child_liveness(expected_lease_id, pid_is_running)
     }
 
+    /// Explicit operator recovery for legacy records which predate child identity.
+    /// Callers must first prove the exact daemon lease PID is dead and no owner remains.
+    pub fn reconcile_dead_daemon_lease_jobs_allow_missing_child_identity(
+        &self,
+        expected_lease_id: &str,
+    ) -> Result<DaemonLeaseJobDiagnostics> {
+        self.reconcile_dead_daemon_lease_jobs_with_child_liveness_and_terminal_result_internal(
+            expected_lease_id,
+            pid_is_running,
+            recovered_terminal_agent_task_result,
+            true,
+        )
+    }
+
     pub(super) fn reconcile_dead_daemon_lease_jobs_with_child_liveness(
         &self,
         expected_lease_id: &str,
@@ -344,6 +358,21 @@ impl JobStore {
         expected_lease_id: &str,
         pid_is_alive: impl Fn(u32) -> bool,
         terminal_child_result: impl Fn(&StoredJob) -> Option<RecoveredTerminalJob>,
+    ) -> Result<DaemonLeaseJobDiagnostics> {
+        self.reconcile_dead_daemon_lease_jobs_with_child_liveness_and_terminal_result_internal(
+            expected_lease_id,
+            pid_is_alive,
+            terminal_child_result,
+            false,
+        )
+    }
+
+    fn reconcile_dead_daemon_lease_jobs_with_child_liveness_and_terminal_result_internal(
+        &self,
+        expected_lease_id: &str,
+        pid_is_alive: impl Fn(u32) -> bool,
+        terminal_child_result: impl Fn(&StoredJob) -> Option<RecoveredTerminalJob>,
+        allow_missing_child_identity: bool,
     ) -> Result<DaemonLeaseJobDiagnostics> {
         let diagnostics = self.daemon_lease_job_diagnostics(expected_lease_id);
         if diagnostics.unowned_count() > 0 {
@@ -369,14 +398,24 @@ impl JobStore {
                 if let Some((status, exit_code)) = recovered_terminal_from_result(&stored.events) {
                     DeadLeaseJobDisposition::RecoveredOuterResult(status, exit_code)
                 } else if let Some(pid) = last_progress_child_pid(&stored.events) {
-                    if pid_is_alive(pid) {
-                        diagnostics.protected_job_ids.push(*job_id);
-                        DeadLeaseJobDisposition::ProtectedLive
-                    } else if let Some(recovered) = terminal_child_result(stored) {
-                        DeadLeaseJobDisposition::RecoveredLinkedRun(recovered)
-                    } else {
-                        DeadLeaseJobDisposition::TerminalizeDead
-                    }
+                    if pid_is_alive(pid)
+                    && last_progress_child_started_at(&stored.events).is_none_or(|expected| {
+                        crate::core::engine::invocation::InvocationChildRecord::process_started_at(
+                            pid,
+                        )
+                        .as_deref()
+                            == Some(expected.as_str())
+                    })
+                {
+                    diagnostics.protected_job_ids.push(*job_id);
+                    DeadLeaseJobDisposition::ProtectedLive
+                } else if let Some(recovered) = terminal_child_result(stored) {
+                    DeadLeaseJobDisposition::RecoveredLinkedRun(recovered)
+                } else {
+                    DeadLeaseJobDisposition::TerminalizeDead
+                }
+                } else if allow_missing_child_identity {
+                    DeadLeaseJobDisposition::TerminalizeDead
                 } else {
                     ambiguous_job_ids.push(*job_id);
                     continue;
@@ -741,6 +780,54 @@ impl JobStore {
         T: Serialize + Send + 'static,
         F: FnOnce(JobHandle) -> Result<T> + Send + 'static,
     {
+        self.run_background_with_start_policy(
+            operation,
+            source_snapshot,
+            metadata,
+            path_materialization_plan,
+            true,
+            run,
+        )
+    }
+
+    pub(crate) fn run_background_deferred_start_with_source_snapshot_metadata_and_path_materialization_plan<
+        T,
+        F,
+    >(
+        &self,
+        operation: impl Into<String>,
+        source_snapshot: Option<SourceSnapshot>,
+        metadata: Option<Value>,
+        path_materialization_plan: Option<PathMaterializationPlan>,
+        run: F,
+    ) -> JobRunner
+    where
+        T: Serialize + Send + 'static,
+        F: FnOnce(JobHandle) -> Result<T> + Send + 'static,
+    {
+        self.run_background_with_start_policy(
+            operation,
+            source_snapshot,
+            metadata,
+            path_materialization_plan,
+            false,
+            run,
+        )
+    }
+
+    fn run_background_with_start_policy<T, F>(
+        &self,
+        operation: impl Into<String>,
+        source_snapshot: Option<SourceSnapshot>,
+        metadata: Option<Value>,
+        path_materialization_plan: Option<PathMaterializationPlan>,
+        start_before_run: bool,
+        run: F,
+    ) -> JobRunner
+    where
+        T: Serialize + Send + 'static,
+        F: FnOnce(JobHandle) -> Result<T> + Send + 'static,
+    {
         let job = self.create_with_source_snapshot_metadata_and_path_materialization_plan(
             operation,
             source_snapshot,
@@ -752,7 +839,7 @@ impl JobStore {
         let worker_store = self.clone();
 
         let handle = thread::spawn(move || {
-            if worker_store.start(job_id).is_err() {
+            if start_before_run && worker_store.start(job_id).is_err() {
                 return;
             }
             let job_handle = JobHandle {
@@ -804,6 +891,58 @@ impl JobStore {
 
         self.append_status_event(job_id, next_status, message)?;
         self.get(job_id)
+    }
+
+    pub(crate) fn start_with_child_identity(
+        &self,
+        job_id: Uuid,
+        pid: u32,
+        started_at: String,
+    ) -> Result<Job> {
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let (prior, started) = {
+            let stored = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            validate_transition(stored.job.status, JobStatus::Running)?;
+            let prior = stored.clone();
+            let now = timestamp_ms();
+            stored.job.status = JobStatus::Running;
+            stored.job.started_at_ms = Some(now);
+            stored.job.updated_at_ms = now;
+            let sequence = self.next_event_sequence.fetch_add(2, Ordering::SeqCst) + 1;
+            stored.events.push(JobEvent {
+                sequence,
+                job_id,
+                kind: JobEventKind::Progress,
+                timestamp_ms: now,
+                message: Some("runner child spawned".to_string()),
+                data: Some(serde_json::json!({ "phase": "spawned", "process": { "root_pid": pid, "started_at": started_at } })),
+            });
+            stored.events.push(JobEvent {
+                sequence: sequence + 1,
+                job_id,
+                kind: JobEventKind::Status,
+                timestamp_ms: now,
+                message: Some("job started".to_string()),
+                data: Some(serde_json::json!({ "status": JobStatus::Running })),
+            });
+            apply_event_retention(&mut stored.events, self.event_retention_limit());
+            stored.job.event_count = stored.events.len();
+            (prior, stored.job.clone())
+        };
+
+        if let Some(persistence) = &self.persistence {
+            let durable = DurableJobStore {
+                jobs: inner.jobs.values().cloned().collect(),
+            };
+            if let Err(error) = write_durable_store(&persistence.path, &durable) {
+                *inner.jobs.get_mut(&job_id).expect("job exists") = prior;
+                return Err(error);
+            }
+        }
+        Ok(started)
     }
 
     pub(super) fn ensure_transition(&self, job_id: Uuid, next_status: JobStatus) -> Result<()> {
@@ -979,6 +1118,18 @@ fn last_progress_child_pid(events: &[JobEvent]) -> Option<u32> {
         .filter(|pid| *pid > 0)
 }
 
+fn last_progress_child_started_at(events: &[JobEvent]) -> Option<String> {
+    events
+        .iter()
+        .rev()
+        .find(|event| event.kind == JobEventKind::Progress)
+        .and_then(|event| event.data.as_ref())
+        .and_then(|data| data.get("process"))
+        .and_then(|process| process.get("started_at"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
 impl JobHandle {
     pub(crate) fn job_id(&self) -> Uuid {
         self.job_id
@@ -989,6 +1140,11 @@ impl JobHandle {
             .get(self.job_id)
             .map(|job| job.status == JobStatus::Cancelled)
             .unwrap_or(true)
+    }
+
+    pub(crate) fn start_with_child_identity(&self, pid: u32, started_at: String) -> Result<Job> {
+        self.store
+            .start_with_child_identity(self.job_id, pid, started_at)
     }
 
     pub(crate) fn stdout(&self, message: impl Into<String>) -> Result<JobEvent> {

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -1449,22 +1449,12 @@ fn enqueue_exec_job(
         request.metadata.as_ref(),
     );
     let runner = job_store
-        .run_background_with_source_snapshot_metadata_and_path_materialization_plan(
+        .run_background_deferred_start_with_source_snapshot_metadata_and_path_materialization_plan(
             operation,
             source_snapshot.clone(),
             run_ref_metadata,
             path_materialization_plan.clone(),
             move |job| {
-                job.progress(json!({
-                    "phase": "started",
-                    "runner_id": plan.runner.id,
-                    "cwd": plan.cwd,
-                    "command": plan.command,
-                    "capture_patch": request.capture_patch,
-                    "job_id": job.job_id(),
-                    "source_snapshot": source_snapshot,
-                    "path_materialization_plan": path_materialization_plan,
-                }))?;
                 let baseline = if request.capture_patch {
                     Some(capture_baseline(&plan.cwd)?)
                 } else {
@@ -1474,10 +1464,25 @@ fn enqueue_exec_job(
                 let progress_sink = Arc::new(move |data| {
                     let _ = progress_job.progress(data);
                 });
+                let started_job = job.clone();
+                let child_started = Arc::new(move |pid| {
+                    let started_at =
+                        crate::core::engine::invocation::InvocationChildRecord::process_started_at(
+                            pid,
+                        )
+                        .ok_or_else(|| {
+                            Error::internal_unexpected(
+                                "capture runner child process start identity",
+                            )
+                        })?;
+                    started_job.start_with_child_identity(pid, started_at)?;
+                    Ok(())
+                });
                 let process_output = execute_runner_process_until_cancelled_with_progress(
                     &plan,
                     || job.is_cancelled(),
                     Some(progress_sink),
+                    Some(child_started),
                 )?;
                 let stdout = process_output.stdout.clone();
                 let stderr = process_output.stderr.clone();

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -770,6 +770,7 @@ pub fn ensure_running(addr: &str) -> Result<DaemonStartResult> {
 pub fn adopt_orphaned_lease(
     lease_id: &str,
     confirm_pid_dead: bool,
+    recover_missing_child_identity: bool,
     addr: &str,
 ) -> Result<DaemonOrphanAdoptionResult> {
     if !confirm_pid_dead {
@@ -791,7 +792,11 @@ pub fn adopt_orphaned_lease(
             let store = super::JobStore::open_without_reconciliation(
                 crate::core::paths::daemon_jobs_file()?,
             )?;
-            store.reconcile_dead_daemon_lease_jobs(lease_id)
+            if recover_missing_child_identity {
+                store.reconcile_dead_daemon_lease_jobs_allow_missing_child_identity(lease_id)
+            } else {
+                store.reconcile_dead_daemon_lease_jobs(lease_id)
+            }
         },
         || start_or_return_live_unlocked(addr),
     )

--- a/src/core/runner/execution/process.rs
+++ b/src/core/runner/execution/process.rs
@@ -422,6 +422,7 @@ pub(crate) fn execute_runner_process_until_cancelled_with_progress(
     plan: &PreparedRunnerProcess,
     is_cancelled: impl FnMut() -> bool,
     progress_sink: Option<RunnerCommandProgressSink>,
+    child_started: Option<Arc<dyn Fn(u32) -> Result<()> + Send + Sync + 'static>>,
 ) -> Result<ProcessOutput> {
     let mut command = std::process::Command::new(&plan.command[0]);
     command.args(&plan.command[1..]).current_dir(&plan.cwd);
@@ -431,6 +432,7 @@ pub(crate) fn execute_runner_process_until_cancelled_with_progress(
         &mut command,
         is_cancelled,
         progress_sink,
+        child_started,
         &plan.env,
         &plan.secret_env_names,
         plan.runner.settings.concurrency_limit,
@@ -524,6 +526,7 @@ pub(super) fn command_output_until_cancelled_with_progress(
     command: &mut std::process::Command,
     is_cancelled: impl FnMut() -> bool,
     progress_sink: Option<RunnerCommandProgressSink>,
+    child_started: Option<Arc<dyn Fn(u32) -> Result<()> + Send + Sync + 'static>>,
     env: &HashMap<String, String>,
     secret_env_names: &[String],
     concurrency_limit: Option<usize>,
@@ -547,6 +550,7 @@ pub(super) fn command_output_until_cancelled_with_progress(
         is_cancelled,
         progress_sink,
         stdout_line_observer,
+        child_started,
         concurrency_limit,
     )?;
     let output = measured.output;

--- a/src/core/runner/execution/worker.rs
+++ b/src/core/runner/execution/worker.rs
@@ -24,7 +24,12 @@ pub(crate) fn exec_worker_local_until_cancelled_with_progress(
 ) -> Result<(RunnerExecOutput, i32)> {
     let mut is_cancelled = is_cancelled;
     exec_worker_local_with_process_output(runner_id, options, |plan| {
-        execute_runner_process_until_cancelled_with_progress(plan, &mut is_cancelled, progress_sink)
+        execute_runner_process_until_cancelled_with_progress(
+            plan,
+            &mut is_cancelled,
+            progress_sink,
+            None,
+        )
     })
 }
 

--- a/src/core/runner/resource_metrics.rs
+++ b/src/core/runner/resource_metrics.rs
@@ -127,6 +127,7 @@ pub(crate) fn measured_command_output_until_cancelled_with_progress(
     mut is_cancelled: impl FnMut() -> bool,
     progress_sink: Option<RunnerCommandProgressSink>,
     stdout_line_observer: Option<StdoutLineObserver>,
+    child_started: Option<Arc<dyn Fn(u32) -> Result<()> + Send + Sync + 'static>>,
     concurrency_limit: Option<usize>,
 ) -> Result<MeasuredOutput> {
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
@@ -136,6 +137,15 @@ pub(crate) fn measured_command_output_until_cancelled_with_progress(
         Error::internal_io(err.to_string(), Some("execute runner command".to_string()))
     })?;
     let pid = child.id();
+    if let Some(child_started) = child_started {
+        if let Err(error) = child_started(pid) {
+            // The caller cannot safely recover a child it never durably recorded.
+            // Preserve the actionable persistence error after reaping this child.
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(error);
+        }
+    }
     let guard_violation = Arc::new(Mutex::new(None));
     let collector = ResourceMetricsCollector::start(
         pid,
@@ -665,6 +675,7 @@ fn clock_ticks_per_second() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
 
     #[test]
     fn heartbeat_payload_includes_elapsed_pid_and_optional_resources() {
@@ -683,6 +694,32 @@ mod tests {
         assert_eq!(payload["process"]["root_pid"], 1234);
         assert_eq!(payload["process"]["resources"]["process_count"], 3);
         assert_eq!(payload["process"]["resources"]["child_process_count"], 2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn child_started_failure_kills_and_reaps_the_spawned_child() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "sleep 30"]);
+        let pid = Arc::new(AtomicU32::new(0));
+        let callback_pid = Arc::clone(&pid);
+        let error = measured_command_output_until_cancelled_with_progress(
+            &mut command,
+            || false,
+            None,
+            None,
+            Some(Arc::new(move |child_pid| {
+                callback_pid.store(child_pid, Ordering::SeqCst);
+                Err(Error::internal_unexpected("persist child identity"))
+            })),
+            None,
+        )
+        .expect_err("callback failure returns");
+
+        assert!(error.message.contains("persist child identity"));
+        assert!(!crate::core::process::pid_is_running(
+            pid.load(Ordering::SeqCst)
+        ));
     }
 
     #[test]

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -405,7 +405,7 @@ fn exact_lease_adoption_refuses_owner_lock_and_preserves_store() {
             .expect("owner lock")
             .expect("owner acquired");
 
-        let error = super::adopt_orphaned_lease("lease-dead", true, "127.0.0.1:0")
+        let error = super::adopt_orphaned_lease("lease-dead", true, false, "127.0.0.1:0")
             .expect_err("owner lock blocks adoption");
         assert!(error.message.contains("owner lock is held"));
         assert_eq!(std::fs::read(&jobs_path).expect("store bytes"), before);
@@ -460,6 +460,39 @@ fn exact_lease_adoption_reconciles_terminal_children_idempotently() {
         );
         assert_eq!(recovered.events(job.id).expect("events").len(), event_count);
     });
+}
+
+#[test]
+fn exact_adoption_requires_explicit_legacy_child_identity_recovery() {
+    let legacy = JobStore::default().with_daemon_lease("lease-dead".to_string());
+    let job = legacy.create("runner.exec");
+    legacy.start(job.id).expect("start legacy job");
+
+    let normal = super::adopt_orphaned_lease_with_operations(
+        "lease-dead",
+        || Ok(fake_dead_status(fake_daemon(4242, "lease-dead"))),
+        |_| false,
+        || Ok(Some(())),
+        || legacy.reconcile_dead_daemon_lease_jobs("lease-dead"),
+        || Ok(fake_daemon(4343, "replacement")),
+    );
+    assert!(normal
+        .expect_err("normal adoption rejects missing identity")
+        .message
+        .contains("recorded child PID"));
+    assert_eq!(legacy.get(job.id).expect("job").status, JobStatus::Running);
+
+    let adopted = super::adopt_orphaned_lease_with_operations(
+        "lease-dead",
+        || Ok(fake_dead_status(fake_daemon(4242, "lease-dead"))),
+        |_| false,
+        || Ok(Some(())),
+        || legacy.reconcile_dead_daemon_lease_jobs_allow_missing_child_identity("lease-dead"),
+        || Ok(fake_daemon(4343, "replacement")),
+    )
+    .expect("explicit legacy adoption");
+    assert_eq!(adopted.active_jobs_terminalized, 1);
+    assert_eq!(legacy.get(job.id).expect("job").status, JobStatus::Failed);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- persist runner child PID and process-start identity before a durable job becomes externally `Running`
- reconcile dead children while protecting live children and detecting PID reuse
- kill and reap the spawned child if identity persistence fails
- add an explicit operator-approved recovery flag for legacy active jobs that lack child identity; automatic adoption remains fail-closed

Closes #8198.

## Root cause

`runner.exec` marked a durable job `Running` before spawning its child. If the daemon died in that window, exact orphan adoption had neither a terminal result nor process identity and could never safely reconcile the lease.

## How to test

1. Run `cargo fmt --check`.
2. Run `cargo test core::api_jobs --lib`.
3. Run `cargo test daemon::control --lib`.
4. Run `cargo test resource_metrics --lib`.
5. Verify a live PID with matching start identity blocks adoption, a reused/dead PID terminalizes, normal missing-identity adoption fails closed, and `--recover-missing-child-identity` handles only the explicit legacy path.
6. Verify callback persistence failure kills and waits for the spawned child.

## Verification

- `cargo fmt --check`
- `cargo test core::api_jobs --lib`: 62 passed
- `cargo test daemon::control --lib`: 30 passed
- `cargo test resource_metrics --lib`: 11 passed
- `git diff --check`

## Compatibility

Existing implicit orphan adoption remains fail-closed. Durable runner jobs gain process identity metadata; legacy missing-identity records require a new explicit operator flag after exact lease/PID-death proof.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Diagnosed the daemon-death race, implemented durable child identity and bounded recovery, added deterministic tests, and prepared evidence with Chris.