### PR TITLE
fix: restore core test compilation broken by tunnel extraction (#8488)

### DIFF
--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -227,8 +227,6 @@ pub(crate) mod transient_workspace_policy;
 #[doc(hidden)]
 #[allow(dead_code)]
 pub mod test_support;
-#[cfg(test)]
-mod tunnel_tests;
 pub mod update_check_cache;
 pub mod upgrade;
 pub mod validation_progress;

--- a/crates/homeboy-core/src/preview_ingress_tests.rs
+++ b/crates/homeboy-core/src/preview_ingress_tests.rs
@@ -1,5 +1,4 @@
 use super::preview_ingress::*;
-use super::tunnel::native_preview_token_sha256;
 use crate::test_support;
 use base64::Engine;
 use serde_json::json;
@@ -7,6 +6,16 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::thread;
 use std::time::Duration;
+
+// The tunnel crate owns `native_preview_token_sha256`, but core cannot depend on
+// homeboy-tunnel (it depends on core — that would cycle). These preview_ingress
+// tests only need the same SHA-256 hex the tunnel helper produces, so compute it
+// locally to keep the assertion self-contained.
+fn native_preview_token_sha256(token: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(token.as_bytes());
+    format!("{digest:x}")
+}
 
 #[test]
 fn route_registers_host_to_upstream_origin() {

--- a/crates/homeboy-tunnel/src/lib.rs
+++ b/crates/homeboy-tunnel/src/lib.rs
@@ -23,9 +23,9 @@ pub use lifecycle::{local_url, start, status, stop};
 pub use preview::validate_native_preview_claim;
 pub use types::*;
 
-// Re-exported for sibling `tunnel_tests` integration coverage under `core`,
-// which pulls these in via `use super::tunnel::*`. The glob consumer is not
-// seen by the unused-imports lint, so the allow keeps a clean non-test build.
+// Re-exported for the `tunnel_tests` integration suite, which pulls these in
+// via `use crate::*`. The glob consumer is not seen by the unused-imports lint,
+// so the allow keeps a clean non-test build.
 #[allow(unused_imports)]
 pub(crate) use preview::{preview_artifact_for, preview_policy_allows};
 
@@ -37,6 +37,9 @@ homeboy_core::entity_crud!(ServiceTunnel; list_ids, merge);
 pub fn register() {
     homeboy_core::config::register_config_entity::<ServiceTunnel>();
 }
+
+#[cfg(test)]
+mod tunnel_tests;
 
 #[cfg(test)]
 mod register_tests {

--- a/crates/homeboy-tunnel/src/tunnel_tests.rs
+++ b/crates/homeboy-tunnel/src/tunnel_tests.rs
@@ -1,12 +1,12 @@
-use super::tunnel::*;
-use crate::paths;
-use crate::server::Server;
-use crate::test_support;
+use crate::*;
+use homeboy_core::paths;
+use homeboy_core::server::Server;
+use homeboy_core::test_support;
 use std::collections::{BTreeMap, HashMap};
 use std::time::{Duration, Instant};
 
 fn create_server() {
-    crate::server::save(&Server {
+    homeboy_core::server::save(&Server {
         id: "private-host".to_string(),
         aliases: Vec::new(),
         host: "private.example.test".to_string(),
@@ -198,7 +198,7 @@ fn validation_rejects_auth_mode_without_env_var() {
         })
         .expect_err("missing auth env should fail");
 
-        assert_eq!(err.code, crate::ErrorCode::ValidationInvalidArgument);
+        assert_eq!(err.code, homeboy_core::ErrorCode::ValidationInvalidArgument);
         assert!(err.message.contains("auth.env_var"));
     });
 }
@@ -335,7 +335,7 @@ fn start_cleans_runtime_state_when_readiness_fails() {
         })
         .expect_err("readiness should fail");
 
-        assert_eq!(err.code, crate::ErrorCode::ValidationInvalidArgument);
+        assert_eq!(err.code, homeboy_core::ErrorCode::ValidationInvalidArgument);
         let state_path =
             paths::service_tunnel_runtime_state_file("failing-preview").expect("state path");
         assert!(!state_path.exists());
@@ -529,7 +529,7 @@ fn preview_start_fails_when_listener_process_exits_after_readiness() {
         })
         .expect_err("exited listener must not start successfully");
 
-        assert_eq!(err.code, crate::ErrorCode::ValidationInvalidArgument);
+        assert_eq!(err.code, homeboy_core::ErrorCode::ValidationInvalidArgument);
         assert!(err.message.contains("exited after becoming ready"));
         let refreshed = status("flapping-preview").expect("status refresh");
         assert!(!refreshed.running);
@@ -907,7 +907,7 @@ fn native_preview_claim_rejects_wrong_token_without_leaking_expected_token() {
 
     let err = validate_native_preview_claim(&tunnel, request).expect_err("wrong token fails");
 
-    assert_eq!(err.code, crate::ErrorCode::ValidationInvalidArgument);
+    assert_eq!(err.code, homeboy_core::ErrorCode::ValidationInvalidArgument);
     assert!(err.message.contains("not recognized"));
     assert!(!err.message.contains("secret-token"));
     assert!(!err.details.to_string().contains("secret-token"));


### PR DESCRIPTION
## Summary
The tunnel extraction (#8488) moved tunnel code into `homeboy-tunnel` but **left two test files behind in core** still referencing `super::tunnel`, which no longer exists there. Both are compiled (declared in core `lib.rs`), so core's `--tests` build has been **broken on main since #8488** — `error[E0432]: unresolved import super::tunnel`.

It slipped through because the merge-branch CI Test gate skips final enforcement once the PR is closed (a known quirk from earlier findings).

## Fix
- **`tunnel_tests.rs`** (1045 lines) tests tunnel behavior → moved into the `homeboy-tunnel` crate where it belongs (`super::tunnel::*` → `use crate::*`; `crate::` core refs → `homeboy_core::`). **18 tests restored.**
- **`preview_ingress_tests.rs`** tests core's `preview_ingress` but used one tunnel helper (`native_preview_token_sha256`). Core cannot depend on `homeboy-tunnel` (would cycle), so the trivial SHA-256 hex helper is inlined locally. **12 tests restored.**

## Verification
`cargo check -p homeboy-core --tests` and `-p homeboy-tunnel --tests` clean; the 18 tunnel + 12 preview_ingress tests pass. Core's full test suite compiles again (6212 tests now build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)