### PR TITLE
refactor: introduce homeboy-runner-contract crate (runner-decouple stage 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,7 @@ dependencies = [
  "homeboy-process",
  "homeboy-product-identity",
  "homeboy-redaction",
+ "homeboy-runner-contract",
  "keyring",
  "libc",
  "regex",
@@ -899,6 +900,13 @@ version = "0.1.0"
 dependencies = [
  "regex",
  "serde_json",
+]
+
+[[package]]
+name = "homeboy-runner-contract"
+version = "0.1.0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -29,6 +29,7 @@ homeboy-process = { version = "0.1.0", path = "../homeboy-process" }
 homeboy-product-identity = { version = "0.1.0", path = "../homeboy-product-identity" }
 homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 homeboy-lab-contract = { version = "0.1.0", path = "../homeboy-lab-contract" }
+homeboy-runner-contract = { version = "0.1.0", path = "../homeboy-runner-contract" }
 homeboy-redaction = { version = "0.1.0", path = "../homeboy-redaction" }
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
@@ -641,7 +641,10 @@ pub(crate) fn project_terminal_artifacts(
                 }
             });
             if let Some(runner_id) = record.runner_id().filter(|runner_id| {
-                std::env::var(crate::runner::RUNNER_ID_ENV).ok().as_deref() != Some(*runner_id)
+                std::env::var(homeboy_runner_contract::RUNNER_ID_ENV)
+                    .ok()
+                    .as_deref()
+                    != Some(*runner_id)
             }) {
                 if runner_id.trim().is_empty() {
                     return Err(Error::validation_invalid_argument(

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -279,7 +279,7 @@ pub fn submit_plan(
     });
     metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
         admission.runtime.clone();
-    if let Ok(runner_id) = std::env::var(crate::runner::RUNNER_ID_ENV) {
+    if let Ok(runner_id) = std::env::var(homeboy_runner_contract::RUNNER_ID_ENV) {
         if !runner_id.trim().is_empty() {
             metadata["runner_id"] = json!(runner_id);
         }

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -796,7 +796,7 @@ fn remote_runner_request_compiles_canonical_execution_envelope() {
         .env
         .insert("TOKEN_A".to_string(), "secret".to_string());
     request.env.insert(
-        crate::runner::RUNNER_PLACEMENT_RESOLVED_ENV.to_string(),
+        homeboy_runner_contract::RUNNER_PLACEMENT_RESOLVED_ENV.to_string(),
         "1".to_string(),
     );
     request.secret_env_names = vec!["TOKEN_A".to_string()];
@@ -821,7 +821,7 @@ fn remote_runner_request_compiles_canonical_execution_envelope() {
     assert_eq!(dispatch.env["PUBLIC_VALUE"], "visible");
     assert!(!dispatch
         .env
-        .contains_key(crate::runner::RUNNER_PLACEMENT_RESOLVED_ENV));
+        .contains_key(homeboy_runner_contract::RUNNER_PLACEMENT_RESOLVED_ENV));
     assert_eq!(dispatch.require_paths, vec!["/srv/extrachill/cache"]);
     assert!(dispatch.source_snapshot.is_some());
     assert_eq!(
@@ -841,7 +841,7 @@ fn remote_runner_request_compiles_canonical_execution_envelope() {
     assert!(!request
         .public_metadata()
         .env
-        .contains_key(crate::runner::RUNNER_PLACEMENT_RESOLVED_ENV));
+        .contains_key(homeboy_runner_contract::RUNNER_PLACEMENT_RESOLVED_ENV));
 }
 
 #[test]

--- a/crates/homeboy-core/src/resource_policy_context.rs
+++ b/crates/homeboy-core/src/resource_policy_context.rs
@@ -118,7 +118,7 @@ pub fn reset_captured_context_for_test() {
 }
 
 pub fn is_runner_hosted_exec() -> bool {
-    std::env::var(crate::runner::RUNNER_HOSTED_EXEC_ENV)
+    std::env::var(homeboy_runner_contract::RUNNER_HOSTED_EXEC_ENV)
         .ok()
         .is_some_and(|value| value == "1")
 }
@@ -146,23 +146,23 @@ pub fn is_ci_execution() -> bool {
 /// and daemon job preparation rather than trusting the resolved marker alone.
 pub fn is_managed_runner_placement_context() -> bool {
     is_runner_hosted_exec()
-        && std::env::var(crate::runner::RUNNER_PLACEMENT_RESOLVED_ENV)
+        && std::env::var(homeboy_runner_contract::RUNNER_PLACEMENT_RESOLVED_ENV)
             .ok()
             .is_some_and(|value| value == "1")
-        && std::env::var(crate::runner::RUNNER_ID_ENV)
+        && std::env::var(homeboy_runner_contract::RUNNER_ID_ENV)
             .ok()
             .is_some_and(|value| !value.trim().is_empty())
 }
 
 pub fn clear_runner_hosted_exec() {
-    std::env::remove_var(crate::runner::RUNNER_HOSTED_EXEC_ENV);
+    std::env::remove_var(homeboy_runner_contract::RUNNER_HOSTED_EXEC_ENV);
 }
 
 /// Remove the private runner-placement transport context after CLI routing.
 /// Child workloads and persisted artifacts must not inherit controller routing
 /// markers once their single placement decision has been consumed.
 pub fn clear_managed_runner_placement_context() {
-    std::env::remove_var(crate::runner::RUNNER_HOSTED_EXEC_ENV);
-    std::env::remove_var(crate::runner::RUNNER_PLACEMENT_RESOLVED_ENV);
-    std::env::remove_var(crate::runner::RUNNER_ID_ENV);
+    std::env::remove_var(homeboy_runner_contract::RUNNER_HOSTED_EXEC_ENV);
+    std::env::remove_var(homeboy_runner_contract::RUNNER_PLACEMENT_RESOLVED_ENV);
+    std::env::remove_var(homeboy_runner_contract::RUNNER_ID_ENV);
 }

--- a/crates/homeboy-core/src/runner/execution/mod.rs
+++ b/crates/homeboy-core/src/runner/execution/mod.rs
@@ -39,11 +39,12 @@ pub(crate) const RUNNER_EXEC_WAIT_TIMEOUT_ENV: &str = "HOMEBOY_RUNNER_EXEC_WAIT_
 /// only mirroring it. Off by default — the default contract leaves the remote job
 /// in flight and uncancelled (#6891).
 pub(crate) const RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV: &str = "HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT";
-pub const RUNNER_HOSTED_EXEC_ENV: &str = "HOMEBOY_RUNNER_HOSTED_EXEC";
-/// Private process marker added only while RunnerExecOptions crosses a remote
-/// runner boundary. It is intentionally absent from CLI parsing and argv.
-pub const RUNNER_PLACEMENT_RESOLVED_ENV: &str = "HOMEBOY_RUNNER_PLACEMENT_RESOLVED";
-pub const RUNNER_ID_ENV: &str = "HOMEBOY_RUNNER_ID";
+// These runner env-var markers now live in the shared runner-contract crate so
+// core can reference them without a core -> runner edge. Re-exported here so the
+// existing `runner::execution::RUNNER_*_ENV` call sites keep resolving.
+pub use homeboy_runner_contract::{
+    RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV, RUNNER_PLACEMENT_RESOLVED_ENV,
+};
 
 pub(crate) fn is_internal_control_env(name: &str) -> bool {
     name == RUNNER_PLACEMENT_RESOLVED_ENV

--- a/crates/homeboy-core/src/runner/mod.rs
+++ b/crates/homeboy-core/src/runner/mod.rs
@@ -182,12 +182,10 @@ pub(crate) use workspace::{
     VerifiedLabWorkspaceProvenance, WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum RunnerKind {
-    Local,
-    Ssh,
-}
+// RunnerKind now lives in the shared runner-contract crate so core code can
+// name it without a core -> runner edge. Re-exported here so the many
+// `runner::RunnerKind` call sites (and the CLI) keep resolving unchanged.
+pub use homeboy_runner_contract::RunnerKind;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Runner {

--- a/crates/homeboy-core/src/upgrade/runners/orchestration.rs
+++ b/crates/homeboy-core/src/upgrade/runners/orchestration.rs
@@ -5,10 +5,10 @@ use super::*;
 use crate::runner;
 use crate::runner::Runner;
 use crate::runner::RunnerExecOptions;
-use crate::runner::RunnerKind;
 use crate::runner::RunnerStatusReport;
 use crate::upgrade::ExtensionUpgradeEntry;
 use crate::Result;
+use homeboy_runner_contract::RunnerKind;
 use std::path::Path;
 
 pub fn upgrade_configured_runners(

--- a/crates/homeboy-core/src/upgrade/runners/source_checkout.rs
+++ b/crates/homeboy-core/src/upgrade/runners/source_checkout.rs
@@ -5,11 +5,11 @@ use crate::runner;
 use crate::runner::Runner;
 use crate::runner::RunnerCapabilityPreflight;
 use crate::runner::RunnerExecOptions;
-use crate::runner::RunnerKind;
 use crate::runner::RunnerRequiredTool;
 use crate::runner::RunnerWorkspaceSyncMode;
 use crate::runner::RunnerWorkspaceSyncOptions;
 use crate::Result;
+use homeboy_runner_contract::RunnerKind;
 use std::path::Path;
 use std::process::Command;
 

--- a/crates/homeboy-runner-contract/Cargo.toml
+++ b/crates/homeboy-runner-contract/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "homeboy-runner-contract"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Chris Huber <chubes@extrachill.com>"]
+description = "Shared runner contract types + env-var constants for homeboy. Behavior-free data that both homeboy-core and the optional homeboy-runner feature crate depend on, so core can reference runner concepts without depending on runner behavior."
+repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
+
+[lib]
+name = "homeboy_runner_contract"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }

--- a/crates/homeboy-runner-contract/src/lib.rs
+++ b/crates/homeboy-runner-contract/src/lib.rs
@@ -1,0 +1,28 @@
+//! Shared runner contract: behavior-free types and env-var constants that both
+//! `homeboy-core` and the optional `homeboy-runner` feature crate depend on.
+//!
+//! Runner is an optional Lab-offload feature; core must not depend on runner
+//! *behavior*. But some core code legitimately needs to name runner *concepts*
+//! (e.g. the runner kind, or the env-var markers used when an exec crosses a
+//! remote-runner boundary). Those plain-data contracts live here so core can
+//! reference them without a `core -> runner` edge.
+
+use serde::{Deserialize, Serialize};
+
+/// The kind of runner backing a homeboy runner definition.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerKind {
+    Local,
+    Ssh,
+}
+
+/// Set while a hosted exec runs inside a runner (as opposed to the local host).
+pub const RUNNER_HOSTED_EXEC_ENV: &str = "HOMEBOY_RUNNER_HOSTED_EXEC";
+
+/// Private process marker added only while a runner exec crosses a remote
+/// runner boundary. Intentionally absent from CLI parsing and argv.
+pub const RUNNER_PLACEMENT_RESOLVED_ENV: &str = "HOMEBOY_RUNNER_PLACEMENT_RESOLVED";
+
+/// Identifies the runner an exec is bound to.
+pub const RUNNER_ID_ENV: &str = "HOMEBOY_RUNNER_ID";


### PR DESCRIPTION
## Summary
First stage of decoupling the **optional runner feature** from core. Runner is an optional Lab-offload feature — core must not depend on runner *behavior*. This introduces a shared `homeboy-runner-contract` crate for behavior-free runner data that both core and (eventually) `homeboy-runner` depend on, so core can name runner concepts without a `core -> runner` edge.

## This cut (smallest safe first slice)
Moves the cleanest, zero-dependency contracts:
- `RunnerKind` enum (Local/Ssh)
- `RUNNER_ID_ENV`, `RUNNER_PLACEMENT_RESOLVED_ENV`, `RUNNER_HOSTED_EXEC_ENV`

Both are **re-exported from their old locations** (`runner::RunnerKind`, `runner::execution::RUNNER_*_ENV`) so the ~45 internal/CLI call sites keep resolving unchanged. Only the **external-core consumers** (6 files: upgrade/runners, agent_task_lifecycle, api_jobs, resource_policy_context) are repointed to `homeboy_runner_contract::` — severing those reverse edges.

## Context
Part of the staged runner extraction plan. Reuses the proven "move shared types down" pattern (same as homeboy-lab-contract). Later stages move the remaining contract types (Runner, RunnerExecOptions, etc.) and invert the behavioral edges via hook registries (the keystones from #8488).

## Verification
`cargo check` clean for `-p homeboy-core --lib` and `-p homeboy-cli --lib`. Reverse-edge file count: 42 → 40 (this cut fully severs the RunnerKind/env-const edges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)