### PR TITLE
Fix cook Lab handoff ownership

### DIFF
--- a/crates/homeboy-cli/src/command_contract/lab.rs
+++ b/crates/homeboy-cli/src/command_contract/lab.rs
@@ -43,6 +43,20 @@ fn scope_lab_cli_arguments_at_path(
     } else {
         command
     };
+    // Cook coordinates durable promotion and finalization, so it cannot hand
+    // its controller lifecycle to the generic queue. Keep parsing the inherited
+    // dispatch flag for a precise validation error, but do not advertise it.
+    let command = if matches!(
+        path.iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .as_slice(),
+        ["agent-task", "cook"]
+    ) {
+        command.mut_arg("queue_only", |arg| arg.hide(true))
+    } else {
+        command
+    };
     command.mut_subcommands(|subcommand| {
         let mut subcommand_path = path.to_vec();
         subcommand_path.push(subcommand.get_name().to_string());

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -114,6 +114,16 @@ where
             None,
         ));
     }
+    if args.dispatch.core.queue_only {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "queue-only",
+            "agent-task cook cannot queue its controller-owned lifecycle; it must retain provider completion to ingest artifacts, promote candidates, run gates, and finalize",
+            None,
+            Some(vec![
+                "Use `homeboy agent-task run-plan --plan <materialized-plan> --record-run-id <run-id> --queue-only` only when a controller owns the corresponding continuation.".to_string(),
+            ]),
+        ));
+    }
 
     let mut dispatch_args = args.dispatch.clone();
     if dispatch_args.prompt.is_none() {
@@ -130,7 +140,6 @@ where
                 .unwrap_or_else(|| agent_task_lifecycle::cook_attempt_run_id(cook_id, 1)),
         );
     }
