### PR TITLE
fix(test): correct core_fingerprint/artifact_portability tests for crate layout

### DIFF
--- a/crates/homeboy-core/src/code_audit/core_fingerprint/tests.rs
+++ b/crates/homeboy-core/src/code_audit/core_fingerprint/tests.rs
@@ -116,7 +116,7 @@ pub fn undo() -> Result<()> {
     Ok(())
 }
 "#;
-    let nested_fp = fingerprint_from_grammar(nested_content, &grammar, "src/core/engine/undo.rs")
+    let nested_fp = fingerprint_from_grammar(nested_content, &grammar, "src/engine/undo.rs")
         .expect("fingerprint should succeed");
 
     assert_eq!(nested_fp.namespace.as_deref(), Some("crate::engine"));

--- a/crates/homeboy-core/src/code_audit/detectors/artifact_portability.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/artifact_portability.rs
@@ -723,7 +723,12 @@ mod tests {
 
     #[test]
     fn homeboy_config_declares_homeboy_run_marker() {
-        let raw = std::fs::read_to_string("homeboy.json").expect("homeboy config");
+        // homeboy.json lives at the repository root; this crate builds two levels
+        // down (crates/homeboy-core), so resolve it relative to the manifest dir
+        // rather than the (per-crate) test working directory.
+        let config_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../homeboy.json");
+        let raw = std::fs::read_to_string(&config_path).expect("homeboy config");
         let component: crate::component::Component =
             serde_json::from_str(&raw).expect("component config");
         let audit = component.audit.expect("audit config");


### PR DESCRIPTION
## Summary
Two `code_audit` unit tests were written against the pre-extraction `src/core/` tree and **never actually ran in CI** (workspace-member tests weren't being executed — see homeboy-extensions #2271), so their staleness went unnoticed.

- **`rust_namespace_comes_from_file_path_not_crate_imports`** asserted a `crate::engine` namespace but fed the deriver a `src/core/engine/undo.rs` path, which yields `crate::core::engine`. Use `src/engine/undo.rs` to match the crate's actual post-extraction layout.
- **`homeboy_config_declares_homeboy_run_marker`** read `homeboy.json` relative to the working directory, which only resolved when tests ran from the repo root. Under per-crate (`-p homeboy-core`) testing the cwd is the crate dir, so resolve via `CARGO_MANIFEST_DIR` (`../../homeboy.json`).

## Context
These surfaced when running `cargo test -p homeboy-core` locally — part of validating that core's test suite actually passes now that it compiles again (#8434) and will run in CI (#2271). Both fixed tests pass under `cargo test -p homeboy-core`.

Other apparent failures during local runs were **disk-pressure artifacts** on the dev VPS (workspace-sync tests failing with "0 MiB available"), not real regressions — those are best surfaced by CI with adequate disk, not chased locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)