### PR TITLE
Fix cross-platform Lab snapshot hashing

### DIFF
--- a/crates/homeboy-core/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-core/src/agent_task_scheduler/harvest.rs
@@ -698,7 +698,7 @@ mod committed_harvest_tests {
             "workspace_verification": {
                 "schema": "homeboy/lab-workspace-verification/v2", "identity": "snapshot:provider-ready",
                 "content_hash": content_hash, "sync_excludes": snapshot.sync_excludes,
-                "permission_policy": "unix-executable", "content_hash_algorithm": "homeboy-workspace-content-v2+unix-executable",
+                "permission_policy": "unix-owner-executable", "content_hash_algorithm": "homeboy-workspace-content-v3+unix-owner-executable",
                 "source_snapshot": snapshot,
                 "primary_workspace": { "identity": "snapshot:provider-ready", "remote_path": workspace.path().display().to_string() }
             }
@@ -934,7 +934,7 @@ mod committed_harvest_tests {
                 "workspace_verification": {
                     "schema": "homeboy/lab-workspace-verification/v2", "identity": synced.snapshot_identity,
                     "content_hash": content_hash, "sync_excludes": snapshot.sync_excludes,
-                    "permission_policy": "unix-executable", "content_hash_algorithm": "homeboy-workspace-content-v2+unix-executable",
+                    "permission_policy": "unix-owner-executable", "content_hash_algorithm": "homeboy-workspace-content-v3+unix-owner-executable",
                     "source_snapshot": snapshot,
                     "primary_workspace": { "identity": synced.snapshot_identity, "remote_path": remote.display().to_string() }
                 }
@@ -1022,7 +1022,7 @@ mod committed_harvest_tests {
             "workspace_verification": {
                 "schema": "homeboy/lab-workspace-verification/v2", "identity": "snapshot:runner-resident",
                 "content_hash": content_hash, "sync_excludes": snapshot.sync_excludes,
-                "permission_policy": "unix-executable", "content_hash_algorithm": "homeboy-workspace-content-v2+unix-executable",
+                "permission_policy": "unix-owner-executable", "content_hash_algorithm": "homeboy-workspace-content-v3+unix-owner-executable",
                 "source_snapshot": snapshot,
                 "primary_workspace": { "identity": "snapshot:runner-resident", "remote_path": workspace.path().display().to_string() }
             }

--- a/crates/homeboy-core/src/runner/lab/offload/metadata.rs
+++ b/crates/homeboy-core/src/runner/lab/offload/metadata.rs
@@ -588,13 +588,26 @@ pub(crate) fn attach_lab_workspace_metadata(
 ) -> Result<()> {
     let source_snapshot = inputs.source_snapshot;
     let primary_workspace_plan = &inputs.primary_synced_workspace.materialization_plan;
+    let source_path = source_snapshot.local_path.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "source_snapshot.local_path",
+            "Lab workspace verification requires a controller source path",
+            None,
+            None,
+        )
+    })?;
     let permission_policy = crate::runner::WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY;
     let content_hash = crate::runner::workspace_content_hash(
-        Path::new(&source_snapshot.local_path.clone().unwrap_or_default()),
+        Path::new(source_path),
         &source_snapshot.sync_excludes,
     )?;
     let content_hash_algorithm = crate::runner::workspace_content_hash_algorithm(permission_policy)
         .expect("default workspace content permission policy is supported");
+    let content_manifest = crate::runner::workspace_content_manifest_for_policy(
+        Path::new(source_path),
+        &source_snapshot.sync_excludes,
+        permission_policy,
+    )?;
     lab_metadata["source_snapshot"] =
         serde_json::to_value(source_snapshot).unwrap_or(serde_json::json!(null));
     lab_metadata["workspace_content_hash"] = serde_json::json!(content_hash);
@@ -607,6 +620,7 @@ pub(crate) fn attach_lab_workspace_metadata(
         "content_hash_algorithm": content_hash_algorithm,
         "permission_policy": permission_policy,
         "content_hash": content_hash,
+        "content_manifest": content_manifest,
         "sync_excludes": source_snapshot.sync_excludes,
         "source_snapshot": source_snapshot,
         "primary_workspace": primary_workspace_plan,

--- a/crates/homeboy-core/src/runner/lab/offload/tests/capability_metadata.rs
+++ b/crates/homeboy-core/src/runner/lab/offload/tests/capability_metadata.rs
@@ -252,6 +252,18 @@ fn lab_offload_workspace_verification_metadata_survives_process_env_hydration() 
         Some(&remote_path.display().to_string()),
         None,
     );
+    let mut missing_source_path = snapshot.clone();
+    missing_source_path.local_path = None;
+    let error = attach_lab_workspace_metadata(
+        &mut metadata,
+        LabWorkspaceMetadataInputs {
+            source_snapshot: &missing_source_path,
+            legacy_path_materialization_plan: &path_materialization_plan,
+            primary_synced_workspace: &synced_workspace,
+        },
+    )
+    .expect_err("verification metadata requires the controller source path");
+    assert!(error.message.contains("requires a controller source path"));
     attach_lab_workspace_metadata(
         &mut metadata,
         LabWorkspaceMetadataInputs {
@@ -310,19 +322,31 @@ fn lab_offload_workspace_verification_metadata_survives_process_env_hydration() 
         metadata["workspace_verification"]["permission_policy"],
         crate::runner::WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY
     );
-    assert!(metadata["workspace_verification"]
-        .get("content_manifest")
-        .is_none());
-    assert!(metadata["workspace_verification"].get("entries").is_none());
+    assert_eq!(
+        metadata["workspace_verification"]["content_manifest"]["entry_count"],
+        1
+    );
+    assert_eq!(
+        metadata["workspace_verification"]["content_manifest"]["entries"][0]["path"],
+        "README.md"
+    );
+    assert_eq!(
+        metadata["workspace_verification"]["content_manifest"]["entries"][0]["kind"],
+        "file"
+    );
+    assert!(
+        metadata["workspace_verification"]["content_manifest"]["entries"][0]
+            .get("content_sha256")
+            .is_none()
+    );
     let serialized_metadata = serde_json::to_string(&metadata).expect("metadata JSON");
-    assert!(!serialized_metadata.contains("README.md"));
     assert!(!serialized_metadata.contains("verified contents"));
 
     std::fs::write(remote.path().join("README.md"), "changed contents\n")
         .expect("change remote file");
     let error = verify_lab_workspace_from_env(&remote_path.display().to_string(), remote.path())
         .expect_err("changed remote content must fail verification");
-    assert!(error.contains("homeboy-workspace-content-v2+"));
+    assert!(error.contains("homeboy-workspace-content-v3+"));
     assert!(error.contains("expected sha256:"));
     assert!(error.contains("got sha256:"));
     assert!(error.contains("homeboy runner workspace sync --mode snapshot"));

--- a/crates/homeboy-core/src/runner/mod.rs
+++ b/crates/homeboy-core/src/runner/mod.rs
@@ -177,8 +177,8 @@ pub use workspace::{
 };
 pub(crate) use workspace::{
     verify_lab_workspace_from_env, verify_lab_workspace_git_root, workspace_content_hash,
-    workspace_content_hash_algorithm, VerifiedLabWorkspaceProvenance,
-    WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+    workspace_content_hash_algorithm, workspace_content_manifest_for_policy,
+    VerifiedLabWorkspaceProvenance, WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/homeboy-core/src/runner/workspace/mod.rs
+++ b/crates/homeboy-core/src/runner/workspace/mod.rs
@@ -44,7 +44,8 @@ pub(crate) use provenance::{
 pub(crate) use snapshot::{
     copy_snapshot_to_directory, effective_snapshot_excludes, local_snapshot_stats,
     materialize_snapshot, materialize_snapshot_git, snapshot_identity, workspace_content_hash,
-    workspace_content_hash_algorithm, WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+    workspace_content_hash_algorithm, workspace_content_manifest_for_policy,
+    WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
 };
 pub(crate) use types::{canonical_workspace_path, DEFAULT_EXCLUDES};
 pub(crate) use util::{

--- a/crates/homeboy-core/src/runner/workspace/provenance.rs
+++ b/crates/homeboy-core/src/runner/workspace/provenance.rs
@@ -5,12 +5,16 @@ use crate::engine::shell;
 use crate::observation::{LAB_OFFLOAD_METADATA_ENV, SOURCE_SNAPSHOT_METADATA_ENV};
 use crate::source_snapshot::SourceSnapshot;
 
-use super::snapshot::{workspace_content_hash_for_policy, workspace_content_hash_v1};
+use super::snapshot::{
+    workspace_content_hash_for_policy, workspace_content_hash_v1,
+    workspace_content_manifest_for_policy, WorkspaceContentManifest, WorkspaceContentManifestEntry,
+};
 use super::workspace_content_hash_algorithm;
 
 const LAB_SOURCE_SNAPSHOT_SYNC_MODE: &str = "lab_offload";
 const SYNTHETIC_SNAPSHOT_BASELINE_REF: &str = "refs/heads/homeboy-snapshot-baseline";
 const SYNTHETIC_SNAPSHOT_AUTHOR: &str = "Homeboy Snapshot <snapshot@homeboy.invalid> 0 +0000";
+const CONTENT_MANIFEST_DIFFERENCE_LIMIT: usize = 8;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct VerifiedLabWorkspaceProvenance {
@@ -22,6 +26,7 @@ pub(crate) struct VerifiedLabWorkspaceProvenance {
     content_hash: String,
     content_hash_algorithm: String,
     permission_policy: Option<String>,
+    content_manifest: Option<WorkspaceContentManifest>,
     sync_excludes: Vec<String>,
     local_source_path: Option<String>,
     remote_workspace_path: String,
@@ -488,6 +493,14 @@ pub(crate) fn verify_lab_workspace(
             }
             None => return Err("is missing workspace verification metadata".to_string()),
         };
+    let content_manifest = verification
+        .and_then(|verification| verification.get("content_manifest"))
+        .map(|value| serde_json::from_value(value.clone()))
+        .transpose()
+        .map_err(|error| format!("has invalid workspace content manifest: {error}"))?;
+    if let Some(manifest) = &content_manifest {
+        validate_content_manifest(manifest, permission_policy)?;
+    }
     if workspace_identity != verification_identity {
         return Err("workspace identity does not match workspace verification".to_string());
     }
@@ -500,6 +513,7 @@ pub(crate) fn verify_lab_workspace(
         content_hash: expected_content_hash.to_string(),
         content_hash_algorithm,
         permission_policy: permission_policy.map(str::to_string),
+        content_manifest,
         sync_excludes: snapshot.sync_excludes,
         local_source_path: snapshot.local_path,
         remote_workspace_path: recorded_remote_path.to_string(),
@@ -521,7 +535,10 @@ fn verify_snapshot_workspace_content(
         "homeboy-workspace-content-v1" => {
             workspace_content_hash_v1(workspace, &provenance.sync_excludes)
         }
-        algorithm if algorithm.starts_with("homeboy-workspace-content-v2+") => {
+        algorithm
+            if algorithm.starts_with("homeboy-workspace-content-v2+")
+                || algorithm == "homeboy-workspace-content-v3+unix-owner-executable" =>
+        {
             workspace_content_hash_for_policy(
                 workspace,
                 &provenance.sync_excludes,
@@ -553,10 +570,110 @@ fn verify_snapshot_workspace_content(
             ),
             _ => unreachable!("workspace verification mode was validated above"),
         };
+        let entry_diagnostic = provenance
+            .content_manifest
+            .as_ref()
+            .and_then(|expected| {
+                workspace_content_manifest_for_policy(
+                    workspace,
+                    &provenance.sync_excludes,
+                    provenance.permission_policy.as_deref()?,
+                )
+                .ok()
+                .map(|actual| content_manifest_difference(expected, &actual))
+            })
+            .unwrap_or_default();
         return Err(format!(
-            "workspace content hash does not match the controller materialization using {} (expected {}, got {}); operator diagnostic: `{diagnostic}`",
-            provenance.content_hash_algorithm, provenance.content_hash, actual_content_hash,
+            "workspace content hash does not match the controller materialization using {} (expected {}, got {});{} operator diagnostic: `{diagnostic}`",
+            provenance.content_hash_algorithm, provenance.content_hash, actual_content_hash, entry_diagnostic,
         ));
+    }
+    Ok(())
+}
+
+fn content_manifest_difference(
+    expected: &WorkspaceContentManifest,
+    actual: &WorkspaceContentManifest,
+) -> String {
+    let mut differing = Vec::with_capacity(CONTENT_MANIFEST_DIFFERENCE_LIMIT);
+    for entry in &expected.entries {
+        if differing.len() == CONTENT_MANIFEST_DIFFERENCE_LIMIT {
+            break;
+        }
+        match actual
+            .entries
+            .iter()
+            .find(|candidate| candidate.path == entry.path)
+        {
+            Some(candidate) if candidate == entry => {}
+            Some(candidate) => differing.push(format!(
+                "{} ({})",
+                entry.path,
+                content_manifest_entry_difference(entry, candidate)
+            )),
+            None => differing.push(format!("{} (missing)", entry.path)),
+        }
+    }
+    for entry in &actual.entries {
+        if differing.len() == CONTENT_MANIFEST_DIFFERENCE_LIMIT {
+            break;
+        }
+        if !expected
+            .entries
+            .iter()
+            .any(|candidate| candidate.path == entry.path)
+        {
+            differing.push(format!("{} (unexpected)", entry.path));
+        }
+    }
+    format!(
+        " entry diagnostics: {} differing logical entries in a bounded {}-entry sample (controller total {}, runner total {}): {};",
+        differing.len(),
+        expected.entries.len().max(actual.entries.len()),
+        expected.entry_count,
+        actual.entry_count,
+        if differing.is_empty() { "sample metadata matched; content differs outside bounded metadata".to_string() } else { differing.join(", ") },
+    )
+}
+
+fn content_manifest_entry_difference(
+    expected: &WorkspaceContentManifestEntry,
+    actual: &WorkspaceContentManifestEntry,
+) -> &'static str {
+    if expected.kind != actual.kind {
+        "kind changed"
+    } else if expected.owner_executable != actual.owner_executable {
+        "owner-executable capability changed"
+    } else {
+        "metadata changed"
+    }
+}
+
+fn validate_content_manifest(
+    manifest: &WorkspaceContentManifest,
+    permission_policy: Option<&str>,
+) -> std::result::Result<(), String> {
+    if manifest.entries.len() > 16 || manifest.entry_count < manifest.entries.len() {
+        return Err("has invalid bounded workspace content manifest".to_string());
+    }
+    for entry in &manifest.entries {
+        if entry.path.is_empty()
+            || entry.path.len() > super::snapshot::WORKSPACE_CONTENT_DIAGNOSTIC_PATH_LIMIT
+            || entry.path.contains('\0')
+            || !matches!(entry.kind.as_str(), "file" | "directory")
+        {
+            return Err("has invalid bounded workspace content manifest entry".to_string());
+        }
+        if entry.kind == "directory" && entry.owner_executable.is_some() {
+            return Err("has invalid directory workspace content manifest entry".to_string());
+        }
+        if entry.kind == "file"
+            && permission_policy
+                == Some(super::snapshot::WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE)
+            && entry.owner_executable.is_none()
+        {
+            return Err("has incomplete v3 workspace content manifest entry".to_string());
+        }
     }
     Ok(())
 }
@@ -879,6 +996,82 @@ mod tests {
     }
 
     #[test]
+    fn content_hash_mismatch_reports_bounded_logical_entry_diagnostics() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("file-00.txt"), "controller secret\n")
+            .expect("source file");
+        for index in 1..20 {
+            std::fs::write(
+                workspace.path().join(format!("file-{index:02}.txt")),
+                "baseline\n",
+            )
+            .expect("source file");
+        }
+        let snapshot = snapshot(workspace.path());
+        let content_hash =
+            super::super::workspace_content_hash(workspace.path(), &snapshot.sync_excludes)
+                .expect("content hash");
+        let content_manifest = workspace_content_manifest_for_policy(
+            workspace.path(),
+            &snapshot.sync_excludes,
+            WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+        )
+        .expect("content manifest");
+        let mut v2 = lab(workspace.path(), &snapshot);
+        v2["workspace_verification"]["schema"] =
+            serde_json::json!("homeboy/lab-workspace-verification/v2");
+        v2["workspace_verification"]["permission_policy"] =
+            serde_json::json!(WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY);
+        v2["workspace_verification"]["content_hash_algorithm"] = serde_json::json!(
+            workspace_content_hash_algorithm(WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY)
+                .expect("content hash algorithm")
+        );
+        v2["workspace_verification"]["content_hash"] = serde_json::json!(content_hash);
+        v2["workspace_verification"]["content_manifest"] =
+            serde_json::to_value(content_manifest).expect("manifest JSON");
+
+        std::fs::write(workspace.path().join("file-00.txt"), "runner mutation\n")
+            .expect("mutate materialization");
+        let error = verify_lab_workspace(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot,
+            v2,
+        )
+        .expect_err("changed materialization must fail");
+
+        assert!(error.contains("entry diagnostics: 0 differing logical entries"));
+        assert!(error.contains("sample metadata matched; content differs outside bounded metadata"));
+        assert!(error.contains("bounded 16-entry sample"));
+        assert!(!error.contains("controller secret"));
+        assert!(!error.contains("runner mutation"));
+    }
+
+    #[test]
+    fn content_manifest_validation_rejects_oversized_and_long_path_metadata() {
+        let entry = WorkspaceContentManifestEntry {
+            path: "file.txt".to_string(),
+            kind: "file".to_string(),
+            owner_executable: Some(false),
+        };
+        let oversized = WorkspaceContentManifest {
+            entry_count: 17,
+            entries: vec![entry.clone(); 17],
+        };
+        assert!(validate_content_manifest(&oversized, None).is_err());
+
+        let long_path = WorkspaceContentManifest {
+            entry_count: 1,
+            entries: vec![WorkspaceContentManifestEntry {
+                path: "a"
+                    .repeat(super::super::snapshot::WORKSPACE_CONTENT_DIAGNOSTIC_PATH_LIMIT + 1),
+                ..entry
+            }],
+        };
+        assert!(validate_content_manifest(&long_path, None).is_err());
+    }
+
+    #[test]
     fn verified_snapshot_baseline_supports_committed_and_uncommitted_candidate_harvesting() {
         let workspace = tempfile::tempdir().expect("workspace");
         std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");
@@ -1084,7 +1277,8 @@ mod tests {
     }
 
     #[test]
-    fn verifier_accepts_legacy_v1_and_current_v2_content_hashes() {
+    #[cfg(unix)]
+    fn verifier_accepts_legacy_v1_v2_and_current_v3_content_hashes() {
         let workspace = tempfile::tempdir().expect("workspace");
         std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");
         let snapshot = snapshot(workspace.path());
@@ -1097,18 +1291,22 @@ mod tests {
         )
         .expect("legacy v1 metadata remains valid");
 
-        let content_hash =
-            super::super::workspace_content_hash(workspace.path(), &snapshot.sync_excludes)
-                .expect("v2 content hash");
+        let content_hash = workspace_content_hash_for_policy(
+            workspace.path(),
+            &snapshot.sync_excludes,
+            super::super::snapshot::WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
+        )
+        .expect("historical v2 content hash");
         let mut v2 = lab(workspace.path(), &snapshot);
         v2["workspace_verification"]["schema"] =
             serde_json::json!("homeboy/lab-workspace-verification/v2");
         v2["workspace_verification"]["permission_policy"] =
-            serde_json::json!(WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY);
-        v2["workspace_verification"]["content_hash_algorithm"] = serde_json::json!(
-            workspace_content_hash_algorithm(WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY)
-                .expect("default content hash algorithm")
-        );
+            serde_json::json!(super::super::snapshot::WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE);
+        v2["workspace_verification"]["content_hash_algorithm"] =
+            serde_json::json!(workspace_content_hash_algorithm(
+                super::super::snapshot::WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE
+            )
+            .expect("historical v2 content hash algorithm"));
         v2["workspace_verification"]["content_hash"] = serde_json::json!(content_hash);
         verify_lab_workspace(
             &workspace.path().display().to_string(),
@@ -1116,7 +1314,58 @@ mod tests {
             snapshot.clone(),
             v2,
         )
-        .expect("v2 metadata verifies with v2 algorithm");
+        .expect("historical v2 metadata remains valid");
+
+        let content_hash =
+            super::super::workspace_content_hash(workspace.path(), &snapshot.sync_excludes)
+                .expect("current v3 content hash");
+        let mut v3 = lab(workspace.path(), &snapshot);
+        v3["workspace_verification"]["schema"] =
+            serde_json::json!("homeboy/lab-workspace-verification/v2");
+        v3["workspace_verification"]["permission_policy"] =
+            serde_json::json!(WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY);
+        v3["workspace_verification"]["content_hash_algorithm"] = serde_json::json!(
+            workspace_content_hash_algorithm(WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY)
+                .expect("current v3 content hash algorithm")
+        );
+        v3["workspace_verification"]["content_hash"] = serde_json::json!(content_hash);
+        verify_lab_workspace(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot,
+            v3,
+        )
+        .expect("current v3 metadata verifies");
+    }
+
+    #[test]
+    fn verifier_accepts_portable_v2_content_hash_on_all_platforms() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");
+        let snapshot = snapshot(workspace.path());
+        let content_hash = workspace_content_hash_for_policy(
+            workspace.path(),
+            &snapshot.sync_excludes,
+            WORKSPACE_CONTENT_PERMISSION_PORTABLE,
+        )
+        .expect("portable v2 content hash");
+        let mut v2 = lab(workspace.path(), &snapshot);
+        v2["workspace_verification"]["schema"] =
+            serde_json::json!("homeboy/lab-workspace-verification/v2");
+        v2["workspace_verification"]["permission_policy"] =
+            serde_json::json!(WORKSPACE_CONTENT_PERMISSION_PORTABLE);
+        v2["workspace_verification"]["content_hash_algorithm"] = serde_json::json!(
+            workspace_content_hash_algorithm(WORKSPACE_CONTENT_PERMISSION_PORTABLE)
+                .expect("portable v2 content hash algorithm")
+        );
+        v2["workspace_verification"]["content_hash"] = serde_json::json!(content_hash);
+        verify_lab_workspace(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot,
+            v2,
+        )
+        .expect("portable v2 metadata remains valid");
     }
 
     #[test]

--- a/crates/homeboy-core/src/runner/workspace/snapshot.rs
+++ b/crates/homeboy-core/src/runner/workspace/snapshot.rs
@@ -18,10 +18,27 @@ use super::util::{
 const RUNNER_WORKSPACE_METADATA_FILE: &str = ".homeboy/runner-workspace.json";
 pub(crate) const WORKSPACE_CONTENT_PERMISSION_PORTABLE: &str = "portable-content-only";
 pub(crate) const WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE: &str = "unix-executable";
+pub(crate) const WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE: &str = "unix-owner-executable";
+const WORKSPACE_CONTENT_DIAGNOSTIC_ENTRY_LIMIT: usize = 16;
+pub(crate) const WORKSPACE_CONTENT_DIAGNOSTIC_PATH_LIMIT: usize = 192;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub(crate) struct WorkspaceContentManifest {
+    pub(crate) entry_count: usize,
+    pub(crate) entries: Vec<WorkspaceContentManifestEntry>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub(crate) struct WorkspaceContentManifestEntry {
+    pub(crate) path: String,
+    pub(crate) kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) owner_executable: Option<bool>,
+}
 
 #[cfg(unix)]
 pub(crate) const WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY: &str =
-    WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE;
+    WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE;
 #[cfg(not(unix))]
 pub(crate) const WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY: &str =
     WORKSPACE_CONTENT_PERMISSION_PORTABLE;
@@ -64,6 +81,9 @@ pub(crate) fn workspace_content_hash_algorithm(policy: &str) -> Option<String> {
         WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE if cfg!(unix) => {
             Some("homeboy-workspace-content-v2+unix-executable".to_string())
         }
+        WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE if cfg!(unix) => {
+            Some("homeboy-workspace-content-v3+unix-owner-executable".to_string())
+        }
         _ => None,
     }
 }
@@ -73,14 +93,15 @@ pub(crate) fn workspace_content_hash_for_policy(
     excludes: &[String],
     policy: &str,
 ) -> Result<String> {
-    let algorithm = workspace_content_hash_algorithm(policy).ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "permission_policy",
-            "workspace content hash policy is unsupported on this platform",
-            Some(policy.to_string()),
-            None,
-        )
-    })?;
+    let (algorithm, executable_capability) =
+        workspace_content_hash_contract(policy).ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "permission_policy",
+                "workspace content hash policy is unsupported on this platform",
+                Some(policy.to_string()),
+                None,
+            )
+        })?;
     let mut hasher = Sha256::new();
     hasher.update(algorithm.as_bytes());
     hasher.update(b"\0");
@@ -92,9 +113,49 @@ pub(crate) fn workspace_content_hash_for_policy(
         excludes,
         &mut vec![root.clone()],
         &mut hasher,
-        policy == WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
+        executable_capability,
+        None,
     )?;
     Ok(format!("sha256:{:x}", hasher.finalize()))
+}
+
+/// A bounded, content-free sample used only to explain a verification mismatch.
+/// The complete hash remains the authority; this manifest never contains bytes.
+pub(crate) fn workspace_content_manifest_for_policy(
+    path: &Path,
+    excludes: &[String],
+    policy: &str,
+) -> Result<WorkspaceContentManifest> {
+    let executable_capability = match workspace_content_hash_contract(policy) {
+        Some((_, capability)) => capability,
+        None => {
+            return Err(Error::validation_invalid_argument(
+                "permission_policy",
+                "workspace content hash policy is unsupported on this platform",
+                Some(policy.to_string()),
+                None,
+            ));
+        }
+    };
+    let root = content_hash_root(path)?;
+    let mut manifest = WorkspaceContentManifest {
+        entry_count: 0,
+        entries: Vec::with_capacity(WORKSPACE_CONTENT_DIAGNOSTIC_ENTRY_LIMIT),
+    };
+    // Use the authoritative v2 traversal so diagnostics and the content hash
+    // have identical symlink, exclusion, and metadata behavior.
+    let mut hasher = Sha256::new();
+    collect_content_hash_entries_v2(
+        &root,
+        &root,
+        Path::new(""),
+        excludes,
+        &mut vec![root.clone()],
+        &mut hasher,
+        executable_capability,
+        Some(&mut manifest),
+    )?;
+    Ok(manifest)
 }
 
 /// Exact historical v1 algorithm for controllers that emitted
@@ -136,7 +197,8 @@ fn collect_content_hash_entries_v2(
     excludes: &[String],
     ancestors: &mut Vec<std::path::PathBuf>,
     hasher: &mut Sha256,
-    include_executable_bit: bool,
+    executable_capability: ExecutableCapability,
+    mut manifest: Option<&mut WorkspaceContentManifest>,
 ) -> Result<()> {
     let mut children = fs::read_dir(path)
         .map_err(|err| {
@@ -197,6 +259,12 @@ fn collect_content_hash_entries_v2(
             if !is_runner_metadata_directory {
                 hasher.update(relative.as_bytes());
                 hasher.update(b"\0dir\0");
+                record_workspace_content_manifest_entry(
+                    &mut manifest,
+                    relative.clone(),
+                    "directory",
+                    None,
+                );
             }
             ancestors.push(canonical);
             collect_content_hash_entries_v2(
@@ -206,7 +274,8 @@ fn collect_content_hash_entries_v2(
                 excludes,
                 ancestors,
                 hasher,
-                include_executable_bit,
+                executable_capability,
+                manifest.as_deref_mut(),
             )?;
             ancestors.pop();
         } else if metadata.is_file() {
@@ -215,25 +284,97 @@ fn collect_content_hash_entries_v2(
             })?;
             hasher.update(relative.as_bytes());
             hasher.update(b"\0file\0");
-            if include_executable_bit {
-                hasher.update([file_is_executable(&metadata) as u8]);
+            if let Some(executable) = executable_capability.value(&metadata) {
+                hasher.update([executable as u8]);
             }
             hasher.update((contents.len() as u64).to_le_bytes());
-            hasher.update(contents);
+            hasher.update(&contents);
+            record_workspace_content_manifest_entry(
+                &mut manifest,
+                relative,
+                "file",
+                executable_capability.owner_value(&metadata),
+            );
         }
     }
     Ok(())
 }
 
+fn record_workspace_content_manifest_entry(
+    manifest: &mut Option<&mut WorkspaceContentManifest>,
+    path: String,
+    kind: &str,
+    owner_executable: Option<bool>,
+) {
+    let Some(manifest) = manifest.as_deref_mut() else {
+        return;
+    };
+    manifest.entry_count += 1;
+    if path.len() <= WORKSPACE_CONTENT_DIAGNOSTIC_PATH_LIMIT
+        && manifest.entries.len() < WORKSPACE_CONTENT_DIAGNOSTIC_ENTRY_LIMIT
+    {
+        manifest.entries.push(WorkspaceContentManifestEntry {
+            path,
+            kind: kind.to_string(),
+            owner_executable,
+        });
+    }
+}
+
 #[cfg(unix)]
-fn file_is_executable(metadata: &fs::Metadata) -> bool {
+fn file_has_any_execute_bit(metadata: &fs::Metadata) -> bool {
     use std::os::unix::fs::PermissionsExt;
     metadata.permissions().mode() & 0o111 != 0
 }
 
+#[cfg(unix)]
+fn file_is_owner_executable(metadata: &fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    // Snapshot extraction may apply the runner's umask to group/other bits.
+    // The owner execute bit is the portable capability required to run a file.
+    metadata.permissions().mode() & 0o100 != 0
+}
+
 #[cfg(not(unix))]
-fn file_is_executable(_metadata: &fs::Metadata) -> bool {
+fn file_has_any_execute_bit(_metadata: &fs::Metadata) -> bool {
     false
+}
+
+#[cfg(not(unix))]
+fn file_is_owner_executable(_metadata: &fs::Metadata) -> bool {
+    false
+}
+
+#[derive(Clone, Copy)]
+enum ExecutableCapability {
+    None,
+    Any,
+    Owner,
+}
+
+impl ExecutableCapability {
+    fn value(self, metadata: &fs::Metadata) -> Option<bool> {
+        match self {
+            Self::None => None,
+            Self::Any => Some(file_has_any_execute_bit(metadata)),
+            Self::Owner => Some(file_is_owner_executable(metadata)),
+        }
+    }
+    fn owner_value(self, metadata: &fs::Metadata) -> Option<bool> {
+        (!matches!(self, Self::None)).then(|| file_is_owner_executable(metadata))
+    }
+}
+
+fn workspace_content_hash_contract(policy: &str) -> Option<(String, ExecutableCapability)> {
+    let capability = match policy {
+        WORKSPACE_CONTENT_PERMISSION_PORTABLE => ExecutableCapability::None,
+        WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE if cfg!(unix) => ExecutableCapability::Any,
+        WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE if cfg!(unix) => {
+            ExecutableCapability::Owner
+        }
+        _ => return None,
+    };
+    workspace_content_hash_algorithm(policy).map(|algorithm| (algorithm, capability))
 }
 
 #[cfg(unix)]

--- a/crates/homeboy-core/src/runner/workspace/tests/snapshot.rs
+++ b/crates/homeboy-core/src/runner/workspace/tests/snapshot.rs
@@ -6,8 +6,10 @@ use std::sync::{Mutex, OnceLock};
 
 use crate::runner::workspace::snapshot::{
     copy_snapshot_to_directory, snapshot_archive_command, snapshot_install_command,
-    synthetic_checkout_value, workspace_content_hash, workspace_content_hash_for_policy,
+    synthetic_checkout_value, workspace_content_hash, workspace_content_hash_algorithm,
+    workspace_content_hash_for_policy, workspace_content_manifest_for_policy,
     WORKSPACE_CONTENT_PERMISSION_PORTABLE, WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
+    WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
 };
 
 #[test]
@@ -902,6 +904,144 @@ fn workspace_content_hash_unix_policy_binds_executable_bit_without_umask_bits() 
         .expect("executable hash"),
         non_executable
     );
+}
+
+#[test]
+#[cfg(unix)]
+fn workspace_content_hash_owner_executable_policy_normalizes_non_owner_execute_bits() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let controller = tempfile::tempdir().expect("controller workspace");
+    let runner = tempfile::tempdir().expect("runner workspace");
+    for workspace in [controller.path(), runner.path()] {
+        fs::write(workspace.join("tool"), "#!/bin/sh\n").expect("tool");
+    }
+
+    // A non-owner execute bit can be removed when tar extraction applies the
+    // Linux runner's umask. It must not alter the cross-platform identity.
+    fs::set_permissions(
+        controller.path().join("tool"),
+        fs::Permissions::from_mode(0o641),
+    )
+    .expect("controller permissions");
+    fs::set_permissions(
+        runner.path().join("tool"),
+        fs::Permissions::from_mode(0o640),
+    )
+    .expect("runner permissions");
+    assert_eq!(
+        workspace_content_hash_for_policy(
+            controller.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
+        )
+        .expect("controller hash"),
+        workspace_content_hash_for_policy(
+            runner.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
+        )
+        .expect("runner hash"),
+        "non-owner execute bits are host metadata, not portable executable capability"
+    );
+
+    fs::set_permissions(
+        runner.path().join("tool"),
+        fs::Permissions::from_mode(0o740),
+    )
+    .expect("runner owner-executable permissions");
+    assert_ne!(
+        workspace_content_hash_for_policy(
+            controller.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
+        )
+        .expect("controller hash"),
+        workspace_content_hash_for_policy(
+            runner.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
+        )
+        .expect("runner hash"),
+        "owner execute changes remain fail-closed"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn workspace_content_hash_versions_legacy_any_execute_separately_from_owner_execute() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let controller = tempfile::tempdir().expect("controller workspace");
+    let runner = tempfile::tempdir().expect("runner workspace");
+    for workspace in [controller.path(), runner.path()] {
+        fs::write(workspace.join("tool"), "#!/bin/sh\n").expect("tool");
+    }
+    fs::set_permissions(
+        controller.path().join("tool"),
+        fs::Permissions::from_mode(0o641),
+    )
+    .expect("controller permissions");
+    fs::set_permissions(
+        runner.path().join("tool"),
+        fs::Permissions::from_mode(0o640),
+    )
+    .expect("runner permissions");
+
+    assert_ne!(
+        workspace_content_hash_for_policy(
+            controller.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE
+        )
+        .expect("legacy controller hash"),
+        workspace_content_hash_for_policy(
+            runner.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE
+        )
+        .expect("legacy runner hash"),
+        "v2 unix-executable preserves its historical any-execute semantics"
+    );
+    assert_eq!(
+        workspace_content_hash_for_policy(
+            controller.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE
+        )
+        .expect("v3 controller hash"),
+        workspace_content_hash_for_policy(
+            runner.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE
+        )
+        .expect("v3 runner hash"),
+        "v3 owner-only executable capability normalizes non-owner execute bits"
+    );
+    assert_eq!(
+        workspace_content_hash_algorithm(WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE).as_deref(),
+        Some("homeboy-workspace-content-v2+unix-executable")
+    );
+    assert_eq!(
+        workspace_content_hash_algorithm(WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE)
+            .as_deref(),
+        Some("homeboy-workspace-content-v3+unix-owner-executable")
+    );
+}
+
+#[test]
+fn workspace_content_manifest_omits_long_paths_but_counts_them() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    fs::write(workspace.path().join("a".repeat(193)), "contents\n").expect("long path file");
+
+    let manifest = workspace_content_manifest_for_policy(
+        workspace.path(),
+        &[],
+        crate::runner::WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+    )
+    .expect("content manifest");
+    assert_eq!(manifest.entry_count, 1);
+    assert!(manifest.entries.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- version owner-executable snapshot identity as `homeboy-workspace-content-v3+unix-owner-executable`
- preserve historical v1 and v2 verification semantics
- attach bounded, digest-free logical-entry metadata for actionable mismatch diagnostics
- validate manifest size, path, kind, and policy shape before comparison

## Root cause

The v2 `unix-executable` contract treated any execute bit as semantic. Snapshot extraction on a Linux runner can normalize group/other execute bits relative to a macOS controller, causing a clean materialization to fail committed-harvest provenance before provider execution.

The new v3 contract binds only the owner execute bit, which is the executable capability for operator-owned worktree files. The existing v2 identifier retains its original `0o111` semantics so persisted and mixed-version evidence is never interpreted under a different algorithm.

## How to test

1. Run `cargo fmt --check`.
2. Run `cargo check --locked`.
3. Review the policy tests covering portable v2, historical Unix v2, current Unix v3, group/other execute normalization, long-path sampling, malformed manifests, and bounded mismatch output.
4. After the current `homeboy-core` crate-split test-import failures on `main` are repaired, run `cargo test -p homeboy-core workspace_content_hash` and `cargo test -p homeboy-core content_hash_mismatch_reports_bounded_logical_entry_diagnostics`.
5. With matching patched controller and Lab binaries, run a clean `agent-task run-plan --placement lab` workload and verify it reaches provider execution rather than failing committed-harvest provenance.

## Verification

- `cargo fmt --check`: passed
- `cargo check --locked`: passed
- `git diff --check`: passed
- Focused unit execution: currently blocked before filtering by 747 unrelated stale crate-split test imports on `main`
- Independent read-only code review: completed after three correction rounds; no remaining runtime blocker identified

## Compatibility

This adds a v3 snapshot-hash policy and keeps v1 plus historical v2 verification intact. An older runner does not understand v3 metadata, so controller and runner binaries must be upgraded together before v3 workloads execute. No existing algorithm identifier changes meaning.

Closes #8411

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Root-cause analysis, implementation, tests, and iterative independent code review; Chris reviews and owns the change.