### PR TITLE
Preserve controller plan identity after Lab projection

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -846,7 +846,7 @@ fn materialize_agent_task_retry_handoff(
         return Ok(None);
     }
 
-    let source_plan = agent_task_lifecycle::load_plan(&retry.run_id)?;
+    let source_plan = agent_task_lifecycle::load_controller_plan(&retry.run_id)?;
     let primary_workspace = retry_plan_primary_workspace(&source_plan)?;
     let record = agent_task_lifecycle::retry(&retry.run_id, retry.new_run_id.as_deref())?;
     let plan = agent_task_lifecycle::load_plan(&record.run_id)?;

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -635,7 +635,6 @@ fn detached_retry_materializes_failed_plan_and_persists_bounded_preacceptance_fa
         );
         agent_task_lifecycle::submit_plan(&source_plan, Some("failed-run"))
             .expect("source run submitted");
-        let source_plan = agent_task_lifecycle::load_plan("failed-run").expect("source plan");
         let failure = Error::internal_unexpected("provider exited before completion");
         agent_task_lifecycle::record_pre_execution_failure(
             "failed-run",
@@ -644,6 +643,18 @@ fn detached_retry_materializes_failed_plan_and_persists_bounded_preacceptance_fa
             &failure,
         )
         .expect("source failure persisted");
