### PR TITLE
Add lease-safe forced daemon stop

### DIFF
--- a/crates/homeboy-cli/src/commands/daemon.rs
+++ b/crates/homeboy-cli/src/commands/daemon.rs
@@ -109,6 +109,9 @@ enum DaemonCommand {
         /// Require this exact live daemon lease before stopping
         #[arg(long)]
         lease_id: Option<String>,
+        /// Directly SIGTERM a matching stale or unreachable daemon lease. Requires --lease-id.
+        #[arg(long, requires = "lease_id")]
+        force: bool,
     },
     /// Show daemon state and selected local address
     Status,
@@ -225,10 +228,12 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
             daemon::supervise(&addr, &startup_token)?;
             Ok((DaemonOutput::Serve(DaemonStartResult { pid: std::process::id(), address: addr, state_path: String::new(), lease_id: String::new() }), 0))
         }
-        DaemonCommand::Stop { lease_id } => Ok((
-            DaemonOutput::Stop(match lease_id {
-                Some(lease_id) => daemon::stop_for_lease(&lease_id)?,
-                None => daemon::stop()?,
+        DaemonCommand::Stop { lease_id, force } => Ok((
+            DaemonOutput::Stop(match (force, lease_id) {
+                (true, Some(lease_id)) => daemon::force_stop_for_lease(&lease_id)?,
+                (true, None) => unreachable!("clap requires --lease-id with --force"),
+                (false, Some(lease_id)) => daemon::stop_for_lease(&lease_id)?,
+                (false, None) => daemon::stop()?,
             }),
             0,
         )),
@@ -376,6 +381,20 @@ mod tests {
             "homeboy",
             "daemon",
             "stop",
+            "--lease-id",
+            "lease-live",
+        ])
+        .is_ok());
+    }
+
+    #[test]
+    fn force_stop_requires_lease_id() {
+        assert!(Cli::try_parse_from(["homeboy", "daemon", "stop", "--force"]).is_err());
+        assert!(Cli::try_parse_from([
+            "homeboy",
+            "daemon",
+            "stop",
+            "--force",
             "--lease-id",
             "lease-live",
         ])

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -20,7 +20,9 @@ use crate::error::{Error, RemoteCommandFailedDetails, Result, TargetDetails};
 use crate::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnalysisJobRunner};
 use crate::lab_contract::RunnerWorkload;
 use crate::paths;
-use crate::process::pid_is_running;
+use crate::process::{
+    pid_has_environment_value, pid_is_running, terminate_pid_with_sigterm_and_wait,
+};
 use crate::runner::{
     execute_runner_process_until_cancelled_with_progress, prepare_daemon_local_process,
     BrokerScope, Runner, RunnerProcessRequest,
@@ -54,6 +56,7 @@ const DAEMON_LEASE_SCHEMA: &str = "homeboy.daemon.session_lease.v1";
 const DAEMON_STARTUP_TOKEN_ENV: &str = "HOMEBOY_DAEMON_STARTUP_TOKEN";
 const RUNTIME_PATH_FILE_LIMIT: usize = 2_000;
 const RUNTIME_PATH_SUFFIXES: &[&str] = &["_COMPONENT_PATH", "_PROVIDER_PATH", "_RUNTIME_PATH"];
+const FORCE_STOP_WAIT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct DaemonState {
@@ -282,6 +285,8 @@ pub struct DaemonStopResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pid: Option<u32>,
     pub state_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub termination_evidence: Option<DaemonTerminationEvidence>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -819,6 +824,114 @@ pub fn stop_for_lease(expected_lease_id: &str) -> Result<DaemonStopResult> {
     stop_with_force_for_lease(expected_lease_id, false)
 }
 
+/// Terminate a stale or unreachable daemon directly from its persisted lease.
+/// This deliberately does not use the daemon HTTP lifecycle endpoint.
+pub fn force_stop_for_lease(expected_lease_id: &str) -> Result<DaemonStopResult> {
+    let _lock = acquire_daemon_operation_lock()?;
+    let path = state_path()?;
+    let state_path_display = path.display().to_string();
+    let validation = validate_lease_file(&path)?;
+    if validation.invalid_pid.is_some()
+        || (validation.state.is_none() && validation.stale_reason.is_some() && path.exists())
+    {
+        return Err(corrupt_daemon_lease_error(&path, validation.stale_reason));
+    }
+    let state = validation.state.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "lease_id",
+            "forced daemon stop requires a persisted live daemon lease",
+            Some(expected_lease_id.to_string()),
+            None,
+        )
+    })?;
+    if state.lease_id != expected_lease_id {
+        return Err(Error::validation_invalid_argument(
+            "lease_id",
+            format!(
+                "forced daemon stop expected lease `{expected_lease_id}` but persisted live lease is `{}`; refusing to signal",
+                state.lease_id
+            ),
+            Some(expected_lease_id.to_string()),
+            None,
+        ));
+    }
+    if state.startup_token.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "daemon_lease",
+            format!(
+                "daemon lease at {} does not contain a startup token; refusing to signal pid {}",
+                path.display(),
+                state.pid
+            ),
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+    let active_job_ids = active_daemon_job_ids()?;
+    if !active_job_ids.is_empty() {
+        return Err(active_jobs_block_daemon_stop_error(&state, &active_job_ids));
+    }
+
+    let identity = DaemonLeaseIdentity::from_state(&state);
+    let current_state = read_lease_if_identity_matches(&path, &identity)?;
+    if current_state.pid != state.pid {
+        return Err(Error::internal_unexpected(format!(
+            "daemon lease changed pid from {} to {}; refusing to signal",
+            state.pid, current_state.pid
+        )));
+    }
+    if !pid_is_running(state.pid) {
+        remove_lease_if_identity_matches(&path, &identity)?;
+        return Ok(DaemonStopResult {
+            stopped: false,
+            pid: Some(state.pid),
+            state_path: state_path_display,
+            termination_evidence: None,
+        });
+    }
+    if !pid_has_environment_value(state.pid, DAEMON_STARTUP_TOKEN_ENV, &state.startup_token)? {
+        return Err(Error::validation_invalid_argument(
+            "daemon_lease",
+            format!(
+                "process {} does not own the persisted daemon startup token; refusing to signal a potentially reused PID",
+                state.pid
+            ),
+            Some(state.pid.to_string()),
+            None,
+        ));
+    }
+
+    let _ = read_lease_if_identity_matches(&path, &identity)?;
+    terminate_pid_with_sigterm_and_wait(state.pid, FORCE_STOP_WAIT)?;
+    let evidence = DaemonTerminationEvidence {
+        classification: DaemonTerminationClassification::CleanStop,
+        observed_at: chrono::Utc::now().to_rfc3339(),
+        lease_id: Some(state.lease_id.clone()),
+        pid: Some(state.pid),
+        binary_identity: Some(state.build_identity.display.clone()),
+        active_jobs: 0,
+        resource_evidence: "unavailable: forced stop does not collect OS resource snapshots"
+            .to_string(),
+        os_evidence: format!(
+            "SIGTERM sent to recorded daemon PID and process death verified within {}ms",
+            FORCE_STOP_WAIT.as_millis()
+        ),
+        exit_code: None,
+        signal: Some(libc::SIGTERM),
+        stdout: None,
+        stderr: None,
+        stop_requested: true,
+    };
+    write_termination_evidence(&evidence)?;
+    remove_lease_if_identity_matches(&path, &identity)?;
+    Ok(DaemonStopResult {
+        stopped: true,
+        pid: Some(state.pid),
+        state_path: state_path_display,
+        termination_evidence: Some(evidence),
+    })
+}
+
 fn stop_with_force_for_lease(expected_lease_id: &str, force: bool) -> Result<DaemonStopResult> {
     let _lock = acquire_daemon_operation_lock()?;
     let path = state_path()?;
@@ -864,6 +977,7 @@ fn stop_unlocked_with_force(force: bool) -> Result<DaemonStopResult> {
             stopped: false,
             pid: None,
             state_path: state_path_display,
+            termination_evidence: None,
         });
     };
 
