### PR TITLE
fix(audit): dead-code scan must keep serde/clap attribute-string fn references

### DIFF
--- a/crates/homeboy-core/src/code_audit/import_matching.rs
+++ b/crates/homeboy-core/src/code_audit/import_matching.rs
@@ -501,13 +501,27 @@ pub(crate) fn contains_word_in_code(content: &str, word: &str) -> bool {
     contains_word(&blank_comments_and_strings(content), word)
 }
 
-/// Replace the interior of line comments (`//`, `#`) and double-quoted string
-/// literals with spaces, preserving byte offsets and newlines. Language-agnostic
-/// and deliberately conservative: it only needs to stop identifiers inside
-/// comments/strings from reading as code references.
+/// Replace the interior of line comments (`//`, and `#` line comments in
+/// shell/ruby-style sources) and double-quoted string literals with spaces,
+/// preserving byte offsets and newlines.
+///
+/// **Attribute lines are preserved.** In Rust, `#[serde(default = "some_fn")]`
+/// and `#[clap(...)]` call functions *by name from inside the attribute
+/// string* — those are genuine references, not prose. So on any line containing
+/// `#[` we keep the string contents (and never treat `#` as a comment). This
+/// keeps the detector from both (a) mistaking `#[...]` for a `#` comment and
+/// (b) blanking a serde/clap-resolved function reference.
 fn blank_comments_and_strings(content: &str) -> String {
     let mut out = String::with_capacity(content.len());
     for line in content.split_inclusive('\n') {
+        // Attribute lines (e.g. `#[serde(default = "default_true")]`) can carry
+        // real, macro-resolved function references inside their strings. Keep
+        // them verbatim so those references still count.
+        if line.contains("#[") {
+            out.push_str(line);
+            continue;
+        }
+
         let bytes = line.as_bytes();
         let mut i = 0;
         let mut in_string = false;
@@ -828,6 +842,30 @@ fn production(values: BTreeMap<String, f64>) {}
         assert!(!contains_word_in_code(
             "# see validate_only\n",
             "validate_only"
+        ));
+    }
+
+    #[test]
+    fn contains_word_in_code_keeps_serde_and_clap_attribute_references() {
+        // serde/clap call functions by name from inside the attribute string —
+        // those ARE real references and must survive string-blanking, or their
+        // targets get falsely flagged as dead code.
+        assert!(contains_word_in_code(
+            "    #[serde(default = \"plan_schema\")]\n    schema: String,",
+            "plan_schema"
+        ));
+        assert!(contains_word_in_code(
+            "    #[serde(deserialize_with = \"builtins::default_deploy\")]\n",
+            "default_deploy"
+        ));
+        assert!(contains_word_in_code(
+            r#"#[clap(value_parser = "parse_target")]"#,
+            "parse_target"
+        ));
+        // But a plain (non-attribute) string mention is still ignored.
+        assert!(!contains_word_in_code(
+            r#"let s = "plan_schema is a name";"#,
+            "plan_schema"
         ));
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #8478 — closing a false-positive it introduced. #8478 blanked all double-quoted strings before the dead-code reference scan (so comment/test-data mentions stop masking dead code). But it over-corrected for **Rust attribute lines** two ways:

1. It treated `#` as a line-comment start — but in Rust `#[...]` is an **attribute**, not a comment. `#[serde(...)]` got blanked from `#` onward.
2. It blanked the attribute's **string contents** — but serde/clap call functions *by name* from inside those strings: `#[serde(default = "plan_schema")]`, `#[clap(value_parser = "...")]`. Those are **genuine references**.

Net effect of #8478 alone: functions referenced *only* via serde/clap attribute strings (there are many `*_schema` / `default_*` fns in core — I hit `plan_schema` while hand-verifying the #8481 dead-code sweep) would be **falsely reported as dead**.

## Fix

In `blank_comments_and_strings`, preserve any line containing `#[` verbatim — don't treat `#` as a comment there, don't blank its strings. Prose strings and `#`-style line comments on non-attribute lines are still blanked, so **#8478's original behavior is unchanged** (the `validate_only` string-test-data case still gets flagged).

## Why this matters

This is the exact inverse of #8478, and both are needed for a correct detector:
- **string test-data** (`"validate_only"` in a similarity test) → NOT a reference → ignore
- **attribute string** (`"plan_schema"` in `#[serde(...)]`) → IS a reference → keep

Getting this wrong in either direction produces bad audit findings. Now both are right.

## Verification

- `cargo check -p homeboy-core --lib` — clean
- **25 dead_code + 39 import_matching tests pass**, including the #8478 `validate_only` regression test
- New test covers serde `default`/`deserialize_with`, clap `value_parser`, and a negative plain-string case

Refs #8425