### PR TITLE
Introduce reusable immutable component deployment payloads

### DIFF
--- a/src/core/deploy/orchestration/mod.rs
+++ b/src/core/deploy/orchestration/mod.rs
@@ -434,7 +434,6 @@ mod tests {
         checkout_deploy_tags, deploy_tag_for_version, restore_branches, TagCheckout,
     };
     use crate::core::deploy::planning::{load_project_components, ExtensionSkippedComponent};
-    use crate::core::deploy::types::ComponentDeployResult;
     use crate::core::project::ProjectComponentAttachment;
     use crate::test_support::{home_env_guard, with_isolated_home};
     use std::collections::HashMap;
@@ -447,7 +446,6 @@ mod tests {
         auto_pull_version_drift_message, check_uncommitted_changes, check_unreleased_commits,
         verify_expected_version,
     };
-    use super::smoke_check::run_post_deploy_smoke;
 
     fn make_component(id: &str, local_path: &str) -> Component {
         Component::new(id.to_string(), local_path.to_string(), String::new(), None)
@@ -1394,89 +1392,6 @@ mod tests {
         assert!(
             !artifact.starts_with(&component.local_path),
             "the stale configured-checkout artifact must not be reused"
-        );
-    }
-
-    fn deployed_result(id: &str) -> ComponentDeployResult {
-        let component = make_component(id, "/tmp/does-not-matter");
-        ComponentDeployResult::new(&component, "/srv/site").with_status("deployed")
-    }
-
-    #[test]
-    fn post_deploy_smoke_is_noop_without_config() {
-        let project = Project {
-            id: "site".to_string(),
-            ..Project::default()
-        };
-        let mut results = vec![deployed_result("plugin")];
-
-        assert_eq!(run_post_deploy_smoke(&project, &mut results), None);
-        assert_eq!(results[0].status, "deployed");
-    }
-
-    #[test]
-    fn post_deploy_smoke_noop_when_disabled() {
-        let project = Project {
-            id: "site".to_string(),
-            smoke_check: Some(crate::core::project::SmokeCheckConfig {
-                enabled: false,
-                url: "https://example.test/".to_string(),
-                ..Default::default()
-            }),
-            ..Project::default()
-        };
-        let mut results = vec![deployed_result("plugin")];
-
-        assert_eq!(run_post_deploy_smoke(&project, &mut results), None);
-    }
-
-    #[test]
-    fn post_deploy_smoke_failure_records_error_and_fails() {
-        // enabled smoke against an unreachable URL fails the deploy and records
-        // the error on the deployed component.
-        let project = Project {
-            id: "site".to_string(),
-            smoke_check: Some(crate::core::project::SmokeCheckConfig {
-                enabled: true,
-                // Reserved TEST-NET address (RFC 5737) so the request fails fast.
-                url: "http://192.0.2.1:9/".to_string(),
-                timeout_secs: 1,
-                ..Default::default()
-            }),
-            ..Project::default()
-        };
-        let mut results = vec![deployed_result("plugin")];
-
-        assert_eq!(run_post_deploy_smoke(&project, &mut results), Some(true));
-        assert!(
-            results[0].error.is_some(),
-            "failed smoke must record an error on the deployed component"
-        );
-    }
-
-    #[test]
-    fn post_deploy_smoke_warn_only_does_not_fail() {
-        let project = Project {
-            id: "site".to_string(),
-            smoke_check: Some(crate::core::project::SmokeCheckConfig {
-                enabled: true,
-                url: "http://192.0.2.1:9/".to_string(),
-                timeout_secs: 1,
-                warn_only: true,
-                ..Default::default()
-            }),
-            ..Project::default()
-        };
-        let mut results = vec![deployed_result("plugin")];
-
-        assert_eq!(run_post_deploy_smoke(&project, &mut results), Some(false));
-        assert_eq!(
-            results[0].status, "deployed",
-            "warn_only smoke must not fail the deploy"
-        );
-        assert!(
-            results[0].warnings.iter().any(|w| w.contains("warn_only")),
-            "warn_only smoke failure should be surfaced as a warning"
         );
     }
 

--- a/src/core/deploy/orchestration/mod.rs
+++ b/src/core/deploy/orchestration/mod.rs
@@ -7,8 +7,8 @@ use crate::core::project::Project;
 use crate::core::release::version;
 
 use super::execution::{
-    execute_preflighted_component_deploy, prepare_component_deploy, release_artifact_plan,
-    resolve_planned_release_artifact, PreparedComponentDeploy, ReleaseArtifactPlan,
+    execute_preflighted_component_deploy, release_artifact_plan, resolve_planned_release_artifact,
+    ReleaseArtifactPlan,
 };
 use super::orchestration_ref_checkout::{ExactRefCheckout, ExactRefIdentity};
 use super::orchestration_tag_checkout::{checkout_deploy_tags, restore_branches};
@@ -20,6 +20,7 @@ use super::version_overrides::fetch_remote_versions_for_project;
 
 mod modes;
 mod preflight;
+mod prepared_payloads;
 mod smoke_check;
 
 use modes::{extension_skipped_results, run_check_mode, run_dry_run_mode};
@@ -28,6 +29,7 @@ use preflight::{
     guard_local_build_source_freshness, local_build_components, sync_components,
     verify_expected_version, warn_non_default_branch,
 };
+use prepared_payloads::prepare_component_deployments;
 use smoke_check::run_post_deploy_smoke;
 
 /// Main deploy orchestration entry point.
@@ -297,7 +299,7 @@ pub(super) fn deploy_components(
     let mut succeeded: u32 = 0;
     let mut failed: u32 = 0;
 
-    for prepared in &prepared_deployments {
+    for prepared in prepared_deployments.iter() {
         let component = &prepared.component;
 
         let mut result = execute_preflighted_component_deploy(prepared, ctx, base_path, &project);
@@ -410,49 +412,6 @@ fn validate_supported_build_configs(components: &[Component]) -> Result<()> {
     }
 
     Ok(())
-}
-
-fn prepare_component_deployments(
-    components: &[Component],
-    config: &DeployConfig,
-    project: &Project,
-    base_path: &str,
-    local_versions: &HashMap<String, String>,
-    remote_versions: &HashMap<String, String>,
-    release_artifacts: &HashMap<String, ReleaseArtifactLease>,
-) -> std::result::Result<Vec<PreparedComponentDeploy>, Vec<ComponentDeployResult>> {
-    let mut prepared_deployments = Vec::new();
-    let mut failures = Vec::new();
-
-    for component in components {
-        let source_path = component.local_path.clone();
-        let mut component = crate::core::project::apply_component_overrides(component, project);
-        if config.requested_ref.is_some() {
-            // Project overrides configure deployment behavior, but an exact-ref
-            // checkout is the authoritative source tree for every build stage.
-            component.local_path = source_path;
-        }
-        let effective_config = config.clone();
-
-        match prepare_component_deploy(
-            &component,
-            &effective_config,
-            base_path,
-            project,
-            local_versions.get(&component.id).cloned(),
-            remote_versions.get(&component.id).cloned(),
-            release_artifacts.get(&component.id).cloned(),
-        ) {
-            Ok(prepared) => prepared_deployments.push(prepared),
-            Err(result) => failures.push(result),
-        }
-    }
-
-    if failures.is_empty() {
-        Ok(prepared_deployments)
-    } else {
-        Err(failures)
-    }
 }
 
 fn validate_effective_remote_paths(
@@ -1522,7 +1481,7 @@ mod tests {
     }
 
     #[test]
-    fn deploy_preflight_cleans_homeboy_build_dir_after_failed_build() {
+    fn deploy_preflight_preserves_preexisting_artifact_after_failed_build() {
         with_isolated_home(|_| {
             let dir = TempDir::new().expect("temp dir");
             let component = failing_build_artifact_component(
@@ -1561,8 +1520,8 @@ mod tests {
             assert_eq!(failures.len(), 1);
             assert_eq!(failures[0].build_exit_code, Some(42));
             assert!(
-                !dir.path().join(".homeboy-build").exists(),
-                "deploy-context failed builds must clean Homeboy-generated build artifacts"
+                dir.path().join(".homeboy-build/plugin.zip").exists(),
+                "failed preparation must preserve an artifact that existed before it started"
             );
         });
     }

--- a/src/core/deploy/orchestration/prepared_payloads.rs
+++ b/src/core/deploy/orchestration/prepared_payloads.rs
@@ -1,0 +1,125 @@
+use std::collections::HashMap;
+
+use crate::core::component::Component;
+use crate::core::project::Project;
+
+use super::super::execution::{prepare_component_deploy, PreparedComponentDeploy};
+use super::super::preparation::{ComponentPayloadPreparationRequest, PreparedPayloadCollection};
+use super::super::release_download::{ReleaseArtifactLease, ReleaseArtifactStore};
+use super::super::types::{ComponentDeployResult, DeployConfig};
+
+pub(super) struct PreparedDeployments {
+    deployments: Vec<PreparedComponentDeploy>,
+    // Retains payload copies and release leases through every transfer.
+    _payloads: PreparedPayloadCollection,
+}
+
+impl std::ops::Deref for PreparedDeployments {
+    type Target = [PreparedComponentDeploy];
+
+    fn deref(&self) -> &Self::Target {
+        &self.deployments
+    }
+}
+
+pub(super) fn prepare_component_deployments(
+    components: &[Component],
+    config: &DeployConfig,
+    project: &Project,
+    base_path: &str,
+    local_versions: &HashMap<String, String>,
+    remote_versions: &HashMap<String, String>,
+    release_artifacts: &HashMap<String, ReleaseArtifactLease>,
+) -> std::result::Result<PreparedDeployments, Vec<ComponentDeployResult>> {
+    let mut prepared_deployments = Vec::new();
+    let mut failures = Vec::new();
+    let mut payloads = PreparedPayloadCollection::default();
+    let mut release_artifact_store = ReleaseArtifactStore::default();
+
+    for component in components {
+        let source_path = component.local_path.clone();
+        let mut component = crate::core::project::apply_component_overrides(component, project);
+        if config.requested_ref.is_some() {
+            component.local_path = source_path;
+        }
+        let effective_config = config.clone();
+        let is_artifact_deploy =
+            !component.deploy_config().is_git_deploy() && !component.is_file_component();
+        let effective_config =
+            if is_artifact_deploy && !config.skip_build && config.prepared_artifact.is_none() {
+                let mut preparation_config = effective_config.clone();
+                // The existing detached checkout is the authoritative exact-ref source.
+                preparation_config.requested_ref = None;
+                let request =
+                    ComponentPayloadPreparationRequest::new(&component, &preparation_config);
+                if let Some(lease) = release_artifacts.get(&component.id).cloned() {
+                    if let Err(error) = payloads.insert(request.clone(), Some(lease)) {
+                        failures.push(ComponentDeployResult::failed(
+                            &component,
+                            base_path,
+                            local_versions.get(&component.id).cloned(),
+                            remote_versions.get(&component.id).cloned(),
+                            error.to_string(),
+                        ));
+                        continue;
+                    }
+                }
+                match payloads.prepare(request, &mut release_artifact_store) {
+                    Ok(payload) => {
+                        let mut prepared = effective_config;
+                        prepared.prepared_artifact = Some(payload.artifact.clone());
+                        prepared.skip_build = true;
+                        prepared.requested_ref = None;
+                        prepared
+                    }
+                    Err(error) => {
+                        let mut failure = ComponentDeployResult::failed(
+                            &component,
+                            base_path,
+                            local_versions.get(&component.id).cloned(),
+                            remote_versions.get(&component.id).cloned(),
+                            error.to_string(),
+                        );
+                        if let Some(exit_code) = preparation_build_exit_code(&error.to_string()) {
+                            failure = failure.with_build_exit_code(Some(exit_code));
+                        }
+                        failures.push(failure);
+                        continue;
+                    }
+                }
+            } else {
+                effective_config
+            };
+
+        match prepare_component_deploy(
+            &component,
+            &effective_config,
+            base_path,
+            project,
+            local_versions.get(&component.id).cloned(),
+            remote_versions.get(&component.id).cloned(),
+            release_artifacts.get(&component.id).cloned(),
+        ) {
+            Ok(prepared) => prepared_deployments.push(prepared),
+            Err(result) => failures.push(result),
+        }
+    }
+
+    if failures.is_empty() {
+        Ok(PreparedDeployments {
+            deployments: prepared_deployments,
+            _payloads: payloads,
+        })
+    } else {
+        Err(failures)
+    }
+}
+
+fn preparation_build_exit_code(message: &str) -> Option<i32> {
+    message
+        .strip_prefix("Invalid argument 'build': Build failed (exit code ")?
+        .split_once(')')?
+        .0
+        .parse()
+        .ok()
+}

--- a/src/core/deploy/orchestration/smoke_check.rs
+++ b/src/core/deploy/orchestration/smoke_check.rs
@@ -52,3 +52,98 @@ pub(super) fn run_post_deploy_smoke(
     }
     Some(true)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::component::Component;
+    use crate::core::project::SmokeCheckConfig;
+
+    fn deployed_result(id: &str) -> ComponentDeployResult {
+        let component = Component::new(
+            id.to_string(),
+            "/tmp/does-not-matter".to_string(),
+            String::new(),
+            None,
+        );
+        ComponentDeployResult::new(&component, "/srv/site").with_status("deployed")
+    }
+
+    #[test]
+    fn post_deploy_smoke_is_noop_without_config() {
+        let project = Project {
+            id: "site".to_string(),
+            ..Project::default()
+        };
+        let mut results = vec![deployed_result("plugin")];
+
+        assert_eq!(run_post_deploy_smoke(&project, &mut results), None);
+        assert_eq!(results[0].status, "deployed");
+    }
+
+    #[test]
+    fn post_deploy_smoke_noop_when_disabled() {
+        let project = Project {
+            id: "site".to_string(),
+            smoke_check: Some(SmokeCheckConfig {
+                enabled: false,
+                url: "https://example.test/".to_string(),
+                ..Default::default()
+            }),
+            ..Project::default()
+        };
+        let mut results = vec![deployed_result("plugin")];
+
+        assert_eq!(run_post_deploy_smoke(&project, &mut results), None);
+    }
+
+    #[test]
+    fn post_deploy_smoke_failure_records_error_and_fails() {
+        // enabled smoke against an unreachable URL fails the deploy and records
+        // the error on the deployed component.
+        let project = Project {
+            id: "site".to_string(),
+            smoke_check: Some(SmokeCheckConfig {
+                enabled: true,
+                // Reserved TEST-NET address (RFC 5737) so the request fails fast.
+                url: "http://192.0.2.1:9/".to_string(),
+                timeout_secs: 1,
+                ..Default::default()
+            }),
+            ..Project::default()
+        };
+        let mut results = vec![deployed_result("plugin")];
+
+        assert_eq!(run_post_deploy_smoke(&project, &mut results), Some(true));
+        assert!(
+            results[0].error.is_some(),
+            "failed smoke must record an error on the deployed component"
+        );
+    }
+
+    #[test]
+    fn post_deploy_smoke_warn_only_does_not_fail() {
+        let project = Project {
+            id: "site".to_string(),
+            smoke_check: Some(SmokeCheckConfig {
+                enabled: true,
+                url: "http://192.0.2.1:9/".to_string(),
+                timeout_secs: 1,
+                warn_only: true,
+                ..Default::default()
+            }),
+            ..Project::default()
+        };
+        let mut results = vec![deployed_result("plugin")];
+
+        assert_eq!(run_post_deploy_smoke(&project, &mut results), Some(false));
+        assert_eq!(
+            results[0].status, "deployed",
+            "warn_only smoke must not fail the deploy"
+        );
+        assert!(
+            results[0].warnings.iter().any(|w| w.contains("warn_only")),
+            "warn_only smoke failure should be surfaced as a warning"
+        );
+    }
+}

--- a/src/core/deploy/orchestration_ref_checkout.rs
+++ b/src/core/deploy/orchestration_ref_checkout.rs
@@ -39,7 +39,7 @@ pub(crate) fn resolve_exact_ref(
 }
 
 impl ExactRefCheckout {
-    pub(super) fn materialize(component: &Component, requested_ref: &str) -> Result<Self> {
+    pub(crate) fn materialize(component: &Component, requested_ref: &str) -> Result<Self> {
         let identity = resolve_exact_ref(component, requested_ref)?;
         let source_root = source_root(component)?;
         let component_prefix = git::get_component_path_prefix(&component.local_path);
@@ -104,7 +104,7 @@ impl ExactRefCheckout {
         })
     }
 
-    pub(super) fn verify(&self) -> Result<()> {
+    pub(crate) fn verify(&self) -> Result<()> {
         let actual_sha = git::run_git(
             &self.worktree_path,
             &["rev-parse", "--verify", "HEAD^{commit}"],
@@ -128,7 +128,7 @@ impl ExactRefCheckout {
 
     /// Hydrate dependencies in the detached source tree, never the configured
     /// checkout. This makes an exact-ref build self-contained.
-    pub(super) fn hydrate_dependencies(
+    pub(crate) fn hydrate_dependencies(
         &self,
         skip: bool,
     ) -> Result<Option<deps::DependencyInstallResult>> {

--- a/src/core/deploy/preparation.rs
+++ b/src/core/deploy/preparation.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -6,8 +7,12 @@ use sha2::{Digest, Sha256};
 use crate::core::component::Component;
 use crate::core::error::{Error, Result};
 
-use super::release_download::ReleaseArtifactLease;
-use super::{DeployConfig, PreparedDeployArtifact};
+use super::execution::{
+    release_artifact_plan, resolve_planned_release_artifact, ReleaseArtifactPlan,
+};
+use super::orchestration_ref_checkout::{ExactRefCheckout, ExactRefIdentity};
+use super::release_download::{ReleaseArtifactLease, ReleaseArtifactStore};
+use super::{sha256_file, DeployConfig, PreparedDeployArtifact};
 
 /// Immutable, target-independent inputs used to prepare a component payload.
 ///
@@ -31,6 +36,7 @@ pub(crate) struct ComponentPayloadPreparationSource {
     pub scopes: Option<crate::core::component::ScopeConfig>,
     pub artifact_inputs: Vec<crate::core::component::ArtifactInput>,
     pub scripts: Option<crate::core::component::ComponentScriptsConfig>,
+    pub version_targets: Option<Vec<crate::core::component::VersionTarget>>,
     pub env: std::collections::BTreeMap<String, String>,
     pub remote_url: Option<String>,
     pub github: crate::core::component::GithubConfig,
@@ -50,6 +56,7 @@ impl ComponentPayloadPreparationRequest {
                 scopes: component.scopes.clone(),
                 artifact_inputs: component.artifact_inputs.clone(),
                 scripts: component.scripts.clone(),
+                version_targets: component.version_targets.clone(),
                 env: component.env.clone(),
                 remote_url: component.remote_url.clone(),
                 github: component.github.clone(),
@@ -80,6 +87,26 @@ impl ComponentPayloadPreparationRequest {
         component.insert("github".to_string(), redact_github(github));
         component.insert("remote_url".to_string(), redact_remote_url(remote_url));
         canonical_json(evidence)
+    }
+
+    fn component(&self) -> Component {
+        Component {
+            id: self.component.id.clone(),
+            local_path: self.component.local_path.clone(),
+            build_artifact: self.component.build_artifact.clone(),
+            build_command: self.component.build_command.clone(),
+            extensions: self.component.extensions.clone(),
+            capability_extensions: self.component.capability_extensions.clone(),
+            scopes: self.component.scopes.clone(),
+            artifact_inputs: self.component.artifact_inputs.clone(),
+            scripts: self.component.scripts.clone(),
+            version_targets: self.component.version_targets.clone(),
+            env: self.component.env.clone(),
+            remote_url: self.component.remote_url.clone(),
+            github: self.component.github.clone(),
+            release: self.component.release.clone(),
+            ..Component::default()
+        }
     }
 
     #[allow(dead_code)]
@@ -213,16 +240,95 @@ impl From<&DeployConfig> for PreparationConfig {
     }
 }
 
-/// Request-indexed payload ownership. Inserting an equal request retains the
-/// original resource lease until the collection itself is dropped.
+/// Immutable local payload prepared without project or target inputs.
+///
+/// Orchestration invokes this after resolving project and SSH context, but before
+/// any target mutation such as transfer, install, hooks, or smoke checks.
+pub(crate) struct PreparedComponentPayload {
+    pub artifact: PreparedDeployArtifact,
+    pub source_commit: String,
+    pub exact_ref: Option<ExactRefIdentity>,
+    _release_artifact: Option<ReleaseArtifactLease>,
+    _exact_ref_checkout: Option<ExactRefCheckout>,
+    payload_artifact: PreparedArtifactCleanup,
+}
+
+/// Owns only the temporary copy made by preparation. The configured component
+/// artifact is caller-owned and must survive both successful and failed deploys.
+struct PreparedArtifactCleanup(Option<PathBuf>);
+
+impl Drop for PreparedArtifactCleanup {
+    fn drop(&mut self) {
+        if let Some(path) = self.0.take() {
+            let _ = std::fs::remove_dir_all(path);
+        }
+    }
+}
+
+/// Cleans only source output that did not exist when this preparation began.
+/// It remains armed through every post-build validation and copy operation.
+struct GeneratedSourceArtifactCleanup {
+    artifact: PathBuf,
+    artifact_existed: bool,
+    artifact_parent: Option<PathBuf>,
+    artifact_parent_existed: bool,
+    build_dir: PathBuf,
+    build_dir_existed: bool,
+    armed: bool,
+}
+
+impl GeneratedSourceArtifactCleanup {
+    fn new(component: &Component) -> Result<Self> {
+        let artifact = artifact_path(component)?;
+        let build_dir = Path::new(&component.local_path)
+            .join(crate::core::defaults::deploy_generated_build_dir());
+        let artifact_parent = artifact.parent().map(Path::to_path_buf);
+        Ok(Self {
+            artifact_existed: artifact.exists(),
+            artifact_parent_existed: artifact_parent.as_ref().is_some_and(|path| path.exists()),
+            artifact_parent,
+            build_dir_existed: build_dir.exists(),
+            artifact,
+            build_dir,
+            armed: true,
+        })
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for GeneratedSourceArtifactCleanup {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        if !self.artifact_existed {
+            let _ = std::fs::remove_file(&self.artifact);
+            if !self.artifact_parent_existed {
+                if let Some(parent) = self.artifact_parent.as_ref() {
+                    let _ = std::fs::remove_dir(parent);
+                }
+            }
+        }
+        if !self.build_dir_existed {
+            let _ = std::fs::remove_dir_all(&self.build_dir);
+        }
+    }
+}
+
+/// Request-indexed payload ownership. Equal requests share one prepared payload
+/// and its RAII resources until this collection is dropped.
 #[derive(Default)]
 pub(crate) struct PreparedPayloadCollection {
     entries: HashMap<String, PreparedPayloadEntry>,
 }
 
 struct PreparedPayloadEntry {
-    _request: ComponentPayloadPreparationRequest,
-    _release_artifact: Option<ReleaseArtifactLease>,
+    request: ComponentPayloadPreparationRequest,
+    payload: Option<PreparedComponentPayload>,
+    release_artifact: Option<ReleaseArtifactLease>,
 }
 
 impl PreparedPayloadCollection {
@@ -235,16 +341,17 @@ impl PreparedPayloadCollection {
         match self.entries.entry(identity) {
             std::collections::hash_map::Entry::Vacant(entry) => {
                 entry.insert(PreparedPayloadEntry {
-                    _request: request,
-                    _release_artifact: release_artifact,
+                    request,
+                    payload: None,
+                    release_artifact,
                 });
                 Ok(())
             }
             std::collections::hash_map::Entry::Occupied(mut entry) => {
                 let existing = entry.get_mut();
-                match (&existing._release_artifact, release_artifact) {
+                match (&existing.release_artifact, release_artifact) {
                     (None, Some(release_artifact)) => {
-                        existing._release_artifact = Some(release_artifact);
+                        existing.release_artifact = Some(release_artifact);
                         Ok(())
                     }
                     (Some(existing), Some(candidate)) if **existing != *candidate => {
@@ -261,9 +368,278 @@ impl PreparedPayloadCollection {
         }
     }
 
+    /// Prepare a component once and return its immutable artifact identity. This
+    /// boundary intentionally has no project or remote target inputs.
+    pub fn prepare(
+        &mut self,
+        request: ComponentPayloadPreparationRequest,
+        release_artifacts: &mut ReleaseArtifactStore,
+    ) -> Result<&PreparedComponentPayload> {
+        let identity = request.identity();
+        if let Some(existing) = self.entries.get_mut(&identity) {
+            if existing.payload.is_none() {
+                let release_artifact = existing.release_artifact.take();
+                existing.payload = Some(prepare_payload(
+                    &existing.request,
+                    release_artifacts,
+                    release_artifact,
+                )?);
+            }
+        } else {
+            let payload = prepare_payload(&request, release_artifacts, None)?;
+            self.entries.insert(
+                identity.clone(),
+                PreparedPayloadEntry {
+                    request,
+                    payload: Some(payload),
+                    release_artifact: None,
+                },
+            );
+        }
+        Ok(self.entries[&identity]
+            .payload
+            .as_ref()
+            .expect("prepared payload is populated exactly once"))
+    }
+
     #[cfg(test)]
     pub fn len(&self) -> usize {
         self.entries.len()
+    }
+}
+
+fn prepare_payload(
+    request: &ComponentPayloadPreparationRequest,
+    release_artifacts: &mut ReleaseArtifactStore,
+    retained_release_artifact: Option<ReleaseArtifactLease>,
+) -> Result<PreparedComponentPayload> {
+    if let Some(artifact) = request.config.prepared_artifact.clone() {
+        artifact.validate(
+            &request.component.id,
+            request.config.expected_version.as_deref(),
+        )?;
+        return Ok(PreparedComponentPayload {
+            source_commit: artifact.source_commit.clone(),
+            artifact,
+            exact_ref: None,
+            _release_artifact: None,
+            _exact_ref_checkout: None,
+            payload_artifact: PreparedArtifactCleanup(None),
+        });
+    }
+
+    let component = request.component();
+    let checkout = request
+        .config
+        .requested_ref
+        .as_deref()
+        .map(|reference| ExactRefCheckout::materialize(&component, reference))
+        .transpose()?;
+    if let Some(checkout) = checkout.as_ref() {
+        checkout.verify()?;
+        checkout.hydrate_dependencies(request.config.skip_deps_hydration)?;
+    }
+    let component = checkout
+        .as_ref()
+        .map(|checkout| checkout.component.clone())
+        .unwrap_or(component);
+    let exact_ref = checkout.as_ref().map(|checkout| checkout.identity.clone());
+
+    let release_artifact = match release_artifact_plan(
+        &component,
+        &DeployConfig::from_preparation(request),
+        false,
+        false,
+    ) {
+        ReleaseArtifactPlan::Reuse { tag, .. } => Some(match retained_release_artifact {
+            Some(artifact) => artifact,
+            None => resolve_planned_release_artifact(&component, &tag, release_artifacts).map_err(
+                |message| {
+                    Error::validation_invalid_argument("releaseArtifact", message, None, None)
+                },
+            )?,
+        }),
+        ReleaseArtifactPlan::LocalBuild { .. } => None,
+    };
+    let mut generated_source_artifact = None;
+    if release_artifact.is_none() && !request.config.skip_build {
+        let cleanup = GeneratedSourceArtifactCleanup::new(&component)?;
+        let (build_exit_code, build_error) = crate::core::build::build_component(&component);
+        if let Some(message) = build_error {
+            return Err(Error::validation_invalid_argument(
+                "build",
+                format!(
+                    "Build failed (exit code {}): {message}",
+                    build_exit_code.map_or_else(|| "unknown".to_string(), |code| code.to_string())
+                ),
+                None,
+                None,
+            ));
+        }
+        generated_source_artifact = Some(cleanup);
+    }
+    let path = release_artifact
+        .as_ref()
+        .map(|artifact| artifact.path.clone())
+        .unwrap_or(artifact_path(&component)?);
+    let metadata = std::fs::metadata(&path).map_err(|error| {
+        Error::internal_io(
+            format!("Prepared artifact is unavailable: {error}"),
+            Some(path.display().to_string()),
+        )
+    })?;
+    if !metadata.is_file() || metadata.len() == 0 {
+        return Err(Error::validation_invalid_argument(
+            "artifact",
+            "Prepared artifact must be a non-empty file",
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+    let digest = sha256_file(&path)?;
+    if let Some(release_artifact) = release_artifact.as_ref() {
+        if metadata.len() != release_artifact.size || digest != release_artifact.sha256 {
+            return Err(Error::validation_invalid_argument(
+                "releaseArtifact",
+                "Retained release artifact does not match its verified size or SHA-256",
+                Some(path.display().to_string()),
+                None,
+            ));
+        }
+    }
+    let version =
+        crate::core::release::version::get_component_version(&component).unwrap_or_default();
+    if request
+        .config
+        .expected_version
+        .as_deref()
+        .is_some_and(|expected| expected != version)
+    {
+        return Err(Error::validation_invalid_argument(
+            "version",
+            "Prepared artifact source version does not match expected version",
+            None,
+            None,
+        ));
+    }
+    let source_commit = exact_ref
+        .as_ref()
+        .map(|identity| identity.resolved_sha.clone())
+        .or_else(|| {
+            crate::core::engine::command::run_in_optional(
+                &component.local_path,
+                "git",
+                &["rev-parse", "HEAD"],
+            )
+        })
+        .unwrap_or_default();
+    let (durable_path, payload_artifact) = if release_artifact.is_some() {
+        (path.clone(), PreparedArtifactCleanup(None))
+    } else {
+        copy_prepared_artifact(&path)?
+    };
+    let artifact = PreparedDeployArtifact {
+        component_id: component.id.clone(),
+        path: durable_path.display().to_string(),
+        durable_path: durable_path.display().to_string(),
+        size_bytes: metadata.len(),
+        sha256: digest,
+        version: version.clone(),
+        tag: exact_ref
+            .as_ref()
+            .map(|identity| identity.requested_ref.clone())
+            .unwrap_or_else(|| format!("v{version}")),
+        source_commit: source_commit.clone(),
+    };
+    artifact.validate(&component.id, request.config.expected_version.as_deref())?;
+    if let Some(cleanup) = generated_source_artifact.as_mut() {
+        cleanup.disarm();
+    }
+    Ok(PreparedComponentPayload {
+        artifact,
+        source_commit,
+        exact_ref,
+        _release_artifact: release_artifact,
+        _exact_ref_checkout: checkout,
+        payload_artifact,
+    })
+}
+
+fn copy_prepared_artifact(source: &Path) -> Result<(PathBuf, PreparedArtifactCleanup)> {
+    let directory = std::env::temp_dir()
+        .join("homeboy-deploy-payload")
+        .join(uuid::Uuid::new_v4().to_string());
+    std::fs::create_dir_all(&directory).map_err(|error| {
+        Error::internal_io(
+            format!("Failed to create prepared artifact directory: {error}"),
+            Some(directory.display().to_string()),
+        )
+    })?;
+    let cleanup = PreparedArtifactCleanup(Some(directory.clone()));
+    let filename = source.file_name().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "artifact",
+            "Prepared artifact path has no file name",
+            Some(source.display().to_string()),
+            None,
+        )
+    })?;
+    let destination = directory.join(filename);
+    std::fs::copy(source, &destination).map_err(|error| {
+        Error::internal_io(
+            format!("Failed to copy prepared artifact: {error}"),
+            Some(source.display().to_string()),
+        )
+    })?;
+    Ok((destination, cleanup))
+}
+
+fn artifact_path(component: &Component) -> Result<PathBuf> {
+    component
+        .build_artifact
+        .as_ref()
+        .map(|artifact| {
+            let path = Path::new(artifact);
+            Ok(if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                Path::new(&component.local_path).join(path)
+            })
+        })
+        .transpose()?
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "build_artifact",
+                "Component has no build artifact to prepare",
+                None,
+                None,
+            )
+        })
+}
+
+impl DeployConfig {
+    fn from_preparation(request: &ComponentPayloadPreparationRequest) -> Self {
+        Self {
+            component_ids: vec![request.component.id.clone()],
+            all: false,
+            outdated: false,
+            behind_upstream: false,
+            dry_run: false,
+            check: false,
+            force: false,
+            skip_build: request.config.skip_build,
+            keep_deps: request.config.keep_deps,
+            skip_deps_hydration: request.config.skip_deps_hydration,
+            expected_version: request.config.expected_version.clone(),
+            no_pull: request.config.no_pull,
+            allow_stale_source: request.config.allow_stale_source,
+            allow_downgrade: false,
+            head: request.config.head,
+            requested_ref: request.config.requested_ref.clone(),
+            tagged: request.config.tagged,
+            prepared_artifact: None,
+            resume_run_id: None,
+        }
     }
 }
 
@@ -642,5 +1018,269 @@ mod tests {
         )
         .expect("conflicting lease");
         assert!(collection.insert(request, Some(conflicting)).is_err());
+    }
+
+    #[test]
+    fn equal_inserted_request_builds_once_and_cleans_only_its_payload_copy() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let source_artifact = temp.path().join("build/fixture.zip");
+        let build_count = temp.path().join("build-count");
+        let mut component = component();
+        component.local_path = temp.path().display().to_string();
+        component.build_artifact = Some("build/fixture.zip".to_string());
+        component.scripts = Some(crate::core::component::ComponentScriptsConfig {
+            build: vec![format!(
+                "mkdir -p build && printf payload > build/fixture.zip && printf build >> {}",
+                build_count.display()
+            )],
+            ..Default::default()
+        });
+        let request = ComponentPayloadPreparationRequest::new(&component, &config());
+        let mut collection = PreparedPayloadCollection::default();
+        collection
+            .insert(request.clone(), None)
+            .expect("insert request");
+
+        let payload_path = collection
+            .prepare(request.clone(), &mut ReleaseArtifactStore::default())
+            .expect("prepare inserted request")
+            .artifact
+            .effective_path()
+            .to_string();
+        collection
+            .prepare(request, &mut ReleaseArtifactStore::default())
+            .expect("reuse prepared payload");
+
+        assert_eq!(
+            std::fs::read_to_string(&build_count).expect("build count"),
+            "build"
+        );
+        assert!(
+            source_artifact.exists(),
+            "source artifact remains caller-owned"
+        );
+        assert_ne!(Path::new(&payload_path), source_artifact);
+        assert!(
+            Path::new(&payload_path).exists(),
+            "payload copy is retained"
+        );
+
+        drop(collection);
+        assert!(
+            source_artifact.exists(),
+            "dropping payload never removes source artifact"
+        );
+        assert!(
+            !Path::new(&payload_path).exists(),
+            "dropping payload removes its owned copy"
+        );
+    }
+
+    #[test]
+    fn inserted_release_lease_is_consumed_by_equal_preparation_request() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let artifact_path = temp.path().join("fixture.zip");
+        std::fs::write(&artifact_path, "payload").expect("artifact");
+        std::fs::write(temp.path().join("package.json"), r#"{"version":"1.0.0"}"#)
+            .expect("package manifest");
+        let lease =
+            ReleaseArtifactLease::test_new(super::super::release_download::ReleaseArtifact {
+                path: artifact_path.clone(),
+                tag: "v1.0.0".to_string(),
+                commit: Some("0123456789abcdef".to_string()),
+                url: "https://example.test/fixture.zip".to_string(),
+                name: "fixture.zip".to_string(),
+                size: 7,
+                sha256: sha256_file(&artifact_path).expect("sha"),
+            })
+            .expect("lease");
+        let observer = lease.clone();
+        let mut component = component();
+        component.local_path = temp.path().display().to_string();
+        component.build_artifact = Some("fixture.zip".to_string());
+        component.remote_url = Some("https://github.com/example/fixture".to_string());
+        component.version_targets = Some(vec![crate::core::component::VersionTarget {
+            file: "package.json".to_string(),
+            pattern: Some(r#""version"\s*:\s*"([^"]+)""#.to_string()),
+            artifact_path: None,
+        }]);
+        let mut deploy_config = config();
+        deploy_config.expected_version = Some("1.0.0".to_string());
+        let request = ComponentPayloadPreparationRequest::new(&component, &deploy_config);
+        let mut collection = PreparedPayloadCollection::default();
+        collection
+            .insert(request.clone(), Some(lease))
+            .expect("insert lease");
+
+        let payload = collection
+            .prepare(request, &mut ReleaseArtifactStore::default())
+            .expect("prepare retained lease");
+        assert_eq!(Path::new(payload.artifact.effective_path()), artifact_path);
+        assert_eq!(observer.test_strong_count(), 2, "payload retains the lease");
+        drop(collection);
+        assert_eq!(
+            observer.test_strong_count(),
+            1,
+            "payload releases its lease"
+        );
+    }
+
+    #[test]
+    fn retained_release_mismatch_creates_no_payload_or_local_build_effect() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let artifact_path = temp.path().join("fixture.zip");
+        let build_counter = temp.path().join("build-count");
+        std::fs::write(&artifact_path, "payload").expect("artifact");
+        let lease =
+            ReleaseArtifactLease::test_new(super::super::release_download::ReleaseArtifact {
+                path: artifact_path,
+                tag: "v1.0.0".to_string(),
+                commit: None,
+                url: "https://example.test/fixture.zip".to_string(),
+                name: "fixture.zip".to_string(),
+                size: 7,
+                sha256: "wrong".to_string(),
+            })
+            .expect("lease");
+        let mut component = component();
+        component.local_path = temp.path().display().to_string();
+        component.build_artifact = Some("fixture.zip".to_string());
+        component.remote_url = Some("https://github.com/example/fixture".to_string());
+        component.scripts = Some(crate::core::component::ComponentScriptsConfig {
+            build: vec![format!("printf build > {}", build_counter.display())],
+            ..Default::default()
+        });
+        let mut deploy_config = config();
+        deploy_config.expected_version = Some("1.0.0".to_string());
+        let request = ComponentPayloadPreparationRequest::new(&component, &deploy_config);
+        let mut collection = PreparedPayloadCollection::default();
+        collection
+            .insert(request.clone(), Some(lease))
+            .expect("insert lease");
+
+        let error = match collection.prepare(request, &mut ReleaseArtifactStore::default()) {
+            Ok(_) => panic!("mismatched retained release must fail"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("does not match"));
+        assert_eq!(collection.len(), 1, "request is retained without a payload");
+        assert!(
+            !build_counter.exists(),
+            "release mismatch must not build or target"
+        );
+    }
+
+    #[test]
+    fn failed_post_build_validation_removes_only_new_source_output() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let artifact = temp.path().join("build/fixture.zip");
+        let mut component = component();
+        component.local_path = temp.path().display().to_string();
+        component.build_artifact = Some("build/fixture.zip".to_string());
+        component.scripts = Some(crate::core::component::ComponentScriptsConfig {
+            build: vec!["mkdir -p build && printf payload > build/fixture.zip".to_string()],
+            ..Default::default()
+        });
+        let mut deploy_config = config();
+        deploy_config.expected_version = Some("9.9.9".to_string());
+        let request = ComponentPayloadPreparationRequest::new(&component, &deploy_config);
+
+        let error = match PreparedPayloadCollection::default()
+            .prepare(request, &mut ReleaseArtifactStore::default())
+        {
+            Ok(_) => panic!("version validation must fail after build"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("source version"));
+        assert!(
+            !artifact.exists(),
+            "new source artifact is cleaned after validation failure"
+        );
+    }
+
+    #[test]
+    fn exact_ref_preparation_builds_detached_bytes_and_cleans_owned_resources() {
+        fn git(path: &Path, args: &[&str]) -> String {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .output()
+                .expect("run git");
+            assert!(output.status.success(), "git {:?}: {:?}", args, output);
+            String::from_utf8(output.stdout)
+                .expect("git output")
+                .trim()
+                .to_string()
+        }
+
+        let repo = tempfile::tempdir().expect("repo");
+        git(repo.path(), &["init", "-q"]);
+        git(
+            repo.path(),
+            &["config", "user.email", "homeboy@example.test"],
+        );
+        git(repo.path(), &["config", "user.name", "Homeboy Test"]);
+        std::fs::write(repo.path().join("payload.txt"), "accepted\n").expect("accepted payload");
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-q", "-m", "accepted"]);
+        git(repo.path(), &["branch", "accepted"]);
+        let accepted_sha = git(repo.path(), &["rev-parse", "accepted"]);
+        std::fs::write(repo.path().join("payload.txt"), "configured\n")
+            .expect("configured payload");
+        git(repo.path(), &["commit", "-am", "configured", "-q"]);
+        let configured_head = git(repo.path(), &["rev-parse", "HEAD"]);
+        let mut component = component();
+        component.local_path = repo.path().display().to_string();
+        component.build_artifact = Some("build/fixture.zip".to_string());
+        component.scripts = Some(crate::core::component::ComponentScriptsConfig {
+            build: vec![
+                "mkdir -p build && git show HEAD:payload.txt > build/fixture.zip".to_string(),
+            ],
+            ..Default::default()
+        });
+        let mut deploy_config = config();
+        deploy_config.requested_ref = Some("accepted".to_string());
+        deploy_config.skip_deps_hydration = true;
+        let request = ComponentPayloadPreparationRequest::new(&component, &deploy_config);
+        let mut collection = PreparedPayloadCollection::default();
+        let payload_path = collection
+            .prepare(request, &mut ReleaseArtifactStore::default())
+            .expect("prepare exact ref")
+            .artifact
+            .effective_path()
+            .to_string();
+
+        assert_eq!(
+            std::fs::read_to_string(&payload_path).expect("payload bytes"),
+            "accepted\n"
+        );
+        assert_eq!(
+            collection
+                .entries
+                .values()
+                .next()
+                .unwrap()
+                .payload
+                .as_ref()
+                .unwrap()
+                .source_commit,
+            accepted_sha
+        );
+        assert_eq!(git(repo.path(), &["rev-parse", "HEAD"]), configured_head);
+        assert_eq!(
+            std::fs::read_to_string(repo.path().join("payload.txt")).expect("configured content"),
+            "configured\n"
+        );
+        drop(collection);
+        assert!(
+            !Path::new(&payload_path).exists(),
+            "payload copy is cleaned"
+        );
+        assert_eq!(
+            git(repo.path(), &["worktree", "list", "--porcelain"])
+                .matches("worktree ")
+                .count(),
+            1
+        );
     }
 }

--- a/src/core/deploy/preparation.rs
+++ b/src/core/deploy/preparation.rs
@@ -349,6 +349,18 @@ impl PreparedPayloadCollection {
             }
             std::collections::hash_map::Entry::Occupied(mut entry) => {
                 let existing = entry.get_mut();
+                if let Some(payload) = existing.payload.as_ref() {
+                    return match (&payload._release_artifact, release_artifact) {
+                        (Some(existing), Some(candidate)) if **existing == *candidate => Ok(()),
+                        (_, None) => Ok(()),
+                        _ => Err(Error::validation_invalid_argument(
+                            "release_artifact",
+                            "Prepared payload cannot be rebound to a different release artifact",
+                            None,
+                            None,
+                        )),
+                    };
+                }
                 match (&existing.release_artifact, release_artifact) {
                     (None, Some(release_artifact)) => {
                         existing.release_artifact = Some(release_artifact);
@@ -1117,6 +1129,38 @@ mod tests {
             .expect("prepare retained lease");
         assert_eq!(Path::new(payload.artifact.effective_path()), artifact_path);
         assert_eq!(observer.test_strong_count(), 2, "payload retains the lease");
+
+        collection
+            .insert(
+                ComponentPayloadPreparationRequest::new(&component, &deploy_config),
+                Some(observer.clone()),
+            )
+            .expect("equal consumer reuses the verified release artifact");
+        let conflicting_temp = tempfile::tempdir().expect("conflicting temp dir");
+        let conflicting_path = conflicting_temp.path().join("conflicting.zip");
+        std::fs::write(&conflicting_path, "changed").expect("conflicting artifact");
+        let conflicting =
+            ReleaseArtifactLease::test_new(super::super::release_download::ReleaseArtifact {
+                path: conflicting_path,
+                tag: "v1.0.0".to_string(),
+                commit: Some("fedcba9876543210".to_string()),
+                url: "https://example.test/conflicting.zip".to_string(),
+                name: "fixture.zip".to_string(),
+                size: 7,
+                sha256: "different".to_string(),
+            })
+            .expect("conflicting lease");
+        assert!(collection
+            .insert(
+                ComponentPayloadPreparationRequest::new(&component, &deploy_config),
+                Some(conflicting),
+            )
+            .is_err());
+        assert_eq!(
+            observer.test_strong_count(),
+            2,
+            "equal consumers do not retain a redundant lease"
+        );
         drop(collection);
         assert_eq!(
             observer.test_strong_count(),


### PR DESCRIPTION
## Summary
Introduce a component-scoped immutable prepared payload that separates source/build ownership from project-bound deployment.

## What changed
- Add canonical preparation requests, deterministic identities, redacted evidence, payload deduplication, and RAII cleanup ownership.
- Prepare exact-ref and release/local-build artifacts once, then retain payload bytes and release leases through project-bound transfer.
- Adapt existing single-project deploy orchestration without changing public command or result JSON contracts.

## How to test
1. Run `cargo fmt --check`; expect exits successfully.
2. Run `git diff --check origin/main...HEAD`; expect reports no whitespace errors.
3. Run `cargo test core::deploy::preparation --lib -- --test-threads=1`; expect 14 tests pass.
4. Run `cargo test core::deploy::orchestration_ref_checkout --lib -- --test-threads=1`; expect 11 tests pass.
5. Run `cargo test core::deploy::release_download --lib -- --test-threads=1`; expect 31 tests pass.
6. Run `cargo test core::deploy::orchestration --lib -- --test-threads=1`; expect 51 tests pass.

## Compatibility
Internal orchestration primitive only; existing deploy callers, CLI behavior, and result JSON remain supported. Failed preparation now preserves artifacts that predated preparation and removes only newly generated owned output. Preparation remains after project/SSH context resolution for single-project compatibility, but before transfer, install, hooks, smoke checks, lifecycle writes, or other target mutation.

## Evidence
- CI expected: GitHub Actions required checks
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8234
- audit: Passed
- focused-tests: Passed
- lint: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy + OpenCode
- **Model:** openai/gpt-5.6-sol and openai/gpt-5.6-terra
- **Used for:** Prepared and reviewed the implementation, recovery patch, tests, and PR dossier with Chris.

## Source relationships
- Closes #8234
- Relates to #8229
