### PR TITLE
Persist durable cook recipes and restart continuations

### DIFF
--- a/src/commands/agent_task/run.rs
+++ b/src/commands/agent_task/run.rs
@@ -143,8 +143,24 @@ where
             .run_id
             .clone()
             .unwrap_or_else(|| format!("agent-task-{}", uuid::Uuid::new_v4()));
-        let request = dispatch_service::resolve_dispatch_request(dispatch_args.into())?;
-        (run_id, dispatch_service::build_dispatch_plan(&request)?)
+        let mut request = dispatch_service::resolve_dispatch_request(dispatch_args.into())?;
+        let plan = match dispatch_service::build_dispatch_plan(&request) {
+            Ok(plan) => plan,
+            // A managed promotion handle may be intentionally unavailable until
+            // after provider execution. Keep the compiled task durable and let
+            // promotion report its established controlled policy failure.
+            Err(error)
+                if request.workspace.as_deref() == Some(args.to_worktree.as_str())
+                    && error.message.contains(
+                        "neither an existing directory nor a resolvable managed worktree handle",
+                    ) =>
+            {
+                request.workspace = None;
+                dispatch_service::build_dispatch_plan(&request)?
+            }
+            Err(error) => return Err(error),
+        };
+        (run_id, plan)
     };
     let cook_id = requested_cook_id.unwrap_or_else(|| run_id.clone());
     // Capture the resolved task workspace before dispatch. The provider may
@@ -313,9 +329,12 @@ pub(super) fn run_next() -> CmdResult<Value> {
 
 pub(super) fn run_next_with_executor<E>(executor: E) -> CmdResult<Value>
 where
-    E: AgentTaskExecutorAdapter,
+    E: AgentTaskExecutorAdapter + Clone,
 {
-    let result = agent_task_service::run_next(executor)?;
+    let result = agent_task_service::run_next_with_cook_dispatcher(
+        executor,
+        crate::commands::infra::route::reconstruct_cook_attempt_dispatcher,
+    )?;
     let Some(aggregate) = result.value else {
         return Ok((serde_json::json!({ "claimed": false }), 0));
     };

--- a/src/commands/agent_task/tests/promotion_review.rs
+++ b/src/commands/agent_task/tests/promotion_review.rs
@@ -286,6 +286,10 @@ struct MirroredAttemptDispatcher {
 }
 
 impl crate::core::agent_task_service::AgentTaskCookAttemptDispatcher for MirroredAttemptDispatcher {
+    fn durable_recipe(&self) -> homeboy::core::Result<serde_json::Value> {
+        Ok(serde_json::json!({ "kind": "local" }))
+    }
+
     fn dispatch_attempt(
         &self,
         plan: AgentTaskPlan,

--- a/src/commands/agent_task/tests/support.rs
+++ b/src/commands/agent_task/tests/support.rs
@@ -89,6 +89,7 @@ pub(crate) fn init_runtime_component_checkout(path: &std::path::Path) {
     run(&["commit", "-m", "init"]);
 }
 
+#[derive(Clone)]
 pub(crate) struct InspectingExecutor {
     pub(crate) run_id: String,
     pub(crate) observed_status: Arc<Mutex<Option<AgentTaskRunRecord>>>,

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -323,6 +323,88 @@ struct LabCookAttemptDispatcher {
     job_overrides: runners::LabJobOverrides,
 }
 
+pub(crate) fn reconstruct_cook_attempt_dispatcher(
+    recipe: &serde_json::Value,
+) -> homeboy::core::Result<
+    Option<Arc<dyn crate::core::agent_task_service::AgentTaskCookAttemptDispatcher>>,
+> {
+    let kind = recipe
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cook_recipe.promotion_transport.attempt_dispatch",
+                "durable attempt dispatcher recipe is missing its kind",
+                None,
+                None,
+            )
+        })?;
+    if kind == "local" {
+        return Ok(None);
+    }
+    if kind != "lab" {
+        return Err(Error::validation_invalid_argument(
+            "cook_recipe.promotion_transport.attempt_dispatch.kind",
+            format!("unsupported durable attempt dispatcher kind `{kind}`"),
+            None,
+            None,
+        ));
+    }
+    let value = |name: &str| {
+        recipe.get(name).cloned().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cook_recipe.promotion_transport.attempt_dispatch",
+                format!("Lab attempt dispatcher recipe is missing `{name}`"),
+                None,
+                None,
+            )
+        })
+    };
+    let overrides = value("job_overrides")?;
+    let dispatcher = LabCookAttemptDispatcher {
+        runner_id: decode_cook_dispatch_field("runner_id", value("runner_id")?)?,
+        allow_local_fallback: decode_cook_dispatch_field(
+            "allow_local_fallback",
+            value("allow_local_fallback")?,
+        )?,
+        allow_dirty_lab_workspace: decode_cook_dispatch_field(
+            "allow_dirty_lab_workspace",
+            value("allow_dirty_lab_workspace")?,
+        )?,
+        skip_deps_hydration: decode_cook_dispatch_field(
+            "skip_deps_hydration",
+            value("skip_deps_hydration")?,
+        )?,
+        source_path: decode_cook_dispatch_field("source_path", value("source_path")?)?,
+        job_overrides: runners::LabJobOverrides {
+            env: decode_cook_dispatch_field("job_overrides.env", overrides["env"].clone())?,
+            secret_env_names: decode_cook_dispatch_field(
+                "job_overrides.secret_env_names",
+                overrides["secret_env_names"].clone(),
+            )?,
+            workspace_root: decode_cook_dispatch_field(
+                "job_overrides.workspace_root",
+                overrides["workspace_root"].clone(),
+            )?,
+        },
+    };
+    Ok(Some(Arc::new(dispatcher)))
+}
+
+fn decode_cook_dispatch_field<T: serde::de::DeserializeOwned>(
+    name: &str,
+    value: serde_json::Value,
+) -> homeboy::core::Result<T> {
+    serde_json::from_value(value).map_err(|error| {
+        Error::validation_invalid_argument(
+            "cook_recipe.promotion_transport.attempt_dispatch",
+            format!("malformed Lab attempt dispatcher field `{name}`: {error}"),
+            None,
+            None,
+        )
+    })
+}
+
 fn cook_attempt_source_path<'a>(
     derived_cook_baseline: Option<&'a DerivedCookBaselineCapability>,
     controller_source_path: Option<&'a Path>,
