### PR TITLE
Fix agent-task promotion recovery state

### DIFF
--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -8,7 +8,8 @@ use homeboy::core::agent_tasks::finalization::{
 };
 use homeboy::core::agent_tasks::lifecycle as agent_task_lifecycle;
 use homeboy::core::agent_tasks::promotion::{
-    promote, AgentTaskPromotionOptions, AgentTaskPromotionReport, AgentTaskPromotionStatus,
+    promote, resume_promoted_patch, AgentTaskPromotionOptions, AgentTaskPromotionReport,
+    AgentTaskPromotionStatus,
 };
 use homeboy::core::agent_tasks::provider::{
     AgentTaskExecutorProvider, AgentTaskProviderCatalog, ExtensionProviderAgentTaskExecutor,
@@ -204,7 +205,7 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
         .ok()
         .map(|record| record.run_id);
     let (raw, source_path) = read_promotion_source(&args.source)?;
-    let report = promote(AgentTaskPromotionOptions {
+    let promotion_options = AgentTaskPromotionOptions {
         source: raw,
         source_run_id: source_run_id.clone(),
         source_path,
@@ -221,7 +222,34 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
             argv: args.provider_argv,
             ..Default::default()
         }),
-    })?;
+    };
+    let previous_promotion = source_run_id.as_ref().and_then(|run_id| {
+        agent_task_lifecycle::status(run_id)
+            .ok()
+            .and_then(|record| record.metadata.get("latest_promotion").cloned())
+    });
+    let report = if let Some(previous) = previous_promotion
+        .filter(|previous| previous.get("status").and_then(Value::as_str) == Some("gate_failed"))
+    {
+        let target_path = previous
+            .pointer("/target/path")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                homeboy::core::Error::validation_invalid_argument(
+                    "promotion",
+                    "gate-failed promotion has no materialized target path to resume",
+                    None,
+                    None,
+                )
+            })?;
+        resume_promoted_patch(
+            promotion_options,
+            std::path::Path::new(target_path),
+            &previous,
+        )?
+    } else {
+        promote(promotion_options)?
+    };
     let exit_code = if report.status == AgentTaskPromotionStatus::GateFailed {
         1
     } else {
@@ -230,8 +258,17 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
     let mut value = serde_json::to_value(&report).unwrap_or(Value::Null);
     value["handoff"] = promotion_handoff(&report, &to_worktree);
     if let Some(run_id) = source_run_id.filter(|_| !args.dry_run) {
-        let record =
-            agent_task_lifecycle::record_promotion(&run_id, promotion_status_event(&report))?;
+        // Finalization consumes the complete report as its durable gate proof.
+        // A status-only projection cannot prove the candidate or its gates.
+        let record = agent_task_lifecycle::record_promotion(
+            &run_id,
+            serde_json::to_value(&report).map_err(|error| {
+                homeboy::core::Error::internal_json(
+                    error.to_string(),
+                    Some("serialize agent-task promotion report".to_string()),
+                )
+            })?,
+        )?;
         value["recorded_on_run"] = serde_json::json!({
             "run_id": record.run_id,
             "metadata_key": "latest_promotion",
@@ -733,21 +770,6 @@ fn promotion_handoff(report: &AgentTaskPromotionReport, to_worktree: &str) -> Va
             "homeboy agent-task finalize-pr --run-id <run-id> --path {finalize_path} --title <title> --commit-message <message>"
         ),
         "next_actions": next_actions
-    })
-}
-
-fn promotion_status_event(report: &AgentTaskPromotionReport) -> Value {
-    serde_json::json!({
-        "schema": "homeboy/agent-task-promotion-status/v1",
-        "status": report.status,
-        "source_run_id": report.source.run_id,
-        "source_task_id": report.source.task_id,
-        "patch_artifact_id": report.patch_artifact.id,
-        "patch_artifact_path": report.patch_artifact.path,
-        "to_worktree": report.to_worktree,
-        "target": report.target,
-        "changed_files": report.changed_files,
-        "operator_notification": report.operator_notification,
     })
 }
 

