### PR TITLE
Preserve managed workspaces across agent-task retry

### DIFF
--- a/src/commands/agent_task/run.rs
+++ b/src/commands/agent_task/run.rs
@@ -115,18 +115,12 @@ where
         ));
     }
 
-    // Capture the exact workspace state before dispatch. The provider may
-    // commit and leave a clean tree, so resolving this after it runs would
-    // silently widen the promotion range.
-    let source_worktree_path = agent_task_service::source_worktree_path(
-        args.dispatch.cwd.clone(),
-        args.dispatch.workspace.clone(),
-    );
-    let task_base_sha = source_worktree_path.as_deref().and_then(git_head_sha);
-
     let mut dispatch_args = args.dispatch.clone();
     if dispatch_args.prompt.is_none() {
         dispatch_args.prompt = args.goal.clone();
+    }
+    if dispatch_args.cwd.is_none() && dispatch_args.workspace.is_none() {
+        dispatch_args.workspace = Some(args.to_worktree.clone());
     }
     let requested_cook_id = dispatch_args.run_id.clone();
     if let Some(cook_id) = requested_cook_id.as_deref() {
@@ -153,6 +147,15 @@ where
         (run_id, dispatch_service::build_dispatch_plan(&request)?)
     };
     let cook_id = requested_cook_id.unwrap_or_else(|| run_id.clone());
