### PR TITLE
fix(agent-task): hydrate Lab terminal aggregates

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -47,7 +47,6 @@ pub fn reconcile_deferred_candidate(run_id: &str) -> Result<bool> {
         // read retries from durable state rather than inventing a projection.
         Err(_) => return Ok(false),
     };
-    let plan = store::read_plan_path(&record.plan_path)?;
     let mut changed = false;
 
     for outcome in &mut aggregate.outcomes {
@@ -167,6 +166,7 @@ pub fn reconcile_deferred_candidate(run_id: &str) -> Result<bool> {
         return Ok(false);
     }
 
+    let plan = store::read_controller_plan(&run_id)?;
     aggregate.status = aggregate_status(&aggregate.outcomes);
     aggregate.totals = aggregate_totals(plan.tasks.len(), &aggregate.outcomes);
     let aggregate_path = store::aggregate_path(&run_id)?.display().to_string();
@@ -463,7 +463,7 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     if !is_terminal_run_state(record.state) {
         if let (Ok(aggregate), Ok(plan)) = (
             store::read_aggregate(&record.run_id),
-            store::read_plan_path(&record.plan_path),
+            store::read_controller_plan(&record.run_id),
         ) {
             let aggregate_path = store::aggregate_path(&record.run_id)
                 .map(|path| path.display().to_string())
@@ -691,6 +691,34 @@ pub fn recover_transport_proxy(run_id: &str) -> Result<Option<TransportProxyReco
     }
 }
 
+/// Replays already-persisted terminal runner evidence into an incomplete
+/// controller projection. It is intentionally limited to an existing terminal
+/// job snapshot and cannot dispatch or resume provider work.
+pub fn recover_terminal_transport_proxy_evidence(run_id: &str) -> Result<bool> {
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    if !is_terminal_run_state(record.state) {
+        return Ok(false);
+    }
+    let (Some(runner_id), Some(runner_job_id)) = (
+        transport_proxy_runner_id(&record),
+        transport_proxy_runner_job_id(&record),
+    ) else {
+        return Ok(false);
+    };
+    let snapshot = crate::runners::runner_job_log_snapshot(&runner_id, &runner_job_id)?;
+    if !matches!(
+        snapshot.job.status,
+        crate::api_jobs::JobStatus::Succeeded
+            | crate::api_jobs::JobStatus::Failed
+            | crate::api_jobs::JobStatus::Cancelled
+    ) {
+        return Ok(false);
+    }
+    reconcile_runner_job_snapshot(&mut record, &snapshot)?;
+    store::write_record(&record)?;
+    Ok(store::read_aggregate(&record.run_id).is_ok())
+}
+
 /// Resume an unbound proxy where the controller never learned the runner job
 /// identity. The persisted command and workspace belong to the runner, so this
 /// must execute through the runner rather than through the local scheduler.
@@ -824,10 +852,10 @@ pub(crate) fn reconcile_runner_job_snapshot(
         // A transport-only terminal result can arrive before the daemon has
         // published the inner agent-task aggregate. Adopt that later evidence
         // when it proves the same controller run rather than losing its patch.
-        if let Some(event) = crate::runner::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_job_events(
-            Some(&snapshot.events),
-        ) {
-            project_terminal_runner_lifecycle_event(record, snapshot, &event)?;
+        if let Some(event) = terminal_runner_lifecycle_event(record, snapshot)? {
+            if store::read_aggregate(&record.run_id).ok().as_ref() != Some(&event.aggregate) {
+                project_terminal_runner_lifecycle_event(record, snapshot, &event)?;
+            }
         }
         return Ok(());
     }
@@ -863,18 +891,39 @@ pub(crate) fn reconcile_runner_job_snapshot(
         crate::api_jobs::JobStatus::Succeeded
         | crate::api_jobs::JobStatus::Failed
         | crate::api_jobs::JobStatus::Cancelled => {
-            if let Some(event) = crate::runner::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_job_events(
-                Some(&snapshot.events),
-            ) {
+            if let Some(event) = terminal_runner_lifecycle_event(&reconciled, snapshot)? {
                 project_terminal_runner_lifecycle_event(&mut reconciled, snapshot, &event)?;
             } else {
-                apply_runner_job_terminal_state(&mut reconciled, snapshot.job.status, &snapshot.events);
+                apply_runner_job_terminal_state(
+                    &mut reconciled,
+                    snapshot.job.status,
+                    &snapshot.events,
+                );
                 store::write_record(&reconciled)?;
             }
         }
     }
     *record = reconciled;
     Ok(())
+}
+
+fn terminal_runner_lifecycle_event(
+    record: &AgentTaskRunRecord,
+    snapshot: &crate::runner::RunnerJobLogSnapshot,
+) -> Result<Option<crate::runner::agent_task_lifecycle_event::AgentTaskRunPlanLifecycleEvent>> {
+    let runner_id = record.runner_id().unwrap_or_default();
+    let runner_job_id = record.runner_job_id().unwrap_or_default();
+    if let Some(event) = crate::runner::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_persisted_job_events(
+        &snapshot.events,
+        runner_id,
+        runner_job_id,
+        &record.run_id,
+    )? {
+        return Ok(Some(event));
+    }
+    Ok(crate::runner::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_job_events(
+        Some(&snapshot.events),
+    ))
 }
 
 fn project_terminal_runner_lifecycle_event(

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -1247,6 +1247,81 @@ fn late_inner_aggregate_recovers_patch_after_transport_only_terminal_result() {
 }
 
 #[test]
+fn terminal_proxy_reconciliation_hydrates_persisted_nested_result_idempotently() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-persisted-result",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("running proxy");
+        record.plan_path =
+            "/home/lab/.local/share/homeboy/agent-task-runs/agent-task-persisted-result/plan.json"
+                .to_string();
+        store::write_record(&record).expect("runner-local plan projection");
+        apply_runner_job_terminal_state(&mut record, crate::api_jobs::JobStatus::Succeeded, &[]);
+        store::write_record(&record).expect("legacy terminal projection without aggregate");
+
+        let mut aggregate = succeeded_aggregate(&test_plan());
+        aggregate.outcomes[0].artifacts = vec![AgentTaskArtifact {
+            schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+            id: "final-patch".to_string(),
+            kind: "patch".to_string(),
+            name: Some("final.patch".to_string()),
+            label: None,
+            role: Some("patch".to_string()),
+            semantic_key: None,
+            path: Some("artifacts/final.patch".to_string()),
+            url: None,
+            mime: Some("text/x-diff".to_string()),
+            size_bytes: Some(18_928),
+            sha256: Some(
+                "062f5c460c2dfb279277b75d5a16a04e3178ace1f35ce7b10da5e17441b37071".to_string(),
+            ),
+            metadata: json!({ "source_snapshot": "snapshot-1" }),
+        }];
+        aggregate.outcomes[0].evidence_refs = vec![AgentTaskEvidenceRef {
+            kind: "transcript".to_string(),
+            uri: "homeboy://lab/transcript".to_string(),
+            label: Some("Provider transcript".to_string()),
+        }];
+        aggregate.outcomes[0].metadata = json!({
+            "provider": "opencode",
+            "provider_run_id": "provider-run-1",
+        });
+        let snapshot = persisted_terminal_result_snapshot(&aggregate);
+
+        reconcile_runner_job_snapshot(&mut record, &snapshot).expect("hydrate persisted result");
+        let status = status(&record.run_id).expect("hydrated status without runner plan access");
+        let artifact_report = artifacts(&record.run_id).expect("hydrated artifacts");
+        assert_eq!(status.state, AgentTaskRunState::Succeeded);
+        assert_eq!(artifact_report.artifacts.len(), 1);
+        assert_eq!(artifact_report.artifacts[0].id, "final-patch");
+        assert_eq!(artifact_report.artifacts[0].size_bytes, Some(18_928));
+        assert_eq!(
+            artifact_report.artifacts[0].sha256.as_deref(),
+            Some("062f5c460c2dfb279277b75d5a16a04e3178ace1f35ce7b10da5e17441b37071")
+        );
+        assert!(artifact_report
+            .evidence_refs
+            .iter()
+            .any(|reference| reference.kind == "transcript"));
+
+        reconcile_runner_job_snapshot(&mut record, &snapshot).expect("idempotent replay");
+        assert_eq!(
+            artifacts(&record.run_id)
+                .expect("replayed artifacts")
+                .artifacts
+                .len(),
+            1
+        );
+    });
+}
+
+#[test]
 fn disconnected_runner_marks_nonterminal_proxy_stale_without_advancing_heartbeat() {
     with_isolated_home(|_| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];
@@ -3301,6 +3376,24 @@ fn terminal_child_snapshot(aggregate: &AgentTaskAggregate) -> crate::runner::Run
             })),
         }],
     }