--- a/src/core/agent_task_finalization.rs
+++ b/src/core/agent_task_finalization.rs
@@ -388,6 +388,7 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     mut options: AgentTaskPrFinalizationOptions,
     backend: &mut B,
 ) -> Result<AgentTaskPrFinalizationReport> {
+    let mut durable_changed_files = Vec::new();
     if !options.manual_finalization {
         let lifecycle = backend.hydrate_run(&options.run_id)?;
         validate_durable_publication_eligibility(&lifecycle)?;
@@ -401,6 +402,7 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
             ));
         }
         validate_gate_proof_binding(&gate_proof, &options)?;
+        durable_changed_files = gate_proof.promotion.changed_files.clone();
         options.normalized_gate_results = gate_proof.promotion.gate_results;
         if options.normalized_gate_results.is_empty() {
             return Err(Error::validation_invalid_argument(
@@ -432,14 +434,21 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
         .unwrap_or_else(|| backend.current_branch(&options.path))?;
     refuse_protected_head(&head, &options.protected_branches)?;
 
-    let mut changed_files = if options.changed_files.is_empty() {
+    let mut working_changed_files = if options.changed_files.is_empty() {
         backend.changed_files(&options.path)?
     } else {
         options.changed_files.clone()
     };
+    working_changed_files.sort();
+    working_changed_files.dedup();
+    let mut changed_files = if working_changed_files.is_empty() && !options.manual_finalization {
+        durable_changed_files
+    } else {
+        working_changed_files.clone()
+    };
     changed_files.sort();
     changed_files.dedup();
-    let has_uncommitted_changes = !changed_files.is_empty();
+    let has_uncommitted_changes = !working_changed_files.is_empty();
     if changed_files.is_empty() && options.manual_finalization {
         changed_files = backend.changed_files_since(&options.path, &options.base)?;
         changed_files.sort();
@@ -469,6 +478,14 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
         backend.commit_all(&options.path, &options.commit_message)?;
         backend.push_branch(&options.path, &head)?;
     } else if !backend.branch_is_published(&options.path, &head)? {
+        if !options.manual_finalization {
+            return Err(Error::validation_invalid_argument(
+                "path",
+                "clean recovered candidate must exactly match its remote branch before finalization",
+                None,
+                None,
+            ));
+        }
         backend.push_branch(&options.path, &head)?;
     }
     let body = render_review_dossier(&options.review_dossier, &options.review_profile);
@@ -1398,6 +1415,28 @@ mod tests {
             }
         )
         .is_err());
+    }
+
+    #[test]
+    fn durable_finalization_publishes_clean_synced_recovered_candidate() {
+        let mut gate_proof = successful_gate_proof();
+        gate_proof.promotion.changed_files = vec!["src/lib.rs".to_string()];
+        let mut backend = MockBackend {
+            lifecycle: Some(successful_lifecycle("openai/gpt-5.6-terra")),
+            gate_proof: Some(gate_proof),
+            branch_published: true,
+            ..Default::default()
+        };
+        let mut finalization_options = options();
+        finalization_options.manual_finalization = false;
+
+        let report = finalize_pr_with_backend(finalization_options, &mut backend)
+            .expect("clean synced candidate publishes");
+
+        assert_eq!(report.status, "review_ready");
+        assert_eq!(report.changed_files, vec!["src/lib.rs"]);
+        assert!(!backend.committed && !backend.pushed);
+        assert!(backend.created);
     }
 
     #[test]

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -1369,6 +1369,59 @@ fn record_promotion_persists_latest_event_on_run_metadata() {
 }
 
 #[test]
+fn corrected_promotion_replaces_gate_failed_latest_proof() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        let run_id = "run-corrected-promotion";
+        submit_plan(&plan, Some(run_id)).expect("submitted");
+
+        let gate_failed = json!({
+            "schema": "homeboy/agent-task-promotion-report/v1",
+            "status": "gate_failed",
+            "source": { "kind": "aggregate", "task_id": "task-a", "run_id": run_id },
+            "to_worktree": "homeboy@fix-8307",
+            "target": { "worktree": "homeboy@fix-8307", "path": "/repo" },
+            "patch_artifact": { "id": "first.patch", "kind": "patch", "path": "first.patch" },
+            "changed_files": ["src/lib.rs"],
+            "gate_results": [{ "id": "test", "name": "cargo test", "kind": "command", "status": "failed" }],
+            "provenance": { "candidate": { "kind": "git", "fingerprint": { "schema": "homeboy/agent-task-candidate-fingerprint/v1", "target_path": "/repo", "head": "base", "base": "base", "changed_files": ["src/lib.rs"], "sha256": "first" } } },
+            "operator_notification": { "status": "blocked", "message": "gates failed" }
+        });
+        let corrected = json!({
+            "schema": "homeboy/agent-task-promotion-report/v1",
+            "status": "applied",
+            "source": { "kind": "aggregate", "task_id": "task-a", "run_id": run_id },
+            "to_worktree": "homeboy@fix-8307",
+            "target": { "worktree": "homeboy@fix-8307", "path": "/repo" },
+            "patch_artifact": { "id": "corrected.patch", "kind": "patch", "path": "corrected.patch" },
+            "changed_files": ["src/lib.rs"],
+            "gate_results": [{ "id": "test", "name": "cargo test", "kind": "command", "status": "passed" }],
+            "provenance": { "candidate": { "kind": "git", "fingerprint": { "schema": "homeboy/agent-task-candidate-fingerprint/v1", "target_path": "/repo", "head": "base", "base": "base", "changed_files": ["src/lib.rs"], "sha256": "corrected" } } },
+            "operator_notification": { "status": "completed", "message": "gates passed" }
+        });
+
+        record_promotion(run_id, gate_failed).expect("gate failure recorded");
+        let updated = record_promotion(run_id, corrected.clone()).expect("correction recorded");
+
+        let latest: crate::core::agent_task_promotion::AgentTaskPromotionReport =
+            serde_json::from_value(updated.metadata["latest_promotion"].clone())
+                .expect("latest promotion is finalization proof");
+        assert_eq!(
+            latest.status,
+            crate::core::agent_task_promotion::AgentTaskPromotionStatus::Applied
+        );
+        assert_eq!(latest.patch_artifact.id, "corrected.patch");
+        assert_eq!(
+            updated.metadata["promotions"]
+                .as_array()
+                .expect("history")
+                .len(),
+            2
+        );
+    });
+}
+
+#[test]
 fn pre_dispatch_failure_persists_failed_run_without_provider_handle() {
     with_isolated_home(|_| {
         let record = record_pre_dispatch_failure(AgentTaskPreDispatchFailure {

--- a/src/core/agent_task_promotion/mod.rs
+++ b/src/core/agent_task_promotion/mod.rs
@@ -22,6 +22,7 @@ pub use fingerprint::{
 };
 pub(crate) use patch::{normalize_promotion_patch, validate_artifact_content};
 pub use promote::promote;
+pub use promote::resume_promoted_patch;
 pub use types::{
     AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandCapture,
     AgentTaskPromotionCommandReport, AgentTaskPromotionNotification, AgentTaskPromotionOptions,

--- a/src/core/agent_task_promotion/promote.rs
+++ b/src/core/agent_task_promotion/promote.rs
@@ -23,9 +23,9 @@ use super::committed_changes::{committed_changes_patch, CommittedChangesPatch};
 use super::patch::write_normalized_patch;
 pub(crate) use super::patch::{normalize_promotion_patch, validate_artifact_content};
 use super::types::{
-    AgentTaskPromotionArtifactRef, AgentTaskPromotionNotification, AgentTaskPromotionOptions,
-    AgentTaskPromotionReport, AgentTaskPromotionSource, AgentTaskPromotionStatus,
-    AgentTaskPromotionTarget, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
+    AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandReport, AgentTaskPromotionNotification,
+    AgentTaskPromotionOptions, AgentTaskPromotionReport, AgentTaskPromotionSource,
+    AgentTaskPromotionStatus, AgentTaskPromotionTarget, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
 };
 
 mod gate_run;
@@ -48,6 +48,181 @@ pub fn promote(options: AgentTaskPromotionOptions) -> Result<AgentTaskPromotionR
                 "target_workspace": report.target.path,
             });
         }
+    }
+    Ok(report)
+}
+
+/// Rebuild a full proof for a clean candidate that was already applied before
+/// its deterministic gates failed. The reverse apply check proves the original
+/// artifact remains in the candidate before any gate result is trusted.
+pub fn resume_promoted_patch(
+    options: AgentTaskPromotionOptions,
+    target_path: &Path,
+    previous: &Value,
+) -> Result<AgentTaskPromotionReport> {
+    validate_resume_provenance(&options, target_path, previous)?;
+    let source_value: Value = serde_json::from_str(&options.source).map_err(|error| {
+        Error::validation_invalid_json(
+            error,
+            Some("agent-task promotion source".to_string()),
+            Some(options.source.clone()),
+        )
+    })?;
+    let (source_kind, outcome) = select_outcome(source_value, options.task_id.as_deref())?;
+    let artifact = select_patch_artifact(&outcome, options.artifact_id.as_deref())?;
+    let patch_path = resolve_artifact_path(&artifact, options.source_path.as_deref())?;
+    let patch = std::fs::read_to_string(&patch_path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("read patch artifact {}", patch_path.display())),
+        )
+    })?;
+    validate_artifact_content(&artifact, &patch)?;
+    let normalized_patch = normalize_promotion_patch(&patch, &options.to_worktree)?;
+    let command_evidence = vec![verify_patch_is_present(
+        target_path,
+        &normalized_patch.content,
+    )?];
+    let mut provider = ExternalPromotionWorkspaceProvider::from_options(&options);
+    let gates = run_promotion_gates(&options, &mut provider, target_path)?;
+    let target =
+        AgentTaskPromotionTarget::from_worktree(options.to_worktree.clone(), Some(target_path));
+    let candidate = if gates.status == AgentTaskPromotionStatus::Applied {
+        Some(crate::core::agent_task_promotion::candidate_fingerprint(
+            &target_path.display().to_string(),
+        )?)
+    } else {
+        None
+    };
+    let mut report = AgentTaskPromotionReport {
+        schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
+        status: gates.status,
+        source: promotion_source(&source_kind, &outcome, &options),
+        to_worktree: options.to_worktree,
+        target: target.clone(),
+        patch_artifact: AgentTaskPromotionArtifactRef {
+            id: artifact.id,
+            kind: artifact.kind,
+            path: patch_path.display().to_string(),
+            sha256: artifact.sha256,
+        },
+        changed_files: normalized_patch.changed_files,
+        command_evidence,
+        deterministic_gates: gates.deterministic_gates,
+        gate_results: gates.gate_results,
+        provenance: json!({
+            "source_schema": outcome.schema,
+            "artifact_metadata": artifact.metadata,
+            "worktree_path": target_path,
+            "dependencies_materialized": gates.dependencies_materialized,
+            "candidate": candidate,
+            "resumed_from_gate_failed_promotion": true,
+        }),
+        operator_notification: promotion_notification(gates.status, &target),
+    };
+    if let Some(provenance) = provider.provenance() {
+        report.provenance["worktree_provider"] = provenance.clone();
+    }
+    Ok(report)
+}
+
+fn validate_resume_provenance(
+    options: &AgentTaskPromotionOptions,
+    target_path: &Path,
+    previous: &Value,
+) -> Result<()> {
+    if previous.get("status").and_then(Value::as_str) != Some("gate_failed") {
+        return Err(Error::validation_invalid_argument(
+            "promotion",
+            "promotion resume requires a durable gate-failed promotion",
+            None,
+            None,
+        ));
+    }
+    let previous_run = previous
+        .get("source_run_id")
+        .and_then(Value::as_str)
+        .or_else(|| previous.pointer("/source/run_id").and_then(Value::as_str));
+    if previous_run != options.source_run_id.as_deref() {
+        return Err(Error::validation_invalid_argument(
+            "promotion",
+            "promotion resume source run does not match the durable gate-failed promotion",
+            None,
+            None,
+        ));
+    }
+    if previous.get("to_worktree").and_then(Value::as_str) != Some(options.to_worktree.as_str())
+        || previous.pointer("/target/worktree").and_then(Value::as_str)
+            != Some(options.to_worktree.as_str())
+        || previous.pointer("/target/path").and_then(Value::as_str)
+            != Some(target_path.to_string_lossy().as_ref())
+    {
+        return Err(Error::validation_invalid_argument(
+            "promotion",
+            "promotion resume target does not match the durable gate-failed promotion",
+            None,
+            None,
+        ));
+    }
+    let status = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(target_path)
+        .output()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    if !status.status.success() || !status.stdout.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "promotion resume requires a clean Git worktree",
+            Some(target_path.display().to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn verify_patch_is_present(
+    target_path: &Path,
+    patch: &str,
+) -> Result<AgentTaskPromotionCommandReport> {
+    use std::io::Write;
+
+    let mut child = std::process::Command::new("git")
+        .args(["apply", "--reverse", "--check", "-"])
+        .current_dir(target_path)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    child
+        .stdin
+        .as_mut()
+        .expect("piped stdin")
+        .write_all(patch.as_bytes())
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    let output = child
+        .wait_with_output()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    let report = AgentTaskPromotionCommandReport {
+        command: vec![
+            "git".to_string(),
+            "apply".to_string(),
+            "--reverse".to_string(),
+            "--check".to_string(),
+            "-".to_string(),
+        ],
+        exit_code: output.status.code().unwrap_or(1),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        capture: Default::default(),
+    };
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "promotion",
+            "promotion resume could not prove the recorded patch is present in the clean target",
+            None,
+            None,
+        ));
     }
     Ok(report)
 }

