### PR TITLE
refactor: recover cycle-break cuts 2-4 (policy relocate, projection move, path-materialization leaf)

### DIFF
--- a/src/command_contract/lab/handoff.rs
+++ b/src/command_contract/lab/handoff.rs
@@ -1,6 +1,6 @@
 //! Durable handoff and run-location evidence for detached Lab jobs.
 
-use crate::core::runner_execution_envelope::PathMaterializationPlan;
+use crate::core::path_materialization::PathMaterializationPlan;
 
 use super::RunnerWorkloadArtifactRef;
 

--- a/src/command_contract/lab/handoff.rs
+++ b/src/command_contract/lab/handoff.rs
@@ -1,10 +1,6 @@
 //! Durable handoff and run-location evidence for detached Lab jobs.
 
-use crate::core::run_outcome_envelope::RunOutcomeEnvelope;
-use crate::core::runner_execution_envelope::{
-    PathMaterializationPlan, RunnerExecutionArtifactRef, RunnerExecutionNextAction,
-    RunnerExecutionRecord,
-};
+use crate::core::runner_execution_envelope::PathMaterializationPlan;
 
 use super::RunnerWorkloadArtifactRef;
 
@@ -257,46 +253,6 @@ impl RunnerHandoffEnvelope {
             evidence,
             follow_commands,
         }
-    }
-
-    pub fn runner_execution_record(&self) -> RunnerExecutionRecord {
-        let record = if self.status == "running" {
-            RunnerExecutionRecord::in_flight(self.job_id.clone(), self.runner_id.clone(), "daemon")
-        } else {
-            RunnerExecutionRecord::terminal(
-                self.job_id.clone(),
-                self.runner_id.clone(),
-                "daemon",
-                if self.status == "succeeded" { 0 } else { 1 },
-            )
-        };
-        record
-            .with_job_id(self.job_id.clone())
-            .with_mirror_run_id(
-                self.mirror_run_id
-                    .clone()
-                    .or_else(|| self.persisted_run_id.clone())
-                    .or_else(|| self.durable_run_id.clone()),
-            )
-            .with_path_materialization_plan(self.path_materialization_plan.clone())
-            .with_artifact_refs(self.evidence.artifact_refs.iter().map(|artifact| {
-                RunnerExecutionArtifactRef {
-                    id: artifact.id.clone(),
-                    name: artifact.name.clone(),
-                    path: artifact.path.clone(),
-                    url: artifact.url.clone(),
-                }
-            }))
-            .with_next_actions(self.evidence.next_commands.iter().map(|command| {
-                RunnerExecutionNextAction {
-                    label: command.label.clone(),
-                    command: command.command.clone(),
-                }
-            }))
-    }
-
-    pub fn run_outcome_envelope(&self) -> RunOutcomeEnvelope {
-        RunOutcomeEnvelope::from_runner_execution_record(&self.runner_execution_record())
     }
 }
 

--- a/src/command_contract/lab/workload.rs
+++ b/src/command_contract/lab/workload.rs
@@ -48,7 +48,7 @@ pub struct RunnerWorkloadAgentTask {
     pub plan_ref: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_provider_policy:
-        Option<crate::core::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy>,
+        Option<crate::core::agent_task_schedule::ResolvedAgentTaskProviderPolicy>,
     pub dispatch_kind: RunnerWorkloadAgentTaskDispatchKind,
     pub lifecycle_mirror_policy: RunnerWorkloadAgentTaskLifecycleMirrorPolicy,
 }

--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -1704,6 +1704,63 @@ fn display_path(path: &Path) -> String {
     path.to_string_lossy().to_string()
 }
 
