### PR TITLE
Allocate run-scoped agent-task scratch

### DIFF
--- a/src/core/agent_task/executor.rs
+++ b/src/core/agent_task/executor.rs
@@ -58,6 +58,23 @@ impl AgentTaskExecutor {
         }
     }
 
+    /// Set the scheduler-owned temporary directory through the declared runtime
+    /// environment contract without inferring environment names from config.
+    pub fn set_runtime_tmpdir(&mut self, path: &str) {
+        if !self.config.is_object() {
+            self.config = Value::Object(Default::default());
+        }
+        let config = self.config.as_object_mut().expect("executor config object");
+        if !config.get("runtime_env").is_some_and(Value::is_object) {
+            config.insert("runtime_env".to_string(), Value::Object(Default::default()));
+        }
+        config
+            .get_mut("runtime_env")
+            .and_then(Value::as_object_mut)
+            .expect("runtime environment object")
+            .insert("TMPDIR".to_string(), Value::String(path.to_string()));
+    }
+
     pub fn runtime_selection(&self) -> AgentTaskRuntimeSelection {
         let explicit = self.runtime_selection.clone().unwrap_or_default();
         AgentTaskRuntimeSelection {
@@ -130,6 +147,28 @@ mod tests {
         assert_eq!(executor.config["workspace"]["root"], "/candidate");
         assert_eq!(executor.config["workspace_root"], "/candidate");
         assert_eq!(executor.config["unrelated_root"], "/original");
+    }
+
+    #[test]
+    fn sets_only_tmpdir_in_declared_runtime_environment() {
+        let mut executor = AgentTaskExecutor {
+            backend: "test".to_string(),
+            selector: None,
+            runtime_selection: None,
+            required_capabilities: Vec::new(),
+            secret_env: Vec::new(),
+            model: None,
+            config: json!({
+                "runtime_env": { "KEEP": "value", "TMPDIR": "/old" },
+                "unrelated_tmpdir": "/unchanged"
+            }),
+        };
+
+        executor.set_runtime_tmpdir("/allocated");
+
+        assert_eq!(executor.config["runtime_env"]["TMPDIR"], "/allocated");
+        assert_eq!(executor.config["runtime_env"]["KEEP"], "value");
+        assert_eq!(executor.config["unrelated_tmpdir"], "/unchanged");
     }
 }
 

--- a/src/core/agent_task_provider/tests/scheduler_tests.rs
+++ b/src/core/agent_task_provider/tests/scheduler_tests.rs
@@ -429,6 +429,46 @@ fn provider_command_receives_executor_config_env() {
 }
 
 #[test]
+fn provider_attempts_receive_distinct_allocated_runtime_tmpdirs() {
+    crate::test_support::with_isolated_home(|_| {
+        let state = unique_state_path("scratch-attempts");
+        let state_path = state.to_string_lossy().replace('\\', "\\\\");
+        let command = format!(
+            "node {}",
+            script(&format!(
+                "let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); let tmp=req.executor.config.runtime_env.TMPDIR; let entries=[]; try {{ entries=JSON.parse(fs.readFileSync('{state_path}','utf8')); }} catch (_) {{}} entries.push({{tmp,keep:req.executor.config.runtime_env.KEEP}}); fs.writeFileSync('{state_path}',JSON.stringify(entries)); process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:entries.length===1?'failed':'succeeded',failure_classification:entries.length===1?'execution_failed':null,summary:tmp}}));"
+            ))
+        );
+        let (mut request, provider) = request("task-scratch-retry", command);
+        request.executor.config = json!({ "runtime_env": { "KEEP": "preserved" } });
+        let mut plan = AgentTaskPlan::new("plan-scratch-retry", vec![request]);
+        plan.options.retry.max_attempts = 2;
+        plan.options.retry.retryable_failure_classifications =
+            vec![AgentTaskFailureClassification::ExecutionFailed];
+
+        let aggregate =
+            AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
+                provider,
+            ]))
+            .with_run_id("run-scratch-retry")
+            .run(plan);
+
+        assert_eq!(aggregate.totals.succeeded, 1);
+        let attempts: Vec<Value> =
+            serde_json::from_str(&fs::read_to_string(&state).expect("attempt records"))
+                .expect("attempt JSON");
+        assert_eq!(attempts.len(), 2);
+        assert_eq!(attempts[0]["keep"], "preserved");
+        assert_eq!(attempts[1]["keep"], "preserved");
+        assert_ne!(attempts[0]["tmp"], attempts[1]["tmp"]);
+        for attempt in attempts {
+            let tmpdir = PathBuf::from(attempt["tmp"].as_str().expect("TMPDIR"));
+            assert!(tmpdir.is_dir());
+        }
+    });
+}
+
+#[test]
 fn provider_command_receives_declared_secret_env() {
     let secret_name = format!("HOMEBOY_TEST_AGENT_TASK_SECRET_{}", std::process::id());
     std::env::set_var(&secret_name, "hydrated-secret");

--- a/src/core/agent_task_scheduler/mod.rs
+++ b/src/core/agent_task_scheduler/mod.rs
@@ -393,6 +393,30 @@ where
                 if let Some(root) = request.workspace.root.as_deref() {
                     request.executor.remap_workspace_root(root);
                 }
+                let run_id = self.run_id.as_deref().unwrap_or(&plan.plan_id);
+                let scratch = match crate::core::controller_scratch::allocate_attempt(
+                    run_id,
+                    &plan.plan_id,
+                    &request.task_id,
+                    scheduled.attempt,
+                ) {
+                    Ok(scratch) => scratch,
+                    Err(error) => {
+                        let outcome =
+                            scratch_allocation_failure(task_id.clone(), error.to_string());
+                        events.push(event(
+                            &task_id,
+                            AgentTaskState::Failed,
+                            scheduled.attempt,
+                            outcome.summary.clone(),
+                        ));
+                        record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
+                        continue;
+                    }
+                };
+                request
+                    .executor
+                    .set_runtime_tmpdir(scratch.path.to_string_lossy().as_ref());
                 let executor_key = executor_key(&request);
                 let executor = Arc::clone(&self.executor);
                 let plan_id = plan.plan_id.clone();
@@ -790,6 +814,28 @@ fn retry_attempt_evidence(outcome: &AgentTaskOutcome, running: &RunningTask) -> 
         "artifacts": outcome.artifacts,
         "evidence_refs": outcome.evidence_refs,
     })
