### PR TITLE
Carry gate-feedback candidates through remediation

### DIFF
--- a/crates/homeboy-core/src/agent_task_candidate_baseline.rs
+++ b/crates/homeboy-core/src/agent_task_candidate_baseline.rs
@@ -1,0 +1,96 @@
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::{Error, Result};
+
+/// Verify that a dirty worktree is exactly the gate-feedback candidate described
+/// by its durable promotion artifact, without mutating its real Git index.
+pub(crate) fn validate_gate_feedback_candidate_baseline(
+    root: &Path,
+    cook_loop: &Value,
+) -> Result<String> {
+    let artifact = cook_loop
+        .get("patch_artifact")
+        .and_then(Value::as_object)
+        .ok_or_else(|| invalid("recorded patch artifact is not an object"))?;
+    let path = artifact
+        .get("path")
+        .and_then(Value::as_str)
+        .filter(|path| !path.is_empty())
+        .ok_or_else(|| invalid("recorded patch artifact has no path"))?;
+    let expected_sha256 = artifact
+        .get("sha256")
+        .and_then(Value::as_str)
+        .filter(|sha256| !sha256.is_empty())
+        .ok_or_else(|| invalid("recorded patch artifact has no sha256"))?;
+    let patch = std::fs::read(path)
+        .map_err(|error| invalid(&format!("recorded patch artifact is unreadable: {error}")))?;
+    if format!("{:x}", Sha256::digest(&patch)) != expected_sha256 {
+        return Err(invalid(
+            "recorded patch artifact sha256 does not match its content",
+        ));
+    }
+    let patch = String::from_utf8(patch)
+        .map_err(|error| invalid(&format!("recorded patch artifact is not UTF-8: {error}")))?;
+    if patch_tree(root, &patch)? != workspace_tree(root)? {
+        return Err(invalid(
+            "recorded patch artifact does not match the promoted candidate worktree state",
+        ));
+    }
+    Ok(patch)
+}
+
+fn patch_tree(root: &Path, patch: &str) -> Result<String> {
+    let index = tempfile::NamedTempFile::new().map_err(|error| invalid(&error.to_string()))?;
+    let patch_file = tempfile::NamedTempFile::new().map_err(|error| invalid(&error.to_string()))?;
+    std::fs::write(patch_file.path(), patch).map_err(|error| invalid(&error.to_string()))?;
+    let index_path = index.path().display().to_string();
+    git_with_index(root, &["read-tree", "HEAD"], &index_path)?;
+    git_with_index(
+        root,
+        &[
+            "apply",
+            "--cached",
+            "--binary",
+            &patch_file.path().display().to_string(),
+        ],
+        &index_path,
+    )?;
+    git_with_index(root, &["write-tree"], &index_path)
+}
+
+fn workspace_tree(root: &Path) -> Result<String> {
+    let index = tempfile::NamedTempFile::new().map_err(|error| invalid(&error.to_string()))?;
+    let index_path = index.path().display().to_string();
+    git_with_index(root, &["read-tree", "HEAD"], &index_path)?;
+    git_with_index(root, &["add", "--all"], &index_path)?;
+    git_with_index(root, &["write-tree"], &index_path)
+}
+
+fn git_with_index(root: &Path, args: &[&str], index_path: &str) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .env("GIT_INDEX_FILE", index_path)
+        .current_dir(root)
+        .output()
+        .map_err(|error| invalid(&error.to_string()))?;
+    if !output.status.success() {
+        return Err(invalid(&format!(
+            "candidate baseline Git operation failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn invalid(message: &str) -> Error {
+    Error::validation_invalid_argument(
+        "gate_feedback_candidate_baseline",
+        message.to_string(),
+        None,
+        None,
+    )
+}

--- a/crates/homeboy-core/src/agent_task_promotion/apply.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/apply.rs
@@ -196,6 +196,8 @@ pub(crate) struct AgentTaskPromotionApplyRequest {
     pub(crate) patch: Option<String>,
     pub(crate) patch_path: String,
     pub(crate) changed_files: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) gate_feedback_baseline: Option<serde_json::Value>,
     #[serde(default)]
     pub(crate) dry_run: bool,
 }
@@ -310,7 +312,10 @@ impl ExternalPromotionWorkspaceProvider {
         self.invocation.as_ref()
     }
 
-    fn resolve_configured_fallback(&mut self, to_workspace: &str) -> Result<()> {
+    fn resolve_configured_fallback(
+        &mut self,
+        request: &AgentTaskPromotionApplyRequest,
+    ) -> Result<()> {
         let configured_fallback = self.configured_fallback.as_ref().ok_or_else(|| {
             Error::validation_invalid_argument(
                 "promotion_provider",
@@ -322,8 +327,9 @@ impl ExternalPromotionWorkspaceProvider {
             )
         })?;
         let resolution = worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
-            to_workspace,
+            &request.to_workspace,
             &configured_fallback.config,
+            request.gate_feedback_baseline.as_ref(),
         )?;
         let executable = configured_fallback
             .executable
@@ -383,7 +389,7 @@ impl AgentTaskPromotionWorkspaceProvider for ExternalPromotionWorkspaceProvider 
         request: AgentTaskPromotionApplyRequest,
     ) -> Result<AgentTaskPromotionWorkspace> {
         if self.invocation.is_none() {
-            self.resolve_configured_fallback(&request.to_workspace)?;
+            self.resolve_configured_fallback(&request)?;
         }
         let invocation = self.invocation.as_ref().ok_or_else(|| {
             Error::validation_invalid_argument(

--- a/crates/homeboy-core/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/promote.rs
@@ -237,6 +237,7 @@ pub(crate) fn promote_with_provider(
             Some(options.source.clone()),
         )
     })?;
+    let source_for_provenance = source_value.clone();
     let (source_kind, outcome) = select_outcome(source_value, options.task_id.as_deref())?;
 
     if !matches!(
@@ -287,6 +288,8 @@ pub(crate) fn promote_with_provider(
         }
         Err(error) => return Err(error),
     };
+    let gate_feedback_baseline =
+        gate_feedback_baseline_for_artifact(&source_for_provenance, &outcome, &artifact)?;
     let patch_path = resolve_artifact_path(&artifact, options.source_path.as_deref())?;
     let patch = std::fs::read_to_string(&patch_path).map_err(|error| {
         Error::internal_io(
@@ -354,6 +357,7 @@ pub(crate) fn promote_with_provider(
             patch: Some(normalized_patch.content.clone()),
             patch_path: provider_patch_path,
             changed_files: changed_files.clone(),
+            gate_feedback_baseline,
             dry_run: options.dry_run,
         })?;
         command_evidence.extend(target.command_evidence);
@@ -410,6 +414,92 @@ pub(crate) fn promote_with_provider(
     })
 }
 
+fn gate_feedback_baseline_for_artifact(
+    source: &Value,
+    outcome: &AgentTaskOutcome,
+    selected: &AgentTaskArtifact,
+) -> Result<Option<Value>> {
+    let canonical = outcome
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.id == selected.id)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "artifact_id",
+                "selected patch artifact is missing from canonical outcome artifacts",
+                None,
+                None,
+            )
+        })?;
+    let source_baseline = source_canonical_artifact(source, &outcome.task_id, &canonical.id)?
+        .and_then(|artifact| artifact.get("metadata"))
+        .and_then(|metadata| metadata.get("gate_feedback_baseline"))
+        .cloned();
+    let baseline = source_baseline
+        .clone()
+        .or_else(|| canonical.metadata.get("gate_feedback_baseline").cloned());
+    if let Some(raw) = source_baseline.as_ref() {
+        if canonical.metadata.get("gate_feedback_baseline") != Some(raw) {
+            return Err(Error::validation_invalid_argument(
+                "artifact_id",
+                "canonical patch artifact baseline provenance changed during source deserialization",
+                Some(canonical.id.clone()),
+                None,
+            ));
+        }
+    }
+    for typed in &outcome.typed_artifacts {
+        if let Some(duplicate) = typed
+            .artifact
+            .as_ref()
+            .filter(|artifact| artifact.id == canonical.id)
+            .and_then(|artifact| artifact.metadata.get("gate_feedback_baseline"))
+        {
+            if baseline.as_ref() != Some(duplicate) {
+                return Err(Error::validation_invalid_argument(
+                    "artifact_id",
+                    "typed patch artifact baseline provenance conflicts with the canonical artifact",
+                    Some(canonical.id.clone()),
+                    None,
+                ));
+            }
+        }
+    }
+    Ok(baseline)
+}
+
+fn source_canonical_artifact<'a>(
+    source: &'a Value,
+    task_id: &str,
+    artifact_id: &str,
+) -> Result<Option<&'a Value>> {
+    let outcomes = if source.get("schema").and_then(Value::as_str)
+        == Some(AGENT_TASK_OUTCOME_SCHEMA)
+    {
+        std::slice::from_ref(source)
+    } else if source.get("schema").and_then(Value::as_str) == Some(AGENT_TASK_AGGREGATE_SCHEMA) {
+        source
+            .get("outcomes")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    } else {
+        return Ok(None);
+    };
+    let outcome = outcomes
+        .iter()
+        .find(|outcome| outcome.get("task_id").and_then(Value::as_str) == Some(task_id));
+    let artifact = outcome
+        .and_then(|outcome| outcome.get("artifacts"))
+        .and_then(Value::as_array)
+        .and_then(|artifacts| {
+            artifacts
+                .iter()
+                .find(|artifact| artifact.get("id").and_then(Value::as_str) == Some(artifact_id))
+        });
+    Ok(artifact)
+}
+
 fn outcome_has_patch_artifacts(outcome: &AgentTaskOutcome) -> bool {
     outcome
         .artifacts
@@ -444,6 +534,9 @@ fn promote_committed_changes(
         patch: Some(normalized_patch.content.clone()),
         patch_path: committed_patch.patch_path.display().to_string(),
         changed_files: normalized_patch.changed_files.clone(),
+        gate_feedback_baseline: artifact
+            .and_then(|artifact| artifact.metadata.get("gate_feedback_baseline"))
+            .cloned(),
         dry_run: options.dry_run,
     })?;
     command_evidence.extend(target.command_evidence);

