### PR TITLE
fix: mark internal workspace crates publish = false

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [workspace]
 # Internal crates split out of the homeboy monolith to gain per-crate
-# incremental compilation and lower peak build memory. They are published as
-# dependencies of the `homeboy` crate; the shipped CLI artifact remains the
-# single `homeboy` binary.
+# incremental compilation and lower peak build memory. They are path-only
+# dependencies of the `homeboy` crate and are NOT published to crates.io
+# (each sets `publish = false`); the shipped CLI artifact remains the single
+# `homeboy` binary.
 members = ["crates/*"]
 
 [package]

--- a/crates/homeboy-cli-contract/Cargo.toml
+++ b/crates/homeboy-cli-contract/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 authors = ["Chris Huber <chubes@extrachill.com>"]
 description = "Shared CLI contract types (e.g. execution Placement) used by both the homeboy CLI and core routing"
 repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
 
 [lib]
 name = "homeboy_cli_contract"

--- a/crates/homeboy-engine-primitives/Cargo.toml
+++ b/crates/homeboy-engine-primitives/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 authors = ["Chris Huber <chubes@extrachill.com>"]
 description = "Low-level execution primitives (shell, command, text, run_dir, template, output parsing, identifiers) for homeboy"
 repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
 
 [lib]
 name = "homeboy_engine_primitives"

--- a/crates/homeboy-error/Cargo.toml
+++ b/crates/homeboy-error/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 authors = ["Chris Huber <chubes@extrachill.com>"]
 description = "Structured error types, error codes, and result alias for homeboy"
 repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
 
 [lib]
 name = "homeboy_error"

--- a/crates/homeboy-finding/Cargo.toml
+++ b/crates/homeboy-finding/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 authors = ["Chris Huber <chubes@extrachill.com>"]
 description = "Structured finding/diagnostic types for homeboy audit and review output"
 repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
 
 [lib]
 name = "homeboy_finding"

--- a/crates/homeboy-output/Cargo.toml
+++ b/crates/homeboy-output/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 authors = ["Chris Huber <chubes@extrachill.com>"]
 description = "Structured bulk-operation result and output aggregation types for homeboy"
 repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
 
 [lib]
 name = "homeboy_output"

--- a/crates/homeboy-paths/Cargo.toml
+++ b/crates/homeboy-paths/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 authors = ["Chris Huber <chubes@extrachill.com>"]
 description = "Filesystem path resolution (config/data/artifact/rig/runtime dirs) for homeboy"
 repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
 
 [lib]
 name = "homeboy_paths"

--- a/crates/homeboy-process/Cargo.toml
+++ b/crates/homeboy-process/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 authors = ["Chris Huber <chubes@extrachill.com>"]
 description = "Process spawning, signaling, and lifecycle helpers for homeboy"
 repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
 
 [lib]
 name = "homeboy_process"

--- a/crates/homeboy-product-identity/Cargo.toml
+++ b/crates/homeboy-product-identity/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 authors = ["Chris Huber <chubes@extrachill.com>"]
 description = "Homeboy-owned product literals (name, binary, config/env/artifact prefixes)"
 repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
 
 [lib]
 name = "homeboy_product_identity"

--- a/crates/homeboy-redaction/Cargo.toml
+++ b/crates/homeboy-redaction/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 authors = ["Chris Huber <chubes@extrachill.com>"]
 description = "Secret/sensitive-value redaction helpers for homeboy"
 repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
 
 [lib]
 name = "homeboy_redaction"


### PR DESCRIPTION
## 🚨 Internal crates were being published to crates.io

The nine internal crates split out of the monolith (`homeboy-error`, `homeboy-redaction`, `homeboy-paths`, `homeboy-output`, `homeboy-process`, `homeboy-finding`, `homeboy-product-identity`, `homeboy-engine-primitives`, `homeboy-cli-contract`) are **implementation details** — reached only as path dependencies of the `homeboy` crate. They were never meant for the public registry.

They were missing `publish = false`, so the crates.io release pipeline published **all nine as 0.1.0** to the public registry. (Confirmed live via the crates.io API.)

## Fix
- Set `publish = false` on every crate under `crates/` so future releases skip them.
- Corrected the workspace comment in the root `Cargo.toml` (they're path-only deps, not crates.io packages).

## Follow-up (not in this PR)
The already-published `0.1.0` versions can't be deleted — crates.io only supports `yank` (hides from new dependency resolution, stays downloadable). Recommend yanking all nine `0.1.0` versions:
```
for c in homeboy-error homeboy-redaction homeboy-cli-contract homeboy-paths \
         homeboy-engine-primitives homeboy-finding homeboy-output \
         homeboy-process homeboy-product-identity; do
  cargo yank --version 0.1.0 "$c"
done
```

## Priority
Merge ASAP so the next release doesn't re-publish. No code changes — manifest metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)