### PR TITLE
feat(audit): ref-aware changed-since comparison with stable finding identity (salvaged from #8440)

### DIFF
--- a/crates/homeboy-core/src/code_audit/baseline.rs
+++ b/crates/homeboy-core/src/code_audit/baseline.rs
@@ -260,6 +260,42 @@ pub fn finding_baseline_fingerprint(finding: &Finding) -> String {
     AuditFinding(finding).fingerprint()
 }
 
+/// Build an in-memory comparison baseline from persisted and reference findings.
+///
+/// Changed-since audit must recognize debt present in the selected git ref even
+/// when its `homeboy.json` baseline has not yet recorded that finding.
+pub fn baseline_with_reference_findings(
+    persisted: Option<AuditBaseline>,
+    reference: &CodeAuditResult,
+) -> AuditBaseline {
+    let mut baseline = persisted.unwrap_or(AuditBaseline {
+        created_at: "reference".to_string(),
+        context_id: reference.component_id.clone(),
+        item_count: 0,
+        known_fingerprints: Vec::new(),
+        metadata: AuditBaselineMetadata {
+            outliers_count: 0,
+            alignment_score: None,
+            known_outliers: Vec::new(),
+            policy_sections: Vec::new(),
+        },
+    });
+    let mut fingerprints = baseline
+        .known_fingerprints
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    for section in &baseline.metadata.policy_sections {
+        fingerprints.extend(section.known_fingerprints.iter().cloned());
+    }
+    fingerprints.extend(reference.findings.iter().map(finding_baseline_fingerprint));
+
+    baseline.known_fingerprints = fingerprints.into_iter().collect();
+    baseline.item_count = baseline.known_fingerprints.len();
+    baseline
+}
+
 /// Load an audit baseline from a git ref (e.g., `origin/main`).
 ///
 /// Uses `git show` to read the persisted baseline without checkout.
@@ -840,6 +876,94 @@ mod tests {
             AuditFinding(&f2).fingerprint(),
             "fingerprint should not change when line count changes"
         );
+    }
+
+    #[test]
+    fn reference_findings_make_changed_structural_metrics_contextual() {
+        let reference = make_result(
+            vec![make_finding_with_kind(
+                "structural",
+                "src/extracted.rs",
+                "File has 1,024 lines (threshold: 1,000)",
+                AuditFinding::GodFile,
+            )],
+            "reference_structural",
+        );
+        let candidate = make_result(
+            vec![make_finding_with_kind(
+                "structural",
+                "src/extracted.rs",
+                "File has 1,111 lines (threshold: 1,000)",
+                AuditFinding::GodFile,
+            )],
+            "candidate_structural",
+        );
+
+        let comparison = compare(
+            &candidate,
+            &baseline_with_reference_findings(None, &reference),
+        );
+
+        assert!(comparison.new_items.is_empty());
+    }
+
+    #[test]
+    fn reference_baseline_keeps_new_structural_threshold_crossing_introduced() {
+        let reference = make_result(Vec::new(), "reference_no_structural_finding");
+        let candidate = make_result(
+            vec![make_finding_with_kind(
+                "structural",
+                "src/newly-large.rs",
+                "File has 1,001 lines (threshold: 1,000)",
+                AuditFinding::GodFile,
+            )],
+            "candidate_new_structural_finding",
+        );
+
+        let comparison = compare(
+            &candidate,
+            &baseline_with_reference_findings(None, &reference),
+        );
+
+        assert_eq!(comparison.new_items.len(), 1);
+    }
+
+    #[test]
+    fn reference_baseline_preserves_core_boundary_policy_identity() {
+        let reference = make_result(
+            vec![make_finding_with_kind(
+                SOURCE_POLICY_CORE_BOUNDARY_POLICY,
+                "src/core/tool.rs",
+                "Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line 7 in behavioral context `run`",
+                AuditFinding::CoreBoundaryLeak,
+            )],
+            "reference_core_boundary",
+        );
+        let candidate = make_result(
+            vec![
+                make_finding_with_kind(
+                    SOURCE_POLICY_CORE_BOUNDARY_POLICY,
+                    "src/core/tool.rs",
+                    "Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line 19 in behavioral context `run`",
+                    AuditFinding::CoreBoundaryLeak,
+                ),
+                make_finding_with_kind(
+                    SOURCE_POLICY_CORE_BOUNDARY_POLICY,
+                    "src/core/tool.rs",
+                    "Core boundary leak (core-agnostic-source) configured ecosystem term `wordpress` appears at line 19 in behavioral context `run`",
+                    AuditFinding::CoreBoundaryLeak,
+                ),
+            ],
+            "candidate_core_boundary",
+        );
+
+        let comparison = compare(
+            &candidate,
+            &baseline_with_reference_findings(None, &reference),
+        );
+
+        assert_eq!(comparison.new_items.len(), 1);
+        assert!(comparison.new_items[0].description.contains("`wordpress`"));
     }
 
     #[test]

