### PR TITLE
Restore core test compilation after recent splits

### DIFF
--- a/crates/homeboy-core/src/runner/connection/tests/recovery.rs
+++ b/crates/homeboy-core/src/runner/connection/tests/recovery.rs
@@ -382,7 +382,7 @@ esac
             false,
         )
         .expect("create local server");
-        super::super::create(
+        crate::runner::create(
             &serde_json::json!({
                 "id": "local-runner",
                 "kind": "ssh",


### PR DESCRIPTION
## Summary
Restore current-main homeboy-core lib-test compilation after recent module and scheduler changes.

## What changed
- Uses the native runner owner path from the split connection recovery test.
- Adds Debug to internal harvest preflight values so fail-closed expect\_err assertions compile without changing behavior.

## How to test
1. Run `cargo test -p homeboy-core runner::connection::tests::recovery --lib`; expect passes.
2. Run `cargo test -p homeboy-core harvest --lib`; expect passes.
3. Run `cargo test -p homeboy-core deploy::preparation --lib`; expect passes.
4. Run `cargo test -p homeboy-core deploy::orchestration --lib`; expect passes.
5. Run `cargo check -p homeboy-core`; expect passes.
6. Run `homeboy review audit --changed-since origin/main --profile pr --placement local`; expect passes.

## Compatibility
No production, external API, or extension compatibility impact; this changes test compilation support and derives Debug on internal types only.

## Evidence
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8458
- audit: Passed
- build: Passed
- tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed current-main test compilation regressions, implemented the focused repair, and ran deterministic verification; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8458
