### PR TITLE
fix(runner): correct create() path in decomposed connection test

### DIFF
--- a/crates/homeboy-core/src/runner/connection/tests/recovery.rs
+++ b/crates/homeboy-core/src/runner/connection/tests/recovery.rs
@@ -382,7 +382,7 @@ esac
             false,
         )
         .expect("create local server");
-        super::super::create(
+        crate::runner::create(
             &serde_json::json!({
                 "id": "local-runner",
                 "kind": "ssh",


### PR DESCRIPTION
## Summary
- Fixes the one real compile error surfaced by the first CI run to actually execute `cargo test --workspace` (E0425 in `runner/connection/tests/recovery.rs`).
- PR #8453 (connection god-file decompose) relocated this test one module level deeper, so `super::super::create` began resolving to `connection` instead of `runner`. Switched to the depth-independent absolute path `crate::runner::create`.

## Context
After the `homeboy-core` extraction, `cargo test` at the hybrid workspace root silently stopped compiling member-crate tests. homeboy-extensions #2271 added `--workspace` to the Test gate; this is the first run where core's test build actually ran — and it caught this latent breakage.

Note: the sibling `HarvestPreflight: Debug` error seen in that same run was already fixed on main by #8465, so it is not addressed here.

## Verification
- `cargo check -p homeboy-core --tests` → clean (exit 0); no remaining E0425.
- Other `super::super[::super]::create` call sites are at different module depths and compiled fine in CI — intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)