### PR TITLE
refactor(fuzz): extract result-envelope persistence into core service

### DIFF
--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -11,9 +11,10 @@ use homeboy::core::engine::invocation::InvocationRequirements;
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::{self, ExtensionCapability, ExtensionRunner, FuzzConfig};
 use homeboy::core::fuzz::{
-    fuzz_gate_profile_contract, parse_fuzz_results_file, FuzzArtifact, FuzzCampaign,
-    FuzzCoverageReconciliation, FuzzExecutionRequest, FuzzFindingStatus, FuzzGateProfile,
-    FuzzSamplingRequest, FuzzSequencePlan, FuzzTargetInventory, FUZZ_CONTRACT_VERSION,
+    fuzz_gate_profile_contract, fuzz_result_envelope_evidence_ref, parse_fuzz_results_file,
+    persist_fuzz_run_result_envelope, FuzzArtifact, FuzzCampaign, FuzzCoverageReconciliation,
+    FuzzExecutionRequest, FuzzFindingStatus, FuzzGateProfile, FuzzSamplingRequest,
+    FuzzSequencePlan, FuzzTargetInventory, FUZZ_CONTRACT_VERSION,
     FUZZ_COVERAGE_RECONCILIATION_SCHEMA, FUZZ_EXECUTION_REQUEST_SCHEMA, FUZZ_SEQUENCE_PLAN_SCHEMA,
 };
 use homeboy::core::lifecycle::LifecyclePhaseStatus;
