### PR TITLE
Use configured worktree providers for cook promotion

### DIFF
--- a/src/commands/agent_task/tests/promotion_review.rs
+++ b/src/commands/agent_task/tests/promotion_review.rs
@@ -185,7 +185,7 @@ fn cook_returns_durable_id_when_promotion_provider_is_missing() {
         assert!(value["stop_reason"]
             .as_str()
             .expect("stop reason")
-            .contains("workspace provider command"));
+            .contains("configured worktree provider"));
     });
 }
 

--- a/src/core/agent_task_promotion/apply.rs
+++ b/src/core/agent_task_promotion/apply.rs
@@ -232,10 +232,16 @@ pub(crate) trait AgentTaskPromotionWorkspaceProvider {
 pub(crate) struct ExternalPromotionWorkspaceProvider {
     invocation: Option<CommandInvocation>,
     provenance: Option<serde_json::Value>,
+    configured_fallback: Option<ConfiguredPromotionWorkspaceProvider>,
+}
+
+struct ConfiguredPromotionWorkspaceProvider {
+    config: crate::core::defaults::HomeboyConfig,
+    executable: Option<PathBuf>,
 }
 
 impl ExternalPromotionWorkspaceProvider {
-    pub(crate) fn from_options(options: &AgentTaskPromotionOptions) -> Result<Self> {
+    pub(crate) fn from_options(options: &AgentTaskPromotionOptions) -> Self {
         let config = crate::core::defaults::load_config();
         Self::from_options_with_config_and_environment(
             options,
@@ -250,57 +256,37 @@ impl ExternalPromotionWorkspaceProvider {
         config: &crate::core::defaults::HomeboyConfig,
         executable: Option<PathBuf>,
         promotion_command: Option<String>,
-    ) -> Result<Self> {
+    ) -> Self {
         if let Some(invocation) = options.provider_invocation.clone() {
-            return Ok(Self {
+            return Self {
                 invocation: Some(invocation),
                 provenance: None,
-            });
+                configured_fallback: None,
+            };
         }
         if let Some(command) = options.provider_command.clone().or(promotion_command) {
             eprintln!(
                 "Warning: agent-task promotion provider string command is deprecated; use argv-capable provider invocation instead"
             );
-            return Ok(Self {
+            return Self {
                 invocation: Some(CommandInvocation {
                     argv: command.split_whitespace().map(str::to_string).collect(),
                     display: Some(command),
                     ..Default::default()
                 }),
                 provenance: None,
-            });
+                configured_fallback: None,
+            };
         }
 
-        let resolution = worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
-            &options.to_worktree,
-            config,
-        )?;
-        let executable = executable.map(Ok).unwrap_or_else(|| {
-            std::env::current_exe().map_err(|error| {
-                Error::internal_io(
-                    error.to_string(),
-                    Some("resolve current Homeboy executable for promotion provider".to_string()),
-                )
-            })
-        })?;
-        let workspace = resolution.worktree.path;
-        Ok(Self {
-            invocation: Some(CommandInvocation {
-                argv: vec![
-                    executable.display().to_string(),
-                    "agent-task".to_string(),
-                    "promotion-provider".to_string(),
-                    "--workspace".to_string(),
-                    workspace.clone(),
-                ],
-                ..Default::default()
+        Self {
+            invocation: None,
+            provenance: None,
+            configured_fallback: Some(ConfiguredPromotionWorkspaceProvider {
+                config: config.clone(),
+                executable,
             }),
-            provenance: Some(serde_json::json!({
-                "id": resolution.provider_id,
-                "handle": resolution.worktree.handle,
-                "path": workspace,
-            })),
-        })
+        }
     }
 
     pub(crate) fn provenance(&self) -> Option<&serde_json::Value> {
@@ -309,6 +295,66 @@ impl ExternalPromotionWorkspaceProvider {
 
     pub(super) fn invocation(&self) -> Option<&CommandInvocation> {
         self.invocation.as_ref()
+    }
+
+    fn resolve_configured_fallback(&mut self, to_workspace: &str) -> Result<()> {
+        let configured_fallback = self.configured_fallback.as_ref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "promotion_provider",
+                format!(
+                    "agent-task promotion requires a workspace provider command; pass --provider-command or set {PROMOTION_PROVIDER_COMMAND_ENV}"
+                ),
+                None,
+                None,
+            )
+        })?;
+        let resolution = worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
+            to_workspace,
+            &configured_fallback.config,
+        )?;
+        let executable = configured_fallback
+            .executable
+            .clone()
+            .map(Ok)
+            .unwrap_or_else(|| {
+                std::env::current_exe().map_err(|error| {
+                    Error::internal_io(
+                        error.to_string(),
+                        Some(
+                            "resolve current Homeboy executable for promotion provider".to_string(),
+                        ),
+                    )
+                })
+            })?;
+        let workspace = resolution.worktree.path;
+        self.invocation = Some(CommandInvocation {
+            argv: vec![
+                executable.display().to_string(),
+                "agent-task".to_string(),
+                "promotion-provider".to_string(),
+                "--workspace".to_string(),
+                workspace.clone(),
+            ],
+            ..Default::default()
+        });
+        self.provenance = Some(serde_json::json!({
+            "id": resolution.provider_id,
+            "handle": resolution.worktree.handle,
+            "path": workspace,
+        }));
+        Ok(())
+    }
+
+    fn with_configured_provider_provenance(&self, mut error: Error) -> Error {
+        if let Some(provenance) = self.provenance() {
+            if !error.details.is_object() {
+                error.details = serde_json::json!({});
+            }
+            if let Some(details) = error.details.as_object_mut() {
+                details.insert("worktree_provider".to_string(), provenance.clone());
+            }
+        }
+        error
     }
 }
 
@@ -323,6 +369,9 @@ impl AgentTaskPromotionWorkspaceProvider for ExternalPromotionWorkspaceProvider 
         &mut self,
         request: AgentTaskPromotionApplyRequest,
     ) -> Result<AgentTaskPromotionWorkspace> {
+        if self.invocation.is_none() {
+            self.resolve_configured_fallback(&request.to_workspace)?;
+        }
         let invocation = self.invocation.as_ref().ok_or_else(|| {
             Error::validation_invalid_argument(
                 "promotion_provider",
@@ -334,6 +383,7 @@ impl AgentTaskPromotionWorkspaceProvider for ExternalPromotionWorkspaceProvider 
             )
         })?;
         run_provider_command(invocation, &request)
+            .map_err(|error| self.with_configured_provider_provenance(error))
     }
 
     fn verify(

--- a/src/core/agent_task_promotion/apply.rs
+++ b/src/core/agent_task_promotion/apply.rs
@@ -13,7 +13,7 @@ use crate::core::agent_task_gate::{
 };
 use crate::core::command_invocation::CommandInvocation;
 use crate::core::stream_capture::StreamCaptureMetadata;
-use crate::core::{Error, Result};
+use crate::core::{worktree_providers, Error, Result};
 
 use super::types::{
     AgentTaskPromotionCommandCapture, AgentTaskPromotionCommandReport, AgentTaskPromotionOptions,
@@ -231,29 +231,84 @@ pub(crate) trait AgentTaskPromotionWorkspaceProvider {
 
 pub(crate) struct ExternalPromotionWorkspaceProvider {
     invocation: Option<CommandInvocation>,
+    provenance: Option<serde_json::Value>,
 }
 
 impl ExternalPromotionWorkspaceProvider {
-    pub(crate) fn from_options(options: &AgentTaskPromotionOptions) -> Self {
-        Self {
-            invocation: options
-                .provider_invocation
-                .clone()
-                .or_else(|| options
-                    .provider_command
-                    .clone()
-                .or_else(|| std::env::var(PROMOTION_PROVIDER_COMMAND_ENV).ok())
-                .map(|command| {
-                    eprintln!(
-                        "Warning: agent-task promotion provider string command is deprecated; use argv-capable provider invocation instead"
-                    );
-                    CommandInvocation {
-                        argv: command.split_whitespace().map(str::to_string).collect(),
-                        display: Some(command),
-                        ..Default::default()
-                    }
-                })),
+    pub(crate) fn from_options(options: &AgentTaskPromotionOptions) -> Result<Self> {
+        let config = crate::core::defaults::load_config();
+        Self::from_options_with_config_and_environment(
+            options,
+            &config,
+            None,
+            std::env::var(PROMOTION_PROVIDER_COMMAND_ENV).ok(),
+        )
+    }
+
+    pub(super) fn from_options_with_config_and_environment(
+        options: &AgentTaskPromotionOptions,
+        config: &crate::core::defaults::HomeboyConfig,
+        executable: Option<PathBuf>,
+        promotion_command: Option<String>,
+    ) -> Result<Self> {
+        if let Some(invocation) = options.provider_invocation.clone() {
+            return Ok(Self {
+                invocation: Some(invocation),
+                provenance: None,
+            });
         }
+        if let Some(command) = options.provider_command.clone().or(promotion_command) {
+            eprintln!(
+                "Warning: agent-task promotion provider string command is deprecated; use argv-capable provider invocation instead"
+            );
+            return Ok(Self {
+                invocation: Some(CommandInvocation {
+                    argv: command.split_whitespace().map(str::to_string).collect(),
+                    display: Some(command),
+                    ..Default::default()
+                }),
+                provenance: None,
+            });
+        }
+
+        let resolution = worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
+            &options.to_worktree,
+            config,
+        )?;
+        let executable = executable.map(Ok).unwrap_or_else(|| {
+            std::env::current_exe().map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("resolve current Homeboy executable for promotion provider".to_string()),
+                )
+            })
+        })?;
+        let workspace = resolution.worktree.path;
+        Ok(Self {
+            invocation: Some(CommandInvocation {
+                argv: vec![
+                    executable.display().to_string(),
+                    "agent-task".to_string(),
+                    "promotion-provider".to_string(),
+                    "--workspace".to_string(),
+                    workspace.clone(),
+                ],
+                ..Default::default()
+            }),
+            provenance: Some(serde_json::json!({
+                "id": resolution.provider_id,
+                "handle": resolution.worktree.handle,
+                "path": workspace,
+            })),
+        })
+    }
+
+    pub(crate) fn provenance(&self) -> Option<&serde_json::Value> {
+        self.provenance.as_ref()
+    }
+
+    pub(super) fn invocation(&self) -> Option<&CommandInvocation> {
+        self.invocation.as_ref()
     }
 }
 

--- a/src/core/agent_task_promotion/promote.rs
+++ b/src/core/agent_task_promotion/promote.rs
@@ -29,7 +29,7 @@ use super::types::{
 };
 
 pub fn promote(options: AgentTaskPromotionOptions) -> Result<AgentTaskPromotionReport> {
-    let mut provider = ExternalPromotionWorkspaceProvider::from_options(&options)?;
+    let mut provider = ExternalPromotionWorkspaceProvider::from_options(&options);
     let mut report = promote_with_provider(options, &mut provider)?;
     if let Some(provenance) = provider.provenance() {
         report.provenance["worktree_provider"] = provenance.clone();

--- a/src/core/agent_task_promotion/promote.rs
+++ b/src/core/agent_task_promotion/promote.rs
@@ -29,8 +29,11 @@ use super::types::{
 };
 
 pub fn promote(options: AgentTaskPromotionOptions) -> Result<AgentTaskPromotionReport> {
-    let mut provider = ExternalPromotionWorkspaceProvider::from_options(&options);
+    let mut provider = ExternalPromotionWorkspaceProvider::from_options(&options)?;
     let mut report = promote_with_provider(options, &mut provider)?;
+    if let Some(provenance) = provider.provenance() {
+        report.provenance["worktree_provider"] = provenance.clone();
+    }
     if let Ok(runner_id) = std::env::var("HOMEBOY_LAB_RUNNER_ID") {
         if !runner_id.trim().is_empty() {
             report.provenance["lab_offload"] = json!({

--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -197,7 +197,7 @@ fn promotion_options(to_worktree: &str) -> AgentTaskPromotionOptions {
 }
 
 #[test]
-fn configured_command_provider_constructs_native_promotion_adapter_with_provenance() {
+fn configured_command_provider_is_resolved_lazily_with_provenance() {
     let workspace = tempfile::tempdir().expect("workspace");
     git(workspace.path(), &["init", "-b", "cook-target"]);
     let provider = tempfile::NamedTempFile::new().expect("provider command");
@@ -256,8 +256,21 @@ fn configured_command_provider_constructs_native_promotion_adapter_with_provenan
         &config,
         Some(PathBuf::from("/fixture/homeboy")),
         None,
-    )
-    .expect("configured provider resolves");
+    );
+    let mut provider = provider;
+    assert!(provider.invocation().is_none());
+    assert!(provider.provenance().is_none());
+
+    let error = provider
+        .apply_patch(AgentTaskPromotionApplyRequest {
+            schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
+            to_workspace: "fixture@cook-target".to_string(),
+            patch: Some(VALID_PATCH.to_string()),
+            patch_path: "changes.patch".to_string(),
+            changed_files: vec!["src/lib.rs".to_string()],
+            dry_run: false,
+        })
+        .expect_err("fixture executable is not an adapter");
 
     assert_eq!(
         provider.invocation().expect("invocation").argv,
@@ -270,9 +283,14 @@ fn configured_command_provider_constructs_native_promotion_adapter_with_provenan
         ]
     );
     assert_eq!(provider.provenance().expect("provenance")["id"], "fixture");
+    assert_eq!(error.details["worktree_provider"]["id"], "fixture");
     assert_eq!(
-        provider.provenance().expect("provenance")["handle"],
+        error.details["worktree_provider"]["handle"],
         "fixture@cook-target"
+    );
+    assert_eq!(
+        error.details["worktree_provider"]["path"],
+        workspace.path().display().to_string()
     );
 }
 
@@ -342,9 +360,18 @@ fn lookup_only_configured_provider_cannot_construct_a_promotion_adapter() {
         &config,
         Some(PathBuf::from("/fixture/homeboy")),
         None,
-    )
-    .err()
-    .expect("lookup-only provider must not authorize promotion");
+    );
+    let mut error = error;
+    let error = error
+        .apply_patch(AgentTaskPromotionApplyRequest {
+            schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
+            to_workspace: "fixture@cook-target".to_string(),
+            patch: Some(VALID_PATCH.to_string()),
+            patch_path: "changes.patch".to_string(),
+            changed_files: vec!["src/lib.rs".to_string()],
+            dry_run: false,
+        })
+        .expect_err("lookup-only provider must not authorize promotion");
 
     assert!(error
         .message
@@ -365,8 +392,7 @@ fn explicit_promotion_provider_sources_precede_configured_resolution() {
         &HomeboyConfig::default(),
         Some(PathBuf::from("/fixture/homeboy")),
         Some("environment-provider".to_string()),
-    )
-    .expect("explicit argv does not resolve configured providers");
+    );
 
     assert_eq!(
         provider.invocation().expect("invocation").argv,
@@ -379,8 +405,7 @@ fn explicit_promotion_provider_sources_precede_configured_resolution() {
         &HomeboyConfig::default(),
         Some(PathBuf::from("/fixture/homeboy")),
         Some("environment-provider".to_string()),
-    )
-    .expect("explicit command does not resolve configured providers");
+    );
     assert_eq!(
         provider.invocation().expect("invocation").argv,
         vec!["command-provider".to_string()]
@@ -392,8 +417,7 @@ fn explicit_promotion_provider_sources_precede_configured_resolution() {
         &HomeboyConfig::default(),
         Some(PathBuf::from("/fixture/homeboy")),
         Some("environment-provider".to_string()),
-    )
-    .expect("environment command does not resolve configured providers");
+    );
     assert_eq!(
         provider.invocation().expect("invocation").argv,
         vec!["environment-provider".to_string()]
@@ -482,48 +506,48 @@ fn validate_patch_rejects_empty_patch() {
 
 #[test]
 fn promote_reports_no_changes_for_empty_patch_metadata() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let patch_path = temp.path().join("patch.diff");
-    std::fs::write(&patch_path, "").expect("write empty patch");
-    let source_path = temp.path().join("outcome.json");
-    let outcome = AgentTaskOutcome {
-        schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
-        task_id: "task-1".to_string(),
-        status: AgentTaskOutcomeStatus::Succeeded,
-        summary: None,
-        failure_classification: None,
-        artifacts: vec![AgentTaskArtifact {
-            schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-            id: "patch".to_string(),
-            kind: "patch".to_string(),
-            name: Some("patch.diff".to_string()),
-            label: None,
-            role: None,
-            semantic_key: None,
-            path: Some("patch.diff".to_string()),
-            url: None,
-            mime: Some("text/x-patch".to_string()),
-            size_bytes: Some(0),
-            sha256: Some(
-                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_string(),
-            ),
-            metadata: serde_json::json!({ "role": "patch" }),
-        }],
-        typed_artifacts: Vec::new(),
-        evidence_refs: Vec::new(),
-        diagnostics: Vec::new(),
-        outputs: Value::Null,
-        workflow: None,
-        follow_up: None,
-        metadata: Value::Null,
-    };
-    let source = serde_json::to_string(&outcome).expect("serialize outcome");
-    std::fs::write(&source_path, &source).expect("write source");
+    crate::test_support::with_isolated_home(|_| {
+        let prior_promotion_command = std::env::var_os("HOMEBOY_AGENT_TASK_PROMOTION_COMMAND");
+        std::env::remove_var("HOMEBOY_AGENT_TASK_PROMOTION_COMMAND");
+        let temp = tempfile::tempdir().expect("tempdir");
+        let patch_path = temp.path().join("patch.diff");
+        std::fs::write(&patch_path, "").expect("write empty patch");
+        let source_path = temp.path().join("outcome.json");
+        let outcome = AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: "task-1".to_string(),
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: None,
+            failure_classification: None,
+            artifacts: vec![AgentTaskArtifact {
+                schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                id: "patch".to_string(),
+                kind: "patch".to_string(),
+                name: Some("patch.diff".to_string()),
+                label: None,
+                role: None,
+                semantic_key: None,
+                path: Some("patch.diff".to_string()),
+                url: None,
+                mime: Some("text/x-patch".to_string()),
+                size_bytes: Some(0),
+                sha256: Some(
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_string(),
+                ),
+                metadata: serde_json::json!({ "role": "patch" }),
+            }],
+            typed_artifacts: Vec::new(),
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            outputs: Value::Null,
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        };
+        let source = serde_json::to_string(&outcome).expect("serialize outcome");
+        std::fs::write(&source_path, &source).expect("write source");
 
-    let mut provider = FakePromotionWorkspaceProvider::default();
-
-    let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        let report = promote(AgentTaskPromotionOptions {
             source,
             source_run_id: Some("run-empty".to_string()),
             source_path: Some(source_path),
@@ -541,15 +565,16 @@ fn promote_reports_no_changes_for_empty_patch_metadata() {
             },
             provider_command: None,
             provider_invocation: None,
-        },
-        &mut provider,
-    )
-    .expect("empty patch reports no changes");
+        })
+        .expect("empty patch reports no changes");
 
-    assert_eq!(report.status, AgentTaskPromotionStatus::NoChanges);
-    assert!(report.changed_files.is_empty());
-    assert!(provider.apply_calls.is_empty());
-    assert!(provider.verify_calls.is_empty());
+        assert_eq!(report.status, AgentTaskPromotionStatus::NoChanges);
+        assert!(report.changed_files.is_empty());
+        match prior_promotion_command {
+            Some(command) => std::env::set_var("HOMEBOY_AGENT_TASK_PROMOTION_COMMAND", command),
+            None => std::env::remove_var("HOMEBOY_AGENT_TASK_PROMOTION_COMMAND"),
+        }
+    });
 }
 
 #[test]

--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -8,8 +8,8 @@ use sha2::{Digest, Sha256};
 
 use super::apply::{
     run_provider_command, AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspace,
-    AgentTaskPromotionWorkspaceProvider, AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA,
-    AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
+    AgentTaskPromotionWorkspaceProvider, ExternalPromotionWorkspaceProvider,
+    AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA, AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
 };
 use super::promote::{
     normalize_promotion_patch, promote, promote_with_provider, select_patch_artifact,
@@ -29,6 +29,10 @@ use crate::core::agent_task_gate::{
     AgentTaskGateReport, AgentTaskGateRevealPolicy, AgentTaskGateVisibility, VerifyGateOptions,
 };
 use crate::core::command_invocation::CommandInvocation;
+use crate::core::defaults::{
+    HomeboyConfig, WorktreeProviderCommands, WorktreeProviderConfig, WorktreeProviderKind,
+    WorktreeProviderListResultMapping,
+};
 use crate::core::{Error, Result};
 
 const VALID_PATCH: &str = "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
@@ -171,6 +175,228 @@ fn git(cwd: &Path, args: &[&str]) {
         "git {} failed: {}",
         args.join(" "),
         String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn promotion_options(to_worktree: &str) -> AgentTaskPromotionOptions {
+    AgentTaskPromotionOptions {
+        source: "{}".to_string(),
+        source_run_id: None,
+        source_path: None,
+        source_worktree_path: None,
+        base_ref: None,
+        task_base_sha: None,
+        to_worktree: to_worktree.to_string(),
+        task_id: None,
+        artifact_id: None,
+        dry_run: false,
+        gates: VerifyGateOptions::default(),
+        provider_command: None,
+        provider_invocation: None,
+    }
+}
+
+#[test]
+fn configured_command_provider_constructs_native_promotion_adapter_with_provenance() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    git(workspace.path(), &["init", "-b", "cook-target"]);
+    let provider = tempfile::NamedTempFile::new().expect("provider command");
+    std::fs::write(
+        provider.path(),
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' '{}'\n",
+            serde_json::json!({
+                "worktrees": [{
+                    "handle": "fixture@cook-target",
+                    "path": workspace.path(),
+                    "branch": "cook-target",
+                    "safety": { "dirty": false, "unpushed": false, "primary": false }
+                }]
+            })
+        ),
+    )
+    .expect("write provider command");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(provider.path())
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(provider.path(), permissions).expect("make provider executable");
+    }
+    let mut config = HomeboyConfig::default();
+    config.worktree_providers.insert(
+        "fixture".to_string(),
+        WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: true,
+            commands: WorktreeProviderCommands {
+                resolve: Some(vec![
+                    provider.path().display().to_string(),
+                    "{handle}".to_string(),
+                ]),
+                ..Default::default()
+            },
+            list_result_mapping: Some(WorktreeProviderListResultMapping {
+                items: "$.worktrees".to_string(),
+                handle: "$.handle".to_string(),
+                path: "$.path".to_string(),
+                branch: "$.branch".to_string(),
+                dirty: "$.safety.dirty".to_string(),
+                unpushed: "$.safety.unpushed".to_string(),
+                primary: "$.safety.primary".to_string(),
+            }),
+        },
+    );
+
+    let provider = ExternalPromotionWorkspaceProvider::from_options_with_config_and_environment(
+        &promotion_options("fixture@cook-target"),
+        &config,
+        Some(PathBuf::from("/fixture/homeboy")),
+        None,
+    )
+    .expect("configured provider resolves");
+
+    assert_eq!(
+        provider.invocation().expect("invocation").argv,
+        vec![
+            "/fixture/homeboy".to_string(),
+            "agent-task".to_string(),
+            "promotion-provider".to_string(),
+            "--workspace".to_string(),
+            workspace.path().display().to_string(),
+        ]
+    );
+    assert_eq!(provider.provenance().expect("provenance")["id"], "fixture");
+    assert_eq!(
+        provider.provenance().expect("provenance")["handle"],
+        "fixture@cook-target"
+    );
+}
+
+#[test]
+fn lookup_only_configured_provider_cannot_construct_a_promotion_adapter() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    git(workspace.path(), &["init", "-b", "cook-target"]);
+    let provider = tempfile::NamedTempFile::new().expect("provider command");
+    std::fs::write(
+        provider.path(),
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' '{}'\n",
+            serde_json::json!({
+                "worktrees": [{
+                    "handle": "fixture@cook-target",
+                    "path": workspace.path(),
+                    "branch": "cook-target",
+                    "safety": { "dirty": false, "unpushed": false, "primary": false }
+                }]
+            })
+        ),
+    )
+    .expect("write provider command");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(provider.path())
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(provider.path(), permissions).expect("make provider executable");
+    }
+    let mut config = HomeboyConfig::default();
+    config.worktree_providers.insert(
+        "fixture".to_string(),
+        WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: false,
+            commands: WorktreeProviderCommands {
+                resolve: Some(vec![
+                    provider.path().display().to_string(),
+                    "{handle}".to_string(),
+                ]),
+                ..Default::default()
+            },
+            list_result_mapping: Some(WorktreeProviderListResultMapping {
+                items: "$.worktrees".to_string(),
+                handle: "$.handle".to_string(),
+                path: "$.path".to_string(),
+                branch: "$.branch".to_string(),
+                dirty: "$.safety.dirty".to_string(),
+                unpushed: "$.safety.unpushed".to_string(),
+                primary: "$.safety.primary".to_string(),
+            }),
+        },
+    );
+
+    crate::core::worktree_providers::resolve_worktree_provider_from_config(
+        "fixture@cook-target",
+        &config,
+    )
+    .expect("lookup-only provider resolves for non-mutating callers");
+
+    let error = ExternalPromotionWorkspaceProvider::from_options_with_config_and_environment(
+        &promotion_options("fixture@cook-target"),
+        &config,
+        Some(PathBuf::from("/fixture/homeboy")),
+        None,
+    )
+    .err()
+    .expect("lookup-only provider must not authorize promotion");
+
+    assert!(error
+        .message
+        .contains("not apply-enabled provider(s): fixture"));
+}
+
+#[test]
+fn explicit_promotion_provider_sources_precede_configured_resolution() {
+    let mut options = promotion_options("fixture@missing");
+    options.provider_command = Some("command-provider".to_string());
+    options.provider_invocation = Some(CommandInvocation {
+        argv: vec!["argv-provider".to_string()],
+        ..Default::default()
+    });
+
+    let provider = ExternalPromotionWorkspaceProvider::from_options_with_config_and_environment(
+        &options,
+        &HomeboyConfig::default(),
+        Some(PathBuf::from("/fixture/homeboy")),
+        Some("environment-provider".to_string()),
+    )
+    .expect("explicit argv does not resolve configured providers");
+
+    assert_eq!(
+        provider.invocation().expect("invocation").argv,
+        vec!["argv-provider".to_string()]
+    );
+
+    options.provider_invocation = None;
+    let provider = ExternalPromotionWorkspaceProvider::from_options_with_config_and_environment(
+        &options,
+        &HomeboyConfig::default(),
+        Some(PathBuf::from("/fixture/homeboy")),
+        Some("environment-provider".to_string()),
+    )
+    .expect("explicit command does not resolve configured providers");
+    assert_eq!(
+        provider.invocation().expect("invocation").argv,
+        vec!["command-provider".to_string()]
+    );
+
+    options.provider_command = None;
+    let provider = ExternalPromotionWorkspaceProvider::from_options_with_config_and_environment(
+        &options,
+        &HomeboyConfig::default(),
+        Some(PathBuf::from("/fixture/homeboy")),
+        Some("environment-provider".to_string()),
+    )
+    .expect("environment command does not resolve configured providers");
+    assert_eq!(
+        provider.invocation().expect("invocation").argv,
+        vec!["environment-provider".to_string()]
     );
 }
 
