### PR TITLE
Isolate harvest context across parallel cook batches

### DIFF
--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -127,29 +127,13 @@ fn run_batch_cook_fanout_plan_with_executor<E>(
 where
     E: homeboy::core::agent_tasks::scheduler::AgentTaskExecutorAdapter + Clone,
 {
-    // A batch is one controller or one Lab child process. Per-cell mixed
-    // placement would require independent process boundaries, so every cell
-    // shares the immutable context captured by its owning process.
-    let harvest_context = batch_harvest_context()?;
-    run_batch_cook_fanout_plan_with_cell_executor(
-        plan,
-        harvest_context,
-        move |cook, plan, context| {
-            let invocation = cook.to_cook_invocation(plan)?;
-            let run_id = invocation.options.initial_run_id.clone();
-            let request = dispatch_service::resolve_dispatch_request(invocation.dispatch.into())?;
-            let initial_plan = dispatch_service::build_dispatch_plan(&request)?;
-            let mut options = invocation.options;
-            options.initial_run_id = run_id;
-            options.initial_plan = initial_plan;
-            options.harvest_context = context;
-            let result = agent_task_service::run_cook(options, executor.clone())?;
-            Ok(serde_json::json!({
-                "exit_code": result.exit_code,
-                "result": serde_json::to_value(result.value).unwrap_or(Value::Null),
-            }))
-        },
-    )
+    run_batch_cook_fanout_plan_with_terminal(plan, None, move |options| {
+        let result = agent_task_service::run_cook(options, executor.clone())?;
+        Ok(serde_json::json!({
+            "exit_code": result.exit_code,
+            "result": serde_json::to_value(result.value).unwrap_or(Value::Null),
+        }))
+    })
 }
 
 fn batch_harvest_context() -> Result<homeboy::core::agent_task_scheduler::HarvestExecutionContext> {
@@ -160,50 +144,36 @@ fn batch_harvest_context() -> Result<homeboy::core::agent_task_scheduler::Harves
     }
 }
 