@@ -24,8 +25,7 @@ use uuid::Uuid;
 use super::planning::{load_sequence_plan, plan_inventory_selection, with_sequence_plan_metadata};
 use super::report::{
     evaluate_expected_metric_gates, evaluate_fuzz_gates_for_profile, fuzz_coverage_completeness,
-    fuzz_result_envelope_evidence_ref, fuzz_result_envelope_from_campaign, gate_status,
-    persist_fuzz_run_result_envelope,
+    fuzz_result_envelope_from_campaign, gate_status,
 };
 use super::types::{
     FuzzArtifactPostprocessOutput, FuzzCampaignContract, FuzzExecutionOutput, FuzzPlanArgs,

--- a/src/commands/fuzz/inspect.rs
+++ b/src/commands/fuzz/inspect.rs
@@ -4,8 +4,8 @@ use homeboy::core::artifact_ref::{artifact_uri, EvidenceRef};
 use homeboy::core::fuzz::inspect_fuzz_result_envelope_artifact;
 use homeboy::core::observation::{runs_service, ArtifactRecord, ObservationStore};
 
-use super::report::fuzz_result_envelope_evidence_ref;
 use super::types::{FuzzInspectArgs, FuzzInspectCandidate, FuzzInspectOutput};
+use homeboy::core::fuzz::fuzz_result_envelope_evidence_ref;
 
 /// Artifact kinds that hold the raw fuzz runner input/result pair, ordered by
 /// inspection preference. `fuzz_results` is the verbatim file a runner wrote to

--- a/src/commands/fuzz/report.rs
+++ b/src/commands/fuzz/report.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use homeboy::core::artifact_ref::EvidenceRef;
 use homeboy::core::fuzz::{
     fuzz_gate_profile_contract, parse_fuzz_case_log_file, parse_fuzz_observation_set_value,
     parse_fuzz_results_file, parse_fuzz_target_inventory_file, rank_fuzz_observation_set_hotspots,
@@ -9,12 +8,9 @@ use homeboy::core::fuzz::{
     FuzzResultEnvelope, FUZZ_CONTRACT_VERSION, FUZZ_EXECUTION_REQUEST_SCHEMA,
     FUZZ_RESULT_ENVELOPE_SCHEMA,
 };
-use homeboy::core::observation::{ArtifactRecord, ObservationStore};
 use homeboy::core::performance_hotspots::{
     summarize_performance_hotspots, PerformanceHotspotSummary, PerformanceMetricPoint,
 };
-
-pub(super) const FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND: &str = "fuzz_result_envelope";
 
 use super::types::{
     FuzzCoverageCompletenessOutput, FuzzCoverageSelectorSummaryOutput, FuzzGateEvaluation,
@@ -68,22 +64,11 @@ pub(super) fn run_report(args: FuzzReportArgs) -> homeboy::core::Result<FuzzRepo
     let status = gate_status(&gates);
     envelope.status = status.clone();
 
-    if let Some(path) = args.output_envelope.as_ref() {
-        let json = fuzz_result_envelope_json(&envelope)?;
-        std::fs::write(path, json).map_err(|error| {
-            homeboy::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
-        })?;
-    }
-    let persisted_envelope = persist_fuzz_result_envelope(
+    let evidence_refs = homeboy::core::fuzz::report_fuzz_result_envelope(
         args.run.run_id.as_deref(),
         &envelope,
         args.output_envelope.as_deref(),
     )?;
-    let evidence_refs = persisted_envelope
-        .as_ref()
-        .map(fuzz_result_envelope_evidence_ref)
-        .into_iter()
-        .collect();
 
     Ok(FuzzReportOutput {
         command: "fuzz.report".to_string(),
@@ -178,96 +163,6 @@ fn report_gate_contract(
     Vec<homeboy::core::fuzz::FuzzGate>,
 ) {
     fuzz_gate_profile_contract(profile.as_core())
-}
-
-pub(super) fn persist_fuzz_result_envelope(
-    run_id: Option<&str>,
-    envelope: &FuzzResultEnvelope,
-    envelope_path: Option<&Path>,
-) -> homeboy::core::Result<Option<ArtifactRecord>> {
-    persist_fuzz_result_envelope_with_source(run_id, envelope, envelope_path, "homeboy fuzz report")
-}
-
-pub(super) fn persist_fuzz_run_result_envelope(
-    run_id: Option<&str>,
-    envelope: &FuzzResultEnvelope,
-) -> homeboy::core::Result<Option<ArtifactRecord>> {
-    persist_fuzz_result_envelope_with_source(run_id, envelope, None, "homeboy fuzz run")
-}
-
-fn persist_fuzz_result_envelope_with_source(
-    run_id: Option<&str>,
-    envelope: &FuzzResultEnvelope,
-    envelope_path: Option<&Path>,
-    source: &str,
-) -> homeboy::core::Result<Option<ArtifactRecord>> {
-    let Some(run_id) = run_id.filter(|run_id| !run_id.trim().is_empty()) else {
-        return Ok(None);
-    };
-    let store = ObservationStore::open_initialized()?;
-    if store.get_run(run_id)?.is_none() {
-        return Ok(None);
-    }
-
-    if let Some(path) = envelope_path.filter(|path| path.is_file()) {
-        return record_fuzz_result_envelope_artifact(&store, run_id, path, envelope, source);
-    }
-
-    let mut artifact_file = tempfile::Builder::new()
-        .suffix(".json")
-        .tempfile()
-        .map_err(|error| {
-            homeboy::core::Error::internal_io(
-                error.to_string(),
-                Some("create temporary fuzz result envelope artifact".to_string()),
-            )
-        })?;
-    serde_json::to_writer_pretty(&mut artifact_file, envelope).map_err(|error| {
-        homeboy::core::Error::internal_unexpected(format!(
-            "failed to encode fuzz result envelope: {error}"
-        ))
-    })?;
-    record_fuzz_result_envelope_artifact(&store, run_id, artifact_file.path(), envelope, source)
-}
-
-fn record_fuzz_result_envelope_artifact(
-    store: &ObservationStore,
-    run_id: &str,
-    path: &Path,
-    envelope: &FuzzResultEnvelope,
-    source: &str,
-) -> homeboy::core::Result<Option<ArtifactRecord>> {
-    let metadata = serde_json::json!({
-        "schema": envelope.schema.as_str(),
-        "envelope_id": envelope.id.as_str(),
-        "status": envelope.status.as_str(),
-        "campaign_id": envelope.campaign.as_ref().map(|campaign| campaign.id.as_str()),
-        "source": source,
-        "evidence": {
-            "role": "result",
-            "semantic_key": "fuzz.result_envelope",
-        },
-    });
-    store
-        .record_artifact_with_metadata(run_id, FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND, path, metadata)
-        .map(Some)
-}
-
-pub(super) fn fuzz_result_envelope_evidence_ref(artifact: &ArtifactRecord) -> EvidenceRef {
-    EvidenceRef::for_artifact(
-        artifact,
-        "Fuzz result envelope",
-        Some("result".to_string()),
-        Some("fuzz.result_envelope".to_string()),
-    )
-}
-
-fn fuzz_result_envelope_json(envelope: &FuzzResultEnvelope) -> homeboy::core::Result<String> {
-    serde_json::to_string_pretty(envelope).map_err(|error| {
-        homeboy::core::Error::internal_unexpected(format!(
-            "failed to encode fuzz result envelope: {error}"
-        ))
-    })
 }
 
 pub(super) fn fuzz_result_metadata(

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -18,7 +18,6 @@ use super::replay::{run_minimize, run_replay};
 use super::report::{
     evaluate_expected_metric_gates, evaluate_fuzz_gates, fuzz_coverage_completeness,
     fuzz_observation_hotspots, fuzz_performance_hotspots, gate_status, run_report, run_validate,
-    FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND,
 };
 use super::types::{
     FuzzCommand, FuzzDiscoverArgs, FuzzExecutionOutput, FuzzGateProfileArg, FuzzIsolationArg,
@@ -34,6 +33,7 @@ use super::{run_contract, run_discover, FuzzArgs};
 use clap::Parser;
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::FuzzConfig;
+use homeboy::core::fuzz::FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND;
 use homeboy::core::fuzz::{
     FuzzCampaign, FuzzCase, FuzzCoverageSkip, FuzzCoverageSummary, FuzzExecutionRequest,
     FuzzFinding, FuzzFindingStatus, FuzzSamplingRequest, FuzzSequencePlan, FuzzTargetInventory,

--- a/src/core/fuzz/mod.rs
+++ b/src/core/fuzz/mod.rs
@@ -13,6 +13,7 @@ mod hotspots;
 mod normalize;
 mod observations;
 mod parse;
+mod result_envelope_persistence;
 mod schema_defaults;
 mod schemas;
 mod types;
@@ -58,6 +59,11 @@ pub use parse::{
     parse_fuzz_case_log_file, parse_fuzz_exploration_policy_file, parse_fuzz_result_envelope_file,
     parse_fuzz_results_file, parse_fuzz_sequence_plan_file, parse_fuzz_target_inventory_file,
     parse_fuzz_workload_file,
+};
+pub use result_envelope_persistence::{
+    fuzz_result_envelope_evidence_ref, fuzz_result_envelope_json, persist_fuzz_result_envelope,
+    persist_fuzz_run_result_envelope, report_fuzz_result_envelope,
+    FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND,
 };
 pub use schemas::{
     standardized_fuzz_skip_reason_codes, FUZZ_ACTION_MODEL_SCHEMA, FUZZ_ARTIFACT_SCHEMA,

--- a/src/core/fuzz/result_envelope_persistence.rs
+++ b/src/core/fuzz/result_envelope_persistence.rs
@@ -1,0 +1,137 @@
+//! Fuzz result-envelope persistence.
+//!
+//! Boundary: the caller computes the `FuzzResultEnvelope` and (optionally) the
+//! run id and an on-disk envelope path. This module owns the persistence
+//! orchestration: opening the observation store, recording the envelope as a
+//! run artifact (materializing a temp file when no path is supplied), encoding
+//! the envelope to JSON, and building the evidence reference. Command modules
+//! stay thin adapters that delegate here.
+
+use std::path::Path;
+
+use crate::core::artifact_ref::EvidenceRef;
+use crate::core::fuzz::FuzzResultEnvelope;
+use crate::core::observation::{ArtifactRecord, ObservationStore};
+
+/// Observation-store artifact kind for a persisted fuzz result envelope.
+pub const FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND: &str = "fuzz_result_envelope";
+
+/// Write (optionally) and persist a `homeboy fuzz report` result envelope,
+/// returning the evidence references for any persisted artifact.
+///
+/// When `envelope_path` is supplied the envelope JSON is written there first;
+/// the envelope is then recorded as a run artifact when `run_id` refers to a
+/// known run. This owns the full report-time persistence concern so the command
+/// module stays a thin adapter.
+pub fn report_fuzz_result_envelope(
+    run_id: Option<&str>,
+    envelope: &FuzzResultEnvelope,
+    envelope_path: Option<&Path>,
+) -> crate::core::Result<Vec<EvidenceRef>> {
+    if let Some(path) = envelope_path {
+        let json = fuzz_result_envelope_json(envelope)?;
+        std::fs::write(path, json).map_err(|error| {
+            crate::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
+        })?;
+    }
+    let persisted = persist_fuzz_result_envelope(run_id, envelope, envelope_path)?;
+    Ok(persisted
+        .as_ref()
+        .map(fuzz_result_envelope_evidence_ref)
+        .into_iter()
+        .collect())
+}
+
+/// Persist a fuzz result envelope produced by `homeboy fuzz report`.
+pub fn persist_fuzz_result_envelope(
+    run_id: Option<&str>,
+    envelope: &FuzzResultEnvelope,
+    envelope_path: Option<&Path>,
+) -> crate::core::Result<Option<ArtifactRecord>> {
+    persist_fuzz_result_envelope_with_source(run_id, envelope, envelope_path, "homeboy fuzz report")
+}
+
+/// Persist a fuzz result envelope produced by `homeboy fuzz run`.
+pub fn persist_fuzz_run_result_envelope(
+    run_id: Option<&str>,
+    envelope: &FuzzResultEnvelope,
+) -> crate::core::Result<Option<ArtifactRecord>> {
+    persist_fuzz_result_envelope_with_source(run_id, envelope, None, "homeboy fuzz run")
+}
+
+fn persist_fuzz_result_envelope_with_source(
+    run_id: Option<&str>,
+    envelope: &FuzzResultEnvelope,
+    envelope_path: Option<&Path>,
+    source: &str,
+) -> crate::core::Result<Option<ArtifactRecord>> {
+    let Some(run_id) = run_id.filter(|run_id| !run_id.trim().is_empty()) else {
+        return Ok(None);
+    };
+    let store = ObservationStore::open_initialized()?;
+    if store.get_run(run_id)?.is_none() {
+        return Ok(None);
+    }
+
+    if let Some(path) = envelope_path.filter(|path| path.is_file()) {
+        return record_fuzz_result_envelope_artifact(&store, run_id, path, envelope, source);
+    }
+
+    let mut artifact_file = tempfile::Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .map_err(|error| {
+            crate::core::Error::internal_io(
+                error.to_string(),
+                Some("create temporary fuzz result envelope artifact".to_string()),
+            )
+        })?;
+    serde_json::to_writer_pretty(&mut artifact_file, envelope).map_err(|error| {
+        crate::core::Error::internal_unexpected(format!(
+            "failed to encode fuzz result envelope: {error}"
+        ))
+    })?;
+    record_fuzz_result_envelope_artifact(&store, run_id, artifact_file.path(), envelope, source)
+}
+
+fn record_fuzz_result_envelope_artifact(
+    store: &ObservationStore,
+    run_id: &str,
+    path: &Path,
+    envelope: &FuzzResultEnvelope,
+    source: &str,
+) -> crate::core::Result<Option<ArtifactRecord>> {
+    let metadata = serde_json::json!({
+        "schema": envelope.schema.as_str(),
+        "envelope_id": envelope.id.as_str(),
+        "status": envelope.status.as_str(),
+        "campaign_id": envelope.campaign.as_ref().map(|campaign| campaign.id.as_str()),
+        "source": source,
+        "evidence": {
+            "role": "result",
+            "semantic_key": "fuzz.result_envelope",
+        },
+    });
+    store
+        .record_artifact_with_metadata(run_id, FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND, path, metadata)
+        .map(Some)
+}
+
+/// Build the evidence reference for a persisted fuzz result-envelope artifact.
+pub fn fuzz_result_envelope_evidence_ref(artifact: &ArtifactRecord) -> EvidenceRef {
+    EvidenceRef::for_artifact(
+        artifact,
+        "Fuzz result envelope",
+        Some("result".to_string()),
+        Some("fuzz.result_envelope".to_string()),
+    )
+}
+
+/// Encode a fuzz result envelope to pretty JSON.
+pub fn fuzz_result_envelope_json(envelope: &FuzzResultEnvelope) -> crate::core::Result<String> {
+    serde_json::to_string_pretty(envelope).map_err(|error| {
+        crate::core::Error::internal_unexpected(format!(
+            "failed to encode fuzz result envelope: {error}"
+        ))
+    })
+}


### PR DESCRIPTION
## Summary
- Extracts fuzz result-envelope persistence out of the `fuzz report` command into a new `core::fuzz::result_envelope_persistence` service, so the command stays a thin adapter.
- Adds a `report_fuzz_result_envelope` core entry point that owns the report-time flow (optional envelope-file write → store persistence → evidence refs) in one module-qualified call.
- Updates `report.rs`, `execution.rs`, `inspect.rs`, and the fuzz tests to delegate to the shared core primitive.

## Why
Second in the thin-adapter series (follows #8293). The architecture audit flagged `fuzz/report.rs` for **direct filesystem mutation + run artifact persistence** leaked into the command layer. The persistence logic (`persist_fuzz_result_envelope*`, `record_fuzz_result_envelope_artifact`, the evidence-ref builder, and the `fuzz_result_envelope` artifact-kind const) was command-local but store-backed and reused by three call sites — a natural core-service extraction that centralizes it for all callers.

## Verification
- `homeboy review audit homeboy --only thin_command_adapter_violation`: **8 → 7**; `fuzz/report.rs` no longer flagged. (`fuzz/execution.rs` still flagged — it has a separate `persist_fuzz_run_evidence` orchestration slated for a follow-up PR.)
- `cargo check --lib`: clean (only pre-existing unrelated dead-code warnings).
- `core_boundary_leak` detector: 0 findings in the new core file.
- `cargo fmt` applied. No behavior change — same store calls, same file writes, same outputs.