### PR TITLE
Close promotion provider scripts before execution

### DIFF
--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -225,6 +225,7 @@ fn configured_command_provider_is_resolved_lazily_with_provenance() {
         permissions.set_mode(0o755);
         std::fs::set_permissions(provider.path(), permissions).expect("make provider executable");
     }
+    let provider_path = provider.into_temp_path();
     let mut config = HomeboyConfig::default();
     config.worktree_providers.insert(
         "fixture".to_string(),
@@ -234,7 +235,7 @@ fn configured_command_provider_is_resolved_lazily_with_provenance() {
             apply_enabled: true,
             commands: WorktreeProviderCommands {
                 resolve: Some(vec![
-                    provider.path().display().to_string(),
+                    provider_path.display().to_string(),
                     "{handle}".to_string(),
                 ]),
                 ..Default::default()
@@ -323,6 +324,7 @@ fn lookup_only_configured_provider_cannot_construct_a_promotion_adapter() {
         permissions.set_mode(0o755);
         std::fs::set_permissions(provider.path(), permissions).expect("make provider executable");
     }
+    let provider_path = provider.into_temp_path();
     let mut config = HomeboyConfig::default();
     config.worktree_providers.insert(
         "fixture".to_string(),
@@ -332,7 +334,7 @@ fn lookup_only_configured_provider_cannot_construct_a_promotion_adapter() {
             apply_enabled: false,
             commands: WorktreeProviderCommands {
                 resolve: Some(vec![
-                    provider.path().display().to_string(),
+                    provider_path.display().to_string(),
                     "{handle}".to_string(),
                 ]),
                 ..Default::default()


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `homeboy-8196-independent-review` into review-ready branch `fix/promotion-provider-test-etxtbsy`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:homeboy-8196-independent-review`
- **Homeboy run ID:** `homeboy-8196-independent-review`
- **Manual proof:** none recorded by this Homeboy finalization
- **Stable evidence:** see artifact refs below

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `fix/promotion-provider-test-etxtbsy`

## Source refs
- https://github.com/Extra-Chill/homeboy/issues/8196
- https://github.com/Extra-Chill/homeboy/pull/8211

## Attempt summary
Fix Linux ETXTBSY in the configured-provider tests by consuming each NamedTempFile into a TempPath before executing it.

## Gate results
- promotion-tests: passed (targeted)
- format: passed (targeted)

## Verification capability
- `targeted_checks_run`: `cargo test --lib agent_task_promotion::tests`, `cargo fmt --all -- --check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: `homeboy / Audit`, `homeboy / Lint`, `homeboy / Test differential gate`
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- src/core/agent_task_promotion/tests.rs

## Artifact refs
- https://github.com/Extra-Chill/homeboy/actions/runs/29379640914

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `fix/promotion-provider-test-etxtbsy`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Linux ETXTBSY differential failure and implemented the test portability fix; Chris reviews and owns the change.
