### PR TITLE
refactor: relocate lab routing from command_contract to commands

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -64,9 +64,12 @@ pub use lab::{
     RUN_LOCATION_INDEX_SCHEMA,
 };
 pub(crate) use lab::{
-    LAB_NO_EXTRA_CAPABILITIES, LAB_TRACE_SECRET_ENV_SOURCES, LAB_TUNNEL_SECRET_ENV_SOURCES,
-    RIG_SOURCE_MANAGEMENT_LAB_UNSUPPORTED_REASON, RIG_UP_LAB_UNSUPPORTED_REASON,
+    LAB_AGENT_TASK_SECRET_ENV_SOURCES, LAB_NO_EXTRA_CAPABILITIES, LAB_TRACE_SECRET_ENV_SOURCES,
+    LAB_TUNNEL_SECRET_ENV_SOURCES, RIG_SOURCE_MANAGEMENT_LAB_UNSUPPORTED_REASON,
+    RIG_UP_LAB_UNSUPPORTED_REASON,
 };
+// Lab-label constants needed by the relocated lab routing in
+// commands::contract_lab_routing (the spec module itself stays private).
 pub use output::{
     CommandDescriptor, CommandDispatchFamily, CommandJsonFamily, CommandOutputContractKind,
     CommandOutputDescriptor, CommandOutputFileMode, CommandRawOutputMode, CommandResponseMode,
@@ -81,6 +84,14 @@ pub use spec::{
     registered_command_json_family, runtime_extension_command_doc_slugs, support_command_doc_slugs,
     CommandDocKind, CommandDocSpec, CommandLabSupportSummary, CommandPathSafetySpec,
     CommandSafetySpec, CommandSpec, COMMAND_DOC_REGISTRY, COMMAND_SPECS,
+};
+pub(crate) use spec::{
+    AGENT_TASK_AUTH_STATUS_LAB_LABEL, AGENT_TASK_CONTROLLER_FROM_SPEC_LAB_LABEL,
+    AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL, AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL,
+    AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL, AGENT_TASK_FANOUT_STATUS_LAB_LABEL,
+    AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL, AGENT_TASK_PROMOTE_LAB_LABEL,
+    AGENT_TASK_PROVIDERS_LAB_LABEL, AGENT_TASK_RUN_LAB_LABEL, AGENT_TASK_STATUS_LAB_LABEL,
+    RUNTIME_REFRESH_LAB_LABEL,
 };
 pub(crate) use spec::{
     AUDIT_LAB_LABEL, BENCH_LAB_LABEL, FUZZ_DOCTOR_LAB_LABEL, FUZZ_LAB_LABEL, LINT_LAB_LABEL,

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -111,10 +111,7 @@ fn lab_cli_arguments_are_visible_for_path(path: &[String]) -> bool {
 }
 
 mod handoff;
-mod placement;
 mod support;
-#[cfg(test)]
-mod tests;
 mod types;
 mod workload;
 
@@ -122,8 +119,3 @@ pub use handoff::*;
 pub use support::*;
 pub use types::*;
 pub use workload::*;
-
-#[cfg(test)]
-pub(crate) use placement::{
-    AGENT_TASK_COOK_COORDINATOR_CONTROLLER_REASON, AGENT_TASK_FANOUT_COORDINATOR_CONTROLLER_REASON,
-};

--- a/src/commands/contract_lab_routing.rs
+++ b/src/commands/contract_lab_routing.rs
@@ -3,7 +3,8 @@
 use std::collections::BTreeSet;
 
 use crate::cli_surface::Commands;
-use crate::command_contract::spec::{
+use crate::command_contract::CommandDescriptor;
+use crate::command_contract::{
     AGENT_TASK_AUTH_STATUS_LAB_LABEL, AGENT_TASK_CONTROLLER_FROM_SPEC_LAB_LABEL,
     AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL, AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL,
     AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL, AGENT_TASK_FANOUT_STATUS_LAB_LABEL,
@@ -11,13 +12,12 @@ use crate::command_contract::spec::{
     AGENT_TASK_PROVIDERS_LAB_LABEL, AGENT_TASK_RUN_LAB_LABEL, AGENT_TASK_STATUS_LAB_LABEL,
     RUNTIME_REFRESH_LAB_LABEL,
 };
-use crate::command_contract::CommandDescriptor;
 use crate::commands::{adapter, agent_task};
 use crate::core::agent_tasks::provider::{default_backend, provider_requires_cwd_git_checkout};
 use crate::core::engine::execution_context::{self, ResolveOptions};
 use crate::core::extension::ExtensionCapability;
 
-use super::{
+use crate::command_contract::{
     CommandPortabilityContract, LabCommandContract, LabCommandPortability, LabWorkspaceModePolicy,
     LAB_AGENT_TASK_SECRET_ENV_SOURCES, LAB_NO_EXTRA_CAPABILITIES,
 };
@@ -222,7 +222,7 @@ impl Commands {
 
     pub fn lab_route_contract(
         &self,
-    ) -> crate::core::Result<Option<super::LabCommandRouteContract>> {
+    ) -> crate::core::Result<Option<crate::command_contract::LabCommandRouteContract>> {
         let Some(contract) = self.lab_contract() else {
             return Ok(None);
         };

--- a/src/commands/contract_lab_routing_tests.rs
+++ b/src/commands/contract_lab_routing_tests.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 
 use crate::cli_surface::{Cli, Commands};
 
-use super::{LabCommandPortability, LabSourcePathMode, LabWorkspaceModePolicy};
+use crate::command_contract::{LabCommandPortability, LabSourcePathMode, LabWorkspaceModePolicy};
 
 fn parsed_command(args: &[&str]) -> Commands {
     Cli::try_parse_from(args)
@@ -75,7 +75,9 @@ fn agent_task_cook_coordinator_stays_controller_local() {
 
     assert_eq!(
         contract.portability,
-        LabCommandPortability::LocalOnly(super::AGENT_TASK_COOK_COORDINATOR_CONTROLLER_REASON)
+        LabCommandPortability::LocalOnly(
+            crate::commands::contract_lab_routing::AGENT_TASK_COOK_COORDINATOR_CONTROLLER_REASON
+        )
     );
     assert!(!contract.routing_policy.default_lab_offload);
 }
@@ -99,7 +101,9 @@ fn agent_task_cook_no_finalize_is_still_controller_local() {
 
     assert_eq!(
         contract.portability,
-        LabCommandPortability::LocalOnly(super::AGENT_TASK_COOK_COORDINATOR_CONTROLLER_REASON)
+        LabCommandPortability::LocalOnly(
+            crate::commands::contract_lab_routing::AGENT_TASK_COOK_COORDINATOR_CONTROLLER_REASON
+        )
     );
 }
 
@@ -116,7 +120,9 @@ fn fanout_and_child_cook_coordinators_stay_controller_local() {
     let coordinator_contract = coordinator.lab_contract().expect("fanout contract");
     assert_eq!(
         coordinator_contract.portability,
-        LabCommandPortability::LocalOnly(super::AGENT_TASK_FANOUT_COORDINATOR_CONTROLLER_REASON)
+        LabCommandPortability::LocalOnly(
+            crate::commands::contract_lab_routing::AGENT_TASK_FANOUT_COORDINATOR_CONTROLLER_REASON
+        )
     );
 
     let child = parsed_command(&[
@@ -135,7 +141,9 @@ fn fanout_and_child_cook_coordinators_stay_controller_local() {
             .lab_contract()
             .expect("child cook contract")
             .portability,
-        LabCommandPortability::LocalOnly(super::AGENT_TASK_COOK_COORDINATOR_CONTROLLER_REASON)
+        LabCommandPortability::LocalOnly(
+            crate::commands::contract_lab_routing::AGENT_TASK_COOK_COORDINATOR_CONTROLLER_REASON
+        )
     );
 }
 
@@ -161,7 +169,7 @@ fn agent_task_promote_with_runner_only_source_remains_lab_portable() {
 
     assert_eq!(
         contract.hot_label,
-        super::super::spec::AGENT_TASK_PROMOTE_LAB_LABEL
+        crate::command_contract::AGENT_TASK_PROMOTE_LAB_LABEL
     );
     assert_eq!(contract.portability, LabCommandPortability::Portable);
     assert_eq!(
@@ -206,7 +214,9 @@ fn rig_source_management_explains_lab_setup_boundary() {
         );
         assert_eq!(
             contract.portability,
-            LabCommandPortability::LocalOnly(super::RIG_SOURCE_MANAGEMENT_LAB_UNSUPPORTED_REASON)
+            LabCommandPortability::LocalOnly(
+                crate::command_contract::RIG_SOURCE_MANAGEMENT_LAB_UNSUPPORTED_REASON
+            )
         );
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -216,6 +216,9 @@ pub mod cleanup;
 pub mod component;
 pub mod config;
 pub mod contract;
+pub mod contract_lab_routing;
+#[cfg(test)]
+mod contract_lab_routing_tests;
 pub mod contract_output_routing;
 pub mod docs;
 pub mod extension;


### PR DESCRIPTION
## Summary

Relocates the lab-routing module (the biggest CLI-coupled piece) out of `command_contract` to the CLI side. Applies the pattern proven in #8251.

## The change
`command_contract/lab/placement.rs` held the `impl Commands` lab-routing surface (`lab_contract`, `lab_route_contract`, `portability_contract`, `supports_lab_runner`, ...) plus its behavior tests in `lab/tests.rs`. Both depend on `cli_surface::Commands` and command handler modules (`adapter`, `agent_task`) — CLI-side code living in `command_contract`.

- `placement.rs` → `commands/contract_lab_routing.rs`
- `lab/tests.rs` → `commands/contract_lab_routing_tests.rs`
- Repointed intra-`command_contract` paths (super:: lab types, spec label constants) to `command_contract` public re-exports.
- Exposed the lab-label constants + `LAB_AGENT_TASK_SECRET_ENV_SOURCES` as `pub(crate)` re-exports at the `command_contract` boundary (the `spec` module itself stays private).

The `impl Commands` methods remain globally available as inherent methods on the CLI enum, so all core/commands callers are unchanged.

## Result
`command_contract` commands-coupling is now down to **two files**:
- `descriptors.rs` — the dispatch macro (definition-only; `crate::commands` paths only resolve at CLI expansion sites, so no real compile dependency).
- `safety_manifest.rs` — `cli_surface` *type* imports.

The type layer (`lab` types, `output`, `spec`, `constants`, `registry`, `public_variants`) is clean and nearly extractable.

## Verification
- `cargo check --lib` — 0 errors.
- `cargo check --lib --tests` — 0 errors.
- `cargo fmt` clean.

## Context
`command_contract` decomposition → `homeboy-cli`. Next: handle `descriptors`/`safety_manifest`, then extract `homeboy-command-contract`, then `homeboy-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)