### PR TITLE
Fix Lab handoff result reconciliation

### DIFF
--- a/src/core/activity.rs
+++ b/src/core/activity.rs
@@ -130,6 +130,10 @@ pub struct ActivityReport {
 }
 
 pub fn activity_report(scope: ActivityScope, limit: usize) -> Result<ActivityReport> {
+    // Agent-task lifecycle is authoritative over the runner/session mirrors.
+    // Refresh accepted daemon handoffs first so controller wait expiry is not
+    // projected as a terminal local failure.
+    let _ = agent_task_lifecycle::reconcile_active_runner_handoffs();
     let mut collector = ActivityCollector::default();
     observation::collect(&mut collector, limit)?;
     agent_tasks::collect(&mut collector, limit)?;

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -505,6 +505,31 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     Ok(record)
 }
 
+/// Refresh every accepted runner handoff before a read model (such as activity)
+/// projects lifecycle state. A controller wait expiry is not terminal: the
+/// runner daemon remains the authority until it reports a terminal job result.
+pub fn reconcile_active_runner_handoffs() -> Result<usize> {
+    let run_ids = list_records()?
+        .into_iter()
+        .filter(|record| {
+            record.state == AgentTaskRunState::Running
+                && record.runner_id().is_some()
+                && record.runner_job_id().is_some()
+        })
+        .map(|record| record.run_id)
+        .collect::<Vec<_>>();
+    let mut reconciled = 0;
+    for run_id in run_ids {
+        // `status` owns snapshot validation, persistence, and the exact
+        // no-PID daemon-loss projection. A bad remote record must not prevent
+        // unrelated activity from being listed.
+        if status(&run_id).is_ok() {
+            reconciled += 1;
+        }
+    }
+    Ok(reconciled)
+}
+
 fn reconcile_runner_job_state(record: &mut AgentTaskRunRecord) -> Result<()> {
     if record.state != AgentTaskRunState::Running {
         return Ok(());
@@ -1310,6 +1335,34 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
     }
     let metadata = record.ensure_metadata_object();
     metadata.insert("kind".to_string(), json!("lab_offload_detached_handoff"));
+    metadata.insert("phase".to_string(), json!("awaiting_runner_result"));
+    metadata.insert(
+        "phase_activity".to_string(),
+        json!("controller handoff complete; awaiting authoritative runner daemon result"),
+    );
+    metadata.insert("provider_state".to_string(), json!("active"));
+    let source_snapshot = metadata
+        .get("source_checkout")
+        .cloned()
+        .unwrap_or(Value::Null);
+    metadata.insert(
+        "runner_handoff".to_string(),
+        json!({
+            "state": "in_flight",
+            "authority": "runner_daemon",
+            "identity": {
+                "run_id": run_id,
+                "runner_id": input.runner_id,
+                "runner_job_id": input.runner_job_id,
+            },
+            "source_snapshot": source_snapshot,
+            "continuation": {
+                "intent": "reconcile_runner_job",
+                "on_active": "retain_running",
+                "on_terminal": "project_authoritative_daemon_result_once",
+            },
+        }),
+    );
     metadata.insert("runner_id".to_string(), json!(input.runner_id));
     metadata.insert("runner_job_id".to_string(), json!(input.runner_job_id));
     metadata.insert(

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -311,6 +311,20 @@ fn detached_cook_attempt_proxy_advances_after_daemon_acceptance() {
         assert_eq!(accepted.run_id, attempt_run_id);
         assert_eq!(accepted.state, AgentTaskRunState::Running);
         assert_eq!(accepted.metadata["runner_job_id"], "job-7970");
+        assert_eq!(accepted.metadata["phase"], "awaiting_runner_result");
+        assert_eq!(
+            accepted.metadata["phase_activity"],
+            "controller handoff complete; awaiting authoritative runner daemon result"
+        );
+        assert_eq!(accepted.metadata["runner_handoff"]["state"], "in_flight");
+        assert_eq!(
+            accepted.metadata["runner_handoff"]["continuation"]["intent"],
+            "reconcile_runner_job"
+        );
+        assert_eq!(
+            accepted.metadata["runner_handoff"]["identity"]["runner_job_id"],
+            "job-7970"
+        );
         assert_eq!(
             accepted.metadata["runner_execution_record"]["status"],
             "running"
@@ -738,6 +752,86 @@ fn reachable_running_child_clears_disconnected_liveness_and_refreshes_heartbeat(
         assert!(record.metadata.get("stale_running_reason").is_none());
         assert!(record.metadata.get("retryable").is_none());
         assert_ne!(record.lifecycle.heartbeat, disconnected_heartbeat);
+    });
+}
+
+#[test]
+fn accepted_handoff_projects_remote_failure_and_cancellation_without_a_lifecycle_event() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        for (run_id, job_status, expected_state) in [
+            (
+                "agent-task-remote-failure",
+                crate::core::api_jobs::JobStatus::Failed,
+                AgentTaskRunState::Failed,
+            ),
+            (
+                "agent-task-remote-cancellation",
+                crate::core::api_jobs::JobStatus::Cancelled,
+                AgentTaskRunState::Cancelled,
+            ),
+        ] {
+            let mut record = record_detached_lab_run(DetachedLabRunRecord {
+                run_id,
+                runner_id: "homeboy-lab",
+                runner_job_id: "00000000-0000-0000-0000-000000000123",
+                remote_workspace: "/runner/workspace/repo",
+                remote_command: &command,
+            })
+            .expect("accepted handoff");
+            let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+            snapshot.job.status = job_status;
+            snapshot.events.clear();
+
+            reconcile_runner_job_snapshot(&mut record, &snapshot)
+                .expect("terminal daemon result reconciles");
+
+            assert_eq!(record.state, expected_state);
+            assert_eq!(record.metadata["runner_job_status"], json!(job_status));
+        }
+    });
+}
+
+#[test]
+fn accepted_handoff_projects_a_remote_timeout_aggregate_even_when_daemon_transport_succeeds() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-remote-timeout",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("accepted handoff");
+        let mut aggregate = succeeded_aggregate(&test_plan());
+        aggregate.status = AgentTaskAggregateStatus::Failed;
+        aggregate.totals = AgentTaskAggregateTotals {
+            timed_out: 1,
+            ..Default::default()
+        };
+        aggregate.outcomes[0].status = AgentTaskOutcomeStatus::Timeout;
+        aggregate.events[0].state = AgentTaskState::Failed;
+
+        let mut snapshot = terminal_child_snapshot(&aggregate);
+        let identity = snapshot.events[0]
+            .data
+            .as_mut()
+            .and_then(|event| event.get_mut("identity"))
+            .and_then(Value::as_object_mut)
+            .expect("terminal lifecycle identity");
+        identity.insert("persisted_run_id".to_string(), json!(record.run_id));
+        identity.insert("run_id".to_string(), json!(record.run_id));
+
+        reconcile_runner_job_snapshot(&mut record, &snapshot)
+            .expect("remote timeout aggregate reconciles");
+
+        assert_eq!(record.state, AgentTaskRunState::Failed);
+        assert_eq!(
+            record.totals.as_ref().map(|totals| totals.timed_out),
+            Some(1)
+        );
+        assert_eq!(record.metadata["runner_job_status"], "succeeded");
     });
 }
 

