### PR TITLE
Replace global upgrade quiescence with blue-green runtime promotion

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -269,6 +269,7 @@ pub fn submit_plan(
         .unwrap_or_else(default_run_id);
     let plan_path = store::write_plan(&run_id, plan)?;
 
+    let admission = crate::controller_runtime::admit_current()?;
     let mut metadata = json!({
         "task_count": plan.tasks.len(),
         "max_concurrency": plan.options.max_concurrency,
@@ -277,7 +278,7 @@ pub fn submit_plan(
         "note": "submitted tasks are durable; provider run ids are recorded after an executor returns them as generic artifacts or evidence refs"
     });
     metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
-        crate::controller_runtime::pin_current()?;
+        admission.runtime.clone();
     if let Ok(runner_id) = std::env::var(crate::runner::RUNNER_ID_ENV) {
         if !runner_id.trim().is_empty() {
             metadata["runner_id"] = json!(runner_id);

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -160,17 +160,17 @@ fn submit_plan_persists_owner_only_plan_file_before_observation() {
 }
 
 #[test]
-fn active_pinned_run_blocks_controller_binary_replacement() {
+fn active_pinned_run_does_not_block_controller_promotion() {
     with_isolated_home(|_| {
         submit_plan(&test_plan(), Some("active-pinned-runtime")).expect("submitted");
 
-        let error = crate::upgrade::refuse_upgrade_while_durable_runs_are_active()
-            .expect_err("active durable run must hold its controller runtime");
-
-        assert!(error.message.contains("active-pinned-runtime"));
-        assert!(error
-            .message
-            .contains("refusing to replace the controller binary"));
+        // Promotion no longer drains durable work. The record owns its pinned
+        // runtime and remains available while later admissions switch.
+        crate::controller_runtime::activate_current_generation()
+            .expect("active durable run must not block promotion");
+        let after = submit_plan(&test_plan(), Some("post-promotion-runtime"))
+            .expect("post-switch submission");
+        assert_eq!(after.state, AgentTaskRunState::Queued);
     });
 }
 

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -1,11 +1,30 @@
 //! Immutable controller executable provenance for durable orchestration work.
 
 use serde_json::{json, Value};
-use std::path::PathBuf;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use crate::{build_identity, paths, Error, Result};
 
 pub(crate) const CONTROLLER_RUNTIME_METADATA_KEY: &str = "controller_runtime";
+
+const ACTIVE_GENERATION_FILE: &str = "active.json";
+const ADMISSION_LOCK_DIR: &str = "admission.lock";
+
+/// Holds the short admission critical section.  Keeping selection and durable
+/// record creation together prevents a submission from observing A after B is
+/// published.
+pub(crate) struct RuntimeAdmission {
+    lock_path: PathBuf,
+    pub runtime: Value,
+}
+
+impl Drop for RuntimeAdmission {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir(&self.lock_path);
+    }
+}
 
 pub(crate) fn pin_current() -> Result<Value> {
     let identity = build_identity::current();
@@ -30,25 +49,81 @@ pub(crate) fn pin_current() -> Result<Value> {
                 Some("pin controller executable".to_string()),
             )
         })?;
+        make_executable_read_only(&pinned_path)?;
     }
 
+    let digest = executable_digest(&pinned_path)?;
+
     Ok(json!({
-        "schema": "homeboy/controller-runtime-pin/v1",
+        "schema": "homeboy/controller-runtime-pin/v2",
         "requested": identity.display,
         "originating": {
             "build_identity": identity.display,
             "executable": executable,
             "pinned_executable": pinned_path,
+            "sha256": digest,
         },
         "current": identity.display,
         "executed": identity.display,
     }))
 }
 
+/// Select the durable active generation while serializing only admission.  The
+/// first admission initializes it; subsequent admissions must use the already
+/// selected immutable artifact rather than whichever binary happened to start
+/// the submitting process.
+pub(crate) fn admit_current() -> Result<RuntimeAdmission> {
+    let root = runtime_root()?;
+    let lock_path = root.join(ADMISSION_LOCK_DIR);
+    acquire_admission_lock(&lock_path)?;
+    let active = root.join(ACTIVE_GENERATION_FILE);
+    let runtime = if active.exists() {
+        let value = fs::read_to_string(&active).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("read active controller generation".to_string()),
+            )
+        })?;
+        serde_json::from_str(&value).map_err(|error| {
+            Error::validation_invalid_json(
+                error,
+                Some("parse active controller generation".to_string()),
+                None,
+            )
+        })?
+    } else {
+        let runtime = pin_current()?;
+        write_active_generation(&active, &runtime)?;
+        runtime
+    };
+    if let Err(error) = validate_pin(&runtime) {
+        let _ = fs::remove_dir(&lock_path);
+        return Err(error);
+    }
+    Ok(RuntimeAdmission { lock_path, runtime })
+}
+
+/// Publish the current executable as the generation selected for future
+/// admissions. Existing records retain their own pinned runtime metadata.
+pub(crate) fn activate_current_generation() -> Result<Value> {
+    let root = runtime_root()?;
+    let lock_path = root.join(ADMISSION_LOCK_DIR);
+    acquire_admission_lock(&lock_path)?;
+    let result = (|| {
+        let runtime = pin_current()?;
+        validate_pin(&runtime)?;
+        write_active_generation(&root.join(ACTIVE_GENERATION_FILE), &runtime)?;
+        Ok(runtime)
+    })();
+    let _ = fs::remove_dir(lock_path);
+    result
+}
+
 pub(crate) fn validate_for_mutation(metadata: &Value, current_identity: &str) -> Result<()> {
     let Some(runtime) = metadata.get(CONTROLLER_RUNTIME_METADATA_KEY) else {
         return Ok(());
     };
+    validate_pin(runtime)?;
     let originating = runtime
         .pointer("/originating/build_identity")
         .and_then(Value::as_str)
@@ -72,6 +147,141 @@ pub(crate) fn validate_for_mutation(metadata: &Value, current_identity: &str) ->
     ))
 }
 
