### PR TITLE
Fix runner job identity and detached cook handoff

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -289,6 +289,7 @@ fn run_split_placement_cook(
         allow_local_fallback: cli.placement.allows_local_fallback(),
         allow_dirty_lab_workspace: cli.allow_dirty_lab_workspace,
         skip_deps_hydration: cli.skip_deps_hydration,
+        detach_after_handoff: cli.detach_after_handoff,
         source_path,
         job_overrides: lab_job_overrides(cli)?,
     });
@@ -319,6 +320,7 @@ struct LabCookAttemptDispatcher {
     allow_local_fallback: bool,
     allow_dirty_lab_workspace: bool,
     skip_deps_hydration: bool,
+    detach_after_handoff: bool,
     source_path: Option<PathBuf>,
     job_overrides: runners::LabJobOverrides,
 }
@@ -375,6 +377,10 @@ pub(crate) fn reconstruct_cook_attempt_dispatcher(
             "skip_deps_hydration",
             value("skip_deps_hydration")?,
         )?,
+        detach_after_handoff: decode_cook_dispatch_field(
+            "detach_after_handoff",
+            value("detach_after_handoff")?,
+        )?,
         source_path: decode_cook_dispatch_field("source_path", value("source_path")?)?,
         job_overrides: runners::LabJobOverrides {
             env: decode_cook_dispatch_field("job_overrides.env", overrides["env"].clone())?,
@@ -422,6 +428,7 @@ impl crate::core::agent_task_service::AgentTaskCookAttemptDispatcher for LabCook
             "allow_local_fallback": self.allow_local_fallback,
             "allow_dirty_lab_workspace": self.allow_dirty_lab_workspace,
             "skip_deps_hydration": self.skip_deps_hydration,
+            "detach_after_handoff": self.detach_after_handoff,
             "source_path": self.source_path,
             "job_overrides": {
                 "env": self.job_overrides.env,
@@ -480,7 +487,7 @@ impl crate::core::agent_task_service::AgentTaskCookAttemptDispatcher for LabCook
                 mutation_flag: None,
                 timeout: None,
                 active_run_id: Some(run_id),
-                detach_after_handoff: false,
+                detach_after_handoff: self.detach_after_handoff,
                 output_file_requested: false,
                 read_only_polling: false,
                 require_controller_git_bundle: false,
@@ -534,14 +541,7 @@ impl crate::core::agent_task_service::AgentTaskCookAttemptDispatcher for LabCook
                     self.runner_id
                 )]),
             )),
