### PR TITLE
Remove terminal legacy agent-task backfill

### DIFF
--- a/src/core/agent_task_finalization.rs
+++ b/src/core/agent_task_finalization.rs
@@ -1482,13 +1482,12 @@ mod tests {
             )
             .expect("terminal record");
             crate::core::agent_task_lifecycle::rewrite_record_for_test(&record.run_id, |record| {
-                record.lifecycle.provider_runtime[0].metadata = json!({
-                    "evidence_source": "canonical_executor_outcome"
-                });
+                record.lifecycle.provider_runtime.clear();
             })
             .expect("obsolete record persisted");
             let before = crate::core::agent_task_lifecycle::status(&record.run_id)
                 .expect("obsolete record loads");
+            assert!(before.lifecycle.provider_runtime.is_empty());
 
             let mut backend = MockBackend {
                 hydrate_run_id: Some(record.run_id.clone()),
@@ -1510,6 +1509,8 @@ mod tests {
             );
             assert_eq!(before, after);
             assert!(!backend.committed);
+            assert!(!backend.pushed);
+            assert!(!backend.created);
         });
     }
 

--- a/src/core/agent_task_finalization.rs
+++ b/src/core/agent_task_finalization.rs
@@ -1450,62 +1450,65 @@ mod tests {
     }
 
     #[test]
