### PR TITLE
Finalize committed manual branches

### DIFF
--- a/src/core/agent_task_finalization.rs
+++ b/src/core/agent_task_finalization.rs
@@ -255,6 +255,8 @@ pub trait AgentTaskPrFinalizationBackend {
     }
     fn current_branch(&mut self, path: &str) -> Result<String>;
     fn changed_files(&mut self, path: &str) -> Result<Vec<String>>;
+    fn changed_files_since(&mut self, path: &str, base: &str) -> Result<Vec<String>>;
+    fn branch_is_published(&mut self, path: &str, head: &str) -> Result<bool>;
     fn commit_all(&mut self, path: &str, message: &str) -> Result<()>;
     fn push_branch(&mut self, path: &str, head: &str) -> Result<()>;
     fn find_open_pr(
@@ -437,6 +439,12 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     };
     changed_files.sort();
     changed_files.dedup();
+    let has_uncommitted_changes = !changed_files.is_empty();
+    if changed_files.is_empty() && options.manual_finalization {
+        changed_files = backend.changed_files_since(&options.path, &options.base)?;
+        changed_files.sort();
+        changed_files.dedup();
+    }
     let intent = build_pr_publication_intent(&options, &head, &changed_files, proof.clone());
     validate_publication_intent(&intent)?;
 
@@ -457,8 +465,12 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     if !options.manual_finalization {
         backend.validate_candidate(&options)?;
     }
