### PR TITLE
Make daemon operation locks crash-safe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ toml = "1.0.3"
 sha2 = "0.10.9"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_IO"] }
 
 [features]
 default = []

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -304,7 +304,10 @@ impl DaemonLeaseIdentity {
 
 #[derive(Debug)]
 pub(super) struct DaemonOperationLock {
-    path: PathBuf,
+    // The open descriptor retains the advisory lock. The lock file itself is
+    // intentionally persistent so process death releases ownership safely.
+    #[allow(dead_code)]
+    file: File,
 }
 
 /// Held by the serving daemon for its entire lifetime. Unlike the short
@@ -2204,30 +2207,21 @@ fn acquire_daemon_operation_lock() -> Result<DaemonOperationLock> {
         Error::internal_io(e.to_string(), Some(format!("create {}", parent.display())))
     })?;
     let path = parent.join("operation.lock");
-    let mut file = match OpenOptions::new().write(true).create_new(true).open(&path) {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            return Err(Error::internal_unexpected(format!(
-                "daemon lifecycle operation already in progress; lock file exists at {}",
-                path.display()
-            ))
-            .with_hint(format!(
-                "If no homeboy daemon start/stop command is running, remove {} and retry",
-                path.display()
-            )));
-        }
-        Err(error) => {
-            return Err(Error::internal_io(
-                error.to_string(),
-                Some(format!("create {}", path.display())),
-            ));
-        }
-    };
-    let body = format!("pid={}\n", std::process::id());
-    file.write_all(body.as_bytes()).map_err(|e| {
-        Error::internal_io(e.to_string(), Some(format!("write {}", path.display())))
-    })?;
-    Ok(DaemonOperationLock { path })
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(&path)
+        .map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("open {}", path.display())))
+        })?;
+    if !try_lock_file_exclusive(&file, "daemon lifecycle")? {
+        return Err(Error::internal_unexpected(format!(
+            "daemon lifecycle operation already in progress; lock is held at {}",
+            path.display()
+        )));
+    }
+    Ok(DaemonOperationLock { file })
 }
 
 pub(super) fn try_acquire_daemon_owner_lock() -> Result<Option<DaemonOwnerLock>> {
@@ -2255,25 +2249,71 @@ pub(super) fn try_acquire_daemon_owner_lock() -> Result<Option<DaemonOwnerLock>>
                 Some("open daemon owner lock".to_string()),
             )
         })?;
-    #[cfg(unix)]
-    unsafe {
-        if libc::flock(
-            std::os::fd::AsRawFd::as_raw_fd(&file),
-            libc::LOCK_EX | libc::LOCK_NB,
-        ) != 0
-        {
-            if std::io::Error::last_os_error().kind() == std::io::ErrorKind::WouldBlock {
-                return Ok(None);
-            }
-            return Err(Error::internal_io(
-                std::io::Error::last_os_error().to_string(),
-                Some("lock daemon owner".to_string()),
-            ));
-        }
+    if try_lock_file_exclusive(&file, "daemon owner")? {
+        Ok(Some(DaemonOwnerLock { file }))
+    } else {
+        Ok(None)
     }
-    #[cfg(not(unix))]
-    let _ = &file;
-    Ok(Some(DaemonOwnerLock { file }))
+}
+
+/// Acquires a non-blocking exclusive advisory lock backed by the OS. Platforms
+/// without an implementation fail closed rather than treating a lock file as
+/// proof of mutual exclusion.
+#[cfg(unix)]
+fn try_lock_file_exclusive(file: &File, operation: &str) -> Result<bool> {
+    use std::os::fd::AsRawFd;
+
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+        return Ok(true);
+    }
+    let error = std::io::Error::last_os_error();
+    if error.kind() == std::io::ErrorKind::WouldBlock {
+        return Ok(false);
+    }
+    Err(Error::internal_io(
+        error.to_string(),
+        Some(format!("lock {operation}")),
+    ))
+}
+
+#[cfg(windows)]
+fn try_lock_file_exclusive(file: &File, operation: &str) -> Result<bool> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::ERROR_LOCK_VIOLATION;
+    use windows_sys::Win32::Storage::FileSystem::{
+        LockFileEx, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
+    };
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+
+    let mut overlapped: OVERLAPPED = unsafe { std::mem::zeroed() };
+    if unsafe {
+        LockFileEx(
+            file.as_raw_handle(),
+            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+            0,
+            u32::MAX,
+            u32::MAX,
+            &mut overlapped,
+        )
+    } != 0
+    {
+        return Ok(true);
+    }
+    let error = std::io::Error::last_os_error();
+    if error.raw_os_error() == Some(ERROR_LOCK_VIOLATION as i32) {
+        return Ok(false);
+    }
+    Err(Error::internal_io(
+        error.to_string(),
+        Some(format!("lock {operation}")),
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn try_lock_file_exclusive(_file: &File, operation: &str) -> Result<bool> {
+    Err(Error::internal_unexpected(format!(
+        "{operation} lock is not implemented on this platform"
+    )))
 }
 
 fn acquire_daemon_owner_lock() -> Result<DaemonOwnerLock> {
@@ -2322,12 +2362,6 @@ pub(super) fn acquire_daemon_operation_lock_for_ensure(
             }
             Err(err) => return Err(err),
         }
-    }
-}
-
-impl Drop for DaemonOperationLock {
-    fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
     }
 }
 

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -3,6 +3,10 @@ use crate::core::api_jobs::{JobEventKind, JobStatus, JobStore};
 use crate::core::observation::{ArtifactRecord, NewRunRecord, ObservationStore};
 use crate::test_support::HomeGuard;
 use base64::Engine;
