### PR TITLE
Validate publishable workspace manifests before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -443,6 +443,10 @@ jobs:
         if: inputs.release_tag == ''
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Preflight crates.io packages
+        if: inputs.release_tag == '' && needs.check.outputs.recovery-release != 'true'
+        run: cargo package --workspace --allow-dirty --no-verify
+
       - uses: Extra-Chill/homeboy-action@v2
         id: release
         if: inputs.release_tag == '' && needs.check.outputs.recovery-release != 'true'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,8 @@
 [workspace]
 # Internal crates split out of the homeboy monolith to gain per-crate
-# incremental compilation and lower peak build memory. These are path-only
-# members, never published to crates.io; the shipped artifact is still the
-# single `homeboy` binary. First extraction (homeboy-redaction) proves the
-# pattern ahead of larger extractions (e.g. runner).
+# incremental compilation and lower peak build memory. They are published as
+# dependencies of the `homeboy` crate; the shipped CLI artifact remains the
+# single `homeboy` binary.
 members = ["crates/*"]
 
 [package]
@@ -36,16 +35,17 @@ name = "bench-audit-self"
 path = "src/bin/bench-audit-self.rs"
 
 [dependencies]
-# Internal workspace crates (path-only, not published)
-homeboy-cli-contract = { path = "crates/homeboy-cli-contract" }
-homeboy-error = { path = "crates/homeboy-error" }
-homeboy-finding = { path = "crates/homeboy-finding" }
-homeboy-output = { path = "crates/homeboy-output" }
-homeboy-paths = { path = "crates/homeboy-paths" }
-homeboy-process = { path = "crates/homeboy-process" }
-homeboy-product-identity = { path = "crates/homeboy-product-identity" }
-homeboy-engine-primitives = { path = "crates/homeboy-engine-primitives" }
-homeboy-redaction = { path = "crates/homeboy-redaction" }
+# Internal workspace crates. Cargo uses the path locally and the version when
+# packaging the publishable homeboy crate for crates.io.
+homeboy-cli-contract = { version = "0.1.0", path = "crates/homeboy-cli-contract" }
+homeboy-error = { version = "0.1.0", path = "crates/homeboy-error" }
+homeboy-finding = { version = "0.1.0", path = "crates/homeboy-finding" }
+homeboy-output = { version = "0.1.0", path = "crates/homeboy-output" }
+homeboy-paths = { version = "0.1.0", path = "crates/homeboy-paths" }
+homeboy-process = { version = "0.1.0", path = "crates/homeboy-process" }
+homeboy-product-identity = { version = "0.1.0", path = "crates/homeboy-product-identity" }
+homeboy-engine-primitives = { version = "0.1.0", path = "crates/homeboy-engine-primitives" }
+homeboy-redaction = { version = "0.1.0", path = "crates/homeboy-redaction" }
 
 # Core library dependencies
 base64 = "0.22"

--- a/crates/homeboy-engine-primitives/Cargo.toml
+++ b/crates/homeboy-engine-primitives/Cargo.toml
@@ -12,7 +12,7 @@ name = "homeboy_engine_primitives"
 path = "src/lib.rs"
 
 [dependencies]
-homeboy-error = { path = "../homeboy-error" }
+homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 regex = "1.11"

--- a/crates/homeboy-paths/Cargo.toml
+++ b/crates/homeboy-paths/Cargo.toml
@@ -12,6 +12,6 @@ name = "homeboy_paths"
 path = "src/lib.rs"
 
 [dependencies]
-homeboy-error = { path = "../homeboy-error" }
-homeboy-product-identity = { path = "../homeboy-product-identity" }
+homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
+homeboy-product-identity = { version = "0.1.0", path = "../homeboy-product-identity" }
 shellexpand = "3.1"

--- a/crates/homeboy-process/Cargo.toml
+++ b/crates/homeboy-process/Cargo.toml
@@ -12,6 +12,6 @@ name = "homeboy_process"
 path = "src/lib.rs"
 
 [dependencies]
-homeboy-error = { path = "../homeboy-error" }
+homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
 libc = "0.2"
 ctrlc = "3.4"

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -215,6 +215,26 @@ fn release_planning_skips_quality_gates_already_owned_by_gate_jobs() {
 }
 
 #[test]
+fn release_prepare_validates_publishable_workspace_before_mutating_release_state() {
+    let prepare = job_section(release_workflow(), "prepare");
+    let package_preflight = prepare
+        .find("name: Preflight crates.io packages")
+        .expect("prepare must validate crates.io package manifests");
+    let release_action = prepare
+        .find("uses: Extra-Chill/homeboy-action@v2")
+        .expect("prepare must run the release action");
+
+    assert!(
+        prepare.contains("run: cargo package --workspace --allow-dirty --no-verify"),
+        "publish preflight must package every workspace crate without publishing"
+    );
+    assert!(
+        package_preflight < release_action,
+        "package preflight must run before release preparation can create a tag"
+    );
+}
+
+#[test]
 fn release_prepare_waits_for_command_policy_not_raw_gates() {
     let prepare = job_section(release_workflow(), "prepare");
 


### PR DESCRIPTION
## Summary
Make extracted Homeboy workspace crates publishable and catch manifest failures before release mutation.

## What changed
- Declare compatible versions alongside every root and sibling workspace path dependency so Cargo can package crates for crates.io.
- Run cargo package --workspace before the release action creates a version commit, tag, or GitHub Release.

## How to test
1. Run `cargo package --workspace --allow-dirty --no-verify --offline`; expect all ten workspace packages are produced.
2. Run `cargo test --test release_workflow_test --offline`; expect 17 release workflow tests pass.

## Compatibility
No runtime behavior changes; release publication now fails before mutation when workspace manifests are not publishable.

## Evidence
- CI expected: Audit
- CI expected: Lint
- CI expected: Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8237
- format: Passed
- package-workspace: Passed
- release-workflow: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the crates.io manifest contract, implemented versioned path dependencies and the pre-tag package gate, and drafted deterministic tests; Chris owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8237
