### PR TITLE
Fix runner source build identity

### DIFF
--- a/crates/homeboy-cli/build.rs
+++ b/crates/homeboy-cli/build.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 fn main() {
     let manifest_dir =
@@ -25,69 +24,6 @@ fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR missing"));
     fs::write(out_dir.join("generated_docs.rs"), generated)
         .expect("Failed to write generated_docs.rs");
-
-    emit_git_build_identity(&manifest_dir);
-}
-
-fn emit_git_build_identity(manifest_dir: &Path) {
-    let git_dir = resolve_git_dir(manifest_dir).unwrap_or_else(|| manifest_dir.join(".git"));
-    println!("cargo:rerun-if-changed={}", git_dir.join("HEAD").display());
-    if let Ok(head) = fs::read_to_string(git_dir.join("HEAD")) {
-        if let Some(reference) = head.trim().strip_prefix("ref: ") {
-            println!(
-                "cargo:rerun-if-changed={}",
-                git_dir.join(reference).display()
-            );
-        }
-    }
-
-    if let Some(commit) = git_output(manifest_dir, &["rev-parse", "--short=12", "HEAD"]) {
-        println!("cargo:rustc-env=HOMEBOY_BUILD_GIT_COMMIT={commit}");
-    }
-    if let Some(status) = git_output(manifest_dir, &["status", "--porcelain"]) {
-        println!(
-            "cargo:rustc-env=HOMEBOY_BUILD_GIT_DIRTY={}",
-            if status.trim().is_empty() {
-                "false"
-            } else {
-                "true"
-            }
-        );
-    }
-}
-
-fn resolve_git_dir(manifest_dir: &Path) -> Option<PathBuf> {
-    let git_path = manifest_dir.join(".git");
-    if git_path.is_dir() {
-        return Some(git_path);
-    }
-
-    let git_file = fs::read_to_string(&git_path).ok()?;
-    let raw_path = git_file.trim().strip_prefix("gitdir: ")?.trim();
-    let path = PathBuf::from(raw_path);
-    Some(if path.is_absolute() {
-        path
-    } else {
-        manifest_dir.join(path)
-    })
-}
-
-fn git_output(manifest_dir: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(manifest_dir)
-        .args(args)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if value.is_empty() {
-        None
-    } else {
-        Some(value)
-    }
 }
 
 fn collect_md_files(docs_root: &Path, dir: &Path, out: &mut Vec<PathBuf>) {

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Chris Huber <chubes@extrachill.com>"]
 description = "Core engine for homeboy: build/deploy/test/triage orchestration, runners, agent-task, code audit, and evidence"
 repository = "https://github.com/Extra-Chill/homeboy"
 publish = false
+build = "build.rs"
 
 [lib]
 name = "homeboy_core"

--- a/crates/homeboy-core/build.rs
+++ b/crates/homeboy-core/build.rs
@@ -1,0 +1,97 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn main() {
+    let manifest_dir =
+        PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR missing"));
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .expect("homeboy-core must be nested below the workspace root");
+    let manifest = workspace_root.join("Cargo.toml");
+
+    println!("cargo:rerun-if-changed={}", manifest.display());
+    println!(
+        "cargo:rustc-env=HOMEBOY_BUILD_VERSION={}",
+        root_package_version(&manifest)
+    );
+    emit_git_build_identity(workspace_root);
+}
+
+fn root_package_version(manifest: &Path) -> String {
+    let manifest = fs::read_to_string(manifest).expect("read root Cargo.toml");
+    let package = manifest
+        .split("[package]")
+        .nth(1)
+        .expect("root Cargo.toml must contain [package]");
+    package
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("version = "))
+        .and_then(|value| value.trim_matches('"').split('"').next())
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .expect("root Cargo.toml [package] must contain a version")
+}
+
+fn emit_git_build_identity(workspace_root: &Path) {
+    let git_dir = resolve_git_dir(workspace_root).unwrap_or_else(|| workspace_root.join(".git"));
+    println!("cargo:rerun-if-changed={}", git_dir.join("HEAD").display());
+    if let Ok(head) = fs::read_to_string(git_dir.join("HEAD")) {
+        if let Some(reference) = head.trim().strip_prefix("ref: ") {
+            println!(
+                "cargo:rerun-if-changed={}",
+                git_dir.join(reference).display()
+            );
+        }
+    }
+
+    if let Some(commit) = git_output(workspace_root, &["rev-parse", "--short=12", "HEAD"]) {
+        println!("cargo:rustc-env=HOMEBOY_BUILD_GIT_COMMIT={commit}");
+    }
+    if let Some(status) = git_output(workspace_root, &["status", "--porcelain"]) {
+        println!(
+            "cargo:rustc-env=HOMEBOY_BUILD_GIT_DIRTY={}",
+            if status.trim().is_empty() {
+                "false"
+            } else {
+                "true"
+            }
+        );
+    }
+}
+
+fn resolve_git_dir(workspace_root: &Path) -> Option<PathBuf> {
+    let git_path = workspace_root.join(".git");
+    if git_path.is_dir() {
+        return Some(git_path);
+    }
+
+    let git_file = fs::read_to_string(&git_path).ok()?;
+    let raw_path = git_file.trim().strip_prefix("gitdir: ")?.trim();
+    let path = PathBuf::from(raw_path);
+    Some(if path.is_absolute() {
+        path
+    } else {
+        workspace_root.join(path)
+    })
+}
+
+fn git_output(workspace_root: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(workspace_root)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}

