### PR TITLE
fix: report real homeboy version in rig-schema error + refresh stale fanout assertions

### DIFF
--- a/crates/homeboy-error/src/lib.rs
+++ b/crates/homeboy-error/src/lib.rs
@@ -592,8 +592,12 @@ impl Error {
         serde_error: impl Into<String>,
         context: impl Into<String>,
         component: Option<String>,
+        active_version: &str,
     ) -> Self {
-        let active = env!("CARGO_PKG_VERSION");
+        // The active version is supplied by the caller: `env!(CARGO_PKG_VERSION)`
+        // evaluated inside this error crate would report the crate's own version
+        // (e.g. 0.1.0), not the running homeboy build the operator needs to see.
+        let active = active_version;
         let serde_error = serde_error.into();
         let message = match &component {
             Some(name) => format!(

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -3077,14 +3077,16 @@ mod tests {
             .expect_err("fanout submit-batch must not run locally under Lab placement");
 
         assert_eq!(err.code.as_str(), "validation.invalid_argument");
-        assert!(err
-            .message
-            .contains("Lab placement refused local execution"));
-        assert!(err.message.contains("automatic Lab offload disabled"));
+        // submit-batch needs an explicit runner under Lab placement: it does
+        // not auto-offload, so `--placement lab` without an eligible runner is
+        // refused rather than silently running locally.
+        assert!(err.message.contains("--placement lab"));
+        assert!(err.message.contains("requires an eligible Lab runner"));
+        assert!(err.message.contains("agent-task fanout submit-batch"));
     }
 
     #[test]
-    fn agent_task_fanout_run_plan_supports_lab_runner_routing() {
+    fn agent_task_fanout_run_plan_coordination_is_controller_local() {
         let normalized = vec![
             "homeboy".to_string(),
             "--runner".to_string(),
@@ -3099,13 +3101,21 @@ mod tests {
         ];
         let cli = Cli::parse_from(&normalized);
 
+        // Fanout coordination is controller-owned so durable batch state,
+        // worktree ownership, and recovery stay local; the coordinator itself
+        // is not Lab-portable, though the independent cooks it generates may use
+        // their own Lab placement (#8045).
         let command = lab_offload_command(&cli.command).unwrap().unwrap();
         assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
         assert_eq!(cli.placement, crate::cli_surface::Placement::Lab);
         assert_eq!(command.hot_label, "agent-task fanout run-plan");
-        assert!(command.is_portable());
-        assert!(command.routing_policy.default_lab_offload);
-        assert!(command.routing_policy.requires_extension_parity);
+        assert!(!command.is_portable());
+        assert!(!command.routing_policy.default_lab_offload);
+        assert!(!command.routing_policy.requires_extension_parity);
+        assert!(cli
+            .command
+            .lab_runner_unsupported_reason()
+            .is_some_and(|reason| reason.contains("controller-owned")));
     }
 
     #[test]

--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -225,6 +225,7 @@ fn validate_rig_spec_file(path: &Path, source_root: &Path, rig_id: &str) -> Resu
             e.to_string(),
             format!("parse rig spec {}", path.display()),
             None,
+            env!("CARGO_PKG_VERSION"),
         )
     })?;
     if spec.id.is_empty() {

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -291,7 +291,12 @@ fn rig_spec_parse_error(
     let context = format!("parse rig spec {}", path.display());
     if matches!(err.classify(), serde_json::error::Category::Data) {
         let component = value.and_then(component_with_unrecognized_schema);
-        return Error::rig_schema_unsupported(err.to_string(), context, component);
+        return Error::rig_schema_unsupported(
+            err.to_string(),
+            context,
+            component,
+            env!("CARGO_PKG_VERSION"),
+        );
     }
     Error::validation_invalid_json(err, Some(context), received)
 }


### PR DESCRIPTION
## Summary

Three deterministic Test-gate reds found in a post-burndown sweep of `main`. One is a real user-facing production bug; two are stale assertions that drifted from #8045 / a changed refusal message.

### 1. Wrong "active version" in rig-schema-unsupported error (**production bug**)

`Error::rig_schema_unsupported` builds a message like *"this rig may require a newer homeboy — active version is X"*. After error handling moved into the `homeboy-error` crate, its `env!("CARGO_PKG_VERSION")` resolves to **that crate's own version (0.1.0)** rather than the running homeboy build. So an operator hitting an unrecognized rig schema was told their active version is `0.1.0` and to upgrade past it — useless guidance.

Fix: take the active version as a caller-supplied argument; both call sites (`rig/mod.rs`, `rig/install.rs`) pass the **main crate's** `CARGO_PKG_VERSION`. Fixes `data_shape_error_surfaces_schema_unsupported_with_component`.

### 2. Stale fanout run-plan portability assertion

`agent_task_fanout_run_plan_supports_lab_runner_routing` still asserted the pre-#8045 portable contract, but fanout `run-plan` coordination is now controller-local (like cook-batch — #8174 fixed the cook-batch twin). Updated to the local-only contract (`!is_portable()`, coordinator reason) and renamed to `_coordination_is_controller_local`.

### 3. Stale submit-batch deny message

`agent_task_fanout_submit_batch_requires_explicit_runner_under_lab_placement` asserted an obsolete message ("Lab placement refused local execution" / "automatic Lab offload disabled"). The refusal now reads *"--placement lab requires an eligible Lab runner for `agent-task fanout submit-batch`"*. Matched the current wording (error code unchanged).

## Verification

- `commands::infra::route` + `core::rig::schema_error_tests` — **80 pass** serially.
- (The remaining ~8 `infra::route` parallel-order flakes are the separate, pre-existing HOME-hermeticity issue: those Review-contract tests resolve ambient component/extension config and race `with_isolated_home` neighbors — not addressed here.)