### PR TITLE
Fix detached Lab cook ownership

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -379,7 +379,10 @@ pub(crate) fn reconstruct_cook_attempt_dispatcher(
         )?,
         detach_after_handoff: decode_cook_dispatch_field(
             "detach_after_handoff",
-            value("detach_after_handoff")?,
+            recipe
+                .get("detach_after_handoff")
+                .cloned()
+                .unwrap_or_else(|| serde_json::json!(false)),
         )?,
         source_path: decode_cook_dispatch_field("source_path", value("source_path")?)?,
         job_overrides: runners::LabJobOverrides {

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -36,6 +36,16 @@ fn lab_cook_dispatcher_recipe_round_trips_exact_transport() {
         .expect("Lab dispatcher reconstructed");
 
     assert_eq!(reconstructed.durable_recipe().unwrap(), recipe);
+
+    let mut legacy_recipe = recipe;
+    legacy_recipe
+        .as_object_mut()
+        .expect("dispatcher recipe")
+        .remove("detach_after_handoff");
+    let legacy = reconstruct_cook_attempt_dispatcher(&legacy_recipe)
+        .unwrap()
+        .expect("legacy Lab dispatcher reconstructed");
+    assert_eq!(legacy.durable_recipe().unwrap()["detach_after_handoff"], false);
 }
 
 #[test]

--- a/crates/homeboy-core/src/agent_task_service/cook.rs
+++ b/crates/homeboy-core/src/agent_task_service/cook.rs
@@ -189,6 +189,29 @@ where
         }
         agent_task_lifecycle::record_cook_attempt(&cook_id, attempt, &run_id)?;
         let record = agent_task_lifecycle::status(&run_id)?;
+        if record.state == agent_task_lifecycle::AgentTaskRunState::Running
+            && record.runner_job_id().is_some()
+        {
+            // A detached runner handoff has durably accepted the provider
+            // child. Its daemon owns timeout and provider rotation; this
+            // controller returns without attempting to read a future aggregate.
+            attempts.push(AgentTaskCookAttemptReport {
+                attempt,
+                run_id: run_id.clone(),
+                run_state: format!("{:?}", record.state),
+                aggregate_path: record.aggregate_path,
+                promotion: None,
+                feedback: None,
+            });
+            return Ok(cook_report(
+                cook_id,
+                "in_flight",
+                attempts,
+                None,
+                Some("provider attempt accepted by the runner daemon".to_string()),
+                0,
+            ));
+        }
         let plan = agent_task_lifecycle::load_plan_for_execution(&run_id)?;
         budget_limit.get_or_insert_with(|| plan.options.execution_budget.clone());
         let aggregate = agent_task_lifecycle::read_aggregate(&run_id)?;
@@ -1173,6 +1196,9 @@ fn source_spec_path(spec: &str) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent_task::{
+        AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
+    };
     use crate::agent_task_finalization::{
         AgentTaskPrDurableGateProof, AgentTaskPrFinalizationBackend, AgentTaskPrRef,
     };
@@ -1204,6 +1230,119 @@ mod tests {
             format!("{retry_attempt:?}"),
             "HarvestExecutionContext { source_snapshot: None, lab_offload: None }"
         );
