### PR TITLE
Unify Lab-offloaded agent-task observability

### DIFF
--- a/src/commands/agent_task/run.rs
+++ b/src/commands/agent_task/run.rs
@@ -236,11 +236,34 @@ pub(super) fn run_plan(args: RunPlanArgs) -> CmdResult<Value> {
     if let Some(timeout_ms) = args.timeout_ms {
         plan.options.timeout_ms = Some(timeout_ms);
     }
+    emit_runner_lifecycle_progress(&plan, args.record_run_id.as_deref());
     run_loaded_plan(
         plan,
         args.record_run_id.as_deref(),
         ExtensionProviderAgentTaskExecutor::discover(),
     )
+}
+
+fn emit_runner_lifecycle_progress(plan: &AgentTaskPlan, run_id: Option<&str>) {
+    if std::env::var_os("HOMEBOY_LAB_RUNNER_ID").is_none() {
+        return;
+    }
+    for task in &plan.tasks {
+        println!(
+            "HOMEBOY_RUNNER_PROGRESS {}",
+            serde_json::json!({
+                "schema": "homeboy/runner-progress/v1",
+                "phase": "provider_dispatch",
+                "current_item": task.task_id,
+                "metadata": {
+                    "agent_task_run_id": run_id,
+                    "task_id": task.task_id,
+                    "provider": task.executor.backend,
+                    "event": "provider_selected",
+                },
+            })
+        );
+    }
 }
 
 pub(super) fn run_loaded_plan<E>(

--- a/src/core/agent_task_lifecycle/cancellation.rs
+++ b/src/core/agent_task_lifecycle/cancellation.rs
@@ -33,6 +33,8 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
     } else {
         LiveCancellationOutcome::NotRunning
     };
+    let runner_id = record.runner_id().map(str::to_string);
+    let runner_job_id = record.runner_job_id().map(str::to_string);
 
     let cancelled_at = now_timestamp();
     let was_stale_running = record.state == AgentTaskRunState::Running;
@@ -68,6 +70,18 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
                 }),
             );
         }
