### PR TITLE
Bind prepared payloads into mutation-free project plans

### DIFF
--- a/crates/homeboy-core/src/deploy/binding.rs
+++ b/crates/homeboy-core/src/deploy/binding.rs
@@ -1,0 +1,295 @@
+//! Target-only binding for immutable component payloads.
+//!
+//! This layer deliberately does not resolve source, build, contact a target, or
+//! retain payload resources. Callers keep process-local payload ownership alive.
+
+use std::collections::{HashMap, HashSet};
+
+use serde::Serialize;
+
+use crate::component::Component;
+use crate::error::{Error, Result};
+use crate::project::Project;
+
+use super::path_roots::resolve_effective_remote_path;
+use super::policy::{protected_path_suffixes, validate_deploy_target};
+use super::PreparedDeployArtifact;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ProjectPayloadBinding {
+    pub component: Component,
+    pub artifact: PreparedDeployArtifact,
+    pub install_dir: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct ProjectPayloadBindingEvidence {
+    pub project_id: String,
+    pub component_id: String,
+    pub install_dir: String,
+    pub strategy: String,
+    pub install: InstallInstructions,
+    pub artifact: PayloadIdentityEvidence,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct InstallInstructions {
+    pub extract_command: Option<String>,
+    pub remote_owner: Option<String>,
+    pub cli_path: Option<String>,
+    pub hooks: std::collections::HashMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct PayloadIdentityEvidence {
+    pub component_id: String,
+    pub size_bytes: u64,
+    pub sha256: String,
+    pub version: String,
+    pub tag: String,
+    pub source_commit: String,
+}
+
+impl ProjectPayloadBinding {
+    pub fn evidence(&self, project_id: &str) -> ProjectPayloadBindingEvidence {
+        ProjectPayloadBindingEvidence {
+            project_id: project_id.to_string(),
+            component_id: self.component.id.clone(),
+            install_dir: self.install_dir.clone(),
+            strategy: self
+                .component
+                .deploy_strategy()
+                .unwrap_or("rsync")
+                .to_string(),
+            install: InstallInstructions {
+                extract_command: self.component.extract_command.clone(),
+                remote_owner: self.component.remote_owner.clone(),
+                cli_path: self.component.cli_path.clone(),
+                hooks: self.component.hooks.clone(),
+            },
+            artifact: PayloadIdentityEvidence {
+                component_id: self.artifact.component_id.clone(),
+                size_bytes: self.artifact.size_bytes,
+                sha256: self.artifact.sha256.clone(),
+                version: self.artifact.version.clone(),
+                tag: self.artifact.tag.clone(),
+                source_commit: self.artifact.source_commit.clone(),
+            },
+        }
+    }
+}
+
+/// Bind already-prepared artifacts to one project's effective install policy.
+/// No filesystem, source, network, lifecycle, transfer, or install effect occurs here.
+pub(crate) fn bind_project_payloads(
+    project: &Project,
+    base_path: &str,
+    components: &[Component],
+    payloads: &HashMap<String, PreparedDeployArtifact>,
+) -> Result<Vec<ProjectPayloadBinding>> {
+    validate_deploy_together(components)?;
+
+    components
+        .iter()
+        .map(|component| {
+            let artifact = payloads.get(&component.id).cloned().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "prepared_artifact",
+                    format!(
+                        "No prepared payload exists for component '{}'",
+                        component.id
+                    ),
+                    None,
+                    None,
+                )
+            })?;
+            if artifact.component_id != component.id {
+                return Err(Error::validation_invalid_argument(
+                    "prepared_artifact.component_id",
+                    format!(
+                        "Prepared artifact is for '{}' rather than '{}'",
+                        artifact.component_id, component.id
+                    ),
+                    None,
+                    None,
+                ));
+            }
+            match component.deploy_strategy() {
+                Some("git" | "file") => {
+                    return Err(Error::validation_invalid_argument(
+                        "deploy_strategy",
+                        "Prepared artifacts require an artifact deploy strategy",
+                        None,
+                        None,
+                    ));
+                }
+                _ => {}
+            }
+            let install_dir = resolve_effective_remote_path(project, component, base_path)?;
+            validate_deploy_target(
+                &install_dir,
+                base_path,
+                &component.id,
+                &protected_path_suffixes(component),
+            )?;
+            Ok(ProjectPayloadBinding {
+                component: component.clone(),
+                artifact,
+                install_dir,
+            })
+        })
+        .collect()
+}
+
+fn validate_deploy_together(components: &[Component]) -> Result<()> {
+    let selected = components
+        .iter()
+        .map(|component| component.id.as_str())
+        .collect::<HashSet<_>>();
+    let mut missing = Vec::new();
+    for component in components {
+        for companion in &component.deploy_together {
+            if companion != &component.id && !selected.contains(companion.as_str()) {
+                missing.push(format!("{} requires {}", component.id, companion));
+            }
+        }
+    }
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        missing.sort();
+        Err(Error::validation_invalid_argument(
+            "deploy_together",
+            "Deploy selection omits coupled components",
+            None,
+            Some(missing),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn component(id: &str, remote_path: &str) -> Component {
+        Component {
+            id: id.to_string(),
+            remote_path: remote_path.to_string(),
+            ..Component::default()
+        }
+    }
+
+    fn payload(id: &str) -> PreparedDeployArtifact {
+        PreparedDeployArtifact {
+            component_id: id.to_string(),
+            path: "/private/tmp/payload.zip".to_string(),
+            durable_path: "/private/tmp/payload.zip".to_string(),
+            size_bytes: 7,
+            sha256: "hash".to_string(),
+            version: "1.0.0".to_string(),
+            tag: "v1.0.0".to_string(),
+            source_commit: "commit".to_string(),
+        }
+    }
+
+    fn project(id: &str) -> Project {
+        Project {
+            id: id.to_string(),
+            ..Project::default()
+        }
+    }
+
+    #[test]
+    fn binds_one_payload_to_two_project_paths_without_changing_identity() {
+        let component = component("fixture", "plugins/one");
+        let payload = payload("fixture");
+        let payloads = HashMap::from([("fixture".to_string(), payload.clone())]);
+        let first = bind_project_payloads(
+            &project("first"),
+            "/srv/first",
+            std::slice::from_ref(&component),
+            &payloads,
+        )
+        .expect("first binding");
+        let mut second_component = component;
+        second_component.remote_path = "plugins/two".to_string();
+        let second = bind_project_payloads(
+            &project("second"),
+            "/srv/second",
+            &[second_component],
+            &payloads,
+        )
+        .expect("second binding");
+
+        assert_eq!(first[0].artifact, payload);
+        assert_eq!(second[0].artifact, payload);
+        assert_eq!(first[0].install_dir, "/srv/first/plugins/one");
+        assert_eq!(second[0].install_dir, "/srv/second/plugins/two");
+    }
+
+    #[test]
+    fn rejects_invalid_bindings_before_effects() {
+        let mut coupled = component("one", "plugins/one");
+        coupled.deploy_together = vec!["two".to_string()];
+        let payloads = HashMap::from([("one".to_string(), payload("one"))]);
+        assert!(
+            bind_project_payloads(&project("site"), "/srv/site", &[coupled], &payloads)
+                .unwrap_err()
+                .to_string()
+                .contains("omits coupled")
+        );
+
+        let unsafe_component = component("one", "../outside");
+        assert!(bind_project_payloads(
+            &project("site"),
+            "/srv/site",
+            &[unsafe_component],
+            &payloads
+        )
+        .is_err());
+
+        assert!(bind_project_payloads(
+            &project("site"),
+            "/srv/site",
+            &[component("one", "")],
+            &payloads
+        )
+        .is_err());
+
+        let mut git_component = component("one", "plugins/one");
+        git_component.deploy_strategy = Some("git".to_string());
+        assert!(
+            bind_project_payloads(&project("site"), "/srv/site", &[git_component], &payloads)
+                .unwrap_err()
+                .to_string()
+                .contains("artifact deploy strategy")
+        );
+
+        let mismatch = HashMap::from([("one".to_string(), payload("other"))]);
+        assert!(bind_project_payloads(
+            &project("site"),
+            "/srv/site",
+            &[component("one", "plugins/one")],
+            &mismatch
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("rather than"));
+    }
+
+    #[test]
+    fn evidence_excludes_payload_paths() {
+        let payloads = HashMap::from([("fixture".to_string(), payload("fixture"))]);
+        let binding = bind_project_payloads(
+            &project("site"),
+            "/srv/site",
+            &[component("fixture", "plugins/fixture")],
+            &payloads,
+        )
+        .expect("binding");
+        let evidence = serde_json::to_string(&binding[0].evidence("site")).expect("evidence");
+
+        assert!(!evidence.contains("/private/tmp"));
+        assert!(!evidence.contains("durable_path"));
+    }
+}

--- a/crates/homeboy-core/src/deploy/mod.rs
+++ b/crates/homeboy-core/src/deploy/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod binding;
 mod effect;
 mod execution;
 mod generated_artifacts;
@@ -44,7 +45,7 @@ pub fn preflight_exact_ref(
 }
 
 use crate::component;
-use crate::context::resolve_project_ssh_with_base_path;
+use crate::context::{require_project_base_path, resolve_project_ssh_with_base_path};
 use crate::error::{Error, Result};
 use crate::phase_timing::PhaseTimer;
 use crate::project;
@@ -71,8 +72,35 @@ fn run_with_release_artifacts(
     if config.expected_version.is_none() {
         project::validate_deploy_component_local_paths(&project, &config.component_ids)?;
     }
+    preflight_prepared_payload_binding(&project, project_id, config)?;
     let (ctx, base_path) = resolve_project_ssh_with_base_path(project_id)?;
     orchestration::deploy_components(config, &project, &ctx, &base_path, release_artifacts)
+}
+
+/// Bind caller-supplied payloads before SSH context or lifecycle work begins.
+/// Locally prepared payloads follow the same binding primitive after preparation
+/// retains their process-local ownership guards.
+fn preflight_prepared_payload_binding(
+    project: &project::Project,
+    project_id: &str,
+    config: &DeployConfig,
+) -> Result<()> {
+    let Some(artifact) = config.prepared_artifact.as_ref() else {
+        return Ok(());
+    };
+    let base_path = require_project_base_path(project_id, project)?;
+    let components = config
+        .component_ids
+        .iter()
+        .map(|component_id| project::resolve_project_component(project, component_id))
+        .collect::<Result<Vec<_>>>()?;
+    binding::bind_project_payloads(
+        project,
+        &base_path,
+        &components,
+        &std::collections::HashMap::from([(artifact.component_id.clone(), artifact.clone())]),
+    )?;
+    Ok(())
 }
 
 /// Read deployed component versions without running deploy planning or git
@@ -153,6 +181,13 @@ pub fn run_multi(
         for component_id in component_ids {
             prepared_artifact.validate(component_id, config.expected_version.as_deref())?;
         }
+    }
+
+    // Every supplied payload must bind safely before this multi-target run
+    // creates lifecycle state or resolves an SSH context for any project.
+    for project_id in &valid_project_ids {
+        let project = project::load(project_id)?;
+        preflight_prepared_payload_binding(&project, project_id, config)?;
     }
 
     log_status!(

--- a/crates/homeboy-core/src/deploy/orchestration/prepared_payloads.rs
+++ b/crates/homeboy-core/src/deploy/orchestration/prepared_payloads.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::component::Component;
 use crate::project::Project;
 
+use super::super::binding::bind_project_payloads;
 use super::super::execution::{prepare_component_deploy, PreparedComponentDeploy};
 use super::super::preparation::{ComponentPayloadPreparationRequest, PreparedPayloadCollection};
 use super::super::types::{ComponentDeployResult, DeployConfig};
@@ -36,6 +37,11 @@ pub(super) fn prepare_component_deployments(
     let mut payloads = PreparedPayloadCollection::default();
     let mut release_artifact_store = ReleaseArtifactStore::default();
 
+    let mut binding_payloads = config
+        .prepared_artifact
+        .as_ref()
+        .map(|artifact| HashMap::from([(artifact.component_id.clone(), artifact.clone())]))
+        .unwrap_or_default();
     for component in components {
         let source_path = component.local_path.clone();
         let mut component = crate::project::apply_component_overrides(component, project);
@@ -66,6 +72,7 @@ pub(super) fn prepare_component_deployments(
                 }
                 match payloads.prepare(request, &mut release_artifact_store) {
                     Ok(payload) => {
+                        binding_payloads.insert(component.id.clone(), payload.artifact.clone());
                         let mut prepared = effective_config;
                         prepared.prepared_artifact = Some(payload.artifact.clone());
                         prepared.skip_build = true;
@@ -102,6 +109,31 @@ pub(super) fn prepare_component_deployments(
         ) {
             Ok(prepared) => prepared_deployments.push(prepared),
             Err(result) => failures.push(result),
+        }
+    }
+
+    // Bind payloads to this project's policy before execution preflight. The
+    // collection above retains the process-local artifact cleanup guards.
+    if !binding_payloads.is_empty() {
+        let binding_components = prepared_deployments
+            .iter()
+            .map(|deployment| deployment.component.clone())
+            .collect::<Vec<_>>();
+        if let Err(error) =
+            bind_project_payloads(project, base_path, &binding_components, &binding_payloads)
+        {
+            return Err(binding_components
+                .iter()
+                .map(|component| {
+                    ComponentDeployResult::failed(
+                        component,
+                        base_path,
+                        local_versions.get(&component.id).cloned(),
+                        remote_versions.get(&component.id).cloned(),
+                        error.to_string(),
+                    )
+                })
+                .collect());
         }
     }
 


### PR DESCRIPTION
## Summary
Add a mutation-free project binding layer that combines immutable prepared payloads with target-specific deployment policy before any remote effects.

## What changed
- Introduces validated target bindings that preserve immutable payload identity while applying project-specific remote paths and install instructions.
- Rejects missing or unsafe target paths, payload/component mismatches, incomplete deploy-together groups, and unsupported strategies before SSH or lifecycle effects.
- Routes supplied prepared payloads through binding before orchestration while preserving existing single-project behavior.

## How to test
1. Run `cargo test -p homeboy-core deploy::binding --lib`; expect passes.
2. Run `cargo test -p homeboy-core deploy::preparation --lib`; expect passes.
3. Run `cargo test -p homeboy-core deploy::orchestration --lib`; expect passes.
4. Run `rustfmt --edition 2021 --check crates/homeboy-core/src/deploy/binding.rs crates/homeboy-core/src/deploy/mod.rs crates/homeboy-core/src/deploy/orchestration/prepared_payloads.rs`; expect passes.
5. Run `git diff --check`; expect passes.
6. Run `homeboy review audit --changed-since origin/main --profile pr --placement local`; expect passes.

## Compatibility
No external API or extension compatibility impact is intended. Existing single-project deployment behavior remains supported through the new internal binding layer; project overrides affect binding/install instructions, not payload identity.

## Evidence
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8233
- audit: Passed
- format: Passed
- tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Prepared and rebased the mutation-free binding implementation, repaired prerequisite control-plane/test infrastructure, and ran deterministic verification; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8233
- Relates to Extra-Chill/homeboy#8229
