### PR TITLE
Make PID-less daemon orphan recovery exact and observable

### DIFF
--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -13,7 +13,7 @@ homeboy daemon <COMMAND>
 - `start` — start the local daemon in the background
 - `serve` — run the daemon in the foreground
 - `stop` — stop the background daemon recorded in the state file
-- `status` — show daemon state and selected local address
+- `status` — show daemon state, active-job recovery evidence, and selected local address
 - `broker-config` — render a deployable reverse-runner broker service recipe
 
 ## Local HTTP API
@@ -24,6 +24,37 @@ address and PID to the daemon state file so headless clients can discover it via
 
 Always treat the API as a local UI contract. It is not a hosted or remote
 multi-user service.
+
+## Dead-Lease Recovery
+
+When `status` reports a dead lease, `active_job_recovery_evidence` lists each
+active job's exact ID, lease, timestamps, terminal evidence, child identity,
+and `linked_durable_run_id` plus `linked_durable_run_state` (`terminal`,
+`active`, or `unresolved`). Active and unresolved linked runs are reported as
+blocking evidence. Status is read-only: it never reconciles or changes durable
+jobs.
+
+For an exact PID-dead lease, confirm every reported PID-less blocker after
+independently proving its child is gone:
+
+```sh
+homeboy daemon adopt-orphan --lease-id <dead-lease> --confirm-pid-dead \
+  --confirm-untracked-child-dead <job-id> \
+  --confirm-untracked-child-dead <job-id>
+```
+
+Each confirmation must name one unresolved active job owned by that exact lease
+with no recorded child identity. The operation records the
+`operator_confirmed_untracked_child_dead_after_dead_daemon_lease` audit event.
+The complete lease is classified before one persistence write: linked terminal
+runs reconcile authoritatively, while linked active or unresolved runs, live
+children, missing confirmations, and invalid confirmations block mutation.
+It retains the owner lock, lease confirmation, PID revalidation, and live-child
+protections.
+
+`--recover-missing-child-identity` remains as weaker legacy compatibility: it
+applies to every eligible PID-less job on the adopted lease. Prefer exact
+`--confirm-untracked-child-dead <job-id>` confirmations.
 
 ## VPS Reverse Runner Broker
 

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -3,8 +3,9 @@ use serde::Serialize;
 use std::path::PathBuf;
 
 use homeboy::core::daemon::{
-    self, BrokerConfig, BrokerConfigOptions, DaemonLeaselessRecoveryResult, DaemonOrphanAdoptionResult, DaemonStartResult, DaemonStateLossRecoveryResult, DaemonStatus, DaemonStopResult,
-    ServiceIdentity,
+    self, BrokerConfig, BrokerConfigOptions, DaemonLeaselessRecoveryResult,
+    DaemonOrphanAdoptionResult, DaemonStartResult, DaemonStateLossRecoveryResult, DaemonStatus,
+    DaemonStopResult, ServiceIdentity,
 };
 use homeboy::core::http_api::{AnalysisJobRunOutput, AnalysisJobRunner};
 
@@ -168,18 +169,49 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
             DaemonOutput::AdoptOrphan(daemon::adopt_orphaned_lease(&lease_id, confirm_pid_dead, recover_missing_child_identity, &confirm_untracked_child_dead, &addr)?),
             0,
         )),
