### PR TITLE
refactor: move runner capability tool types to runner-contract (runner-decouple stage 2)

### DIFF
--- a/crates/homeboy-core/src/rig/capabilities.rs
+++ b/crates/homeboy-core/src/rig/capabilities.rs
@@ -7,7 +7,8 @@ use serde::Serialize;
 use super::expand::expand_vars;
 use super::pipeline::{PipelineOutcome, PipelineStepOutcome};
 use super::spec::{ExecutableRequirementSpec, FilesystemAssertionSpec, RigSpec};
-use crate::runner::{RunnerCapabilityPreflight, RunnerToolCapabilityRequirement};
+use crate::runner::RunnerCapabilityPreflight;
+use homeboy_runner_contract::RunnerToolCapabilityRequirement;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RigRequirementCheckPlan {

--- a/crates/homeboy-core/src/runner/capabilities.rs
+++ b/crates/homeboy-core/src/runner/capabilities.rs
@@ -22,13 +22,9 @@ pub struct RunnerCapabilityPreflight {
     pub timeout: Option<Duration>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct RunnerToolCapabilityRequirement {
-    pub tool: String,
-    pub command: String,
-    pub env: Vec<String>,
-    pub capabilities: Vec<String>,
-}
+// RunnerToolCapabilityRequirement now lives in the shared runner-contract crate
+// (behavior-free data). Re-exported so existing call sites resolve unchanged.
+pub use homeboy_runner_contract::RunnerToolCapabilityRequirement;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PreparedLabRunnerCapability {
@@ -61,38 +57,22 @@ pub enum LabRunnerGateDecision {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct RunnerRequiredTool {
-    id: String,
-}
+// RunnerRequiredTool (data + pure constructors) now lives in the shared
+// runner-contract crate. Re-exported so existing call sites resolve unchanged.
+pub use homeboy_runner_contract::RunnerRequiredTool;
 
-impl RunnerRequiredTool {
-    pub fn new(id: impl Into<String>) -> Self {
-        Self { id: id.into() }
-    }
-
-    pub fn homeboy() -> Self {
-        Self::new("homeboy")
-    }
-
-    pub fn git() -> Self {
-        Self::new("git")
-    }
-
-    pub fn id(&self) -> &str {
-        &self.id
-    }
-
-    pub(crate) fn remediation(&self) -> String {
-        RunnerToolRegistry::spec_for_required_tool(self)
-            .map(|spec| spec.capability_remediation)
-            .unwrap_or_else(|| {
-                format!(
-                    "Install '{}' on the runner and ensure it is on PATH.",
-                    self.id()
-                )
-            })
-    }
+/// Remediation text for a required tool. Lives in core (not on the contract
+/// type) because it consults core's runner tool registry — an inherent method
+/// can't span crates, so it's a free function here.
+pub(crate) fn required_tool_remediation(tool: &RunnerRequiredTool) -> String {
+    RunnerToolRegistry::spec_for_required_tool(tool)
+        .map(|spec| spec.capability_remediation)
+        .unwrap_or_else(|| {
+            format!(
+                "Install '{}' on the runner and ensure it is on PATH.",
+                tool.id()
+            )
+        })
 }
 
 pub fn prepare_lab_runner_capability(
@@ -215,7 +195,7 @@ pub(crate) fn validate_runner_capability_preflight(
     };
     let mut remediation = missing_tools
         .iter()
-        .map(|tool| tool.remediation())
+        .map(required_tool_remediation)
         .collect::<Vec<_>>();
     remediation.extend(missing_components.iter().map(|component| {
         format!("Register component '{component}' on the runner capability profile or choose a runner with that component.")
@@ -509,7 +489,7 @@ fn evaluate_lab_runner_capabilities(
     };
     let mut remediation = missing_tools
         .iter()
-        .map(|tool| tool.remediation())
+        .map(required_tool_remediation)
         .collect::<Vec<_>>();
     match mode {
         LabRunnerGateMode::Automatic => remediation.push(

--- a/crates/homeboy-core/src/upgrade/runners/commands.rs
+++ b/crates/homeboy-core/src/upgrade/runners/commands.rs
@@ -4,9 +4,9 @@ use crate::runner;
 use crate::runner::Runner;
 use crate::runner::RunnerCapabilityPreflight;
 use crate::runner::RunnerExecOptions;
-use crate::runner::RunnerRequiredTool;
 use crate::Error;
 use crate::Result;
+use homeboy_runner_contract::RunnerRequiredTool;
 
 pub fn runner_upgrade_command(
     homeboy_path: &str,

--- a/crates/homeboy-core/src/upgrade/runners/source_checkout.rs
+++ b/crates/homeboy-core/src/upgrade/runners/source_checkout.rs
@@ -5,11 +5,11 @@ use crate::runner;
 use crate::runner::Runner;
 use crate::runner::RunnerCapabilityPreflight;
 use crate::runner::RunnerExecOptions;
-use crate::runner::RunnerRequiredTool;
 use crate::runner::RunnerWorkspaceSyncMode;
 use crate::runner::RunnerWorkspaceSyncOptions;
 use crate::Result;
 use homeboy_runner_contract::RunnerKind;
+use homeboy_runner_contract::RunnerRequiredTool;
 use std::path::Path;
 use std::process::Command;
 

--- a/crates/homeboy-runner-contract/src/lib.rs
+++ b/crates/homeboy-runner-contract/src/lib.rs
@@ -26,3 +26,36 @@ pub const RUNNER_PLACEMENT_RESOLVED_ENV: &str = "HOMEBOY_RUNNER_PLACEMENT_RESOLV
 
 /// Identifies the runner an exec is bound to.
 pub const RUNNER_ID_ENV: &str = "HOMEBOY_RUNNER_ID";
+
+/// A tool that must be present on a runner for a capability to be satisfied.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RunnerRequiredTool {
+    id: String,
+}
+
+impl RunnerRequiredTool {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self { id: id.into() }
+    }
+
+    pub fn homeboy() -> Self {
+        Self::new("homeboy")
+    }
+
+    pub fn git() -> Self {
+        Self::new("git")
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+/// A tool + command capability requirement probed on a runner.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RunnerToolCapabilityRequirement {
+    pub tool: String,
+    pub command: String,
+    pub env: Vec<String>,
+    pub capabilities: Vec<String>,
+}


### PR DESCRIPTION
## Summary
Stage 2 of decoupling the optional runner feature from core. Moves two more behavior-free contract types out of runner into `homeboy-runner-contract`:
- `RunnerRequiredTool` (data + pure constructors `new`/`homeboy`/`git`/`id`)
- `RunnerToolCapabilityRequirement`

## Inherent-impl handling
`RunnerRequiredTool::remediation()` consulted core's runner tool registry, so it can't live on the contract type (an inherent impl can't span crates — E0116). It's now a `required_tool_remediation(&RunnerRequiredTool)` free function in core's `runner/capabilities.rs`; the two call sites are updated.

Both types are re-exported from `runner::capabilities` so internal/CLI call sites resolve unchanged. External-core consumers (`upgrade/runners`, `rig/capabilities`) are repointed to `homeboy_runner_contract::`, severing those reverse edges.

## Deferred (honest scoping)
`RunnerCapabilityPreflight` (the highest-value type here, ext=5) stays in core this stage — it has a `From<PreparedLabRunnerCapability>` that couples it to a core type (orphan rule), so it moves when the lab-capability cluster does. `RunnerExecOptions` is likewise deferred: its fields reference `SourceSnapshot` + `RunnerCapabilityPreflight` (core types), which must move down first.

## Context
Part of the staged runner extraction plan. Reuses the proven "move shared types down" + re-export shim pattern.

## Verification
`cargo check` clean for `-p homeboy-runner-contract`, `-p homeboy-core --lib`, `-p homeboy-cli --lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)