### PR TITLE
refactor: move apply_lab_contract_to_descriptor into output type layer

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -59,7 +59,6 @@ pub use support::*;
 pub use types::*;
 pub use workload::*;
 
-pub(crate) use placement::apply_lab_contract_to_descriptor;
 #[cfg(test)]
 pub(crate) use placement::{
     AGENT_TASK_COOK_COORDINATOR_CONTROLLER_REASON, AGENT_TASK_FANOUT_COORDINATOR_CONTROLLER_REASON,

--- a/src/command_contract/lab/placement.rs
+++ b/src/command_contract/lab/placement.rs
@@ -373,22 +373,6 @@ fn provider_requires_cwd_git_checkout_for_dispatch(
         || configured_backend.is_some_and(|backend| !backend.trim().is_empty())
 }
 
-pub(crate) fn apply_lab_contract_to_descriptor(
-    descriptor: &mut CommandDescriptor,
-    contract: Option<LabCommandContract>,
-) {
-    descriptor.supports_lab_runner = contract
-        .is_some_and(|contract| matches!(contract.portability, LabCommandPortability::Portable));
-    descriptor.lab_runner_unsupported_reason =
-        contract.and_then(|contract| match contract.portability {
-            LabCommandPortability::Portable => None,
-            LabCommandPortability::LocalOnly(reason) => Some(reason),
-        });
-    descriptor.lab_offload_captures_mutation_patch =
-        contract.is_some_and(|contract| contract.capture_mutation_patch);
-    descriptor.lab_offload_mutation_flag = contract.and_then(|contract| contract.mutation_flag);
-}
-
 pub(crate) fn agent_task_lab_extension_ids(
     args: &agent_task::AgentTaskArgs,
 ) -> crate::core::Result<Vec<String>> {

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -11,8 +11,28 @@
 //! [`crate::command_contract::lab`], which post-processes the descriptor
 //! returned from [`Commands::descriptor`].
 
-use super::lab::apply_lab_contract_to_descriptor;
+use super::lab::{LabCommandContract, LabCommandPortability};
 use super::spec::CommandSpec;
+
+/// Populate the Lab-offload fields on a [`CommandDescriptor`] from a resolved
+/// [`LabCommandContract`]. Pure data transformation over contract/descriptor
+/// types (no CLI dependency), so it lives with the descriptor definitions
+/// rather than the CLI-coupled routing in `lab/placement.rs`.
+fn apply_lab_contract_to_descriptor(
+    descriptor: &mut CommandDescriptor,
+    contract: Option<LabCommandContract>,
+) {
+    descriptor.supports_lab_runner = contract
+        .is_some_and(|contract| matches!(contract.portability, LabCommandPortability::Portable));
+    descriptor.lab_runner_unsupported_reason =
+        contract.and_then(|contract| match contract.portability {
+            LabCommandPortability::Portable => None,
+            LabCommandPortability::LocalOnly(reason) => Some(reason),
+        });
+    descriptor.lab_offload_captures_mutation_patch =
+        contract.is_some_and(|contract| contract.capture_mutation_patch);
+    descriptor.lab_offload_mutation_flag = contract.and_then(|contract| contract.mutation_flag);
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandResponseMode {


### PR DESCRIPTION
## Summary

Prerequisite cleanup for relocating the `command_contract` routing modules to the CLI side. Removes the last **production** type-layer → routing dependency inside `command_contract`.

## The problem
`apply_lab_contract_to_descriptor` is a pure data transform over `CommandDescriptor` and `LabCommandContract` (both type-layer types) — **no CLI dependency**. But it lived in the CLI-coupled `lab/placement.rs` routing module, and `output.rs` (type layer) reached into `placement` to call it via `with_lab_contract`. That made the type layer depend on the routing layer — backwards, and a blocker for pulling routing out.

## What changed
- Moved `apply_lab_contract_to_descriptor` into `output.rs`, next to `CommandDescriptor` and its only caller (`with_lab_contract`).
- Removed it from `lab/placement.rs` and dropped `lab.rs`'s re-export of it.

## Result
The `command_contract` type layer (`lab` types, `output`, `spec`, `constants`, `registry`, `public_variants`) is now free of any **production** dependency on the CLI-coupled routing modules (`placement`, `output_routing`). Only a `#[cfg(test)]` const re-export remains. This clears the way to relocate `placement`/`output_routing`/`descriptors` to the CLI side and make `command_contract` extractable.

## Verification
- `cargo check --lib` — 0 errors.
- `cargo check --lib --tests` — 0 errors.
- `cargo fmt` clean.

## Context
Part of the `command_contract` decomposition → `homeboy-cli` extraction. Note: main was briefly broken by a merge collision (fixed in #8243) that added `lab/placement.rs` as a duplicate of the earlier `lab_routing.rs`; this PR builds on the repaired state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)