### PR TITLE
refactor: move runner workspace sync types to runner-contract (runner-decouple stage 4)

### DIFF
--- a/crates/homeboy-core/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-core/src/agent_task_scheduler/harvest.rs
@@ -1103,9 +1103,9 @@ mod committed_harvest_tests {
             .expect("create runner");
             let (synced, exit_code) = crate::runner::sync_workspace(
                 "lab-snapshot-git",
-                crate::runner::RunnerWorkspaceSyncOptions {
+                homeboy_runner_contract::RunnerWorkspaceSyncOptions {
                     path: source.path().display().to_string(),
-                    mode: crate::runner::RunnerWorkspaceSyncMode::SnapshotGit,
+                    mode: homeboy_runner_contract::RunnerWorkspaceSyncMode::SnapshotGit,
                     controller_routed_git: false,
                     changed_since_base: None,
                     git_fetch_refs: Vec::new(),

--- a/crates/homeboy-core/src/daemon/patch_capture.rs
+++ b/crates/homeboy-core/src/daemon/patch_capture.rs
@@ -419,9 +419,9 @@ mod tests {
             .expect("create runner");
             let (sync, exit_code) = crate::runner::sync_workspace(
                 "patch-baseline",
-                crate::runner::RunnerWorkspaceSyncOptions {
+                homeboy_runner_contract::RunnerWorkspaceSyncOptions {
                     path: source.display().to_string(),
-                    mode: crate::runner::RunnerWorkspaceSyncMode::Git,
+                    mode: homeboy_runner_contract::RunnerWorkspaceSyncMode::Git,
                     controller_routed_git: false,
                     ..Default::default()
                 },

--- a/crates/homeboy-core/src/runner/workspace/types.rs
+++ b/crates/homeboy-core/src/runner/workspace/types.rs
@@ -27,45 +27,11 @@ pub(crate) const DEFAULT_EXCLUDES: &[&str] = &[
     "*.pfx",
 ];
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum RunnerWorkspaceSyncMode {
-    #[default]
-    Snapshot,
-    SnapshotGit,
-    Git,
-}
-
-impl RunnerWorkspaceSyncMode {
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::Snapshot => "snapshot",
-            Self::SnapshotGit => "snapshot-git",
-            Self::Git => "git",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct RunnerWorkspaceSyncOptions {
-    pub path: String,
-    pub mode: RunnerWorkspaceSyncMode,
-    pub controller_routed_git: bool,
-    pub changed_since_base: Option<String>,
-    pub git_fetch_refs: Vec<String>,
-    pub snapshot_includes: Vec<String>,
-    pub allow_dirty_lab_workspace: bool,
-    /// Opaque per-run token (e.g. an agent-task run id) folded into the
-    /// deterministic remote workspace path so two distinct cook/dispatch runs
-    /// at the same source HEAD never share a long-lived remote checkout.
-    ///
-    /// Without this, the git-mode remote path is keyed only on
-    /// `(source path, HEAD)`, so a later unrelated run reuses the earlier run's
-    /// workspace directory and can observe leftover untracked artifacts from it
-    /// (cross-run contamination, see #4393). When set, each run gets an
-    /// isolated `_lab_workspaces/<name>-<digest>` directory.
-    pub run_isolation_token: Option<String>,
-}
+// RunnerWorkspaceSyncMode + RunnerWorkspaceSyncOptions are behavior-free data;
+// they now live in the shared runner-contract crate so core can name them
+// without a core -> runner edge. Re-exported so internal/CLI call sites resolve
+// unchanged.
+pub use homeboy_runner_contract::{RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RunnerWorkspaceSyncOutput {

--- a/crates/homeboy-core/src/upgrade/runners/source_checkout.rs
+++ b/crates/homeboy-core/src/upgrade/runners/source_checkout.rs
@@ -4,12 +4,12 @@ use super::*;
 use crate::runner;
 use crate::runner::Runner;
 use crate::runner::RunnerExecOptions;
-use crate::runner::RunnerWorkspaceSyncMode;
-use crate::runner::RunnerWorkspaceSyncOptions;
 use crate::Result;
 use homeboy_runner_contract::RunnerCapabilityPreflight;
 use homeboy_runner_contract::RunnerKind;
 use homeboy_runner_contract::RunnerRequiredTool;
+use homeboy_runner_contract::RunnerWorkspaceSyncMode;
+use homeboy_runner_contract::RunnerWorkspaceSyncOptions;
 use std::path::Path;
 use std::process::Command;
 

--- a/crates/homeboy-runner-contract/src/lib.rs
+++ b/crates/homeboy-runner-contract/src/lib.rs
@@ -17,6 +17,48 @@ pub enum RunnerKind {
     Ssh,
 }
 
+/// How a runner workspace is synced before a job runs.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerWorkspaceSyncMode {
+    #[default]
+    Snapshot,
+    SnapshotGit,
+    Git,
+}
+
+impl RunnerWorkspaceSyncMode {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Snapshot => "snapshot",
+            Self::SnapshotGit => "snapshot-git",
+            Self::Git => "git",
+        }
+    }
+}
+
+/// Options controlling how a runner workspace is synced before a job runs.
+#[derive(Debug, Clone, Default)]
+pub struct RunnerWorkspaceSyncOptions {
+    pub path: String,
+    pub mode: RunnerWorkspaceSyncMode,
+    pub controller_routed_git: bool,
+    pub changed_since_base: Option<String>,
+    pub git_fetch_refs: Vec<String>,
+    pub snapshot_includes: Vec<String>,
+    pub allow_dirty_lab_workspace: bool,
+    /// Opaque per-run token (e.g. an agent-task run id) folded into the
+    /// deterministic remote workspace path so two distinct cook/dispatch runs
+    /// at the same source HEAD never share a long-lived remote checkout.
+    ///
+    /// Without this, the git-mode remote path is keyed only on
+    /// `(source path, HEAD)`, so a later unrelated run reuses the earlier run's
+    /// workspace directory and can observe leftover untracked artifacts from it
+    /// (cross-run contamination, see #4393). When set, each run gets an
+    /// isolated `_lab_workspaces/<name>-<digest>` directory.
+    pub run_isolation_token: Option<String>,
+}
+
 /// Set while a hosted exec runs inside a runner (as opposed to the local host).
 pub const RUNNER_HOSTED_EXEC_ENV: &str = "HOMEBOY_RUNNER_HOSTED_EXEC";
 


### PR DESCRIPTION
## Summary
Stage 4 of decoupling the optional runner feature from core. Moves two more behavior-free contract types out of `runner/workspace/types.rs` into `homeboy-runner-contract`:
- `RunnerWorkspaceSyncMode` (enum + its pure `label()` method)
- `RunnerWorkspaceSyncOptions`

Both are plain data, re-exported from `runner::workspace::types` so internal/CLI call sites resolve unchanged. External consumers (`upgrade/runners`, `daemon/patch_capture`, `agent_task_scheduler/harvest`) repointed to `homeboy_runner_contract::`, severing those reverse edges.

## Plan correction
`RunnerExecOptions` was the original stage-4 target, but on inspection it's a **~30-method behavior builder** depending on core's `SourceSnapshot` — a behavioral (hook-invert) edge, **not a movable type**. Corrected course and picked these clean plain-data types instead.

## Verification
`cargo check` clean for `-p homeboy-runner-contract`, `-p homeboy-core --lib`, `-p homeboy-cli --lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)