### PR TITLE
Protect active daemon jobs during reconnect

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -89,7 +89,11 @@ enum DaemonCommand {
         startup_token: String,
     },
     /// Stop the background daemon recorded in the state file
-    Stop,
+    Stop {
+        /// Explicitly interrupt active durable daemon jobs
+        #[arg(long)]
+        force: bool,
+    },
     /// Show daemon state and selected local address
     Status,
     /// Render deployable reverse-runner broker service configuration
@@ -213,7 +217,7 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
                 0,
             ))
         }
-        DaemonCommand::Stop => Ok((DaemonOutput::Stop(daemon::stop()?), 0)),
+        DaemonCommand::Stop { force } => Ok((DaemonOutput::Stop(daemon::stop_with_force(force)?), 0)),
         DaemonCommand::Status => Ok((DaemonOutput::Status(daemon::read_status()?), 0)),
         DaemonCommand::BrokerConfig {
             listen_addr,

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -408,6 +408,13 @@ struct FileUploadRequest {
     content_base64: String,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct LifecycleStopRequest {
+    lease_id: String,
+    #[serde(default)]
+    force: bool,
+}
+
 pub fn parse_bind_addr(addr: &str) -> Result<SocketAddr> {
     let parsed: SocketAddr = addr.parse().map_err(|e| {
         Error::validation_invalid_argument(
@@ -794,11 +801,47 @@ fn runtime_snapshot_stale_reason(snapshot: &DaemonRuntimeSnapshot) -> Option<Str
 }
 
 pub fn stop() -> Result<DaemonStopResult> {
+    stop_with_force(false)
+}
+
+/// Stop a daemon only after preserving its active durable work, unless the
+/// caller supplied an explicit destructive force request.
+pub fn stop_with_force(force: bool) -> Result<DaemonStopResult> {
     let _lock = acquire_daemon_operation_lock()?;
-    stop_unlocked()
+    stop_unlocked_with_force(force)
+}
+
+fn stop_with_force_for_lease(expected_lease_id: &str, force: bool) -> Result<DaemonStopResult> {
+    let _lock = acquire_daemon_operation_lock()?;
+    let path = state_path()?;
+    let validation = validate_lease_file(&path)?;
+    let state = validation.state.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "lease_id",
+            "daemon lifecycle stop requires a live recorded lease",
+            Some(expected_lease_id.to_string()),
+            None,
+        )
+    })?;
+    if state.lease_id != expected_lease_id {
+        return Err(Error::validation_invalid_argument(
+            "lease_id",
+            format!(
+                "daemon lifecycle stop expected lease `{expected_lease_id}` but live lease is `{}`; refusing replacement",
+                state.lease_id
+            ),
+            Some(expected_lease_id.to_string()),
+            None,
+        ));
+    }
+    stop_unlocked_with_force(force)
 }
 
 fn stop_unlocked() -> Result<DaemonStopResult> {
+    stop_unlocked_with_force(false)
+}
+
+fn stop_unlocked_with_force(force: bool) -> Result<DaemonStopResult> {
     let path = state_path()?;
     let state_path_display = path.display().to_string();
     let validation = validate_lease_file(&path)?;
@@ -858,6 +901,10 @@ fn stop_unlocked() -> Result<DaemonStopResult> {
     }
 
     if pid_is_running(pid) {
+        let active_job_ids = active_daemon_job_ids()?;
+        if !force && !active_job_ids.is_empty() {
+            return Err(active_jobs_block_daemon_stop_error(state, &active_job_ids));
+        }
         write_termination_evidence(&DaemonTerminationEvidence {
             classification: DaemonTerminationClassification::CleanStop,
             observed_at: chrono::Utc::now().to_rfc3339(),
@@ -891,6 +938,37 @@ fn stop_unlocked() -> Result<DaemonStopResult> {
         pid: Some(pid),
         state_path: state_path_display,
     })
+}
+
+fn active_daemon_job_ids() -> Result<Vec<Uuid>> {
+    let mut job_ids = JobStore::open_without_reconciliation(paths::daemon_jobs_file()?)?
+        .list()
+        .into_iter()
+        .filter(|job| matches!(job.status, JobStatus::Queued | JobStatus::Running))
+        .map(|job| job.id)
+        .collect::<Vec<_>>();
+    job_ids.sort();
+    Ok(job_ids)
+}
+
+fn active_jobs_block_daemon_stop_error(state: &DaemonState, active_job_ids: &[Uuid]) -> Error {
+    let current_identity = state.build_identity.display.clone();
+    let requested_identity = build_identity::current().display;
+    let mut error = Error::validation_invalid_argument(
+        "daemon_stop",
+        format!(
+            "refusing routine daemon stop for lease `{}` ({current_identity}) while active durable jobs exist: {}. Requested Homeboy identity is `{requested_identity}`; wait for those jobs to finish or use the owning command's explicit --force option",
+            state.lease_id,
+            active_job_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(", "),
+        ),
+        Some(state.lease_id.clone()),
+        Some(vec!["Inspect `homeboy daemon status` and the listed durable jobs before replacing this daemon.".to_string()]),
+    );
+    error.details["active_job_ids"] = serde_json::json!(active_job_ids);
+    error.details["current_daemon_identity"] = serde_json::json!(current_identity);
+    error.details["requested_homeboy_identity"] = serde_json::json!(requested_identity);
+    error.details["lifecycle_mutation"] = serde_json::json!("stop");
+    error
 }
 
 pub fn serve(addr: SocketAddr) -> Result<DaemonState> {
@@ -1126,6 +1204,19 @@ where
             Ok(body) => daemon_endpoint_response("jobs.exec", body),
             Err(err) => error_response(400, err),
         },
+        ("POST", "/lifecycle/stop") => match lifecycle_stop_request(body)
+            .and_then(|request| validate_lifecycle_stop_request(&request).map(|_| request))
+        {
+            Ok(request) => daemon_endpoint_response(
+                "lifecycle.stop",
+                json!({
+                    "lease_id": request.lease_id,
+                    "force": request.force,
+                    "accepted": true,
+                }),
+            ),
+            Err(err) => error_response(400, err),
+        },
         ("POST", "/files/mkdir") => match create_runner_file_directory(body, &broker_auth) {
             Ok(body) => daemon_endpoint_response("files.mkdir", body),
             Err(err) => remote_runner::auth_or_bad_request(err),
@@ -1143,6 +1234,7 @@ where
             body: json!({ "error": "method_not_allowed" }),
             artifact: None,
         },
+        ("GET", "/lifecycle/stop") => method_not_allowed(),
         ("GET", "/files/mkdir") | ("GET", "/files/upload") | ("GET", "/files/download") => {
             method_not_allowed()
         }
@@ -1164,6 +1256,58 @@ where
         }
         _ => route_read_only_api(method, path, body, job_store, analysis_runner),
     }
+}
+
+fn lifecycle_stop_request(body: Option<serde_json::Value>) -> Result<LifecycleStopRequest> {
+    let request: LifecycleStopRequest = serde_json::from_value(body.unwrap_or_else(|| json!({})))
+        .map_err(|error| {
+        Error::validation_invalid_argument(
+            "body",
+            format!("invalid daemon lifecycle stop request: {error}"),
+            None,
+            None,
+        )
+    })?;
+    if request.lease_id.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "lease_id",
+            "daemon lifecycle stop requires the exact live lease ID",
+            None,
+            None,
+        ));
+    }
+    Ok(request)
+}
+
+fn validate_lifecycle_stop_request(request: &LifecycleStopRequest) -> Result<()> {
+    let path = state_path()?;
+    let validation = validate_lease_file(&path)?;
+    let state = validation.state.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "lease_id",
+            "daemon lifecycle stop requires a live recorded lease",
+            Some(request.lease_id.clone()),
+            None,
+        )
+    })?;
+    if !validation.running || state.lease_id != request.lease_id {
+        return Err(Error::validation_invalid_argument(
+            "lease_id",
+            format!(
+                "daemon lifecycle stop expected live lease `{}` but found `{}`; refusing replacement",
+                request.lease_id, state.lease_id
+            ),
+            Some(request.lease_id.clone()),
+            None,
+        ));
+    }
+    if !request.force {
+        let active_job_ids = active_daemon_job_ids()?;
+        if !active_job_ids.is_empty() {
+            return Err(active_jobs_block_daemon_stop_error(&state, &active_job_ids));
+        }
+    }
+    Ok(())
 }
 
 fn daemon_freshness_report(job_store: &JobStore) -> Result<DaemonFreshnessReport> {
@@ -1679,6 +1823,60 @@ mod tests {
 
         assert_eq!(metadata["durable_run_id"], "agent-task-run-123");
         assert_eq!(metadata["agent_task_run_id"], "agent-task-run-123");
+    }
+
+    #[test]
+    fn routine_stop_names_active_jobs_and_daemon_identities() {
+        let state = DaemonState {
+            schema: DAEMON_LEASE_SCHEMA.to_string(),
+            lease_id: "lease-a".to_string(),
+            startup_token: "token-a".to_string(),
+            address: "127.0.0.1:7421".to_string(),
+            pid: 42,
+            state_path: "/tmp/state.json".to_string(),
+            started_at: "now".to_string(),
+            last_seen_at: "now".to_string(),
+            build_identity: build_identity::current(),
+            binary_sha256: None,
+            runtime_paths: DaemonRuntimeSnapshot {
+                loaded_at: "now".to_string(),
+                paths: Vec::new(),
+            },
+        };
+        let job_id = Uuid::parse_str("92e0a4b0-d0c1-4231-a83f-654734792797").expect("job id");
+
+        let error = active_jobs_block_daemon_stop_error(&state, &[job_id]);
+
+        assert!(error.message.contains(&job_id.to_string()));
+        assert_eq!(error.details["active_job_ids"], serde_json::json!([job_id]));
+        assert_eq!(
+            error.details["current_daemon_identity"],
+            state.build_identity.display
+        );
+        assert_eq!(
+            error.details["requested_homeboy_identity"],
+            build_identity::current().display
+        );
+    }
+
+    #[test]
+    fn routine_stop_gate_reads_queued_and_running_durable_jobs() {
+        with_isolated_home(|_| {
+            let store = JobStore::open_without_reconciliation(
+                paths::daemon_jobs_file().expect("daemon jobs path"),
+            )
+            .expect("open daemon jobs");
+            let queued = store.create("runner.exec");
+            let running = store.create("runner.exec");
+            store.start(running.id).expect("start durable job");
+            let mut expected = vec![queued.id, running.id];
+            expected.sort();
+
+            assert_eq!(
+                active_daemon_job_ids().expect("active daemon jobs"),
+                expected
+            );
+        });
     }
 }
 
