### PR TITLE
fix: repair trace-variant rig fixture, store migration count, and Lab runtime-path preflight

### DIFF
--- a/src/commands/trace/test_fixture.rs
+++ b/src/commands/trace/test_fixture.rs
@@ -430,12 +430,9 @@ pub(super) fn write_trace_rig_with_variant(
 "#,
     )
     .expect("write variant overlay");
-    let rig_dir = home.path().join(".config").join("homeboy").join("rigs");
-    fs::create_dir_all(&rig_dir).expect("mkdir rigs");
-    fs::write(
-        rig_dir.join(format!("{}.json", rig_id)),
-        format!(
-            r#"{{
+
+    let rig_spec = format!(
+        r#"{{
                     "components": {{
                         "{component_id}": {{ "path": "{}" }}
                     }},
@@ -449,8 +446,18 @@ pub(super) fn write_trace_rig_with_variant(
                         }}
                     }}
                 }}"#,
-            path.display()
-        ),
-    )
-    .expect("write rig");
+        path.display()
+    );
+
+    // The rig-source metadata above declares `package_path` as the rig source,
+    // so `rig check`'s package-lint validates the package contents. It must
+    // therefore contain a `rig.json` (the contract entrypoint) or the
+    // "specs satisfy the Homeboy rig contract" step fails with "No rig specs
+    // found". Write the spec into the package as well as the installed
+    // registry.
+    fs::write(package_path.join("rig.json"), &rig_spec).expect("write package rig.json");
+
+    let rig_dir = home.path().join(".config").join("homeboy").join("rigs");
+    fs::create_dir_all(&rig_dir).expect("mkdir rigs");
+    fs::write(rig_dir.join(format!("{}.json", rig_id)), &rig_spec).expect("write rig");
 }

--- a/src/core/runner/lab_args/provider_config.rs
+++ b/src/core/runner/lab_args/provider_config.rs
@@ -412,7 +412,9 @@ fn is_materializable_provider_config_path_key(
     }) || matches!(
         key,
         "workspace_root" | "source" | "source_cli" | "provider_root" | "provider_support" | "path"
-    )
+    ) || location
+        .trim_start_matches("$.")
+        .starts_with("runtime_component_paths.")
 }
 
 fn is_provider_plugin_path_location(location: &str) -> bool {

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -175,7 +175,7 @@ mod store_init_tests {
             for handle in handles {
                 let status = handle.join().expect("worker joined");
                 assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-                assert_eq!(status.migration_count, 6);
+                assert_eq!(status.migration_count, 8);
             }
         });
     }


### PR DESCRIPTION
## Summary

Three more `main` Test-gate reds. Two are stale test fixtures/expectations; the third is a real production preflight gap.

### 1. Trace variant rig fixture (fixture)

`write_trace_rig_with_variant` declares rig-source metadata pointing at `package_path`, so `rig check`'s package-lint validates the package contents — but the fixture only wrote a `rig.json` into the installed registry, leaving the package with just an `overlays/` dir. The "rig package specs satisfy the Homeboy rig contract" step then failed with "No rig specs found", so both trace-variant tests hit `rig '<id>' check failed`. Write the rig spec into `package_path/rig.json` too.

Fixes `trace_run_resolves_named_variants_and_reports_unknown_names`, `trace_compare_variant_resolves_named_variants`.

### 2. Store concurrent-init migration count (fixture)

`initialization_is_safe_under_concurrent_setup` still asserted `migration_count == 6` while the sibling init test (and `CURRENT_SCHEMA_VERSION`) expect 8 after new migrations landed. Bump to 8; the concurrency behavior is unchanged.

### 3. Lab provider-config runtime-path preflight (**production fix**)

`preflight_provider_config_paths_materialized_in_args` validates that provider-config keys whose values are controller paths are materialized before Lab dispatch. `runtime_component_paths` (a map of component → absolute controller path) is documented as one of those controller paths, but its **nested values were never treated as materializable** — so a provider config pointing `runtime_component_paths` at a missing/unsynced path passed preflight and only failed later on the runner. Recognize `runtime_component_paths.*` locations so their path values are checked before dispatch.

Fixes `provider_config_materialization_preflight_rejects_missing_runtime_path` (and closes a real "fails on the runner instead of preflight" gap).

## Verification

- `commands::trace::tests` — 18 pass.
- `core::observation::store::store_init_tests` — 9 pass.
- `core::runner::lab_args` — 73 pass.