--- a/crates/homeboy-core/src/agent_task_promotion/tests.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/tests.rs
@@ -164,6 +164,73 @@ fn write_empty_patch_source(temp: &tempfile::TempDir) -> (PathBuf, String) {
     (source_path, source)
 }
 
+#[test]
+fn aggregate_promotion_forwards_canonical_gate_feedback_baseline() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let patch_path = temp.path().join("remediation.patch");
+    std::fs::write(&patch_path, VALID_PATCH).expect("write remediation patch");
+    let baseline = serde_json::json!({
+        "source_run_id": "source-run",
+        "source_task_id": "source-task",
+        "source_patch_task_id": "source-task",
+        "to_worktree": "fixture@target",
+        "current_diff": "diff --git a/a b/a",
+        "failed_gates": [],
+        "patch_artifact": { "path": "/candidate.patch", "sha256": "a".repeat(64) }
+    });
+    let source = serde_json::json!({
+        "schema": "homeboy/agent-task-aggregate/v1",
+        "outcomes": [{
+            "schema": AGENT_TASK_OUTCOME_SCHEMA,
+            "task_id": "follow-up",
+            "status": "succeeded",
+            "artifacts": [{
+                "schema": AGENT_TASK_ARTIFACT_SCHEMA,
+                "id": "patch",
+                "kind": "patch",
+                "path": patch_path,
+                "size_bytes": VALID_PATCH.len(),
+                "sha256": sha256_hex(VALID_PATCH),
+                "metadata": { "gate_feedback_baseline": baseline }
+            }],
+            "typed_artifacts": [{
+                "name": "patch",
+                "payload": { "artifact_id": "patch" },
+                "metadata": { "normalized_from": "artifact" }
+            }]
+        }]
+    })
+    .to_string();
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(temp.path().to_path_buf()),
+        ..Default::default()
+    };
+    promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("follow-up-run".to_string()),
+            source_path: None,
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            to_worktree: "fixture@target".to_string(),
+            task_id: Some("follow-up".to_string()),
+            artifact_id: Some("patch".to_string()),
+            dry_run: false,
+            gates: VerifyGateOptions::default(),
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+    )
+    .expect("aggregate promotion");
+    assert_eq!(
+        provider.apply_calls[0].gate_feedback_baseline,
+        Some(baseline),
+        "only canonical artifact metadata authorizes the dirty target"
+    );
+}
+
 fn recoverable_patch_source(temp: &tempfile::TempDir, patch_count: usize) -> (PathBuf, String) {
     let artifacts = (0..patch_count)
         .map(|index| {
@@ -357,6 +424,7 @@ fn configured_command_provider_is_resolved_lazily_with_provenance() {
             patch: Some(VALID_PATCH.to_string()),
             patch_path: "changes.patch".to_string(),
             changed_files: vec!["src/lib.rs".to_string()],
+            gate_feedback_baseline: None,
             dry_run: false,
         })
         .expect_err("fixture executable is not an adapter");
@@ -459,6 +527,7 @@ fn lookup_only_configured_provider_cannot_construct_a_promotion_adapter() {
             patch: Some(VALID_PATCH.to_string()),
             patch_path: "changes.patch".to_string(),
             changed_files: vec!["src/lib.rs".to_string()],
+            gate_feedback_baseline: None,
             dry_run: false,
         })
         .expect_err("lookup-only provider must not authorize promotion");
@@ -1603,6 +1672,7 @@ fn provider_command_response_supplies_workspace_and_evidence() {
         patch: None,
         patch_path: temp.path().join("changes.patch").display().to_string(),
         changed_files: vec!["src/lib.rs".to_string()],
+        gate_feedback_baseline: None,
         dry_run: false,
     };
     let workspace = run_provider_command(
@@ -1644,6 +1714,7 @@ fn provider_failure_surfaces_bounded_stdout_and_stderr_evidence() {
         patch: None,
         patch_path: "changes.patch".to_string(),
         changed_files: vec!["src/lib.rs".to_string()],
+        gate_feedback_baseline: None,
         dry_run: false,
     };
 
@@ -1679,6 +1750,7 @@ fn provider_response_overflow_is_terminated_with_bounded_evidence() {
         patch: None,
         patch_path: "changes.patch".to_string(),
         changed_files: vec!["src/lib.rs".to_string()],
+        gate_feedback_baseline: None,
         dry_run: false,
     };
 

--- a/crates/homeboy-core/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-core/src/agent_task_scheduler/attempt_workspace.rs
@@ -78,10 +78,15 @@ fn incomplete_transport_error(message: String) -> crate::Error {
 pub(super) struct AttemptWorkspace {
     source_root: PathBuf,
     root: PathBuf,
+    base_sha: String,
     retain: AtomicBool,
 }
 
 impl AttemptWorkspace {
+    pub(super) fn base_sha(&self) -> &str {
+        &self.base_sha
+    }
+
     pub(super) fn retain_for_diagnostics(&self) {
         self.retain.store(true, Ordering::Release);
     }
@@ -119,6 +124,14 @@ impl Drop for AttemptWorkspace {
 pub(super) struct HarvestPreflight {
     pub(super) base_sha: Option<String>,
     pub(super) source_provenance: Option<serde_json::Value>,
+    pub(super) candidate_baseline: Option<CandidateBaseline>,
+}
+
+/// A gate-feedback retry may start from the promoted, uncommitted candidate.
+/// This patch is derived only after its recorded provenance reproduces the
+/// exact worktree tree, so it cannot authorize arbitrary existing dirt.
+pub(super) struct CandidateBaseline {
+    patch: String,
 }
 
 pub(super) fn prepare_committed_harvest(
@@ -130,6 +143,7 @@ pub(super) fn prepare_committed_harvest(
         return Ok(HarvestPreflight {
             base_sha: None,
             source_provenance: None,
+            candidate_baseline: None,
         });
     };
     let snapshot_signaled = context.snapshot_signaled();
@@ -138,6 +152,7 @@ pub(super) fn prepare_committed_harvest(
         return Ok(HarvestPreflight {
             base_sha: None,
             source_provenance: None,
+            candidate_baseline: None,
         });
     }
     let source_provenance = if let Some(capability) = derived_cook_baseline {
@@ -230,13 +245,60 @@ pub(super) fn prepare_committed_harvest(
         });
     }
     let status = git_output(root, &["status", "--porcelain", "--untracked-files=all"])?;
-    if !status.trim().is_empty() {
-        return Err(HarvestError::DirtyWorkspace { status });
-    }
+    let candidate_baseline = if status.trim().is_empty() {
+        None
+    } else {
+        Some(verified_gate_feedback_baseline(root, request, &status)?)
+    };
     Ok(HarvestPreflight {
         base_sha: Some(git_output(root, &["rev-parse", "HEAD"])?),
         source_provenance,
+        candidate_baseline,
     })
+}
+
+fn verified_gate_feedback_baseline(
+    root: &Path,
+    request: &AgentTaskRequest,
+    status: &str,
+) -> Result<CandidateBaseline, HarvestError> {
+    let cook_loop = request
+        .inputs
+        .get("cook_loop")
+        .and_then(serde_json::Value::as_object);
+    let is_gate_feedback = request
+        .metadata
+        .get("cook_loop")
+        .and_then(|value| value.get("kind"))
+        .and_then(serde_json::Value::as_str)
+        == Some("deterministic-gate-feedback");
+    let Some(cook_loop) = cook_loop else {
+        return Err(HarvestError::DirtyWorkspace {
+            status: status.to_string(),
+        });
+    };
+    let required = [
+        "source_run_id",
+        "source_task_id",
+        "source_patch_task_id",
+        "patch_artifact",
+        "failed_gates",
+        "next_attempt",
+        "to_worktree",
+    ];
+    if !is_gate_feedback || required.iter().any(|key| !cook_loop.contains_key(*key)) {
+        return Err(HarvestError::DirtyWorkspace {
+            status: status.to_string(),
+        });
+    }
+    let patch = crate::agent_task_candidate_baseline::validate_gate_feedback_candidate_baseline(
+        root,
+        &serde_json::Value::Object(cook_loop.clone()),
+    )
+    .map_err(|error| HarvestError::CandidateBaselineMismatch {
+        message: error.message,
+    })?;
+    Ok(CandidateBaseline { patch })
 }
 
 fn snapshot_harvest_error(message: String) -> HarvestError {
@@ -295,6 +357,7 @@ fn validate_derived_cook_baseline(
 pub(super) fn prepare_attempt_workspace(
     request: &mut AgentTaskRequest,
     base: Option<&str>,
+    candidate_baseline: Option<&CandidateBaseline>,
 ) -> Result<Option<Arc<AttemptWorkspace>>, HarvestError> {
     let Some(root) = request.workspace.root.as_deref().map(PathBuf::from) else {
         return Ok(None);
@@ -315,12 +378,12 @@ pub(super) fn prepare_attempt_workspace(
         &["worktree", "add", "--detach", &attempt_root_string, base],
     )?;
     // Establish cleanup ownership before anything that can fail below.
-    let workspace = Arc::new(AttemptWorkspace {
+    let mut workspace = Arc::new(AttemptWorkspace {
         source_root: root.clone(),
         root: attempt_root.clone(),
+        base_sha: base.to_string(),
         retain: AtomicBool::new(false),
     });
-    let base_fingerprint = fingerprint(base.as_bytes());
     let adoption = request
         .workspace
         .attempt
@@ -329,15 +392,54 @@ pub(super) fn prepare_attempt_workspace(
     if let Some(adoption) = adoption.as_ref() {
         apply_adopted_candidate(&attempt_root, adoption)?;
     }
+    if let Some(candidate_baseline) = candidate_baseline {
+        apply_gate_feedback_baseline(&attempt_root, candidate_baseline)?;
+    }
+    let attempt_base_sha = git_output(&attempt_root, &["rev-parse", "HEAD"])?;
+    Arc::get_mut(&mut workspace)
+        .expect("attempt workspace has no other owners during setup")
+        .base_sha = attempt_base_sha;
+    let attempt_base = workspace.base_sha().to_string();
+    let base_fingerprint = fingerprint(attempt_base.as_bytes());
     remap_workspace_config(&mut request.executor.config, &root, &attempt_root);
     request.workspace.root = Some(attempt_root.display().to_string());
     request.workspace.attempt = Some(crate::agent_task::AgentTaskAttemptWorkspace {
         identity,
-        base_ref: base.to_string(),
+        base_ref: attempt_base,
         base_fingerprint,
         adoption,
     });
     Ok(Some(workspace))
+}
+
+fn apply_gate_feedback_baseline(
+    root: &Path,
+    baseline: &CandidateBaseline,
+) -> Result<(), HarvestError> {
+    let patch = tempfile::NamedTempFile::new().map_err(|error| HarvestError::Git {
+        command: "create gate-feedback baseline patch".to_string(),
+        message: error.to_string(),
+    })?;
+    std::fs::write(patch.path(), &baseline.patch).map_err(|error| HarvestError::Git {
+        command: "write gate-feedback baseline patch".to_string(),
+        message: error.to_string(),
+    })?;
+    let patch_path = patch.path().display().to_string();
+    git_output(root, &["apply", "--index", "--binary", &patch_path])?;
+    git_output(
+        root,
+        &[
+            "-c",
+            "user.name=Homeboy",
+            "-c",
+            "user.email=homeboy@localhost",
+            "commit",
+            "--no-verify",
+            "-m",
+            "homeboy: gate-feedback candidate baseline",
+        ],
+    )?;
+    Ok(())
 }
 
 pub(super) fn remap_workspace_config(

--- a/crates/homeboy-core/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-core/src/agent_task_scheduler/engine.rs
@@ -393,21 +393,28 @@ where
                     .or(harvest_preflight.base_sha.clone());
                 let source_workspace_root = request.workspace.root.clone();
                 let source_provenance = harvest_preflight.source_provenance;
-                let attempt_workspace =
-                    match prepare_attempt_workspace(&mut request, task_base_sha.as_deref()) {
-                        Ok(workspace) => workspace,
-                        Err(error) => {
-                            record_harvest_setup_failure(
-                                &task_id,
-                                scheduled.attempt,
-                                error,
-                                &mut completed_by_task,
-                                &mut outcomes,
-                                &mut events,
-                            );
-                            continue;
-                        }
-                    };
+                let attempt_workspace = match prepare_attempt_workspace(
+                    &mut request,
+                    task_base_sha.as_deref(),
+                    harvest_preflight.candidate_baseline.as_ref(),
+                ) {
+                    Ok(workspace) => workspace,
+                    Err(error) => {
+                        record_harvest_setup_failure(
+                            &task_id,
+                            scheduled.attempt,
+                            error,
+                            &mut completed_by_task,
+                            &mut outcomes,
+                            &mut events,
+                        );
+                        continue;
+                    }
+                };
+                let task_base_sha = attempt_workspace
+                    .as_ref()
+                    .map(|workspace| workspace.base_sha().to_string())
+                    .or(task_base_sha);
                 if let Some(adoption) = scheduled.adoption.as_ref() {
                     if let Err(mut outcome) = validate_and_apply_candidate_adoption(
                         &request,

--- a/crates/homeboy-core/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-core/src/agent_task_scheduler/harvest.rs
@@ -155,6 +155,7 @@ fn patch_artifact_metadata(
             ),
         ]));
     }
+    attach_gate_feedback_baseline_metadata(&mut artifact.metadata, running);
 }
 
 fn harvest_committed_patch_with_metadata(
@@ -257,6 +258,12 @@ fn harvest_committed_patch_with_metadata(
         "changed_files": changed_files,
     });
     Ok(())
+}
+
+fn attach_gate_feedback_baseline_metadata(metadata: &mut serde_json::Value, running: &RunningTask) {
+    if running.request.metadata["cook_loop"]["kind"] == "deterministic-gate-feedback" {
+        metadata["gate_feedback_baseline"] = running.request.inputs["cook_loop"].clone();
+    }
 }
 
 fn committed_change_metadata_for_range(
@@ -419,6 +426,7 @@ pub(crate) enum HarvestError {
     ArtifactDirectory { path: PathBuf, message: String },
     ArtifactWrite { path: PathBuf, message: String },
     Adoption { message: String },
+    CandidateBaselineMismatch { message: String },
 }
 
 pub(super) fn committed_harvest_preflight_outcome(task_id: String) -> AgentTaskOutcome {
@@ -480,6 +488,11 @@ pub(super) fn committed_harvest_failure(
             format!("could not materialize explicitly adopted candidate: {message}"),
             serde_json::json!({ "error": message }),
         ),
+        HarvestError::CandidateBaselineMismatch { message } => (
+            "agent_task.gate_feedback_candidate_baseline_mismatch",
+            format!("refusing gate-feedback retry candidate baseline: {message}"),
+            serde_json::json!({ "error": message }),
+        ),
     };
     outcome.status = AgentTaskOutcomeStatus::Failed;
     outcome.failure_classification = Some(AgentTaskFailureClassification::ExecutionFailed);
@@ -533,6 +546,184 @@ mod committed_harvest_tests {
             .expect("git command runs");
         assert!(output.status.success(), "git {args:?} failed");
         String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn gate_feedback_request(
+        workspace: &Path,
+        current_diff: String,
+        patch_artifact: &Path,
+        patch_sha256: &str,
+    ) -> AgentTaskRequest {
+        AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "source-gate-fix-2".to_string(),
+            group_key: None,
+            parent_plan_id: Some("source-run".to_string()),
+            executor: AgentTaskExecutor {
+                backend: "test".to_string(),
+                selector: None,
+                runtime_selection: None,
+                required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
+                model: None,
+                config: serde_json::Value::Null,
+            },
+            instructions:
+                "Continue the Homeboy cook loop from the current candidate worktree state."
+                    .to_string(),
+            inputs: serde_json::json!({ "cook_loop": {
+                "source_run_id": "source-run",
+                "source_task_id": "source",
+                "source_patch_task_id": "source",
+                "patch_artifact": {
+                    "id": "candidate",
+                    "path": patch_artifact,
+                    "sha256": patch_sha256,
+                },
+                "failed_gates": [{ "gate_id": "visible" }],
+                "next_attempt": 2,
+                "to_worktree": workspace.display().to_string(),
+                "current_diff": current_diff,
+            }}),
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace {
+                root: Some(workspace.display().to_string()),
+                ..Default::default()
+            },
+            component_contracts: Vec::new(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            artifact_declarations: Vec::new(),
+            metadata: serde_json::json!({ "cook_loop": { "kind": "deterministic-gate-feedback" }}),
+        }
+    }
+
+    fn candidate_patch(workspace: &Path) -> (PathBuf, String) {
+        git(workspace, &["add", "--all"]);
+        let patch = git_output_raw(
+            workspace,
+            &["diff", "--cached", "--binary", "--full-index", "HEAD"],
+        )
+        .expect("candidate patch");
+        git(workspace, &["reset", "--quiet"]);
+        let path = workspace
+            .parent()
+            .expect("workspace has test parent")
+            .join("candidate.patch");
+        std::fs::write(&path, &patch).expect("write candidate patch");
+        let sha256 = format!("{:x}", Sha256::digest(patch.as_bytes()));
+        (path, sha256)
+    }
+
+    #[test]
+    fn gate_feedback_baseline_allows_only_the_recorded_candidate_and_harvests_remediation_delta() {
+        let _home = crate::test_support::HomeGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir(&workspace).expect("workspace");
+        git(&workspace, &["init", "--quiet", "-b", "main"]);
+        git(&workspace, &["config", "user.email", "test@example.com"]);
+        git(&workspace, &["config", "user.name", "Homeboy Test"]);
+        std::fs::write(workspace.join("candidate.txt"), "base\n").expect("base");
+        git(&workspace, &["add", "candidate.txt"]);
+        git(&workspace, &["commit", "--quiet", "-m", "base"]);
+        std::fs::write(workspace.join("candidate.txt"), "candidate\n").expect("candidate");
+        std::fs::write(workspace.join("new-candidate.txt"), "new candidate\n")
+            .expect("new candidate");
+        let current_diff = git_output_raw(&workspace, &["diff", "HEAD"]).expect("current diff");
+        let (patch_artifact, patch_sha256) = candidate_patch(&workspace);
+        let mut request =
+            gate_feedback_request(&workspace, current_diff, &patch_artifact, &patch_sha256);
+
+        let preflight =
+            prepare_committed_harvest(&request, None, &HarvestExecutionContext::default())
+                .expect("recorded promoted candidate is accepted");
+        let source_base = preflight.base_sha.expect("source base");
+        let attempt = prepare_attempt_workspace(
+            &mut request,
+            Some(&source_base),
+            preflight.candidate_baseline.as_ref(),
+        )
+        .expect("attempt workspace")
+        .expect("isolated attempt");
+        let attempt_root = PathBuf::from(request.workspace.root.as_deref().expect("attempt root"));
+        assert_eq!(
+            std::fs::read_to_string(attempt_root.join("candidate.txt"))
+                .expect("candidate baseline"),
+            "candidate\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(attempt_root.join("new-candidate.txt"))
+                .expect("new candidate baseline"),
+            "new candidate\n"
+        );
+        std::fs::write(attempt_root.join("remediation.txt"), "green\n").expect("remediation");
+        git(&attempt_root, &["add", "remediation.txt"]);
+        git(&attempt_root, &["commit", "--quiet", "-m", "remediation"]);
+        let remediation_base = attempt.base_sha().to_string();
+        let patch = git_output_raw(
+            &attempt_root,
+            &["diff", "--binary", &remediation_base, "HEAD"],
+        )
+        .expect("remediation delta");
+        assert!(patch.contains("remediation.txt"));
+        assert!(!patch.contains("new-candidate.txt"));
+        assert!(
+            !patch.contains("-base"),
+            "candidate is not replayed in remediation"
+        );
+    }
+
+    #[test]
+    fn gate_feedback_baseline_rejects_mismatched_or_extra_dirty_changes() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir(&workspace).expect("workspace");
+        git(&workspace, &["init", "--quiet", "-b", "main"]);
+        git(&workspace, &["config", "user.email", "test@example.com"]);
+        git(&workspace, &["config", "user.name", "Homeboy Test"]);
+        std::fs::write(workspace.join("file.txt"), "base\n").expect("base");
+        git(&workspace, &["add", "file.txt"]);
+        git(&workspace, &["commit", "--quiet", "-m", "base"]);
+        std::fs::write(workspace.join("file.txt"), "candidate\n").expect("candidate");
+        let recorded = git_output_raw(&workspace, &["diff", "HEAD"]).expect("recorded diff");
+        let (patch_artifact, patch_sha256) = candidate_patch(&workspace);
+        std::fs::write(workspace.join("extra.txt"), "unrelated\n").expect("extra");
+        let error = prepare_committed_harvest(
+            &gate_feedback_request(&workspace, recorded.clone(), &patch_artifact, &patch_sha256),
+            None,
+            &HarvestExecutionContext::default(),
+        )
+        .expect_err("untracked unrelated dirt must fail closed");
+        assert!(matches!(
+            error,
+            HarvestError::CandidateBaselineMismatch { .. }
+        ));
+
+        std::fs::remove_file(workspace.join("extra.txt")).expect("remove extra");
+        let error = prepare_committed_harvest(
+            &gate_feedback_request(
+                &workspace,
+                "not a patch".to_string(),
+                &patch_artifact,
+                "bad",
+            ),
+            None,
+            &HarvestExecutionContext::default(),
+        )
+        .expect_err("mismatched recorded diff must fail closed");
+        assert!(matches!(
+            error,
+            HarvestError::CandidateBaselineMismatch { .. }
+        ));
+
+        let mut ordinary =
+            gate_feedback_request(&workspace, String::new(), &patch_artifact, &patch_sha256);
+        ordinary.metadata = serde_json::Value::Null;
+        let error = prepare_committed_harvest(&ordinary, None, &HarvestExecutionContext::default())
+            .expect_err("ordinary dirty worktree remains refused");
+        assert!(matches!(error, HarvestError::DirtyWorkspace { .. }));
     }
 
     #[test]
@@ -769,7 +960,7 @@ mod committed_harvest_tests {
             prepare_committed_harvest(&request, None, &context).expect("snapshot retry preflight");
         assert_eq!(retry_preflight.base_sha.as_deref(), Some(baseline.as_str()));
         assert_eq!(source_provenance["source_revision"], "a".repeat(40));
-        let attempt = prepare_attempt_workspace(&mut request, Some(&baseline))
+        let attempt = prepare_attempt_workspace(&mut request, Some(&baseline), None)
             .expect("provider-ready attempt")
             .expect("attempt workspace");
         assert_ne!(
@@ -818,6 +1009,16 @@ mod committed_harvest_tests {
                 metadata: serde_json::Value::Null,
             },
         ];
+        request.metadata = serde_json::json!({
+            "cook_loop": { "kind": "deterministic-gate-feedback" }
+        });
+        request.inputs = serde_json::json!({
+            "cook_loop": {
+                "source_run_id": "promoted-run",
+                "source_task_id": "snapshot-task",
+                "patch_artifact": { "sha256": "c".repeat(64) }
+            }
+        });
         let running = RunningTask {
             task_id: "snapshot-task".to_string(),
             request: request.clone(),
@@ -864,6 +1065,11 @@ mod committed_harvest_tests {
             );
         }
         assert_eq!(outcome.artifacts[0].metadata["kept"], true);
+        assert_eq!(
+            outcome.artifacts[0].metadata["gate_feedback_baseline"],
+            running.request.inputs["cook_loop"],
+            "provider-supplied patches retain promotion baseline provenance"
+        );
         drop(attempt);
         std::env::remove_var(crate::observation::SOURCE_SNAPSHOT_METADATA_ENV);
         std::env::remove_var(crate::observation::LAB_OFFLOAD_METADATA_ENV);

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -43,6 +43,7 @@ pub mod agent_task_aggregate;
 pub mod agent_task_artifacts;
 pub mod agent_task_batch;
 pub use homeboy_lab_contract::agent_task_config;
+pub(crate) mod agent_task_candidate_baseline;
 pub(crate) mod agent_task_config_materialization;
 pub mod agent_task_contract;
 pub mod agent_task_controller_service;

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -120,21 +120,23 @@ pub fn resolve_worktree_provider_from_config(
     handle: &str,
     config: &HomeboyConfig,
 ) -> Result<WorktreeProviderResolution> {
-    resolve_worktree_provider_with_policy_from_config(handle, config, false)
+    resolve_worktree_provider_with_policy_from_config(handle, config, false, None)
 }
 
 /// Resolve a workspace only from providers explicitly authorized for apply operations.
 pub fn resolve_apply_enabled_worktree_provider_from_config(
     handle: &str,
     config: &HomeboyConfig,
+    gate_feedback_baseline: Option<&serde_json::Value>,
 ) -> Result<WorktreeProviderResolution> {
-    resolve_worktree_provider_with_policy_from_config(handle, config, true)
+    resolve_worktree_provider_with_policy_from_config(handle, config, true, gate_feedback_baseline)
 }
 
 fn resolve_worktree_provider_with_policy_from_config(
     handle: &str,
     config: &HomeboyConfig,
     require_apply_enabled: bool,
+    gate_feedback_baseline: Option<&serde_json::Value>,
 ) -> Result<WorktreeProviderResolution> {
     let mut provider_ids = config
         .worktree_providers
@@ -158,7 +160,7 @@ fn resolve_worktree_provider_with_policy_from_config(
             attempted.push(provider_id.clone());
             let worktrees = run_provider_resolve_command(&provider_id, provider, command, handle)?;
             if let Some(worktree) = worktrees.into_iter().find(|item| item.handle == handle) {
-                validate_provider_handle(&provider_id, &worktree)?;
+                validate_provider_handle(&provider_id, &worktree, gate_feedback_baseline)?;
                 return Ok(WorktreeProviderResolution {
                     provider_id,
                     worktree,
@@ -172,7 +174,7 @@ fn resolve_worktree_provider_with_policy_from_config(
         attempted.push(provider_id.clone());
         let worktrees = run_provider_list_command(&provider_id, provider, command)?;
         if let Some(worktree) = worktrees.into_iter().find(|item| item.handle == handle) {
-            validate_provider_handle(&provider_id, &worktree)?;
+            validate_provider_handle(&provider_id, &worktree, gate_feedback_baseline)?;
             return Ok(WorktreeProviderResolution {
                 provider_id,
                 worktree,
@@ -434,7 +436,11 @@ fn mapping_error(provider_id: &str, field: &str, path: &str, detail: &str) -> Er
     )
 }
 
-fn validate_provider_handle(provider_id: &str, worktree: &WorktreeProviderHandle) -> Result<()> {
+fn validate_provider_handle(
+    provider_id: &str,
+    worktree: &WorktreeProviderHandle,
+    gate_feedback_baseline: Option<&serde_json::Value>,
+) -> Result<()> {
     let path = std::path::PathBuf::from(&worktree.path);
     if !path.is_dir() {
         return Err(Error::validation_invalid_argument(
@@ -459,8 +465,20 @@ fn validate_provider_handle(provider_id: &str, worktree: &WorktreeProviderHandle
             None,
         ));
     }
+    let verified_gate_feedback_baseline = worktree.safety.dirty
+        && gate_feedback_baseline
+            .map(|baseline| {
+                crate::agent_task_candidate_baseline::validate_gate_feedback_candidate_baseline(
+                    &path, baseline,
+                )
+            })
+            .transpose()?
+            .is_some();
     let blocked = [
-        (worktree.safety.dirty, "dirty"),
+        (
+            worktree.safety.dirty && !verified_gate_feedback_baseline,
+            "dirty",
+        ),
         (worktree.safety.unpushed, "unpushed"),
         (worktree.safety.primary, "primary"),
     ]
@@ -468,9 +486,18 @@ fn validate_provider_handle(provider_id: &str, worktree: &WorktreeProviderHandle
     .filter_map(|(blocked, name)| blocked.then_some(name))
     .collect::<Vec<_>>();
     if !blocked.is_empty() {
+        let baseline_state = if worktree.safety.dirty {
+            if gate_feedback_baseline.is_some() {
+                "gate_feedback_baseline=present"
+            } else {
+                "gate_feedback_baseline=missing"
+            }
+        } else {
+            "gate_feedback_baseline=not_required"
+        };
         return Err(Error::validation_invalid_argument(
             "to_worktree",
-            format!("worktree provider `{provider_id}` marked `{}` as {}; refusing to cook into an unsafe destination", worktree.handle, blocked.join(", ")),
+            format!("worktree provider `{provider_id}` marked `{}` as {}; {baseline_state}; refusing to cook into an unsafe destination", worktree.handle, blocked.join(", ")),
             Some(worktree.handle.clone()),
             Some(vec!["Use a clean, pushed, non-primary provider-managed worktree on the intended branch.".to_string()]),
         ));


### PR DESCRIPTION
## Summary
Allow deterministic gate-feedback retries to execute and promote remediation against their exact hash-verified candidate baseline without weakening ordinary dirty-worktree protection.

## What changed
- Validate canonical candidate artifacts against complete target trees, including tracked and untracked files, before local retry execution.
- Commit the verified candidate only inside the isolated attempt workspace and harvest remediation relative to that synthetic baseline.
- Carry baseline provenance on remediation artifacts into promotion so only the exact dirty target can accept the delta.

## How to test
1. Run `Run cargo check -p homeboy-core -p homeboy-cli`; expect Both crates compile successfully.
2. Run `Run cargo build --bin homeboy`; expect The Homeboy binary builds successfully.
3. Run `Replay a gate-feedback follow-up against a promoted candidate with a new file`; expect The provider executes in an isolated candidate baseline and emits a remediation-only patch.

## Compatibility
This adds a narrow provenance-gated exception for deterministic gate-feedback remediation. Ordinary dirty worktrees and every existing unpushed/primary safety gate retain their behavior; no CLI flags or public schemas are removed.

## Evidence
- Binary build: Passed
- Cargo check: Passed
- Diff check: Passed
- Formatting: Passed
- Live follow-up execution: Passed
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8435

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the gate-feedback baseline mismatch, drafted the scheduler and promotion provenance repair, and replayed the real WP Docs follow-up lifecycle; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8435