-            LabRouteOutcome::InFlight(_) => Err(Error::validation_invalid_argument(
-                "agent-task cook attempt",
-                format!("Lab handoff for provider attempt {run_id} is still in flight"),
-                Some(run_id.to_string()),
-                Some(vec![format!(
-                    "Inspect the controller-owned attempt with `homeboy agent-task status {run_id}`."
-                )]),
-            )),
+            LabRouteOutcome::InFlight(_) => Ok(()),
         }
     }
 }

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -18,6 +18,7 @@ fn lab_cook_dispatcher_recipe_round_trips_exact_transport() {
         allow_local_fallback: true,
         allow_dirty_lab_workspace: false,
         skip_deps_hydration: true,
+        detach_after_handoff: true,
         source_path: Some(PathBuf::from("/controller/source")),
         job_overrides: runners::LabJobOverrides {
             env: [("MODE".to_string(), "test".to_string())].into(),

--- a/crates/homeboy-core/src/api_jobs/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/mod.rs
@@ -9,6 +9,7 @@ pub use remote_runner::{
     RunnerJobLifecycleMetadata,
 };
 pub(crate) use store::LocalChildStartDiscriminator;
+pub(crate) use store::LocalRunnerJob;
 pub use store::{JobHandle, JobRunner, JobStore};
 pub use summary::active_runner_job_run_summary;
 pub use types::{
@@ -117,6 +118,47 @@ mod tests {
         assert_eq!(jobs.len(), 2);
         assert_eq!(jobs[0].id, first.id);
         assert_eq!(jobs[1].id, second.id);
+    }
+
+    #[test]
+    fn local_runner_jobs_retain_durable_identity_in_active_projection() {
+        let store = JobStore::default();
+        let (release, wait) = std::sync::mpsc::channel::<()>();
+        let runner = store
+            .run_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
+                "runner.exec",
+                None,
+                None,
+                None,
+                Some(super::store::LocalRunnerJob {
+                    runner_id: "homeboy-lab".to_string(),
+                    command: vec!["homeboy".to_string(), "agent-task".to_string(), "run-plan".to_string()],
+                    cwd: Some("/runner/worktree".to_string()),
+                    lifecycle: Some(RunnerJobLifecycleMetadata {
+                        source: Some("runner-daemon".to_string()),
+                        kind: Some("agent-task-run-plan".to_string()),
+                        durable_run_id: Some("agent-task-durable-run".to_string()),
+                        active_child_count: None,
+                        active_cell_count: None,
+                    }),
+                }),
+                move |_job| {
+                    let _ = wait.recv();
+                    Ok(serde_json::json!({}))
+                },
+            );
+
+        let active = store.active_runner_jobs();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].job_id, runner.job_id.to_string());
+        assert_eq!(active[0].runner_id, "homeboy-lab");
+        assert_eq!(
+            active[0].durable_run_id.as_deref(),
+            Some("agent-task-durable-run")
+        );
+        assert_eq!(active[0].kind, "agent-task-run-plan");
+        release.send(()).expect("release runner job");
+        runner.handle.join().expect("runner job exits");
     }
 
     #[test]

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -385,6 +385,7 @@ impl JobStore {
                     execution_request: Some(request),
                     request: public_request,
                 }),
+                local_runner: None,
                 local_child: None,
             },
         );

--- a/crates/homeboy-core/src/api_jobs/store.rs
+++ b/crates/homeboy-core/src/api_jobs/store.rs
@@ -54,8 +54,21 @@ pub(super) struct StoredJob {
     pub(super) events: Vec<JobEvent>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) remote_runner: Option<remote_runner::StoredRemoteRunnerJob>,
+    /// Typed execution identity for a daemon-local child submitted on behalf of
+    /// a remote runner. This lets `/jobs` project the accepted runner job without
+    /// inventing a synthetic durable run ID.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) local_runner: Option<LocalRunnerJob>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) local_child: Option<LocalChildExecution>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct LocalRunnerJob {
+    pub(crate) runner_id: String,
+    pub(crate) command: Vec<String>,
+    pub(crate) cwd: Option<String>,
+    pub(crate) lifecycle: Option<super::remote_runner::RunnerJobLifecycleMetadata>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -253,6 +266,23 @@ impl JobStore {
         metadata: Option<Value>,
         path_materialization_plan: Option<PathMaterializationPlan>,
     ) -> Job {
+        self.create_with_source_snapshot_metadata_path_materialization_and_local_runner(
+            operation,
+            source_snapshot,
+            metadata,
+            path_materialization_plan,
+            None,
+        )
+    }
+
+    fn create_with_source_snapshot_metadata_path_materialization_and_local_runner(
+        &self,
+        operation: impl Into<String>,
+        source_snapshot: Option<SourceSnapshot>,
+        metadata: Option<Value>,
+        path_materialization_plan: Option<PathMaterializationPlan>,
+        local_runner: Option<LocalRunnerJob>,
+    ) -> Job {
         let now = timestamp_ms();
         let job = Job {
             id: Uuid::new_v4(),
@@ -283,6 +313,7 @@ impl JobStore {
                 job: job.clone(),
                 events: Vec::new(),
                 remote_runner: None,
+                local_runner,
                 local_child: None,
             },
         );
@@ -988,6 +1019,11 @@ impl JobStore {
                     .map(|remote| {
                         super::summary::active_runner_job_summary(&stored.job, &remote.request, now)
                     })
+                    .or_else(|| {
+                        stored.local_runner.as_ref().map(|local| {
+                            super::summary::active_local_runner_job_summary(&stored.job, local, now)
+                        })
+                    })
                     .unwrap_or_else(|| super::summary::active_daemon_job_summary(&stored.job, now))
             })
             .collect();
