### PR TITLE
refactor: give spec.rs a commands-free ops_command_spec macro

### DIFF
--- a/src/command_contract/descriptors.rs
+++ b/src/command_contract/descriptors.rs
@@ -42,3 +42,27 @@ macro_rules! ops_command_descriptor {
     (api, $consumer:ident) => { $consumer!((api, Api, crate::commands::api::ApiArgs, CommandSpec { subcommand_safety: API_SUBCOMMAND_SAFETY, ..command_spec("api", CommandJsonFamily::Ops) }, crate::commands::api::run)) };
     (upgrade, $consumer:ident) => { $consumer!((upgrade, Upgrade, crate::commands::upgrade::UpgradeArgs, command_spec_with_output_notes_and_safety("upgrade", CommandJsonFamily::Ops, "upgrades the active Homeboy binary, extensions, runners, and services unless --check or skip flags are used", operator_safety(None, UPGRADE_DANGEROUS_FLAGS)), crate::commands::upgrade::run)) };
 }
+
+/// Commands-free spec table for the ops command family.
+///
+/// This mirrors the `$spec` field of [`ops_command_descriptor`] but omits the
+/// `crate::commands` Args type and handler binding, so it can be expanded inside
+/// `command_contract` (e.g. `spec.rs`) without depending on the `commands`
+/// module. The full descriptor macro (with Args + handler) is expanded only on
+/// the CLI side.
+#[macro_export]
+macro_rules! ops_command_spec {
+    (ssh) => { command_spec("ssh", CommandJsonFamily::Ops) };
+    (server) => { CommandSpec { subcommand_safety: SERVER_SUBCOMMAND_SAFETY, ..command_spec("server", CommandJsonFamily::Ops) } };
+    (db) => { command_spec("db", CommandJsonFamily::Ops) };
+    (file) => { CommandSpec { subcommand_safety: FILE_SUBCOMMAND_SAFETY, ..command_spec("file", CommandJsonFamily::Ops) } };
+    (logs) => { command_spec("logs", CommandJsonFamily::Ops) };
+    (triage) => { command_spec_with_safety("triage", CommandJsonFamily::Ops, operator_safety(None, TRIAGE_DANGEROUS_FLAGS)) };
+    (deploy) => { command_spec_with_safety("deploy", CommandJsonFamily::Ops, operator_safety(Some("--dry-run"), DEPLOY_DANGEROUS_FLAGS)) };
+    (daemon) => { command_spec("daemon", CommandJsonFamily::Ops) };
+    (status) => { command_spec("status", CommandJsonFamily::Ops) };
+    (git) => { command_spec("git", CommandJsonFamily::Ops) };
+    (self_cmd) => { command_spec_with_output_notes("self", CommandJsonFamily::Ops, "inspects the active Homeboy runtime and renders built-in CLI documentation") };
+    (api) => { CommandSpec { subcommand_safety: API_SUBCOMMAND_SAFETY, ..command_spec("api", CommandJsonFamily::Ops) } };
+    (upgrade) => { command_spec_with_output_notes_and_safety("upgrade", CommandJsonFamily::Ops, "upgrades the active Homeboy binary, extensions, runners, and services unless --check or skip flags are used", operator_safety(None, UPGRADE_DANGEROUS_FLAGS)) };
+}

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -597,12 +597,6 @@ const RIG_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[paths_safety(
     "reads rig package files and emits the standard JSON lint report without evaluating the live environment",
 )];
 
