### PR TITLE
Preserve selected provider model in Lab-offloaded agent tasks

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -144,12 +144,7 @@ where
             .clone()
             .unwrap_or_else(|| format!("agent-task-{}", uuid::Uuid::new_v4()));
         let mut request = dispatch_service::resolve_dispatch_request(dispatch_args.into())?;
-        if request.core.resolved_provider_policy.is_none() {
-            request.core.resolved_provider_policy = Some(
-                dispatch_service::controller_resolved_execution_policy(&request),
-            );
-        }
-        let plan = match dispatch_service::build_dispatch_plan(&request) {
+        let plan = match dispatch_service::build_controller_dispatch_plan(&mut request) {
             Ok(plan) => plan,
             // A managed promotion handle may be intentionally unavailable until
             // after provider execution. Keep the compiled task durable and let
@@ -161,7 +156,7 @@ where
                     ) =>
             {
                 request.workspace = None;
-                dispatch_service::build_dispatch_plan(&request)?
+                dispatch_service::build_controller_dispatch_plan(&mut request)?
             }
             Err(error) => return Err(error),
         };

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -685,9 +685,10 @@ fn materialize_agent_task_cook_plan(
     if dispatch.cwd.is_none() && dispatch.workspace.is_none() {
         dispatch.workspace = Some(cook.to_worktree.clone());
     }
-    let request =
+    let mut request =
         homeboy::core::agent_tasks::dispatch_service::resolve_dispatch_request(dispatch.into())?;
-    homeboy::core::agent_tasks::dispatch_service::build_dispatch_plan(&request).map(Some)
+    homeboy::core::agent_tasks::dispatch_service::build_controller_dispatch_plan(&mut request)
+        .map(Some)
 }
 
 fn lab_route_dispatch_timeout(command: &Commands) -> Option<std::time::Duration> {

--- a/crates/homeboy-core/src/agent_task_dispatch_plan.rs
+++ b/crates/homeboy-core/src/agent_task_dispatch_plan.rs
@@ -1264,6 +1264,97 @@ mod tests {
     }
 
     #[test]
+    fn controller_plan_compilation_uses_initial_global_rotation_model() {
+        with_isolated_home(|_| {
+            let mut config = defaults::load_config();
+            config.agent_task.rotation = Some(
+                crate::agent_task_scheduler::AgentTaskProviderRotationPolicy {
+                    entries: vec![
+                        crate::agent_task_scheduler::AgentTaskProviderRotationEntry {
+                            model: Some("openai/gpt-5.6-terra".to_string()),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                },
+            );
+            defaults::save_config(&config).expect("save config");
+            let mut request = dispatch_request(DispatchRequestOverrides {
+                prompt: Some("Cook with the selected global model.".to_string()),
+                backend: Some("opencode".to_string()),
+                ..DispatchRequestOverrides::default()
+            });
+
+            let plan =
+                crate::agent_task_dispatch_service::build_controller_dispatch_plan(&mut request)
+                    .expect("controller plan");
+
+            assert_eq!(
+                plan.tasks[0].executor.model.as_deref(),
+                Some("openai/gpt-5.6-terra")
+            );
+            assert_eq!(
+                plan.tasks[0]
+                    .executor
+                    .runtime_selection
+                    .as_ref()
+                    .and_then(|selection| selection.model.as_deref()),
+                Some("openai/gpt-5.6-terra")
+            );
+        });
+    }
+
+    #[test]
+    fn controller_plan_compilation_preserves_submitted_provider_policy() {
+        with_isolated_home(|_| {
+            let mut config = defaults::load_config();
+            config.agent_task.rotation = Some(
+                crate::agent_task_scheduler::AgentTaskProviderRotationPolicy {
+                    entries: vec![
+                        crate::agent_task_scheduler::AgentTaskProviderRotationEntry {
+                            model: Some("global-model".to_string()),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                },
+            );
+            defaults::save_config(&config).expect("save config");
+            let submitted_policy =
+                crate::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy {
+                    backend: "opencode".to_string(),
+                    selector: None,
+                    model: Some("submitted-model".to_string()),
+                    rotation: None,
+                    rotation_starts_with_first_entry: false,
+                    retry: AgentTaskRetryPolicy::default(),
+                    liveness_timeout_ms: None,
+                };
+            let mut request = dispatch_request(DispatchRequestOverrides {
+                prompt: Some("Cook with the submitted model.".to_string()),
+                core: DispatchCoreInputs {
+                    resolved_provider_policy: Some(submitted_policy.clone()),
+                    ..DispatchCoreInputs::default()
+                },
+                ..DispatchRequestOverrides::default()
+            });
+
+            let plan =
+                crate::agent_task_dispatch_service::build_controller_dispatch_plan(&mut request)
+                    .expect("controller plan");
+
+            assert_eq!(
+                request.core.resolved_provider_policy,
+                Some(submitted_policy)
+            );
+            assert_eq!(
+                plan.tasks[0].executor.model.as_deref(),
+                Some("submitted-model")
+            );
+        });
+    }
+
+    #[test]
     fn builds_dispatch_plan_from_stored_prompt_reference() {
         with_isolated_home(|_| {
             agent_task_prompts::save_prompt("homeboy-7388", "Use the prompt store.")

--- a/crates/homeboy-core/src/agent_task_dispatch_service.rs
+++ b/crates/homeboy-core/src/agent_task_dispatch_service.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::agent_task_dispatch_plan::{
-    build_dispatch_plan_with_provider_requirements, preflight_dispatch_provider_secrets,
+    build_dispatch_plan, build_dispatch_plan_with_provider_requirements,
+    preflight_dispatch_provider_secrets,
 };
 use crate::agent_task_lifecycle as lifecycle;
 use crate::agent_task_lifecycle::{AgentTaskRunRecord, AgentTaskRunState};
@@ -328,6 +329,17 @@ pub fn controller_resolved_execution_policy(
         rotation,
         rotation_starts_with_first_entry: true,
     }
+}
+
+/// Build a controller-owned plan with a durable execution policy when the
+/// caller did not submit one explicitly.
+pub fn build_controller_dispatch_plan(
+    request: &mut AgentTaskDispatchRequest,
+) -> Result<AgentTaskPlan> {
+    if request.core.resolved_provider_policy.is_none() {
+        request.core.resolved_provider_policy = Some(controller_resolved_execution_policy(request));
+    }
+    build_dispatch_plan(request)
 }
 
 /// Resolve a typed dispatch request, using the supplied default-backend resolver

--- a/crates/homeboy-core/src/agent_tasks.rs
+++ b/crates/homeboy-core/src/agent_tasks.rs
@@ -200,8 +200,9 @@ pub mod dispatch_service {
         preflight_dispatch_provider_secrets,
     };
     pub use super::super::agent_task_dispatch_service::{
-        controller_resolved_execution_policy, dispatch, dispatch_with_provider_requirements,
-        resolve_dispatch_request, resolve_dispatch_request_with_default, run_dispatch_command,
+        build_controller_dispatch_plan, controller_resolved_execution_policy, dispatch,
+        dispatch_with_provider_requirements, resolve_dispatch_request,
+        resolve_dispatch_request_with_default, run_dispatch_command,
         run_dispatch_command_with_provider_catalog, AgentTaskDispatchCommand,
         AgentTaskDispatchReport, AgentTaskDispatchRequest, DispatchCoreInputs,
         DISPATCH_RESULT_SCHEMA,

--- a/crates/homeboy-core/src/runner/lab_args/tests.rs
+++ b/crates/homeboy-core/src/runner/lab_args/tests.rs
@@ -1716,7 +1716,7 @@ mod materialize_specs_tests {
             "tasks": [{
                 "task_id": "task-1",
                 "workspace": { "root": controller },
-                "executor": { "config": {
+                "executor": { "backend": "opencode", "model": "openai/gpt-5.6-terra", "config": {
                     "workspace": controller,
                     "workspace_root": controller,
                     "provider_plugin_paths": [controller_plugin],
@@ -1756,6 +1756,11 @@ mod materialize_specs_tests {
         assert_eq!(
             staged["tasks"][0]["workspace"]["root"],
             runner.display().to_string()
+        );
+        assert_eq!(staged["tasks"][0]["executor"]["backend"], "opencode");
+        assert_eq!(
+            staged["tasks"][0]["executor"]["model"],
+            "openai/gpt-5.6-terra"
         );
         assert_eq!(
             staged["tasks"][0]["metadata"]["workspace_source_provenance"]["controller_root"],


### PR DESCRIPTION
## Summary
Preserve the controller-selected provider model through Lab cook-plan compilation and materialization.

## What changed
- Added one shared controller plan compiler used by local and Lab cooks, preserving explicit policies and attaching the configured rotation policy when absent.
- Added deterministic tests proving rotation entry zero reaches executor.model/runtime\_selection.model and survives Lab staged-plan remapping.

## How to test
1. Run `cargo test -p homeboy-core controller_plan_compilation --lib`; expect 2 focused controller policy tests pass..
2. Run `cargo test -p homeboy-core materialize_agent_task_specs_remaps_and_stages_cook_attempt_plan_for_runner_harvest --lib`; expect The Lab staged-plan model preservation test passes..
3. Run `cargo check -p homeboy-cli`; expect The Homeboy CLI and touched core compile successfully..

## Compatibility
Behavioral correction: Lab-offloaded cooks now invoke the controller-selected model instead of the adapter default. Explicit submitted provider policies remain unchanged; no public API or extension-path compatibility impact.

## Evidence
- CI expected: Audit
- CI expected: Lint
- CI expected: Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8466
- build: Passed
- controller-policy-tests: Passed
- lab-materialization-test: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode direct recovery executor
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab model-propagation defect, implemented the shared controller plan compiler and deterministic regression coverage; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8466