+#[cfg(unix)]
+use std::process::Command;
+#[cfg(unix)]
+use std::time::{Duration, Instant};
 
 const DAEMON_TEST_RESPONSE_LIMIT_BYTES: u64 = 64 * 1024;
 
@@ -655,10 +659,62 @@ fn daemon_operation_lock_rejects_concurrent_start_or_stop() {
     assert!(err
         .message
         .contains("daemon lifecycle operation already in progress"));
+    assert!(err.message.contains("operation.lock"));
+}
+
+#[cfg(unix)]
+#[test]
+fn daemon_operation_lock_recovers_after_owner_exits_without_drop() {
+    const HOLDER_ENV: &str = "HOMEBOY_TEST_DAEMON_OPERATION_LOCK_HOLDER";
+
+    if std::env::var_os(HOLDER_ENV).is_some() {
+        let ready = state_path()
+            .expect("state path")
+            .with_file_name("operation-lock-holder.ready");
+        let release = state_path()
+            .expect("state path")
+            .with_file_name("operation-lock-holder.release");
+        let _lock = acquire_daemon_operation_lock().expect("child acquires operation lock");
+        std::fs::write(&ready, "ready").expect("signal operation lock holder");
+        while !release.exists() {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        // Simulate an interrupted lifecycle process: no Rust destructors run.
+        std::process::exit(0);
+    }
+
+    let _home = HomeGuard::new();
+    let ready = state_path()
+        .expect("state path")
+        .with_file_name("operation-lock-holder.ready");
+    let release = state_path()
+        .expect("state path")
+        .with_file_name("operation-lock-holder.release");
+    let mut child = Command::new(std::env::current_exe().expect("current test executable"))
+        .arg("--exact")
+        .arg("core::daemon::daemon_test::daemon_operation_lock_recovers_after_owner_exits_without_drop")
+        .arg("--nocapture")
+        .env(HOLDER_ENV, "1")
+        .spawn()
+        .expect("start operation lock holder");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !ready.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    if !ready.exists() {
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!("operation lock holder did not become ready");
+    }
+
+    let err = acquire_daemon_operation_lock().expect_err("live child excludes lifecycle operation");
     assert!(err
-        .hints
-        .iter()
-        .any(|hint| hint.message.contains("operation.lock")));
+        .message
+        .contains("daemon lifecycle operation already in progress"));
+
+    std::fs::write(&release, "release").expect("release operation lock holder");
+    assert!(child.wait().expect("wait for lock holder").success());
+    acquire_daemon_operation_lock().expect("recover after interrupted lock holder");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Use OS-owned daemon lifecycle locks so process death cannot leave a permanent recovery blocker.

## What changed
- Replace the create-new daemon operation sentinel with a non-blocking OS advisory lock.
- Share the same cross-platform lock primitive with the existing daemon owner lock.
- Prove concurrent exclusion and automatic recovery after subprocess exit without Rust cleanup.

## How to test
1. Run `cargo test daemon_operation_lock --lib`; expect 2 tests pass.
2. Run `cargo test owner_lock --lib`; expect 3 tests pass.
3. Run `cargo fmt --check`; expect passes.
4. Run `git diff --check origin/main...HEAD`; expect passes.

## Compatibility
No public extension-path change. Internal lifecycle locking remains fail-fast for live owners and now recovers automatically after owner death.

## Evidence
- CI expected: Homeboy CI
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8273
- daemon\_operation\_lock: Passed
- diff\_check: Passed
- format: Passed
- owner\_lock: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode recovery via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Root-caused and repaired crash-persistent daemon lifecycle locking with subprocess coverage; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8273
