### PR TITLE
fix(release): fail closed when release plans against a stale checkout

### DIFF
--- a/src/core/release/planner.rs
+++ b/src/core/release/planner.rs
@@ -77,6 +77,14 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
                 .flatten()
         });
 
+        // A stale checkout whose HEAD still sits at the latest tag while its
+        // upstream is ahead would report `release-already-at-head` and silently
+        // skip genuinely-releasable work. Fail closed with an actionable refresh
+        // hint instead of skipping. (#7945 / #7435)
+        if let Some(ref tag) = release_already_at_head {
+            guard_stale_primary_at_head(component_id, &release_scope.git_root, tag)?;
+        }
+
         if let Some(skip_plan) = release_skip_plan(
             component_id,
             options,
@@ -192,6 +200,41 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
         semver_recommendation,
         warnings,
         hints,
+    ))
+}
+
+/// Fail closed when a checkout reports `release-already-at-head` only because it
+/// is stale — HEAD sits at the latest tag while its upstream is ahead.
+///
+/// Without this guard, `homeboy release` plans against a registered primary that
+/// is behind `origin/<branch>` and silently skips (or reports `bump: none`),
+/// hiding genuinely-releasable merged work. The check uses **local** tracking
+/// refs (no network fetch), so it never slows planning or breaks offline and
+/// materialized-checkout flows; it only fires when git already knows the
+/// checkout is behind. (#7945 / #7435)
+fn guard_stale_primary_at_head(component_id: &str, git_root: &str, tag: &str) -> Result<()> {
+    let Ok(snapshot) = crate::core::git::get_repo_snapshot(git_root) else {
+        return Ok(());
+    };
+
+    let behind = snapshot.behind.unwrap_or(0);
+    if behind == 0 {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "release-stale-checkout",
+        format!(
+            "Refusing to skip `{component_id}` as release-already-at-head: the checkout HEAD is at tag {tag} but its upstream ({branch}) is {behind} commit(s) ahead. Planning against this stale checkout would hide releasable merged work.",
+            branch = snapshot.branch,
+        ),
+        None,
+        Some(vec![
+            format!(
+                "Refresh the checkout to its upstream, then rerun: git -C {git_root} pull --ff-only && homeboy release {component_id}"
+            ),
+            "If you intend to release exactly this commit, check out the ref you want to release before planning.".to_string(),
+        ]),
     ))
 }
 
@@ -378,5 +421,83 @@ mod tests {
             entries,
             entry_count,
         }
+    }
+
+    use std::path::Path;
+    use std::process::Command;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git command runs");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// Build a local clone whose HEAD is at `v1.0.0` and an "origin" that is
+    /// `extra_upstream_commits` ahead, then update tracking refs without
+    /// checking out. Returns the local clone path.
+    fn stale_checkout_fixture(root: &Path, extra_upstream_commits: usize) -> std::path::PathBuf {
+        let origin = root.join("origin");
+        let local = root.join("local");
+        std::fs::create_dir_all(&origin).expect("origin dir");
+
+        git(&origin, &["init", "-b", "main"]);
+        git(&origin, &["config", "user.email", "t@example.com"]);
+        git(&origin, &["config", "user.name", "T"]);
+        std::fs::write(origin.join("f.txt"), "0\n").expect("seed file");
+        git(&origin, &["add", "."]);
+        git(&origin, &["commit", "-m", "release: v1.0.0"]);
+        git(&origin, &["tag", "v1.0.0"]);
+
+        git(
+            &origin,
+            &["clone", ".", local.to_str().expect("local path")],
+        );
+        git(&local, &["config", "user.email", "t@example.com"]);
+        git(&local, &["config", "user.name", "T"]);
+
+        for index in 0..extra_upstream_commits {
+            std::fs::write(origin.join("f.txt"), format!("{}\n", index + 1)).expect("write");
+            git(&origin, &["add", "."]);
+            git(&origin, &["commit", "-m", &format!("feat: change {index}")]);
+        }
+
+        // Update tracking refs locally (no working-tree move): the local clone
+        // now knows origin/main is ahead while HEAD stays at v1.0.0.
+        git(&local, &["fetch", "origin"]);
+        local
+    }
+
+    #[test]
+    fn guard_fails_closed_when_checkout_is_behind_upstream() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let local = stale_checkout_fixture(dir.path(), 2);
+
+        let result = guard_stale_primary_at_head("demo", local.to_str().expect("path"), "v1.0.0");
+        let error = result.expect_err("behind checkout must fail closed");
+        assert!(
+            error.message.contains("stale") || error.message.contains("ahead"),
+            "error should explain the stale checkout, got: {}",
+            error.message
+        );
+    }
+
+    #[test]
+    fn guard_allows_checkout_at_upstream_head() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        // Zero extra upstream commits: HEAD == origin/main, genuinely at head.
+        let local = stale_checkout_fixture(dir.path(), 0);
+
+        assert!(
+            guard_stale_primary_at_head("demo", local.to_str().expect("path"), "v1.0.0").is_ok(),
+            "an up-to-date checkout at the tag must still skip cleanly"
+        );
     }
 }


### PR DESCRIPTION
## Summary
`homeboy release` plans against the registered primary checkout. When that checkout's HEAD still sits at the latest tag while its upstream is ahead — a **stale primary** that wasn't refreshed after a merge — the planner correctly computes `tag_commit == head_commit` and emits `release-already-at-head` / `bump: none`, **silently skipping genuinely-releasable merged work**.

This is the shared root cause of two reports:
- **#7945** — `extrachill-community` primary was `behind 1`, HEAD literally at `v1.20.0`; release reported `Invalid bump type: none`.
- **#7435** — `extrachill-users` primary at `v0.23.0` with 2 unreleased `feat:` commits upstream; release skipped as `release-already-at-head` while `homeboy changes` correctly listed the 2 commits.

(The #7435 report hypothesized a version-string comparison; the actual code already compares commits — the real trigger is the stale checkout. See issue comment.)

## Fix
- When `release-already-at-head` would fire, `guard_stale_primary_at_head` inspects the checkout's **local** tracking refs via `get_repo_snapshot` (no network fetch) and **fails closed** with an actionable refresh hint when the checkout is behind its upstream.
- Up-to-date checkouts at the tag still skip cleanly; checkouts without an upstream (offline / materialized) are unaffected — the guard is a no-op there.

## Why local (no fetch)
Planning must stay fast and work offline / in materialized checkouts. The guard only fires when git **already knows** the checkout is behind (`@{upstream}` tracking refs), which covers the reported cases without adding a network round-trip to every release.

## Tests
- New git-fixture tests: `guard_fails_closed_when_checkout_is_behind_upstream` (2 commits ahead → error) and `guard_allows_checkout_at_upstream_head` (0 ahead → ok).
- `cargo fmt` clean; `cargo check --lib` passes. Full test-binary run deferred to CI per repo policy.

Fixes #7945
Fixes #7435