### PR TITLE
Reconcile malformed agent-task lifecycle records

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -36,8 +36,8 @@ pub use args::{
     AgentTaskLoopDefineArgs, AgentTaskLoopResumeArgs, AgentTaskLoopStatusArgs, CancelArgs,
     CompileLoopArgs, ContractArgs, ContractFormat, DiagnoseArgs, EvidenceArgs, FinalizePrArgs,
     GateFeedbackArgs, LatestArgs, ListArgs, PromoteArgs, PromotionProviderArgs, ProvidersArgs,
-    ReplayProviderBoundaryArgs, RetryArgs, ReviewArgs, RunPlanArgs, StatusArgs, SubmitArgs,
-    VerifyGateArgs,
+    ReconcileRecordsArgs, ReplayProviderBoundaryArgs, RetryArgs, ReviewArgs, RunPlanArgs,
+    StatusArgs, SubmitArgs, VerifyGateArgs,
 };
 pub(crate) use status::diagnostic_summary_from_aggregate;
 
@@ -62,6 +62,7 @@ pub fn run(args: AgentTaskArgs, _global: &GlobalArgs) -> CmdResult<Value> {
                 status::list_active(active_args.into())
             }
         }
+        AgentTaskCommand::ReconcileRecords(args) => status::reconcile_records(args.dry_run),
         AgentTaskCommand::Latest(latest_args) => status::list_runs(
             agent_task_service::AgentTaskDiscoveryFilter::Latest,
             latest_args.into(),

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -43,6 +43,7 @@ pub enum AgentTaskCommand {
     Status(StatusArgs),
     List(ListArgs),
     Active(ActiveArgs),
+    ReconcileRecords(ReconcileRecordsArgs),
     Latest(LatestArgs),
     Logs(StatusArgs),
     Artifacts(StatusArgs),
@@ -81,6 +82,11 @@ pub struct ActiveArgs {
     #[arg(long = "reconcile")]
     pub reconcile: bool,
     #[arg(long = "dry-run", requires = "reconcile")]
+    pub dry_run: bool,
+}
+#[derive(Args, Debug)]
+pub struct ReconcileRecordsArgs {
+    #[arg(long = "dry-run")]
     pub dry_run: bool,
 }
 #[derive(Args, Debug)]

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -122,6 +122,11 @@ pub(super) fn reconcile_active(dry_run: bool) -> CmdResult<Value> {
     Ok((serde_json::to_value(report).unwrap_or(Value::Null), exit))
 }
 
+pub(super) fn reconcile_records(dry_run: bool) -> CmdResult<Value> {
+    let report = agent_task_lifecycle::reconcile_record_health(dry_run)?;
+    Ok((serde_json::to_value(report).unwrap_or(Value::Null), 0))
+}
+
 /// Group active-run ids by liveness classification for a scannable triage view.
 fn active_liveness_buckets(report: &agent_task_service::AgentTaskDiscoveryReport) -> Value {
     use agent_task_service_direct::AgentTaskLiveness;

--- a/crates/homeboy-core/src/activity.rs
+++ b/crates/homeboy-core/src/activity.rs
@@ -125,6 +125,8 @@ pub struct ActivityReport {
     pub command: &'static str,
     pub counts: ActivityCounts,
     pub items: Vec<ActivityItem>,
+    #[serde(default)]
+    pub agent_task_record_health: agent_task_lifecycle::AgentTaskRecordHealthSummary,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub next_actions: Vec<String>,
 }
@@ -139,7 +141,9 @@ pub fn activity_report(scope: ActivityScope, limit: usize) -> Result<ActivityRep
     agent_tasks::collect(&mut collector, limit)?;
     daemon_jobs::collect(&mut collector)?;
     runner_sessions::collect(&mut collector);
-    Ok(report_from_items(collector.items(scope, limit), "activity"))
+    let mut report = report_from_items(collector.items(scope, limit), "activity");
+    report.agent_task_record_health = agent_task_lifecycle::record_health_summary()?;
+    Ok(report)
 }
 
 pub fn show_activity(id: &str) -> Result<ActivityReport> {
@@ -154,7 +158,9 @@ pub fn show_activity(id: &str) -> Result<ActivityReport> {
             ]),
         ));
     };
