### PR TITLE
refactor: move engine::baseline into homeboy-engine-primitives (#8425)

### DIFF
--- a/crates/homeboy-core/src/engine/mod.rs
+++ b/crates/homeboy-core/src/engine/mod.rs
@@ -5,9 +5,10 @@
 // Leaf execution primitives moved to the internal `homeboy-engine-primitives`
 // crate. Re-exported here so existing `crate::engine::{shell,command,...}`
 // call sites keep working unchanged.
-pub use homeboy_engine_primitives::{command, identifier, output_parse, shell, template, text};
+pub use homeboy_engine_primitives::{
+    baseline, command, identifier, output_parse, shell, template, text,
+};
 
-pub mod baseline;
 pub mod cli_tool;
 pub mod codebase_scan;
 pub mod detail_output;

--- a/crates/homeboy-engine-primitives/src/baseline.rs
+++ b/crates/homeboy-engine-primitives/src/baseline.rs
@@ -45,7 +45,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::error::{Error, Result};
+use homeboy_error::{Error, Result};
 
 pub trait Fingerprintable {
     fn fingerprint(&self) -> String;
@@ -400,8 +400,7 @@ pub fn load_from_git_ref<M: for<'de> Deserialize<'de> + Serialize>(
     key: &str,
 ) -> Option<Baseline<M>> {
     let git_spec = format!("{}:{}", git_ref, HOMEBOY_JSON);
-    let content =
-        crate::engine::command::run_in_optional(source_path, "git", &["show", &git_spec])?;
+    let content = crate::command::run_in_optional(source_path, "git", &["show", &git_spec])?;
 
     let root: Value = serde_json::from_str(&content).ok()?;
     let value = root.get(BASELINES_KEY)?.get(key)?;

--- a/crates/homeboy-engine-primitives/src/lib.rs
+++ b/crates/homeboy-engine-primitives/src/lib.rs
@@ -6,6 +6,7 @@
 //! own crate so they compile as an independent unit and are re-exported under
 //! `crate::core::engine::*` in the main binary for source compatibility.
 
+pub mod baseline;
 pub mod command;
 pub mod identifier;
 pub mod output_parse;


### PR DESCRIPTION
## Summary

First **phase-2** cut. Phase 1 (cuts 1–5) cleared engine's edges to the layers *above* it. Phase 2 breaks the `engine ↔ extension/component/server` cycle by migrating engine's low-level primitives into the existing `homeboy-engine-primitives` crate.

`engine/baseline.rs` is a pure leaf:
- depends only on `crate::error` (→ `homeboy-error`, already a crate dep) and `crate::engine::command::run_in_optional` (`command` is **already** in the primitives crate)
- no `test_support`, no `product_identity`, no other engine-local deps

Move it into `homeboy-engine-primitives`, repoint its two imports (`homeboy_error`, `crate::command`), and add `baseline` to the existing `pub use homeboy_engine_primitives::{...}` bridge in `engine/mod.rs`. All 15 consumers keep resolving `crate::engine::baseline::*` unchanged.

## Why

`extension → engine` was the dominant cycle edge (89 use-stmts), of which 17 were `engine::baseline`. Those now point at the primitives crate instead of the engine module. This establishes the migration path for the rest of the floor (`run_dir`, `local_files`, `invocation`, `resource`, `codebase_scan`) — see the phase-2 roadmap on #8425.

## Verification

- `cargo check -p homeboy-engine-primitives` — clean (4s)
- `cargo check -p homeboy-core --lib` — clean, 0 errors (re-export bridge preserves all consumers)
- `cargo fmt` applied

## Sequencing

Based on `main`, independent. Pure relocation, behavior-preserving.

Refs #8425