### PR TITLE
Persist local cook rotation model

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -144,6 +144,11 @@ where
             .clone()
             .unwrap_or_else(|| format!("agent-task-{}", uuid::Uuid::new_v4()));
         let mut request = dispatch_service::resolve_dispatch_request(dispatch_args.into())?;
+        if request.core.resolved_provider_policy.is_none() {
+            request.core.resolved_provider_policy = Some(
+                dispatch_service::controller_resolved_execution_policy(&request),
+            );
+        }
         let plan = match dispatch_service::build_dispatch_plan(&request) {
             Ok(plan) => plan,
             // A managed promotion handle may be intentionally unavailable until

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -308,6 +308,23 @@ impl crate::core::agent_task_service::AgentTaskCookAttemptDispatcher for Mirrore
 #[test]
 fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
     with_temp_home(|| {
+        let mut config = homeboy::core::defaults::load_config();
+        config.agent_task.rotation = Some(
+            homeboy::core::agent_task_scheduler::AgentTaskProviderRotationPolicy {
+                entries: vec![
+                    homeboy::core::agent_task_scheduler::AgentTaskProviderRotationEntry {
+                        model: Some("openai/gpt-5.6-terra".to_string()),
+                        ..Default::default()
+                    },
+                    homeboy::core::agent_task_scheduler::AgentTaskProviderRotationEntry {
+                        model: Some("fallback-model".to_string()),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            },
+        );
+        homeboy::core::defaults::save_config(&config).expect("save provider rotation");
         let temp = tempfile::tempdir().expect("tempdir");
         let source = temp.path().join("source");
         let target = temp.path().join("target");
@@ -401,6 +418,13 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
 
         assert_eq!(exit_code, 0, "{value:#}");
         assert_eq!(value["status"], "green_no_finalize");
+        let lifecycle =
+            lifecycle_status("cook-committed-work-attempt-1").expect("local cook lifecycle");
+        assert_eq!(lifecycle.lifecycle.provider_runtime.len(), 1);
+        assert_eq!(
+            lifecycle.lifecycle.provider_runtime[0].metadata["model"],
+            "openai/gpt-5.6-terra"
+        );
         assert_eq!(
             value["attempts"][0]["promotion"]["patch_artifact"]["id"],
             "cook-fixture-component-attempt-1-committed-changes"

--- a/crates/homeboy-core/src/agent_task_dispatch_service.rs
+++ b/crates/homeboy-core/src/agent_task_dispatch_service.rs
@@ -307,6 +307,29 @@ pub fn resolve_dispatch_request(
     resolve_dispatch_request_with_default(command, default_backend_for_component)
 }
 
+/// Resolve the provider policy the controller passes to an execution boundary.
+/// The first configured rotation entry is the initial attempt; remaining
+/// entries are failover attempts.
+pub fn controller_resolved_execution_policy(
+    request: &AgentTaskDispatchRequest,
+) -> ResolvedAgentTaskProviderPolicy {
+    let rotation = crate::defaults::load_config().agent_task.rotation;
+    ResolvedAgentTaskProviderPolicy {
+        backend: request.backend.clone(),
+        selector: request.selector.clone(),
+        model: request.model.clone(),
+        retry: AgentTaskRetryPolicy {
+            max_attempts: request.core.attempts.max(1),
+            ..AgentTaskRetryPolicy::default()
+        },
+        liveness_timeout_ms: rotation
+            .as_ref()
+            .and_then(|policy| policy.liveness_timeout_ms),
+        rotation,
+        rotation_starts_with_first_entry: true,
+    }
+}
+
 /// Resolve a typed dispatch request, using the supplied default-backend resolver
 /// so tests can inject a deterministic policy.
 pub fn resolve_dispatch_request_with_default(

--- a/crates/homeboy-core/src/agent_tasks.rs
+++ b/crates/homeboy-core/src/agent_tasks.rs
@@ -200,8 +200,8 @@ pub mod dispatch_service {
         preflight_dispatch_provider_secrets,
     };
     pub use super::super::agent_task_dispatch_service::{
-        dispatch, dispatch_with_provider_requirements, resolve_dispatch_request,
-        resolve_dispatch_request_with_default, run_dispatch_command,
+        controller_resolved_execution_policy, dispatch, dispatch_with_provider_requirements,
+        resolve_dispatch_request, resolve_dispatch_request_with_default, run_dispatch_command,
         run_dispatch_command_with_provider_catalog, AgentTaskDispatchCommand,
         AgentTaskDispatchReport, AgentTaskDispatchRequest, DispatchCoreInputs,
         DISPATCH_RESULT_SCHEMA,

--- a/crates/homeboy-core/src/runner/lab_args/provider_config.rs
+++ b/crates/homeboy-core/src/runner/lab_args/provider_config.rs
@@ -9,10 +9,7 @@ use std::path::Path;
 use serde_json::Value;
 
 use crate::agent_task_config_materialization::materialize_provider_config_refs;
-use crate::agent_task_dispatch_service::{
-    resolve_dispatch_request, AgentTaskDispatchCommand, ResolvedAgentTaskProviderPolicy,
-};
-use crate::agent_tasks::scheduler::AgentTaskRetryPolicy;
+use crate::agent_task_dispatch_service::{resolve_dispatch_request, AgentTaskDispatchCommand};
 use crate::config::read_json_spec_to_string;
 use crate::defaults;
 use crate::runner_execution_envelope::PathMaterializationPlan;
@@ -211,21 +208,7 @@ pub(in crate::runner) fn inject_agent_task_resolved_provider_policy_in_args(
         None => return Ok(args.to_vec()),
     };
     let request = resolve_dispatch_request(dispatch)?;
-    let rotation = defaults::load_config().agent_task.rotation;
-    let policy = ResolvedAgentTaskProviderPolicy {
-        backend: request.backend,
-        selector: request.selector,
-        model: request.model,
-        retry: AgentTaskRetryPolicy {
-            max_attempts: request.core.attempts.max(1),
-            ..AgentTaskRetryPolicy::default()
-        },
-        liveness_timeout_ms: rotation
-            .as_ref()
-            .and_then(|policy| policy.liveness_timeout_ms),
-        rotation,
-        rotation_starts_with_first_entry: true,
-    };
+    let policy = crate::agent_task_dispatch_service::controller_resolved_execution_policy(&request);
     let encoded = serde_json::to_string(&policy).map_err(|error| {
         Error::internal_json(
             error.to_string(),


### PR DESCRIPTION
## Summary
Make local cook resolve the same controller-owned provider policy as Lab so attempt one durably records its concrete model.

## What changed
- Extract the existing controller-resolved rotation policy builder and reuse it for both Lab argument injection and immediate local execution.
- Assert a local cook configured with a concrete rotation records the first model in durable provider runtime metadata.

## How to test
1. Run `Run cargo check -p homeboy-core -p homeboy-cli`; expect Both crates compile successfully.
2. Run `Run cargo build --bin homeboy`; expect The Homeboy binary builds successfully.
3. Run `Run a no-mutation local cook with a configured rotation`; expect The durable plan, aggregate, task, executor evidence, and provider runtime record rotation entry zero.

## Compatibility
Local cook now starts with configured rotation entry zero, matching the existing Lab contract. Explicit resolved policies remain authoritative, failover entries remain ordered, and no CLI or public data schema changes.

## Evidence
- Binary build: Passed
- Cargo check: Passed
- Changed-file rustfmt: Passed
- Diff check: Passed
- Live local cook: Passed
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8417

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the local-cook provenance regression, drafted the implementation and deterministic coverage, and reviewed the live runtime proof; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8417
