### PR TITLE
test: align stale-daemon refresh_command with version-pinned refresh step

### DIFF
--- a/src/core/runner/lab/offload/tests/capability_metadata.rs
+++ b/src/core/runner/lab/offload/tests/capability_metadata.rs
@@ -928,15 +928,19 @@ fn runner_homeboy_metadata_carries_stale_daemon_details() {
         metadata["stale_daemon"]["job_command_binary_build_identity"],
         "homeboy 0.229.11+new"
     );
+    // The stale-daemon refresh command now leads with a version-pinned
+    // `refresh-homeboy --ref v<current> --reconnect` step before the
+    // disconnect/connect fallback (matching the connection.rs contract).
+    let expected_refresh = format!(
+        "homeboy runner refresh-homeboy lab --ref v{} --reconnect && homeboy runner disconnect lab && homeboy runner connect lab",
+        env!("CARGO_PKG_VERSION")
+    );
     assert_eq!(
         metadata["stale_daemon"]["refresh_command"],
-        "homeboy runner disconnect lab && homeboy runner connect lab"
+        expected_refresh
     );
     assert_eq!(metadata["stale_daemon_severity"], "warning");
-    assert_eq!(
-        metadata["stale_daemon_refresh_command"],
-        "homeboy runner disconnect lab && homeboy runner connect lab"
-    );
+    assert_eq!(metadata["stale_daemon_refresh_command"], expected_refresh);
     assert_eq!(metadata["job_command_binary_version"], "homeboy 0.229.11");
     assert_eq!(
         metadata["job_command_binary_build_identity"],


### PR DESCRIPTION
## Summary

One more `main` Test-gate red. The stale-daemon `refresh_command` metadata now leads with a version-pinned `homeboy runner refresh-homeboy <runner> --ref v<current> --reconnect` step before the disconnect/connect fallback. The `connection.rs` contract test already asserts this (via `env!("CARGO_PKG_VERSION")`), but `runner_homeboy_metadata_carries_stale_daemon_details` in `lab/offload/tests/capability_metadata.rs` still expected the old plain `disconnect && connect` command and failed deterministically.

Match the test to the version-pinned command, following the established `CARGO_PKG_VERSION` pattern so it stays release-agnostic.

## Verification

- `core::runner::lab::offload::tests::capability_metadata` — 27 pass.

## Remaining red-main (hangs + one design question — separate)

The remaining failures are **not** stale-assertion tweaks and need more careful work:
- **Hanging tests** (no timeout on network/broker/daemon connections): `execution::tests::handoff::*`, `execution::tests::exec::test_exec_rejects_disconnected_ssh_runner_without_diagnostic_fallback`, `lab::agent_task_bridge::ensure_agent_task_dispatch_run_id_injects_id_before_dispatch_options`, `daemon::lease_writer_rejects_a_missing_lease_id`. These need connection mocking / bounded timeouts.
- **`runner_workload` `test`↔`trace` canonicalization** (#7972 left it incomplete): `runner_workload_validation_rejects_dispatch_drift` (wants same-family `test`/`trace` to validate) directly contradicts `runner_workload_validation_rejects_command_label_drift` (wants it to fail). Reconciling them is a design decision for the author.
- **`changed_since_retry_route_materializes_private_unavailable_origin_from_bundle`**: fixture's partial-clone source has no resolvable `HEAD` at preflight.