### PR TITLE
Recover stale runner split views safely

### DIFF
--- a/crates/homeboy-paths/src/runtime.rs
+++ b/crates/homeboy-paths/src/runtime.rs
@@ -37,10 +37,8 @@ pub fn daemon_state_loss_recovery_receipt_file(lease_id: &str) -> Result<PathBuf
 }
 
 /// Exact replacement receipt for an approved lease-less recovery.
-pub fn daemon_leaseless_recovery_receipt_file(lease_id: &str) -> Result<PathBuf> {
-    Ok(daemon_state_dir()?
-        .join("leaseless-recovery")
-        .join(format!("{}.json", sanitize_path_segment(lease_id))))
+pub fn daemon_leaseless_recovery_receipt_file() -> Result<PathBuf> {
+    Ok(daemon_state_dir()?.join("leaseless-recovery.json"))
 }
 
 /// Runner connection session state directory (~/.config/homeboy/runner-sessions/).

--- a/crates/homeboy-paths/src/runtime.rs
+++ b/crates/homeboy-paths/src/runtime.rs
@@ -36,6 +36,13 @@ pub fn daemon_state_loss_recovery_receipt_file(lease_id: &str) -> Result<PathBuf
         .join(format!("{}.json", sanitize_path_segment(lease_id))))
 }
 