-    fn durable_finalization_accepts_status_backfilled_legacy_executor_evidence() {
+    fn durable_finalization_rejects_model_less_terminal_record_without_mutation() {
         crate::test_support::with_isolated_home(|_| {
-            let run_id = legacy_generic_terminal_run("cook-3678", false);
+            let plan = AgentTaskPlan::new(
+                "obsolete-generic-plan",
+                vec![durable_task(
+                    "task",
+                    "opencode",
+                    Some("openai/gpt-5.6-terra"),
+                )],
+            );
+            let aggregate = AgentTaskAggregate {
+                schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+                plan_id: plan.plan_id.clone(),
+                status: AgentTaskAggregateStatus::Succeeded,
+                totals: AgentTaskAggregateTotals {
+                    succeeded: 1,
+                    ..Default::default()
+                },
+                outcomes: vec![durable_succeeded_outcome("task", serde_json::Value::Null)],
+                events: Vec::new(),
+                artifact_lineage: Vec::new(),
+                child_runs: Vec::new(),
+                artifact_bindings: Vec::new(),
+                queue: AgentTaskQueueStatus::default(),
+            };
+            let record = crate::core::agent_task_lifecycle::record_completed_run(
+                &plan,
+                &aggregate,
+                Some("model-less-terminal-record"),
+            )
+            .expect("terminal record");
+            crate::core::agent_task_lifecycle::rewrite_record_for_test(&record.run_id, |record| {
+                record.lifecycle.provider_runtime[0].metadata = json!({
+                    "evidence_source": "canonical_executor_outcome"
+                });
+            })
+            .expect("obsolete record persisted");
+            let before = crate::core::agent_task_lifecycle::status(&record.run_id)
+                .expect("obsolete record loads");
+
             let mut backend = MockBackend {
-                changed_files: vec!["src/lib.rs".to_string()],
-                hydrate_run_id: Some(run_id),
+                hydrate_run_id: Some(record.run_id.clone()),
                 gate_proof: Some(successful_gate_proof()),
                 ..Default::default()
             };
             let mut finalization_options = options();
-            finalization_options.manual_finalization = false;
-
-            let report = finalize_pr_with_backend(finalization_options, &mut backend)
-                .expect("status-backfilled run finalizes");
-
-            assert_eq!(report.pr_action, "created");
-            assert!(backend.committed && backend.pushed && backend.created);
-        });
-    }
-
-    #[test]
-    fn durable_finalization_fails_closed_when_status_backfill_does_not_persist() {
-        crate::test_support::with_isolated_home(|_| {
-            let run_id = legacy_generic_terminal_run("failed-backfill-finalization", false);
-            crate::core::agent_task_lifecycle::fail_next_record_write_for_test();
-            let mut backend = MockBackend {
-                hydrate_run_id: Some(run_id.clone()),
-                gate_proof: Some(successful_gate_proof()),
-                ..Default::default()
-            };
-            let mut finalization_options = options();
-            finalization_options.run_id = run_id;
+            finalization_options.run_id = record.run_id.clone();
             finalization_options.manual_finalization = false;
 
             let error = finalize_pr_with_backend(finalization_options, &mut backend)
-                .expect_err("unpersisted runtime evidence cannot finalize");
+                .expect_err("model-less terminal record is rejected");
+            let after = crate::core::agent_task_lifecycle::status(&record.run_id)
+                .expect("obsolete record remains readable");
 
-            assert_eq!(error.code, crate::core::ErrorCode::InternalIoError);
-            assert!(!backend.committed);
-        });
-    }
-
-    #[test]
-    fn durable_finalization_rejects_status_backfilled_timed_out_evidence() {
-        crate::test_support::with_isolated_home(|_| {
-            let run_id = legacy_generic_terminal_run("timed-out-backfill-finalization", true);
-            let mut backend = MockBackend {
-                hydrate_run_id: Some(run_id.clone()),
-                gate_proof: Some(successful_gate_proof()),
-                ..Default::default()
-            };
-            let mut finalization_options = options();
-            finalization_options.run_id = run_id;
-            finalization_options.manual_finalization = false;
-
-            assert!(finalize_pr_with_backend(finalization_options, &mut backend).is_err());
+            assert_eq!(
+                error.code,
+                crate::core::ErrorCode::ValidationInvalidArgument
+            );
+            assert_eq!(before, after);
             assert!(!backend.committed);
         });
     }
@@ -1854,51 +1857,6 @@ mod tests {
             follow_up: None,
             metadata,
         }
-    }
-
-    fn legacy_generic_terminal_run(run_id: &str, timed_out: bool) -> String {
-        let plan = AgentTaskPlan::new(
-            "legacy-generic-plan",
-            vec![durable_task(
-                "task",
-                "opencode",
-                Some("openai/gpt-5.6-terra"),
-            )],
-        );
-        let mut aggregate = AgentTaskAggregate {
-            schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
-            plan_id: plan.plan_id.clone(),
-            status: AgentTaskAggregateStatus::Succeeded,
-            totals: AgentTaskAggregateTotals {
-                succeeded: 1,
-                ..Default::default()
-            },
-            outcomes: vec![durable_succeeded_outcome("task", serde_json::Value::Null)],
-            events: Vec::new(),
-            artifact_lineage: Vec::new(),
-            child_runs: Vec::new(),
-            artifact_bindings: Vec::new(),
-            queue: AgentTaskQueueStatus::default(),
-        };
-        if timed_out {
-            aggregate.status = AgentTaskAggregateStatus::CandidateRecoverable;
-            aggregate.totals = AgentTaskAggregateTotals {
-                candidate_recoverable: 1,
-                ..Default::default()
-            };
-            aggregate.outcomes[0].status = AgentTaskOutcomeStatus::CandidateRecoverable;
-        }
-        let record = crate::core::agent_task_lifecycle::record_completed_run(
-            &plan,
-            &aggregate,
-            Some(run_id),
-        )
-        .expect("terminal record");
-        crate::core::agent_task_lifecycle::rewrite_record_for_test(&record.run_id, |record| {
-            record.lifecycle.provider_runtime.clear();
-        })
-        .expect("legacy lifecycle persisted");
-        record.run_id
     }
 
     fn successful_gate_proof() -> AgentTaskPrDurableGateProof {

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -469,15 +469,6 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
                 record = reconciled;
             }
         }
-    } else if let (Ok(aggregate), Ok(plan)) = (
-        store::read_aggregate(&record.run_id),
-        store::read_plan_path(&record.plan_path),
-    ) {
-        if let Some(reconciled) = store::mutate_record(&record.run_id, |latest| {
-            backfill_terminal_generic_runtime_evidence(latest, &plan, &aggregate)
-        })? {
-            record = reconciled;
-        }
     }
     let before_liveness_reconciliation = record.clone();
     reconcile_runner_job_state(&mut record)?;
@@ -1719,9 +1710,4 @@ pub fn record_promotion(run_id: &str, promotion: Value) -> Result<AgentTaskRunRe
         true
     })?;
     Ok(record.expect("promotion mutation always changes the record"))
-}
-
-#[cfg(test)]
-pub(crate) fn fail_next_record_write_for_test() {
-    store::fail_next_record_write_for_test();
 }

