### PR TITLE
Preserve controller plan ownership across Lab cook handoff

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -329,8 +329,8 @@ pub fn record_completed_run(
 }
 
 pub fn load_plan(run_id: &str) -> Result<AgentTaskPlan> {
-    let record = store::read_record(&resolve_run_id(run_id)?)?;
-    store::read_plan_path(&record.plan_path)
+    let run_id = resolve_run_id(run_id)?;
+    store::read_controller_plan(&run_id)
 }
 
 /// Load the plan owned by this controller's durable run identity. Runner paths
@@ -343,8 +343,8 @@ pub fn load_controller_plan(run_id: &str) -> Result<AgentTaskPlan> {
 /// Load a durable plan for a scheduler or provider execution. This is the only
 /// read path allowed to upgrade a legacy execution-budget envelope.
 pub fn load_plan_for_execution(run_id: &str) -> Result<AgentTaskPlan> {
-    let record = store::read_record(&resolve_run_id(run_id)?)?;
-    store::read_plan_path_for_execution(&record.plan_path)
+    let run_id = resolve_run_id(run_id)?;
+    store::read_controller_plan_for_execution(&run_id)
 }
 
 pub fn mark_running(run_id: &str) -> Result<AgentTaskRunRecord> {
@@ -461,10 +461,8 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     let _ = reconcile_deferred_candidate(&resolved_run_id)?;
     let mut record = store::read_record(&resolved_run_id)?;
     if !is_terminal_run_state(record.state) {
-        if let (Ok(aggregate), Ok(plan)) = (
-            store::read_aggregate(&record.run_id),
-            store::read_controller_plan(&record.run_id),
-        ) {
+        if let Ok(aggregate) = store::read_aggregate(&record.run_id) {
+            let plan = store::read_controller_plan(&record.run_id)?;
             let aggregate_path = store::aggregate_path(&record.run_id)
                 .map(|path| path.display().to_string())
                 .unwrap_or_else(|_| "aggregate.json".to_string());
@@ -1474,14 +1472,14 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
             None,
         ));
     }
-    if let Err(error) = store::read_plan_path(&record.plan_path) {
+    if let Err(error) = store::read_controller_plan(&run_id) {
         fail_missing_lab_attempt_plan(&mut record, &error)?;
         return Err(Error::internal_io(
             format!(
                 "cannot bind Lab runner job because durable attempt plan is unavailable: {}",
                 error.message
             ),
-            Some(record.plan_path),
+            Some(run_id),
         ));
     }
     record.updated_at = Some(now_timestamp());
@@ -1606,7 +1604,7 @@ fn record_lab_offload_proxy(
     // A previous interruption may have committed the record but not its plan.
     // Repair from the controller-compiled plan before exposing another handoff
     // phase; without it the runner would later create a fake running attempt.
-    if store::read_plan_path(&record.plan_path).is_err() {
+    if store::read_controller_plan(&run_id).is_err() {
         if let Some(durable_plan) = durable_plan {
             let plan_path = store::write_plan(&run_id, durable_plan)?;
             record.plan_path = plan_path.display().to_string();

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -558,6 +558,72 @@ fn retry_uses_controller_plan_when_runner_projection_replaces_plan_path() {
         let error = retry(&record.run_id, Some("missing-controller-plan"))
             .expect_err("missing controller plan fails closed");
         assert_eq!(error.code, ErrorCode::InternalIoError);
+        assert!(error
+            .message
+            .contains("controller-owned durable plan is unavailable"));
+    });
+}
+
+#[test]
+fn cook_lab_handoff_controller_reads_ignore_runner_plan_projection() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+        ];
+        let record = record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "cook-lab-attempt",
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace",
+            remote_command: &command,
+            durable_plan: Some(&plan),
+        })
+        .expect("cook handoff persists its controller plan");
+        let aggregate = succeeded_aggregate(&plan);
+        record_run_aggregate(&record.run_id, &plan, &aggregate)
+            .expect("runner result mirrored to the controller");
+        rewrite_record_for_test(&record.run_id, |record| {
+            record.plan_path =
+                "/home/chubes/.local/share/homeboy/agent-task-runs/cook-lab-attempt/plan.json"
+                    .to_string();
+            record.state = AgentTaskRunState::Running;
+        })
+        .expect("runner transport projection replaces display path");
+
+        assert_eq!(
+            status(&record.run_id).expect("controller status").plan_id,
+            plan.plan_id
+        );
+        assert_eq!(
+            logs(&record.run_id).expect("controller logs").run_id,
+            record.run_id
+        );
+        assert_eq!(
+            artifacts(&record.run_id)
+                .expect("controller artifacts")
+                .run_id,
+            record.run_id
+        );
+        let retry = retry(&record.run_id, Some("cook-lab-retry"))
+            .expect("controller retry uses its durable plan");
+        assert_eq!(
+            load_controller_plan(&retry.run_id).expect("retry plan"),
+            plan
+        );
+
+        std::fs::remove_file(record.plan_path)
+            .expect("remove authoritative controller plan despite projected display path");
+        rewrite_record_for_test(&record.run_id, |record| {
+            record.state = AgentTaskRunState::Running;
+        })
+        .expect("restore active handoff projection");
+        let error = status(&record.run_id).expect_err("missing controller plan fails closed");
+        assert_eq!(error.code, ErrorCode::InternalIoError);
+        assert!(error
+            .message
+            .contains("controller-owned durable plan is unavailable"));
     });
 }
 

