### PR TITLE
fix: align automatic release bump with policy

### DIFF
--- a/crates/homeboy-core/src/release/planner.rs
+++ b/crates/homeboy-core/src/release/planner.rs
@@ -19,7 +19,15 @@ use super::types::{
     ReleaseChangelogPlan, ReleaseOptions, ReleasePlan, ReleaseSemverRecommendation,
 };
 
-const OVERSIZED_PATCH_RELEASE_ITEM_THRESHOLD: usize = 50;
+pub(super) const OVERSIZED_PATCH_RELEASE_ITEM_THRESHOLD: usize = 50;
+
+pub(super) fn oversized_patch_release_bump(bump: &str, item_count: usize) -> &str {
+    if bump == "patch" && item_count >= OVERSIZED_PATCH_RELEASE_ITEM_THRESHOLD {
+        "minor"
+    } else {
+        bump
+    }
+}
 
 /// Plan a release: run all preflight validations, then return a description
 /// of the steps the executor will run. Used by `--dry-run` to preview work
@@ -252,8 +260,8 @@ fn apply_oversized_patch_release_policy(
 
     let commit_count = semver_recommendation.commits.len();
     let changelog_entry_count = changelog_plan.entry_count;
-    if commit_count < OVERSIZED_PATCH_RELEASE_ITEM_THRESHOLD
-        && changelog_entry_count < OVERSIZED_PATCH_RELEASE_ITEM_THRESHOLD
+    if oversized_patch_release_bump("patch", commit_count) == "patch"
+        && oversized_patch_release_bump("patch", changelog_entry_count) == "patch"
     {
         return None;
     }
@@ -273,8 +281,8 @@ fn apply_oversized_patch_release_policy(
 
 #[cfg(test)]
 mod tests {
-    use super::apply_oversized_patch_release_policy;
     use super::guard_stale_primary_at_head;
+    use super::{apply_oversized_patch_release_policy, oversized_patch_release_bump};
     use crate::release::types::{
         ReleaseChangelogPlan, ReleaseSemverCommit, ReleaseSemverRecommendation,
     };
@@ -348,6 +356,13 @@ mod tests {
         assert!(recommendation.reasons.iter().any(|reason| {
             reason.contains("release-train-sized patch ranges require a minor bump")
         }));
+    }
+
+    #[test]
+    fn oversized_patch_release_escalates_automatic_bump() {
+        assert_eq!(oversized_patch_release_bump("patch", 50), "minor");
+        assert_eq!(oversized_patch_release_bump("patch", 49), "patch");
+        assert_eq!(oversized_patch_release_bump("minor", 50), "minor");
     }
 
     #[test]

--- a/crates/homeboy-core/src/release/workflow.rs
+++ b/crates/homeboy-core/src/release/workflow.rs
@@ -490,7 +490,11 @@ fn resolve_bump(release_scope: &ReleaseScope) -> Result<Option<(String, usize)>>
                 .iter()
                 .filter(|c| c.category.to_changelog_entry_type().is_some())
                 .count();
-            Ok(Some((bump.as_str().to_string(), releasable)))
+            Ok(Some((
+                super::planner::oversized_patch_release_bump(bump.as_str(), commits.len())
+                    .to_string(),
+                releasable,
+            )))
         }
         None => Ok(None),
     }
@@ -1421,5 +1425,130 @@ mod tests {
             dir,
             &["git", "checkout", "-q", "-b", "feature/retry-release"],
         );
+    }
+
+    #[test]
+    fn oversized_automatic_release_exports_a_replayable_minor_bump() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        setup_release_range_fixture(temp.path(), "1.2.3", 50);
+
+        let (automatic, exit_code) = run_command(dry_run_release_input(temp.path(), None))
+            .expect("automatic dry run should plan the release");
+        assert_eq!(exit_code, 0);
+        assert_eq!(automatic.bump_type, "minor");
+        assert_eq!(automatic.new_version.as_deref(), Some("1.3.0"));
+        assert_eq!(automatic.tag.as_deref(), Some("v1.3.0"));
+
+        let (replayed, exit_code) = run_command(dry_run_release_input(
+            temp.path(),
+            Some(automatic.bump_type.clone()),
+        ))
+        .expect("exported bump should replay the dry-run release");
+        assert_eq!(exit_code, 0);
+        assert_eq!(replayed.new_version, automatic.new_version);
+        assert_eq!(replayed.tag, automatic.tag);
+    }
+
+    #[test]
+    fn explicit_patch_on_oversized_range_keeps_the_underbump_guard() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        setup_release_range_fixture(temp.path(), "1.2.3", 50);
+
+        let plan = crate::release::plan(
+            "fixture",
+            &ReleaseOptions {
+                bump_type: "patch".to_string(),
+                dry_run: true,
+                path_override: Some(temp.path().to_string_lossy().to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("explicit patch plan should describe the underbump policy");
+        let bump_policy = plan
+            .plan
+            .steps
+            .iter()
+            .find(|step| step.id == "preflight.bump_policy")
+            .expect("bump policy step");
+        assert_eq!(
+            bump_policy
+                .inputs
+                .get("requested")
+                .and_then(|value| value.as_str()),
+            Some("patch")
+        );
+        assert_eq!(
+            bump_policy
+                .inputs
+                .get("recommended")
+                .and_then(|value| value.as_str()),
+            Some("minor")
+        );
+        assert_eq!(
+            bump_policy
+                .inputs
+                .get("underbump")
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn small_fix_only_automatic_release_remains_a_patch() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        setup_release_range_fixture(temp.path(), "1.2.3", 1);
+
+        let (result, exit_code) = run_command(dry_run_release_input(temp.path(), None))
+            .expect("small fix dry run should plan the release");
+        assert_eq!(exit_code, 0);
+        assert_eq!(result.bump_type, "patch");
+        assert_eq!(result.new_version.as_deref(), Some("1.2.4"));
+        assert_eq!(result.tag.as_deref(), Some("v1.2.4"));
+    }
+
+    fn dry_run_release_input(
+        path: &std::path::Path,
+        bump_override: Option<String>,
+    ) -> ReleaseCommandInput {
+        ReleaseCommandInput {
+            component_id: "fixture".to_string(),
+            path_override: Some(path.to_string_lossy().to_string()),
+            dry_run: true,
+            bump_override,
+            ..Default::default()
+        }
+    }
+
+    fn setup_release_range_fixture(dir: &std::path::Path, version: &str, commit_count: usize) {
+        run_in(dir, &["git", "init", "-q", "--initial-branch", "main"]);
+        run_in(dir, &["git", "config", "user.email", "test@example.com"]);
+        run_in(dir, &["git", "config", "user.name", "Test"]);
+        run_in(dir, &["git", "config", "commit.gpgsign", "false"]);
+        std::fs::write(
+            dir.join("homeboy.json"),
+            r#"{
+                "id": "fixture",
+                "changelog_target": "CHANGELOG.md",
+                "version_targets": [
+                    { "file": "VERSION", "pattern": "^([0-9]+\\.[0-9]+\\.[0-9]+)$" }
+                ]
+            }"#,
+        )
+        .expect("write homeboy config");
+        std::fs::write(dir.join("VERSION"), format!("{version}\n")).expect("write version");
+        std::fs::write(dir.join("CHANGELOG.md"), "# Changelog\n").expect("write changelog");
+        std::fs::write(dir.join("work.txt"), "0\n").expect("write work");
+        run_in(dir, &["git", "add", "."]);
+        run_in(dir, &["git", "commit", "-q", "-m", "chore: initial"]);
+        run_in(dir, &["git", "tag", &format!("v{version}")]);
+
+        for index in 1..=commit_count {
+            std::fs::write(dir.join("work.txt"), format!("{index}\n")).expect("write work");
+            run_in(dir, &["git", "add", "work.txt"]);
+            run_in(
+                dir,
+                &["git", "commit", "-q", "-m", &format!("fix: change {index}")],
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
Make automatic oversized patch release planning export the policy-required minor bump so the generated bump is replayable by release preparation.

## What changed
- Apply oversized patch escalation while resolving automatic release scope, preserve explicit patch override validation, and cover automatic replay, explicit underbump, and small patch behavior.

## How to test
1. Run `cargo test --test release_workflow_test`; expect 18 tests pass.
2. Run `cargo check --bin homeboy`; expect command completes successfully.

## Compatibility
No backwards compatibility impact: explicit bump overrides retain existing fail-closed underbump behavior; only automatic release planning changes for oversized patch trains.

## Evidence
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8443
- cargo\_check: Passed
- release\_workflow\_test: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Prepared and verified the release policy repair; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8443
