### PR TITLE
Preserve provider model through Lab publication

### DIFF
--- a/src/core/agent_task_lifecycle/conversion.rs
+++ b/src/core/agent_task_lifecycle/conversion.rs
@@ -477,6 +477,18 @@ pub(crate) fn run_provider_handle(
     outcome: &AgentTaskOutcome,
     handle: AgentTaskExecutionHandle,
 ) -> AgentTaskRunProviderHandle {
+    let mut metadata = handle.metadata;
+    if metadata.get("model").and_then(Value::as_str).is_none() {
+        if let Some(model) = outcome.metadata.get("model").and_then(Value::as_str) {
+            if !metadata.is_object() {
+                metadata = json!({});
+            }
+            metadata
+                .as_object_mut()
+                .expect("provider handle metadata object")
+                .insert("model".to_string(), json!(model));
+        }
+    }
     AgentTaskRunProviderHandle {
         kind: handle.kind,
         task_id: handle.task_id,
@@ -493,7 +505,7 @@ pub(crate) fn run_provider_handle(
             crate::core::agent_task::AgentTaskOutcomeStatus::Cancelled => AgentTaskState::Cancelled,
             _ => AgentTaskState::Failed,
         }),
-        metadata: handle.metadata,
+        metadata,
     }
 }
 

--- a/src/core/agent_task_lifecycle/failure_recording.rs
+++ b/src/core/agent_task_lifecycle/failure_recording.rs
@@ -733,6 +733,7 @@ pub(crate) fn apply_aggregate_to_record(
     record.tasks = tasks_for_aggregate(plan, aggregate);
     record.artifact_refs = artifact_refs_for_outcomes(&aggregate.outcomes);
     record.provider_handles = provider_handles_for_outcomes(&aggregate.outcomes);
+    persist_provider_handle_models(&mut record.provider_handles, plan);
     record.latest_executor_evidence = latest_executor_evidence(&record.run_id, plan, aggregate);
     update_lifecycle_from_record(record, plan);
     let provider_run_ids: Vec<String> = record
@@ -748,5 +749,38 @@ pub(crate) fn apply_aggregate_to_record(
     metadata.insert("provider_run_ids".to_string(), json!(provider_run_ids));
     if let Some(evidence) = latest_executor_evidence_value {
         metadata.insert("latest_executor_evidence".to_string(), evidence);
+    }
+}
+
+fn persist_provider_handle_models(
+    handles: &mut [AgentTaskRunProviderHandle],
+    plan: &AgentTaskPlan,
+) {
+    for handle in handles {
+        if handle
+            .metadata
+            .get("model")
+            .and_then(Value::as_str)
+            .is_some_and(|model| !model.trim().is_empty())
+        {
+            continue;
+        }
+        let Some(model) = plan
+            .tasks
+            .iter()
+            .find(|task| task.task_id == handle.task_id)
+            .and_then(|task| task.executor.model())
+            .filter(|model| !model.trim().is_empty())
+        else {
+            continue;
+        };
+        if !handle.metadata.is_object() {
+            handle.metadata = json!({});
+        }
+        handle
+            .metadata
+            .as_object_mut()
+            .expect("provider handle metadata object")
+            .insert("model".to_string(), json!(model));
     }
 }

--- a/src/core/agent_task_scheduler/engine.rs
+++ b/src/core/agent_task_scheduler/engine.rs
@@ -527,6 +527,7 @@ where
                         &mut outcome,
                         running_task.adoption.as_ref(),
                     );
+                    persist_resolved_provider_model(&mut outcome, &running_task.request);
                     if let Err(error) = harvest_uncommitted_patch(&mut outcome, &running_task)
                         .and_then(|_| harvest_committed_patch(&mut outcome, &running_task))
                     {
@@ -800,6 +801,24 @@ where
             artifact_bindings,
         }
     }
+}
+
+fn persist_resolved_provider_model(outcome: &mut AgentTaskOutcome, request: &AgentTaskRequest) {
+    let Some(model) = request
+        .executor
+        .model()
+        .filter(|model| !model.trim().is_empty())
+    else {
+        return;
+    };
+    if !outcome.metadata.is_object() {
+        outcome.metadata = serde_json::json!({});
+    }
+    outcome
+        .metadata
+        .as_object_mut()
+        .expect("outcome metadata object")
+        .insert("model".to_string(), serde_json::json!(model));
 }
 
 #[derive(Debug, Clone)]

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -1197,6 +1197,136 @@ mod tests {
     }
 
     #[test]