+}
+
+fn persisted_terminal_result_snapshot(
+    aggregate: &AgentTaskAggregate,
+) -> crate::runner::RunnerJobLogSnapshot {
+    let mut snapshot = terminal_child_snapshot(aggregate);
+    snapshot.events[0].kind = JobEventKind::Result;
+    snapshot.events[0].data = Some(json!({
+        "exit_code": 0,
+        "stdout": format!("HOMEBOY_RUNNER_PROGRESS {{\"phase\":\"finished\"}}\n{}", json!({
+            "schema": "homeboy/command-result/v3",
+            "command": "agent-task",
+            "success": true,
+            "exit_code": 0,
+            "data": aggregate,
+        }))
+    }));
+    snapshot
 }
 
 fn succeeded_aggregate(plan: &AgentTaskPlan) -> AgentTaskAggregate {

--- a/crates/homeboy-core/src/agent_task_service/execution.rs
+++ b/crates/homeboy-core/src/agent_task_service/execution.rs
@@ -285,7 +285,14 @@ pub fn terminal_run_result(run_id: &str) -> Result<Option<AgentTaskRunResult<Age
         return Ok(None);
     }
 
-    let aggregate = agent_task_lifecycle::read_aggregate(&record.run_id).map_err(|_| {
+    let aggregate = match agent_task_lifecycle::read_aggregate(&record.run_id) {
+        Ok(aggregate) => aggregate,
+        Err(_) => {
+            // A terminal Lab result may have been persisted before its typed
+            // aggregate projection. Reconcile only that recorded terminal
+            // evidence; never resume or rerun the provider for this path.
+            agent_task_lifecycle::recover_terminal_transport_proxy_evidence(&record.run_id)?;
+            agent_task_lifecycle::read_aggregate(&record.run_id).map_err(|_| {
         Error::validation_invalid_argument(
             "run_id",
             format!(
@@ -298,7 +305,9 @@ pub fn terminal_run_result(run_id: &str) -> Result<Option<AgentTaskRunResult<Age
                 record.run_id
             )]),
         )
-    })?;
+            })?
+        }
+    };
     Ok(Some(AgentTaskRunResult {
         exit_code: aggregate_exit_code(&aggregate),
         value: crate::agent_task_artifacts::reviewer_facing_aggregate(&aggregate),

--- a/crates/homeboy-core/src/runner/agent_task_lifecycle_event.rs
+++ b/crates/homeboy-core/src/runner/agent_task_lifecycle_event.rs
@@ -73,6 +73,65 @@ pub(crate) fn agent_task_run_plan_lifecycle_event_from_job_events(
     })
 }
 
+/// Rehydrates a typed lifecycle event from a persisted runner terminal result.
+/// This is recovery-only: it uses the originally dispatched workload identity
+/// and never starts provider execution.
+pub(crate) fn agent_task_run_plan_lifecycle_event_from_persisted_job_events(
+    job_events: &[JobEvent],
+    runner_id: &str,
+    runner_job_id: &str,
+    persisted_run_id: &str,
+) -> Result<Option<AgentTaskRunPlanLifecycleEvent>> {
+    let Some(result) = job_events.iter().rev().find_map(|event| {
+        (event.kind == JobEventKind::Result)
+            .then_some(event.data.as_ref())
+            .flatten()
+    }) else {
+        return Ok(None);
+    };
+    let workload = result
+        .pointer("/data/runner_workload")
+        .or_else(|| result.get("runner_workload"))
+        .map(|value| serde_json::from_value::<RunnerWorkload>(value.clone()))
+        .transpose()
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse persisted Lab runner workload for agent-task recovery".to_string()),
+            )
+        })?;
+    if let Some(event) = agent_task_run_plan_lifecycle_event_from_workload_result(
+        workload.as_ref(),
+        runner_id,
+        runner_job_id,
+        result,
+    )? {
+        return Ok(Some(event));
+    }
+
+    let Some(stdout) = result.get("stdout").and_then(serde_json::Value::as_str) else {
+        return Ok(None);
+    };
+    let envelope = parse_offloaded_run_plan_envelope(stdout)?;
+    let Some(data) = envelope.get("data") else {
+        return Ok(None);
+    };
+    let Some(aggregate) = agent_task_aggregate_from_terminal_result(data)? else {
+        return Ok(None);
+    };
+    Ok(Some(AgentTaskRunPlanLifecycleEvent {
+        schema: AGENT_TASK_RUN_PLAN_LIFECYCLE_EVENT_SCHEMA.to_string(),
+        identity: AgentTaskDispatchIdentity {
+            runner_id: runner_id.to_string(),
+            runner_job_id: runner_job_id.to_string(),
+            persisted_run_id: Some(persisted_run_id.to_string()),
+            run_id: Some(persisted_run_id.to_string()),
+            ..AgentTaskDispatchIdentity::default()
+        },
+        aggregate,
+    }))
+}
+
 pub(crate) fn agent_task_run_plan_lifecycle_event_from_value(
     value: &serde_json::Value,
 ) -> Option<AgentTaskRunPlanLifecycleEvent> {
@@ -110,7 +169,7 @@ pub(crate) fn agent_task_run_plan_lifecycle_event_from_workload_result(
         return Ok(Some(event));
     }
 
-    let Some(aggregate) = result.get("data").and_then(agent_task_aggregate_from_value) else {
+    let Some(aggregate) = agent_task_aggregate_from_terminal_result(result)? else {
         return Ok(None);
     };
 
@@ -127,6 +186,43 @@ pub(crate) fn agent_task_run_plan_lifecycle_event_from_workload_result(
     }))
 }
 