-    Ok(report_from_items(vec![item.clone()], "activity.show"))
+    let mut result = report_from_items(vec![item.clone()], "activity.show");
+    result.agent_task_record_health = report.agent_task_record_health;
+    Ok(result)
 }
 
 pub fn resolve_activity(id: &str) -> Result<ActivityItem> {
@@ -197,6 +203,7 @@ fn report_from_items(items: Vec<ActivityItem>, command: &'static str) -> Activit
         command,
         counts,
         items,
+        agent_task_record_health: agent_task_lifecycle::AgentTaskRecordHealthSummary::healthy(),
         next_actions,
     }
 }

--- a/crates/homeboy-core/src/agent_task_lifecycle/health.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/health.rs
@@ -1,0 +1,200 @@
+use super::*;
+use crate::observation::{ObservationStore, RunRecord};
+
+const HEALTH_SAMPLE_LIMIT: usize = 20;
+const QUARANTINE_KEY: &str = "agent_task_lifecycle_quarantine";
+
+pub(crate) fn diagnose_run(
+    run: &RunRecord,
+) -> std::result::Result<AgentTaskRunRecord, AgentTaskRecordHealthItem> {
+    let quarantined = run.metadata_json.get(QUARANTINE_KEY).is_some();
+    let remediation = if quarantined {
+        "inspect metadata.agent_task_lifecycle_quarantine and restore a durable plan before rerunning reconciliation"
+    } else {
+        "run `homeboy agent-task reconcile-records --dry-run` to inspect repair evidence"
+    };
+    let record = store::record_from_run(run).map_err(|_| AgentTaskRecordHealthItem {
+        run_id: run.id.clone(),
+        reason: if run.metadata_json.get("agent_task_run").is_none() {
+            AgentTaskRecordHealthReason::MissingMetadata
+        } else {
+            AgentTaskRecordHealthReason::MalformedMetadata
+        },
+        quarantined,
+        remediation: remediation.to_string(),
+    })?;
+    let reason = if record.schema != schemas::RUN
+        || record.lifecycle.schema != RUN_LIFECYCLE_RECORD_SCHEMA
+    {
+        Some(AgentTaskRecordHealthReason::LegacySchema)
+    } else if RunExecutionState::from(record.state) != record.lifecycle.execution.state {
+        Some(AgentTaskRecordHealthReason::ConflictingProjections)
+    } else {
+        None
+    };
+    match reason {
+        Some(reason) => Err(AgentTaskRecordHealthItem {
+            run_id: run.id.clone(),
+            reason,
+            quarantined,
+            remediation: remediation.to_string(),
+        }),
+        None => Ok(record),
+    }
+}
+
+pub(crate) fn record_health_item(
+    health: &mut AgentTaskRecordHealthSummary,
+    item: AgentTaskRecordHealthItem,
+) {
+    match item.reason {
+        AgentTaskRecordHealthReason::MissingMetadata
+        | AgentTaskRecordHealthReason::MalformedMetadata => health.malformed += 1,
+        AgentTaskRecordHealthReason::LegacySchema => health.legacy += 1,
+        AgentTaskRecordHealthReason::ConflictingProjections => health.conflicting += 1,
+    }
+    if item.quarantined {
+        health.quarantined += 1;
+    }
+    if health.samples.len() < HEALTH_SAMPLE_LIMIT {
+        health.samples.push(item);
+    }
+}
+
+pub fn record_health_summary() -> Result<AgentTaskRecordHealthSummary> {
+    Ok(store::read_records_with_health()?.1)
+}
+
+pub fn reconcile_record_health(dry_run: bool) -> Result<AgentTaskRecordReconciliationReport> {
+    let mut report = AgentTaskRecordReconciliationReport {
+        schema: AGENT_TASK_RECORD_RECONCILIATION_SCHEMA.to_string(),
+        dry_run,
+        considered: 0,
+        migrated: 0,
+        quarantined: 0,
+        records: Vec::new(),
+    };
+    for run in store::observation_runs()? {
+        let Err(item) = diagnose_run(&run) else {
+            continue;
+        };
+        // Quarantine is durable operator evidence, not a retry queue. Repeating
+        // apply must be a no-op until an operator supplies new source evidence.
+        if item.quarantined {
+            continue;
+        }
+        report.considered += 1;
+        let reconstructable = matches!(
+            item.reason,
+            AgentTaskRecordHealthReason::MissingMetadata
+                | AgentTaskRecordHealthReason::MalformedMetadata
+        ) && store::read_controller_plan(&run.id).is_ok();
+        let action = if reconstructable || item.reason == AgentTaskRecordHealthReason::LegacySchema
+        {
+            "migrate"
+        } else {
+            "quarantine"
+        };
+        report.records.push(AgentTaskRecordReconciliationItem {
+            run_id: run.id.clone(),
+            reason: item.reason.clone(),
+            action: if dry_run {
+                format!("would-{action}")
+            } else {
+                action.to_string()
+            },
+        });
+        if dry_run {
+            continue;
+        }
+        if reconstructable {
+            store::write_record(&reconstruct_record(&run)?)?;
+            report.migrated += 1;
+        } else if item.reason == AgentTaskRecordHealthReason::LegacySchema {
+            let mut record = store::record_from_run(&run)?;
+            let original = serde_json::to_value(&record).unwrap_or(Value::Null);
+            record.schema = schemas::RUN.to_string();
+            record.lifecycle.schema = RUN_LIFECYCLE_RECORD_SCHEMA.to_string();
+            record.ensure_metadata_object().insert(
+                "lifecycle_reconstruction".to_string(),
+                json!({ "source": "legacy_typed_record", "original_record": original }),
+            );
+            store::write_record(&record)?;
+            report.migrated += 1;
+        } else {
+            quarantine(&run, &item)?;
+            report.quarantined += 1;
+        }
+    }
+    Ok(report)
+}
+
+fn reconstruct_record(run: &RunRecord) -> Result<AgentTaskRunRecord> {
+    let plan = store::read_controller_plan(&run.id)?;
+    let state = match run.status.as_str() {
+        "pass" => AgentTaskRunState::Succeeded,
+        "fail" => AgentTaskRunState::Failed,
+        "skipped" => AgentTaskRunState::Cancelled,
+        _ => AgentTaskRunState::Running,
+    };
+    let timestamp = run
+        .finished_at
+        .clone()
+        .or_else(|| Some(run.started_at.clone()));
+    let mut lifecycle = RunLifecycleRecord::with_execution_state(RunExecutionState::from(state));
+    lifecycle.updated_at = timestamp.clone();
+    lifecycle.execution.updated_at = timestamp.clone();
+    lifecycle.execution.started_at = Some(run.started_at.clone());
+    if !matches!(
+        state,
+        AgentTaskRunState::Running | AgentTaskRunState::Queued
+    ) {
+        lifecycle.execution.finished_at = timestamp.clone();
+    }
+    Ok(AgentTaskRunRecord {
+        schema: schemas::RUN.to_string(),
+        run_id: run.id.clone(),
+        plan_id: plan.plan_id,
+        state,
+        submitted_at: run.started_at.clone(),
+        updated_at: timestamp,
+        plan_path: store::run_dir(&run.id)?
+            .join("plan.json")
+            .display()
+            .to_string(),
+        aggregate_path: None,
+        totals: None,
+        tasks: plan.tasks.iter().map(queued_task).collect(),
+        artifact_refs: Vec::new(),
+        provider_handles: Vec::new(),
+        latest_executor_evidence: None,
+        lifecycle,
+        metadata: json!({
+            "lifecycle_reconstruction": {
+                "source": "observation_status_and_durable_plan",
+                "original_metadata": run.metadata_json,
+                "authoritative_terminal_status": run.status,
+            }
+        }),
+    })
+}
+
+fn quarantine(run: &RunRecord, item: &AgentTaskRecordHealthItem) -> Result<()> {
+    let mut metadata = run.metadata_json.clone();
+    if !metadata.is_object() {
+        metadata = json!({ "homeboy_original_metadata": metadata });
+    }
+    metadata.as_object_mut().expect("metadata object").insert(
+        QUARANTINE_KEY.to_string(),
+        json!({
+            "schema": "homeboy/agent-task-lifecycle-quarantine/v1",
+            "reason_code": item.reason,
+            "remediation": item.remediation,
+            "original_metadata": run.metadata_json,
+        }),
+    );
+    ObservationStore::open_initialized()?.upsert_imported_run_preserving_terminal(&RunRecord {
+        metadata_json: metadata,
+        ..run.clone()
+    })
+}

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1232,10 +1232,9 @@ pub fn list_records() -> Result<Vec<AgentTaskRunRecord>> {
     for record in store::read_records()? {
         match status(&record.run_id) {
             Ok(record) => records.push(record),
-            Err(error) => eprintln!(
-                "Warning: skipping malformed agent-task run status for {}: {}",
-                record.run_id, error.message
-            ),
+            // Discovery health owns malformed-record reporting. A transient
+            // status refresh failure must not reintroduce stderr-only state.
+            Err(_) => (),
         }
     }
     records.sort_by(|left, right| {
@@ -1248,6 +1247,27 @@ pub fn list_records() -> Result<Vec<AgentTaskRunRecord>> {
             .then_with(|| right.run_id.cmp(&left.run_id))
     });
     Ok(records)
+}
+
+pub fn list_records_with_health() -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)>
+{
+    let (records, health) = store::read_records_with_health()?;
+    let mut refreshed = Vec::new();
+    for record in records {
+        if let Ok(record) = status(&record.run_id) {
+            refreshed.push(record);
+        }
+    }
+    refreshed.sort_by(|left, right| {
+        right
+            .updated_at
+            .as_ref()
+            .unwrap_or(&right.submitted_at)
+            .cmp(left.updated_at.as_ref().unwrap_or(&left.submitted_at))
+            .then_with(|| right.submitted_at.cmp(&left.submitted_at))
+            .then_with(|| right.run_id.cmp(&left.run_id))
+    });
+    Ok((refreshed, health))
 }
 
 /// Resolve an aggregate artifact back to its controller-owned durable run.