+    fn typed_run_plan_lifecycle_persists_remapped_provider_model_for_publication() {
+        crate::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let plan_path = temp.path().join("plan.json");
+            let plan = AgentTaskPlan::new(
+                "plan-remapped-model",
+                vec![crate::core::agent_task::AgentTaskRequest {
+                    schema: crate::core::agent_task::AGENT_TASK_REQUEST_SCHEMA.to_string(),
+                    task_id: "cook".to_string(),
+                    group_key: None,
+                    parent_plan_id: None,
+                    executor: crate::core::agent_task::AgentTaskExecutor {
+                        backend: "opencode".to_string(),
+                        selector: None,
+                        runtime_selection: None,
+                        required_capabilities: Vec::new(),
+                        secret_env: Vec::new(),
+                        model: Some("openai/gpt-5.6-terra".to_string()),
+                        config: Value::Null,
+                    },
+                    instructions: "apply the change".to_string(),
+                    inputs: Value::Null,
+                    source_refs: Vec::new(),
+                    workspace: Default::default(),
+                    component_contracts: Vec::new(),
+                    policy: Default::default(),
+                    limits: Default::default(),
+                    expected_artifacts: Vec::new(),
+                    artifact_declarations: Vec::new(),
+                    metadata: Value::Null,
+                }],
+            );
+            fs::write(
+                &plan_path,
+                serde_json::to_vec(&plan).expect("serialize remapped plan"),
+            )
+            .expect("write remapped plan");
+            let agent_task = RunnerWorkloadAgentTask {
+                run_id: "run-remapped-model".to_string(),
+                plan_ref: Some(format!("@{}", plan_path.display())),
+                resolved_provider_policy: Some(
+                    crate::core::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy {
+                        backend: "opencode".to_string(),
+                        selector: None,
+                        model: Some("openai/gpt-5.6-terra".to_string()),
+                        rotation: None,
+                        rotation_starts_with_first_entry: true,
+                        retry: Default::default(),
+                        liveness_timeout_ms: None,
+                    },
+                ),
+                dispatch_kind:
+                    crate::command_contract::RunnerWorkloadAgentTaskDispatchKind::RunPlan,
+                lifecycle_mirror_policy:
+                    RunnerWorkloadAgentTaskLifecycleMirrorPolicy::RunPlanAggregate,
+            };
+            let events = vec![JobEvent {
+                sequence: 1,
+                job_id: uuid::Uuid::nil(),
+                kind: JobEventKind::Result,
+                timestamp_ms: 1,
+                message: None,
+                data: Some(serde_json::json!({
+                    "agent_task_lifecycle_event": {
+                        "schema": "homeboy/agent-task-run-plan-lifecycle-event/v1",
+                        "identity": {
+                            "runner_id": "lab-default",
+                            "runner_job_id": "job-remapped-model",
+                            "run_id": "run-remapped-model"
+                        },
+                        "aggregate": serde_json::to_value(AgentTaskAggregate {
+                            schema: "homeboy/agent-task-aggregate/v1".to_string(),
+                            plan_id: plan.plan_id.clone(),
+                            status: crate::core::agent_task_scheduler::AgentTaskAggregateStatus::Succeeded,
+                            totals: AgentTaskAggregateTotals {
+                                succeeded: 1,
+                                ..Default::default()
+                            },
+                            outcomes: vec![crate::core::agent_task::AgentTaskOutcome {
+                                schema: crate::core::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                                task_id: "cook".to_string(),
+                                status: crate::core::agent_task::AgentTaskOutcomeStatus::Succeeded,
+                                summary: None,
+                                failure_classification: None,
+                                artifacts: Vec::new(),
+                                typed_artifacts: Vec::new(),
+                                evidence_refs: Vec::new(),
+                                diagnostics: Vec::new(),
+                                outputs: Value::Null,
+                                workflow: None,
+                                follow_up: None,
+                                metadata: serde_json::json!({
+                                    "provider_handle": {
+                                        "task_id": "cook",
+                                        "backend": "opencode",
+                                        "run_id": "provider-run-8263",
+                                        "metadata": {"provider_owned": true}
+                                    }
+                                }),
+                            }],
+                            events: Vec::new(),
+                            artifact_lineage: Vec::new(),
+                            child_runs: Vec::new(),
+                            artifact_bindings: Vec::new(),
+                            queue: Default::default(),
+                        }).expect("serialize aggregate")
+                    }
+                })),
+            }];
+
+            mirror_agent_task_run_plan_lifecycle(
+                &[],
+                Some(&agent_task),
+                None,
+                "not parsed",
+                None,
+                Some(&events),
+            )
+            .expect("remapped Lab aggregate mirrored");
+
+            let record = agent_task_lifecycle::status("run-remapped-model").expect("status");
+            assert_eq!(record.lifecycle.provider_runtime.len(), 1);
+            assert_eq!(
+                record.lifecycle.provider_runtime[0].metadata["model"],
+                "openai/gpt-5.6-terra"
+            );
+        });
+    }
+
+    #[test]
     fn legacy_run_plan_lifecycle_branch_uses_argv_and_stdout_only_without_typed_workload() {
         crate::test_support::with_isolated_home(|_| {
             let temp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary
Preserve the resolved provider model across Lab aggregate mirroring so changed candidates can be published.

## What changed
- Persist the selected executor model on scheduler outcomes before harvesting provider results.
- Backfill provider-handle model metadata from outcomes and the remapped plan before lifecycle publication.
- Cover the typed Lab remapping path that previously rejected a completed candidate.

## How to test
1. Run `cargo test typed_run_plan_lifecycle_persists_remapped_provider_model_for_publication`; expect passes.
2. Run `cargo fmt --check`; expect passes.
3. Run `git diff --check`; expect passes.

## Compatibility
No public extension-path change. This only strengthens internal durable provider identity used by Lab publication.

## Evidence
- CI expected: Homeboy CI
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8263
- diff\_check: Passed
- focused\_lab\_publication\_test: Passed
- format: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode recovery via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Root-caused and repaired the Lab provider-model publication failure with deterministic coverage; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8263