-    dispatch_args.core.queue_only = false;
     let (run_id, initial_plan) = if let Some(attempt_plan) = args.attempt_plan.as_deref() {
         let run_id = dispatch_args.run_id.clone().ok_or_else(|| {
             homeboy::core::Error::internal_unexpected(

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -8,6 +8,43 @@ use crate::cli_surface::{Cli, Commands};
 use super::super::AgentTaskCommand;
 
 #[test]
+fn cook_rejects_queue_only_before_creating_a_durable_recipe() {
+    with_isolated_home(|_| {
+        let cli = Cli::parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the fix",
+            "--to-worktree",
+            "missing@worktree",
+            "--verify",
+            "true",
+            "--queue-only",
+            "--run-id",
+            "cook-queue-only",
+        ]);
+        let Commands::AgentTask(args) = cli.command else {
+            panic!("agent-task cook command");
+        };
+        let AgentTaskCommand::Cook(cook) = args.command else {
+            panic!("cook command");
+        };
+
+        let error = super::super::run::run_cook_with_executor(
+            cook,
+            ExtensionProviderAgentTaskExecutor::default(),
+        )
+        .expect_err("queue-only cook must fail before resolving its worktree");
+
+        assert!(error
+            .message
+            .contains("cannot queue its controller-owned lifecycle"));
+        assert!(!homeboy::core::agent_task_service::recipe_exists("cook-queue-only").unwrap());
+    });
+}
+
+#[test]
 fn from_spec_dispatch_defaults_use_spec_git_checkout() {
     let repo = tempfile::tempdir().expect("repo dir");
     let git_status = Command::new("git")

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -329,16 +329,34 @@ fn run_split_placement_cook(
     output_file: Option<&str>,
     runner_id: Option<&str>,
 ) -> homeboy::core::Result<Option<i32>> {
-    if cli.placement == homeboy::cli_surface::Placement::Local {
-        return Ok(None);
-    }
-    let Some(runner_id) = runner_id else {
-        return Ok(None);
-    };
     let Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
         command: crate::commands::agent_task::AgentTaskCommand::Cook(cook),
     }) = &cli.command
     else {
+        return Ok(None);
+    };
+    if cook.dispatch.core.queue_only {
+        return Err(Error::validation_invalid_argument(
+            "queue-only",
+            "agent-task cook cannot queue its controller-owned lifecycle; it must retain provider completion to ingest artifacts, promote candidates, run gates, and finalize",
+            None,
+            Some(vec![
+                "Use `homeboy agent-task run-plan --plan <materialized-plan> --record-run-id <run-id> --queue-only` only when a controller owns the corresponding continuation.".to_string(),
+            ]),
+        ));
+    }
+    if cli.placement == homeboy::cli_surface::Placement::Local {
+        if cli.runner.is_some() {
+            return Err(Error::validation_invalid_argument(
+                "runner",
+                "--placement local cannot be combined with --runner for agent-task cook; omit --runner for a fully local cook or select Lab placement for its provider attempt",
+                cli.runner.clone(),
+                None,
+            ));
+        }
+        return Ok(None);
+    }
+    let Some(runner_id) = runner_id else {
         return Ok(None);
     };
 

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -927,6 +927,33 @@ fn explicit_local_cook_does_not_enter_lab_attempt_dispatch() {
 }
 
 #[test]
+fn explicit_local_cook_runner_is_rejected_before_worktree_resolution() {
+    let cli = Cli::parse_from([
+        "homeboy",
+        "--placement",
+        "local",
+        "--runner",
+        "homeboy-lab",
+        "agent-task",
+        "cook",
+        "--to-worktree",
+        "missing@worktree",
+        "--verify",
+        "true",
+        "--prompt",
+        "stay local",
+    ]);
+
+    let error = run_split_placement_cook(&cli, &[], None, Some("homeboy-lab"))
+        .expect_err("mixed local placement and runner must fail before plan materialization");
+
+    assert_eq!(error.details["field"], "runner");
+    assert!(error
+        .message
+        .contains("--placement local cannot be combined with --runner"));
+}
+
+#[test]
 fn cook_to_worktree_provider_workspace_survives_failed_attempt_and_lab_retry() {
     crate::test_support::with_isolated_home(|_| {
         let workspace = tempfile::tempdir().expect("workspace");

--- a/crates/homeboy-cli/src/commands/utils/resource_policy.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy.rs
@@ -147,6 +147,29 @@ pub fn hot_command(command: &Commands) -> Option<HotCommand> {
         return None;
     }
 
+    if matches!(
+        command,
+        Commands::AgentTask(agent_task::AgentTaskArgs {
+            command: agent_task::AgentTaskCommand::Cook(cook),
+        }) if cook.dispatch.core.queue_only
+    ) {
+        return None;
+    }
+
+    // Cook's controller remains local, but its materialized provider attempt
+    // can run on Lab. Resource policy must recommend that supported boundary,
+    // rather than treating the whole coordinator as an unavailable offload.
+    if matches!(
+        command,
+        Commands::AgentTask(agent_task::AgentTaskArgs {
+            command: agent_task::AgentTaskCommand::Cook(_),
+        })
+    ) {
+        return Some(HotCommand::lab_supported(
+            "agent-task cook/run-plan/retry --run",
+        ));
+    }
+
     let contract = command.lab_contract()?;
 
     match contract.portability {
@@ -527,7 +550,7 @@ mod tests {
     }
 
     #[test]
-    fn verified_agent_task_cook_keeps_its_controller_on_a_warm_controller() {
+    fn verified_agent_task_cook_can_offload_its_provider_attempt() {
         let cli = Cli::parse_from([
             "homeboy",
             "agent-task",
@@ -540,8 +563,26 @@ mod tests {
             "cargo test --locked",
         ]);
         let command = hot_command(&cli.command).expect("verified cook is hot");
-        assert!(!command.lab_offload_supported);
+        assert!(command.lab_offload_supported);
         assert_eq!(command.label, "agent-task cook/run-plan/retry --run");
+    }
+
+    #[test]
+    fn queue_only_cook_skips_resource_preflight_for_controller_validation() {
+        let cli = Cli::parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the fix",
+            "--to-worktree",
+            "example@worktree",
+            "--verify",
+            "true",
+            "--queue-only",
+        ]);
+
+        assert!(hot_command(&cli.command).is_none());
     }
 
     #[test]

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -1,0 +1,65 @@
+use std::process::Command;
+
+fn homeboy() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_homeboy"))
+}
+
+#[test]
+fn cook_rejects_invalid_controller_transport_before_worktree_resolution() {
+    let output = homeboy()
+        .args([
+            "--placement",
+            "local",
+            "--runner",
+            "homeboy-lab",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the fix",
+            "--to-worktree",
+            "missing@worktree",
+            "--verify",
+            "true",
+        ])
+        .output()
+        .expect("run homeboy");
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--placement local cannot be combined with --runner"));
+    assert!(!stdout.contains("worktree provider"));
+}
+
+#[test]
+fn cook_rejects_queue_only_before_worktree_resolution() {
+    let output = homeboy()
+        .args([
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the fix",
+            "--to-worktree",
+            "missing@worktree",
+            "--verify",
+            "true",
+            "--queue-only",
+        ])
+        .output()
+        .expect("run homeboy");
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("cannot queue its controller-owned lifecycle"));
+    assert!(!stdout.contains("worktree provider"));
+}
+
+#[test]
+fn cook_help_does_not_advertise_queue_only() {
+    let output = homeboy()
+        .args(["agent-task", "cook", "--help"])
+        .output()
+        .expect("run homeboy help");
+
+    assert!(output.status.success());
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("\n      --queue-only\n"));
+}


### PR DESCRIPTION
## Summary
Keep the cook lifecycle on the controller while offloading only eligible provider execution to Lab.

## What changed
- Classify cook as a controller-owned handoff, reject recursive queue-only transports before worktree resolution, and align resource policy with the supported provider offload boundary.

## How to test
1. Run `cargo test --test cook_lab_handoff_test -- --nocapture`; expect All three cook handoff regression tests pass..
2. Run `cargo check --workspace`; expect The Homeboy workspace compiles successfully..
3. Run `git diff --check`; expect The patch contains no whitespace errors..

## Compatibility
No CLI invocation is removed; invalid recursive cook queueing now fails earlier, while supported cook Lab execution completes through the controller-owned lifecycle.

## Evidence
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8454
- cargo-check: Passed
- diff-check: Passed
- focused-tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the control-plane failure, drafted the implementation and regression tests, and ran deterministic verification with Chris supervising.

## Source relationships
- Closes Extra-Chill/homeboy#8454
