### PR TITLE
Preserve promoted baselines across cook gate retries

### DIFF
--- a/src/commands/agent_task/tests/promotion_review.rs
+++ b/src/commands/agent_task/tests/promotion_review.rs
@@ -187,7 +187,7 @@ fn cook_returns_durable_id_when_promotion_provider_is_missing() {
         assert!(value["stop_reason"]
             .as_str()
             .expect("stop reason")
-            .contains("workspace provider command"));
+            .contains("no worktree providers are configured"));
     });
 }
 

--- a/src/commands/agent_task/tests/promotion_review.rs
+++ b/src/commands/agent_task/tests/promotion_review.rs
@@ -1,6 +1,7 @@
 //! Agent-task command promotion source resolution and review/loop reporting tests.
 
 use super::support::*;
+use crate::core::agent_task_service::DerivedCookBaselineCapability;
 
 #[test]
 fn promotion_source_resolves_completed_run_id() {
@@ -285,7 +286,12 @@ struct MirroredAttemptDispatcher {
 }
 
 impl crate::core::agent_task_service::AgentTaskCookAttemptDispatcher for MirroredAttemptDispatcher {
-    fn dispatch_attempt(&self, plan: AgentTaskPlan, run_id: &str) -> homeboy::core::Result<()> {
+    fn dispatch_attempt(
+        &self,
+        plan: AgentTaskPlan,
+        run_id: &str,
+        _derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+    ) -> homeboy::core::Result<()> {
         homeboy::core::agent_tasks::service::run_loaded_plan(
             plan,
             Some(run_id),

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -18,6 +18,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use crate::core::agent_task_service::DerivedCookBaselineCapability;
 use crate::core::io::output_file::write_output_file;
 
 pub fn route_after_parse(
@@ -294,11 +295,21 @@ struct LabCookAttemptDispatcher {
     job_overrides: runners::LabJobOverrides,
 }
 
+fn cook_attempt_source_path<'a>(
+    derived_cook_baseline: Option<&'a DerivedCookBaselineCapability>,
+    controller_source_path: Option<&'a Path>,
+) -> Option<&'a Path> {
+    derived_cook_baseline
+        .map(|capability| capability.canonical_path())
+        .or(controller_source_path)
+}
+
 impl crate::core::agent_task_service::AgentTaskCookAttemptDispatcher for LabCookAttemptDispatcher {
     fn dispatch_attempt(
         &self,
         plan: homeboy::core::agent_tasks::scheduler::AgentTaskPlan,
         run_id: &str,
+        derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
     ) -> homeboy::core::Result<()> {
         let serialized_plan = serde_json::to_string(&plan).map_err(|error| {
             Error::internal_json(
@@ -345,7 +356,13 @@ impl crate::core::agent_task_service::AgentTaskCookAttemptDispatcher for LabCook
                 require_controller_git_bundle: false,
                 local_output_file: None,
                 durable_agent_task_plan: Some(&plan),
-                source_path: self.source_path.as_deref(),
+                // A retry's baseline is controller-owned capability, not plan
+                // data. Stage that exact clean checkout; never substitute the
+                // controller's original workspace during nested Lab dispatch.
+                source_path: cook_attempt_source_path(
+                    derived_cook_baseline,
+                    self.source_path.as_deref(),
+                ),
                 job_overrides: self.job_overrides.clone(),
             },
             Some(&self.runner_id),
@@ -2057,6 +2074,24 @@ mod tests {
         for cli in [&cook, &batch, &retry] {
             assert_eq!(lab_route_dispatch_timeout(&cli.command), None);
         }
+    }
+
+    #[test]
+    fn cook_retry_lab_source_is_the_derived_baseline_not_the_controller_workspace() {
+        let baseline = tempfile::tempdir().expect("baseline");
+        let controller = tempfile::tempdir().expect("controller");
+        let capability = crate::core::agent_task_service::test_derived_cook_baseline_capability(
+            baseline.path().to_path_buf(),
+            "baseline-commit".to_string(),
+            "baseline-tree".to_string(),
+            "task",
+            Some(serde_json::json!({"parent": "snapshot"})),
+        );
+
+        assert_eq!(
+            super::cook_attempt_source_path(Some(&capability), Some(controller.path())),
+            Some(capability.canonical_path())
+        );
     }
 
     #[test]

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -175,6 +175,7 @@ pub fn route_after_parse(
             source_path: retry_handoff
                 .as_ref()
                 .map(|handoff| handoff.primary_workspace.as_path()),
+            verified_cook_baseline: None,
             require_controller_git_bundle: retry_handoff.is_some(),
             job_overrides,
         },
@@ -311,6 +312,10 @@ impl crate::core::agent_task_service::AgentTaskCookAttemptDispatcher for LabCook
         run_id: &str,
         derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
     ) -> homeboy::core::Result<()> {
+        // The capability has already bound the promoted artifact and exact
+        // baseline to this retry; only its evidence crosses the Lab boundary.
+        let verified_cook_baseline =
+            derived_cook_baseline.map(DerivedCookBaselineCapability::verified_baseline_provenance);
         let serialized_plan = serde_json::to_string(&plan).map_err(|error| {
             Error::internal_json(
                 error.to_string(),
@@ -363,6 +368,7 @@ impl crate::core::agent_task_service::AgentTaskCookAttemptDispatcher for LabCook
                     derived_cook_baseline,
                     self.source_path.as_deref(),
                 ),
+                verified_cook_baseline: verified_cook_baseline.as_ref(),
                 job_overrides: self.job_overrides.clone(),
             },
             Some(&self.runner_id),
@@ -2085,12 +2091,23 @@ mod tests {
             "baseline-commit".to_string(),
             "baseline-tree".to_string(),
             "task",
-            Some(serde_json::json!({"parent": "snapshot"})),
+            Some(serde_json::json!({"workspace_snapshot_identity": "snapshot:parent"})),
         );
 
         assert_eq!(
             super::cook_attempt_source_path(Some(&capability), Some(controller.path())),
             Some(capability.canonical_path())
+        );
+        assert_eq!(
+            capability.verified_baseline_provenance(),
+            serde_json::json!({
+                "source_run_id": "test-source-run",
+                "source_task_id": "task",
+                "promoted_patch_artifact_sha256": "test-artifact-sha256",
+                "baseline_commit": "baseline-commit",
+                "baseline_tree": "baseline-tree",
+                "parent_snapshot_identity": "snapshot:parent",
+            })
         );
     }
 

--- a/src/core/agent_task_scheduler/attempt_workspace.rs
+++ b/src/core/agent_task_scheduler/attempt_workspace.rs
@@ -76,7 +76,23 @@ pub(super) fn prepare_committed_harvest(
             source_provenance: None,
         });
     }
-    let source_provenance = if snapshot_signaled {
+    let derived_baseline = request.inputs.pointer("/cook_loop/baseline");
+    let source_provenance = if let Some(baseline) = derived_baseline {
+        validate_derived_cook_baseline(root, baseline)?;
+        let ambient: serde_json::Value =
+            std::env::var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV)
+                .ok()
+                .and_then(|raw| serde_json::from_str(&raw).ok())
+                .ok_or_else(|| {
+                    snapshot_harvest_error("missing ambient parent snapshot".to_string())
+                })?;
+        if baseline.get("parent_snapshot") != Some(&ambient) {
+            return Err(snapshot_harvest_error(
+                "derived baseline parent snapshot does not match ambient snapshot".to_string(),
+            ));
+        }
+        Some(serde_json::json!({ "parent_snapshot": ambient, "cook_baseline": baseline }))
+    } else if snapshot_signaled {
         let provenance =
             crate::core::runner::verify_lab_workspace_from_env(&root.display().to_string(), root)
                 .map_err(snapshot_harvest_error)?;
@@ -157,6 +173,45 @@ fn snapshot_harvest_error(message: String) -> HarvestError {
         command: "verify Lab snapshot harvest provenance".to_string(),
         message,
     }
+}
+
+fn validate_derived_cook_baseline(
+    root: &Path,
+    baseline: &serde_json::Value,
+) -> Result<(), HarvestError> {
+    let path = baseline
+        .get("derived_workspace_path")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            snapshot_harvest_error("derived baseline has no workspace path".to_string())
+        })?;
+    if root.display().to_string() != path
+        || !root.starts_with(std::env::temp_dir().join("homeboy-cook-follow-up-baselines"))
+    {
+        return Err(snapshot_harvest_error(
+            "derived baseline workspace path is not Homeboy-owned".to_string(),
+        ));
+    }
+    let status = git_output(root, &["status", "--porcelain", "--untracked-files=all"])?;
+    if !status.is_empty() {
+        return Err(HarvestError::DirtyWorkspace { status });
+    }
+    let head = git_output(root, &["rev-parse", "HEAD"])?;
+    let tree = git_output(root, &["rev-parse", "HEAD^{tree}"])?;
+    if baseline
+        .get("baseline_commit")
+        .and_then(serde_json::Value::as_str)
+        != Some(head.as_str())
+        || baseline
+            .get("baseline_tree")
+            .and_then(serde_json::Value::as_str)
+            != Some(tree.as_str())
+    {
+        return Err(snapshot_harvest_error(
+            "derived baseline HEAD/tree does not match its internal contract".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 /// Give each provider dispatch a detached checkout at the caller's clean base.

--- a/src/core/agent_task_scheduler/attempt_workspace.rs
+++ b/src/core/agent_task_scheduler/attempt_workspace.rs
@@ -174,7 +174,9 @@ fn validate_derived_cook_baseline(
     let canonical_root = root.canonicalize().map_err(|error| {
         snapshot_harvest_error(format!("canonicalize derived baseline root: {error}"))
     })?;
-    if canonical_root != capability.canonical_path() || request.task_id != capability.source_task_id() {
+    if canonical_root != capability.canonical_path()
+        || request.task_id != capability.source_task_id()
+    {
         return Err(snapshot_harvest_error(
             "derived baseline capability does not bind this workspace and task".to_string(),
         ));

--- a/src/core/agent_task_scheduler/attempt_workspace.rs
+++ b/src/core/agent_task_scheduler/attempt_workspace.rs
@@ -80,7 +80,7 @@ pub(super) fn prepare_committed_harvest(
     let source_provenance = if let Some(capability) = derived_cook_baseline {
         validate_derived_cook_baseline(root, request, capability)?;
         Some(serde_json::json!({
-            "cook_baseline": capability.artifact_provenance(),
+            "verified_cook_baseline": capability.verified_baseline_provenance(),
             "parent_snapshot": capability.parent_snapshot(),
         }))
     } else if snapshot_signaled {
@@ -110,14 +110,30 @@ pub(super) fn prepare_committed_harvest(
                 )));
             }
         }
-        Some(serde_json::json!({
+        let mut source_provenance = serde_json::json!({
             "source_revision": provenance.source_revision,
             "workspace_snapshot_identity": provenance.workspace_identity,
             "snapshot_hash": provenance.snapshot_hash,
             "runner_id": provenance.runner_id,
             "workspace_path": root.display().to_string(),
             "materialization_mode": provenance.materialization_mode,
-        }))
+        });
+        // This is descriptive controller evidence only. Verification above
+        // remains the authority for the remote Lab snapshot.
+        if let Some(verified_baseline) =
+            std::env::var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV)
+                .ok()
+                .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+                .and_then(|metadata| {
+                    metadata
+                        .get("source_provenance")
+                        .and_then(|provenance| provenance.get("verified_cook_baseline"))
+                        .cloned()
+                })
+        {
+            source_provenance["verified_cook_baseline"] = verified_baseline;
+        }
+        Some(source_provenance)
     } else {
         None
     };

--- a/src/core/agent_task_scheduler/attempt_workspace.rs
+++ b/src/core/agent_task_scheduler/attempt_workspace.rs
@@ -59,6 +59,7 @@ pub(super) struct HarvestPreflight {
 
 pub(super) fn prepare_committed_harvest(
     request: &AgentTaskRequest,
+    derived_cook_baseline: Option<&crate::core::agent_task_service::DerivedCookBaselineCapability>,
 ) -> Result<HarvestPreflight, HarvestError> {
     let Some(root) = request.workspace.root.as_deref().map(Path::new) else {
         return Ok(HarvestPreflight {
@@ -76,22 +77,12 @@ pub(super) fn prepare_committed_harvest(
             source_provenance: None,
         });
     }
-    let derived_baseline = request.inputs.pointer("/cook_loop/baseline");
-    let source_provenance = if let Some(baseline) = derived_baseline {
-        validate_derived_cook_baseline(root, baseline)?;
-        let ambient: serde_json::Value =
-            std::env::var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV)
-                .ok()
-                .and_then(|raw| serde_json::from_str(&raw).ok())
-                .ok_or_else(|| {
-                    snapshot_harvest_error("missing ambient parent snapshot".to_string())
-                })?;
-        if baseline.get("parent_snapshot") != Some(&ambient) {
-            return Err(snapshot_harvest_error(
-                "derived baseline parent snapshot does not match ambient snapshot".to_string(),
-            ));
-        }
-        Some(serde_json::json!({ "parent_snapshot": ambient, "cook_baseline": baseline }))
+    let source_provenance = if let Some(capability) = derived_cook_baseline {
+        validate_derived_cook_baseline(root, request, capability)?;
+        Some(serde_json::json!({
+            "cook_baseline": capability.artifact_provenance(),
+            "parent_snapshot": capability.parent_snapshot(),
+        }))
     } else if snapshot_signaled {
         let provenance =
             crate::core::runner::verify_lab_workspace_from_env(&root.display().to_string(), root)
@@ -177,19 +168,15 @@ fn snapshot_harvest_error(message: String) -> HarvestError {
 
 fn validate_derived_cook_baseline(
     root: &Path,
-    baseline: &serde_json::Value,
+    request: &AgentTaskRequest,
+    capability: &crate::core::agent_task_service::DerivedCookBaselineCapability,
 ) -> Result<(), HarvestError> {
-    let path = baseline
-        .get("derived_workspace_path")
-        .and_then(serde_json::Value::as_str)
-        .ok_or_else(|| {
-            snapshot_harvest_error("derived baseline has no workspace path".to_string())
-        })?;
-    if root.display().to_string() != path
-        || !root.starts_with(std::env::temp_dir().join("homeboy-cook-follow-up-baselines"))
-    {
+    let canonical_root = root.canonicalize().map_err(|error| {
+        snapshot_harvest_error(format!("canonicalize derived baseline root: {error}"))
+    })?;
+    if canonical_root != capability.canonical_path() || request.task_id != capability.source_task_id() {
         return Err(snapshot_harvest_error(
-            "derived baseline workspace path is not Homeboy-owned".to_string(),
+            "derived baseline capability does not bind this workspace and task".to_string(),
         ));
     }
     let status = git_output(root, &["status", "--porcelain", "--untracked-files=all"])?;
@@ -198,17 +185,27 @@ fn validate_derived_cook_baseline(
     }
     let head = git_output(root, &["rev-parse", "HEAD"])?;
     let tree = git_output(root, &["rev-parse", "HEAD^{tree}"])?;
-    if baseline
-        .get("baseline_commit")
-        .and_then(serde_json::Value::as_str)
-        != Some(head.as_str())
-        || baseline
-            .get("baseline_tree")
-            .and_then(serde_json::Value::as_str)
-            != Some(tree.as_str())
-    {
+    if head != capability.commit() || tree != capability.tree() {
         return Err(snapshot_harvest_error(
             "derived baseline HEAD/tree does not match its internal contract".to_string(),
+        ));
+    }
+    if let Some(parent_snapshot) = capability.parent_snapshot() {
+        let ambient: serde_json::Value =
+            std::env::var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV)
+                .ok()
+                .and_then(|raw| serde_json::from_str(&raw).ok())
+                .ok_or_else(|| {
+                    snapshot_harvest_error("missing ambient parent snapshot".to_string())
+                })?;
+        if parent_snapshot != &ambient {
+            return Err(snapshot_harvest_error(
+                "derived baseline parent snapshot does not match ambient snapshot".to_string(),
+            ));
+        }
+    } else if std::env::var_os(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV).is_some() {
+        return Err(snapshot_harvest_error(
+            "derived baseline is missing its Lab parent snapshot".to_string(),
         ));
     }
     Ok(())

--- a/src/core/agent_task_scheduler/engine.rs
+++ b/src/core/agent_task_scheduler/engine.rs
@@ -347,23 +347,21 @@ where
                     continue;
                 }
                 let task_id = request.task_id.clone();
-                let harvest_preflight = match prepare_committed_harvest(
-                    &request,
-                    derived_cook_baseline,
-                ) {
-                    Ok(preflight) => preflight,
-                    Err(error) => {
-                        record_harvest_setup_failure(
-                            &task_id,
-                            scheduled.attempt,
-                            error,
-                            &mut completed_by_task,
-                            &mut outcomes,
-                            &mut events,
-                        );
-                        continue;
-                    }
-                };
+                let harvest_preflight =
+                    match prepare_committed_harvest(&request, derived_cook_baseline) {
+                        Ok(preflight) => preflight,
+                        Err(error) => {
+                            record_harvest_setup_failure(
+                                &task_id,
+                                scheduled.attempt,
+                                error,
+                                &mut completed_by_task,
+                                &mut outcomes,
+                                &mut events,
+                            );
+                            continue;
+                        }
+                    };
                 let task_base_sha = scheduled
                     .task_base_sha
                     .clone()

--- a/src/core/agent_task_scheduler/engine.rs
+++ b/src/core/agent_task_scheduler/engine.rs
@@ -4,6 +4,8 @@ use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Instant;
 
+use crate::core::agent_task_service::DerivedCookBaselineCapability;
+
 use super::*;
 
 /// Authoritative execution adapter consumed by the agent-task scheduler.
@@ -42,13 +44,34 @@ where
     }
 
     pub fn run(&self, plan: AgentTaskPlan) -> AgentTaskAggregate {
-        self.run_with_cancellation(plan, AgentTaskCancellationToken::default())
+        self.run_with_derived_cook_baseline(plan, None)
+    }
+
+    pub(crate) fn run_with_derived_cook_baseline(
+        &self,
+        plan: AgentTaskPlan,
+        derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+    ) -> AgentTaskAggregate {
+        self.run_with_cancellation_and_derived_cook_baseline(
+            plan,
+            AgentTaskCancellationToken::default(),
+            derived_cook_baseline,
+        )
     }
 
     pub(crate) fn run_with_cancellation(
         &self,
         plan: AgentTaskPlan,
         cancellation: AgentTaskCancellationToken,
+    ) -> AgentTaskAggregate {
+        self.run_with_cancellation_and_derived_cook_baseline(plan, cancellation, None)
+    }
+
+    fn run_with_cancellation_and_derived_cook_baseline(
+        &self,
+        plan: AgentTaskPlan,
+        cancellation: AgentTaskCancellationToken,
+        derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
     ) -> AgentTaskAggregate {
         let mut plan = plan.canonicalize();
         let max_concurrency = plan.options.max_concurrency.max(1);
@@ -324,7 +347,10 @@ where
                     continue;
                 }
                 let task_id = request.task_id.clone();
-                let harvest_preflight = match prepare_committed_harvest(&request) {
+                let harvest_preflight = match prepare_committed_harvest(
+                    &request,
+                    derived_cook_baseline,
+                ) {
                     Ok(preflight) => preflight,
                     Err(error) => {
                         record_harvest_setup_failure(
@@ -343,13 +369,7 @@ where
                     .clone()
                     .or(harvest_preflight.base_sha.clone());
                 let source_workspace_root = request.workspace.root.clone();
-                let source_provenance = harvest_preflight.source_provenance.or_else(|| {
-                    request
-                        .inputs
-                        .pointer("/cook_loop/baseline")
-                        .cloned()
-                        .map(|baseline| serde_json::json!({ "cook_baseline": baseline }))
-                });
+                let source_provenance = harvest_preflight.source_provenance;
                 let attempt_workspace =
                     match prepare_attempt_workspace(&mut request, task_base_sha.as_deref()) {
                         Ok(workspace) => workspace,

--- a/src/core/agent_task_scheduler/engine.rs
+++ b/src/core/agent_task_scheduler/engine.rs
@@ -343,6 +343,13 @@ where
                     .clone()
                     .or(harvest_preflight.base_sha.clone());
                 let source_workspace_root = request.workspace.root.clone();
+                let source_provenance = harvest_preflight.source_provenance.or_else(|| {
+                    request
+                        .inputs
+                        .pointer("/cook_loop/baseline")
+                        .cloned()
+                        .map(|baseline| serde_json::json!({ "cook_baseline": baseline }))
+                });
                 let attempt_workspace =
                     match prepare_attempt_workspace(&mut request, task_base_sha.as_deref()) {
                         Ok(workspace) => workspace,
@@ -450,7 +457,7 @@ where
                     run_id: self.run_id.clone(),
                     artifact_nonce: uuid::Uuid::new_v4().to_string(),
                     task_base_sha,
-                    source_provenance: harvest_preflight.source_provenance,
+                    source_provenance,
                     scratch: scratch.clone(),
                     adoption: scheduled.adoption,
                     join_handle: None,

--- a/src/core/agent_task_scheduler/harvest.rs
+++ b/src/core/agent_task_scheduler/harvest.rs
@@ -652,6 +652,16 @@ mod committed_harvest_tests {
                 .expect("content hash");
         let lab = serde_json::json!({
             "runner_id": "lab", "remote_workspace": path, "sync_mode": "snapshot", "status": "offloaded",
+            "source_provenance": {
+                "verified_cook_baseline": {
+                    "source_run_id": "promoted-run",
+                    "source_task_id": "snapshot-task",
+                    "promoted_patch_artifact_sha256": "c".repeat(64),
+                    "baseline_commit": "d".repeat(40),
+                    "baseline_tree": "e".repeat(40),
+                    "parent_snapshot_identity": "snapshot:parent"
+                }
+            },
             "source_snapshot": snapshot,
             "workspace_verification": {
                 "schema": "homeboy/lab-workspace-verification/v2", "identity": "snapshot:provider-ready",
@@ -782,6 +792,12 @@ mod committed_harvest_tests {
         .expect("external patch provenance");
         for artifact in &outcome.artifacts {
             assert_eq!(artifact.metadata["source_provenance"], source_provenance);
+            assert_eq!(
+                artifact.metadata["source_provenance"]["verified_cook_baseline"]
+                    ["promoted_patch_artifact_sha256"],
+                "c".repeat(64),
+                "Lab retry artifact retains controller-verified baseline evidence"
+            );
         }
         assert_eq!(outcome.artifacts[0].metadata["kept"], true);
         drop(attempt);

--- a/src/core/agent_task_scheduler/harvest.rs
+++ b/src/core/agent_task_scheduler/harvest.rs
@@ -863,7 +863,7 @@ mod committed_harvest_tests {
             metadata: serde_json::Value::Null,
         };
 
-        let preflight = prepare_committed_harvest(&request)
+        let preflight = prepare_committed_harvest(&request, None)
             .expect("runner-resident snapshot harvest preflight");
 
         assert!(preflight.base_sha.is_some());

--- a/src/core/agent_task_scheduler/harvest.rs
+++ b/src/core/agent_task_scheduler/harvest.rs
@@ -697,7 +697,8 @@ mod committed_harvest_tests {
             artifact_declarations: Vec::new(),
             metadata: serde_json::Value::Null,
         };
-        let preflight = prepare_committed_harvest(&request).expect("snapshot preflight");
+        let preflight =
+            prepare_committed_harvest(&request, None).expect("snapshot preflight");
         let baseline = preflight.base_sha.expect("synthetic baseline");
         let source_provenance = preflight.source_provenance.expect("source provenance");
         assert!(workspace.path().join(".git").is_dir());
@@ -913,7 +914,8 @@ mod committed_harvest_tests {
             metadata: serde_json::Value::Null,
         };
 
-        let preflight = prepare_committed_harvest(&request).expect("local non-Git no-op");
+        let preflight =
+            prepare_committed_harvest(&request, None).expect("local non-Git no-op");
 
         assert!(preflight.base_sha.is_none());
         assert!(preflight.source_provenance.is_none());

--- a/src/core/agent_task_scheduler/harvest.rs
+++ b/src/core/agent_task_scheduler/harvest.rs
@@ -697,8 +697,7 @@ mod committed_harvest_tests {
             artifact_declarations: Vec::new(),
             metadata: serde_json::Value::Null,
         };
-        let preflight =
-            prepare_committed_harvest(&request, None).expect("snapshot preflight");
+        let preflight = prepare_committed_harvest(&request, None).expect("snapshot preflight");
         let baseline = preflight.base_sha.expect("synthetic baseline");
         let source_provenance = preflight.source_provenance.expect("source provenance");
         assert!(workspace.path().join(".git").is_dir());
@@ -914,8 +913,7 @@ mod committed_harvest_tests {
             metadata: serde_json::Value::Null,
         };
 
-        let preflight =
-            prepare_committed_harvest(&request, None).expect("local non-Git no-op");
+        let preflight = prepare_committed_harvest(&request, None).expect("local non-Git no-op");
 
         assert!(preflight.base_sha.is_none());
         assert!(preflight.source_provenance.is_none());

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -492,6 +492,24 @@ impl DerivedCookBaselineCapability {
             "source_patch_artifact_sha256": self.artifact_sha256,
         })
     }
+
+    /// Evidence derived from the controller-validated capability. It is not
+    /// authorization for remote workspace or snapshot verification.
+    pub(crate) fn verified_baseline_provenance(&self) -> Value {
+        serde_json::json!({
+            "source_run_id": self.source_run_id,
+            "source_task_id": self.source_task_id,
+            "promoted_patch_artifact_sha256": self.artifact_sha256,
+            "baseline_commit": self.commit,
+            "baseline_tree": self.tree,
+            "parent_snapshot_identity": self.parent_snapshot.as_ref().and_then(|snapshot| {
+                snapshot
+                    .get("workspace_snapshot_identity")
+                    .cloned()
+                    .or_else(|| snapshot.get("identity").cloned())
+            }),
+        })
+    }
 }
 
 impl CookFollowUpBaseline {

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -4,6 +4,7 @@
 
 use serde_json::Value;
 use std::path::PathBuf;
+use std::process::Command;
 use std::sync::Arc;
 
 use crate::core::agent_task::AgentTaskExecutor;
@@ -312,7 +313,7 @@ where
                 ));
             }
             AgentTaskCookLoopStatus::RetryRequested => {
-                let Some(follow_up_request) = follow_up_request else {
+                let Some(mut follow_up_request) = follow_up_request else {
                     return Ok(cook_report(
                         cook_id,
                         "policy_failure",
@@ -367,6 +368,21 @@ where
                         ));
                     }
                 };
+                let baseline = match materialize_follow_up_baseline(&promotion, &run_id) {
+                    Ok(baseline) => baseline,
+                    Err(error) => {
+                        return Ok(cook_report(
+                            cook_id,
+                            "policy_failure",
+                            attempts,
+                            None,
+                            Some(error.to_string()),
+                            1,
+                        ));
+                    }
+                };
+                follow_up_request.workspace.root = Some(baseline.path.display().to_string());
+                follow_up_request.inputs["cook_loop"]["baseline"] = baseline.provenance.clone();
                 let mut follow_up_plan = AgentTaskPlan::new(
                     format!("{cook_id}-cook-attempt-{}", attempt + 1),
                     vec![follow_up_request],
@@ -402,6 +418,176 @@ where
         Some("cook attempt budget exhausted".to_string()),
         1,
     ))
+}
+
+/// A cook-owned detached checkout turns the already-promoted dirty candidate
+/// into a clean commit before the scheduler creates its normal attempt checkout.
+struct CookFollowUpBaseline {
+    source_root: PathBuf,
+    path: PathBuf,
+    provenance: Value,
+}
+
+impl Drop for CookFollowUpBaseline {
+    fn drop(&mut self) {
+        let _ = Command::new("git")
+            .args(["worktree", "remove", "--force"])
+            .arg(&self.path)
+            .current_dir(&self.source_root)
+            .status();
+        let _ = Command::new("git")
+            .args(["worktree", "prune"])
+            .current_dir(&self.source_root)
+            .status();
+    }
+}
+
+fn materialize_follow_up_baseline(
+    promotion: &AgentTaskPromotionReport,
+    source_run_id: &str,
+) -> Result<CookFollowUpBaseline> {
+    let source_root = promotion
+        .provenance
+        .get("worktree_path")
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "promotion.provenance.worktree_path",
+                "gate-failed promotion did not report its managed target workspace",
+                None,
+                None,
+            )
+        })?;
+    let head = git_output(&source_root, &["rev-parse", "HEAD"])?;
+    let index = tempfile::NamedTempFile::new().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("create cook baseline Git index".to_string()),
+        )
+    })?;
+    let index_path = index.path().display().to_string();
+    git_output_with_env(
+        &source_root,
+        &["read-tree", "HEAD"],
+        &[("GIT_INDEX_FILE", &index_path)],
+    )?;
+    git_output_with_env(
+        &source_root,
+        &["add", "--all"],
+        &[("GIT_INDEX_FILE", &index_path)],
+    )?;
+    let patch = git_output_with_env(
+        &source_root,
+        &[
+            "diff",
+            "--cached",
+            "--binary",
+            "--full-index",
+            "--find-renames",
+            "HEAD",
+        ],
+        &[("GIT_INDEX_FILE", &index_path)],
+    )?;
+    if patch.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "promotion",
+            "gate-failed promotion target has no candidate changes to baseline",
+            None,
+            None,
+        ));
+    }
+    let parent = std::env::temp_dir().join("homeboy-cook-follow-up-baselines");
+    std::fs::create_dir_all(&parent).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("create cook baseline directory".to_string()),
+        )
+    })?;
+    let path = parent.join(format!("baseline-{}", uuid::Uuid::new_v4()));
+    let path_string = path.display().to_string();
+    git_output(
+        &source_root,
+        &["worktree", "add", "--detach", &path_string, &head],
+    )?;
+    let baseline = CookFollowUpBaseline {
+        source_root,
+        path,
+        provenance: serde_json::json!({
+            "source_run_id": source_run_id,
+            "source_task_id": promotion.source.task_id,
+            "source_patch_artifact_id": promotion.patch_artifact.id,
+            "promotion_target_head": head,
+        }),
+    };
+    let patch_path = baseline.path.join(".homeboy-cook-baseline.patch");
+    std::fs::write(&patch_path, patch.as_bytes()).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("write cook baseline patch".to_string()),
+        )
+    })?;
+    git_output(
+        &baseline.path,
+        &["apply", "--index", &patch_path.display().to_string()],
+    )?;
+    std::fs::remove_file(&patch_path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("remove cook baseline patch".to_string()),
+        )
+    })?;
+    git_output(
+        &baseline.path,
+        &[
+            "-c",
+            "user.name=Homeboy",
+            "-c",
+            "user.email=homeboy@localhost",
+            "commit",
+            "--no-verify",
+            "-m",
+            "homeboy: cook promoted baseline",
+        ],
+    )?;
+    let commit = git_output(&baseline.path, &["rev-parse", "HEAD"])?;
+    let tree = git_output(&baseline.path, &["rev-parse", "HEAD^{tree}"])?;
+    let mut baseline = baseline;
+    baseline.provenance["baseline_commit"] = Value::String(commit);
+    baseline.provenance["baseline_tree"] = Value::String(tree);
+    Ok(baseline)
+}
+
+fn git_output(cwd: &std::path::Path, args: &[&str]) -> Result<String> {
+    git_output_with_env(cwd, args, &[])
+}
+
+fn git_output_with_env(
+    cwd: &std::path::Path,
+    args: &[&str],
+    env: &[(&str, &str)],
+) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .envs(env.iter().copied())
+        .current_dir(cwd)
+        .output()
+        .map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("git {}", args.join(" "))))
+        })?;
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "promotion",
+            format!(
+                "git {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+            None,
+            None,
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -964,5 +1150,74 @@ mod tests {
             }
             assert!(backend.committed && backend.pushed && backend.created);
         });
