### PR TITLE
Make Lab agent-task handoff and harvest provenance durable

### DIFF
--- a/src/core/agent_task_scheduler/harvest.rs
+++ b/src/core/agent_task_scheduler/harvest.rs
@@ -778,6 +778,92 @@ mod committed_harvest_tests {
     }
 
     #[test]
+    fn lab_resident_snapshot_preflight_does_not_require_controller_source_path() {
+        let _guard = LAB_ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("Lab environment lock");
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source");
+        let path = workspace.path().display().to_string();
+        let snapshot = SourceSnapshot {
+            runner_id: "lab".to_string(),
+            local_path: None,
+            remote_path: Some(path.clone()),
+            workspace_root: None,
+            git_branch: Some("main".to_string()),
+            git_sha: Some("b".repeat(40)),
+            dirty: false,
+            sync_mode: "lab_offload".to_string(),
+            workspace_snapshot_identity: Some("snapshot:runner-resident".to_string()),
+            snapshot_hash: "sha256:runner-resident".to_string(),
+            synced_at: "2026-01-01T00:00:00Z".to_string(),
+            sync_excludes: vec![".git".to_string(), ".git/**".to_string()],
+        };
+        let content_hash =
+            crate::core::runner::workspace_content_hash(workspace.path(), &snapshot.sync_excludes)
+                .expect("content hash");
+        let lab = serde_json::json!({
+            "runner_id": "lab", "remote_workspace": path, "sync_mode": "snapshot", "status": "offloaded",
+            "source_snapshot": snapshot,
+            "workspace_verification": {
+                "schema": "homeboy/lab-workspace-verification/v2", "identity": "snapshot:runner-resident",
+                "content_hash": content_hash, "sync_excludes": snapshot.sync_excludes,
+                "permission_policy": "unix-executable", "content_hash_algorithm": "homeboy-workspace-content-v2+unix-executable",
+                "source_snapshot": snapshot,
+                "primary_workspace": { "identity": "snapshot:runner-resident", "remote_path": workspace.path().display().to_string() }
+            }
+        });
+        std::env::set_var(
+            crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV,
+            serde_json::to_string(&snapshot).expect("snapshot JSON"),
+        );
+        std::env::set_var(
+            crate::core::observation::LAB_OFFLOAD_METADATA_ENV,
+            serde_json::to_string(&lab).expect("Lab JSON"),
+        );
+        let request = AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "runner-resident-snapshot-task".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "test".to_string(),
+                selector: None,
+                runtime_selection: None,
+                required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
+                model: None,
+                config: serde_json::Value::Null,
+            },
+            instructions: String::new(),
+            inputs: serde_json::Value::Null,
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace {
+                root: Some(workspace.path().display().to_string()),
+                ..Default::default()
+            },
+            component_contracts: Vec::new(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            artifact_declarations: Vec::new(),
+            metadata: serde_json::Value::Null,
+        };
+
+        let preflight = prepare_committed_harvest(&request)
+            .expect("runner-resident snapshot harvest preflight");
+
+        assert!(preflight.base_sha.is_some());
+        assert_eq!(
+            preflight.source_provenance.expect("source provenance")["workspace_snapshot_identity"],
+            "snapshot:runner-resident"
+        );
+        std::env::remove_var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV);
+        std::env::remove_var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV);
+    }
+
+    #[test]
     fn local_non_git_workspace_skips_harvest_preflight_without_lab_transport() {
         let _guard = LAB_ENV_LOCK
             .get_or_init(|| Mutex::new(()))

--- a/src/core/agent_task_service/execution.rs
+++ b/src/core/agent_task_service/execution.rs
@@ -68,11 +68,22 @@ pub fn run_loaded_plan<E>(
 where
     E: AgentTaskExecutorAdapter,
 {
-    prepare_plan_for_execution(&mut plan, record_run_id)?;
-
     if let Some(run_id) = record_run_id {
+        // A runner has its own lifecycle store. Materialize the handed-off plan
+        // before any preparation can invoke runner-scoped lifecycle commands.
         agent_task_lifecycle::submit_plan(&plan, Some(run_id))?;
+        if let Err(error) = prepare_plan_for_execution(&mut plan, Some(run_id)) {
+            agent_task_lifecycle::record_pre_execution_failure(
+                run_id,
+                &plan,
+                "prepare_plan_for_execution",
+                &error,
+            )?;
+            return Err(error);
+        }
         agent_task_lifecycle::mark_running(run_id)?;
+    } else {
+        prepare_plan_for_execution(&mut plan, None)?;
     }
 
     let aggregate = run_plan_with_scheduler(plan.clone(), record_run_id, executor);

--- a/src/core/agent_task_service/tests.rs
+++ b/src/core/agent_task_service/tests.rs
@@ -92,6 +92,45 @@ fn service_run_loaded_plan_persists_durable_lifecycle() {
 }
 
 #[test]
+fn runner_handoff_materializes_the_run_before_preparation_failure() {
+    with_isolated_home(|_| {
+        let mut plan = test_plan();
+        plan.tasks[0]
+            .executor
+            .secret_env
+            .push("__HOMEBOY_TEST_MISSING_RUNNER_HANDOFF_SECRET__".to_string());
+        std::env::remove_var("__HOMEBOY_TEST_MISSING_RUNNER_HANDOFF_SECRET__");
+
+        let error = run_loaded_plan(
+            plan,
+            Some("controller-proxy-interrupted-runner-handoff"),
+            SucceedingExecutor,
+        )
+        .expect_err("runner preparation fails after receiving the durable plan");
+        let record = lifecycle_status("controller-proxy-interrupted-runner-handoff")
+            .expect("runner-scoped status resolves from its materialized record");
+        let log = agent_task_lifecycle::logs("controller-proxy-interrupted-runner-handoff")
+            .expect("runner-scoped logs resolve from its materialized record");
+        let recovery = run_submitted(
+            "controller-proxy-interrupted-runner-handoff".to_string(),
+            SucceedingExecutor,
+        )
+        .expect("runner-scoped run resolves the materialized terminal record");
+
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert_eq!(record.state, AgentTaskRunState::Failed);
+        assert_eq!(record.tasks[0].state, AgentTaskState::Failed);
+        assert!(!log.events.is_empty());
+        assert_eq!(recovery.exit_code, 1);
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["phase"],
+            "prepare_plan_for_execution"
+        );
+        assert!(agent_task_lifecycle::load_plan(&record.run_id).is_ok());
+    });
+}
+
+#[test]
 fn submitted_terminal_runs_reuse_durable_evidence_without_reexecution() {
     with_isolated_home(|_| {
         for (run_id, expected_exit_code) in [("terminal-succeeded", 0), ("terminal-failed", 1)] {

--- a/src/core/runner/workspace/provenance.rs
+++ b/src/core/runner/workspace/provenance.rs
@@ -158,10 +158,6 @@ pub(crate) fn verify_lab_workspace(
     snapshot: SourceSnapshot,
     lab: serde_json::Value,
 ) -> std::result::Result<VerifiedLabWorkspaceProvenance, String> {
-    snapshot
-        .local_path
-        .as_deref()
-        .ok_or("is missing controller source path")?;
     let recorded_remote_path = snapshot
         .remote_path
         .as_deref()


### PR DESCRIPTION
## Summary
Make interrupted Lab agent-task recovery resolve the same durable record on both controller and runner, and allow runner-resident snapshot harvest to verify without a controller-local path.

## What changed
- Materialize the durable run and plan before runner-side preparation can fail, recording preparation failures in the runner lifecycle store.
- Verify runner-resident snapshot harvest from its remote identity and content provenance instead of requiring an unavailable controller source path.

## How to test
1. Run `cargo test --lib runner_handoff_materializes_the_run_before_preparation_failure`; expect passes with 1 focused regression test.
2. Run `cargo test --lib lab_resident_snapshot_preflight_does_not_require_controller_source_path`; expect passes with 1 focused regression test.
3. Run `cargo check --lib`; expect passes.
4. Run `cargo build --release --bin homeboy`; expect passes.

## Compatibility
No CLI or persisted schema is removed. Existing controller-local paths remain accepted; runner-resident snapshots now use their recorded remote provenance, and pre-execution failures become durably observable.

## Evidence
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8248
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8248#issuecomment-4976857186
- focused-tests: Passed
- lib-check: Passed
- release-build: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-terra
- **Used for:** Diagnosed the controller/Lab ownership failures, prepared the implementation and regression tests on Lab, and orchestrated Homeboy promotion and verification; Chris reviews and owns the change.

## Source relationships
- Closes #8248