+/// Exact replacement receipt for an approved lease-less recovery.
+pub fn daemon_leaseless_recovery_receipt_file(lease_id: &str) -> Result<PathBuf> {
+    Ok(daemon_state_dir()?
+        .join("leaseless-recovery")
+        .join(format!("{}.json", sanitize_path_segment(lease_id))))
+}
+
 /// Runner connection session state directory (~/.config/homeboy/runner-sessions/).
 pub fn runner_sessions_dir() -> Result<PathBuf> {
     Ok(homeboy()?.join("runner-sessions"))

--- a/src/commands/runner/status.rs
+++ b/src/commands/runner/status.rs
@@ -6,6 +6,7 @@ use homeboy::core::agent_runtime_manifest::{
     AgentRuntimeRuntimeDiagnosticDeclaration, AgentRuntimeSourceConsistencyDiagnostic,
     AgentRuntimeToolDiagnosticDeclaration,
 };
+use homeboy::core::daemon::DaemonStaleReasonCode;
 use homeboy::core::runners::{
     self as runner, RunnerActiveJobState, RunnerAvailability, RunnerBinarySource, RunnerSession,
     RunnerStatusReport, RunnerTunnelMode, RuntimeMaterializationStatus,
@@ -981,7 +982,7 @@ fn reverse_runner_status_hints(
 pub(super) fn runner_status_operator_commands(
     report: &RunnerStatusReport,
 ) -> Vec<RunnerOperatorCommand> {
-    let Some(session) = report.session.as_ref().filter(|_| report.connected) else {
+    let Some(session) = report.session.as_ref() else {
         return Vec::new();
     };
 
@@ -1086,6 +1087,21 @@ pub(super) fn runner_status_operator_commands(
             command: warning.refresh_command.clone(),
             description: "Restart the active runner daemon so the control plane uses the configured job command binary.".to_string(),
         });
+    }
+
+    if let Some(freshness) = report.daemon_freshness.as_ref().filter(|freshness| {
+        freshness.active_jobs > 0
+            && freshness.stale_reason_code == Some(DaemonStaleReasonCode::VersionMismatch)
+    }) {
+        if let Some(command) = freshness.adoption_command.as_ref() {
+            commands.push(RunnerOperatorCommand {
+                scope: "daemon_reconcile_split_view",
+                runner_id: report.runner_id.clone(),
+                job_id: None,
+                command: command.clone(),
+                description: "Reconcile the stale daemon split view only after the remote owner-lock, process, and listener probes prove no daemon-owned process remains alive.".to_string(),
+            });
+        }
     }
 
     commands

--- a/src/commands/runner/tests/status.rs
+++ b/src/commands/runner/tests/status.rs
@@ -6,7 +6,8 @@ use homeboy::core::agent_runtime_manifest::{
     AgentRuntimeSourceConsistencyDiagnostic, AgentRuntimeToolDiagnosticDeclaration,
 };
 use homeboy::core::api_jobs::{JobEvent, JobStatus};
-use homeboy::core::runner::{RunnerActiveJobSource, RunnerActiveJobState};
+use homeboy::core::daemon::{DaemonFreshnessReport, DaemonStaleReasonCode};
+use homeboy::core::runner::{RunnerActiveJobError, RunnerActiveJobSource, RunnerActiveJobState};
 use homeboy::core::runners::{self as runner, RunnerSession, RunnerStatusReport, RunnerTunnelMode};
 
 use super::super::jobs::format_job_event;
@@ -153,6 +154,83 @@ fn reverse_runner_status_commands_include_lifecycle_operations() {
     assert!(serialized.contains("homeboy agent-task status run-123 --full"));
     assert!(serialized.contains("homeboy agent-task retry run-123"));
     assert!(!serialized.contains("runner job logs"));
+}
+
+#[test]
+fn disconnected_split_view_status_exposes_bounded_reconciliation_command() {
+    let mut report = RunnerStatusReport {
+        runner_id: "homeboy-lab".to_string(),
+        connected: false,
+        state: runner::RunnerSessionState::Disconnected,
+        session: Some(RunnerSession {
+            runner_id: "homeboy-lab".to_string(),
+            mode: RunnerTunnelMode::DirectSsh,
+            role: runner::RunnerSessionRole::Controller,
+            server_id: Some("lab-server".to_string()),
+            controller_id: None,
+            broker_url: None,
+            remote_daemon_address: Some("127.0.0.1:7331".to_string()),
+            local_port: Some(7331),
+            local_url: Some("http://127.0.0.1:7331".to_string()),
+            tunnel_pid: Some(12345),
+            remote_daemon_pid: Some(23456),
+            remote_daemon_lease_id: Some("lease-23456".to_string()),
+            homeboy_version: "homeboy old".to_string(),
+            homeboy_build_identity: Some("homeboy old+daemon".to_string()),
+            connected_at: "2026-06-26T00:00:00Z".to_string(),
+            worker_identity: None,
+            worker_pid: None,
+            last_seen_at: None,
+            leaseless_recovery_evidence: None,
+        }),
+        stale_daemon: None,
+        daemon_freshness: Some(DaemonFreshnessReport {
+            fresh: false,
+            stale_reason_code: Some(DaemonStaleReasonCode::VersionMismatch),
+            restartable: false,
+            lease_id: Some("lease-23456".to_string()),
+            pid: Some(23456),
+            recovery_evidence: None,
+            ownership_evidence: None,
+            adoption_command: Some("homeboy runner connect homeboy-lab --reconcile-leaseless-orphans --confirm-no-daemon-owner".to_string()),
+            binary_hash: None,
+            daemon_version: None,
+            daemon_build_identity: None,
+            runtime_paths: None,
+            active_jobs: 1,
+            termination_evidence: None,
+            repair_plan: Vec::new(),
+        }),
+        active_jobs: Vec::new(),
+        active_runner_jobs: Vec::new(),
+        stale_runner_jobs: Vec::new(),
+        active_job_count: 1,
+        stale_runner_job_count: 0,
+        active_job_state: RunnerActiveJobState::Available,
+        active_job_source: Some(RunnerActiveJobSource::DirectDaemon),
+        active_job_error: Some(RunnerActiveJobError {
+            code: "active_job_view_inconsistent".to_string(),
+            message: "freshness has one job while /jobs has none".to_string(),
+        }),
+        session_path: "/tmp/session.json".to_string(),
+    };
+
+    let commands = runner_status_operator_commands(&report);
+
+    assert!(commands.iter().any(|command| {
+        command.scope == "daemon_reconcile_split_view"
+            && command.command.contains("--reconcile-leaseless-orphans")
+            && command.description.contains("process")
+    }));
+
+    report
+        .daemon_freshness
+        .as_mut()
+        .expect("freshness")
+        .active_jobs = 0;
+    assert!(runner_status_operator_commands(&report)
+        .iter()
+        .all(|command| command.scope != "daemon_reconcile_split_view"));
 }
 
 #[test]

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -813,6 +813,12 @@ fn replay_leaseless_recovery(
         receipt.phase = StateLossRecoveryPhase::Reconciled;
         write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
     }
+    if receipt.phase == StateLossRecoveryPhase::Reconciled {
+        receipt.phase = StateLossRecoveryPhase::ReplacementStarting;
+        receipt.replacement_startup_token = Some(uuid::Uuid::new_v4().to_string());
+        write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
+        return replay_leaseless_recovery(status, addr);
+    }
     if receipt.phase == StateLossRecoveryPhase::ReplacementStarting {
         if let Some(state) = status.state.as_ref().filter(|_| status.running) {
             if receipt.replacement_startup_token.as_deref() != Some(&state.startup_token) {

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -768,6 +768,97 @@ where
     })
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct LeaselessRecoveryReceipt {
+    affected_job_ids: Vec<uuid::Uuid>,
+    affected_jobs: Vec<crate::core::api_jobs::LeaselessOrphanAffectedJob>,
+    historical_lease_ids: Vec<String>,
+    evidence_snapshot_path: String,
+    ownership_proof: Vec<String>,
+    replacement: DaemonStartResult,
+}
+
+impl LeaselessRecoveryReceipt {
+    fn into_result(self) -> DaemonLeaselessRecoveryResult {
+        DaemonLeaselessRecoveryResult {
+            affected_job_count: self.affected_job_ids.len(),
+            affected_job_ids: self.affected_job_ids,
+            affected_jobs: self.affected_jobs,
+            historical_lease_ids: self.historical_lease_ids,
+            evidence_snapshot_path: self.evidence_snapshot_path,
+            ownership_proof: self.ownership_proof,
+            retry_guidance: "Recovery already completed for this exact replacement daemon; no additional daemon was started.".to_string(),
+            replacement: self.replacement,
+        }
+    }
+}
+
+fn replay_leaseless_recovery(
+    status: &super::DaemonStatus,
+) -> Result<Option<DaemonLeaselessRecoveryResult>> {
+    if status.freshness.active_jobs != 0 || !status.fresh || !status.running {
+        return Ok(None);
+    }
+    let Some(state) = status.state.as_ref() else {
+        return Ok(None);
+    };
+    let receipt_path = crate::core::paths::daemon_leaseless_recovery_receipt_file(&state.lease_id)?;
+    let Some(receipt) = read_leaseless_recovery_receipt(&receipt_path)? else {
+        return Ok(None);
+    };
+    if receipt.replacement.lease_id != state.lease_id
+        || receipt.replacement.pid != state.pid
+        || receipt.replacement.address != state.address
+    {
+        return Ok(None);
+    }
+    Ok(Some(receipt.into_result()))
+}
+
+fn read_leaseless_recovery_receipt(path: &Path) -> Result<Option<LeaselessRecoveryReceipt>> {
+    match std::fs::read(path) {
+        Ok(raw) => serde_json::from_slice(&raw).map(Some).map_err(|error| {
+            Error::internal_json(error.to_string(), Some(format!("read {}", path.display())))
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(Error::internal_io(
+            error.to_string(),
+            Some(format!("read {}", path.display())),
+        )),
+    }
+}
+
+fn write_leaseless_recovery_receipt(path: &Path, receipt: &LeaselessRecoveryReceipt) -> Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        Error::internal_unexpected("lease-less recovery receipt path has no parent")
+    })?;
+    std::fs::create_dir_all(parent).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("create {}", parent.display())),
+        )
+    })?;
+    let temporary = path.with_extension(format!("{}.tmp", uuid::Uuid::new_v4()));
+    let body = serde_json::to_vec_pretty(receipt).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize lease-less recovery receipt".to_string()),
+        )
+    })?;
+    std::fs::write(&temporary, body).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("write {}", temporary.display())),
+        )
+    })?;
+    std::fs::rename(&temporary, path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("rename {}", path.display())),
+        )
+    })
+}
+
 /// Spawn the daemon in the background, then poll the state file until the new
 /// process publishes its address (or a timeout elapses).
 pub fn start_background(addr: &str) -> Result<DaemonStartResult> {
@@ -991,6 +1082,9 @@ pub fn reconcile_leaseless_orphans(
     parse_bind_addr(addr)?;
     let _lock = acquire_daemon_operation_lock()?;
     let status = read_status()?;
+    if let Some(result) = replay_leaseless_recovery(&status)? {
+        return Ok(result);
+    }
     if status.freshness.active_jobs == 0
         || !matches!(
             status.freshness.stale_reason_code,
@@ -1049,16 +1143,21 @@ pub fn reconcile_leaseless_orphans(
     let affected_job_count = reconciled.reconciled_count();
     drop(owner_lock);
     let replacement = start_or_return_live_unlocked(addr)?;
-    Ok(DaemonLeaselessRecoveryResult {
+    let receipt = LeaselessRecoveryReceipt {
         affected_job_ids: reconciled.reconciled_job_ids,
-        affected_job_count,
         affected_jobs: reconciled.affected_jobs,
         historical_lease_ids: reconciled.historical_lease_ids,
         evidence_snapshot_path: snapshot_path.display().to_string(),
         ownership_proof,
-        retry_guidance: "Recorded job output and artifacts were retained. Retry eligible work through its original command or workflow.".to_string(),
         replacement,
-    })
+    };
+    let receipt_path =
+        crate::core::paths::daemon_leaseless_recovery_receipt_file(&receipt.replacement.lease_id)?;
+    write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
+    let mut result = receipt.into_result();
+    result.affected_job_count = affected_job_count;
+    result.retry_guidance = "Recorded job output and artifacts were retained. Retry eligible work through its original command or workflow.".to_string();
+    Ok(result)
 }
 
 fn prove_no_daemon_owner(addr: &str) -> Result<Vec<String>> {

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -775,12 +775,17 @@ struct LeaselessRecoveryReceipt {
     historical_lease_ids: Vec<String>,
     evidence_snapshot_path: String,
     ownership_proof: Vec<String>,
-    replacement: DaemonStartResult,
+    phase: StateLossRecoveryPhase,
+    replacement: Option<DaemonStartResult>,
+    replacement_startup_token: Option<String>,
 }
 
 impl LeaselessRecoveryReceipt {
-    fn into_result(self) -> DaemonLeaselessRecoveryResult {
-        DaemonLeaselessRecoveryResult {
+    fn into_result(self) -> Result<DaemonLeaselessRecoveryResult> {
+        let replacement = self.replacement.ok_or_else(|| {
+            Error::internal_unexpected("lease-less receipt has no replacement daemon identity")
+        })?;
+        Ok(DaemonLeaselessRecoveryResult {
             affected_job_count: self.affected_job_ids.len(),
             affected_job_ids: self.affected_job_ids,
             affected_jobs: self.affected_jobs,
@@ -788,31 +793,58 @@ impl LeaselessRecoveryReceipt {
             evidence_snapshot_path: self.evidence_snapshot_path,
             ownership_proof: self.ownership_proof,
             retry_guidance: "Recovery already completed for this exact replacement daemon; no additional daemon was started.".to_string(),
-            replacement: self.replacement,
-        }
+            replacement,
+        })
     }
 }
 
 fn replay_leaseless_recovery(
     status: &super::DaemonStatus,
 ) -> Result<Option<DaemonLeaselessRecoveryResult>> {
-    if status.freshness.active_jobs != 0 || !status.fresh || !status.running {
+    let receipt_path = crate::core::paths::daemon_leaseless_recovery_receipt_file()?;
+    let Some(mut receipt) = read_leaseless_recovery_receipt(&receipt_path)? else {
         return Ok(None);
-    }
+    };
     let Some(state) = status.state.as_ref() else {
         return Ok(None);
     };
-    let receipt_path = crate::core::paths::daemon_leaseless_recovery_receipt_file(&state.lease_id)?;
-    let Some(receipt) = read_leaseless_recovery_receipt(&receipt_path)? else {
+    if receipt.phase == StateLossRecoveryPhase::ReplacementStarting {
+        if status.running
+            && receipt.replacement_startup_token.as_deref() == Some(&state.startup_token)
+        {
+            receipt.phase = StateLossRecoveryPhase::ReplacementStarted;
+            receipt.replacement = Some(DaemonStartResult {
+                pid: state.pid,
+                address: state.address.clone(),
+                state_path: state.state_path.clone(),
+                lease_id: state.lease_id.clone(),
+            });
+            write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
+        } else if status.running {
+            return Err(Error::validation_invalid_argument(
+                "reconcile_leaseless_orphans",
+                "lease-less recovery replay found a mismatched live daemon",
+                None,
+                None,
+            ));
+        } else {
+            return Ok(None);
+        }
+    }
+    if status.freshness.active_jobs != 0 || !status.fresh || !status.running {
         return Ok(None);
-    };
-    if receipt.replacement.lease_id != state.lease_id
-        || receipt.replacement.pid != state.pid
-        || receipt.replacement.address != state.address
+    }
+    let replacement = receipt.replacement.as_ref().ok_or_else(|| {
+        Error::internal_unexpected("completed lease-less receipt has no replacement")
+    })?;
+    if receipt.phase != StateLossRecoveryPhase::ReplacementStarted
+        || replacement.lease_id != state.lease_id
+        || replacement.pid != state.pid
+        || replacement.address != state.address
     {
         return Ok(None);
     }
-    Ok(Some(receipt.into_result()))
+    Ok(Some(receipt.into_result()?))
 }
 
 fn read_leaseless_recovery_receipt(path: &Path) -> Result<Option<LeaselessRecoveryReceipt>> {
@@ -1142,19 +1174,42 @@ pub fn reconcile_leaseless_orphans(
     }
     let affected_job_count = reconciled.reconciled_count();
     drop(owner_lock);
-    let replacement = start_or_return_live_unlocked(addr)?;
     let receipt = LeaselessRecoveryReceipt {
         affected_job_ids: reconciled.reconciled_job_ids,
         affected_jobs: reconciled.affected_jobs,
         historical_lease_ids: reconciled.historical_lease_ids,
         evidence_snapshot_path: snapshot_path.display().to_string(),
         ownership_proof,
-        replacement,
+        phase: StateLossRecoveryPhase::Reconciled,
+        replacement: None,
+        replacement_startup_token: None,
     };
-    let receipt_path =
-        crate::core::paths::daemon_leaseless_recovery_receipt_file(&receipt.replacement.lease_id)?;
+    let receipt_path = crate::core::paths::daemon_leaseless_recovery_receipt_file()?;
     write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
-    let mut result = receipt.into_result();
+    let mut receipt = receipt;
+    let startup_token = uuid::Uuid::new_v4().to_string();
+    receipt.phase = StateLossRecoveryPhase::ReplacementStarting;
+    receipt.replacement_startup_token = Some(startup_token.clone());
+    write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
+    let replacement = start_or_return_live_unlocked_with_startup_token(addr, &startup_token)?;
+    let status = read_status()?;
+    if !status.running
+        || status
+            .state
+            .as_ref()
+            .is_none_or(|state| state.startup_token != startup_token)
+    {
+        return Err(Error::validation_invalid_argument(
+            "reconcile_leaseless_orphans",
+            "replacement startup did not publish the expected lease-less recovery startup token",
+            None,
+            None,
+        ));
+    }
+    receipt.phase = StateLossRecoveryPhase::ReplacementStarted;
+    receipt.replacement = Some(replacement);
+    write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
+    let mut result = receipt.into_result()?;
     result.affected_job_count = affected_job_count;
     result.retry_guidance = "Recorded job output and artifacts were retained. Retry eligible work through its original command or workflow.".to_string();
     Ok(result)

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -744,6 +744,18 @@ where
             Some(vec!["Wait for the recorded child process to finish, then retry recovery.".to_string()]),
         ));
     }
+    if !reconciled.preserved_remote_job_ids.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "job_store",
+            format!(
+                "deferred lease-less recovery because {} broker-owned remote job(s) remain active or unexpired: {}",
+                reconciled.preserved_remote_job_ids.len(),
+                reconciled.preserved_remote_job_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(", "),
+            ),
+            None,
+            Some(vec!["Wait for each broker-owned claim to expire or reach a terminal state, then retry recovery.".to_string()]),
+        ));
+    }
     let affected_job_count = reconciled.reconciled_count();
     let replacement = start()?;
     Ok(DaemonLeaselessOrphanReconciliationResult {
@@ -1020,6 +1032,18 @@ pub fn reconcile_leaseless_orphans(
             ),
             None,
             Some(vec!["Wait for the recorded child process to finish, then retry recovery.".to_string()]),
+        ));
+    }
+    if !reconciled.preserved_remote_job_ids.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "reconcile_leaseless_orphans",
+            format!(
+                "deferred lease-less recovery because {} broker-owned remote job(s) remain active or unexpired: {}",
+                reconciled.preserved_remote_job_ids.len(),
+                reconciled.preserved_remote_job_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(", "),
+            ),
+            None,
+            Some(vec!["Wait for each broker-owned claim to expire or reach a terminal state, then retry recovery.".to_string()]),
         ));
     }
     let affected_job_count = reconciled.reconciled_count();

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -800,18 +800,29 @@ impl LeaselessRecoveryReceipt {
 
 fn replay_leaseless_recovery(
     status: &super::DaemonStatus,
+    addr: &str,
 ) -> Result<Option<DaemonLeaselessRecoveryResult>> {
     let receipt_path = crate::core::paths::daemon_leaseless_recovery_receipt_file()?;
     let Some(mut receipt) = read_leaseless_recovery_receipt(&receipt_path)? else {
         return Ok(None);
     };
-    let Some(state) = status.state.as_ref() else {
-        return Ok(None);
-    };
+    if receipt.phase == StateLossRecoveryPhase::Prepared {
+        if status.freshness.active_jobs > 0 {
+            return Ok(None);
+        }
+        receipt.phase = StateLossRecoveryPhase::Reconciled;
+        write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
+    }
     if receipt.phase == StateLossRecoveryPhase::ReplacementStarting {
-        if status.running
-            && receipt.replacement_startup_token.as_deref() == Some(&state.startup_token)
-        {
+        if let Some(state) = status.state.as_ref().filter(|_| status.running) {
+            if receipt.replacement_startup_token.as_deref() != Some(&state.startup_token) {
+                return Err(Error::validation_invalid_argument(
+                    "reconcile_leaseless_orphans",
+                    "lease-less recovery replay found a mismatched live daemon",
+                    None,
+                    None,
+                ));
+            }
             receipt.phase = StateLossRecoveryPhase::ReplacementStarted;
             receipt.replacement = Some(DaemonStartResult {
                 pid: state.pid,
@@ -820,17 +831,39 @@ fn replay_leaseless_recovery(
                 lease_id: state.lease_id.clone(),
             });
             write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
-        } else if status.running {
-            return Err(Error::validation_invalid_argument(
-                "reconcile_leaseless_orphans",
-                "lease-less recovery replay found a mismatched live daemon",
-                None,
-                None,
-            ));
         } else {
-            return Ok(None);
+            let token = receipt
+                .replacement_startup_token
+                .as_deref()
+                .ok_or_else(|| {
+                    Error::internal_unexpected(
+                        "lease-less replacement-starting receipt has no startup token",
+                    )
+                })?;
+            let replacement = start_or_return_live_unlocked_with_startup_token(addr, token)?;
+            let started = read_status()?;
+            if !started.running
+                || started
+                    .state
+                    .as_ref()
+                    .is_none_or(|state| state.startup_token != token)
+            {
+                return Err(Error::validation_invalid_argument(
+                    "reconcile_leaseless_orphans",
+                    "replacement replay did not publish its expected startup token",
+                    None,
+                    None,
+                ));
+            }
+            receipt.phase = StateLossRecoveryPhase::ReplacementStarted;
+            receipt.replacement = Some(replacement);
+            write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
+            return Ok(Some(receipt.into_result()?));
         }
     }
+    let Some(state) = status.state.as_ref() else {
+        return Ok(None);
+    };
     if status.freshness.active_jobs != 0 || !status.fresh || !status.running {
         return Ok(None);
     }
@@ -1114,7 +1147,7 @@ pub fn reconcile_leaseless_orphans(
     parse_bind_addr(addr)?;
     let _lock = acquire_daemon_operation_lock()?;
     let status = read_status()?;
-    if let Some(result) = replay_leaseless_recovery(&status)? {
+    if let Some(result) = replay_leaseless_recovery(&status, addr)? {
         return Ok(result);
     }
     if status.freshness.active_jobs == 0
@@ -1147,6 +1180,18 @@ pub fn reconcile_leaseless_orphans(
     let raw_store = read_job_store_bytes(&jobs_path)?;
     let snapshot_path = snapshot_job_store(&jobs_path, &raw_store)?;
     let store = super::JobStore::open_without_reconciliation_from_bytes(&jobs_path, &raw_store)?;
+    let receipt_path = crate::core::paths::daemon_leaseless_recovery_receipt_file()?;
+    let mut receipt = LeaselessRecoveryReceipt {
+        affected_job_ids: Vec::new(),
+        affected_jobs: Vec::new(),
+        historical_lease_ids: Vec::new(),
+        evidence_snapshot_path: snapshot_path.display().to_string(),
+        ownership_proof: ownership_proof.clone(),
+        phase: StateLossRecoveryPhase::Prepared,
+        replacement: None,
+        replacement_startup_token: None,
+    };
+    write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
     let reconciled = store.reconcile_leaseless_orphan_jobs()?;
     if !reconciled.protected_job_ids.is_empty() {
         return Err(Error::validation_invalid_argument(
@@ -1174,7 +1219,7 @@ pub fn reconcile_leaseless_orphans(
     }
     let affected_job_count = reconciled.reconciled_count();
     drop(owner_lock);
-    let receipt = LeaselessRecoveryReceipt {
+    receipt = LeaselessRecoveryReceipt {
         affected_job_ids: reconciled.reconciled_job_ids,
         affected_jobs: reconciled.affected_jobs,
         historical_lease_ids: reconciled.historical_lease_ids,
@@ -1184,9 +1229,7 @@ pub fn reconcile_leaseless_orphans(
         replacement: None,
         replacement_startup_token: None,
     };
-    let receipt_path = crate::core::paths::daemon_leaseless_recovery_receipt_file()?;
     write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
-    let mut receipt = receipt;
     let startup_token = uuid::Uuid::new_v4().to_string();
     receipt.phase = StateLossRecoveryPhase::ReplacementStarting;
     receipt.replacement_startup_token = Some(startup_token.clone());

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -713,10 +713,15 @@ where
     Start: FnOnce() -> Result<super::DaemonStartResult>,
 {
     let status = status()?;
-    if !matches!(
-        status.freshness.stale_reason_code,
-        Some(DaemonStaleReasonCode::LeaseMissing | DaemonStaleReasonCode::LeaseCorrupt)
-    ) || status.freshness.active_jobs == 0
+    if status.freshness.active_jobs == 0
+        || !matches!(
+            status.freshness.stale_reason_code,
+            Some(
+                DaemonStaleReasonCode::LeaseMissing
+                    | DaemonStaleReasonCode::LeaseCorrupt
+                    | DaemonStaleReasonCode::VersionMismatch
+            )
+        )
     {
         return Err(Error::validation_invalid_argument(
             "job_store",
@@ -954,9 +959,11 @@ where
     })
 }
 
-/// Explicitly recover legacy unowned durable jobs when the daemon lease is
-/// missing or unreadable. Process and configured-listener probes are fail-closed
-/// because no trustworthy lease identity exists to adopt.
+/// Explicitly recover durable jobs when no daemon owner can be proven. This
+/// covers missing lease metadata and stale version-mismatched daemons whose
+/// typed `/jobs` view no longer accounts for their durable active jobs.
+/// Process and configured-listener probes are fail-closed because replacement
+/// is safe only after ownership has been ruled out.
 pub fn reconcile_leaseless_orphans(
     confirm_no_daemon_owner: bool,
     addr: &str,
@@ -972,13 +979,19 @@ pub fn reconcile_leaseless_orphans(
     parse_bind_addr(addr)?;
     let _lock = acquire_daemon_operation_lock()?;
     let status = read_status()?;
-    if !matches!(
-        status.freshness.stale_reason_code,
-        Some(DaemonStaleReasonCode::LeaseMissing | DaemonStaleReasonCode::LeaseCorrupt)
-    ) {
+    if status.freshness.active_jobs == 0
+        || !matches!(
+            status.freshness.stale_reason_code,
+            Some(
+                DaemonStaleReasonCode::LeaseMissing
+                    | DaemonStaleReasonCode::LeaseCorrupt
+                    | DaemonStaleReasonCode::VersionMismatch
+            )
+        )
+    {
         return Err(Error::validation_invalid_argument(
             "reconcile_leaseless_orphans",
-            "lease-less recovery requires missing or corrupt daemon lease metadata; use exact lease recovery for recorded leases",
+            "recovery requires active jobs with missing, corrupt, or version-mismatched daemon freshness; use exact lease recovery for recorded dead leases",
             None,
             None,
         ));

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -1548,7 +1548,11 @@ mod remote_daemon {
         let leaseless_reconciliation_available = status.active_jobs > 0
             && matches!(
                 status.stale_reason_code,
-                Some(DaemonStaleReasonCode::LeaseMissing | DaemonStaleReasonCode::LeaseCorrupt)
+                Some(
+                    DaemonStaleReasonCode::LeaseMissing
+                        | DaemonStaleReasonCode::LeaseCorrupt
+                        | DaemonStaleReasonCode::VersionMismatch
+                )
             );
         let mut ownership_evidence = if proven_dead {
             Some(format!(
@@ -1557,7 +1561,7 @@ mod remote_daemon {
                 lease_id.as_deref().expect("proven dead lease")
             ))
         } else if leaseless_reconciliation_available {
-            Some("active durable jobs have missing or corrupt daemon lease metadata; explicit reconciliation will verify the owner lock, process list, and configured listener before terminalizing them".to_string())
+            Some("active durable jobs require explicit reconciliation; it will verify the owner lock, process list, and configured listener before terminalizing them".to_string())
         } else {
             Some("remote daemon lease evidence is unavailable; active jobs are protected from implicit replacement".to_string())
         };
@@ -2476,6 +2480,10 @@ mod tests {
         assert!(warning.contains("VersionMismatch"));
         assert!(warning.contains("active jobs were preserved"));
         assert!(warning.contains("refresh-homeboy homeboy-lab --reconnect"));
+        assert_eq!(
+            recovery.adoption_command.as_deref(),
+            Some("homeboy runner connect homeboy-lab --reconcile-leaseless-orphans --confirm-no-daemon-owner")
+        );
     }
 
     #[test]

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -256,6 +256,65 @@ fn version_mismatched_split_view_refuses_preserved_remote_claim_before_replaceme
 }
 
 #[test]
+fn completed_leaseless_recovery_replays_the_exact_replacement_without_starting_another() {
+    with_isolated_home(|_| {
+        let replacement = fake_daemon(4343, "replacement-lease");
+        let state = fake_daemon_state(replacement.clone());
+        let status = DaemonStatus {
+            running: true,
+            fresh: true,
+            reachable: true,
+            freshness: DaemonFreshnessReport {
+                fresh: true,
+                stale_reason_code: None,
+                restartable: false,
+                lease_id: Some(replacement.lease_id.clone()),
+                pid: Some(replacement.pid),
+                recovery_evidence: None,
+                ownership_evidence: None,
+                adoption_command: None,
+                binary_hash: None,
+                daemon_version: None,
+                daemon_build_identity: None,
+                runtime_paths: None,
+                active_jobs: 0,
+                termination_evidence: None,
+                repair_plan: Vec::new(),
+            },
+            stale_reason: None,
+            state: Some(state),
+            state_path: "/fake/daemon-state.json".to_string(),
+            state_identity: "fresh-replacement".to_string(),
+            process_candidates: Vec::new(),
+            active_job_recovery_evidence: Vec::new(),
+            termination_evidence: None,
+        };
+        let receipt = super::LeaselessRecoveryReceipt {
+            affected_job_ids: Vec::new(),
+            affected_jobs: Vec::new(),
+            historical_lease_ids: vec!["stale-lease".to_string()],
+            evidence_snapshot_path: "/fake/recovery.snapshot".to_string(),
+            ownership_proof: vec!["owner lock was acquired".to_string()],
+            replacement: replacement.clone(),
+        };
+        let path =
+            crate::core::paths::daemon_leaseless_recovery_receipt_file(&replacement.lease_id)
+                .expect("receipt path");
+        super::write_leaseless_recovery_receipt(&path, &receipt).expect("write receipt");
+
+        let replay = super::replay_leaseless_recovery(&status)
+            .expect("replay lookup")
+            .expect("exact completed recovery replays");
+
+        assert_eq!(replay.replacement, replacement);
+        assert_eq!(replay.affected_job_count, 0);
+        assert!(replay
+            .retry_guidance
+            .contains("no additional daemon was started"));
+    });
+}
+
+#[test]
 fn leaseless_store_aborts_on_ambiguous_or_live_owner_probe() {
     for probe in [
         || {

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -165,6 +165,46 @@ fn corrupt_lease_reconciliation_terminalizes_queued_durable_agent_task_after_pro
 }
 
 #[test]
+fn version_mismatched_split_view_reconciles_only_after_no_owner_proof() {
+    with_isolated_home(|_| {
+        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let store = JobStore::open_without_reconciliation(&path).expect("store");
+        let job = store.create("runner.exec");
+        record_test_absent_local_child(&store, job.id);
+        let mut status = leaseless_status(1);
+        status.freshness.stale_reason_code = Some(DaemonStaleReasonCode::VersionMismatch);
+
+        let result = reconcile_leaseless_orphan_store_with_operations(
+            || Ok(status),
+            || {
+                Ok(vec![
+                    "owner lock acquired".to_string(),
+                    "no daemon process".to_string(),
+                ])
+            },
+            || {
+                let snapshot = path.with_extension("split-view.snapshot.json");
+                std::fs::copy(&path, &snapshot).expect("snapshot");
+                let store = JobStore::open_without_reconciliation(&path).expect("recovery store");
+                Ok((snapshot, store.reconcile_leaseless_orphan_jobs()?))
+            },
+            || Ok(fake_daemon(4343, "replacement-lease")),
+        )
+        .expect("version-mismatched split view is recoverable after proof");
+
+        assert_eq!(result.affected_job_ids, vec![job.id.to_string()]);
+        assert_eq!(
+            JobStore::open_without_reconciliation(&path)
+                .expect("reopen store")
+                .get(job.id)
+                .expect("job")
+                .status,
+            JobStatus::Failed
+        );
+    });
+}
+
+#[test]
 fn leaseless_store_aborts_on_ambiguous_or_live_owner_probe() {
     for probe in [
         || {

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -303,7 +303,7 @@ fn completed_leaseless_recovery_replays_the_exact_replacement_without_starting_a
             crate::core::paths::daemon_leaseless_recovery_receipt_file().expect("receipt path");
         super::write_leaseless_recovery_receipt(&path, &receipt).expect("write receipt");
 
-        let replay = super::replay_leaseless_recovery(&status)
+        let replay = super::replay_leaseless_recovery(&status, "127.0.0.1:0")
             .expect("replay lookup")
             .expect("exact completed recovery replays");
 

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -295,11 +295,12 @@ fn completed_leaseless_recovery_replays_the_exact_replacement_without_starting_a
             historical_lease_ids: vec!["stale-lease".to_string()],
             evidence_snapshot_path: "/fake/recovery.snapshot".to_string(),
             ownership_proof: vec!["owner lock was acquired".to_string()],
-            replacement: replacement.clone(),
+            phase: super::StateLossRecoveryPhase::ReplacementStarted,
+            replacement: Some(replacement.clone()),
+            replacement_startup_token: Some("fake-startup-token".to_string()),
         };
         let path =
-            crate::core::paths::daemon_leaseless_recovery_receipt_file(&replacement.lease_id)
-                .expect("receipt path");
+            crate::core::paths::daemon_leaseless_recovery_receipt_file().expect("receipt path");
         super::write_leaseless_recovery_receipt(&path, &receipt).expect("write receipt");
 
         let replay = super::replay_leaseless_recovery(&status)

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -201,6 +201,57 @@ fn version_mismatched_split_view_reconciles_only_after_no_owner_proof() {
                 .status,
             JobStatus::Failed
         );
+        let replay = JobStore::open_without_reconciliation(&path)
+            .expect("reopen terminal store")
+            .reconcile_leaseless_orphan_jobs()
+            .expect("identical version-mismatch reconciliation is idempotent");
+        assert_eq!(replay.reconciled_count(), 0);
+    });
+}
+
+#[test]
+fn version_mismatched_split_view_refuses_preserved_remote_claim_before_replacement() {
+    with_isolated_home(|_| {
+        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let store = JobStore::open_without_reconciliation(&path)
+            .expect("store")
+            .with_daemon_lease("stale-lease".to_string());
+        let remote_job = store
+            .submit_remote_runner_job(
+                serde_json::from_value(serde_json::json!({
+                    "runner_id": "remote-runner",
+                    "command": ["true"],
+                }))
+                .expect("remote request"),
+            )
+            .expect("queue remote job");
+        let mut status = leaseless_status(1);
+        status.freshness.stale_reason_code = Some(DaemonStaleReasonCode::VersionMismatch);
+
+        let error = reconcile_leaseless_orphan_store_with_operations(
+            || Ok(status),
+            || {
+                Ok(vec![
+                    "owner lock acquired".to_string(),
+                    "no daemon process".to_string(),
+                ])
+            },
+            || {
+                let snapshot = path.with_extension("remote-claim.snapshot.json");
+                std::fs::copy(&path, &snapshot).expect("snapshot");
+                let store = JobStore::open_without_reconciliation(&path).expect("recovery store");
+                Ok((snapshot, store.reconcile_leaseless_orphan_jobs()?))
+            },
+            || unreachable!("preserved remote claim must block replacement"),
+        )
+        .expect_err("active broker-owned claim blocks version-mismatch recovery");
+
+        assert!(error.message.contains("broker-owned remote job"));
+        assert!(error.message.contains(&remote_job.id.to_string()));
+        assert_eq!(
+            store.get(remote_job.id).expect("remote job").status,
+            JobStatus::Queued
+        );
     });
 }
 


### PR DESCRIPTION
## Summary
Adds a bounded, crash-safe recovery path when daemon freshness claims active jobs but the typed runner job view is empty.

## What changed
- Persists phased recovery state, proves absence of live ownership before mutation, preserves remote claims, binds replacement to an exact startup token, and exposes the managed recovery command from runner status.

## How to test
1. Run `cargo test leaseless_recovery`; expect 22 focused recovery tests pass.
2. Run `cargo test version_mismatched_split_view`; expect 2 split-view replacement tests pass.
3. Run `cargo test disconnected_split_view_status`; expect status exposes the bounded recovery command.
4. Run `cargo check`; expect workspace compiles successfully.
5. Run `cargo fmt --check`; expect formatting is clean.

## Compatibility
No public CLI command is removed or changed incompatibly. The new behavior is additive and remains fail-closed when ownership or liveness cannot be proven.

## Evidence
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8333
- cargo\_check: Passed
- cargo\_fmt: Passed
- disconnected\_split\_view\_status: Passed
- leaseless\_recovery: Passed
- version\_mismatched\_split\_view: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Investigated the runner split-view failure, drafted the implementation and deterministic tests, and performed review-driven revisions; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8333