-    backend.commit_all(&options.path, &options.commit_message)?;
-    backend.push_branch(&options.path, &head)?;
+    if has_uncommitted_changes {
+        backend.commit_all(&options.path, &options.commit_message)?;
+        backend.push_branch(&options.path, &head)?;
+    } else if !backend.branch_is_published(&options.path, &head)? {
+        backend.push_branch(&options.path, &head)?;
+    }
     let body = render_review_dossier(&options.review_dossier, &options.review_profile);
     let existing = backend.find_open_pr(&options.path, &options.base, &head)?;
     let (action, pr) = match existing {
@@ -853,6 +865,8 @@ mod tests {
     struct MockBackend {
         branch: String,
         changed_files: Vec<String>,
+        changed_files_since: Vec<String>,
+        branch_published: bool,
         existing_pr: Option<AgentTaskPrRef>,
         create_error: bool,
         hydrate_error: bool,
@@ -864,6 +878,11 @@ mod tests {
         pushed: bool,
         created: bool,
         create_calls: u8,
+        changed_files_calls: u8,
+        changed_files_since_calls: u8,
+        branch_is_published_calls: u8,
+        commit_calls: u8,
+        push_calls: u8,
         updated: bool,
         last_body: String,
     }
@@ -931,16 +950,29 @@ mod tests {
         }
 
         fn changed_files(&mut self, _path: &str) -> Result<Vec<String>> {
+            self.changed_files_calls += 1;
             Ok(self.changed_files.clone())
+        }
+
+        fn changed_files_since(&mut self, _path: &str, _base: &str) -> Result<Vec<String>> {
+            self.changed_files_since_calls += 1;
+            Ok(self.changed_files_since.clone())
+        }
+
+        fn branch_is_published(&mut self, _path: &str, _head: &str) -> Result<bool> {
+            self.branch_is_published_calls += 1;
+            Ok(self.branch_published)
         }
 
         fn commit_all(&mut self, _path: &str, _message: &str) -> Result<()> {
             self.committed = true;
+            self.commit_calls += 1;
             Ok(())
         }
 
         fn push_branch(&mut self, _path: &str, _head: &str) -> Result<()> {
             self.pushed = true;
+            self.push_calls += 1;
             Ok(())
         }
 
@@ -1004,6 +1036,11 @@ mod tests {
         assert!(backend.committed);
         assert!(backend.pushed);
         assert!(backend.created);
+        assert_eq!(backend.changed_files_calls, 1);
+        assert_eq!(backend.changed_files_since_calls, 0);
+        assert_eq!(backend.branch_is_published_calls, 0);
+        assert_eq!(backend.commit_calls, 1);
+        assert_eq!(backend.push_calls, 1);
         assert!(backend.last_body.contains("## AI assistance"));
         assert!(backend.last_body.contains("## Summary"));
         assert!(backend.last_body.contains("## How to test"));
@@ -1203,6 +1240,32 @@ mod tests {
         assert!(!backend.committed);
         assert!(!backend.pushed);
         assert!(!backend.created);
+        assert_eq!(backend.changed_files_calls, 1);
+        assert_eq!(backend.changed_files_since_calls, 1);
+        assert_eq!(backend.branch_is_published_calls, 0);
+        assert_eq!(backend.commit_calls, 0);
+        assert_eq!(backend.push_calls, 0);
+    }
+
+    #[test]
+    fn manual_finalization_uses_committed_diff_without_recommitting_or_republishing() {
+        let mut backend = MockBackend {
+            changed_files_since: vec!["src/lib.rs".to_string()],
+            branch_published: true,
+            ..Default::default()
+        };
+
+        let report = finalize_pr_with_backend(options(), &mut backend).expect("finalized");
+
+        assert_eq!(report.status, "review_ready");
+        assert_eq!(report.changed_files, vec!["src/lib.rs"]);
+        assert!(backend.created);
+        assert_eq!(backend.changed_files_calls, 1);
+        assert_eq!(backend.changed_files_since_calls, 1);
+        assert_eq!(backend.branch_is_published_calls, 1);
+        assert_eq!(backend.commit_calls, 0);
+        assert_eq!(backend.push_calls, 0);
+        assert_eq!(backend.create_calls, 1);
     }
 
     #[test]

--- a/src/core/agent_task_finalization/backend.rs
+++ b/src/core/agent_task_finalization/backend.rs
@@ -6,11 +6,12 @@ use crate::core::agent_task_promotion::{AgentTaskPromotionCandidate, AgentTaskPr
 use crate::core::error::{Error, Result};
 use crate::core::git::{
     commit_at, get_head_commit, get_uncommitted_changes, pr_create, pr_edit, pr_find, push_at,
-    remote_branch_commit, CommitOptions, PrCreateOptions, PrEditOptions, PrFindOptions, PrState,
-    PushOptions,
+    remote_branch_commit, resolve_default_remote, run_git, CommitOptions, PrCreateOptions,
+    PrEditOptions, PrFindOptions, PrState, PushOptions,
 };
 use crate::core::run_lifecycle_record::RunLifecycleRecord;
 use serde::de::DeserializeOwned;
+use std::path::Path;
 
 pub struct RealAgentTaskPrFinalizationBackend;
 
@@ -67,21 +68,7 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
     }
 
     fn changed_files_since(&mut self, path: &str, base: &str) -> Result<Vec<String>> {
-        let output = std::process::Command::new("git")
-            .args(["diff", "--name-only", &format!("{}...HEAD", base)])
-            .current_dir(path)
-            .output()
-            .map_err(|error| Error::git_command_failed(error.to_string()))?;
-        if !output.status.success() {
-            return Err(Error::git_command_failed(format!(
-                "git diff from base failed: {}",
-                String::from_utf8_lossy(&output.stderr)
-            )));
-        }
-        Ok(String::from_utf8_lossy(&output.stdout)
-            .lines()
-            .map(str::to_string)
-            .collect())
+        changed_files_since_remote_branch(path, base)
     }
 
     fn branch_is_published(&mut self, path: &str, head: &str) -> Result<bool> {
@@ -189,6 +176,30 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
     }
 }
 
+fn changed_files_since_remote_branch(path: &str, base: &str) -> Result<Vec<String>> {
+    let root = Path::new(path);
+    run_git(
+        root,
+        &["check-ref-format", "--branch", base],
+        "validate PR base branch",
+    )?;
+    let remote = resolve_default_remote(root);
+    let base_ref = format!("refs/heads/{base}");
+    run_git(
+        root,
+        &["fetch", "--no-tags", &remote, &base_ref],
+        "fetch PR base branch",
+    )?;
+    Ok(run_git(
+        root,
+        &["diff", "--name-only", "FETCH_HEAD...HEAD"],
+        "discover changes from PR base branch",
+    )?
+    .lines()
+    .map(str::to_string)
+    .collect())
+}
+
 pub(super) fn validate_real_candidate_fingerprint(
     options: &AgentTaskPrFinalizationOptions,
 ) -> Result<()> {
@@ -263,4 +274,105 @@ fn deserialize_persisted_value<T: DeserializeOwned>(
         .ok_or_else(|| Error::validation_invalid_argument("run_id", missing_message, None, None))?;
     serde_json::from_value(value)
         .map_err(|_| Error::validation_invalid_argument("run_id", invalid_message, None, None))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+    use tempfile::tempdir;
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("runs git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_output(path: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("runs git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).expect("git output is UTF-8")
+    }
+
+    #[test]
+    fn changed_files_since_remote_branch_ignores_a_stale_local_base() {
+        let root = tempdir().expect("temporary directory");
+        let remote = root.path().join("remote.git");
+        let source = root.path().join("source");
+        let checkout = root.path().join("checkout");
+        git(
+            root.path(),
+            &["init", "--bare", remote.to_str().expect("remote path")],
+        );
+        std::fs::create_dir(&source).expect("source directory");
+        git(&source, &["init", "--initial-branch=main"]);
+        git(&source, &["config", "user.email", "test@example.com"]);
+        git(&source, &["config", "user.name", "Test User"]);
+        std::fs::write(source.join("base.txt"), "base\n").expect("base file");
+        git(&source, &["add", "base.txt"]);
+        git(&source, &["commit", "-m", "base"]);
+        git(
+            &source,
+            &[
+                "remote",
+                "add",
+                "origin",
+                remote.to_str().expect("remote path"),
+            ],
+        );
+        git(&source, &["push", "-u", "origin", "main"]);
+        git(&remote, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+
+        git(
+            root.path(),
+            &[
+                "clone",
+                remote.to_str().expect("remote path"),
+                checkout.to_str().expect("checkout path"),
+            ],
+        );
+        git(&checkout, &["remote", "rename", "origin", "upstream"]);
+        git(&checkout, &["config", "user.email", "test@example.com"]);
+        git(&checkout, &["config", "user.name", "Test User"]);
+
+        std::fs::write(source.join("upstream.txt"), "upstream\n").expect("upstream file");
+        git(&source, &["add", "upstream.txt"]);
+        git(&source, &["commit", "-m", "upstream change"]);
+        git(&source, &["push", "origin", "main"]);
+
+        git(&checkout, &["fetch", "upstream", "main"]);
+        git(&checkout, &["switch", "-c", "fix/manual", "FETCH_HEAD"]);
+        std::fs::write(checkout.join("candidate.txt"), "candidate\n").expect("candidate file");
+        git(&checkout, &["add", "candidate.txt"]);
+        git(&checkout, &["commit", "-m", "candidate change"]);
+
+        assert_eq!(
+            git_output(&checkout, &["diff", "--name-only", "main...HEAD"])
+                .lines()
+                .collect::<Vec<_>>(),
+            vec!["candidate.txt", "upstream.txt"]
+        );
+        assert_eq!(
+            changed_files_since_remote_branch(checkout.to_str().expect("checkout path"), "main")
+                .expect("discovers remote-base changes"),
+            vec!["candidate.txt"]
+        );
+    }
 }

--- a/src/core/agent_task_finalization/backend.rs
+++ b/src/core/agent_task_finalization/backend.rs
@@ -5,8 +5,9 @@ use super::{
 use crate::core::agent_task_promotion::{AgentTaskPromotionCandidate, AgentTaskPromotionReport};
 use crate::core::error::{Error, Result};
 use crate::core::git::{
-    commit_at, get_uncommitted_changes, pr_create, pr_edit, pr_find, push_at, CommitOptions,
-    PrCreateOptions, PrEditOptions, PrFindOptions, PrState, PushOptions,
+    commit_at, get_head_commit, get_uncommitted_changes, pr_create, pr_edit, pr_find, push_at,
+    remote_branch_commit, CommitOptions, PrCreateOptions, PrEditOptions, PrFindOptions, PrState,
+    PushOptions,
 };
 use crate::core::run_lifecycle_record::RunLifecycleRecord;
 use serde::de::DeserializeOwned;
@@ -63,6 +64,30 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
         files.sort();
         files.dedup();
         Ok(files)
+    }
+
+    fn changed_files_since(&mut self, path: &str, base: &str) -> Result<Vec<String>> {
+        let output = std::process::Command::new("git")
+            .args(["diff", "--name-only", &format!("{}...HEAD", base)])
+            .current_dir(path)
+            .output()
+            .map_err(|error| Error::git_command_failed(error.to_string()))?;
+        if !output.status.success() {
+            return Err(Error::git_command_failed(format!(
+                "git diff from base failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(str::to_string)
+            .collect())
+    }
+
+    fn branch_is_published(&mut self, path: &str, head: &str) -> Result<bool> {
+        let local_commit = get_head_commit(path)?;
+        Ok(remote_branch_commit(path, head)?
+            .is_some_and(|remote_commit| remote_commit == local_commit))
     }
 
     fn commit_all(&mut self, path: &str, message: &str) -> Result<()> {

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -1198,6 +1198,12 @@ mod tests {
         fn changed_files(&mut self, _path: &str) -> Result<Vec<String>> {
             Ok(vec!["src/lib.rs".to_string()])
         }
+        fn changed_files_since(&mut self, _path: &str, _base: &str) -> Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+        fn branch_is_published(&mut self, _path: &str, _head: &str) -> Result<bool> {
+            Ok(false)
+        }
         fn commit_all(&mut self, _path: &str, _message: &str) -> Result<()> {
             self.committed = true;
             Ok(())


### PR DESCRIPTION
## Summary
Allow explicit manual PR finalization to publish clean branches whose candidate changes are already committed.

## What changed
- Discover committed candidate files against a freshly fetched branch from the repository's default remote when the manual-finalization worktree is clean.
- Skip recommitting clean candidates and skip pushing only when the remote branch already resolves to local HEAD.

## How to test
1. Run `cargo test agent_task_finalization`; expect All 23 focused finalization tests pass, including dirty, equivalent-clean, committed-clean, and stale-local-base candidates..
2. Run `cargo fmt --check`; expect Rust formatting is clean..
3. Run `cargo clippy --lib`; expect The library completes Clippy with no new warnings from this change..

## Compatibility
Existing dirty-worktree commit/push behavior and non-manual durable promotion validation are preserved. This extends the explicit manual recovery path without changing extension interfaces.

## Evidence
- CI expected: Audit
- CI expected: Lint
- CI expected: Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8306
- clippy: Passed
- focused-tests: Passed
- format: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the finalization control-plane defect, implemented the backend contract and deterministic remote-base coverage, and verified the repair; Chris reviews and owns the change.

## Source relationships
- Closes #8306
