### PR TITLE
fix(release): require declared build artifact

### DIFF
--- a/crates/homeboy-core/src/release/execution_dispatch.rs
+++ b/crates/homeboy-core/src/release/execution_dispatch.rs
@@ -110,6 +110,7 @@ pub(super) fn execute_release_plan_step(
                 context.component_id,
                 &context.component.local_path,
                 None,
+                context.component.build_artifact.as_deref(),
                 context.options.skip_build_validation,
             )
             .and_then(|result| {

--- a/crates/homeboy-core/src/release/executor.rs
+++ b/crates/homeboy-core/src/release/executor.rs
@@ -765,6 +765,7 @@ mod tests {
                 "fixture",
                 &component.path().to_string_lossy(),
                 None,
+                None,
                 false,
             )
             .expect("package step");
@@ -800,6 +801,105 @@ mod tests {
             assert!(!build_dir.exists());
             assert!(std::path::Path::new(durable_path).is_file());
         });
+    }
+
+    #[test]
+    fn run_package_collects_declared_component_artifact_alongside_provider_artifacts() {
+        crate::test_support::with_isolated_home(|_| {
+            let component = tempfile::tempdir().expect("component tempdir");
+            let package = release_package_extension(
+                "nodejs",
+                "mkdir -p packages/plugin/dist target; \
+                 printf plugin > packages/plugin/dist/plugin.zip; \
+                 printf npm > target/plugin-1.2.3.tgz; \
+                 printf '[{\"path\":\"target/plugin-1.2.3.tgz\",\"type\":\"npm\"}]'",
+            );
+            crate::extension::save_manifest(&package).expect("save package extension");
+
+            let mut state = ReleaseState {
+                version: Some("1.2.3".to_string()),
+                ..ReleaseState::default()
+            };
+            run_package(
+                &[package],
+                &mut state,
+                "plugin",
+                &component.path().to_string_lossy(),
+                None,
+                Some("packages/plugin/dist/plugin.zip"),
+                false,
+            )
+            .expect("package step should collect declared artifact");
+
+            assert_eq!(state.artifacts.len(), 2);
+            assert_eq!(state.artifacts[0].path, "target/plugin-1.2.3.tgz");
+            assert_eq!(state.artifacts[1].path, "packages/plugin/dist/plugin.zip");
+            assert!(state.artifacts[1]
+                .durable_path
+                .as_deref()
+                .is_some_and(|path| std::path::Path::new(path).is_file()));
+        });
+    }
+
+    #[test]
+    fn run_package_rejects_unrelated_provider_artifact_when_declared_artifact_is_absent() {
+        crate::test_support::with_isolated_home(|_| {
+            let component = tempfile::tempdir().expect("component tempdir");
+            let package = release_package_extension(
+                "nodejs",
+                "mkdir -p target; printf npm > target/plugin-1.2.3.tgz; \
+                 printf '[{\"path\":\"target/plugin-1.2.3.tgz\",\"type\":\"npm\"}]'",
+            );
+            crate::extension::save_manifest(&package).expect("save package extension");
+
+            let error = run_package(
+                &[package],
+                &mut ReleaseState::default(),
+                "plugin",
+                &component.path().to_string_lossy(),
+                None,
+                Some("packages/plugin/dist/plugin.zip"),
+                false,
+            )
+            .expect_err("unrelated provider artifact must not complete the release package");
+
+            assert!(error
+                .message
+                .contains("was not produced by release.package"));
+            assert_eq!(error.details["field"], "build_artifact");
+        });
+    }
+
+    #[test]
+    fn github_release_refuses_missing_declared_artifact_before_publication() {
+        let component_dir = tempfile::tempdir().expect("component tempdir");
+        let npm_artifact = component_dir.path().join("target/plugin-1.2.3.tgz");
+        std::fs::create_dir_all(npm_artifact.parent().expect("parent")).expect("target dir");
+        std::fs::write(&npm_artifact, "npm").expect("npm artifact");
+        let component = Component {
+            id: "plugin".to_string(),
+            local_path: component_dir.path().to_string_lossy().to_string(),
+            build_artifact: Some("packages/plugin/dist/plugin.zip".to_string()),
+            ..Component::default()
+        };
+        let state = ReleaseState {
+            tag: Some("v1.2.3".to_string()),
+            artifacts: vec![ReleaseArtifact {
+                path: npm_artifact.display().to_string(),
+                durable_path: None,
+                artifact_type: Some("npm".to_string()),
+                platform: None,
+            }],
+            ..ReleaseState::default()
+        };
+
+        let error = super::run_github_release(&component, &state)
+            .expect_err("missing declared artifact must block GitHub publication");
+
+        assert!(error
+            .message
+            .contains("absent from the GitHub Release assets"));
+        assert!(!error.message.contains("no remote_url"));
     }
 
     fn release_package_extension(id: &str, command: &str) -> ExtensionManifest {
@@ -856,6 +956,7 @@ mod tests {
                 "fixture",
                 &component.path().to_string_lossy(),
                 None,
+                None,
                 false,
             )
             .expect("package step");
@@ -889,6 +990,7 @@ mod tests {
                 &mut state,
                 "intelligence-horse-theme",
                 &component.path().to_string_lossy(),
+                None,
                 None,
                 false,
             )
@@ -990,6 +1092,7 @@ mod tests {
                 "fixture",
                 &component.path().to_string_lossy(),
                 None,
+                None,
                 true,
             )
             .expect_err("failing final package should surface output");
@@ -1020,6 +1123,7 @@ mod tests {
                 &mut state,
                 "fixture",
                 &component.path().to_string_lossy(),
+                None,
                 None,
                 false,
             )
@@ -1057,6 +1161,7 @@ mod tests {
                 &mut state,
                 "fixture",
                 &component.path().to_string_lossy(),
+                None,
                 None,
                 false,
             )
@@ -1108,6 +1213,7 @@ mod tests {
                 &mut state,
                 "fixture",
                 &component.path().to_string_lossy(),
+                None,
                 None,
                 false,
             )

--- a/crates/homeboy-core/src/release/executor/github_release/run.rs
+++ b/crates/homeboy-core/src/release/executor/github_release/run.rs
@@ -49,6 +49,7 @@ pub(crate) fn run_github_release(
             "github.release: tag state not set (git.tag must run first)".to_string(),
         )
     })?;
