### PR TITLE
Fix detached Lab handoff recovery

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2,6 +2,16 @@ use super::*;
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 
+const LAB_HANDOFF_ACCEPTANCE_TIMEOUT_SECONDS: i64 = 120;
+
+fn lab_handoff_acceptance_timeout_seconds() -> i64 {
+    std::env::var("HOMEBOY_TEST_LAB_HANDOFF_ACCEPTANCE_TIMEOUT_SECONDS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .filter(|seconds| *seconds >= 0)
+        .unwrap_or(LAB_HANDOFF_ACCEPTANCE_TIMEOUT_SECONDS)
+}
+
 /// Merge a completed deferred-cleanup candidate into its timeout outcome.
 ///
 /// The worker owns the mutable workspace until it exits; this lifecycle-side
@@ -1405,8 +1415,17 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
             task.state = AgentTaskState::Running;
         }
     }
+    let accepted_at = record.updated_at.clone();
     let metadata = record.ensure_metadata_object();
     metadata.insert("kind".to_string(), json!("lab_offload_detached_handoff"));
+    metadata.insert(
+        "handoff_acceptance".to_string(),
+        json!({
+            "state": "accepted",
+            "accepted_at": accepted_at,
+            "runner_job_id": input.runner_job_id,
+        }),
+    );
     metadata.insert("phase".to_string(), json!("awaiting_runner_result"));
     metadata.insert(
         "phase_activity".to_string(),
@@ -1529,6 +1548,22 @@ fn record_lab_offload_proxy(
     // It remains controller-owned until a runner-local record is independently
     // discovered, so controller-generated commands must keep resolving here.
     metadata.insert("lifecycle_store_owner".to_string(), json!("controller"));
+    if metadata
+        .get("handoff_acceptance")
+        .and_then(|acceptance| acceptance.get("state"))
+        .and_then(Value::as_str)
+        != Some("accepted")
+    {
+        let now = chrono::Utc::now();
+        metadata.insert(
+            "handoff_acceptance".to_string(),
+            json!({
+                "state": "pending",
+                "started_at": now.to_rfc3339(),
+                "deadline_at": (now + chrono::Duration::seconds(lab_handoff_acceptance_timeout_seconds())).to_rfc3339(),
+            }),
+        );
+    }
     metadata.insert("runner_id".to_string(), json!(runner_id));
     if remote_workspace != "pending" {
         metadata.insert("remote_workspace".to_string(), json!(remote_workspace));

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1525,6 +1525,10 @@ fn record_lab_offload_proxy(
     }
     let metadata = record.ensure_metadata_object();
     metadata.insert("kind".to_string(), json!("lab_offload_controller_proxy"));
+    // This record is the controller's durable projection of a runner handoff.
+    // It remains controller-owned until a runner-local record is independently
+    // discovered, so controller-generated commands must keep resolving here.
+    metadata.insert("lifecycle_store_owner".to_string(), json!("controller"));
     metadata.insert("runner_id".to_string(), json!(runner_id));
     if remote_workspace != "pending" {
         metadata.insert("remote_workspace".to_string(), json!(remote_workspace));

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -308,6 +308,7 @@ fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
         assert_eq!(planned.state, AgentTaskRunState::Queued);
         assert!(planned.metadata.get("runner_job_id").is_none());
         assert_eq!(planned.metadata["lifecycle_store_owner"], "controller");
+        assert_eq!(planned.metadata["handoff_acceptance"]["state"], "pending");
         assert!(load_plan("agent-task-controller-proxy")
             .expect("proxy plan")
             .tasks[0]
@@ -337,6 +338,7 @@ fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
         assert_eq!(running.state, AgentTaskRunState::Running);
         assert_eq!(running.metadata["runner_job_id"], "job-123");
         assert_eq!(running.metadata["lifecycle_store_owner"], "controller");
+        assert_eq!(running.metadata["handoff_acceptance"]["state"], "accepted");
         assert_eq!(
             running.metadata["runner_execution_record"]["status"],
             "running"

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -307,6 +307,7 @@ fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
 
         assert_eq!(planned.state, AgentTaskRunState::Queued);
         assert!(planned.metadata.get("runner_job_id").is_none());
+        assert_eq!(planned.metadata["lifecycle_store_owner"], "controller");
         assert!(load_plan("agent-task-controller-proxy")
             .expect("proxy plan")
             .tasks[0]
@@ -335,6 +336,7 @@ fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
         .expect("accepted child binds proxy");
         assert_eq!(running.state, AgentTaskRunState::Running);
         assert_eq!(running.metadata["runner_job_id"], "job-123");
+        assert_eq!(running.metadata["lifecycle_store_owner"], "controller");
         assert_eq!(
             running.metadata["runner_execution_record"]["status"],
             "running"

--- a/crates/homeboy-core/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-core/src/agent_task_service/discovery.rs
@@ -288,9 +288,16 @@ fn liveness_summary(runs: &[AgentTaskDiscoveryRun]) -> AgentTaskLivenessSummary 
 fn classify_liveness(
     record: &AgentTaskRunRecord,
     last_update_age_minutes: Option<i64>,
+    now: chrono::DateTime<chrono::Utc>,
 ) -> AgentTaskLiveness {
     if record.state != agent_task_lifecycle::AgentTaskRunState::Running {
-        // Queued runs are genuinely pending work, not stale.
+        if record.state == agent_task_lifecycle::AgentTaskRunState::Queued
+            && handoff_acceptance_expired(record, now)
+        {
+            return AgentTaskLiveness::Unreconciled;
+        }
+        // Queued runs are genuinely pending work unless their controller-owned
+        // Lab handoff exceeded its durable acceptance deadline.
         return AgentTaskLiveness::Active;
     }
 
@@ -311,6 +318,19 @@ fn classify_liveness(
         // we genuinely cannot confirm this run either way.
         (false, false) => AgentTaskLiveness::Unreconciled,
     }
+}
+
+fn handoff_acceptance_expired(
+    record: &AgentTaskRunRecord,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    record
+        .metadata
+        .get("handoff_acceptance")
+        .filter(|acceptance| acceptance.get("state").and_then(Value::as_str) == Some("pending"))
+        .and_then(|acceptance| acceptance.get("deadline_at").and_then(Value::as_str))
+        .and_then(|deadline| chrono::DateTime::parse_from_rfc3339(deadline).ok())
+        .is_some_and(|deadline| deadline.with_timezone(&chrono::Utc) <= now)
 }
 
 /// Label where a run executes so an operator can trace the runner process.
@@ -365,7 +385,7 @@ fn discovery_run(
     let last_update = record.updated_at.clone();
     let last_update_age_minutes = age_minutes(last_update.as_deref(), now);
     let source = run_source(&record);
-    let liveness = classify.then(|| classify_liveness(&record, last_update_age_minutes));
+    let liveness = classify.then(|| classify_liveness(&record, last_update_age_minutes, now));
 
     // Runner metadata describes execution placement, not necessarily lifecycle
     // record ownership. Controller handoff projections retain their durable

--- a/crates/homeboy-core/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-core/src/agent_task_service/discovery.rs
@@ -367,16 +367,21 @@ fn discovery_run(
     let source = run_source(&record);
     let liveness = classify.then(|| classify_liveness(&record, last_update_age_minutes));
 
-    // A runner-backed run's durable record (status/logs/artifacts/review) lives
-    // on the runner, so the emitted recovery commands must be runner-scoped to
-    // resolve against the run's actual location. Local runs use the bare
-    // command. This keeps "commands emitted in run metadata valid for the run
-    // location" (#5681).
+    // Runner metadata describes execution placement, not necessarily lifecycle
+    // record ownership. Controller handoff projections retain their durable
+    // record locally across runner reconnects, so their commands must remain
+    // controller-scoped until a runner-local record is independently discovered.
     let runner_id = metadata_string(&record.metadata, "runner_id")
         .filter(|runner_id| !runner_id.trim().is_empty());
-    let command_prefix = match runner_id.as_deref() {
-        Some(runner_id) => format!("homeboy --runner {runner_id} agent-task"),
-        None => "homeboy agent-task".to_string(),
+    let command_prefix = if metadata_string(&record.metadata, "lifecycle_store_owner").as_deref()
+        == Some("controller")
+    {
+        "homeboy agent-task".to_string()
+    } else {
+        match runner_id.as_deref() {
+            Some(runner_id) => format!("homeboy --runner {runner_id} agent-task"),
+            None => "homeboy agent-task".to_string(),
+        }
     };
 
     AgentTaskDiscoveryRun {

--- a/crates/homeboy-core/src/agent_task_service/tests.rs
+++ b/crates/homeboy-core/src/agent_task_service/tests.rs
@@ -683,6 +683,64 @@ fn discovery_runner_backed_run_emits_runner_scoped_commands() {
     });
 }
 
+#[test]
+fn discovery_keeps_controller_handoff_commands_resolvable_after_runner_reconnect() {
+    with_isolated_home(|_| {
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+        agent_task_lifecycle::record_lab_offload_planned(
+            agent_task_lifecycle::LabOffloadProxyPlan {
+                run_id: "controller-handoff-reconnect",
+                runner_id: "homeboy-lab",
+                remote_workspace: "/runner/workspace/homeboy",
+                remote_command: &command,
+                durable_plan: Some(&discovery_plan()),
+            },
+        )
+        .expect("controller handoff persisted before runner acceptance");
+        let before_acceptance = discover_runs(AgentTaskDiscoveryFilter::Active).expect("listed");
+        let queued = before_acceptance
+            .runs
+            .iter()
+            .find(|run| run.run_id == "controller-handoff-reconnect")
+            .expect("unaccepted controller handoff listed");
+        assert_eq!(
+            queued.commands.status,
+            "homeboy agent-task status controller-handoff-reconnect"
+        );
+        agent_task_lifecycle::record_detached_lab_run(agent_task_lifecycle::DetachedLabRunRecord {
+            run_id: "controller-handoff-reconnect",
+            runner_id: "homeboy-lab",
+            runner_job_id: "reconnected-daemon-job",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        })
+        .expect("accepted handoff remains controller materialized");
+
+        let report = discover_runs(AgentTaskDiscoveryFilter::Active).expect("listed");
+        let run = report
+            .runs
+            .iter()
+            .find(|run| run.run_id == "controller-handoff-reconnect")
+            .expect("accepted controller handoff listed");
+
+        assert_eq!(run.runner_id.as_deref(), Some("homeboy-lab"));
+        assert_eq!(
+            run.commands.status,
+            "homeboy agent-task status controller-handoff-reconnect"
+        );
+        assert_eq!(
+            run.commands.logs,
+            "homeboy agent-task logs controller-handoff-reconnect"
+        );
+        assert!(agent_task_lifecycle::status(&run.run_id).is_ok());
+        assert!(agent_task_lifecycle::logs(&run.run_id).is_ok());
+    });
+}
+
 #[derive(Clone)]
 struct SucceedingExecutor;
 

--- a/crates/homeboy-core/src/agent_task_service/tests.rs
+++ b/crates/homeboy-core/src/agent_task_service/tests.rs
@@ -741,6 +741,54 @@ fn discovery_keeps_controller_handoff_commands_resolvable_after_runner_reconnect
     });
 }
 
+#[test]
+fn reconcile_terminalizes_an_unaccepted_controller_handoff_after_its_deadline() {
+    with_isolated_home(|_| {
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+        agent_task_lifecycle::record_lab_offload_planned(
+            agent_task_lifecycle::LabOffloadProxyPlan {
+                run_id: "controller-handoff-unaccepted",
+                runner_id: "homeboy-lab",
+                remote_workspace: "/runner/workspace/homeboy",
+                remote_command: &command,
+                durable_plan: Some(&discovery_plan()),
+            },
+        )
+        .expect("controller handoff persisted before runner acceptance");
+        agent_task_lifecycle::rewrite_record_for_test("controller-handoff-unaccepted", |record| {
+            record.metadata["handoff_acceptance"]["deadline_at"] =
+                serde_json::json!("2000-01-01T00:00:00+00:00");
+        })
+        .expect("expire acceptance deadline");
+
+        let active = discover_runs(AgentTaskDiscoveryFilter::Active).expect("listed");
+        let run = active
+            .runs
+            .iter()
+            .find(|run| run.run_id == "controller-handoff-unaccepted")
+            .expect("unaccepted handoff listed");
+        assert_eq!(run.liveness, Some(AgentTaskLiveness::Unreconciled));
+        assert_eq!(
+            run.commands.status,
+            "homeboy agent-task status controller-handoff-unaccepted"
+        );
+
+        let reconciliation = reconcile_stale_active_runs(false).expect("reconciled");
+        assert_eq!(reconciliation.reconciled, 1);
+        assert_eq!(reconciliation.runs[0].action, "reconciled");
+        assert_eq!(
+            lifecycle_status("controller-handoff-unaccepted")
+                .expect("terminal controller record")
+                .state,
+            AgentTaskRunState::Cancelled
+        );
+    });
+}
+
 #[derive(Clone)]
 struct SucceedingExecutor;
 

--- a/crates/homeboy-core/tests/agent_task_handoff_reconnect.rs
+++ b/crates/homeboy-core/tests/agent_task_handoff_reconnect.rs
@@ -1,0 +1,122 @@
+use homeboy_core::agent_task_lifecycle::{
+    record_detached_lab_run, record_lab_offload_planned, status, DetachedLabRunRecord,
+    LabOffloadProxyPlan,
+};
+use homeboy_core::agent_task_service::{
+    discover_runs, reconcile_stale_active_runs, AgentTaskDiscoveryFilter, AgentTaskLiveness,
+};
+
+struct EnvironmentGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
+
+impl EnvironmentGuard {
+    fn isolated() -> Self {
+        let root = tempfile::tempdir().expect("temporary home");
+        let root = root.keep();
+        let values = [
+            ("HOME", Some(root.clone().into_os_string())),
+            (
+                "XDG_CONFIG_HOME",
+                Some(root.join("config").into_os_string()),
+            ),
+            ("XDG_DATA_HOME", Some(root.join("data").into_os_string())),
+            (
+                "HOMEBOY_ARTIFACT_ROOT",
+                Some(root.join("artifacts").into_os_string()),
+            ),
+            (
+                "HOMEBOY_RUNTIME_TMPDIR",
+                Some(root.join("runtime").into_os_string()),
+            ),
+            (
+                "HOMEBOY_TEST_LAB_HANDOFF_ACCEPTANCE_TIMEOUT_SECONDS",
+                Some("0".into()),
+            ),
+        ];
+        let previous = values
+            .iter()
+            .map(|(name, value)| {
+                let prior = std::env::var_os(name);
+                std::env::set_var(name, value.as_ref().expect("test value"));
+                (*name, prior)
+            })
+            .collect();
+        Self(previous)
+    }
+}
+
+impl Drop for EnvironmentGuard {
+    fn drop(&mut self) {
+        for (name, value) in self.0.drain(..).rev() {
+            match value {
+                Some(value) => std::env::set_var(name, value),
+                None => std::env::remove_var(name),
+            }
+        }
+    }
+}
+
+#[test]
+fn controller_handoff_remains_resolvable_and_reconciles_when_unaccepted() {
+    let _environment = EnvironmentGuard::isolated();
+    let command = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+    ];
+
+    record_lab_offload_planned(LabOffloadProxyPlan {
+        run_id: "unaccepted-handoff",
+        runner_id: "homeboy-lab",
+        remote_workspace: "/runner/workspace/homeboy",
+        remote_command: &command,
+        durable_plan: None,
+    })
+    .expect("persist controller proxy");
+
+    let active = discover_runs(AgentTaskDiscoveryFilter::Active).expect("discover unaccepted run");
+    let run = active.runs.first().expect("unaccepted run");
+    assert_eq!(run.liveness, Some(AgentTaskLiveness::Unreconciled));
+    assert_eq!(
+        run.commands.status,
+        "homeboy agent-task status unaccepted-handoff"
+    );
+
+    let reconciled = reconcile_stale_active_runs(false).expect("reconcile unaccepted handoff");
+    assert_eq!(reconciled.reconciled, 1);
+    assert_eq!(
+        status("unaccepted-handoff")
+            .expect("terminal controller record")
+            .state,
+        homeboy_core::agent_task_lifecycle::AgentTaskRunState::Cancelled
+    );
+
+    record_lab_offload_planned(LabOffloadProxyPlan {
+        run_id: "accepted-handoff",
+        runner_id: "homeboy-lab",
+        remote_workspace: "/runner/workspace/homeboy",
+        remote_command: &command,
+        durable_plan: None,
+    })
+    .expect("persist second controller proxy");
+    record_detached_lab_run(DetachedLabRunRecord {
+        run_id: "accepted-handoff",
+        runner_id: "homeboy-lab",
+        runner_job_id: "accepted-daemon-job",
+        remote_workspace: "/runner/workspace/homeboy",
+        remote_command: &command,
+    })
+    .expect("record authoritative runner acceptance");
+
+    let active = discover_runs(AgentTaskDiscoveryFilter::Active).expect("discover accepted run");
+    let run = active
+        .runs
+        .iter()
+        .find(|run| run.run_id == "accepted-handoff")
+        .expect("accepted run");
+    assert_eq!(run.liveness, Some(AgentTaskLiveness::Active));
+    assert_eq!(run.runner_job_id.as_deref(), Some("accepted-daemon-job"));
+    assert_eq!(
+        run.commands.status,
+        "homeboy agent-task status accepted-handoff"
+    );
+}


### PR DESCRIPTION
## Summary
- record an explicit pending/accepted boundary for detached Lab handoffs
- keep controller-owned handoff lifecycle commands resolvable on the controller
- classify expired, unaccepted handoffs as unreconciled so the existing reconciler terminalizes them without fabricating provider completion
- add an integration test covering accepted and unaccepted handoffs across reconnect semantics

Closes #8436.

## How to test
1. Run `cargo test -p homeboy-core --test agent_task_handoff_reconnect`.
2. Run `cargo fmt --check`.
3. Run `cargo check -p homeboy`.
4. Run `git diff --check origin/main...HEAD`.

## Compatibility
- Existing accepted Lab handoffs retain runner job identity and remain active.
- Existing records without the new acceptance metadata retain their prior liveness behavior.
- Reconciliation remains explicit through the existing `agent-task active --reconcile` path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Diagnosed the detached handoff lifecycle defect, implemented the recovery contract and integration coverage, and reviewed verification results with Chris.