### PR TITLE
Route fanout child cooks to Lab

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
@@ -104,7 +104,7 @@ pub struct AgentTaskFanoutBatchStatusArgs {
     pub batch_id: String,
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 pub struct AgentTaskFanoutRunPlanArgs {
     #[command(flatten)]
     pub input: AgentTaskFanoutInputArgs,

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -113,6 +113,38 @@ fn run_batch_cook_fanout(args: AgentTaskFanoutRunPlanArgs) -> CmdResult<Value> {
     run_batch_cook_fanout_plan(plan)
 }
 
+/// Keeps durable batch coordination on the controller while routing each
+/// independent provider attempt through the selected transport.
+pub(crate) fn run_batch_cook_fanout_with_attempt_dispatcher<F>(
+    args: AgentTaskFanoutRunPlanArgs,
+    attempt_dispatcher: F,
+) -> CmdResult<Value>
+where
+    F: Fn(
+            &AgentTaskCookServiceOptions,
+        )
+            -> std::sync::Arc<dyn crate::core::agent_task_service::AgentTaskCookAttemptDispatcher>
+        + Clone
+        + Send
+        + Sync,
+{
+    let mut plan = load_batch_cook_fanout_plan(&args.input)?;
+    if let Some(record_run_id) = args.record_run_id {
+        plan.fanout_id = record_run_id;
+    }
+    run_batch_cook_fanout_plan_with_terminal(plan, None, move |mut options| {
+        options.attempt_dispatcher = Some(attempt_dispatcher(&options));
+        let result = agent_task_service::run_cook(
+            options,
+            provider::ExtensionProviderAgentTaskExecutor::discover(),
+        )?;
+        Ok(serde_json::json!({
+            "exit_code": result.exit_code,
+            "result": serde_json::to_value(result.value).unwrap_or(Value::Null),
+        }))
+    })
+}
+
 fn run_batch_cook_fanout_plan(plan: BatchCookFanoutPlan) -> CmdResult<Value> {
     run_batch_cook_fanout_plan_with_executor(
         plan,

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -99,6 +99,10 @@ pub fn route_after_parse(
         return Ok(Some(exit_code));
     }
 
+    if let Some(exit_code) = run_split_placement_fanout(cli, output_file, cli.runner.as_deref())? {
+        return Ok(Some(exit_code));
+    }
+
     let run_handoff = if lab_command.is_some() && inferred_runner_id.is_some() {
         materialize_agent_task_run_handoff(cli, normalized_args)?
     } else {
@@ -239,6 +243,68 @@ pub fn route_after_parse(
     }
 }
 
+/// Fanout keeps durable batch state, worktree ownership, artifact ingestion,
+/// gates, and finalization on the controller. Each child provider attempt is
+/// the only unit handed to the explicitly selected Lab runner.
+fn run_split_placement_fanout(
+    cli: &Cli,
+    output_file: Option<&str>,
+    runner_id: Option<&str>,
+) -> homeboy::core::Result<Option<i32>> {
+    if cli.placement == homeboy::cli_surface::Placement::Local {
+        return Ok(None);
+    }
+    let Some(runner_id) = runner_id else {
+        return Ok(None);
+    };
+    let Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+        command:
+            crate::commands::agent_task::AgentTaskCommand::Fanout(
+                crate::commands::agent_task::AgentTaskFanoutArgs {
+                    command: crate::commands::agent_task::AgentTaskFanoutCommand::RunPlan(args),
+                },
+            ),
+    }) = &cli.command
+    else {
+        return Ok(None);
+    };
+
+    let dispatcher = LabCookAttemptDispatcher {
+        runner_id: runner_id.to_string(),
+        allow_local_fallback: false,
+        allow_dirty_lab_workspace: cli.allow_dirty_lab_workspace,
+        skip_deps_hydration: cli.skip_deps_hydration,
+        detach_after_handoff: cli.detach_after_handoff,
+        source_path: None,
+        job_overrides: lab_job_overrides(cli)?,
+    };
+    let (value, exit_code) =
+        crate::commands::agent_task::fanout::run_batch_cook_fanout_with_attempt_dispatcher(
+            args.clone(),
+            move |options| {
+                let mut dispatcher = dispatcher.clone();
+                dispatcher.source_path = options
+                    .initial_plan
+                    .tasks
+                    .first()
+                    .and_then(|task| task.workspace.root.as_ref())
+                    .map(PathBuf::from);
+                Arc::new(dispatcher)
+            },
+        )?;
+    let stdout = serde_json::to_string_pretty(&value).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize controller-owned fanout result".to_string()),
+        )
+    })?;
+    if let Some(path) = output_file {
+        write_output_file(path, &stdout)?;
+    }
+    print!("{stdout}");
+    Ok(Some(exit_code))
+}
+
 /// Cook owns controller-local target resolution, promotion, gates, retries, and
 /// finalization. Its provider attempt is the only portable unit: a materialized
 /// typed run-plan that mirrors its aggregate and artifacts back into the same
@@ -314,7 +380,7 @@ fn run_split_placement_cook(
 
 /// The controller supplies this transport to the cook service. Every attempt
 /// uses the same durable run id, while Lab only executes the provider plan.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct LabCookAttemptDispatcher {
     runner_id: String,
     allow_local_fallback: bool,


### PR DESCRIPTION
## Summary
Keep fanout coordination on the controller while routing independent child cook attempts to Lab.

## What changed
- Added split-placement handling for batch-cook fanout run-plan.
- Injected the selected Lab attempt dispatcher into each isolated child cook.
- Added deterministic coverage for three runner-backed child handoffs without local provider execution.

## How to test
1. Run `cargo test -p homeboy-cli commands::agent_task::fanout::tests --lib`; expect All fanout tests pass, including three independent Lab child handoffs.
2. Run `git diff --check`; expect No whitespace errors are reported.

## Compatibility
No persisted-schema compatibility change. Existing local fanout behavior is unchanged; explicit Lab fanout now routes only provider attempts while preserving controller ownership.

## Evidence
- CI expected: Repository pull request checks
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8403
- diff-check: Passed
- fanout-tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Prepared and reconstructed the control-plane recovery candidate after a shared-stash race, removed unrelated formatting churn, and verified fanout behavior with Chris.

## Source relationships
- Closes Extra-Chill/homeboy#8403