@@ -1011,32 +1237,34 @@ fn promote_applies_normalized_lab_sandbox_patch_with_fake_workspace_provider() {
 }
 
 #[test]
-fn promote_requires_provider_for_apply() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let (source_path, source) = write_patch_source(&temp);
+fn promote_rejects_unresolved_configured_provider_for_apply() {
+    crate::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (source_path, source) = write_patch_source(&temp);
 
-    let err = promote(AgentTaskPromotionOptions {
-        source,
-        source_run_id: None,
-        source_path: Some(source_path),
-        source_worktree_path: None,
-        base_ref: None,
-        task_base_sha: None,
-        to_worktree: "repo@controlled-worktree".to_string(),
-        task_id: None,
-        artifact_id: None,
-        dry_run: false,
-        gates: VerifyGateOptions {
-            verify: Vec::new(),
-            private_verify: Vec::new(),
-            private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
-        },
-        provider_command: None,
-        provider_invocation: None,
-    })
-    .expect_err("missing provider rejected");
+        let err = promote(AgentTaskPromotionOptions {
+            source,
+            source_run_id: None,
+            source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            to_worktree: "repo@controlled-worktree".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: Vec::new(),
+                private_verify: Vec::new(),
+                private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+            },
+            provider_command: None,
+            provider_invocation: None,
+        })
+        .expect_err("unresolved configured provider rejected");
 