--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -12,8 +12,8 @@ use super::apply::{
     AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA, AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
 };
 use super::promote::{
-    normalize_promotion_patch, promote, promote_with_provider, select_patch_artifact,
-    validate_artifact_content,
+    normalize_promotion_patch, promote, promote_with_provider, resume_promoted_patch,
+    select_patch_artifact, validate_artifact_content,
 };
 use super::types::{
     AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandCapture,
@@ -1217,6 +1217,68 @@ fn promote_verification_failure_keeps_the_applied_target_recoverable() {
     assert_eq!(provider.apply_calls.len(), 1);
     assert_eq!(provider.verify_calls.len(), 1);
     assert_eq!(report.operator_notification.status, "blocked");
+}
+
+#[test]
+fn resume_promoted_patch_rebuilds_green_proof_for_clean_committed_candidate() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let target = temp.path().join("target");
+    std::fs::create_dir(&target).expect("target");
+    git(&target, &["init"]);
+    git(&target, &["config", "user.email", "test@example.com"]);
+    git(&target, &["config", "user.name", "Test"]);
+    std::fs::create_dir_all(target.join("src")).expect("src");
+    std::fs::write(target.join("src/lib.rs"), "old\n").expect("base");
+    git(&target, &["add", "."]);
+    git(&target, &["commit", "-m", "base"]);
+    std::fs::write(target.join("src/lib.rs"), "new\n").expect("apply candidate");
+    git(&target, &["add", "."]);
+    git(&target, &["commit", "-m", "candidate plus gate correction"]);
+    let (source_path, source) = write_patch_source(&temp);
+    let options = AgentTaskPromotionOptions {
+        source,
+        source_run_id: Some("run-8307".to_string()),
+        source_path: Some(source_path),
+        source_worktree_path: None,
+        base_ref: None,
+        task_base_sha: None,
+        to_worktree: "repo@fix-8307".to_string(),
+        task_id: None,
+        artifact_id: None,
+        dry_run: false,
+        gates: VerifyGateOptions {
+            verify: vec!["true".to_string()],
+            private_verify: Vec::new(),
+            private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+        },
+        provider_command: None,
+        provider_invocation: None,
+    };
+    let previous = serde_json::json!({
+        "schema": "homeboy/agent-task-promotion-status/v1",
+        "status": "gate_failed",
+        "source_run_id": "run-8307",
+        "to_worktree": "repo@fix-8307",
+        "target": { "worktree": "repo@fix-8307", "path": target },
+    });
+
+    let report = resume_promoted_patch(options, &target, &previous).expect("resume proof");
+
+    assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
+    assert_eq!(
+        report.command_evidence[0].command,
+        vec!["git", "apply", "--reverse", "--check", "-"]
+    );
+    assert_eq!(report.gate_results.len(), 1);
+    assert_eq!(
+        report.gate_results[0].status,
+        crate::core::gate::HomeboyGateStatus::Passed
+    );
+    assert_eq!(
+        report.provenance["resumed_from_gate_failed_promotion"],
+        true
+    );
+    assert!(report.provenance["candidate"].is_object());
 }
 
 #[test]

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -295,10 +295,10 @@ pub mod loop_definition {
 /// Promotion reports and entry point.
 pub mod promotion {
     pub use super::super::agent_task_promotion::{
-        promote, AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandReport,
-        AgentTaskPromotionNotification, AgentTaskPromotionOptions, AgentTaskPromotionReport,
-        AgentTaskPromotionSource, AgentTaskPromotionStatus, AgentTaskPromotionTarget,
-        AGENT_TASK_PROMOTION_REPORT_SCHEMA,
+        promote, resume_promoted_patch, AgentTaskPromotionArtifactRef,
+        AgentTaskPromotionCommandReport, AgentTaskPromotionNotification, AgentTaskPromotionOptions,
+        AgentTaskPromotionReport, AgentTaskPromotionSource, AgentTaskPromotionStatus,
+        AgentTaskPromotionTarget, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
     };
 }
 


### PR DESCRIPTION
## Summary

Make agent-task promotion and PR finalization resumable after a patch is applied but its first deterministic gate fails.

Promotion previously persisted a lossy `promotion-status/v1` projection as `latest_promotion`, while normal finalization requires the complete `promotion-report/v1` as durable gate and candidate proof. A corrected candidate could therefore be clean and pushed while finalization remained permanently blocked by an invalid durable record.

## What changed

- Persist the complete promotion report as the durable latest-promotion proof while retaining append-only promotion history.
- Resume a prior gate-failed promotion only when the source run and target match, the Git worktree is clean, and `git apply --reverse --check` proves the original patch is present.
- Rerun deterministic gates against the committed candidate and persist the rebuilt green report.
- Finalize a recovered clean candidate without recommitting it, using durable changed-file evidence and requiring its exact remote branch to match.
- Preserve idempotent PR create/update behavior and existing protected-branch, candidate-fingerprint, model, and gate checks.

## How to test

1. Run `cargo test --lib resume_promoted_patch_rebuilds_green_proof_for_clean_committed_candidate`.
2. Run `cargo test --lib corrected_promotion_replaces_gate_failed_latest_proof`.
3. Run `cargo test --lib core::agent_task_finalization::tests`.
4. Run `cargo test --lib commands::agent_task::tests::promotion_review`.
5. Run `cargo fmt --check`.
6. Run `git diff --check origin/main...HEAD`.

All commands pass. The finalization module runs 23 tests; the promotion-review module runs 6 tests.

## Compatibility

The durable `latest_promotion` value now stores the already-defined full promotion report instead of the lossy status projection. Historical gate-failed records are recovered only through explicit re-promotion with patch-presence and deterministic-gate proof; unrelated invalid records continue to fail closed.

Closes #8307.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Root-cause analysis, implementation, deterministic regression coverage, and rebase conflict reconciliation. Chris reviews and owns the change.