--- a/src/core/agent_task_lifecycle/lifecycle_record_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_record_ops.rs
@@ -107,57 +107,6 @@ pub(crate) fn update_lifecycle_from_record(record: &mut AgentTaskRunRecord, plan
     };
 }
 
-/// Backfill only generic executor evidence that older terminal records could
-/// derive from their durable plan and aggregate. Existing lifecycle entries
-/// are authoritative and must not be reprojected during a status read.
-pub(crate) fn backfill_terminal_generic_runtime_evidence(
-    record: &mut AgentTaskRunRecord,
-    plan: &AgentTaskPlan,
-    aggregate: &AgentTaskAggregate,
-) -> bool {
-    let mut missing = tasks_for_aggregate(plan, aggregate)
-        .into_iter()
-        .filter(|task| {
-            !record
-                .provider_handles
-                .iter()
-                .any(|handle| handle.task_id == task.task_id)
-                && !record
-                    .lifecycle
-                    .provider_runtime
-                    .iter()
-                    .any(|runtime| runtime.task_id == task.task_id)
-                && !matches!(
-                    task.state,
-                    AgentTaskState::Queued | AgentTaskState::Blocked | AgentTaskState::Skipped
-                )
-        })
-        .map(|task| ProviderRuntimeLifecycle {
-            task_id: task.task_id,
-            backend: task.backend.clone(),
-            state: provider_runtime_state_for_task_state(Some(task.state)),
-            stream_uri: None,
-            external_runtime_ids: Vec::new(),
-            metadata: json!({
-                "evidence_source": "canonical_executor_outcome",
-                "executor": {
-                    "backend": task.backend,
-                    "selector": task.selector,
-                    "model": task.model,
-                },
-                "model": task.model,
-            }),
-        })
-        .collect::<Vec<_>>();
-
-    if missing.is_empty() {
-        return false;
-    }
-
-    record.lifecycle.provider_runtime.append(&mut missing);
-    true
-}
-
 pub(crate) fn cleanup_lifecycle_for_plan(
     plan: &AgentTaskPlan,
     updated_at: Option<String>,

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -1970,44 +1970,6 @@ fn completed_generic_executor_outcome_preserves_runtime_evidence_without_provide
 }
 
 #[test]
