### PR TITLE
test: use reverse-tunnel session for disconnect session-file cleanup test

### DIFF
--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -3534,9 +3534,13 @@ esac
         test_support::with_isolated_home(|_| {
             crate::core::runner::create(r#"{"id":"lab-local","kind":"local"}"#, false)
                 .expect("create runner");
+            // A reverse-tunnel session: disconnect removes local session state
+            // without the direct-SSH remote-daemon-stop path, which (since
+            // #8250) refuses to unbind a leaseless direct-SSH daemon. This test
+            // asserts local session-file cleanup, not remote stop.
             let session = RunnerSession {
                 runner_id: "lab-local".to_string(),
-                mode: RunnerTunnelMode::DirectSsh,
+                mode: RunnerTunnelMode::Reverse,
                 role: RunnerSessionRole::Controller,
                 server_id: None,
                 controller_id: None,


### PR DESCRIPTION
## Summary

`core::runner::connection::tests::disconnect_removes_existing_session_file` failed deterministically on `main`.

#8250 ("protect active daemon jobs during reconnect") made `disconnect` refuse a **direct-SSH** session with no daemon lease — *"refusing unbound remote stop"* — so it can't unbind an active remote daemon unsafely. The test built a **leaseless direct-SSH** session and expected disconnect to succeed, so it now hits that refusal.

## Fix

The test's actual assertion is **local session-file cleanup**, not remote daemon stop. Switch its fixture to a **reverse-tunnel** session, which `disconnect` cleans up without the direct-SSH remote-daemon-stop guard — so it exercises exactly what it asserts.

## Verification

- `core::runner::connection` — 70 pass.

## Note

The other pre-existing red I found (`homeboy_refresh::materialize_failure_preserves_compiler_diagnostics_and_active_binary`) is a **local-environment** issue, not a code/CI red: it builds a fixture with `cargo` under the isolated `HOME`, which hides `~/.rustup`, so cargo fails with rustup's "no default toolchain" (exit 1) instead of the intended compiler failure (exit 101). It passes where `RUSTUP_HOME`/`CARGO_HOME` survive the HOME override (CI). Left as-is.