--- a/crates/homeboy-core/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-core/src/agent_task_service/discovery.rs
@@ -369,7 +369,7 @@ fn discovery_run(
     classify: bool,
     now: chrono::DateTime<chrono::Utc>,
 ) -> AgentTaskDiscoveryRun {
-    let plan = agent_task_lifecycle::load_plan(&record.run_id).ok();
+    let plan = agent_task_lifecycle::load_controller_plan(&record.run_id).ok();
     let first_task = plan.as_ref().and_then(|plan| plan.tasks.first());
     let repo = plan
         .as_ref()

--- a/crates/homeboy-core/src/lifecycle_store.rs
+++ b/crates/homeboy-core/src/lifecycle_store.rs
@@ -39,17 +39,31 @@ pub(super) fn read_plan_path(path: &str) -> Result<AgentTaskPlan> {
 }
 
 pub(super) fn read_controller_plan(run_id: &str) -> Result<AgentTaskPlan> {
-    let plan = read_json(&run_dir(run_id)?.join("plan.json"))?;
+    let path = run_dir(run_id)?.join("plan.json");
+    let plan = read_json(&path).map_err(|error| {
+        if error.code == ErrorCode::InternalIoError {
+            Error::internal_io(
+                format!(
+                    "controller-owned durable plan is unavailable for run `{run_id}`: {}",
+                    error.message
+                ),
+                Some(path.display().to_string()),
+            )
+        } else {
+            error
+        }
+    })?;
     validate_execution_budget(&plan)?;
     Ok(plan)
 }
 
-/// Execution owns the one permitted durable legacy rewrite. Read-only callers
-/// (notably status) use `read_plan_path` and never mutate a plan preview.
-pub(super) fn read_plan_path_for_execution(path: &str) -> Result<AgentTaskPlan> {
+/// Controller lifecycle operations resolve the plan from their durable run
+/// identity. `AgentTaskRunRecord::plan_path` can be runner-local transport
+/// evidence after a Lab projection and is never controller execution authority.
+pub(super) fn read_controller_plan_for_execution(run_id: &str) -> Result<AgentTaskPlan> {
     crate::config::with_config_lock(|| {
-        let path = PathBuf::from(path);
-        let mut plan = read_json(&path)?;
+        let path = run_dir(run_id)?.join("plan.json");
+        let mut plan = read_controller_plan(run_id)?;
         if migrate_execution_budget(&mut plan)? {
             write_private_json(&path, &plan)?;
         }


### PR DESCRIPTION
## Summary
Resolve controller lifecycle plans by durable run identity so Lab projections cannot make status, logs, artifacts, retry, or reconciliation dereference runner-local paths.

## What changed
- Added one authoritative controller-plan resolver and applied it at lifecycle read boundaries, with precise fail-closed diagnostics when the controller plan is absent.

## How to test
1. Run `cargo test -p homeboy-core --test agent_task_handoff_reconnect`; expect The controller handoff remains resolvable and reconciles deterministically..
2. Run `cargo check -p homeboy-core && cargo check -p homeboy-cli`; expect Both affected crates compile successfully..
3. Run `Dispatch a Lab cook, then run controller status, logs, and artifacts`; expect All controller lifecycle reads resolve the controller-owned plan after handoff..

## Compatibility
No intentional public API or extension-path compatibility change. Persisted runner projections remain readable because controller resolution is derived from the durable run id.

## Evidence
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8490
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8494
- cli-check: Passed
- core-check: Passed
- diff-check: Passed
- format: Passed
- handoff-test: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy recovery workflow
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab handoff regression, implemented controller-owned plan resolution, reconciled current-main changes, and added deterministic lifecycle coverage; Chris reviews and owns the change.

## Source relationships
- Closes #8494
- Relates to #8382
- Relates to #8471
- Relates to #8490
