### PR TITLE
fix(core): compile homeboy-core test target after crate extraction (#8400)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,12 @@ windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage
 default = []
 slow-tests = []
 
+# Root-binary tests reuse the hermetic harness that now lives in homeboy-core.
+# Enabling the core crate's `test-support` feature for dev builds exposes
+# `homeboy_core::test_support` (re-exported as `crate::test_support`). (#8400)
+[dev-dependencies]
+homeboy-core = { version = "0.1.0", path = "crates/homeboy-core", features = ["test-support"] }
+
 [profile.dist]
 inherits = "release"
 lto = "thin"

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -12,6 +12,12 @@ publish = false
 name = "homeboy_core"
 path = "src/lib.rs"
 
+[features]
+# Exposes the hermetic `test_support` harness to dependent crates (the root
+# binary) so their tests can reuse core's isolation helpers without duplicating
+# them. Enabled as a dev-dependency feature by the root crate. (#8400)
+test-support = []
+
 [dependencies]
 homeboy-cli-contract = { version = "0.1.0", path = "../homeboy-cli-contract" }
 homeboy-error = { version = "0.1.0", path = "../homeboy-error" }

--- a/crates/homeboy-core/src/agent_runtime_manifest.rs
+++ b/crates/homeboy-core/src/agent_runtime_manifest.rs
@@ -1361,7 +1361,7 @@ mod tests {
     #[test]
     fn sample_runtime_materialization_fixture_is_plain_data() {
         let manifest: AgentRuntimeManifest = serde_json::from_str(include_str!(
-            "../../tests/fixtures/sample_runtime_materialization_manifest.json"
+            "../../../tests/fixtures/sample_runtime_materialization_manifest.json"
         ))
         .expect("sample runtime fixture parses");
 

--- a/crates/homeboy-core/src/agent_task_loop_definition.rs
+++ b/crates/homeboy-core/src/agent_task_loop_definition.rs
@@ -538,7 +538,7 @@ mod tests {
     #[test]
     fn compiles_repo_loop_entity_fanout_into_concrete_agent_tasks() {
         let spec: Value = serde_json::from_str(include_str!(
-            "../../tests/fixtures/agent_task_loop/wpsg_controller_fanout.json"
+            "../../../tests/fixtures/agent_task_loop/wpsg_controller_fanout.json"
         ))
         .expect("fixture parses");
 

--- a/crates/homeboy-core/src/browser_evidence.rs
+++ b/crates/homeboy-core/src/browser_evidence.rs
@@ -410,7 +410,7 @@ mod tests {
     #[test]
     fn validates_synthetic_browser_origin_fixture() {
         let payload: Value = serde_json::from_str(include_str!(
-            "../../tests/fixtures/browser_origin_evidence/synthetic-origin.json"
+            "../../../tests/fixtures/browser_origin_evidence/synthetic-origin.json"
         ))
         .expect("synthetic browser origin fixture should be valid JSON");
 

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -16,7 +16,9 @@ pub use policy::{
     ReleaseGateConfig, ReleaseGateLocalHotPolicy, RELEASE_GATE_LOCAL_HOT_ENV,
 };
 
-#[cfg(test)]
+// Available to the shared test harness under the `test-support` feature, not
+// just this crate's own `#[cfg(test)]` builds. (#8400)
+#[cfg(any(test, feature = "test-support"))]
 pub(crate) use io::reset_config_cache_for_test;
 
 pub(crate) use builtins::deploy_generated_build_dir;

--- a/crates/homeboy-core/src/defaults/io.rs
+++ b/crates/homeboy-core/src/defaults/io.rs
@@ -63,7 +63,7 @@ fn clear_config_cache() {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 pub(crate) fn reset_config_cache_for_test() {
     clear_config_cache();
 }

--- a/crates/homeboy-core/src/extension/component_script.rs
+++ b/crates/homeboy-core/src/extension/component_script.rs
@@ -151,7 +151,7 @@ fn run_component_scripts_with_env_and_timeout(
     })
 }
 
-pub(crate) fn run_component_scripts_with_env(
+pub fn run_component_scripts_with_env(
     component: &Component,
     capability: ExtensionCapability,
     source_path: &Path,
@@ -282,12 +282,13 @@ fn command_with_args(command: &str, script_args: &[String]) -> String {
     )
 }
 
-pub(crate) fn source_path(component: &Component, path_override: Option<&str>) -> PathBuf {
+pub fn source_path(component: &Component, path_override: Option<&str>) -> PathBuf {
     path_override
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from(&component.local_path))
 }
 
-#[cfg(test)]
-#[path = "../../../../tests/core/extension/component_script_test.rs"]
-mod component_script_test;
+// The command-layer integration test for component scripts
+// (`tests/core/extension/component_script_test.rs`) drives `crate::commands::…`
+// and therefore lives in the root binary's test tree, not this crate. It is
+// included from `src/commands/test.rs`. (#8400)

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -148,11 +148,16 @@ pub use homeboy_lab_contract::path_materialization;
 pub mod performance_hotspots;
 pub mod phase_timing;
 pub mod plan;
+// Shared hermetic test helpers. Compiled for this crate's own tests and, via the
+// `test-support` feature, exposed to dependent crates (the root binary) whose
+// tests reuse the same isolation harness. (#8400)
 pub mod preview_client;
 pub mod preview_consumer;
 pub mod preview_ingress;
 #[cfg(test)]
 mod preview_ingress_tests;
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
 // process moved to the internal `homeboy-process` crate. Re-exported so existing
 // `crate::core::process::*` call sites keep working unchanged.
 pub use homeboy_process as process;

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -107,7 +107,7 @@ impl HermeticTestContext {
             .env("HOMEBOY_RUNTIME_TMPDIR", self.runtime_dir())
             .env("TMPDIR", self.temp_dir())
             .env(
-                crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
+                crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
                 self.invocation_runtime.path(),
             )
             .env("HOMEBOY_NO_UPDATE_CHECK", "1");
@@ -151,18 +151,18 @@ pub(crate) struct AuditHomeGuard {
     _guard: MutexGuard<'static, ()>,
 }
 
-pub(crate) struct ArtifactRootOverrideGuard;
+pub struct ArtifactRootOverrideGuard;
 
 impl ArtifactRootOverrideGuard {
     pub(crate) fn new(path: PathBuf) -> Self {
-        crate::core::set_artifact_root_override(Some(path));
+        crate::set_artifact_root_override(Some(path));
         Self
     }
 }
 
 impl Drop for ArtifactRootOverrideGuard {
     fn drop(&mut self) {
-        crate::core::set_artifact_root_override(None);
+        crate::set_artifact_root_override(None);
     }
 }
 
@@ -197,10 +197,10 @@ impl HomeGuard {
         let prior_artifact_root = std::env::var("HOMEBOY_ARTIFACT_ROOT").ok();
         let prior_runtime_tmpdir = std::env::var("HOMEBOY_RUNTIME_TMPDIR").ok();
         let prior_invocation_runtime =
-            std::env::var(crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
+            std::env::var(crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
         let prior_no_update_check = std::env::var("HOMEBOY_NO_UPDATE_CHECK").ok();
         let prior_daemon_binary_sha =
-            std::env::var(crate::core::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV).ok();
+            std::env::var(crate::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV).ok();
         // The isolated HOME hosts `~/.config/homeboy/extensions/**/*.sh`
         // capability scripts that tests execute. On `noexec`-`/tmp` hosts a
         // plain `TempDir::new()` lands the whole HOME on a `noexec` mount,
@@ -215,19 +215,19 @@ impl HomeGuard {
         std::env::remove_var("HOMEBOY_ARTIFACT_ROOT");
         std::env::set_var("HOMEBOY_NO_UPDATE_CHECK", "1");
         std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", context.runtime_dir());
-        crate::core::set_artifact_root_override(None);
+        crate::set_artifact_root_override(None);
         // Pin invocation runtime to a SHORT tempdir, isolated from `$TMPDIR`
         // and from the home tempdir (which itself can already live on a long
         // path on macOS, e.g. `/var/folders/<14>/T/.tmpXXXXXX/...`). Using
         // `/tmp` directly keeps tests within the platform `sockaddr_un`
         // budget regardless of host configuration.
         std::env::set_var(
-            crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
+            crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
             context.invocation_runtime.path(),
         );
         // Avoid hashing the giant debug test binary on every daemon-state write.
         std::env::set_var(
-            crate::core::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV,
+            crate::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV,
             TEST_DAEMON_BINARY_SHA,
         );
         Self {
@@ -393,50 +393,61 @@ impl Drop for HomeGuard {
             Some(value) => std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", value),
             None => std::env::remove_var("HOMEBOY_RUNTIME_TMPDIR"),
         }
-        crate::core::set_artifact_root_override(None);
+        crate::set_artifact_root_override(None);
         match &self.prior_invocation_runtime {
             Some(value) => std::env::set_var(
-                crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
+                crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
                 value,
             ),
-            None => std::env::remove_var(
-                crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
-            ),
+            None => {
+                std::env::remove_var(crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV)
+            }
         }
         match &self.prior_no_update_check {
             Some(value) => std::env::set_var("HOMEBOY_NO_UPDATE_CHECK", value),
             None => std::env::remove_var("HOMEBOY_NO_UPDATE_CHECK"),
         }
         match &self.prior_daemon_binary_sha {
-            Some(value) => {
-                std::env::set_var(crate::core::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV, value)
-            }
-            None => std::env::remove_var(crate::core::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV),
+            Some(value) => std::env::set_var(crate::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV, value),
+            None => std::env::remove_var(crate::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV),
         }
         reset_cached_test_state();
     }
 }
 
-pub(crate) fn with_isolated_home<R>(body: impl FnOnce(&TempDir) -> R) -> R {
+pub fn with_isolated_home<R>(body: impl FnOnce(&TempDir) -> R) -> R {
     let home = HomeGuard::new();
     body(&home.context.root)
 }
 
-pub(crate) fn with_isolated_audit_home<R>(body: impl FnOnce(&TempDir) -> R) -> R {
+pub fn with_isolated_audit_home<R>(body: impl FnOnce(&TempDir) -> R) -> R {
     let guard = AuditHomeGuard::new();
     body(&guard.home.context.root)
 }
 
-#[cfg(test)]
-fn reset_cached_test_state() {
-    crate::core::defaults::reset_config_cache_for_test();
-    crate::commands::utils::entity_suggest::reset_entity_suggestion_cache_for_test();
+/// Optional command-layer cache reset hook.
+///
+/// `test_support` lives in `homeboy-core`, which must not depend upward on the
+/// CLI `commands` layer. When the root binary's tests need a command-layer
+/// cache (e.g. the entity-suggestion cache) reset during home isolation, it
+/// registers a hook via [`set_command_layer_reset_hook`]. Core's own tests do
+/// not register one, so this is a no-op there. (#8400)
+static COMMAND_LAYER_RESET_HOOK: OnceLock<fn()> = OnceLock::new();
+
+/// Register a command-layer cache reset invoked on each isolated-home setup.
+/// Idempotent: only the first registration wins.
+pub fn set_command_layer_reset_hook(hook: fn()) {
+    let _ = COMMAND_LAYER_RESET_HOOK.set(hook);
 }
 
-#[cfg(not(test))]
-fn reset_cached_test_state() {}
+fn reset_cached_test_state() {
+    crate::defaults::reset_config_cache_for_test();
+    if let Some(hook) = COMMAND_LAYER_RESET_HOOK.get() {
+        hook();
+    }
+}
 
-pub(crate) fn write_source_extension(home: &std::path::Path, id: &str, file_extension: &str) {
+pub fn write_source_extension(home: &std::path::Path, id: &str, file_extension: &str) {
     let extension_dir = home.join(".config/homeboy/extensions").join(id);
     std::fs::create_dir_all(&extension_dir).expect("extension dir");
     std::fs::write(
@@ -466,11 +477,11 @@ pub(crate) fn write_source_extension(home: &std::path::Path, id: &str, file_exte
     }
 }
 
-pub(crate) fn shared_git_repo_fixture(name: &str) -> (TempDir, PathBuf) {
+pub fn shared_git_repo_fixture(name: &str) -> (TempDir, PathBuf) {
     shared_git_repo_fixture_from_template(name, shared_empty_git_repo_template())
 }
 
-pub(crate) fn shared_committed_git_repo_fixture(name: &str) -> (TempDir, PathBuf) {
+pub fn shared_committed_git_repo_fixture(name: &str) -> (TempDir, PathBuf) {
     shared_git_repo_fixture_from_template(name, shared_committed_git_repo_template())
 }
 
@@ -520,7 +531,7 @@ fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-pub(crate) fn run_git_fixture_command(repo: &Path, args: &[&str]) {
+pub fn run_git_fixture_command(repo: &Path, args: &[&str]) {
     let output = Command::new("git")
         .args(args)
         .current_dir(repo)
@@ -554,7 +565,7 @@ fn run_git_template_command(repo: &Path, args: &[&str]) {
     );
 }
 
-pub(crate) fn git_fixture_output(repo: &Path, args: &[&str]) -> String {
+pub fn git_fixture_output(repo: &Path, args: &[&str]) -> String {
     let output = Command::new("git")
         .args(args)
         .current_dir(repo)
@@ -655,7 +666,7 @@ pub(crate) fn home_env_guard() -> MutexGuard<'static, ()> {
 }
 
 /// Serializes tests that mutate or capture process-global environment state.
-pub(crate) fn env_lock() -> MutexGuard<'static, ()> {
+pub fn env_lock() -> MutexGuard<'static, ()> {
     home_lock().lock().unwrap_or_else(|e| e.into_inner())
 }
 
@@ -672,7 +683,7 @@ fn audit_lock() -> &'static Mutex<()> {
 /// Spin up a single-shot localhost HTTP server returning `status` once, used to
 /// probe public-artifact-URL reachability. Returns the base URL ending in
 /// `/homeboy`. Shared by `runs` and `bench` artifact-viewer tests.
-pub(crate) fn serve_public_artifact_base_once(status: u16) -> String {
+pub fn serve_public_artifact_base_once(status: u16) -> String {
     use std::io::{Read, Write};
     use std::net::TcpListener;
 

--- a/crates/homeboy-core/src/tunnel_tests.rs
+++ b/crates/homeboy-core/src/tunnel_tests.rs
@@ -1024,7 +1024,7 @@ fn preview_artifact_serializes_structured_reviewer_contract() {
     let artifact = preview_artifact_for(&tunnel, &state, &context).expect("artifact");
     let serialized = serde_json::to_value(&artifact).expect("serialize artifact");
     let expected: serde_json::Value = serde_json::from_str(include_str!(
-        "../../tests/fixtures/output_contracts/tunnel/preview-artifact.json"
+        "../../../tests/fixtures/output_contracts/tunnel/preview-artifact.json"
     ))
     .expect("fixture");
 

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -519,6 +519,14 @@ fn test_observation_initial_metadata(
     })
 }
 
+// Command-layer integration test for component scripts. It drives
+// `crate::commands::test::run` and other CLI types, so it lives in the root
+// binary's test tree (moved out of homeboy-core, which cannot depend upward on
+// the command layer). (#8400)
+#[cfg(test)]
+#[path = "../../tests/core/extension/component_script_test.rs"]
+mod component_script_test;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,53 @@ pub mod help_topics;
 /// This is public so integration tests can use the same isolation contract as
 /// unit tests. It is hidden from normal API documentation and has no role in
 /// production command execution.
-#[doc(hidden)]
-#[allow(dead_code)] // Unit-test-only helpers share this module with public CLI fixtures.
-pub mod test_support;
+///
+/// The hermetic test harness now lives in `homeboy-core` (behind its
+/// `test-support` feature) so both the core crate's tests and the root binary's
+/// tests share one isolation implementation. This module re-exports it so
+/// existing `crate::test_support::*` call sites keep working, and registers the
+/// root-only command-layer cache reset hook the first time it is touched. (#8400)
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support {
+    #[doc(inline)]
+    pub use homeboy_core::test_support::{
+        env_lock, git_fixture_output, run_git_fixture_command, serve_public_artifact_base_once,
+        set_command_layer_reset_hook, shared_committed_git_repo_fixture, shared_git_repo_fixture,
+        write_source_extension, ArtifactRootOverrideGuard,
+    };
+
+    use std::sync::Once;
+    use tempfile::TempDir;
+
+    static REGISTER_COMMAND_LAYER_RESET: Once = Once::new();
+
+    /// Register the CLI-layer cache reset (entity-suggestion cache) that the
+    /// core harness cannot call directly without depending upward on
+    /// `commands`. Invoked from the isolated-home entry point below.
+    fn ensure_command_layer_reset_registered() {
+        REGISTER_COMMAND_LAYER_RESET.call_once(|| {
+            homeboy_core::test_support::set_command_layer_reset_hook(|| {
+                crate::commands::utils::entity_suggest::reset_entity_suggestion_cache_for_test();
+            });
+        });
+    }
+
+    /// Root-side wrapper around [`homeboy_core::test_support::with_isolated_home`]
+    /// that guarantees the command-layer reset hook is registered first, so the
+    /// entity-suggestion cache is cleared during root-binary test isolation.
+    pub fn with_isolated_home<R>(body: impl FnOnce(&TempDir) -> R) -> R {
+        ensure_command_layer_reset_registered();
+        homeboy_core::test_support::with_isolated_home(body)
+    }
+
+    /// Root-side wrapper around
+    /// [`homeboy_core::test_support::with_isolated_audit_home`] with the same
+    /// command-layer reset registration guarantee.
+    pub fn with_isolated_audit_home<R>(body: impl FnOnce(&TempDir) -> R) -> R {
+        ensure_command_layer_reset_registered();
+        homeboy_core::test_support::with_isolated_audit_home(body)
+    }
+}
 
 /// Helper for `#[serde(skip_serializing_if = "is_zero")]` on `usize` fields.
 pub fn is_zero(v: &usize) -> bool {

--- a/tests/core/code_audit/audit_runtime_regression_test.rs
+++ b/tests/core/code_audit/audit_runtime_regression_test.rs
@@ -67,11 +67,11 @@
 
 use std::path::PathBuf;
 
-use crate::core::code_audit::{
+use crate::code_audit::{
     self, run_main_audit_workflow, AuditProfile, AuditRunWorkflowArgs, AuditRunWorkflowResult,
     Finding,
 };
-use crate::core::engine::baseline::BaselineFlags;
+use crate::engine::baseline::BaselineFlags;
 
 /// Component id declared in the fixture's `homeboy.json`.
 const FIXTURE_COMPONENT_ID: &str = "audit-runtime-fixture";

--- a/tests/core/code_audit/detectors/thin_command_adapter_test.rs
+++ b/tests/core/code_audit/detectors/thin_command_adapter_test.rs
@@ -1,6 +1,6 @@
 use super::AuditFinding;
 use super::ThinCommandAdapterConfig;
-use crate::core::component::ThinCommandAdapterMarkerGroup;
+use crate::component::ThinCommandAdapterMarkerGroup;
 
 fn write(root: &std::path::Path, rel: &str, body: &str) {
     let path = root.join(rel);

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -1,10 +1,10 @@
-use crate::core::code_audit::report::{
+use crate::code_audit::report::{
     build_audit_summary, build_changed_since_summary, compute_fixability,
     compute_fixability_with_analysis, finding_kind_key, from_main_workflow,
     AuditChangedSinceSummary, AuditCommandOutput,
 };
-use crate::core::code_audit::test_helpers::{empty_result, make_finding};
-use crate::core::code_audit::{AuditFinding, Finding, FindingConfidence, Severity};
+use crate::code_audit::test_helpers::{empty_result, make_finding};
+use crate::code_audit::{AuditFinding, Finding, FindingConfidence, Severity};
 
 #[test]
 fn test_build_audit_summary_empty_result() {
@@ -64,7 +64,7 @@ fn test_build_audit_summary_prioritizes_warnings_in_top_findings() {
         kind: AuditFinding::DuplicateFunction,
     });
 
-    let summary = crate::core::code_audit::report::build_audit_summary(&result, 1);
+    let summary = crate::code_audit::report::build_audit_summary(&result, 1);
 
     assert_eq!(summary.top_findings[0].severity.as_deref(), Some("warning"));
     assert_eq!(
@@ -196,8 +196,8 @@ fn test_build_changed_since_summary_splits_introduced_from_context() {
         kind: AuditFinding::UnreferencedExport,
     });
 
-    let comparison = crate::core::engine::baseline::Comparison {
-        new_items: vec![crate::core::engine::baseline::NewItem {
+    let comparison = crate::engine::baseline::Comparison {
+        new_items: vec![crate::engine::baseline::NewItem {
             fingerprint: "dead_code::src/large.rs::UnreferencedExport".to_string(),
             description: "New unused export".to_string(),
             context_label: "dead_code".to_string(),
@@ -295,9 +295,8 @@ fn test_compute_fixability_counts_fixes_from_real_audit() {
     fs::write(root.join("commands/bad.rs"), "pub fn run() {}\n").unwrap();
 
     // Run a real audit
-    let result =
-        crate::core::code_audit::audit_path_with_id("fixability-test", &root.to_string_lossy())
-            .expect("audit should run");
+    let result = crate::code_audit::audit_path_with_id("fixability-test", &root.to_string_lossy())
+        .expect("audit should run");
 
     // Compute fixability
     let fixability = compute_fixability(&result);
@@ -342,10 +341,10 @@ fn test_compute_fixability_with_analysis() {
         .unwrap();
         fs::write(root.join("commands/bad.fixture"), "pub fn run() {}\n").unwrap();
 
-        let audit = crate::core::code_audit::audit_path_with_id_with_plan_and_analysis(
+        let audit = crate::code_audit::audit_path_with_id_with_plan_and_analysis(
             "fixability-context-test",
             &root.to_string_lossy(),
-            &crate::core::code_audit::AuditExecutionPlan::full(),
+            &crate::code_audit::AuditExecutionPlan::full(),
             &[],
             &["source-fixture".to_string()],
         )
@@ -439,13 +438,12 @@ fn test_finding_kind_key() {
 #[test]
 fn test_from_main_workflow() {
     let output = AuditCommandOutput::Summary(build_audit_summary(&empty_result(), 0));
-    let (output, exit_code) =
-        from_main_workflow(crate::core::code_audit::run::AuditRunWorkflowResult {
-            output,
-            exit_code: 3,
-            findings: Vec::new(),
-            timing: crate::core::code_audit::AuditTiming::default(),
-        });
+    let (output, exit_code) = from_main_workflow(crate::code_audit::run::AuditRunWorkflowResult {
+        output,
+        exit_code: 3,
+        findings: Vec::new(),
+        timing: crate::code_audit::AuditTiming::default(),
+    });
 
     assert_eq!(exit_code, 3);
     assert!(matches!(output, AuditCommandOutput::Summary(_)));

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -6,14 +6,14 @@ use super::{
     apply_finding_filters, build_comparison_output, compute_fixability_if_requested,
     default_audit_exit_code, scope_convention_outliers_to_findings, AuditRunWorkflowArgs,
 };
-use crate::core::code_audit::checks::CheckStatus;
-use crate::core::code_audit::conventions::{Deviation, Outlier};
-use crate::core::code_audit::findings::{Finding, Severity};
-use crate::core::code_audit::{
+use crate::code_audit::checks::CheckStatus;
+use crate::code_audit::conventions::{Deviation, Outlier};
+use crate::code_audit::findings::{Finding, Severity};
+use crate::code_audit::{
     AuditAnalysisContext, AuditExecutionPlan, AuditFinding, AuditProfile, AuditSummary,
     CodeAuditResult, ConventionReport, DetectorRuntime,
 };
-use crate::core::plan::PlanStepStatus;
+use crate::plan::PlanStepStatus;
 
 fn make_finding(kind: AuditFinding, file: &str) -> Finding {
     Finding {
@@ -50,8 +50,8 @@ fn make_analysis() -> AuditAnalysisContext {
     AuditAnalysisContext::default()
 }
 
-fn make_timing() -> crate::core::code_audit::AuditTiming {
-    crate::core::code_audit::AuditTiming::default()
+fn make_timing() -> crate::code_audit::AuditTiming {
+    crate::code_audit::AuditTiming::default()
 }
 
 fn make_convention_report(name: &str, outliers: Vec<Outlier>) -> ConventionReport {
@@ -98,7 +98,7 @@ fn make_args(include_fixability: bool) -> AuditRunWorkflowArgs {
         exclude_labels: vec![],
         profile: AuditProfile::Full,
         extension_overrides: vec![],
-        baseline_flags: crate::core::engine::baseline::BaselineFlags {
+        baseline_flags: crate::engine::baseline::BaselineFlags {
             baseline: false,
             ignore_baseline: false,
             ratchet: false,
@@ -126,15 +126,13 @@ fn make_changed_since_args() -> AuditRunWorkflowArgs {
     args
 }
 
-fn make_baseline(
-    known_fingerprints: Vec<&str>,
-) -> crate::core::code_audit::baseline::AuditBaseline {
-    crate::core::code_audit::baseline::AuditBaseline {
+fn make_baseline(known_fingerprints: Vec<&str>) -> crate::code_audit::baseline::AuditBaseline {
+    crate::code_audit::baseline::AuditBaseline {
         created_at: "2026-04-28T00:00:00Z".to_string(),
         context_id: "test".to_string(),
         item_count: known_fingerprints.len(),
         known_fingerprints: known_fingerprints.into_iter().map(str::to_string).collect(),
-        metadata: crate::core::code_audit::baseline::AuditBaselineMetadata {
+        metadata: crate::code_audit::baseline::AuditBaselineMetadata {
             outliers_count: 0,
             alignment_score: None,
             known_outliers: vec![],
@@ -272,7 +270,7 @@ mod full_audit_structural_complexity_tests {
 
         assert_eq!(workflow.exit_code, 0);
         match workflow.output {
-            crate::core::code_audit::report::AuditCommandOutput::Compared {
+            crate::code_audit::report::AuditCommandOutput::Compared {
                 passed,
                 baseline_comparison,
                 ..
@@ -327,12 +325,12 @@ fn changed_since_comparison_marks_existing_touched_findings_as_contextual() {
     let mut result = make_result(vec![existing_finding]);
     result.findings[0].convention = "structural".to_string();
 
-    let baseline = crate::core::code_audit::baseline::AuditBaseline {
+    let baseline = crate::code_audit::baseline::AuditBaseline {
         created_at: "2026-04-28T00:00:00Z".to_string(),
         context_id: "test".to_string(),
         item_count: 1,
         known_fingerprints: vec!["structural::src/large.rs::GodFile".to_string()],
-        metadata: crate::core::code_audit::baseline::AuditBaselineMetadata {
+        metadata: crate::code_audit::baseline::AuditBaselineMetadata {
             outliers_count: 1,
             alignment_score: None,
             known_outliers: vec!["src/large.rs".to_string()],
@@ -351,7 +349,7 @@ fn changed_since_comparison_marks_existing_touched_findings_as_contextual() {
 
     assert_eq!(workflow.exit_code, 0);
     match workflow.output {
-        crate::core::code_audit::report::AuditCommandOutput::Compared {
+        crate::code_audit::report::AuditCommandOutput::Compared {
             passed,
             changed_since,
             baseline_comparison,
@@ -361,7 +359,7 @@ fn changed_since_comparison_marks_existing_touched_findings_as_contextual() {
             assert!(baseline_comparison.new_items.is_empty());
             assert_eq!(
                 changed_since,
-                Some(crate::core::code_audit::report::AuditChangedSinceSummary {
+                Some(crate::code_audit::report::AuditChangedSinceSummary {
                     introduced_findings: 0,
                     contextual_findings: 1,
                 })
@@ -379,12 +377,12 @@ fn changed_since_comparison_counts_new_findings_as_introduced() {
     introduced_finding.convention = "dead_code".to_string();
     let result = make_result(vec![existing_finding, introduced_finding]);
 
-    let baseline = crate::core::code_audit::baseline::AuditBaseline {
+    let baseline = crate::code_audit::baseline::AuditBaseline {
         created_at: "2026-04-28T00:00:00Z".to_string(),
         context_id: "test".to_string(),
         item_count: 1,
         known_fingerprints: vec!["structural::src/large.rs::GodFile".to_string()],
-        metadata: crate::core::code_audit::baseline::AuditBaselineMetadata {
+        metadata: crate::code_audit::baseline::AuditBaselineMetadata {
             outliers_count: 1,
             alignment_score: None,
             known_outliers: vec!["src/large.rs".to_string()],
@@ -403,7 +401,7 @@ fn changed_since_comparison_counts_new_findings_as_introduced() {
 
     assert_eq!(workflow.exit_code, 1);
     match workflow.output {
-        crate::core::code_audit::report::AuditCommandOutput::Compared {
+        crate::code_audit::report::AuditCommandOutput::Compared {
             passed,
             changed_since,
             baseline_comparison,
@@ -413,7 +411,7 @@ fn changed_since_comparison_counts_new_findings_as_introduced() {
             assert_eq!(baseline_comparison.new_items.len(), 1);
             assert_eq!(
                 changed_since,
-                Some(crate::core::code_audit::report::AuditChangedSinceSummary {
+                Some(crate::code_audit::report::AuditChangedSinceSummary {
                     introduced_findings: 1,
                     contextual_findings: 1,
                 })
@@ -441,7 +439,7 @@ fn json_summary_names_baseline_known_findings_separately_from_blocking_findings(
 
     assert_eq!(workflow.exit_code, 0);
     match workflow.output {
-        crate::core::code_audit::report::AuditCommandOutput::Summary(summary) => {
+        crate::code_audit::report::AuditCommandOutput::Summary(summary) => {
             assert_eq!(summary.total_findings, 1);
             assert_eq!(summary.finding_groups.len(), 1);
 
@@ -480,7 +478,7 @@ fn json_summary_for_targeted_detector_counts_current_and_unbaselined_findings() 
 
     assert_eq!(workflow.exit_code, 1);
     match workflow.output {
-        crate::core::code_audit::report::AuditCommandOutput::Summary(summary) => {
+        crate::code_audit::report::AuditCommandOutput::Summary(summary) => {
             assert_eq!(summary.total_findings, 2);
             assert_eq!(summary.finding_groups.len(), 1);
             assert_eq!(summary.finding_groups[0].kind, "god_file");

--- a/tests/core/component/audit_test.rs
+++ b/tests/core/component/audit_test.rs
@@ -1,4 +1,4 @@
-use homeboy::core::component::{
+use crate::component::{
     AuditConfig, ConfigKeyUsageConfig, ConfigKeyUsagePattern, ConfigKeyUsageRule,
     MutatingResourceAccessConfig, PublicRegistryExposureConfig, RedirectValidationConfig,
 };

--- a/tests/core/daemon/artifact_download_test.rs
+++ b/tests/core/daemon/artifact_download_test.rs
@@ -1,6 +1,6 @@
 use super::*;
-use crate::core::observation::ArtifactRecord;
-use crate::core::observation::NewRunRecord;
+use crate::observation::ArtifactRecord;
+use crate::observation::NewRunRecord;
 use crate::test_support::HomeGuard;
 
 #[test]
@@ -49,7 +49,7 @@ fn route_serves_run_scoped_artifact_store_tokens() {
     let path = artifact_root.join(locator);
     fs::create_dir_all(path.parent().expect("artifact parent")).expect("artifact parent");
     fs::write(&path, br#"{"ok":true}"#).expect("artifact-store file");
-    let token = crate::core::runner::runner_artifact_store_token("lab", &run.id, locator)
+    let token = crate::runner::runner_artifact_store_token("lab", &run.id, locator)
         .rsplit('/')
         .next()
         .expect("artifact token")

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -10,9 +10,9 @@ use super::{
     reconcile_dead_lease_and_ensure_running_with_operations,
     reconcile_leaseless_orphan_store_with_operations,
 };
-use crate::core::api_jobs::{JobEventKind, JobStatus, JobStore};
-use crate::core::build_identity::BuildIdentity;
-use crate::core::daemon::{
+use crate::api_jobs::{JobEventKind, JobStatus, JobStore};
+use crate::build_identity::BuildIdentity;
+use crate::daemon::{
     DaemonFreshnessReport, DaemonRuntimeSnapshot, DaemonStaleReasonCode, DaemonState, DaemonStatus,
 };
 use crate::test_support::with_isolated_home;
@@ -55,9 +55,7 @@ fn record_test_local_child(store: &JobStore, job_id: uuid::Uuid, pid: u32) {
             job_id,
             pid,
             None,
-            crate::core::api_jobs::LocalChildStartDiscriminator::LinuxProcStatStarttimeTicks {
-                ticks: 1,
-            },
+            crate::api_jobs::LocalChildStartDiscriminator::LinuxProcStatStarttimeTicks { ticks: 1 },
         )
         .expect("record local child identity");
 }
@@ -71,7 +69,7 @@ fn record_test_absent_local_child(store: &JobStore, job_id: uuid::Uuid) {
             job_id,
             u32::MAX,
             None,
-            crate::core::api_jobs::LocalChildStartDiscriminator::Unsupported {
+            crate::api_jobs::LocalChildStartDiscriminator::Unsupported {
                 evidence: "test process identity unavailable".to_string(),
             },
         )
@@ -81,7 +79,7 @@ fn record_test_absent_local_child(store: &JobStore, job_id: uuid::Uuid) {
 #[test]
 fn leaseless_store_requires_missing_lease_and_no_owner_then_preserves_evidence() {
     with_isolated_home(|_| {
-        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let path = crate::paths::daemon_jobs_file().expect("jobs path");
         let store = JobStore::open_without_reconciliation(&path).expect("store");
         let job = store.create("runner.exec");
         record_test_absent_local_child(&store, job.id);
@@ -125,7 +123,7 @@ fn leaseless_store_requires_missing_lease_and_no_owner_then_preserves_evidence()
 #[test]
 fn corrupt_lease_reconciliation_terminalizes_queued_durable_agent_task_after_proof() {
     with_isolated_home(|_| {
-        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let path = crate::paths::daemon_jobs_file().expect("jobs path");
         let store = JobStore::open_without_reconciliation(&path).expect("store");
         let job = store.create("agent-task.cook");
 
@@ -167,7 +165,7 @@ fn corrupt_lease_reconciliation_terminalizes_queued_durable_agent_task_after_pro
 #[test]
 fn version_mismatched_split_view_reconciles_only_after_no_owner_proof() {
     with_isolated_home(|_| {
-        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let path = crate::paths::daemon_jobs_file().expect("jobs path");
         let store = JobStore::open_without_reconciliation(&path).expect("store");
         let job = store.create("runner.exec");
         record_test_absent_local_child(&store, job.id);
@@ -212,7 +210,7 @@ fn version_mismatched_split_view_reconciles_only_after_no_owner_proof() {
 #[test]
 fn version_mismatched_split_view_refuses_preserved_remote_claim_before_replacement() {
     with_isolated_home(|_| {
-        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let path = crate::paths::daemon_jobs_file().expect("jobs path");
         let store = JobStore::open_without_reconciliation(&path)
             .expect("store")
             .with_daemon_lease("stale-lease".to_string());
@@ -299,8 +297,7 @@ fn completed_leaseless_recovery_replays_the_exact_replacement_without_starting_a
             replacement: Some(replacement.clone()),
             replacement_startup_token: Some("fake-startup-token".to_string()),
         };
-        let path =
-            crate::core::paths::daemon_leaseless_recovery_receipt_file().expect("receipt path");
+        let path = crate::paths::daemon_leaseless_recovery_receipt_file().expect("receipt path");
         super::write_leaseless_recovery_receipt(&path, &receipt).expect("write receipt");
 
         let replay = super::replay_leaseless_recovery(&status, "127.0.0.1:0")
@@ -319,12 +316,12 @@ fn completed_leaseless_recovery_replays_the_exact_replacement_without_starting_a
 fn leaseless_store_aborts_on_ambiguous_or_live_owner_probe() {
     for probe in [
         || {
-            Err(crate::core::Error::internal_unexpected(
+            Err(crate::Error::internal_unexpected(
                 "daemon listener probe was ambiguous",
             ))
         },
         || {
-            Err(crate::core::Error::validation_invalid_argument(
+            Err(crate::Error::validation_invalid_argument(
                 "owner_probe",
                 "a Homeboy daemon listener is live",
                 None,
@@ -422,7 +419,7 @@ fn multiple_ambiguous_candidates_block_recovery_and_pid_reuse_blocks_adoption() 
 #[test]
 fn concurrent_leaseless_recovery_callers_commit_once_and_preserve_job_evidence() {
     with_isolated_home(|_| {
-        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let path = crate::paths::daemon_jobs_file().expect("jobs path");
         let store = JobStore::open_without_reconciliation(&path).expect("store");
         let job = store.create("runner.exec");
         record_test_absent_local_child(&store, job.id);
@@ -491,14 +488,13 @@ fn concurrent_leaseless_recovery(
     lifecycle: Arc<Mutex<bool>>,
     starts: Arc<Mutex<usize>>,
     path: std::path::PathBuf,
-) -> std::thread::JoinHandle<
-    crate::core::error::Result<super::DaemonLeaselessOrphanReconciliationResult>,
-> {
+) -> std::thread::JoinHandle<crate::error::Result<super::DaemonLeaselessOrphanReconciliationResult>>
+{
     std::thread::spawn(move || {
         barrier.wait();
         let mut committed = lifecycle.lock().expect("lifecycle lock");
         if *committed {
-            return Err(crate::core::Error::validation_invalid_argument(
+            return Err(crate::Error::validation_invalid_argument(
                 "lifecycle",
                 "replacement daemon already committed by concurrent recovery",
                 None,
@@ -596,14 +592,14 @@ fn leaseless_snapshot_uses_the_exact_bytes_opened_for_reconciliation() {
 #[test]
 fn exact_lease_adoption_refuses_owner_lock_and_preserves_store() {
     with_isolated_home(|_| {
-        let state_path = crate::core::paths::daemon_state_file().expect("state path");
+        let state_path = crate::paths::daemon_state_file().expect("state path");
         let mut state = fake_daemon_state(fake_daemon(999_999, "lease-dead"));
         state.state_path = state_path.display().to_string();
         std::fs::create_dir_all(state_path.parent().expect("state parent")).expect("state parent");
         std::fs::write(&state_path, serde_json::to_vec(&state).expect("state json"))
             .expect("state");
 
-        let jobs_path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let jobs_path = crate::paths::daemon_jobs_file().expect("jobs path");
         let store = JobStore::open_without_reconciliation(&jobs_path)
             .expect("store")
             .with_daemon_lease("lease-dead".to_string());
@@ -627,7 +623,7 @@ fn exact_lease_adoption_refuses_owner_lock_and_preserves_store() {
 fn legacy_child_recovery_refuses_operation_and_owner_locks_without_mutation() {
     with_isolated_home(|_| {
         let (store, job, endpoint) = legacy_recovery_fixture("lease-dead");
-        let before = std::fs::read(crate::core::paths::daemon_jobs_file().expect("jobs path"))
+        let before = std::fs::read(crate::paths::daemon_jobs_file().expect("jobs path"))
             .expect("store bytes");
 
         let operation = super::super::acquire_daemon_operation_lock().expect("operation lock");
@@ -644,7 +640,7 @@ fn legacy_child_recovery_refuses_operation_and_owner_locks_without_mutation() {
             .message
             .contains("operation already in progress"));
         assert_eq!(
-            std::fs::read(crate::core::paths::daemon_jobs_file().expect("jobs path"))
+            std::fs::read(crate::paths::daemon_jobs_file().expect("jobs path"))
                 .expect("store bytes"),
             before
         );
@@ -719,9 +715,9 @@ fn legacy_child_recovery_refuses_live_daemon_endpoint_and_lease_mismatch() {
 fn legacy_child_recovery_requires_matching_persisted_lease_address() {
     with_isolated_home(|_| {
         let (_store, job, endpoint) = legacy_recovery_fixture("lease-dead");
-        let jobs_path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let jobs_path = crate::paths::daemon_jobs_file().expect("jobs path");
         let before = std::fs::read(&jobs_path).expect("store bytes");
-        std::fs::remove_file(crate::core::paths::daemon_state_file().expect("state path"))
+        std::fs::remove_file(crate::paths::daemon_state_file().expect("state path"))
             .expect("remove state");
         let missing = super::recover_missing_child_identity(
             "lease-dead",
@@ -756,7 +752,7 @@ fn legacy_child_recovery_requires_matching_persisted_lease_address() {
 #[test]
 fn leaseless_recovery_blocks_a_surviving_recorded_process_group() {
     with_isolated_home(|_| {
-        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let path = crate::paths::daemon_jobs_file().expect("jobs path");
         let marker_dir = tempfile::tempdir().expect("marker dir");
         let marker = marker_dir.path().join("descendant.pid");
         let store = JobStore::open_without_reconciliation(&path)
@@ -776,7 +772,7 @@ fn leaseless_recovery_blocks_a_surviving_recorded_process_group() {
                     "-c",
                     &format!(
                         "sleep 30 & echo $! > {}",
-                        crate::core::engine::shell::quote_arg(marker_for_child.to_str().expect("marker"))
+                        crate::engine::shell::quote_arg(marker_for_child.to_str().expect("marker"))
                     ),
                 ]);
                 unsafe {
@@ -789,13 +785,13 @@ fn leaseless_recovery_blocks_a_surviving_recorded_process_group() {
                 }
                 let mut child = command.spawn().expect("spawn root");
                 let pid = child.id();
-                let pgid = crate::core::process::isolated_process_group_id(pid)
+                let pgid = crate::process::isolated_process_group_id(pid)
                     .expect("read process group")
                     .expect("Unix group identity");
-                let discriminator = match crate::core::process::linux_process_starttime_ticks(pid) {
-                    Ok(Some(ticks)) => crate::core::api_jobs::LocalChildStartDiscriminator::LinuxProcStatStarttimeTicks { ticks },
+                let discriminator = match crate::process::linux_process_starttime_ticks(pid) {
+                    Ok(Some(ticks)) => crate::api_jobs::LocalChildStartDiscriminator::LinuxProcStatStarttimeTicks { ticks },
                     Ok(None) => panic!("root exited before identity persisted"),
-                    Err(evidence) => crate::core::api_jobs::LocalChildStartDiscriminator::Unsupported { evidence },
+                    Err(evidence) => crate::api_jobs::LocalChildStartDiscriminator::Unsupported { evidence },
                 };
                 job.start_with_reserved_child_identity(pid, Some(pgid), discriminator)
                     .expect("persist root and group identity");
@@ -813,7 +809,7 @@ fn leaseless_recovery_blocks_a_surviving_recorded_process_group() {
             .trim()
             .parse()
             .expect("descendant pid");
-        assert!(crate::core::process::pid_is_running(descendant));
+        assert!(crate::process::pid_is_running(descendant));
 
         let blocked = JobStore::open_without_reconciliation(&path)
             .expect("reopen store")
@@ -825,8 +821,7 @@ fn leaseless_recovery_blocks_a_surviving_recorded_process_group() {
             JobStatus::Running
         );
 
-        crate::core::process::terminate_isolated_process_group(pgid)
-            .expect("terminate recorded group");
+        crate::process::terminate_isolated_process_group(pgid).expect("terminate recorded group");
         std::thread::sleep(Duration::from_millis(150));
         let recovered = JobStore::open_without_reconciliation(&path)
             .expect("reopen store")
@@ -847,7 +842,7 @@ fn leaseless_recovery_blocks_a_surviving_recorded_process_group() {
 #[test]
 fn local_child_reservation_recovery_requires_death_before_one_replacement() {
     with_isolated_home(|_| {
-        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let path = crate::paths::daemon_jobs_file().expect("jobs path");
         let store = JobStore::open_without_reconciliation(&path)
             .expect("durable store")
             .with_daemon_lease("lease-dead".to_string());
@@ -877,10 +872,10 @@ fn local_child_reservation_recovery_requires_death_before_one_replacement() {
                     }
                     let mut child = child_command.spawn().expect("spawn child");
                     let pid = child.id();
-                    let discriminator = match crate::core::process::linux_process_starttime_ticks(pid) {
-                        Ok(Some(ticks)) => crate::core::api_jobs::LocalChildStartDiscriminator::LinuxProcStatStarttimeTicks { ticks },
+                    let discriminator = match crate::process::linux_process_starttime_ticks(pid) {
+                        Ok(Some(ticks)) => crate::api_jobs::LocalChildStartDiscriminator::LinuxProcStatStarttimeTicks { ticks },
                         Ok(None) => panic!("child exited before identity persisted"),
-                        Err(evidence) => crate::core::api_jobs::LocalChildStartDiscriminator::Unsupported { evidence },
+                        Err(evidence) => crate::api_jobs::LocalChildStartDiscriminator::Unsupported { evidence },
                     };
                     job.start_with_reserved_child_identity(pid, None, discriminator)
                         .expect("persist child identity before running");
@@ -940,10 +935,9 @@ fn local_child_reservation_recovery_requires_death_before_one_replacement() {
         )
         .expect_err("live local child blocks replacement");
         assert!(blocked.message.contains("active child process"));
-        assert!(crate::core::process::pid_is_running(pid));
+        assert!(crate::process::pid_is_running(pid));
 
-        crate::core::process::terminate_isolated_process_group(pid)
-            .expect("terminate process group");
+        crate::process::terminate_isolated_process_group(pid).expect("terminate process group");
         reaped_rx
             .recv_timeout(Duration::from_secs(3))
             .expect("child reaped");
@@ -1052,7 +1046,7 @@ fn legacy_child_recovery_exact_evidence_is_idempotent_and_conflicts_fail_closed(
 #[test]
 fn exact_lease_adoption_reconciles_terminal_children_idempotently() {
     with_isolated_home(|_| {
-        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let path = crate::paths::daemon_jobs_file().expect("jobs path");
         let store = JobStore::open_without_reconciliation(&path)
             .expect("store")
             .with_daemon_lease("lease-dead".to_string());
@@ -1270,7 +1264,7 @@ fn locked_start_operations_publish_once_and_converge_concurrent_callers() {
 #[allow(unreachable_code, unused_variables)]
 fn dead_matching_lease_reconciles_jobs_before_starting_replacement() {
     with_isolated_home(|_| {
-        let path = crate::core::paths::daemon_jobs_file().expect("daemon jobs path");
+        let path = crate::paths::daemon_jobs_file().expect("daemon jobs path");
         let store = JobStore::open_without_reconciliation(&path)
             .expect("create durable store")
             .with_daemon_lease("lease-dead".to_string());
@@ -1340,7 +1334,7 @@ fn dead_matching_lease_reconciles_jobs_before_starting_replacement() {
 #[test]
 fn legacy_unowned_job_blocks_replacement_start() {
     with_isolated_home(|_| {
-        let path = crate::core::paths::daemon_jobs_file().expect("daemon jobs path");
+        let path = crate::paths::daemon_jobs_file().expect("daemon jobs path");
         let store = JobStore::open_without_reconciliation(&path).expect("create durable store");
         let job = store.create("runner.exec");
         store.start(job.id).expect("job starts");
@@ -1365,7 +1359,7 @@ fn legacy_unowned_job_blocks_replacement_start() {
 #[allow(unreachable_code, unused_variables)]
 fn state_loss_exact_lease_recovery_terminalizes_only_matching_jobs_and_starts_once() {
     with_isolated_home(|_| {
-        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let path = crate::paths::daemon_jobs_file().expect("jobs path");
         let store = JobStore::open_without_reconciliation(&path)
             .expect("store")
             .with_daemon_lease("exact-lease".to_string());
@@ -1482,7 +1476,7 @@ fn state_loss_exact_recovery_refuses_live_pid_lock_endpoint_and_mixed_lease() {
     assert!(replay.message.contains("absent daemon state"));
 
     with_isolated_home(|_| {
-        let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+        let path = crate::paths::daemon_jobs_file().expect("jobs path");
         let exact = JobStore::open_without_reconciliation(&path)
             .expect("store")
             .with_daemon_lease("exact-lease".to_string());
@@ -1507,7 +1501,7 @@ fn state_loss_exact_recovery_refuses_live_pid_lock_endpoint_and_mixed_lease() {
                     JobStore::open_without_reconciliation_from_bytes(&path, &raw).expect("store");
                 let diagnostics = recovered.daemon_lease_job_diagnostics("exact-lease");
                 if !diagnostics.other_lease_job_ids.is_empty() {
-                    return Err(crate::core::Error::validation_invalid_argument(
+                    return Err(crate::Error::validation_invalid_argument(
                         "lease_id",
                         "mixed exact leases",
                         None,
@@ -1546,7 +1540,7 @@ fn state_loss_recovery_requires_a_concrete_unreachable_recorded_endpoint() {
 #[test]
 fn state_loss_receipt_survives_start_failure_and_replay_starts_once() {
     with_isolated_home(|_| {
-        let receipt_path = crate::core::paths::daemon_state_loss_recovery_receipt_file("lease-old")
+        let receipt_path = crate::paths::daemon_state_loss_recovery_receipt_file("lease-old")
             .expect("receipt path");
         let job_id = uuid::Uuid::new_v4();
         let mut receipt = super::StateLossRecoveryReceipt {
@@ -1562,9 +1556,7 @@ fn state_loss_receipt_survives_start_failure_and_replay_starts_once() {
         };
         super::write_state_loss_receipt(&receipt_path, &receipt).expect("persist receipt");
         let error = super::complete_state_loss_replacement(&mut receipt, &receipt_path, || {
-            Err(crate::core::Error::internal_unexpected(
-                "replacement failed",
-            ))
+            Err(crate::Error::internal_unexpected("replacement failed"))
         })
         .expect_err("failed replacement preserves receipt");
         assert_eq!(error.details["state_loss_recovery"]["phase"], "reconciled");
@@ -1641,7 +1633,7 @@ fn state_loss_replay_allows_zero_active_jobs_only_with_a_matching_receipt() {
 #[test]
 fn replacement_starting_replay_adopts_only_the_persisted_startup_token() {
     with_isolated_home(|_| {
-        let receipt_path = crate::core::paths::daemon_state_loss_recovery_receipt_file("lease-old")
+        let receipt_path = crate::paths::daemon_state_loss_recovery_receipt_file("lease-old")
             .expect("receipt path");
         let mut receipt = super::StateLossRecoveryReceipt {
             lease_id: "lease-old".to_string(),
@@ -1655,7 +1647,7 @@ fn replacement_starting_replay_adopts_only_the_persisted_startup_token() {
             replacement_startup_token: None,
         };
         let error = super::start_state_loss_replacement_with(&mut receipt, &receipt_path, |_| {
-            Err(crate::core::Error::internal_unexpected(
+            Err(crate::Error::internal_unexpected(
                 "interrupted after launch intent",
             ))
         })
@@ -1728,7 +1720,7 @@ fn ensure_with_fake_operations(
     barrier: Arc<Barrier>,
     state: Arc<Mutex<FakeEnsureState>>,
     daemon: super::DaemonStartResult,
-) -> std::thread::JoinHandle<crate::core::error::Result<super::DaemonStartResult>> {
+) -> std::thread::JoinHandle<crate::error::Result<super::DaemonStartResult>> {
     std::thread::spawn(move || {
         barrier.wait();
         let read_state = Arc::clone(&state);
@@ -1758,7 +1750,7 @@ fn locked_start_with_fake_operations(
     barrier: Arc<Barrier>,
     state: Arc<Mutex<FakeEnsureState>>,
     daemon: super::DaemonStartResult,
-) -> std::thread::JoinHandle<crate::core::error::Result<super::DaemonStartResult>> {
+) -> std::thread::JoinHandle<crate::error::Result<super::DaemonStartResult>> {
     std::thread::spawn(move || {
         barrier.wait();
         let read_state = Arc::clone(&state);
@@ -1806,8 +1798,8 @@ fn fake_daemon(pid: u32, lease_id: &str) -> super::DaemonStartResult {
     }
 }
 
-fn legacy_recovery_fixture(lease_id: &str) -> (JobStore, crate::core::api_jobs::Job, String) {
-    let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+fn legacy_recovery_fixture(lease_id: &str) -> (JobStore, crate::api_jobs::Job, String) {
+    let path = crate::paths::daemon_jobs_file().expect("jobs path");
     let store = JobStore::open_without_reconciliation(&path)
         .expect("store")
         .with_daemon_lease(lease_id.to_string());
@@ -1821,7 +1813,7 @@ fn legacy_recovery_fixture(lease_id: &str) -> (JobStore, crate::core::api_jobs::
 }
 
 fn write_legacy_recovery_state(lease_id: &str, pid: u32, endpoint: &str) {
-    let state_path = crate::core::paths::daemon_state_file().expect("state path");
+    let state_path = crate::paths::daemon_state_file().expect("state path");
     let mut state = fake_daemon_state(super::DaemonStartResult {
         pid,
         address: endpoint.to_string(),

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1,6 +1,6 @@
 use super::*;
-use crate::core::api_jobs::{JobEventKind, JobStatus, JobStore};
-use crate::core::observation::{ArtifactRecord, NewRunRecord, ObservationStore};
+use crate::api_jobs::{JobEventKind, JobStatus, JobStore};
+use crate::observation::{ArtifactRecord, NewRunRecord, ObservationStore};
 use crate::test_support::HomeGuard;
 use base64::Engine;
 #[cfg(unix)]
@@ -46,7 +46,7 @@ fn status_reports_active_job_recovery_evidence_without_mutating_the_store() {
     let mut state = daemon_state_for_test(u32::MAX, "127.0.0.1:49152");
     state.lease_id = "evidence-lease".to_string();
     write_daemon_state_for_test(&state);
-    let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+    let path = crate::paths::daemon_jobs_file().expect("jobs path");
     let store = JobStore::open_without_reconciliation(&path)
         .expect("store")
         .with_daemon_lease(state.lease_id.clone());
@@ -63,7 +63,7 @@ fn status_reports_active_job_recovery_evidence_without_mutating_the_store() {
     assert_eq!(evidence.operation, "runner.exec");
     assert_eq!(
         evidence.disposition,
-        crate::core::api_jobs::DaemonActiveJobRecoveryDisposition::MissingChildIdentityRecoverable
+        crate::api_jobs::DaemonActiveJobRecoveryDisposition::MissingChildIdentityRecoverable
     );
 }
 
@@ -73,7 +73,7 @@ fn status_marks_pidless_jobs_non_recoverable_while_the_lease_is_live() {
     let mut state = daemon_state_for_test(std::process::id(), "127.0.0.1:49152");
     state.lease_id = "live-evidence-lease".to_string();
     write_daemon_state_for_test(&state);
-    let path = crate::core::paths::daemon_jobs_file().expect("jobs path");
+    let path = crate::paths::daemon_jobs_file().expect("jobs path");
     let store = JobStore::open_without_reconciliation(&path)
         .expect("store")
         .with_daemon_lease(state.lease_id);
@@ -85,7 +85,7 @@ fn status_marks_pidless_jobs_non_recoverable_while_the_lease_is_live() {
     assert_eq!(status.active_job_recovery_evidence.len(), 1);
     assert_eq!(
         status.active_job_recovery_evidence[0].disposition,
-        crate::core::api_jobs::DaemonActiveJobRecoveryDisposition::BlockingAmbiguous
+        crate::api_jobs::DaemonActiveJobRecoveryDisposition::BlockingAmbiguous
     );
 }
 
@@ -103,7 +103,7 @@ fn write_legacy_daemon_state_for_test(pid: u32, address: &str) -> (std::path::Pa
 }
 
 fn create_local_runner_for_file_api(id: &str, workspace_root: &std::path::Path) {
-    crate::core::runner::create(
+    crate::runner::create(
         &serde_json::json!({
             "id": id,
             "kind": "local",
@@ -1430,7 +1430,7 @@ fn daemon_http_error_envelope_includes_error_payload() {
 #[test]
 fn routes_remote_runner_session_registration() {
     let _home = HomeGuard::new();
-    crate::core::runner::create(
+    crate::runner::create(
         r#"{"id":"homeboy-lab","kind":"local","workspace_root":"/runner/workspaces"}"#,
         false,
     )
@@ -1456,12 +1456,9 @@ fn routes_remote_runner_session_registration() {
         serde_json::json!("controller")
     );
 
-    let status = crate::core::runner::status("homeboy-lab").expect("runner status");
+    let status = crate::runner::status("homeboy-lab").expect("runner status");
     assert!(status.connected);
-    assert_eq!(
-        status.state,
-        crate::core::runner::RunnerSessionState::Connected
-    );
+    assert_eq!(status.state, crate::runner::RunnerSessionState::Connected);
     let session = status.session.expect("session");
     assert_eq!(session.controller_id.as_deref(), Some("extra-chill"));
     assert_eq!(
@@ -1510,7 +1507,7 @@ fn route_with_body_validates_exec_requests() {
 
 fn create_lab_local_runner() -> HomeGuard {
     let home = HomeGuard::new();
-    crate::core::runner::create(r#"{"id":"lab-local","kind":"local"}"#, false)
+    crate::runner::create(r#"{"id":"lab-local","kind":"local"}"#, false)
         .expect("create lab local runner");
     home
 }
@@ -1632,13 +1629,13 @@ fn daemon_exec_derives_implicit_command_secret_names_before_workload_validation(
         .expect("cwd")
         .to_string_lossy()
         .to_string();
-    let plan = crate::core::plan::HomeboyPlan::builder_for_description(
-        crate::core::plan::PlanKind::LabOffload,
+    let plan = crate::plan::HomeboyPlan::builder_for_description(
+        crate::plan::PlanKind::LabOffload,
         "test",
     )
     .build();
-    let command_contract = crate::core::runner::LabOffloadCommand {
-        command: crate::command_contract::LabCommandContract::portable(
+    let command_contract = crate::runner::LabOffloadCommand {
+        command: crate::lab_contract::LabCommandContract::portable(
             "tunnel preview-client start",
             None,
             false,
@@ -1648,8 +1645,8 @@ fn daemon_exec_derives_implicit_command_secret_names_before_workload_validation(
         required_capabilities: Vec::new(),
         workload: None,
     };
-    let workload = crate::core::runner::workload::build_runner_workload(
-        crate::core::runner::workload::RunnerWorkloadBuildInput {
+    let workload = crate::runner::workload::build_runner_workload(
+        crate::runner::workload::RunnerWorkloadBuildInput {
             plan: &plan,
             command: &command_contract,
             capture_patch: false,
@@ -1893,20 +1890,20 @@ fn exec_capture_patch_records_remote_delta_artifact() {
 #[test]
 fn runner_exec_rejects_requests_that_violate_runner_policy_before_daemon_dispatch() {
     let _home = HomeGuard::new();
-    crate::core::server::create(
+    crate::server::create(
         r#"{"id":"lab-server","host":"192.0.2.10","user":"user"}"#,
         false,
     )
     .expect("create server");
-    crate::core::runner::create(
+    crate::runner::create(
         r#"{"id":"lab-server","kind":"ssh","server_id":"lab-server","workspace_root":"/srv/homeboy"}"#,
         false,
     )
     .expect("create ssh runner");
 
-    let err = crate::core::runner::exec(
+    let err = crate::runner::exec(
         "lab-server",
-        crate::core::runner::RunnerExecOptions {
+        crate::runner::RunnerExecOptions {
             cwd: Some("/srv/homeboy/project".to_string()),
             project_id: None,
             allow_diagnostic_ssh: false,
@@ -1942,7 +1939,7 @@ fn runner_exec_rejects_requests_that_violate_runner_policy_before_daemon_dispatc
     assert_eq!(err.details["field"], "raw_exec");
 }
 
-fn wait_for_job(store: &JobStore, job_id: &str) -> crate::core::api_jobs::Job {
+fn wait_for_job(store: &JobStore, job_id: &str) -> crate::api_jobs::Job {
     let id = uuid::Uuid::parse_str(job_id).expect("uuid");
     for _ in 0..100 {
         let job = store.get(id).expect("job");

--- a/tests/core/engine/invocation_test.rs
+++ b/tests/core/engine/invocation_test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::core::engine::run_dir::RunDir;
+use crate::engine::run_dir::RunDir;
 use crate::test_support::{home_env_guard, with_isolated_home};
 
 #[test]
@@ -226,7 +226,7 @@ fn write_test_child_record(invocation_id: &str, owner_pid: u32, root_pid: u32, p
         invocation_id: invocation_id.to_string(),
         owner_pid,
         owner_started_at: None,
-        child: crate::core::engine::resource::ChildProcessIdentity {
+        child: crate::engine::resource::ChildProcessIdentity {
             root_pid,
             command_label: "sleep".to_string(),
         },
@@ -449,8 +449,8 @@ fn preserve_artifacts_emits_manifest_for_invocation_files() {
             .preserve_artifacts(&run_dir)
             .expect("preserve artifacts")
             .expect("artifact path");
-        let manifest = homeboy::core::artifact_manifest::read_manifest_from_root(&preserved)
-            .expect("read manifest");
+        let manifest =
+            crate::artifact_manifest::read_manifest_from_root(&preserved).expect("read manifest");
 
         assert_eq!(manifest.artifacts.len(), 1);
         assert_eq!(manifest.artifacts[0].path, "nested/result.json");
@@ -475,8 +475,8 @@ fn preserve_artifacts_normalizes_existing_manifest() {
             "HOMEBOY_INVOCATION_ARTIFACT_DIR",
         ));
         std::fs::write(artifact.join("declared.log"), "hello").expect("write artifact");
-        let manifest = homeboy::core::artifact_manifest::ArtifactManifest::new(vec![
-            homeboy::core::artifact_manifest::ArtifactManifestEntry {
+        let manifest = crate::artifact_manifest::ArtifactManifest::new(vec![
+            crate::artifact_manifest::ArtifactManifestEntry {
                 id: None,
                 path: "declared.log".to_string(),
                 kind: "runner-log".to_string(),
@@ -490,19 +490,19 @@ fn preserve_artifacts_normalizes_existing_manifest() {
                 public_url_state: None,
                 size_bytes: None,
                 sha256: None,
-                redaction: Some(homeboy::core::artifact_manifest::ArtifactRedactionState::Raw),
+                redaction: Some(crate::artifact_manifest::ArtifactRedactionState::Raw),
                 metadata: serde_json::json!({ "source": "test" }),
             },
         ]);
-        homeboy::core::artifact_manifest::write_manifest_to_root(&artifact, &manifest)
+        crate::artifact_manifest::write_manifest_to_root(&artifact, &manifest)
             .expect("write source manifest");
 
         let preserved = guard
             .preserve_artifacts(&run_dir)
             .expect("preserve artifacts")
             .expect("artifact path");
-        let manifest = homeboy::core::artifact_manifest::read_manifest_from_root(&preserved)
-            .expect("read manifest");
+        let manifest =
+            crate::artifact_manifest::read_manifest_from_root(&preserved).expect("read manifest");
 
         assert_eq!(manifest.artifacts.len(), 1);
         assert_eq!(manifest.artifacts[0].path, "declared.log");

--- a/tests/core/extension/bench/aggregation_test.rs
+++ b/tests/core/extension/bench/aggregation_test.rs
@@ -1,7 +1,5 @@
-use crate::core::extension::bench::test_support::{
-    results_with_scenarios, scenario_with_iterations,
-};
-use crate::core::observation::timeline::{
+use crate::extension::bench::test_support::{results_with_scenarios, scenario_with_iterations};
+use crate::observation::timeline::{
     ObservationEvent, ObservationSpanDefinition, ObservationSpanResult, ObservationSpanStatus,
 };
 

--- a/tests/core/extension/bench/phase_tag_test.rs
+++ b/tests/core/extension/bench/phase_tag_test.rs
@@ -25,12 +25,12 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::core::extension::bench::parsing::{
+use crate::extension::bench::parsing::{
     parse_bench_results_str, BenchMetricDirection, BenchMetricPhase, BenchMetricPolicy,
     BenchResults, BenchScenario,
 };
-use crate::core::extension::bench::report::{BenchComparisonDiff, BenchPhaseGroups};
-use crate::core::extension::bench::test_support::scenario_with_iterations;
+use crate::extension::bench::report::{BenchComparisonDiff, BenchPhaseGroups};
+use crate::extension::bench::test_support::scenario_with_iterations;
 
 fn policy(direction: BenchMetricDirection, phase: Option<BenchMetricPhase>) -> BenchMetricPolicy {
     BenchMetricPolicy {

--- a/tests/core/extension/bench/report_comparison_test.rs
+++ b/tests/core/extension/bench/report_comparison_test.rs
@@ -5,17 +5,17 @@ use super::{
     aggregate_comparison, aggregate_comparison_with_axes, BenchComparisonDiff, BenchPhaseGroups,
     RigBenchEntry,
 };
-use crate::core::extension::bench::artifact::{
+use crate::extension::bench::artifact::{
     BenchArtifact, BenchArtifactViewer, BenchPreviewLifecycleMetadata,
 };
-use crate::core::extension::bench::diagnostic::{BenchDiagnostic, BenchDiagnosticSource};
-use crate::core::extension::bench::distribution::BenchRunDistribution;
-use crate::core::extension::bench::parsing::{
+use crate::extension::bench::diagnostic::{BenchDiagnostic, BenchDiagnosticSource};
+use crate::extension::bench::distribution::BenchRunDistribution;
+use crate::extension::bench::parsing::{
     BenchMetricDirection, BenchMetricPhase, BenchMetricPolicy, BenchMetrics, BenchResults,
     BenchRunSnapshot, BenchScenario,
 };
-use crate::core::extension::bench::run::{BenchRunFailure, BenchRunWorkflowResult};
-use crate::core::extension::bench::side_by_side::BenchSideBySideMetric;
+use crate::extension::bench::run::{BenchRunFailure, BenchRunWorkflowResult};
+use crate::extension::bench::side_by_side::BenchSideBySideMetric;
 
 mod fixtures {
     use super::*;
@@ -567,7 +567,7 @@ fn axis_diffs_cover_two_by_two_rig_matrix() {
     assert_eq!(agent_task_aggregate.cells.len(), 4);
     assert_eq!(
         agent_task_aggregate.cells[0].status,
-        Some(crate::core::agent_task::AgentTaskOutcomeStatus::Succeeded)
+        Some(crate::agent_task::AgentTaskOutcomeStatus::Succeeded)
     );
     let sdk_substrate = out
         .axis_diffs

--- a/tests/core/extension/bench/runs_flag_test.rs
+++ b/tests/core/extension/bench/runs_flag_test.rs
@@ -9,12 +9,10 @@
 //! 4. Scenarios missing from some runs aggregate from the runs that emitted
 //!    them instead of failing the whole bench.
 
-use crate::core::extension::bench::aggregation::aggregate_runs;
-use crate::core::extension::bench::artifact::BenchArtifact;
-use crate::core::extension::bench::parsing::{BenchResults, BenchScenario};
-use crate::core::extension::bench::test_support::{
-    results_with_scenarios, scenario_with_iterations,
-};
+use crate::extension::bench::aggregation::aggregate_runs;
+use crate::extension::bench::artifact::BenchArtifact;
+use crate::extension::bench::parsing::{BenchResults, BenchScenario};
+use crate::extension::bench::test_support::{results_with_scenarios, scenario_with_iterations};
 
 fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
     scenario_with_iterations(id, metrics, 1)

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -1,9 +1,9 @@
-use homeboy::core::api_jobs::{JobEventKind, JobStatus, JobStore, RemoteRunnerJobRequest};
-use homeboy::core::http_api::{
+use crate::api_jobs::{JobEventKind, JobStatus, JobStore, RemoteRunnerJobRequest};
+use crate::http_api::{
     self, AnalysisJobRunOutput, AnalysisJobRunner, HttpApiRequest, HttpEndpoint, HttpMethod,
     JobReadyRunKind,
 };
-use homeboy::core::observation::{
+use crate::observation::{
     ArtifactRecord, NewFindingRecord, NewRunRecord, ObservationStore, RunRecord, RunStatus,
 };
 
@@ -13,7 +13,7 @@ use crate::test_support::with_isolated_home;
 struct FakeAnalysisJobRunner;
 
 impl AnalysisJobRunner for FakeAnalysisJobRunner {
-    fn run_analysis_job(&self, argv: Vec<String>) -> homeboy::core::Result<AnalysisJobRunOutput> {
+    fn run_analysis_job(&self, argv: Vec<String>) -> crate::Result<AnalysisJobRunOutput> {
         Ok(AnalysisJobRunOutput {
             exit_code: 0,
             output: serde_json::json!({ "argv": argv }),
@@ -288,7 +288,7 @@ fn test_handle_with_jobs() {
     store
         .append_event(
             job.id,
-            homeboy::core::api_jobs::JobEventKind::Stdout,
+            crate::api_jobs::JobEventKind::Stdout,
             Some("audit output".to_string()),
             None,
         )
@@ -562,7 +562,7 @@ fn artifact_content_serves_encoded_artifact_store_locator() {
         std::fs::create_dir_all(path.parent().expect("artifact parent"))
             .expect("create artifact parent");
         std::fs::write(&path, br#"{"steps":[]}"#).expect("artifact-store file");
-        let token = homeboy::core::runner::runner_artifact_store_token("lab", &run.id, locator)
+        let token = crate::runner::runner_artifact_store_token("lab", &run.id, locator)
             .rsplit('/')
             .next()
             .expect("artifact token")

--- a/tests/core/issues/render_test.rs
+++ b/tests/core/issues/render_test.rs
@@ -1,7 +1,7 @@
 use serde_json::json;
 
 use super::{build_findings_from_native_output, IssueRenderContext};
-use crate::core::code_audit::FindingConfidence;
+use crate::code_audit::FindingConfidence;
 
 #[test]
 fn test_build_findings_from_native_output() {

--- a/tests/core/lint_baseline_test.rs
+++ b/tests/core/lint_baseline_test.rs
@@ -1,5 +1,5 @@
-use homeboy::core::extension::lint::baseline as lint_baseline;
-use homeboy::core::finding::HomeboyFinding;
+use crate::extension::lint::baseline as lint_baseline;
+use crate::finding::HomeboyFinding;
 use std::path::Path;
 
 fn lint_finding(id: &str, category: &str, message: &str) -> HomeboyFinding {

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -3,11 +3,11 @@
 //! These isolate `HOME` / `XDG_DATA_HOME` so the developer's real local DB is
 //! never read or written.
 
-use crate::core::observation::store::{
+use crate::observation::store::{
     self, ObservationStore, CURRENT_SCHEMA_VERSION, LAB_OFFLOAD_METADATA_ENV,
     SOURCE_SNAPSHOT_METADATA_ENV,
 };
-use crate::core::observation::{
+use crate::observation::{
     FindingListFilter, NewFindingRecord, NewRunRecord, RunContext, RunListFilter, RunProvenance,
     RunRecord, RunStatus,
 };
@@ -1032,7 +1032,7 @@ mod write_retry {
     #[test]
     fn execute_with_retry_inner_exhausts_and_surfaces_lock_error() {
         let attempts = Cell::new(0u32);
-        let result: crate::core::Result<usize> =
+        let result: crate::Result<usize> =
             execute_with_retry_inner("persist run".to_string(), 4, 1, |_, _| {}, &mut || {
                 attempts.set(attempts.get() + 1);
                 Err(locked_error())
@@ -1046,7 +1046,7 @@ mod write_retry {
     #[test]
     fn execute_with_retry_inner_does_not_retry_persistent_error() {
         let attempts = Cell::new(0u32);
-        let result: crate::core::Result<usize> = execute_with_retry_inner(
+        let result: crate::Result<usize> = execute_with_retry_inner(
             "insert run record".to_string(),
             6,
             1,

--- a/tests/core/project/path_resolution_test.rs
+++ b/tests/core/project/path_resolution_test.rs
@@ -6,13 +6,13 @@
 
 use super::*;
 
-use crate::core::component::ScopedExtensionConfig;
-use crate::core::extension::{DeployCapability, ExtensionManifest};
+use crate::component::ScopedExtensionConfig;
+use crate::extension::{DeployCapability, ExtensionManifest};
 use crate::test_support::with_isolated_home;
 use std::collections::HashMap;
 
 fn install_wordpress_extension() {
-    crate::core::extension::save_manifest(&ExtensionManifest {
+    crate::extension::save_manifest(&ExtensionManifest {
         id: "wordpress".to_string(),
         name: "WordPress".to_string(),
         version: "1.0.0".to_string(),

--- a/tests/core/rig/app_test.rs
+++ b/tests/core/rig/app_test.rs
@@ -3,10 +3,8 @@
 use std::collections::HashMap;
 use std::fs;
 
-use crate::core::rig::app::{
-    install_inner, uninstall_inner, AppLauncherAction, AppLauncherOptions,
-};
-use crate::core::rig::spec::{
+use crate::rig::app::{install_inner, uninstall_inner, AppLauncherAction, AppLauncherOptions};
+use crate::rig::spec::{
     AppLauncherPlatform, AppLauncherPreflight, AppLauncherSpec, ComponentSpec, RigSpec,
 };
 
@@ -281,7 +279,7 @@ fn test_uninstall_removes_generated_linux_desktop_file_from_temp_dir() {
 fn test_public_linux_install_refuses_on_non_linux_hosts() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let rig = rig_with_linux_launcher(&tmp.path().to_string_lossy());
-    let result = crate::core::rig::app::install(&rig, AppLauncherOptions { dry_run: false });
+    let result = crate::rig::app::install(&rig, AppLauncherOptions { dry_run: false });
     if cfg!(target_os = "linux") {
         assert!(result.is_ok(), "Linux should allow install");
     } else {
@@ -294,7 +292,7 @@ fn test_public_linux_install_refuses_on_non_linux_hosts() {
 fn test_update_reports_update_action() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let rig = rig_with_launcher(&tmp.path().to_string_lossy());
-    let report = crate::core::rig::app::update(&rig, AppLauncherOptions { dry_run: true })
+    let report = crate::rig::app::update(&rig, AppLauncherOptions { dry_run: true })
         .expect("update dry-run");
     assert_eq!(report.action, AppLauncherAction::Update);
     assert!(report.dry_run);
@@ -304,7 +302,7 @@ fn test_update_reports_update_action() {
 fn test_public_install_refuses_unsupported_platforms() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let rig = rig_with_launcher(&tmp.path().to_string_lossy());
-    let result = crate::core::rig::app::install(&rig, AppLauncherOptions { dry_run: false });
+    let result = crate::rig::app::install(&rig, AppLauncherOptions { dry_run: false });
     if cfg!(target_os = "macos") {
         assert!(result.is_ok(), "macOS should allow install");
     } else {
@@ -317,7 +315,7 @@ fn test_public_install_refuses_unsupported_platforms() {
 fn test_public_install_dry_run_is_cross_platform_preview() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let rig = rig_with_launcher(&tmp.path().to_string_lossy());
-    let report = crate::core::rig::app::install(&rig, AppLauncherOptions { dry_run: true })
+    let report = crate::rig::app::install(&rig, AppLauncherOptions { dry_run: true })
         .expect("dry-run preview");
     assert!(report.dry_run);
     assert!(!tmp.path().join("Studio (Dev).app").exists());

--- a/tests/core/rig/bench_default_baseline_spec_test.rs
+++ b/tests/core/rig/bench_default_baseline_spec_test.rs
@@ -4,8 +4,8 @@
 //! the field serializes — consumers (rig spec authors, downstream
 //! tooling) read this directly off disk.
 
-use crate::core::extension::bench::BenchGateOp;
-use crate::core::rig::spec::{BenchMetricGateCondition, BenchSpec, RigSpec, WorkloadSpec};
+use crate::extension::bench::BenchGateOp;
+use crate::rig::spec::{BenchMetricGateCondition, BenchSpec, RigSpec, WorkloadSpec};
 
 /// Parses a minimal RigSpec JSON via serde and returns the embedded
 /// `BenchSpec` (or panics).

--- a/tests/core/rig/check_test.rs
+++ b/tests/core/rig/check_test.rs
@@ -4,8 +4,8 @@
 //! `file` and `command` probes exercise the full one-of-three logic,
 //! short-circuit on validation errors, and cover substring matching.
 
-use crate::core::rig::check::evaluate;
-use crate::core::rig::spec::{CheckSpec, RigSpec};
+use crate::rig::check::evaluate;
+use crate::rig::spec::{CheckSpec, RigSpec};
 
 fn minimal_rig() -> RigSpec {
     RigSpec {
@@ -158,7 +158,7 @@ fn test_evaluate_command_unexpected_exit() {
 
 #[test]
 fn test_evaluate_newer_than_left_newer_passes() {
-    use crate::core::rig::spec::{NewerThanSpec, TimeSource};
+    use crate::rig::spec::{NewerThanSpec, TimeSource};
     let tmp_dir = tempfile::tempdir().expect("tmpdir");
     let older = tmp_dir.path().join("older.txt");
     let newer = tmp_dir.path().join("newer.txt");
@@ -186,7 +186,7 @@ fn test_evaluate_newer_than_left_newer_passes() {
 
 #[test]
 fn test_evaluate_newer_than_left_older_fails() {
-    use crate::core::rig::spec::{NewerThanSpec, TimeSource};
+    use crate::rig::spec::{NewerThanSpec, TimeSource};
     let tmp_dir = tempfile::tempdir().expect("tmpdir");
     let older = tmp_dir.path().join("older.txt");
     let newer = tmp_dir.path().join("newer.txt");
@@ -215,7 +215,7 @@ fn test_evaluate_newer_than_left_older_fails() {
 
 #[test]
 fn test_evaluate_newer_than_missing_left_process_passes() {
-    use crate::core::rig::spec::{DiscoverSpec, NewerThanSpec, TimeSource};
+    use crate::rig::spec::{DiscoverSpec, NewerThanSpec, TimeSource};
     let tmp_dir = tempfile::tempdir().expect("tmpdir");
     let bundle = tmp_dir.path().join("bundle.js");
     std::fs::write(&bundle, "x").expect("write");
@@ -244,7 +244,7 @@ fn test_evaluate_newer_than_missing_left_process_passes() {
 
 #[test]
 fn test_evaluate_newer_than_rejects_empty_time_source() {
-    use crate::core::rig::spec::{NewerThanSpec, TimeSource};
+    use crate::rig::spec::{NewerThanSpec, TimeSource};
     let rig = minimal_rig();
     let spec = CheckSpec {
         newer_than: Some(NewerThanSpec {

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -1,12 +1,12 @@
 //! Rig install lifecycle tests. Covers `src/core/rig/install.rs`.
 
-use crate::core::rig::install::local_package_source_root_for_dependencies;
-use crate::core::rig::{
+use crate::rig::install::local_package_source_root_for_dependencies;
+use crate::rig::{
     declared_id, discover_rigs, install, list, list_ids, load, load_local_source,
     read_source_metadata, read_stack_source_metadata, run_check, run_lint,
 };
-use crate::core::ErrorCode;
 use crate::test_support::HomeGuard;
+use crate::ErrorCode;
 use std::fs;
 use std::path::Path;
 
@@ -67,7 +67,7 @@ mod discovery {
         assert_eq!(result.installed.len(), 1);
         assert_eq!(result.installed[0].id, "alpha");
 
-        let installed = crate::core::paths::rig_config("alpha").expect("rig path");
+        let installed = crate::paths::rig_config("alpha").expect("rig path");
         assert!(installed.exists());
         #[cfg(unix)]
         assert_eq!(fs::read_link(&installed).expect("symlink"), source);
@@ -97,13 +97,13 @@ mod install_flows {
         assert_eq!(result.installed.len(), 1);
         assert_eq!(result.installed_stacks.len(), 1);
         assert_eq!(result.installed_stacks[0].id, "studio-combined");
-        let installed = crate::core::paths::stack_config("studio-combined").expect("stack path");
+        let installed = crate::paths::stack_config("studio-combined").expect("stack path");
         assert!(installed.exists());
         #[cfg(unix)]
         assert_eq!(fs::read_link(&installed).expect("symlink"), stack_path);
-        assert_eq!(crate::core::stack::list().expect("stack list").len(), 1);
+        assert_eq!(crate::stack::list().expect("stack list").len(), 1);
         assert_eq!(
-            crate::core::stack::load("studio-combined")
+            crate::stack::load("studio-combined")
                 .expect("load stack")
                 .component,
             "studio"
@@ -141,8 +141,7 @@ mod install_flows {
                 .expect("reinstall replaces owned stack link");
 
             assert_eq!(result.installed_stacks.len(), 1);
-            let installed =
-                crate::core::paths::stack_config("studio-combined").expect("stack path");
+            let installed = crate::paths::stack_config("studio-combined").expect("stack path");
             assert!(installed.exists());
             #[cfg(unix)]
             assert_eq!(fs::read_link(&installed).expect("symlink"), stack_path);
@@ -427,7 +426,7 @@ mod install_flows {
 
         assert!(report.success, "direct rig.json check should pass");
         assert_eq!(
-            crate::core::rig::expand::expand_vars(&rig, "${package.root}/marker.txt"),
+            crate::rig::expand::expand_vars(&rig, "${package.root}/marker.txt"),
             package.path().join("marker.txt").to_string_lossy()
         );
         assert!(read_source_metadata("direct-alpha").is_none());
@@ -469,7 +468,7 @@ mod install_flows {
         let result = install(package.path().to_str().unwrap(), None, false).expect("install");
 
         assert_eq!(result.installed.len(), 1);
-        let installed_path = crate::core::paths::rig_config("alpha").expect("rig config");
+        let installed_path = crate::paths::rig_config("alpha").expect("rig config");
         #[cfg(unix)]
         assert!(fs::read_link(&installed_path).is_err());
         let installed = fs::read_to_string(&installed_path).expect("installed rig");
@@ -777,7 +776,7 @@ mod install_flows {
 
             install(package.path().to_str().unwrap(), None, false).expect("install");
 
-            let installed_path = crate::core::paths::rig_config(id).expect("rig config");
+            let installed_path = crate::paths::rig_config(id).expect("rig config");
             let installed = fs::read_to_string(&installed_path).expect("installed rig");
             assert!(!installed.contains("$append"));
             assert!(!installed.contains("$merge_by"));
@@ -835,7 +834,7 @@ mod install_flows {
         );
 
         install(package.path().to_str().unwrap(), None, false).expect("install");
-        let installed_path = crate::core::paths::rig_config("replacer").expect("rig config");
+        let installed_path = crate::paths::rig_config("replacer").expect("rig config");
         let installed = fs::read_to_string(&installed_path).expect("installed rig");
         let value: serde_json::Value = serde_json::from_str(&installed).expect("materialized json");
         let labels: Vec<&str> = value["pipeline"]["check"]
@@ -940,8 +939,8 @@ mod multi_rig {
             install(package.path().to_str().unwrap(), Some("beta"), false).expect("install");
         assert_eq!(result.installed.len(), 1);
         assert_eq!(result.installed[0].id, "beta");
-        assert!(crate::core::paths::rig_config("beta").unwrap().exists());
-        assert!(!crate::core::paths::rig_config("alpha").unwrap().exists());
+        assert!(crate::paths::rig_config("beta").unwrap().exists());
+        assert!(!crate::paths::rig_config("alpha").unwrap().exists());
     }
 
     #[test]
@@ -965,10 +964,10 @@ mod multi_rig {
         assert_eq!(result.installed.len(), 1);
         assert_eq!(result.installed[0].id, "alpha");
         assert!(result.installed_stacks.is_empty());
-        assert!(crate::core::paths::rig_config("alpha").unwrap().exists());
-        assert!(!crate::core::paths::rig_config("beta").unwrap().exists());
+        assert!(crate::paths::rig_config("alpha").unwrap().exists());
+        assert!(!crate::paths::rig_config("beta").unwrap().exists());
         assert_eq!(
-            fs::read_link(crate::core::paths::stack_config("stale-stack").unwrap())
+            fs::read_link(crate::paths::stack_config("stale-stack").unwrap())
                 .expect("stale stack symlink remains reported by sources list"),
             stale_stack
         );
@@ -992,8 +991,8 @@ mod multi_rig {
 
         assert_eq!(result.installed.len(), 1);
         assert_eq!(result.installed[0].id, "alpha");
-        assert!(crate::core::paths::rig_config("alpha").unwrap().exists());
-        assert!(!crate::core::paths::rig_config("broken").unwrap().exists());
+        assert!(crate::paths::rig_config("alpha").unwrap().exists());
+        assert!(!crate::paths::rig_config("broken").unwrap().exists());
     }
 
     #[test]
@@ -1019,8 +1018,8 @@ mod multi_rig {
 
         let result = install(package.path().to_str().unwrap(), None, true).expect("install");
         assert_eq!(result.installed.len(), 2);
-        assert!(crate::core::paths::rig_config("alpha").unwrap().exists());
-        assert!(crate::core::paths::rig_config("beta").unwrap().exists());
+        assert!(crate::paths::rig_config("alpha").unwrap().exists());
+        assert!(crate::paths::rig_config("beta").unwrap().exists());
     }
 }
 
@@ -1034,9 +1033,9 @@ mod refresh_and_identity {
         let refreshed = minimal_rig("alpha").replace("alpha rig", "alpha rig refreshed");
         write_rig(package.path(), "alpha", &refreshed);
 
-        fs::create_dir_all(crate::core::paths::rigs().expect("rigs dir")).expect("rigs dir");
+        fs::create_dir_all(crate::paths::rigs().expect("rigs dir")).expect("rigs dir");
         fs::write(
-            crate::core::paths::rig_config("alpha").expect("alpha rig path"),
+            crate::paths::rig_config("alpha").expect("alpha rig path"),
             minimal_rig("alpha"),
         )
         .expect("stale installed rig");
@@ -1044,8 +1043,8 @@ mod refresh_and_identity {
         let result = install(package.path().to_str().unwrap(), None, false).expect("refresh");
 
         assert_eq!(result.installed.len(), 1);
-        let installed = fs::read_to_string(crate::core::paths::rig_config("alpha").unwrap())
-            .expect("installed rig");
+        let installed =
+            fs::read_to_string(crate::paths::rig_config("alpha").unwrap()).expect("installed rig");
         assert!(installed.contains("alpha rig refreshed"));
         assert_eq!(
             read_source_metadata("alpha").expect("metadata").rig_path,
@@ -1061,8 +1060,8 @@ mod refresh_and_identity {
         let refreshed = minimal_rig("alpha").replace("alpha rig", "alpha rig refreshed");
         let source = write_rig(package.path(), "alpha", &refreshed);
 
-        fs::create_dir_all(crate::core::paths::rigs().expect("rigs dir")).expect("rigs dir");
-        let installed = crate::core::paths::rig_config("alpha").expect("alpha rig path");
+        fs::create_dir_all(crate::paths::rigs().expect("rigs dir")).expect("rigs dir");
+        let installed = crate::paths::rig_config("alpha").expect("alpha rig path");
         std::os::unix::fs::symlink(package.path().join("missing-rig.json"), &installed)
             .expect("broken rig symlink");
 
@@ -1080,9 +1079,9 @@ mod refresh_and_identity {
         let package = tempfile::tempdir().expect("package");
         write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
-        fs::create_dir_all(crate::core::paths::rigs().expect("rigs dir")).expect("rigs dir");
+        fs::create_dir_all(crate::paths::rigs().expect("rigs dir")).expect("rigs dir");
         fs::write(
-            crate::core::paths::rig_config("alpha").expect("alpha rig path"),
+            crate::paths::rig_config("alpha").expect("alpha rig path"),
             minimal_rig("beta"),
         )
         .expect("conflicting installed rig");
@@ -1098,9 +1097,9 @@ mod refresh_and_identity {
         write_rig(package.path(), "studio", &minimal_rig("studio"));
         let stack_path = write_stack(package.path(), "studio-combined", "studio");
 
-        fs::create_dir_all(crate::core::paths::stacks().expect("stacks dir")).expect("stacks dir");
+        fs::create_dir_all(crate::paths::stacks().expect("stacks dir")).expect("stacks dir");
         fs::write(
-            crate::core::paths::stack_config("studio-combined").expect("stack path"),
+            crate::paths::stack_config("studio-combined").expect("stack path"),
             fs::read_to_string(&stack_path).expect("package stack"),
         )
         .expect("existing stack");
@@ -1121,8 +1120,8 @@ mod refresh_and_identity {
         write_stack(package.path(), "studio-combined", "studio");
         let manual_stack = minimal_stack("studio-combined", "other");
 
-        fs::create_dir_all(crate::core::paths::stacks().expect("stacks dir")).expect("stacks dir");
-        let stack_config = crate::core::paths::stack_config("studio-combined").expect("stack path");
+        fs::create_dir_all(crate::paths::stacks().expect("stacks dir")).expect("stacks dir");
+        let stack_config = crate::paths::stack_config("studio-combined").expect("stack path");
         fs::write(&stack_config, &manual_stack).expect("conflicting stack");
 
         let err =
@@ -1137,9 +1136,9 @@ mod refresh_and_identity {
     #[test]
     fn installed_filename_is_runtime_identity_when_declared_id_differs() {
         let _home = HomeGuard::new();
-        fs::create_dir_all(crate::core::paths::rigs().expect("rigs dir")).expect("rigs dir");
+        fs::create_dir_all(crate::paths::rigs().expect("rigs dir")).expect("rigs dir");
         fs::write(
-            crate::core::paths::rig_config("replacement").expect("replacement rig path"),
+            crate::paths::rig_config("replacement").expect("replacement rig path"),
             minimal_rig("alpha"),
         )
         .expect("replacement rig");
@@ -1176,16 +1175,14 @@ mod refresh_and_identity {
     #[test]
     fn rig_list_ids_skip_non_json_files() {
         let _home = HomeGuard::new();
-        fs::create_dir_all(crate::core::paths::rigs().expect("rigs dir")).expect("rigs dir");
+        fs::create_dir_all(crate::paths::rigs().expect("rigs dir")).expect("rigs dir");
         fs::write(
-            crate::core::paths::rig_config("alpha").expect("alpha rig path"),
+            crate::paths::rig_config("alpha").expect("alpha rig path"),
             minimal_rig("alpha"),
         )
         .expect("alpha rig");
         fs::write(
-            crate::core::paths::rigs()
-                .expect("rigs dir")
-                .join("ignore.txt"),
+            crate::paths::rigs().expect("rigs dir").join("ignore.txt"),
             "not json",
         )
         .expect("non-json rig sidecar");
@@ -1224,14 +1221,14 @@ mod git_url {
         assert!(result.installed[0]
             .spec_path
             .ends_with("packages/studio/rig.json"));
-        assert!(crate::core::paths::rig_config("studio").unwrap().exists());
-        assert!(!crate::core::paths::rig_config("other").unwrap().exists());
+        assert!(crate::paths::rig_config("studio").unwrap().exists());
+        assert!(!crate::paths::rig_config("other").unwrap().exists());
         assert_eq!(result.installed_stacks.len(), 1);
         assert_eq!(result.installed_stacks[0].id, "studio-combined");
-        assert!(crate::core::paths::stack_config("studio-combined")
+        assert!(crate::paths::stack_config("studio-combined")
             .unwrap()
             .exists());
-        assert!(!crate::core::paths::stack_config("root-combined")
+        assert!(!crate::paths::stack_config("root-combined")
             .unwrap()
             .exists());
 

--- a/tests/core/rig/lease_test.rs
+++ b/tests/core/rig/lease_test.rs
@@ -1,12 +1,12 @@
 //! Tests for active rig run leases.
 
-use crate::core::error::ErrorCode;
-use crate::core::rig::lease::{
+use crate::error::ErrorCode;
+use crate::rig::lease::{
     acquire_active_run_lease, acquire_active_run_lease_with_settings, active_run_leases,
     release_active_run_lease, ReleaseLeaseOutcome, RIG_LEASE_TTL_ENV,
 };
-use crate::core::rig::spec::{RigResourcesSpec, RigSpec};
-use crate::core::rig::{run_up, RigRunLease};
+use crate::rig::spec::{RigResourcesSpec, RigSpec};
+use crate::rig::{run_up, RigRunLease};
 use crate::test_support::with_isolated_home;
 
 struct EnvVarGuard {
@@ -104,10 +104,9 @@ fn test_acquire_active_run_lease_blocks_overlapping_resources_until_drop() {
 #[test]
 fn test_resource_conflict_reports_active_run_context_when_available() {
     with_isolated_home(|_| {
-        let _run_id =
-            EnvVarGuard::set(crate::core::observation::ACTIVE_RUN_ID_ENV, "trace-run-123");
+        let _run_id = EnvVarGuard::set(crate::observation::ACTIVE_RUN_ID_ENV, "trace-run-123");
         let _lab_metadata = EnvVarGuard::set(
-            crate::core::observation::LAB_OFFLOAD_METADATA_ENV,
+            crate::observation::LAB_OFFLOAD_METADATA_ENV,
             r#"{"runner_id":"lab-runner-1"}"#,
         );
         let studio = rig("studio", resources());
@@ -267,7 +266,7 @@ fn test_acquire_active_run_lease_prunes_stale_pid() {
             runner_id: None,
             resources: resources(),
         };
-        let lease_dir = crate::core::paths::rig_leases_dir().expect("lease dir");
+        let lease_dir = crate::paths::rig_leases_dir().expect("lease dir");
         std::fs::create_dir_all(&lease_dir).expect("create lease dir");
         std::fs::write(
             lease_dir.join("studio.json"),
@@ -283,7 +282,7 @@ fn test_acquire_active_run_lease_prunes_stale_pid() {
 }
 
 fn write_lease(lease: &RigRunLease) {
-    let lease_dir = crate::core::paths::rig_leases_dir().expect("lease dir");
+    let lease_dir = crate::paths::rig_leases_dir().expect("lease dir");
     std::fs::create_dir_all(&lease_dir).expect("create lease dir");
     std::fs::write(
         lease_dir.join(format!("{}.json", lease.rig_id)),

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -3,10 +3,8 @@
 //! End-to-end pipeline runs exercise real services + filesystem mutations
 //! and are covered by the manual smoke documented in #1468.
 
-use crate::core::rig::pipeline::{
-    run_pipeline, run_pipeline_check_groups, run_pipeline_with_settings,
-};
-use crate::core::rig::spec::RigSpec;
+use crate::rig::pipeline::{run_pipeline, run_pipeline_check_groups, run_pipeline_with_settings};
+use crate::rig::spec::RigSpec;
 
 #[test]
 fn test_run_pipeline_check_groups() {
@@ -807,8 +805,8 @@ mod dag {
     use std::collections::HashMap;
     use std::fs;
 
-    use crate::core::rig::pipeline::run_pipeline;
-    use crate::core::rig::spec::{ComponentSpec, PipelineStep, RigSpec, StackOp};
+    use crate::rig::pipeline::run_pipeline;
+    use crate::rig::spec::{ComponentSpec, PipelineStep, RigSpec, StackOp};
 
     fn command(id: &str, depends_on: &[&str], cmd: String, cwd: Option<String>) -> PipelineStep {
         PipelineStep::Command {
@@ -1107,8 +1105,8 @@ mod git_steps {
     use std::fs;
     use std::process::Command;
 
-    use crate::core::rig::pipeline::run_pipeline;
-    use crate::core::rig::spec::{ComponentSpec, GitOp, PipelineStep, RigSpec};
+    use crate::rig::pipeline::run_pipeline;
+    use crate::rig::spec::{ComponentSpec, GitOp, PipelineStep, RigSpec};
 
     fn run_git(repo: &std::path::Path, args: &[&str]) -> String {
         let output = Command::new("git")
@@ -1236,9 +1234,9 @@ mod extension_lifecycle {
     use std::collections::HashMap;
     use std::fs;
 
-    use crate::core::component::ScopedExtensionConfig;
-    use crate::core::rig::pipeline::run_pipeline;
-    use crate::core::rig::spec::{ComponentSpec, PipelineStep, RigSpec};
+    use crate::component::ScopedExtensionConfig;
+    use crate::rig::pipeline::run_pipeline;
+    use crate::rig::spec::{ComponentSpec, PipelineStep, RigSpec};
     use crate::test_support;
 
     fn rig_with_step(component_path: String, step: PipelineStep) -> RigSpec {
@@ -1395,9 +1393,9 @@ mod command_env {
     use std::collections::HashMap;
     use std::fs;
 
-    use crate::core::rig::pipeline::run_pipeline;
-    use crate::core::rig::spec::{PipelineStep, RigSpec};
-    use crate::core::rig::toolchain;
+    use crate::rig::pipeline::run_pipeline;
+    use crate::rig::spec::{PipelineStep, RigSpec};
+    use crate::rig::toolchain;
     use crate::test_support::home_env_guard;
 
     fn rig_with_command(cmd: String, env: HashMap<String, String>) -> RigSpec {

--- a/tests/core/rig/pipeline_test/patch.rs
+++ b/tests/core/rig/pipeline_test/patch.rs
@@ -4,8 +4,8 @@
 use std::collections::HashMap;
 use std::fs;
 
-use crate::core::rig::pipeline::run_pipeline;
-use crate::core::rig::spec::{ComponentSpec, PatchOp, PipelineStep, RigSpec};
+use crate::rig::pipeline::run_pipeline;
+use crate::rig::spec::{ComponentSpec, PatchOp, PipelineStep, RigSpec};
 
 fn rig_with_patch(component_path: &str, step: PipelineStep) -> RigSpec {
     let mut components = HashMap::new();

--- a/tests/core/rig/pipeline_test/shared_path.rs
+++ b/tests/core/rig/pipeline_test/shared_path.rs
@@ -6,9 +6,9 @@
 use std::collections::HashMap;
 use std::fs;
 
-use crate::core::rig::pipeline::{cleanup_shared_paths, run_pipeline};
-use crate::core::rig::spec::{PipelineStep, RigSpec, SharedPathOp, SharedPathSpec};
-use crate::core::rig::state::RigState;
+use crate::rig::pipeline::{cleanup_shared_paths, run_pipeline};
+use crate::rig::spec::{PipelineStep, RigSpec, SharedPathOp, SharedPathSpec};
+use crate::rig::state::RigState;
 use crate::test_support::with_isolated_home;
 
 fn rig_with_shared_path(id: &str, shared: SharedPathSpec, op: SharedPathOp) -> RigSpec {

--- a/tests/core/rig/public_preview_spec_test.rs
+++ b/tests/core/rig/public_preview_spec_test.rs
@@ -1,4 +1,4 @@
-use crate::core::rig::WorkloadSpec;
+use crate::rig::WorkloadSpec;
 
 #[test]
 fn test_trace_public_preview_parse() {
@@ -72,7 +72,7 @@ fn test_trace_public_preview_parse_homeboy_native() {
     assert_eq!(preview.local_origin, "http://127.0.0.1:49823");
     assert_eq!(
         preview.mode,
-        crate::core::rig::TracePublicPreviewMode::HomeboyNative
+        crate::rig::TracePublicPreviewMode::HomeboyNative
     );
     let native = preview.native.as_ref().expect("native settings");
     assert_eq!(

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -3,14 +3,14 @@
 use std::collections::HashMap;
 use std::process::Command;
 
-use crate::core::observation::{ObservationStore, RunListFilter};
-use crate::core::paths;
-use crate::core::resource_lifecycle_index::{
+use crate::observation::{ObservationStore, RunListFilter};
+use crate::paths;
+use crate::resource_lifecycle_index::{
     resource_lifecycle_index_from_artifacts, ResourceLifecycleResourceStatus,
 };
-use crate::core::rig::runner::{run_check, run_up};
-use crate::core::rig::spec::{ComponentSpec, PipelineStep, RigResourcesSpec, RigSpec};
-use crate::core::rig::{RigSourceMetadata, RigState};
+use crate::rig::runner::{run_check, run_up};
+use crate::rig::spec::{ComponentSpec, PipelineStep, RigResourcesSpec, RigSpec};
+use crate::rig::{RigSourceMetadata, RigState};
 use crate::test_support::with_isolated_home;
 
 fn observation_spec(id: &str) -> RigSpec {
@@ -68,7 +68,7 @@ impl Drop for XdgDataHomeGuard {
     }
 }
 
-fn list_rig_runs(rig_id: &str) -> Vec<crate::core::observation::RunRecord> {
+fn list_rig_runs(rig_id: &str) -> Vec<crate::observation::RunRecord> {
     ObservationStore::open_initialized()
         .expect("observation store")
         .list_runs(RunListFilter {
@@ -167,7 +167,7 @@ fn test_run_check_persists_failing_observation() {
         let runs = list_rig_runs(&rig.id);
         assert_eq!(runs.len(), 1);
         let run = &runs[0];
-        let persisted_index = crate::core::rig::artifact_index_for_run(
+        let persisted_index = crate::rig::artifact_index_for_run(
             &ObservationStore::open_initialized().expect("store"),
             run,
         )

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -15,18 +15,18 @@
 
 use std::collections::HashMap;
 
-use crate::core::rig::pipeline::PipelineOutcome;
-use crate::core::rig::runner::{
+use crate::rig::pipeline::PipelineOutcome;
+use crate::rig::runner::{
     head_sha_and_branch, run_check, run_check_groups, run_down, run_down_with_settings, run_repair,
     run_status, run_up, snapshot_state, CheckReport, RigStatusReport, ServiceStatusReport,
     SymlinkStatusState, UpReport,
 };
-use crate::core::rig::spec::{
+use crate::rig::spec::{
     ComponentSpec, ExecutableRequirementSpec, FilesystemAssertionKind, FilesystemAssertionSpec,
     PipelineStep, RigRequirementsSpec, RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec,
     SharedPathOp, SharedPathSpec, SymlinkSpec,
 };
-use crate::core::rig::state::RigState;
+use crate::rig::state::RigState;
 use crate::test_support::with_isolated_home;
 
 fn empty_pipeline(name: &str) -> PipelineOutcome {
@@ -642,7 +642,7 @@ fn test_run_down_cleans_state_owned_shared_paths() {
             app_launcher: None,
         };
 
-        let up = crate::core::rig::pipeline::run_pipeline(&rig, "up", true).expect("up pipeline");
+        let up = crate::rig::pipeline::run_pipeline(&rig, "up", true).expect("up pipeline");
         assert!(up.is_success());
         assert!(link.is_symlink());
 

--- a/tests/core/rig/service_test.rs
+++ b/tests/core/rig/service_test.rs
@@ -4,16 +4,16 @@
 //! in the end-to-end smoke described in #1468. Unit scope here covers the
 //! pure types and status-enum ergonomics that back the runner's reporting.
 
-use crate::core::rig::service::ServiceStatus;
+use crate::rig::service::ServiceStatus;
 
 #[cfg(unix)]
 mod lifecycle {
     use std::collections::HashMap;
     use std::time::{Duration, Instant};
 
-    use crate::core::rig::service::{self, ServiceStatus};
-    use crate::core::rig::spec::{DiscoverSpec, RigSpec, ServiceKind, ServiceSpec};
-    use crate::core::rig::state::{RigState, ServiceState};
+    use crate::rig::service::{self, ServiceStatus};
+    use crate::rig::spec::{DiscoverSpec, RigSpec, ServiceKind, ServiceSpec};
+    use crate::rig::state::{RigState, ServiceState};
     use crate::test_support::with_isolated_home;
 
     fn command_rig(id: &str, command: &str, cwd: Option<String>) -> RigSpec {
@@ -368,7 +368,7 @@ fn test_service_status_stale_carries_pid() {
 
 #[test]
 fn test_parse_etime_mm_ss() {
-    use crate::core::rig::service::parse_etime_seconds;
+    use crate::rig::service::parse_etime_seconds;
     // 2 minutes 30 seconds.
     assert_eq!(parse_etime_seconds("02:30"), Some(150));
     assert_eq!(parse_etime_seconds("0:01"), Some(1));
@@ -376,14 +376,14 @@ fn test_parse_etime_mm_ss() {
 
 #[test]
 fn test_parse_etime_hh_mm_ss() {
-    use crate::core::rig::service::parse_etime_seconds;
+    use crate::rig::service::parse_etime_seconds;
     // 1h 02m 03s.
     assert_eq!(parse_etime_seconds("01:02:03"), Some(3_723));
 }
 
 #[test]
 fn test_parse_etime_dd_hh_mm_ss() {
-    use crate::core::rig::service::parse_etime_seconds;
+    use crate::rig::service::parse_etime_seconds;
     // 4 days, 9 hours, 27 minutes, 59 seconds — the format BSD `ps` emits
     // for a long-running daemon (matches what `etime` printed during dev).
     assert_eq!(parse_etime_seconds("04-09:27:59"), Some(379_679));
@@ -391,7 +391,7 @@ fn test_parse_etime_dd_hh_mm_ss() {
 
 #[test]
 fn test_parse_etime_rejects_garbage() {
-    use crate::core::rig::service::parse_etime_seconds;
+    use crate::rig::service::parse_etime_seconds;
     assert_eq!(parse_etime_seconds(""), None);
     assert_eq!(parse_etime_seconds("not-a-time"), None);
     assert_eq!(parse_etime_seconds("01"), None);

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -1,6 +1,6 @@
 //! Rig source lifecycle tests. Covers `src/core/rig/source.rs`.
 
-use crate::core::rig::{
+use crate::rig::{
     install, list_ids, list_sources, load, remove_source, update_all_sources, update_source,
     update_source_for_rig,
 };
@@ -87,21 +87,17 @@ fn test_remove_source() {
     write_rig(package.path(), "beta", &minimal_rig("beta"));
 
     install(package.path().to_str().unwrap(), None, true).expect("install all");
-    let manual = crate::core::paths::rig_config("manual").expect("manual rig path");
+    let manual = crate::paths::rig_config("manual").expect("manual rig path");
     fs::write(&manual, minimal_rig("manual")).expect("manual rig");
 
     let result = remove_source(&package.path().to_string_lossy()).expect("remove source");
     assert_eq!(result.removed.len(), 2);
     assert!(result.skipped.is_empty());
     assert!(result.removed_package_path.is_none());
-    assert!(!crate::core::paths::rig_config("alpha").unwrap().exists());
-    assert!(!crate::core::paths::rig_config("beta").unwrap().exists());
-    assert!(!crate::core::paths::rig_source_metadata("alpha")
-        .unwrap()
-        .exists());
-    assert!(!crate::core::paths::rig_source_metadata("beta")
-        .unwrap()
-        .exists());
+    assert!(!crate::paths::rig_config("alpha").unwrap().exists());
+    assert!(!crate::paths::rig_config("beta").unwrap().exists());
+    assert!(!crate::paths::rig_source_metadata("alpha").unwrap().exists());
+    assert!(!crate::paths::rig_source_metadata("beta").unwrap().exists());
     assert!(manual.exists());
     assert!(package.path().exists());
 }
@@ -113,7 +109,7 @@ fn remove_source_preserves_replaced_config_but_drops_metadata() {
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
     install(package.path().to_str().unwrap(), None, false).expect("install");
-    let config = crate::core::paths::rig_config("alpha").expect("rig config");
+    let config = crate::paths::rig_config("alpha").expect("rig config");
     fs::remove_file(&config).expect("remove symlink");
     fs::write(&config, minimal_rig("replacement")).expect("replacement rig");
 
@@ -121,9 +117,7 @@ fn remove_source_preserves_replaced_config_but_drops_metadata() {
     assert!(result.removed.is_empty());
     assert_eq!(result.skipped.len(), 1);
     assert!(config.exists());
-    assert!(!crate::core::paths::rig_source_metadata("alpha")
-        .unwrap()
-        .exists());
+    assert!(!crate::paths::rig_source_metadata("alpha").unwrap().exists());
 }
 
 #[test]
@@ -134,7 +128,7 @@ fn remove_source_preserves_replaced_stack_config_but_drops_metadata() {
     write_stack(package.path(), "alpha-combined", "alpha");
 
     install(package.path().to_str().unwrap(), None, false).expect("install");
-    let config = crate::core::paths::stack_config("alpha-combined").expect("stack config");
+    let config = crate::paths::stack_config("alpha-combined").expect("stack config");
     fs::remove_file(&config).expect("remove symlink");
     fs::write(&config, minimal_stack("alpha-combined", "manual")).expect("replacement stack");
 
@@ -143,7 +137,7 @@ fn remove_source_preserves_replaced_stack_config_but_drops_metadata() {
     assert!(result.removed_stacks.is_empty());
     assert_eq!(result.skipped_stacks.len(), 1);
     assert!(config.exists());
-    assert!(!crate::core::paths::stack_source_metadata("alpha-combined")
+    assert!(!crate::paths::stack_source_metadata("alpha-combined")
         .unwrap()
         .exists());
 }
@@ -155,7 +149,7 @@ fn remove_source_treats_copied_config_as_owned_when_contents_match() {
     let source = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
     install(package.path().to_str().unwrap(), None, false).expect("install");
-    let config = crate::core::paths::rig_config("alpha").expect("rig config");
+    let config = crate::paths::rig_config("alpha").expect("rig config");
     fs::remove_file(&config).expect("remove symlink");
     fs::copy(&source, &config).expect("copy rig config");
 
@@ -166,23 +160,20 @@ fn remove_source_treats_copied_config_as_owned_when_contents_match() {
     assert_eq!(result.removed.len(), 1);
     assert!(result.skipped.is_empty());
     assert!(!config.exists());
-    assert!(!crate::core::paths::rig_source_metadata("alpha")
-        .unwrap()
-        .exists());
+    assert!(!crate::paths::rig_source_metadata("alpha").unwrap().exists());
 }
 
 #[test]
 fn sources_list_reports_corrupt_metadata_and_missing_configs() {
     let _home = HomeGuard::new();
-    fs::create_dir_all(crate::core::paths::rig_sources().expect("sources dir"))
-        .expect("sources dir");
+    fs::create_dir_all(crate::paths::rig_sources().expect("sources dir")).expect("sources dir");
     fs::write(
-        crate::core::paths::rig_source_metadata("broken").expect("broken metadata"),
+        crate::paths::rig_source_metadata("broken").expect("broken metadata"),
         "not json",
     )
     .expect("broken metadata");
     fs::write(
-        crate::core::paths::rig_source_metadata("missing").expect("missing metadata"),
+        crate::paths::rig_source_metadata("missing").expect("missing metadata"),
         r#"{
             "source": "/tmp/package",
             "package_path": "/tmp/package",
@@ -258,19 +249,19 @@ fn missing_linked_source_gets_rig_source_diagnostic_not_not_found_hint() {
 #[test]
 fn sources_list_skips_non_json_and_collects_invalid_stack_metadata() {
     let _home = HomeGuard::new();
-    fs::create_dir_all(crate::core::paths::rig_sources().expect("rig sources dir"))
+    fs::create_dir_all(crate::paths::rig_sources().expect("rig sources dir"))
         .expect("rig sources dir");
-    fs::create_dir_all(crate::core::paths::stack_sources().expect("stack sources dir"))
+    fs::create_dir_all(crate::paths::stack_sources().expect("stack sources dir"))
         .expect("stack sources dir");
     fs::write(
-        crate::core::paths::rig_sources()
+        crate::paths::rig_sources()
             .expect("rig sources dir")
             .join("ignored.txt"),
         "not json",
     )
     .expect("non-json metadata");
     fs::write(
-        crate::core::paths::stack_source_metadata("broken-stack").expect("stack metadata"),
+        crate::paths::stack_source_metadata("broken-stack").expect("stack metadata"),
         "not json",
     )
     .expect("broken stack metadata");
@@ -296,7 +287,7 @@ fn update_git_source_fast_forwards_package_and_refreshes_metadata() {
         .to_string();
 
     install(&source, None, false).expect("install");
-    let before = crate::core::rig::read_source_metadata("alpha")
+    let before = crate::rig::read_source_metadata("alpha")
         .expect("metadata")
         .source_revision;
 
@@ -315,11 +306,11 @@ fn update_git_source_fast_forwards_package_and_refreshes_metadata() {
     assert_eq!(result.updated[0].id, "alpha");
     assert_eq!(result.updated[0].previous_revision, before);
     assert_ne!(result.updated[0].source_revision, before);
-    let installed = fs::read_to_string(crate::core::paths::rig_config("alpha").unwrap())
-        .expect("installed rig");
+    let installed =
+        fs::read_to_string(crate::paths::rig_config("alpha").unwrap()).expect("installed rig");
     assert!(installed.contains("alpha rig updated"));
     assert_eq!(
-        crate::core::rig::read_source_metadata("alpha")
+        crate::rig::read_source_metadata("alpha")
             .expect("metadata")
             .source_revision,
         result.updated[0].source_revision
@@ -338,7 +329,7 @@ fn update_git_source_refreshes_owned_stack_specs() {
         .to_string();
 
     install(&source, None, false).expect("install");
-    let before = crate::core::rig::read_stack_source_metadata("alpha-combined")
+    let before = crate::rig::read_stack_source_metadata("alpha-combined")
         .expect("stack metadata")
         .source_revision;
 
@@ -355,7 +346,7 @@ fn update_git_source_refreshes_owned_stack_specs() {
     assert_eq!(result.updated_stacks.len(), 1);
     assert_eq!(result.updated_stacks[0].id, "alpha-combined");
     assert_ne!(result.updated_stacks[0].source_revision, before);
-    let installed = fs::read_to_string(crate::core::paths::stack_config("alpha-combined").unwrap())
+    let installed = fs::read_to_string(crate::paths::stack_config("alpha-combined").unwrap())
         .expect("installed stack");
     assert!(installed.contains("updated stack"));
 }
@@ -371,8 +362,7 @@ fn update_all_reports_broken_sources_and_continues() {
         .to_string_lossy()
         .to_string();
     install(&broken_source, None, false).expect("install broken source");
-    let broken_metadata =
-        crate::core::rig::read_source_metadata("broken").expect("broken metadata");
+    let broken_metadata = crate::rig::read_source_metadata("broken").expect("broken metadata");
     fs::remove_dir_all(&broken_metadata.package_path).expect("remove installed package clone");
 
     let good_package = tempfile::tempdir().expect("good package");
@@ -397,8 +387,8 @@ fn update_all_reports_broken_sources_and_continues() {
     assert!(result.failed[0].reason.contains("missing"));
     assert_eq!(result.updated.len(), 1);
     assert_eq!(result.updated[0].id, "good");
-    let installed = fs::read_to_string(crate::core::paths::rig_config("good").unwrap())
-        .expect("installed good rig");
+    let installed =
+        fs::read_to_string(crate::paths::rig_config("good").unwrap()).expect("installed good rig");
     assert!(installed.contains("good rig updated"));
 }
 
@@ -413,7 +403,7 @@ fn refresh_source_selector_updates_recorded_package() {
         .to_string();
 
     install(&source, None, false).expect("install");
-    let before = crate::core::rig::read_source_metadata("alpha")
+    let before = crate::rig::read_source_metadata("alpha")
         .expect("metadata")
         .source_revision;
 
@@ -435,14 +425,12 @@ fn refresh_source_selector_updates_recorded_package() {
     assert_eq!(result.updated[0].source, source);
     assert_eq!(
         result.updated[0].path,
-        crate::core::paths::rig_config("alpha")
-            .unwrap()
-            .to_string_lossy()
+        crate::paths::rig_config("alpha").unwrap().to_string_lossy()
     );
     assert_eq!(result.updated[0].previous_revision, before);
     assert_ne!(result.updated[0].source_revision, before);
     assert!(
-        fs::read_to_string(crate::core::paths::rig_config("alpha").unwrap())
+        fs::read_to_string(crate::paths::rig_config("alpha").unwrap())
             .expect("installed rig")
             .contains("alpha rig refreshed")
     );
@@ -487,7 +475,7 @@ fn update_git_source_skips_user_replaced_stack_specs() {
         .to_string();
 
     install(&source, None, false).expect("install");
-    let config = crate::core::paths::stack_config("alpha-combined").expect("stack config");
+    let config = crate::paths::stack_config("alpha-combined").expect("stack config");
     fs::remove_file(&config).expect("remove symlink");
     fs::write(&config, minimal_stack("alpha-combined", "manual")).expect("manual stack");
     fs::write(

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -1,7 +1,7 @@
 //! Spec parsing tests — serde round-trips, pipeline step discriminants,
 //! service-kind parsing. Covers `src/core/rig/spec.rs`.
 
-use crate::core::rig::{
+use crate::rig::{
     FilesystemAssertionKind, PipelineStep, RigRequirementsSpec, RigResourcesSpec, RigSpec,
     ServiceKind, ServiceSpec, SharedPathSpec, SymlinkSpec, TraceConfig, TraceVariantSpec,
     WorkloadSpec,
@@ -607,7 +607,7 @@ fn test_spec_pipeline_step_id_and_dependencies_parse() {
 
 #[test]
 fn test_spec_git_step_parses_with_args() {
-    use crate::core::rig::spec::GitOp;
+    use crate::rig::spec::GitOp;
     let json = r#"{
         "id": "r",
         "components": { "studio": { "path": "/tmp/studio" } },
@@ -641,7 +641,7 @@ fn test_spec_git_step_parses_with_args() {
 
 #[test]
 fn test_spec_git_op_current_branch_kebab_serializes() {
-    use crate::core::rig::spec::GitOp;
+    use crate::rig::spec::GitOp;
     let json = r#"{
         "id": "r",
         "components": { "studio": { "path": "/tmp/studio" } },
@@ -660,7 +660,7 @@ fn test_spec_git_op_current_branch_kebab_serializes() {
 
 #[test]
 fn test_spec_stack_step_parses_sync_shape() {
-    use crate::core::rig::spec::StackOp;
+    use crate::rig::spec::StackOp;
     let json = r#"{
         "id": "r",
         "components": {
@@ -719,7 +719,7 @@ fn test_spec_round_trip_preserves_shape() {
 
 #[test]
 fn test_spec_patch_step_parses_full_shape() {
-    use crate::core::rig::spec::PatchOp;
+    use crate::rig::spec::PatchOp;
     let json = r#"{
         "id": "r",
         "components": { "playground": { "path": "/tmp/pg" } },
@@ -764,7 +764,7 @@ fn test_spec_patch_step_parses_full_shape() {
 
 #[test]
 fn test_spec_patch_op_defaults_to_apply_when_omitted() {
-    use crate::core::rig::spec::PatchOp;
+    use crate::rig::spec::PatchOp;
     let json = r#"{
         "id": "r",
         "components": { "c": { "path": "/tmp/c" } },

--- a/tests/core/rig/stack_test.rs
+++ b/tests/core/rig/stack_test.rs
@@ -2,10 +2,10 @@
 
 use std::collections::HashMap;
 
-use crate::core::error::Error;
-use crate::core::plan::{HomeboyPlan, PlanKind};
-use crate::core::rig::spec::{ComponentSpec, RigSpec};
-use crate::core::stack::{GitRef, StackPrEntry, StackSpec, SyncOutput, SyncPreview};
+use crate::error::Error;
+use crate::plan::{HomeboyPlan, PlanKind};
+use crate::rig::spec::{ComponentSpec, RigSpec};
+use crate::stack::{GitRef, StackPrEntry, StackSpec, SyncOutput, SyncPreview};
 
 use super::{plan_stack_sync, run_component_sync, run_sync_with, validate_component_stack_path};
 

--- a/tests/core/rig/state_test.rs
+++ b/tests/core/rig/state_test.rs
@@ -6,8 +6,8 @@
 
 use std::collections::BTreeMap;
 
-use crate::core::rig::spec::RigResourcesSpec;
-use crate::core::rig::state::{
+use crate::rig::spec::RigResourcesSpec;
+use crate::rig::state::{
     ComponentSnapshot, MaterializedRigState, RigState, RigStateSnapshot, ServiceState,
     SharedPathState,
 };

--- a/tests/core/rig/workloads_test.rs
+++ b/tests/core/rig/workloads_test.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use crate::core::rig::spec::RigSpec;
-use crate::core::rig::{
+use crate::rig::spec::RigSpec;
+use crate::rig::{
     check_groups_for_extension_workloads, env_provider_extensions_for_extension_workloads,
     extension_ids_for_workloads, extension_workload_inputs, required_component_id_for_workload,
     required_extension_ids_for_workload, runner_capabilities_for_extension,
@@ -188,9 +188,9 @@ fn test_invocation_requirements_for_extension_workloads() {
     )
     .expect("parse rig spec");
 
-    let requirements = crate::core::rig::invocation_requirements_for_extension_workloads(
+    let requirements = crate::rig::invocation_requirements_for_extension_workloads(
         &rig_spec,
-        crate::core::rig::RigWorkloadKind::Bench,
+        crate::rig::RigWorkloadKind::Bench,
         "extension-a",
     );
 

--- a/tests/core/stack/apply_test.rs
+++ b/tests/core/stack/apply_test.rs
@@ -9,10 +9,8 @@
 //! End-to-end correctness is verified out-of-band via the live-verify
 //! fixture spec described in the PR body.
 
-use crate::core::stack::apply::{
-    checkout_force, cherry_pick, rebase, url_matches, CherryPickResult,
-};
-use crate::core::stack::{save, GitRef, StackSpec};
+use crate::stack::apply::{checkout_force, cherry_pick, rebase, url_matches, CherryPickResult};
+use crate::stack::{save, GitRef, StackSpec};
 use crate::test_support::with_isolated_home;
 use std::fs;
 use std::process::Command;

--- a/tests/core/stack/inspect_test.rs
+++ b/tests/core/stack/inspect_test.rs
@@ -6,7 +6,7 @@
 //! intentionally not exercised end-to-end (they require a live `gh` and
 //! GitHub) — `no_pr: true` keeps tests deterministic.
 
-use crate::core::stack::inspect::{inspect_at, InspectOptions};
+use crate::stack::inspect::{inspect_at, InspectOptions};
 
 mod support;
 use support::{commit_file, git, init_repo};

--- a/tests/core/stack/push_test.rs
+++ b/tests/core/stack/push_test.rs
@@ -1,7 +1,7 @@
 //! Tests for `core::stack::push` — publishing the materialized target branch.
 
-use crate::core::stack::push::{local_branch_ref, push, remote_branch_ref, PushStatus};
-use crate::core::stack::spec::{GitRef, StackSpec};
+use crate::stack::push::{local_branch_ref, push, remote_branch_ref, PushStatus};
+use crate::stack::spec::{GitRef, StackSpec};
 use std::process::Command;
 use tempfile::TempDir;
 

--- a/tests/core/stack/spec_test.rs
+++ b/tests/core/stack/spec_test.rs
@@ -1,6 +1,6 @@
 //! Spec parsing + path expansion tests for `core::stack::spec`.
 
-use crate::core::stack::spec::{expand_path, parse_git_ref, GitRef, StackPrEntry, StackSpec};
+use crate::stack::spec::{expand_path, parse_git_ref, GitRef, StackPrEntry, StackSpec};
 
 const STUDIO_FIXTURE: &str = r#"{
     "id": "studio-combined",

--- a/tests/core/stack/status_test.rs
+++ b/tests/core/stack/status_test.rs
@@ -6,7 +6,7 @@
 //! commit reachability. End-to-end reporting is verified out-of-band via
 //! the live-verify fixture spec described in the PR body.
 
-use crate::core::stack::status::{commit_reachable, count_revs, git_ref_exists, patch_in_base};
+use crate::stack::status::{commit_reachable, count_revs, git_ref_exists, patch_in_base};
 use std::fs;
 
 mod support;

--- a/tests/core/stack/sync_test.rs
+++ b/tests/core/stack/sync_test.rs
@@ -11,7 +11,7 @@
 //! from the spec. The cherry-pick orchestration after that decision is
 //! the same machinery `apply` uses (already tested in `apply_test.rs`).
 
-use crate::core::stack::sync::{is_droppable, sync_would_mutate_from_parts, PrMeta};
+use crate::stack::sync::{is_droppable, sync_would_mutate_from_parts, PrMeta};
 use std::fs;
 
 mod support;

--- a/tests/utils/autofix_test.rs
+++ b/tests/utils/autofix_test.rs
@@ -1,4 +1,4 @@
-use homeboy::core::refactor::auto::{
+use crate::refactor::auto::{
     parse_fix_results_file, standard_outcome, summarize_optional_fix_results, AutofixMode,
 };
 
@@ -13,7 +13,10 @@ fn test_standard_outcome_dry_run_preview() {
 
     assert_eq!(outcome.status, "auto_fix_preview");
     assert!(!outcome.rerun_recommended);
-    assert!(outcome.hints.iter().any(|h| h.contains("Dry-run only")));
+    assert!(outcome
+        .hints
+        .iter()
+        .any(|h: &String| h.contains("Dry-run only")));
 }
 
 #[test]
@@ -37,7 +40,7 @@ fn test_standard_outcome_write_rerun_hint() {
     assert!(outcome
         .hints
         .iter()
-        .any(|h| h.contains("Re-run checks: homeboy review test homeboy --analyze")));
+        .any(|h: &String| h.contains("Re-run checks: homeboy review test homeboy --analyze")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
The homeboy-core crate extraction (#8389) rewrote `src/` paths but left the `#[path]`-included test files under `tests/core/**` referencing the pre-extraction crate root. The extracted crate's test target therefore failed to compile (**740 errors** on `main`). This restores it.

## Changes
- **Mechanical path rewrite** across the 44 `tests/core/**` files the crate `#[path]`-includes: `crate::core::X` → `crate::X`, and `homeboy::X` → `crate::X`.
- **Shared test harness across the crate boundary:** move `test_support` into homeboy-core behind a `test-support` feature. The root binary enables it via `[dev-dependencies]` and re-exports `crate::test_support`, registering a **command-layer cache reset hook** so core never depends upward on the CLI `commands` layer (the one `entity_suggest` reset it needed). Root-used helpers promoted from `pub(crate)` to `pub`.
- **Fixture depths:** 4 `include_str!` paths corrected for the new crate depth (`../../tests` → `../../../tests`); `reset_config_cache_for_test` gated on `any(test, feature = "test-support")`.
- **`daemon_test.rs`:** `crate::command_contract::LabCommandContract` → `crate::lab_contract::LabCommandContract` (the type now lives in `homeboy-lab-contract`, re-exported by core as `lab_contract`).
- **Relocation:** the component-script test drives `crate::commands::test::run`, so it is a command-layer integration test and cannot live in core. Moved its `#[path]` include from `homeboy-core` to the root binary's `src/commands/test.rs`; promoted the two core fns it exercises (`run_component_scripts_with_env`, `source_path`) to `pub`.

## Verification
- `cargo check -p homeboy-core --lib --tests --features test-support` → **compiles clean** (740 → 0 errors; only pre-existing dead-code warnings).
- `cargo fmt` clean.
- Full test run deferred to CI per repo policy (the VPS cannot link the full suite).

## Scope note
The **root binary** test target has a *separate* set of ~34 pre-existing #8389 cross-crate visibility errors (`RUNNER_*_ENV`, `resource_policy_context_*`, `result_types`, etc.) in files this PR does **not** touch — those need their own follow-up and are out of scope here. This PR fixes exactly what #8400 tracks: the homeboy-core test target.

Refs #8400

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (via OpenCode), running as chubes-bot on the Extra Chill VPS
- **Used for:** Diagnosed the crate-boundary test breakage, implemented the path rewrites + shared-harness feature, and verified the homeboy-core test target compiles.