### PR TITLE
Fix recovered Lab artifact promotion paths

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -152,13 +152,8 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
     let promotion_candidates = aggregate_review
         .as_ref()
         .map(|review| {
-            let promotion_source = aggregate_source
-                .as_ref()
-                .map(|(_aggregate, path)| path.as_str())
-                .or(record.aggregate_path.as_deref())
-                .unwrap_or(&args.run_id);
             promotion_candidates(
-                promotion_source,
+                &record.run_id,
                 args.to_worktree.as_deref(),
                 args.provider_command.as_deref(),
                 &args.provider_argv,

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -98,7 +98,7 @@ fn review_reports_completed_aggregate_and_promotion_hints() {
                 "homeboy",
                 "agent-task",
                 "promote",
-                value["aggregate_path"].as_str().expect("aggregate path"),
+                "run-review-completed",
                 "--task-id",
                 "task-a",
                 "--artifact-id",

--- a/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
@@ -1,5 +1,6 @@
 use super::*;
 use sha2::Digest;
+use std::path::PathBuf;
 
 pub fn record_pre_execution_failure(
     run_id: &str,
@@ -689,6 +690,80 @@ pub(crate) fn project_terminal_artifacts(
         }
     }
     Ok(())
+}
+
+/// Locate the controller-owned copy of a lifecycle artifact. Aggregate paths
+/// describe producer provenance and can point at a runner after reconciliation;
+/// promotion must consume the controller projection instead.
+pub fn verified_controller_artifact_projection_path(
+    run_id: &str,
+    task_id: &str,
+    artifact: &AgentTaskArtifact,
+) -> Result<Option<PathBuf>> {
+    let Some(expected_sha256) = artifact.sha256.as_deref() else {
+        return Ok(None);
+    };
+    let Some(expected_size) = artifact
+        .size_bytes
+        .and_then(|size| i64::try_from(size).ok())
+    else {
+        return Ok(None);
+    };
+    let store = crate::observation::ObservationStore::open_initialized()?;
+    let candidates: Vec<_> = store
+        .list_artifacts(run_id)?
+        .into_iter()
+        .filter(|candidate| {
+            candidate.artifact_type == "file"
+                && candidate.kind == artifact.kind
+                && candidate
+                    .metadata_json
+                    .pointer("/agent_task/task_id")
+                    .and_then(serde_json::Value::as_str)
+                    == Some(task_id)
+                && candidate
+                    .metadata_json
+                    .pointer("/agent_task/logical_artifact_id")
+                    .and_then(serde_json::Value::as_str)
+                    == Some(artifact.id.as_str())
+        })
+        .collect();
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+    if candidates.len() != 1 {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!(
+                "multiple controller-side artifact projections match run '{run_id}', task '{task_id}', and artifact '{}'",
+                artifact.id
+            ),
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+    let candidate = &candidates[0];
+    let path = PathBuf::from(&candidate.path);
+    let actual_size = std::fs::metadata(&path)
+        .ok()
+        .and_then(|metadata| i64::try_from(metadata.len()).ok());
+    let actual_sha256 = crate::artifact_metadata::sha256_file(&path).ok();
+    if candidate.sha256.as_deref() != Some(expected_sha256)
+        || candidate.size_bytes != Some(expected_size)
+        || actual_size != Some(expected_size)
+        || actual_sha256.as_deref() != Some(expected_sha256)
+    {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!(
+                "controller-side artifact projection for run '{run_id}', task '{task_id}', and artifact '{}' does not match the aggregate SHA-256 and size",
+                artifact.id
+            ),
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+    Ok(Some(path))
 }
 
 fn unique_logical_artifact_id(

--- a/crates/homeboy-core/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/promote.rs
@@ -68,7 +68,12 @@ pub fn resume_promoted_patch(
     })?;
     let (source_kind, outcome) = select_outcome(source_value, options.task_id.as_deref())?;
     let artifact = select_patch_artifact(&outcome, options.artifact_id.as_deref())?;
-    let patch_path = resolve_artifact_path(&artifact, options.source_path.as_deref())?;
+    let patch_path = resolve_artifact_path(
+        &artifact,
+        &outcome.task_id,
+        options.source_run_id.as_deref(),
+        options.source_path.as_deref(),
+    )?;
     let patch = std::fs::read_to_string(&patch_path).map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -300,7 +305,12 @@ pub(crate) fn promote_with_provider(
     }
     let gate_feedback_baseline =
         gate_feedback_baseline_for_artifact(&source_for_provenance, &outcome, &artifact)?;
-    let patch_path = resolve_artifact_path(&artifact, options.source_path.as_deref())?;
+    let patch_path = resolve_artifact_path(
+        &artifact,
+        &outcome.task_id,
+        options.source_run_id.as_deref(),
+        options.source_path.as_deref(),
+    )?;
     let patch = std::fs::read_to_string(&patch_path).map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -924,6 +934,8 @@ pub(crate) fn select_patch_artifact(
 
 fn resolve_artifact_path(
     artifact: &AgentTaskArtifact,
+    task_id: &str,
+    source_run_id: Option<&str>,
     source_path: Option<&Path>,
 ) -> Result<PathBuf> {
     let path = artifact.path.as_ref().ok_or_else(|| {
@@ -936,6 +948,23 @@ fn resolve_artifact_path(
     })?;
     let path = PathBuf::from(path);
     if path.is_absolute() {
+        if let Some(run_id) = source_run_id {
+            if let Some(projected) =
+                crate::agent_task_lifecycle::verified_controller_artifact_projection_path(
+                    run_id, task_id, artifact,
+                )?
+            {
+                return Ok(projected);
+            }
+        }
+        if !path.is_file() {
+            return Err(Error::validation_invalid_argument(
+                "artifact.path",
+                "promotion could not find a verified controller-side artifact projection; reconcile the run on this controller before promoting its runner-produced artifact",
+                Some(path.display().to_string()),
+                None,
+            ));
+        }
         return Ok(path);
     }
     if let Some(source_path) = source_path.and_then(Path::parent) {

--- a/crates/homeboy-core/src/agent_task_promotion/tests.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/tests.rs
@@ -121,6 +121,186 @@ fn sha256_hex(content: &str) -> String {
     format!("{:x}", hasher.finalize())
 }
 
+fn record_controller_projection(
+    run_id: &str,
+    task_id: &str,
+    artifact_id: &str,
+    contents: &str,
+) -> PathBuf {
+    let store =
+        crate::observation::ObservationStore::open_initialized().expect("observation store");
+    store
+        .upsert_imported_run(&crate::observation::RunRecord {
+            id: run_id.to_string(),
+            kind: "agent-task".to_string(),
+            component_id: None,
+            started_at: "2026-07-16T00:00:00Z".to_string(),
+            finished_at: Some("2026-07-16T00:00:01Z".to_string()),
+            status: "pass".to_string(),
+            command: Some("homeboy agent-task".to_string()),
+            cwd: None,
+            homeboy_version: Some("test".to_string()),
+            git_sha: None,
+            rig_id: None,
+            metadata_json: serde_json::json!({}),
+        })
+        .expect("record run");
+    let input = tempfile::NamedTempFile::new().expect("projection input");
+    std::fs::write(input.path(), contents).expect("write projection input");
+    PathBuf::from(
+        store
+            .record_artifact_with_id(
+                run_id,
+                "patch",
+                input.path(),
+                "controller-finalized-patch",
+                serde_json::json!({
+                    "agent_task": {
+                        "task_id": task_id,
+                        "logical_artifact_id": artifact_id,
+                    }
+                }),
+            )
+            .expect("record controller projection")
+            .path,
+    )
+}
+
+fn recovered_runner_aggregate(
+    task_id: &str,
+    artifact_id: &str,
+    sha256: &str,
+    size: usize,
+) -> String {
+    serde_json::json!({
+        "schema": "homeboy/agent-task-aggregate/v1",
+        "plan_id": "recovered-lab-plan",
+        "status": "succeeded",
+        "totals": { "skipped": 0, "succeeded": 1 },
+        "outcomes": [{
+            "schema": AGENT_TASK_OUTCOME_SCHEMA,
+            "task_id": task_id,
+            "status": "succeeded",
+            "artifacts": [{
+                "schema": AGENT_TASK_ARTIFACT_SCHEMA,
+                "id": artifact_id,
+                "kind": "patch",
+                "path": "/home/runner/.homeboy/executor-finalized/patch.diff",
+                "size_bytes": size,
+                "sha256": sha256,
+                "metadata": { "executor_artifact_finalized": true }
+            }]
+        }]
+    })
+    .to_string()
+}
+
+#[test]
+fn promotion_uses_verified_controller_projection_for_recovered_runner_aggregate_sources() {
+    crate::test_support::with_isolated_home(|_| {
+        let run_id = "recovered-lab-run";
+        let task_id = "implement";
+        let artifact_id = "patch";
+        let projected_path =
+            record_controller_projection(run_id, task_id, artifact_id, VALID_PATCH);
+        let source = recovered_runner_aggregate(
+            task_id,
+            artifact_id,
+            &sha256_hex(VALID_PATCH),
+            VALID_PATCH.len(),
+        );
+
+        for aggregate_file_source in [false, true] {
+            let aggregate_file = tempfile::NamedTempFile::new().expect("aggregate source");
+            std::fs::write(aggregate_file.path(), &source).expect("write aggregate source");
+            let source_path = aggregate_file_source.then(|| aggregate_file.path().to_path_buf());
+            let temp = tempfile::tempdir().expect("promotion tempdir");
+            let mut provider = FakePromotionWorkspaceProvider {
+                workspace_path: Some(temp.path().join("target")),
+                ..Default::default()
+            };
+
+            let report = promote_with_provider(
+                AgentTaskPromotionOptions {
+                    source: source.clone(),
+                    source_run_id: Some(run_id.to_string()),
+                    source_path,
+                    source_worktree_path: None,
+                    base_ref: None,
+                    task_base_sha: None,
+                    to_worktree: "homeboy@recovered-promotion".to_string(),
+                    task_id: Some(task_id.to_string()),
+                    artifact_id: Some(artifact_id.to_string()),
+                    dry_run: false,
+                    gates: VerifyGateOptions::default(),
+                    provider_command: None,
+                    provider_invocation: None,
+                },
+                &mut provider,
+            )
+            .expect("recovered aggregate promotes from controller projection");
+
+            assert_eq!(
+                report.patch_artifact.path,
+                projected_path.display().to_string()
+            );
+            assert_eq!(
+                provider.applied_patch_contents,
+                vec![VALID_PATCH.to_string()]
+            );
+        }
+    });
+}
+
+#[test]
+fn promotion_rejects_missing_or_mismatched_recovered_controller_projection() {
+    crate::test_support::with_isolated_home(|_| {
+        let run_id = "recovered-lab-run";
+        let task_id = "implement";
+        let artifact_id = "patch";
+        let source = recovered_runner_aggregate(
+            task_id,
+            artifact_id,
+            &sha256_hex(VALID_PATCH),
+            VALID_PATCH.len(),
+        );
+        let temp = tempfile::tempdir().expect("promotion tempdir");
+        let mut provider = FakePromotionWorkspaceProvider {
+            workspace_path: Some(temp.path().join("target")),
+            ..Default::default()
+        };
+        let options = || AgentTaskPromotionOptions {
+            source: source.clone(),
+            source_run_id: Some(run_id.to_string()),
+            source_path: None,
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            to_worktree: "homeboy@recovered-promotion".to_string(),
+            task_id: Some(task_id.to_string()),
+            artifact_id: Some(artifact_id.to_string()),
+            dry_run: false,
+            gates: VerifyGateOptions::default(),
+            provider_command: None,
+            provider_invocation: None,
+        };
+
+        let missing = promote_with_provider(options(), &mut provider)
+            .expect_err("missing projection rejected");
+        assert!(missing
+            .message
+            .contains("verified controller-side artifact projection"));
+
+        record_controller_projection(run_id, task_id, artifact_id, "different patch bytes");
+        let mismatched = promote_with_provider(options(), &mut provider)
+            .expect_err("mismatched projection rejected");
+        assert!(mismatched
+            .message
+            .contains("does not match the aggregate SHA-256 and size"));
+        assert!(provider.apply_calls.is_empty());
+    });
+}
+
 fn write_patch_source(temp: &tempfile::TempDir) -> (PathBuf, String) {
     let patch_path = temp.path().join("changes.patch");
     std::fs::write(&patch_path, VALID_PATCH).expect("write patch");


### PR DESCRIPTION
## Summary
Make recovered Lab patch candidates promotable from the controller after artifact reconciliation.

## What changed
- Resolve recovered absolute artifact paths through the verified controller-side lifecycle projection and generate review promotion commands from durable run IDs.

## How to test
1. Run `cargo test -p homeboy-core agent_task_promotion::tests::promotion_ --lib`; expect Five focused promotion tests pass..
2. Run `cargo check -p homeboy-cli`; expect The Homeboy CLI and dependencies compile..
3. Run `cargo fmt --check`; expect Formatting is clean..
4. Run `git diff --check`; expect The patch has no whitespace errors..

## Compatibility
Preserves readable local absolute paths and relative aggregate artifact paths; recovered runner-only paths now require a hash- and size-verified controller projection.

## Evidence
- CI expected: GitHub Actions repository checks
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8479
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8507
- cli-check: Passed
- diff-check: Passed
- format: Passed
- promotion-tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Investigated the recovered-artifact failure, implemented lifecycle-owned projection resolution, and added deterministic tests; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8507
- Relates to Extra-Chill/homeboy#8479