@@ -875,6 +989,7 @@ fn stop_unlocked_with_force(force: bool) -> Result<DaemonStopResult> {
             stopped: false,
             pid: Some(state.pid),
             state_path: state_path_display,
+            termination_evidence: None,
         });
     }
 
@@ -945,6 +1060,7 @@ fn stop_unlocked_with_force(force: bool) -> Result<DaemonStopResult> {
         stopped,
         pid: Some(pid),
         state_path: state_path_display,
+        termination_evidence: None,
     })
 }
 
@@ -965,7 +1081,7 @@ fn active_jobs_block_daemon_stop_error(state: &DaemonState, active_job_ids: &[Uu
     let mut error = Error::validation_invalid_argument(
         "daemon_stop",
         format!(
-            "refusing routine daemon stop for lease `{}` ({current_identity}) while active durable jobs exist: {}. Requested Homeboy identity is `{requested_identity}`; wait for those jobs to finish or use the owning command's explicit --force option",
+            "refusing daemon stop for lease `{}` ({current_identity}) while active durable jobs exist: {}. Requested Homeboy identity is `{requested_identity}`; wait for those jobs to finish before stopping the daemon",
             state.lease_id,
             active_job_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(", "),
         ),

--- a/crates/homeboy-process/src/lib.rs
+++ b/crates/homeboy-process/src/lib.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 /// Generic process step shape shared by command/runner adapters.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -51,6 +52,134 @@ pub fn pid_is_running(pid: u32) -> bool {
     {
         pid == std::process::id()
     }
+}
+
+/// Prove a live process owns one exact environment value.
+///
+/// This is intended for persisted random ownership tokens. Callers should
+/// re-check immediately before signaling because PIDs can be reused.
+pub fn pid_has_environment_value(pid: u32, key: &str, value: &str) -> Result<bool> {
+    if pid == 0 || pid > i32::MAX as u32 {
+        return Err(Error::validation_invalid_argument(
+            "pid",
+            "recorded process PID is invalid",
+            Some(pid.to_string()),
+            None,
+        ));
+    }
+    if key.is_empty()
+        || key.contains('=')
+        || key.chars().any(char::is_whitespace)
+        || value.chars().any(char::is_whitespace)
+    {
+        return Err(Error::validation_invalid_argument(
+            "process_environment",
+            "process environment ownership checks require a non-empty key and whitespace-free value",
+            Some(key.to_string()),
+            None,
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let expected = format!("{key}={value}");
+        match std::fs::read(format!("/proc/{pid}/environ")) {
+            Ok(environment) => {
+                return Ok(environment_contains_assignment(
+                    &environment,
+                    expected.as_bytes(),
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => {
+                return Err(Error::internal_io(
+                    error.to_string(),
+                    Some(format!("inspect process {pid} environment")),
+                ));
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Err(Error::validation_invalid_argument(
+            "pid",
+            "exact process environment ownership checks require Linux /proc evidence",
+            Some(pid.to_string()),
+            None,
+        ))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn environment_contains_assignment(environment: &[u8], expected: &[u8]) -> bool {
+    environment
+        .split(|byte| *byte == 0)
+        .any(|entry| entry == expected)
+}
+
+/// Send SIGTERM to a recorded PID and prove it exited within `timeout`.
+/// Platform-specific signaling stays in this process abstraction so lifecycle
+/// callers do not need to issue ad hoc shell commands.
+pub fn terminate_pid_with_sigterm_and_wait(pid: u32, timeout: Duration) -> Result<()> {
+    if pid == 0 || pid > i32::MAX as u32 {
+        return Err(Error::validation_invalid_argument(
+            "pid",
+            "recorded process PID is invalid",
+            Some(pid.to_string()),
+            None,
+        ));
+    }
+
+    #[cfg(unix)]
+    {
+        unsafe {
+            if libc::kill(pid as libc::pid_t, libc::SIGTERM) != 0 {
+                let error = std::io::Error::last_os_error();
+                if error.raw_os_error() == Some(libc::ESRCH) {
+                    return Ok(());
+                }
+                return Err(Error::internal_io(
+                    error.to_string(),
+                    Some(format!("send SIGTERM to process {pid}")),
+                ));
+            }
+        }
+        let deadline = Instant::now() + timeout;
+        while process_is_running_after_sigterm(pid) {
+            if Instant::now() >= deadline {
+                return Err(Error::internal_unexpected(format!(
+                    "process {pid} remained alive for {}ms after SIGTERM",
+                    timeout.as_millis()
+                )));
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        return Ok(());
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = timeout;
+        Err(Error::validation_invalid_argument(
+            "pid",
+            "SIGTERM process termination is unsupported on this platform",
+            Some(pid.to_string()),
+            None,
+        ))
+    }
+}
+
+#[cfg(unix)]
+fn process_is_running_after_sigterm(pid: u32) -> bool {
+    // A directly owned child can remain a zombie after SIGTERM. Reap it before
+    // falling back to PID liveness so bounded termination works on macOS too.
+    let mut status = 0;
+    let reaped = unsafe { libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG) };
+    if reaped == pid as libc::pid_t {
+        return false;
+    }
+    pid_is_running(pid)
 }
 
 /// Read Linux `/proc/<pid>/stat` field 22, the kernel tick at which this
@@ -535,6 +664,20 @@ mod tests {
 
         assert_eq!(process.state, 'Z');
         assert_eq!(process.process_group_id, 456);
+    }
+
+    #[test]
+    fn force_stop_environment_ownership_requires_an_exact_assignment() {
+        let environment = b"HOME=/tmp\0HOMEBOY_DAEMON_STARTUP_TOKEN=lease-token\0";
+
+        assert!(environment_contains_assignment(
+            environment,
+            b"HOMEBOY_DAEMON_STARTUP_TOKEN=lease-token"
+        ));
+        assert!(!environment_contains_assignment(
+            environment,
+            b"HOMEBOY_DAEMON_STARTUP_TOKEN=lease"
+        ));
     }
 }
 

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -12,7 +12,7 @@ homeboy daemon <COMMAND>
 
 - `start` — start the local daemon in the background
 - `serve` — run the daemon in the foreground
-- `stop` — stop the background daemon recorded in the state file
+- `stop` — gracefully stop the background daemon recorded in the state file
 - `status` — show daemon state, active-job recovery evidence, and selected local address
 - `broker-config` — render a deployable reverse-runner broker service recipe
 
@@ -26,6 +26,17 @@ Always treat the API as a local UI contract. It is not a hosted or remote
 multi-user service.
 
 ## Dead-Lease Recovery
+
+When a recorded daemon is stale or unreachable but its PID is still live, an
+operator can use a lease-bound local force stop. It never uses the daemon HTTP
+endpoint, sends SIGTERM only after the persisted lease matches exactly, waits
+for process death, and refuses while durable jobs are active. Forced process
+termination currently requires Linux `/proc` evidence that the target owns the
+persisted daemon startup token:
+
+```sh
+homeboy daemon stop --force --lease-id <exact-live-lease>
+```
 
 When `status` reports a dead lease, `active_job_recovery_evidence` lists each
 active job's exact ID, lease, timestamps, terminal evidence, child identity,

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -736,6 +736,114 @@ fn stop_refuses_stale_lease_that_points_at_reused_pid() {
     );
 }
 
+#[cfg(unix)]
+fn spawn_force_stop_test_process(startup_token: Option<&str>) -> std::process::Child {
+    let mut command = Command::new("sleep");
+    command.arg("30").env_clear();
+    if let Some(startup_token) = startup_token {
+        command.env(DAEMON_STARTUP_TOKEN_ENV, startup_token);
+    }
+    command.spawn().expect("start force-stop test process")
+}
+
+#[cfg(unix)]
+#[test]
+fn force_stop_lease_mismatch_cannot_signal_a_process() {
+    let _home = HomeGuard::new();
+    let mut child = spawn_force_stop_test_process(None);
+    let mut state = daemon_state_for_test(child.id(), "127.0.0.1:1");
+    state.binary_sha256 = Some("stale-binary-hash".to_string());
+    write_daemon_state_for_test(&state);
+
+    let error = force_stop_for_lease("other-lease").expect_err("mismatched lease is rejected");
+
+    assert!(error.message.contains("refusing to signal"));
+    assert!(pid_is_running(child.id()));
+    child.kill().expect("cleanup test process");
+    child.wait().expect("reap test process");
+}
+
+#[cfg(unix)]
+#[test]
+fn force_stop_active_jobs_block_signaling() {
+    let _home = HomeGuard::new();
+    let mut child = spawn_force_stop_test_process(None);
+    let mut state = daemon_state_for_test(child.id(), "127.0.0.1:1");
+    state.binary_sha256 = Some("stale-binary-hash".to_string());
+    write_daemon_state_for_test(&state);
+    let store = JobStore::open_without_reconciliation(
+        &crate::paths::daemon_jobs_file().expect("jobs path"),
+    )
+    .expect("store")
+    .with_daemon_lease(state.lease_id.clone());
+    let job = store.create("runner.exec");
+    store.start(job.id).expect("start job");
+
+    let error = force_stop_for_lease(&state.lease_id).expect_err("active job blocks force stop");
+
+    assert_eq!(error.details["active_job_ids"], serde_json::json!([job.id]));
+    assert!(pid_is_running(child.id()));
+    child.kill().expect("cleanup test process");
+    child.wait().expect("reap test process");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn force_stop_matching_zero_job_stale_daemon_is_terminated_and_verified() {
+    let _home = HomeGuard::new();
+    let startup_token = "force-stop-owned-process";
+    let child = spawn_force_stop_test_process(Some(startup_token));
+    let pid = child.id();
+    let mut state = daemon_state_for_test(pid, "127.0.0.1:1");
+    state.binary_sha256 = Some("stale-binary-hash".to_string());
+    state.startup_token = startup_token.to_string();
+    write_daemon_state_for_test(&state);
+
+    let result = force_stop_for_lease(&state.lease_id).expect("force stop stale daemon");
+
+    assert!(result.stopped);
+    assert_eq!(result.pid, Some(pid));
+    let evidence = result.termination_evidence.expect("termination evidence");
+    assert_eq!(evidence.lease_id.as_deref(), Some(state.lease_id.as_str()));
+    assert_eq!(evidence.pid, Some(pid));
+    assert_eq!(evidence.signal, Some(libc::SIGTERM));
+    assert!(evidence.os_evidence.contains("process death verified"));
+    assert!(!pid_is_running(pid));
+    assert!(!state_path().expect("state path").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn force_stop_matching_lease_cannot_signal_a_reused_pid() {
+    let _home = HomeGuard::new();
+    let mut child = spawn_force_stop_test_process(None);
+    let mut state = daemon_state_for_test(child.id(), "127.0.0.1:1");
+    state.binary_sha256 = Some("stale-binary-hash".to_string());
+    write_daemon_state_for_test(&state);
+
+    force_stop_for_lease(&state.lease_id)
+        .expect_err("unowned matching lease cannot signal reused pid");
+
+    assert!(pid_is_running(child.id()));
+    child.kill().expect("cleanup test process");
+    child.wait().expect("reap test process");
+}
+
+#[test]
+fn force_stop_default_non_force_behavior_remains_unchanged() {
+    let _home = HomeGuard::new();
+    let mut state = daemon_state_for_test(std::process::id(), "127.0.0.1:49152");
+    state.binary_sha256 = Some("stale-binary-hash".to_string());
+    write_daemon_state_for_test(&state);
+
+    let result = stop().expect("routine stop stale lease");
+
+    assert!(!result.stopped);
+    assert_eq!(result.pid, Some(std::process::id()));
+    assert!(result.termination_evidence.is_none());
+    assert!(state_path().expect("state path").exists());
+}
+
 #[test]
 fn stop_reports_corrupt_lease_without_signalling_pid() {
     let _home = HomeGuard::new();


### PR DESCRIPTION
## Summary
Add an explicit, fail-closed force-stop path for live stale or unreachable daemon leases so operators do not need out-of-band kill commands.

## What changed
- Add `homeboy daemon stop --force --lease-id <id>` while preserving graceful stop as the default.
- Require an exact lease, zero active durable jobs, and Linux `/proc` proof that the PID owns the persisted startup token before SIGTERM.
- Wait for process death, persist structured termination evidence, remove the matched lease, and refuse PID reuse or ambiguous ownership.

## How to test
1. Run `cargo check --workspace`; expect the workspace to compile successfully.
2. On Linux, run `cargo test --workspace force_stop`; expect six focused force-stop tests to pass, including SIGTERM and PID-reuse refusal.

## Current main limitation
The unchanged force-stop candidate passed the complete Linux filter before rebasing. Current `main` cannot compile its broader test harness because of unrelated regressions tracked in [#8458](https://github.com/Extra-Chill/homeboy/issues/8458). `cargo check --workspace` passes after rebase; CI is expected to expose the same baseline test blocker until #8458 lands.

## Compatibility
This is an additive CLI and structured-output change. Existing `daemon stop` behavior is unchanged. Forced process termination is intentionally Linux-only because other platforms cannot provide equivalent exact process-environment ownership evidence.

## Evidence
- `cargo check --workspace`: passed on the rebased branch.
- `cargo test --workspace force_stop`: six focused tests passed on Linux before the unrelated current-main test regression.
- Source context: [#8001](https://github.com/Extra-Chill/homeboy/issues/8001).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Designed and implemented the force-stop lifecycle, process ownership checks, tests, and PR draft with Chris.

## Source relationships
- Relates to #8001
