### PR TITLE
Prevent scheduler retry and scratch-state hangs

### DIFF
--- a/src/core/agent_task_scheduler/engine.rs
+++ b/src/core/agent_task_scheduler/engine.rs
@@ -74,6 +74,13 @@ where
         derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
     ) -> AgentTaskAggregate {
         let mut plan = plan.canonicalize();
+        // A scheduler without a durable run record still needs a private
+        // controller-scratch namespace. Plan IDs are semantic labels and can
+        // legitimately repeat across independent in-process executions.
+        let scratch_run_id = self
+            .run_id
+            .clone()
+            .unwrap_or_else(|| format!("ephemeral-{}", uuid::Uuid::new_v4()));
         let max_concurrency = plan.options.max_concurrency.max(1);
         let total_tasks = plan.tasks.len();
         let max_queue_depth = plan.options.max_queue_depth.or(plan.options.max_tasks);
@@ -119,7 +126,9 @@ where
         let mut events = Vec::new();
         let mut cancellation_notified = false;
         let execution_budget = plan.options.execution_budget.clone();
-        let max_attempts = execution_budget.max_provider_executions;
+        // Legacy retry policy remains an operator-facing cap; the execution
+        // budget adds a shared hard ceiling across retries and rotations.
+        let retry_max_attempts = plan.options.retry.max_attempts;
         let (tx, rx) = mpsc::channel();
         let cancellation_tx = tx.clone();
         cancellation.on_cancel(Arc::new(move || {
@@ -397,9 +406,12 @@ where
                 if let Some(root) = request.workspace.root.as_deref() {
                     request.executor.remap_workspace_root(root);
                 }
-                let run_id = self.run_id.as_deref().unwrap_or(&plan.plan_id);
-                let scratch = match crate::core::controller_scratch::allocate_attempt(
-                    run_id,
+                #[cfg(test)]
+                let scratch_allocation = crate::core::controller_scratch::allocate_test_attempt;
+                #[cfg(not(test))]
+                let scratch_allocation = crate::core::controller_scratch::allocate_attempt;
+                let scratch = match scratch_allocation(
+                    &scratch_run_id,
                     &plan.plan_id,
                     &request.task_id,
                     scheduled.attempt,
@@ -609,7 +621,8 @@ where
                         &outcome,
                         result.attempt,
                         execution_budget.max_same_provider_retries,
-                        max_attempts,
+                        execution_budget.max_provider_executions,
+                        retry_max_attempts,
                         retry_budget_total,
                         retry_budget_used,
                         &plan.options.retry.retryable_failure_classifications,
@@ -657,7 +670,7 @@ where
                             policy,
                             running_task.rotation_index,
                             result.attempt,
-                            max_attempts,
+                            execution_budget.max_provider_executions,
                             execution_budget.max_provider_rotations,
                         ) {
                             release_scratch(&result.scratch, "provider_rotation", &outcome);

--- a/src/core/agent_task_scheduler/harvest.rs
+++ b/src/core/agent_task_scheduler/harvest.rs
@@ -582,6 +582,7 @@ mod committed_harvest_tests {
             scratch: crate::core::controller_scratch::ControllerScratchAllocation {
                 path: PathBuf::from("/test/controller-scratch/1"),
                 lease_id: "test-lease-1".to_string(),
+                index_path: PathBuf::from("/test/controller-scratch/resources.json"),
             },
             adoption: None,
             join_handle: None,
@@ -787,6 +788,7 @@ mod committed_harvest_tests {
             scratch: crate::core::controller_scratch::ControllerScratchAllocation {
                 path: PathBuf::from("/test/controller-scratch/1"),
                 lease_id: "test-lease-1".to_string(),
+                index_path: PathBuf::from("/test/controller-scratch/resources.json"),
             },
             adoption: None,
             join_handle: None,

--- a/src/core/agent_task_scheduler/scheduling.rs
+++ b/src/core/agent_task_scheduler/scheduling.rs
@@ -1374,11 +1374,18 @@ impl AgentTaskScheduleSupport {
         attempt: u32,
         max_same_provider_retries: u32,
         max_provider_executions: u32,
+        retry_max_attempts: u32,
         retry_budget_total: Option<u32>,
         retry_budget_used: u32,
         retryable_failure_classifications: &[AgentTaskFailureClassification],
     ) -> bool {
+        // A zero legacy limit means no legacy cap. It does not authorize
+        // retries for an otherwise unbounded default budget.
+        let legacy_retry_permits_attempt = (retry_max_attempts == 0
+            && max_provider_executions != u32::MAX)
+            || attempt < retry_max_attempts;
         attempt < max_provider_executions
+            && legacy_retry_permits_attempt
             && attempt <= max_same_provider_retries
             && retry_budget_total
                 .map(|budget| retry_budget_used < budget)

--- a/src/core/agent_task_scheduler/tests/fixtures.rs
+++ b/src/core/agent_task_scheduler/tests/fixtures.rs
@@ -20,6 +20,11 @@ pub(super) struct RetryOnceExecutor {
 }
 
 #[derive(Default)]
+pub(super) struct RetryTwiceExecutor {
+    pub(super) attempts: Arc<AtomicUsize>,
+}
+
+#[derive(Default)]
 pub(super) struct EmptyIncompleteThenSuccessExecutor {
     pub(super) attempts: Arc<AtomicUsize>,
 }
@@ -56,6 +61,24 @@ impl AgentTaskExecutorAdapter for RetryOnceExecutor {
         };
 
         outcome(request.task_id, status)
+    }
+}
+
+impl AgentTaskExecutorAdapter for RetryTwiceExecutor {
+    fn execute(
+        &self,
+        request: AgentTaskRequest,
+        _context: AgentTaskExecutionContext,
+    ) -> AgentTaskOutcome {
+        let attempt = self.attempts.fetch_add(1, Ordering::SeqCst) + 1;
+        outcome(
+            request.task_id,
+            if attempt < 3 {
+                AgentTaskOutcomeStatus::Failed
+            } else {
+                AgentTaskOutcomeStatus::Succeeded
+            },
+        )
     }
 }
 

--- a/src/core/agent_task_scheduler/tests/outcome_tests.rs
+++ b/src/core/agent_task_scheduler/tests/outcome_tests.rs
@@ -304,6 +304,8 @@ fn incomplete_empty_executor_result_is_retryable_provider_failure() {
     let scheduler = AgentTaskScheduler::new(executor);
     let mut plan = plan_with_tasks(1);
     plan.options.retry.max_attempts = 2;
+    plan.options.execution_budget.max_provider_executions = 2;
+    plan.options.execution_budget.max_same_provider_retries = 1;
     plan.options.retry.retryable_failure_classifications =
         vec![AgentTaskFailureClassification::Provider];
 

--- a/src/core/agent_task_scheduler/tests/scheduling_tests/concurrency.rs
+++ b/src/core/agent_task_scheduler/tests/scheduling_tests/concurrency.rs
@@ -385,10 +385,17 @@ pub(super) mod concurrency_tests {
                     .expect("scratch roots")
                     .push(scratch_root.clone());
                 std::thread::sleep(Duration::from_millis(3_000));
+                let run_id = scratch_root
+                    .ancestors()
+                    .nth(4)
+                    .and_then(std::path::Path::file_name)
+                    .expect("scheduler scratch run id");
                 let scratch_index = scratch_root
                     .ancestors()
                     .nth(6)
                     .expect("controller scratch root")
+                    .join("test-indexes")
+                    .join(run_id)
                     .join("resources.json");
                 let active = serde_json::from_str::<Value>(
                     &fs::read_to_string(scratch_index).expect("scratch index"),
@@ -462,10 +469,17 @@ pub(super) mod concurrency_tests {
             std::thread::sleep(Duration::from_millis(2));
         }
         let scratch_root = scratch_roots.lock().expect("scratch roots")[0].clone();
+        let run_id = scratch_root
+            .ancestors()
+            .nth(4)
+            .and_then(std::path::Path::file_name)
+            .expect("scheduler scratch run id");
         let scratch_index = scratch_root
             .ancestors()
             .nth(6)
             .expect("controller scratch root")
+            .join("test-indexes")
+            .join(run_id)
             .join("resources.json");
         assert!(scratch_active_while_running.load(Ordering::SeqCst));
         let cleanup_action = aggregate
@@ -671,6 +685,8 @@ pub(super) mod concurrency_tests {
             "workspace_root": source.display().to_string(),
         });
         plan.options.retry.max_attempts = 2;
+        plan.options.execution_budget.max_provider_executions = 2;
+        plan.options.execution_budget.max_same_provider_retries = 1;
         plan.options.retry.retryable_failure_classifications =
             vec![AgentTaskFailureClassification::Transient];
 

--- a/src/core/agent_task_scheduler/tests/scheduling_tests/retry_failure.rs
+++ b/src/core/agent_task_scheduler/tests/scheduling_tests/retry_failure.rs
@@ -56,7 +56,8 @@ mod retry_failure_tests {
         let attempts = Arc::clone(&executor.attempts);
         let scheduler = AgentTaskScheduler::new(executor);
         let mut plan = plan_with_tasks(1);
-        plan.options.retry.max_attempts = 2;
+        plan.options.execution_budget.max_provider_executions = 2;
+        plan.options.execution_budget.max_same_provider_retries = 1;
 
         let aggregate = scheduler.run(plan);
 
@@ -66,5 +67,64 @@ mod retry_failure_tests {
         assert!(aggregate.events.iter().any(|event| {
             event.task_id == "task-1" && event.state == AgentTaskState::Queued && event.attempt == 2
         }));
+    }
+
+    #[test]
+    fn default_unbounded_budget_does_not_retry_without_a_retry_policy() {
+        let executor = RetryOnceExecutor::default();
+        let attempts = Arc::clone(&executor.attempts);
+        let scheduler = AgentTaskScheduler::new(executor);
+        let plan = AgentTaskPlan::new("default-no-retry", vec![request("task-1")]);
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Failed);
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn legacy_retry_policy_retries_with_the_legacy_unbounded_budget() {
+        let executor = RetryOnceExecutor::default();
+        let attempts = Arc::clone(&executor.attempts);
+        let scheduler = AgentTaskScheduler::new(executor);
+        let mut plan = AgentTaskPlan::new("legacy-retry", vec![request("task-1")]);
+        plan.options.retry.max_attempts = 2;
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn lower_retry_cap_wins_over_execution_budget() {
+        let executor = RetryTwiceExecutor::default();
+        let attempts = Arc::clone(&executor.attempts);
+        let scheduler = AgentTaskScheduler::new(executor);
+        let mut plan = plan_with_tasks(1);
+        plan.options.retry.max_attempts = 2;
+        plan.options.execution_budget.max_provider_executions = 3;
+        plan.options.execution_budget.max_same_provider_retries = 2;
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Failed);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn lower_execution_budget_wins_over_retry_cap() {
+        let executor = RetryTwiceExecutor::default();
+        let attempts = Arc::clone(&executor.attempts);
+        let scheduler = AgentTaskScheduler::new(executor);
+        let mut plan = plan_with_tasks(1);
+        plan.options.retry.max_attempts = 3;
+        plan.options.execution_budget.max_provider_executions = 2;
+        plan.options.execution_budget.max_same_provider_retries = 1;
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Failed);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
     }
 }

--- a/src/core/controller_scratch.rs
+++ b/src/core/controller_scratch.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -44,6 +44,7 @@ pub struct ControllerScratchResource {
 pub struct ControllerScratchAllocation {
     pub path: PathBuf,
     pub lease_id: String,
+    pub(crate) index_path: PathBuf,
 }
 
 /// Allocate and durably register one scheduler-owned temporary root for a
@@ -54,6 +55,30 @@ pub fn allocate_attempt(
     plan_id: &str,
     task_id: &str,
     attempt: u32,
+) -> Result<ControllerScratchAllocation> {
+    allocate_attempt_at_index(run_id, plan_id, task_id, attempt, index_path()?)
+}
+
+#[cfg(test)]
+pub fn allocate_test_attempt(
+    run_id: &str,
+    plan_id: &str,
+    task_id: &str,
+    attempt: u32,
+) -> Result<ControllerScratchAllocation> {
+    let index_path = paths::homeboy_data()?.join(format!(
+        "controller-scratch/test-indexes/{}/resources.json",
+        paths::sanitize_path_segment(run_id)
+    ));
+    allocate_attempt_at_index(run_id, plan_id, task_id, attempt, index_path)
+}
+
+fn allocate_attempt_at_index(
+    run_id: &str,
+    plan_id: &str,
+    task_id: &str,
+    attempt: u32,
+    index_path: PathBuf,
 ) -> Result<ControllerScratchAllocation> {
     let root = paths::homeboy_data()?.join("controller-scratch/attempts");
     fs::create_dir_all(&root).map_err(|error| {
@@ -96,29 +121,35 @@ pub fn allocate_attempt(
         ));
     }
 
-    let mut index = read_index()?;
-    index.resources.push(ControllerScratchResource {
-        path: path.display().to_string(),
-        run_id: run_id.to_string(),
-        plan_id: plan_id.to_string(),
-        task_id: task_id.to_string(),
-        attempt,
-        root_bound: root.display().to_string(),
-        owner_pid: std::process::id(),
-        lifecycle_state: "active".to_string(),
-        lease_id: lease_id.clone(),
-        reconstructable: true,
-        retention: "P7D".to_string(),
-        source_ref: None,
-        created_at: chrono::Utc::now().to_rfc3339(),
-        finalized_at: None,
-        terminal_reason: None,
-        terminal_evidence: None,
-        interrupted_at: None,
-    });
-    write_index(&index)?;
+    with_index_lock(&index_path, || {
+        let mut index = read_index_at_unlocked(&index_path)?;
+        index.resources.push(ControllerScratchResource {
+            path: path.display().to_string(),
+            run_id: run_id.to_string(),
+            plan_id: plan_id.to_string(),
+            task_id: task_id.to_string(),
+            attempt,
+            root_bound: root.display().to_string(),
+            owner_pid: std::process::id(),
+            lifecycle_state: "active".to_string(),
+            lease_id: lease_id.clone(),
+            reconstructable: true,
+            retention: "P7D".to_string(),
+            source_ref: None,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            finalized_at: None,
+            terminal_reason: None,
+            terminal_evidence: None,
+            interrupted_at: None,
+        });
+        write_index_at_unlocked(&index_path, &index)
+    })?;
 
-    Ok(ControllerScratchAllocation { path, lease_id })
+    Ok(ControllerScratchAllocation {
+        path,
+        lease_id,
+        index_path,
+    })
 }
 
 /// Releases one scheduler-owned attempt after its candidate evidence has been
@@ -129,26 +160,28 @@ pub fn release_attempt(
     reason: &str,
     evidence: serde_json::Value,
 ) -> Result<()> {
-    let mut index = read_index()?;
-    let Some(resource) = index.resources.iter_mut().find(|resource| {
-        resource.lease_id == allocation.lease_id
-            && Path::new(&resource.path) == allocation.path.as_path()
-    }) else {
-        return Err(Error::validation_invalid_argument(
-            "controller_scratch.lease_id",
-            "allocated scratch lease is not registered",
-            Some(allocation.lease_id.clone()),
-            None,
-        ));
-    };
-    if resource.finalized_at.is_none() {
-        resource.lifecycle_state = "released".to_string();
-        resource.finalized_at = Some(chrono::Utc::now().to_rfc3339());
-        resource.terminal_reason = Some(reason.to_string());
-        resource.terminal_evidence = Some(evidence);
-        write_index(&index)?;
-    }
-    Ok(())
+    with_index_lock(&allocation.index_path, || {
+        let mut index = read_index_at_unlocked(&allocation.index_path)?;
+        let Some(resource) = index.resources.iter_mut().find(|resource| {
+            resource.lease_id == allocation.lease_id
+                && Path::new(&resource.path) == allocation.path.as_path()
+        }) else {
+            return Err(Error::validation_invalid_argument(
+                "controller_scratch.lease_id",
+                "allocated scratch lease is not registered",
+                Some(allocation.lease_id.clone()),
+                None,
+            ));
+        };
+        if resource.finalized_at.is_none() {
+            resource.lifecycle_state = "released".to_string();
+            resource.finalized_at = Some(chrono::Utc::now().to_rfc3339());
+            resource.terminal_reason = Some(reason.to_string());
+            resource.terminal_evidence = Some(evidence);
+            write_index_at_unlocked(&allocation.index_path, &index)?;
+        }
+        Ok(())
+    })
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -210,7 +243,14 @@ pub struct ControllerScratchCleanupOptions {
 /// `metadata.controller_scratch` object or array. Providers own materializing
 /// the path; Homeboy owns its durable lifecycle and cleanup policy.
 pub fn register_outcome_resources(run_id: &str, outcomes: &[AgentTaskOutcome]) -> Result<()> {
-    let mut index = read_index()?;
+    let index_path = index_path()?;
+    with_index_lock(&index_path, || {
+        register_outcome_resources_unlocked(run_id, outcomes)
+    })
+}
+
+fn register_outcome_resources_unlocked(run_id: &str, outcomes: &[AgentTaskOutcome]) -> Result<()> {
+    let mut index = read_index_unlocked()?;
     let mut changed = false;
     for outcome in outcomes {
         let values = outcome
@@ -294,7 +334,7 @@ pub fn register_outcome_resources(run_id: &str, outcomes: &[AgentTaskOutcome]) -
         }
     }
     if changed {
-        write_index(&index)?;
+        write_index_unlocked(&index)?;
     }
     Ok(())
 }
@@ -302,7 +342,12 @@ pub fn register_outcome_resources(run_id: &str, outcomes: &[AgentTaskOutcome]) -
 /// Marks all resources owned by a terminal run as finalized, including failed
 /// and cancelled exits, so retention starts regardless of task outcome.
 pub fn finalize_run(run_id: &str) -> Result<()> {
-    let mut index = read_index()?;
+    let index_path = index_path()?;
+    with_index_lock(&index_path, || finalize_run_unlocked(run_id))
+}
+
+fn finalize_run_unlocked(run_id: &str) -> Result<()> {
+    let mut index = read_index_unlocked()?;
     let now = chrono::Utc::now().to_rfc3339();
     let mut changed = false;
     for resource in &mut index.resources {
@@ -314,13 +359,20 @@ pub fn finalize_run(run_id: &str) -> Result<()> {
         }
     }
     if changed {
-        write_index(&index)?;
+        write_index_unlocked(&index)?;
     }
     Ok(())
 }
 
 pub fn cleanup(options: ControllerScratchCleanupOptions) -> Result<ControllerScratchCleanupOutput> {
-    let mut index = read_index()?;
+    let index_path = index_path()?;
+    with_index_lock(&index_path, || cleanup_unlocked(options))
+}
+
+fn cleanup_unlocked(
+    options: ControllerScratchCleanupOptions,
+) -> Result<ControllerScratchCleanupOutput> {
+    let mut index = read_index_unlocked()?;
     let mut candidates = Vec::new();
     let mut skipped = legacy_unknown_paths(&std::env::temp_dir())?;
     let mut applied_count = 0;
@@ -362,7 +414,7 @@ pub fn cleanup(options: ControllerScratchCleanupOptions) -> Result<ControllerScr
         });
     }
     if reconciled {
-        write_index(&index)?;
+        write_index_unlocked(&index)?;
     }
 
     let candidate_count = eligible.len();
@@ -508,7 +560,7 @@ fn remove_candidate(
     candidate: &ControllerScratchCandidate,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Result<Option<u64>> {
-    let mut index = read_index()?;
+    let mut index = read_index_unlocked()?;
     let Some(resource) = index.resources.iter_mut().find(|resource| {
         resource.lease_id == candidate.lease_id
             && !resource.lease_id.is_empty()
@@ -519,7 +571,7 @@ fn remove_candidate(
     };
     let path = PathBuf::from(&resource.path);
     if !path.exists() || cleanup_block_reason(resource, &path, now)?.is_some() {
-        write_index(&index)?;
+        write_index_unlocked(&index)?;
         return Ok(None);
     }
     let bytes = path_size(&path)?;
@@ -529,7 +581,7 @@ fn remove_candidate(
             Some(format!("remove {}", path.display())),
         )
     })?;
-    write_index(&index)?;
+    write_index_unlocked(&index)?;
     Ok(Some(bytes))
 }
 
@@ -562,7 +614,7 @@ fn git_dirty_or_unpushed(path: &Path) -> bool {
 }
 
 fn legacy_unknown_paths(root: &Path) -> Result<Vec<ControllerScratchSkipped>> {
-    let index = read_index()?;
+    let index = read_index_unlocked()?;
     let known: std::collections::HashSet<_> = index
         .resources
         .iter()
@@ -617,8 +669,75 @@ fn path_size(path: &Path) -> Result<u64> {
 fn index_path() -> Result<PathBuf> {
     Ok(paths::homeboy_data()?.join("controller-scratch/resources.json"))
 }
+
+fn with_index_lock<T>(index_path: &Path, operation: impl FnOnce() -> Result<T>) -> Result<T> {
+    let lock_path = index_path.with_extension("lock");
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("create {}", parent.display())),
+            )
+        })?;
+    }
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|error| {
+            Error::internal_io(error.to_string(), Some(lock_path.display().to_string()))
+        })?;
+    let _guard = ControllerScratchIndexLock::lock(file)?;
+    operation()
+}
+
+struct ControllerScratchIndexLock {
+    file: File,
+}
+
+impl ControllerScratchIndexLock {
+    #[cfg(unix)]
+    fn lock(file: File) -> Result<Self> {
+        use std::os::fd::AsRawFd;
+
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+            return Err(Error::internal_io(
+                std::io::Error::last_os_error().to_string(),
+                Some("lock controller scratch index".to_string()),
+            ));
+        }
+        Ok(Self { file })
+    }
+
+    #[cfg(not(unix))]
+    fn lock(file: File) -> Result<Self> {
+        Ok(Self { file })
+    }
+}
+
+impl Drop for ControllerScratchIndexLock {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+
+            let _ = unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
+        }
+    }
+}
+
+#[cfg(test)]
 fn read_index() -> Result<ControllerScratchIndex> {
-    let path = index_path()?;
+    let index_path = index_path()?;
+    with_index_lock(&index_path, read_index_unlocked)
+}
+
+fn read_index_unlocked() -> Result<ControllerScratchIndex> {
+    read_index_at_unlocked(&index_path()?)
+}
+
+fn read_index_at_unlocked(path: &Path) -> Result<ControllerScratchIndex> {
     match fs::read_to_string(&path) {
         Ok(raw) => serde_json::from_str(&raw).map_err(|error| {
             Error::internal_json(error.to_string(), Some(path.display().to_string()))
@@ -633,8 +752,18 @@ fn read_index() -> Result<ControllerScratchIndex> {
         )),
     }
 }
+
+#[cfg(test)]
 fn write_index(index: &ControllerScratchIndex) -> Result<()> {
-    let path = index_path()?;
+    let index_path = index_path()?;
+    with_index_lock(&index_path, || write_index_unlocked(index))
+}
+
+fn write_index_unlocked(index: &ControllerScratchIndex) -> Result<()> {
+    write_index_at_unlocked(&index_path()?, index)
+}
+
+fn write_index_at_unlocked(path: &Path, index: &ControllerScratchIndex) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|error| {
             Error::internal_io(error.to_string(), Some(parent.display().to_string()))
@@ -642,7 +771,9 @@ fn write_index(index: &ControllerScratchIndex) -> Result<()> {
     }
     let raw = serde_json::to_vec_pretty(index)
         .map_err(|error| Error::internal_json(error.to_string(), None))?;
-    fs::write(path, raw).map_err(|error| Error::internal_io(error.to_string(), None))
+    let temporary = path.with_extension(format!("{}.tmp", uuid::Uuid::new_v4()));
+    fs::write(&temporary, raw).map_err(|error| Error::internal_io(error.to_string(), None))?;
+    fs::rename(&temporary, path).map_err(|error| Error::internal_io(error.to_string(), None))
 }
 fn schema() -> String {
     CONTROLLER_SCRATCH_SCHEMA.to_string()
@@ -774,6 +905,45 @@ mod tests {
             assert_eq!(resource.owner_pid, std::process::id());
             assert!(resource.reconstructable);
             assert!(!resource.created_at.is_empty());
+        });
+    }
+
+    #[test]
+    fn concurrent_allocation_and_release_preserves_every_lease() {
+        crate::test_support::with_isolated_home(|_| {
+            const WORKERS: usize = 8;
+            const ALLOCATIONS_PER_WORKER: usize = 12;
+            let handles: Vec<_> = (0..WORKERS)
+                .map(|worker| {
+                    std::thread::spawn(move || {
+                        for attempt in 1..=ALLOCATIONS_PER_WORKER {
+                            let allocation = allocate_attempt(
+                                &format!("run-{worker}"),
+                                "parallel-plan",
+                                &format!("task-{worker}"),
+                                attempt as u32,
+                            )
+                            .expect("allocate");
+                            release_attempt(&allocation, "completed", serde_json::json!({}))
+                                .expect("release");
+                        }
+                    })
+                })
+                .collect();
+            for handle in handles {
+                handle.join().expect("worker");
+            }
+
+            let index = read_index().expect("parse index after concurrent updates");
+            assert_eq!(index.resources.len(), WORKERS * ALLOCATIONS_PER_WORKER);
+            assert!(index
+                .resources
+                .iter()
+                .all(|resource| resource.lifecycle_state == "released"));
+            assert!(index
+                .resources
+                .iter()
+                .all(|resource| resource.finalized_at.is_some()));
         });
     }
 


### PR DESCRIPTION
## Summary
Stop review-test hangs caused by unlimited scheduler retries and concurrent controller-scratch index corruption.

## What changed
- Restore retry.max\_attempts as a cap alongside execution budgets while preserving finite execution-budget-only retries.
- Give unrecorded scheduler runs unique scratch identities and isolate unit-test scratch indexes.
- Serialize every controller-scratch read-modify-write transaction and publish index updates atomically.

## How to test
1. Run `cargo test --locked --lib core::agent_task_scheduler::tests -- --test-threads=4`; expect All 76 tests complete in seconds.
2. Run `cargo test --locked --lib core::controller_scratch::tests -- --test-threads=4`; expect All 11 tests pass, including concurrent allocation and release.
3. Run `cargo test --locked --lib evidence_command_ -- --test-threads=4`; expect All evidence tests complete without the prior hang.

## Compatibility
Existing legacy retry.max\_attempts plans remain supported; the unified execution budget remains a hard cap, and the lower configured cap wins. Durable scheduler runs retain their declared run identity.

## Evidence
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/actions/runs/29391215215
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8271
- controller-scratch: Passed
- lifecycle-evidence: Passed
- scheduler-parallel: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the six-hour CI hang, implemented scheduler/scratch fixes, and built deterministic parallel regression coverage with Chris.

## Source relationships
- Closes Extra-Chill/homeboy#8271
- Relates to Extra-Chill/homeboy-action#283
