### PR TITLE
fix: materialize nested publication artifacts relative to the manifest source

### DIFF
--- a/src/core/observation/store/artifacts.rs
+++ b/src/core/observation/store/artifacts.rs
@@ -275,10 +275,14 @@ impl ObservationStore {
                 "Inserted artifact record {id} but could not read it back"
             ))
         })?;
+        // Nested publication artifacts referenced by a manifest are authored
+        // relative to the *original* manifest path, not the UUID-addressed
+        // stored copy. Pass both so the materializer can locate a nested
+        // artifact-store ref next to the manifest as recorded.
         crate::core::publication_artifacts::index_published_artifact_refs(
             self,
             &artifact,
-            Some(&stored_path),
+            &[stored_path.as_path(), path],
         )?;
         Ok(artifact)
     }

--- a/src/core/publication_artifacts.rs
+++ b/src/core/publication_artifacts.rs
@@ -10,7 +10,7 @@ use crate::core::{paths, runner, Result};
 pub(crate) fn index_published_artifact_refs(
     store: &ObservationStore,
     source: &ArtifactRecord,
-    source_path: Option<&Path>,
+    source_paths: &[&Path],
 ) -> Result<()> {
     if source.artifact_type != "file" || !json_artifact(source) {
         return Ok(());
@@ -26,11 +26,15 @@ pub(crate) fn index_published_artifact_refs(
     };
 
     let artifact_root = paths::artifact_root()?;
-    let source_bases = source_path
-        .and_then(Path::parent)
-        .into_iter()
-        .map(Path::to_path_buf)
-        .collect::<Vec<_>>();
+    let mut source_bases = Vec::new();
+    for source_path in source_paths {
+        if let Some(parent) = source_path.parent() {
+            let parent = parent.to_path_buf();
+            if !source_bases.contains(&parent) {
+                source_bases.push(parent);
+            }
+        }
+    }
     index_manifest_refs(store, source, &manifest, |locator| {
         let Some(path) = artifact_store_path(&artifact_root, locator) else {
             return Ok(None);


### PR DESCRIPTION
## Summary

A real artifact-store bug caught in the post-burndown sweep. Recording a publication manifest is supposed to index its nested artifact-store refs and **materialize** each nested artifact into the local artifact store — but it never did for locally-recorded manifests.

## Root cause

`record_artifact` copies the manifest to a UUID-addressed path in the artifact store, then calls `index_published_artifact_refs` with only that **stored** copy as the source base. The materializer therefore searched for each nested artifact next to the stored copy (e.g. `.../artifacts/<uuid>/…`) — where nested artifacts never live. The nested artifacts are authored **relative to the original manifest path**, so materialization always found nothing and every nested ref was recorded as `Missing` (never indexed, never materialized).

## Fix

Pass **both** the stored copy and the original manifest path as source bases, so the materializer can locate a nested artifact-store ref next to the manifest as it was recorded. `index_published_artifact_refs` now takes a slice of source paths and dedupes their parent directories.

## Verification

- Fixes `artifact_get_fetches_nested_publication_artifact_store_ref` and `artifacts_command_derives_viewer_links_from_public_artifact_url_metadata`.
- `commands::runs` + `core::publication_artifacts` + `core::observation::store::artifacts` — **190 pass**, no regressions.

## Note

Rest of the sweep was clean: `core::deploy/release/extension/audit/scope/context` (1446 pass), `core::server/git`, `commands::status/deploy/component`, `core::component/stack/fleet` (536 pass) all green.