### PR TITLE
Preserve lazy cook promotion and provider failure evidence

### DIFF
--- a/src/core/agent_task_promotion/apply.rs
+++ b/src/core/agent_task_promotion/apply.rs
@@ -232,10 +232,16 @@ pub(crate) trait AgentTaskPromotionWorkspaceProvider {
 pub(crate) struct ExternalPromotionWorkspaceProvider {
     invocation: Option<CommandInvocation>,
     provenance: Option<serde_json::Value>,
+    configured_fallback: Option<ConfiguredPromotionWorkspaceProvider>,
+}
+
+struct ConfiguredPromotionWorkspaceProvider {
+    config: crate::core::defaults::HomeboyConfig,
+    executable: Option<PathBuf>,
 }
 
 impl ExternalPromotionWorkspaceProvider {
-    pub(crate) fn from_options(options: &AgentTaskPromotionOptions) -> Result<Self> {
+    pub(crate) fn from_options(options: &AgentTaskPromotionOptions) -> Self {
         let config = crate::core::defaults::load_config();
         Self::from_options_with_config_and_environment(
             options,
@@ -250,57 +256,37 @@ impl ExternalPromotionWorkspaceProvider {
         config: &crate::core::defaults::HomeboyConfig,
         executable: Option<PathBuf>,
         promotion_command: Option<String>,
-    ) -> Result<Self> {
+    ) -> Self {
         if let Some(invocation) = options.provider_invocation.clone() {
-            return Ok(Self {
+            return Self {
                 invocation: Some(invocation),
                 provenance: None,
-            });
+                configured_fallback: None,
+            };
         }
         if let Some(command) = options.provider_command.clone().or(promotion_command) {
             eprintln!(
                 "Warning: agent-task promotion provider string command is deprecated; use argv-capable provider invocation instead"
             );
-            return Ok(Self {
+            return Self {
                 invocation: Some(CommandInvocation {
                     argv: command.split_whitespace().map(str::to_string).collect(),
                     display: Some(command),
                     ..Default::default()
                 }),
                 provenance: None,
-            });
+                configured_fallback: None,
+            };
         }
 
-        let resolution = worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
-            &options.to_worktree,
-            config,
-        )?;
-        let executable = executable.map(Ok).unwrap_or_else(|| {
-            std::env::current_exe().map_err(|error| {
-                Error::internal_io(
-                    error.to_string(),
-                    Some("resolve current Homeboy executable for promotion provider".to_string()),
-                )
-            })
-        })?;
-        let workspace = resolution.worktree.path;
-        Ok(Self {
-            invocation: Some(CommandInvocation {
-                argv: vec![
-                    executable.display().to_string(),
-                    "agent-task".to_string(),
-                    "promotion-provider".to_string(),
-                    "--workspace".to_string(),
-                    workspace.clone(),
-                ],
-                ..Default::default()
+        Self {
+            invocation: None,
+            provenance: None,
+            configured_fallback: Some(ConfiguredPromotionWorkspaceProvider {
+                config: config.clone(),
+                executable,
             }),
-            provenance: Some(serde_json::json!({
-                "id": resolution.provider_id,
-                "handle": resolution.worktree.handle,
-                "path": workspace,
-            })),
-        })
+        }
     }
 
     pub(crate) fn provenance(&self) -> Option<&serde_json::Value> {
@@ -309,6 +295,66 @@ impl ExternalPromotionWorkspaceProvider {
 
     pub(super) fn invocation(&self) -> Option<&CommandInvocation> {
         self.invocation.as_ref()
+    }
+
+    fn resolve_configured_fallback(&mut self, to_workspace: &str) -> Result<()> {
+        let configured_fallback = self.configured_fallback.as_ref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "promotion_provider",
+                format!(
+                    "agent-task promotion requires a workspace provider command; pass --provider-command or set {PROMOTION_PROVIDER_COMMAND_ENV}"
+                ),
+                None,
+                None,
+            )
+        })?;
+        let resolution = worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
+            to_workspace,
+            &configured_fallback.config,
+        )?;
+        let executable = configured_fallback
+            .executable
+            .clone()
+            .map(Ok)
+            .unwrap_or_else(|| {
+                std::env::current_exe().map_err(|error| {
+                    Error::internal_io(
+                        error.to_string(),
+                        Some(
+                            "resolve current Homeboy executable for promotion provider".to_string(),
+                        ),
+                    )
+                })
+            })?;
+        let workspace = resolution.worktree.path;
+        self.invocation = Some(CommandInvocation {
+            argv: vec![
+                executable.display().to_string(),
+                "agent-task".to_string(),
+                "promotion-provider".to_string(),
+                "--workspace".to_string(),
+                workspace.clone(),
+            ],
+            ..Default::default()
+        });
+        self.provenance = Some(serde_json::json!({
+            "id": resolution.provider_id,
+            "handle": resolution.worktree.handle,
+            "path": workspace,
+        }));
+        Ok(())
+    }
+
+    fn with_configured_provider_provenance(&self, mut error: Error) -> Error {
+        if let Some(provenance) = self.provenance() {
+            if !error.details.is_object() {
+                error.details = serde_json::json!({});
+            }
+            if let Some(details) = error.details.as_object_mut() {
+                details.insert("worktree_provider".to_string(), provenance.clone());
+            }
+        }
+        error
     }
 }
 
@@ -323,6 +369,9 @@ impl AgentTaskPromotionWorkspaceProvider for ExternalPromotionWorkspaceProvider 
         &mut self,
         request: AgentTaskPromotionApplyRequest,
     ) -> Result<AgentTaskPromotionWorkspace> {
+        if self.invocation.is_none() {
+            self.resolve_configured_fallback(&request.to_workspace)?;
+        }
         let invocation = self.invocation.as_ref().ok_or_else(|| {
             Error::validation_invalid_argument(
                 "promotion_provider",
@@ -334,6 +383,7 @@ impl AgentTaskPromotionWorkspaceProvider for ExternalPromotionWorkspaceProvider 
             )
         })?;
         run_provider_command(invocation, &request)
+            .map_err(|error| self.with_configured_provider_provenance(error))
     }
 
     fn verify(

--- a/src/core/agent_task_promotion/promote.rs
+++ b/src/core/agent_task_promotion/promote.rs
@@ -29,7 +29,7 @@ use super::types::{
 };
 
 pub fn promote(options: AgentTaskPromotionOptions) -> Result<AgentTaskPromotionReport> {
-    let mut provider = ExternalPromotionWorkspaceProvider::from_options(&options)?;
+    let mut provider = ExternalPromotionWorkspaceProvider::from_options(&options);
     let mut report = promote_with_provider(options, &mut provider)?;
     if let Some(provenance) = provider.provenance() {
         report.provenance["worktree_provider"] = provenance.clone();

--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -197,7 +197,7 @@ fn promotion_options(to_worktree: &str) -> AgentTaskPromotionOptions {
 }
 
 #[test]
-fn configured_command_provider_constructs_native_promotion_adapter_with_provenance() {
+fn configured_command_provider_is_resolved_lazily_with_provenance() {
     let workspace = tempfile::tempdir().expect("workspace");
     git(workspace.path(), &["init", "-b", "cook-target"]);
     let provider = tempfile::NamedTempFile::new().expect("provider command");
@@ -256,8 +256,21 @@ fn configured_command_provider_constructs_native_promotion_adapter_with_provenan
         &config,
         Some(PathBuf::from("/fixture/homeboy")),
         None,
-    )
-    .expect("configured provider resolves");
+    );
+    let mut provider = provider;
+    assert!(provider.invocation().is_none());
+    assert!(provider.provenance().is_none());
+
+    let error = provider
+        .apply_patch(AgentTaskPromotionApplyRequest {
+            schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
+            to_workspace: "fixture@cook-target".to_string(),
+            patch: Some(VALID_PATCH.to_string()),
+            patch_path: "changes.patch".to_string(),
+            changed_files: vec!["src/lib.rs".to_string()],
+            dry_run: false,
+        })
+        .expect_err("fixture executable is not an adapter");
 
     assert_eq!(
         provider.invocation().expect("invocation").argv,
@@ -270,9 +283,14 @@ fn configured_command_provider_constructs_native_promotion_adapter_with_provenan
         ]
     );
     assert_eq!(provider.provenance().expect("provenance")["id"], "fixture");
+    assert_eq!(error.details["worktree_provider"]["id"], "fixture");
     assert_eq!(
-        provider.provenance().expect("provenance")["handle"],
+        error.details["worktree_provider"]["handle"],
         "fixture@cook-target"
+    );
+    assert_eq!(
+        error.details["worktree_provider"]["path"],
+        workspace.path().display().to_string()
     );
 }
 
@@ -342,9 +360,18 @@ fn lookup_only_configured_provider_cannot_construct_a_promotion_adapter() {
         &config,
         Some(PathBuf::from("/fixture/homeboy")),
         None,
-    )
-    .err()
-    .expect("lookup-only provider must not authorize promotion");
+    );
+    let mut error = error;
+    let error = error
+        .apply_patch(AgentTaskPromotionApplyRequest {
+            schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
+            to_workspace: "fixture@cook-target".to_string(),
+            patch: Some(VALID_PATCH.to_string()),
+            patch_path: "changes.patch".to_string(),
+            changed_files: vec!["src/lib.rs".to_string()],
+            dry_run: false,
+        })
+        .expect_err("lookup-only provider must not authorize promotion");
 
     assert!(error
         .message
@@ -365,8 +392,7 @@ fn explicit_promotion_provider_sources_precede_configured_resolution() {
         &HomeboyConfig::default(),
         Some(PathBuf::from("/fixture/homeboy")),
         Some("environment-provider".to_string()),
-    )
-    .expect("explicit argv does not resolve configured providers");
+    );
 
     assert_eq!(
         provider.invocation().expect("invocation").argv,
@@ -379,8 +405,7 @@ fn explicit_promotion_provider_sources_precede_configured_resolution() {
         &HomeboyConfig::default(),
         Some(PathBuf::from("/fixture/homeboy")),
         Some("environment-provider".to_string()),
-    )
-    .expect("explicit command does not resolve configured providers");
+    );
     assert_eq!(
         provider.invocation().expect("invocation").argv,
         vec!["command-provider".to_string()]
@@ -392,8 +417,7 @@ fn explicit_promotion_provider_sources_precede_configured_resolution() {
         &HomeboyConfig::default(),
         Some(PathBuf::from("/fixture/homeboy")),
         Some("environment-provider".to_string()),
-    )
-    .expect("environment command does not resolve configured providers");
+    );
     assert_eq!(
         provider.invocation().expect("invocation").argv,
         vec!["environment-provider".to_string()]
@@ -482,48 +506,48 @@ fn validate_patch_rejects_empty_patch() {
 
 #[test]
 fn promote_reports_no_changes_for_empty_patch_metadata() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let patch_path = temp.path().join("patch.diff");
-    std::fs::write(&patch_path, "").expect("write empty patch");
-    let source_path = temp.path().join("outcome.json");
-    let outcome = AgentTaskOutcome {
-        schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
-        task_id: "task-1".to_string(),
-        status: AgentTaskOutcomeStatus::Succeeded,
-        summary: None,
-        failure_classification: None,
-        artifacts: vec![AgentTaskArtifact {
-            schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-            id: "patch".to_string(),
-            kind: "patch".to_string(),
-            name: Some("patch.diff".to_string()),
-            label: None,
-            role: None,
-            semantic_key: None,
-            path: Some("patch.diff".to_string()),
-            url: None,
-            mime: Some("text/x-patch".to_string()),
-            size_bytes: Some(0),
-            sha256: Some(
-                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_string(),
-            ),
-            metadata: serde_json::json!({ "role": "patch" }),
-        }],
-        typed_artifacts: Vec::new(),
-        evidence_refs: Vec::new(),
-        diagnostics: Vec::new(),
-        outputs: Value::Null,
-        workflow: None,
-        follow_up: None,
-        metadata: Value::Null,
-    };
-    let source = serde_json::to_string(&outcome).expect("serialize outcome");
-    std::fs::write(&source_path, &source).expect("write source");
+    crate::test_support::with_isolated_home(|_| {
+        let prior_promotion_command = std::env::var_os("HOMEBOY_AGENT_TASK_PROMOTION_COMMAND");
+        std::env::remove_var("HOMEBOY_AGENT_TASK_PROMOTION_COMMAND");
+        let temp = tempfile::tempdir().expect("tempdir");
+        let patch_path = temp.path().join("patch.diff");
+        std::fs::write(&patch_path, "").expect("write empty patch");
+        let source_path = temp.path().join("outcome.json");
+        let outcome = AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: "task-1".to_string(),
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: None,
+            failure_classification: None,
+            artifacts: vec![AgentTaskArtifact {
+                schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                id: "patch".to_string(),
+                kind: "patch".to_string(),
+                name: Some("patch.diff".to_string()),
+                label: None,
+                role: None,
+                semantic_key: None,
+                path: Some("patch.diff".to_string()),
+                url: None,
+                mime: Some("text/x-patch".to_string()),
+                size_bytes: Some(0),
+                sha256: Some(
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_string(),
+                ),
+                metadata: serde_json::json!({ "role": "patch" }),
+            }],
+            typed_artifacts: Vec::new(),
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            outputs: Value::Null,
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        };
+        let source = serde_json::to_string(&outcome).expect("serialize outcome");
+        std::fs::write(&source_path, &source).expect("write source");
 
-    let mut provider = FakePromotionWorkspaceProvider::default();
-
-    let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        let report = promote(AgentTaskPromotionOptions {
             source,
             source_run_id: Some("run-empty".to_string()),
             source_path: Some(source_path),
@@ -541,15 +565,16 @@ fn promote_reports_no_changes_for_empty_patch_metadata() {
             },
             provider_command: None,
             provider_invocation: None,
-        },
-        &mut provider,
-    )
-    .expect("empty patch reports no changes");
+        })
+        .expect("empty patch reports no changes");
 
-    assert_eq!(report.status, AgentTaskPromotionStatus::NoChanges);
-    assert!(report.changed_files.is_empty());
-    assert!(provider.apply_calls.is_empty());
-    assert!(provider.verify_calls.is_empty());
+        assert_eq!(report.status, AgentTaskPromotionStatus::NoChanges);
+        assert!(report.changed_files.is_empty());
+        match prior_promotion_command {
+            Some(command) => std::env::set_var("HOMEBOY_AGENT_TASK_PROMOTION_COMMAND", command),
+            None => std::env::remove_var("HOMEBOY_AGENT_TASK_PROMOTION_COMMAND"),
+        }
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `homeboy-8196-independent-review` into review-ready branch `fix/cook-configured-promotion-provider-followup`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:homeboy-8196-independent-review`
- **Homeboy run ID:** `homeboy-8196-independent-review`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `fix/cook-configured-promotion-provider-followup`

## Source refs
- https://github.com/Extra-Chill/homeboy/issues/8196
- https://github.com/Extra-Chill/homeboy/pull/8204
- https://github.com/Automattic/agents-api/issues/426

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** none recorded
- **Supersedes:** https://github.com/Extra-Chill/homeboy/pull/8208
- **Depends on:** none recorded

## Attempt summary
Follow-up to merged #8204: configured fallback resolves only when apply is required; empty promotions remain no-op; selected provider provenance survives adapter failures.

## Gate results
- promotion-tests: passed (targeted)
- worktree-provider-tests: passed (targeted)
- typed-adapter: passed (targeted)
- format: passed (targeted)

## Verification capability
- `targeted_checks_run`: `cargo test --lib agent_task_promotion::tests`, `cargo test --lib worktree_providers::tests`, `cargo test --test agent_task_promotion_provider`, `cargo fmt --all -- --check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: `GitHub Actions repository test suite`
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- src/core/agent_task_promotion/apply.rs
- src/core/agent_task_promotion/promote.rs
- src/core/agent_task_promotion/tests.rs

## Artifact refs
- none recorded

## Sibling PR relationship
- Review sibling generated PRs for the same finding before merging; superseded runtime fixes should be narrowed or closed after safer evidence/test-only coverage lands.

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `fix/cook-configured-promotion-provider-followup`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Reviewed and corrected lazy provider resolution and failure evidence after #8204; Chris reviews and owns the change.
