### PR TITLE
refactor(contract): extract contract export writing + fix dispatch marker

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -459,7 +459,7 @@
           ],
           "label": "runner execution orchestration",
           "patterns": [
-            "\\b(execute_[A-Za-z0-9_]+|dispatch_[A-Za-z0-9_]+)\\s*\\("
+            "\\b(execute_[A-Za-z0-9_]+|dispatch_(job|jobs|runner|remote|exec|command|work|workload)[A-Za-z0-9_]*)\\s*\\("
           ]
         }
       ]

--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -19,6 +19,7 @@
 
 mod constants;
 mod descriptors;
+pub mod export;
 mod lab;
 mod output;
 mod public_variants;

--- a/src/command_contract/export.rs
+++ b/src/command_contract/export.rs
@@ -1,0 +1,55 @@
+//! Contract export document writing.
+//!
+//! Boundary: the `contract export` command builds the export documents from the
+//! command-contract registry; this module owns the filesystem orchestration —
+//! creating the output directory and writing each document as pretty JSON. It
+//! takes plain data (file name + JSON value) so no command types are involved.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+/// A single contract export document to write.
+pub struct ContractExportDocument {
+    pub file_name: &'static str,
+    pub schema: &'static str,
+    pub description: &'static str,
+    pub value: Value,
+}
+
+/// A written contract export file.
+pub struct WrittenContractExport {
+    pub path: PathBuf,
+    pub schema: &'static str,
+    pub description: &'static str,
+}
+
+/// Create `dir` and write each export document into it as pretty JSON with a
+/// trailing newline. Returns the written files in input order.
+pub fn write_contract_export_documents(
+    dir: &Path,
+    documents: Vec<ContractExportDocument>,
+) -> crate::core::Result<Vec<WrittenContractExport>> {
+    std::fs::create_dir_all(dir).map_err(|error| io_error(error, dir))?;
+
+    let mut written = Vec::new();
+    for document in documents {
+        let path = dir.join(document.file_name);
+        let body = serde_json::to_string_pretty(&document.value).map_err(json_error)?;
+        std::fs::write(&path, format!("{body}\n")).map_err(|error| io_error(error, &path))?;
+        written.push(WrittenContractExport {
+            path,
+            schema: document.schema,
+            description: document.description,
+        });
+    }
+    Ok(written)
+}
+
+fn io_error(error: std::io::Error, path: &Path) -> crate::core::Error {
+    crate::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
+}
+
+fn json_error(error: serde_json::Error) -> crate::core::Error {
+    crate::core::Error::internal_json(error.to_string(), Some("export contracts".to_string()))
+}

--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -7,6 +7,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::{json, Value};
 
+use crate::command_contract::export::{write_contract_export_documents, ContractExportDocument};
 use crate::command_contract::{
     contract_constants, registered_contract, registered_contracts, ArtifactPostprocessPlan,
     CommandDispatchFamily, CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode,
@@ -710,22 +711,20 @@ fn artifact_reference_type(reference: &ArtifactReference) -> &'static str {
 }
 
 fn export_contracts(args: ContractExportArgs) -> CmdResult<ContractExportOutput> {
-    fs::create_dir_all(&args.dir).map_err(|error| io_error(error, &args.dir))?;
-
-    let exports = [
-        ExportDocument {
+    let documents = vec![
+        ContractExportDocument {
             file_name: "command-registry.json",
             schema: COMMAND_REGISTRY_EXPORT_SCHEMA,
             description: "Top-level command registry metadata derived from Homeboy's command contract registry.",
             value: serde_json::to_value(command_registry_export()).map_err(json_error)?,
         },
-        ExportDocument {
+        ContractExportDocument {
             file_name: "public-output-variants.json",
             schema: PUBLIC_OUTPUT_VARIANTS_EXPORT_SCHEMA,
             description: "Public command output variants and their discriminator/golden fixture anchors.",
             value: serde_json::to_value(public_output_variants_export()).map_err(json_error)?,
         },
-        ExportDocument {
+        ContractExportDocument {
             file_name: "schema-catalog.json",
             schema: CONTRACT_SCHEMA_CATALOG_SCHEMA,
             description: "Homeboy-owned contract schema IDs with field metadata and canonical examples.",
@@ -733,17 +732,14 @@ fn export_contracts(args: ContractExportArgs) -> CmdResult<ContractExportOutput>
         },
     ];
 
-    let mut files = Vec::new();
-    for export in exports {
-        let path = args.dir.join(export.file_name);
-        let body = serde_json::to_string_pretty(&export.value).map_err(json_error)?;
-        fs::write(&path, format!("{body}\n")).map_err(|error| io_error(error, &path))?;
-        files.push(ContractExportFile {
-            path: path.to_string_lossy().to_string(),
-            schema: export.schema,
-            description: export.description,
-        });
-    }
+    let files = write_contract_export_documents(&args.dir, documents)?
+        .into_iter()
+        .map(|written| ContractExportFile {
+            path: written.path.to_string_lossy().to_string(),
+            schema: written.schema,
+            description: written.description,
+        })
+        .collect();
 
     Ok((
         ContractExportOutput {
@@ -756,13 +752,6 @@ fn export_contracts(args: ContractExportArgs) -> CmdResult<ContractExportOutput>
         },
         0,
     ))
-}
-
-struct ExportDocument {
-    file_name: &'static str,
-    schema: &'static str,
-    description: &'static str,
-    value: Value,
 }
 
 fn command_registry_export() -> CommandRegistryExport {
@@ -1538,10 +1527,6 @@ fn output_contract(value: CommandOutputContractKind) -> &'static str {
         CommandOutputContractKind::JsonEnvelope => "json_envelope",
         CommandOutputContractKind::RawOnly => "raw_only",
     }
-}
-
-fn io_error(error: std::io::Error, path: &Path) -> homeboy::core::Error {
-    homeboy::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
 }
 
 fn json_error(error: serde_json::Error) -> homeboy::core::Error {


### PR DESCRIPTION
## Summary
- Extracts the contract-export filesystem orchestration out of `contract.rs` into `command_contract::export::write_contract_export_documents`, which takes the export documents as plain data.
- The command builds the documents from the command-contract registry and delegates directory creation + file writes.
- Fixes a detector false positive so the `dispatch_*` marker no longer flags non-runner functions.

## Why
Final entry in the thin-adapter series (#8293, #8296, #8304, #8308, #8315, #8323, #8330). The architecture audit flagged `contract.rs` for **direct filesystem mutation + runner execution orchestration**. Two distinct issues:
1. `export_contracts` created the output dir and wrote 3 JSON export files inline — genuine filesystem orchestration, now a reusable `command_contract` primitive.
2. **False positive (refs #8331):** the `runner execution orchestration` marker matched a bare `dispatch_*` prefix, flagging `dispatch_family()` — a contract-metadata display mapper (`CommandDispatchFamily -> &'static str`) with nothing to do with runner dispatch.

## Detector fix (#8331)
Narrowed the `dispatch_*` marker to job/runner dispatch verbs: `dispatch_(job|jobs|runner|remote|exec|command|work|workload)[A-Za-z0-9_]*`. Mirrors the #8297 (`RunDir::create`) and #8328 (`runner::exec`) primitive-call fixes. The detector's own unit tests use their own inline patterns and are unaffected.

## Verification
- `homeboy review audit homeboy --only thin_command_adapter_violation`: `contract.rs` no longer flagged.
- `cargo check --lib --tests`: clean (0 errors, no warnings in touched files).
- `homeboy.json` remains valid.
- `cargo fmt` applied. No behavior change — identical export files, same directory layout, same output.