### PR TITLE
fix(release): make binary releases authoritative

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -443,9 +443,9 @@ jobs:
         if: inputs.release_tag == ''
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Preflight crates.io packages
+      - name: Preflight internal workspace packages
         if: inputs.release_tag == '' && needs.check.outputs.recovery-release != 'true'
-        run: cargo package --workspace --allow-dirty --no-verify
+        run: cargo package --workspace --exclude homeboy --allow-dirty --no-verify
 
       - uses: Extra-Chill/homeboy-action@v2
         id: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@
 #   1. Quality gate (audit, lint, test)
 #   2. Version bump + changelog generation from conventional commits
 #   3. Cross-platform binary builds via cargo-dist
-#   4. Publish to GitHub Releases, crates.io, and Homebrew
+#   4. Publish GitHub Release assets and the Homebrew formula
 #
 # No human input needed — version is computed from commit types:
 #   fix: → patch, feat: → minor, BREAKING CHANGE → major
@@ -443,9 +443,9 @@ jobs:
         if: inputs.release_tag == ''
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Preflight internal workspace packages
+      - name: Preflight release workspace build
         if: inputs.release_tag == '' && needs.check.outputs.recovery-release != 'true'
-        run: cargo package --workspace --exclude homeboy --allow-dirty --no-verify
+        run: cargo build --workspace --all-targets --locked
 
       - uses: Extra-Chill/homeboy-action@v2
         id: release
