### PR TITLE
Reconnect dead daemon leases with no active jobs

### DIFF
--- a/crates/homeboy-core/src/runner/connection/remote_daemon.rs
+++ b/crates/homeboy-core/src/runner/connection/remote_daemon.rs
@@ -349,6 +349,13 @@ pub(super) fn remote_daemon_connect_action_with_controller_identity(
         return Ok(RemoteDaemonConnectAction::Start);
     };
 
+    // `daemon status` proves this exact recorded PID is no longer running.
+    // With no durable work left to reconcile, ensure-running can safely replace
+    // the stale lease without requiring another orphan-adoption cycle.
+    if status.stale_reason_code == Some(DaemonStaleReasonCode::PidDead) && status.active_jobs == 0 {
+        return Ok(RemoteDaemonConnectAction::Start);
+    }
+
     if !status.reachable {
         return Err(format!(
             "remote daemon is unreachable; refusing to replace or persist a session{}",

--- a/crates/homeboy-core/src/runner/connection/tests/recovery.rs
+++ b/crates/homeboy-core/src/runner/connection/tests/recovery.rs
@@ -708,17 +708,15 @@ fn refuses_to_replace_proven_dead_daemon_with_active_jobs_when_lease_mismatches(
 }
 
 #[test]
-fn dead_recorded_daemon_routes_to_idempotent_ensure_start() {
-    let status = RemoteDaemonStatus {
-        daemon: None,
-        stale_reason: Some("daemon lease pid is not running".to_string()),
-        stale_reason_code: Some(DaemonStaleReasonCode::PidDead),
-        fresh: false,
-        reachable: false,
-        active_jobs: 0,
-        endpoint_probe_error: None,
-        termination_evidence: None,
-    };
+fn dead_recorded_daemon_without_active_jobs_routes_to_idempotent_ensure_start() {
+    let status = remote_daemon_status_for_test_with_reason(
+        false,
+        false,
+        0,
+        "lease-dead",
+        4545,
+        Some(DaemonStaleReasonCode::PidDead),
+    );
 
     assert_eq!(
         remote_daemon_connect_action(Some(&direct_ssh_session("lease-dead")), &status)


### PR DESCRIPTION
## Summary
Allow runner connect to idempotently start a replacement daemon when status proves the recorded lease PID is dead and no durable jobs remain.

## What changed
- Treat PidDead plus zero active jobs as a safe Start action before the generic unreachable-daemon refusal, while preserving refusal for stale jobs and other unreachable states.

## How to test
1. Run `cargo test -p homeboy-core runner::connection::tests::recovery::dead_recorded_daemon_without_active_jobs_routes_to_idempotent_ensure_start --lib`; expect The targeted recovery test passes..
2. Run `cargo check -p homeboy-core -p homeboy-cli`; expect Both crates compile successfully..
3. Run `Create a runner session whose recorded daemon PID is dead with zero active jobs, then run homeboy runner connect <runner>`; expect Homeboy starts and connects a replacement daemon without another orphan-adoption cycle..

## Compatibility
Behavior changes only for a proven-dead daemon lease with zero active jobs. Existing refusal and explicit recovery behavior remain unchanged when active jobs or uncertain liveness must be preserved.

## Evidence
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8001
- cargo-check: Passed
- diff-check: Passed
- targeted-recovery-test: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the dead-daemon recovery loop, implemented the reconnect fix and deterministic test, rebased the candidate, and verified runtime behavior with Chris.

## Source relationships
- Closes #8001
