### PR TITLE
refactor: invert lab-runner hint edges off command_contract

### DIFF
--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -124,6 +124,16 @@ impl CliRuntime {
                 _ => None,
             })
         });
+        // Register the Lab-runner hint provider so core::runner can compose
+        // `--runner`/`--placement` unsupported errors from the command-spec table
+        // without depending on `command_contract`.
+        crate::core::runner::set_lab_runner_hint_provider(|| {
+            let summary = crate::command_contract::lab_runner_support_summary();
+            crate::core::runner::LabRunnerHint {
+                hint: summary.hint,
+                unsupported_message: summary.unsupported_message,
+            }
+        });
 
         if is_top_level_version_request(&args) {
             println!("{}", upgrade::current_build_version());

--- a/src/core/runner/cli_resolver.rs
+++ b/src/core/runner/cli_resolver.rs
@@ -82,3 +82,54 @@ pub fn resolve_agent_task_dispatch(
         None => Ok(None),
     }
 }
+
+/// Human-readable strings describing which commands support Lab-runner offload.
+///
+/// Built by the CLI layer from the command-spec table and registered via
+/// [`set_lab_runner_hint_provider`]; core reads them when composing
+/// `--runner`/`--placement` unsupported errors, without depending on
+/// `command_contract`'s spec table.
+#[derive(Debug, Clone)]
+pub struct LabRunnerHint {
+    /// Short hint listing the currently Lab-portable commands.
+    pub hint: String,
+    /// Full "`--runner` is only supported for ..." message.
+    pub unsupported_message: String,
+}
+
+type LabRunnerHintProvider = fn() -> LabRunnerHint;
+
+fn lab_runner_hint_provider() -> &'static RwLock<Option<LabRunnerHintProvider>> {
+    static PROVIDER: OnceLock<RwLock<Option<LabRunnerHintProvider>>> = OnceLock::new();
+    PROVIDER.get_or_init(|| RwLock::new(None))
+}
+
+/// Register the provider that supplies Lab-runner support hint strings. Called
+/// once during startup by the CLI layer.
+pub fn set_lab_runner_hint_provider(provider: LabRunnerHintProvider) {
+    let mut guard = lab_runner_hint_provider()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = Some(provider);
+}
+
+/// Resolve the Lab-runner support hints via the registered provider, falling
+/// back to a generic message when no provider is registered (e.g. in tests or
+/// non-CLI embeddings).
+pub fn resolve_lab_runner_hint() -> LabRunnerHint {
+    let provider = {
+        let guard = lab_runner_hint_provider()
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *guard
+    };
+    match provider {
+        Some(f) => f(),
+        None => LabRunnerHint {
+            hint: "Lab offload support is command-specific.".to_string(),
+            unsupported_message:
+                "--runner is only supported for commands with portable Lab offload support."
+                    .to_string(),
+        },
+    }
+}

--- a/src/core/runner/lab/offload/execute.rs
+++ b/src/core/runner/lab/offload/execute.rs
@@ -44,7 +44,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             Some(unsupported_runner_hints(
                 runner_id,
                 request.normalized_args,
-                lab_runner_support_summary().hint,
+                resolve_lab_runner_hint().hint,
             )),
         )
     };
@@ -56,7 +56,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             }
             return Err(unsupported_runner_error(
                 runner_id,
-                lab_runner_support_summary().unsupported_message,
+                resolve_lab_runner_hint().unsupported_message,
             ));
         }
         if request.placement == homeboy_cli_contract::Placement::Lab {

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -44,13 +44,13 @@ pub use types::{
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::command_contract::lab_runner_support_summary;
 use crate::core::agent_task_lifecycle;
 use crate::core::agent_tasks::provider::provider_runner_source_contracts;
 use crate::core::engine::shell;
 use crate::core::lab_contract::RunnerWorkload;
 use crate::core::plan::{HomeboyPlan, PlanStep, PlanStepStatus, PlanValues};
 use crate::core::redaction::{redact_argv, redact_argv_display, RedactionPolicy};
+use crate::core::runner::resolve_lab_runner_hint;
 use crate::core::runner_execution_envelope::PathMaterializationPlan;
 use crate::core::source_snapshot::SourceSnapshot;
 use crate::core::{Error, ErrorCode, Result};

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -2,8 +2,8 @@ use std::io::Read;
 use std::process::Stdio;
 use std::time::Duration;
 
-use crate::command_contract::lab_runner_unsupported_hint;
 use crate::core::lab_contract::LabCommandPortability;
+use crate::core::runner::resolve_lab_runner_hint;
 use crate::core::{Error, ErrorCode, Result};
 
 use super::daemon_freshness::repair_or_fail;
@@ -533,7 +533,7 @@ pub(super) fn resolve_lab_runner_selection_from_placement(
                 "runner",
                 message,
                 Some(runner_id.to_string()),
-                Some(vec![lab_runner_unsupported_hint()]),
+                Some(vec![resolve_lab_runner_hint().hint]),
             ));
         }
 
@@ -549,7 +549,7 @@ pub(super) fn resolve_lab_runner_selection_from_placement(
             "placement",
             "--placement lab is unavailable for this local-only command",
             None,
-            Some(vec![lab_runner_unsupported_hint()]),
+            Some(vec![resolve_lab_runner_hint().hint]),
         ));
     }
 

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -22,8 +22,9 @@ pub use broker_auth::{
 mod capabilities;
 mod cli_resolver;
 pub use cli_resolver::{
-    resolve_agent_task_dispatch, resolve_command_label, set_agent_task_dispatch_resolver,
-    set_command_label_resolver,
+    resolve_agent_task_dispatch, resolve_command_label, resolve_lab_runner_hint,
+    set_agent_task_dispatch_resolver, set_command_label_resolver, set_lab_runner_hint_provider,
+    LabRunnerHint,
 };
 mod command_path;
 mod connection;


### PR DESCRIPTION
## Summary
Removes the last two **production** edges from `core` up into `command_contract`, on the path to extracting `homeboy-core` as its own crate.

`core::runner` called `command_contract::{lab_runner_support_summary, lab_runner_unsupported_hint}` to compose `--runner`/`--placement` unsupported errors (these build hint strings from the command-spec table).

**Inversion** — mirrors the existing command-label / agent-task-dispatch resolvers in `cli_resolver.rs`:
- core exposes `set_lab_runner_hint_provider` / `resolve_lab_runner_hint` (+ a `LabRunnerHint` struct and a generic fallback when unregistered)
- the CLI layer registers the real provider at startup in `cli_runtime`
- the four core call sites read hint strings through the hook

## Result
`core → command_contract` **production** edges: **0**. The remaining core up-edges into `command_contract` / `cli_surface` / `commands` are all **test-only** (next cuts).

## Verification
- `cargo check --lib` and `--lib --tests` clean.
- `runner::lab_selection` tests pass (hint strings now flow through the provider).

## Context
Part of the `homeboy-core` extraction path (481k LOC — the real build/RAM prize). Branched from fresh `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)