+    // Capture the resolved task workspace before dispatch. The provider may
+    // commit and leave a clean tree, so resolving this after it runs would
+    // silently widen the promotion range.
+    let source_worktree_path = initial_plan
+        .tasks
+        .first()
+        .and_then(|task| task.workspace.root.as_ref())
+        .map(std::path::PathBuf::from);
+    let task_base_sha = source_worktree_path.as_deref().and_then(git_head_sha);
     // Keep this cook on one runtime generation through provider work and PR finalization.
     let _runtime_generation = homeboy::core::runtime_promotion::pin_cook_generation(&cook_id)?;
     let title = args

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -249,10 +249,11 @@ fn run_split_placement_cook(
         .clone()
         .unwrap_or_else(|| format!("agent-task-{}", uuid::Uuid::new_v4()));
     let attempt_run_id = agent_task_lifecycle::cook_attempt_run_id(&cook_id, 1);
-    let source_path = homeboy::core::agent_tasks::service::source_worktree_path(
-        cook.dispatch.cwd.clone(),
-        cook.dispatch.workspace.clone(),
-    );
+    let source_path = plan
+        .tasks
+        .first()
+        .and_then(|task| task.workspace.root.as_ref())
+        .map(PathBuf::from);
     let mut controller = cook.clone();
     controller.dispatch.run_id = Some(cook_id);
     controller.attempt_run_id = Some(attempt_run_id);
@@ -470,6 +471,9 @@ fn materialize_agent_task_cook_plan(
     if dispatch.prompt.is_none() {
         dispatch.prompt = cook.goal.clone();
     }
+    if dispatch.cwd.is_none() && dispatch.workspace.is_none() {
+        dispatch.workspace = Some(cook.to_worktree.clone());
+    }
     let request =
         homeboy::core::agent_tasks::dispatch_service::resolve_dispatch_request(dispatch.into())?;
     homeboy::core::agent_tasks::dispatch_service::build_dispatch_plan(&request).map(Some)
@@ -510,6 +514,34 @@ fn materialize_agent_task_retry_handoff(
     let primary_workspace = retry_plan_primary_workspace(&source_plan)?;
     let record = agent_task_lifecycle::retry(&retry.run_id, retry.new_run_id.as_deref())?;
     let plan = agent_task_lifecycle::load_plan(&record.run_id)?;
+    let retry_workspace = retry_plan_primary_workspace(&plan).map_err(|error| {
+        Error::validation_invalid_argument(
+            "workspace",
+            "agent-task retry lost its git-backed task workspace while serializing the replacement plan",
+            Some(primary_workspace.display().to_string()),
+            Some(vec![
+                format!(
+                    "The original persisted plan uses {}; inspect the replacement plan for workspace serialization loss.",
+                    primary_workspace.display()
+                ),
+                error.message,
+            ]),
+        )
+    })?;
+    if retry_workspace != primary_workspace {
+        return Err(Error::validation_invalid_argument(
+            "workspace",
+            "agent-task retry changed its git-backed task workspace while serializing the replacement plan",
+            Some(format!(
+                "original: {}; replacement: {}",
+                primary_workspace.display(),
+                retry_workspace.display()
+            )),
+            Some(vec![
+                "Retry preserves the original task workspace; inspect the replacement plan serialization before retrying through Lab.".to_string(),
+            ]),
+        ));
+    }
     let serialized_plan = serde_json::to_string(&plan).map_err(|error| {
         Error::internal_json(
             error.to_string(),
@@ -603,7 +635,7 @@ fn retry_plan_primary_workspace(
         1 => Ok(roots.into_iter().next().expect("one retry workspace")),
         0 => Err(Error::validation_invalid_argument(
             "workspace",
-            "agent-task retry --run through Lab requires one git-backed task workspace; the controller cwd cannot become the task primary",
+            "agent-task retry --run through Lab cannot rematerialize a task workspace because the original persisted plan has none; the controller cwd cannot become the task primary",
             None,
             Some(vec![
                 "Record workspace.root or executor.config.workspace_root in the task plan before retrying.".to_string(),
@@ -2209,6 +2241,10 @@ mod tests {
             let remote_plan: homeboy::core::agent_tasks::scheduler::AgentTaskPlan =
                 serde_json::from_str(&remote.plan).expect("serialized retry plan");
             assert_eq!(remote_plan, handoff.plan);
+            assert_eq!(
+                remote_plan.tasks[0].workspace.root.as_deref(),
+                Some(workspace.path().to_str().expect("workspace utf8"))
+            );
             // The emitted command is accepted by the real CLI parser without
             // inventing a global --cwd. The route carries the selected task
             // checkout separately, and workspace staging maps it to the job cwd.
@@ -2233,6 +2269,112 @@ mod tests {
             assert_eq!(
                 replacement.metadata["pre_execution_failure"]["phase"],
                 "detached_lab_handoff_preacceptance"
+            );
+        });
+    }
+
+    #[test]
+    fn cook_to_worktree_provider_workspace_survives_failed_attempt_and_lab_retry() {
+        crate::test_support::with_isolated_home(|_| {
+            let workspace = tempfile::tempdir().expect("workspace");
+            git_init(workspace.path());
+            let provider_dir = tempfile::tempdir().expect("provider dir");
+            let provider = provider_dir.path().join("provider");
+            let payload = serde_json::json!({
+                "worktrees": [{
+                    "handle": "blocks-engine@cook-six-fixture-generic-parity",
+                    "path": workspace.path(),
+                    "branch": "main",
+                    "safety": { "dirty": false, "unpushed": false, "primary": false }
+                }]
+            });
+            fs::write(
+                &provider,
+                format!("#!/bin/sh\nprintf '%s\\n' '{}'\n", payload),
+            )
+            .expect("write provider");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+
+                let mut permissions = fs::metadata(&provider)
+                    .expect("provider metadata")
+                    .permissions();
+                permissions.set_mode(0o755);
+                fs::set_permissions(&provider, permissions).expect("make provider executable");
+            }
+            let mut config = homeboy::core::defaults::HomeboyConfig::default();
+            config.worktree_providers.insert(
+                "fixture".to_string(),
+                homeboy::core::defaults::WorktreeProviderConfig {
+                    enabled: true,
+                    kind: homeboy::core::defaults::WorktreeProviderKind::Command,
+                    apply_enabled: false,
+                    commands: homeboy::core::defaults::WorktreeProviderCommands {
+                        resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
+                        ..Default::default()
+                    },
+                    list_result_mapping: Some(
+                        homeboy::core::defaults::WorktreeProviderListResultMapping {
+                            items: "$.worktrees".to_string(),
+                            handle: "$.handle".to_string(),
+                            path: "$.path".to_string(),
+                            branch: "$.branch".to_string(),
+                            dirty: "$.safety.dirty".to_string(),
+                            unpushed: "$.safety.unpushed".to_string(),
+                            primary: "$.safety.primary".to_string(),
+                        },
+                    ),
+                },
+            );
+            homeboy::core::defaults::save_config(&config).expect("save provider config");
+
+            let cook_cli = Cli::parse_from([
+                "homeboy",
+                "agent-task",
+                "cook",
+                "--to-worktree",
+                "blocks-engine@cook-six-fixture-generic-parity",
+                "--verify",
+                "true",
+                "--backend",
+                "fixture",
+                "--prompt",
+                "retry this task",
+            ]);
+            let plan = materialize_agent_task_cook_plan(&cook_cli)
+                .expect("materialize cook plan")
+                .expect("cook plan");
+            let expected_root = workspace.path().display().to_string();
+            assert_eq!(
+                plan.tasks[0].workspace.root.as_deref(),
+                Some(expected_root.as_str())
+            );
+            agent_task_lifecycle::submit_plan(&plan, Some("failed-run")).expect("submit plan");
+            agent_task_lifecycle::record_pre_execution_failure(
+                "failed-run",
+                &plan,
+                "lab_handoff_preacceptance",
+                &Error::internal_unexpected("Lab rejected the initial attempt"),
+            )
+            .expect("persist failed attempt");
+
+            let retry_args = ["homeboy", "agent-task", "retry", "failed-run", "--run"]
+                .into_iter()
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            let retry_cli = Cli::parse_from(&retry_args);
+            let handoff = materialize_agent_task_retry_handoff(&retry_cli, &retry_args)
+                .expect("materialize retry handoff")
+                .expect("retry handoff");
+
+            assert_eq!(
+                handoff.primary_workspace,
+                workspace.path().canonicalize().expect("root")
+            );
+            assert_eq!(
+                handoff.plan.tasks[0].workspace.root.as_deref(),
+                Some(expected_root.as_str())
             );
         });
     }
@@ -2277,6 +2419,43 @@ mod tests {
                 Err(error) => error,
             };
             assert!(error.message.contains("multiple task workspaces"));
+            assert!(agent_task_lifecycle::status("failed-run-retry-1").is_err());
+        });
+    }
+
+    #[test]
+    fn retry_handoff_identifies_an_original_plan_without_a_workspace() {
+        crate::test_support::with_isolated_home(|_| {
+            let plan = homeboy::core::agent_tasks::scheduler::AgentTaskPlan::new(
+                "missing-workspace",
+                vec![serde_json::from_value(serde_json::json!({
+                    "task_id": "retry-task",
+                    "executor": { "backend": "fixture" },
+                    "instructions": "retry"
+                }))
+                .expect("task")],
+            );
+            agent_task_lifecycle::submit_plan(&plan, Some("failed-run")).expect("source plan");
+            let source_plan = agent_task_lifecycle::load_plan("failed-run").expect("source plan");
+            agent_task_lifecycle::record_pre_execution_failure(
+                "failed-run",
+                &source_plan,
+                "provider_execution",
+                &Error::internal_unexpected("failed"),
+            )
+            .expect("source failure");
+            let normalized = ["homeboy", "agent-task", "retry", "failed-run", "--run"]
+                .into_iter()
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            let cli = Cli::parse_from(&normalized);
+
+            let error = match materialize_agent_task_retry_handoff(&cli, &normalized) {
+                Ok(_) => panic!("missing original workspace must fail before creating a retry"),
+                Err(error) => error,
+            };
+
+            assert!(error.message.contains("original persisted plan has none"));
             assert!(agent_task_lifecycle::status("failed-run-retry-1").is_err());
         });
     }

--- a/src/core/agent_task_dispatch_plan.rs
+++ b/src/core/agent_task_dispatch_plan.rs
@@ -22,7 +22,7 @@ use crate::core::agent_task_scheduler::{
     AgentTaskExecutionBudget, AgentTaskPlan, AgentTaskRetryPolicy,
 };
 use crate::core::agent_task_secrets::validate_secret_env;
-use crate::core::{config, defaults, worktree, Error, Result};
+use crate::core::{config, defaults, worktree, worktree_providers, Error, Result};
 
 use super::agent_task_dispatch_service::AgentTaskDispatchRequest;
 
@@ -399,28 +399,47 @@ fn resolve_dispatch_workspace(
         return Ok(Some(DispatchWorkspaceTarget::path(path, "workspace-path")));
     }
 
-    let record = worktree::resolve(workspace).map_err(|_| {
+    if let Some(record) = worktree::resolve_if_present(workspace)? {
+        let root = std::path::PathBuf::from(&record.worktree_path);
+        if !root.is_dir() {
+            return Err(Error::validation_invalid_argument(
+                "workspace",
+                format!(
+                    "Homeboy worktree '{}' points at a missing directory {}; recreate or remove the stale record",
+                    record.id,
+                    root.display()
+                ),
+                Some(workspace.clone()),
+                None,
+            ));
+        }
+        return Ok(Some(DispatchWorkspaceTarget::record(record)));
+    }
+
+    let resolution = worktree_providers::resolve_worktree_provider(workspace).map_err(|error| {
         Error::validation_invalid_argument(
             "workspace",
             format!(
-                "agent-task cook workspace '{}' is neither an existing directory nor a Homeboy worktree record",
-                workspace
+                "agent-task cook workspace '{}' is neither an existing directory nor a resolvable managed worktree handle: {}",
+                workspace, error.message
             ),
             Some(workspace.clone()),
             Some(vec![
                 "Pass --cwd <path> for an explicit checkout".to_string(),
                 "Pass --workspace <path> for an existing workspace path".to_string(),
                 "Create or list Homeboy task worktrees with `homeboy worktree create` and `homeboy worktree list`".to_string(),
+                "Configure a worktree provider that can resolve the managed handle.".to_string(),
             ]),
         )
     })?;
-    let root = std::path::PathBuf::from(&record.worktree_path);
+    let root = std::path::PathBuf::from(&resolution.worktree.path);
     if !root.is_dir() {
         return Err(Error::validation_invalid_argument(
             "workspace",
             format!(
-                "Homeboy worktree '{}' points at a missing directory {}; recreate or remove the stale record",
-                record.id,
+                "managed worktree '{}' resolved by provider '{}' points at a missing directory {}",
+                workspace,
+                resolution.provider_id,
                 root.display()
             ),
             Some(workspace.clone()),
@@ -428,7 +447,7 @@ fn resolve_dispatch_workspace(
         ));
     }
 
-    Ok(Some(DispatchWorkspaceTarget::record(record)))
+    Ok(Some(DispatchWorkspaceTarget::provider(resolution)))
 }
 
 #[derive(Debug, Clone)]
@@ -480,6 +499,30 @@ impl DispatchWorkspaceTarget {
                 "root": record.worktree_path,
                 "source_checkout": record.source_checkout,
                 "task_url": record.task_url,
+            }),
+        }
+    }
+
+    fn provider(resolution: worktree_providers::WorktreeProviderResolution) -> Self {
+        let root = std::path::PathBuf::from(&resolution.worktree.path);
+        Self {
+            root: root.clone(),
+            slug: Some(resolution.worktree.handle.clone()),
+            kind: Some("worktree-provider".to_string()),
+            component_id: None,
+            branch: Some(resolution.worktree.branch.clone()),
+            base_ref: None,
+            metadata: serde_json::json!({
+                "kind": "worktree-provider",
+                "provider_id": resolution.provider_id,
+                "handle": resolution.worktree.handle,
+                "root": root.display().to_string(),
+                "branch": resolution.worktree.branch,
+                "safety": {
+                    "dirty": resolution.worktree.safety.dirty,
+                    "unpushed": resolution.worktree.safety.unpushed,
+                    "primary": resolution.worktree.safety.primary,
+                },
             }),
         }
     }


### PR DESCRIPTION
## Summary
- treat the required `agent-task cook --to-worktree` handle as the dispatch workspace when no explicit `--cwd` or `--workspace` is supplied
- resolve managed handles through Homeboy records or configured worktree providers and persist the resolved checkout in the task plan
- preserve the workspace through failed attempts and Lab retry reconstruction, with distinct diagnostics for genuinely missing or changed retry workspaces

## Why
A cook launched with only its required managed `--to-worktree` could lose workspace identity before provider execution. A subsequent `agent-task retry --run` then had no git-backed checkout to rematerialize on Lab and could not recover through the durable lifecycle.

Closes #8312.

## How to test
1. Run `cargo test --lib cook_to_worktree_provider_workspace_survives_failed_attempt_and_lab_retry -- --nocapture`.
2. Run `cargo test --lib retry_handoff -- --nocapture`.
3. Run `cargo test --lib detached_retry_materializes -- --nocapture`.
4. Run `cargo test --lib agent_task_dispatch_plan -- --nocapture`.
5. Run `cargo fmt --check`.

## Compatibility
Existing explicit `--cwd` and `--workspace` inputs retain precedence. Calls relying only on the already-required `--to-worktree` now gain a persisted managed workspace; no product- or framework-specific assumptions are introduced.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Diagnosed the Lab retry workspace loss, implemented the generic worktree-provider resolution fix, and added deterministic lifecycle coverage.
