### PR TITLE
fix(release): import guard_stale_primary_at_head in planner tests (red build)

### DIFF
--- a/src/core/release/planner.rs
+++ b/src/core/release/planner.rs
@@ -274,6 +274,7 @@ fn apply_oversized_patch_release_policy(
 #[cfg(test)]
 mod tests {
     use super::apply_oversized_patch_release_policy;
+    use super::guard_stale_primary_at_head;
     use crate::core::release::types::{
         ReleaseChangelogPlan, ReleaseSemverCommit, ReleaseSemverRecommendation,
     };


### PR DESCRIPTION
## Summary
One-line fix for a **red test build on `main`**: the `release::planner` test module calls `guard_stale_primary_at_head` but never imported it.

## The bug
`guard_stale_primary_at_head` is defined at `planner.rs:215` and used in production at `:85`. The `#[cfg(test)] mod tests` block calls it at lines 483 and 499, but its `use` list only had `super::apply_oversized_patch_release_policy` — the `guard_stale_primary_at_head` import was missing. This left `cargo check --lib --tests` / `cargo test` failing on a clean `origin/main`:

```
error[E0425]: cannot find function `guard_stale_primary_at_head` in this scope
  --> src/core/release/planner.rs:483:22 and :499:13
```

## Fix
Add `use super::guard_stale_primary_at_head;` to the test module.

## Verification
- `cargo check --lib --tests`: clean (0 errors) with the import added.
- Found incidentally while running the full test-build check during a god-file decomposition (#8383) — the errors reproduce on a stashed clean base, confirming they're pre-existing and unrelated to that refactor.