### PR TITLE
Fix recovered Lab artifact status reporting

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -1055,6 +1055,9 @@ fn compact_status_summary(record: &Value, run_id: &str) -> Value {
         "run_id": record.get("run_id").cloned().unwrap_or_else(|| json!(run_id)),
         "state": record.get("state").cloned().unwrap_or(Value::Null),
         "work_summary": work_summary,
+        // Keep typed refs so the shared status presentation can classify
+        // recovered terminal patch artifacts by their size and kind.
+        "artifact_refs": record.get("artifact_refs").cloned().unwrap_or(Value::Null),
         "totals": record.get("totals").cloned().unwrap_or(Value::Null),
         "tasks": task_table,
         "refs": refs,

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -1759,6 +1759,25 @@ mod tests {
     }
 
     #[test]
+    fn compact_status_retains_recovered_patch_refs_for_summary_rendering() {
+        let record = json!({
+            "run_id": "recovered-lab-run",
+            "state": "succeeded",
+            "tasks": [{ "task_id": "cook", "state": "succeeded" }],
+            "artifact_refs": [{
+                "task_id": "cook",
+                "kind": "patch",
+                "uri": "homeboy://agent-task/run/recovered-lab-run/artifacts#task=cook&artifact=patch",
+                "size_bytes": 7926
+            }]
+        });
+
+        let summary = compact_status_summary(&record, "recovered-lab-run");
+
+        assert_eq!(summary["artifact_refs"], record["artifact_refs"]);
+    }
+
+    #[test]
     fn compact_work_summary_separates_no_patch_promotion_from_provider_artifacts() {
         let record = json!({
             "run_id": "agent-task-run-artifacts",

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -906,6 +906,51 @@ mod tests {
     }
 
     #[test]
+    fn status_summary_classifies_recovered_finalized_patch_refs_like_review() {
+        let patch = json!({
+            "id": "patch",
+            "kind": "patch",
+            "url": "homeboy://agent-task/run/recovered/artifacts#task=cook&artifact=patch",
+            "size_bytes": 683500,
+            "sha256": "fe060d978ff0d4ad0705a759308728ae29250c1b07587fc5ba8d0223262d9deb",
+            "metadata": {
+                "executor_artifact_finalized": true,
+                "source_provenance": { "runner_id": "homeboy-lab" }
+            }
+        });
+        let payload = json!({
+            "run_id": "recovered",
+            "state": "succeeded",
+            "aggregate_path": "/tmp/recovered-aggregate.json",
+            "tasks": [{ "task_id": "cook", "state": "succeeded" }],
+            "artifact_refs": [
+                { "task_id": "cook", "kind": "patch", "uri": patch["url"], "size_bytes": 683500 },
+                { "task_id": "cook", "kind": "transcript", "uri": "file:///tmp/transcript", "size_bytes": 12 },
+                { "task_id": "cook", "kind": "json", "uri": "file:///tmp/result", "size_bytes": 4 },
+                { "task_id": "cook", "kind": "runtime_log", "uri": "file:///tmp/runtime", "size_bytes": 20 }
+            ],
+            "aggregate": {
+                "outcomes": [{
+                    "artifacts": [patch],
+                    "typed_artifacts": [{
+                        "name": "patch",
+                        "type": "file",
+                        "artifact": { "id": "patch", "kind": "patch", "path": "/tmp/finalized-patch", "size_bytes": 683500 }
+                    }]
+                }]
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
+
+        assert!(summary.contains("Status: succeeded\n"));
+        assert!(summary.contains("Patch candidates: 1 non-empty / 0 empty\n"));
+        assert!(summary.contains("Diff bytes: 683500\n"));
+        assert!(summary.contains("Artifacts: 4\n"));
+        assert!(summary.contains("Next: homeboy agent-task review recovered\n"));
+    }
+
+    #[test]
     fn status_summary_flags_no_op_when_all_patch_artifacts_are_empty() {
         let payload = json!({
             "run_id": "agent-task-deadbeef",


### PR DESCRIPTION
## Summary

- retain recovered artifact references in compact agent-task status data
- make status use the same patch candidate classification as review
- cover URL-backed finalized patch artifacts and compact status retention

This completes the status side of #8479 after the Lab terminal aggregate ingestion repair landed in #8495.

## How to test

1. Run `cargo fmt --check`.
2. Run `cargo check -p homeboy-cli`.
3. Run `cargo test -p homeboy-cli status_summary_classifies_recovered_finalized_patch_refs_like_review --lib`. The current `main` test build is blocked before this test runs by pre-existing unresolved imports in `tests/core/extension/component_script_test.rs`; verify the reported failures are limited to `crate::component`, `crate::engine`, `crate::extension`, and `crate::paths`.
4. Recover a completed Lab agent-task with `homeboy agent-task resume <run-id> --bridge`, then run `homeboy agent-task status <run-id>` and `homeboy agent-task review <run-id>`. Verify both report one non-empty patch candidate and the same diff byte count, and status reports the hydrated artifact count.

## Verification

- `cargo fmt --check` passed.
- `cargo check -p homeboy-cli` passed.
- Homeboy changed-since audit and lint passed with no introduced findings.
- A real recovered Lab terminal result reported one non-empty 683,500-byte patch and seven artifacts consistently in status and review.
- The focused `homeboy-cli` lib test is blocked by the pre-existing test-build imports documented above.

## Compatibility impact

No extension path or public API changes. Structured and rendered status output now reports recovered artifacts instead of false zero values; consumers relying on the incorrect `no_patch_produced` classification will observe the corrected succeeded/candidate state.

Closes #8479.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause analysis, implementation, tests, and end-to-end lifecycle verification under human direction.