### PR TITLE
fix(tunnel): restore core + tunnel test compilation after #8488 extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,7 @@ dependencies = [
  "homeboy-process",
  "homeboy-product-identity",
  "homeboy-redaction",
+ "homeboy-tunnel",
  "keyring",
  "libc",
  "regex",

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -56,3 +56,11 @@ tempfile = "3.14"
 clap = { version = "4.5", features = ["derive", "string"] }
 toml = "1.0.3"
 sha2 = "0.10.9"
+
+[dev-dependencies]
+# Tunnel was extracted to homeboy-tunnel (#8488). Two core test targets
+# (tunnel_tests, preview_ingress_tests) still exercise tunnel behavior /
+# consume the native-preview token helper, so the crate is needed for the
+# test build only. Cargo permits this dev-dependency cycle (tunnel depends on
+# core); it never enters the production graph.
+homeboy-tunnel = { version = "0.1.0", path = "../homeboy-tunnel" }

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -227,8 +227,6 @@ pub(crate) mod transient_workspace_policy;
 #[doc(hidden)]
 #[allow(dead_code)]
 pub mod test_support;
-#[cfg(test)]
-mod tunnel_tests;
 pub mod update_check_cache;
 pub mod upgrade;
 pub mod validation_progress;

--- a/crates/homeboy-core/src/preview_ingress_tests.rs
+++ b/crates/homeboy-core/src/preview_ingress_tests.rs
@@ -1,7 +1,7 @@
 use super::preview_ingress::*;
-use super::tunnel::native_preview_token_sha256;
 use crate::test_support;
 use base64::Engine;
+use homeboy_tunnel::native_preview_token_sha256;
 use serde_json::json;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};

--- a/crates/homeboy-tunnel/src/lib.rs
+++ b/crates/homeboy-tunnel/src/lib.rs
@@ -67,3 +67,11 @@ mod register_tests {
         assert_eq!(count, 1, "ServiceTunnel registered more than once");
     }
 }
+
+// Tunnel lifecycle/expose behavior tests. Relocated here from homeboy-core when
+// tunnel was extracted (#8488) — they exercise this crate's internals
+// (preview_policy_allows, preview_artifact_for) and its public surface, using
+// homeboy-core's public fixtures for isolation.
+#[cfg(test)]
+#[path = "tunnel_tests.rs"]
+mod tunnel_tests;

--- a/crates/homeboy-tunnel/src/tunnel_tests.rs
+++ b/crates/homeboy-tunnel/src/tunnel_tests.rs
@@ -1,12 +1,12 @@
-use super::tunnel::*;
-use crate::paths;
-use crate::server::Server;
-use crate::test_support;
+use crate::*;
+use homeboy_core::paths;
+use homeboy_core::server::Server;
+use homeboy_core::test_support;
 use std::collections::{BTreeMap, HashMap};
 use std::time::{Duration, Instant};
 
 fn create_server() {
-    crate::server::save(&Server {
+    homeboy_core::server::save(&Server {
         id: "private-host".to_string(),
         aliases: Vec::new(),
         host: "private.example.test".to_string(),
@@ -198,7 +198,7 @@ fn validation_rejects_auth_mode_without_env_var() {
         })
         .expect_err("missing auth env should fail");
 
-        assert_eq!(err.code, crate::ErrorCode::ValidationInvalidArgument);
+        assert_eq!(err.code, homeboy_core::ErrorCode::ValidationInvalidArgument);
         assert!(err.message.contains("auth.env_var"));
     });
 }
@@ -335,7 +335,7 @@ fn start_cleans_runtime_state_when_readiness_fails() {
         })
         .expect_err("readiness should fail");
 
-        assert_eq!(err.code, crate::ErrorCode::ValidationInvalidArgument);
+        assert_eq!(err.code, homeboy_core::ErrorCode::ValidationInvalidArgument);
         let state_path =
             paths::service_tunnel_runtime_state_file("failing-preview").expect("state path");
         assert!(!state_path.exists());
@@ -529,7 +529,7 @@ fn preview_start_fails_when_listener_process_exits_after_readiness() {
         })
         .expect_err("exited listener must not start successfully");
 
-        assert_eq!(err.code, crate::ErrorCode::ValidationInvalidArgument);
+        assert_eq!(err.code, homeboy_core::ErrorCode::ValidationInvalidArgument);
         assert!(err.message.contains("exited after becoming ready"));
         let refreshed = status("flapping-preview").expect("status refresh");
         assert!(!refreshed.running);
@@ -907,7 +907,7 @@ fn native_preview_claim_rejects_wrong_token_without_leaking_expected_token() {
 
     let err = validate_native_preview_claim(&tunnel, request).expect_err("wrong token fails");
 
-    assert_eq!(err.code, crate::ErrorCode::ValidationInvalidArgument);
+    assert_eq!(err.code, homeboy_core::ErrorCode::ValidationInvalidArgument);
     assert!(err.message.contains("not recognized"));
     assert!(!err.message.contains("secret-token"));
     assert!(!err.details.to_string().contains("secret-token"));


### PR DESCRIPTION
## Summary

#8488 extracted `tunnel` into `homeboy-tunnel` but **orphaned two test files in core** still referencing the removed `super::tunnel` — breaking the `homeboy-core` **test target** (`cargo check -p homeboy-core --tests` fails with E0432 on current main). #8488's own verification only checked `-p homeboy-tunnel --tests`, so core's break slipped through.

## Fix — relocate each test to where it belongs

**`tunnel_tests.rs` → moves into `homeboy-tunnel`.** It tests tunnel lifecycle/expose behavior *and* the crate-internal `preview_policy_allows` / `preview_artifact_for` (which are `pub(crate)`). Inside the crate it reaches them via `use crate::*`; its core fixtures (`Server`, `paths`, `test_support`, `ErrorCode`) become `homeboy_core::*` (tunnel already deps on core with `test-support`). **No API widening** — the alternative (dev-dep + promoting internals to `pub`) would have leaked tunnel internals.

**`preview_ingress_tests.rs` → stays in core.** It tests core's own `preview_ingress` module and only needs the public `native_preview_token_sha256`, now imported from `homeboy_tunnel`. Added `homeboy-tunnel` as a core **dev-dependency** for this — a dev-only cycle Cargo permits; it never enters the production graph.

Also removed a stray `#[cfg(test)]` that was left dangling over `pub mod update_check_cache` when `mod tunnel_tests;` was deleted.

## Verification

- `cargo check -p homeboy-core --tests` — **clean** (was E0432-broken on main)
- `cargo check -p homeboy-tunnel --tests` — clean
- 18 `tunnel_tests` + 12 `preview_ingress_tests` pass

Fixes the test-target regression from #8488.