+    validate_declared_build_artifact(component, state)?;
     let local_path = &component.local_path;
 
     let remote_url = component
@@ -366,5 +367,53 @@ pub(crate) fn run_github_release(
             "release_body_file": persisted_notes_path,
         })),
         Vec::new(),
+    ))
+}
+
+/// A configured deploy artifact is part of the release contract, including
+/// `--head --from-artifacts` recovery where `release.package` is not run.
+fn validate_declared_build_artifact(component: &Component, state: &ReleaseState) -> Result<()> {
+    let Some(declared_build_artifact) = component
+        .build_artifact
+        .as_deref()
+        .filter(|path| !path.trim().is_empty())
+    else {
+        return Ok(());
+    };
+    let expected_name = std::path::Path::new(declared_build_artifact)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "build_artifact",
+                format!(
+                    "Configured build_artifact '{}' has no filename",
+                    declared_build_artifact
+                ),
+                Some(declared_build_artifact.to_string()),
+                None,
+            )
+        })?;
+    let is_collected = github_release_artifact_paths(state).iter().any(|path| {
+        std::path::Path::new(path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            == Some(expected_name)
+    });
+    if is_collected {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "build_artifact",
+        format!(
+            "Configured build_artifact '{}' is absent from the GitHub Release assets",
+            declared_build_artifact
+        ),
+        Some(declared_build_artifact.to_string()),
+        Some(vec![
+            "Run release.package again and include the configured build_artifact before publishing the GitHub Release.".to_string(),
+        ]),
     ))
 }

--- a/crates/homeboy-core/src/release/executor/package.rs
+++ b/crates/homeboy-core/src/release/executor/package.rs
@@ -28,6 +28,7 @@ pub(crate) fn run_package(
     component_id: &str,
     component_local_path: &str,
     component_source_path: Option<&str>,
+    declared_build_artifact: Option<&str>,
     skip_build_validation: bool,
 ) -> Result<ReleaseStepResult> {
     let package_extensions: Vec<&ExtensionManifest> = extensions
@@ -70,6 +71,13 @@ pub(crate) fn run_package(
         }));
     }
 
