### PR TITLE
ci: compile all workspace test targets to catch crate-extraction orphans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,23 @@ permissions:
   issues: write
 
 jobs:
+  # Non-differential safety net for crate-topology changes. The `review test`
+  # gate below is differentially scoped, so a crate extraction that orphans a
+  # DONOR crate's test wiring (e.g. a test file left referencing a `super::foo`
+  # module after `foo` moved to its own crate) can pass unnoticed — the donor
+  # isn't in the changed scope. This job compiles EVERY crate's test target
+  # (codegen-free, so it's cheap) and fails closed if any of them break.
+  workspace-tests-compile:
+    name: homeboy / Workspace Tests Compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Compile all workspace test targets
+        run: cargo check --workspace --tests --locked
+
   homeboy:
     name: homeboy / ${{ matrix.title }}
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -447,6 +447,16 @@ jobs:
         if: inputs.release_tag == '' && needs.check.outputs.recovery-release != 'true'
         run: cargo build --workspace --locked
 
+      # Compile every crate's TEST target too. `cargo build --workspace` above
+      # only builds lib/bin targets, so a test file that references a module
+      # moved during a crate extraction (e.g. a donor's orphaned `super::foo`
+      # after `foo` was extracted) compiles fine here yet breaks the test gate.
+      # `check --tests` is codegen-free and cheap; it fails the release closed
+      # before shipping a workspace whose tests don't build.
+      - name: Preflight workspace test-target compilation
+        if: inputs.release_tag == '' && needs.check.outputs.recovery-release != 'true'
+        run: cargo check --workspace --tests --locked
+
       - uses: Extra-Chill/homeboy-action@v2
         id: release
         if: inputs.release_tag == '' && needs.check.outputs.recovery-release != 'true'

--- a/crates/homeboy-core/src/extension/component_script.rs
+++ b/crates/homeboy-core/src/extension/component_script.rs
@@ -151,7 +151,7 @@ fn run_component_scripts_with_env_and_timeout(
     })
 }
 
-pub(crate) fn run_component_scripts_with_env(
+pub fn run_component_scripts_with_env(
     component: &Component,
     capability: ExtensionCapability,
     source_path: &Path,
@@ -282,7 +282,7 @@ fn command_with_args(command: &str, script_args: &[String]) -> String {
     )
 }
 
-pub(crate) fn source_path(component: &Component, path_override: Option<&str>) -> PathBuf {
+pub fn source_path(component: &Component, path_override: Option<&str>) -> PathBuf {
     path_override
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from(&component.local_path))

--- a/tests/core/extension/component_script_test.rs
+++ b/tests/core/extension/component_script_test.rs
@@ -8,14 +8,14 @@ use crate::commands::utils::args::{
     BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs,
 };
 use crate::commands::GlobalArgs;
-use crate::component::{Component, ComponentScriptsConfig, ScopedExtensionConfig};
-use crate::engine::run_dir::RunDir;
-use crate::extension::component_script::{
+use homeboy_core::component::{Component, ComponentScriptsConfig, ScopedExtensionConfig};
+use homeboy_core::engine::run_dir::RunDir;
+use homeboy_core::extension::component_script::{
     run_component_scripts, run_component_scripts_with_env, run_component_scripts_with_run_dir,
     source_path,
 };
-use crate::extension::ExtensionCapability;
-use crate::test_support::with_isolated_home;
+use homeboy_core::extension::ExtensionCapability;
+use homeboy_core::test_support::with_isolated_home;
 
 fn component_script_args(root: &Path) -> PositionalComponentArgs {
     PositionalComponentArgs {
@@ -141,7 +141,7 @@ fn component_config_env_is_available_to_component_scripts_and_extra_env_wins() {
 fn component_config_env_is_visible_to_env_providers() {
     with_isolated_home(|_| {
         let dir = tempfile::tempdir().expect("temp dir");
-        let extension_dir = crate::paths::extensions()
+        let extension_dir = homeboy_core::paths::extensions()
             .expect("extensions path")
             .join("fixture-provider-env");
         fs::create_dir_all(&extension_dir).expect("extension dir");
@@ -198,7 +198,7 @@ fn component_config_env_is_visible_to_env_providers() {
 fn component_scripts_include_linked_extension_env_provider_output() {
     with_isolated_home(|_| {
         let dir = tempfile::tempdir().expect("temp dir");
-        let extension_dir = crate::paths::extensions()
+        let extension_dir = homeboy_core::paths::extensions()
             .expect("extensions path")
             .join("fixture-env");
         fs::create_dir_all(&extension_dir).expect("extension dir");
@@ -416,7 +416,7 @@ fn wordpress_phpunit_no_discovery_is_neutral_skipped() {
         assert_eq!(output.status, "skipped");
         assert_eq!(output.test_counts.expect("test counts").total, 0);
         let phase = output.phase.expect("phase report");
-        assert_eq!(phase.status, crate::extension::PhaseStatus::Skipped);
+        assert_eq!(phase.status, homeboy_core::extension::PhaseStatus::Skipped);
         assert_eq!(
             phase.summary,
             "activation/install passed; PHPUnit discovery found zero tests; no PHPUnit assertions ran"
@@ -479,7 +479,7 @@ fn wordpress_phpunit_no_discovery_can_be_required_as_failure() {
         let failure = output.failure.expect("failure report");
         assert_eq!(
             failure.category,
-            crate::extension::PhaseFailureCategory::Findings
+            homeboy_core::extension::PhaseFailureCategory::Findings
         );
     });
 }


### PR DESCRIPTION
## Summary

Systemic fix for the recurring "a crate extraction breaks a **donor's** test target" class — tunnel (#8488 → #8501), and a **second orphan this PR surfaces and fixes**.

**Root cause:** no gate ever compiled the whole workspace's *test* targets.
- The release preflight ran `cargo build --workspace` — lib/bin only, **not `--tests`**.
- The PR `review test` gate is **differentially scoped**, so a donor crate left with an orphaned `super::foo` (after `foo` moved to its own crate) isn't in the changed file scope and ships silently.

## The guard

- **`ci.yml`**: new non-differential `workspace-tests-compile` job running `cargo check --workspace --tests --locked` on every PR. Codegen-free, so it's cheap; runs in parallel with the existing gates.
- **`release.yml`**: the same check as a release preflight, failing closed.

## It immediately paid for itself

Running the guard surfaced a **second, pre-existing orphan** the differential gate had been missing: `tests/core/extension/component_script_test.rs` is `#[path]`-included by `homeboy-cli` but used `crate::{component,extension,engine,paths,test_support}` — which resolve in core, not cli. Fixed by:
- repointing those refs to `homeboy_core::`
- promoting the two helpers the cli integration test consumes (`run_component_scripts_with_env`, `source_path`) from `pub(crate)` to `pub`

## Verification

- `cargo check --workspace --tests --locked` — **green** (verified locally)
- Confirmed the guard **would have failed the tunnel extraction** before merge (reproduced the E0432 with the check on pre-#8501 main)

Closes the process gap noted on #8425. Supersedes #8497 (tunnel itself was fixed by #8501).

Refs #8425