@@ -333,6 +415,22 @@ fn cook_attempt_source_path<'a>(
 }
 
 impl crate::core::agent_task_service::AgentTaskCookAttemptDispatcher for LabCookAttemptDispatcher {
+    fn durable_recipe(&self) -> homeboy::core::Result<serde_json::Value> {
+        Ok(serde_json::json!({
+            "kind": "lab",
+            "runner_id": self.runner_id,
+            "allow_local_fallback": self.allow_local_fallback,
+            "allow_dirty_lab_workspace": self.allow_dirty_lab_workspace,
+            "skip_deps_hydration": self.skip_deps_hydration,
+            "source_path": self.source_path,
+            "job_overrides": {
+                "env": self.job_overrides.env,
+                "secret_env_names": self.job_overrides.secret_env_names,
+                "workspace_root": self.job_overrides.workspace_root,
+            },
+        }))
+    }
+
     fn dispatch_attempt(
         &self,
         plan: homeboy::core::agent_tasks::scheduler::AgentTaskPlan,
@@ -1623,6 +1721,33 @@ mod tests {
     use std::process::Command;
     use std::sync::{Mutex, MutexGuard, OnceLock};
     use tempfile::tempdir;
+
+    #[test]
+    fn lab_cook_dispatcher_recipe_round_trips_exact_transport() {
+        let dispatcher = LabCookAttemptDispatcher {
+            runner_id: "homeboy-lab".to_string(),
+            allow_local_fallback: true,
+            allow_dirty_lab_workspace: false,
+            skip_deps_hydration: true,
+            source_path: Some(PathBuf::from("/controller/source")),
+            job_overrides: runners::LabJobOverrides {
+                env: [("MODE".to_string(), "test".to_string())].into(),
+                secret_env_names: vec!["TOKEN".to_string()],
+                workspace_root: Some("/runner/workspaces".to_string()),
+            },
+        };
+        let recipe =
+            crate::core::agent_task_service::AgentTaskCookAttemptDispatcher::durable_recipe(
+                &dispatcher,
+            )
+            .unwrap();
+
+        let reconstructed = reconstruct_cook_attempt_dispatcher(&recipe)
+            .unwrap()
+            .expect("Lab dispatcher reconstructed");
+
+        assert_eq!(reconstructed.durable_recipe().unwrap(), recipe);
+    }
 
     fn git_init(path: &Path) {
         let output = Command::new("git")

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -502,6 +502,38 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
             )?;
         }
     }
+    // Read-side reconciliation only writes the durable continuation signal.
+    // The separate consumer owns execution and cannot inherit a local closure.
+    if matches!(
+        record.state,
+        AgentTaskRunState::Succeeded
+            | AgentTaskRunState::CandidateRecoverable
+            | AgentTaskRunState::PartialRecoverable
+    ) {
+        if let Some(cook_id) = record
+            .metadata
+            .get("cook_id")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+        {
+            if crate::core::agent_task_service::recipe_exists(&cook_id)? {
+                if let Err(error) = crate::core::agent_task_service::enqueue_terminal_continuation(
+                    &cook_id,
+                    &record.run_id,
+                ) {
+                    record.ensure_metadata_object().insert(
+                        "cook_continuation_scheduler".to_string(),
+                        json!({
+                            "status": "failed",
+                            "error_code": error.code.as_str(),
+                            "message": error.message,
+                        }),
+                    );
+                    store::write_record(&record)?;
+                }
+            }
+        }
+    }
     Ok(record)
 }
 

