### PR TITLE
refactor: relocate ResolvedAgentTaskProviderPolicy to leaf schedule module

### DIFF
--- a/src/command_contract/lab/workload.rs
+++ b/src/command_contract/lab/workload.rs
@@ -48,7 +48,7 @@ pub struct RunnerWorkloadAgentTask {
     pub plan_ref: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_provider_policy:
-        Option<crate::core::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy>,
+        Option<crate::core::agent_task_schedule::ResolvedAgentTaskProviderPolicy>,
     pub dispatch_kind: RunnerWorkloadAgentTaskDispatchKind,
     pub lifecycle_mirror_policy: RunnerWorkloadAgentTaskLifecycleMirrorPolicy,
 }

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -28,26 +28,13 @@ use crate::core::{Error, Result};
 
 pub const DISPATCH_RESULT_SCHEMA: &str = "homeboy/agent-task-dispatch/v1";
 
-/// Controller-compiled provider execution policy carried across a Lab handoff.
-/// Runner-local configuration may satisfy this policy's capabilities and secrets,
-/// but must not select a different provider policy.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ResolvedAgentTaskProviderPolicy {
-    pub backend: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub selector: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub rotation: Option<AgentTaskProviderRotationPolicy>,
-    /// Whether the resolved rotation's first entry is the initial provider
-    /// attempt, rather than a fallback after the request's executor.
-    #[serde(default)]
-    pub rotation_starts_with_first_entry: bool,
-    pub retry: AgentTaskRetryPolicy,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub liveness_timeout_ms: Option<u64>,
-}
+// `ResolvedAgentTaskProviderPolicy` is a plain data struct that lives in the
+// leaf `agent_task_schedule` module (beside its `AgentTaskProviderRotationPolicy`
+// / `AgentTaskRetryPolicy` fields) so the lab-contract type layer can depend on
+// it without pulling in this service's dispatch machinery. Re-exported here to
+// keep existing `agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy`
+// call sites stable.
+pub use crate::core::agent_task_schedule::ResolvedAgentTaskProviderPolicy;
 
 /// Where the effective agent-task backend selection came from. Surfaced before
 /// dispatch so operators can see whether the backend was an explicit override or

--- a/src/core/agent_task_schedule.rs
+++ b/src/core/agent_task_schedule.rs
@@ -612,6 +612,32 @@ mod config {
         }
     }
 
+    /// Controller-compiled provider execution policy carried across a Lab handoff.
+    /// Runner-local configuration may satisfy this policy's capabilities and secrets,
+    /// but must not select a different provider policy.
+    ///
+    /// Lives beside its `AgentTaskProviderRotationPolicy` / `AgentTaskRetryPolicy`
+    /// fields in this leaf module (rather than in `agent_task_dispatch_service`) so
+    /// the lab-contract type layer can depend on it without pulling in the dispatch
+    /// service machinery. `agent_task_dispatch_service` re-exports it for stability.
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    pub struct ResolvedAgentTaskProviderPolicy {
+        pub backend: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub selector: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub model: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub rotation: Option<AgentTaskProviderRotationPolicy>,
+        /// Whether the resolved rotation's first entry is the initial provider
+        /// attempt, rather than a fallback after the request's executor.
+        #[serde(default)]
+        pub rotation_starts_with_first_entry: bool,
+        pub retry: AgentTaskRetryPolicy,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub liveness_timeout_ms: Option<u64>,
+    }
+
     /// One rotation target: executor selector overrides and/or nested provider
     /// config/model, mirroring the dispatch config layer shapes
     /// (`--dispatch-selector` / `--dispatch-provider-config`). Unset fields


### PR DESCRIPTION
## Summary
Second cut toward breaking the `core ⇄ command_contract` cycle. Stacked on #8295.

`ResolvedAgentTaskProviderPolicy` is a plain data struct, but it lived in `agent_task_dispatch_service` (which pulls in six agent-task subsystem modules). The lab-contract type layer `command_contract::lab::workload` holds it as a field, so that entire service dependency was riding on the shared contract surface — feeding the cycle.

- Move the struct into the leaf `agent_task_schedule::config` module, beside its `AgentTaskProviderRotationPolicy` / `AgentTaskRetryPolicy` fields (that module has zero problematic core deps).
- Re-export it from `agent_task_dispatch_service` so all existing `agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy` call sites (8 files) stay unchanged.
- Point `lab/workload.rs` at the leaf location.

**Result:** `lab/workload.rs` no longer depends on `agent_task_dispatch_service`. Its core deps drop to `agent_task_schedule` (leaf), `notification_route`, `secret_env_plan`.

## Verification
- `cargo check --lib` and `cargo check --lib --tests` both clean (pre-existing warnings only).
- No `impl` blocks on the struct (no E0116 hazard); pure data move.

## Base
Targets `refactor/break-cc-core-cycle` (#8295) since it builds on that cut. Rebase to main once #8295 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)