### PR TITLE
Add coherent release-set deploy preflight

### DIFF
--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -3,7 +3,7 @@
 ## Synopsis
 
 ```sh
-homeboy deploy [<project_id>|<component_id>] [<component_ids...>] [-p|--project <id>] [-c|--component <id>]... [--all] [--outdated|--behind-upstream] [--head|--ref <git-ref-or-sha>] [--check] [--dry-run] [--apply] [--json '<spec>']
+homeboy deploy [<project_id>|<component_id>] [<component_ids...>] [-p|--project <id>] [-c|--component <id>]... [--all] [--outdated|--behind-upstream] [--head|--ref <git-ref-or-sha>] [--release-set <path>] [--check] [--dry-run] [--apply] [--json '<spec>']
 # If no component IDs are provided, you must use --all, --outdated, --behind-upstream, or --check.
 
 # Multi-project deployment
@@ -335,3 +335,6 @@ Extension hooks run first, then component hooks. All `post:deploy` hooks are non
 - [component](component.md)
 - [fleet](fleet.md)
 - [hooks](../architecture/hooks.md)
+## Release Sets
+
+`homeboy deploy --project <project> --release-set <path> --dry-run` validates a caller-supplied `homeboy/release-set/v1` manifest before deployment planning. The proof checks registered component membership, clean Git sources, and the same exact-ref resolver used by deploy. Red preflight performs no release or deploy action. See `docs/reference/release-set-manifest.md` for the generic contract and sample.

--- a/docs/reference/release-set-manifest.md
+++ b/docs/reference/release-set-manifest.md
@@ -1,0 +1,17 @@
+# Release Set Manifest
+
+A release set is a caller-supplied, product-agnostic source-membership contract. It is versioned by `schema` and has a deterministic SHA-256 identity after components are sorted by ID.
+
+```json
+{
+  "schema": "homeboy/release-set/v1",
+  "components": [
+    { "id": "component-a", "ref": "0123456789012345678901234567890123456789" },
+    { "id": "component-b", "ref": "0123456789012345678901234567890123456789", "required": false }
+  ]
+}
+```
+
+`id` and `ref` are required. `required` defaults to `true`. IDs must be unique. Missing required components fail preflight; unavailable optional components are omitted from deployment. Consumers can compare the normalized set with observations and receive deterministic `missing`, `unexpected`, and `mismatched` lists.
+
+`homeboy deploy --project <project> --release-set <path> --dry-run` performs the same registry lookup, clean-Git-checkout, and exact-ref resolution that deployment uses. A failed proof prevents lifecycle creation, builds, transfers, and remote deployment. This first deploy vertical requires every component to share one exact ref; broader multi-ref orchestration is intentionally not implied by the generic contract.

--- a/docs/samples/release-set.json
+++ b/docs/samples/release-set.json
@@ -1,0 +1,14 @@
+{
+  "schema": "homeboy/release-set/v1",
+  "components": [
+    {
+      "id": "component-a",
+      "ref": "0123456789012345678901234567890123456789"
+    },
+    {
+      "id": "component-b",
+      "ref": "0123456789012345678901234567890123456789",
+      "required": false
+    }
+  ]
+}

--- a/src/command_contract/registry.rs
+++ b/src/command_contract/registry.rs
@@ -35,6 +35,14 @@ impl ContractRegistryEntry {
 
 pub const CONTRACT_REGISTRY: &[ContractRegistryEntry] = &[
     ContractRegistryEntry {
+        schema_id: crate::core::release_set::RELEASE_SET_SCHEMA,
+        name: "release-set",
+        title: "Release set manifest",
+        owner: "homeboy-core",
+        summary: "Caller-supplied, product-agnostic required or optional component membership and immutable source references.",
+        rust_type: "homeboy::core::release_set::ReleaseSetManifest",
+    },
+    ContractRegistryEntry {
         schema_id: crate::core::lifecycle::LIFECYCLE_CONTRACT_SCHEMA,
         name: "lifecycle-contract",
         title: "Loop lifecycle contract",

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -81,6 +81,9 @@ pub struct DeployArgs {
     /// Deploy from current branch HEAD instead of the latest tag
     #[arg(long)]
     pub head: bool,
+    /// Validate this versioned release-set manifest before any deploy action
+    #[arg(long, value_name = "PATH")]
+    pub release_set: Option<String>,
     /// Deploy an exact Git ref resolved from the declared component repository
     #[arg(
         long = "ref",
@@ -109,6 +112,8 @@ pub struct DeployOutput {
     pub force: bool,
     pub results: Vec<ComponentDeployResult>,
     pub summary: DeploySummary,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release_set_identity: Option<String>,
     #[serde(
         rename = "_homeboy_actionable",
         skip_serializing_if = "Option::is_none"
@@ -126,6 +131,8 @@ pub struct MultiProjectDeployOutput {
     pub dry_run: bool,
     pub check: bool,
     pub force: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release_set_identity: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deploy_run_id: Option<String>,
     #[serde(
@@ -146,13 +153,17 @@ pub fn run(
     mut args: DeployArgs,
     _global: &crate::commands::GlobalArgs,
 ) -> CmdResult<DeployCommandOutput> {
+    let release_set = args.release_set.as_deref().map(load_release_set).transpose()?;
+    if let Some(release_set) = release_set.as_ref() {
+        apply_release_set(release_set, &mut args)?;
+    }
     validate_apply_boundary(&args)?;
 
     // Fleet deploy
     if let Some(ref fleet_id) = args.fleet {
         let fl = homeboy::core::fleet::load(fleet_id)?;
         let (component_ids, config) = resolve_multi_args(&args)?;
-        return run_multi_output(&fl.project_ids, &component_ids, &config, &args);
+        return run_multi_output(&fl.project_ids, &component_ids, &config, &args, release_set.as_ref());
     }
 
     // Shared component deploy (find all projects using the component)
@@ -162,13 +173,13 @@ pub fn run(
         args.component_ids = component_ids;
         args.target_id = None;
         let (component_ids, config) = resolve_multi_args(&args)?;
-        return run_multi_output(&project_ids, &component_ids, &config, &args);
+        return run_multi_output(&project_ids, &component_ids, &config, &args, release_set.as_ref());
     }
 
     // Multi-project deploy
     if let Some(ref project_ids) = args.projects {
         let (component_ids, config) = resolve_multi_args(&args)?;
-        return run_multi_output(project_ids, &component_ids, &config, &args);
+        return run_multi_output(project_ids, &component_ids, &config, &args, release_set.as_ref());
     }
 
     // Single-project deploy: resolve project and component IDs
@@ -214,6 +225,7 @@ pub fn run(
             force: args.force,
             results: result.results,
             summary: result.summary,
+            release_set_identity: release_set.map(|value| value.identity.clone()),
             actionable: Some(deploy_actionable(&project_id)),
         }),
         exit_code,
@@ -251,6 +263,103 @@ fn validate_apply_boundary(args: &DeployArgs) -> homeboy::core::Result<()> {
     ))
 }
 
+fn load_release_set(path: &str) -> homeboy::core::Result<homeboy::core::release_set::NormalizedReleaseSet> {
+    let input = std::fs::read_to_string(path).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "release_set",
+            format!("Cannot read release-set manifest '{path}': {error}"),
+            None,
+            None,
+        )
+    })?;
+    homeboy::core::release_set::ReleaseSetManifest::parse_json(&input).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument("release_set", error, None, None)
+    })
+}
+
+/// Prove every declared component resolves to its caller-supplied exact ref
+/// before handing control to deploy orchestration. This is intentionally before
+/// lifecycle creation, builds, transfers, or remote actions.
+fn apply_release_set(
+    release_set: &homeboy::core::release_set::NormalizedReleaseSet,
+    args: &mut DeployArgs,
+) -> homeboy::core::Result<()> {
+    let mut active = Vec::new();
+    for entry in &release_set.components {
+        match homeboy::core::component::load(&entry.id) {
+            Ok(component) => active.push((entry, component)),
+            Err(_) if !entry.required => continue,
+            Err(error) => {
+                return Err(homeboy::core::Error::validation_invalid_argument(
+                    "release_set",
+                    format!("Required component '{}' is unavailable: {}", entry.id, error.message),
+                    None,
+                    None,
+                ));
+            }
+        }
+    }
+    if active.is_empty() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "release_set",
+            "Release set has no available components to deploy",
+            None,
+            None,
+        ));
+    }
+    let refs = active
+        .iter()
+        .map(|(entry, _)| entry.requested_ref.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    if refs.len() != 1 {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "release_set",
+            "This deploy vertical requires one exact ref shared by every release-set component",
+            None,
+            None,
+        ));
+    }
+    let requested_ref = refs.into_iter().next().expect("non-empty release set");
+    if let Some(ref supplied) = args.requested_ref {
+        if supplied != requested_ref {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "ref",
+                "--ref must match the release-set component ref",
+                None,
+                None,
+            ));
+        }
+    }
+    for (entry, component) in &active {
+        let root = homeboy::core::git::get_git_root(&component.local_path).map_err(|_| {
+            homeboy::core::Error::validation_invalid_argument(
+                "release_set",
+                format!("Component '{}' source is not a Git checkout", entry.id),
+                None,
+                None,
+            )
+        })?;
+        let status = homeboy::core::git::run_git(
+            std::path::Path::new(&root),
+            &["status", "--porcelain"],
+            "validate release-set source cleanliness",
+        )?;
+        if !status.trim().is_empty() {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "release_set",
+                format!("Component '{}' source checkout is dirty", entry.id),
+                None,
+                None,
+            ));
+        }
+        homeboy::core::deploy::preflight_exact_ref(component, &entry.requested_ref)?;
+    }
+    args.component = Some(active.iter().map(|(entry, _)| entry.id.clone()).collect());
+    args.component_ids.clear();
+    args.requested_ref = Some(requested_ref.to_string());
+    Ok(())
+}
+
 fn resolve_shared_component_ids(args: &DeployArgs) -> homeboy::core::Result<Vec<String>> {
     if let Some(ref comps) = args.component {
         Ok(comps.clone())
@@ -281,7 +390,8 @@ fn resolve_single_deploy_target(args: &DeployArgs) -> homeboy::core::Result<(Str
                 || args.outdated
                 || args.behind_upstream
                 || args.check
-                || args.json.is_some();
+                || args.json.is_some()
+                || args.release_set.is_some();
             if comps.is_empty() && !has_selector_flag {
                 return Err(homeboy::core::Error::validation_invalid_argument(
                     "input",
@@ -385,6 +495,7 @@ fn run_multi_output(
     component_ids: &[String],
     config: &DeployConfig,
     args: &DeployArgs,
+    release_set: Option<&homeboy::core::release_set::NormalizedReleaseSet>,
 ) -> CmdResult<DeployCommandOutput> {
     let result = deploy::run_multi(project_ids, component_ids, config)?;
     let exit_code = if result.summary.failed > 0 { 1 } else { 0 };
@@ -400,6 +511,7 @@ fn run_multi_output(
             dry_run: args.dry_run,
             check: args.check,
             force: args.force,
+            release_set_identity: release_set.map(|value| value.identity.clone()),
             deploy_run_id: result.deploy_run_id,
             actionable: Some(actionable),
         }),

--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -32,6 +32,16 @@ pub use types::{
 pub use version_overrides::fetch_remote_versions;
 pub use version_overrides::{RemoteVersionProbeFailure, RemoteVersionProbeResult};
 
+/// Resolve an exact component source reference for a caller-owned preflight.
+/// The resolver is shared with deploy materialization so acceptance criteria do
+/// not diverge between a release-set proof and the eventual deploy action.
+pub(crate) fn preflight_exact_ref(
+    component: &component::Component,
+    requested_ref: &str,
+) -> Result<String> {
+    Ok(orchestration_ref_checkout::resolve_exact_ref(component, requested_ref)?.resolved_sha)
+}
+
 use crate::core::component;
 use crate::core::context::resolve_project_ssh_with_base_path;
 use crate::core::error::{Error, Result};

--- a/src/core/deploy/orchestration_ref_checkout.rs
+++ b/src/core/deploy/orchestration_ref_checkout.rs
@@ -9,7 +9,7 @@ use crate::core::git;
 const REMOTE_REF_QUERY_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct ExactRefIdentity {
+pub(crate) struct ExactRefIdentity {
     pub requested_ref: String,
     pub resolved_sha: String,
     pub source: String,
@@ -23,7 +23,7 @@ pub(super) struct ExactRefCheckout {
     worktree_path: PathBuf,
 }
 
-pub(super) fn resolve_exact_ref(
+pub(crate) fn resolve_exact_ref(
     component: &Component,
     requested_ref: &str,
 ) -> Result<ExactRefIdentity> {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -139,6 +139,7 @@ pub mod quality;
 pub use homeboy_redaction as redaction;
 pub mod refactor;
 pub mod release;
+pub mod release_set;
 pub mod report_compare;
 pub(crate) mod report_compare_render;
 pub mod resource_cleanup_intent;

--- a/src/core/release_set.rs
+++ b/src/core/release_set.rs
@@ -1,0 +1,254 @@
+//! Generic, caller-supplied release-set contract and preflight result.
+//!
+//! This module deliberately describes only membership and immutable source
+//! identity. Product-specific release and deployment policy remains with callers.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const RELEASE_SET_SCHEMA: &str = "homeboy/release-set/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReleaseSetManifest {
+    pub schema: String,
+    pub components: Vec<ReleaseSetComponent>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReleaseSetComponent {
+    pub id: String,
+    #[serde(rename = "ref")]
+    pub requested_ref: String,
+    #[serde(default = "required_by_default")]
+    pub required: bool,
+}
+
+fn required_by_default() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct NormalizedReleaseSet {
+    pub schema: String,
+    pub identity: String,
+    pub components: Vec<ReleaseSetComponent>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ReleaseSetObservation {
+    pub id: String,
+    pub resolved_ref: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ReleaseSetComparison {
+    pub identity: String,
+    pub missing: Vec<String>,
+    pub unexpected: Vec<String>,
+    pub mismatched: Vec<ReleaseSetMismatch>,
+    pub matched: Vec<String>,
+    pub ready: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ReleaseSetMismatch {
+    pub id: String,
+    pub expected_ref: String,
+    pub observed_ref: String,
+}
+
+impl ReleaseSetManifest {
+    pub fn parse_json(input: &str) -> Result<NormalizedReleaseSet, String> {
+        let manifest: Self = serde_json::from_str(input).map_err(|error| error.to_string())?;
+        manifest.normalize()
+    }
+
+    pub fn normalize(self) -> Result<NormalizedReleaseSet, String> {
+        if self.schema != RELEASE_SET_SCHEMA {
+            return Err(format!("release set schema must be {RELEASE_SET_SCHEMA}"));
+        }
+        if self.components.is_empty() {
+            return Err("release set must declare at least one component".to_string());
+        }
+        let mut ids = BTreeSet::new();
+        for component in &self.components {
+            if component.id.trim().is_empty() || component.requested_ref.trim().is_empty() {
+                return Err("release set component id and ref must not be empty".to_string());
+            }
+            if !ids.insert(component.id.clone()) {
+                return Err(format!(
+                    "release set contains duplicate component id '{}'",
+                    component.id
+                ));
+            }
+        }
+        let mut components = self.components;
+        components.sort_by(|left, right| left.id.cmp(&right.id));
+        let canonical = serde_json::to_vec(&(RELEASE_SET_SCHEMA, &components))
+            .map_err(|error| error.to_string())?;
+        let identity = format!("sha256:{:x}", Sha256::digest(canonical));
+        Ok(NormalizedReleaseSet {
+            schema: RELEASE_SET_SCHEMA.to_string(),
+            identity,
+            components,
+        })
+    }
+}
+
+impl NormalizedReleaseSet {
+    pub fn compare(&self, observations: &[ReleaseSetObservation]) -> ReleaseSetComparison {
+        let expected = self
+            .components
+            .iter()
+            .map(|component| (component.id.as_str(), component))
+            .collect::<BTreeMap<_, _>>();
+        let observed = observations
+            .iter()
+            .map(|component| (component.id.as_str(), component))
+            .collect::<BTreeMap<_, _>>();
+        let missing: Vec<String> = self
+            .components
+            .iter()
+            .filter(|component| component.required && !observed.contains_key(component.id.as_str()))
+            .map(|component| component.id.clone())
+            .collect();
+        let unexpected: Vec<String> = observed
+            .keys()
+            .filter(|id| !expected.contains_key(**id))
+            .map(|id| (*id).to_string())
+            .collect();
+        let mismatched: Vec<ReleaseSetMismatch> = self
+            .components
+            .iter()
+            .filter_map(|component| {
+                let observed = observed.get(component.id.as_str())?;
+                (component.requested_ref != observed.resolved_ref).then(|| ReleaseSetMismatch {
+                    id: component.id.clone(),
+                    expected_ref: component.requested_ref.clone(),
+                    observed_ref: observed.resolved_ref.clone(),
+                })
+            })
+            .collect::<Vec<_>>();
+        let matched: Vec<String> = self
+            .components
+            .iter()
+            .filter(|component| {
+                observed
+                    .get(component.id.as_str())
+                    .is_some_and(|value| value.resolved_ref == component.requested_ref)
+            })
+            .map(|component| component.id.clone())
+            .collect();
+        let ready = missing.is_empty() && unexpected.is_empty() && mismatched.is_empty();
+        ReleaseSetComparison {
+            identity: self.identity.clone(),
+            missing,
+            unexpected,
+            mismatched,
+            matched,
+            ready,
+        }
+    }
+
+    /// Runs all validation before invoking a mutation closure. A red comparison
+    /// never calls `mutate`, which makes the boundary directly testable by callers.
+    pub fn mutate_if_ready<T>(
+        &self,
+        observations: &[ReleaseSetObservation],
+        mutate: impl FnOnce() -> T,
+    ) -> Result<T, ReleaseSetComparison> {
+        let comparison = self.compare(observations);
+        if comparison.ready {
+            Ok(mutate())
+        } else {
+            Err(comparison)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest(components: serde_json::Value) -> String {
+        serde_json::json!({ "schema": RELEASE_SET_SCHEMA, "components": components }).to_string()
+    }
+
+    #[test]
+    // 1. Duplicate IDs are rejected.
+    fn rejects_duplicate_component_ids() {
+        let error = ReleaseSetManifest::parse_json(&manifest(serde_json::json!([
+            {"id":"a", "ref":"one"}, {"id":"a", "ref":"two"}
+        ])))
+        .expect_err("duplicate ids must fail");
+        assert!(error.contains("duplicate"));
+    }
+
+    #[test]
+    // 2. Identity is independent of caller component ordering.
+    fn identity_is_stable_across_component_order() {
+        let first = ReleaseSetManifest::parse_json(&manifest(serde_json::json!([
+            {"id":"b", "ref":"two"}, {"id":"a", "ref":"one"}
+        ])))
+        .expect("first manifest");
+        let second = ReleaseSetManifest::parse_json(&manifest(serde_json::json!([
+            {"id":"a", "ref":"one"}, {"id":"b", "ref":"two"}
+        ])))
+        .expect("second manifest");
+        assert_eq!(first.identity, second.identity);
+    }
+
+    #[test]
+    fn identity_changes_when_membership_policy_changes() {
+        let required = ReleaseSetManifest::parse_json(&manifest(serde_json::json!([
+            {"id":"a", "ref":"one"}
+        ])))
+        .expect("required manifest");
+        let optional = ReleaseSetManifest::parse_json(&manifest(serde_json::json!([
+            {"id":"a", "ref":"one", "required":false}
+        ])))
+        .expect("optional manifest");
+
+        assert_ne!(required.identity, optional.identity);
+    }
+
+    #[test]
+    // 3. Comparison reports every red observation class deterministically.
+    fn reports_missing_unexpected_and_mismatched_observations() {
+        let set = ReleaseSetManifest::parse_json(&manifest(serde_json::json!([
+            {"id":"required", "ref":"one"}, {"id":"optional", "ref":"two", "required":false},
+            {"id":"wrong", "ref":"three"}
+        ])))
+        .expect("manifest");
+        let report = set.compare(&[
+            ReleaseSetObservation {
+                id: "wrong".into(),
+                resolved_ref: "other".into(),
+            },
+            ReleaseSetObservation {
+                id: "extra".into(),
+                resolved_ref: "four".into(),
+            },
+        ]);
+        assert_eq!(report.missing, ["required"]);
+        assert!(!report.missing.contains(&"optional".to_string()));
+        assert_eq!(report.unexpected, ["extra"]);
+        assert_eq!(report.mismatched[0].id, "wrong");
+        assert!(!report.ready);
+    }
+
+    #[test]
+    // 4. A red preflight cannot cross the mutation boundary.
+    fn red_preflight_performs_zero_mutations() {
+        let set = ReleaseSetManifest::parse_json(&manifest(serde_json::json!([
+            {"id":"a", "ref":"one"}
+        ])))
+        .expect("manifest");
+        let mut mutations = 0;
+        let result = set.mutate_if_ready(&[], || mutations += 1);
+        assert!(result.is_err());
+        assert_eq!(mutations, 0);
+    }
+}

--- a/tests/commands/deploy_test.rs
+++ b/tests/commands/deploy_test.rs
@@ -102,6 +102,25 @@ fn deploy_parser_accepts_exact_ref() {
 }
 
 #[test]
+fn deploy_parser_accepts_release_set_manifest() {
+    let cli = Cli::try_parse_from([
+        "homeboy",
+        "deploy",
+        "--project",
+        "project-a",
+        "--release-set",
+        "release-set.json",
+        "--dry-run",
+    ])
+    .expect("--release-set should parse");
+
+    let Commands::Deploy(args) = cli.command else {
+        panic!("expected deploy command");
+    };
+    assert_eq!(args.release_set.as_deref(), Some("release-set.json"));
+}
+
+#[test]
 fn deploy_resume_run_id_propagates_to_multi_target_config() {
     let cli = Cli::try_parse_from([
         "homeboy",
@@ -313,6 +332,7 @@ fn deploy_args(mut customize: impl FnMut(&mut DeployArgs)) -> DeployArgs {
         allow_stale_source: false,
         allow_downgrade: false,
         head: false,
+        release_set: None,
         requested_ref: None,
         tagged: false,
         resume: None,


### PR DESCRIPTION
## Summary
Add the first generic coherent release-set vertical to Homeboy deploy.

## What changed
- Adds a versioned caller-supplied manifest with deterministic identity and required/optional component membership.
- Preflights all available components through clean Git and the existing exact-ref resolver before deploy orchestration can mutate.
- Reports the release-set identity in deploy output and exposes reusable expected-versus-observed comparison types.

## How to test
1. Run `cargo fmt --check`; expect passes.
2. Run `cargo test release_set`; expect 6 focused contract/parser tests pass.
3. Run `cargo test exact_ref_dry_run`; expect exact-ref dry-run remains mutation-free.

## Compatibility
Existing deploy behavior is unchanged without --release-set. The first mutation vertical requires one shared exact ref across all available release-set components; generic multi-ref atomic deployment remains follow-up scope.

## Evidence
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8177
- exact-ref-dry-run: Passed
- format: Passed
- release-set-tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy + OpenCode
- **Model:** openai/gpt-5.6-terra; openai/gpt-5.6-sol
- **Used for:** GPT-5.6 Terra drafted the candidate; GPT-5.6 Sol reviewed architecture, corrected optional membership semantics, verified, and finalized with Chris.

## Source relationships
- Relates to #8177