+    }
+
+    #[test]
+    fn follow_up_baseline_is_clean_and_preserves_binary_mode_and_untracked_candidate_state() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        for args in [
+            vec!["init"],
+            vec!["config", "user.name", "Test"],
+            vec!["config", "user.email", "test@example.com"],
+        ] {
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(root)
+                .status()
+                .unwrap()
+                .success());
+        }
+        std::fs::write(root.join("base.txt"), "base\n").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "."])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "-m", "base"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        std::fs::write(root.join("candidate.bin"), [0_u8, 1, 2, 255]).unwrap();
+        std::fs::write(root.join("candidate.sh"), "#!/bin/sh\nexit 0\n").unwrap();
+        let mut permissions = std::fs::metadata(root.join("candidate.sh"))
+            .unwrap()
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(root.join("candidate.sh"), permissions).unwrap();
+        let report: AgentTaskPromotionReport = serde_json::from_value(serde_json::json!({
+            "schema":"homeboy/agent-task-promotion-report/v1", "status":"gate_failed",
+            "source":{"kind":"aggregate","task_id":"candidate-task","run_id":"first-run"},
+            "to_worktree":"fixture@target", "target":{"worktree":"fixture@target"},
+            "patch_artifact":{"id":"candidate","kind":"patch","path":"candidate.patch"}, "changed_files":["candidate.bin", "candidate.sh"],
+            "command_evidence":[], "deterministic_gates":[], "gate_results":[],
+            "provenance":{"worktree_path":root}, "operator_notification":{"status":"blocked","message":"red"}
+        })).unwrap();
+        let baseline = materialize_follow_up_baseline(&report, "first-run").expect("baseline");
+        assert!(git_output(&baseline.path, &["status", "--porcelain"])
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            std::fs::read(baseline.path.join("candidate.bin")).unwrap(),
+            [0_u8, 1, 2, 255]
+        );
+        assert!(
+            baseline
+                .path
+                .join("candidate.sh")
+                .metadata()
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o111
+                != 0
+        );
+        assert!(baseline.provenance["baseline_commit"].is_string());
+        assert!(baseline.provenance["baseline_tree"].is_string());
     }
 }

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -461,6 +461,13 @@ fn materialize_follow_up_baseline(
                 None,
             )
         })?;
