### PR TITLE
Support layered local gate-feedback remediation

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -36,6 +36,20 @@ pub fn route_after_parse(
         return Ok(None);
     }
 
+    // Promotion owns target resolution because gate-feedback artifacts can
+    // authorize an exact dirty candidate. Generic Lab routing has no artifact
+    // provenance and would reject that target before local promotion starts.
+    if cli.placement == homeboy::cli_surface::Placement::Local
+        && matches!(
+            cli.command,
+            Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+                command: crate::commands::agent_task::AgentTaskCommand::Promote(_),
+            })
+        )
+    {
+        return Ok(None);
+    }
+
     if let (Some(runner_id), Commands::Runs(args)) = (cli.runner.as_deref(), &cli.command) {
         if !is_runs_list_runner_option(normalized_args) && !args.has_command_local_runner_option() {
             return Err(crate::commands::runs::global_runner_error(args, runner_id));

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -1,6 +1,27 @@
 #![cfg(test)]
 
 use super::*;
+
+#[test]
+fn explicit_local_promotion_defers_target_resolution_to_promotion() {
+    let args = [
+        "homeboy",
+        "--placement",
+        "local",
+        "agent-task",
+        "promote",
+        "/tmp/aggregate.json",
+        "--to-worktree",
+        "fixture@dirty-candidate",
+    ];
+    let cli = Cli::parse_from(args);
+    let normalized = args
+        .iter()
+        .map(|arg| (*arg).to_string())
+        .collect::<Vec<_>>();
+
+    assert_eq!(route_after_parse(&cli, &normalized, None).unwrap(), None);
+}
 use clap::Parser;
 use homeboy::command_contract::{lab_runner_supports_contract_label, LabCommandPortability};
 use std::fs;

--- a/crates/homeboy-core/src/agent_task_candidate_baseline.rs
+++ b/crates/homeboy-core/src/agent_task_candidate_baseline.rs
@@ -35,12 +35,41 @@ pub(crate) fn validate_gate_feedback_candidate_baseline(
     }
     let patch = String::from_utf8(patch)
         .map_err(|error| invalid(&format!("recorded patch artifact is not UTF-8: {error}")))?;
-    if patch_tree(root, &patch)? != workspace_tree(root)? {
+    verify_patch_is_present(root, &patch)?;
+    let current_diff = cook_loop
+        .get("current_diff")
+        .and_then(Value::as_str)
+        .filter(|diff| !diff.trim().is_empty())
+        .ok_or_else(|| invalid("gate-feedback candidate has no complete current diff"))?;
+    if patch_tree(root, current_diff)? != workspace_tree(root)? {
         return Err(invalid(
-            "recorded patch artifact does not match the promoted candidate worktree state",
+            "recorded current diff does not match the promoted candidate worktree state",
         ));
     }
-    Ok(patch)
+    Ok(current_diff.to_string())
+}
+
+fn verify_patch_is_present(root: &Path, patch: &str) -> Result<()> {
+    let patch_file = tempfile::NamedTempFile::new().map_err(|error| invalid(&error.to_string()))?;
+    std::fs::write(patch_file.path(), patch).map_err(|error| invalid(&error.to_string()))?;
+    let output = Command::new("git")
+        .args([
+            "apply",
+            "--reverse",
+            "--check",
+            "--binary",
+            &patch_file.path().display().to_string(),
+        ])
+        .current_dir(root)
+        .output()
+        .map_err(|error| invalid(&error.to_string()))?;
+    if !output.status.success() {
+        return Err(invalid(&format!(
+            "recorded patch artifact is not present in the candidate worktree: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(())
 }
 
 fn patch_tree(root: &Path, patch: &str) -> Result<String> {
@@ -93,4 +122,61 @@ fn invalid(message: &str) -> Error {
         None,
         None,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layered_remediation_uses_complete_current_diff() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        git(temp.path(), &["init", "-b", "main"]);
+        git(temp.path(), &["config", "user.name", "Homeboy Test"]);
+        git(
+            temp.path(),
+            &["config", "user.email", "homeboy@example.test"],
+        );
+        std::fs::write(temp.path().join("tracked.txt"), "one\n").expect("base file");
+        git(temp.path(), &["add", "tracked.txt"]);
+        git(temp.path(), &["commit", "-m", "base"]);
+
+        std::fs::write(temp.path().join("tracked.txt"), "three\n").expect("candidate file");
+        std::fs::write(temp.path().join("untracked.txt"), "candidate\n")
+            .expect("untracked candidate file");
+        git(temp.path(), &["add", "-N", "untracked.txt"]);
+        let current_diff = git(temp.path(), &["diff", "--binary"]);
+        let remediation = "diff --git a/tracked.txt b/tracked.txt\n--- a/tracked.txt\n+++ b/tracked.txt\n@@ -1 +1 @@\n-two\n+three\n";
+        let artifacts = tempfile::tempdir().expect("artifact tempdir");
+        let artifact = artifacts.path().join("remediation.patch");
+        std::fs::write(&artifact, remediation).expect("remediation artifact");
+        let cook_loop = serde_json::json!({
+            "current_diff": current_diff,
+            "patch_artifact": {
+                "path": artifact,
+                "sha256": format!("{:x}", Sha256::digest(remediation.as_bytes()))
+            }
+        });
+
+        assert_eq!(
+            validate_gate_feedback_candidate_baseline(temp.path(), &cook_loop)
+                .expect("layered candidate baseline"),
+            current_diff
+        );
+    }
+
+    fn git(root: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).to_string()
+    }
 }

--- a/crates/homeboy-core/src/agent_task_candidate_baseline.rs
+++ b/crates/homeboy-core/src/agent_task_candidate_baseline.rs
@@ -41,12 +41,13 @@ pub(crate) fn validate_gate_feedback_candidate_baseline(
         .and_then(Value::as_str)
         .filter(|diff| !diff.trim().is_empty())
         .ok_or_else(|| invalid("gate-feedback candidate has no complete current diff"))?;
-    if patch_tree(root, current_diff)? != workspace_tree(root)? {
+    let current_diff = format!("{}\n", current_diff.trim_end_matches('\n'));
+    if patch_tree(root, &current_diff)? != workspace_tree(root)? {
         return Err(invalid(
             "recorded current diff does not match the promoted candidate worktree state",
         ));
     }
-    Ok(current_diff.to_string())
+    Ok(current_diff)
 }
 
 fn verify_patch_is_present(root: &Path, patch: &str) -> Result<()> {
@@ -150,8 +151,9 @@ mod tests {
         let artifacts = tempfile::tempdir().expect("artifact tempdir");
         let artifact = artifacts.path().join("remediation.patch");
         std::fs::write(&artifact, remediation).expect("remediation artifact");
+        let transported_diff = current_diff.trim_end_matches('\n');
         let cook_loop = serde_json::json!({
-            "current_diff": current_diff,
+            "current_diff": transported_diff,
             "patch_artifact": {
                 "path": artifact,
                 "sha256": format!("{:x}", Sha256::digest(remediation.as_bytes()))

--- a/crates/homeboy-core/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-core/src/agent_task_scheduler/attempt_workspace.rs
@@ -121,6 +121,7 @@ impl Drop for AttemptWorkspace {
     }
 }
 
+#[derive(Debug)]
 pub(super) struct HarvestPreflight {
     pub(super) base_sha: Option<String>,
     pub(super) source_provenance: Option<serde_json::Value>,
@@ -130,6 +131,7 @@ pub(super) struct HarvestPreflight {
 /// A gate-feedback retry may start from the promoted, uncommitted candidate.
 /// This patch is derived only after its recorded provenance reproduces the
 /// exact worktree tree, so it cannot authorize arbitrary existing dirt.
+#[derive(Debug)]
 pub(super) struct CandidateBaseline {
     patch: String,
 }

--- a/crates/homeboy-core/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-core/src/agent_task_scheduler/harvest.rs
@@ -631,8 +631,8 @@ mod committed_harvest_tests {
         std::fs::write(workspace.join("candidate.txt"), "candidate\n").expect("candidate");
         std::fs::write(workspace.join("new-candidate.txt"), "new candidate\n")
             .expect("new candidate");
-        let current_diff = git_output_raw(&workspace, &["diff", "HEAD"]).expect("current diff");
         let (patch_artifact, patch_sha256) = candidate_patch(&workspace);
+        let current_diff = std::fs::read_to_string(&patch_artifact).expect("complete current diff");
         let mut request =
             gate_feedback_request(&workspace, current_diff, &patch_artifact, &patch_sha256);
 
@@ -687,8 +687,8 @@ mod committed_harvest_tests {
         git(&workspace, &["add", "file.txt"]);
         git(&workspace, &["commit", "--quiet", "-m", "base"]);
         std::fs::write(workspace.join("file.txt"), "candidate\n").expect("candidate");
-        let recorded = git_output_raw(&workspace, &["diff", "HEAD"]).expect("recorded diff");
         let (patch_artifact, patch_sha256) = candidate_patch(&workspace);
+        let recorded = std::fs::read_to_string(&patch_artifact).expect("complete recorded diff");
         std::fs::write(workspace.join("extra.txt"), "unrelated\n").expect("extra");
         let error = prepare_committed_harvest(
             &gate_feedback_request(&workspace, recorded.clone(), &patch_artifact, &patch_sha256),


### PR DESCRIPTION
## Summary
Allow local and layered gate-feedback remediation to preserve exact candidate provenance across promotion, isolated retry execution, and transport normalization.

## What changed
- Defer explicit local promotion target resolution to the baseline-aware promotion provider instead of generic Lab routing.
- Hash-verify and reverse-check the latest remediation artifact, then reconstruct the complete candidate from the recorded current diff.
- Reject unrelated dirty changes while supporting tracked and untracked files across multiple remediation layers.
- Normalize a transport-stripped final newline before Git verifies or replays a candidate patch.

## How to test
1. Run `cargo check -p homeboy-core -p homeboy-cli`; expect both production crates to compile.
2. Run `cargo test -p homeboy-core gate_feedback_baseline_`; expect exact-candidate acceptance and unrelated-dirt rejection tests to pass.
3. Run `cargo test -p homeboy-core layered_remediation_uses_complete_current_diff`; expect layered tracked/untracked reconstruction with newline-stripped transport to pass.
4. Run `cargo test -p homeboy-cli explicit_local_promotion_defers_target_resolution_to_promotion`; expect explicit local promotion to bypass generic Lab target materialization.

## Testing note
The three focused tests passed on the implementation branch before rebasing onto current `main`. On current `main`, test compilation stops before discovery at the unrelated existing `runner/connection/tests/recovery.rs` reference to missing `super::super::create`. `cargo check -p homeboy-core -p homeboy-cli` passes on this PR branch.

## Live validation
This repair was exercised by the workflow tracked in [chubes4/wp-docs#14](https://github.com/chubes4/wp-docs/issues/14). A layered remediation-only patch was accepted against the exact dirty candidate, promoted, and passed shell syntax, the offline Blume/Spacefast gate, and the reversible live Studio/MDI round trip. The finalized result is [chubes4/wp-docs#18](https://github.com/chubes4/wp-docs/pull/18).

## Compatibility
This extends the provenance-gated gate-feedback path only. Ordinary dirty worktrees and existing primary/unpushed safety gates retain their behavior. No CLI flags or public schemas are removed.

Closes #8462

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the layered remediation failures, drafted the candidate-baseline and routing fixes, added deterministic coverage, and replayed the real WP Docs lifecycle; Chris reviews and owns the change.