@@ -2279,6 +2477,16 @@ where
         loopback_bind,
         trusted_local: false,
     };
+    let lifecycle_stop = (method == "POST" && path == "/lifecycle/stop")
+        .then(|| {
+            lifecycle_stop_request(parsed_body.clone())
+                .and_then(|request| validate_lifecycle_stop_request(&request).map(|_| request))
+        })
+        .transpose();
+    let lifecycle_stop = match lifecycle_stop {
+        Ok(request) => request,
+        Err(error) => return write_http_response(stream, error_response(400, error)),
+    };
     let response = route_with_job_store_and_body_and_runner_and_auth(
         method,
         path,
@@ -2287,7 +2495,14 @@ where
         analysis_runner,
         broker_auth,
     );
-    write_http_response(stream, response)
+    write_http_response(stream, response)?;
+    if let Some(request) = lifecycle_stop {
+        // The accepted response reaches the controller before the daemon signals
+        // itself. The exact lease and durable-job gate are rechecked under the
+        // daemon lifecycle lock immediately before that signal.
+        let _ = stop_with_force_for_lease(&request.lease_id, request.force);
+    }
+    Ok(())
 }
 
 fn read_http_request(stream: &mut TcpStream) -> std::io::Result<Vec<u8>> {

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -1267,17 +1267,28 @@ pub fn statuses() -> Result<Vec<RunnerStatusReport>> {
 }
 
 pub fn disconnect(runner_id: &str) -> Result<RunnerDisconnectReport> {
-    let runner = load(runner_id)?;
+    disconnect_with_force(runner_id, false)
+}
+
+pub(crate) fn disconnect_with_force(
+    runner_id: &str,
+    force: bool,
+) -> Result<RunnerDisconnectReport> {
+    let promotion_lease =
+        crate::core::runtime_promotion::acquire("runner daemon disconnect", runner_id.to_string())?;
+    promotion_lease.assert_generation()?;
     let session_path = session_path(runner_id)?;
     let session = read_session(runner_id)?;
     if let Some(session) = &session {
         if session.mode == RunnerTunnelMode::DirectSsh {
-            if let Err(err) = disconnect_remote_daemon(&runner, session) {
-                log_status!(
-                    "runner",
-                    "Could not stop remote daemon for runner `{runner_id}` during disconnect: {err}"
-                );
-            }
+            disconnect_remote_daemon(session, force).map_err(|err| {
+                Error::validation_invalid_argument(
+                    "disconnect",
+                    format!("refusing to disconnect runner `{runner_id}` because its remote daemon was not stopped safely: {err}"),
+                    Some(runner_id.to_string()),
+                    Some(vec![format!("homeboy runner status {}", shell::quote_arg(runner_id))]),
+                )
+            })?;
         }
         if let Some(pid) = session.tunnel_pid {
             terminate_pid(pid);
@@ -1300,56 +1311,52 @@ pub fn disconnect(runner_id: &str) -> Result<RunnerDisconnectReport> {
 }
 
 fn disconnect_remote_daemon(
-    runner: &Runner,
     session: &RunnerSession,
+    force: bool,
 ) -> std::result::Result<(), String> {
-    let Some((_, _, client)) =
-        remote_daemon::resolve_ssh_runner(runner).map_err(|err| err.message)?
-    else {
-        return Ok(());
-    };
-    let homeboy =
-        remote_runner_homeboy_path(runner, "runner disconnect").map_err(|err| err.message)?;
-    let output = client.execute(&remote_daemon_disconnect_command(
-        homeboy,
-        session.remote_daemon_pid,
-    ));
-    if !output.success {
-        return Err(command_failure_message(
-            "remote daemon stop failed while disconnecting runner",
-            &output,
+    let local_url = session.local_url.as_deref().ok_or_else(|| {
+        "direct SSH runner session has no live daemon tunnel; refusing unbound remote stop"
+            .to_string()
+    })?;
+    let lease_id = session.remote_daemon_lease_id.as_deref().ok_or_else(|| {
+        "direct SSH runner session has no daemon lease; refusing unbound remote stop".to_string()
+    })?;
+    let client = Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|error| format!("build daemon lifecycle client: {error}"))?;
+    let response = client
+        .post(format!(
+            "{}/lifecycle/stop",
+            local_url.trim_end_matches('/')
+        ))
+        .json(&serde_json::json!({ "lease_id": lease_id, "force": force }))
+        .send()
+        .map_err(|error| format!("request lease-bound daemon stop: {error}"))?;
+    let status = response.status();
+    let body = response
+        .text()
+        .map_err(|error| format!("read lease-bound daemon stop response: {error}"))?;
+    if !status.is_success() {
+        return Err(format!(
+            "lease-bound daemon stop was refused with HTTP {}: {}",
+            status.as_u16(),
+            response_body_excerpt(&body)
         ));
     }
     Ok(())
 }
 
-fn remote_daemon_disconnect_command(homeboy: &str, remote_daemon_pid: Option<u32>) -> String {
-    let mut command = format!(
-        "{} daemon stop >/dev/null 2>&1 || true",
-        shell::quote_arg(homeboy)
-    );
-    if let Some(pid) = remote_daemon_pid {
-        command.push_str("\n");
-        command.push_str(&format!("pid={pid}\n"));
-        command.push_str("if [ -r \"/proc/$pid/cmdline\" ]; then\n");
-        command
-            .push_str("  cmdline=$(tr '\\0' ' ' < \"/proc/$pid/cmdline\" 2>/dev/null || true)\n");
-        command.push_str("  case \"$cmdline\" in\n");
-        command.push_str("    *\" daemon serve \"*)\n");
-        command.push_str("      kill -TERM \"$pid\" 2>/dev/null || true\n");
-        command.push_str("      i=0\n");
-        command.push_str("      while kill -0 \"$pid\" 2>/dev/null && [ \"$i\" -lt 20 ]; do\n");
-        command.push_str("        i=$((i + 1))\n");
-        command.push_str("        sleep 0.1\n");
-        command.push_str("      done\n");
-        command.push_str("      if kill -0 \"$pid\" 2>/dev/null; then\n");
-        command.push_str("        kill -KILL \"$pid\" 2>/dev/null || true\n");
-        command.push_str("      fi\n");
-        command.push_str("      ;;\n");
-        command.push_str("  esac\n");
-        command.push_str("fi");
+fn response_body_excerpt(body: &str) -> String {
+    const LIMIT: usize = 2_000;
+    let trimmed = body.trim();
+    if trimmed.len() <= LIMIT {
+        return trimmed.to_string();
     }
-    command
+    format!(
+        "{}...<truncated>",
+        trimmed.chars().take(LIMIT).collect::<String>()
+    )
 }
 
 mod remote_daemon {
@@ -2356,6 +2363,7 @@ use session_store::*;
 mod tests {
     use clap::Parser;
     use std::collections::HashMap;
+    use std::io::{Read, Write};
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
@@ -3447,15 +3455,37 @@ esac
     }
 
     #[test]
-    fn remote_daemon_disconnect_command_guards_recorded_pid() {
-        let command = remote_daemon_disconnect_command("/opt/homeboy", Some(42));
+    fn routine_disconnect_refuses_an_unbound_session_without_executing_a_configured_binary() {
+        let mut session = direct_ssh_session("lease-live");
+        session.local_url = None;
 
-        assert!(command.contains("/opt/homeboy daemon stop"));
-        assert!(command.contains("pid=42"));
-        assert!(command.contains("/proc/$pid/cmdline"));
-        assert!(command.contains("*\" daemon serve \"*)"));
-        assert!(command.contains("kill -TERM \"$pid\""));
-        assert!(command.contains("kill -KILL \"$pid\""));
+        let error = disconnect_remote_daemon(&session, false)
+            .expect_err("routine disconnect must require the live daemon tunnel and exact lease");
+
+        assert!(error.contains("no live daemon tunnel"));
+    }
+
+    #[test]
+    fn routine_disconnect_posts_the_exact_live_lease_to_the_daemon_tunnel() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("address");
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("request");
+            let mut request = [0; 4096];
+            let length = stream.read(&mut request).expect("read request");
+            let request = String::from_utf8(request[..length].to_vec()).expect("request text");
+            assert!(request.starts_with("POST /lifecycle/stop HTTP/1.1"));
+            assert!(request.contains("\"lease_id\":\"lease-live\""));
+            assert!(request.contains("\"force\":false"));
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}")
+                .expect("response");
+        });
+        let mut session = direct_ssh_session("lease-live");
+        session.local_url = Some(format!("http://{address}"));
+
+        disconnect_remote_daemon(&session, false).expect("guarded lifecycle stop accepted");
+        server.join().expect("server");
     }
 
     #[test]

--- a/src/core/runner/homeboy_refresh.rs
+++ b/src/core/runner/homeboy_refresh.rs
@@ -15,10 +15,10 @@ use crate::core::output::MergeOutput;
 
 use super::connection::active_jobs_before_daemon_replacement;
 use super::{
-    connect_with_orphan_adoption, disconnect, exec, load, materialize_runner_extension_with_env,
-    merge, normalize_runner_command_env_for_homeboy_path, plan_controller_snapshot_extension,
-    RunnerCapabilityPreflight, RunnerExecOptions, RunnerExecOutput,
-    RunnerExtensionMaterializationRequest, RunnerExtensionMaterializationSource,
+    connect_with_orphan_adoption, disconnect_with_force, exec, load,
+    materialize_runner_extension_with_env, merge, normalize_runner_command_env_for_homeboy_path,
+    plan_controller_snapshot_extension, RunnerCapabilityPreflight, RunnerExecOptions,
+    RunnerExecOutput, RunnerExtensionMaterializationRequest, RunnerExtensionMaterializationSource,
     RunnerFileTransfer, RunnerKind,
 };
 
@@ -401,7 +401,7 @@ pub fn refresh_homeboy_binary(
             active_jobs.iter().map(|job| job.job_id.as_str()),
             options.force,
         )?;
-        let _ = disconnect(&plan.runner_id);
+        disconnect_with_force(&plan.runner_id, options.force)?;
         let (_report, connect_exit_code) = connect_with_orphan_adoption(
             &plan.runner_id,
             refresh_owned_lease.as_deref(),

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -88,6 +88,7 @@ pub(crate) use command_path::{
     normalize_runner_command_env_for_homeboy_path, quote_runner_env_value,
     remote_shell_path_preamble,
 };
+pub(crate) use connection::disconnect_with_force;
 pub use connection::{
     connect, connect_reverse, connect_with_leaseless_orphan_reconciliation,
     connect_with_orphan_adoption, connect_with_recovery, disconnect, reverse_broker_artifact,


### PR DESCRIPTION
## Summary
Prevent routine runner reconnect and disconnect paths from replacing a live daemon while it owns accepted jobs.

## What changed
- Routine daemon stop and disconnect now identify queued and running durable jobs and refuse unsafe replacement.
- Reconnect reattaches to a live stale daemon with active jobs instead of rolling its binary or terminating its process tree.

## How to test
1. Run `cargo test --lib routine_stop --no-fail-fast`; expect passes.
2. Run `cargo test --lib reattaches_live_stale_daemon_with_active_jobs_without_replacing_it --no-fail-fast`; expect passes.
3. Run `cargo test --lib routine_disconnect --no-fail-fast`; expect passes.

## Compatibility
No public extension-path change. Routine reconnect becomes intentionally stricter when accepted jobs are active; explicit destructive recovery remains separate.

## Evidence
- CI expected: Homeboy CI
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8135
- diff\_check: Passed
- format: Passed
- routine\_disconnect: Passed
- routine\_stop: Passed
- stale\_daemon\_reattach: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-terra
- **Used for:** Implemented, tested, rebased, and finalized the active-daemon lifecycle repair with Chris.

## Source relationships
- Closes Extra-Chill/homeboy#8135
