### PR TITLE
fix(test): fail changed-scope gate when source changed but zero tests selected

### DIFF
--- a/src/core/extension/test/drift.rs
+++ b/src/core/extension/test/drift.rs
@@ -563,6 +563,17 @@ fn matches_any_pattern(path: &str, patterns: &[String]) -> bool {
     })
 }
 
+/// True when `path` is a production or test source file the component cares
+/// about — i.e. it matches the drift source patterns, the drift test patterns,
+/// or is a recognized test path. Used to decide whether an empty changed-scope
+/// test selection is a false-green (source changed, no tests) versus a
+/// legitimate documentation/config-only no-test scope. (#8340)
+pub fn is_source_relevant_change(opts: &DriftOptions, path: &str) -> bool {
+    matches_any_pattern(path, &opts.source_patterns)
+        || matches_any_pattern(path, &opts.test_patterns)
+        || crate::core::code_audit::walker::is_test_path(path)
+}
+
 /// Collect test files in the repo using extension-declared glob patterns.
 fn collect_test_files(root: &Path, test_patterns: &[String]) -> Vec<PathBuf> {
     use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};

--- a/src/core/extension/test/mod.rs
+++ b/src/core/extension/test/mod.rs
@@ -26,6 +26,14 @@ pub struct TestScopeOutput {
     pub selected_count: usize,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub selected_files: Vec<String>,
+    /// Changed files that are production or test source (per the component's
+    /// drift source/test patterns) yet selected zero tests. A non-empty list
+    /// with `selected_count == 0` is a false-green: source changed but the
+    /// changed-scope gate would otherwise pass without running any test.
+    /// Documentation/config-only changes leave this empty so a genuine no-test
+    /// scope can still pass. (#8340)
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub source_changes_without_tests: Vec<String>,
 }
 
 pub use analyze::{FailureCategory, FailureCluster, TestAnalysis, TestAnalysisInput, TestFailure};
@@ -495,6 +503,22 @@ pub fn compute_changed_test_files_for_files(
     compute_changed_test_files_with_drift_options(component, changed_files, &opts)
 }
 