+        LiveCancellationOutcome::RunnerJobCancelled { job, events } => {
+            metadata.insert(
+                "live_cancellation".to_string(),
+                json!({
+                    "runner_id": runner_id,
+                    "runner_job_id": runner_job_id,
+                    "runner_job_status": job.status,
+                    "runner_job_events": events,
+                    "cancellation": "runner_job_cancel",
+                }),
+            );
+        }
         LiveCancellationOutcome::Unsupported(unsupported) => {
             metadata.insert(
                 "live_cancellation_unsupported".to_string(),
@@ -98,6 +112,10 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
 /// not actually running.
 enum LiveCancellationOutcome {
     Terminated(crate::core::process::ProcessTreeTermination),
+    RunnerJobCancelled {
+        job: crate::core::api_jobs::Job,
+        events: Vec<crate::core::api_jobs::JobEvent>,
+    },
     Unsupported(UnsupportedLiveCancellation),
     NotRunning,
 }
@@ -132,6 +150,13 @@ fn classify_live_cancellation(record: &AgentTaskRunRecord) -> Result<LiveCancell
     if record.is_runner_backed() {
         let runner_id = record.runner_id().map(str::to_string);
         let runner_job_id = record.runner_job_id().map(str::to_string);
+        if let (Some(runner_id), Some(runner_job_id)) =
+            (runner_id.as_deref(), runner_job_id.as_deref())
+        {
+            if let Ok((job, events)) = cancel_runner_job(runner_id, runner_job_id) {
+                return Ok(LiveCancellationOutcome::RunnerJobCancelled { job, events });
+            }
+        }
         let mut recovery_commands = Vec::new();
         if let Some(runner) = runner_id.as_deref() {
             if let Some(job) = runner_job_id.as_deref() {
@@ -178,6 +203,70 @@ fn classify_live_cancellation(record: &AgentTaskRunRecord) -> Result<LiveCancell
     }
 
     Ok(LiveCancellationOutcome::NotRunning)
+}
+
+fn cancel_runner_job(
+    runner_id: &str,
+    runner_job_id: &str,
+) -> Result<(
+    crate::core::api_jobs::Job,
+    Vec<crate::core::api_jobs::JobEvent>,
+)> {
+    #[cfg(test)]
+    if let Some(result) = test_cancel_hook::take(runner_id, runner_job_id) {
+        return result;
+    }
+
+    crate::core::runners::runner_job_cancel(runner_id, runner_job_id)
+}
+
+#[cfg(test)]
+pub(super) mod test_cancel_hook {
+    use super::*;
+    use std::cell::RefCell;
+
+    type CancelHook = Box<
+        dyn FnMut(
+            &str,
+            &str,
+        ) -> Result<(
+            crate::core::api_jobs::Job,
+            Vec<crate::core::api_jobs::JobEvent>,
+        )>,
+    >;
+
+    thread_local! {
+        static HOOK: RefCell<Option<CancelHook>> = const { RefCell::new(None) };
+    }
+
+    pub(in super::super) struct Guard;
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            HOOK.with(|cell| *cell.borrow_mut() = None);
+        }
+    }
+
+    pub(in super::super) fn install(hook: CancelHook) -> Guard {
+        HOOK.with(|cell| *cell.borrow_mut() = Some(hook));
+        Guard
+    }
+
+    pub(super) fn take(
+        runner_id: &str,
+        runner_job_id: &str,
+    ) -> Option<
+        Result<(
+            crate::core::api_jobs::Job,
+            Vec<crate::core::api_jobs::JobEvent>,
+        )>,
+    > {
+        HOOK.with(|cell| {
+            cell.borrow_mut()
+                .as_mut()
+                .map(|hook| hook(runner_id, runner_job_id))
+        })
+    }
 }
 
 pub fn cancel(run_id: &str) -> Result<AgentTaskRunRecord> {

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -222,6 +222,73 @@ fn detached_lab_handoff_persists_inspectable_running_record() {
 }
 
 #[test]
+fn detached_lab_run_plan_uses_one_identity_for_status_logs_artifacts_and_cancellation() {
+    with_isolated_home(|_| {
+        let run_id = "agent-task-detached-run-plan";
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+            "--record-run-id".to_string(),
+            run_id.to_string(),
+        ];
+        record_detached_lab_run(DetachedLabRunRecord {
+            run_id,
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-8341",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        })
+        .expect("detached run-plan is bound to the controller run");
+
+        let status = status(run_id).expect("controller identity resolves status");
+        let logs = logs(run_id).expect("controller identity resolves logs");
+        let artifacts = artifacts(run_id).expect("controller identity resolves artifacts");
+        assert_eq!(status.run_id, run_id);
+        assert_eq!(status.metadata["runner_job_id"], "job-8341");
+        assert!(!logs.events.is_empty());
+        assert!(artifacts.artifacts.is_empty());
+
+        let _cancel =
+            super::cancellation::test_cancel_hook::install(Box::new(|runner_id, job_id| {
+                assert_eq!(runner_id, "homeboy-lab");
+                assert_eq!(job_id, "job-8341");
+                Ok((
+                    crate::core::api_jobs::Job {
+                        id: uuid::Uuid::new_v4(),
+                        operation: "runner.exec".to_string(),
+                        status: crate::core::api_jobs::JobStatus::Cancelled,
+                        created_at_ms: 1,
+                        updated_at_ms: 2,
+                        started_at_ms: Some(1),
+                        finished_at_ms: Some(2),
+                        event_count: 0,
+                        source_snapshot: None,
+                        path_materialization_plan: None,
+                        stale_reason: None,
+                        daemon_lease_id: None,
+                        target_runner_id: None,
+                        target_project_id: None,
+                        claim_id: None,
+                        claimed_by_runner_id: None,
+                        claimed_at_ms: None,
+                        claim_expires_at_ms: None,
+                        artifacts: Vec::new(),
+                    },
+                    Vec::new(),
+                ))
+            }));
+        let cancelled = cancel_run(run_id, Some("operator requested cancellation"))
+            .expect("canonical cancellation reaches the runner job");
+        assert_eq!(cancelled.state, AgentTaskRunState::Cancelled);
+        assert_eq!(
+            cancelled.metadata["live_cancellation"]["cancellation"],
+            "runner_job_cancel"
+        );
+    });
+}
+
+#[test]
 fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
     with_isolated_home(|_| {
         let command = vec![

--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -1858,6 +1858,18 @@ mod tests {
     }
 
     #[test]
+    fn active_runner_jobs_include_daemon_local_jobs_counted_by_freshness() {
+        let store = JobStore::default();
+        let job = store.create("runner.exec");
+
+        let active = store.active_runner_jobs();
+
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].job_id, job.id.to_string());
+        assert_eq!(active[0].source, "daemon");
+    }
+
+    #[test]
     fn durable_remote_runner_restart_failure_moves_to_stale_runner_jobs() {
         let temp = tempfile::tempdir().expect("temp dir");
         let path = temp.path().join("jobs.json");

--- a/src/core/api_jobs/store.rs
+++ b/src/core/api_jobs/store.rs
@@ -981,13 +981,14 @@ impl JobStore {
             .jobs
             .values()
             .filter(|stored| matches!(stored.job.status, JobStatus::Queued | JobStatus::Running))
-            .filter_map(|stored| {
-                let request = stored.remote_runner.as_ref()?.request.clone();
-                Some(super::summary::active_runner_job_summary(
-                    &stored.job,
-                    &request,
-                    now,
-                ))
+            .map(|stored| {
+                stored
+                    .remote_runner
+                    .as_ref()
+                    .map(|remote| {
+                        super::summary::active_runner_job_summary(&stored.job, &remote.request, now)
+                    })
+                    .unwrap_or_else(|| super::summary::active_daemon_job_summary(&stored.job, now))
             })
             .collect();
         jobs.sort_by_key(|job| (job.started_at_ms, job.job_id.clone()));

--- a/src/core/api_jobs/summary.rs
+++ b/src/core/api_jobs/summary.rs
@@ -63,6 +63,43 @@ pub(super) fn active_runner_job_summary(
     }
 }
 
+pub(super) fn active_daemon_job_summary(job: &Job, now_ms: u64) -> ActiveRunnerJobSummary {
+    let started_at_ms = job.started_at_ms.unwrap_or(job.created_at_ms);
+    ActiveRunnerJobSummary {
+        runner_id: job
+            .target_runner_id
+            .clone()
+            .unwrap_or_else(|| "daemon".to_string()),
+        job_id: job.id.to_string(),
+        operation: job.operation.clone(),
+        source: "daemon".to_string(),
+        kind: job.operation.clone(),
+        status: job.status,
+        command: job.operation.clone(),
+        cwd: None,
+        started_at_ms,
+        updated_at_ms: job.updated_at_ms,
+        elapsed_ms: now_ms.saturating_sub(started_at_ms),
+        heartbeat_age_ms: now_ms.saturating_sub(job.updated_at_ms),
+        claim: super::types::JobClaimMetadata {
+            claim_id: job.claim_id.clone(),
+            claimed_by_runner_id: job.claimed_by_runner_id.clone(),
+            claimed_at_ms: job.claimed_at_ms,
+            claim_expires_at_ms: job.claim_expires_at_ms,
+        },
+        claim_expires_in_ms: job
+            .claim_expires_at_ms
+            .map(|expires_at| expires_at.saturating_sub(now_ms)),
+        lifecycle: None,
+        durable_run_id: None,
+        stale_reason: job.stale_reason.clone(),
+        lifecycle_state: Some(runner_job_lifecycle_state(job).to_string()),
+        retryable: Some(runner_job_retryable(job)),
+        active_child_count: None,
+        active_cell_count: None,
+    }
+}
+
 fn request_metadata_u64(request: &RemoteRunnerJobRequest, key: &str) -> Option<u64> {
     request
         .metadata

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::core::api_jobs::JobEventKind;
 use reqwest::blocking::Client;
 use serde_json::{json, Value};
 use std::time::Duration;
@@ -556,7 +557,7 @@ fn direct_daemon_detached_handoff_returns_while_the_workload_remains_running() {
             vec![
                 "sh".to_string(),
                 "-c".to_string(),
-                "printf started > \"$1\"; while [ ! -e \"$2\" ]; do sleep 0.01; done".to_string(),
+                "printf 'HOMEBOY_RUNNER_PROGRESS {\"schema\":\"homeboy/runner-progress/v1\",\"phase\":\"provider_dispatch\",\"current_item\":\"task-8341\",\"metadata\":{\"event\":\"provider_selected\",\"provider\":\"fixture\"}}\\n'; printf started > \"$1\"; while [ ! -e \"$2\" ]; do sleep 0.01; done".to_string(),
                 "sh".to_string(),
                 started.display().to_string(),
                 release.display().to_string(),
@@ -589,6 +590,19 @@ fn direct_daemon_detached_handoff_returns_while_the_workload_remains_running() {
             matches!(job.status, JobStatus::Queued | JobStatus::Running),
             "detached handoff returned only after workload completion"
         );
+        let events = fetch_daemon_events(&client, &daemon_url, &job_id)
+            .expect("live daemon events while workload is blocked");
+        let progress = events
+            .iter()
+            .filter_map(|event| {
+                (event.kind == JobEventKind::Progress)
+                    .then(|| event.data.as_ref())
+                    .flatten()
+            })
+            .find(|data| data["phase"] == "provider_dispatch")
+            .expect("provider progress is forwarded before process completion");
+        assert_eq!(progress["phase"], "provider_dispatch");
+        assert_eq!(progress["metadata"]["event"], "provider_selected");
 
         std::fs::write(&release, "release").expect("release workload");
         wait_for_terminal_daemon_job(&client, &daemon_url, &job_id);

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -645,6 +645,11 @@ pub(super) fn ensure_agent_task_lifecycle_identity_with(
 ) -> Option<(Vec<String>, String)> {
     let (args, run_id) = ensure_agent_task_dispatch_run_id_with(args, preferred)?;
     let invocation = CommandInvocation::for_subcommand(&args, "agent-task")?;
+    // A run-plan already carries the controller-owned durable identity in
+    // --record-run-id. Unlike cook, it has no attempt id to derive or inject.
+    if invocation.child_index_matching(&["run-plan"]).is_some() {
+        return Some((args, run_id));
+    }
     let action_index = invocation.child_index_matching(&["cook"])?;
     let existing_attempt_run_id = invocation
         .option_value_after(action_index, "--attempt-run-id")
@@ -664,6 +669,30 @@ pub(super) fn ensure_agent_task_lifecycle_identity_with(
         )
         .into_args();
     Some((args, attempt_run_id))
+}
+
+#[cfg(test)]
+mod lifecycle_identity_tests {
+    use super::*;
+
+    #[test]
+    fn run_plan_record_identity_is_preserved_for_lab_lifecycle() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+            "--plan".to_string(),
+            "@plan.json".to_string(),
+            "--record-run-id".to_string(),
+            "retry-8341".to_string(),
+        ];
+
+        let (rewritten, run_id) = ensure_agent_task_lifecycle_identity_with(&args, None, None)
+            .expect("run-plan has a durable lifecycle identity");
+
+        assert_eq!(rewritten, args);
+        assert_eq!(run_id, "retry-8341");
+    }
 }
 
 /// Resolves the stable per-run isolation token for an agent-task cook offload:


### PR DESCRIPTION
Closes #8341.

## Summary
- preserve `run-plan --record-run-id` as the canonical lifecycle identity across Lab offload
- reconcile live runner progress through `agent-task status|logs|artifacts` under that identity
- route canonical agent-task cancellation to its bound runner job
- emit structured provider-dispatch progress before the remote task completes
- include daemon-local queued/running jobs in the typed active-job projection so it agrees with freshness

## How to test
1. Run `cargo test --lib detached_lab_run_plan_uses_one_identity_for_status_logs_artifacts_and_cancellation`.
2. Run `cargo test --lib run_plan_record_identity_is_preserved_for_lab_lifecycle`.
3. Run `cargo test --lib core::runner::execution::tests::handoff::direct_daemon_detached_handoff_returns_while_the_workload_remains_running`.
4. Run `cargo test --lib core::agent_task_lifecycle::tests::`.
5. Run `cargo test --lib core::runner::lab::agent_task_bridge::`.
6. Run `cargo test --lib core::api_jobs::tests::`.
7. Run `cargo check && cargo fmt --check`.

The detached-daemon test blocks the remote workload after it emits provider selection and proves the progress event is queryable before process completion.

## Review evidence
- Homeboy scoped lint passed with zero findings.
- Homeboy scoped tests passed: 25 passed, 0 failed.
- The structural audit reports six existing size-threshold findings in touched legacy files; five are informational and one is a warning for the existing 3,099-line lifecycle test module. No audit rule was bypassed or baselined.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Reproduced the Lab observability failure, implemented the lifecycle refactor and regression coverage, reviewed the candidate, and ran verification.
