### PR TITLE
test: repair stale runner exec/handoff/dispatch assertions

### DIFF
--- a/src/core/runner/execution/tests/exec.rs
+++ b/src/core/runner/execution/tests/exec.rs
@@ -916,8 +916,12 @@ fn test_exec_rejects_disconnected_ssh_runner_without_diagnostic_fallback() {
         )
         .expect("create server");
 
+        // Configure an explicit remote homeboy_path so the extension-parity
+        // preflight (which now refuses a bare `homeboy` on a remote runner) is
+        // satisfied and the test reaches the daemon-connection rejection it is
+        // actually exercising.
         super::super::super::create(
-            r#"{"id":"lab-server","kind":"ssh","server_id":"lab-server","workspace_root":"/srv/homeboy"}"#,
+            r#"{"id":"lab-server","kind":"ssh","server_id":"lab-server","workspace_root":"/srv/homeboy","homeboy_path":"/usr/local/bin/homeboy"}"#,
             false,
         )
         .expect("create ssh runner");

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -1119,7 +1119,15 @@ fn terminal_lab_result_transport_error_preserves_recovery_ids() {
     assert!(hints
         .iter()
         .any(|hint| hint.contains(&format!("homeboy runner job logs lab {job_id}"))));
-    assert!(err.message.contains("--placement local"));
+    // The remote job succeeded; this is a transport/reporting failure, so the
+    // guidance steers toward recovering persisted evidence rather than forcing
+    // a local rerun (no `--placement local` remediation).
+    assert!(err
+        .message
+        .contains("Lab transport/reporting failure, not a remote command failure"));
+    assert!(hints
+        .iter()
+        .any(|hint| hint.contains("instead of forcing local execution")));
 }
 
 #[test]

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -1361,14 +1361,15 @@ mod tests {
         let (out, run_id) = ensure_agent_task_dispatch_run_id(&args).expect("agent task args");
 
         assert!(run_id.starts_with("agent-task-"));
+        // `--run-id` is injected right after the `agent-task <action>` prefix,
+        // ahead of the dispatch options.
         assert_eq!(out[0], "homeboy");
         assert_eq!(out[1], "agent-task");
-        assert_eq!(out[2], "agent-task");
-        assert_eq!(out[3], "cook");
-        assert_eq!(out[4], "--run-id");
-        assert_eq!(out[5], run_id);
-        assert_eq!(out[6], "--repo");
-        assert_eq!(out[7], "homeboy");
+        assert_eq!(out[2], "cook");
+        assert_eq!(out[3], "--run-id");
+        assert_eq!(out[4], run_id);
+        assert_eq!(out[5], "--repo");
+        assert_eq!(out[6], "homeboy");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three more deterministic runner-test reds on `main`. (These were previously mislabeled as "hangs" — the SSH-backed ones simply take the bounded `ConnectTimeout=10s` when probing an unreachable fixture host; they do not hang.)

### 1. `test_exec_rejects_disconnected_ssh_runner_without_diagnostic_fallback`

A new extension-parity preflight now refuses a bare `homeboy` on a remote runner **before** the daemon-connection check. The fixture SSH runner set no `homeboy_path`, so it tripped the parity preflight with a different message than the test asserts. Configure an explicit `homeboy_path` so the test reaches (and asserts) the daemon-connection rejection it targets.

### 2. `ensure_agent_task_dispatch_run_id_injects_id_before_dispatch_options`

The expected argv had a **duplicated `agent-task`** entry (off-by-one). The function correctly injects `--run-id` right after `agent-task cook` — `[homeboy, agent-task, cook, --run-id, <id>, --repo, homeboy]`. Aligned the expected indices.

### 3. `terminal_lab_result_transport_error_preserves_recovery_ids`

A Lab transport/reporting failure (the remote job **succeeded** but its result report was unparseable) now steers toward recovering persisted evidence rather than forcing a local rerun, so the error message no longer contains `--placement local`. Assert the current transport-failure message and the evidence-recovery guidance ("instead of forcing local execution") the code actually emits.

## Verification

- All three pass (`core::runner::execution::tests::exec`, `handoff::terminal_lab_result_*`, `lab::agent_task_bridge`).

## Remaining red-main (genuine deep test-infra — separate)

- `reverse_broker_exec_submits_job_and_polls_result` / `reverse_broker_exec_detached_surfaces_persisted_run_id`: the in-test mock broker (`daemon::serve_listener` on an ephemeral loopback port) returns "error sending request" to the exec's `POST /runner/jobs` — a mock-server/startup-race issue in the broker test harness, not a stale assertion.
- `daemon::lease_writer_rejects_a_missing_lease_id`: ~21s slow (a real network attempt without a bound).
- `runner_workload` `test`↔`trace` canonicalization (contradictory tests from an incomplete #7972) — a design decision.