@@ -695,7 +695,6 @@ jobs:
     if: ${{ always() && needs.plan.result == 'success' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
     runs-on: ubuntu-22.04
     outputs:
@@ -755,6 +754,7 @@ jobs:
           commands: release
           release-head: 'true'
           release-from-artifacts: artifacts
+          release-skip-publish: 'true'
 
   announce:
     needs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,8 @@
 [workspace]
 # Internal crates split out of the homeboy monolith to gain per-crate
 # incremental compilation and lower peak build memory. They are path-only
-# dependencies of the `homeboy` crate and are NOT published to crates.io
-# (each sets `publish = false`); the shipped CLI artifact remains the single
-# `homeboy` binary.
+# dependencies of the `homeboy` crate. The entire workspace is private; the
+# shipped CLI artifact remains the single `homeboy` binary.
 members = ["crates/*"]
 
 [package]
@@ -17,6 +16,7 @@ description = "Headless automation for agentic software engineering workflows"
 repository = "https://github.com/Extra-Chill/homeboy"
 homepage = "https://github.com/Extra-Chill/homeboy"
 exclude = ["/artifacts/"]
+publish = false
 
 [lib]
 name = "homeboy"
@@ -35,20 +35,19 @@ name = "bench-audit-self"
 path = "src/bin/bench-audit-self.rs"
 
 [dependencies]
-# Internal workspace crates. Cargo uses the path locally and the version when
-# packaging the publishable homeboy crate for crates.io.
-homeboy-cli-contract = { version = "0.1.0", path = "crates/homeboy-cli-contract" }
-homeboy-error = { version = "0.1.0", path = "crates/homeboy-error" }
-homeboy-finding = { version = "0.1.0", path = "crates/homeboy-finding" }
-homeboy-output = { version = "0.1.0", path = "crates/homeboy-output" }
-homeboy-paths = { version = "0.1.0", path = "crates/homeboy-paths" }
-homeboy-process = { version = "0.1.0", path = "crates/homeboy-process" }
-homeboy-product-identity = { version = "0.1.0", path = "crates/homeboy-product-identity" }
-homeboy-engine-primitives = { version = "0.1.0", path = "crates/homeboy-engine-primitives" }
-homeboy-cli = { version = "0.1.0", path = "crates/homeboy-cli" }
-homeboy-core = { version = "0.1.0", path = "crates/homeboy-core" }
-homeboy-lab-contract = { version = "0.1.0", path = "crates/homeboy-lab-contract" }
-homeboy-redaction = { version = "0.1.0", path = "crates/homeboy-redaction" }
+# Private workspace crates shipped only in the Homeboy binary.
+homeboy-cli-contract = { path = "crates/homeboy-cli-contract" }
+homeboy-error = { path = "crates/homeboy-error" }
+homeboy-finding = { path = "crates/homeboy-finding" }
+homeboy-output = { path = "crates/homeboy-output" }
+homeboy-paths = { path = "crates/homeboy-paths" }
+homeboy-process = { path = "crates/homeboy-process" }
+homeboy-product-identity = { path = "crates/homeboy-product-identity" }
+homeboy-engine-primitives = { path = "crates/homeboy-engine-primitives" }
+homeboy-cli = { path = "crates/homeboy-cli" }
+homeboy-core = { path = "crates/homeboy-core" }
+homeboy-lab-contract = { path = "crates/homeboy-lab-contract" }
+homeboy-redaction = { path = "crates/homeboy-redaction" }
 
 # Core library dependencies
 base64 = "0.22"

--- a/crates/homeboy-core/src/upgrade/constants.rs
+++ b/crates/homeboy-core/src/upgrade/constants.rs
@@ -1,7 +1,5 @@
 pub(crate) const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub(crate) const CRATES_IO_API: &str = "https://crates.io/api/v1/crates/homeboy";
-
 pub(crate) const GITHUB_RELEASES_API: &str =
     "https://api.github.com/repos/Extra-Chill/homeboy/releases/latest";
 

--- a/crates/homeboy-core/src/upgrade/execution.rs
+++ b/crates/homeboy-core/src/upgrade/execution.rs
@@ -77,9 +77,14 @@ pub(crate) fn execute_upgrade(
             })?
         }
         InstallMethod::Secondary => {
-            let cmd = &defaults.install_methods.secondary.upgrade_command;
+            // Legacy cargo-installed binaries are replaced with the release
+            // asset now that Homeboy's private workspace is not on crates.io.
+            let cmd = &defaults.install_methods.binary.upgrade_command;
             Command::new("sh").args(["-c", cmd]).output().map_err(|e| {
-                Error::internal_io(e.to_string(), Some("run secondary upgrade".to_string()))
+                Error::internal_io(
+                    e.to_string(),
+                    Some("run release binary upgrade".to_string()),
+                )
             })?
         }
         InstallMethod::Source => {

--- a/crates/homeboy-core/src/upgrade/helpers.rs
+++ b/crates/homeboy-core/src/upgrade/helpers.rs
@@ -5,7 +5,7 @@ use crate::{build_identity, extension, git};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use super::constants::{CRATES_IO_API, GITHUB_RELEASES_API, VERSION};
+use super::constants::{GITHUB_RELEASES_API, VERSION};
 use super::execution::{execute_upgrade, resolve_source_workspace};
 use super::runners;
 use super::services;
@@ -20,26 +20,7 @@ pub fn current_build_version() -> String {
     build_identity::current().display
 }
 
-pub(crate) fn fetch_latest_secondary_version() -> Result<String> {
-    let client = reqwest::blocking::Client::builder()
-        .user_agent(format!("homeboy/{}", VERSION))
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .map_err(|e| Error::internal_io(e.to_string(), Some("create HTTP client".to_string())))?;
-
-    let response: CratesIoResponse = client
-        .get(CRATES_IO_API)
-        .send()
-        .map_err(|e| Error::internal_io(e.to_string(), Some("query crates.io".to_string())))?
-        .json()
-        .map_err(|e| {
-            Error::internal_json(e.to_string(), Some("parse crates.io response".to_string()))
-        })?;
-
-    Ok(response.crate_info.newest_version)
-}
-
-pub(crate) fn fetch_latest_github_version() -> Result<String> {
+fn fetch_latest_github_version_at(url: &str) -> Result<String> {
     let client = reqwest::blocking::Client::builder()
         .user_agent(format!("homeboy/{}", VERSION))
         .timeout(std::time::Duration::from_secs(10))
@@ -47,7 +28,7 @@ pub(crate) fn fetch_latest_github_version() -> Result<String> {
         .map_err(|e| Error::internal_io(e.to_string(), Some("create HTTP client".to_string())))?;
 
     let response: GitHubRelease = client
-        .get(GITHUB_RELEASES_API)
+        .get(url)
         .send()
         .map_err(|e| Error::internal_io(e.to_string(), Some("query GitHub releases".to_string())))?
         .json()
@@ -67,13 +48,11 @@ pub(crate) fn fetch_latest_github_version() -> Result<String> {
 }
 
 pub fn fetch_latest_version(method: InstallMethod) -> Result<String> {
-    match method {
-        InstallMethod::Secondary => fetch_latest_secondary_version(),
-        InstallMethod::Homebrew
-        | InstallMethod::Source
-        | InstallMethod::Binary
-        | InstallMethod::Unknown => fetch_latest_github_version(),
-    }
+    fetch_latest_github_version_at(latest_version_endpoint(method))
+}
+
+fn latest_version_endpoint(_method: InstallMethod) -> &'static str {
+    GITHUB_RELEASES_API
 }
 
 pub fn detect_install_method() -> InstallMethod {
@@ -802,6 +781,19 @@ mod runner_source_upgrade_tests {
     use super::*;
     use std::process::Command;
     use tempfile::tempdir;
+
+    #[test]
+    fn every_install_method_discovers_versions_from_github_releases() {
+        for method in [
+            InstallMethod::Homebrew,
+            InstallMethod::Secondary,
+            InstallMethod::Source,
+            InstallMethod::Binary,
+            InstallMethod::Unknown,
+        ] {
+            assert_eq!(latest_version_endpoint(method), GITHUB_RELEASES_API);
+        }
+    }
 
     #[test]
     fn detected_source_install_forwards_source_method_to_runners() {

--- a/crates/homeboy-core/src/upgrade/types.rs
+++ b/crates/homeboy-core/src/upgrade/types.rs
@@ -197,17 +197,6 @@ pub struct RunnerDaemonDriftEntry {
 }
 
 #[derive(Deserialize)]
-pub(super) struct CratesIoResponse {
-    #[serde(rename = "crate")]
-    pub(super) crate_info: CrateInfo,
-}
-
-#[derive(Deserialize)]
-pub(super) struct CrateInfo {
-    pub(super) newest_version: String,
-}
-
-#[derive(Deserialize)]
 pub(super) struct GitHubRelease {
     pub(super) tag_name: String,
 }

--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -279,10 +279,7 @@ A skipped release is **not** reported as success: the process exits with code `5
 Publish steps are designed to be idempotent:
 
 - **GitHub releases**: If tag exists, assets are updated via `--clobber`
-- **crates.io**: If version already published, step skips gracefully
-
-GitHub release CI publishes to crates.io when the repository has a `CARGO_REGISTRY_TOKEN`
-secret configured.
+- **Homebrew**: The generated formula is republished from the GitHub Release assets
 
 This allows safe retry after `partial_success` without manual cleanup.
 

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -93,7 +93,7 @@ homeboy upgrade --skip-runners
 
 - `command`: `upgrade.check`
 - `current_version`: Current installed version
-- `latest_version`: Latest available version from crates.io (may be null if network fails)
+- `latest_version`: Latest GitHub Release version (may be null if network fails)
 - `update_available`: Boolean indicating if an update is available
 - `install_method`: Detected installation method (`homebrew`, `cargo`, `source`, or `unknown`)
 
@@ -121,7 +121,7 @@ Runner upgrade entries include the configured `homeboy_path`, observed configure
 
 ## Notes
 
-- Version checking queries the crates.io API. Network failures are handled gracefully.
+- Version checking queries the GitHub Releases API. Network failures are handled gracefully.
 - On Unix platforms, successful source installs automatically restart into the new binary. Binary and package-manager installs do not require a restart.
 
 ## Related

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -10,8 +10,8 @@ fn cargo_manifest() -> &'static str {
     include_str!("../Cargo.toml")
 }
 
-fn homeboy_lab_contract_manifest() -> &'static str {
-    include_str!("../crates/homeboy-lab-contract/Cargo.toml")
+fn dist_workspace_manifest() -> &'static str {
+    include_str!("../dist-workspace.toml")
 }
 
 fn release_quality_policy(
@@ -223,31 +223,43 @@ fn release_planning_skips_quality_gates_already_owned_by_gate_jobs() {
 }
 
 #[test]
-fn release_prepare_packages_internal_workspace_members_before_mutating_release_state() {
+fn release_preflight_validates_the_private_workspace_build_before_mutating_release_state() {
     let prepare = job_section(release_workflow(), "prepare");
     let package_preflight = prepare
-        .find("name: Preflight internal workspace packages")
-        .expect("prepare must validate internal workspace package manifests");
+        .find("name: Preflight release workspace build")
+        .expect("prepare must validate the complete release build");
     let release_action = prepare
         .find("uses: Extra-Chill/homeboy-action@v2")
         .expect("prepare must run the release action");
 
     assert!(
-        prepare.contains("run: cargo package --workspace --exclude homeboy --allow-dirty --no-verify"),
-        "package preflight must archive every internal workspace crate without requiring the root package's path dependencies in crates.io"
+        prepare.contains("run: cargo build --workspace --all-targets --locked"),
+        "release preflight must build every private workspace target with the locked dependency graph"
     );
     assert!(
-        cargo_manifest().contains("homeboy-lab-contract = { version = \"0.1.0\", path = \"crates/homeboy-lab-contract\" }"),
-        "the root package must depend on the extracted Lab contract crate through the workspace"
+        cargo_manifest().contains("publish = false"),
+        "the root package must not be planned for crates.io publication"
     );
     assert!(
-        homeboy_lab_contract_manifest().contains("publish = false"),
-        "the extracted Lab contract crate must remain an internal-only package"
+        cargo_manifest().contains("homeboy-lab-contract = { path = \"crates/homeboy-lab-contract\" }"),
+        "the root package must consume the extracted Lab contract crate as a private path dependency"
     );
     assert!(
         package_preflight < release_action,
         "package preflight must run before release preparation can create a tag"
     );
+}
+
+#[test]
+fn release_workflow_publishes_binary_channels_not_crates_io() {
+    let workflow = release_workflow();
+    let host = job_section(workflow, "host");
+
+    assert!(!workflow.contains("crates.io"));
+    assert!(!host.contains("CARGO_REGISTRY_TOKEN"));
+    assert!(host.contains("release-skip-publish: 'true'"));
+    assert!(dist_workspace_manifest().contains("ci = \"github\""));
+    assert!(dist_workspace_manifest().contains("publish-jobs = [\"homebrew\"]"));
 }
 
 #[test]

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -6,6 +6,14 @@ fn release_quality_policy_script() -> &'static str {
     include_str!("../.github/release-quality-policy.sh")
 }
 
+fn cargo_manifest() -> &'static str {
+    include_str!("../Cargo.toml")
+}
+
+fn homeboy_lab_contract_manifest() -> &'static str {
+    include_str!("../crates/homeboy-lab-contract/Cargo.toml")
+}
+
 fn release_quality_policy(
     blocking_commands: &str,
     audit_result: &str,
@@ -215,18 +223,26 @@ fn release_planning_skips_quality_gates_already_owned_by_gate_jobs() {
 }
 
 #[test]
-fn release_prepare_validates_publishable_workspace_before_mutating_release_state() {
+fn release_prepare_packages_internal_workspace_members_before_mutating_release_state() {
     let prepare = job_section(release_workflow(), "prepare");
     let package_preflight = prepare
-        .find("name: Preflight crates.io packages")
-        .expect("prepare must validate crates.io package manifests");
+        .find("name: Preflight internal workspace packages")
+        .expect("prepare must validate internal workspace package manifests");
     let release_action = prepare
         .find("uses: Extra-Chill/homeboy-action@v2")
         .expect("prepare must run the release action");
 
     assert!(
-        prepare.contains("run: cargo package --workspace --allow-dirty --no-verify"),
-        "publish preflight must package every workspace crate without publishing"
+        prepare.contains("run: cargo package --workspace --exclude homeboy --allow-dirty --no-verify"),
+        "package preflight must archive every internal workspace crate without requiring the root package's path dependencies in crates.io"
+    );
+    assert!(
+        cargo_manifest().contains("homeboy-lab-contract = { version = \"0.1.0\", path = \"crates/homeboy-lab-contract\" }"),
+        "the root package must depend on the extracted Lab contract crate through the workspace"
+    );
+    assert!(
+        homeboy_lab_contract_manifest().contains("publish = false"),
+        "the extracted Lab contract crate must remain an internal-only package"
     );
     assert!(
         package_preflight < release_action,


### PR DESCRIPTION
Closes #8350

## Summary

- make GitHub Release binaries and the Homebrew formula the authoritative Homeboy distribution channels
- keep the root package and extracted workspace crates private, path-only workspace dependencies
- replace the crates.io package preflight with the actual locked workspace all-target build topology before release state mutation
- retain GitHub-release version discovery and route legacy cargo installations through the release-binary upgrader

## Source relationship

This is a direct repair for the publishable-topology failure evidenced in #8350 and is rebased as the existing two-commit change onto current `origin/main` (`ff82c4887`). The rebase preserves the newer `homeboy-core` and `homeboy-cli` extraction: upgrade changes now live in `crates/homeboy-core`, and both newly extracted root dependencies remain present as private path dependencies.

Change kind: release workflow/configuration repair with a narrowly bounded upgrade compatibility adjustment and deterministic contract coverage.

Verification capability: the release workflow contract is independently runnable and passes. The package-scoped upgrade and workspace all-target harnesses were run, but current main cannot compile extracted crate tests due the separately tracked #8408 harness break. No gate was bypassed or disabled.

Runtime scope: only the legacy `Secondary` (cargo-installed) upgrade path changes, reusing the existing binary release command because no Homeboy crates are published. Homebrew, source, binary, and unknown-method behavior is otherwise unchanged.

## Stranger-runnable tests

1. `cargo test --locked --test release_workflow_test`
   Result: passes, 18 tests. Covers private workspace preflight ordering and GitHub Release/Homebrew-only publication topology.
2. `rustfmt --edition 2021 --check crates/homeboy-core/src/upgrade/constants.rs crates/homeboy-core/src/upgrade/execution.rs crates/homeboy-core/src/upgrade/helpers.rs crates/homeboy-core/src/upgrade/types.rs tests/release_workflow_test.rs`
   Result: passes for every Rust file changed by this PR.
3. `cargo test --locked -p homeboy-core upgrade::`
   Result: blocked before test selection by current-main #8408 (`crate::core`, `homeboy::core`, and test-support paths in the extracted `homeboy-core` harness). This command contains the GitHub-release discovery and upgrade coverage added here.
4. `cargo build --workspace --all-targets --locked`
   Result: blocked by the same current-main #8408 extracted test harness errors; production libraries compile before all-target test compilation reaches that baseline failure.
5. `cargo fmt --all -- --check`
   Result: current main has unrelated pre-existing rustfmt drift in `crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs` and `crates/homeboy-core/src/agent_task_service/cook.rs`; changed-file formatting passes in test 2.
6. `git diff --check origin/main...HEAD`
   Result: passes.

## Compatibility impact

- Existing Homebrew and GitHub-release binary users keep the same authoritative channels.
- Existing cargo-installed binaries can still upgrade, but migrate through the GitHub release binary installer because future Homeboy crates remain unpublished.
- Source installs retain source-build behavior.
- crates.io publication is intentionally removed; this matches the private workspace architecture and avoids the impossible bootstrap topology from #8350.

## AI assistance

AI assistance was used to inspect the repository, rebase and resolve extraction-era conflicts, run verification, and draft this PR. The resulting diff was reviewed against the issue evidence and current-main architecture.