+    }
+
+    #[derive(Debug)]
+    struct AcceptedDetachedAttemptDispatcher;
+
+    impl AgentTaskCookAttemptDispatcher for AcceptedDetachedAttemptDispatcher {
+        fn durable_recipe(&self) -> Result<Value> {
+            Ok(serde_json::json!({ "kind": "test-detached" }))
+        }
+
+        fn dispatch_attempt(
+            &self,
+            plan: AgentTaskPlan,
+            run_id: &str,
+            _derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+        ) -> Result<()> {
+            agent_task_lifecycle::submit_plan(&plan, Some(run_id))?;
+            agent_task_lifecycle::record_detached_lab_run(
+                agent_task_lifecycle::DetachedLabRunRecord {
+                    run_id,
+                    runner_id: "fixture-lab",
+                    runner_job_id: "accepted-daemon-job",
+                    remote_workspace: "/runner/workspace",
+                    remote_command: &["homeboy".to_string(), "agent-task".to_string()],
+                },
+            )?;
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct UnusedExecutor;
+
+    impl AgentTaskExecutorAdapter for UnusedExecutor {
+        fn execute(
+            &self,
+            _request: crate::agent_task::AgentTaskRequest,
+            _context: crate::agent_task_scheduler::AgentTaskExecutionContext,
+        ) -> crate::agent_task::AgentTaskOutcome {
+            panic!("accepted detached attempts must remain daemon-owned")
+        }
+    }
+
+    #[test]
+    fn cook_returns_after_accepted_detached_attempt_without_waiting_for_daemon_completion() {
+        crate::test_support::with_isolated_home(|_| {
+            let run_id = "cook-detached-attempt-1";
+            let plan = AgentTaskPlan::new(
+                "cook-detached",
+                vec![AgentTaskRequest {
+                    schema: crate::agent_task::AGENT_TASK_REQUEST_SCHEMA.to_string(),
+                    task_id: "provider".to_string(),
+                    group_key: None,
+                    parent_plan_id: None,
+                    executor: AgentTaskExecutor {
+                        backend: "fixture".to_string(),
+                        selector: None,
+                        runtime_selection: None,
+                        required_capabilities: Vec::new(),
+                        secret_env: Vec::new(),
+                        model: None,
+                        config: Value::Null,
+                    },
+                    instructions: "complete the task".to_string(),
+                    inputs: Value::Null,
+                    source_refs: Vec::new(),
+                    workspace: AgentTaskWorkspace::default(),
+                    component_contracts: Vec::new(),
+                    policy: AgentTaskPolicy::default(),
+                    limits: AgentTaskLimits::default(),
+                    expected_artifacts: Vec::new(),
+                    artifact_declarations: Vec::new(),
+                    metadata: Value::Null,
+                }],
+            );
+            let result = run_cook(
+                AgentTaskCookServiceOptions {
+                    cook_id: "cook-detached".to_string(),
+                    initial_run_id: run_id.to_string(),
+                    initial_plan: plan,
+                    to_worktree: "fixture@detached".to_string(),
+                    source_worktree_path: None,
+                    provider_command: None,
+                    provider_invocation: None,
+                    gates: VerifyGateOptions::default(),
+                    max_attempts: 1,
+                    no_finalize: true,
+                    base: "main".to_string(),
+                    task_base_sha: None,
+                    head: None,
+                    title: "Detached cook".to_string(),
+                    commit_message: "test".to_string(),
+                    source_refs: Vec::new(),
+                    protected_branches: Vec::new(),
+                    ai_tool: "test".to_string(),
+                    ai_model: None,
+                    ai_used_for: "test".to_string(),
+                    attempt_dispatcher: Some(Arc::new(AcceptedDetachedAttemptDispatcher)),
+                    harvest_context: Default::default(),
+                },
+                UnusedExecutor,
+            )
+            .expect("accepted detached cook returns");
+
+            assert_eq!(result.exit_code, 0);
+            assert_eq!(result.value.status, "in_flight");
+            assert_eq!(result.value.attempts.len(), 1);
+            assert_eq!(result.value.attempts[0].run_id, run_id);
+            let record = agent_task_lifecycle::status(run_id).expect("detached attempt record");
+            assert_eq!(record.state, agent_task_lifecycle::AgentTaskRunState::Running);
+            assert_eq!(record.runner_id(), Some("fixture-lab"));
+            assert_eq!(record.runner_job_id(), Some("accepted-daemon-job"));
+        });
     }
 
     #[derive(Default)]

--- a/crates/homeboy-core/src/runner/execution/tests/handoff.rs
+++ b/crates/homeboy-core/src/runner/execution/tests/handoff.rs
@@ -631,6 +631,20 @@ fn direct_daemon_detached_handoff_returns_while_the_workload_remains_running() {
             matches!(job.status, JobStatus::Queued | JobStatus::Running),
             "detached handoff returned only after workload completion"
         );
+        let active_jobs: Value = client
+            .get(format!("{daemon_url}/jobs"))
+            .send()
+            .expect("list daemon jobs")
+            .json()
+            .expect("decode daemon jobs");
+        assert!(
+            active_jobs["data"]["body"]["active_runner_jobs"]
+                .as_array()
+                .expect("typed active jobs")
+                .iter()
+                .any(|summary| { summary["job_id"] == job_id && summary["runner_id"] == "lab" }),
+            "accepted daemon child must be visible through the typed runner projection"
+        );
         let events = fetch_daemon_events(&client, &daemon_url, &job_id)
             .expect("live daemon events while workload is blocked");
         let progress = events
@@ -647,6 +661,22 @@ fn direct_daemon_detached_handoff_returns_while_the_workload_remains_running() {
 
         std::fs::write(&release, "release").expect("release workload");
         wait_for_terminal_daemon_job(&client, &daemon_url, &job_id);
+        let terminal_jobs: Value = client
+            .get(format!("{daemon_url}/jobs"))
+            .send()
+            .expect("list terminal daemon jobs")
+            .json()
+            .expect("decode terminal daemon jobs");
+        assert_eq!(
+            terminal_jobs["data"]["body"]["jobs"]
+                .as_array()
+                .expect("typed jobs")
+                .iter()
+                .filter(|job| job["id"] == job_id)
+                .count(),
+            1,
+            "the terminal daemon child must retain one durable typed job projection"
+        );
     });
 }
 


### PR DESCRIPTION
## Summary

- complete #8407's accepted Lab handoff by making controller-owned cook return `in_flight` instead of reading an aggregate that the daemon has not produced yet
- retain the accepted attempt and runner-job identity in the cook report while timeout and provider rotation remain daemon-owned
- preserve compatibility for durable dispatcher recipes created before `detach_after_handoff` was persisted by defaulting the missing field to `false`
- cover accepted detached cook behavior plus active and exactly-once terminal typed `/jobs` projection

Fixes #8385.

## How to test

1. Run `cargo check`.
2. Run `cargo test -p homeboy-core cook_returns_after_accepted_detached_attempt_without_waiting_for_daemon_completion --lib`.
3. Run `cargo test -p homeboy-core direct_daemon_detached_handoff_returns_while_the_workload_remains_running --lib`.
4. Run `cargo test -p homeboy-cli lab_cook_dispatcher_recipe_round_trips_exact_transport --lib`.
5. Confirm the cook test returns `in_flight` with one accepted attempt without invoking the local executor.
6. Confirm the handoff test sees the accepted active job under its configured runner and one terminal typed job after completion.

`cargo check` passes on the current extracted `homeboy-cli`/`homeboy-core` layout. The three focused tests passed immediately before the crate extraction. Current `main` test targets are independently blocked by #8400 while the extracted test-only imports, fixtures, and visibility boundaries are repaired; CI is the authoritative branch gate meanwhile.

## Compatibility

Existing durable Lab dispatcher recipes without `detach_after_handoff` deserialize with `false`, preserving foreground behavior. Explicit detached cooks now return after accepted handoff while the daemon continues the persisted provider budget. No extension or runtime-specific contract is introduced.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode and Homeboy
- **Used for:** Diagnosed the detached lifecycle regression, implemented and reviewed the fix and deterministic coverage, reconciled concurrent upstream ownership fixes and crate extractions, and orchestrated verification and PR finalization; Chris reviews and owns the change.