--- a/crates/homeboy-core/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/mod.rs
@@ -32,12 +32,14 @@ use lifecycle_store as store;
 mod cancellation;
 mod conversion;
 mod failure_recording;
+mod health;
 mod lifecycle_ops;
 mod lifecycle_record_ops;
 mod records;
 
 pub use cancellation::*;
 pub use failure_recording::*;
+pub use health::*;
 pub use lifecycle_ops::*;
 pub use lifecycle_record_ops::cook_attempt_run_id;
 pub use records::*;

--- a/crates/homeboy-core/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/records.rs
@@ -9,6 +9,66 @@ pub(crate) mod schemas {
     pub(crate) const COOK_INDEX: &str = "homeboy/agent-task-cook-index/v1";
 }
 
+pub const AGENT_TASK_RECORD_HEALTH_SCHEMA: &str = "homeboy/agent-task-record-health/v1";
+pub const AGENT_TASK_RECORD_RECONCILIATION_SCHEMA: &str =
+    "homeboy/agent-task-record-reconciliation/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskRecordHealthReason {
+    MissingMetadata,
+    MalformedMetadata,
+    LegacySchema,
+    ConflictingProjections,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskRecordHealthItem {
+    pub run_id: String,
+    pub reason: AgentTaskRecordHealthReason,
+    pub quarantined: bool,
+    pub remediation: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskRecordHealthSummary {
+    pub schema: String,
+    pub healthy: usize,
+    pub malformed: usize,
+    pub legacy: usize,
+    pub conflicting: usize,
+    pub quarantined: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub samples: Vec<AgentTaskRecordHealthItem>,
+}
+
+impl AgentTaskRecordHealthSummary {
+    pub(crate) fn healthy() -> Self {
+        Self {
+            schema: AGENT_TASK_RECORD_HEALTH_SCHEMA.to_string(),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskRecordReconciliationItem {
+    pub run_id: String,
+    pub reason: AgentTaskRecordHealthReason,
+    pub action: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskRecordReconciliationReport {
+    pub schema: String,
+    pub dry_run: bool,
+    pub considered: usize,
+    pub migrated: usize,
+    pub quarantined: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub records: Vec<AgentTaskRecordReconciliationItem>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskRunRecord {
     pub schema: String,

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -3001,6 +3001,129 @@ fn list_records_skips_malformed_observation_records() {
     });
 }
 
+#[test]
+fn record_health_reconciles_plan_backed_missing_metadata_idempotently() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        submit_plan(&plan, Some("repairable-metadata")).expect("submitted");
+        let store = crate::observation::ObservationStore::open_initialized().expect("store");
+        let mut observation = store
+            .get_run("repairable-metadata")
+            .expect("read")
+            .expect("observation");
+        observation.metadata_json = json!({ "legacy_source": "fixture" });
+        store
+            .upsert_imported_run(&observation)
+            .expect("malformed fixture stored");
+
+        let before = record_health_summary().expect("health");
+        assert_eq!(before.malformed, 1);
+        assert_eq!(
+            before.samples[0].reason,
+            AgentTaskRecordHealthReason::MissingMetadata
+        );
+        let dry_run = reconcile_record_health(true).expect("dry run");
+        assert_eq!(dry_run.records[0].action, "would-migrate");
+        assert_eq!(
+            record_health_summary()
+                .expect("unmodified health")
+                .malformed,
+            1
+        );
+
+        let applied = reconcile_record_health(false).expect("applied");
+        assert_eq!(applied.migrated, 1);
+        let repaired = status("repairable-metadata").expect("reconstructed record");
+        assert_eq!(repaired.state, AgentTaskRunState::Running);
+        assert_eq!(
+            repaired.metadata["lifecycle_reconstruction"]["original_metadata"]["legacy_source"],
+            json!("fixture")
+        );
+        let healthy = record_health_summary().expect("healthy health");
+        assert_eq!(healthy.malformed + healthy.legacy + healthy.conflicting, 0);
+        assert_eq!(
+            reconcile_record_health(false).expect("repeat").considered,
+            0
+        );
+    });
+}
+
+#[test]
+fn record_health_migrates_legacy_and_quarantines_conflicting_projections() {
+    with_isolated_home(|_| {
+        submit_plan(&test_plan(), Some("legacy-record")).expect("submitted");
+        rewrite_record_for_test("legacy-record", |record| {
+            record.schema = "homeboy/agent-task-run/v0".to_string();
+        })
+        .expect("legacy stored");
+        let legacy = reconcile_record_health(false).expect("legacy migrated");
+        assert_eq!(legacy.migrated, 1);
+        let legacy_record = status("legacy-record").expect("legacy loaded");
+        assert_eq!(legacy_record.schema, schemas::RUN);
+        assert!(legacy_record
+            .metadata
+            .get("lifecycle_reconstruction")
+            .is_some());
+
+        submit_plan(&test_plan(), Some("conflicting-record")).expect("submitted");
+        rewrite_record_for_test("conflicting-record", |record| {
+            record.lifecycle.execution.state = RunExecutionState::Succeeded;
+        })
+        .expect("conflict stored");
+        let dry_run = reconcile_record_health(true).expect("conflict dry run");
+        assert_eq!(
+            dry_run.records[0].reason,
+            AgentTaskRecordHealthReason::ConflictingProjections
+        );
+        assert_eq!(dry_run.records[0].action, "would-quarantine");
+        let applied = reconcile_record_health(false).expect("conflict quarantined");
+        assert_eq!(applied.quarantined, 1);
+        let health = record_health_summary().expect("quarantine health");
+        assert_eq!(health.conflicting, 1);
+        assert_eq!(health.quarantined, 1);
+        assert_eq!(
+            reconcile_record_health(false)
+                .expect("repeat no-op")
+                .considered,
+            0
+        );
+    });
+}
+
+#[test]
+fn record_health_recovers_after_interrupted_migration_without_changing_terminal_status() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        submit_plan(&plan, Some("interrupted-terminal")).expect("submitted");
+        let store = crate::observation::ObservationStore::open_initialized().expect("store");
+        let mut observation = store
+            .get_run("interrupted-terminal")
+            .expect("read")
+            .expect("observation");
+        observation.status = "pass".to_string();
+        observation.finished_at = Some("2026-01-01T00:01:00Z".to_string());
+        observation.metadata_json = json!({});
+        store
+            .upsert_imported_run(&observation)
+            .expect("terminal malformed fixture");
+
+        store::fail_next_record_write_for_test();
+        assert!(reconcile_record_health(false).is_err());
+        assert_eq!(
+            record_health_summary().expect("still malformed").malformed,
+            1
+        );
+        let applied = reconcile_record_health(false).expect("retry migration");
+        assert_eq!(applied.migrated, 1);
+        let repaired = status("interrupted-terminal").expect("repaired");
+        assert_eq!(repaired.state, AgentTaskRunState::Succeeded);
+        assert_eq!(
+            repaired.lifecycle.execution.finished_at.as_deref(),
+            Some("2026-01-01T00:01:00Z")
+        );
+    });
+}
+
 fn outcome_with_refs(
     task_id: &str,
     artifacts: Vec<AgentTaskArtifact>,

--- a/crates/homeboy-core/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-core/src/agent_task_service/discovery.rs
@@ -50,6 +50,9 @@ pub struct AgentTaskDiscoveryReport {
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub truncated: bool,
     pub runs: Vec<AgentTaskDiscoveryRun>,
+    /// Bounded health evidence for malformed, legacy, conflicting, or
+    /// quarantined lifecycle rows omitted from the typed run projection.
+    pub record_health: agent_task_lifecycle::AgentTaskRecordHealthSummary,
     /// Liveness buckets for the `active` filter so operators can separate
     /// genuinely-active runs from stale/suspect/unreconciled records at a
     /// glance. Only populated for the `active` filter; `None` elsewhere.
@@ -217,7 +220,7 @@ pub fn discover_runs_with_options(
     filter: AgentTaskDiscoveryFilter,
     options: AgentTaskDiscoveryOptions,
 ) -> Result<AgentTaskDiscoveryReport> {
-    let mut records = agent_task_lifecycle::list_records()?;
+    let (mut records, record_health) = agent_task_lifecycle::list_records_with_health()?;
     let is_active = filter == AgentTaskDiscoveryFilter::Active;
     if is_active {
         records.retain(|record| {
@@ -264,6 +267,7 @@ pub fn discover_runs_with_options(
         limit: effective_limit,
         truncated,
         runs,
+        record_health,
         liveness_summary,
         lab_discovery: AgentTaskLabDiscoveryHint::default(),
     })

--- a/crates/homeboy-core/src/agent_task_service/tests.rs
+++ b/crates/homeboy-core/src/agent_task_service/tests.rs
@@ -372,6 +372,9 @@ fn discovery_lists_durable_runs_with_operator_commands() {
         assert_eq!(report.filter, "all");
         assert_eq!(report.count, 1);
         assert_eq!(report.total, 1);
+        assert_eq!(report.record_health.malformed, 0);
+        assert_eq!(report.record_health.legacy, 0);
+        assert_eq!(report.record_health.conflicting, 0);
         assert!(!report.truncated);
         assert!(report.limit.is_none());
         assert!(report

--- a/crates/homeboy-core/src/agent_tasks.rs
+++ b/crates/homeboy-core/src/agent_tasks.rs
@@ -249,15 +249,18 @@ pub mod lifecycle {
     pub use super::super::agent_task_lifecycle::{
         aggregate_source, artifacts, cancel, cancel_run, claim_next_queued_run,
         cook_attempt_run_id, cook_index, list_records, load_controller_plan, load_plan, logs,
-        mark_resuming, mark_running, record_completed_run, record_cook_attempt,
-        record_detached_lab_run, record_lab_offload_phase, record_lab_offload_planned,
-        record_pre_dispatch_failure, record_pre_execution_failure, record_promotion,
-        record_remote_dispatch_failure, record_run_aggregate, retry, run_id_for_aggregate_path,
-        run_record_exists, run_status, status, submit_plan, AgentTaskArtifactRef,
-        AgentTaskCookIndex, AgentTaskCookIndexAttempt, AgentTaskEventEnvelope,
-        AgentTaskPreDispatchFailure, AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts,
-        AgentTaskRunLog, AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState,
-        AgentTaskRunStatus, AgentTaskRunTask, DetachedLabRunRecord, LabOffloadProxyPlan,
+        mark_resuming, mark_running, reconcile_record_health, record_completed_run,
+        record_cook_attempt, record_detached_lab_run, record_health_summary,
+        record_lab_offload_phase, record_lab_offload_planned, record_pre_dispatch_failure,
+        record_pre_execution_failure, record_promotion, record_remote_dispatch_failure,
+        record_run_aggregate, retry, run_id_for_aggregate_path, run_record_exists, run_status,
+        status, submit_plan, AgentTaskArtifactRef, AgentTaskCookIndex, AgentTaskCookIndexAttempt,
+        AgentTaskEventEnvelope, AgentTaskPreDispatchFailure, AgentTaskRecordHealthItem,
+        AgentTaskRecordHealthReason, AgentTaskRecordHealthSummary,
+        AgentTaskRecordReconciliationItem, AgentTaskRecordReconciliationReport,
+        AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts, AgentTaskRunLog,
+        AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState, AgentTaskRunStatus,
+        AgentTaskRunTask, DetachedLabRunRecord, LabOffloadProxyPlan,
     };
 }
 

--- a/crates/homeboy-core/src/lifecycle_store.rs
+++ b/crates/homeboy-core/src/lifecycle_store.rs
@@ -242,24 +242,33 @@ pub(super) fn record_lacks_typed_metadata(run_id: &str) -> Result<bool> {
 }
 
 pub(super) fn read_records() -> Result<Vec<AgentTaskRunRecord>> {
+    Ok(read_records_with_health()?.0)
+}
+
+pub(super) fn read_records_with_health(
+) -> Result<(Vec<AgentTaskRunRecord>, super::AgentTaskRecordHealthSummary)> {
+    let mut health = super::AgentTaskRecordHealthSummary::healthy();
+    let mut records = Vec::new();
+    for run in observation_runs()? {
+        match super::health::diagnose_run(&run) {
+            Ok(record) => {
+                health.healthy += 1;
+                records.push(record);
+            }
+            Err(item) => super::health::record_health_item(&mut health, item),
+        }
+    }
+    Ok((records, health))
+}
+
+pub(super) fn observation_runs() -> Result<Vec<RunRecord>> {
     let store = ObservationStore::open_initialized()?;
     let filter = RunListFilter {
         kind: Some("agent-task".to_string()),
         limit: Some(1000),
         ..Default::default()
     };
-    let mut records = Vec::new();
-    for run in store.list_runs(filter)? {
-        match record_from_run(&run) {
-            Ok(record) => records.push(record),
-            Err(error) => eprintln!(
-                "Warning: skipping malformed agent-task run record {}: {}",
-                run.id, error.message
-            ),
-        }
-    }
-
-    Ok(records)
+    store.list_runs(filter)
 }
 
 fn observation_metadata(
@@ -291,7 +300,7 @@ fn merge_observation_metadata(mut existing: Value, typed: Value) -> Value {
     existing
 }
 
-fn record_from_run(run: &RunRecord) -> Result<AgentTaskRunRecord> {
+pub(super) fn record_from_run(run: &RunRecord) -> Result<AgentTaskRunRecord> {
     let value = run.metadata_json.get("agent_task_run").ok_or_else(|| {
         Error::new(
             ErrorCode::InternalJsonError,
@@ -379,7 +388,7 @@ fn read_json<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Result<T> {
         .map_err(|error| Error::internal_json(error.to_string(), Some(path.display().to_string())))
 }
 
-fn run_dir(run_id: &str) -> Result<PathBuf> {
+pub(super) fn run_dir(run_id: &str) -> Result<PathBuf> {
     Ok(paths::homeboy_data()?
         .join("agent-task-runs")
         .join(sanitize_run_id(run_id)))


### PR DESCRIPTION
## Summary
Replace stderr-only malformed lifecycle warnings with bounded health evidence and deterministic, provenance-preserving reconciliation.

## What changed
- Add versioned health and reconciliation schemas, surface bounded summaries in discovery and activity, reconstruct plan-backed records, migrate legacy schemas, and quarantine conflicting projections without changing terminal evidence.

## How to test
1. Run `cargo test`; expect The complete workspace test suite passes..
2. Run `homeboy agent-task reconcile-records --dry-run`; expect Homeboy reports stable reason codes and proposed migrate or quarantine actions without mutation..
3. Run `homeboy agent-task reconcile-records`; expect Reconstructable records migrate idempotently and conflicting records remain inspectable in quarantine with original evidence preserved..

## Compatibility
Discovery and activity JSON gain additive record-health fields, and the CLI gains reconcile-records. Existing typed lifecycle records and terminal evidence remain unchanged; malformed rows are no longer emitted as ad hoc stderr warnings.

## Evidence
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8287
- cargo-test: Passed
- diff-check: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Implemented lifecycle record health, deterministic migration and quarantine, CLI/API summaries, and high-signal recovery coverage with Chris.

## Source relationships
- Closes #8287
