### PR TITLE
fix: canonicalize same-family workload command labels (#7972)

### DIFF
--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -407,10 +407,21 @@ fn validate_runner_workload_command_fallback(
         ));
     }
 
+    let dispatched_family = dispatched_command_family(command_args);
+
     if let Some(dispatched_label) =
         dispatched_command_label(command_args, &workload.kind.command_label)
     {
-        if dispatched_label != workload.kind.command_label {
+        // A differing surface label is only drift when the commands are not the
+        // same workload family. Same-family labels (e.g. `test` and `trace`,
+        // both Quality) canonicalize to one runner-workload identity, so a
+        // labelled dispatch that resolves to the workload's family is a match
+        // even when the surface label differs (#7972). When the dispatched
+        // family is Unknown we cannot canonicalize, so fall back to strict
+        // label matching.
+        let canonical_same_family = dispatched_family != RunnerWorkloadCommandFamily::Unknown
+            && dispatched_family == workload.kind.command_family;
+        if dispatched_label != workload.kind.command_label && !canonical_same_family {
             return Err(workload_error(
                 "runner_workload.kind.command_label",
                 format!(
@@ -421,7 +432,6 @@ fn validate_runner_workload_command_fallback(
         }
     }
 
-    let dispatched_family = dispatched_command_family(command_args);
     if dispatched_family != RunnerWorkloadCommandFamily::Unknown
         && dispatched_family != workload.kind.command_family
     {
@@ -1061,11 +1071,16 @@ mod tests {
             proof_id: None,
         });
 
+        // A dispatch whose label belongs to no known workload family (here
+        // `status`) cannot be canonicalized to this `trace` (Quality) workload,
+        // so the strict label check still rejects genuine command drift. (A
+        // same-family alias like `test` is intentionally accepted — see
+        // `runner_workload_validation_rejects_dispatch_drift`.)
         let err = validate_runner_workload_dispatch(
             Some(&workload),
             "lab-a",
             Some("/srv/homeboy/work"),
-            &["homeboy".to_string(), "test".to_string()],
+            &["homeboy".to_string(), "status".to_string()],
             &secret_plan(&["HOMEBODY_TRACE_SECRET"]),
             true,
         )


### PR DESCRIPTION
## Summary

Fixes the last contradictory-test cluster from the red-main burndown. #7972 introduced runner-workload command-identity canonicalization but left two tests asserting **opposite** outcomes for the identical dispatch:

- `runner_workload_validation_rejects_dispatch_drift` — expects a `test` dispatch to **validate** against a `trace` (Quality) workload.
- `runner_workload_validation_rejects_command_label_drift` — expected the same dispatch to **fail**.

#7972's intent is that same-family labels (`test`/`trace`, both `Quality`) resolve to one runner-workload identity, but it never reconciled the older strict-drift test.

## Change

The fallback command validator now accepts a differing surface label when the **dispatched command's family matches the workload's family** — falling back to strict label matching when the dispatched family is `Unknown` (and therefore not canonicalizable). Updated `rejects_command_label_drift` to dispatch a genuinely un-canonicalizable label (`status`, Unknown family) so it still exercises real command-label drift rejection.

## Verification

- `core::runner::workload::tests` — **23 pass** (both formerly-contradictory tests now consistent).

## Note

An earlier draft (#8244, now closed) also carried a #8236 build-break fix, but that was fixed independently by #8243 — so this is the workload canonicalization alone, a clean single-file change on current `main`.