+/// Remote runner results add a `data` envelope around the command result. Some
+/// commands add their own `data` envelope, so inspect those result boundaries
+/// instead of treating a valid aggregate as opaque terminal metadata.
+fn agent_task_aggregate_from_terminal_result(
+    value: &serde_json::Value,
+) -> Result<Option<AgentTaskAggregate>> {
+    const MAX_ENVELOPE_DEPTH: usize = 8;
+
+    let mut current = value;
+    for _ in 0..MAX_ENVELOPE_DEPTH {
+        if let Some(aggregate) = agent_task_aggregate_from_value(current) {
+            return Ok(Some(aggregate));
+        }
+        if current.get("schema").and_then(serde_json::Value::as_str)
+            == Some("homeboy/agent-task-aggregate/v1")
+            || current.get("plan_id").is_some()
+        {
+            return serde_json::from_value(current.clone())
+                .map(Some)
+                .map_err(|error| {
+                    Error::internal_json(
+                        error.to_string(),
+                        Some("hydrate nested Lab terminal agent-task aggregate".to_string()),
+                    )
+                });
+        }
+        let Some(next) = current.get("data") else {
+            return Ok(None);
+        };
+        current = next;
+    }
+
+    Err(Error::internal_unexpected(
+        "Lab terminal agent-task aggregate exceeded the supported result-envelope depth",
+    ))
+}
+
 fn agent_task_aggregate_from_value(value: &serde_json::Value) -> Option<AgentTaskAggregate> {
     if value.get("schema").and_then(serde_json::Value::as_str)
         == Some("homeboy/agent-task-aggregate/v1")
@@ -135,4 +231,122 @@ fn agent_task_aggregate_from_value(value: &serde_json::Value) -> Option<AgentTas
         return serde_json::from_value(value.clone()).ok();
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lab_contract::{
+        RunnerWorkload, RunnerWorkloadAgentTask, RunnerWorkloadAgentTaskDispatchKind,
+        RunnerWorkloadAgentTaskLifecycleMirrorPolicy,
+    };
+
+    fn workload() -> RunnerWorkload {
+        serde_json::from_value(serde_json::json!({
+            "schema": "homeboy/runner-workload/v1",
+            "workload_id": "lab-agent-task",
+            "kind": { "command_label": "agent-task", "command_family": "agent_task" },
+            "agent_task": RunnerWorkloadAgentTask {
+                run_id: "controller-run".to_string(),
+                plan_ref: None,
+                resolved_provider_policy: None,
+                dispatch_kind: RunnerWorkloadAgentTaskDispatchKind::RunPlan,
+                lifecycle_mirror_policy: RunnerWorkloadAgentTaskLifecycleMirrorPolicy::RunPlanAggregate,
+            },
+            "workspace_mappings": { "source_path_mode": "snapshot", "workspace_mode_policy": "snapshot", "mapping_ref": null },
+            "required_capabilities": [],
+            "required_secrets": { "categories": [], "secret_env_plan": {} },
+            "required_extensions": [],
+            "mutation_policy": { "capture_patch": true, "mutation_flag": null, "allow_dirty_lab_workspace": false },
+            "assignment": { "runner_id": "homeboy-lab", "runner_mode": null, "source": null },
+            "state": { "status": "submitted", "remote_workspace": null, "fallback_reason": null },
+            "result_refs": { "plan_id": "lab-agent-task", "proof_id": null, "workspace_mapping_ref": null, "artifacts": [] }
+        }))
+        .expect("workload fixture")
+    }
+
+    #[test]
+    fn hydrates_nested_terminal_aggregate_with_finalized_artifacts_and_provider_metadata() {
+        let result = serde_json::json!({
+            "exit_code": 0,
+            "data": {
+                "data": {
+                    "schema": "homeboy/agent-task-aggregate/v1",
+                    "plan_id": "plan-lab",
+                    "status": "succeeded",
+                    "totals": { "skipped": 0, "succeeded": 1 },
+                    "outcomes": [{
+                        "schema": "homeboy/agent-task-outcome/v1",
+                        "task_id": "implement",
+                        "status": "succeeded",
+                        "artifacts": [{
+                            "schema": "homeboy/agent-task-artifact/v1",
+                            "id": "final-patch",
+                            "kind": "patch",
+                            "path": "artifacts/final.patch",
+                            "size_bytes": 18928,
+                            "sha256": "062f5c460c2dfb279277b75d5a16a04e3178ace1f35ce7b10da5e17441b37071",
+                            "metadata": { "source_snapshot": "snapshot-1" }
+                        }],
+                        "typed_artifacts": [],
+                        "evidence_refs": [{ "kind": "transcript", "uri": "homeboy://lab/transcript", "label": "Provider transcript" }],
+                        "diagnostics": [],
+                        "outputs": null,
+                        "metadata": { "provider_run_id": "provider-run-1", "provider": "opencode" }
+                    }]
+                }
+            }
+        });
+
+        let event = agent_task_run_plan_lifecycle_event_from_workload_result(
+            Some(&workload()),
+            "homeboy-lab",
+            "runner-job-1",
+            &result,
+        )
+        .expect("nested aggregate hydrates")
+        .expect("lifecycle event");
+
+        assert_eq!(event.identity.run_id.as_deref(), Some("controller-run"));
+        assert_eq!(event.aggregate.outcomes[0].task_id, "implement");
+        assert_eq!(
+            event.aggregate.outcomes[0].artifacts[0].size_bytes,
+            Some(18_928)
+        );
+        assert_eq!(
+            event.aggregate.outcomes[0].artifacts[0].sha256.as_deref(),
+            Some("062f5c460c2dfb279277b75d5a16a04e3178ace1f35ce7b10da5e17441b37071")
+        );
+        assert_eq!(
+            event.aggregate.outcomes[0].metadata["provider_run_id"],
+            "provider-run-1"
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_nested_terminal_aggregate_with_hydration_context() {
+        let result = serde_json::json!({
+            "data": {
+                "data": {
+                    "schema": "homeboy/agent-task-aggregate/v1",
+                    "plan_id": "plan-lab",
+                    "status": "not-a-valid-status"
+                }
+            }
+        });
+
+        let error = agent_task_run_plan_lifecycle_event_from_workload_result(
+            Some(&workload()),
+            "homeboy-lab",
+            "runner-job-1",
+            &result,
+        )
+        .expect_err("malformed aggregate must fail hydration");
+
+        assert_eq!(error.code, crate::ErrorCode::InternalJsonError);
+        assert_eq!(
+            error.details["context"],
+            "hydrate nested Lab terminal agent-task aggregate"
+        );
+    }
 }


### PR DESCRIPTION
Closes #8479

## Summary
- Hydrate a persisted terminal Lab command result into the controller-owned agent-task aggregate and lifecycle projection.
- Preserve artifact IDs, hashes, byte sizes, provenance metadata, evidence references, and provider metadata; repeated reconciliation is idempotent.
- Read controller-owned plans for status and deferred reconciliation, so runner-local absolute plan paths are not required.
- Reject malformed nested aggregates with actionable JSON hydration context while retaining local execution behavior.

## Evidence
- Source relationship: adopted authorized commit `a0da81d5a8c3bfa77e7dabf7329eb0e73e61f747`, cleanly rebased onto `origin/main` at `8a659ea2f`.
- Change kind: bounded controller recovery/projection for already-persisted terminal Lab evidence.
- Verification capability: unit coverage exercises nested aggregate parsing, malformed aggregate rejection, artifact hash/size retention, controller-plan status access, and idempotent replay.
- Scope: runtime changes only replay terminal evidence for the recorded runner job and controller run; they never dispatch or resume provider work.

## Stranger-runnable tests
1. Run `cargo test -p homeboy-core agent_task_lifecycle::tests`. Currently blocked before test execution by upstream `origin/main` compile errors: `preview_ingress_tests.rs` and `tunnel_tests.rs` import removed `crate::tunnel`.
2. Run `cargo test -p homeboy-core runner::agent_task_lifecycle_event::tests`. Currently blocked by the same upstream `crate::tunnel` errors.
3. Run `cargo fmt --check`. Passes.
4. Run `git diff --check`. Passes.

## Compatibility
- No wire-schema change. Existing persisted terminal Lab command-result envelopes, including nested `data` envelopes, can now be projected into controller lifecycle state. Local execution and existing typed lifecycle events retain their behavior.

## AI Disclosure
Assisted by OpenCode using `openai/gpt-5.6-sol`.