### PR TITLE
fix(release): honor --skip-build-validation for package completeness

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -115,11 +115,18 @@ pub(super) fn execute_release_plan_step(
                 context.options.skip_build_validation,
             )
             .and_then(|result| {
-                executor::package_preflight::validate_package_completeness(
-                    context.component,
-                    std::path::Path::new(&context.component.local_path),
-                    &context.state.artifacts,
-                )?;
+                // `--skip-build-validation` bypasses build-structure
+                // assertions in both `preflight.package` and `package`;
+                // package-completeness is one such assertion (#8189).
+                if executor::package_preflight::should_validate_package_completeness(
+                    context.options.skip_build_validation,
+                ) {
+                    executor::package_preflight::validate_package_completeness(
+                        context.component,
+                        std::path::Path::new(&context.component.local_path),
+                        &context.state.artifacts,
+                    )?;
+                }
                 Ok(result)
             })
             .unwrap_or_else(|err| failed_result("package", "package", err)),

--- a/src/core/release/executor/package_preflight.rs
+++ b/src/core/release/executor/package_preflight.rs
@@ -15,6 +15,17 @@ pub(crate) fn run_package_preflight(component_local_path: &str) -> Result<()> {
     super::lockfile_guard::guard_local_file_dependencies(component_path)
 }
 
+/// Whether the package-completeness structure assertion should run.
+///
+/// `--skip-build-validation` is documented to bypass build-structure
+/// assertions in both `preflight.package` and `package`. Package-completeness
+/// (every tracked runtime file present in the ZIP) is such a structure
+/// assertion, so an explicit override must skip it rather than fail closed
+/// (#8189).
+pub(crate) fn should_validate_package_completeness(skip_build_validation: bool) -> bool {
+    !skip_build_validation
+}
+
 /// Confirm that the durable artifacts produced by the final package step
 /// include every tracked runtime file in the configured release scope.
 pub(crate) fn validate_package_completeness(
@@ -298,6 +309,16 @@ mod tests {
         }];
         validate_package_completeness(&component, repo.path(), &artifacts)
             .expect("excluded runtime file should not fail");
+    }
+
+    #[test]
+    fn skip_build_validation_bypasses_package_completeness() {
+        // #8189: when the operator passes --skip-build-validation, the
+        // package-completeness structure assertion must not run, matching the
+        // documented CLI contract.
+        assert!(!should_validate_package_completeness(true));
+        // Default release behavior still enforces completeness.
+        assert!(should_validate_package_completeness(false));
     }
 
     fn run_git(repo: &Path, args: &[&str]) {


### PR DESCRIPTION
## Summary
`homeboy release <c> --skip-build-validation` still failed in `preflight.package` on tracked files missing from the ZIP, even though the flag is documented to bypass build-structure assertions in both `preflight.package` and `package` (#8189).

The package-completeness check (`validate_package_completeness` — every tracked runtime file present in the release archive) is exactly such a structure assertion, but it was invoked unconditionally in the `package` dispatch step regardless of the flag.

## Fix
- Add `should_validate_package_completeness(skip_build_validation)` in `package_preflight.rs` documenting the contract.
- Gate the completeness assertion in `execution_dispatch.rs` on that helper so `--skip-build-validation` skips it while normal releases still enforce it.

## Tests
- New unit test `skip_build_validation_bypasses_package_completeness` covering both the skip and default paths.
- `cargo fmt` clean; `cargo check --lib` passes (only pre-existing unused-import warnings in unrelated files). Full suite deferred to CI per repo policy.

Fixes #8189