### PR TITLE
fix(audit): OrphanedInternal check must ignore comment/string call mentions

### DIFF
--- a/crates/homeboy-core/src/code_audit/dead_code.rs
+++ b/crates/homeboy-core/src/code_audit/dead_code.rs
@@ -10,7 +10,7 @@ use std::collections::{HashMap, HashSet};
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
-use super::import_matching::contains_word_in_code;
+use super::import_matching::{blank_comments_and_strings, contains_word_in_code};
 use super::walker::is_test_path;
 use crate::component::AuditConfig;
 
@@ -221,9 +221,15 @@ pub(crate) fn analyze_dead_code_with_config(
                 // file content. internal_calls may miss names in the skip list
                 // (e.g., "write" is skipped to avoid matching the write! macro,
                 // but it could also be a real function name in this file).
+                //
+                // Match against a code-only view so a mention inside a comment
+                // or string literal (`// TODO call foo()`, `"foo() example"`)
+                // does not falsely count as a call and mask the dead function —
+                // the same correctness rule the UnreferencedExport scan uses.
+                let code = blank_comments_and_strings(&fp.content);
                 let call_pattern = format!("{}(", method);
                 let method_pattern = format!(".{}(", method);
-                if fp.content.contains(&call_pattern) || fp.content.contains(&method_pattern) {
+                if code.contains(&call_pattern) || code.contains(&method_pattern) {
                     continue;
                 }
 
@@ -686,6 +692,43 @@ mod tests {
     }
 
     #[test]
+    fn test_file_caller_suppresses_unreferenced_export() {
+        // A public function whose only caller lives in a test file must NOT be
+        // flagged as dead — the tests exercise it, so it's live code. This is
+        // load-bearing: an early manual dead-code sweep produced a false
+        // positive precisely because it forgot to scan test files as reference
+        // sources (e.g. `compute_fixability`, used only by `report_test.rs`).
+        let owner = make_fingerprint(
+            "src/report.rs",
+            vec!["compute_fixability"],
+            vec!["compute_fixability"],
+            vec![],
+            vec![],
+        );
+        let mut test_caller = make_fingerprint(
+            "src/report_test.rs",
+            vec!["exercises_fixability"],
+            vec![],
+            vec![],
+            vec![],
+        );
+        test_caller
+            .internal_calls
+            .push("compute_fixability".to_string());
+        test_caller.content =
+            "fn exercises_fixability() { let f = compute_fixability(&result); }".to_string();
+
+        let findings = analyze_dead_code(&[&owner, &test_caller], &[]);
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.kind == AuditFinding::UnreferencedExport
+                    && f.description.contains("compute_fixability")),
+            "a function called only from a test file must not be flagged as unreferenced"
+        );
+    }
+
+    #[test]
     fn function_pointer_reference_suppresses_unreferenced_export() {
         let exported = make_fingerprint(
             "src/foo.rs",
@@ -818,6 +861,32 @@ mod tests {
             .collect();
         assert_eq!(orphaned.len(), 1);
         assert!(orphaned[0].description.contains("dead_helper"));
+    }
+
+    #[test]
+    fn orphaned_internal_content_fallback_ignores_comment_and_string_calls() {
+        // The same-file "is it called?" fallback scans raw content for
+        // `name(` / `.name(`. A mention inside a comment or string literal must
+        // NOT count as a call, or a genuinely-dead private fn stays hidden —
+        // the mirror of the UnreferencedExport comment/string fix.
+        let mut fp = make_fingerprint(
+            "src/foo.rs",
+            vec!["public_fn", "dead_helper"],
+            vec!["public_fn"],
+            vec!["public_fn"], // dead_helper NOT in internal_calls
+            vec![("dead_helper", "private")],
+        );
+        // dead_helper appears only in a comment and a string — not real calls.
+        fp.content = "// remember to wire dead_helper() up later\n\
+             fn public_fn() { let doc = \"call dead_helper() from here\"; }"
+            .to_string();
+
+        let findings = analyze_dead_code(&[&fp], &[]);
+        assert!(
+            findings.iter().any(|f| f.kind == AuditFinding::OrphanedInternal
+                && f.description.contains("dead_helper")),
+            "dead_helper is only mentioned in a comment/string, so it must still be flagged as orphaned"
+        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/code_audit/import_matching.rs
+++ b/crates/homeboy-core/src/code_audit/import_matching.rs
@@ -511,7 +511,7 @@ pub(crate) fn contains_word_in_code(content: &str, word: &str) -> bool {
 /// `#[` we keep the string contents (and never treat `#` as a comment). This
 /// keeps the detector from both (a) mistaking `#[...]` for a `#` comment and
 /// (b) blanking a serde/clap-resolved function reference.
-fn blank_comments_and_strings(content: &str) -> String {
+pub(crate) fn blank_comments_and_strings(content: &str) -> String {
     let mut out = String::with_capacity(content.len());
     for line in content.split_inclusive('\n') {
         // Attribute lines (e.g. `#[serde(default = "default_true")]`) can carry


### PR DESCRIPTION
## Summary

The `OrphanedInternal` check (private fn never called within its own file) has the **same comment/string bug** that #8478 fixed for `UnreferencedExport` — in the same file. Its same-file "is it called?" fallback scanned raw content:

```rust
if fp.content.contains(&call_pattern) || fp.content.contains(&method_pattern) { continue; }
```

`.contains("foo(")` matches inside **comments and string literals**. So a genuinely-dead private fn mentioned as `foo()` in a `// TODO` or a string was treated as called → never flagged.

## Fix

Run the fallback against `blank_comments_and_strings(&fp.content)` (promoted to `pub(crate)`) so only real code calls count — the same code-only rule the `UnreferencedExport` scan already uses. The detector is now consistent across both dead-code checks.

## Tests

- `orphaned_internal_content_fallback_ignores_comment_and_string_calls` — a private fn mentioned only in a comment/string is still flagged.
- `test_file_caller_suppresses_unreferenced_export` — locks in that a public fn called only from a **test file** is NOT flagged dead. This behavior was already *correct* (the detector scans test-file fingerprints as reference sources), but was **untested** — and a manual dead-code sweep false-positived on exactly this (e.g. `compute_fixability`, used only by `report_test.rs`). Regression test guards it.

## Verification

- `cargo check -p homeboy-core --lib` — clean
- **27 dead_code + 38 import_matching tests pass**

Refs #8425