### PR TITLE
Fix split-placement provider lifecycle identity

### DIFF
--- a/src/commands/agent_task/status.rs
+++ b/src/commands/agent_task/status.rs
@@ -1105,6 +1105,10 @@ fn liveness_summary(record: &Value) -> Value {
         .get("stale_running")
         .and_then(Value::as_bool)
         .unwrap_or(false);
+    let runner_job_id = metadata
+        .get("runner_job_id")
+        .and_then(Value::as_str)
+        .filter(|job_id| !job_id.trim().is_empty());
 
     json!({
         "status": if stale { "stale" } else { "active" },
@@ -1112,8 +1116,9 @@ fn liveness_summary(record: &Value) -> Value {
         "runner_job_status": metadata.get("runner_job_status"),
         "runner_job_last_seen_at": metadata.get("runner_job_last_seen_at"),
         "provider_boundary": {
-            "status": if provider_handle_count == 0 { "absent" } else { "recorded" },
+            "status": if provider_handle_count > 0 || runner_job_id.is_some() { "recorded" } else { "absent" },
             "provider_handle_count": provider_handle_count,
+            "runner_job_id": runner_job_id,
         },
         "stale_reason": metadata.get("stale_running_reason"),
         "next_action": if stale {
@@ -1720,6 +1725,28 @@ mod tests {
         assert_eq!(
             stale["liveness"]["next_action"],
             "homeboy agent-task active --reconcile"
+        );
+
+        let accepted_handoff = compact_status_summary(
+            &json!({
+                "run_id": "agent-task-run-bound",
+                "state": "running",
+                "tasks": [],
+                "provider_handles": [],
+                "metadata": {
+                    "runner_id": "homeboy-lab",
+                    "runner_job_id": "accepted-daemon-job"
+                }
+            }),
+            "agent-task-run-bound",
+        );
+        assert_eq!(
+            accepted_handoff["liveness"]["provider_boundary"]["status"],
+            "recorded"
+        );
+        assert_eq!(
+            accepted_handoff["liveness"]["provider_boundary"]["runner_job_id"],
+            "accepted-daemon-job"
         );
     }
 

--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -146,6 +146,16 @@ pub(super) fn exec_via_daemon(
         &cwd,
         &command,
     )?;
+    if let Some(run_id) = run_id.as_deref() {
+        // The daemon has durably accepted this child. Bind it before waiting so
+        // a lost controller still leaves cancellation and reconciliation with a
+        // concrete runner job identity.
+        crate::core::agent_task_lifecycle::record_runner_job_identity(
+            run_id,
+            &runner.id,
+            &job.id.to_string(),
+        )?;
+    }
     let persisted_run_id = mirror_evidence
         .then(|| persist_lab_offload_handoff_run(runner, &cwd, &command, &job, run_id.as_deref()))
         .flatten();

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -563,6 +563,17 @@ fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
 #[test]
 fn direct_daemon_detached_handoff_returns_while_the_workload_remains_running() {
     crate::test_support::with_isolated_home(|_| {
+        let run_id = "cook-8332-attempt-1";
+        crate::core::agent_task_lifecycle::record_lab_offload_phase(
+            run_id,
+            "lab",
+            "dispatching",
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("persist controller proxy before daemon acceptance");
         let workspace = tempfile::tempdir().expect("workspace");
         let started = workspace.path().join("started");
         let release = workspace.path().join("release");
@@ -595,7 +606,7 @@ fn direct_daemon_detached_handoff_returns_while_the_workload_remains_running() {
             None,
             Vec::new(),
             None,
-            None,
+            Some(run_id.to_string()),
             true,
             false,
             false,
@@ -609,6 +620,10 @@ fn direct_daemon_detached_handoff_returns_while_the_workload_remains_running() {
             "detached handoff waited for the blocked workload"
         );
         let job_id = output.job_id.expect("durably accepted daemon job");
+        let controller_record = crate::core::agent_task_lifecycle::status(run_id)
+            .expect("controller record remains observable after accepted handoff");
+        assert_eq!(controller_record.runner_id(), Some("lab"));
+        assert_eq!(controller_record.runner_job_id(), Some(job_id.as_str()));
         wait_for_path(&started, "blocked workload start");
         let client = Client::builder().no_proxy().build().expect("daemon client");
         let job = fetch_daemon_job(&client, &daemon_url, &job_id).expect("running daemon job");

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -643,6 +643,12 @@ pub(super) fn ensure_agent_task_lifecycle_identity_with(
     preferred: Option<&str>,
     preferred_attempt_run_id: Option<&str>,
 ) -> Option<(Vec<String>, String)> {
+    // `run-plan --record-run-id` is already the portable attempt identity. It
+    // has no `cook` subcommand to decorate, but still needs to cross the daemon
+    // boundary so the accepted job can be joined to the controller lifecycle.
+    if let Some((_, run_id)) = agent_task_run_plan_recording_args(args) {
+        return Some((args.to_vec(), run_id));
+    }
     let (args, run_id) = ensure_agent_task_dispatch_run_id_with(args, preferred)?;
     let invocation = CommandInvocation::for_subcommand(&args, "agent-task")?;
     // A run-plan already carries the controller-owned durable identity in
@@ -1665,6 +1671,25 @@ mod tests {
 
         assert_eq!(run_id, "retry-run");
         assert_eq!(out, args);
+    }
+
+    #[test]
+    fn lifecycle_identity_preserves_materialized_run_plan_id() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+            "--plan".to_string(),
+            "@/runner/retry-plan.json".to_string(),
+            "--record-run-id".to_string(),
+            "cook-8332-attempt-1".to_string(),
+        ];
+
+        let (out, run_id) = ensure_agent_task_lifecycle_identity_with(&args, None, None)
+            .expect("materialized run-plan has a lifecycle identity");
+
+        assert_eq!(out, args);
+        assert_eq!(run_id, "cook-8332-attempt-1");
     }
 
     #[test]


### PR DESCRIPTION
Fixes https://github.com/Extra-Chill/homeboy/issues/8332

## Summary
- Preserve `agent-task run-plan --record-run-id` as the lifecycle identity across the Lab bridge.
- Record the accepted direct-daemon `runner_id` and `runner_job_id` before synchronous polling begins.
- Surface an accepted runner job as a recorded provider boundary even before a provider handle is available.
- Extend behavioral handoff coverage to prove the controller can observe and target the accepted daemon job.

## Root cause
The split-placement cook materialized a `run-plan --record-run-id` provider attempt, but the Lab lifecycle identity helper only completed its identity path for `cook`. The accepted daemon child therefore was not bound to the controller attempt before polling. If the controller disappeared, status retained an ownerless `running` record with no provider boundary or runner job identity.

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test core::runner::execution::tests::handoff:: --lib`.
3. Run `cargo test core::runner::lab::agent_task_bridge::tests:: --lib`.
4. Confirm the direct-daemon detached handoff test records the accepted job ID in the controller lifecycle before the blocked workload is released.

## Verification
- `cargo fmt --check`
- `cargo test core::runner::execution::tests::handoff:: --lib` (26 passed)
- `cargo test core::runner::lab::agent_task_bridge::tests:: --lib` (35 passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode
- **Used for:** Diagnosed the split-placement lifecycle gap, drafted the repair and deterministic tests, and reviewed verification evidence with Chris.