### PR TITLE
Recover provider rotation from incompatible scratch indexes

### DIFF
--- a/src/core/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
+++ b/src/core/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
@@ -525,6 +525,68 @@ mod provider_rotation_tests {
     }
 
     #[test]
+    fn timed_out_attempt_rotates_after_recovering_a_malformed_scratch_index() {
+        struct TimeoutThenSuccessExecutor {
+            calls: AtomicUsize,
+            scratch_index: std::path::PathBuf,
+            scratch_roots: Arc<Mutex<Vec<String>>>,
+        }
+
+        impl AgentTaskExecutorAdapter for TimeoutThenSuccessExecutor {
+            fn execute(
+                &self,
+                request: AgentTaskRequest,
+                _context: AgentTaskExecutionContext,
+            ) -> AgentTaskOutcome {
+                self.scratch_roots.lock().expect("scratch roots").push(
+                    request.executor.config["runtime_env"]["TMPDIR"]
+                        .as_str()
+                        .expect("scheduler scratch root")
+                        .to_string(),
+                );
+                if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    fs::write(&self.scratch_index, "{ stale").expect("corrupt stale index");
+                    std::thread::sleep(Duration::from_millis(25));
+                    return outcome(request.task_id, AgentTaskOutcomeStatus::Succeeded);
+                }
+                outcome(request.task_id, AgentTaskOutcomeStatus::Succeeded)
+            }
+        }
+
+        let _home = crate::test_support::HomeGuard::new();
+        let run_id = "timeout-rotation-scratch-recovery";
+        let scratch_index = crate::core::paths::homeboy_data()
+            .expect("homeboy data")
+            .join("controller-scratch/test-indexes")
+            .join(run_id)
+            .join("resources.json");
+        let scratch_roots = Arc::new(Mutex::new(Vec::new()));
+        let scheduler = AgentTaskScheduler::new(TimeoutThenSuccessExecutor {
+            calls: AtomicUsize::new(0),
+            scratch_index,
+            scratch_roots: Arc::clone(&scratch_roots),
+        })
+        .with_run_id(run_id);
+        let mut plan = plan_with_tasks(1);
+        plan.tasks[0].limits.timeout_ms = Some(1);
+        plan.options.rotation = Some(rotation_policy(vec![entry("fallback-backend-a")]));
+        enable_rotation(&mut plan);
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        let scratch_roots = scratch_roots.lock().expect("scratch roots").clone();
+        assert_eq!(scratch_roots.len(), 2);
+        assert_ne!(
+            scratch_roots[0], scratch_roots[1],
+            "the rotated provider receives a new scratch root"
+        );
+        assert!(aggregate.events.iter().any(|event| {
+            event.message.as_deref() == Some("provider rotation queued: entry 1 of 1")
+        }));
+    }
+
+    #[test]
     fn does_not_rotate_on_task_level_failure_classifications() {
         for classification in [
             AgentTaskFailureClassification::ExecutionFailed,

--- a/src/core/controller_scratch.rs
+++ b/src/core/controller_scratch.rs
@@ -122,7 +122,7 @@ fn allocate_attempt_at_index(
     }
 
     with_index_lock(&index_path, || {
-        let mut index = read_index_at_unlocked(&index_path)?;
+        let mut index = read_or_recover_index_at_unlocked(&index_path)?;
         index.resources.push(ControllerScratchResource {
             path: path.display().to_string(),
             run_id: run_id.to_string(),
@@ -753,6 +753,140 @@ fn read_index_at_unlocked(path: &Path) -> Result<ControllerScratchIndex> {
     }
 }
 
+/// A controller using an older non-atomic writer can expose transient partial
+/// bytes even while this process holds the index lock. Retry once before
+/// classifying the durable index as malformed.
+fn read_or_recover_index_at_unlocked(path: &Path) -> Result<ControllerScratchIndex> {
+    let raw = read_index_bytes(path)?;
+    let first_error = match serde_json::from_str(&raw) {
+        Ok(index) => return Ok(index),
+        Err(error) => error,
+    };
+    let retried_raw = read_index_bytes(path)?;
+    match serde_json::from_str(&retried_raw) {
+        Ok(index) => Ok(index),
+        Err(retried_error) => {
+            if let Ok(document) = serde_json::from_str::<serde_json::Value>(&retried_raw) {
+                return salvage_compatible_resources(path, document, &retried_error.to_string());
+            }
+            let quarantine_path = preserve_index_bytes(path, "corrupt")?;
+            eprintln!(
+                "Homeboy quarantined syntactically invalid controller scratch index {} to {} after two reads; first parse error: {}; retry parse error: {}; allocating a fresh scratch root",
+                path.display(),
+                quarantine_path.display(),
+                first_error,
+                retried_error
+            );
+            Ok(ControllerScratchIndex {
+                schema: schema(),
+                resources: Vec::new(),
+            })
+        }
+    }
+}
+
+fn read_index_bytes(path: &Path) -> Result<String> {
+    match fs::read_to_string(path) {
+        Ok(raw) => Ok(raw),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok("{}".to_string()),
+        Err(error) => Err(Error::internal_io(
+            error.to_string(),
+            Some(path.display().to_string()),
+        )),
+    }
+}
+
+fn salvage_compatible_resources(
+    path: &Path,
+    document: serde_json::Value,
+    parse_context: &str,
+) -> Result<ControllerScratchIndex> {
+    let Some(document) = document.as_object() else {
+        return quarantine_incompatible_index(
+            path,
+            parse_context,
+            "top-level JSON value is not an object",
+        );
+    };
+    let Some(resources) = document
+        .get("resources")
+        .and_then(serde_json::Value::as_array)
+    else {
+        return quarantine_incompatible_index(
+            path,
+            parse_context,
+            "top-level resources field is not an array",
+        );
+    };
+    let mut compatible_resources = Vec::with_capacity(resources.len());
+    let mut incompatible_count = 0;
+    for resource in resources {
+        match serde_json::from_value(resource.clone()) {
+            Ok(resource) => compatible_resources.push(resource),
+            Err(_) => incompatible_count += 1,
+        }
+    }
+    let preserved_path = preserve_index_bytes(path, "incompatible")?;
+    eprintln!(
+        "Homeboy salvaged {} compatible controller scratch resources from {} after typed parse failure ({} incompatible resource(s); context: {}); preserved original bytes at {}",
+        compatible_resources.len(),
+        path.display(),
+        incompatible_count,
+        parse_context,
+        preserved_path.display()
+    );
+    Ok(ControllerScratchIndex {
+        schema: document
+            .get("schema")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(schema),
+        resources: compatible_resources,
+    })
+}
+
+fn quarantine_incompatible_index(
+    path: &Path,
+    parse_context: &str,
+    shape_context: &str,
+) -> Result<ControllerScratchIndex> {
+    let quarantine_path = preserve_index_bytes(path, "incompatible")?;
+    eprintln!(
+        "Homeboy quarantined controller scratch index {} to {} because it is syntactically valid but structurally incompatible ({}; parse context: {}); allocating a fresh scratch root",
+        path.display(),
+        quarantine_path.display(),
+        shape_context,
+        parse_context
+    );
+    Ok(ControllerScratchIndex {
+        schema: schema(),
+        resources: Vec::new(),
+    })
+}
+
+fn preserve_index_bytes(path: &Path, classification: &str) -> Result<PathBuf> {
+    let preserved_path = path.with_file_name(format!(
+        "{}.{}-{}",
+        path.file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("resources.json"),
+        classification,
+        uuid::Uuid::new_v4()
+    ));
+    fs::rename(path, &preserved_path).map_err(|error| {
+        Error::internal_io(
+            format!(
+                "could not preserve controller scratch index {} at {}: {}",
+                path.display(),
+                preserved_path.display(),
+                error
+            ),
+            Some(path.display().to_string()),
+        )
+    })?;
+    Ok(preserved_path)
+}
+
 #[cfg(test)]
 fn write_index(index: &ControllerScratchIndex) -> Result<()> {
     let index_path = index_path()?;
@@ -905,6 +1039,71 @@ mod tests {
             assert_eq!(resource.owner_pid, std::process::id());
             assert!(resource.reconstructable);
             assert!(!resource.created_at.is_empty());
+        });
+    }
+
+    #[test]
+    fn allocation_quarantines_a_malformed_index_and_registers_a_fresh_lease() {
+        crate::test_support::with_isolated_home(|_| {
+            let index_path = index_path().expect("index path");
+            fs::create_dir_all(index_path.parent().expect("index parent")).expect("index parent");
+            fs::write(&index_path, "{ stale").expect("malformed index");
+
+            let allocation = allocate_attempt("run-1", "plan-1", "task-1", 2)
+                .expect("allocation recovers malformed index");
+            let index = read_index().expect("replacement index");
+
+            assert_eq!(index.resources.len(), 1);
+            assert_eq!(index.resources[0].lease_id, allocation.lease_id);
+            let quarantined = fs::read_dir(index_path.parent().expect("index parent"))
+                .expect("index directory")
+                .filter_map(|entry| entry.ok())
+                .map(|entry| entry.file_name().to_string_lossy().to_string())
+                .filter(|name| name.starts_with("resources.json.corrupt-"))
+                .collect::<Vec<_>>();
+            assert_eq!(quarantined.len(), 1);
+        });
+    }
+
+    #[test]
+    fn allocation_salvages_valid_leases_from_a_typed_incompatible_resource() {
+        crate::test_support::with_isolated_home(|_| {
+            let index_path = index_path().expect("index path");
+            fs::create_dir_all(index_path.parent().expect("index parent")).expect("index parent");
+            let valid = resource(Path::new("/scratch/valid"), Path::new("/scratch"));
+            fs::write(
+                &index_path,
+                serde_json::json!({
+                    "schema": CONTROLLER_SCRATCH_SCHEMA,
+                    "resources": [
+                        valid,
+                        { "path": 42 }
+                    ]
+                })
+                .to_string(),
+            )
+            .expect("typed incompatible index");
+
+            let allocation = allocate_attempt("run-1", "plan-1", "task-1", 2)
+                .expect("allocation salvages compatible leases");
+            let index = read_index().expect("replacement index");
+
+            assert_eq!(index.resources.len(), 2);
+            assert!(index
+                .resources
+                .iter()
+                .any(|resource| resource.lease_id == "test-lease"));
+            assert!(index
+                .resources
+                .iter()
+                .any(|resource| resource.lease_id == allocation.lease_id));
+            let preserved = fs::read_dir(index_path.parent().expect("index parent"))
+                .expect("index directory")
+                .filter_map(|entry| entry.ok())
+                .map(|entry| entry.file_name().to_string_lossy().to_string())
+                .filter(|name| name.starts_with("resources.json.incompatible-"))
+                .collect::<Vec<_>>();
+            assert_eq!(preserved.len(), 1);
         });
     }
 


### PR DESCRIPTION
## Summary

- recover provider rotation when the shared controller scratch index cannot be deserialized
- retry the locked read once, then distinguish invalid JSON from typed/schema incompatibility
- preserve original bytes and salvage every individually compatible lease before registering the fresh attempt
- add scheduler coverage proving a timed-out attempt receives a distinct scratch root and reaches the fallback provider

Closes #8317.

## Root cause and scope

A real `agent-task` run timed out provider attempt 1, queued provider rotation, then aborted attempt 2 with `agent_task.controller_scratch_allocation_failed: JSON error`. The live index was valid when inspected later, so the original parse failure may have been transient or caused by a typed incompatibility that another operation subsequently rewrote. This change does not assume which one occurred: it retries once, preserves unreadable source bytes, salvages compatible resources from structurally valid JSON, and only starts an empty index when no resources can safely be recovered.

## How to test

1. Run `cargo test allocation_ --lib`.
2. Run `cargo test provider_rotation_tests --lib`.
3. Run `cargo check`.
4. Confirm the malformed-index allocation test preserves diagnostic bytes and registers a fresh lease.
5. Confirm the typed-incompatibility test preserves an existing valid lease while dropping only the malformed resource.
6. Confirm the scheduler timeout test reaches provider rotation with a distinct attempt scratch root.

## Verification

- `cargo fmt --check`
- `cargo test allocation_ --lib` (4 passed)
- `cargo test provider_rotation_tests --lib` (14 passed)
- `cargo check`

Existing unrelated compiler warnings remain.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause investigation, implementation, tests, and verification under human direction.