-macro_rules! registered_ops_spec {
-    (($module:ident, $variant:ident, $args:path, $spec:expr, $handler:path)) => {
-        $spec
-    };
-}
-
 pub const COMMAND_SPECS: &[CommandSpec] = &[
     CommandSpec {
         output_notes: "unified active/recent activity read model in the standard JSON envelope",
@@ -623,8 +617,8 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         subcommand_safety: PROJECT_SUBCOMMAND_SAFETY,
         ..command_spec("project", CommandJsonFamily::Workspace)
     },
-    crate::ops_command_descriptor!(ssh, registered_ops_spec),
-    crate::ops_command_descriptor!(server, registered_ops_spec),
+    crate::ops_command_spec!(ssh),
+    crate::ops_command_spec!(server),
     command_spec_with_representative_argv(
         &["homeboy", "bench"],
         lab_command_spec_with_summary(
@@ -660,19 +654,19 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         )
     },
     command_spec("observe", CommandJsonFamily::Quality),
-    crate::ops_command_descriptor!(db, registered_ops_spec),
+    crate::ops_command_spec!(db),
     CommandSpec {
         subcommand_safety: DEPS_SUBCOMMAND_SAFETY,
         ..command_spec("deps", CommandJsonFamily::Ops)
     },
-    crate::ops_command_descriptor!(file, registered_ops_spec),
+    crate::ops_command_spec!(file),
     CommandSpec {
         subcommand_safety: FLEET_SUBCOMMAND_SAFETY,
         ..command_spec("fleet", CommandJsonFamily::Ops)
     },
-    crate::ops_command_descriptor!(logs, registered_ops_spec),
-    crate::ops_command_descriptor!(triage, registered_ops_spec),
-    crate::ops_command_descriptor!(deploy, registered_ops_spec),
+    crate::ops_command_spec!(logs),
+    crate::ops_command_spec!(triage),
+    crate::ops_command_spec!(deploy),
     CommandSpec {
         subcommand_safety: COMPONENT_SUBCOMMAND_SAFETY,
         ..command_spec("component", CommandJsonFamily::Workspace)
@@ -686,7 +680,7 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         CommandJsonFamily::Workspace,
         "lists, shows, exports constants, exports schemas, validates, normalizes, and emits Homeboy-owned contract metadata and command manifests through the central contract surface",
     ),
-    crate::ops_command_descriptor!(daemon, registered_ops_spec),
+    crate::ops_command_spec!(daemon),
     command_spec_with_representative_argv(
         &["homeboy", "extension", "refresh", "."],
         lab_command_spec_with_summary(
@@ -696,7 +690,7 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
             EXTENSION_LAB_SUPPORT,
         ),
     ),
-    crate::ops_command_descriptor!(status, registered_ops_spec),
+    crate::ops_command_spec!(status),
     command_spec_with_output_notes_and_safety(
         "cleanup",
         CommandJsonFamily::Workspace,
@@ -709,7 +703,7 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
             dangerous_flags: CLEANUP_DANGEROUS_FLAGS,
         },
     ),
-    crate::ops_command_descriptor!(git, registered_ops_spec),
+    crate::ops_command_spec!(git),
     command_spec_with_output_notes_and_safety(
         "release",
         CommandJsonFamily::Workspace,
@@ -805,10 +799,10 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         CommandJsonFamily::Workspace,
         "inspects persisted evidence, artifacts, artifact postprocessing, and finding reconciliation workflows",
     ),
-    crate::ops_command_descriptor!(self_cmd, registered_ops_spec),
+    crate::ops_command_spec!(self_cmd),
     command_spec("stack", CommandJsonFamily::Workspace),
-    crate::ops_command_descriptor!(api, registered_ops_spec),
-    crate::ops_command_descriptor!(upgrade, registered_ops_spec),
+    crate::ops_command_spec!(api),
+    crate::ops_command_spec!(upgrade),
 ];
 
 pub const COMMAND_DOC_REGISTRY: &[CommandDocSpec] = &[


### PR DESCRIPTION
## Summary

Removes the last non-macro-definition `crate::commands` coupling from the `command_contract` type layer, clearing the way to extract `homeboy-command-contract`.

## The problem
`command_contract/spec.rs` built the ops command specs by expanding `ops_command_descriptor!(name, registered_ops_spec)`. The `registered_ops_spec` adapter emitted only the `$spec` field and discarded the `crate::commands` Args type + handler. So spec.rs didn't *truly* compile-depend on `commands` (discarded `:path` fragments aren't resolved) — but the macro rows still textually threaded `crate::commands` paths through spec.rs, which blocks a clean crate extraction.

## The fix
- Added a **commands-free** `ops_command_spec!(name)` macro (in `descriptors.rs`) that encodes only the spec expressions (`command_spec("ssh", CommandJsonFamily::Ops)`, etc.).
- Switched spec.rs's 13 ops-command sites from `ops_command_descriptor!(name, registered_ops_spec)` → `ops_command_spec!(name)`.
- Removed the now-unused `registered_ops_spec` adapter.

## Result
`spec.rs` is now **free of any `crate::commands` reference**. The full `ops_command_descriptors!`/`ops_command_descriptor!` macros (which bind Args + handlers) are unchanged and still serve the two CLI-side expansion sites in `commands/`.

After this + the in-flight lab-routing relocation (#8256), `command_contract`'s only remaining `crate::commands` is inside the `#[macro_export]` descriptor macro *bodies* — definition-only, resolving at the CLI expansion sites — which does not block extraction.

## Verification
- `cargo check --lib` — 0 errors.
- `cargo check --lib --tests` — 0 errors.
- `cargo fmt` clean.

## Context
`command_contract` decomposition → `homeboy-cli`. Next: extract `homeboy-command-contract` (once #8256 lands), then `homeboy-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)