### PR TITLE
fix(agent-task): project verified timeout patches

### DIFF
--- a/crates/homeboy-core/src/agent_task_aggregate.rs
+++ b/crates/homeboy-core/src/agent_task_aggregate.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::fmt;
 
 use super::agent_task::{
@@ -313,6 +314,22 @@ fn reconcile_outcome(
         );
     }
 
+    if outcome.status == AgentTaskOutcomeStatus::CandidateRecoverable {
+        let artifact_ids = outcome
+            .artifacts
+            .iter()
+            .filter(|artifact| is_verified_recoverable_patch(outcome, artifact))
+            .map(|artifact| artifact.id.clone())
+            .collect::<Vec<_>>();
+        if artifact_ids.len() == 1 {
+            return (
+                AgentTaskReconciliationDecision::ApplyCandidate,
+                "timed-out provider produced a verified recoverable patch candidate".to_string(),
+                artifact_ids,
+            );
+        }
+    }
+
     if matches!(
         outcome.status,
         AgentTaskOutcomeStatus::ProviderError | AgentTaskOutcomeStatus::Timeout
@@ -352,10 +369,7 @@ fn reconcile_outcome(
         .filter(|artifact| is_apply_artifact(artifact))
         .map(|artifact| artifact.id.clone())
         .collect::<Vec<_>>();
-    if matches!(
-        outcome.status,
-        AgentTaskOutcomeStatus::Succeeded | AgentTaskOutcomeStatus::CandidateRecoverable
-    ) && !apply_artifact_ids.is_empty()
+    if matches!(outcome.status, AgentTaskOutcomeStatus::Succeeded) && !apply_artifact_ids.is_empty()
     {
         return (
             AgentTaskReconciliationDecision::ApplyCandidate,
@@ -384,6 +398,43 @@ fn reconcile_outcome(
         },
         artifact_ids(outcome),
     )
+}
+
+/// Timeout recovery is promotable only from an immutable, fully bound artifact.
+/// Promotion repeats the content validation before applying the patch.
+fn is_verified_recoverable_patch(outcome: &AgentTaskOutcome, artifact: &AgentTaskArtifact) -> bool {
+    if !is_apply_artifact(artifact)
+        || artifact.kind != "patch"
+        || artifact.metadata.get("task_id").and_then(Value::as_str) != Some(&outcome.task_id)
+        || !non_empty_metadata_string(artifact, "run_id")
+        || !non_empty_metadata_string(artifact, "base_ref")
+        || !non_empty_metadata_string(artifact, "repository_identity")
+        || !non_empty_metadata_string(artifact, "workspace_identity")
+    {
+        return false;
+    }
+    let Some(expected_sha256) = artifact.sha256.as_deref() else {
+        return false;
+    };
+    if expected_sha256.len() != 64 || !expected_sha256.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return false;
+    }
+    let Some(path) = artifact.path.as_deref() else {
+        return false;
+    };
+    let Ok(content) = std::fs::read(path) else {
+        return false;
+    };
+    !content.is_empty() && expected_sha256 == format!("{:x}", Sha256::digest(&content))
+}
+
+fn non_empty_metadata_string(artifact: &AgentTaskArtifact, key: &str) -> bool {
+    artifact
+        .metadata
+        .get(key)
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.is_empty())
 }
 
 fn has_known_empty_change_set(outcome: &AgentTaskOutcome) -> bool {
@@ -555,6 +606,95 @@ mod tests {
         assert_eq!(report.retry_plan[0].task_id, "retry");
         assert_eq!(report.issue_report_candidates[0].task_id, "issue");
         assert_eq!(report.review_candidates[0].task_id, "review");
+    }
+
+    #[test]
+    fn aggregate_projects_only_verified_recoverable_timeout_patches_for_promotion() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let patch = b"diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-old\n+new\n";
+        let patch_path = temp.path().join("uncommitted-changes.patch");
+        std::fs::write(&patch_path, patch).expect("write patch");
+        let sha256 = format!("{:x}", Sha256::digest(patch));
+        let recoverable = AgentTaskOutcome {
+            failure_classification: Some(AgentTaskFailureClassification::Timeout),
+            ..outcome(
+                "timed-out",
+                AgentTaskOutcomeStatus::CandidateRecoverable,
+                vec![AgentTaskArtifact {
+                    schema: "homeboy/agent-task-artifact/v1".to_string(),
+                    id: "uncommitted-changes".to_string(),
+                    kind: "patch".to_string(),
+                    name: None,
+                    label: None,
+                    role: Some("patch".to_string()),
+                    semantic_key: None,
+                    path: Some(patch_path.display().to_string()),
+                    url: None,
+                    mime: Some("text/x-patch".to_string()),
+                    size_bytes: Some(patch.len() as u64),
+                    sha256: Some(sha256),
+                    metadata: json!({
+                        "run_id": "run-1",
+                        "task_id": "timed-out",
+                        "base_ref": "base-fingerprint",
+                        "repository_identity": "repository-identity",
+                        "workspace_identity": "workspace-identity"
+                    }),
+                }],
+            )
+        };
+
+        let report = aggregate_agent_task_outcomes(&[recoverable]);
+
+        assert_eq!(report.summary.apply_candidates, 1);
+        assert_eq!(report.summary.retry_candidates, 0);
+        assert_eq!(
+            report.apply_candidates[0].artifact_ids,
+            vec!["uncommitted-changes"]
+        );
+    }
+
+    #[test]
+    fn aggregate_rejects_empty_or_fingerprint_mismatched_recoverable_patches() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let patch_path = temp.path().join("candidate.patch");
+        std::fs::write(&patch_path, b"changed").expect("write patch");
+        let candidate = |id: &str, size_bytes: u64, sha256: &str| AgentTaskOutcome {
+            failure_classification: Some(AgentTaskFailureClassification::Timeout),
+            ..outcome(
+                id,
+                AgentTaskOutcomeStatus::CandidateRecoverable,
+                vec![AgentTaskArtifact {
+                    schema: "homeboy/agent-task-artifact/v1".to_string(),
+                    id: format!("{id}-patch"),
+                    kind: "patch".to_string(),
+                    name: None,
+                    label: None,
+                    role: Some("patch".to_string()),
+                    semantic_key: None,
+                    path: Some(patch_path.display().to_string()),
+                    url: None,
+                    mime: Some("text/x-patch".to_string()),
+                    size_bytes: Some(size_bytes),
+                    sha256: Some(sha256.to_string()),
+                    metadata: json!({
+                        "run_id": "run-1", "task_id": id, "base_ref": "base-fingerprint",
+                        "repository_identity": "repository-identity", "workspace_identity": "workspace-identity"
+                    }),
+                }],
+            )
+        };
+        let report = aggregate_agent_task_outcomes(&[
+            candidate(
+                "empty",
+                0,
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            ),
+            candidate("mismatched", 7, &"0".repeat(64)),
+        ]);
+
+        assert_eq!(report.summary.apply_candidates, 0);
+        assert_eq!(report.summary.retry_candidates, 2);
     }
 
     #[test]