+}
+
+fn scratch_allocation_failure(task_id: String, error: String) -> AgentTaskOutcome {
+    AgentTaskOutcome {
+        schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+        task_id,
+        status: AgentTaskOutcomeStatus::Failed,
+        summary: Some(format!("could not allocate provider scratch root: {error}")),
+        failure_classification: Some(AgentTaskFailureClassification::ExecutionFailed),
+        artifacts: Vec::new(),
+        typed_artifacts: Vec::new(),
+        evidence_refs: Vec::new(),
+        diagnostics: vec![AgentTaskDiagnostic {
+            class: "agent_task.controller_scratch_allocation_failed".to_string(),
+            message: error,
+            data: serde_json::Value::Null,
+        }],
+        outputs: serde_json::Value::Null,
+        workflow: None,
+        follow_up: None,
+        metadata: serde_json::Value::Null,
+    }
 }
 
 enum SchedulerEvent {

--- a/src/core/controller_scratch.rs
+++ b/src/core/controller_scratch.rs
@@ -13,9 +13,17 @@ pub const CONTROLLER_SCRATCH_SCHEMA: &str = "homeboy/controller-scratch/v1";
 pub struct ControllerScratchResource {
     pub path: String,
     pub run_id: String,
+    #[serde(default)]
+    pub plan_id: String,
     pub task_id: String,
+    #[serde(default)]
+    pub attempt: u32,
     pub root_bound: String,
     pub owner_pid: u32,
+    #[serde(default)]
+    pub lifecycle_state: String,
+    #[serde(default)]
+    pub lease_id: String,
     pub reconstructable: bool,
     pub retention: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -23,6 +31,84 @@ pub struct ControllerScratchResource {
     pub created_at: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub finalized_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControllerScratchAllocation {
+    pub path: PathBuf,
+    pub lease_id: String,
+}
+
+/// Allocate and durably register one scheduler-owned temporary root for a
+/// provider dispatch attempt. Allocation remains separate from terminal lease
+/// handling and retention policy.
+pub fn allocate_attempt(
+    run_id: &str,
+    plan_id: &str,
+    task_id: &str,
+    attempt: u32,
+) -> Result<ControllerScratchAllocation> {
+    let root = paths::homeboy_data()?.join("controller-scratch/attempts");
+    fs::create_dir_all(&root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("create {}", root.display())),
+        )
+    })?;
+    let root = root.canonicalize().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("canonicalize {}", root.display())),
+        )
+    })?;
+    let lease_id = uuid::Uuid::new_v4().to_string();
+    let path = root
+        .join(paths::sanitize_path_segment(run_id))
+        .join(paths::sanitize_path_segment(plan_id))
+        .join(paths::sanitize_path_segment(task_id))
+        .join(format!("attempt-{attempt}"))
+        .join(&lease_id);
+    fs::create_dir_all(&path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("create {}", path.display())),
+        )
+    })?;
+    let path = path.canonicalize().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("canonicalize {}", path.display())),
+        )
+    })?;
+    if path == root || !path.starts_with(&root) {
+        return Err(Error::validation_invalid_argument(
+            "controller_scratch.path",
+            "allocated scratch path must be contained by its root",
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+
+    let mut index = read_index()?;
+    index.resources.push(ControllerScratchResource {
+        path: path.display().to_string(),
+        run_id: run_id.to_string(),
+        plan_id: plan_id.to_string(),
+        task_id: task_id.to_string(),
+        attempt,
+        root_bound: root.display().to_string(),
+        owner_pid: std::process::id(),
+        lifecycle_state: "active".to_string(),
+        lease_id: lease_id.clone(),
+        reconstructable: true,
+        retention: "P7D".to_string(),
+        source_ref: None,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        finalized_at: None,
+    });
+    write_index(&index)?;
+
+    Ok(ControllerScratchAllocation { path, lease_id })
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -116,9 +202,13 @@ pub fn register_outcome_resources(run_id: &str, outcomes: &[AgentTaskOutcome]) -
             let resource = ControllerScratchResource {
                 path: path.display().to_string(),
                 run_id: run_id.to_string(),
+                plan_id: String::new(),
                 task_id: outcome.task_id.clone(),
+                attempt: 0,
                 root_bound: root.display().to_string(),
                 owner_pid: std::process::id(),
+                lifecycle_state: "provider_registered".to_string(),
+                lease_id: String::new(),
                 reconstructable: value
                     .get("reconstructable")
                     .and_then(serde_json::Value::as_bool)
@@ -412,9 +502,13 @@ mod tests {
         ControllerScratchResource {
             path: path.display().to_string(),
             run_id: "missing-terminal-run".to_string(),
+            plan_id: String::new(),
             task_id: "task-1".to_string(),
+            attempt: 0,
             root_bound: root.display().to_string(),
             owner_pid: u32::MAX,
+            lifecycle_state: "active".to_string(),
+            lease_id: "test-lease".to_string(),
             reconstructable: true,
             retention: "0s".to_string(),
             source_ref: None,
@@ -435,6 +529,33 @@ mod tests {
             cleanup_block_reason(&resource, &scratch).expect("check"),
             Some("owner process is still running".to_string())
         );
+    }
+
+    #[test]
+    fn allocation_is_unique_contained_and_durably_indexed() {
+        crate::test_support::with_isolated_home(|_| {
+            let first = allocate_attempt("run-1", "plan-1", "task-1", 1).expect("first");
+            let second = allocate_attempt("run-1", "plan-1", "task-1", 2).expect("second");
+            let index = read_index().expect("index");
+
+            assert_ne!(first.path, second.path);
+            assert!(first.path.is_dir());
+            assert!(second.path.is_dir());
+            let resource = index
+                .resources
+                .iter()
+                .find(|resource| resource.lease_id == first.lease_id)
+                .expect("first resource");
+            assert!(Path::new(&resource.path).starts_with(&resource.root_bound));
+            assert_eq!(resource.run_id, "run-1");
+            assert_eq!(resource.plan_id, "plan-1");
+            assert_eq!(resource.task_id, "task-1");
+            assert_eq!(resource.attempt, 1);
+            assert_eq!(resource.lifecycle_state, "active");
+            assert_eq!(resource.owner_pid, std::process::id());
+            assert!(resource.reconstructable);
+            assert!(!resource.created_at.is_empty());
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `verify-homeboy-8147-focused` into review-ready branch `feat/8147-agent-task-scratch-allocation-final`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:verify-homeboy-8147-focused`
- **Homeboy run ID:** `verify-homeboy-8147-focused`
- **Manual proof:** none recorded by this Homeboy finalization
- **Stable evidence:** see artifact refs below

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `feat/8147-agent-task-scratch-allocation-final`

## Source refs
- https://github.com/Extra-Chill/homeboy/issues/8147
- https://github.com/Extra-Chill/homeboy/issues/8121

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** runtime-fix
- **Supersedes:** none recorded
- **Depends on:** https://github.com/Extra-Chill/homeboy/pull/8225

## Runtime guardrails
- **Why this is not broader than the packet evidence:** The change affects only agent-task provider attempts: Homeboy allocates one controller-owned root and explicitly sets runtime_env.TMPDIR without inferring or rewriting any other environment key.
- **Evidence discriminators preserved:** Agent-task scheduler dispatch attempt number and explicit runtime_env.TMPDIR
- **Nearby contracts preserved:** Existing runtime_env entries other than TMPDIR are preserved, Terminal lease release and cleanup retention remain unchanged for #8146 and #8148

## Attempt summary
Homeboy promoted the signed #8147 candidate and verified allocation, retry isolation, and explicit runtime-context injection on Lab.

## Gate results
- scratch_tests: passed (targeted)
- retry_isolation: passed (targeted)
- executor_context: passed (targeted)
- format: passed (targeted)
- diff_check: passed (targeted)

## Verification capability
- `targeted_checks_run`: `cargo test scratch --lib`, `cargo test runtime_tmpdir --lib`, `cargo test sets_only_tmpdir --lib`, `cargo fmt --check`, `git diff --check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: `GitHub Actions`
- `manual_reviewer_check`: Confirm external runtime providers that consume executor.config.runtime_env accept TMPDIR override semantics; no extension allocates or cleans the controller-owned root.

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- src/core/agent_task/executor.rs
- src/core/agent_task_provider/tests/scheduler_tests.rs
- src/core/agent_task_scheduler/mod.rs
- src/core/controller_scratch.rs

## Artifact refs
- verify-homeboy-8147-focused
- verify-homeboy-8147-runtime-context
- verify-homeboy-8147-executor-context

## Sibling PR relationship
- Review sibling generated PRs for the same finding before merging; superseded runtime fixes should be narrowed or closed after safer evidence/test-only coverage lands.

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `feat/8147-agent-task-scratch-allocation-final`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Prepared and rebased the isolated allocation candidate, reviewed its generic ownership contract, and orchestrated signed promotion and deterministic Lab verification with Chris.