--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -784,6 +784,11 @@ pub(super) fn daemon_job_wait_timeout(
     ));
     error.details["runner_id"] = Value::String(runner.id.clone());
     error.details["job_id"] = Value::String(job_id.clone());
+    // The controller stopped waiting, not the daemon job. Preserve this
+    // discriminator so the Lab adapter retains the durable handoff rather than
+    // recording a pre-dispatch failure for an already accepted job.
+    error.details["status"] = Value::String("controller_wait_expired".to_string());
+    error.details["reason"] = Value::String("controller_wait_expired".to_string());
     error.details["remote_cwd"] = Value::String(cwd.to_string());
     error.details["command"] = json!(redact_argv(command));
     error.details["cancel_on_wait_timeout"] = Value::String(
@@ -839,6 +844,7 @@ pub(super) fn daemon_job_wait_timeout(
             ));
         }
     }
+    error.retryable = Some(true);
     error.with_hint(timeout_hint)
 }
 

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -44,6 +44,9 @@ fn timeout_mirrors_remote_job_without_cancelling() {
         assert!(err.message.contains(job_id.to_string().as_str()));
         assert!(err.message.contains("lab"));
         assert!(err.message.contains("was not cancelled"));
+        assert_eq!(err.details["status"], "controller_wait_expired");
+        assert_eq!(err.details["reason"], "controller_wait_expired");
+        assert_eq!(err.retryable, Some(true));
         assert!(err.hints.iter().any(|hint| hint
             .message
             .contains(&format!("homeboy runs show {run_id}"))));
@@ -75,6 +78,29 @@ fn timeout_mirrors_remote_job_without_cancelling() {
             mirrored.metadata_json["lab"]["remote_job"]["id"].as_str(),
             Some(job_id.to_string().as_str())
         );
+    });
+}
+
+#[test]
+fn controller_wait_expiry_is_distinct_from_a_remote_job_failure() {
+    crate::test_support::with_isolated_home(|_| {
+        let runner = ssh_runner();
+        let job = running_job_with_id(uuid::Uuid::new_v4());
+        let error = daemon_job_wait_timeout(
+            &runner,
+            "/srv/homeboy/project",
+            &["homeboy".to_string(), "agent-task".to_string()],
+            &job,
+            &[],
+            "runner daemon job",
+            true,
+        );
+
+        assert_eq!(
+            error.details["job_id"].as_str(),
+            Some(job.id.to_string().as_str())
+        );
+        assert_eq!(error.details["reason"], "controller_wait_expired");
     });
 }
 