--- a/src/core/agent_task_scheduler/attempt_workspace.rs
+++ b/src/core/agent_task_scheduler/attempt_workspace.rs
@@ -12,7 +12,7 @@ use super::*;
 
 /// Immutable provenance for one scheduler execution. Controller-local callers
 /// use an empty context; only a Lab subprocess captures its paired transport.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct HarvestExecutionContext {
     source_snapshot: Option<crate::core::source_snapshot::SourceSnapshot>,
     lab_offload: Option<serde_json::Value>,

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -39,6 +39,10 @@ use super::AgentTaskRunResult;
 /// Executes one provider attempt while cook retains ownership of promotion,
 /// gates, retries, and finalization.
 pub trait AgentTaskCookAttemptDispatcher: Send + Sync + std::fmt::Debug {
+    /// Durable, generic transport descriptor used to reconstruct this
+    /// dispatcher in a fresh controller process.
+    fn durable_recipe(&self) -> Result<Value>;
+
     /// `derived_cook_baseline` is process-local authority for a gate-fix retry.
     /// Implementations must not serialize it into the provider request.
     fn dispatch_attempt(
@@ -116,6 +120,9 @@ pub fn run_cook<E>(
 where
     E: AgentTaskExecutorAdapter + Clone,
 {
+    // The durable reconstruction boundary must exist before an external provider
+    // can accept the first attempt.
+    super::persist_initial_recipe(&options)?;
     let max_attempts = options.max_attempts.max(1);
     let mut attempts = Vec::new();
     let mut run_id = options.initial_run_id.clone();
@@ -409,6 +416,7 @@ where
                 follow_up_plan.options = plan.options.clone();
                 follow_up_plan.options.execution_budget = AgentTaskExecutionBudget::new(1, 0, 0);
                 follow_up_plan.options.retry.max_attempts = 1;
+                super::record_recipe_attempt(&cook_id, attempt + 1, &next_run_id, &follow_up_plan)?;
                 if let Some(dispatcher) = &options.attempt_dispatcher {
                     dispatcher.dispatch_attempt(
                         follow_up_plan,

--- a/src/core/agent_task_service/cook_recipe.rs
+++ b/src/core/agent_task_service/cook_recipe.rs
@@ -1,0 +1,1076 @@
+//! Durable, versioned input boundary for cook continuation scheduling.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::Digest;
+
+use crate::core::agent_task_scheduler::AgentTaskPlan;
+use crate::core::agent_task_service::cook::{
+    AgentTaskCookAttemptDispatcher, AgentTaskCookServiceOptions,
+};
+use crate::core::command_invocation::CommandInvocation;
+use crate::core::{paths, Error, Result};
+
+pub const COOK_RECIPE_SCHEMA: &str = "homeboy/agent-task-cook-recipe/v1";
+const CONTINUATION_SCHEMA: &str = "homeboy/agent-task-cook-continuation/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct AgentTaskCookRecipe {
+    pub schema: String,
+    pub cook_id: String,
+    pub attempts: Vec<AgentTaskCookRecipeAttempt>,
+    pub promotion_transport: Value,
+    pub gate_policy: Value,
+    pub retry_budget: Value,
+    pub finalization: Value,
+    pub source_refs: Vec<String>,
+    pub runtime_generation: String,
+    pub sensitive_mappings: Vec<String>,
+    pub harvest_context: crate::core::agent_task_scheduler::HarvestExecutionContext,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct AgentTaskCookRecipeAttempt {
+    pub attempt: u32,
+    pub run_id: String,
+    pub plan: AgentTaskPlan,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct AgentTaskCookContinuation {
+    pub schema: String,
+    pub key: String,
+    pub cook_id: String,
+    pub run_id: String,
+    #[serde(default)]
+    pub retries: u32,
+}
+
+#[derive(Debug)]
+pub struct ClaimedCookContinuation {
+    continuation: AgentTaskCookContinuation,
+    path: PathBuf,
+}
+
+impl ClaimedCookContinuation {
+    pub fn continuation(&self) -> &AgentTaskCookContinuation {
+        &self.continuation
+    }
+
+    pub fn complete(self) -> Result<()> {
+        fs::rename(&self.path, continuation_state_path(&self.path, "completed")).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(self.path.display().to_string()))
+        })
+    }
+
+    pub fn retry(mut self) -> Result<()> {
+        const MAX_CONTINUATION_RETRIES: u32 = 3;
+        self.continuation.retries = self.continuation.retries.saturating_add(1);
+        if self.continuation.retries > MAX_CONTINUATION_RETRIES {
+            return self.fail("cook continuation retry budget exhausted");
+        }
+        fs::write(
+            &self.path,
+            serde_json::to_vec(&self.continuation)
+                .map_err(|error| Error::internal_json(error.to_string(), None))?,
+        )
+        .map_err(|error| {
+            Error::internal_io(error.to_string(), Some(self.path.display().to_string()))
+        })?;
+        fs::rename(&self.path, continuation_state_path(&self.path, "pending")).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(self.path.display().to_string()))
+        })
+    }
+
+    pub fn fail(self, diagnostic: &str) -> Result<()> {
+        fail_claimed_path(&self.path, diagnostic)
+    }
+}
+
+/// The consumer boundary is deliberately injected: status/reconciliation only
+/// writes durable signals and never invokes process-local closures.
+pub trait AgentTaskCookContinuationScheduler {
+    /// Returns true only when this call created the durable queue entry.
+    fn enqueue(&self, continuation: &AgentTaskCookContinuation) -> Result<bool>;
+}
+
+pub fn persist_initial_recipe(
+    options: &AgentTaskCookServiceOptions,
+) -> Result<AgentTaskCookRecipe> {
+    let attempt_dispatch = options
+        .attempt_dispatcher
+        .as_ref()
+        .map(|dispatcher| dispatcher.durable_recipe())
+        .transpose()?
+        .unwrap_or_else(|| serde_json::json!({ "kind": "local" }));
+    let recipe = AgentTaskCookRecipe {
+        schema: COOK_RECIPE_SCHEMA.to_string(),
+        cook_id: options.cook_id.clone(),
+        attempts: vec![AgentTaskCookRecipeAttempt {
+            attempt: 1,
+            run_id: options.initial_run_id.clone(),
+            plan: options.initial_plan.clone(),
+        }],
+        promotion_transport: serde_json::json!({
+            "provider_command": options.provider_command,
+            "provider_invocation": options.provider_invocation,
+            "attempt_dispatch": attempt_dispatch,
+        }),
+        gate_policy: serde_json::to_value(&options.gates).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize cook gate policy".to_string()),
+            )
+        })?,
+        retry_budget: serde_json::json!({ "max_attempts": options.max_attempts, "execution_budget": options.initial_plan.options.execution_budget }),
+        finalization: serde_json::json!({
+            "no_finalize": options.no_finalize,
+            "base": options.base,
+            "head": options.head,
+            "title": options.title,
+            "commit_message": options.commit_message,
+            "protected_branches": options.protected_branches,
+            "ai_tool": options.ai_tool,
+            "ai_model": options.ai_model,
+            "ai_used_for": options.ai_used_for,
+            "to_worktree": options.to_worktree,
+            "source_worktree_path": options.source_worktree_path,
+            "task_base_sha": options.task_base_sha,
+        }),
+        source_refs: options.source_refs.clone(),
+        runtime_generation: crate::core::build_identity::current().display,
+        sensitive_mappings: sensitive_mappings(&options.initial_plan)?,
+        harvest_context: options.harvest_context.clone(),
+    };
+    validate_recipe(&recipe)?;
+    if recipe_exists(&recipe.cook_id)? {
+        let existing = load_recipe(&recipe.cook_id)?;
+        let mut expected = recipe.clone();
+        expected.attempts = existing.attempts.clone();
+        expected.sensitive_mappings = existing.sensitive_mappings.clone();
+        if existing != expected || existing.attempts.first() != recipe.attempts.first() {
+            return Err(Error::validation_invalid_argument(
+                "cook_recipe",
+                "durable cook recipe already exists with different execution inputs",
+                Some(recipe.cook_id.clone()),
+                None,
+            ));
+        }
+        return Ok(existing);
+    }
+    write_recipe(&recipe)?;
+    Ok(recipe)
+}
+
+pub fn record_recipe_attempt(
+    cook_id: &str,
+    attempt: u32,
+    run_id: &str,
+    plan: &AgentTaskPlan,
+) -> Result<AgentTaskCookRecipe> {
+    let mut recipe = load_recipe(cook_id)?;
+    let candidate = AgentTaskCookRecipeAttempt {
+        attempt,
+        run_id: run_id.to_string(),
+        plan: plan.clone(),
+    };
+    if let Some(existing) = recipe
+        .attempts
+        .iter()
+        .find(|existing| existing.attempt == attempt || existing.run_id == run_id)
+    {
+        let existing_value = serde_json::to_value(existing)
+            .map_err(|error| Error::internal_json(error.to_string(), None))?;
+        let candidate_value = serde_json::to_value(&candidate)
+            .map_err(|error| Error::internal_json(error.to_string(), None))?;
+        if existing_value == candidate_value {
+            return Ok(recipe);
+        }
+        return Err(Error::validation_invalid_argument(
+            "cook_recipe.attempts",
+            "durable cook attempt identity is already bound to different inputs",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    if attempt != recipe.attempts.len() as u32 + 1 {
+        return Err(Error::validation_invalid_argument(
+            "cook_recipe.attempts",
+            "durable cook attempts must be appended in order",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    recipe.attempts.push(candidate);
+    recipe.sensitive_mappings = recipe
+        .attempts
+        .iter()
+        .map(|attempt| sensitive_mappings(&attempt.plan))
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect();
+    recipe.sensitive_mappings.sort();
+    recipe.sensitive_mappings.dedup();
+    validate_recipe(&recipe)?;
+    write_recipe(&recipe)?;
+    Ok(recipe)
+}
+
+pub fn load_recipe(cook_id: &str) -> Result<AgentTaskCookRecipe> {
+    let path = recipe_path(cook_id)?;
+    let raw = fs::read_to_string(&path)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    let recipe = serde_json::from_str(&raw).map_err(|error| {
+        Error::validation_invalid_argument(
+            "cook_recipe",
+            format!("malformed durable cook recipe: {error}"),
+            Some(cook_id.to_string()),
+            None,
+        )
+    })?;
+    validate_recipe(&recipe)?;
+    Ok(recipe)
+}
+
+/// Legacy cook indexes predate this durable scheduler contract. Their status
+/// projection remains read-only and preserves the previous orphan behavior.
+pub fn recipe_exists(cook_id: &str) -> Result<bool> {
+    Ok(recipe_path(cook_id)?.exists())
+}
+
+pub fn enqueue_terminal_continuation(cook_id: &str, run_id: &str) -> Result<bool> {
+    let recipe = load_recipe(cook_id)?;
+    if !recipe
+        .attempts
+        .iter()
+        .any(|attempt| attempt.run_id == run_id)
+    {
+        return Err(Error::validation_invalid_argument(
+            "cook_recipe.attempts",
+            "terminal run is not declared by the durable cook recipe",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    let continuation = AgentTaskCookContinuation {
+        schema: CONTINUATION_SCHEMA.to_string(),
+        key: format!("{cook_id}:{run_id}"),
+        cook_id: cook_id.to_string(),
+        run_id: run_id.to_string(),
+        retries: 0,
+    };
+    DurableCookContinuationQueue.enqueue(&continuation)
+}
+
+pub fn claim_continuation() -> Result<Option<ClaimedCookContinuation>> {
+    let root = queue_root()?;
+    fs::create_dir_all(&root)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(root.display().to_string())))?;
+    reclaim_dead_claims(&root)?;
+    for entry in fs::read_dir(&root)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(root.display().to_string())))?
+    {
+        let path = entry
+            .map_err(|error| {
+                Error::internal_io(error.to_string(), Some(root.display().to_string()))
+            })?
+            .path();
+        if path.extension().and_then(|value| value.to_str()) != Some("pending") {
+            continue;
+        }
+        let claimed = path.with_extension(format!("claimed.{}", std::process::id()));
+        if fs::rename(&path, &claimed).is_err() {
+            continue;
+        }
+        let raw = fs::read_to_string(&claimed).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(claimed.display().to_string()))
+        })?;
+        let continuation = match serde_json::from_str(&raw) {
+            Ok(continuation) => continuation,
+            Err(error) => {
+                let error = Error::validation_invalid_argument(
+                    "cook_continuation",
+                    format!("malformed durable continuation: {error}"),
+                    Some(claimed.display().to_string()),
+                    None,
+                );
+                fail_claimed_path(&claimed, &error.message)?;
+                return Err(error);
+            }
+        };
+        if let Err(error) = validate_continuation(&continuation) {
+            fail_claimed_path(&claimed, &error.message)?;
+            return Err(error);
+        }
+        return Ok(Some(ClaimedCookContinuation {
+            continuation,
+            path: claimed,
+        }));
+    }
+    Ok(None)
+}
+
+pub fn reconstruct_options(recipe: &AgentTaskCookRecipe) -> Result<AgentTaskCookServiceOptions> {
+    reconstruct_options_with_dispatcher(recipe, None)
+}
+
+pub fn reconstruct_options_with_dispatcher(
+    recipe: &AgentTaskCookRecipe,
+    attempt_dispatcher: Option<Arc<dyn AgentTaskCookAttemptDispatcher>>,
+) -> Result<AgentTaskCookServiceOptions> {
+    validate_recipe(recipe)?;
+    if recipe.runtime_generation != crate::core::build_identity::current().display {
+        return Err(Error::validation_invalid_argument(
+            "cook_recipe.runtime_generation",
+            format!(
+                "cook recipe is pinned to Homeboy runtime `{}` but this process is `{}`",
+                recipe.runtime_generation,
+                crate::core::build_identity::current().display
+            ),
+            Some(recipe.cook_id.clone()),
+            None,
+        ));
+    }
+    let initial = recipe
+        .attempts
+        .first()
+        .expect("validated recipe has attempt");
+    let gates = serde_json::from_value(recipe.gate_policy.clone()).map_err(|error| {
+        Error::validation_invalid_argument(
+            "cook_recipe.gate_policy",
+            format!("malformed gate policy: {error}"),
+            None,
+            None,
+        )
+    })?;
+    let provider_command = recipe
+        .promotion_transport
+        .get("provider_command")
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok());
+    let provider_invocation = recipe
+        .promotion_transport
+        .get("provider_invocation")
+        .filter(|value| !value.is_null())
+        .cloned()
+        .map(serde_json::from_value::<CommandInvocation>)
+        .transpose()
+        .map_err(|error| {
+            Error::validation_invalid_argument(
+                "cook_recipe.promotion_transport",
+                format!("malformed provider invocation: {error}"),
+                None,
+                None,
+            )
+        })?;
+    let field = |name: &str| {
+        recipe.finalization.get(name).cloned().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cook_recipe.finalization",
+                format!("missing finalization field `{name}`"),
+                None,
+                None,
+            )
+        })
+    };
+    let dispatch_kind = recipe
+        .promotion_transport
+        .pointer("/attempt_dispatch/kind")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cook_recipe.promotion_transport.attempt_dispatch",
+                "durable cook recipe is missing its attempt dispatcher kind",
+                Some(recipe.cook_id.clone()),
+                None,
+            )
+        })?;
+    if dispatch_kind == "local" && attempt_dispatcher.is_some() {
+        return Err(Error::validation_invalid_argument(
+            "cook_recipe.promotion_transport.attempt_dispatch",
+            "local cook recipe cannot be reconstructed with an external dispatcher",
+            Some(recipe.cook_id.clone()),
+            None,
+        ));
+    }
+    if dispatch_kind != "local" && attempt_dispatcher.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "cook_recipe.promotion_transport.attempt_dispatch",
+            format!("cook recipe requires `{dispatch_kind}` attempt dispatcher reconstruction"),
+            Some(recipe.cook_id.clone()),
+            None,
+        ));
+    }
+    Ok(AgentTaskCookServiceOptions {
+        cook_id: recipe.cook_id.clone(),
+        initial_run_id: initial.run_id.clone(),
+        initial_plan: initial.plan.clone(),
+        to_worktree: serde_json::from_value(field("to_worktree")?)
+            .map_err(recipe_value_error("to_worktree"))?,
+        source_worktree_path: serde_json::from_value(field("source_worktree_path")?)
+            .map_err(recipe_value_error("source_worktree_path"))?,
+        provider_command,
+        provider_invocation,
+        gates,
+        max_attempts: recipe
+            .retry_budget
+            .get("max_attempts")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "cook_recipe.retry_budget",
+                    "missing max_attempts",
+                    None,
+                    None,
+                )
+            })? as u32,
+        no_finalize: serde_json::from_value(field("no_finalize")?)
+            .map_err(recipe_value_error("no_finalize"))?,
+        base: serde_json::from_value(field("base")?).map_err(recipe_value_error("base"))?,
+        task_base_sha: serde_json::from_value(field("task_base_sha")?)
+            .map_err(recipe_value_error("task_base_sha"))?,
+        head: serde_json::from_value(field("head")?).map_err(recipe_value_error("head"))?,
+        title: serde_json::from_value(field("title")?).map_err(recipe_value_error("title"))?,
+        commit_message: serde_json::from_value(field("commit_message")?)
+            .map_err(recipe_value_error("commit_message"))?,
+        source_refs: recipe.source_refs.clone(),
+        protected_branches: serde_json::from_value(field("protected_branches")?)
+            .map_err(recipe_value_error("protected_branches"))?,
+        ai_tool: serde_json::from_value(field("ai_tool")?)
+            .map_err(recipe_value_error("ai_tool"))?,
+        ai_model: serde_json::from_value(field("ai_model")?)
+            .map_err(recipe_value_error("ai_model"))?,
+        ai_used_for: serde_json::from_value(field("ai_used_for")?)
+            .map_err(recipe_value_error("ai_used_for"))?,
+        attempt_dispatcher,
+        harvest_context: recipe.harvest_context.clone(),
+    })
+}
+
+/// Consume one durable continuation through an injected normal cook boundary.
+/// Production supplies `run_cook`; tests use side-effect-free recorders.
+pub fn consume_next_with(
+    execute: impl FnOnce(AgentTaskCookServiceOptions) -> Result<i32>,
+) -> Result<Option<i32>> {
+    let Some(claim) = claim_continuation()? else {
+        return Ok(None);
+    };
+    consume_claimed_with(claim, execute).map(Some)
+}
+
+pub fn consume_claimed_with(
+    claim: ClaimedCookContinuation,
+    execute: impl FnOnce(AgentTaskCookServiceOptions) -> Result<i32>,
+) -> Result<i32> {
+    consume_claimed_with_dispatcher(claim, |_| Ok(None), execute)
+}
+
+pub fn consume_claimed_with_dispatcher(
+    claim: ClaimedCookContinuation,
+    dispatcher: impl FnOnce(&Value) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
+    execute: impl FnOnce(AgentTaskCookServiceOptions) -> Result<i32>,
+) -> Result<i32> {
+    let recipe = match load_recipe(&claim.continuation().cook_id) {
+        Ok(recipe) => recipe,
+        Err(error) => {
+            claim.fail(&error.message)?;
+            return Err(error);
+        }
+    };
+    let attempt_dispatcher = match dispatcher(&recipe.promotion_transport["attempt_dispatch"]) {
+        Ok(dispatcher) => dispatcher,
+        Err(error) => {
+            claim.fail(&error.message)?;
+            return Err(error);
+        }
+    };
+    let options = match reconstruct_options_with_dispatcher(&recipe, attempt_dispatcher) {
+        Ok(options) => options,
+        Err(error) => {
+            claim.fail(&error.message)?;
+            return Err(error);
+        }
+    };
+    match execute(options) {
+        Ok(exit_code) => {
+            claim.complete()?;
+            Ok(exit_code)
+        }
+        Err(error) if error.retryable == Some(true) => {
+            claim.retry()?;
+            Err(error)
+        }
+        Err(error) => {
+            claim.fail(&error.message)?;
+            Err(error)
+        }
+    }
+}
+
+fn recipe_value_error(field: &'static str) -> impl FnOnce(serde_json::Error) -> Error {
+    move |error| {
+        Error::validation_invalid_argument(
+            "cook_recipe.finalization",
+            format!("malformed finalization field `{field}`: {error}"),
+            None,
+            None,
+        )
+    }
+}
+
+struct DurableCookContinuationQueue;
+impl AgentTaskCookContinuationScheduler for DurableCookContinuationQueue {
+    fn enqueue(&self, continuation: &AgentTaskCookContinuation) -> Result<bool> {
+        validate_continuation(continuation)?;
+        let root = queue_root()?;
+        fs::create_dir_all(&root).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(root.display().to_string()))
+        })?;
+        let hash = format!("{:x}", sha2::Sha256::digest(continuation.key.as_bytes()));
+        let path = root.join(format!("{hash}.pending"));
+        if root.join(format!("{hash}.completed")).exists()
+            || root.join(format!("{hash}.failed")).exists()
+            || fs::read_dir(&root)
+                .map_err(|error| {
+                    Error::internal_io(error.to_string(), Some(root.display().to_string()))
+                })?
+                .filter_map(std::result::Result::ok)
+                .filter_map(|entry| entry.file_name().into_string().ok())
+                .any(|name| name.starts_with(&format!("{hash}.claimed.")))
+        {
+            return Ok(false);
+        }
+        let mut file = match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => return Ok(false),
+            Err(error) => {
+                return Err(Error::internal_io(
+                    error.to_string(),
+                    Some(path.display().to_string()),
+                ))
+            }
+        };
+        file.write_all(
+            &serde_json::to_vec(continuation)
+                .map_err(|error| Error::internal_json(error.to_string(), None))?,
+        )
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+        file.sync_all().map_err(|error| {
+            Error::internal_io(error.to_string(), Some(path.display().to_string()))
+        })?;
+        Ok(true)
+    }
+}
+
+fn validate_recipe(recipe: &AgentTaskCookRecipe) -> Result<()> {
+    if recipe.schema != COOK_RECIPE_SCHEMA {
+        return Err(Error::validation_invalid_argument(
+            "cook_recipe.schema",
+            format!(
+                "unsupported cook recipe schema `{}`; supported schema is `{COOK_RECIPE_SCHEMA}`",
+                recipe.schema
+            ),
+            Some(recipe.schema.clone()),
+            None,
+        ));
+    }
+    if recipe.cook_id.is_empty()
+        || recipe.attempts.is_empty()
+        || recipe.runtime_generation.is_empty()
+    {
+        return Err(Error::validation_invalid_argument("cook_recipe", "cook recipe requires cook_id, at least one exact attempt, and pinned runtime generation", None, None));
+    }
+    for attempt in &recipe.attempts {
+        if attempt.run_id.is_empty() || attempt.plan.tasks.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "cook_recipe.attempts",
+                "each cook attempt requires an exact run id and compiled non-empty plan",
+                Some(attempt.run_id.clone()),
+                None,
+            ));
+        }
+    }
+    if recipe
+        .sensitive_mappings
+        .iter()
+        .any(|mapping| mapping.trim().is_empty())
+    {
+        return Err(Error::validation_invalid_argument(
+            "cook_recipe.sensitive_mappings",
+            "sensitive mappings must be explicit non-empty durable identifiers",
+            None,
+            None,
+        ));
+    }
+    let declared = recipe
+        .sensitive_mappings
+        .iter()
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut required_mappings = Vec::new();
+    for attempt in &recipe.attempts {
+        required_mappings.extend(sensitive_mappings(&attempt.plan)?);
+    }
+    let required = required_mappings
+        .iter()
+        .collect::<std::collections::BTreeSet<_>>();
+    if declared != required {
+        return Err(Error::validation_invalid_argument(
+            "cook_recipe.sensitive_mappings",
+            "durable sensitive mappings do not exactly match the compiled attempt plans",
+            None,
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn validate_continuation(continuation: &AgentTaskCookContinuation) -> Result<()> {
+    if continuation.schema != CONTINUATION_SCHEMA
+        || continuation.key.is_empty()
+        || continuation.cook_id.is_empty()
+        || continuation.run_id.is_empty()
+    {
+        return Err(Error::validation_invalid_argument(
+            "cook_continuation",
+            "unknown or malformed cook continuation; inspect the durable queue entry",
+            None,
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn sensitive_mappings(plan: &AgentTaskPlan) -> Result<Vec<String>> {
+    let mappings = plan
+        .tasks
+        .iter()
+        .flat_map(|task| task.executor.secret_env.iter().cloned())
+        .collect::<Vec<_>>();
+    if mappings.iter().any(|mapping| mapping.trim().is_empty()) {
+        return Err(Error::validation_invalid_argument(
+            "executor.secret_env",
+            "cook recipes require explicit non-empty sensitive mappings",
+            None,
+            None,
+        ));
+    }
+    Ok(mappings)
+}
+
+fn write_recipe(recipe: &AgentTaskCookRecipe) -> Result<()> {
+    let path = recipe_path(&recipe.cook_id)?;
+    fs::create_dir_all(path.parent().expect("recipe path has parent"))
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    crate::core::engine::local_files::write_json_file_owner_only(&path, recipe)
+}
+
+fn recipe_path(cook_id: &str) -> Result<PathBuf> {
+    Ok(paths::homeboy_data()?
+        .join("agent-task-cooks")
+        .join(paths::sanitize_path_segment(cook_id))
+        .join("recipe.json"))
+}
+fn queue_root() -> Result<PathBuf> {
+    Ok(paths::homeboy_data()?.join("agent-task-cook-continuations"))
+}
+
+fn continuation_base_path(path: &std::path::Path) -> PathBuf {
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+    let base = name
+        .split_once(".claimed.")
+        .map(|(base, _)| base)
+        .or_else(|| name.rsplit_once('.').map(|(base, _)| base))
+        .unwrap_or(name);
+    path.with_file_name(base)
+}
+
+fn continuation_state_path(path: &std::path::Path, state: &str) -> PathBuf {
+    continuation_base_path(path).with_extension(state)
+}
+
+fn fail_claimed_path(path: &std::path::Path, diagnostic: &str) -> Result<()> {
+    let failed = continuation_state_path(path, "failed");
+    fs::rename(path, &failed)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    let diagnostic_path = continuation_state_path(path, "diagnostic");
+    fs::write(&diagnostic_path, diagnostic).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(diagnostic_path.display().to_string()),
+        )
+    })
+}
+
+fn reclaim_dead_claims(root: &std::path::Path) -> Result<()> {
+    for entry in fs::read_dir(root)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(root.display().to_string())))?
+    {
+        let path = entry
+            .map_err(|error| {
+                Error::internal_io(error.to_string(), Some(root.display().to_string()))
+            })?
+            .path();
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        let Some(pid) = name
+            .rsplit_once(".claimed.")
+            .map(|(_, pid)| pid)
+            .and_then(|value| value.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        if !crate::core::process::pid_is_running(pid) {
+            fs::rename(&path, continuation_state_path(&path, "pending")).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(path.display().to_string()))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::agent_task::{
+        AgentTaskExecutor, AgentTaskLimits, AgentTaskOutcome, AgentTaskOutcomeStatus,
+        AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
+    };
+    use crate::core::agent_task_scheduler::{
+        AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
+        AgentTaskProgressEvent, AgentTaskState,
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn recipe() -> AgentTaskCookRecipe {
+        let request = AgentTaskRequest {
+            schema: crate::core::agent_task::AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "task".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "test".to_string(),
+                selector: None,
+                runtime_selection: None,
+                required_capabilities: Vec::new(),
+                secret_env: vec!["TEST_TOKEN".to_string()],
+                model: None,
+                config: Value::Null,
+            },
+            instructions: "test".to_string(),
+            inputs: Value::Null,
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace::default(),
+            component_contracts: Vec::new(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            artifact_declarations: Vec::new(),
+            metadata: Value::Null,
+        };
+        let plan = AgentTaskPlan::new("plan", vec![request]);
+        AgentTaskCookRecipe {
+            schema: COOK_RECIPE_SCHEMA.to_string(),
+            cook_id: "cook".to_string(),
+            attempts: vec![AgentTaskCookRecipeAttempt {
+                attempt: 1,
+                run_id: "run".to_string(),
+                plan: plan.clone(),
+            }],
+            promotion_transport: serde_json::json!({"provider_command": null, "provider_invocation": null, "attempt_dispatch": { "kind": "local" }}),
+            gate_policy: serde_json::json!({"verify": [], "private_verify": [], "private_gate_reveal": "summary_only"}),
+            retry_budget: serde_json::json!({"max_attempts": 1, "execution_budget": plan.options.execution_budget}),
+            finalization: serde_json::json!({"no_finalize": true, "base": "main", "head": null, "title": "title", "commit_message": "message", "protected_branches": [], "ai_tool": "test", "ai_model": null, "ai_used_for": "test", "to_worktree": "target", "source_worktree_path": null, "task_base_sha": null}),
+            source_refs: vec!["issue".to_string()],
+            runtime_generation: crate::core::build_identity::current().display,
+            sensitive_mappings: vec!["TEST_TOKEN".to_string()],
+            harvest_context: Default::default(),
+        }
+    }
+
+    fn persist_recipe_run() -> (AgentTaskCookRecipe, AgentTaskPlan) {
+        let recipe = recipe();
+        let plan = recipe.attempts[0].plan.clone();
+        write_recipe(&recipe).unwrap();
+        crate::core::agent_task_lifecycle::submit_plan(&plan, Some("run")).unwrap();
+        crate::core::agent_task_lifecycle::record_cook_attempt("cook", 1, "run").unwrap();
+        (recipe, plan)
+    }
+
+    fn succeeded_aggregate(plan: &AgentTaskPlan) -> AgentTaskAggregate {
+        AgentTaskAggregate {
+            schema: crate::core::agent_task::AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+            plan_id: plan.plan_id.clone(),
+            status: AgentTaskAggregateStatus::Succeeded,
+            totals: AgentTaskAggregateTotals {
+                queued: 1,
+                succeeded: 1,
+                ..Default::default()
+            },
+            outcomes: vec![AgentTaskOutcome {
+                schema: crate::core::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: "task".to_string(),
+                status: AgentTaskOutcomeStatus::Succeeded,
+                summary: Some("ok".to_string()),
+                failure_classification: None,
+                artifacts: Vec::new(),
+                typed_artifacts: Vec::new(),
+                evidence_refs: Vec::new(),
+                diagnostics: Vec::new(),
+                outputs: Value::Null,
+                workflow: None,
+                follow_up: None,
+                metadata: Value::Null,
+            }],
+            events: vec![AgentTaskProgressEvent {
+                task_id: "task".to_string(),
+                state: AgentTaskState::Succeeded,
+                attempt: 1,
+                message: Some("ok".to_string()),
+            }],
+            artifact_lineage: Vec::new(),
+            child_runs: Vec::new(),
+            artifact_bindings: Vec::new(),
+            queue: Default::default(),
+        }
+    }
+
+    #[test]
+    fn recipe_schema_fails_closed_for_unknown_versions_and_missing_mappings() {
+        let mut invalid = recipe();
+        invalid.schema = "homeboy/agent-task-cook-recipe/v2".to_string();
+        assert!(validate_recipe(&invalid)
+            .unwrap_err()
+            .message
+            .contains("unsupported"));
+        invalid.schema = COOK_RECIPE_SCHEMA.to_string();
+        invalid.sensitive_mappings = vec![String::new()];
+        assert!(validate_recipe(&invalid)
+            .unwrap_err()
+            .message
+            .contains("sensitive mappings"));
+    }
+
+    #[test]
+    fn durable_queue_deduplicates_and_survives_consumer_restart() {
+        crate::test_support::with_isolated_home(|_| {
+            write_recipe(&recipe()).unwrap();
+            assert!(enqueue_terminal_continuation("cook", "run").unwrap());
+            assert!(!enqueue_terminal_continuation("cook", "run").unwrap());
+            let first = claim_continuation()
+                .unwrap()
+                .expect("durable queued continuation");
+            assert_eq!(first.continuation().key, "cook:run");
+            assert!(claim_continuation().unwrap().is_none());
+        });
+    }
+
+    #[test]
+    fn consumer_reconstructs_options_once_and_completed_work_never_replays() {
+        crate::test_support::with_isolated_home(|_| {
+            write_recipe(&recipe()).unwrap();
+            enqueue_terminal_continuation("cook", "run").unwrap();
+            let mut observed = None;
+            assert_eq!(
+                consume_next_with(|options| {
+                    observed = Some(options);
+                    Ok(0)
+                })
+                .unwrap(),
+                Some(0)
+            );
+            let options = observed.expect("normal cook hook received options");
+            assert_eq!(options.cook_id, "cook");
+            assert_eq!(options.initial_run_id, "run");
+            assert!(!enqueue_terminal_continuation("cook", "run").unwrap());
+            assert!(
+                consume_next_with(|_| panic!("completed continuation replayed"))
+                    .unwrap()
+                    .is_none()
+            );
+        });
+    }
+
+    #[test]
+    fn dead_claim_is_reclaimed_and_retry_is_bounded() {
+        crate::test_support::with_isolated_home(|_| {
+            write_recipe(&recipe()).unwrap();
+            enqueue_terminal_continuation("cook", "run").unwrap();
+            let claim = claim_continuation().unwrap().unwrap();
+            let dead = continuation_base_path(&claim.path).with_extension("claimed.4294967295");
+            fs::rename(&claim.path, &dead).unwrap();
+            claim_continuation().unwrap().unwrap().retry().unwrap();
+            for _ in 0..3 {
+                let claim = claim_continuation().unwrap().unwrap();
+                assert!(
+                    consume_claimed_with(claim, |_| Err(Error::internal_unexpected(
+                        "retry".to_string()
+                    )
+                    .with_retryable(true)))
+                    .is_err()
+                );
+            }
+            assert!(claim_continuation().unwrap().is_none());
+        });
+    }
+
+    #[test]
+    fn malformed_continuation_is_terminalized_with_a_diagnostic() {
+        crate::test_support::with_isolated_home(|_| {
+            let root = queue_root().unwrap();
+            fs::create_dir_all(&root).unwrap();
+            fs::write(root.join("malformed.pending"), b"not json").unwrap();
+
+            let error = claim_continuation().unwrap_err();
+
+            assert!(error.message.contains("malformed durable continuation"));
+            assert!(root.join("malformed.failed").exists());
+            assert!(fs::read_to_string(root.join("malformed.diagnostic"))
+                .unwrap()
+                .contains("malformed durable continuation"));
+            assert!(!root.join("malformed.pending").exists());
+        });
+    }
+
+    #[test]
+    fn failed_and_cancelled_attempts_do_not_enqueue_continuations() {
+        crate::test_support::with_isolated_home(|_| {
+            let (_, plan) = persist_recipe_run();
+            crate::core::agent_task_lifecycle::record_pre_execution_failure(
+                "run",
+                &plan,
+                "test",
+                &Error::internal_unexpected("failed"),
+            )
+            .unwrap();
+
+            crate::core::agent_task_lifecycle::status("run").unwrap();
+
+            assert!(claim_continuation().unwrap().is_none());
+        });
+        crate::test_support::with_isolated_home(|_| {
+            persist_recipe_run();
+            crate::core::agent_task_lifecycle::cancel_run("run", Some("cancelled")).unwrap();
+
+            crate::core::agent_task_lifecycle::status("run").unwrap();
+
+            assert!(claim_continuation().unwrap().is_none());
+        });
+    }
+
+    #[test]
+    fn status_only_enqueues_and_never_invokes_the_consumer() {
+        crate::test_support::with_isolated_home(|_| {
+            let (_, plan) = persist_recipe_run();
+            let aggregate = succeeded_aggregate(&plan);
+            crate::core::agent_task_lifecycle::record_run_aggregate("run", &plan, &aggregate)
+                .unwrap();
+            let executions = AtomicUsize::new(0);
+
+            crate::core::agent_task_lifecycle::status("run").unwrap();
+
+            assert_eq!(executions.load(Ordering::SeqCst), 0);
+            assert_eq!(
+                consume_next_with(|_| {
+                    executions.fetch_add(1, Ordering::SeqCst);
+                    Ok(0)
+                })
+                .unwrap(),
+                Some(0)
+            );
+            assert_eq!(executions.load(Ordering::SeqCst), 1);
+        });
+    }
+
+    #[test]
+    fn concurrent_consumers_execute_one_continuation_once() {
+        crate::test_support::with_isolated_home(|_| {
+            write_recipe(&recipe()).unwrap();
+            enqueue_terminal_continuation("cook", "run").unwrap();
+            let executions = AtomicUsize::new(0);
+
+            let results = std::thread::scope(|scope| {
+                let first = scope.spawn(|| {
+                    consume_next_with(|_| {
+                        executions.fetch_add(1, Ordering::SeqCst);
+                        Ok(0)
+                    })
+                    .unwrap()
+                });
+                let second = scope.spawn(|| {
+                    consume_next_with(|_| {
+                        executions.fetch_add(1, Ordering::SeqCst);
+                        Ok(0)
+                    })
+                    .unwrap()
+                });
+                [first.join().unwrap(), second.join().unwrap()]
+            });
+
+            assert_eq!(executions.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                results.iter().filter(|result| **result == Some(0)).count(),
+                1
+            );
+            assert_eq!(results.iter().filter(|result| result.is_none()).count(), 1);
+        });
+    }
+
+    #[test]
+    fn retry_attempts_are_appended_idempotently_before_scheduling() {
+        crate::test_support::with_isolated_home(|_| {
+            write_recipe(&recipe()).unwrap();
+            let mut retry_plan = recipe().attempts[0].plan.clone();
+            retry_plan.plan_id = "retry-plan".to_string();
+
+            record_recipe_attempt("cook", 2, "run-2", &retry_plan).unwrap();
+            record_recipe_attempt("cook", 2, "run-2", &retry_plan).unwrap();
+
+            let persisted = load_recipe("cook").unwrap();
+            assert_eq!(persisted.attempts.len(), 2);
+            assert_eq!(persisted.attempts[1].run_id, "run-2");
+            let resumed = reconstruct_options(&persisted).unwrap();
+            assert_eq!(persist_initial_recipe(&resumed).unwrap(), persisted);
+            assert!(enqueue_terminal_continuation("cook", "run-2").unwrap());
+
+            let mut conflicting = retry_plan;
+            conflicting.plan_id = "different".to_string();
+            assert!(record_recipe_attempt("cook", 2, "run-2", &conflicting).is_err());
+        });
+    }
+
+    #[test]
+    fn malformed_recipe_is_reported_by_status_without_executing_work() {
+        crate::test_support::with_isolated_home(|_| {
+            let (_, plan) = persist_recipe_run();
+            let aggregate = succeeded_aggregate(&plan);
+            crate::core::agent_task_lifecycle::record_run_aggregate("run", &plan, &aggregate)
+                .unwrap();
+            fs::write(recipe_path("cook").unwrap(), b"not json").unwrap();
+
+            let record = crate::core::agent_task_lifecycle::status("run").unwrap();
+
+            assert_eq!(
+                record.metadata["cook_continuation_scheduler"]["status"],
+                "failed"
+            );
+            assert!(record.metadata["cook_continuation_scheduler"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("malformed durable cook recipe"));
+            assert!(claim_continuation().unwrap().is_none());
+        });
+    }
+}

--- a/src/core/agent_task_service/execution.rs
+++ b/src/core/agent_task_service/execution.rs
@@ -201,8 +201,39 @@ where
 
 pub fn run_next<E>(executor: E) -> Result<AgentTaskRunResult<Option<AgentTaskAggregate>>>
 where
-    E: AgentTaskExecutorAdapter,
+    E: AgentTaskExecutorAdapter + Clone,
 {
+    run_next_with_cook_dispatcher(executor, |_| Ok(None))
+}
+
+pub fn run_next_with_cook_dispatcher<E>(
+    executor: E,
+    dispatcher: impl FnOnce(
+        &Value,
+    ) -> Result<
+        Option<std::sync::Arc<dyn super::cook::AgentTaskCookAttemptDispatcher>>,
+    >,
+) -> Result<AgentTaskRunResult<Option<AgentTaskAggregate>>>
+where
+    E: AgentTaskExecutorAdapter + Clone,
+{
+    if let Some(claim) = super::claim_continuation()? {
+        let cook_id = claim.continuation().cook_id.clone();
+        let run_id = claim.continuation().run_id.clone();
+        let exit_code = super::consume_claimed_with_dispatcher(claim, dispatcher, |options| {
+            super::run_cook(options, executor.clone()).map(|result| result.exit_code)
+        })?;
+        let latest_run_id = agent_task_lifecycle::cook_index(&cook_id)
+            .map(|index| index.latest_run_id)
+            .unwrap_or(run_id);
+        let aggregate = agent_task_lifecycle::read_aggregate(&latest_run_id).ok();
+        return Ok(AgentTaskRunResult {
+            value: aggregate.map(|aggregate| {
+                crate::core::agent_task_artifacts::reviewer_facing_aggregate(&aggregate)
+            }),
+            exit_code,
+        });
+    }
     let Some(record) = agent_task_lifecycle::claim_next_queued_run()? else {
         return Ok(AgentTaskRunResult {
             value: None,

--- a/src/core/agent_task_service/mod.rs
+++ b/src/core/agent_task_service/mod.rs
@@ -6,12 +6,14 @@
 //! `crate::core::agent_task_service::*` unchanged.
 
 mod cook;
+mod cook_recipe;
 mod discovery;
 mod execution;
 mod reconcile;
 mod status_support;
 
 pub use cook::*;
+pub use cook_recipe::*;
 pub use discovery::*;
 pub use execution::*;
 pub use reconcile::*;

--- a/src/core/agent_task_service/tests.rs
+++ b/src/core/agent_task_service/tests.rs
@@ -683,6 +683,7 @@ fn discovery_runner_backed_run_emits_runner_scoped_commands() {
     });
 }
 
+#[derive(Clone)]
 struct SucceedingExecutor;
 
 impl AgentTaskExecutorAdapter for SucceedingExecutor {

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -367,11 +367,11 @@ pub mod service {
         evidence_ref_task_id, hydrate_evidence_ref, hydrate_evidence_summary, logs,
         normalize_plan_workspaces, offloaded_status_remediation,
         persist_provider_boundary_replay_evidence, promotion_source, read_plan, resume, retry,
-        run_cook, run_loaded_plan, run_next, run_status, run_submitted, run_submitted_with_timeout,
-        source_worktree_path, status, submit_plan_spec, AgentTaskCookAttemptReport,
-        AgentTaskCookReport, AgentTaskCookServiceOptions, AgentTaskDiscoveryCommands,
-        AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter, AgentTaskDiscoveryReport,
-        AgentTaskDiscoveryRun, AgentTaskHydratedEvidence, AgentTaskRetryServiceResult,
-        AgentTaskRunResult,
+        run_cook, run_loaded_plan, run_next, run_next_with_cook_dispatcher, run_status,
+        run_submitted, run_submitted_with_timeout, source_worktree_path, status, submit_plan_spec,
+        AgentTaskCookAttemptReport, AgentTaskCookReport, AgentTaskCookServiceOptions,
+        AgentTaskDiscoveryCommands, AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter,
+        AgentTaskDiscoveryReport, AgentTaskDiscoveryRun, AgentTaskHydratedEvidence,
+        AgentTaskRetryServiceResult, AgentTaskRunResult,
     };
 }


### PR DESCRIPTION
## Summary
Persist complete versioned cook recipes before provider handoff and let the normal controller queue resume terminal cooks exactly once after restart.

## What changed
- Adds owner-only recipe persistence, canonical continuation states, atomic claim/reclaim, malformed diagnostics, exact retry-plan append, Lab dispatcher round-trip, and run-next continuation consumption.

## How to test
1. Run `cargo test --locked agent_task_service::cook_recipe --lib -- --test-threads=1`; expect All durable recipe, queue, replay, malformed, cancellation, concurrency, and status-only tests pass..
2. Run `cargo test --locked agent_task_lifecycle --lib -- --test-threads=1`; expect All lifecycle reconciliation tests pass..
3. Run `cargo test --locked agent_task_controller_service --lib -- --test-threads=1`; expect All controller queue tests pass..
4. Run `cargo test --locked promotion_review --lib -- --test-threads=1`; expect Promotion compatibility tests pass..
5. Run `cargo check --locked`; expect The locked workspace compiles..

## Compatibility
No extension path or public CLI input is removed. Existing local cooks remain local; Lab cooks persist and reconstruct their exact transport. Malformed/unknown recipes fail closed with durable diagnostics.

## Evidence
- CI expected: Repository CI
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8363
- cargo-check: Passed
- controller-tests: Passed
- cook-tests: Passed
- diff-check: Passed
- format: Passed
- lab-dispatch-roundtrip: Passed
- lifecycle-tests: Passed
- promotion-review: Passed
- recipe-tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** OpenCode recovery agents drafted the initial durable recipe and queue; openai/gpt-5.6-sol completed the scheduler contract, Lab transport reconstruction, replay safety, production review, and deterministic coverage. Chris reviewed and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8363