-        DaemonCommand::ReconcileLeaselessOrphans { confirm_no_daemon_owner, addr } => Ok((
-            DaemonOutput::ReconcileLeaselessOrphans(daemon::reconcile_leaseless_orphans(confirm_no_daemon_owner, &addr)?),
+        DaemonCommand::ReconcileLeaselessOrphans {
+            confirm_no_daemon_owner,
+            addr,
+        } => Ok((
+            DaemonOutput::ReconcileLeaselessOrphans(daemon::reconcile_leaseless_orphans(
+                confirm_no_daemon_owner,
+                &addr,
+            )?),
             0,
         )),
-        DaemonCommand::RecoverMissingLeaseState { lease_id, recorded_pid, recorded_endpoint, confirm_pid_dead, confirm_control_plane_lost, addr } => Ok((
-            DaemonOutput::RecoverMissingLeaseState(daemon::recover_missing_lease_state(&lease_id, recorded_pid, &recorded_endpoint, confirm_pid_dead, confirm_control_plane_lost, &addr)?),
+        DaemonCommand::RecoverMissingLeaseState {
+            lease_id,
+            recorded_pid,
+            recorded_endpoint,
+            confirm_pid_dead,
+            confirm_control_plane_lost,
+            addr,
+        } => Ok((
+            DaemonOutput::RecoverMissingLeaseState(daemon::recover_missing_lease_state(
+                &lease_id,
+                recorded_pid,
+                &recorded_endpoint,
+                confirm_pid_dead,
+                confirm_control_plane_lost,
+                &addr,
+            )?),
             0,
         )),
         DaemonCommand::Serve { addr } => serve(&addr),
-        DaemonCommand::Supervise { addr, startup_token } => {
+        DaemonCommand::Supervise {
+            addr,
+            startup_token,
+        } => {
             daemon::supervise(&addr, &startup_token)?;
-            Ok((DaemonOutput::Serve(DaemonStartResult { pid: std::process::id(), address: addr, state_path: String::new(), lease_id: String::new() }), 0))
+            Ok((
+                DaemonOutput::Serve(DaemonStartResult {
+                    pid: std::process::id(),
+                    address: addr,
+                    state_path: String::new(),
+                    lease_id: String::new(),
+                }),
+                0,
+            ))
         }
         DaemonCommand::Stop => Ok((DaemonOutput::Stop(daemon::stop()?), 0)),
         DaemonCommand::Status => Ok((DaemonOutput::Status(daemon::read_status()?), 0)),

--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -746,8 +746,14 @@ mod tests {
         let confirmed = store.create("runner.exec");
         store.start(confirmed.id).expect("start confirmed job");
         let live_child = store.create("runner.exec");
+        store.start(live_child.id).expect("start live child");
         store
-            .start_with_child_identity(live_child.id, 4242, "live-child".to_string())
+            .append_event(
+                live_child.id,
+                JobEventKind::Progress,
+                None,
+                Some(json!({ "process": { "root_pid": 4242 } })),
+            )
             .expect("record live child");
         let before = std::fs::read(&path).expect("store bytes");
 

--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -11,7 +11,8 @@ pub use remote_runner::{
 pub use store::{JobHandle, JobRunner, JobStore};
 pub use summary::active_runner_job_run_summary;
 pub use types::{
-    ActiveRunnerJobRunSummary, ActiveRunnerJobSummary, DaemonLeaseJobDiagnostics, Job,
+    ActiveRunnerJobRunSummary, ActiveRunnerJobSummary, DaemonActiveJobRecoveryDisposition,
+    DaemonActiveJobRecoveryEvidence, DaemonLeaseJobDiagnostics, DaemonLinkedDurableRunState, Job,
     JobClaimMetadata, JobEvent, JobEventKind, JobStatus, LeaselessOrphanAffectedJob,
     LeaselessOrphanJobDiagnostics, RunnerJobLifecycleOwner, RunnerJobSource,
 };
@@ -24,7 +25,7 @@ mod tests {
     use serde_json::json;
 
     use super::persistence::recovered_terminal_from_result;
-    use super::store::RecoveredTerminalJob;
+    use super::store::{LinkedDurableRunResolution, RecoveredTerminalJob};
     use super::*;
     use crate::core::secret_env_plan::SecretEnvPlan;
     use crate::core::source_snapshot::SourceSnapshot;
@@ -685,6 +686,191 @@ mod tests {
             .expect("explicit legacy recovery");
 
         assert_eq!(store.get(job.id).expect("job").status, JobStatus::Failed);
+    }
+
+    #[test]
+    fn linked_active_or_unresolved_job_blocks_confirmed_recovery_before_persisting() {
+        for linked in [
+            LinkedDurableRunResolution::Active("run-active".to_string()),
+            LinkedDurableRunResolution::Unresolved("run-unresolved".to_string()),
+        ] {
+            let temp = tempfile::tempdir().expect("temp dir");
+            let path = temp.path().join("jobs.json");
+            let store = JobStore::open_without_reconciliation(&path)
+                .expect("store")
+                .with_daemon_lease("lease-dead".to_string());
+            let selected = store.create("runner.exec");
+            store.start(selected.id).expect("start selected");
+            let linked_job = store.create("runner.exec");
+            store
+                .start_with_child_identity(linked_job.id, 4242, "dead-child".to_string())
+                .expect("record child");
+            let before = std::fs::read(&path).expect("store bytes");
+
+            let result = store
+                .reconcile_dead_daemon_lease_jobs_with_confirmed_no_pid_jobs_and_linked_resolver(
+                    "lease-dead",
+                    &[selected.id],
+                    |_| false,
+                    |stored| {
+                        (stored.job.id == linked_job.id)
+                            .then(|| linked.clone())
+                            .unwrap_or(LinkedDurableRunResolution::None)
+                    },
+                );
+
+            match linked {
+                LinkedDurableRunResolution::Active(_) => assert_eq!(
+                    result
+                        .expect("active returns diagnostics")
+                        .protected_job_ids,
+                    vec![linked_job.id]
+                ),
+                LinkedDurableRunResolution::Unresolved(_) => assert!(result
+                    .expect_err("unresolved errors")
+                    .message
+                    .contains("cannot be safely resolved")),
+                _ => unreachable!(),
+            }
+            assert_eq!(std::fs::read(&path).expect("store bytes"), before);
+        }
+    }
+
+    #[test]
+    fn confirmed_pidless_job_with_unselected_live_child_returns_diagnostics_without_persisting() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("jobs.json");
+        let store = JobStore::open_without_reconciliation(&path)
+            .expect("store")
+            .with_daemon_lease("lease-dead".to_string());
+        let confirmed = store.create("runner.exec");
+        store.start(confirmed.id).expect("start confirmed job");
+        let live_child = store.create("runner.exec");
+        store
+            .start_with_child_identity(live_child.id, 4242, "live-child".to_string())
+            .expect("record live child");
+        let before = std::fs::read(&path).expect("store bytes");
+
+        let diagnostics = store
+            .reconcile_dead_daemon_lease_jobs_with_confirmed_no_pid_jobs_and_linked_resolver(
+                "lease-dead",
+                &[confirmed.id],
+                |pid| pid == 4242,
+                |_| LinkedDurableRunResolution::None,
+            )
+            .expect("live child returns protected diagnostics");
+
+        assert_eq!(diagnostics.protected_job_ids, vec![live_child.id]);
+        assert_eq!(std::fs::read(&path).expect("store bytes"), before);
+    }
+
+    #[test]
+    fn status_evidence_reports_linked_active_and_unresolved_as_blocking() {
+        let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
+        let active = store.create("runner.exec");
+        store.start(active.id).expect("start active");
+        let unresolved = store.create("runner.exec");
+        store.start(unresolved.id).expect("start unresolved");
+
+        let evidence = store.active_daemon_job_recovery_evidence_with_linked_durable_run_resolver(
+            Some("lease-dead"),
+            |_| false,
+            |stored| match stored.job.id {
+                id if id == active.id => {
+                    LinkedDurableRunResolution::Active("run-active".to_string())
+                }
+                id if id == unresolved.id => {
+                    LinkedDurableRunResolution::Unresolved("run-unresolved".to_string())
+                }
+                _ => LinkedDurableRunResolution::None,
+            },
+        );
+
+        assert!(evidence
+            .iter()
+            .all(|job| job.disposition == DaemonActiveJobRecoveryDisposition::BlockingAmbiguous));
+        let active_evidence = evidence
+            .iter()
+            .find(|job| job.job_id == active.id)
+            .expect("active evidence");
+        assert_eq!(
+            active_evidence.linked_durable_run_id.as_deref(),
+            Some("run-active")
+        );
+        assert_eq!(
+            active_evidence.linked_durable_run_state,
+            Some(DaemonLinkedDurableRunState::Active)
+        );
+        let unresolved_evidence = evidence
+            .iter()
+            .find(|job| job.job_id == unresolved.id)
+            .expect("unresolved evidence");
+        assert_eq!(
+            unresolved_evidence.linked_durable_run_id.as_deref(),
+            Some("run-unresolved")
+        );
+        assert_eq!(
+            unresolved_evidence.linked_durable_run_state,
+            Some(DaemonLinkedDurableRunState::Unresolved)
+        );
+    }
+
+    #[test]
+    fn confirmed_recovery_fails_closed_for_unresolved_linked_durable_run() {
+        let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
+        let mut request = remote_runner_request("homeboy-lab", None);
+        request.lifecycle = Some(RunnerJobLifecycleMetadata {
+            source: Some("runner-daemon".to_string()),
+            kind: Some("runner.exec".to_string()),
+            durable_run_id: Some("missing-linked-run".to_string()),
+            active_child_count: None,
+            active_cell_count: None,
+        });
+        let job = store
+            .submit_remote_runner_job(request)
+            .expect("queue linked job");
+
+        let error = store
+            .reconcile_dead_daemon_lease_jobs_with_confirmed_no_pid_jobs("lease-dead", &[job.id])
+            .expect_err("unresolved linked run blocks confirmation");
+
+        assert!(error.message.contains("cannot be safely resolved"));
+        assert_eq!(store.get(job.id).expect("job").status, JobStatus::Queued);
+    }
+
+    #[test]
+    fn terminal_linked_run_is_authoritative_for_confirmed_recovery() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("jobs.json");
+        let store = JobStore::open_without_reconciliation(&path)
+            .expect("store")
+            .with_daemon_lease("lease-dead".to_string());
+        let selected = store.create("runner.exec");
+        store.start(selected.id).expect("start selected");
+        let before = std::fs::read(&path).expect("store bytes");
+
+        let diagnostics = store
+            .reconcile_dead_daemon_lease_jobs_with_confirmed_no_pid_jobs_and_linked_resolver(
+                "lease-dead",
+                &[],
+                |_| false,
+                |_| {
+                    LinkedDurableRunResolution::Terminal(RecoveredTerminalJob::test_result(
+                        JobStatus::Succeeded,
+                        "run-terminal",
+                        json!({ "status": "succeeded" }),
+                        Vec::new(),
+                    ))
+                },
+            )
+            .expect("linked terminal evidence is reconciled authoritatively");
+
+        assert_eq!(diagnostics.terminalized_count(), 1);
+        assert_eq!(
+            store.get(selected.id).expect("job").status,
+            JobStatus::Succeeded
+        );
+        assert_ne!(std::fs::read(&path).expect("store bytes"), before);
     }
 
     #[test]

--- a/src/core/api_jobs/store.rs
+++ b/src/core/api_jobs/store.rs
@@ -19,8 +19,9 @@ use super::persistence::{read_durable_store, reconcile_stale_jobs};
 use super::remote_runner;
 use super::remote_runner::JobArtifactMetadata;
 use super::types::{
-    DaemonLeaseJobDiagnostics, Job, JobEvent, JobEventKind, JobStatus, LeaselessOrphanAffectedJob,
-    LeaselessOrphanJobDiagnostics,
+    DaemonActiveJobRecoveryDisposition, DaemonActiveJobRecoveryEvidence, DaemonLeaseJobDiagnostics,
+    DaemonLinkedDurableRunState, Job, JobEvent, JobEventKind, JobStatus,
+    LeaselessOrphanAffectedJob, LeaselessOrphanJobDiagnostics,
 };
 use crate::core::agent_task_scheduler::AgentTaskAggregateStatus;
 use crate::core::agent_task_service;
@@ -320,6 +321,113 @@ impl JobStore {
         diagnostics
     }
 
+    /// Read active-job recovery evidence without reconciling or persisting jobs.
+    pub fn active_daemon_job_recovery_evidence(
+        &self,
+        current_lease_id: Option<&str>,
+        pid_is_alive: impl Fn(u32) -> bool,
+    ) -> Vec<DaemonActiveJobRecoveryEvidence> {
+        self.active_daemon_job_recovery_evidence_with_linked_durable_run_resolver(
+            current_lease_id,
+            pid_is_alive,
+            resolve_linked_durable_run,
+        )
+    }
+
+    pub(super) fn active_daemon_job_recovery_evidence_with_linked_durable_run_resolver(
+        &self,
+        current_lease_id: Option<&str>,
+        pid_is_alive: impl Fn(u32) -> bool,
+        resolve_linked: impl Fn(&StoredJob) -> LinkedDurableRunResolution,
+    ) -> Vec<DaemonActiveJobRecoveryEvidence> {
+        let inner = self.inner.lock().expect("job store mutex poisoned");
+        let mut evidence = inner
+            .jobs
+            .values()
+            .filter_map(|stored| {
+                let job = &stored.job;
+                if !matches!(job.status, JobStatus::Queued | JobStatus::Running) {
+                    return None;
+                }
+                let terminal_evidence =
+                    recovered_terminal_from_result(&stored.events).map(|(status, _)| status);
+                let linked = resolve_linked(stored);
+                let (
+                    linked_durable_run_id,
+                    linked_durable_run_state,
+                    linked_durable_run_terminal_status,
+                ) = match &linked {
+                    LinkedDurableRunResolution::None => (None, None, None),
+                    LinkedDurableRunResolution::Terminal(result) => (
+                        Some(result.run_id.clone()),
+                        Some(DaemonLinkedDurableRunState::Terminal),
+                        Some(result.status),
+                    ),
+                    LinkedDurableRunResolution::Active(run_id) => (
+                        Some(run_id.clone()),
+                        Some(DaemonLinkedDurableRunState::Active),
+                        None,
+                    ),
+                    LinkedDurableRunResolution::Unresolved(run_id) => (
+                        Some(run_id.clone()),
+                        Some(DaemonLinkedDurableRunState::Unresolved),
+                        None,
+                    ),
+                };
+                let child_pid = last_progress_child_pid(&stored.events);
+                let child_started_at = last_progress_child_started_at(&stored.events);
+                let child_is_live = child_pid.is_some_and(|pid| {
+                    pid_is_alive(pid) && child_started_at.as_deref().is_none_or(|expected| {
+                        crate::core::engine::invocation::InvocationChildRecord::process_started_at(
+                            pid,
+                        )
+                        .as_deref()
+                            == Some(expected)
+                    })
+                });
+                let disposition = if matches!(
+                    linked,
+                    LinkedDurableRunResolution::Active(_)
+                        | LinkedDurableRunResolution::Unresolved(_)
+                ) {
+                    DaemonActiveJobRecoveryDisposition::BlockingAmbiguous
+                } else if terminal_evidence.is_some()
+                    || linked_durable_run_terminal_status.is_some()
+                {
+                    DaemonActiveJobRecoveryDisposition::TerminalEvidence
+                } else if child_is_live {
+                    DaemonActiveJobRecoveryDisposition::ProtectedLive
+                } else if child_pid.is_some() || child_started_at.is_some() {
+                    DaemonActiveJobRecoveryDisposition::DeadChild
+                } else if current_lease_id
+                    .is_some_and(|lease| job.daemon_lease_id.as_deref() == Some(lease))
+                {
+                    DaemonActiveJobRecoveryDisposition::MissingChildIdentityRecoverable
+                } else {
+                    DaemonActiveJobRecoveryDisposition::BlockingAmbiguous
+                };
+                Some(DaemonActiveJobRecoveryEvidence {
+                    job_id: job.id,
+                    operation: job.operation.clone(),
+                    status: job.status,
+                    daemon_lease_id: job.daemon_lease_id.clone(),
+                    created_at_ms: job.created_at_ms,
+                    updated_at_ms: job.updated_at_ms,
+                    started_at_ms: job.started_at_ms,
+                    terminal_evidence,
+                    child_pid,
+                    child_started_at,
+                    linked_durable_run_id,
+                    linked_durable_run_state,
+                    linked_durable_run_terminal_status,
+                    disposition,
+                })
+            })
+            .collect::<Vec<_>>();
+        evidence.sort_by_key(|job| (job.created_at_ms, job.job_id));
+        evidence
+    }
+
     pub fn reconcile_dead_daemon_lease_jobs(
         &self,
         expected_lease_id: &str,
@@ -337,7 +445,8 @@ impl JobStore {
         self.reconcile_dead_daemon_lease_jobs_with_child_liveness_and_terminal_result_with_no_pid_recovery(
             expected_lease_id,
             pid_is_running,
-            recovered_terminal_agent_task_result,
+            |_| None,
+            resolve_linked_durable_run,
             confirmed_no_pid_job_ids,
             false,
         )
@@ -352,9 +461,28 @@ impl JobStore {
         self.reconcile_dead_daemon_lease_jobs_with_child_liveness_and_terminal_result_with_no_pid_recovery(
             expected_lease_id,
             pid_is_running,
-            recovered_terminal_agent_task_result,
+            |_| None,
+            resolve_linked_durable_run,
             &[],
             true,
+        )
+    }
+
+    #[cfg(test)]
+    pub(super) fn reconcile_dead_daemon_lease_jobs_with_confirmed_no_pid_jobs_and_linked_resolver(
+        &self,
+        expected_lease_id: &str,
+        confirmed_no_pid_job_ids: &[Uuid],
+        pid_is_alive: impl Fn(u32) -> bool,
+        resolve_linked: impl Fn(&StoredJob) -> LinkedDurableRunResolution,
+    ) -> Result<DaemonLeaseJobDiagnostics> {
+        self.reconcile_dead_daemon_lease_jobs_with_child_liveness_and_terminal_result_with_no_pid_recovery(
+            expected_lease_id,
+            pid_is_alive,
+            |_| None,
+            resolve_linked,
+            confirmed_no_pid_job_ids,
+            false,
         )
     }
 
@@ -366,7 +494,8 @@ impl JobStore {
         self.reconcile_dead_daemon_lease_jobs_with_child_liveness_and_terminal_result_with_no_pid_recovery(
             expected_lease_id,
             pid_is_alive,
-            recovered_terminal_agent_task_result,
+            |_| None,
+            resolve_linked_durable_run,
             &[],
             false,
         )
@@ -382,6 +511,7 @@ impl JobStore {
             expected_lease_id,
             pid_is_alive,
             terminal_child_result,
+            resolve_linked_durable_run,
             &[],
             false,
         )
@@ -392,6 +522,7 @@ impl JobStore {
         expected_lease_id: &str,
         pid_is_alive: impl Fn(u32) -> bool,
         terminal_child_result: impl Fn(&StoredJob) -> Option<RecoveredTerminalJob>,
+        resolve_linked: impl Fn(&StoredJob) -> LinkedDurableRunResolution,
         confirmed_no_pid_job_ids: &[Uuid],
         allow_missing_child_identity: bool,
     ) -> Result<DaemonLeaseJobDiagnostics> {
@@ -428,36 +559,58 @@ impl JobStore {
         let mut ambiguous_job_ids = Vec::new();
         for job_id in &diagnostics.matching_job_ids {
             let stored = inner.jobs.get(job_id).expect("diagnosed job exists");
-            let disposition =
-                if let Some((status, exit_code)) = recovered_terminal_from_result(&stored.events) {
-                    DeadLeaseJobDisposition::RecoveredOuterResult(status, exit_code)
-                } else if let Some(pid) = last_progress_child_pid(&stored.events) {
-                    if pid_is_alive(pid)
-                    && last_progress_child_started_at(&stored.events).is_none_or(|expected| {
-                        crate::core::engine::invocation::InvocationChildRecord::process_started_at(
-                            pid,
-                        )
-                        .as_deref()
-                            == Some(expected.as_str())
-                    })
-                {
+            let disposition = match resolve_linked(stored) {
+                LinkedDurableRunResolution::Terminal(recovered) => {
+                    DeadLeaseJobDisposition::RecoveredLinkedRun(recovered)
+                }
+                LinkedDurableRunResolution::Active(_) => {
                     diagnostics.protected_job_ids.push(*job_id);
                     DeadLeaseJobDisposition::ProtectedLive
-                } else if let Some(recovered) = terminal_child_result(stored) {
-                    DeadLeaseJobDisposition::RecoveredLinkedRun(recovered)
-                } else {
-                    DeadLeaseJobDisposition::TerminalizeDead
                 }
-                } else if allow_missing_child_identity {
-                    DeadLeaseJobDisposition::TerminalizeDead
-                } else {
-                    ambiguous_job_ids.push(*job_id);
-                    if confirmed_no_pid_job_ids.contains(job_id) {
-                        DeadLeaseJobDisposition::TerminalizeOperatorConfirmedNoPid
+                LinkedDurableRunResolution::Unresolved(run_id) => {
+                    return Err(Error::validation_invalid_argument(
+                        "expected-lease-id",
+                        format!("refusing dead-daemon recovery because linked durable run `{run_id}` for job `{job_id}` cannot be safely resolved"),
+                        Some(expected_lease_id.to_string()),
+                        None,
+                    ));
+                }
+                LinkedDurableRunResolution::None => {
+                    if let Some((status, exit_code)) =
+                        recovered_terminal_from_result(&stored.events)
+                    {
+                        DeadLeaseJobDisposition::RecoveredOuterResult(status, exit_code)
+                    } else if let Some(recovered) = terminal_child_result(stored) {
+                        DeadLeaseJobDisposition::RecoveredLinkedRun(recovered)
+                    } else if let Some(pid) = last_progress_child_pid(&stored.events) {
+                        let child_is_live = pid_is_alive(pid)
+                            && last_progress_child_started_at(&stored.events).is_none_or(
+                                |expected| {
+                                    crate::core::engine::invocation::InvocationChildRecord::process_started_at(pid)
+                                        .as_deref()
+                                        == Some(expected.as_str())
+                                },
+                            );
+                        if child_is_live {
+                            diagnostics.protected_job_ids.push(*job_id);
+                            DeadLeaseJobDisposition::ProtectedLive
+                        } else {
+                            DeadLeaseJobDisposition::TerminalizeDead
+                        }
                     } else {
-                        continue;
+                        if allow_missing_child_identity {
+                            DeadLeaseJobDisposition::TerminalizeDead
+                        } else {
+                            ambiguous_job_ids.push(*job_id);
+                            if confirmed_no_pid_job_ids.contains(job_id) {
+                                DeadLeaseJobDisposition::TerminalizeOperatorConfirmedNoPid
+                            } else {
+                                continue;
+                            }
+                        }
                     }
-                };
+                }
+            };
             dispositions.push((*job_id, disposition));
         }
         let ambiguous_job_ids = ambiguous_job_ids
@@ -492,6 +645,10 @@ impl JobStore {
                 Some(expected_lease_id.to_string()),
                 None,
             ));
+        }
+        if !diagnostics.protected_job_ids.is_empty() {
+            diagnostics.protected_job_ids.sort();
+            return Ok(diagnostics);
         }
 
         let now = timestamp_ms();
@@ -1091,6 +1248,7 @@ enum DeadLeaseJobDisposition {
     TerminalizeOperatorConfirmedNoPid,
 }
 
+#[derive(Clone)]
 pub(super) struct RecoveredTerminalJob {
     status: JobStatus,
     terminal_result: Value,
@@ -1115,25 +1273,23 @@ impl RecoveredTerminalJob {
     }
 }
 
-/// A remote runner workload records its agent-task run ID in a typed execution
-/// envelope. That durable run is authoritative after the runner child exits.
-fn recovered_terminal_agent_task_result(stored: &StoredJob) -> Option<RecoveredTerminalJob> {
-    let run_id = stored
-        .remote_runner
-        .as_ref()?
-        .request
-        .runner_workload
-        .as_ref()?
-        .agent_task
-        .as_ref()?
-        .run_id
-        .trim()
-        .to_string();
-    if run_id.is_empty() {
-        return None;
-    }
+#[derive(Clone)]
+pub(super) enum LinkedDurableRunResolution {
+    None,
+    Terminal(RecoveredTerminalJob),
+    Active(String),
+    Unresolved(String),
+}
 
-    let result = agent_task_service::terminal_run_result(&run_id).ok()??;
+fn resolve_linked_durable_run(stored: &StoredJob) -> LinkedDurableRunResolution {
+    let Some(run_id) = linked_agent_task_run_id(stored) else {
+        return LinkedDurableRunResolution::None;
+    };
+    let result = match agent_task_service::terminal_run_result(&run_id) {
+        Ok(Some(result)) => result,
+        Ok(None) => return LinkedDurableRunResolution::Active(run_id),
+        Err(_) => return LinkedDurableRunResolution::Unresolved(run_id),
+    };
     let status = match result.value.status {
         AgentTaskAggregateStatus::Succeeded => JobStatus::Succeeded,
         AgentTaskAggregateStatus::Cancelled => JobStatus::Cancelled,
@@ -1161,7 +1317,7 @@ fn recovered_terminal_agent_task_result(stored: &StoredJob) -> Option<RecoveredT
             })),
         })
         .collect();
-    Some(RecoveredTerminalJob {
+    LinkedDurableRunResolution::Terminal(RecoveredTerminalJob {
         status,
         terminal_result: serde_json::json!({
             "kind": "agent_task_aggregate",
@@ -1172,6 +1328,19 @@ fn recovered_terminal_agent_task_result(stored: &StoredJob) -> Option<RecoveredT
         run_id,
         artifacts,
     })
+}
+
+fn linked_agent_task_run_id(stored: &StoredJob) -> Option<String> {
+    let run_id = stored
+        .remote_runner
+        .as_ref()?
+        .request
+        .run_ref_metadata()?
+        .get("agent_task_run_id")?
+        .as_str()?
+        .trim()
+        .to_string();
+    (!run_id.is_empty()).then_some(run_id)
 }
 
 /// The reverse runner records the executing child in periodic progress

--- a/src/core/api_jobs/types.rs
+++ b/src/core/api_jobs/types.rs
@@ -236,6 +236,43 @@ pub struct DaemonLeaseJobDiagnostics {
     pub protected_job_ids: Vec<Uuid>,
 }
 
+/// Read-only recovery evidence for one active daemon job.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DaemonActiveJobRecoveryEvidence {
+    pub job_id: Uuid,
+    pub operation: String,
+    pub status: JobStatus,
+    pub daemon_lease_id: Option<String>,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    pub started_at_ms: Option<u64>,
+    pub terminal_evidence: Option<JobStatus>,
+    pub child_pid: Option<u32>,
+    pub child_started_at: Option<String>,
+    pub linked_durable_run_id: Option<String>,
+    pub linked_durable_run_state: Option<DaemonLinkedDurableRunState>,
+    pub linked_durable_run_terminal_status: Option<JobStatus>,
+    pub disposition: DaemonActiveJobRecoveryDisposition,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DaemonLinkedDurableRunState {
+    Terminal,
+    Active,
+    Unresolved,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DaemonActiveJobRecoveryDisposition {
+    TerminalEvidence,
+    DeadChild,
+    MissingChildIdentityRecoverable,
+    ProtectedLive,
+    BlockingAmbiguous,
+}
+
 /// An active durable job terminalized after the daemon lease disappeared.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LeaselessOrphanAffectedJob {

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -12,7 +12,9 @@ use std::time::{Duration, Instant, UNIX_EPOCH};
 use uuid::Uuid;
 
 use crate::command_contract::RunnerWorkload;
-use crate::core::api_jobs::{JobStatus, JobStore, RunnerJobLifecycleMetadata};
+use crate::core::api_jobs::{
+    DaemonActiveJobRecoveryEvidence, JobStatus, JobStore, RunnerJobLifecycleMetadata,
+};
 use crate::core::build_identity;
 use crate::core::error::{Error, RemoteCommandFailedDetails, Result, TargetDetails};
 use crate::core::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnalysisJobRunner};
@@ -88,6 +90,9 @@ pub struct DaemonStatus {
     /// operator can distinguish another runner from an attributable owner.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub process_candidates: Vec<DaemonProcessCandidate>,
+    /// Durable evidence only; status never reconciles or mutates active jobs.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub active_job_recovery_evidence: Vec<DaemonActiveJobRecoveryEvidence>,
     /// Launcher-owned evidence is best effort. A missing record explicitly does
     /// not imply an OS-level cause for a dead daemon.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -523,9 +528,20 @@ pub fn read_status() -> Result<DaemonStatus> {
     let state_path = path.display().to_string();
     let state_identity = daemon_state_identity(&path, &paths::daemon_jobs_file()?)?;
     let validation = validate_lease_file(&path)?;
-    let active_jobs = JobStore::active_count_at_path(paths::daemon_jobs_file()?)?;
-
     let jobs_path = paths::daemon_jobs_file()?;
+    let job_store = JobStore::open_without_reconciliation(&jobs_path)?;
+    let active_job_recovery_evidence = job_store.active_daemon_job_recovery_evidence(
+        (validation.stale_reason_code == Some(DaemonStaleReasonCode::PidDead))
+            .then(|| {
+                validation
+                    .state
+                    .as_ref()
+                    .map(|state| state.lease_id.as_str())
+            })
+            .flatten(),
+        pid_is_running,
+    );
+    let active_jobs = active_job_recovery_evidence.len();
     Ok(DaemonStatus {
         running: validation.running && validation.fresh && validation.reachable,
         fresh: validation.fresh,
@@ -536,6 +552,7 @@ pub fn read_status() -> Result<DaemonStatus> {
         state_path,
         state_identity,
         process_candidates: control::daemon_process_candidates(&jobs_path)?,
+        active_job_recovery_evidence,
         termination_evidence: (!validation.running)
             .then(read_termination_evidence)
             .transpose()?

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -346,6 +346,7 @@ fn leaseless_status(active_jobs: usize) -> DaemonStatus {
         state_path: "/fake/daemon-state.json".to_string(),
         state_identity: "lease-missing-test-state".to_string(),
         process_candidates: Vec::new(),
+        active_job_recovery_evidence: Vec::new(),
         termination_evidence: None,
     }
 }
@@ -1172,6 +1173,7 @@ fn fake_status(daemon: Option<super::DaemonStartResult>, fresh: bool) -> DaemonS
         state_path: "/fake/daemon-state.json".to_string(),
         state_identity: "sha256:fake".to_string(),
         process_candidates: Vec::new(),
+        active_job_recovery_evidence: Vec::new(),
         termination_evidence: None,
     }
 }
@@ -1203,6 +1205,7 @@ fn fake_dead_status(daemon: super::DaemonStartResult) -> DaemonStatus {
         state_path: "/fake/daemon-state.json".to_string(),
         state_identity: "sha256:fake".to_string(),
         process_candidates: Vec::new(),
+        active_job_recovery_evidence: Vec::new(),
         termination_evidence: None,
     }
 }

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -36,6 +36,55 @@ fn write_daemon_state_for_test(state: &DaemonState) {
     std::fs::write(&path, serde_json::to_string(state).expect("state json")).expect("write state");
 }
 
+#[test]
+fn status_reports_active_job_recovery_evidence_without_mutating_the_store() {
+    let _home = HomeGuard::new();
+    let mut state = daemon_state_for_test(u32::MAX, "127.0.0.1:49152");
+    state.lease_id = "evidence-lease".to_string();
+    write_daemon_state_for_test(&state);
+    let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+    let store = JobStore::open_without_reconciliation(&path)
+        .expect("store")
+        .with_daemon_lease(state.lease_id.clone());
+    let job = store.create("runner.exec");
+    store.start(job.id).expect("start job");
+    let before = std::fs::read(&path).expect("store bytes");
+
+    let status = read_status().expect("status");
+
+    assert_eq!(std::fs::read(&path).expect("store bytes"), before);
+    assert_eq!(status.active_job_recovery_evidence.len(), 1);
+    let evidence = &status.active_job_recovery_evidence[0];
+    assert_eq!(evidence.job_id, job.id);
+    assert_eq!(evidence.operation, "runner.exec");
+    assert_eq!(
+        evidence.disposition,
+        crate::core::api_jobs::DaemonActiveJobRecoveryDisposition::MissingChildIdentityRecoverable
+    );
+}
+
+#[test]
+fn status_marks_pidless_jobs_non_recoverable_while_the_lease_is_live() {
+    let _home = HomeGuard::new();
+    let mut state = daemon_state_for_test(std::process::id(), "127.0.0.1:49152");
+    state.lease_id = "live-evidence-lease".to_string();
+    write_daemon_state_for_test(&state);
+    let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+    let store = JobStore::open_without_reconciliation(&path)
+        .expect("store")
+        .with_daemon_lease(state.lease_id);
+    let job = store.create("runner.exec");
+    store.start(job.id).expect("start job");
+
+    let status = read_status().expect("status");
+
+    assert_eq!(status.active_job_recovery_evidence.len(), 1);
+    assert_eq!(
+        status.active_job_recovery_evidence[0].disposition,
+        crate::core::api_jobs::DaemonActiveJobRecoveryDisposition::BlockingAmbiguous
+    );
+}
+
 fn write_legacy_daemon_state_for_test(pid: u32, address: &str) -> (std::path::PathBuf, String) {
     let path = state_path().expect("state path");
     let content = serde_json::json!({


### PR DESCRIPTION
Closes #8200

## Summary
- Expose read-only per-job daemon recovery evidence, including child, terminal, and linked durable-run state.
- Integrate with the existing exact `--confirm-untracked-child-dead <JOB_ID>` recovery primitive from current `main`.
- Classify the complete lease before persistence so live, active-linked, unresolved, or unconfirmed ambiguous jobs block without mutation.

## Compatibility
This adds status output and strengthens fail-closed behavior in the existing recovery path. Existing CLI names remain unchanged. The broad `--recover-missing-child-identity` compatibility option remains available, but cannot override active or unresolved linked runs.

## How to test
1. Run `cargo test linked_active_or_unresolved_job_blocks_confirmed_recovery_before_persisting -- --test-threads=1`; active and unresolved linked runs must block before persistence.
2. Run `cargo test confirmed_pidless_job_with_unselected_live_child_returns_diagnostics_without_persisting -- --test-threads=1`; the live child must remain protected and durable storage must remain byte-for-byte unchanged.
3. Run `cargo test status_evidence_reports_linked_active_and_unresolved_as_blocking -- --test-threads=1`; status must expose linked-run IDs/states as blocking evidence.
4. Run `cargo test core::daemon::control::control_test -- --test-threads=1`; the daemon control module must pass.

All commands passed on `homeboy-lab` after rebasing onto current `main`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode, openai/gpt-5.6-sol
- **Used for:** Rebased onto current main, reconciled the implementation with the newly landed exact-confirmation primitive, resolved conflicts, and ran deterministic Lab verification. Chris reviews and owns the change.