### PR TITLE
refactor: move handoff->execution-record projection into commands layer

### DIFF
--- a/src/command_contract/lab/handoff.rs
+++ b/src/command_contract/lab/handoff.rs
@@ -1,10 +1,6 @@
 //! Durable handoff and run-location evidence for detached Lab jobs.
 
-use crate::core::run_outcome_envelope::RunOutcomeEnvelope;
-use crate::core::runner_execution_envelope::{
-    PathMaterializationPlan, RunnerExecutionArtifactRef, RunnerExecutionNextAction,
-    RunnerExecutionRecord,
-};
+use crate::core::runner_execution_envelope::PathMaterializationPlan;
 
 use super::RunnerWorkloadArtifactRef;
 
@@ -257,46 +253,6 @@ impl RunnerHandoffEnvelope {
             evidence,
             follow_commands,
         }
-    }
-
-    pub fn runner_execution_record(&self) -> RunnerExecutionRecord {
-        let record = if self.status == "running" {
-            RunnerExecutionRecord::in_flight(self.job_id.clone(), self.runner_id.clone(), "daemon")
-        } else {
-            RunnerExecutionRecord::terminal(
-                self.job_id.clone(),
-                self.runner_id.clone(),
-                "daemon",
-                if self.status == "succeeded" { 0 } else { 1 },
-            )
-        };
-        record
-            .with_job_id(self.job_id.clone())
-            .with_mirror_run_id(
-                self.mirror_run_id
-                    .clone()
-                    .or_else(|| self.persisted_run_id.clone())
-                    .or_else(|| self.durable_run_id.clone()),
-            )
-            .with_path_materialization_plan(self.path_materialization_plan.clone())
-            .with_artifact_refs(self.evidence.artifact_refs.iter().map(|artifact| {
-                RunnerExecutionArtifactRef {
-                    id: artifact.id.clone(),
-                    name: artifact.name.clone(),
-                    path: artifact.path.clone(),
-                    url: artifact.url.clone(),
-                }
-            }))
-            .with_next_actions(self.evidence.next_commands.iter().map(|command| {
-                RunnerExecutionNextAction {
-                    label: command.label.clone(),
-                    command: command.command.clone(),
-                }
-            }))
-    }
-
-    pub fn run_outcome_envelope(&self) -> RunOutcomeEnvelope {
-        RunOutcomeEnvelope::from_runner_execution_record(&self.runner_execution_record())
     }
 }
 

--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -1704,6 +1704,63 @@ fn display_path(path: &Path) -> String {
     path.to_string_lossy().to_string()
 }
 
+/// Project a runner handoff envelope into a core `RunnerExecutionRecord`.
+///
+/// This conversion produces core execution types from the lab-contract handoff
+/// envelope. It lives in the CLI/commands layer (which legally depends on both
+/// core and command_contract) rather than on the contract type itself, so the
+/// lab-contract type layer carries no upward dependency on core's runner
+/// execution / run-outcome envelopes.
+fn handoff_runner_execution_record(
+    handoff: &crate::command_contract::RunnerHandoffEnvelope,
+) -> RunnerExecutionRecord {
+    let record = if handoff.status == "running" {
+        RunnerExecutionRecord::in_flight(
+            handoff.job_id.clone(),
+            handoff.runner_id.clone(),
+            "daemon",
+        )
+    } else {
+        RunnerExecutionRecord::terminal(
+            handoff.job_id.clone(),
+            handoff.runner_id.clone(),
+            "daemon",
+            if handoff.status == "succeeded" { 0 } else { 1 },
+        )
+    };
+    record
+        .with_job_id(handoff.job_id.clone())
+        .with_mirror_run_id(
+            handoff
+                .mirror_run_id
+                .clone()
+                .or_else(|| handoff.persisted_run_id.clone())
+                .or_else(|| handoff.durable_run_id.clone()),
+        )
+        .with_path_materialization_plan(handoff.path_materialization_plan.clone())
+        .with_artifact_refs(handoff.evidence.artifact_refs.iter().map(|artifact| {
+            crate::core::runner_execution_envelope::RunnerExecutionArtifactRef {
+                id: artifact.id.clone(),
+                name: artifact.name.clone(),
+                path: artifact.path.clone(),
+                url: artifact.url.clone(),
+            }
+        }))
+        .with_next_actions(handoff.evidence.next_commands.iter().map(|command| {
+            crate::core::runner_execution_envelope::RunnerExecutionNextAction {
+                label: command.label.clone(),
+                command: command.command.clone(),
+            }
+        }))
+}
+
+/// Project a runner handoff envelope into a core `RunOutcomeEnvelope`.
+fn handoff_run_outcome_envelope(
+    handoff: &crate::command_contract::RunnerHandoffEnvelope,
+) -> RunOutcomeEnvelope {
+    RunOutcomeEnvelope::from_runner_execution_record(&handoff_runner_execution_record(handoff))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2072,8 +2129,8 @@ mod tests {
         let handoff: crate::command_contract::RunnerHandoffEnvelope =
             serde_json::from_value(runner_handoff_example()).expect("runner handoff sample");
 
-        let record = handoff.runner_execution_record();
-        let outcome = handoff.run_outcome_envelope();
+        let record = handoff_runner_execution_record(&handoff);
+        let outcome = handoff_run_outcome_envelope(&handoff);
 
         assert_eq!(record.schema, RUNNER_EXECUTION_RECORD_SCHEMA);
         assert_eq!(record.execution_id, "job-1");


### PR DESCRIPTION
## Summary
Third cut (3a) toward breaking the `core ⇄ command_contract` cycle. Stacked on #8301.

`RunnerHandoffEnvelope` (a lab-contract type) carried two conversion methods — `runner_execution_record()` and `run_outcome_envelope()` — that produced core execution/outcome types. These forced the contract layer to import `core::run_outcome_envelope::RunOutcomeEnvelope` and four `core::runner_execution_envelope` types, feeding the cycle. **Their only caller was a single test** in `commands::contract`.

- Relocate the projection into free functions (`handoff_runner_execution_record` / `handoff_run_outcome_envelope`) in `commands::contract`, which already imports the core types and legally depends on both core and command_contract.
- `handoff.rs` sheds `run_outcome_envelope` entirely and all four `runner_execution_envelope` types except the `PathMaterializationPlan` field (relocated in the next cut, 3b).

## Result
`command_contract/lab/handoff.rs` core deps: **`runner_execution_envelope` only** (was `run_outcome_envelope` + 4 exec types).

## Verification
- `cargo check --lib` and `--lib --tests` clean.
- Projection logic unchanged; the one test updated to call the free functions.

## Base
Targets `refactor/split-agent-task-policy-types` (#8301). Part of the stacked cycle-break series (#8295 → #8301 → this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)