+fn runtime_root() -> Result<PathBuf> {
+    let root = paths::homeboy_data()?.join("controller-runtimes");
+    fs::create_dir_all(&root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("create controller runtime directory".to_string()),
+        )
+    })?;
+    Ok(root)
+}
+
+fn write_active_generation(path: &Path, runtime: &Value) -> Result<()> {
+    let temporary = path.with_extension("tmp");
+    fs::write(
+        &temporary,
+        serde_json::to_vec(runtime)
+            .map_err(|error| Error::internal_json(error.to_string(), None))?,
+    )
+    .map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("write active controller generation".to_string()),
+        )
+    })?;
+    fs::rename(temporary, path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("publish active controller generation".to_string()),
+        )
+    })
+}
+
+fn acquire_admission_lock(path: &Path) -> Result<()> {
+    for _ in 0..500 {
+        match fs::create_dir(path) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                std::thread::sleep(std::time::Duration::from_millis(10))
+            }
+            Err(error) => {
+                return Err(Error::internal_io(
+                    error.to_string(),
+                    Some("acquire controller admission lock".to_string()),
+                ))
+            }
+        }
+    }
+    Err(Error::validation_invalid_argument(
+        "controller_admission",
+        "timed out waiting for controller generation admission",
+        None,
+        None,
+    ))
+}
+
+fn validate_pin(runtime: &Value) -> Result<()> {
+    let pinned = runtime
+        .pointer("/originating/pinned_executable")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "controller_runtime",
+                "controller runtime pin has no immutable executable",
+                None,
+                None,
+            )
+        })?;
+    let expected = runtime
+        .pointer("/originating/sha256")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "controller_runtime",
+                "controller runtime pin has no content digest",
+                Some(pinned.to_string()),
+                None,
+            )
+        })?;
+    let path = Path::new(pinned);
+    let metadata = fs::metadata(path).map_err(|_| {
+        Error::validation_invalid_argument(
+            "controller_runtime",
+            format!("pinned controller executable is unavailable: {pinned}"),
+            Some(pinned.to_string()),
+            None,
+        )
+    })?;
+    if !metadata.is_file() || !is_executable(&metadata) || executable_digest(path)? != expected {
+        return Err(Error::validation_invalid_argument(
+            "controller_runtime",
+            format!("pinned controller executable is not immutable and available: {pinned}"),
+            Some(pinned.to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn executable_digest(path: &Path) -> Result<String> {
+    let bytes = fs::read(path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("hash pinned controller executable".to_string()),
+        )
+    })?;
+    Ok(format!("{:x}", Sha256::digest(bytes)))
+}
+
+fn make_executable_read_only(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o500)).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("seal controller runtime pin".to_string()),
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn is_executable(metadata: &fs::Metadata) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        metadata.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = metadata;
+        true
+    }
+}
+
 fn pinned_path(identity: &str) -> Result<PathBuf> {
     Ok(paths::homeboy_data()?
         .join("controller-runtimes")
@@ -85,11 +295,16 @@ mod tests {
 
     #[test]
     fn identity_mismatch_returns_pinned_runtime_recovery_command() {
+        let temporary = tempfile::tempdir().expect("temporary runtime directory");
+        let pinned = temporary.path().join("homeboy-origin");
+        fs::write(&pinned, b"origin").expect("write pinned executable");
+        make_executable_read_only(&pinned).expect("seal executable");
         let metadata = json!({
             "controller_runtime": {
                 "originating": {
                     "build_identity": "homeboy 1.0.0+origin",
-                    "pinned_executable": "/tmp/homeboy-origin",
+                    "pinned_executable": pinned,
+                    "sha256": executable_digest(&pinned).expect("hash executable"),
                 }
             }
         });
@@ -100,6 +315,41 @@ mod tests {
         assert!(error.message.contains("homeboy 1.0.0+origin"));
         assert!(error.details["tried"][0]
             .as_str()
-            .is_some_and(|command| command.contains("/tmp/homeboy-origin")));
+            .is_some_and(|command| command.contains("homeboy-origin")));
+    }
+
+    #[test]
+    fn altered_or_missing_pinned_executable_fails_closed() {
+        let temporary = tempfile::tempdir().expect("temporary runtime directory");
+        let pinned = temporary.path().join("homeboy");
+        fs::write(&pinned, b"generation-a").expect("write pinned executable");
+        make_executable_read_only(&pinned).expect("seal executable");
+        let runtime = json!({
+            "originating": {
+                "pinned_executable": pinned,
+                "sha256": executable_digest(&pinned).expect("hash executable")
+            }
+        });
+        validate_pin(&runtime).expect("sealed pin is valid");
+
+        fs::remove_file(
+            runtime
+                .pointer("/originating/pinned_executable")
+                .and_then(Value::as_str)
+                .expect("path"),
+        )
+        .expect("remove pinned executable");
+        assert!(validate_pin(&runtime).is_err());
+    }
+
+    #[test]
+    fn admission_reuses_the_selected_generation() {
+        crate::test_support::with_isolated_home(|_| {
+            let first = admit_current().expect("first admission");
+            let selected = first.runtime.clone();
+            drop(first);
+            let second = admit_current().expect("second admission");
+            assert_eq!(second.runtime, selected);
+        });
     }
 }

--- a/crates/homeboy-core/src/runtime_promotion.rs
+++ b/crates/homeboy-core/src/runtime_promotion.rs
@@ -107,20 +107,6 @@ pub fn acquire(operation: &str, target: impl Into<String>) -> Result<RuntimeProm
     let generation = current_generation();
     let subprocess_capability = subprocess_capability_from_env();
 
-    if let Some(pin) = active_pin(&root)? {
-        return Err(Error::validation_invalid_argument(
-            "runtime_generation_pin",
-            format!(
-                "runtime promotion waits for active cook `{}` (pid {}) pinned to generation `{}`",
-                pin.cook_id, pin.pid, pin.generation
-            ),
-            Some(pin.cook_id),
-            Some(vec![
-                "Follow: `homeboy activity` and retry after the cook finalizes.".to_string(),
-            ]),
-        ));
-    }
-
     match create_lease_dir(&path) {
         Ok(()) => {
             let capability = uuid::Uuid::new_v4().to_string();
@@ -359,22 +345,6 @@ fn prune_pins(root: &Path) -> Result<()> {
         }
     }
     Ok(())
-}
-
-fn active_pin(root: &Path) -> Result<Option<RuntimeGenerationPin>> {
-    let pins = root.join(PIN_DIR);
-    if !pins.exists() {
-        return Ok(None);
-    }
-    prune_pins(&pins)?;
-    for entry in fs::read_dir(&pins).map_err(io("read runtime generation pins"))? {
-        let path = entry.map_err(io("read runtime generation pin"))?.path();
-        let content = fs::read_to_string(path).map_err(io("read runtime generation pin"))?;
-        if let Ok(pin) = serde_json::from_str(&content) {
-            return Ok(Some(pin));
-        }
-    }
-    Ok(None)
 }
 
 fn current_generation() -> String {

--- a/crates/homeboy-core/src/upgrade/helpers.rs
+++ b/crates/homeboy-core/src/upgrade/helpers.rs
@@ -144,7 +144,6 @@ pub fn run_upgrade_with_method(
     runner_targets: &[String],
     source_path: Option<&Path>,
 ) -> Result<UpgradeResult> {
-    refuse_upgrade_while_durable_runs_are_active()?;
     let promotion_lease = crate::runtime_promotion::acquire(
         "controller upgrade",
         source_path
@@ -243,6 +242,11 @@ pub fn run_upgrade_with_method(
         previous_build_identity.as_deref(),
     )?;
     let upgrade_completed = should_sync_after_upgrade(new_version.as_deref());
+    if upgrade_completed {
+        // This is deliberately a short switch, not a drain: records admitted
+        // before it retain their immutable runtime pin and remain executable.
+        crate::controller_runtime::activate_current_generation()?;
+    }
 
     // Auto-update all installed extensions after the upgrade command completes.
     // This prevents CI/local extension version drift that causes baseline
@@ -315,39 +319,6 @@ pub fn run_upgrade_with_method(
         services_restarted,
         services_pending_restart,
     })
-}
-
-pub(crate) fn refuse_upgrade_while_durable_runs_are_active() -> Result<()> {
-    let active = crate::agent_task_lifecycle::list_records()?
-        .into_iter()
-        .filter(|record| {
-            matches!(
-                record.state,
-                crate::agent_task_lifecycle::AgentTaskRunState::Queued
-                    | crate::agent_task_lifecycle::AgentTaskRunState::Running
-            )
-        })
-        .filter_map(|record| {
-            record
-                .metadata
-                .get(crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY)
-                .and_then(|runtime| runtime.pointer("/originating/build_identity"))
-                .and_then(serde_json::Value::as_str)
-                .map(|identity| format!("{} ({identity})", record.run_id))
-        })
-        .collect::<Vec<_>>();
-    if active.is_empty() {
-        return Ok(());
-    }
-    Err(Error::validation_invalid_argument(
-        "upgrade",
-        format!(
-            "refusing to replace the controller binary while durable orchestration run(s) are active: {}",
-            active.join(", ")
-        ),
-        None,
-        Some(vec!["Wait for the listed runs to become terminal, or recover them through their pinned controller runtime before upgrading.".to_string()]),
-    ))
 }
 
 // Upgrade output must remain visible when a controller captures stdout/stderr.

--- a/crates/homeboy-core/src/upgrade/mod.rs
+++ b/crates/homeboy-core/src/upgrade/mod.rs
@@ -9,8 +9,6 @@ pub mod update_check;
 mod validation;
 
 pub(crate) use constants::VERSION;
-#[cfg(test)]
-pub(crate) use helpers::refuse_upgrade_while_durable_runs_are_active;
 pub use helpers::{
     current_build_version, current_version, detect_install_method, fetch_latest_version,
     run_upgrade_with_method,


### PR DESCRIPTION
## Summary
Replace controller-wide upgrade drains with an atomic admission-generation switch while existing durable runs retain immutable pinned executables.

## What changed
- Adds a locked active-generation pointer, content-addressed immutable runtime validation, and admission pinning; upgrades atomically publish the new generation without blocking existing durable runs.

## How to test
1. Run `cargo check -p homeboy-core --lib`; expect Command exits successfully with warnings only..
2. Run `cargo test -p homeboy-core --lib controller_runtime::tests -- --nocapture`; expect All three controller runtime pin and admission tests pass..
3. Run `cargo test -p homeboy-core --lib active_pinned_run_does_not_block_controller_promotion -- --nocapture`; expect The lifecycle regression test passes and proves active pinned work does not block later admissions..
4. Run `git diff --check`; expect Command exits successfully with no whitespace errors..

## Compatibility
Controller runtime metadata advances from v1 to v2 for newly admitted runs by adding a SHA-256 binding. Existing durable records retain their pinned runtime behavior; upgrades no longer reject solely because queued or running durable work exists.

## Evidence
- CI expected: Audit
- CI expected: Lint
- CI expected: Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8448
- active-run-admission-test: Passed
- cargo-check: Passed
- controller-runtime-tests: Passed
- diff-check: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra and openai/gpt-5.6-sol
- **Used for:** GPT-5.6 Terra drafted the implementation; GPT-5.6 Sol reviewed, promoted, rebased, and verified it with Chris.

## Source relationships
- Closes #8448