+/// Project a runner handoff envelope into a core `RunnerExecutionRecord`.
+///
+/// This conversion produces core execution types from the lab-contract handoff
+/// envelope. It lives in the CLI/commands layer (which legally depends on both
+/// core and command_contract) rather than on the contract type itself, so the
+/// lab-contract type layer carries no upward dependency on core's runner
+/// execution / run-outcome envelopes.
+fn handoff_runner_execution_record(
+    handoff: &crate::command_contract::RunnerHandoffEnvelope,
+) -> RunnerExecutionRecord {
+    let record = if handoff.status == "running" {
+        RunnerExecutionRecord::in_flight(
+            handoff.job_id.clone(),
+            handoff.runner_id.clone(),
+            "daemon",
+        )
+    } else {
+        RunnerExecutionRecord::terminal(
+            handoff.job_id.clone(),
+            handoff.runner_id.clone(),
+            "daemon",
+            if handoff.status == "succeeded" { 0 } else { 1 },
+        )
+    };
+    record
+        .with_job_id(handoff.job_id.clone())
+        .with_mirror_run_id(
+            handoff
+                .mirror_run_id
+                .clone()
+                .or_else(|| handoff.persisted_run_id.clone())
+                .or_else(|| handoff.durable_run_id.clone()),
+        )
+        .with_path_materialization_plan(handoff.path_materialization_plan.clone())
+        .with_artifact_refs(handoff.evidence.artifact_refs.iter().map(|artifact| {
+            crate::core::runner_execution_envelope::RunnerExecutionArtifactRef {
+                id: artifact.id.clone(),
+                name: artifact.name.clone(),
+                path: artifact.path.clone(),
+                url: artifact.url.clone(),
+            }
+        }))
+        .with_next_actions(handoff.evidence.next_commands.iter().map(|command| {
+            crate::core::runner_execution_envelope::RunnerExecutionNextAction {
+                label: command.label.clone(),
+                command: command.command.clone(),
+            }
+        }))
+}
+
+/// Project a runner handoff envelope into a core `RunOutcomeEnvelope`.
+fn handoff_run_outcome_envelope(
+    handoff: &crate::command_contract::RunnerHandoffEnvelope,
+) -> RunOutcomeEnvelope {
+    RunOutcomeEnvelope::from_runner_execution_record(&handoff_runner_execution_record(handoff))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2072,8 +2129,8 @@ mod tests {
         let handoff: crate::command_contract::RunnerHandoffEnvelope =
             serde_json::from_value(runner_handoff_example()).expect("runner handoff sample");
 
-        let record = handoff.runner_execution_record();
-        let outcome = handoff.run_outcome_envelope();
+        let record = handoff_runner_execution_record(&handoff);
+        let outcome = handoff_run_outcome_envelope(&handoff);
 
         assert_eq!(record.schema, RUNNER_EXECUTION_RECORD_SCHEMA);
         assert_eq!(record.execution_id, "job-1");

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -28,26 +28,13 @@ use crate::core::{Error, Result};
 
 pub const DISPATCH_RESULT_SCHEMA: &str = "homeboy/agent-task-dispatch/v1";
 
-/// Controller-compiled provider execution policy carried across a Lab handoff.
-/// Runner-local configuration may satisfy this policy's capabilities and secrets,
-/// but must not select a different provider policy.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ResolvedAgentTaskProviderPolicy {
-    pub backend: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub selector: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub rotation: Option<AgentTaskProviderRotationPolicy>,
-    /// Whether the resolved rotation's first entry is the initial provider
-    /// attempt, rather than a fallback after the request's executor.
-    #[serde(default)]
-    pub rotation_starts_with_first_entry: bool,
-    pub retry: AgentTaskRetryPolicy,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub liveness_timeout_ms: Option<u64>,
-}
+// `ResolvedAgentTaskProviderPolicy` is a plain data struct that lives in the
+// leaf `agent_task_schedule` module (beside its `AgentTaskProviderRotationPolicy`
+// / `AgentTaskRetryPolicy` fields) so the lab-contract type layer can depend on
+// it without pulling in this service's dispatch machinery. Re-exported here to
+// keep existing `agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy`
+// call sites stable.
+pub use crate::core::agent_task_schedule::ResolvedAgentTaskProviderPolicy;
 
 /// Where the effective agent-task backend selection came from. Surfaced before
 /// dispatch so operators can see whether the backend was an explicit override or

--- a/src/core/agent_task_schedule.rs
+++ b/src/core/agent_task_schedule.rs
@@ -612,6 +612,32 @@ mod config {
         }
     }
 