--- a/crates/homeboy-core/src/code_audit/compare.rs
+++ b/crates/homeboy-core/src/code_audit/compare.rs
@@ -1,5 +1,5 @@
 use super::{CodeAuditResult, Finding, Severity};
-use crate::code_audit::findings::normalized_finding_description_for_fingerprint;
+use crate::code_audit::baseline::finding_baseline_fingerprint;
 
 #[derive(Debug, Clone, Copy)]
 pub struct AuditConvergenceScoring {
@@ -50,13 +50,7 @@ pub fn score_delta(
 }
 
 pub fn finding_fingerprint(finding: &Finding) -> String {
-    format!(
-        "{}::{:?}::{}::{}",
-        finding.file,
-        finding.kind,
-        finding.convention,
-        normalized_finding_description_for_fingerprint(&finding.description)
-    )
+    finding_baseline_fingerprint(finding)
 }
 
 #[cfg(test)]
@@ -98,24 +92,61 @@ mod tests {
     }
 
     #[test]
-    fn finding_fingerprint_different_for_distinct() {
+    fn finding_fingerprint_ignores_volatile_structural_metrics() {
         let f1 = Finding {
-            convention: "naming".to_string(),
+            convention: "structural".to_string(),
             severity: Severity::Warning,
             file: "src/target.rs".to_string(),
-            description: "Existing finding".to_string(),
+            description: "File has 1,024 lines (threshold: 1,000)".to_string(),
             suggestion: String::new(),
-            kind: AuditFinding::NamingMismatch,
+            kind: AuditFinding::GodFile,
         };
         let f2 = Finding {
-            convention: "duplication".to_string(),
+            description: "File has 1,111 lines (threshold: 1,000)".to_string(),
+            ..f1.clone()
+        };
+        let f3 = Finding {
+            file: "src/items.rs".to_string(),
+            description: "File has 85 items (threshold: 50)".to_string(),
+            kind: AuditFinding::HighItemCount,
+            ..f1.clone()
+        };
+        let f4 = Finding {
+            description: "File has 112 items (threshold: 50)".to_string(),
+            ..f3.clone()
+        };
+
+        assert_eq!(finding_fingerprint(&f1), finding_fingerprint(&f2));
+        assert_eq!(finding_fingerprint(&f3), finding_fingerprint(&f4));
+    }
+
+    #[test]
+    fn finding_fingerprint_different_for_distinct_kind_or_file() {
+        let finding = Finding {
+            convention: "structural".to_string(),
             severity: Severity::Warning,
             file: "src/target.rs".to_string(),
-            description: "Duplicate function `foo`".to_string(),
+            description: "File has 1,024 lines (threshold: 1,000)".to_string(),
             suggestion: String::new(),
-            kind: AuditFinding::DuplicateFunction,
+            kind: AuditFinding::GodFile,
         };
-        assert_ne!(finding_fingerprint(&f1), finding_fingerprint(&f2));
+        let different_kind = Finding {
+            kind: AuditFinding::HighItemCount,
+            ..finding.clone()
+        };
+        let different_file = Finding {
+            file: "src/other.rs".to_string(),
+            ..finding.clone()
+        };
+
+        assert_ne!(
+            finding_fingerprint(&finding),
+            finding_fingerprint(&different_kind)
+        );
+        assert_ne!(
+            finding_fingerprint(&finding),
+            finding_fingerprint(&different_file)
+        );
     }
 
     #[test]
@@ -132,8 +163,16 @@ mod tests {
             description: "Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line 275 in behavioral context `detect_patterns`".to_string(),
             ..f1.clone()
         };
+        let distinct_policy = Finding {
+            description: "Core boundary leak (core-agnostic-source) configured ecosystem term `wordpress` appears at line 275 in behavioral context `detect_patterns`".to_string(),
+            ..f1.clone()
+        };
 
         assert_eq!(finding_fingerprint(&f1), finding_fingerprint(&f2));
+        assert_ne!(
+            finding_fingerprint(&f1),
+            finding_fingerprint(&distinct_policy)
+        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/code_audit/run.rs
+++ b/crates/homeboy-core/src/code_audit/run.rs
@@ -7,6 +7,7 @@ use crate::code_audit::{self, baseline, AuditTiming, AuditWithAnalysis, CodeAudi
 use crate::git;
 use std::collections::HashSet;
 use std::path::Path;
+use std::process::{Command, Stdio};
 
 use super::report::{self, AuditCommandOutput};
 
@@ -202,15 +203,7 @@ fn scope_convention_outliers_to_findings(result: &mut CodeAuditResult) {
 
 /// Run the audit scan (scoped or full). Returns None if changed-since found no files.
 fn run_audit(args: &AuditRunWorkflowArgs) -> crate::Result<Option<AuditWithAnalysis>> {
-    let plan = if args.baseline_flags.baseline || args.conventions {
-        code_audit::AuditExecutionPlan::full()
-    } else {
-        code_audit::AuditExecutionPlan::from_profile_and_filters(
-            args.profile,
-            &args.only_kinds,
-            &args.exclude_kinds,
-        )
-    };
+    let plan = audit_plan(args);
 
     if let Some(ref git_ref) = args.changed_since {
         let changed = changed_files_for_scope(args, git_ref)?;
@@ -235,6 +228,18 @@ fn run_audit(args: &AuditRunWorkflowArgs) -> crate::Result<Option<AuditWithAnaly
             &args.reference_paths,
             &args.extension_overrides,
         )?))
+    }
+}
+
+fn audit_plan(args: &AuditRunWorkflowArgs) -> code_audit::AuditExecutionPlan {
+    if args.baseline_flags.baseline || args.conventions {
+        code_audit::AuditExecutionPlan::full()
+    } else {
+        code_audit::AuditExecutionPlan::from_profile_and_filters(
+            args.profile,
+            &args.only_kinds,
+            &args.exclude_kinds,
+        )
     }
 }
 
@@ -305,17 +310,24 @@ fn run_comparison_workflow(
     args: &AuditRunWorkflowArgs,
     mut timing: AuditTiming,
 ) -> crate::Result<AuditRunWorkflowResult> {
+    if let Some(ref git_ref) = args.changed_since {
+        let persisted = if args.baseline_flags.ignore_baseline {
+            None
+        } else {
+            baseline::load_baseline(Path::new(&result.source_path))
+                .or_else(|| baseline::load_baseline_from_ref(&result.source_path, git_ref))
+        };
+        let reference = timing.time_phase("reference_baseline", || {
+            audit_reference_result(args, git_ref)
+        })?;
+        let baseline = baseline::baseline_with_reference_findings(persisted, &reference);
+        return build_comparison_output(result, analysis, baseline, args, timing);
+    }
+
     // Try file-based baseline
     if !args.baseline_flags.ignore_baseline {
         if let Some(existing_baseline) = baseline::load_baseline(Path::new(&result.source_path)) {
             return build_comparison_output(result, analysis, existing_baseline, args, timing);
-        }
-    }
-
-    // Try git-ref differential
-    if let Some(ref git_ref) = args.changed_since {
-        if let Some(ref_baseline) = baseline::load_baseline_from_ref(&result.source_path, git_ref) {
-            return build_comparison_output(result, analysis, ref_baseline, args, timing);
         }
     }
 
@@ -363,6 +375,80 @@ fn run_comparison_workflow(
             timing,
         })
     }
+}
+
+/// Audit a selected git ref without modifying the caller's checkout.
+///
+/// `git archive` materializes tracked source into an isolated temporary directory;
+/// the candidate's changed-file scope, plan, reference paths, and extension
+/// overrides are applied to produce comparable canonical finding identities.
+fn audit_reference_result(
+    args: &AuditRunWorkflowArgs,
+    git_ref: &str,
+) -> crate::Result<CodeAuditResult> {
+    let source = Path::new(&args.source_path);
+    let archive = Command::new("git")
+        .args(["archive", "--format=tar", git_ref])
+        .current_dir(source)
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|error| {
+            crate::Error::git_command_failed(format!("git archive {git_ref}: {error}"))
+        })?;
+    if !archive.status.success() {
+        return Err(crate::Error::git_command_failed(format!(
+            "git archive {git_ref}: {}",
+            String::from_utf8_lossy(&archive.stderr).trim()
+        )));
+    }
+
+    let reference_root = tempfile::tempdir().map_err(|error| {
+        crate::Error::internal_io(
+            format!("create audit reference directory: {error}"),
+            Some("audit.reference_baseline".to_string()),
+        )
+    })?;
+    let extraction = Command::new("tar")
+        .args(["-x", "-C"])
+        .arg(reference_root.path())
+        .stdin(Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child
+                .stdin
+                .take()
+                .expect("tar stdin is piped")
+                .write_all(&archive.stdout)?;
+            child.wait()
+        })
+        .map_err(|error| {
+            crate::Error::internal_io(
+                format!("extract audit reference archive: {error}"),
+                Some("audit.reference_baseline".to_string()),
+            )
+        })?;
+    if !extraction.success() {
+        return Err(crate::Error::internal_io(
+            format!("extract audit reference archive exited with {extraction}"),
+            Some("audit.reference_baseline".to_string()),
+        ));
+    }
+
+    let changed = changed_files_for_scope(args, git_ref)?;
+    let reference_path = reference_root.path().to_string_lossy();
+    let mut reference = code_audit::audit_path_scoped_with_plan_and_analysis(
+        &args.component_id,
+        &reference_path,
+        &changed,
+        None,
+        &audit_plan(args),
+        &args.reference_paths,
+        &args.extension_overrides,
+    )?
+    .result;
+    apply_finding_filters(&mut reference, &args.only_kinds, &args.exclude_kinds);
+    Ok(reference)
 }
 
 /// Build comparison output from a result and baseline.