@@ -1156,11 +1192,38 @@ impl JobStore {
         T: Serialize + Send + 'static,
         F: FnOnce(JobHandle) -> Result<T> + Send + 'static,
     {
-        let job = self.create_with_source_snapshot_metadata_and_path_materialization_plan(
+        self.run_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
             operation,
             source_snapshot,
             metadata,
             path_materialization_plan,
+            None,
+            run,
+        )
+    }
+
+    pub(crate) fn run_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner<
+        T,
+        F,
+    >(
+        &self,
+        operation: impl Into<String>,
+        source_snapshot: Option<SourceSnapshot>,
+        metadata: Option<Value>,
+        path_materialization_plan: Option<PathMaterializationPlan>,
+        local_runner: Option<LocalRunnerJob>,
+        run: F,
+    ) -> JobRunner
+    where
+        T: Serialize + Send + 'static,
+        F: FnOnce(JobHandle) -> Result<T> + Send + 'static,
+    {
+        let job = self.create_with_source_snapshot_metadata_path_materialization_and_local_runner(
+            operation,
+            source_snapshot,
+            metadata,
+            path_materialization_plan,
+            local_runner,
         );
         self.reserve_local_child(job.id)
             .expect("new local child reservation must persist");

--- a/crates/homeboy-core/src/api_jobs/summary.rs
+++ b/crates/homeboy-core/src/api_jobs/summary.rs
@@ -2,6 +2,7 @@ use serde_json::Value;
 
 use super::persistence::request_metadata_string;
 use super::remote_runner::RemoteRunnerJobRequest;
+use super::store::LocalRunnerJob;
 use super::types::{ActiveRunnerJobRunSummary, ActiveRunnerJobSummary, Job, JobStatus};
 use crate::redaction::redact_argv_display;
 
@@ -92,6 +93,51 @@ pub(super) fn active_daemon_job_summary(job: &Job, now_ms: u64) -> ActiveRunnerJ
             .map(|expires_at| expires_at.saturating_sub(now_ms)),
         lifecycle: None,
         durable_run_id: None,
+        stale_reason: job.stale_reason.clone(),
+        lifecycle_state: Some(runner_job_lifecycle_state(job).to_string()),
+        retryable: Some(runner_job_retryable(job)),
+        active_child_count: None,
+        active_cell_count: None,
+    }
+}
+
+pub(super) fn active_local_runner_job_summary(
+    job: &Job,
+    local: &LocalRunnerJob,
+    now_ms: u64,
+) -> ActiveRunnerJobSummary {
+    let started_at_ms = job.started_at_ms.unwrap_or(job.created_at_ms);
+    let lifecycle = local.lifecycle.clone();
+    ActiveRunnerJobSummary {
+        runner_id: local.runner_id.clone(),
+        job_id: job.id.to_string(),
+        operation: job.operation.clone(),
+        source: lifecycle
+            .as_ref()
+            .and_then(|lifecycle| lifecycle.source.clone())
+            .unwrap_or_else(|| "runner-daemon".to_string()),
+        kind: lifecycle
+            .as_ref()
+            .and_then(|lifecycle| lifecycle.kind.clone())
+            .unwrap_or_else(|| job.operation.clone()),
+        status: job.status,
+        command: redact_argv_display(&local.command),
+        cwd: local.cwd.clone(),
+        started_at_ms,
+        updated_at_ms: job.updated_at_ms,
+        elapsed_ms: now_ms.saturating_sub(started_at_ms),
+        heartbeat_age_ms: now_ms.saturating_sub(job.updated_at_ms),
+        claim: super::types::JobClaimMetadata {
+            claim_id: job.claim_id.clone(),
+            claimed_by_runner_id: job.claimed_by_runner_id.clone(),
+            claimed_at_ms: job.claimed_at_ms,
+            claim_expires_at_ms: job.claim_expires_at_ms,
+        },
+        claim_expires_in_ms: job
+            .claim_expires_at_ms
+            .map(|expires_at| expires_at.saturating_sub(now_ms)),
+        lifecycle: lifecycle.clone(),
+        durable_run_id: lifecycle.and_then(|lifecycle| lifecycle.durable_run_id),
         stale_reason: job.stale_reason.clone(),
         lifecycle_state: Some(runner_job_lifecycle_state(job).to_string()),
         retryable: Some(runner_job_retryable(job)),

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -12,7 +12,8 @@ use std::time::{Duration, Instant, UNIX_EPOCH};
 use uuid::Uuid;
 
 use crate::api_jobs::{
-    DaemonActiveJobRecoveryEvidence, JobStatus, JobStore, RunnerJobLifecycleMetadata,
+    DaemonActiveJobRecoveryEvidence, JobStatus, JobStore, LocalRunnerJob,
+    RunnerJobLifecycleMetadata,
 };
 use crate::build_identity;
 use crate::error::{Error, RemoteCommandFailedDetails, Result, TargetDetails};
@@ -1611,11 +1612,17 @@ fn enqueue_exec_job(
         request.metadata.as_ref(),
     );
     let runner = job_store
-        .run_local_child_background_with_source_snapshot_metadata_and_path_materialization_plan(
+        .run_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
             operation,
             source_snapshot.clone(),
             run_ref_metadata,
             path_materialization_plan.clone(),
+            Some(LocalRunnerJob {
+                runner_id: plan.runner.id.clone(),
+                command: plan.command.clone(),
+                cwd: Some(plan.cwd.clone()),
+                lifecycle: request.lifecycle.clone(),
+            }),
             move |job| {
                 let mut plan = plan;
                 plan.env.insert(


### PR DESCRIPTION
## Summary
Retain accepted daemon-local runner identity so typed job views converge, and honor detached handoff for split-placement cooks.

## What changed
- Persist additive local runner lifecycle metadata for daemon exec jobs and project it through the typed active-job view.
- Carry detach-after-handoff through Lab cook dispatcher serialization and treat accepted in-flight handoff as successful.

## How to test
1. Run `rustfmt --edition 2021 --check <changed Rust files>`; expect All seven changed Rust files are formatted..
2. Run `cargo test -p homeboy-core local_runner_jobs -- --nocapture`; expect The accepted local runner job retains its durable identity in the active projection; currently blocked by unrelated post-extraction baseline test-path errors..
3. Run `cargo test -p homeboy lab_cook_dispatcher_recipe_round_trips_exact_transport -- --nocapture`; expect The cook dispatcher round-trips detach-after-handoff; currently blocked by unrelated post-extraction test-bridge errors..
4. Run `cargo test -p homeboy-core runs_list_includes_active_runner_jobs -- --nocapture`; expect The runs list includes active typed runner jobs; currently blocked by unrelated post-extraction baseline test-path errors..

## Compatibility
The durable job-store field is additive and serde-defaulted, so existing stores remain readable. The CLI change restores the documented detach-after-handoff behavior.

## Evidence
- CI expected: Repository CI full test suite after the upstream extraction test paths are repaired
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8126
- changed-files-format: Passed
- diff-check: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Investigated the runner control-plane failure, implemented the repair and deterministic tests, resolved two upstream refactor rebases, and prepared verification evidence with Chris.

## Source relationships
- Closes #8126
