### PR TITLE
fix(audit): dead-code detector must ignore comment/string mentions (would have caught validate_write)

### DIFF
--- a/crates/homeboy-core/src/code_audit/dead_code.rs
+++ b/crates/homeboy-core/src/code_audit/dead_code.rs
@@ -10,7 +10,7 @@ use std::collections::{HashMap, HashSet};
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
-use super::import_matching::contains_word;
+use super::import_matching::contains_word_in_code;
 use super::walker::is_test_path;
 use crate::component::AuditConfig;
 
@@ -157,7 +157,10 @@ pub(crate) fn analyze_dead_code_with_config(
                     if other.internal_calls.contains(export) {
                         return true;
                     }
-                    if contains_word(&other.content, export) {
+                    // Match against code only — an identifier that appears solely
+                    // in a comment or string literal (e.g. similarity-test data)
+                    // is not a real reference and must not mask dead code.
+                    if contains_word_in_code(&other.content, export) {
                         return true;
                     }
                     // Check if the other file imports something that matches
@@ -617,6 +620,42 @@ mod tests {
             .filter(|f| f.kind == AuditFinding::UnreferencedExport)
             .collect();
         assert_eq!(unreferenced.len(), 2); // compute and transform both unreferenced
+    }
+
+    #[test]
+    fn string_literal_mention_does_not_mask_unreferenced_export() {
+        // Regression: a dead `pub fn validate_only` survived because another
+        // file contained the identifier only as string-similarity TEST DATA
+        // (e.g. `normalized_similarity("validate_write", "validate_only")`).
+        // A raw whole-word content scan counted that as a reference. The
+        // code-only match must ignore identifiers inside string literals.
+        let mut owner = make_fingerprint(
+            "src/validate_write.rs",
+            vec!["validate_only"],
+            vec!["validate_only"],
+            vec![],
+            vec![],
+        );
+        owner.content = "pub fn validate_only(root: &Path) -> Result<()> { Ok(()) }".to_string();
+
+        let mut other = make_fingerprint("src/fixes.rs", vec!["score"], vec![], vec![], vec![]);
+        // `validate_only` appears ONLY inside a string literal and a comment.
+        other.content = r#"
+            // Typical renames: validate_write -> validate_only
+            fn score() -> f64 {
+                normalized_similarity("validate_write", "validate_only")
+            }
+        "#
+        .to_string();
+
+        let findings = analyze_dead_code(&[&owner, &other], &[]);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.kind == AuditFinding::UnreferencedExport
+                    && f.description.contains("validate_only")),
+            "validate_only should be flagged as unreferenced despite string/comment mentions"
+        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/code_audit/import_matching.rs
+++ b/crates/homeboy-core/src/code_audit/import_matching.rs
@@ -488,6 +488,84 @@ pub(crate) fn contains_word(text: &str, word: &str) -> bool {
     false
 }
 
+/// Like [`contains_word`], but ignores matches that occur only inside line
+/// comments or double-quoted string literals.
+///
+/// A raw whole-word scan counts an identifier as "used" even when it appears
+/// solely as prose in a comment or as test/fixture string data. That produces
+/// false negatives in reference analysis — e.g. a dead `pub fn validate_only`
+/// looked "referenced" because another file contained the string literal
+/// `"validate_only"` as similarity-test data. Blanking comments and string
+/// contents first keeps only genuine code references.
+pub(crate) fn contains_word_in_code(content: &str, word: &str) -> bool {
+    contains_word(&blank_comments_and_strings(content), word)
+}
+
+/// Replace the interior of line comments (`//`, `#`) and double-quoted string
+/// literals with spaces, preserving byte offsets and newlines. Language-agnostic
+/// and deliberately conservative: it only needs to stop identifiers inside
+/// comments/strings from reading as code references.
+fn blank_comments_and_strings(content: &str) -> String {
+    let mut out = String::with_capacity(content.len());
+    for line in content.split_inclusive('\n') {
+        let bytes = line.as_bytes();
+        let mut i = 0;
+        let mut in_string = false;
+        let mut escaped = false;
+        let mut in_comment = false;
+        while i < bytes.len() {
+            let ch = bytes[i] as char;
+            if in_comment {
+                out.push(if ch == '\n' { '\n' } else { ' ' });
+                i += 1;
+                continue;
+            }
+            if in_string {
+                match ch {
+                    _ if escaped => {
+                        escaped = false;
+                        out.push(' ');
+                    }
+                    '\\' => {
+                        escaped = true;
+                        out.push(' ');
+                    }
+                    '"' => {
+                        in_string = false;
+                        out.push('"');
+                    }
+                    '\n' => out.push('\n'),
+                    _ => out.push(' '),
+                }
+                i += 1;
+                continue;
+            }
+            // Not in string/comment.
+            if ch == '"' {
+                in_string = true;
+                out.push('"');
+                i += 1;
+                continue;
+            }
+            if ch == '/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+                in_comment = true;
+                out.push(' ');
+                i += 1;
+                continue;
+            }
+            if ch == '#' {
+                in_comment = true;
+                out.push(' ');
+                i += 1;
+                continue;
+            }
+            out.push(ch);
+            i += 1;
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -722,6 +800,35 @@ fn production(values: BTreeMap<String, f64>) {}
         assert!(!contains_word("SerializeMe", "Serialize"));
         assert!(!contains_word("MySerialize", "Serialize"));
         assert!(!contains_word("_Serialize_ext", "Serialize"));
+    }
+
+    #[test]
+    fn contains_word_in_code_ignores_comments_and_strings() {
+        // Real code reference — counts.
+        assert!(contains_word_in_code(
+            "let x = validate_only(root);",
+            "validate_only"
+        ));
+        // Only inside a line comment — does not count.
+        assert!(!contains_word_in_code(
+            "// rename validate_write -> validate_only\nfn score() {}",
+            "validate_only"
+        ));
+        // Only inside a string literal (similarity test data) — does not count.
+        assert!(!contains_word_in_code(
+            r#"let s = normalized_similarity("validate_write", "validate_only");"#,
+            "validate_only"
+        ));
+        // A real call on the same line as an unrelated string still counts.
+        assert!(contains_word_in_code(
+            r#"log("running"); validate_only(root);"#,
+            "validate_only"
+        ));
+        // `#` line comment (e.g. shell/ruby-style) is also ignored.
+        assert!(!contains_word_in_code(
+            "# see validate_only\n",
+            "validate_only"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Chubes called it: the audit **should** have flagged the orphaned `engine::validate_write` module (removed in #8474) — and it didn't. This fixes the detector gap.

### Root cause

The `UnreferencedExport` check has a raw-content fallback:
```rust
if contains_word(&other.content, export) { return true; }  // "referenced"
```
`contains_word` matches the whole `other.content` string — **including comments and string literals**. `validate_only` survived audits because `orphaned_test_fixes.rs` contains:
```rust
normalized_similarity("validate_write", "validate_only")  // string-similarity TEST DATA
```
That string literal counted as a "reference", masking the dead function. Same class of false-positive that inflates raw grep counts throughout the codebase.

### Fix

Add `contains_word_in_code`, which blanks the interior of line comments (`//`, `#`) and double-quoted string literals — preserving byte offsets and newlines — before the whole-word match. Wire it into the cross-file reference scan in `dead_code.rs`.

Structured signals (`internal_calls`, `imports`) are untouched; only the raw-content fallback becomes code-aware. Conservative by design: it just stops identifiers-in-prose from reading as code references.

### Tests

- `import_matching::contains_word_in_code_ignores_comments_and_strings` — real refs match; comment-only and string-only mentions don't; mixed lines still match real refs; `#` comments handled.
- `dead_code::string_literal_mention_does_not_mask_unreferenced_export` — reproduces the exact `validate_only` scenario and asserts it's now flagged.

## Verification

- `cargo check -p homeboy-core --lib` — clean
- **25 dead_code + 38 import_matching tests pass**, no regressions

Refs #8425