### PR TITLE
perf(test): skip giant-binary hashing in the shared home guard

### DIFF
--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -128,9 +128,18 @@ pub(crate) struct HomeGuard {
     prior_runtime_tmpdir: Option<String>,
     prior_invocation_runtime: Option<String>,
     prior_no_update_check: Option<String>,
+    prior_daemon_binary_sha: Option<String>,
     context: HermeticTestContext,
     _guard: MutexGuard<'static, ()>,
 }
+
+/// A fixed, well-formed (64-hex) SHA the daemon uses in place of hashing the
+/// running executable during tests. Hashing the multi-hundred-MB debug test
+/// binary costs ~20s per daemon-state write; a stable placeholder keeps daemon
+/// tests fast and deterministic. It is only honored via
+/// `HOMEBOY_TEST_DAEMON_BINARY_SHA`, which no released binary sets.
+const TEST_DAEMON_BINARY_SHA: &str =
+    "0000000000000000000000000000000000000000000000000000000000000000";
 
 pub(crate) struct AuditGuard {
     _guard: MutexGuard<'static, ()>,
@@ -190,6 +199,8 @@ impl HomeGuard {
         let prior_invocation_runtime =
             std::env::var(crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
         let prior_no_update_check = std::env::var("HOMEBOY_NO_UPDATE_CHECK").ok();
+        let prior_daemon_binary_sha =
+            std::env::var(crate::core::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV).ok();
         // The isolated HOME hosts `~/.config/homeboy/extensions/**/*.sh`
         // capability scripts that tests execute. On `noexec`-`/tmp` hosts a
         // plain `TempDir::new()` lands the whole HOME on a `noexec` mount,
@@ -214,6 +225,11 @@ impl HomeGuard {
             crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
             context.invocation_runtime.path(),
         );
+        // Avoid hashing the giant debug test binary on every daemon-state write.
+        std::env::set_var(
+            crate::core::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV,
+            TEST_DAEMON_BINARY_SHA,
+        );
         Self {
             prior,
             prior_xdg_data_home,
@@ -221,6 +237,7 @@ impl HomeGuard {
             prior_runtime_tmpdir,
             prior_invocation_runtime,
             prior_no_update_check,
+            prior_daemon_binary_sha,
             context,
             _guard: guard,
         }
@@ -389,6 +406,12 @@ impl Drop for HomeGuard {
         match &self.prior_no_update_check {
             Some(value) => std::env::set_var("HOMEBOY_NO_UPDATE_CHECK", value),
             None => std::env::remove_var("HOMEBOY_NO_UPDATE_CHECK"),
+        }
+        match &self.prior_daemon_binary_sha {
+            Some(value) => {
+                std::env::set_var(crate::core::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV, value)
+            }
+            None => std::env::remove_var(crate::core::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV),
         }
         reset_cached_test_state();
     }


### PR DESCRIPTION
## Summary

The `core::daemon` test module took **~11 minutes** to run. Root cause: every daemon-state write (`write_state`) computes `binary_sha256` by hashing the **running executable**. Negligible for a released ~30-50 MB binary, but the debug **test** binary is ~670 MB, so each write costs ~20s — and most of the ~114 daemon tests write state.

## Fix

#8238 already added a test-only `HOMEBOY_TEST_DAEMON_BINARY_SHA` override (scoped to the broker fixtures) to dodge this. Promote it to the shared `test_support::HomeGuard` with a fixed, well-formed **64-hex** placeholder, so every test that isolates HOME gets fast, deterministic daemon startup.

The placeholder is:
- **length-valid** — `write_state_establishes_daemon_session_lease_identity` asserts a 64-char hash;
- **distinct** from the explicit mismatch fixtures (`unknown`, `stale-binary-hash`), so binary-hash-**mismatch** detection tests still fire correctly.

Prior env value is saved and restored on `Drop`.

## Verification

- `core::daemon` — **114 pass in ~3.2s** (was ~646s — a ~200x speedup).
- No regressions: `core::agent_task_service` / `core::observation` / `commands::runner::status` / `core::runner::lab::offload` — 293 pass.

## Note

While sweeping I found **2 pre-existing reds unrelated to this change** (they fail on clean `main` too): `core::runner::connection::tests::disconnect_removes_existing_session_file` and `core::runner::homeboy_refresh::tests::materialize_failure_preserves_compiler_diagnostics_and_active_binary` — both git-fixture related. Filing/fixing those separately.