### PR TITLE
fix(audit): thin_command_adapter + command_status detector precision (#8299, #8300)

### DIFF
--- a/src/core/code_audit/conventions/mod.rs
+++ b/src/core/code_audit/conventions/mod.rs
@@ -444,6 +444,10 @@ pub enum AuditFinding {
     UnboundedOutputCapture,
     /// Declared command scenario output differs from its expected status contract.
     CommandStatusContractViolation,
+    /// A declared command-status scenario references a golden fixture file that
+    /// is missing or unreadable. This is test-data hygiene (write or remove the
+    /// fixture), distinct from an actual status-contract violation.
+    CommandStatusFixtureMissing,
     /// A command-layer module accumulates orchestration/business logic that
     /// should live in a core service. Command modules are expected to stay thin
     /// adapters (argument parsing, typed request construction, output
@@ -522,6 +526,7 @@ impl AuditFinding {
             "non_portable_artifact_path",
             "unbounded_output_capture",
             "command_status_contract_violation",
+            "command_status_fixture_missing",
             "thin_command_adapter_violation",
         ]
     }

--- a/src/core/code_audit/detectors/command_status_contracts.rs
+++ b/src/core/code_audit/detectors/command_status_contracts.rs
@@ -52,7 +52,7 @@ pub(in crate::core::code_audit) fn run(
     for scenario in &config.scenarios {
         let fixture = root.join(&scenario.file);
         let Ok(content) = std::fs::read_to_string(&fixture) else {
-            findings.push(finding(
+            findings.push(fixture_missing_finding(
                 &scenario.file,
                 &scenario.id,
                 "scenario fixture is missing or unreadable".to_string(),
@@ -363,6 +363,27 @@ fn finding(file: &str, scenario_id: &str, description: String, suggestion: Strin
     }
 }
 
+/// A declared scenario's golden fixture file is missing or unreadable. This is
+/// test-data hygiene, not a status-contract violation, so it gets its own kind
+/// and a non-"violates contract" description.
+fn fixture_missing_finding(
+    file: &str,
+    scenario_id: &str,
+    description: String,
+    suggestion: String,
+) -> Finding {
+    Finding {
+        convention: "command_status_contracts".to_string(),
+        severity: Severity::Warning,
+        file: file.to_string(),
+        description: format!(
+            "Command status scenario '{scenario_id}' fixture unavailable: {description}"
+        ),
+        suggestion,
+        kind: AuditFinding::CommandStatusFixtureMissing,
+    }
+}
+
 fn json_value_label(value: &serde_json::Value) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| "<unserializable>".to_string())
 }
@@ -572,6 +593,33 @@ mod tests {
         assert_eq!(findings.len(), 1);
         assert!(findings[0].description.contains("/success"));
         assert!(findings[0].suggestion.contains("successful empty results"));
+    }
+
+    #[test]
+    fn missing_fixture_reports_distinct_kind_not_contract_violation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // No fixture file is written, so the declared scenario's golden fixture
+        // is missing.
+        let config = CommandStatusContractConfig {
+            required_commands: Vec::new(),
+            required_output_error_commands: Vec::new(),
+            scenarios: vec![scenario(
+                "review-artifact-golden",
+                Some("review"),
+                "does-not-exist.json",
+                None,
+                false,
+                [("/success", serde_json::json!(false))],
+            )],
+        };
+
+        let findings = run(dir.path(), &config);
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.kind, AuditFinding::CommandStatusFixtureMissing);
+        assert_ne!(finding.kind, AuditFinding::CommandStatusContractViolation);
+        assert!(finding.description.contains("fixture unavailable"));
+        assert!(!finding.description.contains("violates contract"));
     }
 
     fn scenario<const N: usize>(

--- a/src/core/code_audit/execution_plan.rs
+++ b/src/core/code_audit/execution_plan.rs
@@ -491,7 +491,10 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
     },
     DetectorDescriptor {
         id: "command_status_contracts",
-        findings: &[AuditFinding::CommandStatusContractViolation],
+        findings: &[
+            AuditFinding::CommandStatusContractViolation,
+            AuditFinding::CommandStatusFixtureMissing,
+        ],
         access: DetectorAccess::RootOnly,
         runtime: DetectorRuntime::Generic(GenericDetectorRunner::CommandStatusContracts),
         timing_id: "detector.command_status_contracts",

--- a/src/core/code_audit/findings.rs
+++ b/src/core/code_audit/findings.rs
@@ -184,7 +184,8 @@ impl AuditFinding {
             | AuditFinding::StaleDocReference
             | AuditFinding::UnwiredNestedRustTest
             | AuditFinding::NonPortableArtifactPath
-            | AuditFinding::CommandStatusContractViolation => FindingConfidence::Structural,
+            | AuditFinding::CommandStatusContractViolation
+            | AuditFinding::CommandStatusFixtureMissing => FindingConfidence::Structural,
 
             // Depends on cross-file reference resolution or declared ownership maps.
             AuditFinding::UnusedParameter


### PR DESCRIPTION
## Summary
Two `code_audit` detector-precision fixes that eliminate the last false positives found during the thin-command-adapter refactor series.

### #8300 — command_status: distinguish missing fixture from contract violation
A declared `command_status_contracts` scenario whose golden fixture is missing/unreadable was reported as `command_status_contract_violation` — the same kind as genuine status-contract drift. Added a distinct `command_status_fixture_missing` kind (structural confidence, wired through `all_names` + detector descriptor) with a "fixture unavailable" (not "violates contract") description.

### #8299 — thin_command_adapter: exempt core delegation, skip imports
The detector counted any `persist_*`/`execute_*`/`dispatch_*` marker match, including:
- **bare calls to core-imported functions** (delegation, not a leak) — e.g. a command that `use`s and calls `persist_loop_inventory_run`
- the **`use` import line** for such a symbol (not a call at all)

Both were false positives that scored "orchestration" purely because a name matched a regex. Fixed conservatively:
- Skip `use`/`pub use` import lines entirely.
- Suppress a bare marker-named **call** only when its callee is a proven `core::` import in the same file. Command-local helpers of the same shape, and unknown callees, **still count** — never silently drop a real leak.

## Verification
- `cargo test --lib code_audit::detectors::thin_command_adapter`: **18 pass** (15 existing + 3 new: core-import exempt, local helper counts, unknown callee counts).
- `cargo test --lib command_status_contracts::tests`: **8 pass** (incl. new missing-fixture kind test).
- `cargo test --lib code_audit::conventions::tests::test_all_names`: passes.
- `cargo check --lib`: clean (all `AuditFinding` matches remain exhaustive).

## Series wrap-up
Completes the detector-accuracy work from the thin-command-adapter campaign. All 5 precision issues now resolved: #8297 ✅, #8328 ✅, #8331 ✅, #8335 ✅, and #8299 + #8300 (this PR).