### PR TITLE
refactor: relocate output routing from command_contract to commands

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -21,7 +21,6 @@ mod constants;
 mod descriptors;
 mod lab;
 mod output;
-mod output_routing;
 mod public_variants;
 mod registry;
 pub mod safety_manifest;

--- a/src/commands/contract_output_routing.rs
+++ b/src/commands/contract_output_routing.rs
@@ -6,10 +6,10 @@
 //! output contract type definitions) free of `commands` dependencies.
 
 use crate::cli_surface::Commands;
-use crate::command_contract::spec::CommandSpec;
+use crate::command_contract::CommandSpec;
 use crate::commands::{adapter, file, logs, report, review, runner, runtime, trace};
 
-use super::output::{
+use crate::command_contract::{
     CommandDescriptor, CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor,
     CommandOutputFileMode, CommandRawOutputMode, CommandResponseMode, CommandResponsePlan,
     CommandStdoutMode,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -216,6 +216,7 @@ pub mod cleanup;
 pub mod component;
 pub mod config;
 pub mod contract;
+pub mod contract_output_routing;
 pub mod docs;
 pub mod extension;
 pub mod fleet;


### PR DESCRIPTION
## Summary

First relocation step: physically move a CLI-coupled routing module out of `command_contract` to the CLI side (`commands/`). Proves the relocation pattern before the larger `placement`/`descriptors` moves.

## The change
`command_contract/output_routing.rs` held the `impl Commands` output-descriptor routing (`descriptor`, `output_descriptor`, `response_plan`). It depends on `cli_surface::Commands` and eight command handler modules — it's CLI-side code that was living in `command_contract` (which we're decomposing into a core-shareable type layer).

Moved it to `commands/contract_output_routing.rs` (`git mv`, history preserved) and repointed its `super::output`/`spec` imports to the `command_contract` public re-exports. The `impl Commands` methods stay globally available to all callers — they're inherent methods on the CLI `Commands` enum, so relocating the file doesn't change where they can be called from.

## Result
`command_contract` no longer depends on `commands` via output routing. Remaining `command_contract` commands-coupling: the `descriptors` dispatch macro, `lab/placement` routing, and `safety_manifest`'s `cli_surface` type imports — each relocated in follow-ups.

## Verification
- `cargo check --lib` — 0 errors.
- `cargo check --lib --tests` — 0 errors.
- `cargo fmt` clean.

## Context
Part of the `command_contract` decomposition → `homeboy-cli` extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)