### PR TITLE
Retain release artifacts with cleanup-safe leases

### DIFF
--- a/src/core/deploy/execution/mod.rs
+++ b/src/core/deploy/execution/mod.rs
@@ -177,10 +177,16 @@ mod tests {
         )
         .expect("prepared artifact should pass local preflight");
 
-        assert_eq!(prepared.artifact_path, Some(durable_artifact));
+        assert_eq!(prepared.artifact_path, Some(durable_artifact.clone()));
         assert!(
             !build_counter.exists(),
             "prepared deployment must not build"
+        );
+        assert!(!prepared.cleanup_local_artifact);
+        drop(prepared);
+        assert!(
+            durable_artifact.exists(),
+            "caller-owned prepared artifacts remain outside downloaded-artifact cleanup"
         );
     }
 

--- a/src/core/deploy/execution/prepare.rs
+++ b/src/core/deploy/execution/prepare.rs
@@ -9,7 +9,7 @@ use super::super::generated_artifacts::GeneratedBuildArtifactCleanupGuard;
 use super::super::path_roots::{component_remote_path, resolve_effective_remote_path};
 use super::super::policy::{owner_hint_for_path, protected_path_suffixes, validate_deploy_target};
 use super::super::provenance::capture_build_provenance;
-use super::super::release_download::ReleaseArtifact;
+use super::super::release_download::ReleaseArtifactLease;
 use super::super::types::{
     BuildProvenance, BuildSource, ComponentDeployResult, DeployArtifactSource, DeployConfig,
 };