--- a/crates/homeboy-core/src/agent_task_aggregate.rs
+++ b/crates/homeboy-core/src/agent_task_aggregate.rs
@@ -405,9 +405,15 @@ fn reconcile_outcome(
 fn is_verified_recoverable_patch(outcome: &AgentTaskOutcome, artifact: &AgentTaskArtifact) -> bool {
     if !is_apply_artifact(artifact)
         || artifact.kind != "patch"
+        || outcome.failure_classification != Some(AgentTaskFailureClassification::Timeout)
         || artifact.metadata.get("task_id").and_then(Value::as_str) != Some(&outcome.task_id)
         || !non_empty_metadata_string(artifact, "run_id")
+        || !artifact
+            .metadata
+            .get("producer_attempt")
+            .is_some_and(Value::is_u64)
         || !non_empty_metadata_string(artifact, "base_ref")
+        || !non_empty_metadata_string(artifact, "provider_backend")
         || !non_empty_metadata_string(artifact, "repository_identity")
         || !non_empty_metadata_string(artifact, "workspace_identity")
     {
@@ -426,7 +432,9 @@ fn is_verified_recoverable_patch(outcome: &AgentTaskOutcome, artifact: &AgentTas
     let Ok(content) = std::fs::read(path) else {
         return false;
     };
-    !content.is_empty() && expected_sha256 == format!("{:x}", Sha256::digest(&content))
+    !content.is_empty()
+        && artifact.size_bytes == Some(content.len() as u64)
+        && expected_sha256 == format!("{:x}", Sha256::digest(&content))
 }
 
 fn non_empty_metadata_string(artifact: &AgentTaskArtifact, key: &str) -> bool {
@@ -636,7 +644,9 @@ mod tests {
                     metadata: json!({
                         "run_id": "run-1",
                         "task_id": "timed-out",
+                        "producer_attempt": 1,
                         "base_ref": "base-fingerprint",
+                        "provider_backend": "provider",
                         "repository_identity": "repository-identity",
                         "workspace_identity": "workspace-identity"
                     }),
@@ -678,7 +688,8 @@ mod tests {
                     size_bytes: Some(size_bytes),
                     sha256: Some(sha256.to_string()),
                     metadata: json!({
-                        "run_id": "run-1", "task_id": id, "base_ref": "base-fingerprint",
+                        "run_id": "run-1", "task_id": id, "producer_attempt": 1,
+                        "base_ref": "base-fingerprint", "provider_backend": "provider",
                         "repository_identity": "repository-identity", "workspace_identity": "workspace-identity"
                     }),
                 }],

--- a/crates/homeboy-core/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/promote.rs
@@ -288,6 +288,16 @@ pub(crate) fn promote_with_provider(
         }
         Err(error) => return Err(error),
     };
+    if outcome.status == AgentTaskOutcomeStatus::CandidateRecoverable
+        && !has_recoverable_candidate_provenance(&outcome, &artifact)
+    {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            "recoverable-candidate promotion requires a fingerprinted artifact bound to its producing run, task, base, and workspace",
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
     let gate_feedback_baseline =
         gate_feedback_baseline_for_artifact(&source_for_provenance, &outcome, &artifact)?;
     let patch_path = resolve_artifact_path(&artifact, options.source_path.as_deref())?;
@@ -505,6 +515,33 @@ fn outcome_has_patch_artifacts(outcome: &AgentTaskOutcome) -> bool {
         .artifacts
         .iter()
         .any(|artifact| is_actionable_patch_artifact(artifact) || is_empty_patch_artifact(artifact))
+}
+
+fn has_recoverable_candidate_provenance(
+    outcome: &AgentTaskOutcome,
+    artifact: &AgentTaskArtifact,
+) -> bool {
+    artifact.kind == "patch"
+        && artifact.sha256.as_deref().is_some_and(valid_sha256)
+        && artifact.metadata.get("task_id").and_then(Value::as_str) == Some(&outcome.task_id)
+        && [
+            "run_id",
+            "base_ref",
+            "repository_identity",
+            "workspace_identity",
+        ]
+        .iter()
+        .all(|key| {
+            artifact
+                .metadata
+                .get(*key)
+                .and_then(Value::as_str)
+                .is_some_and(|value| !value.is_empty())
+        })
+}
+
+fn valid_sha256(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn promote_committed_changes(

--- a/crates/homeboy-core/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/promote.rs
@@ -289,7 +289,7 @@ pub(crate) fn promote_with_provider(
         Err(error) => return Err(error),
     };
     if outcome.status == AgentTaskOutcomeStatus::CandidateRecoverable
-        && !has_recoverable_candidate_provenance(&outcome, &artifact)
+        && !has_recoverable_candidate_provenance(&options, &outcome, &artifact)
     {
         return Err(Error::validation_invalid_argument(
             "artifact_id",
@@ -518,15 +518,22 @@ fn outcome_has_patch_artifacts(outcome: &AgentTaskOutcome) -> bool {
 }
 
 fn has_recoverable_candidate_provenance(
+    options: &AgentTaskPromotionOptions,
     outcome: &AgentTaskOutcome,
     artifact: &AgentTaskArtifact,
 ) -> bool {
     artifact.kind == "patch"
+        && artifact.size_bytes.is_some_and(|size| size > 0)
         && artifact.sha256.as_deref().is_some_and(valid_sha256)
         && artifact.metadata.get("task_id").and_then(Value::as_str) == Some(&outcome.task_id)
+        && artifact
+            .metadata
+            .get("producer_attempt")
+            .is_some_and(Value::is_u64)
         && [
             "run_id",
             "base_ref",
+            "provider_backend",
             "repository_identity",
             "workspace_identity",
         ]
@@ -537,6 +544,12 @@ fn has_recoverable_candidate_provenance(
                 .get(*key)
                 .and_then(Value::as_str)
                 .is_some_and(|value| !value.is_empty())
+        })
+        && options.source_run_id.as_deref().is_none_or(|run_id| {
+            artifact.metadata.get("run_id").and_then(Value::as_str) == Some(run_id)
+        })
+        && options.task_base_sha.as_deref().is_none_or(|base_ref| {
+            artifact.metadata.get("base_ref").and_then(Value::as_str) == Some(base_ref)
         })
 }
 

--- a/crates/homeboy-core/src/agent_task_promotion/tests.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/tests.rs
@@ -247,7 +247,9 @@ fn recoverable_patch_source(temp: &tempfile::TempDir, patch_count: usize) -> (Pa
                     "role": "patch",
                     "run_id": "recoverable-run",
                     "task_id": "task-1",
+                    "producer_attempt": 1,
                     "base_ref": "base-fingerprint",
+                    "provider_backend": "provider",
                     "repository_identity": "repository-identity",
                     "workspace_identity": "workspace-identity"
                 }
@@ -314,6 +316,41 @@ fn promote_recoverable_candidate_applies_exactly_one_actionable_patch() {
         AgentTaskPromotionStatus::Applied
     );
     assert_eq!(apply_calls, 1);
+}
+
+#[test]
+fn promote_recoverable_candidate_rejects_mismatched_run_provenance() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let (source_path, source) = recoverable_patch_source(&temp, 1);
+    let mut source: Value = serde_json::from_str(&source).expect("source JSON");
+    source["artifacts"][0]["metadata"]["run_id"] = Value::String("different-run".to_string());
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(temp.path().join("target")),
+        ..Default::default()
+    };
+
+    let error = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source: source.to_string(),
+            source_run_id: Some("recoverable-run".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            to_worktree: "repo@recoverable".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions::default(),
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+    )
+    .expect_err("mismatched provenance rejected");
+
+    assert!(error.message.contains("fingerprinted artifact"));
+    assert!(provider.apply_calls.is_empty());
 }
 
 #[test]

--- a/crates/homeboy-core/src/agent_task_promotion/tests.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/tests.rs
@@ -243,7 +243,14 @@ fn recoverable_patch_source(temp: &tempfile::TempDir, patch_count: usize) -> (Pa
                 "path": name,
                 "size_bytes": VALID_PATCH.len(),
                 "sha256": sha256_hex(VALID_PATCH),
-                "metadata": { "role": "patch" }
+                "metadata": {
+                    "role": "patch",
+                    "run_id": "recoverable-run",
+                    "task_id": "task-1",
+                    "base_ref": "base-fingerprint",
+                    "repository_identity": "repository-identity",
+                    "workspace_identity": "workspace-identity"
+                }
             })
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
Closes #8457

## Summary
- projects exactly one non-empty, content-verified timeout recovery patch as an apply candidate while retaining `candidate_recoverable`, timeout classification, and diagnostics
- fails closed for missing, empty, size-mismatched, hash-mismatched, or incomplete provenance artifacts
- binds recovery promotion to the source run and supplied task base, then reuses the normal artifact-content validation, workspace-provider gates, and candidate-fingerprint finalization flow

## Source relationship and scope
- Source relationship: completes the existing recovery candidate commit `baa2e6a69` for issue #8457.
- Change kind: bounded runtime validation and regression coverage in the aggregate and promotion contracts.
- Verification capability: library compilation and the public promotion-provider integration path are executable; internal core unit-test compilation is presently blocked by unrelated existing errors.
- Scope rationale: the runtime change only recognizes scheduler-produced timeout artifacts carrying the existing candidate-adoption provenance discriminators; successful-provider and ordinary patch behavior are unchanged.

## Compatibility impact
Recoverable timeout patches without the established fingerprint, content binding, or provenance are no longer eligible for automatic projection/promotion. Valid scheduler-harvested candidates retain their existing promotion and finalization path. No schema version or CLI interface changes.

## Testing
1. Run `cargo check -p homeboy-core --lib`; expected: passes (warnings only).
2. Run `rustfmt --check crates/homeboy-core/src/agent_task_aggregate.rs crates/homeboy-core/src/agent_task_promotion/promote.rs crates/homeboy-core/src/agent_task_promotion/tests.rs`; expected: passes.
3. Run `git diff --check origin/main...HEAD`; expected: passes.
4. Run `cargo test -p homeboy --test agent_task_promotion_provider`; expected: 2 tests pass.
5. Run `cargo test -p homeboy-core --lib aggregate_projects_only_verified_recoverable_timeout_patches -- --exact`; currently blocked before executing tests by unrelated pre-existing errors: missing `super::super::create` in `runner/connection/tests/recovery.rs:385` and missing `Debug` for `HarvestPreflight` in `agent_task_scheduler/harvest.rs:698,715,725`.
6. Run `cargo fmt --check`; currently reports the unrelated existing formatting difference in `crates/homeboy-core/src/code_audit/detectors/artifact_portability.rs:726`.

## AI Assistance
AI assistance: Yes.
Tool: OpenAI GPT-5.6 Terra via OpenCode.
Used for: contract review, focused implementation, verification execution, and PR drafting; changes were reviewed against the existing aggregate, candidate-adoption, promotion, and finalization contracts.