### PR TITLE
refactor: drop lab handoff dependency on core::artifacts

### DIFF
--- a/src/command_contract/lab/handoff.rs
+++ b/src/command_contract/lab/handoff.rs
@@ -12,8 +12,14 @@ pub const RUNNER_HANDOFF_ENVELOPE_SCHEMA: &str = "homeboy/runner-exec-handoff/v1
 pub const RUN_LOCATION_INDEX_SCHEMA: &str = "homeboy/run-location-index/v1";
 pub const RUNNER_ARTIFACT_MANIFEST_REF_NAME: &str = "runner-artifact-manifest-ref";
 pub const RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA: &str = "homeboy/runner-artifact-manifest-ref/v1";
-pub const RUNNER_ARTIFACT_MANIFEST_SCHEMA: &str = crate::core::artifacts::ARTIFACT_MANIFEST_SCHEMA;
-pub const RUNNER_ARTIFACT_MANIFEST_FILE: &str = crate::core::artifacts::ARTIFACT_MANIFEST_FILE;
+// Canonical artifact-manifest identifiers. These MUST stay in sync with
+// `core::artifact_manifest::{ARTIFACT_MANIFEST_SCHEMA, ARTIFACT_MANIFEST_FILE}`;
+// a compile-time assertion in that module guards against drift. Defined locally
+// here so this lab-contract type layer carries no upward dependency on core.
+pub const ARTIFACT_MANIFEST_SCHEMA: &str = "homeboy/artifact-manifest/v1";
+pub const ARTIFACT_MANIFEST_FILE: &str = "homeboy-artifact-manifest.json";
+pub const RUNNER_ARTIFACT_MANIFEST_SCHEMA: &str = ARTIFACT_MANIFEST_SCHEMA;
+pub const RUNNER_ARTIFACT_MANIFEST_FILE: &str = ARTIFACT_MANIFEST_FILE;
 pub const RUNNER_ARTIFACT_ROOT_DIR_SUFFIX: &str = "-homeboy-artifacts";
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/src/core/artifact_manifest.rs
+++ b/src/core/artifact_manifest.rs
@@ -13,6 +13,35 @@ pub const ARTIFACT_MANIFEST_FILE: &str = "homeboy-artifact-manifest.json";
 pub const ARTIFACT_MANIFEST_SCHEMA: &str = "homeboy/artifact-manifest/v1";
 pub const RUNTIME_AGENT_ARTIFACT_PATHS_SCHEMA: &str = "homeboy/runtime-agent-artifact-paths/v1";
 
+// Drift guard: the lab-contract type layer (`command_contract::lab::handoff`)
+// carries its own copies of these identifiers so it stays free of any upward
+// dependency on core. If either literal changes here, these assertions force the
+// matching update there (and vice versa).
+const fn str_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+const _: () = {
+    assert!(str_eq(
+        crate::command_contract::RUNNER_ARTIFACT_MANIFEST_FILE,
+        ARTIFACT_MANIFEST_FILE
+    ));
+    assert!(str_eq(
+        crate::command_contract::RUNNER_ARTIFACT_MANIFEST_SCHEMA,
+        ARTIFACT_MANIFEST_SCHEMA
+    ));
+};
+
 /// Stable runtime-agent artifact path for an agent execution transcript.
 pub const RUNTIME_AGENT_TRANSCRIPT_ARTIFACT_PATH: &str = "artifacts/agent-loop/transcript.json";
 


### PR DESCRIPTION
## Summary
First cut toward breaking the `core ⇄ command_contract` dependency cycle that blocks extracting the shared lab-contract types into a foundation crate (and, downstream, `command_contract` and `homeboy-cli`).

`command_contract::lab::handoff` aliased the artifact-manifest identifiers directly from `core::artifacts`, forcing an upward dependency on `core`. This removes that dep:

- Define `ARTIFACT_MANIFEST_SCHEMA` / `ARTIFACT_MANIFEST_FILE` locally in `handoff.rs` (they are stable schema-ID string literals).
- Add a compile-time **drift guard** in `core::artifact_manifest` (a `const fn str_eq` over the public `RUNNER_ARTIFACT_MANIFEST_*` re-exports) so the duplicated literals can never diverge silently.

## Verification
- `cargo check --lib` clean (only pre-existing unused-import warnings).
- Proved the drift guard **fails compilation on mismatch** (E0080) and compiles clean when consistent.
- `core::artifacts` references in `command_contract/lab/`: **0** (was in `handoff.rs`).

## Context
Part of the bottom-up plan: the 3 `command_contract/lab/` files (`types`, `workload`, `handoff`) are the entire shared surface between `core` and `command_contract`. Removing their upward core deps one at a time lets them move into a `homeboy-lab-contract` foundation crate below both, breaking the cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)