+        let store = homeboy::core::observation::ObservationStore::open_initialized()
+            .expect("observation store");
+        let mut observed = store
+            .get_run("failed-run")
+            .expect("read source run")
+            .expect("source run exists");
+        observed.metadata_json["agent_task_run"]["plan_path"] = serde_json::json!(
+            "/home/chubes/.local/share/homeboy/agent-task-runs/failed-run/plan.json"
+        );
+        store
+            .upsert_imported_run_preserving_terminal(&observed)
+            .expect("mirror runner transport path");
 
         let normalized = [
             "homeboy",

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -332,6 +332,13 @@ pub fn load_plan(run_id: &str) -> Result<AgentTaskPlan> {
     store::read_plan_path(&record.plan_path)
 }
 
+/// Load the plan owned by this controller's durable run identity. Runner paths
+/// projected into lifecycle metadata are transport evidence, not retry input.
+pub fn load_controller_plan(run_id: &str) -> Result<AgentTaskPlan> {
+    let run_id = resolve_run_id(run_id)?;
+    store::read_controller_plan(&run_id)
+}
+
 /// Load a durable plan for a scheduler or provider execution. This is the only
 /// read path allowed to upgrade a legacy execution-budget envelope.
 pub fn load_plan_for_execution(run_id: &str) -> Result<AgentTaskPlan> {
@@ -1698,7 +1705,7 @@ pub fn mark_resuming(run_id: &str) -> Result<AgentTaskRunRecord> {
 
 pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRunRecord> {
     let source = store::read_record(&resolve_run_id(run_id)?)?;
-    let plan = store::read_plan_path(&source.plan_path)?;
+    let plan = load_controller_plan(&source.run_id)?;
     let mut retry = submit_plan(&plan, requested_run_id)?;
     let metadata = retry.ensure_metadata_object();
     if let Some(route) =

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -539,6 +539,29 @@ fn failed_lab_handoff_retry_recovers_the_materialized_user_plan() {
 }
 
 #[test]
+fn retry_uses_controller_plan_when_runner_projection_replaces_plan_path() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        let record =
+            submit_plan(&plan, Some("runner-projected-retry")).expect("controller plan submitted");
+        let mut projected = store::read_record(&record.run_id).expect("source record");
+        projected.plan_path =
+            "/home/chubes/.local/share/homeboy/agent-task-runs/runner-projected-retry/plan.json"
+                .to_string();
+        store::write_record(&projected).expect("runner projection mirrored");
+
+        let retry_record = retry(&record.run_id, Some("runner-projected-retry-local"))
+            .expect("local retry uses controller plan");
+        assert_eq!(load_plan(&retry_record.run_id).expect("retry plan"), plan);
+
+        std::fs::remove_file(record.plan_path).expect("remove authoritative controller plan");
+        let error = retry(&record.run_id, Some("missing-controller-plan"))
+            .expect_err("missing controller plan fails closed");
+        assert_eq!(error.code, ErrorCode::InternalIoError);
+    });
+}
+
+#[test]
 fn controller_proxy_records_pre_execution_phase_progress() {
     with_isolated_home(|_| {
         let source = json!({

--- a/crates/homeboy-core/src/agent_tasks.rs
+++ b/crates/homeboy-core/src/agent_tasks.rs
@@ -247,16 +247,16 @@ pub mod gate {
 pub mod lifecycle {
     pub use super::super::agent_task_lifecycle::{
         aggregate_source, artifacts, cancel, cancel_run, claim_next_queued_run,
-        cook_attempt_run_id, cook_index, list_records, load_plan, logs, mark_resuming,
-        mark_running, record_completed_run, record_cook_attempt, record_detached_lab_run,
-        record_lab_offload_phase, record_lab_offload_planned, record_pre_dispatch_failure,
-        record_pre_execution_failure, record_promotion, record_remote_dispatch_failure,
-        record_run_aggregate, retry, run_id_for_aggregate_path, run_record_exists, run_status,
-        status, submit_plan, AgentTaskArtifactRef, AgentTaskCookIndex, AgentTaskCookIndexAttempt,
-        AgentTaskEventEnvelope, AgentTaskPreDispatchFailure, AgentTaskRemoteDispatchFailure,
-        AgentTaskRunArtifacts, AgentTaskRunLog, AgentTaskRunProviderHandle, AgentTaskRunRecord,
-        AgentTaskRunState, AgentTaskRunStatus, AgentTaskRunTask, DetachedLabRunRecord,
-        LabOffloadProxyPlan,
+        cook_attempt_run_id, cook_index, list_records, load_controller_plan, load_plan, logs,
+        mark_resuming, mark_running, record_completed_run, record_cook_attempt,
+        record_detached_lab_run, record_lab_offload_phase, record_lab_offload_planned,
+        record_pre_dispatch_failure, record_pre_execution_failure, record_promotion,
+        record_remote_dispatch_failure, record_run_aggregate, retry, run_id_for_aggregate_path,
+        run_record_exists, run_status, status, submit_plan, AgentTaskArtifactRef,
+        AgentTaskCookIndex, AgentTaskCookIndexAttempt, AgentTaskEventEnvelope,
+        AgentTaskPreDispatchFailure, AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts,
+        AgentTaskRunLog, AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState,
+        AgentTaskRunStatus, AgentTaskRunTask, DetachedLabRunRecord, LabOffloadProxyPlan,
     };
 }
 

--- a/crates/homeboy-core/src/lifecycle_store.rs
+++ b/crates/homeboy-core/src/lifecycle_store.rs
@@ -38,6 +38,12 @@ pub(super) fn read_plan_path(path: &str) -> Result<AgentTaskPlan> {
     Ok(plan)
 }
 
+pub(super) fn read_controller_plan(run_id: &str) -> Result<AgentTaskPlan> {
+    let plan = read_json(&run_dir(run_id)?.join("plan.json"))?;
+    validate_execution_budget(&plan)?;
+    Ok(plan)
+}
+
 /// Execution owns the one permitted durable legacy rewrite. Read-only callers
 /// (notably status) use `read_plan_path` and never mutate a plan preview.
 pub(super) fn read_plan_path_for_execution(path: &str) -> Result<AgentTaskPlan> {


### PR DESCRIPTION
## Summary
Resolve retries from the authoritative controller-owned plan even when mirrored Lab lifecycle metadata contains a runner-local plan path.

## What changed
- Added an explicit controller-plan resolver and used it for retry construction and Lab retry handoff serialization. Runner-local plan paths remain transport evidence, while a genuinely absent controller plan fails closed.

## How to test
1. Run `cargo test -p homeboy-core retry_uses_controller_plan_when_runner_projection_replaces_plan_path --lib`; expect The controller-plan regression test passes..
2. Run `cargo check -p homeboy-core`; expect The core crate compiles successfully..
3. Run `cargo check -p homeboy-cli`; expect The CLI crate compiles successfully..
4. Run `git diff --check`; expect The change contains no whitespace errors..

## Compatibility
Internal orchestration repair. Existing local and attached Lab retry behavior is preserved; retries with no authoritative controller plan continue to fail closed.

## Evidence
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8382
- cli-check: Passed
- core-check: Passed
- core-regression: Passed
- diff-check: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Prepared and reviewed the controller-plan identity recovery with deterministic regression coverage; Chris reviews and owns the change.

## Source relationships
- Closes #8382
