### PR TITLE
fix(audit): treat *_fixture(s).rs as test paths in is_test_path

### DIFF
--- a/src/core/code_audit/walker.rs
+++ b/src/core/code_audit/walker.rs
@@ -132,9 +132,14 @@ pub fn is_test_path(relative_path: &str) -> bool {
     let file_name = relative_path.rsplit('/').next().unwrap_or(relative_path);
 
     // Rust: foo_test.rs, foo_tests.rs, and bare test.rs / tests.rs modules
-    // (conventionally wired as `#[cfg(test)] mod tests;`).
+    // (conventionally wired as `#[cfg(test)] mod tests;`). Also cover shared
+    // test-fixture modules — `*_fixture(s).rs` (e.g. test_fixture.rs) — which are
+    // conventionally `#[cfg(test)] mod` fixtures consumed by sibling `*_tests.rs`
+    // files, not production code.
     if file_name.ends_with("_test.rs")
         || file_name.ends_with("_tests.rs")
+        || file_name.ends_with("_fixture.rs")
+        || file_name.ends_with("_fixtures.rs")
         || file_name == "test.rs"
         || file_name == "tests.rs"
     {
@@ -219,6 +224,10 @@ mod tests {
         // Bare `tests.rs` / `test.rs` modules (conventionally `#[cfg(test)] mod tests;`).
         assert!(is_test_path("src/commands/bench/tests.rs"));
         assert!(is_test_path("src/core/triage/test.rs"));
+        // Shared `*_fixture(s).rs` test-support modules (conventionally
+        // `#[cfg(test)] mod test_fixture;`), consumed by sibling `*_tests.rs`.
+        assert!(is_test_path("src/commands/trace/test_fixture.rs"));
+        assert!(is_test_path("src/core/runner/exec_fixtures.rs"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Extends `code_audit::walker::is_test_path` to recognize `*_fixture.rs` and `*_fixtures.rs` as test paths, so shared test-fixture modules are excluded from production-code audit detectors.

## Why
`src/commands/trace/test_fixture.rs` is declared `#[cfg(test)] mod test_fixture;` and consumed only by sibling `*_tests.rs` files (compare_variant_tests, experiment_tests, guardrail_tests, matrix_tests, profile_tests, rig_tests, run_phase_tests, tests). But `is_test_path` only matched `_test.rs` / `_tests.rs` / `test.rs` / `tests.rs` — not `*_fixture.rs`. So the fixture's setup code (`fs::create_dir_all`, `fs::write`, `Command::new("git")` to build test scenarios) was scanned as production command code and flagged by the `thin_command_adapter` detector for "direct filesystem mutation + direct process execution" — a false positive.

Resolves #8335. This is the last remaining `thin_command_adapter_violation` in `src/commands/`, and it was never real command orchestration — just test fixtures misclassified by the path filter.

## The fix is precise
- `test_fixture.rs` ends with `_fixture.rs` → now correctly excluded.
- The existing negative-case test `test_helpers.rs` (deliberately NOT a test path) is **preserved** — it does not end with `_fixture(s).rs`, so the broad `test_` prefix was intentionally avoided.

## Verification
- `cargo test --lib code_audit::walker::tests::test_is_test_path`: all 3 pass, including new fixture assertions and the preserved negative case.
- `cargo check --lib`: clean.

## Series context
Final precision fix in the thin-command-adapter refactor series (#8293, #8296, #8304, #8308, #8315, #8323, #8330, #8334). Companion detector-accuracy issues: #8297 (fixed), #8328 (fixed), #8331 (fixed in #8334), #8335 (this).