--- a/crates/homeboy-core/src/build_identity.rs
+++ b/crates/homeboy-core/src/build_identity.rs
@@ -12,7 +12,7 @@ pub struct BuildIdentity {
 
 pub fn current() -> BuildIdentity {
     identity_from_parts(
-        env!("CARGO_PKG_VERSION"),
+        env!("HOMEBOY_BUILD_VERSION"),
         option_env!("HOMEBOY_BUILD_GIT_COMMIT"),
         option_env!("HOMEBOY_BUILD_GIT_DIRTY"),
     )

--- a/crates/homeboy-core/src/runner/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-core/src/runner/homeboy_refresh/tests/part_a.rs
@@ -114,9 +114,35 @@ fn materialize_plan_uses_clean_runner_cache() {
 fn materialize_script_records_the_peeled_commit_for_tags_and_direct_commits() {
     let fixture = tempfile::tempdir().expect("fixture directory");
     let source = fixture.path().join("source");
-    let tools = fixture.path().join("tools");
-    std::fs::create_dir_all(&source).expect("source directory");
-    std::fs::create_dir_all(&tools).expect("tool directory");
+    let core = source.join("crates/homeboy-core");
+    std::fs::create_dir_all(core.join("src")).expect("source directory");
+
+    std::fs::write(
+        source.join("Cargo.toml"),
+        "[workspace]\nmembers = [\"crates/homeboy-core\"]\n\n[package]\nname = \"homeboy\"\nversion = \"9.8.7\"\nedition = \"2021\"\n\n[[bin]]\nname = \"homeboy\"\npath = \"src/main.rs\"\n\n[dependencies]\nhomeboy-core = { path = \"crates/homeboy-core\" }\n",
+    )
+    .expect("write root manifest");
+    std::fs::create_dir_all(source.join("src")).expect("root source directory");
+    std::fs::write(
+        source.join("src/main.rs"),
+        "fn main() { println!(\"{\\\"data\\\":{\\\"git_commit\\\":\\\"{}\\\",\\\"git_dirty\\\":{}}}\", homeboy_core::git_commit(), homeboy_core::git_dirty()); }\n",
+    )
+    .expect("write root binary");
+    std::fs::write(
+        core.join("Cargo.toml"),
+        "[package]\nname = \"homeboy-core\"\nversion = \"0.1.0\"\nedition = \"2021\"\nbuild = \"build.rs\"\n",
+    )
+    .expect("write core manifest");
+    std::fs::copy(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("build.rs"),
+        core.join("build.rs"),
+    )
+    .expect("copy core build identity script");
+    std::fs::write(
+        core.join("src/lib.rs"),
+        "pub fn git_commit() -> &'static str { env!(\"HOMEBOY_BUILD_GIT_COMMIT\") }\npub fn git_dirty() -> bool { env!(\"HOMEBOY_BUILD_GIT_DIRTY\") == \"true\" }\n",
+    )
+    .expect("write core build identity consumer");
 
     for args in [
         vec!["init", "--quiet"],
@@ -174,18 +200,6 @@ fn materialize_script_records_the_peeled_commit_for_tags_and_direct_commits() {
     .to_string();
     assert_ne!(annotated_object, commit, "fixture tag is annotated");
 
-    let cargo = tools.join("cargo");
-    std::fs::write(
-        &cargo,
-        "#!/bin/sh\nwhile [ \"$#\" -gt 0 ]; do\n  if [ \"$1\" = \"--manifest-path\" ]; then manifest=$2; break; fi\n  shift\ndone\ndir=$(dirname \"$manifest\")\nmkdir -p \"$dir/target/release\"\nprintf '%s\\n' '#!/bin/sh' 'dir=$(cd \"$(dirname \"$0\")/../..\" && pwd)' 'commit=$(git -C \"$dir\" rev-parse --short=12 HEAD)' 'printf \"{\\\"data\\\":{\\\"git_commit\\\":\\\"%s\\\",\\\"git_dirty\\\":false}}\\n\" \"$commit\"' > \"$dir/target/release/homeboy\"\nchmod 0755 \"$dir/target/release/homeboy\"\n",
-    )
-    .expect("write fake cargo");
-    let status = Command::new("chmod")
-        .args(["0755", cargo.to_str().expect("cargo path")])
-        .status()
-        .expect("make fake cargo executable");
-    assert!(status.success(), "fake cargo is executable");
-
     for (index, git_ref) in ["annotated", "lightweight", commit.as_str()]
         .iter()
         .enumerate()
@@ -200,14 +214,6 @@ fn materialize_script_records_the_peeled_commit_for_tags_and_direct_commits() {
         );
         let output = Command::new("bash")
             .args(["-c", &script])
-            .env(
-                "PATH",
-                format!(
-                    "{}:{}",
-                    tools.display(),
-                    std::env::var("PATH").expect("PATH")
-                ),
-            )
             .output()
             .expect("run materialize script");
         assert!(
@@ -223,9 +229,9 @@ fn materialize_script_records_the_peeled_commit_for_tags_and_direct_commits() {
         verify_materialized_identity(
             &ssh_bootstrap_plan(),
             &stdout,
-            &parse_identity(&stdout).expect("fake binary identity"),
+            &parse_identity(&stdout).expect("source-built binary identity"),
         )
-        .expect("peeled source identity matches the built commit");
+        .expect("peeled source identity matches the nested-workspace build commit");
     }
 }
 


### PR DESCRIPTION
Closes #8422

## Summary

- move Git commit and dirty-state build metadata emission to `homeboy-core`, which owns `BuildIdentity` after the crate extraction
- report the root Homeboy package version instead of the private core crate placeholder version
- replace the mocked refresh identity test with a real nested-workspace source build covering annotated tags, lightweight tags, and direct commits

## Root cause

The crate extraction moved `BuildIdentity` into `homeboy-core`, but Git metadata remained emitted by `homeboy-cli/build.rs`. Cargo build-script environment does not propagate into dependency crates, so source-ref refreshes produced `homeboy 0.1.0` without `git_commit` and were correctly rejected by transactional identity validation.

## How to test

1. Run `cargo check --bin homeboy`.
2. Run `cargo build --release --bin homeboy && ./target/release/homeboy self identity`. Confirm the result reports the root Homeboy version and the current 12-character Git commit.
3. Run `cargo test -p homeboy-core materialize_script_records_the_peeled_commit_for_tags_and_direct_commits --lib` once the existing extracted-core test harness compiles. Confirm annotated tags, lightweight tags, and direct commits all produce the peeled source commit.
4. Run `rustfmt --edition 2021 --check crates/homeboy-core/build.rs crates/homeboy-core/src/build_identity.rs crates/homeboy-core/src/runner/homeboy_refresh/tests/part_a.rs crates/homeboy-cli/build.rs`.
5. Run `git diff --check origin/main...HEAD`.

## Verification

- `cargo check --bin homeboy`: passed.
- `cargo build --release --bin homeboy && ./target/release/homeboy self identity`: passed; reports `version: 0.286.8` and `git_commit: 2819bc74684a`.
- Changed-file rustfmt and `git diff --check`: passed.
- The focused `homeboy-core` test target is blocked before test selection by the existing extracted test harness unresolved `crate::core`/`homeboy` paths (750 errors); this change does not weaken or bypass that gate.
- Homeboy umbrella review was also deferred by the local hot-machine resource guard.

## Compatibility

Tagged/release binary behavior and strict identity validation are unchanged. Source builds now expose the same product version and Git identity contract that existed before crate extraction. No extension paths or external runtime contracts change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Diagnosed the extraction regression, implemented the build-identity ownership repair and deterministic coverage, and ran focused verification. Chris reviews and owns the change.