-fn run_batch_cook_fanout_plan_with_cell_executor<F>(
+/// Runs one controller-owned batch. The controller captures one immutable Lab
+/// process context; each cell receives a clone after its dispatch plan and cook
+/// options have been constructed. Batch cook specs currently have no per-cell
+/// runner or placement field, so they cannot request mixed local/Lab routing.
+fn run_batch_cook_fanout_plan_with_terminal<F>(
     plan: BatchCookFanoutPlan,
-    harvest_context: homeboy::core::agent_task_scheduler::HarvestExecutionContext,
-    cell_executor: F,
+    worker_limit: Option<usize>,
+    terminal: F,
 ) -> CmdResult<Value>
 where
-    F: Fn(
-            &BatchCookSpec,
-            &BatchCookFanoutPlan,
-            homeboy::core::agent_task_scheduler::HarvestExecutionContext,
-        ) -> Result<Value>
-        + Clone
-        + Send,
+    F: Fn(AgentTaskCookServiceOptions) -> Result<Value> + Clone + Send,
 {
-    let workers = plan
-        .cooks
-        .len()
-        .min(std::thread::available_parallelism().map_or(1, usize::from));
-    run_batch_cook_fanout_plan_with_cell_executor_and_workers(
-        plan,
-        harvest_context,
-        workers,
-        cell_executor,
-    )
+    let harvest_context = batch_harvest_context()?;
+    let workers = worker_limit.unwrap_or_else(|| {
+        plan.cooks
+            .len()
+            .min(std::thread::available_parallelism().map_or(1, usize::from))
+    });
+    run_batch_cook_fanout_plan_with_terminal_and_workers(plan, harvest_context, workers, terminal)
 }
 
-fn run_batch_cook_fanout_plan_with_cell_executor_and_workers<F>(
+fn run_batch_cook_fanout_plan_with_terminal_and_workers<F>(
     plan: BatchCookFanoutPlan,
     harvest_context: homeboy::core::agent_task_scheduler::HarvestExecutionContext,
     workers: usize,
-    cell_executor: F,
+    terminal: F,
 ) -> CmdResult<Value>
 where
-    F: Fn(
-            &BatchCookSpec,
-            &BatchCookFanoutPlan,
-            homeboy::core::agent_task_scheduler::HarvestExecutionContext,
-        ) -> Result<Value>
-        + Clone
-        + Send,
+    F: Fn(AgentTaskCookServiceOptions) -> Result<Value> + Clone + Send,
 {
-    // A batch is one controller or one Lab child process. Per-cell mixed
-    // placement would require independent process boundaries, so every cell
-    // shares the immutable context captured by its owning process.
     let total = plan.cooks.len();
     let workers = workers.min(total);
     let plan = Arc::new(plan);
@@ -214,7 +184,7 @@ where
             let plan = Arc::clone(&plan);
             let next = Arc::clone(&next);
             let tx = tx.clone();
-            let cell_executor = cell_executor.clone();
+            let terminal = terminal.clone();
             let harvest_context = harvest_context.clone();
             scope.spawn(move || loop {
                 let index = {
@@ -227,7 +197,18 @@ where
                     index
                 };
                 let cook = &plan.cooks[index];
-                let cell = cell_executor(cook, &plan, harvest_context.clone());
+                let cell = (|| -> Result<Value> {
+                    let invocation = cook.to_cook_invocation(&plan)?;
+                    let run_id = invocation.options.initial_run_id.clone();
+                    let request =
+                        dispatch_service::resolve_dispatch_request(invocation.dispatch.into())?;
+                    let initial_plan = dispatch_service::build_dispatch_plan(&request)?;
+                    let mut options = invocation.options;
+                    options.initial_run_id = run_id;
+                    options.initial_plan = initial_plan;
+                    options.harvest_context = harvest_context.clone();
+                    terminal(options)
+                })();
                 let _ = tx.send((index, cell));
             });
         }
@@ -1105,11 +1086,11 @@ mod tests {
     use super::*;
     use crate::cli_surface::{Cli, Commands};
     use crate::commands::agent_task::{AgentTaskCommand, AgentTaskFanoutCommand};
-    use crate::test_support::with_isolated_home;
+    use crate::test_support::{env_lock, with_isolated_home};
     use clap::Parser;
     use serde_json::json;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Barrier, OnceLock};
+    use std::sync::Barrier;
 
     fn test_batch_plan() -> BatchCookFanoutPlan {
         BatchCookFanoutPlan::from_value(
@@ -1117,8 +1098,8 @@ mod tests {
                 "schema": AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA,
                 "fanout_id": "test-batch",
                 "cooks": [
-                    {"cook_id": "first", "prompt": "first", "to_worktree": "homeboy@first", "verify": ["true"]},
-                    {"cook_id": "second", "prompt": "second", "to_worktree": "homeboy@second", "verify": ["true"]}
+                    {"cook_id": "first", "prompt": "first", "cwd": env!("CARGO_MANIFEST_DIR"), "to_worktree": "homeboy@first", "verify": ["true"]},
+                    {"cook_id": "second", "prompt": "second", "cwd": env!("CARGO_MANIFEST_DIR"), "to_worktree": "homeboy@second", "verify": ["true"]}
                 ]
             }),
             &args(),
@@ -1126,32 +1107,18 @@ mod tests {
         .expect("test batch plan")
     }
 
-    fn run_test_batch<F>(
-        context: homeboy::core::agent_task_scheduler::HarvestExecutionContext,
-        executor: F,
-    ) -> CmdResult<Value>
+    fn run_test_batch<F>(terminal: F) -> CmdResult<Value>
     where
-        F: Fn(
-                &BatchCookSpec,
-                &BatchCookFanoutPlan,
-                homeboy::core::agent_task_scheduler::HarvestExecutionContext,
-            ) -> Result<Value>
-            + Clone
-            + Send,
+        F: Fn(AgentTaskCookServiceOptions) -> Result<Value> + Clone + Send,
     {
-        run_batch_cook_fanout_plan_with_cell_executor_and_workers(
-            test_batch_plan(),
-            context,
-            2,
-            executor,
-        )
+        run_batch_cook_fanout_plan_with_terminal(test_batch_plan(), None, terminal)
     }
 
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| std::sync::Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    fn run_test_batch_with_workers<F>(workers: usize, terminal: F) -> CmdResult<Value>
+    where
+        F: Fn(AgentTaskCookServiceOptions) -> Result<Value> + Clone + Send,
+    {
+        run_batch_cook_fanout_plan_with_terminal(test_batch_plan(), Some(workers), terminal)
     }
 
     struct EnvRestore(Vec<(&'static str, Option<std::ffi::OsString>)>);
@@ -1184,75 +1151,85 @@ mod tests {
         }
     }
 
-    fn lab_context(label: &str) -> homeboy::core::agent_task_scheduler::HarvestExecutionContext {
-        let snapshot = json!({
-            "runner_id": format!("lab-{label}"), "dirty": false, "sync_mode": "snapshot",
-            "snapshot_hash": label, "synced_at": "2026-07-15T00:00:00Z", "sync_excludes": []
-        });
-        let snapshot = snapshot.to_string();
-        let lab = format!(r#"{{"label":"{label}"}}"#);
-        let env = EnvRestore::set(&[
-            ("HOMEBOY_SOURCE_SNAPSHOT_JSON", Some(&snapshot)),
-            ("HOMEBOY_LAB_OFFLOAD_JSON", Some(&lab)),
-        ]);
-        let context =
-            homeboy::core::agent_task_scheduler::HarvestExecutionContext::from_current_process()
-                .expect("Lab context");
-        drop(env);
-        context
+    #[test]
+    fn cook_batch_constructs_cells_and_delivers_controller_context_to_terminal_body() {
+        let _env_lock = env_lock();
+        let expected_context = format!(
+            "{:?}",
+            batch_harvest_context().expect("controller harvest context")
+        );
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let (value, exit_code) = run_test_batch({
+            let observed = Arc::clone(&observed);
+            move |options| {
+                observed.lock().expect("terminal options").push((
+                    options.cook_id,
+                    options.initial_plan.tasks.len(),
+                    format!("{:?}", options.harvest_context),
+                ));
+                Ok(json!({"exit_code": 0, "result": {"status": "succeeded"}}))
+            }
+        })
+        .expect("batch executes");
+
+        assert_eq!(exit_code, 0);
+        let observed = observed.lock().expect("terminal options");
+        assert_eq!(observed.len(), 2);
+        assert!(observed.iter().all(|(_, tasks, _)| *tasks == 1));
+        assert!(observed
+            .iter()
+            .all(|(_, _, context)| context == &expected_context));
+        assert_eq!(value["cooks"][0]["cook_id"], "first");
+        assert_eq!(value["cooks"][1]["cook_id"], "second");
     }
 
     #[test]
     fn cook_batch_runs_two_cells_concurrently_in_plan_order() {
+        let _env_lock = env_lock();
         let barrier = Arc::new(Barrier::new(2));
         let entered = Arc::new(AtomicUsize::new(0));
-        let (value, exit_code) = run_test_batch(
-            homeboy::core::agent_task_scheduler::HarvestExecutionContext::default(),
-            {
-                let barrier = Arc::clone(&barrier);
-                let entered = Arc::clone(&entered);
-                move |cook, _, _| {
-                    entered.fetch_add(1, Ordering::SeqCst);
-                    barrier.wait();
-                    Ok(json!({"exit_code": 0, "result": {"cell": cook.cook_id}}))
-                }
-            },
-        )
+        let (value, exit_code) = run_test_batch_with_workers(2, {
+            let barrier = Arc::clone(&barrier);
+            let entered = Arc::clone(&entered);
+            move |options| {
+                entered.fetch_add(1, Ordering::SeqCst);
+                barrier.wait();
+                Ok(json!({"exit_code": 0, "result": {"cell": options.cook_id}}))
+            }
+        })
         .expect("batch executes");
 
         assert_eq!(exit_code, 0);
         assert_eq!(entered.load(Ordering::SeqCst), 2);
         assert_eq!(value["cooks"][0]["cook_id"], "first");
-        assert_eq!(value["cooks"][0]["result"]["cell"], "first");
+        assert_eq!(value["cooks"][0]["result"]["cell"], "cook-first");
         assert_eq!(value["cooks"][1]["cook_id"], "second");
-        assert_eq!(value["cooks"][1]["result"]["cell"], "second");
+        assert_eq!(value["cooks"][1]["result"]["cell"], "cook-second");
     }
 
     #[test]
     fn cook_batch_isolates_cell_failure() {
+        let _env_lock = env_lock();
         let executed = Arc::new(Mutex::new(Vec::new()));
-        let (value, exit_code) = run_test_batch(
-            homeboy::core::agent_task_scheduler::HarvestExecutionContext::default(),
-            {
-                let executed = Arc::clone(&executed);
-                move |cook, _, _| {
-                    executed
-                        .lock()
-                        .expect("executed cells")
-                        .push(cook.cook_id.clone());
-                    if cook.cook_id == "first" {
-                        Err(Error::validation_invalid_argument(
-                            "setup",
-                            "cook setup failed",
-                            None,
-                            None,
-                        ))
-                    } else {
-                        Ok(json!({"exit_code": 0, "result": {"status": "succeeded"}}))
-                    }
+        let (value, exit_code) = run_test_batch({
+            let executed = Arc::clone(&executed);
+            move |options| {
+                executed
+                    .lock()
+                    .expect("executed cells")
+                    .push(options.cook_id.clone());
+                if options.cook_id == "cook-first" {
+                    Err(Error::validation_invalid_argument(
+                        "setup",
+                        "cook setup failed",
+                        None,
+                        None,
+                    ))
+                } else {
+                    Ok(json!({"exit_code": 0, "result": {"status": "succeeded"}}))
                 }
-            },
-        )
+            }
+        })
         .expect("batch completes despite cell failure");
 
         assert_eq!(exit_code, 1);
@@ -1268,7 +1245,7 @@ mod tests {
 
     #[test]
     fn cook_batch_controller_context_ignores_ambient_incomplete_lab_pair() {
-        let _lock = env_lock();
+        let _env_lock = env_lock();
         let _env = EnvRestore::set(&[
             ("HOMEBOY_RUNNER_HOSTED_EXEC", None),
             (
@@ -1277,15 +1254,14 @@ mod tests {
             ),
             ("HOMEBOY_LAB_OFFLOAD_JSON", None),
         ]);
-        let context = batch_harvest_context().expect("controller context");
         let observed = Arc::new(Mutex::new(Vec::new()));
-        let (value, exit_code) = run_test_batch(context, {
+        let (value, exit_code) = run_test_batch({
             let observed = Arc::clone(&observed);
-            move |_, _, context| {
+            move |options| {
                 observed
                     .lock()
                     .expect("contexts")
-                    .push(format!("{context:?}"));
+                    .push(format!("{:?}", options.harvest_context));
                 Ok(json!({"exit_code": 0, "result": {"status": "succeeded"}}))
             }
         })
@@ -1304,16 +1280,52 @@ mod tests {
 
     #[test]
     fn cook_batch_context_does_not_leak_between_invocations() {
-        let controller = homeboy::core::agent_task_scheduler::HarvestExecutionContext::default();
-        let lab = lab_context("second-batch");
+        let _env_lock = env_lock();
         let observed = Arc::new(Mutex::new(Vec::new()));
-        for context in [controller, lab] {
+        {
+            let _env = EnvRestore::set(&[
+                ("HOMEBOY_RUNNER_HOSTED_EXEC", None),
+                ("HOMEBOY_SOURCE_SNAPSHOT_JSON", None),
+                ("HOMEBOY_LAB_OFFLOAD_JSON", None),
+            ]);
             let observed = Arc::clone(&observed);
-            run_test_batch(context, move |_, _, context| {
-                observed
-                    .lock()
-                    .expect("contexts")
-                    .push(format!("{context:?}"));
+            let expected_context = format!(
+                "{:?}",
+                batch_harvest_context().expect("controller harvest context")
+            );
+            run_test_batch(move |options| {
+                observed.lock().expect("contexts").push((
+                    format!("{:?}", options.harvest_context),
+                    expected_context.clone(),
+                ));
+                Ok(json!({"exit_code": 0, "result": {}}))
+            })
+            .expect("controller batch executes");
+        }
+        {
+            let snapshot = json!({
+                "runner_id": "lab-second-batch", "dirty": false, "sync_mode": "snapshot",
+                "snapshot_hash": "second-batch", "synced_at": "2026-07-15T00:00:00Z", "sync_excludes": []
+            })
+            .to_string();
+            let _env = EnvRestore::set(&[
+                ("HOMEBOY_RUNNER_HOSTED_EXEC", Some("1")),
+                ("HOMEBOY_SOURCE_SNAPSHOT_JSON", Some(&snapshot)),
+                (
+                    "HOMEBOY_LAB_OFFLOAD_JSON",
+                    Some(r#"{"label":"second-batch"}"#),
+                ),
+            ]);
+            let observed = Arc::clone(&observed);
+            let expected_context = format!(
+                "{:?}",
+                batch_harvest_context().expect("Lab harvest context")
+            );
+            run_test_batch(move |options| {
+                observed.lock().expect("contexts").push((
+                    format!("{:?}", options.harvest_context),
+                    expected_context.clone(),
+                ));
                 Ok(json!({"exit_code": 0, "result": {}}))
             })
             .expect("batch executes");
@@ -1321,14 +1333,16 @@ mod tests {
 
         let observed = observed.lock().expect("contexts");
         assert_eq!(observed.len(), 4);
-        assert_eq!(observed[0], observed[1]);
+        assert_eq!(observed[0].0, observed[0].1);
+        assert_eq!(observed[1].0, observed[1].1);
         assert_eq!(
-            observed[0],
+            observed[0].0,
             "HarvestExecutionContext { source_snapshot: None, lab_offload: None }"
         );
-        assert_eq!(observed[2], observed[3]);
-        assert!(observed[2].contains("lab-second-batch"));
-        assert_ne!(observed[0], observed[2]);
+        assert_eq!(observed[2].0, observed[2].1);
+        assert_eq!(observed[3].0, observed[3].1);
+        assert!(observed[2].0.contains("lab-second-batch"));
+        assert_ne!(observed[0].0, observed[2].0);
     }
 
     fn args() -> AgentTaskFanoutInputArgs {

--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
+use std::sync::{mpsc, Arc, Mutex};
 
 use homeboy::core::agent_task_provider::AgentTaskProviderProfileDeclaration;
 use homeboy::core::agent_tasks::batch;
@@ -113,34 +114,90 @@ fn run_batch_cook_fanout(args: AgentTaskFanoutRunPlanArgs) -> CmdResult<Value> {
 }
 
 fn run_batch_cook_fanout_plan(plan: BatchCookFanoutPlan) -> CmdResult<Value> {
-    let executor = provider::ExtensionProviderAgentTaskExecutor::discover();
-    let mut results = Vec::new();
-    let mut failed = 0usize;
+    run_batch_cook_fanout_plan_with_executor(
+        plan,
+        provider::ExtensionProviderAgentTaskExecutor::discover(),
+    )
+}
 
-    for cook in &plan.cooks {
-        let invocation = cook.to_cook_invocation(&plan)?;
-        let run_id = invocation.options.initial_run_id.clone();
-        let request = dispatch_service::resolve_dispatch_request(invocation.dispatch.into())?;
-        let initial_plan = dispatch_service::build_dispatch_plan(&request)?;
-        let mut options = invocation.options;
-        options.initial_run_id = run_id;
-        options.initial_plan = initial_plan;
-        let result = agent_task_service::run_cook(options, executor.clone())?;
-        let value = serde_json::to_value(result.value).unwrap_or(Value::Null);
-        let exit_code = result.exit_code;
-        if exit_code != 0 {
-            failed += 1;
+fn run_batch_cook_fanout_plan_with_executor<E>(
+    plan: BatchCookFanoutPlan,
+    executor: E,
+) -> CmdResult<Value>
+where
+    E: homeboy::core::agent_tasks::scheduler::AgentTaskExecutorAdapter + Clone,
+{
+    // A batch is one controller or one Lab child process. Per-cell mixed
+    // placement would require independent process boundaries, so every cell
+    // shares the immutable context captured by its owning process.
+    let total = plan.cooks.len();
+    let workers = total.min(std::thread::available_parallelism().map_or(1, usize::from));
+    let plan = Arc::new(plan);
+    let next = Arc::new(Mutex::new(0usize));
+    let (tx, rx) = mpsc::channel();
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            let plan = Arc::clone(&plan);
+            let next = Arc::clone(&next);
+            let tx = tx.clone();
+            let executor = executor.clone();
+            scope.spawn(move || loop {
+                let index = {
+                    let mut next = next.lock().expect("batch cook work queue");
+                    if *next == plan.cooks.len() {
+                        return;
+                    }
+                    let index = *next;
+                    *next += 1;
+                    index
+                };
+                let cook = &plan.cooks[index];
+                let cell = (|| -> Result<Value> {
+                    let invocation = cook.to_cook_invocation(&plan)?;
+                    let run_id = invocation.options.initial_run_id.clone();
+                    let request =
+                        dispatch_service::resolve_dispatch_request(invocation.dispatch.into())?;
+                    let initial_plan = dispatch_service::build_dispatch_plan(&request)?;
+                    let mut options = invocation.options;
+                    options.initial_run_id = run_id;
+                    options.initial_plan = initial_plan;
+                    let result = agent_task_service::run_cook(options, executor.clone())?;
+                    Ok(serde_json::json!({
+                        "exit_code": result.exit_code,
+                        "result": serde_json::to_value(result.value).unwrap_or(Value::Null),
+                    }))
+                })();
+                let _ = tx.send((index, cell));
+            });
         }
-        results.push(serde_json::json!({
+    });
+    drop(tx);
+
+    let mut results = (0..total).map(|_| None).collect::<Vec<Option<Value>>>();
+    for (index, cell) in rx {
+        let cook = &plan.cooks[index];
+        let cell = match cell {
+            Ok(cell) => cell,
+            Err(error) => serde_json::json!({
+                "exit_code": 1,
+                "result": { "error": error.to_string() },
+            }),
+        };
+        results[index] = Some(serde_json::json!({
             "cook_id": cook.cook_id,
             "run_id": cook.run_id(),
             "worktree": cook.to_worktree,
             "head": cook.head,
             "workspace_materialization": cook.workspace_materialization,
-            "exit_code": exit_code,
-            "result": value,
+            "exit_code": cell["exit_code"],
+            "result": cell["result"],
         }));
     }
+    let results = results.into_iter().flatten().collect::<Vec<_>>();
+    let failed = results
+        .iter()
+        .filter(|result| result["exit_code"].as_i64() != Some(0))
+        .count();
 
     Ok((
         serde_json::json!({

--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -131,6 +131,11 @@ where
     // placement would require independent process boundaries, so every cell
     // shares the immutable context captured by its owning process.
     let total = plan.cooks.len();
+    let harvest_context = if std::env::var_os("HOMEBOY_RUNNER_HOSTED_EXEC").is_some() {
+        homeboy::core::agent_task_scheduler::HarvestExecutionContext::from_current_process()?
+    } else {
+        homeboy::core::agent_task_scheduler::HarvestExecutionContext::default()
+    };
     let workers = total.min(std::thread::available_parallelism().map_or(1, usize::from));
     let plan = Arc::new(plan);
     let next = Arc::new(Mutex::new(0usize));
@@ -141,6 +146,7 @@ where
             let next = Arc::clone(&next);
             let tx = tx.clone();
             let executor = executor.clone();
+            let harvest_context = harvest_context.clone();
             scope.spawn(move || loop {
                 let index = {
                     let mut next = next.lock().expect("batch cook work queue");
@@ -161,6 +167,7 @@ where
                     let mut options = invocation.options;
                     options.initial_run_id = run_id;
                     options.initial_plan = initial_plan;
+                    options.harvest_context = harvest_context.clone();
                     let result = agent_task_service::run_cook(options, executor.clone())?;
                     Ok(serde_json::json!({
                         "exit_code": result.exit_code,
@@ -631,6 +638,8 @@ impl BatchCookSpec {
                     .or_else(|| agent_task_service::ai_model_from_tool(&self.ai_tool)),
                 ai_used_for: self.ai_used_for.clone(),
                 attempt_dispatcher: None,
+                harvest_context:
+                    crate::core::agent_task_scheduler::HarvestExecutionContext::default(),
             },
         })
     }

--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -130,13 +130,82 @@ where
     // A batch is one controller or one Lab child process. Per-cell mixed
     // placement would require independent process boundaries, so every cell
     // shares the immutable context captured by its owning process.
-    let total = plan.cooks.len();
-    let harvest_context = if std::env::var_os("HOMEBOY_RUNNER_HOSTED_EXEC").is_some() {
-        homeboy::core::agent_task_scheduler::HarvestExecutionContext::from_current_process()?
+    let harvest_context = batch_harvest_context()?;
+    run_batch_cook_fanout_plan_with_cell_executor(
+        plan,
+        harvest_context,
+        move |cook, plan, context| {
+            let invocation = cook.to_cook_invocation(plan)?;
+            let run_id = invocation.options.initial_run_id.clone();
+            let request = dispatch_service::resolve_dispatch_request(invocation.dispatch.into())?;
+            let initial_plan = dispatch_service::build_dispatch_plan(&request)?;
+            let mut options = invocation.options;
+            options.initial_run_id = run_id;
+            options.initial_plan = initial_plan;
+            options.harvest_context = context;
+            let result = agent_task_service::run_cook(options, executor.clone())?;
+            Ok(serde_json::json!({
+                "exit_code": result.exit_code,
+                "result": serde_json::to_value(result.value).unwrap_or(Value::Null),
+            }))
+        },
+    )
+}
+
+fn batch_harvest_context() -> Result<homeboy::core::agent_task_scheduler::HarvestExecutionContext> {
+    if std::env::var_os("HOMEBOY_RUNNER_HOSTED_EXEC").is_some() {
+        homeboy::core::agent_task_scheduler::HarvestExecutionContext::from_current_process()
     } else {
-        homeboy::core::agent_task_scheduler::HarvestExecutionContext::default()
-    };
-    let workers = total.min(std::thread::available_parallelism().map_or(1, usize::from));
+        Ok(homeboy::core::agent_task_scheduler::HarvestExecutionContext::default())
+    }
+}
+
+fn run_batch_cook_fanout_plan_with_cell_executor<F>(
+    plan: BatchCookFanoutPlan,
+    harvest_context: homeboy::core::agent_task_scheduler::HarvestExecutionContext,
+    cell_executor: F,
+) -> CmdResult<Value>
+where
+    F: Fn(
+            &BatchCookSpec,
+            &BatchCookFanoutPlan,
+            homeboy::core::agent_task_scheduler::HarvestExecutionContext,
+        ) -> Result<Value>
+        + Clone
+        + Send,
+{
+    let workers = plan
+        .cooks
+        .len()
+        .min(std::thread::available_parallelism().map_or(1, usize::from));
+    run_batch_cook_fanout_plan_with_cell_executor_and_workers(
+        plan,
+        harvest_context,
+        workers,
+        cell_executor,
+    )
+}
+
+fn run_batch_cook_fanout_plan_with_cell_executor_and_workers<F>(
+    plan: BatchCookFanoutPlan,
+    harvest_context: homeboy::core::agent_task_scheduler::HarvestExecutionContext,
+    workers: usize,
+    cell_executor: F,
+) -> CmdResult<Value>
+where
+    F: Fn(
+            &BatchCookSpec,
+            &BatchCookFanoutPlan,
+            homeboy::core::agent_task_scheduler::HarvestExecutionContext,
+        ) -> Result<Value>
+        + Clone
+        + Send,
+{
+    // A batch is one controller or one Lab child process. Per-cell mixed
+    // placement would require independent process boundaries, so every cell
+    // shares the immutable context captured by its owning process.
+    let total = plan.cooks.len();
+    let workers = workers.min(total);
     let plan = Arc::new(plan);
     let next = Arc::new(Mutex::new(0usize));
     let (tx, rx) = mpsc::channel();
@@ -145,7 +214,7 @@ where
             let plan = Arc::clone(&plan);
             let next = Arc::clone(&next);
             let tx = tx.clone();
-            let executor = executor.clone();
+            let cell_executor = cell_executor.clone();
             let harvest_context = harvest_context.clone();
             scope.spawn(move || loop {
                 let index = {
@@ -158,22 +227,7 @@ where
                     index
                 };
                 let cook = &plan.cooks[index];
-                let cell = (|| -> Result<Value> {
-                    let invocation = cook.to_cook_invocation(&plan)?;
-                    let run_id = invocation.options.initial_run_id.clone();
-                    let request =
-                        dispatch_service::resolve_dispatch_request(invocation.dispatch.into())?;
-                    let initial_plan = dispatch_service::build_dispatch_plan(&request)?;
-                    let mut options = invocation.options;
-                    options.initial_run_id = run_id;
-                    options.initial_plan = initial_plan;
-                    options.harvest_context = harvest_context.clone();
-                    let result = agent_task_service::run_cook(options, executor.clone())?;
-                    Ok(serde_json::json!({
-                        "exit_code": result.exit_code,
-                        "result": serde_json::to_value(result.value).unwrap_or(Value::Null),
-                    }))
-                })();
+                let cell = cell_executor(cook, &plan, harvest_context.clone());
                 let _ = tx.send((index, cell));
             });
         }
@@ -1054,6 +1108,228 @@ mod tests {
     use crate::test_support::with_isolated_home;
     use clap::Parser;
     use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Barrier, OnceLock};
+
+    fn test_batch_plan() -> BatchCookFanoutPlan {
+        BatchCookFanoutPlan::from_value(
+            json!({
+                "schema": AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA,
+                "fanout_id": "test-batch",
+                "cooks": [
+                    {"cook_id": "first", "prompt": "first", "to_worktree": "homeboy@first", "verify": ["true"]},
+                    {"cook_id": "second", "prompt": "second", "to_worktree": "homeboy@second", "verify": ["true"]}
+                ]
+            }),
+            &args(),
+        )
+        .expect("test batch plan")
+    }
+
+    fn run_test_batch<F>(
+        context: homeboy::core::agent_task_scheduler::HarvestExecutionContext,
+        executor: F,
+    ) -> CmdResult<Value>
+    where
+        F: Fn(
+                &BatchCookSpec,
+                &BatchCookFanoutPlan,
+                homeboy::core::agent_task_scheduler::HarvestExecutionContext,
+            ) -> Result<Value>
+            + Clone
+            + Send,
+    {
+        run_batch_cook_fanout_plan_with_cell_executor_and_workers(
+            test_batch_plan(),
+            context,
+            2,
+            executor,
+        )
+    }
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    struct EnvRestore(Vec<(&'static str, Option<std::ffi::OsString>)>);
+
+    impl EnvRestore {
+        fn set(values: &[(&'static str, Option<&str>)]) -> Self {
+            let prior = values
+                .iter()
+                .map(|(name, value)| {
+                    let previous = std::env::var_os(name);
+                    match value {
+                        Some(value) => std::env::set_var(name, value),
+                        None => std::env::remove_var(name),
+                    }
+                    (*name, previous)
+                })
+                .collect();
+            Self(prior)
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            for (name, value) in self.0.drain(..) {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+
+    fn lab_context(label: &str) -> homeboy::core::agent_task_scheduler::HarvestExecutionContext {
+        let snapshot = json!({
+            "runner_id": format!("lab-{label}"), "dirty": false, "sync_mode": "snapshot",
+            "snapshot_hash": label, "synced_at": "2026-07-15T00:00:00Z", "sync_excludes": []
+        });
+        let snapshot = snapshot.to_string();
+        let lab = format!(r#"{{"label":"{label}"}}"#);
+        let env = EnvRestore::set(&[
+            ("HOMEBOY_SOURCE_SNAPSHOT_JSON", Some(&snapshot)),
+            ("HOMEBOY_LAB_OFFLOAD_JSON", Some(&lab)),
+        ]);
+        let context =
+            homeboy::core::agent_task_scheduler::HarvestExecutionContext::from_current_process()
+                .expect("Lab context");
+        drop(env);
+        context
+    }
+
+    #[test]
+    fn cook_batch_runs_two_cells_concurrently_in_plan_order() {
+        let barrier = Arc::new(Barrier::new(2));
+        let entered = Arc::new(AtomicUsize::new(0));
+        let (value, exit_code) = run_test_batch(
+            homeboy::core::agent_task_scheduler::HarvestExecutionContext::default(),
+            {
+                let barrier = Arc::clone(&barrier);
+                let entered = Arc::clone(&entered);
+                move |cook, _, _| {
+                    entered.fetch_add(1, Ordering::SeqCst);
+                    barrier.wait();
+                    Ok(json!({"exit_code": 0, "result": {"cell": cook.cook_id}}))
+                }
+            },
+        )
+        .expect("batch executes");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(entered.load(Ordering::SeqCst), 2);
+        assert_eq!(value["cooks"][0]["cook_id"], "first");
+        assert_eq!(value["cooks"][0]["result"]["cell"], "first");
+        assert_eq!(value["cooks"][1]["cook_id"], "second");
+        assert_eq!(value["cooks"][1]["result"]["cell"], "second");
+    }
+
+    #[test]
+    fn cook_batch_isolates_cell_failure() {
+        let executed = Arc::new(Mutex::new(Vec::new()));
+        let (value, exit_code) = run_test_batch(
+            homeboy::core::agent_task_scheduler::HarvestExecutionContext::default(),
+            {
+                let executed = Arc::clone(&executed);
+                move |cook, _, _| {
+                    executed
+                        .lock()
+                        .expect("executed cells")
+                        .push(cook.cook_id.clone());
+                    if cook.cook_id == "first" {
+                        Err(Error::validation_invalid_argument(
+                            "setup",
+                            "cook setup failed",
+                            None,
+                            None,
+                        ))
+                    } else {
+                        Ok(json!({"exit_code": 0, "result": {"status": "succeeded"}}))
+                    }
+                }
+            },
+        )
+        .expect("batch completes despite cell failure");
+
+        assert_eq!(exit_code, 1);
+        assert_eq!(executed.lock().expect("executed cells").len(), 2);
+        assert_eq!(value["cooks"][0]["exit_code"], 1);
+        assert!(value["cooks"][0]["result"]["error"]
+            .as_str()
+            .expect("failure message")
+            .contains("cook setup failed"));
+        assert_eq!(value["cooks"][1]["exit_code"], 0);
+        assert_eq!(value["cooks"][1]["result"]["status"], "succeeded");
+    }
+
+    #[test]
+    fn cook_batch_controller_context_ignores_ambient_incomplete_lab_pair() {
+        let _lock = env_lock();
+        let _env = EnvRestore::set(&[
+            ("HOMEBOY_RUNNER_HOSTED_EXEC", None),
+            (
+                "HOMEBOY_SOURCE_SNAPSHOT_JSON",
+                Some("{\"incomplete\":true}"),
+            ),
+            ("HOMEBOY_LAB_OFFLOAD_JSON", None),
+        ]);
+        let context = batch_harvest_context().expect("controller context");
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let (value, exit_code) = run_test_batch(context, {
+            let observed = Arc::clone(&observed);
+            move |_, _, context| {
+                observed
+                    .lock()
+                    .expect("contexts")
+                    .push(format!("{context:?}"));
+                Ok(json!({"exit_code": 0, "result": {"status": "succeeded"}}))
+            }
+        })
+        .expect("controller batch executes");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(value["status"], "succeeded");
+        assert_eq!(
+            observed.lock().expect("contexts").as_slice(),
+            [
+                "HarvestExecutionContext { source_snapshot: None, lab_offload: None }",
+                "HarvestExecutionContext { source_snapshot: None, lab_offload: None }"
+            ]
+        );
+    }
+
+    #[test]
+    fn cook_batch_context_does_not_leak_between_invocations() {
+        let controller = homeboy::core::agent_task_scheduler::HarvestExecutionContext::default();
+        let lab = lab_context("second-batch");
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        for context in [controller, lab] {
+            let observed = Arc::clone(&observed);
+            run_test_batch(context, move |_, _, context| {
+                observed
+                    .lock()
+                    .expect("contexts")
+                    .push(format!("{context:?}"));
+                Ok(json!({"exit_code": 0, "result": {}}))
+            })
+            .expect("batch executes");
+        }
+
+        let observed = observed.lock().expect("contexts");
+        assert_eq!(observed.len(), 4);
+        assert_eq!(observed[0], observed[1]);
+        assert_eq!(
+            observed[0],
+            "HarvestExecutionContext { source_snapshot: None, lab_offload: None }"
+        );
+        assert_eq!(observed[2], observed[3]);
+        assert!(observed[2].contains("lab-second-batch"));
+        assert_ne!(observed[0], observed[2]);
+    }
 
     fn args() -> AgentTaskFanoutInputArgs {
         AgentTaskFanoutInputArgs {

--- a/src/commands/agent_task/run.rs
+++ b/src/commands/agent_task/run.rs
@@ -195,6 +195,9 @@ where
                 .or_else(|| agent_task_service::ai_model_from_tool(&args.ai_tool)),
             ai_used_for: args.ai_used_for,
             attempt_dispatcher,
+            harvest_context:
+                homeboy::core::agent_task_scheduler::HarvestExecutionContext::from_current_process(
+                )?,
         },
         executor,
     )?;

--- a/src/commands/bench/fanout.rs
+++ b/src/commands/bench/fanout.rs
@@ -91,7 +91,7 @@ pub(super) fn run_matrix_fanout(
         "report": run_args.report,
     });
 
-    let scheduler = AgentTaskScheduler::new(LocalBenchMatrixExecutor);
+    let scheduler = AgentTaskScheduler::new_controller(LocalBenchMatrixExecutor);
     let scheduler_aggregate = scheduler.run(schedule);
     let matrix_aggregate =
         AgentTaskMatrixAggregate::from_outcomes(&matrix_plan, &scheduler_aggregate.outcomes);

--- a/src/core/agent_task_deterministic_loop.rs
+++ b/src/core/agent_task_deterministic_loop.rs
@@ -22,7 +22,7 @@ where
     pub fn new(definition: AgentTaskLoopDefinition, executor: E) -> Self {
         Self {
             definition,
-            scheduler: AgentTaskScheduler::new(executor),
+            scheduler: AgentTaskScheduler::new_controller(executor),
         }
     }
 }

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -230,8 +230,22 @@ where
         });
     }
 
+    let harvest_context =
+        match crate::core::agent_task_scheduler::HarvestExecutionContext::from_current_process() {
+            Ok(context) => context,
+            Err(error) => {
+                lifecycle::record_pre_execution_failure(
+                    &run_id,
+                    &plan,
+                    "validate_harvest_transport",
+                    &error,
+                )?;
+                return Err(error);
+            }
+        };
     lifecycle::mark_running(&run_id)?;
-    let aggregate = AgentTaskScheduler::for_current_process(executor)?
+    let aggregate = AgentTaskScheduler::new_controller(executor)
+        .with_harvest_context(harvest_context)
         .with_run_id(run_id.clone())
         .run(plan.clone());
     let record = lifecycle::record_run_aggregate(&run_id, &plan, &aggregate)?;

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -231,7 +231,7 @@ where
     }
 
     lifecycle::mark_running(&run_id)?;
-    let aggregate = AgentTaskScheduler::new(executor)
+    let aggregate = AgentTaskScheduler::for_current_process(executor)?
         .with_run_id(run_id.clone())
         .run(plan.clone());
     let record = lifecycle::record_run_aggregate(&run_id, &plan, &aggregate)?;

--- a/src/core/agent_task_fanout.rs
+++ b/src/core/agent_task_fanout.rs
@@ -303,7 +303,7 @@ where
 {
     pub fn new(executor: E) -> Self {
         Self {
-            scheduler: AgentTaskScheduler::new(executor),
+            scheduler: AgentTaskScheduler::new_controller(executor),
         }
     }
 

--- a/src/core/agent_task_scheduler/attempt_workspace.rs
+++ b/src/core/agent_task_scheduler/attempt_workspace.rs
@@ -10,6 +10,45 @@ use sha2::{Digest, Sha256};
 use super::harvest::git_is_repository;
 use super::*;
 
+/// Immutable provenance for one scheduler execution. Controller-local callers
+/// use an empty context; only a Lab subprocess captures its paired transport.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct HarvestExecutionContext {
+    source_snapshot: Option<crate::core::source_snapshot::SourceSnapshot>,
+    lab_offload: Option<serde_json::Value>,
+}
+
+impl HarvestExecutionContext {
+    pub(crate) fn lab_subprocess_from_env() -> Self {
+        Self {
+            source_snapshot: std::env::var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV)
+                .ok()
+                .and_then(|raw| serde_json::from_str(&raw).ok()),
+            lab_offload: std::env::var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV)
+                .ok()
+                .and_then(|raw| serde_json::from_str(&raw).ok()),
+        }
+    }
+
+    fn snapshot_signaled(&self) -> bool {
+        self.source_snapshot.is_some() || self.lab_offload.is_some()
+    }
+
+    fn source_snapshot(
+        &self,
+    ) -> Result<crate::core::source_snapshot::SourceSnapshot, HarvestError> {
+        self.source_snapshot.clone().ok_or_else(|| {
+            snapshot_harvest_error("is missing source snapshot transport metadata".to_string())
+        })
+    }
+
+    fn lab_offload(&self) -> Result<serde_json::Value, HarvestError> {
+        self.lab_offload.clone().ok_or_else(|| {
+            snapshot_harvest_error("is missing Lab dispatch transport metadata".to_string())
+        })
+    }
+}
+
 #[derive(Debug)]
 pub(super) struct AttemptWorkspace {
     source_root: PathBuf,
@@ -60,6 +99,7 @@ pub(super) struct HarvestPreflight {
 pub(super) fn prepare_committed_harvest(
     request: &AgentTaskRequest,
     derived_cook_baseline: Option<&crate::core::agent_task_service::DerivedCookBaselineCapability>,
+    context: &HarvestExecutionContext,
 ) -> Result<HarvestPreflight, HarvestError> {
     let Some(root) = request.workspace.root.as_deref().map(Path::new) else {
         return Ok(HarvestPreflight {
@@ -67,7 +107,7 @@ pub(super) fn prepare_committed_harvest(
             source_provenance: None,
         });
     };
-    let snapshot_signaled = lab_snapshot_transport_applies_to_workspace(root);
+    let snapshot_signaled = context.snapshot_signaled();
     let is_repository = git_is_repository(root)?;
     if !snapshot_signaled && !is_repository {
         return Ok(HarvestPreflight {
@@ -76,15 +116,19 @@ pub(super) fn prepare_committed_harvest(
         });
     }
     let source_provenance = if let Some(capability) = derived_cook_baseline {
-        validate_derived_cook_baseline(root, request, capability)?;
+        validate_derived_cook_baseline(root, request, capability, context)?;
         Some(serde_json::json!({
             "verified_cook_baseline": capability.verified_baseline_provenance(),
             "parent_snapshot": capability.parent_snapshot(),
         }))
     } else if snapshot_signaled {
-        let provenance =
-            crate::core::runner::verify_lab_workspace_from_env(&root.display().to_string(), root)
-                .map_err(snapshot_harvest_error)?;
+        let provenance = crate::core::runner::verify_lab_workspace(
+            &root.display().to_string(),
+            root,
+            context.source_snapshot()?,
+            context.lab_offload()?,
+        )
+        .map_err(snapshot_harvest_error)?;
         if is_repository {
             crate::core::runner::verify_lab_workspace_git_root(root, &provenance)
                 .map_err(snapshot_harvest_error)?;
@@ -118,17 +162,12 @@ pub(super) fn prepare_committed_harvest(
         });
         // This is descriptive controller evidence only. Verification above
         // remains the authority for the remote Lab snapshot.
-        if let Some(verified_baseline) =
-            std::env::var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV)
-                .ok()
-                .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
-                .and_then(|metadata| {
-                    metadata
-                        .get("source_provenance")
-                        .and_then(|provenance| provenance.get("verified_cook_baseline"))
-                        .cloned()
-                })
-        {
+        if let Some(verified_baseline) = context.lab_offload.as_ref().and_then(|metadata| {
+            metadata
+                .get("source_provenance")
+                .and_then(|provenance| provenance.get("verified_cook_baseline"))
+                .cloned()
+        }) {
             source_provenance["verified_cook_baseline"] = verified_baseline;
         }
         Some(source_provenance)
@@ -136,9 +175,11 @@ pub(super) fn prepare_committed_harvest(
         None
     };
     if !is_repository {
-        crate::core::runner::materialize_verified_lab_snapshot_git_baseline_from_env(
+        crate::core::runner::materialize_verified_lab_snapshot_git_baseline(
             &root.display().to_string(),
             root,
+            context.source_snapshot()?,
+            context.lab_offload()?,
         )
         .map_err(|message| HarvestError::Git {
             command: "materialize verified Lab snapshot Git baseline".to_string(),
@@ -173,41 +214,6 @@ pub(super) fn prepare_committed_harvest(
     })
 }
 
-/// Ambient Lab metadata may survive in a controller process that subsequently
-/// executes locally. Snapshot verification belongs only to the workspace that
-/// the Lab envelope says was snapshot-transported, not to every Git checkout
-/// running under that process.
-fn lab_snapshot_transport_applies_to_workspace(root: &Path) -> bool {
-    let Ok(raw) = std::env::var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV) else {
-        return false;
-    };
-    let Ok(metadata) = serde_json::from_str::<serde_json::Value>(&raw) else {
-        return false;
-    };
-    if !matches!(
-        metadata
-            .get("sync_mode")
-            .and_then(serde_json::Value::as_str),
-        Some("snapshot" | "snapshot-git")
-    ) {
-        return false;
-    }
-    let Some(remote_workspace) = metadata
-        .get("remote_workspace")
-        .and_then(serde_json::Value::as_str)
-    else {
-        return false;
-    };
-
-    match (
-        root.canonicalize(),
-        Path::new(remote_workspace).canonicalize(),
-    ) {
-        (Ok(root), Ok(remote_workspace)) => root == remote_workspace,
-        _ => root == Path::new(remote_workspace),
-    }
-}
-
 fn snapshot_harvest_error(message: String) -> HarvestError {
     HarvestError::Git {
         command: "verify Lab snapshot harvest provenance".to_string(),
@@ -219,6 +225,7 @@ fn validate_derived_cook_baseline(
     root: &Path,
     request: &AgentTaskRequest,
     capability: &crate::core::agent_task_service::DerivedCookBaselineCapability,
+    context: &HarvestExecutionContext,
 ) -> Result<(), HarvestError> {
     let canonical_root = root.canonicalize().map_err(|error| {
         snapshot_harvest_error(format!("canonicalize derived baseline root: {error}"))
@@ -242,19 +249,14 @@ fn validate_derived_cook_baseline(
         ));
     }
     if let Some(parent_snapshot) = capability.parent_snapshot() {
-        let ambient: serde_json::Value =
-            std::env::var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV)
-                .ok()
-                .and_then(|raw| serde_json::from_str(&raw).ok())
-                .ok_or_else(|| {
-                    snapshot_harvest_error("missing ambient parent snapshot".to_string())
-                })?;
+        let ambient = serde_json::to_value(context.source_snapshot()?)
+            .map_err(|error| snapshot_harvest_error(error.to_string()))?;
         if parent_snapshot != &ambient {
             return Err(snapshot_harvest_error(
                 "derived baseline parent snapshot does not match ambient snapshot".to_string(),
             ));
         }
-    } else if std::env::var_os(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV).is_some() {
+    } else if context.source_snapshot.is_some() {
         return Err(snapshot_harvest_error(
             "derived baseline is missing its Lab parent snapshot".to_string(),
         ));

--- a/src/core/agent_task_scheduler/attempt_workspace.rs
+++ b/src/core/agent_task_scheduler/attempt_workspace.rs
@@ -13,13 +13,13 @@ use super::*;
 /// Immutable provenance for one scheduler execution. Controller-local callers
 /// use an empty context; only a Lab subprocess captures its paired transport.
 #[derive(Debug, Clone, Default)]
-pub(crate) struct HarvestExecutionContext {
+pub struct HarvestExecutionContext {
     source_snapshot: Option<crate::core::source_snapshot::SourceSnapshot>,
     lab_offload: Option<serde_json::Value>,
 }
 
 impl HarvestExecutionContext {
-    pub(crate) fn from_current_process() -> crate::core::Result<Self> {
+    pub fn from_current_process() -> crate::core::Result<Self> {
         let source = std::env::var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV).ok();
         let lab = std::env::var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV).ok();
         match (source, lab) {

--- a/src/core/agent_task_scheduler/attempt_workspace.rs
+++ b/src/core/agent_task_scheduler/attempt_workspace.rs
@@ -19,14 +19,32 @@ pub(crate) struct HarvestExecutionContext {
 }
 
 impl HarvestExecutionContext {
-    pub(crate) fn lab_subprocess_from_env() -> Self {
-        Self {
-            source_snapshot: std::env::var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV)
-                .ok()
-                .and_then(|raw| serde_json::from_str(&raw).ok()),
-            lab_offload: std::env::var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV)
-                .ok()
-                .and_then(|raw| serde_json::from_str(&raw).ok()),
+    pub(crate) fn from_current_process() -> crate::core::Result<Self> {
+        let source = std::env::var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV).ok();
+        let lab = std::env::var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV).ok();
+        match (source, lab) {
+            (None, None) => Ok(Self::default()),
+            (Some(source), Some(lab)) if !source.trim().is_empty() && !lab.trim().is_empty() => {
+                let lab_offload: serde_json::Value = serde_json::from_str(&lab).map_err(|error| {
+                    incomplete_transport_error(format!("invalid Lab offload metadata: {error}"))
+                })?;
+                if !lab_offload.is_object() {
+                    return Err(incomplete_transport_error(
+                        "Lab offload metadata must be a JSON object".to_string(),
+                    ));
+                }
+                Ok(Self {
+                    source_snapshot: serde_json::from_str(&source).map_err(|error| {
+                        incomplete_transport_error(format!("invalid source snapshot metadata: {error}"))
+                    })?,
+                    lab_offload: Some(lab_offload),
+                })
+            }
+            (source, lab) => Err(incomplete_transport_error(format!(
+                "expected paired non-empty source snapshot and Lab offload metadata (source_snapshot={}, lab_offload={})",
+                source.is_some_and(|value| !value.trim().is_empty()),
+                lab.is_some_and(|value| !value.trim().is_empty()),
+            ))),
         }
     }
 
@@ -47,6 +65,15 @@ impl HarvestExecutionContext {
             snapshot_harvest_error("is missing Lab dispatch transport metadata".to_string())
         })
     }
+}
+
+fn incomplete_transport_error(message: String) -> crate::core::Error {
+    crate::core::Error::validation_invalid_argument(
+        "lab_transport",
+        format!("incomplete Lab snapshot transport: {message}"),
+        None,
+        Some(vec!["Run the command on the controller without Lab transport metadata, or use a Lab child process with the exact paired snapshot metadata.".to_string()]),
+    )
 }
 
 #[derive(Debug)]

--- a/src/core/agent_task_scheduler/engine.rs
+++ b/src/core/agent_task_scheduler/engine.rs
@@ -25,6 +25,7 @@ pub trait AgentTaskExecutorAdapter: Send + Sync + 'static {
 pub struct AgentTaskScheduler<E> {
     executor: Arc<E>,
     run_id: Option<String>,
+    harvest_context: HarvestExecutionContext,
 }
 
 impl<E> AgentTaskScheduler<E>
@@ -35,11 +36,17 @@ where
         Self {
             executor: Arc::new(executor),
             run_id: None,
+            harvest_context: HarvestExecutionContext::default(),
         }
     }
 
     pub fn with_run_id(mut self, run_id: impl Into<String>) -> Self {
         self.run_id = Some(run_id.into());
+        self
+    }
+
+    pub(crate) fn with_harvest_context(mut self, context: HarvestExecutionContext) -> Self {
+        self.harvest_context = context;
         self
     }
 
@@ -356,21 +363,24 @@ where
                     continue;
                 }
                 let task_id = request.task_id.clone();
-                let harvest_preflight =
-                    match prepare_committed_harvest(&request, derived_cook_baseline) {
-                        Ok(preflight) => preflight,
-                        Err(error) => {
-                            record_harvest_setup_failure(
-                                &task_id,
-                                scheduled.attempt,
-                                error,
-                                &mut completed_by_task,
-                                &mut outcomes,
-                                &mut events,
-                            );
-                            continue;
-                        }
-                    };
+                let harvest_preflight = match prepare_committed_harvest(
+                    &request,
+                    derived_cook_baseline,
+                    &self.harvest_context,
+                ) {
+                    Ok(preflight) => preflight,
+                    Err(error) => {
+                        record_harvest_setup_failure(
+                            &task_id,
+                            scheduled.attempt,
+                            error,
+                            &mut completed_by_task,
+                            &mut outcomes,
+                            &mut events,
+                        );
+                        continue;
+                    }
+                };
                 let task_base_sha = scheduled
                     .task_base_sha
                     .clone()

--- a/src/core/agent_task_scheduler/engine.rs
+++ b/src/core/agent_task_scheduler/engine.rs
@@ -46,14 +46,6 @@ where
         }
     }
 
-    /// Build a scheduler at a process execution boundary. Both Lab transport
-    /// values must be present and valid, otherwise execution is rejected
-    /// before provider dispatch or harvest setup.
-    pub(crate) fn for_current_process(executor: E) -> crate::core::Result<Self> {
-        Ok(Self::new_controller(executor)
-            .with_harvest_context(HarvestExecutionContext::from_current_process()?))
-    }
-
     pub fn with_run_id(mut self, run_id: impl Into<String>) -> Self {
         self.run_id = Some(run_id.into());
         self

--- a/src/core/agent_task_scheduler/engine.rs
+++ b/src/core/agent_task_scheduler/engine.rs
@@ -33,11 +33,25 @@ where
     E: AgentTaskExecutorAdapter,
 {
     pub fn new(executor: E) -> Self {
+        Self::new_controller(executor)
+    }
+
+    /// Construct a controller-local scheduler that intentionally ignores
+    /// ambient Lab transport metadata.
+    pub(crate) fn new_controller(executor: E) -> Self {
         Self {
             executor: Arc::new(executor),
             run_id: None,
             harvest_context: HarvestExecutionContext::default(),
         }
+    }
+
+    /// Build a scheduler at a process execution boundary. Both Lab transport
+    /// values must be present and valid, otherwise execution is rejected
+    /// before provider dispatch or harvest setup.
+    pub(crate) fn for_current_process(executor: E) -> crate::core::Result<Self> {
+        Ok(Self::new_controller(executor)
+            .with_harvest_context(HarvestExecutionContext::from_current_process()?))
     }
 
     pub fn with_run_id(mut self, run_id: impl Into<String>) -> Self {

--- a/src/core/agent_task_scheduler/harvest.rs
+++ b/src/core/agent_task_scheduler/harvest.rs
@@ -504,6 +504,27 @@ mod committed_harvest_tests {
 
     static LAB_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
+    #[test]
+    fn process_context_rejects_incomplete_lab_transport_before_scheduler_execution() {
+        let _guard = LAB_ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("Lab environment lock");
+        std::env::set_var(
+            crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV,
+            r#"{"runner_id":"lab"}"#,
+        );
+        std::env::remove_var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV);
+
+        let error = HarvestExecutionContext::from_current_process()
+            .expect_err("a lone source snapshot must be rejected");
+
+        assert!(error
+            .to_string()
+            .contains("incomplete Lab snapshot transport"));
+        std::env::remove_var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV);
+    }
+
     fn git(cwd: &Path, args: &[&str]) -> String {
         let output = Command::new("git")
             .args(args)
@@ -712,7 +733,7 @@ mod committed_harvest_tests {
             metadata: serde_json::Value::Null,
         };
         assert!(!workspace.path().join(".git").exists());
-        let context = HarvestExecutionContext::lab_subprocess_from_env();
+        let context = HarvestExecutionContext::from_current_process().expect("Lab context");
         let preflight =
             prepare_committed_harvest(&request, None, &context).expect("snapshot preflight");
         let baseline = preflight.base_sha.expect("synthetic baseline");
@@ -922,7 +943,7 @@ mod committed_harvest_tests {
                 artifact_declarations: Vec::new(),
                 metadata: serde_json::Value::Null,
             };
-            let context = HarvestExecutionContext::lab_subprocess_from_env();
+            let context = HarvestExecutionContext::from_current_process().expect("Lab context");
             let first = prepare_committed_harvest(&request, None, &context)
                 .expect("snapshot-git preflight");
             let second = prepare_committed_harvest(&request, None, &context)
@@ -1011,7 +1032,7 @@ mod committed_harvest_tests {
             metadata: serde_json::Value::Null,
         };
 
-        let context = HarvestExecutionContext::lab_subprocess_from_env();
+        let context = HarvestExecutionContext::from_current_process().expect("Lab context");
         let preflight = prepare_committed_harvest(&request, None, &context)
             .expect("runner-resident snapshot harvest preflight");
 

--- a/src/core/agent_task_scheduler/harvest.rs
+++ b/src/core/agent_task_scheduler/harvest.rs
@@ -712,12 +712,14 @@ mod committed_harvest_tests {
             metadata: serde_json::Value::Null,
         };
         assert!(!workspace.path().join(".git").exists());
-        let preflight = prepare_committed_harvest(&request, None).expect("snapshot preflight");
+        let context = HarvestExecutionContext::lab_subprocess_from_env();
+        let preflight =
+            prepare_committed_harvest(&request, None, &context).expect("snapshot preflight");
         let baseline = preflight.base_sha.expect("synthetic baseline");
         let source_provenance = preflight.source_provenance.expect("source provenance");
         assert!(workspace.path().join(".git").is_dir());
         let retry_preflight =
-            prepare_committed_harvest(&request, None).expect("snapshot retry preflight");
+            prepare_committed_harvest(&request, None, &context).expect("snapshot retry preflight");
         assert_eq!(retry_preflight.base_sha.as_deref(), Some(baseline.as_str()));
         assert_eq!(source_provenance["source_revision"], "a".repeat(40));
         let attempt = prepare_attempt_workspace(&mut request, Some(&baseline))
@@ -920,9 +922,11 @@ mod committed_harvest_tests {
                 artifact_declarations: Vec::new(),
                 metadata: serde_json::Value::Null,
             };
-            let first = prepare_committed_harvest(&request, None).expect("snapshot-git preflight");
-            let second =
-                prepare_committed_harvest(&request, None).expect("snapshot-git retry preflight");
+            let context = HarvestExecutionContext::lab_subprocess_from_env();
+            let first = prepare_committed_harvest(&request, None, &context)
+                .expect("snapshot-git preflight");
+            let second = prepare_committed_harvest(&request, None, &context)
+                .expect("snapshot-git retry preflight");
             assert_eq!(first.base_sha, second.base_sha);
             assert_eq!(first.base_sha, snapshot.synthetic_checkout_commit);
             std::env::remove_var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV);
@@ -1007,7 +1011,8 @@ mod committed_harvest_tests {
             metadata: serde_json::Value::Null,
         };
 
-        let preflight = prepare_committed_harvest(&request, None)
+        let context = HarvestExecutionContext::lab_subprocess_from_env();
+        let preflight = prepare_committed_harvest(&request, None, &context)
             .expect("runner-resident snapshot harvest preflight");
 
         assert!(preflight.base_sha.is_some());
@@ -1020,13 +1025,16 @@ mod committed_harvest_tests {
     }
 
     #[test]
-    fn local_non_git_workspace_skips_harvest_preflight_without_lab_transport() {
+    fn controller_context_ignores_ambient_lab_signal_without_leaking_it_to_local_cells() {
         let _guard = LAB_ENV_LOCK
             .get_or_init(|| Mutex::new(()))
             .lock()
             .expect("Lab environment lock");
         std::env::remove_var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV);
-        std::env::remove_var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV);
+        std::env::set_var(
+            crate::core::observation::LAB_OFFLOAD_METADATA_ENV,
+            r#"{"status":"run_local"}"#,
+        );
         let workspace = tempfile::tempdir().expect("workspace");
         let request = AgentTaskRequest {
             schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
@@ -1057,11 +1065,15 @@ mod committed_harvest_tests {
             metadata: serde_json::Value::Null,
         };
 
-        let preflight = prepare_committed_harvest(&request, None).expect("local non-Git no-op");
+        let preflight =
+            prepare_committed_harvest(&request, None, &HarvestExecutionContext::default())
+                .expect("local controller cell ignores ambient Lab metadata");
 
         assert!(preflight.base_sha.is_none());
         assert!(preflight.source_provenance.is_none());
         assert!(!workspace.path().join(".git").exists());
+        assert!(std::env::var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV).is_ok());
+        std::env::remove_var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV);
     }
 
     #[test]

--- a/src/core/agent_task_scheduler/harvest.rs
+++ b/src/core/agent_task_scheduler/harvest.rs
@@ -1152,8 +1152,9 @@ mod committed_harvest_tests {
             metadata: serde_json::Value::Null,
         };
 
-        let preflight = prepare_committed_harvest(&request, None)
-            .expect("local Git harvest preflight ignores unrelated Lab metadata");
+        let preflight =
+            prepare_committed_harvest(&request, None, &HarvestExecutionContext::default())
+                .expect("local Git harvest preflight ignores unrelated Lab metadata");
 
         assert_eq!(
             preflight.base_sha.as_deref(),

--- a/src/core/agent_task_scheduler/mod.rs
+++ b/src/core/agent_task_scheduler/mod.rs
@@ -40,6 +40,7 @@ use crate::core::agent_task_timeout_artifacts::{
     append_unique_artifacts, append_unique_evidence_refs, is_actionable_patch_artifact,
     is_empty_patch_artifact, merge_timeout_outcome, TimeoutArtifactDiscovery,
 };
+pub(crate) use attempt_workspace::HarvestExecutionContext;
 use attempt_workspace::{
     prepare_attempt_workspace, prepare_committed_harvest, remap_workspace_config, AttemptWorkspace,
 };

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -150,7 +150,7 @@ where
                     Some(&run_id),
                     executor.clone(),
                     None,
-                    Some(options.harvest_context.clone()),
+                    Some(cook_attempt_harvest_context(&options.harvest_context)),
                 )
                 .map(|_| ())
             };
@@ -421,7 +421,7 @@ where
                         Some(&next_run_id),
                         executor.clone(),
                         Some(baseline.capability()),
-                        Some(options.harvest_context.clone()),
+                        Some(cook_attempt_harvest_context(&options.harvest_context)),
                     )?;
                 }
                 remediation_category_usage.add(reservation);
@@ -459,6 +459,12 @@ struct CookFollowUpBaseline {
     source_root: PathBuf,
     path: PathBuf,
     capability: DerivedCookBaselineCapability,
+}
+
+fn cook_attempt_harvest_context(
+    harvest_context: &crate::core::agent_task_scheduler::HarvestExecutionContext,
+) -> crate::core::agent_task_scheduler::HarvestExecutionContext {
+    harvest_context.clone()
 }
 
 /// Process-local authority for one materialized cook retry baseline. It is not
@@ -1166,6 +1172,37 @@ mod tests {
         ProviderRuntimeLifecycle, ProviderRuntimeState, RunExecutionLifecycle, RunExecutionState,
         RunLifecycleRecord,
     };
+    use std::sync::{Mutex, OnceLock};
+
+    #[test]
+    fn cook_service_retry_uses_the_same_passed_context_after_ambient_mutation() {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let _lock = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let prior = std::env::var_os(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV);
+        let context = crate::core::agent_task_scheduler::HarvestExecutionContext::default();
+        let first_attempt = cook_attempt_harvest_context(&context);
+        std::env::set_var(
+            crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV,
+            "ambient state must not affect a passed cook context",
+        );
+        let retry_attempt = cook_attempt_harvest_context(&context);
+        match prior {
+            Some(value) => std::env::set_var(
+                crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV,
+                value,
+            ),
+            None => std::env::remove_var(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV),
+        }
+
+        assert_eq!(format!("{first_attempt:?}"), format!("{retry_attempt:?}"));
+        assert_eq!(
+            format!("{retry_attempt:?}"),
+            "HarvestExecutionContext { source_snapshot: None, lab_offload: None }"
+        );
+    }
 
     #[derive(Default)]
     struct CaptureBackend {

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -1172,15 +1172,10 @@ mod tests {
         ProviderRuntimeLifecycle, ProviderRuntimeState, RunExecutionLifecycle, RunExecutionState,
         RunLifecycleRecord,
     };
-    use std::sync::{Mutex, OnceLock};
 
     #[test]
     fn cook_service_retry_uses_the_same_passed_context_after_ambient_mutation() {
-        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        let _lock = ENV_LOCK
-            .get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _env_lock = crate::test_support::env_lock();
         let prior = std::env::var_os(crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV);
         let context = crate::core::agent_task_scheduler::HarvestExecutionContext::default();
         let first_attempt = cook_attempt_harvest_context(&context);

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -33,7 +33,7 @@ use crate::core::agent_task_scheduler::{
 use crate::core::command_invocation::CommandInvocation;
 use crate::core::{config, Error, Result};
 
-use super::execution::{run_loaded_plan, run_loaded_plan_with_derived_cook_baseline};
+use super::execution::run_loaded_plan_with_derived_cook_baseline;
 use super::AgentTaskRunResult;
 
 /// Executes one provider attempt while cook retains ownership of promotion,
@@ -77,6 +77,7 @@ pub struct AgentTaskCookServiceOptions {
     pub ai_used_for: String,
     /// The route-selected provider transport. `None` executes locally.
     pub attempt_dispatcher: Option<Arc<dyn AgentTaskCookAttemptDispatcher>>,
+    pub harvest_context: crate::core::agent_task_scheduler::HarvestExecutionContext,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -144,7 +145,14 @@ where
             let execution = if let Some(dispatcher) = &options.attempt_dispatcher {
                 dispatcher.dispatch_attempt(plan.clone(), &run_id, None)
             } else {
-                run_loaded_plan(plan.clone(), Some(&run_id), executor.clone()).map(|_| ())
+                run_loaded_plan_with_derived_cook_baseline(
+                    plan.clone(),
+                    Some(&run_id),
+                    executor.clone(),
+                    None,
+                    Some(options.harvest_context.clone()),
+                )
+                .map(|_| ())
             };
             if let Err(error) = execution {
                 let record = agent_task_lifecycle::status(&run_id).ok();
@@ -413,6 +421,7 @@ where
                         Some(&next_run_id),
                         executor.clone(),
                         Some(baseline.capability()),
+                        Some(options.harvest_context.clone()),
                     )?;
                 }
                 remediation_category_usage.add(reservation);
@@ -1288,6 +1297,8 @@ mod tests {
                 ai_model: Some("openai/gpt-5.6-terra".to_string()),
                 ai_used_for: "Drafted test coverage.".to_string(),
                 attempt_dispatcher: None,
+                harvest_context:
+                    crate::core::agent_task_scheduler::HarvestExecutionContext::default(),
             };
             let mut backend = CaptureBackend::default();
             finalize_cook_pr_with_backend(&options, run_id, &promotion(run_id), &mut backend)

--- a/src/core/agent_task_service/execution.rs
+++ b/src/core/agent_task_service/execution.rs
@@ -100,7 +100,7 @@ where
     }
 
     let aggregate =
-        run_plan_with_scheduler(plan.clone(), record_run_id, executor, derived_cook_baseline);
+        run_plan_with_scheduler(plan.clone(), record_run_id, executor, derived_cook_baseline)?;
     if let Some(run_id) = record_run_id {
         agent_task_lifecycle::record_run_aggregate(run_id, &plan, &aggregate)?;
     }
@@ -296,7 +296,7 @@ fn run_prepared_claimed<E>(
 where
     E: AgentTaskExecutorAdapter,
 {
-    let aggregate = run_plan_with_scheduler(plan.clone(), Some(&run_id), executor, None);
+    let aggregate = run_plan_with_scheduler(plan.clone(), Some(&run_id), executor, None)?;
     agent_task_lifecycle::record_run_aggregate(&run_id, &plan, &aggregate)?;
     Ok(AgentTaskRunResult {
         exit_code: aggregate_exit_code(&aggregate),
@@ -348,25 +348,16 @@ fn run_plan_with_scheduler<E>(
     run_id: Option<&str>,
     executor: E,
     derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
-) -> AgentTaskAggregate
+) -> Result<AgentTaskAggregate>
 where
     E: AgentTaskExecutorAdapter,
 {
-    // Only the Lab child process carries transport provenance. A controller
-    // process always starts with an empty per-run context, even after a Lab
-    // fallback or a preceding fanout cell.
-    let scheduler = if crate::core::lab_routing::is_lab_offload_subprocess() {
-        AgentTaskScheduler::new(executor).with_harvest_context(
-            crate::core::agent_task_scheduler::HarvestExecutionContext::lab_subprocess_from_env(),
-        )
-    } else {
-        AgentTaskScheduler::new(executor)
-    };
+    let scheduler = AgentTaskScheduler::for_current_process(executor)?;
     match run_id {
-        Some(run_id) => scheduler
+        Some(run_id) => Ok(scheduler
             .with_run_id(run_id.to_string())
-            .run_with_derived_cook_baseline(plan, derived_cook_baseline),
-        None => scheduler.run_with_derived_cook_baseline(plan, derived_cook_baseline),
+            .run_with_derived_cook_baseline(plan, derived_cook_baseline)),
+        None => Ok(scheduler.run_with_derived_cook_baseline(plan, derived_cook_baseline)),
     }
 }
 

--- a/src/core/agent_task_service/execution.rs
+++ b/src/core/agent_task_service/execution.rs
@@ -94,16 +94,46 @@ where
             )?;
             return Err(error);
         }
+        let harvest_context =
+            match crate::core::agent_task_scheduler::HarvestExecutionContext::from_current_process()
+            {
+                Ok(context) => context,
+                Err(error) => {
+                    agent_task_lifecycle::record_pre_execution_failure(
+                        run_id,
+                        &plan,
+                        "validate_harvest_transport",
+                        &error,
+                    )?;
+                    return Err(error);
+                }
+            };
         agent_task_lifecycle::mark_running(run_id)?;
+        let aggregate = run_plan_with_scheduler(
+            plan.clone(),
+            record_run_id,
+            executor,
+            derived_cook_baseline,
+            harvest_context,
+        )?;
+        agent_task_lifecycle::record_run_aggregate(run_id, &plan, &aggregate)?;
+        return Ok(AgentTaskRunResult {
+            exit_code: aggregate_exit_code(&aggregate),
+            value: crate::core::agent_task_artifacts::reviewer_facing_aggregate(&aggregate),
+        });
     } else {
         prepare_plan_for_execution(&mut plan, None)?;
     }
 
-    let aggregate =
-        run_plan_with_scheduler(plan.clone(), record_run_id, executor, derived_cook_baseline)?;
-    if let Some(run_id) = record_run_id {
-        agent_task_lifecycle::record_run_aggregate(run_id, &plan, &aggregate)?;
-    }
+    let harvest_context =
+        crate::core::agent_task_scheduler::HarvestExecutionContext::from_current_process()?;
+    let aggregate = run_plan_with_scheduler(
+        plan.clone(),
+        record_run_id,
+        executor,
+        derived_cook_baseline,
+        harvest_context,
+    )?;
     Ok(AgentTaskRunResult {
         exit_code: aggregate_exit_code(&aggregate),
         value: crate::core::agent_task_artifacts::reviewer_facing_aggregate(&aggregate),
@@ -151,7 +181,20 @@ where
     }
     prepare_plan_for_execution(&mut plan, Some(&run_id))?;
     agent_task_lifecycle::mark_running(&run_id)?;
-    run_prepared_claimed(run_id, plan, executor)
+    let harvest_context =
+        match crate::core::agent_task_scheduler::HarvestExecutionContext::from_current_process() {
+            Ok(context) => context,
+            Err(error) => {
+                agent_task_lifecycle::record_pre_execution_failure(
+                    &run_id,
+                    &plan,
+                    "validate_harvest_transport",
+                    &error,
+                )?;
+                return Err(error);
+            }
+        };
+    run_prepared_claimed(run_id, plan, executor, harvest_context)
 }
 
 pub fn run_next<E>(executor: E) -> Result<AgentTaskRunResult<Option<AgentTaskAggregate>>>
@@ -285,18 +328,33 @@ where
         )?;
         return Err(error);
     }
-    run_prepared_claimed(run_id, plan, executor)
+    let harvest_context =
+        match crate::core::agent_task_scheduler::HarvestExecutionContext::from_current_process() {
+            Ok(context) => context,
+            Err(error) => {
+                agent_task_lifecycle::record_pre_execution_failure(
+                    &run_id,
+                    &plan,
+                    "validate_harvest_transport",
+                    &error,
+                )?;
+                return Err(error);
+            }
+        };
+    run_prepared_claimed(run_id, plan, executor, harvest_context)
 }
 
 fn run_prepared_claimed<E>(
     run_id: String,
     plan: AgentTaskPlan,
     executor: E,
+    harvest_context: crate::core::agent_task_scheduler::HarvestExecutionContext,
 ) -> Result<AgentTaskRunResult<AgentTaskAggregate>>
 where
     E: AgentTaskExecutorAdapter,
 {
-    let aggregate = run_plan_with_scheduler(plan.clone(), Some(&run_id), executor, None)?;
+    let aggregate =
+        run_plan_with_scheduler(plan.clone(), Some(&run_id), executor, None, harvest_context)?;
     agent_task_lifecycle::record_run_aggregate(&run_id, &plan, &aggregate)?;
     Ok(AgentTaskRunResult {
         exit_code: aggregate_exit_code(&aggregate),
@@ -348,11 +406,13 @@ fn run_plan_with_scheduler<E>(
     run_id: Option<&str>,
     executor: E,
     derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+    harvest_context: crate::core::agent_task_scheduler::HarvestExecutionContext,
 ) -> Result<AgentTaskAggregate>
 where
     E: AgentTaskExecutorAdapter,
 {
-    let scheduler = AgentTaskScheduler::for_current_process(executor)?;
+    let scheduler =
+        AgentTaskScheduler::new_controller(executor).with_harvest_context(harvest_context);
     match run_id {
         Some(run_id) => Ok(scheduler
             .with_run_id(run_id.to_string())

--- a/src/core/agent_task_service/execution.rs
+++ b/src/core/agent_task_service/execution.rs
@@ -69,7 +69,7 @@ pub fn run_loaded_plan<E>(
 where
     E: AgentTaskExecutorAdapter,
 {
-    run_loaded_plan_with_derived_cook_baseline(plan, record_run_id, executor, None)
+    run_loaded_plan_with_derived_cook_baseline(plan, record_run_id, executor, None, None)
 }
 
 pub(crate) fn run_loaded_plan_with_derived_cook_baseline<E>(
@@ -77,6 +77,7 @@ pub(crate) fn run_loaded_plan_with_derived_cook_baseline<E>(
     record_run_id: Option<&str>,
     executor: E,
     derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+    supplied_harvest_context: Option<crate::core::agent_task_scheduler::HarvestExecutionContext>,
 ) -> Result<AgentTaskRunResult<AgentTaskAggregate>>
 where
     E: AgentTaskExecutorAdapter,
@@ -94,20 +95,20 @@ where
             )?;
             return Err(error);
         }
-        let harvest_context =
-            match crate::core::agent_task_scheduler::HarvestExecutionContext::from_current_process()
-            {
-                Ok(context) => context,
-                Err(error) => {
-                    agent_task_lifecycle::record_pre_execution_failure(
-                        run_id,
-                        &plan,
-                        "validate_harvest_transport",
-                        &error,
-                    )?;
-                    return Err(error);
-                }
-            };
+        let harvest_context = match supplied_harvest_context.clone().map(Ok).unwrap_or_else(
+            crate::core::agent_task_scheduler::HarvestExecutionContext::from_current_process,
+        ) {
+            Ok(context) => context,
+            Err(error) => {
+                agent_task_lifecycle::record_pre_execution_failure(
+                    run_id,
+                    &plan,
+                    "validate_harvest_transport",
+                    &error,
+                )?;
+                return Err(error);
+            }
+        };
         agent_task_lifecycle::mark_running(run_id)?;
         let aggregate = run_plan_with_scheduler(
             plan.clone(),
@@ -125,8 +126,9 @@ where
         prepare_plan_for_execution(&mut plan, None)?;
     }
 
-    let harvest_context =
-        crate::core::agent_task_scheduler::HarvestExecutionContext::from_current_process()?;
+    let harvest_context = supplied_harvest_context.unwrap_or(
+        crate::core::agent_task_scheduler::HarvestExecutionContext::from_current_process()?,
+    );
     let aggregate = run_plan_with_scheduler(
         plan.clone(),
         record_run_id,

--- a/src/core/agent_task_service/execution.rs
+++ b/src/core/agent_task_service/execution.rs
@@ -180,7 +180,6 @@ where
         plan.options.timeout_ms = Some(timeout_ms);
     }
     prepare_plan_for_execution(&mut plan, Some(&run_id))?;
-    agent_task_lifecycle::mark_running(&run_id)?;
     let harvest_context =
         match crate::core::agent_task_scheduler::HarvestExecutionContext::from_current_process() {
             Ok(context) => context,
@@ -194,6 +193,7 @@ where
                 return Err(error);
             }
         };
+    agent_task_lifecycle::mark_running(&run_id)?;
     run_prepared_claimed(run_id, plan, executor, harvest_context)
 }
 

--- a/src/core/agent_task_service/execution.rs
+++ b/src/core/agent_task_service/execution.rs
@@ -352,7 +352,16 @@ fn run_plan_with_scheduler<E>(
 where
     E: AgentTaskExecutorAdapter,
 {
-    let scheduler = AgentTaskScheduler::new(executor);
+    // Only the Lab child process carries transport provenance. A controller
+    // process always starts with an empty per-run context, even after a Lab
+    // fallback or a preceding fanout cell.
+    let scheduler = if crate::core::lab_routing::is_lab_offload_subprocess() {
+        AgentTaskScheduler::new(executor).with_harvest_context(
+            crate::core::agent_task_scheduler::HarvestExecutionContext::lab_subprocess_from_env(),
+        )
+    } else {
+        AgentTaskScheduler::new(executor)
+    };
     match run_id {
         Some(run_id) => scheduler
             .with_run_id(run_id.to_string())

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -233,9 +233,6 @@ fn lab_offload_outcome_to_route_outcome(
                     }),
                 ),
             );
-            if let Some(metadata) = metadata {
-                runners::capture_lab_offload_subprocess_metadata(metadata);
-            }
             for message in messages {
                 eprintln!("{message}");
             }

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -68,9 +68,9 @@ mod worker;
 pub(crate) mod workload;
 mod workspace;
 pub(crate) use workspace::copy_snapshot_to_directory;
-pub(crate) use workspace::materialize_verified_lab_snapshot_git_baseline_from_env;
 #[cfg(test)]
 pub(crate) use workspace::workspace_resource_lifecycle;
+pub(crate) use workspace::{materialize_verified_lab_snapshot_git_baseline, verify_lab_workspace};
 pub(crate) use workspace::{MaterializedWorkspace, WorkspaceCleanupPolicy};
 
 pub use apply::{
@@ -141,8 +141,7 @@ pub use offload_changed_since::{
     prepare_git_lab_offload_changed_since,
 };
 pub use offload_metadata::{
-    capture_lab_offload_subprocess_metadata, lab_offload_metadata,
-    lab_offload_metadata_with_workspace_mapping,
+    lab_offload_metadata, lab_offload_metadata_with_workspace_mapping,
     lab_offload_metadata_with_workspace_mapping_and_runner_workload,
 };
 pub(crate) use resource_metrics::RunnerCommandProgressSink;
@@ -163,8 +162,6 @@ pub use tool_registry::{RunnerToolRegistry, RunnerToolSpec};
 pub(crate) use transport::{select_runner_transport, RunnerFileTransfer, RunnerTransport};
 pub use worker::{run_reverse_worker, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput};
 pub use workspace::reap_run_workspace;
-#[cfg(test)]
-pub(crate) use workspace::verify_lab_workspace;
 pub use workspace::{
     list_workspaces, plan_workspace_pull, prune_workspaces, pull_workspace, sync_workspace,
     workspace_snapshots, ByteFileCounts, RunnerWorkspaceCurrentSummary, RunnerWorkspaceListEntry,

--- a/src/core/runner/offload_metadata.rs
+++ b/src/core/runner/offload_metadata.rs
@@ -173,12 +173,6 @@ fn plan_has_step(plan: &HomeboyPlan, step_id: &str) -> bool {
     plan.steps.iter().any(|step| step.id == step_id)
 }
 
-pub fn capture_lab_offload_subprocess_metadata(metadata: serde_json::Value) {
-    if let Ok(raw) = serde_json::to_string(&metadata) {
-        std::env::set_var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV, raw);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::{

--- a/src/core/runner/workspace/mod.rs
+++ b/src/core/runner/workspace/mod.rs
@@ -37,11 +37,9 @@ pub(crate) use materializer::{
     dependency_cache_manifest_command, dependency_cache_restore_command,
     dependency_cache_save_command,
 };
-#[cfg(test)]
-pub(crate) use provenance::verify_lab_workspace;
 pub(crate) use provenance::{
-    materialize_verified_lab_snapshot_git_baseline_from_env, verify_lab_workspace_from_env,
-    verify_lab_workspace_git_root, VerifiedLabWorkspaceProvenance,
+    materialize_verified_lab_snapshot_git_baseline, verify_lab_workspace,
+    verify_lab_workspace_from_env, verify_lab_workspace_git_root, VerifiedLabWorkspaceProvenance,
 };
 pub(crate) use snapshot::{
     copy_snapshot_to_directory, effective_snapshot_excludes, local_snapshot_stats,

--- a/src/core/runner/workspace/provenance.rs
+++ b/src/core/runner/workspace/provenance.rs
@@ -30,24 +30,6 @@ pub(crate) struct VerifiedLabWorkspaceProvenance {
     synthetic_checkout_tree: Option<String>,
 }
 
-/// Creates a deterministic Git root for a verified Lab snapshot so generic
-/// candidate harvesting can use the same commit and diff paths as Git syncs.
-pub(crate) fn materialize_verified_lab_snapshot_git_baseline_from_env(
-    expected_remote_component_path: &str,
-    materialized_workspace_path: &Path,
-) -> std::result::Result<String, String> {
-    let snapshot: SourceSnapshot = env_json(SOURCE_SNAPSHOT_METADATA_ENV)
-        .ok_or_else(|| "is missing source snapshot transport metadata".to_string())?;
-    let lab: serde_json::Value = env_json(LAB_OFFLOAD_METADATA_ENV)
-        .ok_or_else(|| "is missing Lab dispatch transport metadata".to_string())?;
-    materialize_verified_lab_snapshot_git_baseline(
-        expected_remote_component_path,
-        materialized_workspace_path,
-        snapshot,
-        lab,
-    )
-}
-
 pub(crate) fn materialize_verified_lab_snapshot_git_baseline(
     expected_remote_component_path: &str,
     materialized_workspace_path: &Path,

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -26,8 +26,8 @@
 
 pub use super::runner::{
     apply_change_artifact, apply_workspace_patch, broker_auth_store_path,
-    broker_submit_token_for_runner, broker_token_from_env, capture_lab_offload_subprocess_metadata,
-    connect, connect_with_leaseless_orphan_reconciliation, connect_with_orphan_adoption,
+    broker_submit_token_for_runner, broker_token_from_env, connect,
+    connect_with_leaseless_orphan_reconciliation, connect_with_orphan_adoption,
     connect_with_recovery, reverse_broker_artifact, reverse_broker_reconcile, BrokerAuthGrant,
     BrokerAuthStore, BrokerCredential, BrokerScope, MintedCredential, BROKER_TOKEN_ENV,
     BROKER_TOKEN_HEADER,
@@ -160,8 +160,7 @@ pub mod capabilities {
 /// Lab offload entry points and contracts.
 pub mod lab_offload {
     pub use super::super::runner::{
-        capture_lab_offload_subprocess_metadata, execute_lab_offload,
-        lab_offload_changed_since_ref, lab_offload_metadata,
+        execute_lab_offload, lab_offload_changed_since_ref, lab_offload_metadata,
         lab_offload_metadata_with_workspace_mapping, preflight_lab_offload_changed_since,
         prepare_git_lab_offload_changed_since, LabJobOverrides, LabOffloadCommand,
         LabOffloadOutcome, LabOffloadRequest, LabOffloadSourcePathMode,

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -651,6 +651,11 @@ context = "any"
 }
 
 pub(crate) fn home_env_guard() -> MutexGuard<'static, ()> {
+    env_lock()
+}
+
+/// Serializes tests that mutate or capture process-global environment state.
+pub(crate) fn env_lock() -> MutexGuard<'static, ()> {
     home_lock().lock().unwrap_or_else(|e| e.into_inner())
 }
 


### PR DESCRIPTION
## Summary
- capture one immutable harvest transport context per batch before worker creation
- use explicit controller context for local batch coordinators and strict paired metadata for Lab subprocesses
- centralize scheduler context construction and reject incomplete transport pairs before provider execution
- terminalize pre-execution context failures instead of leaving durable runs running
- execute independent cook cells through bounded parallel workers with deterministic result ordering and failure isolation
- preserve the same context across cook retries without rereading process-global environment

Closes #8327.

## How to test
1. Run `cargo test --locked cook_batch --lib` and confirm the two-cell barrier test proves concurrent entry while preserving plan-order results.
2. Confirm one cell setup failure does not prevent the other cell from succeeding.
3. Set one-sided ambient Lab metadata and confirm an explicit controller batch remains uncontaminated.
4. Run sequential controller/Lab batch contexts in one process and confirm no context leakage.
5. Confirm malformed/incomplete Lab metadata fails before provider dispatch and records a terminal durable failure.
6. Run the cook retry context test and confirm retries retain the originally captured context despite ambient mutation.
7. Run `cargo check --locked`, `cargo fmt --check`, and `git diff --check origin/main...HEAD`.

## Backwards compatibility
- Existing cook-batch CLI and plan schemas are unchanged.
- Batch coordinator placement remains one process context; individual cook provider routing remains downstream.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Diagnosed fanout provenance leakage, implemented immutable context threading and bounded parallel cells, added concurrency/isolation tests, and performed independent review. Chris reviewed and owns the change.