+    let parent_snapshot = std::env::var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV)
+        .ok()
+        .map(|raw| serde_json::from_str::<Value>(&raw))
+        .transpose()
+        .map_err(|error| {
+            Error::validation_invalid_argument("source_snapshot", error.to_string(), None, None)
+        })?;
     let head = git_output(&source_root, &["rev-parse", "HEAD"])?;
     let artifact_bytes = std::fs::read(&promotion.patch_artifact.path).map_err(|error| {
         Error::internal_io(
@@ -525,13 +532,15 @@ fn materialize_follow_up_baseline(
     )?;
     let baseline = CookFollowUpBaseline {
         source_root,
-        path,
+        path: path.clone(),
         provenance: serde_json::json!({
             "source_run_id": source_run_id,
             "source_task_id": promotion.source.task_id,
             "source_patch_artifact_id": promotion.patch_artifact.id,
             "source_patch_artifact_sha256": artifact_sha256,
             "promotion_target_head": head,
+            "derived_workspace_path": path,
+            "parent_snapshot": parent_snapshot,
         }),
     };
     let patch_path = baseline.path.join(".homeboy-cook-baseline.patch");

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -39,7 +39,14 @@ use super::AgentTaskRunResult;
 /// Executes one provider attempt while cook retains ownership of promotion,
 /// gates, retries, and finalization.
 pub trait AgentTaskCookAttemptDispatcher: Send + Sync + std::fmt::Debug {
-    fn dispatch_attempt(&self, plan: AgentTaskPlan, run_id: &str) -> Result<()>;
+    /// `derived_cook_baseline` is process-local authority for a gate-fix retry.
+    /// Implementations must not serialize it into the provider request.
+    fn dispatch_attempt(
+        &self,
+        plan: AgentTaskPlan,
+        run_id: &str,
+        derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+    ) -> Result<()>;
 }
 
 #[derive(Debug, Clone)]
@@ -135,7 +142,7 @@ where
             .unwrap_or(true);
         if needs_execution {
             let execution = if let Some(dispatcher) = &options.attempt_dispatcher {
-                dispatcher.dispatch_attempt(plan.clone(), &run_id)
+                dispatcher.dispatch_attempt(plan.clone(), &run_id, None)
             } else {
                 run_loaded_plan(plan.clone(), Some(&run_id), executor.clone()).map(|_| ())
             };
@@ -394,12 +401,20 @@ where
                 follow_up_plan.options = plan.options.clone();
                 follow_up_plan.options.execution_budget = AgentTaskExecutionBudget::new(1, 0, 0);
                 follow_up_plan.options.retry.max_attempts = 1;
-                run_loaded_plan_with_derived_cook_baseline(
-                    follow_up_plan,
-                    Some(&next_run_id),
-                    executor.clone(),
-                    Some(baseline.capability()),
-                )?;
+                if let Some(dispatcher) = &options.attempt_dispatcher {
+                    dispatcher.dispatch_attempt(
+                        follow_up_plan,
+                        &next_run_id,
+                        Some(baseline.capability()),
+                    )?;
+                } else {
+                    run_loaded_plan_with_derived_cook_baseline(
+                        follow_up_plan,
+                        Some(&next_run_id),
+                        executor.clone(),
+                        Some(baseline.capability()),
+                    )?;
+                }
                 remediation_category_usage.add(reservation);
                 run_id = next_run_id;
             }
@@ -439,7 +454,7 @@ struct CookFollowUpBaseline {
 
 /// Process-local authority for one materialized cook retry baseline. It is not
 /// serializable and never enters a request, environment, or durable record.
-pub(crate) struct DerivedCookBaselineCapability {
+pub struct DerivedCookBaselineCapability {
     canonical_path: PathBuf,
     commit: String,
     tree: String,

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -33,7 +33,7 @@ use crate::core::agent_task_scheduler::{
 use crate::core::command_invocation::CommandInvocation;
 use crate::core::{config, Error, Result};
 
-use super::execution::run_loaded_plan;
+use super::execution::run_loaded_plan_with_derived_cook_baseline;
 use super::AgentTaskRunResult;
 
 /// Executes one provider attempt while cook retains ownership of promotion,
@@ -384,17 +384,24 @@ where
                     }
                 };
                 follow_up_request.workspace.root = Some(baseline.path.display().to_string());
-                follow_up_request.inputs["cook_loop"]["baseline"] = baseline.provenance.clone();
-                let mut follow_up_plan = AgentTaskPlan::new(
+                // Requests retain artifact facts for review, never authorization.
+                follow_up_request.inputs["cook_loop"]["artifact_provenance"] =
+                    baseline.artifact_provenance();
+                let follow_up_plan = AgentTaskPlan::new(
                     format!("{cook_id}-cook-attempt-{}", attempt + 1),
                     vec![follow_up_request],
                 );
                 follow_up_plan.options = plan.options.clone();
                 follow_up_plan.options.execution_budget = AgentTaskExecutionBudget::new(1, 0, 0);
                 follow_up_plan.options.retry.max_attempts = 1;
+                run_loaded_plan_with_derived_cook_baseline(
+                    follow_up_plan,
+                    Some(&next_run_id),
+                    executor.clone(),
+                    Some(baseline.capability()),
+                )?;
                 remediation_category_usage.add(reservation);
                 run_id = next_run_id;
-                next_plan = Some(follow_up_plan);
             }
             AgentTaskCookLoopStatus::RetriesExhausted => {
                 return Ok(cook_report(
@@ -427,7 +434,80 @@ where
 struct CookFollowUpBaseline {
     source_root: PathBuf,
     path: PathBuf,
-    provenance: Value,
+    capability: DerivedCookBaselineCapability,
+}
+
+/// Process-local authority for one materialized cook retry baseline. It is not
+/// serializable and never enters a request, environment, or durable record.
+pub(crate) struct DerivedCookBaselineCapability {
+    canonical_path: PathBuf,
+    commit: String,
+    tree: String,
+    artifact_sha256: String,
+    source_run_id: String,
+    source_task_id: String,
+    parent_snapshot: Option<Value>,
+}
+
+impl DerivedCookBaselineCapability {
+    pub(crate) fn canonical_path(&self) -> &std::path::Path {
+        &self.canonical_path
+    }
+
+    pub(crate) fn commit(&self) -> &str {
+        &self.commit
+    }
+
+    pub(crate) fn tree(&self) -> &str {
+        &self.tree
+    }
+
+    pub(crate) fn source_task_id(&self) -> &str {
+        &self.source_task_id
+    }
+
+    pub(crate) fn parent_snapshot(&self) -> Option<&Value> {
+        self.parent_snapshot.as_ref()
+    }
+
+    pub(crate) fn artifact_provenance(&self) -> Value {
+        serde_json::json!({
+            "source_run_id": self.source_run_id,
+            "source_task_id": self.source_task_id,
+            "source_patch_artifact_sha256": self.artifact_sha256,
+        })
+    }
+}
+
+impl CookFollowUpBaseline {
+    fn capability(&self) -> &DerivedCookBaselineCapability {
+        &self.capability
+    }
+
+    fn artifact_provenance(&self) -> Value {
+        self.capability.artifact_provenance()
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn test_derived_cook_baseline_capability(
+    path: PathBuf,
+    commit: String,
+    tree: String,
+    task_id: &str,
+    parent_snapshot: Option<Value>,
+) -> DerivedCookBaselineCapability {
+    DerivedCookBaselineCapability {
+        canonical_path: path
+            .canonicalize()
+            .expect("test baseline path canonicalizes"),
+        commit,
+        tree,
+        artifact_sha256: "test-artifact-sha256".to_string(),
+        source_run_id: "test-source-run".to_string(),
+        source_task_id: task_id.to_string(),
+        parent_snapshot,
+    }
 }
 
 impl Drop for CookFollowUpBaseline {
@@ -533,15 +613,17 @@ fn materialize_follow_up_baseline(
     let baseline = CookFollowUpBaseline {
         source_root,
         path: path.clone(),
-        provenance: serde_json::json!({
-            "source_run_id": source_run_id,
-            "source_task_id": promotion.source.task_id,
-            "source_patch_artifact_id": promotion.patch_artifact.id,
-            "source_patch_artifact_sha256": artifact_sha256,
-            "promotion_target_head": head,
-            "derived_workspace_path": path,
-            "parent_snapshot": parent_snapshot,
-        }),
+        // The capability is completed only after the committed baseline's
+        // identity has been verified below.
+        capability: DerivedCookBaselineCapability {
+            canonical_path: path,
+            commit: String::new(),
+            tree: String::new(),
+            artifact_sha256,
+            source_run_id: source_run_id.to_string(),
+            source_task_id: promotion.source.task_id.clone(),
+            parent_snapshot,
+        },
     };
     let patch_path = baseline.path.join(".homeboy-cook-baseline.patch");
     std::fs::write(&patch_path, normalized.content.as_bytes()).map_err(|error| {
@@ -589,8 +671,14 @@ fn materialize_follow_up_baseline(
         ));
     }
     let mut baseline = baseline;
-    baseline.provenance["baseline_commit"] = Value::String(commit);
-    baseline.provenance["baseline_tree"] = Value::String(tree);
+    baseline.capability.canonical_path = baseline.path.canonicalize().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("canonicalize cook retry baseline".to_string()),
+        )
+    })?;
+    baseline.capability.commit = commit;
+    baseline.capability.tree = tree;
     Ok(baseline)
 }
 
@@ -1281,7 +1369,15 @@ mod tests {
                 & 0o111
                 != 0
         );
-        assert!(baseline.provenance["baseline_commit"].is_string());
-        assert!(baseline.provenance["baseline_tree"].is_string());
+        assert!(!baseline.capability.commit().is_empty());
+        assert!(!baseline.capability.tree().is_empty());
+        assert_eq!(
+            baseline.artifact_provenance()["source_patch_artifact_sha256"],
+            sha2::Sha256::digest(std::fs::read(&patch_path).unwrap())
+                .to_vec()
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect::<String>()
+        );
     }
 }

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -3,6 +3,7 @@
 //! resolution. Pure move out of the former `agent_task_service.rs` god-file.
 
 use serde_json::Value;
+use sha2::Digest;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
@@ -19,7 +20,8 @@ use crate::core::agent_task_finalization::{
 use crate::core::agent_task_gate::VerifyGateOptions;
 use crate::core::agent_task_lifecycle;
 use crate::core::agent_task_promotion::{
-    promote, AgentTaskPromotionOptions, AgentTaskPromotionReport, AgentTaskPromotionStatus,
+    normalize_promotion_patch, promote, AgentTaskPromotionOptions, AgentTaskPromotionReport,
+    AgentTaskPromotionStatus,
 };
 use crate::core::agent_task_review_dossier::{
     resolve_review_profile, AgentTaskReviewAiAssistance, AgentTaskReviewDossier,
@@ -460,6 +462,32 @@ fn materialize_follow_up_baseline(
             )
         })?;
     let head = git_output(&source_root, &["rev-parse", "HEAD"])?;
+    let artifact_bytes = std::fs::read(&promotion.patch_artifact.path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("read promoted patch artifact".to_string()),
+        )
+    })?;
+    let artifact_sha256 = format!("{:x}", sha2::Sha256::digest(&artifact_bytes));
+    if let Some(expected) = promotion.patch_artifact.sha256.as_deref() {
+        if expected != artifact_sha256 {
+            return Err(Error::validation_invalid_argument(
+                "promotion.patch_artifact.sha256",
+                "promoted artifact bytes no longer match durable sha256",
+                None,
+                None,
+            ));
+        }
+    }
+    let artifact = std::str::from_utf8(&artifact_bytes).map_err(|error| {
+        Error::validation_invalid_argument(
+            "promotion.patch_artifact",
+            format!("patch bytes are not UTF-8: {error}"),
+            None,
+            None,
+        )
+    })?;
+    let normalized = normalize_promotion_patch(artifact, &promotion.to_worktree)?;
     let index = tempfile::NamedTempFile::new().map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -469,7 +497,7 @@ fn materialize_follow_up_baseline(
     let index_path = index.path().display().to_string();
     git_output_with_env(
         &source_root,
-        &["read-tree", "HEAD"],
+        &["read-tree", &head],
         &[("GIT_INDEX_FILE", &index_path)],
     )?;
     git_output_with_env(
@@ -477,26 +505,11 @@ fn materialize_follow_up_baseline(
         &["add", "--all"],
         &[("GIT_INDEX_FILE", &index_path)],
     )?;
-    let patch = git_output_with_env(
+    let target_tree = git_output_with_env(
         &source_root,
-        &[
-            "diff",
-            "--cached",
-            "--binary",
-            "--full-index",
-            "--find-renames",
-            "HEAD",
-        ],
+        &["write-tree"],
         &[("GIT_INDEX_FILE", &index_path)],
     )?;
-    if patch.trim().is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "promotion",
-            "gate-failed promotion target has no candidate changes to baseline",
-            None,
-            None,
-        ));
-    }
     let parent = std::env::temp_dir().join("homeboy-cook-follow-up-baselines");
     std::fs::create_dir_all(&parent).map_err(|error| {
         Error::internal_io(
@@ -517,11 +530,12 @@ fn materialize_follow_up_baseline(
             "source_run_id": source_run_id,
             "source_task_id": promotion.source.task_id,
             "source_patch_artifact_id": promotion.patch_artifact.id,
+            "source_patch_artifact_sha256": artifact_sha256,
             "promotion_target_head": head,
         }),
     };
     let patch_path = baseline.path.join(".homeboy-cook-baseline.patch");
-    std::fs::write(&patch_path, patch.as_bytes()).map_err(|error| {
+    std::fs::write(&patch_path, normalized.content.as_bytes()).map_err(|error| {
         Error::internal_io(
             error.to_string(),
             Some("write cook baseline patch".to_string()),
@@ -529,7 +543,11 @@ fn materialize_follow_up_baseline(
     })?;
     git_output(
         &baseline.path,
-        &["apply", "--index", &patch_path.display().to_string()],
+        &[
+            "apply",
+            "--whitespace=nowarn",
+            &patch_path.display().to_string(),
+        ],
     )?;
     std::fs::remove_file(&patch_path).map_err(|error| {
         Error::internal_io(
@@ -537,6 +555,7 @@ fn materialize_follow_up_baseline(
             Some("remove cook baseline patch".to_string()),
         )
     })?;
+    git_output(&baseline.path, &["add", "--all"])?;
     git_output(
         &baseline.path,
         &[
@@ -552,6 +571,14 @@ fn materialize_follow_up_baseline(
     )?;
     let commit = git_output(&baseline.path, &["rev-parse", "HEAD"])?;
     let tree = git_output(&baseline.path, &["rev-parse", "HEAD^{tree}"])?;
+    if tree != target_tree {
+        return Err(Error::validation_invalid_argument(
+            "promotion",
+            "promotion target contains extra, missing, or unrelated changes; refusing cook retry baseline",
+            None,
+            None,
+        ));
+    }
     let mut baseline = baseline;
     baseline.provenance["baseline_commit"] = Value::String(commit);
     baseline.provenance["baseline_tree"] = Value::String(tree);
@@ -1157,7 +1184,8 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         let temp = tempfile::tempdir().expect("tempdir");
-        let root = temp.path();
+        let root = &temp.path().join("repo");
+        std::fs::create_dir(root).unwrap();
         for args in [
             vec!["init"],
             vec!["config", "user.name", "Test"],
@@ -1190,11 +1218,38 @@ mod tests {
             .permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(root.join("candidate.sh"), permissions).unwrap();
+        assert!(Command::new("git")
+            .args(["add", "--all"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        let patch = Command::new("git")
+            .args([
+                "diff",
+                "--cached",
+                "--binary",
+                "--full-index",
+                "--find-renames",
+                "HEAD",
+            ])
+            .current_dir(root)
+            .output()
+            .unwrap();
+        assert!(patch.status.success());
+        let patch_path = temp.path().join("candidate.patch");
+        std::fs::write(&patch_path, patch.stdout).unwrap();
+        assert!(Command::new("git")
+            .args(["reset"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
         let report: AgentTaskPromotionReport = serde_json::from_value(serde_json::json!({
             "schema":"homeboy/agent-task-promotion-report/v1", "status":"gate_failed",
             "source":{"kind":"aggregate","task_id":"candidate-task","run_id":"first-run"},
             "to_worktree":"fixture@target", "target":{"worktree":"fixture@target"},
-            "patch_artifact":{"id":"candidate","kind":"patch","path":"candidate.patch"}, "changed_files":["candidate.bin", "candidate.sh"],
+            "patch_artifact":{"id":"candidate","kind":"patch","path":patch_path}, "changed_files":["candidate.bin", "candidate.sh"],
             "command_evidence":[], "deterministic_gates":[], "gate_results":[],
             "provenance":{"worktree_path":root}, "operator_notification":{"status":"blocked","message":"red"}
         })).unwrap();

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -33,7 +33,7 @@ use crate::core::agent_task_scheduler::{
 use crate::core::command_invocation::CommandInvocation;
 use crate::core::{config, Error, Result};
 
-use super::execution::run_loaded_plan_with_derived_cook_baseline;
+use super::execution::{run_loaded_plan, run_loaded_plan_with_derived_cook_baseline};
 use super::AgentTaskRunResult;
 
 /// Executes one provider attempt while cook retains ownership of promotion,

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -541,6 +541,22 @@ fn materialize_follow_up_baseline(
                 None,
             )
         })?;
+    let expected_head = promotion.target.head.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "promotion.target.head",
+            "gate-failed promotion did not record the immutable target HEAD",
+            None,
+            None,
+        )
+    })?;
+    if git_output(&source_root, &["rev-parse", "HEAD"])? != expected_head {
+        return Err(Error::validation_invalid_argument(
+            "promotion.target.head",
+            "promotion target HEAD changed after the gate-failed promotion; refusing cook retry baseline",
+            None,
+            None,
+        ));
+    }
     let parent_snapshot = std::env::var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV)
         .ok()
         .map(|raw| serde_json::from_str::<Value>(&raw))
@@ -548,7 +564,6 @@ fn materialize_follow_up_baseline(
         .map_err(|error| {
             Error::validation_invalid_argument("source_snapshot", error.to_string(), None, None)
         })?;
-    let head = git_output(&source_root, &["rev-parse", "HEAD"])?;
     let artifact_bytes = std::fs::read(&promotion.patch_artifact.path).map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -584,7 +599,7 @@ fn materialize_follow_up_baseline(
     let index_path = index.path().display().to_string();
     git_output_with_env(
         &source_root,
-        &["read-tree", &head],
+        &["read-tree", expected_head],
         &[("GIT_INDEX_FILE", &index_path)],
     )?;
     git_output_with_env(
@@ -608,7 +623,7 @@ fn materialize_follow_up_baseline(
     let path_string = path.display().to_string();
     git_output(
         &source_root,
-        &["worktree", "add", "--detach", &path_string, &head],
+        &["worktree", "add", "--detach", &path_string, expected_head],
     )?;
     let baseline = CookFollowUpBaseline {
         source_root,
@@ -1308,6 +1323,7 @@ mod tests {
             .status()
             .unwrap()
             .success());
+        let target_head = git_output(root, &["rev-parse", "HEAD"]).unwrap();
         std::fs::write(root.join("candidate.bin"), [0_u8, 1, 2, 255]).unwrap();
         std::fs::write(root.join("candidate.sh"), "#!/bin/sh\nexit 0\n").unwrap();
         let mut permissions = std::fs::metadata(root.join("candidate.sh"))
@@ -1345,7 +1361,7 @@ mod tests {
         let report: AgentTaskPromotionReport = serde_json::from_value(serde_json::json!({
             "schema":"homeboy/agent-task-promotion-report/v1", "status":"gate_failed",
             "source":{"kind":"aggregate","task_id":"candidate-task","run_id":"first-run"},
-            "to_worktree":"fixture@target", "target":{"worktree":"fixture@target"},
+            "to_worktree":"fixture@target", "target":{"worktree":"fixture@target", "head":target_head},
             "patch_artifact":{"id":"candidate","kind":"patch","path":patch_path}, "changed_files":["candidate.bin", "candidate.sh"],
             "command_evidence":[], "deterministic_gates":[], "gate_results":[],
             "provenance":{"worktree_path":root}, "operator_notification":{"status":"blocked","message":"red"}
@@ -1378,6 +1394,73 @@ mod tests {
                 .iter()
                 .map(|byte| format!("{byte:02x}"))
                 .collect::<String>()
+        );
+    }
+
+    #[test]
+    fn follow_up_baseline_refuses_when_promotion_target_head_has_advanced() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("repo");
+        std::fs::create_dir(&root).unwrap();
+        for args in [
+            vec!["init"],
+            vec!["config", "user.name", "Test"],
+            vec!["config", "user.email", "test@example.com"],
+        ] {
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(&root)
+                .status()
+                .unwrap()
+                .success());
+        }
+        std::fs::write(root.join("base.txt"), "base\n").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "."])
+            .current_dir(&root)
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "-m", "A"])
+            .current_dir(&root)
+            .status()
+            .unwrap()
+            .success());
+        let head_a = git_output(&root, &["rev-parse", "HEAD"]).unwrap();
+        std::fs::write(root.join("advanced.txt"), "B\n").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "."])
+            .current_dir(&root)
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "-m", "B"])
+            .current_dir(&root)
+            .status()
+            .unwrap()
+            .success());
+        let patch_path = temp.path().join("candidate.patch");
+        std::fs::write(&patch_path, "").unwrap();
+        let report: AgentTaskPromotionReport = serde_json::from_value(serde_json::json!({
+            "schema":"homeboy/agent-task-promotion-report/v1", "status":"gate_failed",
+            "source":{"kind":"aggregate","task_id":"candidate-task","run_id":"first-run"},
+            "to_worktree":"fixture@target", "target":{"worktree":"fixture@target", "head":head_a},
+            "patch_artifact":{"id":"candidate","kind":"patch","path":patch_path},
+            "provenance":{"worktree_path":root}, "operator_notification":{"status":"blocked","message":"red"}
+        }))
+        .unwrap();
+
+        let error = match materialize_follow_up_baseline(&report, "first-run") {
+            Ok(_) => panic!("target advancement rejects the stale promotion baseline"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error.message.contains("target HEAD changed"),
+            "unexpected error: {}",
+            error.message
         );
     }
 }

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -387,7 +387,7 @@ where
                 // Requests retain artifact facts for review, never authorization.
                 follow_up_request.inputs["cook_loop"]["artifact_provenance"] =
                     baseline.artifact_provenance();
-                let follow_up_plan = AgentTaskPlan::new(
+                let mut follow_up_plan = AgentTaskPlan::new(
                     format!("{cook_id}-cook-attempt-{}", attempt + 1),
                     vec![follow_up_request],
                 );

--- a/src/core/agent_task_service/execution.rs
+++ b/src/core/agent_task_service/execution.rs
@@ -19,6 +19,7 @@ use crate::core::agent_task_secrets::validate_secret_env_with_fallbacks;
 use crate::core::secret_env_plan::SecretEnvPlan;
 use crate::core::{config, worktree, Error, Result};
 
+use super::cook::DerivedCookBaselineCapability;
 use super::discovery::source_uri;
 
 #[derive(Debug, Clone)]
@@ -61,9 +62,21 @@ pub fn read_plan(spec: &str) -> Result<AgentTaskPlan> {
 }
 
 pub fn run_loaded_plan<E>(
+    plan: AgentTaskPlan,
+    record_run_id: Option<&str>,
+    executor: E,
+) -> Result<AgentTaskRunResult<AgentTaskAggregate>>
+where
+    E: AgentTaskExecutorAdapter,
+{
+    run_loaded_plan_with_derived_cook_baseline(plan, record_run_id, executor, None)
+}
+
+pub(crate) fn run_loaded_plan_with_derived_cook_baseline<E>(
     mut plan: AgentTaskPlan,
     record_run_id: Option<&str>,
     executor: E,
+    derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
 ) -> Result<AgentTaskRunResult<AgentTaskAggregate>>
 where
     E: AgentTaskExecutorAdapter,
@@ -86,7 +99,8 @@ where
         prepare_plan_for_execution(&mut plan, None)?;
     }
 
-    let aggregate = run_plan_with_scheduler(plan.clone(), record_run_id, executor);
+    let aggregate =
+        run_plan_with_scheduler(plan.clone(), record_run_id, executor, derived_cook_baseline);
     if let Some(run_id) = record_run_id {
         agent_task_lifecycle::record_run_aggregate(run_id, &plan, &aggregate)?;
     }
@@ -282,7 +296,7 @@ fn run_prepared_claimed<E>(
 where
     E: AgentTaskExecutorAdapter,
 {
-    let aggregate = run_plan_with_scheduler(plan.clone(), Some(&run_id), executor);
+    let aggregate = run_plan_with_scheduler(plan.clone(), Some(&run_id), executor, None);
     agent_task_lifecycle::record_run_aggregate(&run_id, &plan, &aggregate)?;
     Ok(AgentTaskRunResult {
         exit_code: aggregate_exit_code(&aggregate),
@@ -333,14 +347,17 @@ fn run_plan_with_scheduler<E>(
     plan: AgentTaskPlan,
     run_id: Option<&str>,
     executor: E,
+    derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
 ) -> AgentTaskAggregate
 where
     E: AgentTaskExecutorAdapter,
 {
     let scheduler = AgentTaskScheduler::new(executor);
     match run_id {
-        Some(run_id) => scheduler.with_run_id(run_id.to_string()).run(plan),
-        None => scheduler.run(plan),
+        Some(run_id) => scheduler
+            .with_run_id(run_id.to_string())
+            .run_with_derived_cook_baseline(plan, derived_cook_baseline),
+        None => scheduler.run_with_derived_cook_baseline(plan, derived_cook_baseline),
     }
 }
 

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -47,6 +47,9 @@ pub struct LabRoutingRequest<'a> {
     /// Controller checkout selected independently of CLI argv, such as the
     /// logical primary workspace of a materialized retry plan.
     pub source_path: Option<&'a std::path::Path>,
+    /// Controller-derived evidence carried with a staged source snapshot. It
+    /// never alters runner-side snapshot validation or workspace policy.
+    pub verified_cook_baseline: Option<&'a serde_json::Value>,
     /// Require controller bundle materialization for the selected source
     /// checkout before any runner-side Git transport is attempted.
     pub require_controller_git_bundle: bool,
@@ -76,6 +79,7 @@ pub(crate) fn route_lab_offload(
         local_output_file: request.local_output_file,
         durable_agent_task_plan: request.durable_agent_task_plan,
         source_path: request.source_path,
+        verified_cook_baseline: request.verified_cook_baseline,
         require_controller_git_bundle: request.require_controller_git_bundle,
         job_overrides: request.job_overrides,
     })
@@ -533,6 +537,7 @@ fn execute_lab_offload_with_timeout(
     let local_output_file = request.local_output_file.map(str::to_string);
     let durable_agent_task_plan = request.durable_agent_task_plan.cloned();
     let source_path = request.source_path.map(std::path::Path::to_path_buf);
+    let verified_cook_baseline = request.verified_cook_baseline.cloned();
     let require_controller_git_bundle = request.require_controller_git_bundle;
     let job_overrides = request.job_overrides;
     let (tx, rx) = std::sync::mpsc::channel();
@@ -553,6 +558,7 @@ fn execute_lab_offload_with_timeout(
             local_output_file: local_output_file.as_deref(),
             durable_agent_task_plan: durable_agent_task_plan.as_ref(),
             source_path: source_path.as_deref(),
+            verified_cook_baseline: verified_cook_baseline.as_ref(),
             require_controller_git_bundle,
             job_overrides,
         });
@@ -742,6 +748,7 @@ mod tests {
             local_output_file: None,
             durable_agent_task_plan: None,
             source_path: None,
+            verified_cook_baseline: None,
             require_controller_git_bundle: false,
             job_overrides: runners::LabJobOverrides::default(),
         })
@@ -1045,6 +1052,7 @@ mod tests {
                 local_output_file: None,
                 durable_agent_task_plan: None,
                 source_path: None,
+                verified_cook_baseline: None,
                 require_controller_git_bundle: false,
                 job_overrides: runners::LabJobOverrides::default(),
             },

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -1272,6 +1272,11 @@ pub(crate) fn run_lab_offload_inner(
             primary_synced_workspace: &synced,
         },
     )?;
+    if let Some(verified_cook_baseline) = request.verified_cook_baseline {
+        lab_metadata["source_provenance"] = serde_json::json!({
+            "verified_cook_baseline": verified_cook_baseline,
+        });
+    }
     lab_metadata["dependency_hydration"] =
         dependency_hydration_metadata(&dependency_hydration.record);
     lab_metadata["workspace_resource_lifecycle"] =

--- a/src/core/runner/lab/offload/tests/exec_errors.rs
+++ b/src/core/runner/lab/offload/tests/exec_errors.rs
@@ -376,6 +376,7 @@ fn plan_records_skipped_auto_offload() {
         local_output_file: None,
         durable_agent_task_plan: None,
         source_path: None,
+        verified_cook_baseline: None,
         require_controller_git_bundle: false,
         job_overrides: LabJobOverrides::default(),
     })
@@ -408,6 +409,7 @@ fn lab_placement_refuses_local_execution_without_lab_contract() {
         local_output_file: None,
         durable_agent_task_plan: None,
         source_path: None,
+        verified_cook_baseline: None,
         require_controller_git_bundle: false,
         job_overrides: LabJobOverrides::default(),
     });
@@ -443,6 +445,7 @@ fn lab_placement_refuses_local_only_rig_install_with_actionable_boundary() {
         local_output_file: None,
         durable_agent_task_plan: None,
         source_path: None,
+        verified_cook_baseline: None,
         require_controller_git_bundle: false,
         job_overrides: LabJobOverrides::default(),
     });
@@ -480,6 +483,7 @@ fn build_runner_error_gives_managed_runner_replacement() {
         local_output_file: None,
         durable_agent_task_plan: None,
         source_path: None,
+        verified_cook_baseline: None,
         require_controller_git_bundle: false,
         job_overrides: LabJobOverrides::default(),
     });
@@ -526,6 +530,7 @@ fn build_lab_placement_error_gives_managed_runner_replacement() {
         local_output_file: None,
         durable_agent_task_plan: None,
         source_path: None,
+        verified_cook_baseline: None,
         require_controller_git_bundle: false,
         job_overrides: LabJobOverrides::default(),
     });
@@ -574,6 +579,7 @@ fn unsupported_runner_error_guides_tunnel_service_inspection() {
         local_output_file: None,
         durable_agent_task_plan: None,
         source_path: None,
+        verified_cook_baseline: None,
         require_controller_git_bundle: false,
         job_overrides: LabJobOverrides::default(),
     });

--- a/src/core/runner/lab/offload/types.rs
+++ b/src/core/runner/lab/offload/types.rs
@@ -35,6 +35,9 @@ pub struct LabOffloadRequest<'a> {
     /// This keeps process cwd in the runner job while retaining an exact local
     /// source for Git materialization and path remapping.
     pub source_path: Option<&'a std::path::Path>,
+    /// Controller-derived evidence attached to staged source metadata. This is
+    /// descriptive only; it cannot relax remote snapshot validation.
+    pub verified_cook_baseline: Option<&'a serde_json::Value>,
     /// Select controller-bundle materialization before runner-side Git transport.
     pub require_controller_git_bundle: bool,
     pub job_overrides: LabJobOverrides,

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -2149,6 +2149,7 @@ mod tests {
                 local_output_file: None,
                 durable_agent_task_plan: None,
                 source_path: None,
+                verified_cook_baseline: None,
                 require_controller_git_bundle: true,
                 job_overrides: LabJobOverrides::default(),
             };
@@ -2301,6 +2302,7 @@ mod tests {
                 local_output_file: None,
                 durable_agent_task_plan: None,
                 source_path: Some(source.as_path()),
+                verified_cook_baseline: None,
                 require_controller_git_bundle: false,
                 job_overrides: LabJobOverrides::default(),
             };


### PR DESCRIPTION
## Summary
- reconstruct a clean gate-retry baseline from the exact promoted artifact at the exact recorded target HEAD
- reject unrelated, missing, or concurrently committed target state by comparing canonical trees
- authorize derived baselines through a process-local capability rather than request-controlled metadata
- preserve local and Lab attempt placement while staging the exact derived baseline
- carry verified parent snapshot and promoted-candidate provenance into harvested follow-up artifacts
- clean temporary indexes and worktrees on all paths

Closes #8228.

## How to test
1. Run the focused cook baseline tests covering binary, executable-mode, symlink, and untracked candidate state.
2. Run scheduler committed-harvest tests and confirm forged requests without the internal capability remain subject to strict provenance checks.
3. Run the Lab route regression and confirm gate retry attempt 2 uses the dispatcher and stages the derived baseline rather than the controller workspace.
4. Confirm harvested Lab follow-up artifacts include parent snapshot, baseline commit/tree, prior run/task, and promoted artifact SHA provenance.
5. Confirm advancing the promotion target HEAD or adding unrelated dirt rejects retry baseline creation.
6. Run `cargo check --locked`, `cargo fmt --check`, and `git diff --check origin/main...HEAD`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Diagnosed the nested cook retry failure, designed the isolated baseline/capability contract, implemented deterministic coverage, and performed repeated independent integrity reviews. Chris reviewed and owns the change.