### PR TITLE
refactor: move Language primitive into homeboy-engine-primitives (#8425)

### DIFF
--- a/crates/homeboy-core/src/engine/mod.rs
+++ b/crates/homeboy-core/src/engine/mod.rs
@@ -6,8 +6,8 @@
 // crate. Re-exported here so existing `crate::engine::{shell,command,...}`
 // call sites keep working unchanged.
 pub use homeboy_engine_primitives::{
-    baseline, codebase_scan, command, detail_output, identifier, output_parse, shell, template,
-    text, validation,
+    baseline, codebase_scan, command, detail_output, identifier, language, output_parse, shell,
+    template, text, validation,
 };
 // local_files was `pub(crate)` in-tree; preserve that visibility across the
 // crate boundary rather than widening it via the `pub use` above.
@@ -21,7 +21,6 @@ pub mod executor;
 pub mod format_write;
 pub mod hooks;
 pub mod invocation;
-pub mod language;
 pub mod resource;
 pub mod run_dir;
 pub mod symbol_graph;

--- a/crates/homeboy-engine-primitives/src/language.rs
+++ b/crates/homeboy-engine-primitives/src/language.rs
@@ -4,11 +4,12 @@
 //! (Rust / PHP / JavaScript / TypeScript / Unknown) plus the builtin token
 //! tables and per-language behavioral predicates that many subsystems need.
 //!
-//! It lives in `engine` because it is a foundational primitive with **zero**
-//! dependencies on higher layers (audit, refactor, component). The audit,
-//! refactor, and fixer layers all classify source files, so this type sits
-//! below them in the dependency graph. `code_audit::conventions` re-exports it
-//! for backward compatibility.
+//! It lives in `homeboy-engine-primitives` because it is a foundational
+//! primitive with zero dependencies on higher layers (audit, refactor,
+//! component). The audit, refactor, and fixer layers all classify source
+//! files, so this type sits below them in the dependency graph. Core re-exports
+//! it as `crate::engine::language`, and `code_audit::conventions` re-exports
+//! `Language` for backward compatibility.
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/crates/homeboy-engine-primitives/src/lib.rs
+++ b/crates/homeboy-engine-primitives/src/lib.rs
@@ -12,6 +12,7 @@ pub mod command;
 pub mod detail_output;
 pub mod grammar;
 pub mod identifier;
+pub mod language;
 pub mod local_files;
 pub mod output_parse;
 pub mod shell;


### PR DESCRIPTION
## Summary

When `Language` was relocated out of `code_audit` (#8433) it landed in `engine/language.rs` — but it's a pure, **zero-dependency** source-classification primitive (same category as `baseline`, `codebase_scan`, `grammar`), so its real home is the `homeboy-engine-primitives` crate, not core's engine module.

Move it there and bridge through `engine/mod.rs`'s existing `pub use homeboy_engine_primitives::{...}` re-export, so both existing bridges keep resolving unchanged:
- `crate::engine::language` (core internal)
- `code_audit::conventions::Language` (its **42 consumers**, which re-export through `engine::language`)

Pure relocation — the file has zero `crate::` deps.

## Why

Continues the phase-2 floor migration and puts the canonical language primitive with its siblings. Also unblocks a future `edit_op_apply` migration (it depends on `Language`).

## Verification

- `cargo check -p homeboy-engine-primitives` + `-p homeboy-core --lib` — clean
- language tests pass
- `cargo check --workspace --tests --locked` — **green** (the topology guard added in #8509)

Refs #8425