### PR TITLE
Attach retained Lab artifacts after controller plan loss

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/tests/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/exec.rs
@@ -552,6 +552,11 @@ fn runner_exec_promotes_offloaded_artifacts_from_runner_path() {
             std::fs::read_to_string(&artifacts[0].path).unwrap(),
             "runner output"
         );
+        assert_eq!(artifacts[0].size_bytes, Some(13));
+        assert_eq!(
+            artifacts[0].sha256.as_deref(),
+            Some("c147fa5423d1086ceaa8443d0485bd39777952ce61b68696c1fd15be622421a9")
+        );
     });
 }
 

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1323,16 +1323,6 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
         }
         Err(error) => return Err(error),
     };
-    if let Err(error) = store::read_plan_path(&record.plan_path) {
-        fail_missing_lab_attempt_plan(&mut record, &error)?;
-        return Err(Error::internal_io(
-            format!(
-                "cannot bind Lab runner job because durable attempt plan is unavailable: {}",
-                error.message
-            ),
-            Some(record.plan_path),
-        ));
-    }
     if matches!(
         record.state,
         AgentTaskRunState::Succeeded
@@ -1341,11 +1331,9 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
             | AgentTaskRunState::Failed
             | AgentTaskRunState::Cancelled
     ) {
-        // A retry of the controller-side handoff must not resurrect a terminal
-        // proxy. Its child identity is immutable once terminal state is known.
-        if record.runner_id() == Some(input.runner_id)
-            && record.runner_job_id() == Some(input.runner_job_id)
-        {
+        // A terminal proxy must not be resurrected. A later runner job may
+        // attach finalized evidence, but only from the original Lab runner.
+        if record.runner_id() == Some(input.runner_id) {
             return Ok(record);
         }
         return Err(Error::validation_invalid_argument(
@@ -1353,6 +1341,16 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
             format!("agent-task run '{}' is already terminal", record.run_id),
             Some(record.run_id),
             None,
+        ));
+    }
+    if let Err(error) = store::read_plan_path(&record.plan_path) {
+        fail_missing_lab_attempt_plan(&mut record, &error)?;
+        return Err(Error::internal_io(
+            format!(
+                "cannot bind Lab runner job because durable attempt plan is unavailable: {}",
+                error.message
+            ),
+            Some(record.plan_path),
         ));
     }
     record.updated_at = Some(now_timestamp());

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -727,6 +727,75 @@ fn runner_terminal_reconciliation_is_idempotent_and_preserves_execution_owner() 
 }
 
 #[test]
+fn terminal_lab_artifact_attachment_skips_missing_controller_plan_and_preserves_runner_identity() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-late-artifact",
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-original",
+            remote_workspace: "/home/lab/agent-task-runs/agent-task-late-artifact",
+            remote_command: &command,
+        })
+        .expect("running proxy");
+        let mut record = status("agent-task-late-artifact").expect("status");
+        apply_runner_job_terminal_state(
+            &mut record,
+            crate::core::api_jobs::JobStatus::Succeeded,
+            &[],
+        );
+        store::write_record(&record).expect("terminal record");
+        std::fs::remove_file(&record.plan_path).expect("remove controller plan");
+
+        let attached = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-late-artifact",
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-artifact-attach",
+            remote_workspace: "/home/lab/agent-task-runs/agent-task-late-artifact",
+            remote_command: &command,
+        })
+        .expect("late attachment leaves terminal proxy intact");
+
+        assert_eq!(attached.state, AgentTaskRunState::Succeeded);
+        assert_eq!(attached.runner_id(), Some("homeboy-lab"));
+        assert_eq!(attached.runner_job_id(), Some("job-original"));
+    });
+}
+
+#[test]
+fn terminal_lab_artifact_attachment_refuses_runner_provenance_mismatch() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-late-artifact-mismatch",
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-original",
+            remote_workspace: "/home/lab/agent-task-runs/agent-task-late-artifact-mismatch",
+            remote_command: &command,
+        })
+        .expect("running proxy");
+        let mut record = status("agent-task-late-artifact-mismatch").expect("status");
+        apply_runner_job_terminal_state(
+            &mut record,
+            crate::core::api_jobs::JobStatus::Succeeded,
+            &[],
+        );
+        store::write_record(&record).expect("terminal record");
+
+        let error = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-late-artifact-mismatch",
+            runner_id: "different-lab",
+            runner_job_id: "job-artifact-attach",
+            remote_workspace: "/home/lab/agent-task-runs/agent-task-late-artifact-mismatch",
+            remote_command: &command,
+        })
+        .expect_err("artifact provenance must retain its original runner");
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(error.details["field"], "run_id");
+    });
+}
+
+#[test]
 fn disconnected_proxy_projects_terminal_child_aggregate_once_reachable() {
     with_isolated_home(|_| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];


### PR DESCRIPTION
## Summary
Permit finalized evidence from the original Lab runner to attach to a terminal controller proxy even when its controller-local durable plan is gone.

## What changed
- Evaluate terminal proxy and runner provenance before loading the controller-local plan, preserve the original runner job identity, and add coverage for successful late attachment and runner mismatch refusal.

## How to test
1. Run `cargo check`; expect The workspace compiles successfully..
2. Run `cargo test terminal_lab_artifact_attachment`; expect Both late-attachment lifecycle tests pass after the extracted-crate test harness is repaired..
3. Run `cargo test runner_exec_promotes_offloaded_artifacts_from_runner_path`; expect The runner artifact test verifies mirrored size and SHA-256 after the extracted-crate test harness is repaired..

## Compatibility
No CLI or data-format compatibility change. Active nonterminal handoffs retain the existing durable-plan requirement; terminal attachment remains restricted to the original Lab runner.

## Evidence
- CI expected: cargo test runner\_exec\_promotes\_offloaded\_artifacts\_from\_runner\_path
- CI expected: cargo test terminal\_lab\_artifact\_attachment
- Reviewer-resolvable source evidence: https://github.com/Automattic/blocks-engine/issues/608
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8392
- cargo-check: Passed
- diff-check: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Investigated the retained-artifact failure, rebased and reviewed the implementation, and prepared deterministic coverage; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8392
