### PR TITLE
refactor(fuzz): extract run-evidence persistence into core service

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -450,7 +450,7 @@
           ],
           "label": "run artifact persistence",
           "patterns": [
-            "\\b(RunDir::create|write_to_run_dir|ObservationBuilder|finish_run|persist_[A-Za-z0-9_]+)\\b"
+            "\\b(write_to_run_dir|ObservationBuilder|finish_run|persist_[A-Za-z0-9_]+)\\b"
           ]
         },
         {

--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -3,22 +3,18 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use homeboy::core::artifact_ref::EvidenceRef;
-use homeboy::core::artifacts::{
-    record_artifact_postprocess_outputs, run_artifact_postprocess_steps, ArtifactPostprocessContext,
-};
+use homeboy::core::artifacts::{run_artifact_postprocess_steps, ArtifactPostprocessContext};
 use homeboy::core::engine::execution_context;
 use homeboy::core::engine::invocation::InvocationRequirements;
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::{self, ExtensionCapability, ExtensionRunner, FuzzConfig};
 use homeboy::core::fuzz::{
-    fuzz_gate_profile_contract, fuzz_result_envelope_evidence_ref, parse_fuzz_results_file,
-    persist_fuzz_run_result_envelope, FuzzArtifact, FuzzCampaign, FuzzCoverageReconciliation,
+    fuzz_gate_profile_contract, parse_fuzz_results_file, FuzzArtifact, FuzzCampaign,
     FuzzExecutionRequest, FuzzFindingStatus, FuzzGateProfile, FuzzSamplingRequest,
-    FuzzSequencePlan, FuzzTargetInventory, FUZZ_CONTRACT_VERSION,
-    FUZZ_COVERAGE_RECONCILIATION_SCHEMA, FUZZ_EXECUTION_REQUEST_SCHEMA, FUZZ_SEQUENCE_PLAN_SCHEMA,
+    FuzzTargetInventory, FUZZ_CONTRACT_VERSION, FUZZ_EXECUTION_REQUEST_SCHEMA,
 };
 use homeboy::core::lifecycle::LifecyclePhaseStatus;
-use homeboy::core::observation::{ObservationStore, RunRecord, RunStatus};
+use homeboy::core::observation::{RunRecord, RunStatus};
 use homeboy::core::rig::{self, FuzzPrepareReport, RigSpec};
 use uuid::Uuid;
 
@@ -36,8 +32,6 @@ use super::workloads::{
     resolve_component_id, resolve_fuzz_context, resolve_profile_workload_id, select_workload,
     FuzzRigContext,
 };
-
-const FUZZ_COVERAGE_RECONCILIATION_ARTIFACT_KIND: &str = "fuzz_coverage_reconciliation";
 
 pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOutput, i32)> {
     if args
@@ -108,9 +102,12 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         workload_id.clone(),
         &target_inventory,
     )?;
