### PR TITLE
Require declared artifacts in GitHub releases

### DIFF
--- a/crates/homeboy-core/src/release/execution_dispatch.rs
+++ b/crates/homeboy-core/src/release/execution_dispatch.rs
@@ -107,6 +107,7 @@ pub(super) fn execute_release_plan_step(
             executor::run_package(
                 context.extensions,
                 &mut context.state,
+                context.component,
                 context.component_id,
                 &context.component.local_path,
                 None,

--- a/crates/homeboy-core/src/release/executor.rs
+++ b/crates/homeboy-core/src/release/executor.rs
@@ -762,6 +762,7 @@ mod tests {
             let result = run_package(
                 &[package],
                 &mut state,
+                &Component::default(),
                 "fixture",
                 &component.path().to_string_lossy(),
                 None,
@@ -806,15 +807,25 @@ mod tests {
     #[test]
     fn run_package_collects_declared_component_artifact_alongside_provider_artifacts() {
         crate::test_support::with_isolated_home(|_| {
-            let component = tempfile::tempdir().expect("component tempdir");
+            let component_dir = tempfile::tempdir().expect("component tempdir");
             let package = release_package_extension(
                 "nodejs",
-                "mkdir -p packages/plugin/dist target; \
-                 printf plugin > packages/plugin/dist/plugin.zip; \
-                 printf npm > target/plugin-1.2.3.tgz; \
+                "mkdir -p target; printf npm > target/plugin-1.2.3.tgz; \
                  printf '[{\"path\":\"target/plugin-1.2.3.tgz\",\"type\":\"npm\"}]'",
             );
             crate::extension::save_manifest(&package).expect("save package extension");
+            let component = Component {
+                id: "plugin".to_string(),
+                local_path: component_dir.path().to_string_lossy().to_string(),
+                build_artifact: Some("packages/plugin/dist/plugin.zip".to_string()),
+                scripts: Some(crate::component::ComponentScriptsConfig {
+                    build: vec![
+                        "test ! -e .homeboy-build-count; printf built > .homeboy-build-count; mkdir -p packages/plugin/dist; printf plugin > packages/plugin/dist/plugin.zip".to_string(),
+                    ],
+                    ..Default::default()
+                }),
+                ..Component::default()
+            };
 
             let mut state = ReleaseState {
                 version: Some("1.2.3".to_string()),
@@ -823,8 +834,9 @@ mod tests {
             run_package(
                 &[package],
                 &mut state,
+                &component,
                 "plugin",
-                &component.path().to_string_lossy(),
+                &component.local_path,
                 None,
                 Some("packages/plugin/dist/plugin.zip"),
                 false,
@@ -838,6 +850,11 @@ mod tests {
                 .durable_path
                 .as_deref()
                 .is_some_and(|path| std::path::Path::new(path).is_file()));
+            assert_eq!(
+                std::fs::read_to_string(component_dir.path().join(".homeboy-build-count"))
+                    .expect("component build marker"),
+                "built"
+            );
         });
     }
 
@@ -855,6 +872,7 @@ mod tests {
             let error = run_package(
                 &[package],
                 &mut ReleaseState::default(),
+                &Component::default(),
                 "plugin",
                 &component.path().to_string_lossy(),
                 None,
@@ -865,7 +883,7 @@ mod tests {
 
             assert!(error
                 .message
-                .contains("was not produced by release.package"));
+                .contains("was not produced by the component build or release.package"));
             assert_eq!(error.details["field"], "build_artifact");
         });
     }
@@ -953,6 +971,7 @@ mod tests {
             let result = run_package(
                 &[package_a, non_package_extension("docs"), package_b],
                 &mut state,
+                &Component::default(),
                 "fixture",
                 &component.path().to_string_lossy(),
                 None,
@@ -988,6 +1007,7 @@ mod tests {
             let result = run_package(
                 &[package],
                 &mut state,
+                &Component::default(),
                 "intelligence-horse-theme",
                 &component.path().to_string_lossy(),
                 None,
@@ -1089,6 +1109,7 @@ mod tests {
             let err = run_package(
                 &[package],
                 &mut state,
+                &Component::default(),
                 "fixture",
                 &component.path().to_string_lossy(),
                 None,
@@ -1121,6 +1142,7 @@ mod tests {
             let err = run_package(
                 &[package_a, package_b],
                 &mut state,
+                &Component::default(),
                 "fixture",
                 &component.path().to_string_lossy(),
                 None,
@@ -1159,6 +1181,7 @@ mod tests {
             let err = run_package(
                 &[package],
                 &mut state,
+                &Component::default(),
                 "fixture",
                 &component.path().to_string_lossy(),
                 None,
@@ -1211,6 +1234,7 @@ mod tests {
             let result = run_package(
                 &[package],
                 &mut state,
+                &Component::default(),
                 "fixture",
                 &component.path().to_string_lossy(),
                 None,

--- a/crates/homeboy-core/src/release/executor/package.rs
+++ b/crates/homeboy-core/src/release/executor/package.rs
@@ -4,7 +4,9 @@
 //!
 //! Split out of `executor.rs` to keep packaging/payload logic together.
 
+use crate::component::Component;
 use crate::error::{Error, Result};
+use crate::extension::ExtensionCapability;
 use crate::extension::{self, ExtensionManifest};
 use std::path::{Path, PathBuf};
 
@@ -25,6 +27,7 @@ const PACKAGE_ACTION_MAX_ATTEMPTS: usize = 2;
 pub(crate) fn run_package(
     extensions: &[ExtensionManifest],
     state: &mut ReleaseState,
+    component: &Component,
     component_id: &str,
     component_local_path: &str,
     component_source_path: Option<&str>,
@@ -46,6 +49,8 @@ pub(crate) fn run_package(
             ]),
         ));
     }
+
+    build_declared_component_artifact(component, declared_build_artifact)?;
 
     let extra_config = package_build_config(skip_build_validation);
     let mut responses = Vec::new();
@@ -96,6 +101,35 @@ pub(crate) fn run_package(
     Ok(step_success("package", "package", Some(data), Vec::new()))
 }
 
+/// Run the component-owned build contract before package providers when it is
+/// responsible for the declared deploy artifact. Providers may emit other
+/// release assets without knowing how to build that artifact.
+fn build_declared_component_artifact(
+    component: &Component,
+    declared_build_artifact: Option<&str>,
+) -> Result<()> {
+    if declared_build_artifact.is_none_or(|path| path.trim().is_empty())
+        || !component.has_script(ExtensionCapability::Build)
+    {
+        return Ok(());
+    }
+
+    let (exit_code, build_error) = crate::build::build_component(component);
+    if let Some(error) = build_error {
+        return Err(Error::validation_invalid_argument(
+            "scripts.build",
+            format!(
+                "Failed to build declared build_artifact for component '{}' (exit {:?}): {}",
+                component.id, exit_code, error
+            ),
+            Some(component.id.clone()),
+            None,
+        ));
+    }
+
+    Ok(())
+}
+
 /// Add a component-owned deploy artifact even when its packaging provider also
 /// emits unrelated release artifacts (for example, a registry tarball).
 fn collect_declared_build_artifact(
@@ -115,12 +149,13 @@ fn collect_declared_build_artifact(
         return Err(Error::validation_invalid_argument(
             "build_artifact",
             format!(
-                "Configured build_artifact '{}' was not produced by release.package",
+                "Configured build_artifact '{}' was not produced by the component build or release.package",
                 declared_build_artifact
             ),
             Some(declared_path.display().to_string()),
             Some(vec![
-                "Update the component-owned release.package command to produce the configured build_artifact.".to_string(),
+                "Ensure scripts.build or release.package produces the configured build_artifact."
+                    .to_string(),
             ]),
         ));
     }

--- a/crates/homeboy-core/src/release/package_recovery.rs
+++ b/crates/homeboy-core/src/release/package_recovery.rs
@@ -49,6 +49,7 @@ pub fn package_existing_tag(
     let package_step = run_package(
         &extensions,
         &mut state,
+        &component,
         component_id,
         &component.local_path,
         None,


### PR DESCRIPTION
## Summary
Compose component-owned deploy artifact builds with extension release packages and refuse GitHub publication when the declared artifact is absent.

## What changed
- Run the component build contract once before extension packaging when build\_artifact is declared, persist that artifact alongside provider outputs, carry the behavior into package recovery, and validate GitHub Release assets before publication.

## How to test
1. Run `cargo check --workspace`; expect The workspace compiles successfully..
2. Run `cargo test -p homeboy-core declared_artifact --lib`; expect The declared-artifact fail-closed and publication tests pass..
3. Run `cargo test -p homeboy-core run_package_collects_declared_component_artifact_alongside_provider_artifacts --lib`; expect The component build produces the declared ZIP and Homeboy collects it alongside the provider tarball..

## Compatibility
No CLI or schema removal. Components without build\_artifact retain existing packaging behavior; components with build\_artifact now run their declared build contract and fail closed before GitHub publication if the artifact is missing.

## Evidence
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/3366
- declared-artifact-tests: Passed
- workspace-check: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy and OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Diagnosed the release artifact contract regression, drafted and reviewed the generic fix and deterministic coverage, and orchestrated verification; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#3366