+    /// Controller-compiled provider execution policy carried across a Lab handoff.
+    /// Runner-local configuration may satisfy this policy's capabilities and secrets,
+    /// but must not select a different provider policy.
+    ///
+    /// Lives beside its `AgentTaskProviderRotationPolicy` / `AgentTaskRetryPolicy`
+    /// fields in this leaf module (rather than in `agent_task_dispatch_service`) so
+    /// the lab-contract type layer can depend on it without pulling in the dispatch
+    /// service machinery. `agent_task_dispatch_service` re-exports it for stability.
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    pub struct ResolvedAgentTaskProviderPolicy {
+        pub backend: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub selector: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub model: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub rotation: Option<AgentTaskProviderRotationPolicy>,
+        /// Whether the resolved rotation's first entry is the initial provider
+        /// attempt, rather than a fallback after the request's executor.
+        #[serde(default)]
+        pub rotation_starts_with_first_entry: bool,
+        pub retry: AgentTaskRetryPolicy,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub liveness_timeout_ms: Option<u64>,
+    }
+
     /// One rotation target: executor selector overrides and/or nested provider
     /// config/model, mirroring the dispatch config layer shapes
     /// (`--dispatch-selector` / `--dispatch-provider-config`). Unset fields

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -117,6 +117,7 @@ pub mod observation;
 // `crate::core::output::*` call sites keep working unchanged.
 pub use homeboy_output as output;
 pub(crate) mod ownership;
+pub mod path_materialization;
 pub mod performance_hotspots;
 pub mod phase_timing;
 pub mod plan;