--- a/src/core/runner/lab/offload/errors.rs
+++ b/src/core/runner/lab/offload/errors.rs
@@ -178,6 +178,25 @@ pub(crate) fn in_flight_daemon_disconnect_error(
     disconnected
 }
 
+/// Returns the accepted daemon job only for the controller's local wait expiry.
+/// Other errors carrying a job id are not enough: the explicit discriminator
+/// prevents a remote command failure from being turned into a detached handoff.
+pub(crate) fn controller_wait_expired_job_id(error: &Error) -> Option<&str> {
+    (error
+        .details
+        .get("reason")
+        .and_then(serde_json::Value::as_str)
+        == Some("controller_wait_expired"))
+    .then(|| {
+        error
+            .details
+            .get("job_id")
+            .and_then(serde_json::Value::as_str)
+    })
+    .flatten()
+    .filter(|job_id| !job_id.trim().is_empty())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn in_flight_daemon_disconnect_outcome(
     plan: HomeboyPlan,
@@ -207,13 +226,15 @@ pub(crate) fn in_flight_daemon_disconnect_outcome(
             .build(),
     );
     let error = in_flight_daemon_disconnect_error(runner_id, job_id, Some(run_id), reason, err);
+    let controller_wait_expired = controller_wait_expired_job_id(err).is_some();
     let details = serde_json::json!({
-        "status": "dispatched_detached",
+        "status": "remote_in_flight",
+        "handoff_state": "controller_wait_expired",
         "followup_required": true,
         "durable_run_id": run_id,
         "runner_id": runner_id,
         "job_id": job_id,
-        "reason": reason,
+        "reason": if controller_wait_expired { "controller_wait_expired" } else { reason },
         "message": error.message,
         "retrieval_commands": {
             "status": format!("homeboy agent-task status {run_id}"),
@@ -228,11 +249,11 @@ pub(crate) fn in_flight_daemon_disconnect_outcome(
     }))
     .unwrap_or_else(|_| {
         format!(
-            "Lab offload detached after dispatch. Durable run `{run_id}` continues remotely; inspect with `homeboy agent-task status {run_id}`."
+        "Lab offload controller handoff completed. Durable run `{run_id}` continues remotely; inspect with `homeboy agent-task status {run_id}`."
         )
     });
     let mut stderr = format!(
-        "Lab offload detached after dispatch: durable agent-task run `{run_id}` continues remotely on runner `{runner_id}` daemon job `{job_id}`.\n"
+        "Lab offload controller handoff completed: durable agent-task run `{run_id}` continues remotely on runner `{runner_id}` daemon job `{job_id}`.\n"
     );
     stderr.push_str(&format!("Reason: {reason}\n"));
     stderr.push_str(&format!("Next: homeboy agent-task status {run_id}\n"));
@@ -242,12 +263,12 @@ pub(crate) fn in_flight_daemon_disconnect_outcome(
         "Runner job: homeboy runner job logs {runner_id} {job_id} --follow\n"
     ));
 
-    Ok(LabOffloadOutcome::Offloaded {
+    Ok(LabOffloadOutcome::InFlight {
         plan,
         stdout: format!("{stdout}\n"),
         stderr,
         exit_code: 0,
-        output_file_content: None,
+        output_file_content: Some(format!("{stdout}\n")),
     })
 }
 

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -315,13 +315,17 @@ pub(crate) fn exec_lab_context(
     secret_env_names.dedup();
 
     let pre_dispatch_started = std::time::Instant::now();
+    let source_checkout = context
+        .source_snapshot
+        .as_ref()
+        .and_then(|snapshot| serde_json::to_value(snapshot).ok());
     if let Some(run_id) = context.agent_task_run_id.as_deref() {
         agent_task_lifecycle::record_lab_offload_phase(
             run_id,
             runner_id,
             "executor_preflight",
             Some(&remote_cwd),
-            None,
+            source_checkout.as_ref(),
             None,
             request.durable_agent_task_plan,
         )?;
@@ -347,7 +351,7 @@ pub(crate) fn exec_lab_context(
                 runner_id,
                 "provider_preflight",
                 Some(&remote_cwd),
-                None,
+                source_checkout.as_ref(),
                 None,
                 request.durable_agent_task_plan,
             )?;
@@ -397,7 +401,7 @@ pub(crate) fn exec_lab_context(
             runner_id,
             "provider_dispatch",
             Some(&remote_cwd),
-            None,
+            source_checkout.as_ref(),
             None,
             request.durable_agent_task_plan,
         )?;
@@ -418,11 +422,12 @@ pub(crate) fn exec_lab_context(
                 workspace.preserve();
             }
             let health = runner_daemon_health_failure(&err);
-            if health
+            let in_flight_job_id = health
                 .as_ref()
                 .and_then(|health| health.job_id.as_deref())
-                .is_none()
-            {
+                .or_else(|| controller_wait_expired_job_id(&err))
+                .map(str::to_string);
+            if in_flight_job_id.is_none() {
                 if let Some(run_id) = context.agent_task_run_id.as_deref() {
                     // The controller parent already exists, so a failed handoff
                     // must terminalize it rather than leave a queued ghost.
@@ -443,7 +448,7 @@ pub(crate) fn exec_lab_context(
                         .skip_reason(reason.clone())
                         .build(),
                 );
-                if let Some(job_id) = health.job_id.as_deref() {
+                if let Some(job_id) = in_flight_job_id.as_deref() {
                     if let Some(run_id) = context.agent_task_run_id.as_deref() {
                         return in_flight_daemon_disconnect_outcome(
                             context.plan,
@@ -504,6 +509,20 @@ pub(crate) fn exec_lab_context(
                         ]),
                     )),
                 };
+            }
+            if let Some(job_id) = in_flight_job_id.as_deref() {
+                if let Some(run_id) = context.agent_task_run_id.as_deref() {
+                    return in_flight_daemon_disconnect_outcome(
+                        context.plan,
+                        runner_id,
+                        job_id,
+                        run_id,
+                        &remote_cwd,
+                        &context.remote_command,
+                        "controller wait expired; awaiting authoritative daemon result",
+                        &err,
+                    );
+                }
             }
             return Err(err);
         }

--- a/src/core/runner/lab/offload/tests/workspace_sync.rs
+++ b/src/core/runner/lab/offload/tests/workspace_sync.rs
@@ -424,7 +424,7 @@ fn in_flight_daemon_disconnect_outcome_marks_durable_run_detached() {
         )
         .expect("detached lifecycle record");
 
-        let LabOffloadOutcome::Offloaded {
+        let LabOffloadOutcome::InFlight {
             plan,
             stdout,
             stderr,
@@ -432,14 +432,14 @@ fn in_flight_daemon_disconnect_outcome_marks_durable_run_detached() {
             output_file_content,
         } = outcome
         else {
-            panic!("expected detached offloaded outcome");
+            panic!("expected in-flight handoff outcome");
         };
 
         assert_eq!(exit_code, 0);
-        assert!(output_file_content.is_none());
+        assert!(output_file_content.is_some());
         let json: serde_json::Value = serde_json::from_str(&stdout).expect("json stdout");
         assert_eq!(json["success"], serde_json::json!(true));
-        assert_eq!(json["data"]["status"], "dispatched_detached");
+        assert_eq!(json["data"]["status"], "remote_in_flight");
         assert_eq!(json["data"]["followup_required"], true);
         assert_eq!(json["data"]["durable_run_id"], "run-123");
         assert_eq!(json["data"]["runner_id"], "homeboy-lab");
@@ -459,5 +459,30 @@ fn in_flight_daemon_disconnect_outcome_marks_durable_run_detached() {
             .expect("inspectable agent-task record");
         assert_eq!(record.metadata["runner_id"], "homeboy-lab");
         assert_eq!(record.metadata["runner_job_id"], "job-123");
+        assert_eq!(record.metadata["phase"], "awaiting_runner_result");
+        assert_eq!(
+            record.metadata["runner_handoff"]["authority"],
+            "runner_daemon"
+        );
     });
+}
+
+#[test]
+fn controller_wait_expiry_identifies_only_the_durable_handoff() {
+    let timeout = Error::new(
+        ErrorCode::InternalUnexpected,
+        "runner daemon job job-123 did not finish before timeout",
+        serde_json::json!({
+            "reason": "controller_wait_expired",
+            "job_id": "job-123",
+        }),
+    );
+    assert_eq!(controller_wait_expired_job_id(&timeout), Some("job-123"));
+
+    let remote_failure = Error::new(
+        ErrorCode::InternalUnexpected,
+        "remote command failed",
+        serde_json::json!({ "job_id": "job-123" }),
+    );
+    assert_eq!(controller_wait_expired_job_id(&remote_failure), None);
 }


### PR DESCRIPTION
## Summary
Keep accepted Lab jobs non-terminal after controller wait expiry and reconcile their eventual daemon result into the original attempt.

## What changed
- Record controller wait expiry as a durable in-flight handoff, preserve runner/source identity, reconcile terminal daemon outcomes idempotently, and refresh handoffs before activity projection.

## How to test
1. Run `cargo test core::agent_task_lifecycle --lib -- --test-threads=1`; expect 69 tests pass.
2. Run `cargo test core::runner::execution::tests::handoff --lib -- --test-threads=1`; expect 26 tests pass.
3. Run `cargo test core::runner::lab::offload --lib -- --test-threads=1`; expect 137 tests pass.

## Compatibility
No public CLI flags or extension interfaces are removed. Accepted Lab jobs now remain in-flight instead of being misreported as terminal dispatch failures when only the controller wait expires.

## Evidence
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8325
- diff-check: Passed
- fmt: Passed
- handoff-tests: Passed
- lifecycle-tests: Passed
- offload-tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy/OpenCode
- **Model:** openai/gpt-5.6-terra, openai/gpt-5.6-sol
- **Used for:** Drafted and repaired the implementation, tests, verification, and PR evidence; Chris reviews and owns the change.

## Source relationships
- Closes #8325
