### PR TITLE
Recover late Lab agent-task aggregates

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -803,6 +803,14 @@ pub(crate) fn reconcile_runner_job_snapshot(
     snapshot: &crate::runner::RunnerJobLogSnapshot,
 ) -> Result<()> {
     if is_terminal_run_state(record.state) {
+        // A transport-only terminal result can arrive before the daemon has
+        // published the inner agent-task aggregate. Adopt that later evidence
+        // when it proves the same controller run rather than losing its patch.
+        if let Some(event) = crate::runner::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_job_events(
+            Some(&snapshot.events),
+        ) {
+            project_terminal_runner_lifecycle_event(record, snapshot, &event)?;
+        }
         return Ok(());
     }
     validate_runner_job_snapshot(record, snapshot)?;
@@ -837,21 +845,10 @@ pub(crate) fn reconcile_runner_job_snapshot(
         crate::api_jobs::JobStatus::Succeeded
         | crate::api_jobs::JobStatus::Failed
         | crate::api_jobs::JobStatus::Cancelled => {
-            if let Some(event) = crate::runner::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_job_events(Some(&snapshot.events)) {
-                validate_terminal_child_identity(&reconciled, snapshot, &event)?;
-                let projection_plan = aggregate_projection_plan_from_outcomes(&event.aggregate);
-                let aggregate_path = store::aggregate_path(&reconciled.run_id)
-                    .map(|path| path.display().to_string())
-                    .unwrap_or_else(|_| "aggregate.json".to_string());
-                apply_aggregate_to_record(&mut reconciled, &projection_plan, &event.aggregate, aggregate_path);
-                // The aggregate is the task result. A successful enclosing daemon
-                // job only proves transport completion, not task success.
-                record_runner_job_terminal_metadata(&mut reconciled, snapshot.job.status, &snapshot.events);
-                store::write_aggregate_and_record(&reconciled, &event.aggregate)?;
-                crate::agent_task_lifecycle::record_terminal_artifact_projection(
-                    &mut reconciled,
-                    &event.aggregate,
-                )?;
+            if let Some(event) = crate::runner::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_job_events(
+                Some(&snapshot.events),
+            ) {
+                project_terminal_runner_lifecycle_event(&mut reconciled, snapshot, &event)?;
             } else {
                 apply_runner_job_terminal_state(&mut reconciled, snapshot.job.status, &snapshot.events);
                 store::write_record(&reconciled)?;
@@ -860,6 +857,25 @@ pub(crate) fn reconcile_runner_job_snapshot(
     }
     *record = reconciled;
     Ok(())
+}
+
+fn project_terminal_runner_lifecycle_event(
+    record: &mut AgentTaskRunRecord,
+    snapshot: &crate::runner::RunnerJobLogSnapshot,
+    event: &crate::runner::agent_task_lifecycle_event::AgentTaskRunPlanLifecycleEvent,
+) -> Result<()> {
+    validate_runner_job_snapshot(record, snapshot)?;
+    validate_terminal_child_identity(record, snapshot, event)?;
+    let projection_plan = aggregate_projection_plan_from_outcomes(&event.aggregate);
+    let aggregate_path = store::aggregate_path(&record.run_id)
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|_| "aggregate.json".to_string());
+    apply_aggregate_to_record(record, &projection_plan, &event.aggregate, aggregate_path);
+    // The aggregate is the task result. A successful enclosing daemon job only
+    // proves transport completion, not task success.
+    record_runner_job_terminal_metadata(record, snapshot.job.status, &snapshot.events);
+    store::write_aggregate_and_record(record, &event.aggregate)?;
+    crate::agent_task_lifecycle::record_terminal_artifact_projection(record, &event.aggregate)
 }
 
 fn merge_live_provider_handles(

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -1162,6 +1162,71 @@ fn terminal_runner_reconciliation_never_resurrects_a_controller_record() {
 }
 
 #[test]
+fn late_inner_aggregate_recovers_patch_after_transport_only_terminal_result() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-disconnected-child",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("running proxy");
+
+        // The outer daemon envelope has no captured patch, so its terminal
+        // transport result alone cannot represent the inner agent-task output.
+        let mut transport_only = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        transport_only.events.clear();
+        reconcile_runner_job_snapshot(&mut record, &transport_only)
+            .expect("transport-only terminal result");
+        assert_eq!(record.state, AgentTaskRunState::Succeeded);
+        assert!(artifacts(&record.run_id)
+            .expect("transport-only artifacts")
+            .artifacts
+            .is_empty());
+
+        let mut aggregate = succeeded_aggregate(&test_plan());
+        aggregate.outcomes[0].artifacts.push(AgentTaskArtifact {
+            schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+            id: "inner-patch".to_string(),
+            kind: "patch".to_string(),
+            name: Some("candidate.patch".to_string()),
+            label: None,
+            role: Some("patch".to_string()),
+            semantic_key: None,
+            path: Some("artifacts/candidate.patch".to_string()),
+            url: Some("homeboy://agent-task/run/agent-task-disconnected-child/artifacts#task=task-a&artifact=inner-patch".to_string()),
+            mime: Some("text/x-diff".to_string()),
+            size_bytes: Some(18_928),
+            sha256: Some("062f5c460c2dfb279277b75d5a16a04e3178ace1f35ce7b10da5e17441b37071".to_string()),
+            metadata: Value::Null,
+        });
+        let lifecycle_snapshot = terminal_child_snapshot(&aggregate);
+        reconcile_runner_job_snapshot(&mut record, &lifecycle_snapshot)
+            .expect("late inner lifecycle evidence is adopted");
+
+        let artifacts = artifacts(&record.run_id).expect("controller-visible artifacts");
+        assert_eq!(artifacts.artifacts.len(), 1);
+        assert_eq!(artifacts.artifacts[0].id, "inner-patch");
+        assert_eq!(artifacts.artifacts[0].size_bytes, Some(18_928));
+        assert_eq!(
+            artifacts.artifacts[0].sha256.as_deref(),
+            Some("062f5c460c2dfb279277b75d5a16a04e3178ace1f35ce7b10da5e17441b37071")
+        );
+        assert_eq!(
+            store::read_aggregate(&record.run_id)
+                .expect("persisted inner aggregate")
+                .outcomes[0]
+                .artifacts[0]
+                .sha256
+                .as_deref(),
+            Some("062f5c460c2dfb279277b75d5a16a04e3178ace1f35ce7b10da5e17441b37071")
+        );
+    });
+}
+
+#[test]
 fn disconnected_runner_marks_nonterminal_proxy_stale_without_advancing_heartbeat() {
     with_isolated_home(|_| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];


### PR DESCRIPTION
## Summary

Recover a Lab agent-task's inner aggregate when it arrives after the outer transport proxy has already become terminal.

## Root cause

The outer runner result can complete without a patch before the daemon publishes the inner agent-task lifecycle aggregate. `reconcile_runner_job_snapshot()` treated the terminal controller proxy as immutable and returned before inspecting later lifecycle events, so the finalized patch and evidence never entered the controller-visible artifact or promotion stores.

## What changed

- Inspect terminal snapshots for a validated inner lifecycle event before returning.
- Reuse one projection helper for normal and late terminal aggregate projection.
- Preserve runner-job and controller-run identity validation before adopting late evidence.
- Add regression coverage for a transport-only terminal result followed by an inner aggregate carrying the exact lost-patch evidence shape from #8341.

## How to test

1. Run `cargo check -p homeboy-core`; expect compilation to pass.
2. Run `cargo test -p homeboy-core --test durable_promotion`; expect the durable promotion integration test to pass.
3. Run `cargo test -p homeboy-core late_inner_aggregate_recovers_patch_after_transport_only_terminal_result --lib` after #8400 is resolved; expect the late aggregate to expose one controller-visible patch with matching size and SHA-256.
4. Run `git diff --check origin/main...HEAD`; expect no whitespace errors.

## Gate status

- `cargo check -p homeboy-core`: passed.
- `cargo test -p homeboy-core --test durable_promotion`: passed, 1 test.
- Homeboy lint: passed with zero findings.
- Homeboy review run `a33d29d6-9e0d-485c-8953-ad84b34c92c6`: blocked because the touched lifecycle files already exceed structural thresholds and changed-scope test routing selects zero executable tests.
- The focused lifecycle unit regression is currently blocked by #8400, the existing extracted-crate test-harness failure on `main`.

## Compatibility

No CLI, schema, or data-format compatibility change. Nonterminal reconciliation is unchanged. A terminal proxy only adopts late aggregate evidence after existing runner-job, controller-run, and child identity validation succeeds.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab lifecycle ordering failure, implemented and reviewed the repair and regression coverage, and orchestrated verification; Chris reviews and owns the change.

Closes #8341.
Related: #8400.