### PR DESCRIPTION
## Summary

Salvages the genuinely-valuable feature from **#8440**, which entangled it with an already-superseded test-target-restore. Main's `homeboy-core` test target compiles clean today, so that restore half is dead churn — this PR extracts **only** the audit feature (3 files, 281 lines) onto a clean branch off main.

## Two improvements

**1. Stable baseline fingerprints** (`baseline::finding_baseline_fingerprint`)
Finding identity now ignores volatile structural metrics. A `GodFile` reported at "1,024 lines" and later at "1,111 lines" hash to the **same** known finding instead of reading as newly-introduced debt. `compare::finding_fingerprint` delegates to it.

**2. Ref-aware `--changed-since`** (`run::audit_reference_result` + `baseline::baseline_with_reference_findings`)
`--changed-since <ref>` now materializes the reference ref via `git archive` into an **isolated tempdir** (read-only — never touches the caller's checkout), audits it, and treats pre-existing debt in that ref as known/contextual so it doesn't block a PR — while genuinely new threshold crossings still surface.

## Verification

- `cargo check -p homeboy-core --lib` — clean, 0 errors
- **32 targeted tests pass:** 8 `code_audit::compare::tests` + 24 `code_audit::baseline::tests`, including the two feature tests:
  - `reference_findings_make_changed_structural_metrics_contextual`
  - `reference_baseline_keeps_new_structural_threshold_crossing_introduced`
- Confirmed zero entanglement with `test_support` / `component_script` / the #8440 test churn

## Relationship to #8440

**Supersedes the audit-compare portion of #8440.** Recommend closing #8440 once this lands (its test-restore half is redundant vs main — see assessment comment there).

Refs #8425