### PR TITLE
Fix detached Lab result reconciliation

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -1388,6 +1388,57 @@ fn terminal_proxy_reconciliation_hydrates_persisted_nested_result_idempotently()
 }
 
 #[test]
+fn terminal_proxy_reconciliation_hydrates_persisted_dispatch_terminal_states() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        for (run_id, aggregate_status, outcome_status, expected_state) in [
+            (
+                "agent-task-persisted-dispatch-failure",
+                AgentTaskAggregateStatus::Failed,
+                AgentTaskOutcomeStatus::Failed,
+                AgentTaskRunState::Failed,
+            ),
+            (
+                "agent-task-persisted-dispatch-timeout",
+                AgentTaskAggregateStatus::Failed,
+                AgentTaskOutcomeStatus::Timeout,
+                AgentTaskRunState::Failed,
+            ),
+        ] {
+            let mut record = record_detached_lab_run(DetachedLabRunRecord {
+                run_id,
+                runner_id: "homeboy-lab",
+                runner_job_id: "00000000-0000-0000-0000-000000000123",
+                remote_workspace: "/runner/workspace/repo",
+                remote_command: &command,
+            })
+            .expect("running proxy");
+            let mut aggregate = succeeded_aggregate(&test_plan());
+            aggregate.status = aggregate_status;
+            aggregate.outcomes[0].status = outcome_status;
+            aggregate.outcomes[0].evidence_refs = vec![AgentTaskEvidenceRef {
+                kind: "transcript".to_string(),
+                uri: format!("homeboy://lab/{run_id}/transcript"),
+                label: Some("Provider transcript".to_string()),
+            }];
+
+            reconcile_runner_job_snapshot(
+                &mut record,
+                &persisted_terminal_result_snapshot(&aggregate),
+            )
+            .expect("hydrate persisted dispatch result");
+
+            let artifact_report = artifacts(run_id).expect("controller artifacts");
+            assert_eq!(record.state, expected_state);
+            assert!(artifact_report
+                .evidence_refs
+                .iter()
+                .any(|evidence| evidence.kind == "transcript"));
+        }
+    });
+}
+
+#[test]
 fn disconnected_runner_marks_nonterminal_proxy_stale_without_advancing_heartbeat() {
     with_isolated_home(|_| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];
@@ -3579,7 +3630,10 @@ fn persisted_terminal_result_snapshot(
             "command": "agent-task",
             "success": true,
             "exit_code": 0,
-            "data": aggregate,
+            "data": {
+                "schema": "homeboy/agent-task-dispatch/v1",
+                "aggregate": aggregate,
+            },
         }))
     }));
     snapshot

--- a/crates/homeboy-core/src/runner/agent_task_lifecycle_event.rs
+++ b/crates/homeboy-core/src/runner/agent_task_lifecycle_event.rs
@@ -51,15 +51,17 @@ pub(crate) fn parse_offloaded_run_plan_envelope(stdout: &str) -> Result<serde_js
 }
 
 pub(crate) fn is_agent_task_run_plan_envelope(value: &serde_json::Value) -> bool {
-    value
-        .get("data")
-        .and_then(|data| data.get("schema"))
-        .and_then(serde_json::Value::as_str)
+    let Some(data) = value.get("data") else {
+        return false;
+    };
+    data.get("schema").and_then(serde_json::Value::as_str)
         == Some("homeboy/agent-task-aggregate/v1")
-        || value
-            .get("data")
-            .and_then(|data| data.get("plan_id"))
-            .is_some()
+        || data.get("plan_id").is_some()
+        || data.get("aggregate").is_some_and(|aggregate| {
+            aggregate.get("schema").and_then(serde_json::Value::as_str)
+                == Some("homeboy/agent-task-aggregate/v1")
+                || aggregate.get("plan_id").is_some()
+        })
 }
 
 pub(crate) fn agent_task_run_plan_lifecycle_event_from_job_events(
@@ -212,7 +214,9 @@ fn agent_task_aggregate_from_terminal_result(
                     )
                 });
         }
-        let Some(next) = current.get("data") else {
+        // Command results wrap their payload in `data`; agent-task cook then
+        // wraps the terminal aggregate in its dispatch envelope's `aggregate`.
+        let Some(next) = current.get("data").or_else(|| current.get("aggregate")) else {
             return Ok(None);
         };
         current = next;


### PR DESCRIPTION
## Summary

- recognize detached dispatch envelopes that wrap terminal aggregates under `data.aggregate`
- traverse that bounded aggregate boundary during lifecycle reconciliation
- cover persisted success, failed, and timed-out terminal projections, including evidence visibility

Fixes https://github.com/Extra-Chill/homeboy/issues/8508

## How to test

1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-core terminal_proxy_reconciliation_hydrates_persisted --lib` and confirm 2 tests pass.
3. Run `cargo test -p homeboy-core runner::agent_task_lifecycle_event::tests --lib` and confirm 2 tests pass.
4. Run `git diff --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed the detached reconciliation boundary, implemented the generic fix and deterministic lifecycle coverage, and verified the candidate with Chris.