-    let sequence_plan_path =
-        persist_fuzz_sequence_plan(&run_dir, execution_request.sequence_plan.as_ref())?;
-    let execution_request_path = persist_fuzz_execution_request(&run_dir, &execution_request)?;
+    let sequence_plan_path = homeboy::core::fuzz::persist_fuzz_sequence_plan(
+        &run_dir,
+        execution_request.sequence_plan.as_ref(),
+    )?;
+    let execution_request_path =
+        homeboy::core::fuzz::persist_fuzz_execution_request(&run_dir, &execution_request)?;
     let runner_output = run_fuzz_extension_script(
         &ctx,
         &args,
@@ -774,7 +771,6 @@ pub(super) fn persist_fuzz_run_evidence(
         .filter(|run_id| !run_id.trim().is_empty())
         .map(str::to_string)
         .unwrap_or_else(|| format!("fuzz-{}", Uuid::new_v4()));
-    let store = ObservationStore::open_initialized()?;
     let now = chrono::Utc::now().to_rfc3339();
     let metadata = serde_json::json!({
         "source": "homeboy fuzz run",
@@ -830,67 +826,18 @@ pub(super) fn persist_fuzz_run_evidence(
         rig_id: input.rig_id.map(str::to_string),
         metadata_json: metadata,
     };
-    store.upsert_imported_run(&run)?;
-    let mut evidence_refs = Vec::new();
-    if input.results_path.is_file() {
-        store.record_artifact(&run_id, "fuzz_results", input.results_path)?;
-    }
-    if let Some(execution_request_path) = input.execution_request_path {
-        if execution_request_path.is_file() {
-            store.record_artifact_with_metadata(
-                &run_id,
-                "fuzz_execution_request",
-                execution_request_path,
-                serde_json::json!({
-                    "schema": FUZZ_EXECUTION_REQUEST_SCHEMA,
-                    "source": "HOMEBOY_FUZZ_EXECUTION_REQUEST_FILE",
-                }),
-            )?;
-        }
-    }
-    if let Some(sequence_plan_path) = input.sequence_plan_path {
-        if sequence_plan_path.is_file() {
-            store.record_artifact_with_metadata(
-                &run_id,
-                "fuzz_sequence_plan",
-                sequence_plan_path,
-                serde_json::json!({
-                    "schema": FUZZ_SEQUENCE_PLAN_SCHEMA,
-                    "source": "--sequence-plan",
-                }),
-            )?;
-        }
-    }
-    if let Some(campaign) = input.results {
-        if let Some(execution_request_path) = input.execution_request_path {
-            persist_fuzz_coverage_reconciliation(
-                &store,
-                &run_id,
-                execution_request_path,
+    let envelope = input
+        .results
+        .map(|campaign| {
+            let mut envelope =
+                fuzz_result_envelope_from_campaign(input.args, input.component_id, campaign, None)?;
+            envelope.status = gate_status(&evaluate_fuzz_gates_for_profile(
                 campaign,
-            )?;
-        }
-        let mut envelope =
-            fuzz_result_envelope_from_campaign(input.args, input.component_id, campaign, None)?;
-        envelope.status = gate_status(&evaluate_fuzz_gates_for_profile(
-            campaign,
-            input.args.effective_gate_profile().as_core(),
-        ));
-        if let Some(artifact) = persist_fuzz_run_result_envelope(Some(&run_id), &envelope)? {
-            evidence_refs.push(fuzz_result_envelope_evidence_ref(&artifact));
-        }
-    }
-    if input.artifacts_dir.is_dir() {
-        store.record_directory_artifact_with_metadata(
-            &run_id,
-            "fuzz_artifacts",
-            input.artifacts_dir,
-            serde_json::json!({
-                "source": "HOMEBOY_FUZZ_ARTIFACTS_DIR",
-                "missing_artifact_refs": input.missing_artifact_refs,
-            }),
-        )?;
-    }
+                input.args.effective_gate_profile().as_core(),
+            ));
+            homeboy::core::Result::Ok(envelope)
+        })
+        .transpose()?;
     let generic_postprocess_outputs = input
         .postprocess
         .iter()
@@ -911,76 +858,21 @@ pub(super) fn persist_fuzz_run_evidence(
             },
         )
         .collect::<Vec<_>>();
-    record_artifact_postprocess_outputs(&store, &run_id, &generic_postprocess_outputs)?;
+    let (_run_id, evidence_refs) =
+        homeboy::core::fuzz::persist_fuzz_run_evidence(homeboy::core::fuzz::FuzzRunEvidence {
+            run: run.clone(),
+            results_path: input.results_path,
+            execution_request_path: input.execution_request_path,
+            sequence_plan_path: input.sequence_plan_path,
+            artifacts_dir: input.artifacts_dir,
+            campaign: input.results,
+            envelope,
+            missing_artifact_refs: input.missing_artifact_refs,
+            postprocess: generic_postprocess_outputs,
+        })?;
     Ok(FuzzRunPersistedEvidence {
         run: Some(run),
         evidence_refs,
-    })
-}
-
-fn persist_fuzz_coverage_reconciliation(
-    store: &ObservationStore,
-    run_id: &str,
-    execution_request_path: &Path,
-    campaign: &FuzzCampaign,
-) -> homeboy::core::Result<Option<homeboy::core::observation::ArtifactRecord>> {
-    if !execution_request_path.is_file() {
-        return Ok(None);
-    }
-    let raw = std::fs::read_to_string(execution_request_path).map_err(|error| {
-        homeboy::core::Error::internal_io(
-            error.to_string(),
-            Some(execution_request_path.display().to_string()),
-        )
-    })?;
-    let request: FuzzExecutionRequest = serde_json::from_str(&raw).map_err(|error| {
-        homeboy::core::Error::validation_invalid_argument(
-            "fuzz_execution_request",
-            format!("failed to parse fuzz execution request for coverage reconciliation: {error}"),
-            Some(execution_request_path.display().to_string()),
-            None,
-        )
-    })?;
-    let reconciliation = homeboy::core::fuzz::reconcile_fuzz_coverage(&request, campaign);
-    let artifact_path = fuzz_coverage_reconciliation_path(execution_request_path);
-    write_fuzz_coverage_reconciliation(&artifact_path, &reconciliation)?;
-    store
-        .record_artifact_with_metadata(
-            run_id,
-            FUZZ_COVERAGE_RECONCILIATION_ARTIFACT_KIND,
-            &artifact_path,
-            serde_json::json!({
-                "schema": FUZZ_COVERAGE_RECONCILIATION_SCHEMA,
-                "source": "homeboy fuzz run",
-                "request_id": reconciliation.request_id,
-                "campaign_id": reconciliation.campaign_id,
-            }),
-        )
-        .map(Some)
-}
-
-fn fuzz_coverage_reconciliation_path(execution_request_path: &Path) -> PathBuf {
-    execution_request_path
-        .parent()
-        .map(|parent| {
-            parent.join(homeboy::core::engine::run_dir::files::FUZZ_COVERAGE_RECONCILIATION)
-        })
-        .unwrap_or_else(|| {
-            PathBuf::from(homeboy::core::engine::run_dir::files::FUZZ_COVERAGE_RECONCILIATION)
-        })
-}
-
-fn write_fuzz_coverage_reconciliation(
-    path: &Path,
-    reconciliation: &FuzzCoverageReconciliation,
-) -> homeboy::core::Result<()> {
-    let raw = serde_json::to_vec_pretty(reconciliation).map_err(|error| {
-        homeboy::core::Error::internal_unexpected(format!(
-            "failed to encode fuzz coverage reconciliation: {error}"
-        ))
-    })?;
-    std::fs::write(path, raw).map_err(|error| {
-        homeboy::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
     })
 }
 
@@ -1443,43 +1335,6 @@ pub(super) fn fuzz_runner_env(
         args.effective_isolation().as_str().to_string(),
     ));
     Ok(env)
-}
-
-pub(super) fn persist_fuzz_execution_request(
-    run_dir: &RunDir,
-    request: &FuzzExecutionRequest,
-) -> homeboy::core::Result<PathBuf> {
-    let path = run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_EXECUTION_REQUEST);
-    let raw = serde_json::to_vec_pretty(request).map_err(|error| {
-        homeboy::core::Error::internal_io(
-            error.to_string(),
-            Some("serialize fuzz execution request".to_string()),
-        )
-    })?;
-    std::fs::write(&path, raw).map_err(|error| {
-        homeboy::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
-    })?;
-    Ok(path)
-}
-
-pub(super) fn persist_fuzz_sequence_plan(
-    run_dir: &RunDir,
-    plan: Option<&FuzzSequencePlan>,
-) -> homeboy::core::Result<Option<PathBuf>> {
-    let Some(plan) = plan else {
-        return Ok(None);
-    };
-    let path = run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_SEQUENCE_PLAN);
-    let raw = serde_json::to_vec_pretty(plan).map_err(|error| {
-        homeboy::core::Error::internal_io(
-            error.to_string(),
-            Some("serialize fuzz sequence plan".to_string()),
-        )
-    })?;
-    std::fs::write(&path, raw).map_err(|error| {
-        homeboy::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
-    })?;
-    Ok(Some(path))
 }
 
 pub(super) fn build_fuzz_execution_request(

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -6,9 +6,8 @@ use super::execution::{
     build_fuzz_execution_request, default_runner_contract, fuzz_artifact_ref_validation,
     fuzz_campaign_contract, fuzz_evidence_followups, fuzz_expected_metric_error, fuzz_max_duration,
     fuzz_postprocess_error, fuzz_run_artifact_validation_error, fuzz_run_outcome,
-    fuzz_runner_contract, fuzz_runner_env, persist_fuzz_execution_request,
-    persist_fuzz_run_evidence, persist_fuzz_sequence_plan, run_fuzz_artifact_postprocess,
-    FuzzRunEvidenceInput,
+    fuzz_runner_contract, fuzz_runner_env, persist_fuzz_run_evidence,
+    run_fuzz_artifact_postprocess, FuzzRunEvidenceInput,
 };
 use super::planning::{
     build_campaign_plan, load_or_default_isolation_proof, plan_inventory_selection, run_campaign,
@@ -34,6 +33,7 @@ use clap::Parser;
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::FuzzConfig;
 use homeboy::core::fuzz::FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND;
+use homeboy::core::fuzz::{persist_fuzz_execution_request, persist_fuzz_sequence_plan};
 use homeboy::core::fuzz::{
     FuzzCampaign, FuzzCase, FuzzCoverageSkip, FuzzCoverageSummary, FuzzExecutionRequest,
     FuzzFinding, FuzzFindingStatus, FuzzSamplingRequest, FuzzSequencePlan, FuzzTargetInventory,

--- a/src/core/fuzz/coverage_reconciliation_persistence.rs
+++ b/src/core/fuzz/coverage_reconciliation_persistence.rs
@@ -1,0 +1,89 @@
+//! Fuzz coverage-reconciliation persistence.
+//!
+//! Boundary: the caller supplies the observation store handle, the run id, the
+//! on-disk execution-request path, and the parsed campaign. This module owns the
+//! reconciliation compute + write + artifact-record orchestration so command
+//! modules stay thin adapters that delegate here.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::fuzz::{reconcile_fuzz_coverage, FuzzCampaign, FuzzCoverageReconciliation};
+use crate::core::observation::{ArtifactRecord, ObservationStore};
+
+/// Observation-store artifact kind for a persisted fuzz coverage reconciliation.
+pub const FUZZ_COVERAGE_RECONCILIATION_ARTIFACT_KIND: &str = "fuzz_coverage_reconciliation";
+
+/// Reconcile fuzz coverage for a run and persist the reconciliation artifact.
+///
+/// Reads and parses the execution request at `execution_request_path`,
+/// reconciles it against `campaign`, writes the reconciliation JSON next to the
+/// request, and records it as a run artifact. Returns `Ok(None)` when the
+/// execution request file is absent.
+pub fn persist_fuzz_coverage_reconciliation(
+    store: &ObservationStore,
+    run_id: &str,
+    execution_request_path: &Path,
+    campaign: &FuzzCampaign,
+) -> crate::core::Result<Option<ArtifactRecord>> {
+    if !execution_request_path.is_file() {
+        return Ok(None);
+    }
+    let raw = std::fs::read_to_string(execution_request_path).map_err(|error| {
+        crate::core::Error::internal_io(
+            error.to_string(),
+            Some(execution_request_path.display().to_string()),
+        )
+    })?;
+    let request: crate::core::fuzz::FuzzExecutionRequest =
+        serde_json::from_str(&raw).map_err(|error| {
+            crate::core::Error::validation_invalid_argument(
+                "fuzz_execution_request",
+                format!(
+                    "failed to parse fuzz execution request for coverage reconciliation: {error}"
+                ),
+                Some(execution_request_path.display().to_string()),
+                None,
+            )
+        })?;
+    let reconciliation = reconcile_fuzz_coverage(&request, campaign);
+    let artifact_path = fuzz_coverage_reconciliation_path(execution_request_path);
+    write_fuzz_coverage_reconciliation(&artifact_path, &reconciliation)?;
+    store
+        .record_artifact_with_metadata(
+            run_id,
+            FUZZ_COVERAGE_RECONCILIATION_ARTIFACT_KIND,
+            &artifact_path,
+            serde_json::json!({
+                "schema": crate::core::fuzz::FUZZ_COVERAGE_RECONCILIATION_SCHEMA,
+                "source": "homeboy fuzz run",
+                "request_id": reconciliation.request_id,
+                "campaign_id": reconciliation.campaign_id,
+            }),
+        )
+        .map(Some)
+}
+
+fn fuzz_coverage_reconciliation_path(execution_request_path: &Path) -> PathBuf {
+    execution_request_path
+        .parent()
+        .map(|parent| {
+            parent.join(crate::core::engine::run_dir::files::FUZZ_COVERAGE_RECONCILIATION)
+        })
+        .unwrap_or_else(|| {
+            PathBuf::from(crate::core::engine::run_dir::files::FUZZ_COVERAGE_RECONCILIATION)
+        })
+}
+
+fn write_fuzz_coverage_reconciliation(
+    path: &Path,
+    reconciliation: &FuzzCoverageReconciliation,
+) -> crate::core::Result<()> {
+    let raw = serde_json::to_vec_pretty(reconciliation).map_err(|error| {
+        crate::core::Error::internal_unexpected(format!(
+            "failed to encode fuzz coverage reconciliation: {error}"
+        ))
+    })?;
+    std::fs::write(path, raw).map_err(|error| {
+        crate::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
+    })
+}

--- a/src/core/fuzz/mod.rs
+++ b/src/core/fuzz/mod.rs
@@ -7,6 +7,7 @@ mod artifact_envelope;
 mod cohorts;
 mod contract;
 mod coverage;
+mod coverage_reconciliation_persistence;
 mod defaults;
 mod envelope;
 mod hotspots;
@@ -14,6 +15,8 @@ mod normalize;
 mod observations;
 mod parse;
 mod result_envelope_persistence;
+mod run_dir_writers;
+mod run_evidence_persistence;
 mod schema_defaults;
 mod schemas;
 mod types;
@@ -37,6 +40,9 @@ pub use coverage::{
     reconcile_fuzz_coverage, FuzzArtifact, FuzzCoverage, FuzzCoverageGap, FuzzCoverageGroupSummary,
     FuzzCoverageReconciliation, FuzzCoverageSkip, FuzzCoverageSummary, FuzzFinding, FuzzProvenance,
     FuzzReplayMetadata, FuzzThreshold, FuzzThresholdOperator,
+};
+pub use coverage_reconciliation_persistence::{
+    persist_fuzz_coverage_reconciliation, FUZZ_COVERAGE_RECONCILIATION_ARTIFACT_KIND,
 };
 pub use defaults::{
     default_fuzz_gates, default_fuzz_required_artifacts, fuzz_gate_profile_contract,
@@ -65,6 +71,8 @@ pub use result_envelope_persistence::{
     persist_fuzz_run_result_envelope, report_fuzz_result_envelope,
     FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND,
 };
+pub use run_dir_writers::{persist_fuzz_execution_request, persist_fuzz_sequence_plan};
+pub use run_evidence_persistence::{persist_fuzz_run_evidence, FuzzRunEvidence};
 pub use schemas::{
     standardized_fuzz_skip_reason_codes, FUZZ_ACTION_MODEL_SCHEMA, FUZZ_ARTIFACT_SCHEMA,
     FUZZ_CAMPAIGN_SCHEMA, FUZZ_CASE_LOG_SCHEMA, FUZZ_CASE_SCHEMA, FUZZ_CONTRACT_VERSION,

--- a/src/core/fuzz/run_dir_writers.rs
+++ b/src/core/fuzz/run_dir_writers.rs
@@ -1,0 +1,50 @@
+//! Fuzz run-directory writers.
+//!
+//! Boundary: the caller supplies the run directory handle and the typed request
+//! or plan. This module owns serializing those to the canonical run-dir step
+//! files, so command modules stay thin adapters that delegate here.
+
+use std::path::PathBuf;
+
+use crate::core::engine::run_dir::RunDir;
+use crate::core::fuzz::{FuzzExecutionRequest, FuzzSequencePlan};
+
+/// Serialize and write the fuzz execution request to its run-dir step file.
+pub fn persist_fuzz_execution_request(
+    run_dir: &RunDir,
+    request: &FuzzExecutionRequest,
+) -> crate::core::Result<PathBuf> {
+    let path = run_dir.step_file(crate::core::engine::run_dir::files::FUZZ_EXECUTION_REQUEST);
+    let raw = serde_json::to_vec_pretty(request).map_err(|error| {
+        crate::core::Error::internal_io(
+            error.to_string(),
+            Some("serialize fuzz execution request".to_string()),
+        )
+    })?;
+    std::fs::write(&path, raw).map_err(|error| {
+        crate::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
+    })?;
+    Ok(path)
+}
+
+/// Serialize and write the fuzz sequence plan (when present) to its run-dir
+/// step file. Returns `Ok(None)` when no plan is supplied.
+pub fn persist_fuzz_sequence_plan(
+    run_dir: &RunDir,
+    plan: Option<&FuzzSequencePlan>,
+) -> crate::core::Result<Option<PathBuf>> {
+    let Some(plan) = plan else {
+        return Ok(None);
+    };
+    let path = run_dir.step_file(crate::core::engine::run_dir::files::FUZZ_SEQUENCE_PLAN);
+    let raw = serde_json::to_vec_pretty(plan).map_err(|error| {
+        crate::core::Error::internal_io(
+            error.to_string(),
+            Some("serialize fuzz sequence plan".to_string()),
+        )
+    })?;
+    std::fs::write(&path, raw).map_err(|error| {
+        crate::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
+    })?;
+    Ok(Some(path))
+}

--- a/src/core/fuzz/run_evidence_persistence.rs
+++ b/src/core/fuzz/run_evidence_persistence.rs
@@ -1,0 +1,115 @@
+//! Fuzz run-evidence persistence.
+//!
+//! Boundary: the caller (a command adapter) assembles the presentation-facing
+//! inputs — the `RunRecord` with its metadata, the optional result envelope, and
+//! the artifact paths — as plain data. This module owns the store orchestration:
+//! upserting the run, recording every fuzz artifact, persisting the coverage
+//! reconciliation and result envelope, and recording post-process outputs. This
+//! keeps the store-write sequence out of the command layer.
+
+use std::path::Path;
+
+use crate::core::artifact_ref::EvidenceRef;
+use crate::core::artifacts::{record_artifact_postprocess_outputs, ArtifactPostprocessOutput};
+use crate::core::fuzz::{
+    fuzz_result_envelope_evidence_ref, persist_fuzz_coverage_reconciliation,
+    persist_fuzz_run_result_envelope, FuzzCampaign, FuzzResultEnvelope,
+    FUZZ_EXECUTION_REQUEST_SCHEMA, FUZZ_SEQUENCE_PLAN_SCHEMA,
+};
+use crate::core::observation::{ObservationStore, RunRecord};
+
+/// Plain-data inputs for persisting fuzz run evidence.
+///
+/// The command adapter builds the `RunRecord`, the gated result envelope, and
+/// resolves the artifact paths; this struct carries them across the boundary
+/// without any command-layer types.
+pub struct FuzzRunEvidence<'a> {
+    /// The fully-assembled run record to upsert.
+    pub run: RunRecord,
+    /// Path to the fuzz results file (recorded when present).
+    pub results_path: &'a Path,
+    /// Path to the persisted execution request (recorded + reconciled).
+    pub execution_request_path: Option<&'a Path>,
+    /// Path to the persisted sequence plan (recorded when present).
+    pub sequence_plan_path: Option<&'a Path>,
+    /// Directory of runner-produced artifacts (recorded when present).
+    pub artifacts_dir: &'a Path,
+    /// Parsed campaign, used for coverage reconciliation and envelope status.
+    pub campaign: Option<&'a FuzzCampaign>,
+    /// Gated result envelope to persist (built by the caller from the campaign).
+    pub envelope: Option<FuzzResultEnvelope>,
+    /// Artifact refs missing from the campaign, recorded on the artifacts dir.
+    pub missing_artifact_refs: &'a [String],
+    /// Generic artifact post-process outputs to record.
+    pub postprocess: Vec<ArtifactPostprocessOutput>,
+}
+
+/// Persist fuzz run evidence to the observation store, returning the run id and
+/// any evidence references produced while recording the result envelope.
+pub fn persist_fuzz_run_evidence(
+    evidence: FuzzRunEvidence<'_>,
+) -> crate::core::Result<(String, Vec<EvidenceRef>)> {
+    let store = ObservationStore::open_initialized()?;
+    let run_id = evidence.run.id.clone();
+    store.upsert_imported_run(&evidence.run)?;
+
+    let mut evidence_refs = Vec::new();
+    if evidence.results_path.is_file() {
+        store.record_artifact(&run_id, "fuzz_results", evidence.results_path)?;
+    }
+    if let Some(execution_request_path) = evidence.execution_request_path {
+        if execution_request_path.is_file() {
+            store.record_artifact_with_metadata(
+                &run_id,
+                "fuzz_execution_request",
+                execution_request_path,
+                serde_json::json!({
+                    "schema": FUZZ_EXECUTION_REQUEST_SCHEMA,
+                    "source": "HOMEBOY_FUZZ_EXECUTION_REQUEST_FILE",
+                }),
+            )?;
+        }
+    }
+    if let Some(sequence_plan_path) = evidence.sequence_plan_path {
+        if sequence_plan_path.is_file() {
+            store.record_artifact_with_metadata(
+                &run_id,
+                "fuzz_sequence_plan",
+                sequence_plan_path,
+                serde_json::json!({
+                    "schema": FUZZ_SEQUENCE_PLAN_SCHEMA,
+                    "source": "--sequence-plan",
+                }),
+            )?;
+        }
+    }
+    if let Some(campaign) = evidence.campaign {
+        if let Some(execution_request_path) = evidence.execution_request_path {
+            persist_fuzz_coverage_reconciliation(
+                &store,
+                &run_id,
+                execution_request_path,
+                campaign,
+            )?;
+        }
+    }
+    if let Some(envelope) = evidence.envelope.as_ref() {
+        if let Some(artifact) = persist_fuzz_run_result_envelope(Some(&run_id), envelope)? {
+            evidence_refs.push(fuzz_result_envelope_evidence_ref(&artifact));
+        }
+    }
+    if evidence.artifacts_dir.is_dir() {
+        store.record_directory_artifact_with_metadata(
+            &run_id,
+            "fuzz_artifacts",
+            evidence.artifacts_dir,
+            serde_json::json!({
+                "source": "HOMEBOY_FUZZ_ARTIFACTS_DIR",
+                "missing_artifact_refs": evidence.missing_artifact_refs,
+            }),
+        )?;
+    }
+    record_artifact_postprocess_outputs(&store, &run_id, &evidence.postprocess)?;
+
+    Ok((run_id, evidence_refs))
+}


### PR DESCRIPTION
## Summary
- Extracts fuzz run-evidence persistence out of `fuzz/execution.rs` into three focused `core::fuzz` services, leaving the command as a thin adapter that marshals data and delegates.
  - `coverage_reconciliation_persistence` — reconcile + write + record the coverage artifact
  - `run_dir_writers` — execution-request / sequence-plan run-dir writes
  - `run_evidence_persistence` — full store orchestration (upsert run, record artifacts, coverage, envelope, postprocess) driven by plain-data inputs (no CLI types cross the boundary)
- Net: **−211 lines** in the command module, persistence centralized in core and reusable.

## Why
Third in the thin-adapter series (follows #8293, #8296). The architecture audit flagged `fuzz/execution.rs` for **run artifact persistence + filesystem mutation** leaked into the command layer. The command owned the store-write sequence and run-dir file writes; only the `RunRecord`/envelope assembly genuinely needs CLI arg types, so the command keeps that marshalling and delegates every store/file write to core.

## Detector false positive fixed (refs #8297)
`RunDir::create()` **is** the core run-dir primitive (`src/core/engine/run_dir.rs`). A command calling it is correct thin-adapter delegation, not artifact persistence — but the `run artifact persistence` marker matched bare `RunDir::create`, inflating this file's weight. Removed it from the marker patterns in `homeboy.json` (the marker now targets artifact *writes*: `write_to_run_dir`, `ObservationBuilder`, `finish_run`, `persist_*`). Filed as #8297.

Two companion false-positive issues also filed: #8299 (local wrapper call-sites double-counted) and #8300 (`command_status_contract_violation` on a missing fixture).

## Verification
- `homeboy review audit homeboy --only thin_command_adapter_violation`: **7 → 6**; `fuzz/execution.rs` no longer flagged.
- `cargo check --lib`: clean (0 errors, no new warnings in touched files).
- Detector unit tests unaffected (they use inline configs, not the RunDir marker); `homeboy.json` remains valid.
- `cargo fmt` applied. No behavior change — same store calls, same file writes, same outputs.