### PR TITLE
refactor: move remote-runner artifact-path check to execution_contract (runner-decouple)

### DIFF
--- a/crates/homeboy-core/src/artifact_address.rs
+++ b/crates/homeboy-core/src/artifact_address.rs
@@ -37,7 +37,7 @@ impl ArtifactAddress {
             return Self::public_url(public_url);
         }
 
-        if crate::runners::is_remote_runner_artifact_path(&artifact.path) {
+        if crate::execution_contract::is_remote_runner_artifact_path(&artifact.path) {
             return Self::remote_runner_ref(artifact.path.clone());
         }
 

--- a/crates/homeboy-core/src/daemon/artifact_download.rs
+++ b/crates/homeboy-core/src/daemon/artifact_download.rs
@@ -130,7 +130,7 @@ fn resolve_artifact_download(
 
     if artifact.artifact_type != "file" {
         if artifact.artifact_type == "remote_file"
-            || runner::is_remote_runner_artifact_path(&artifact.path)
+            || crate::execution_contract::is_remote_runner_artifact_path(&artifact.path)
         {
             let download = runner::download_remote_artifact(&artifact.path, None)?;
             let filename = download
@@ -378,7 +378,7 @@ fn artifact_retrieval_contract(
 ) -> serde_json::Value {
     let content_available = artifact.artifact_type == "file"
         || artifact.artifact_type == "remote_file"
-        || runner::is_remote_runner_artifact_path(&artifact.path);
+        || crate::execution_contract::is_remote_runner_artifact_path(&artifact.path);
     let run_id = route_run_id.unwrap_or(&artifact.run_id);
     if content_available {
         let content_url = format!(

--- a/crates/homeboy-core/src/execution_contract.rs
+++ b/crates/homeboy-core/src/execution_contract.rs
@@ -140,6 +140,14 @@ pub fn decode_uri_component_strict(value: &str) -> Option<String> {
     String::from_utf8(decoded).ok()
 }
 
+/// Whether an artifact path is a remote-runner artifact reference, per the
+/// execution contract's artifact rules. Lives here (not in the runner module)
+/// so core code can classify artifact paths without a core -> runner edge — the
+/// classification is a contract concern, not runner behavior.
+pub fn is_remote_runner_artifact_path(path: &str) -> bool {
+    EXECUTION_CONTRACT.artifacts.is_runner_artifact_ref(path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/homeboy-core/src/http_api.rs
+++ b/crates/homeboy-core/src/http_api.rs
@@ -369,7 +369,7 @@ fn artifact_content(run_id: &str, artifact_id: &str) -> Result<Value> {
     };
     if artifact.artifact_type != "file" {
         if artifact.artifact_type == "remote_file"
-            || runner::is_remote_runner_artifact_path(&artifact.path)
+            || crate::execution_contract::is_remote_runner_artifact_path(&artifact.path)
         {
             let download = runner::download_remote_artifact(&artifact.path, None)?;
             let content = std::fs::read(&download.output_path).map_err(|err| {

--- a/crates/homeboy-core/src/observation/evidence_report.rs
+++ b/crates/homeboy-core/src/observation/evidence_report.rs
@@ -499,7 +499,7 @@ pub fn directory_publication_guidance(
         });
     }
 
-    if crate::runners::is_remote_runner_artifact_path(&artifact.path) {
+    if crate::execution_contract::is_remote_runner_artifact_path(&artifact.path) {
         return Some(unpublished_directory_guidance(
             "runner_resident",
             "directory artifact is runner-resident; mirror it to the controller artifact store before using it as review evidence",
@@ -585,7 +585,7 @@ fn artifact_exists(artifact: &ArtifactRecord) -> bool {
         return true;
     }
     if artifact.artifact_type == "remote_file"
-        || crate::runners::is_remote_runner_artifact_path(&artifact.path)
+        || crate::execution_contract::is_remote_runner_artifact_path(&artifact.path)
     {
         return true;
     }

--- a/crates/homeboy-core/src/observation/runs_service/artifact_resolve.rs
+++ b/crates/homeboy-core/src/observation/runs_service/artifact_resolve.rs
@@ -194,7 +194,7 @@ pub fn classify_artifact_storage(artifact: &ArtifactRecord) -> ArtifactStorage {
     if artifact.artifact_type == "file" {
         return ArtifactStorage::LocalFile;
     }
-    if crate::runners::is_remote_runner_artifact_path(&artifact.path)
+    if crate::execution_contract::is_remote_runner_artifact_path(&artifact.path)
         || artifact.artifact_type == "remote_file"
     {
         return ArtifactStorage::Remote;

--- a/crates/homeboy-core/src/observation/runs_service/persisted_cleanup.rs
+++ b/crates/homeboy-core/src/observation/runs_service/persisted_cleanup.rs
@@ -99,7 +99,7 @@ fn classify_persisted_artifact(
             "owning run is active or has an unknown lifecycle state",
         )
     } else if artifact.artifact_type == "url"
-        || crate::runners::is_remote_runner_artifact_path(&artifact.path)
+        || crate::execution_contract::is_remote_runner_artifact_path(&artifact.path)
         || EXECUTION_CONTRACT
             .artifacts
             .is_metadata_only_ref(&artifact.path)

--- a/crates/homeboy-core/src/runner/evidence/tokens.rs
+++ b/crates/homeboy-core/src/runner/evidence/tokens.rs
@@ -5,9 +5,10 @@ use base64::Engine;
 use crate::error::{Error, Result};
 use crate::execution_contract::{decode_uri_component, EXECUTION_CONTRACT};
 
-pub fn is_remote_runner_artifact_path(path: &str) -> bool {
-    EXECUTION_CONTRACT.artifacts.is_runner_artifact_ref(path)
-}
+// Moved to core's execution_contract module (it's a contract concern, not
+// runner behavior) so core code can classify artifact paths without a
+// core -> runner edge. Re-exported so runner-internal call sites resolve.
+pub use crate::execution_contract::is_remote_runner_artifact_path;
 
 pub fn runner_artifact_store_token(runner_id: &str, run_id: &str, locator: &str) -> String {
     let encoded_locator = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(locator);


### PR DESCRIPTION
## Summary
Continues decoupling the optional runner feature from core — but **switches strategy from type-moves to eliminating behavioral edges**, which is where the actual compile-time win lives.

`is_remote_runner_artifact_path` was a runner-module wrapper around `EXECUTION_CONTRACT.artifacts.is_runner_artifact_ref(path)` — but `EXECUTION_CONTRACT` already lives in core. **Classifying an artifact path is a contract concern, not runner behavior.**

Moved the function into core's `execution_contract` module and repointed its **5 external-core callers** (http_api, artifact_address, observation/evidence_report, observation/runs_service/{persisted_cleanup, artifact_resolve}, daemon/artifact_download) to call it directly — severing those reverse edges with **no hook and no type-drag**. Re-exported from `runner::evidence::tokens` so runner-internal call sites resolve unchanged.

## Impact
Reverse-edge file count: **39 → 36** (3 files fully severed).

## Verification
`cargo check` clean for `-p homeboy-core --lib` and `-p homeboy-cli --lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)