-    assert!(err.message.contains("workspace provider command"));
+        assert!(err.message.contains("configured worktree provider"));
+    });
 }
 
 #[test]

--- a/src/core/worktree_providers.rs
+++ b/src/core/worktree_providers.rs
@@ -84,6 +84,13 @@ pub struct WorktreeProviderHandle {
     pub safety: WorktreeProviderHandleSafety,
 }
 
+/// A provider-managed workspace together with the provider that resolved it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeProviderResolution {
+    pub provider_id: String,
+    pub worktree: WorktreeProviderHandle,
+}
+
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct WorktreeProviderHandleSafety {
     pub dirty: bool,
@@ -94,13 +101,41 @@ pub struct WorktreeProviderHandleSafety {
 /// Resolve an externally managed worktree handle without creating or adopting
 /// a Homeboy record. This is intentionally a lookup-only boundary.
 pub fn resolve_worktree_provider_handle(handle: &str) -> Result<WorktreeProviderHandle> {
-    resolve_worktree_provider_handle_from_config(handle, &defaults::load_config())
+    resolve_worktree_provider(handle).map(|resolution| resolution.worktree)
 }
 
 pub fn resolve_worktree_provider_handle_from_config(
     handle: &str,
     config: &HomeboyConfig,
 ) -> Result<WorktreeProviderHandle> {
+    resolve_worktree_provider_from_config(handle, config).map(|resolution| resolution.worktree)
+}
+
+/// Resolve a provider-managed workspace and retain the selected provider id.
+pub fn resolve_worktree_provider(handle: &str) -> Result<WorktreeProviderResolution> {
+    resolve_worktree_provider_from_config(handle, &defaults::load_config())
+}
+
+pub fn resolve_worktree_provider_from_config(
+    handle: &str,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderResolution> {
+    resolve_worktree_provider_with_policy_from_config(handle, config, false)
+}
+
+/// Resolve a workspace only from providers explicitly authorized for apply operations.
+pub fn resolve_apply_enabled_worktree_provider_from_config(
+    handle: &str,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderResolution> {
+    resolve_worktree_provider_with_policy_from_config(handle, config, true)
+}
+
+fn resolve_worktree_provider_with_policy_from_config(
+    handle: &str,
+    config: &HomeboyConfig,
+    require_apply_enabled: bool,
+) -> Result<WorktreeProviderResolution> {
     let mut provider_ids = config
         .worktree_providers
         .keys()
@@ -108,10 +143,15 @@ pub fn resolve_worktree_provider_handle_from_config(
         .collect::<Vec<_>>();
     provider_ids.sort();
     let mut attempted = Vec::new();
+    let mut not_apply_enabled = Vec::new();
 
-    for provider_id in provider_ids {
+    for provider_id in provider_ids.iter().cloned() {
         let provider = &config.worktree_providers[&provider_id];
         if !provider.enabled {
+            continue;
+        }
+        if require_apply_enabled && !provider.apply_enabled {
+            not_apply_enabled.push(provider_id);
             continue;
         }
         if let Some(command) = provider.commands.resolve.as_ref() {
@@ -119,7 +159,10 @@ pub fn resolve_worktree_provider_handle_from_config(
             let worktrees = run_provider_resolve_command(&provider_id, provider, command, handle)?;
             if let Some(worktree) = worktrees.into_iter().find(|item| item.handle == handle) {
                 validate_provider_handle(&provider_id, &worktree)?;
-                return Ok(worktree);
+                return Ok(WorktreeProviderResolution {
+                    provider_id,
+                    worktree,
+                });
             }
             continue;
         }
@@ -130,14 +173,33 @@ pub fn resolve_worktree_provider_handle_from_config(
         let worktrees = run_provider_list_command(&provider_id, provider, command)?;
         if let Some(worktree) = worktrees.into_iter().find(|item| item.handle == handle) {
             validate_provider_handle(&provider_id, &worktree)?;
-            return Ok(worktree);
+            return Ok(WorktreeProviderResolution {
+                provider_id,
+                worktree,
+            });
         }
     }
 
-    let configured = if attempted.is_empty() {
-        "no enabled worktree provider has commands.list configured".to_string()
+    let configured = if provider_ids.is_empty() {
+        "no worktree providers are configured".to_string()
     } else {
-        format!("checked provider(s): {}", attempted.join(", "))
+        format!(
+            "configured provider(s): {}; checked provider(s): {}{}",
+            provider_ids.join(", "),
+            if attempted.is_empty() {
+                "none with an enabled resolve or list command".to_string()
+            } else {
+                attempted.join(", ")
+            },
+            if not_apply_enabled.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "; not apply-enabled provider(s): {}",
+                    not_apply_enabled.join(", ")
+                )
+            },
+        )
     };
     Err(Error::validation_invalid_argument(
         "to_worktree",
@@ -147,7 +209,11 @@ pub fn resolve_worktree_provider_handle_from_config(
         Some(handle.to_string()),
         Some(vec![
             "Create the destination through its workspace provider, or use an existing Homeboy task worktree handle.".to_string(),
-            "Configure an enabled worktree provider commands.list command that returns typed worktree path, branch, and safety metadata.".to_string(),
+            if require_apply_enabled {
+                "Configure an enabled, apply-enabled worktree provider commands.list command that returns typed worktree path, branch, and safety metadata.".to_string()
+            } else {
+                "Configure an enabled worktree provider commands.list command that returns typed worktree path, branch, and safety metadata.".to_string()
+            },
         ]),
     ))
 }
@@ -1049,6 +1115,60 @@ mod tests {
 
         assert_eq!(handle.path, workspace.path().display().to_string());
         assert_eq!(handle.branch, "cook-target");
+    }
+
+    #[test]
+    fn resolution_retains_the_selected_provider_identity() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path(), "cook-target");
+        let script = fake_list_provider_script(serde_json::json!({
+            "worktrees": [{
+                "handle": "fixture@cook-target",
+                "path": workspace.path(),
+                "branch": "cook-target",
+                "safety": { "dirty": false, "unpushed": false, "primary": false }
+            }]
+        }));
+
+        let resolution = resolve_worktree_provider_from_config(
+            "fixture@cook-target",
+            &config_with_provider(list_provider(script, worktrees_mapping())),
+        )
+        .expect("provider handle resolves");
+
+        assert_eq!(resolution.provider_id, "fixture");
+        assert_eq!(
+            resolution.worktree.path,
+            workspace.path().display().to_string()
+        );
+    }
+
+    #[test]
+    fn unresolved_handle_reports_sorted_configured_provider_ids() {
+        let mut config = HomeboyConfig::default();
+        for provider_id in ["zeta", "alpha"] {
+            config.worktree_providers.insert(
+                provider_id.to_string(),
+                WorktreeProviderConfig {
+                    enabled: false,
+                    kind: WorktreeProviderKind::Command,
+                    apply_enabled: false,
+                    commands: WorktreeProviderCommands::default(),
+                    list_result_mapping: None,
+                },
+            );
+        }
+
+        let error = resolve_worktree_provider_from_config("fixture@missing", &config)
+            .expect_err("missing handle fails");
+
+        assert!(
+            error
+                .message
+                .contains("configured provider(s): alpha, zeta"),
+            "{}",
+            error.message
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `homeboy-8196-independent-review` into review-ready branch `fix/cook-configured-promotion-provider-pr`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:homeboy-8196-independent-review`
- **Homeboy run ID:** `homeboy-8196-independent-review`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `fix/cook-configured-promotion-provider-pr`

## Source refs
- https://github.com/Extra-Chill/homeboy/issues/8196
- https://github.com/Automattic/agents-api/issues/426

## Attempt summary
Addressed independent review: configured fallback resolves only when apply is required; empty promotions remain no-op; selected provider provenance survives adapter failures.

## Gate results
- promotion-tests: passed (targeted)
- worktree-provider-tests: passed (targeted)
- typed-adapter: passed (targeted)
- format: passed (targeted)

## Verification capability
- `targeted_checks_run`: `cargo test --lib agent_task_promotion::tests`, `cargo test --lib worktree_providers::tests`, `cargo test --test agent_task_promotion_provider`, `cargo fmt --all -- --check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: `GitHub Actions repository test suite`
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- src/core/agent_task_promotion/apply.rs
- src/core/agent_task_promotion/promote.rs
- src/core/agent_task_promotion/tests.rs
- src/core/worktree_providers.rs

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `fix/cook-configured-promotion-provider-pr`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Implemented, reviewed, and tested configured worktree-provider promotion fallback; Chris reviews and owns the change.