-fn status_backfills_legacy_terminal_generic_runtime_evidence_once() {
-    with_isolated_home(|_| {
-        let mut plan = test_plan();
-        plan.tasks[0].executor.backend = "opencode".to_string();
-        plan.tasks[0].executor.model = Some("openai/gpt-5.6-terra".to_string());
-        let aggregate = succeeded_aggregate(&plan);
-        let record = record_completed_run(&plan, &aggregate, Some("legacy-generic-runtime"))
-            .expect("terminal record");
-
-        rewrite_record_for_test(&record.run_id, |record| {
-            record.lifecycle.provider_runtime.clear();
-        })
-        .expect("legacy lifecycle persisted");
-        let before = store::read_record(&record.run_id).expect("legacy record");
-
-        let migrated = status(&record.run_id).expect("status migrates legacy record");
-        let after_first = store::read_record(&record.run_id).expect("migrated record");
-        let repeated = status(&record.run_id).expect("repeated status is stable");
-        let after_second = store::read_record(&record.run_id).expect("stable record");
-
-        assert_ne!(before, after_first);
-        assert_eq!(after_first, after_second);
-        assert_eq!(migrated, repeated);
-        assert_eq!(migrated.updated_at, record.updated_at);
-        assert_eq!(migrated.lifecycle.updated_at, record.lifecycle.updated_at);
-        assert_eq!(migrated.lifecycle.provider_runtime.len(), 1);
-        assert_eq!(
-            migrated.lifecycle.provider_runtime[0].state,
-            ProviderRuntimeState::Succeeded
-        );
-        assert_eq!(
-            migrated.lifecycle.provider_runtime[0].metadata["evidence_source"],
-            "canonical_executor_outcome"
-        );
-    });
-}
-
-#[test]
 fn status_preserves_existing_terminal_runtime_evidence() {
     with_isolated_home(|_| {
         let mut plan = test_plan();
@@ -2031,72 +1993,6 @@ fn status_preserves_existing_terminal_runtime_evidence() {
         assert_eq!(
             loaded.lifecycle.provider_runtime[0].metadata["manual"],
             true
-        );
-    });
-}
-
-#[test]
-fn status_fails_closed_when_terminal_runtime_backfill_cannot_persist() {
-    with_isolated_home(|_| {
-        let mut plan = test_plan();
-        plan.tasks[0].executor.backend = "opencode".to_string();
-        let aggregate = succeeded_aggregate(&plan);
-        let record = record_completed_run(&plan, &aggregate, Some("failed-runtime-backfill"))
-            .expect("terminal record");
-        rewrite_record_for_test(&record.run_id, |record| {
-            record.lifecycle.provider_runtime.clear();
-        })
-        .expect("legacy lifecycle persisted");
-        store::fail_next_record_write_for_test();
-
-        let error = status(&record.run_id).expect_err("backfill persistence failure is surfaced");
-        let persisted = store::read_record(&record.run_id).expect("unmodified persisted record");
-
-        assert_eq!(error.code, ErrorCode::InternalIoError, "{}", error.message);
-        assert!(persisted.lifecycle.provider_runtime.is_empty());
-    });
-}
-
-#[test]
-fn status_backfills_candidate_recoverable_runtime_once_without_touching_promotion() {
-    with_isolated_home(|_| {
-        let mut plan = test_plan();
-        plan.tasks[0].executor.backend = "opencode".to_string();
-        let mut aggregate = succeeded_aggregate(&plan);
-        aggregate.status = AgentTaskAggregateStatus::CandidateRecoverable;
-        aggregate.totals = AgentTaskAggregateTotals {
-            candidate_recoverable: 1,
-            ..Default::default()
-        };
-        aggregate.outcomes[0].status = AgentTaskOutcomeStatus::CandidateRecoverable;
-        aggregate.events[0].state = AgentTaskState::CandidateRecoverable;
-        let record = record_completed_run(&plan, &aggregate, Some("timed-out-runtime"))
-            .expect("terminal record");
-        rewrite_record_for_test(&record.run_id, |record| {
-            record.lifecycle.provider_runtime.clear();
-        })
-        .expect("legacy lifecycle persisted");
-        let promotion = json!({ "status": "applied", "id": "promotion-1" });
-        let promoted =
-            record_promotion(&record.run_id, promotion.clone()).expect("promotion persisted");
-
-        let migrated = status(&record.run_id).expect("status backfills timed-out evidence");
-        let after_first = store::read_record(&record.run_id).expect("migrated record");
-        let repeated = status(&record.run_id).expect("repeated status is stable");
-        let after_second = store::read_record(&record.run_id).expect("stable record");
-
-        assert_eq!(migrated.state, AgentTaskRunState::CandidateRecoverable);
-        assert_eq!(
-            migrated.lifecycle.provider_runtime[0].state,
-            ProviderRuntimeState::TimedOut
-        );
-        assert_eq!(after_first, after_second);
-        assert_eq!(migrated, repeated);
-        assert_eq!(migrated.metadata["latest_promotion"], promotion);
-        assert_eq!(migrated.updated_at, promoted.updated_at);
-        assert_eq!(
-            migrated.lifecycle.execution.updated_at,
-            promoted.lifecycle.execution.updated_at
         );
     });
 }


### PR DESCRIPTION
## Summary
Remove read-side migration of obsolete terminal agent-task records.

## What changed
- Deleted terminal status backfill, migration-only test hooks, and compatibility tests; obsolete model-less records now remain unchanged and fail finalization closed.

## How to test
1. Run `cargo fmt --check`; expect Command exits successfully..
2. Run `cargo test agent_task_lifecycle --lib`; expect All lifecycle tests pass..
3. Run `cargo test agent_task_finalization --lib`; expect All finalization tests pass, including obsolete empty-runtime records remaining unchanged with no commit, push, or PR..

## Compatibility
Intentional breaking change for obsolete internal Homeboy agent-task records: terminal records without current write-time runtime/model provenance are no longer migrated and cannot be finalized. Fresh current-contract runs are unaffected.

## Evidence
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8302
- finalization: Passed
- format: Passed
- lifecycle: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Removed obsolete terminal compatibility migration code, strengthened fail-closed regression coverage, and verified lifecycle/finalization behavior; Chris reviewed and owns the change.

## Source relationships
- Closes #8302
