### PR TITLE
test: align stale assertions with current service/bench/daemon contracts

### DIFF
--- a/src/commands/bench/tests/run_list_tests.rs
+++ b/src/commands/bench/tests/run_list_tests.rs
@@ -196,7 +196,10 @@ fn run_list_preserves_registered_component_path() {
             BenchOutput::List(result) => {
                 assert_eq!(result.component, "studio");
                 assert_eq!(result.component_id, "studio");
-                assert_eq!(result.count, 2);
+                // The plain (non-rig) fixture lists its in-tree scenarios
+                // `in-tree slow visual` (the `visual` scenario was added with
+                // its artifact fixture in #7992).
+                assert_eq!(result.count, 3);
                 assert_eq!(result.scenarios[0].id, "in-tree");
             }
             _ => panic!("expected list output"),

--- a/src/core/agent_task_service/tests.rs
+++ b/src/core/agent_task_service/tests.rs
@@ -203,9 +203,23 @@ fn service_materializes_component_worktree_before_provider_dispatch() {
             worktree::CleanupPolicy::PreserveOnFailure
         );
         assert_eq!(observed.workspace.mode, AgentTaskWorkspaceMode::Existing);
-        assert_eq!(
-            observed.workspace.root.as_deref(),
-            Some(record.worktree_path.as_str())
+        // Provider dispatch runs in an isolated per-attempt detached worktree
+        // derived from the managed component worktree, so a timed-out provider
+        // cannot contaminate a later rotation (#8092). The managed worktree
+        // stays the preflight source of truth (its metadata is preserved
+        // below), but the provider must NOT be pointed straight at it.
+        let observed_root = observed
+            .workspace
+            .root
+            .as_deref()
+            .expect("provider received a workspace root");
+        assert_ne!(
+            observed_root, record.worktree_path,
+            "provider must run in an isolated attempt worktree, not the managed worktree"
+        );
+        assert!(
+            observed_root.contains("homeboy-agent-task-attempts"),
+            "attempt worktree should live under the agent-task attempts scratch root, got {observed_root}"
         );
         assert_eq!(observed.workspace.slug.as_deref(), Some("fixture"));
         assert!(observed.workspace.kind.is_none());

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -396,14 +396,17 @@ fn test_pid_is_running_rejects_impossible_pid_and_drives_status() {
     let status = read_status().expect("status");
     assert!(!status.running);
     assert!(!status.fresh);
+    // A state file that exists but omits the required `lease_id` is now
+    // classified as a corrupt lease (missing field), reported through the
+    // structured code with a descriptive parse reason — not a missing lease.
     assert!(status
         .stale_reason
         .as_deref()
         .unwrap_or_default()
-        .contains("no schema or lease identity"));
+        .contains("invalid daemon lease"));
     assert_eq!(
         status.freshness.stale_reason_code,
-        Some(DaemonStaleReasonCode::LeaseMissing)
+        Some(DaemonStaleReasonCode::LeaseCorrupt)
     );
 }
 
@@ -458,16 +461,19 @@ fn status_treats_dead_known_legacy_lease_as_missing_metadata_for_recovery() {
 
     let status = read_status().expect("status");
 
-    assert_eq!(
-        status.freshness.stale_reason_code,
-        Some(DaemonStaleReasonCode::LeaseMissing)
-    );
-    assert!(status.state.is_none());
-    assert!(status.freshness.lease_id.is_none());
+    // A legacy state that predates the lease schema lacks the required
+    // `lease_id`, so it is now surfaced as a corrupt lease (missing field)
+    // with a descriptive parse reason rather than the old "no schema" text.
     assert!(status
         .stale_reason
         .as_deref()
-        .is_some_and(|reason| reason.contains("no schema")));
+        .is_some_and(|reason| reason.contains("invalid daemon lease")));
+    assert_eq!(
+        status.freshness.stale_reason_code,
+        Some(DaemonStaleReasonCode::LeaseCorrupt)
+    );
+    assert!(status.state.is_none());
+    assert!(status.freshness.lease_id.is_none());
     assert!(path.exists());
 }
 


### PR DESCRIPTION
## Summary

Three more deterministic Test-gate reds on `main`, each a **stale assertion** that no longer matches the current (intentional) behavior from a recent PR. (Follow-up to #8179/#8184.)

### 1. `agent_task_service` — isolated attempt worktree (#8092)

#8092 gave each provider dispatch a detached per-attempt worktree derived from the managed component worktree, so a timed-out provider cannot contaminate a later rotation. `service_materializes_component_worktree_before_provider_dispatch` still asserted the provider sees the managed `worktree_path` directly. Updated to assert the isolation contract: the observed provider workspace root is a **distinct** attempt worktree under the agent-task attempts scratch root, while the managed worktree metadata (slug, materialization id, mode, cleanup, on-disk persistence) is still verified.

### 2. `bench` — added `visual` scenario (#7992)

#7992 added a `visual` scenario (plus its artifact fixture) to the plain bench fixture's in-tree set (`in-tree slow visual`). `run_list_preserves_registered_component_path` still expected a count of 2 for a plain (non-rig) registered-component list. Updated to 3. (Rig-mode list tests are unaffected — they derive scenarios from rig workloads.)

### 3. `daemon` — lease-corrupt classification

A state file that exists but omits the required `lease_id` is now classified as a **corrupt** lease — structured code `LeaseCorrupt` with a descriptive "invalid daemon lease: missing field `lease_id`" reason — rather than `LeaseMissing` / "no schema or lease identity" free text. Updated `test_pid_is_running_rejects_impossible_pid_and_drives_status` and `status_treats_dead_known_legacy_lease_as_missing_metadata_for_recovery`.

## Verification

- `core::agent_task_service` — 19 pass.
- `commands::bench::tests::run_list_tests` — 9 pass.
- The two daemon tests pass; daemon test target compiles clean.

## Remaining red-main (deeper, separate)

- `lease_writer_rejects_a_missing_lease_id` — hangs ~21s (network/daemon call, not a stale assertion).
- `changed_since_retry_route_materializes_private_unavailable_origin_from_bundle` — fixture's source repo has no resolvable `HEAD` at preflight.
- trace-variant `rig check` rejection; `runner_workload` `test`↔`trace` canonicalization (incomplete #7972); observation-store concurrency; remaining runner clusters.