@@ -39,7 +39,7 @@ pub(crate) fn prepare_component_deploy(
     project: &Project,
     local_version: Option<String>,
     remote_version: Option<String>,
-    release_artifact: Option<ReleaseArtifact>,
+    release_artifact: Option<ReleaseArtifactLease>,
 ) -> std::result::Result<PreparedComponentDeploy, ComponentDeployResult> {
     let is_git_deploy = component.deploy_strategy.as_deref() == Some("git");
     let is_file_deploy = component.deploy_strategy.as_deref() == Some("file");
@@ -78,7 +78,7 @@ pub(crate) fn prepare_component_deploy(
     } else {
         match release_artifact_plan(component, config, is_git_deploy, is_file_deploy) {
                 ReleaseArtifactPlan::Reuse { tag, .. } => match release_artifact {
-                    Some(artifact) => Some(artifact.path),
+                    Some(artifact) => Some(artifact.path.clone()),
                     None => return Err(failed_component_deploy_result(
                         component, base_path, local_version, remote_version, None,
                         format!("artifact source release_asset failed for '{}' tag {tag}: verified run-scoped artifact is unavailable. Refusing to fall back to local_build", component.id),

--- a/src/core/deploy/execution/release_plan.rs
+++ b/src/core/deploy/execution/release_plan.rs
@@ -78,7 +78,7 @@ pub(crate) fn resolve_planned_release_artifact(
     component: &Component,
     tag: &str,
     store: &mut release_download::ReleaseArtifactStore,
-) -> std::result::Result<release_download::ReleaseArtifact, String> {
+) -> std::result::Result<release_download::ReleaseArtifactLease, String> {
     let remote_url = component
         .remote_url
         .as_deref()

--- a/src/core/deploy/orchestration/mod.rs
+++ b/src/core/deploy/orchestration/mod.rs
@@ -14,7 +14,7 @@ use super::orchestration_ref_checkout::{ExactRefCheckout, ExactRefIdentity};
 use super::orchestration_tag_checkout::{checkout_deploy_tags, restore_branches};
 use super::path_roots::{project_with_detected_path_roots, resolve_effective_remote_path};
 use super::planning::{load_project_components, plan_components};
-use super::release_download::{ReleaseArtifact, ReleaseArtifactStore};
+use super::release_download::{ReleaseArtifactLease, ReleaseArtifactStore};
 use super::types::{ComponentDeployResult, DeployConfig, DeployOrchestrationResult, DeploySummary};
 use super::version_overrides::fetch_remote_versions_for_project;
 
@@ -112,7 +112,7 @@ pub(super) fn deploy_components(
     // Release assets are immutable remote inputs. Resolve and verify them before
     // touching any configured checkout, then reuse the same run-scoped bytes for
     // every target/project that requests this component.
-    let mut resolved_release_artifacts: HashMap<String, ReleaseArtifact> = HashMap::new();
+    let mut resolved_release_artifacts: HashMap<String, ReleaseArtifactLease> = HashMap::new();
     for component in &components {
         if let ReleaseArtifactPlan::Reuse { tag, .. } =
             release_artifact_plan(component, config, false, false)
@@ -419,7 +419,7 @@ fn prepare_component_deployments(
     base_path: &str,
     local_versions: &HashMap<String, String>,
     remote_versions: &HashMap<String, String>,
-    release_artifacts: &HashMap<String, ReleaseArtifact>,
+    release_artifacts: &HashMap<String, ReleaseArtifactLease>,
 ) -> std::result::Result<Vec<PreparedComponentDeploy>, Vec<ComponentDeployResult>> {
     let mut prepared_deployments = Vec::new();
     let mut failures = Vec::new();

--- a/src/core/deploy/release_download.rs
+++ b/src/core/deploy/release_download.rs
@@ -12,7 +12,9 @@
 
 use std::collections::HashMap;
 use std::io::Write;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use crate::core::component::{Component, GithubConfig};
 use crate::core::error::{Error, Result};
@@ -53,11 +55,52 @@ pub struct ReleaseArtifact {
     pub sha256: String,
 }
 
+/// Shared payload and runtime-temp pin retained by every lease clone.
+///
+/// Runtime download directories follow the existing retained-artifact policy and
+/// are cleaned by the runtime-temp cleanup command, not when this lease drops.
+#[derive(Debug)]
+struct ReleaseArtifactLeaseInner {
+    artifact: ReleaseArtifact,
+    _runtime_temp_pin: crate::core::engine::temp::RuntimeTempPin,
+}
+
+/// Cloneable ownership of a downloaded release artifact within a deploy scope.
+/// Consumers retain the verified bytes independently without invalidating another
+/// consumer, and the final drop removes only the runtime cleanup pin.
+#[derive(Debug, Clone)]
+pub struct ReleaseArtifactLease(Arc<ReleaseArtifactLeaseInner>);
+
+impl ReleaseArtifactLease {
+    fn new(artifact: ReleaseArtifact) -> Result<Self> {
+        let directory = artifact.path.parent().ok_or_else(|| {
+            Error::internal_io(
+                "Downloaded release artifact has no parent directory".to_string(),
+                Some(artifact.path.display().to_string()),
+            )
+        })?;
+        let runtime_temp_pin = crate::core::engine::temp::pin_runtime_temp_dir(directory)?;
+        Ok(Self(Arc::new(ReleaseArtifactLeaseInner {
+            artifact,
+            _runtime_temp_pin: runtime_temp_pin,
+        })))
+    }
+}
+
+impl Deref for ReleaseArtifactLease {
+    type Target = ReleaseArtifact;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0.artifact
+    }
+}
+
 /// Command-scoped immutable artifact cache. A multi-target deploy resolves and
-/// verifies a release asset once, then fans out the same local bytes.
+/// verifies a release asset once, then fans out independent leases for the same
+/// local bytes.
 #[derive(Default)]
 pub struct ReleaseArtifactStore {
-    artifacts: HashMap<String, ReleaseArtifact>,
+    artifacts: HashMap<String, ReleaseArtifactLease>,
 }
 
 impl ReleaseArtifactStore {
@@ -67,7 +110,7 @@ impl ReleaseArtifactStore {
         github_config: &GithubConfig,
         tag: &str,
         artifact_name: &str,
-    ) -> Result<ReleaseArtifact> {
+    ) -> Result<ReleaseArtifactLease> {
         self.get_or_insert_with(github, tag, artifact_name, || {
             resolve_and_download_release_artifact(github, github_config, tag, artifact_name)
         })
@@ -78,7 +121,7 @@ impl ReleaseArtifactStore {
         github: &GitHubRepo,
         tag: &str,
         artifact_name: &str,
-    ) -> Option<ReleaseArtifact> {
+    ) -> Option<ReleaseArtifactLease> {
         self.artifacts
             .get(&format!(
                 "{}/{}/{}:{tag}:{artifact_name}",
@@ -93,7 +136,7 @@ impl ReleaseArtifactStore {
         tag: &str,
         artifact_name: &str,
         resolve: impl FnOnce() -> Result<ReleaseArtifact>,
-    ) -> Result<ReleaseArtifact> {
+    ) -> Result<ReleaseArtifactLease> {
         let key = format!(
             "{}/{}/{}:{tag}:{artifact_name}",
             github.host, github.owner, github.repo
@@ -101,7 +144,7 @@ impl ReleaseArtifactStore {
         if let Some(artifact) = self.artifacts.get(&key) {
             return Ok(artifact.clone());
         }
-        let artifact = resolve()?;
+        let artifact = ReleaseArtifactLease::new(resolve()?)?;
         self.artifacts.insert(key, artifact.clone());
         Ok(artifact)
     }
@@ -1171,36 +1214,117 @@ mod tests {
     }
 
     #[test]
-    fn release_artifact_store_resolves_once_for_multiple_targets() {
+    fn release_artifact_store_leases_deduplicate_and_retain_downloads() {
         let github = GitHubRepo {
             host: "github.example.test".to_string(),
             owner: "example".to_string(),
             repo: "plugin".to_string(),
         };
         let mut store = ReleaseArtifactStore::default();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("plugin.zip");
         let calls = std::cell::Cell::new(0);
-        let artifact = || ReleaseArtifact {
-            path: PathBuf::from("/tmp/plugin.zip"),
-            tag: "v1.2.3".to_string(),
-            commit: Some("abc123".to_string()),
-            url: "https://github.example.test/api/v3/assets/1".to_string(),
-            name: "plugin.zip".to_string(),
-            size: 7,
-            sha256: "abc".to_string(),
-        };
-        store
+        let first = store
             .get_or_insert_with(&github, "v1.2.3", "plugin.zip", || {
                 calls.set(calls.get() + 1);
-                Ok(artifact())
+                std::fs::write(&path, b"payload").expect("write downloaded artifact");
+                Ok(ReleaseArtifact {
+                    path: path.clone(),
+                    tag: "v1.2.3".to_string(),
+                    commit: Some("abc123".to_string()),
+                    url: "https://github.example.test/api/v3/assets/1".to_string(),
+                    name: "plugin.zip".to_string(),
+                    size: 7,
+                    sha256: "abc".to_string(),
+                })
             })
             .expect("first target resolves asset");
-        store
+        let second = store
             .get_or_insert_with(&github, "v1.2.3", "plugin.zip", || {
                 calls.set(calls.get() + 1);
-                Ok(artifact())
+                panic!("second identical acquisition must reuse the verified download")
             })
             .expect("second target reuses asset");
+
         assert_eq!(calls.get(), 1, "one metadata lookup/download per run");
+        assert_eq!(
+            std::fs::read(&first.path).expect("first lease reads"),
+            b"payload"
+        );
+
+        drop(first);
+        assert_eq!(
+            std::fs::read(&second.path).expect("second lease remains valid"),
+            b"payload"
+        );
+
+        drop(second);
+        assert!(
+            path.exists(),
+            "runtime download retention policy keeps the final artifact for cleanup"
+        );
+        drop(store);
+        assert!(
+            path.exists(),
+            "dropping the final lease does not invent eager deletion"
+        );
+    }
+
+    #[test]
+    fn release_artifact_leases_pin_runtime_downloads_until_the_final_drop() {
+        crate::test_support::with_isolated_home(|_| {
+            let directory = crate::core::engine::temp::runtime_temp_dir("deploy-download")
+                .expect("runtime download directory");
+            let path = directory.join("plugin.zip");
+            std::fs::write(&path, b"payload").expect("write downloaded artifact");
+            let lease = ReleaseArtifactLease::new(ReleaseArtifact {
+                path,
+                tag: "v1.2.3".to_string(),
+                commit: Some("abc123".to_string()),
+                url: "https://github.example.test/api/v3/assets/1".to_string(),
+                name: "plugin.zip".to_string(),
+                size: 7,
+                sha256: "abc".to_string(),
+            })
+            .expect("pin runtime download");
+            let second = lease.clone();
+
+            let pinned = crate::core::engine::temp::cleanup_runtime_tmp(
+                true,
+                0,
+                Some("deploy-download"),
+                10,
+            )
+            .expect("cleanup while pinned");
+            assert_eq!(pinned.removed_count, 0);
+            assert!(directory.exists());
+
+            drop(lease);
+            let still_pinned = crate::core::engine::temp::cleanup_runtime_tmp(
+                true,
+                0,
+                Some("deploy-download"),
+                10,
+            )
+            .expect("cleanup with second lease");
+            assert_eq!(still_pinned.removed_count, 0);
+            assert!(directory.exists());
+
+            drop(second);
+            assert!(
+                !directory.join(".homeboy-runtime-temp-pin-v1").exists(),
+                "the final lease removes its cleanup pin"
+            );
+            let reclaimed = crate::core::engine::temp::cleanup_runtime_tmp(
+                true,
+                0,
+                Some("deploy-download"),
+                10,
+            )
+            .expect("cleanup after final lease");
+            assert_eq!(reclaimed.removed_count, 1);
+            assert!(!directory.exists());
+        });
     }
 
     #[test]
@@ -1238,6 +1362,42 @@ mod tests {
         assert!(
             store.get(&github, "v1.2.3", "plugin.zip").is_none(),
             "a failed verification must not make bytes available to deploy targets"
+        );
+    }
+
+    #[test]
+    fn failed_acquisition_creates_no_live_entry_or_lease() {
+        let github = GitHubRepo {
+            host: "github.example.test".to_string(),
+            owner: "example".to_string(),
+            repo: "plugin".to_string(),
+        };
+        let mut store = ReleaseArtifactStore::default();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let download_dir = temp.path().join("deploy-download");
+        std::fs::create_dir(&download_dir).expect("download directory");
+        let calls = std::cell::Cell::new(0);
+
+        let error = store
+            .get_or_insert_with(&github, "v1.2.3", "plugin.zip", || {
+                calls.set(calls.get() + 1);
+                std::fs::write(download_dir.join("plugin.zip"), b"invalid bytes")
+                    .expect("failed download bytes");
+                Err(Error::validation_invalid_argument(
+                    "releaseArtifact",
+                    "Downloaded release artifact 'plugin.zip' SHA-256 digest does not match GitHub Release metadata".to_string(),
+                    None,
+                    None,
+                ))
+            })
+            .expect_err("failed verification must not yield a lease");
+
+        assert_eq!(calls.get(), 1);
+        assert!(error.to_string().contains("SHA-256 digest does not match"));
+        assert!(store.get(&github, "v1.2.3", "plugin.zip").is_none());
+        assert!(
+            !download_dir.join(".homeboy-runtime-temp-pin-v1").exists(),
+            "failed acquisition must not leave a cleanup pin"
         );
     }
 

--- a/src/core/engine/temp.rs
+++ b/src/core/engine/temp.rs
@@ -6,6 +6,134 @@ use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
+const RUNTIME_TEMP_PIN_FILE: &str = ".homeboy-runtime-temp-pin-v1";
+const RUNTIME_TEMP_PIN_SCHEMA_LINE: &str = "schema=homeboy-runtime-temp-pin-v1";
+
+/// A process-owned pin which prevents runtime-temp cleanup from removing its directory.
+#[derive(Debug)]
+pub(crate) struct RuntimeTempPin {
+    path: PathBuf,
+}
+
+impl Drop for RuntimeTempPin {
+    fn drop(&mut self) {
+        // Pins only control cleanup eligibility. Their directories remain subject to
+        // the existing retention policy after the last owner releases the pin.
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+pub(crate) fn pin_runtime_temp_dir(dir: &Path) -> Result<RuntimeTempPin> {
+    let metadata = fs::symlink_metadata(dir).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("inspect runtime temp directory {}", dir.display())),
+        )
+    })?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(Error::validation_invalid_argument(
+            "runtimeTempDir",
+            format!(
+                "Runtime temp pin requires a real directory: {}",
+                dir.display()
+            ),
+            None,
+            None,
+        ));
+    }
+
+    let path = dir.join(RUNTIME_TEMP_PIN_FILE);
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("create runtime temp pin {}", path.display())),
+            )
+        })?;
+    let record = format!(
+        "{RUNTIME_TEMP_PIN_SCHEMA_LINE}\nowner_pid={}\n",
+        std::process::id()
+    );
+    if let Err(error) = std::io::Write::write_all(&mut file, record.as_bytes()) {
+        let _ = fs::remove_file(&path);
+        return Err(Error::internal_io(
+            error.to_string(),
+            Some(format!("write runtime temp pin {}", path.display())),
+        ));
+    }
+
+    Ok(RuntimeTempPin { path })
+}
+
+enum RuntimeTempPinState {
+    Active(u32),
+    Dead,
+    Malformed(String),
+    Absent,
+}
+
+fn runtime_temp_pin_state(dir: &Path) -> RuntimeTempPinState {
+    let path = dir.join(RUNTIME_TEMP_PIN_FILE);
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return RuntimeTempPinState::Absent;
+        }
+        Err(error) => {
+            return RuntimeTempPinState::Malformed(format!(
+                "runtime temp pin cannot be inspected ({error}); remove {} after verifying no active owner",
+                path.display()
+            ));
+        }
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return RuntimeTempPinState::Malformed(format!(
+            "runtime temp pin is not a regular file; remove {} after verifying no active owner",
+            path.display()
+        ));
+    }
+    let record = match fs::read_to_string(&path) {
+        Ok(record) => record,
+        Err(error) => {
+            return RuntimeTempPinState::Malformed(format!(
+                "runtime temp pin cannot be read ({error}); remove {} after verifying no active owner",
+                path.display()
+            ));
+        }
+    };
+    let mut lines = record.lines();
+    let schema = lines.next();
+    let owner_pid = lines.next();
+    if lines.next().is_some()
+        || schema != Some(RUNTIME_TEMP_PIN_SCHEMA_LINE)
+        || !matches!(owner_pid, Some(line) if line.starts_with("owner_pid="))
+    {
+        return RuntimeTempPinState::Malformed(format!(
+            "runtime temp pin has an unrecognized contract; remove {} after verifying no active owner",
+            path.display()
+        ));
+    }
+    let owner_pid = owner_pid
+        .and_then(|line| line.strip_prefix("owner_pid="))
+        .and_then(|pid| pid.parse::<u32>().ok())
+        .filter(|pid| *pid > 0);
+    let Some(owner_pid) = owner_pid else {
+        return RuntimeTempPinState::Malformed(format!(
+            "runtime temp pin has an invalid owner PID; remove {} after verifying no active owner",
+            path.display()
+        ));
+    };
+
+    if crate::core::process::pid_is_running(owner_pid) {
+        RuntimeTempPinState::Active(owner_pid)
+    } else {
+        RuntimeTempPinState::Dead
+    }
+}
+
 fn runtime_root() -> Result<PathBuf> {
     if let Ok(override_dir) = env::var(runtime_tmpdir_env()) {
         let trimmed = override_dir.trim();
@@ -122,26 +250,65 @@ pub fn cleanup_runtime_tmp(
         } else if !path_is_within_root(&path, &root) {
             row.reason = "entry path is outside runtime tmp root".to_string();
             output.skipped_count += 1;
+        } else if metadata.is_dir() {
+            match runtime_temp_pin_state(&path) {
+                RuntimeTempPinState::Active(owner_pid) => {
+                    row.reason = format!("runtime temp pin owner PID {owner_pid} is running");
+                    output.skipped_count += 1;
+                }
+                RuntimeTempPinState::Malformed(reason) => {
+                    row.reason = reason;
+                    output.skipped_count += 1;
+                }
+                RuntimeTempPinState::Dead | RuntimeTempPinState::Absent => {
+                    cleanup_runtime_tmp_entry(
+                        &path,
+                        &metadata,
+                        cutoff,
+                        apply,
+                        &mut row,
+                        &mut output,
+                    )?;
+                }
+            }
         } else if metadata.modified().is_ok_and(|modified| modified > cutoff) {
             row.reason = "entry is newer than retention cutoff".to_string();
             output.skipped_count += 1;
         } else {
-            row.action = if apply { "removed" } else { "remove" }.to_string();
-            row.reason = "runtime tmp entry is eligible".to_string();
-            row.size_bytes = path_size_bytes(&path, &metadata)?;
-            output.planned_count += 1;
-            output.totals.planned_size_bytes += row.size_bytes;
-            if apply {
-                remove_runtime_tmp_entry(&path, &metadata)?;
-                output.removed_count += 1;
-                output.totals.removed_size_bytes += row.size_bytes;
-            }
+            cleanup_runtime_tmp_entry(&path, &metadata, cutoff, apply, &mut row, &mut output)?;
         }
 
         output.rows.push(row);
     }
 
     Ok(output)
+}
+
+fn cleanup_runtime_tmp_entry(
+    path: &Path,
+    metadata: &fs::Metadata,
+    cutoff: SystemTime,
+    apply: bool,
+    row: &mut RuntimeTempCleanupRow,
+    output: &mut RuntimeTempCleanupOutput,
+) -> Result<()> {
+    if metadata.modified().is_ok_and(|modified| modified > cutoff) {
+        row.reason = "entry is newer than retention cutoff".to_string();
+        output.skipped_count += 1;
+        return Ok(());
+    }
+
+    row.action = if apply { "removed" } else { "remove" }.to_string();
+    row.reason = "runtime tmp entry is eligible".to_string();
+    row.size_bytes = path_size_bytes(path, metadata)?;
+    output.planned_count += 1;
+    output.totals.planned_size_bytes += row.size_bytes;
+    if apply {
+        remove_runtime_tmp_entry(path, metadata)?;
+        output.removed_count += 1;
+        output.totals.removed_size_bytes += row.size_bytes;
+    }
+    Ok(())
 }
 
 fn path_is_within_root(path: &Path, root: &Path) -> bool {
@@ -277,6 +444,48 @@ mod tests {
         assert!(!applied.dry_run);
         assert_eq!(applied.removed_count, 1);
         assert!(!stale.exists());
+
+        env::remove_var(runtime_tmpdir_env());
+    }
+
+    #[test]
+    fn cleanup_runtime_tmp_reclaims_dead_owner_pin() {
+        let _guard = home_env_guard();
+        let root = tempfile::tempdir().expect("tempdir");
+        env::set_var(runtime_tmpdir_env(), root.path());
+        let stale = runtime_temp_dir("deploy-download").expect("runtime directory");
+        std::fs::write(
+            stale.join(RUNTIME_TEMP_PIN_FILE),
+            format!("{RUNTIME_TEMP_PIN_SCHEMA_LINE}\nowner_pid=4294967295\n"),
+        )
+        .expect("dead owner pin");
+
+        let output =
+            cleanup_runtime_tmp(true, 0, Some("deploy-download"), 10).expect("reclaim stale pin");
+        assert_eq!(output.removed_count, 1);
+        assert!(!stale.exists());
+
+        env::remove_var(runtime_tmpdir_env());
+    }
+
+    #[test]
+    fn cleanup_runtime_tmp_skips_malformed_pin_with_remediation() {
+        let _guard = home_env_guard();
+        let root = tempfile::tempdir().expect("tempdir");
+        env::set_var(runtime_tmpdir_env(), root.path());
+        let directory = runtime_temp_dir("deploy-download").expect("runtime directory");
+        std::fs::write(directory.join(RUNTIME_TEMP_PIN_FILE), "not a pin\n")
+            .expect("malformed pin");
+
+        let output = cleanup_runtime_tmp(true, 0, Some("deploy-download"), 10)
+            .expect("inspect malformed pin");
+        assert_eq!(output.removed_count, 0);
+        assert_eq!(output.skipped_count, 1);
+        assert!(output.rows[0].reason.contains("unrecognized contract"));
+        assert!(output.rows[0]
+            .reason
+            .contains("after verifying no active owner"));
+        assert!(directory.exists());
 
         env::remove_var(runtime_tmpdir_env());
     }


### PR DESCRIPTION
## Summary
Give verified release downloads explicit shared lifetime so preparation consumers can safely reuse one acquisition.

## What changed
- Replace path-only release cache values with cloneable leases over one verified artifact and one shared runtime-temp pin.
- Teach runtime-temp cleanup to preserve live PID-owned pins, reclaim dead owners, and fail safe with remediation for malformed pins.
- Keep caller-supplied prepared artifacts non-owned and preserve existing serialized deploy evidence.

## How to test
1. Run `cargo test --lib release_download -- --test-threads=1`; expect 31 release download and lease tests pass.
2. Run `cargo test --lib cleanup_runtime_tmp -- --test-threads=1`; expect 3 cleanup pin contract tests pass.
3. Run `cargo test --lib release_artifact -- --test-threads=1`; expect 19 release artifact integration tests pass.
4. Run `cargo test --lib core::release:: -- --test-threads=1`; expect 328 release tests pass.
5. Run `cargo fmt --check`; expect passes.
6. Run `git diff --check`; expect passes.

## Compatibility
Public deploy CLI and serialized JSON are unchanged. Internal release-artifact callers now hold cloneable leases; runtime-temp entries remain governed by existing retention after the final lease drops.

## Evidence
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8270
- diff-integrity: Passed
- format: Passed
- release-artifact: Passed
- release-download: Passed
- release-suite: Passed
- runtime-temp-cleanup: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy + OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Decomposed the deploy ownership refactor, implemented and reviewed the release-artifact lease primitive, and verified cleanup safety with Chris.

## Source relationships
- Closes #8270
- Relates to #8234
- Relates to #8229
