### PR TITLE
Fix promotion verification socket paths

### DIFF
--- a/crates/homeboy-core/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/promote.rs
@@ -563,13 +563,29 @@ fn run_promotion_gate(
         &format!("gate-{index}"),
         1,
     )?;
+    let runtime_tmpdir = match crate::engine::run_dir::RunDir::create().and_then(|run_dir| {
+        crate::engine::invocation::InvocationGuard::acquire(
+            &run_dir,
+            &crate::engine::invocation::InvocationRequirements::default(),
+        )
+    }) {
+        Ok(runtime_tmpdir) => runtime_tmpdir,
+        Err(error) => {
+            crate::controller_scratch::release_attempt(
+                &allocation,
+                "verification_runtime_setup_failed",
+                serde_json::json!({ "error": error.message }),
+            )?;
+            return Err(error);
+        }
+    };
     let result = provider.verify_with_runtime_tmpdir(
         worktree_path,
         index,
         command,
         visibility,
         reveal_policy,
-        &allocation.path,
+        &runtime_tmpdir.context().tmp_dir,
     );
     let evidence = match &result {
         Ok(report) => serde_json::json!({

--- a/tests/agent_task_promotion_provider.rs
+++ b/tests/agent_task_promotion_provider.rs
@@ -58,6 +58,102 @@ fn promotion_provider_applies_a_typed_patch_request() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn promotion_gate_binds_a_socket_in_the_short_invocation_tmpdir_for_a_long_run_id() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir(&workspace).expect("workspace");
+    git(&workspace, &["init"]);
+    git(&workspace, &["config", "user.email", "test@example.com"]);
+    git(&workspace, &["config", "user.name", "Test User"]);
+    std::fs::write(workspace.join("src.txt"), "old\n").expect("source");
+    git(&workspace, &["add", "src.txt"]);
+    git(&workspace, &["commit", "-m", "initial"]);
+    let patch = temp.path().join("changes.patch");
+    std::fs::write(&patch, PATCH).expect("patch");
+
+    let provider = temp.path().join("promotion-provider.sh");
+    std::fs::write(
+        &provider,
+        format!(
+            "#!/bin/sh\nset -eu\ngit -C '{}' apply '{}'\nprintf '%s\\n' '{{\"schema\":\"homeboy/agent-task-promotion-apply-response/v1\",\"workspace_path\":\"{}\"}}'\n",
+            workspace.display(),
+            patch.display(),
+            workspace.display(),
+        ),
+    )
+    .expect("provider script");
+    let mut permissions = std::fs::metadata(&provider)
+        .expect("provider metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&provider, permissions).expect("provider executable");
+
+    let helper_source = temp.path().join("bind_socket.rs");
+    let helper = temp.path().join("bind_socket");
+    std::fs::write(
+        &helper_source,
+        "use std::{env, os::unix::net::UnixListener, path::PathBuf};\nfn main() { let path = PathBuf::from(env::var_os(\"TMPDIR\").unwrap()).join(\"gate.sock\"); UnixListener::bind(&path).unwrap(); println!(\"{}\", path.display()); }\n",
+    )
+    .expect("socket helper source");
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
+    assert!(
+        Command::new(rustc)
+            .args(["--edition=2021"])
+            .arg(&helper_source)
+            .arg("-o")
+            .arg(&helper)
+            .status()
+            .expect("compile socket helper")
+            .success(),
+        "socket helper compiles"
+    );
+    let run_id = format!("promotion-run-{}", "semantic-id-".repeat(16));
+    let source = serde_json::json!({
+        "schema": "homeboy/agent-task-outcome/v1",
+        "task_id": "socket-gate",
+        "status": "succeeded",
+        "artifacts": [{ "schema": "homeboy/agent-task-artifact/v1", "id": "patch", "kind": "patch", "path": patch }]
+    })
+    .to_string();
+
+    let report = homeboy::core::agent_task_promotion::promote(
+        homeboy::core::agent_task_promotion::AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some(run_id.clone()),
+            source_path: None,
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            to_worktree: "fixture@socket-gate".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: homeboy::core::agent_task_gate::VerifyGateOptions {
+                verify: vec![helper.display().to_string()],
+                private_verify: Vec::new(),
+                private_gate_reveal:
+                    homeboy::core::agent_task_gate::AgentTaskGateRevealPolicy::FullEvidence,
+            },
+            provider_command: Some(provider.display().to_string()),
+            provider_invocation: None,
+        },
+    )
+    .expect("promotion and socket gate succeed");
+
+    assert_eq!(
+        report.status,
+        homeboy::core::agent_task_promotion::AgentTaskPromotionStatus::Applied
+    );
+    let socket_path = report.deterministic_gates[0].stdout.trim();
+    assert!(socket_path.ends_with("gate.sock"));
+    assert!(socket_path.len() < 104, "socket path: {socket_path}");
+    assert!(!socket_path.contains(&run_id));
+}
+
 fn promotion_provider(workspace: &Path, patch: &Path, dry_run: bool) -> std::process::Output {
     let binary = homeboy_bin();
     let mut process = Command::new(binary)


### PR DESCRIPTION
## Summary
Run promotion verification beneath Homeboy's bounded invocation runtime instead of semantic controller-scratch paths.

## What changed
- Promotion gates now allocate an InvocationGuard and pass its short, platform-aware tmp directory to verification subprocesses while retaining durable attempt identity in controller scratch.
- An integration regression uses a deliberately long run id and proves a real Unix socket can bind under the verification TMPDIR.

## How to test
1. Run `cargo test --test agent_task_promotion_provider promotion_gate_binds_a_socket_in_the_short_invocation_tmpdir_for_a_long_run_id --no-fail-fast`; expect The socket-binding regression passes..
2. Run `cargo check -p homeboy-core`; expect The core crate compiles successfully..
3. Run `Check GitHub Actions`; expect Audit, Lint, and Test pass..

## Compatibility
No CLI or persisted-contract change. Existing promotion providers receive a shorter TMPDIR; durable controller-scratch evidence remains unchanged.

## Evidence
- CI expected: Audit
- CI expected: Lint
- CI expected: Test
- Reviewer-resolvable source evidence: https://github.com/Automattic/agents-api/actions/runs/29468956857
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8432
- core-check: Passed
- diff-check: Passed
- format: Passed
- socket-regression: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI gpt-5.6-sol
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the hosted and control-plane failures, prepared the implementation and executable regression, and verified the focused behavior; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8432