+/// Return the subset of `changed_files` that are production or test source per
+/// the component's drift source/test patterns.
+///
+/// This is the "should have selected a test" signal: if any such file changed
+/// but the computed test scope is empty, the changed-scope gate is producing a
+/// false green (source changed, zero tests run). Documentation, config, and
+/// other non-source changes are excluded so a legitimate no-test scope is not
+/// forced to fail. (#8340)
+pub fn source_relevant_changed_files(opts: &DriftOptions, changed_files: &[String]) -> Vec<String> {
+    changed_files
+        .iter()
+        .filter(|file| drift::is_source_relevant_change(opts, file))
+        .cloned()
+        .collect()
+}
+
 fn compute_changed_test_files_with_drift_options(
     component: &Component,
     changed_files: &[String],
@@ -521,13 +545,21 @@ pub fn compute_changed_test_scope_for_files(
     git_ref: &str,
     changed_files: &[String],
 ) -> crate::core::error::Result<TestScopeOutput> {
-    let selected_files = compute_changed_test_files_for_files(component, git_ref, changed_files)?;
+    let opts = resolve_drift_options(component, git_ref)?;
+    let selected_files =
+        compute_changed_test_files_with_drift_options(component, changed_files, &opts)?;
+    let source_changes_without_tests = if selected_files.is_empty() {
+        source_relevant_changed_files(&opts, changed_files)
+    } else {
+        Vec::new()
+    };
 
     Ok(TestScopeOutput {
         mode: "changed".to_string(),
         changed_since: Some(git_ref.to_string()),
         selected_count: selected_files.len(),
         selected_files,
+        source_changes_without_tests,
     })
 }
 
@@ -539,14 +571,10 @@ pub fn compute_changed_test_scope(
     component: &Component,
     git_ref: &str,
 ) -> crate::core::error::Result<TestScopeOutput> {
-    let selected_files = compute_changed_test_files(component, git_ref)?;
+    let source_path = component_source_path(component);
+    let changed_files = git::get_files_changed_since(&source_path.to_string_lossy(), git_ref)?;
 
-    Ok(TestScopeOutput {
-        mode: "changed".to_string(),
-        changed_since: Some(git_ref.to_string()),
-        selected_count: selected_files.len(),
-        selected_files,
-    })
+    compute_changed_test_scope_for_files(component, git_ref, &changed_files)
 }
 
 fn changed_test_file_for_path(file: &str) -> Option<String> {
@@ -924,6 +952,97 @@ mod tests {
                 .iter()
                 .any(|f| f.ends_with("tests/scope_test.rs")),
             "expected changed test file to be included"
+        );
+    }
+
+    /// Initialize a git repo with a committed baseline (`src/lib.rs`,
+    /// `README.md`) so a follow-up commit can be diffed with `HEAD~1`.
+    fn init_scope_repo(root: &Path) -> Component {
+        fs::create_dir_all(root.join("src")).expect("src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname='scope-test'\nversion='0.1.0'\n",
+        )
+        .expect("Cargo.toml");
+        fs::write(root.join("src/lib.rs"), "pub fn thing() {}\n").expect("lib");
+        fs::write(root.join("README.md"), "# scope-test\n").expect("readme");
+
+        for args in [
+            vec!["init"],
+            vec!["config", "user.email", "tests@example.com"],
+            vec!["config", "user.name", "Tests"],
+            vec!["add", "."],
+            vec!["commit", "-m", "init"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(root)
+                .output()
+                .expect("git setup command");
+        }
+
+        Component::new(
+            "scope-test".to_string(),
+            root.to_string_lossy().to_string(),
+            "/tmp/remote".to_string(),
+            None,
+        )
+    }
+
+    fn commit_change(root: &Path, rel: &str, contents: &str) {
+        fs::write(root.join(rel), contents).expect("write change");
+        for args in [vec!["add", rel], vec!["commit", "-m", "change"]] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(root)
+                .output()
+                .expect("git change command");
+        }
+    }
+
+    #[test]
+    fn changed_source_without_selected_tests_flags_false_green() {
+        // #8340: a production source change that maps to no tests must record
+        // the impacted files so the gate can fail closed instead of passing on
+        // zero selection.
+        let dir = TempDir::new().expect("temp dir");
+        let root = dir.path();
+        let component = init_scope_repo(root);
+        // Change production source only; no test file changes, and the trivial
+        // edit does not drift any existing test.
+        commit_change(root, "src/lib.rs", "pub fn thing() {}\npub fn added() {}\n");
+
+        let output = compute_changed_test_scope(&component, "HEAD~1")
+            .expect("scope computation should succeed");
+
+        assert_eq!(output.selected_count, 0, "no test should be selected");
+        assert!(
+            output
+                .source_changes_without_tests
+                .iter()
+                .any(|f| f.ends_with("src/lib.rs")),
+            "changed production source with zero tests must be flagged, got {:?}",
+            output.source_changes_without_tests
+        );
+    }
+
+    #[test]
+    fn docs_only_change_allows_empty_test_scope() {
+        // #8340: a documentation-only change legitimately selects zero tests and
+        // must NOT be flagged as a false green.
+        let dir = TempDir::new().expect("temp dir");
+        let root = dir.path();
+        let component = init_scope_repo(root);
+        commit_change(root, "README.md", "# scope-test\n\nmore docs\n");
+
+        let output = compute_changed_test_scope(&component, "HEAD~1")
+            .expect("scope computation should succeed");
+
+        assert_eq!(output.selected_count, 0, "docs change selects no tests");
+        assert!(
+            output.source_changes_without_tests.is_empty(),
+            "docs-only change must not be flagged as a source change, got {:?}",
+            output.source_changes_without_tests
         );
     }
 }

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -202,10 +202,73 @@ fn run_main_test_workflow_inner(
 
     if let Some(ref scope) = changed_scope {
         if scope.selected_files.is_empty() {
+            let changed_ref = scope.changed_since.as_deref().unwrap_or("unknown");
+
+            // Fail closed when production/test source changed but the scope
+            // selected zero tests: passing green there is not release evidence,
+            // it just means the change-to-test mapping missed the impacted
+            // files. Documentation/config-only changes leave
+            // `source_changes_without_tests` empty and still pass. (#8340)
+            if !scope.source_changes_without_tests.is_empty() {
+                let impacted = &scope.source_changes_without_tests;
+                let preview = impacted
+                    .iter()
+                    .take(10)
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let more = impacted.len().saturating_sub(10);
+                let impacted_summary = if more > 0 {
+                    format!("{preview}, and {more} more")
+                } else {
+                    preview
+                };
+
+                let message = format!(
+                    "Changed-scope test gate selected zero tests, but {} source file(s) changed since {changed_ref}: {impacted_summary}. Zero selection is not valid test evidence for a source change.",
+                    impacted.len(),
+                );
+                let findings = Some(vec![HomeboyFinding::builder("test", message.clone())
+                    .rule("changed_scope_zero_tests_for_source_change")
+                    .category("test-scope")
+                    .severity("error")
+                    .build()]);
+                let hints = Some(vec![
+                    format!(
+                        "Add or route a test for the changed source, or run the full suite: homeboy test {}",
+                        args.component_id
+                    ),
+                    "If these changes are intentionally test-exempt, exclude them from the release/test scope so the gate can pass with a typed reason.".to_string(),
+                ]);
+
+                return Ok(TestRunWorkflowResult {
+                    status: "failed".to_string(),
+                    component: args.component_label,
+                    exit_code: 1,
+                    test_counts: None,
+                    findings,
+                    failure_analysis_input: None,
+                    coverage: None,
+                    baseline_comparison: None,
+                    analysis: None,
+                    autofix: None,
+                    hints,
+                    test_scope: Some(scope.clone()),
+                    summary: if args.json_summary {
+                        Some(build_test_summary(None, None, 0))
+                    } else {
+                        None
+                    },
+                    raw_output: None,
+                    extension_phase_timings: Vec::new(),
+                });
+            }
+
+            // No source-relevant change: a genuine no-test scope
+            // (documentation/config only) may pass.
             let hints = Some(vec![
                 format!(
-                    "No impacted tests found for --changed-since {}",
-                    scope.changed_since.as_deref().unwrap_or("unknown")
+                    "No impacted tests found for --changed-since {changed_ref} (no production or test source changed)"
                 ),
                 format!(
                     "Run full suite if needed: homeboy test {}",


### PR DESCRIPTION
## Summary
The release Test gate could report `status: pass` in ~6s having run **zero tests** when a Rust source file changed. The changed-scope path returned `passed`/exit 0 whenever the computed scope selected no test files — regardless of *what* changed — so a source change that mapped to no tests produced a green gate with no test evidence (#8340).

Example (from the issue): Test job passed for a commit that changed `src/core/code_audit/walker.rs` and added assertions, with `test_scope.selected_count: 0`.

## Fix
- Classify each changed file against the component's drift **source/test patterns** (`is_source_relevant_change`), reusing the existing `DriftOptions` contract (`src/**/*.rs`, `tests/**/*.rs` by default, extension-configurable).
- Add `TestScopeOutput.source_changes_without_tests`: changed production/test source files present when zero tests were selected.
- In the changed-scope run path, **fail closed** (`status: failed`, exit 1) with an actionable `test` finding (`rule: changed_scope_zero_tests_for_source_change`) naming the impacted files when that list is non-empty.
- Documentation/config-only changes leave the list empty and still **pass** with a typed hint, preserving legitimate no-test scopes.

## Contract mapping (from #8340)
- ✅ Changed-scope gate fails closed when relevant production/test source changed but zero tests selected.
- ✅ Result explains why and reports the impacted changed files.
- ✅ Documentation/no-source scopes still pass with a typed reason.
- ✅ Deterministic coverage for both fail-closed source change and allowed docs-only scope.

## Tests
- New: `changed_source_without_selected_tests_flags_false_green`, `docs_only_change_allows_empty_test_scope`.
- `cargo fmt` clean; `cargo check --lib` passes with no new warnings. Full test-binary run deferred to CI per repo policy (VPS cannot safely link the full test suite).

Fixes #8340