+    collect_declared_build_artifact(
+        state,
+        declared_build_artifact,
+        component_id,
+        component_local_path,
+    )?;
+
     let data = if responses.len() == 1 {
         let response = responses.pop().expect("single package response");
         serde_json::json!({
@@ -86,6 +94,59 @@ pub(crate) fn run_package(
     };
 
     Ok(step_success("package", "package", Some(data), Vec::new()))
+}
+
+/// Add a component-owned deploy artifact even when its packaging provider also
+/// emits unrelated release artifacts (for example, a registry tarball).
+fn collect_declared_build_artifact(
+    state: &mut ReleaseState,
+    declared_build_artifact: Option<&str>,
+    component_id: &str,
+    component_local_path: &str,
+) -> Result<()> {
+    let Some(declared_build_artifact) =
+        declared_build_artifact.filter(|path| !path.trim().is_empty())
+    else {
+        return Ok(());
+    };
+    let declared_path =
+        resolve_release_artifact_path(declared_build_artifact, component_local_path);
+    if !declared_path.is_file() {
+        return Err(Error::validation_invalid_argument(
+            "build_artifact",
+            format!(
+                "Configured build_artifact '{}' was not produced by release.package",
+                declared_build_artifact
+            ),
+            Some(declared_path.display().to_string()),
+            Some(vec![
+                "Update the component-owned release.package command to produce the configured build_artifact.".to_string(),
+            ]),
+        ));
+    }
+
+    let declared_path = std::fs::canonicalize(&declared_path).map_err(|error| {
+        Error::internal_io(
+            format!("Failed to resolve configured build_artifact: {}", error),
+            Some(declared_path.display().to_string()),
+        )
+    })?;
+    let already_collected = state.artifacts.iter().any(|artifact| {
+        let path = resolve_release_artifact_path(&artifact.path, component_local_path);
+        std::fs::canonicalize(path).ok().as_ref() == Some(&declared_path)
+    });
+    if already_collected {
+        return Ok(());
+    }
+
+    let artifact_start = state.artifacts.len();
+    state.artifacts.push(ReleaseArtifact {
+        path: declared_build_artifact.to_string(),
+        durable_path: None,
+        artifact_type: None,
+        platform: None,
+    });
+    persist_package_artifacts(state, artifact_start, component_id, component_local_path)
 }
 
 /// Execute a `release.package` action with a bounded retry for transient

--- a/crates/homeboy-core/src/release/package_recovery.rs
+++ b/crates/homeboy-core/src/release/package_recovery.rs
@@ -52,6 +52,7 @@ pub fn package_existing_tag(
         component_id,
         &component.local_path,
         None,
+        component.build_artifact.as_deref(),
         skip_build_validation,
     )?;
     if state.artifacts.is_empty() {


### PR DESCRIPTION
## Summary
Fixes the reopened regression from #3366: a configured component `build_artifact` is now collected alongside extension-provided release artifacts, and GitHub publication refuses to run unless that declared filename is an uploadable asset.

Source relationship: this restores the release-asset invariant intended by #3366 while preserving its multi-provider aggregation.
Change kind: generic owning-layer release artifact collection and final validation.
Scope: no product, package-manager, or extension-specific behavior; the contract applies only when a component declares `build_artifact`.

## Tests
1. Collects an existing declared component artifact alongside an unrelated provider npm tarball and persists it for release upload.
2. Rejects a provider that returns only a valid unrelated npm tarball when the declared artifact is absent.
3. Refuses GitHub publication before remote/GitHub handling when recovered artifacts omit the declared filename.
4. `cargo check -p homeboy-core` passes.

Focused `cargo test -p homeboy-core <test> -- --exact` is currently blocked by pre-existing test-build errors outside this change: `runner/connection/tests/recovery.rs` references missing `super::super::create`, and scheduler harvest tests require `HarvestPreflight: Debug`.

## Compatibility
Single- and multi-extension package providers continue to aggregate their emitted artifacts unchanged. Components without `build_artifact` retain existing behavior. `release package` and `--head --from-artifacts` now both enforce the declared deploy asset before GitHub Release publication.

## AI Disclosure
Implemented with AI assistance; changes were reviewed manually and verified with the commands above.