--- a/src/core/path_materialization.rs
+++ b/src/core/path_materialization.rs
@@ -1,0 +1,263 @@
+//! Path materialization plan types.
+//!
+//! Self-contained data types describing how a runner materializes workspace
+//! paths (existing-remote, git, snapshot) plus their projections. Extracted into
+//! this leaf module (from `runner_execution_envelope`) so the lab-contract type
+//! layer can hold a `PathMaterializationPlan` field without depending on the
+//! wider runner-execution envelope machinery. `runner_execution_envelope`
+//! re-exports these for its existing call sites.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+pub const PATH_MATERIALIZATION_PLAN_SCHEMA: &str = "homeboy/path-materialization-plan/v1";
+pub const PATH_MATERIALIZATION_MODE_EXISTING_REMOTE: &str = "existing_remote";
+pub const PATH_MATERIALIZATION_MODE_GIT: &str = "git";
+pub const PATH_MATERIALIZATION_MODE_SNAPSHOT: &str = "snapshot";
+pub const PATH_MATERIALIZATION_ROLE_PRIMARY_WORKSPACE: &str = "primary_workspace";
+pub const PATH_MATERIALIZATION_ROLE_REQUIRED_PATH: &str = "required_path";
+pub const PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT: &str =
+    "runner_exec.source_snapshot";
+pub const PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_REQUIRE_PATHS: &str = "runner_exec.require_paths";
+pub const PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT: &str = "lab.execution_context";
+pub const PATH_MATERIALIZATION_OWNER_LAB_PROVIDER_CONFIG: &str = "lab.provider_config";
+pub const PATH_MATERIALIZATION_STATUS_MATERIALIZED: &str = "materialized";
+pub const PATH_MATERIALIZATION_STATUS_VALIDATED: &str = "validated";
+
+fn path_materialization_plan_schema() -> String {
+    PATH_MATERIALIZATION_PLAN_SCHEMA.to_string()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathMaterializationMode {
+    ExistingRemote,
+    Git,
+    Snapshot,
+}
+
+impl PathMaterializationMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ExistingRemote => PATH_MATERIALIZATION_MODE_EXISTING_REMOTE,
+            Self::Git => PATH_MATERIALIZATION_MODE_GIT,
+            Self::Snapshot => PATH_MATERIALIZATION_MODE_SNAPSHOT,
+        }
+    }
+}
+
+impl fmt::Display for PathMaterializationMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for PathMaterializationMode {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            PATH_MATERIALIZATION_MODE_EXISTING_REMOTE => Ok(Self::ExistingRemote),
+            PATH_MATERIALIZATION_MODE_GIT => Ok(Self::Git),
+            PATH_MATERIALIZATION_MODE_SNAPSHOT => Ok(Self::Snapshot),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PathMaterializationProjection {
+    pub role: String,
+    pub owner: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_path: Option<String>,
+    pub remote_path: String,
+    pub materialization_mode: String,
+    pub validation_status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PathMaterializationPlanProjection {
+    pub schema: String,
+    pub entries: Vec<PathMaterializationProjection>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub path_remaps: Vec<PathMaterializationPathRemap>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PathMaterializationPathRemap {
+    pub local_path: String,
+    pub remote_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PathMaterializationPlan {
+    #[serde(default = "path_materialization_plan_schema")]
+    pub schema: String,
+    pub entries: Vec<PathMaterializationEntry>,
+}
+
+impl PathMaterializationPlan {
+    pub fn new(entries: impl IntoIterator<Item = PathMaterializationEntry>) -> Self {
+        Self {
+            schema: PATH_MATERIALIZATION_PLAN_SCHEMA.to_string(),
+            entries: entries.into_iter().collect(),
+        }
+    }
+
+    pub fn non_empty(entries: impl IntoIterator<Item = PathMaterializationEntry>) -> Option<Self> {
+        let plan = Self::new(entries);
+        if plan.entries.is_empty() {
+            None
+        } else {
+            Some(plan)
+        }
+    }
+
+    pub fn projection_entries(&self) -> Vec<PathMaterializationProjection> {
+        self.entries
+            .iter()
+            .map(PathMaterializationProjection::from)
+            .collect()
+    }
+
+    pub fn path_remaps(&self) -> Vec<PathMaterializationPathRemap> {
+        self.entries
+            .iter()
+            .filter_map(PathMaterializationPathRemap::from_entry)
+            .collect()
+    }
+
+    pub fn mapping_ref(&self) -> Option<&'static str> {
+        (!self.entries.is_empty()).then_some("path_materialization_plan")
+    }
+
+    pub fn projection(&self) -> PathMaterializationPlanProjection {
+        PathMaterializationPlanProjection {
+            schema: self.schema.clone(),
+            entries: self.projection_entries(),
+            path_remaps: self.path_remaps(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PathMaterializationEntry {
+    pub role: String,
+    pub owner: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_path: Option<String>,
+    pub remote_path: String,
+    pub materialization_mode: String,
+    pub validation_status: String,
+}
+
+impl PathMaterializationEntry {
+    pub fn new(
+        role: impl Into<String>,
+        owner: impl Into<String>,
+        local_path: Option<String>,
+        remote_path: impl Into<String>,
+        materialization_mode: impl Into<String>,
+        validation_status: impl Into<String>,
+    ) -> Self {
+        Self {
+            role: role.into(),
+            owner: owner.into(),
+            local_path,
+            remote_path: remote_path.into(),
+            materialization_mode: materialization_mode.into(),
+            validation_status: validation_status.into(),
+        }
+    }
+
+    pub fn with_mode(
+        role: impl Into<String>,
+        owner: impl Into<String>,
+        local_path: Option<String>,
+        remote_path: impl Into<String>,
+        materialization_mode: PathMaterializationMode,
+        validation_status: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            role,
+            owner,
+            local_path,
+            remote_path,
+            materialization_mode.to_string(),
+            validation_status,
+        )
+    }
+
+    pub fn required_existing_remote(remote_path: impl Into<String>) -> Self {
+        Self::with_mode(
+            PATH_MATERIALIZATION_ROLE_REQUIRED_PATH,
+            PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_REQUIRE_PATHS,
+            None,
+            remote_path,
+            PathMaterializationMode::ExistingRemote,
+            PATH_MATERIALIZATION_STATUS_VALIDATED,
+        )
+    }
+
+    pub fn primary_workspace_materialized(
+        owner: impl Into<String>,
+        local_path: Option<String>,
+        remote_path: impl Into<String>,
+        materialization_mode: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            PATH_MATERIALIZATION_ROLE_PRIMARY_WORKSPACE,
+            owner,
+            local_path,
+            remote_path,
+            materialization_mode,
+            PATH_MATERIALIZATION_STATUS_MATERIALIZED,
+        )
+    }
+
+    pub fn primary_workspace_existing_remote(remote_path: impl Into<String>) -> Self {
+        Self::new(
+            PATH_MATERIALIZATION_ROLE_PRIMARY_WORKSPACE,
+            PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
+            None,
+            remote_path,
+            PATH_MATERIALIZATION_MODE_EXISTING_REMOTE,
+            PATH_MATERIALIZATION_STATUS_VALIDATED,
+        )
+    }
+
+    pub fn mode(&self) -> Option<PathMaterializationMode> {
+        PathMaterializationMode::from_str(&self.materialization_mode).ok()
+    }
+}
+
+impl From<&PathMaterializationEntry> for PathMaterializationProjection {
+    fn from(entry: &PathMaterializationEntry) -> Self {
+        Self {
+            role: entry.role.clone(),
+            owner: entry.owner.clone(),
+            local_path: entry.local_path.clone(),
+            remote_path: entry.remote_path.clone(),
+            materialization_mode: entry.materialization_mode.clone(),
+            validation_status: entry.validation_status.clone(),
+        }
+    }
+}
+
+impl PathMaterializationPathRemap {
+    pub(crate) fn from_entry(entry: &PathMaterializationEntry) -> Option<Self> {
+        let local_path = entry.local_path.as_deref()?.trim();
+        let remote_path = entry.remote_path.trim();
+        if local_path.is_empty() || remote_path.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            local_path: local_path.to_string(),
+            remote_path: remote_path.to_string(),
+        })
+    }
+}

--- a/src/core/runner_execution_envelope.rs
+++ b/src/core/runner_execution_envelope.rs
@@ -14,55 +14,22 @@ pub const RUNNER_EXECUTION_ENVELOPE_SCHEMA: &str = "homeboy/runner-execution-env
 pub const RUNNER_EXECUTION_RECORD_SCHEMA: &str = "homeboy/runner-execution-record/v1";
 pub const ORCHESTRATION_TARGET_PROVENANCE_SCHEMA: &str =
     "homeboy/orchestration-target-provenance/v1";
-pub const PATH_MATERIALIZATION_PLAN_SCHEMA: &str = "homeboy/path-materialization-plan/v1";
-pub const PATH_MATERIALIZATION_MODE_EXISTING_REMOTE: &str = "existing_remote";
-pub const PATH_MATERIALIZATION_MODE_GIT: &str = "git";
-pub const PATH_MATERIALIZATION_MODE_SNAPSHOT: &str = "snapshot";
-pub const PATH_MATERIALIZATION_ROLE_PRIMARY_WORKSPACE: &str = "primary_workspace";
-pub const PATH_MATERIALIZATION_ROLE_REQUIRED_PATH: &str = "required_path";
-pub const PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT: &str =
-    "runner_exec.source_snapshot";
-pub const PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_REQUIRE_PATHS: &str = "runner_exec.require_paths";
-pub const PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT: &str = "lab.execution_context";
-pub const PATH_MATERIALIZATION_OWNER_LAB_PROVIDER_CONFIG: &str = "lab.provider_config";
-pub const PATH_MATERIALIZATION_STATUS_MATERIALIZED: &str = "materialized";
-pub const PATH_MATERIALIZATION_STATUS_VALIDATED: &str = "validated";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PathMaterializationMode {
-    ExistingRemote,
-    Git,
-    Snapshot,
-}
-
-impl PathMaterializationMode {
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::ExistingRemote => PATH_MATERIALIZATION_MODE_EXISTING_REMOTE,
-            Self::Git => PATH_MATERIALIZATION_MODE_GIT,
-            Self::Snapshot => PATH_MATERIALIZATION_MODE_SNAPSHOT,
-        }
-    }
-}
-
-impl fmt::Display for PathMaterializationMode {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(self.as_str())
-    }
-}
-
-impl FromStr for PathMaterializationMode {
-    type Err = ();
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            PATH_MATERIALIZATION_MODE_EXISTING_REMOTE => Ok(Self::ExistingRemote),
-            PATH_MATERIALIZATION_MODE_GIT => Ok(Self::Git),
-            PATH_MATERIALIZATION_MODE_SNAPSHOT => Ok(Self::Snapshot),
-            _ => Err(()),
-        }
-    }
-}
+// Path materialization types live in the leaf `core::path_materialization`
+// module so the lab-contract type layer can hold a `PathMaterializationPlan`
+// field without pulling in this envelope's runner machinery. Re-exported here to
+// keep existing `runner_execution_envelope::PathMaterialization*` call sites stable.
+pub use crate::core::path_materialization::{
+    PathMaterializationEntry, PathMaterializationMode, PathMaterializationPathRemap,
+    PathMaterializationPlan, PathMaterializationPlanProjection, PathMaterializationProjection,
+    PATH_MATERIALIZATION_MODE_EXISTING_REMOTE, PATH_MATERIALIZATION_MODE_GIT,
+    PATH_MATERIALIZATION_MODE_SNAPSHOT, PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
+    PATH_MATERIALIZATION_OWNER_LAB_PROVIDER_CONFIG,
+    PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_REQUIRE_PATHS,
+    PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT, PATH_MATERIALIZATION_PLAN_SCHEMA,
+    PATH_MATERIALIZATION_ROLE_PRIMARY_WORKSPACE, PATH_MATERIALIZATION_ROLE_REQUIRED_PATH,
+    PATH_MATERIALIZATION_STATUS_MATERIALIZED, PATH_MATERIALIZATION_STATUS_VALIDATED,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RunnerExecutionEnvelope {
@@ -184,39 +151,6 @@ pub struct RunnerExecutionProjection {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct PathMaterializationProjection {
-    pub role: String,
-    pub owner: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub local_path: Option<String>,
-    pub remote_path: String,
-    pub materialization_mode: String,
-    pub validation_status: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct PathMaterializationPlanProjection {
-    pub schema: String,
-    pub entries: Vec<PathMaterializationProjection>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub path_remaps: Vec<PathMaterializationPathRemap>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct PathMaterializationPathRemap {
-    pub local_path: String,
-    pub remote_path: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct PathMaterializationPlan {
-    #[serde(default = "path_materialization_plan_schema")]
-    pub schema: String,
-    pub entries: Vec<PathMaterializationEntry>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OrchestrationTargetProvenance {
     #[serde(default = "orchestration_target_provenance_schema")]
     pub schema: String,
@@ -297,142 +231,6 @@ impl OrchestrationTargetProvenance {
     pub fn with_extensions(mut self, extensions: Vec<ExtensionProvenance>) -> Self {
         self.extensions = extensions;
         self
-    }
-}
-
-impl PathMaterializationPlan {
-    pub fn new(entries: impl IntoIterator<Item = PathMaterializationEntry>) -> Self {
-        Self {
-            schema: PATH_MATERIALIZATION_PLAN_SCHEMA.to_string(),
-            entries: entries.into_iter().collect(),
-        }
-    }
-
-    pub fn non_empty(entries: impl IntoIterator<Item = PathMaterializationEntry>) -> Option<Self> {
-        let plan = Self::new(entries);
-        if plan.entries.is_empty() {
-            None
-        } else {
-            Some(plan)
-        }
-    }
-
-    pub fn projection_entries(&self) -> Vec<PathMaterializationProjection> {
-        self.entries
-            .iter()
-            .map(PathMaterializationProjection::from)
-            .collect()
-    }
-
-    pub fn path_remaps(&self) -> Vec<PathMaterializationPathRemap> {
-        self.entries
-            .iter()
-            .filter_map(PathMaterializationPathRemap::from_entry)
-            .collect()
-    }
-
-    pub fn mapping_ref(&self) -> Option<&'static str> {
-        (!self.entries.is_empty()).then_some("path_materialization_plan")
-    }
-
-    pub fn projection(&self) -> PathMaterializationPlanProjection {
-        PathMaterializationPlanProjection {
-            schema: self.schema.clone(),
-            entries: self.projection_entries(),
-            path_remaps: self.path_remaps(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct PathMaterializationEntry {
-    pub role: String,
-    pub owner: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub local_path: Option<String>,
-    pub remote_path: String,
-    pub materialization_mode: String,
-    pub validation_status: String,
-}
-
-impl PathMaterializationEntry {
-    pub fn new(
-        role: impl Into<String>,
-        owner: impl Into<String>,
-        local_path: Option<String>,
-        remote_path: impl Into<String>,
-        materialization_mode: impl Into<String>,
-        validation_status: impl Into<String>,
-    ) -> Self {
-        Self {
-            role: role.into(),
-            owner: owner.into(),
-            local_path,
-            remote_path: remote_path.into(),
-            materialization_mode: materialization_mode.into(),
-            validation_status: validation_status.into(),
-        }
-    }
-
-    pub fn with_mode(
-        role: impl Into<String>,
-        owner: impl Into<String>,
-        local_path: Option<String>,
-        remote_path: impl Into<String>,
-        materialization_mode: PathMaterializationMode,
-        validation_status: impl Into<String>,
-    ) -> Self {
-        Self::new(
-            role,
-            owner,
-            local_path,
-            remote_path,
-            materialization_mode.to_string(),
-            validation_status,
-        )
-    }
-
-    pub fn required_existing_remote(remote_path: impl Into<String>) -> Self {
-        Self::with_mode(
-            PATH_MATERIALIZATION_ROLE_REQUIRED_PATH,
-            PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_REQUIRE_PATHS,
-            None,
-            remote_path,
-            PathMaterializationMode::ExistingRemote,
-            PATH_MATERIALIZATION_STATUS_VALIDATED,
-        )
-    }
-
-    pub fn primary_workspace_materialized(
-        owner: impl Into<String>,
-        local_path: Option<String>,
-        remote_path: impl Into<String>,
-        materialization_mode: impl Into<String>,
-    ) -> Self {
-        Self::new(
-            PATH_MATERIALIZATION_ROLE_PRIMARY_WORKSPACE,
-            owner,
-            local_path,
-            remote_path,
-            materialization_mode,
-            PATH_MATERIALIZATION_STATUS_MATERIALIZED,
-        )
-    }
-
-    pub fn primary_workspace_existing_remote(remote_path: impl Into<String>) -> Self {
-        Self::new(
-            PATH_MATERIALIZATION_ROLE_PRIMARY_WORKSPACE,
-            PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
-            None,
-            remote_path,
-            PATH_MATERIALIZATION_MODE_EXISTING_REMOTE,
-            PATH_MATERIALIZATION_STATUS_VALIDATED,
-        )
-    }
-
-    pub fn mode(&self) -> Option<PathMaterializationMode> {
-        PathMaterializationMode::from_str(&self.materialization_mode).ok()
     }
 }
 
@@ -597,34 +395,6 @@ impl RunnerExecutionRecord {
             artifact_refs: self.artifact_refs.clone(),
             next_actions: self.next_actions.clone(),
         }
-    }
-}
-
-impl From<&PathMaterializationEntry> for PathMaterializationProjection {
-    fn from(entry: &PathMaterializationEntry) -> Self {
-        Self {
-            role: entry.role.clone(),
-            owner: entry.owner.clone(),
-            local_path: entry.local_path.clone(),
-            remote_path: entry.remote_path.clone(),
-            materialization_mode: entry.materialization_mode.clone(),
-            validation_status: entry.validation_status.clone(),
-        }
-    }
-}
-
-impl PathMaterializationPathRemap {
-    fn from_entry(entry: &PathMaterializationEntry) -> Option<Self> {
-        let local_path = entry.local_path.as_deref()?.trim();
-        let remote_path = entry.remote_path.trim();
-        if local_path.is_empty() || remote_path.is_empty() {
-            return None;
-        }
-
-        Some(Self {
-            local_path: local_path.to_string(),
-            remote_path: remote_path.to_string(),
-        })
     }
 }
 
@@ -887,10 +657,6 @@ fn orchestration_target_provenance_schema() -> String {
     ORCHESTRATION_TARGET_PROVENANCE_SCHEMA.to_string()
 }
 
-fn path_materialization_plan_schema() -> String {
-    PATH_MATERIALIZATION_PLAN_SCHEMA.to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use serde_json::json;
@@ -984,7 +750,7 @@ mod tests {
                 url: None,
             }])
             .with_path_materialization_plan(Some(PathMaterializationPlan {
-                schema: path_materialization_plan_schema(),
+                schema: PATH_MATERIALIZATION_PLAN_SCHEMA.to_string(),
                 entries: vec![PathMaterializationEntry::primary_workspace_materialized(
                     PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT,
                     Some("/local/project".to_string()),


### PR DESCRIPTION
## Summary
Recovers three cycle-break cuts that were **stranded by stacked-PR merges**. PRs #8301, #8305, #8310 each merged into their *parent* stacked branch rather than `main`; when the base branches were deleted after #8295 landed, their content never reached `main`. GitHub marks them "merged" (they did — into now-deleted branches), but the changes were lost.

This cherry-picks the three original squash commits onto current `main`:

- **#8301** — relocate `ResolvedAgentTaskProviderPolicy` to leaf `agent_task_schedule` module
- **#8305** — move handoff→execution-record projection into the commands layer (removes `run_outcome_envelope` + 4 runner-exec types from the lab-contract layer)
- **#8310** — extract `PathMaterialization*` cluster into leaf `core::path_materialization` module

Only **#8295** (the `core::artifacts` cut) actually reached main earlier; this restores the rest.

## Result
All three `command_contract/lab/` files depend only on leaf / near-leaf modules again:
| file | core deps |
|---|---|
| `types.rs` | none |
| `workload.rs` | `agent_task_schedule` (leaf), `notification_route` (→`error` crate), `secret_env_plan` (→`redaction` crate) |
| `handoff.rs` | `path_materialization` (leaf) |

The deep subsystem couplings (artifacts hub, agent-task service, runner-exec envelope) that fed the `core ⇄ command_contract` cycle stay eliminated.

## Verification
- Cherry-picked cleanly onto current main (no conflicts; main's intervening fuzz/observation refactors don't overlap).
- `cargo check --lib` clean rebuild (22s, zero errors) after clearing fingerprint.

## Note
Avoid stacked base branches for the remainder of this series — target `main` directly and rebase, to prevent re-stranding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)