### PR TITLE
Keep detached Lab workloads alive after SSH handoff

### DIFF
--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -1356,7 +1356,8 @@ fn spawn_and_wait_for_lease(addr: &str, startup_token: &str) -> Result<DaemonSta
             Some("resolve current executable".to_string()),
         )
     })?;
-    let child = Command::new(exe)
+    let mut command = Command::new(exe);
+    command
         .args([
             "daemon",
             "supervise",
@@ -1368,7 +1369,9 @@ fn spawn_and_wait_for_lease(addr: &str, startup_token: &str) -> Result<DaemonSta
         .env(DAEMON_STARTUP_TOKEN_ENV, startup_token)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::null());
+    detach_from_launcher_session(&mut command);
+    let child = command
         .spawn()
         .map_err(|e| Error::internal_io(e.to_string(), Some("spawn daemon".to_string())))?;
     let pid = child.id();
@@ -1405,6 +1408,27 @@ fn spawn_and_wait_for_lease(addr: &str, startup_token: &str) -> Result<DaemonSta
         thread::sleep(Duration::from_millis(50));
     }
 }
+
+/// Keep the daemon and its workload children alive when a transient launcher
+/// connection, such as direct SSH, disconnects.
+#[cfg(unix)]
+fn detach_from_launcher_session(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+
+    // SAFETY: `pre_exec` runs in the child immediately before exec. `setsid`
+    // only changes that child process's session and reports failure via errno.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+}
+
+#[cfg(not(unix))]
+fn detach_from_launcher_session(_command: &mut Command) {}
 
 /// Resolve the daemon base URL, falling back to the running daemon's address.
 fn resolve_daemon_url(daemon_url: Option<String>) -> Result<String> {

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -534,6 +534,106 @@ fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
 }
 
 #[test]
+fn direct_daemon_detached_handoff_returns_while_the_workload_remains_running() {
+    crate::test_support::with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let started = workspace.path().join("started");
+        let release = workspace.path().join("release");
+        let _release_on_drop = ReleaseBlockedWorkload(release.clone());
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let addr = listener.local_addr().expect("listener address");
+        std::thread::spawn(move || {
+            let _ = crate::core::daemon::serve_listener(listener);
+        });
+        let daemon_url = format!("http://{addr}");
+        let started_at = std::time::Instant::now();
+
+        let (output, exit_code) = exec_via_daemon(
+            &ssh_runner(),
+            &daemon_url,
+            workspace.path().display().to_string(),
+            None,
+            vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "printf started > \"$1\"; while [ ! -e \"$2\" ]; do sleep 0.01; done".to_string(),
+                "sh".to_string(),
+                started.display().to_string(),
+                release.display().to_string(),
+            ],
+            Default::default(),
+            Vec::new(),
+            false,
+            None,
+            None,
+            Vec::new(),
+            None,
+            None,
+            true,
+            false,
+            false,
+            None,
+        )
+        .expect("detached direct-daemon handoff");
+
+        assert_eq!(exit_code, 0);
+        assert!(
+            started_at.elapsed() < Duration::from_secs(1),
+            "detached handoff waited for the blocked workload"
+        );
+        let job_id = output.job_id.expect("durably accepted daemon job");
+        wait_for_path(&started, "blocked workload start");
+        let client = Client::builder().no_proxy().build().expect("daemon client");
+        let job = fetch_daemon_job(&client, &daemon_url, &job_id).expect("running daemon job");
+        assert!(
+            matches!(job.status, JobStatus::Queued | JobStatus::Running),
+            "detached handoff returned only after workload completion"
+        );
+
+        std::fs::write(&release, "release").expect("release workload");
+        wait_for_terminal_daemon_job(&client, &daemon_url, &job_id);
+    });
+}
+
+struct ReleaseBlockedWorkload(std::path::PathBuf);
+
+impl Drop for ReleaseBlockedWorkload {
+    fn drop(&mut self) {
+        let _ = std::fs::write(&self.0, "release");
+    }
+}
+
+fn wait_for_path(path: &std::path::Path, description: &str) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while !path.exists() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for {description}"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_for_terminal_daemon_job(client: &Client, daemon_url: &str, job_id: &str) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        let job = fetch_daemon_job(client, daemon_url, job_id).expect("daemon job");
+        if matches!(
+            job.status,
+            JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
+        ) {
+            assert_eq!(job.status, JobStatus::Succeeded);
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for daemon job completion"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
 fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
     crate::test_support::with_isolated_home(|_| {
         let runner = ssh_runner();

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{SocketAddr, TcpListener};
 use std::sync::{mpsc, Arc, Barrier, Mutex};
 use std::time::Duration;
@@ -16,6 +16,29 @@ use crate::core::daemon::{
     DaemonFreshnessReport, DaemonRuntimeSnapshot, DaemonStaleReasonCode, DaemonState, DaemonStatus,
 };
 use crate::test_support::with_isolated_home;
+
+#[cfg(unix)]
+#[test]
+fn detached_daemon_owner_does_not_inherit_the_launcher_session() {
+    let mut command = Command::new("sh");
+    command.args(["-c", "printf '%s\\n' \"$$\"; sleep 30"]);
+    super::detach_from_launcher_session(&mut command);
+    let mut child = command
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("child");
+    let mut stdout = String::new();
+    BufReader::new(child.stdout.take().expect("child stdout"))
+        .read_line(&mut stdout)
+        .expect("read child pid");
+    let pid = stdout.trim().parse::<libc::pid_t>().expect("child pid");
+
+    // A session leader has a session ID equal to its PID, so the child can no
+    // longer receive SSH-launcher session teardown signals.
+    assert_eq!(unsafe { libc::getsid(pid) }, pid);
+    assert_eq!(unsafe { libc::kill(-pid, libc::SIGTERM) }, 0);
+    child.wait().expect("reap child");
+}
 
 #[derive(Default)]
 struct FakeEnsureState {


### PR DESCRIPTION
## Summary
- start supervised Homeboy daemons in a new Unix session so direct-SSH launcher teardown cannot kill the daemon and its workload tree
- prove detached daemon submission returns before a deliberately blocked workload completes
- prove the daemon owner no longer inherits the launcher session

Closes #8332.

## How to test
1. Run `cargo test --lib direct_daemon_detached_handoff_returns_while_the_workload_remains_running`.
2. Run `cargo test --lib detached_daemon_owner_does_not_inherit_the_launcher_session`.
3. Run `cargo test --lib core::runner::execution::tests::handoff --no-fail-fast`.
4. Run `cargo test --lib core::runner::lab::offload --no-fail-fast`.
5. Run `cargo test --lib core::agent_task_lifecycle::tests --no-fail-fast`.
6. Run `cargo fmt --check && git diff --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI `openai/gpt-5.6-sol` via OpenCode
- **Used for:** Diagnosed the direct-SSH daemon lifetime defect, implemented process isolation, and added behavioral regression coverage with Chris.