### PR TITLE
Support transformed archive package coverage

### DIFF
--- a/crates/homeboy-core/src/component/config.rs
+++ b/crates/homeboy-core/src/component/config.rs
@@ -1,6 +1,8 @@
 use serde::{ser::SerializeMap, Deserialize, Serialize, Serializer};
 use std::collections::HashMap;
 
+use crate::error::{Error, Result as HomeboyResult};
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 
 pub struct VersionTarget {
@@ -231,12 +233,160 @@ pub struct GithubHostConfig {
 pub struct ComponentReleaseConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub github_release: Option<ComponentGithubReleaseConfig>,
+    /// Per-ZIP source-to-archive coverage declarations for transformed packages.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub package_coverage: Vec<PackageCoverageConfig>,
 }
 
 impl ComponentReleaseConfig {
     pub fn is_default(value: &Self) -> bool {
         value == &Self::default()
     }
+
+    pub fn validate_package_coverage(&self) -> HomeboyResult<()> {
+        let mut selectors = Vec::new();
+        for coverage in &self.package_coverage {
+            validate_canonical_coverage_path(&coverage.artifact, "artifact")?;
+            validate_canonical_coverage_path(&coverage.archive_root, "archive_root")?;
+            let selector = (coverage.artifact_match, &coverage.artifact);
+            if selectors.contains(&selector) {
+                return Err(package_coverage_error(
+                    "artifact selectors must be unique across package coverage declarations",
+                ));
+            }
+            selectors.push(selector);
+            if coverage.source_roots.is_empty() {
+                return Err(package_coverage_error(
+                    "source_roots must contain at least one repository-relative directory",
+                ));
+            }
+
+            let mut roots = Vec::new();
+            for root in &coverage.source_roots {
+                validate_canonical_coverage_path(root, "source_roots")?;
+                if roots.iter().any(|existing: &String| {
+                    root == "."
+                        || existing == "."
+                        || root == existing
+                        || root
+                            .strip_prefix(existing)
+                            .is_some_and(|suffix| suffix.starts_with('/'))
+                        || existing
+                            .strip_prefix(root)
+                            .is_some_and(|suffix| suffix.starts_with('/'))
+                }) {
+                    return Err(package_coverage_error(
+                        "source_roots must not overlap within one package coverage declaration",
+                    ));
+                }
+                roots.push(root.clone());
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PackageCoverageConfig {
+    /// Artifact path or glob selector for one emitted ZIP artifact.
+    pub artifact: String,
+    /// Whether `artifact` is an exact path (the default) or a glob pattern.
+    pub artifact_match: PackageCoverageArtifactMatch,
+    /// Repository-relative source directories whose runtime files must be covered.
+    pub source_roots: Vec<String>,
+    /// Archive-relative directory containing the mapped source-root contents.
+    pub archive_root: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PackageCoverageArtifactMatch {
+    #[default]
+    Exact,
+    Glob,
+}
+
+#[derive(Deserialize)]
+struct RawPackageCoverageConfig {
+    artifact: String,
+    #[serde(default)]
+    artifact_match: PackageCoverageArtifactMatch,
+    source_roots: Vec<String>,
+    archive_root: String,
+}
+
+impl<'de> Deserialize<'de> for PackageCoverageConfig {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = RawPackageCoverageConfig::deserialize(deserializer)?;
+        let artifact =
+            normalize_coverage_path(&raw.artifact, "artifact").map_err(serde::de::Error::custom)?;
+        let source_roots = raw
+            .source_roots
+            .iter()
+            .map(|root| normalize_coverage_path(root, "source_roots"))
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(serde::de::Error::custom)?;
+        let archive_root = normalize_coverage_path(&raw.archive_root, "archive_root")
+            .map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            artifact,
+            artifact_match: raw.artifact_match,
+            source_roots,
+            archive_root,
+        })
+    }
+}
+
+fn normalize_coverage_path(value: &str, field: &str) -> std::result::Result<String, String> {
+    let value = value.trim();
+    if value.is_empty()
+        || value.starts_with('/')
+        || value.starts_with('\\')
+        || value.as_bytes().get(1).is_some_and(|byte| *byte == b':')
+    {
+        return Err(format!("{} must be a non-empty relative path", field));
+    }
+
+    let normalized = value.replace('\\', "/");
+    let mut segments = Vec::new();
+    for segment in normalized.split('/') {
+        match segment {
+            "" | "." => continue,
+            ".." => return Err(format!("{} must not contain parent traversal", field)),
+            _ => segments.push(segment),
+        }
+    }
+    if segments.is_empty() {
+        Ok(".".to_string())
+    } else {
+        Ok(segments.join("/"))
+    }
+}
+
+fn validate_canonical_coverage_path(value: &str, field: &str) -> HomeboyResult<()> {
+    let normalized = normalize_coverage_path(value, field)
+        .map_err(|message| package_coverage_error(&message))?;
+    if value != normalized {
+        return Err(package_coverage_error(&format!(
+            "{} must use canonical slash-separated form '{}'",
+            field, normalized
+        )));
+    }
+    Ok(())
+}
+
+fn package_coverage_error(message: &str) -> Error {
+    Error::validation_invalid_argument(
+        "release.package_coverage",
+        message,
+        None,
+        Some(vec![
+            "Declare one artifact selector, one or more non-overlapping source_roots, and an archive_root.".to_string(),
+        ]),
+    )
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]

--- a/crates/homeboy-core/src/component/mod.rs
+++ b/crates/homeboy-core/src/component/mod.rs
@@ -26,7 +26,8 @@ pub use config::{
     ArtifactInput, CleanupArtifactDeclaration, CommandScopeConfig, ComponentDeployConfig,
     ComponentGithubReleaseConfig, ComponentOverrideConfig, ComponentReleaseConfig,
     ComponentScriptsConfig, DependencyStackEdge, GitDeployConfig, GithubConfig, GithubHostConfig,
-    GithubReleaseOwner, ScopeConfig, ScopedExtensionConfig, VersionTarget,
+    GithubReleaseOwner, PackageCoverageArtifactMatch, PackageCoverageConfig, ScopeConfig,
+    ScopedExtensionConfig, VersionTarget,
 };
 pub use inventory::{
     exists, extension_provides_artifact_pattern, inventory, list, list_ids, load,

--- a/crates/homeboy-core/src/component/tests.rs
+++ b/crates/homeboy-core/src/component/tests.rs
@@ -133,6 +133,142 @@ fn component_priority_labels_serialization_roundtrip() {
 }
 
 #[test]
+fn package_coverage_normalizes_paths_and_rejects_malformed_declarations() {
+    let component: Component = serde_json::from_value(serde_json::json!({
+        "id": "fixture",
+        "release": {
+            "package_coverage": [{
+                "artifact": " ./dist//archive.zip/ ",
+                "source_roots": [" ./source//runtime/ "],
+                "archive_root": " ./bundle// "
+            }]
+        }
+    }))
+    .expect("valid package coverage should parse");
+    component
+        .release
+        .validate_package_coverage()
+        .expect("valid package coverage should validate");
+    let coverage = &component.release.package_coverage[0];
+    assert_eq!(coverage.artifact, "dist/archive.zip");
+    assert_eq!(coverage.source_roots, ["source/runtime"]);
+    assert_eq!(coverage.archive_root, "bundle");
+
+    let malformed: Component = serde_json::from_value(serde_json::json!({
+        "id": "fixture",
+        "release": {
+            "package_coverage": [{
+                "artifact": "dist/archive.zip",
+                "source_roots": [],
+                "archive_root": "bundle"
+            }]
+        }
+    }))
+    .expect("shape remains parseable for actionable validation");
+    assert!(malformed.release.validate_package_coverage().is_err());
+
+    let backslash_traversal: std::result::Result<Component, _> =
+        serde_json::from_value(serde_json::json!({
+            "id": "fixture",
+            "release": {
+                "package_coverage": [{
+                    "artifact": "dist/archive.zip",
+                    "source_roots": ["source\\..\\outside"],
+                    "archive_root": "bundle"
+                }]
+            }
+        }));
+    assert!(backslash_traversal.is_err());
+
+    let windows_absolute: std::result::Result<Component, _> =
+        serde_json::from_value(serde_json::json!({
+            "id": "fixture",
+            "release": {
+                "package_coverage": [{
+                    "artifact": "C:\\build\\archive.zip",
+                    "source_roots": ["source"],
+                    "archive_root": "bundle"
+                }]
+            }
+        }));
+    assert!(windows_absolute.is_err());
+
+    let unc_absolute: std::result::Result<Component, _> =
+        serde_json::from_value(serde_json::json!({
+            "id": "fixture",
+            "release": {
+                "package_coverage": [{
+                    "artifact": "\\\\server\\share\\archive.zip",
+                    "source_roots": ["source"],
+                    "archive_root": "bundle"
+                }]
+            }
+        }));
+    assert!(unc_absolute.is_err());
+
+    let dot_overlap: Component = serde_json::from_value(serde_json::json!({
+        "id": "fixture",
+        "release": {
+            "package_coverage": [{
+                "artifact": "dist/archive.zip",
+                "source_roots": [".", "source"],
+                "archive_root": "bundle"
+            }]
+        }
+    }))
+    .expect("canonical paths should parse");
+    assert!(dot_overlap.release.validate_package_coverage().is_err());
+
+    let direct_valid = ComponentReleaseConfig {
+        package_coverage: vec![PackageCoverageConfig {
+            artifact: "dist/archive.zip".to_string(),
+            artifact_match: PackageCoverageArtifactMatch::Exact,
+            source_roots: vec!["source/runtime".to_string()],
+            archive_root: "bundle".to_string(),
+        }],
+        ..Default::default()
+    };
+    direct_valid
+        .validate_package_coverage()
+        .expect("canonical direct configuration should validate");
+
+    for (artifact, source_root, archive_root) in [
+        ("../archive.zip", "source", "bundle"),
+        ("/archive.zip", "source", "bundle"),
+        ("C:\\archive.zip", "source", "bundle"),
+        ("\\\\server\\share\\archive.zip", "source", "bundle"),
+        ("dist/archive.zip", "source\\..\\outside", "bundle"),
+        ("dist/archive.zip", "source", "\\bundle"),
+    ] {
+        let direct = ComponentReleaseConfig {
+            package_coverage: vec![PackageCoverageConfig {
+                artifact: artifact.to_string(),
+                artifact_match: PackageCoverageArtifactMatch::Exact,
+                source_roots: vec![source_root.to_string()],
+                archive_root: archive_root.to_string(),
+            }],
+            ..Default::default()
+        };
+        assert!(direct.validate_package_coverage().is_err());
+    }
+
+    let noncanonical_direct = ComponentReleaseConfig {
+        package_coverage: vec![PackageCoverageConfig {
+            artifact: " ./dist//archive.zip/ ".to_string(),
+            artifact_match: PackageCoverageArtifactMatch::Exact,
+            source_roots: vec![" ./source//runtime/ ".to_string()],
+            archive_root: " ./bundle// ".to_string(),
+        }],
+        ..Default::default()
+    };
+    let error = noncanonical_direct
+        .validate_package_coverage()
+        .expect_err("direct values must already be canonical");
+    assert_eq!(error.code.as_str(), "validation.invalid_argument");
+    assert!(error.message.contains("canonical slash-separated form"));
+}
+
+#[test]
 fn component_env_serialization_roundtrip() {
     let component: Component = serde_json::from_value(serde_json::json!({
         "id": "fixture",

--- a/crates/homeboy-core/src/release/executor/package_preflight.rs
+++ b/crates/homeboy-core/src/release/executor/package_preflight.rs
@@ -2,7 +2,9 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::component::{CommandScopeConfig, Component};
+use crate::component::{
+    CommandScopeConfig, Component, PackageCoverageArtifactMatch, PackageCoverageConfig,
+};
 use crate::error::{Error, Result};
 use crate::release::types::ReleaseArtifact;
 
@@ -33,53 +35,187 @@ pub(crate) fn validate_package_completeness(
     component_path: &Path,
     artifacts: &[ReleaseArtifact],
 ) -> Result<()> {
+    component.release.validate_package_coverage()?;
+    let zip_artifacts: Vec<(&ReleaseArtifact, BTreeSet<String>)> = artifacts
+        .iter()
+        .filter_map(|artifact| {
+            let artifact_path = resolve_artifact_path(component_path, artifact);
+            artifact_path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"))
+                .then(|| read_zip_entries(&artifact_path).map(|entries| (artifact, entries)))
+        })
+        .collect::<Result<_>>()?;
+
+    if zip_artifacts.is_empty() {
+        return Ok(());
+    }
+
+    for coverage in &component.release.package_coverage {
+        let matches: Vec<_> = zip_artifacts
+            .iter()
+            .filter(|(artifact, _)| artifact_matches(coverage, artifact))
+            .collect();
+        if matches.len() != 1 {
+            return Err(Error::validation_invalid_argument(
+                "release.package_coverage",
+                format!(
+                    "Package coverage artifact selector '{}' matched {} ZIP artifacts; it must match exactly one",
+                    coverage.artifact,
+                    matches.len()
+                ),
+                None,
+                None,
+            ));
+        }
+    }
+
+    // Selector ambiguity is invalid configuration independent of repository
+    // contents, so reject it before evaluating mapped source roots.
+    for (artifact, _) in &zip_artifacts {
+        let mappings = component
+            .release
+            .package_coverage
+            .iter()
+            .filter(|coverage| artifact_matches(coverage, artifact))
+            .count();
+        if mappings > 1 {
+            return Err(Error::validation_invalid_argument(
+                "release.package_coverage",
+                format!(
+                    "ZIP artifact '{}' matches multiple package coverage declarations",
+                    artifact.path
+                ),
+                None,
+                None,
+            ));
+        }
+    }
+
     let expected = tracked_runtime_files(component, component_path)?;
+    for coverage in &component.release.package_coverage {
+        for root in &coverage.source_roots {
+            if !expected
+                .iter()
+                .any(|path| source_root_suffix(path, root).is_some())
+            {
+                return Err(Error::validation_invalid_argument(
+                    "release.package_coverage",
+                    format!(
+                        "Package coverage source root '{}' matches no tracked runtime files",
+                        root
+                    ),
+                    None,
+                    None,
+                ));
+            }
+        }
+    }
     if expected.is_empty() {
         return Ok(());
     }
 
-    let mut archive_entries = BTreeSet::new();
-    for artifact in artifacts {
-        let artifact_path = resolve_artifact_path(component_path, artifact);
-        if !artifact_path
-            .extension()
-            .and_then(|extension| extension.to_str())
-            .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"))
-        {
+    for (artifact, entries) in zip_artifacts {
+        let mappings: Vec<&PackageCoverageConfig> = component
+            .release
+            .package_coverage
+            .iter()
+            .filter(|coverage| artifact_matches(coverage, artifact))
+            .collect();
+        debug_assert!(mappings.len() <= 1);
+        // Preserve the shipped identity-layout behavior: an empty archive does
+        // not assert coverage unless the component explicitly mapped it.
+        if entries.is_empty() && mappings.is_empty() {
             continue;
         }
-        archive_entries.extend(read_zip_entries(&artifact_path)?);
+
+        let (expected_paths, strict_archive_paths) = match mappings.first() {
+            Some(coverage) => (mapped_runtime_files(&expected, coverage)?, true),
+            None => (expected.clone(), false),
+        };
+        let missing: Vec<String> = expected_paths
+            .into_iter()
+            .filter(|path| !archive_contains_path(&entries, path, strict_archive_paths))
+            .collect();
+        if !missing.is_empty() {
+            return package_completeness_error(component_path, artifact, missing);
+        }
     }
 
-    if archive_entries.is_empty() {
-        return Ok(());
-    }
+    Ok(())
+}
 
-    let missing: Vec<String> = expected
-        .into_iter()
-        .filter(|path| !archive_contains_path(&archive_entries, path))
-        .collect();
-    if missing.is_empty() {
-        return Ok(());
+fn artifact_matches(coverage: &PackageCoverageConfig, artifact: &ReleaseArtifact) -> bool {
+    let path = normalize_archive_path(&artifact.path);
+    match coverage.artifact_match {
+        PackageCoverageArtifactMatch::Exact => path == coverage.artifact,
+        PackageCoverageArtifactMatch::Glob => glob_match::glob_match(&coverage.artifact, &path),
     }
+}
 
+fn mapped_runtime_files(
+    expected: &[String],
+    coverage: &PackageCoverageConfig,
+) -> Result<Vec<String>> {
+    let mut archive_paths = std::collections::BTreeMap::new();
+    for root in &coverage.source_roots {
+        for source_path in expected {
+            let Some(suffix) = source_root_suffix(source_path, root) else {
+                continue;
+            };
+            let archive_path = if coverage.archive_root == "." {
+                suffix.to_string()
+            } else {
+                format!("{}/{}", coverage.archive_root, suffix)
+            };
+            if let Some(existing) = archive_paths.insert(archive_path.clone(), source_path.clone())
+            {
+                return Err(Error::validation_invalid_argument(
+                    "release.package_coverage",
+                    format!(
+                        "Package coverage maps source files '{}' and '{}' to the same archive path '{}'",
+                        existing, source_path, archive_path
+                    ),
+                    None,
+                    None,
+                ));
+            }
+        }
+    }
+    Ok(archive_paths.into_keys().collect())
+}
+
+fn source_root_suffix<'a>(path: &'a str, root: &str) -> Option<&'a str> {
+    if root == "." {
+        Some(path)
+    } else {
+        path.strip_prefix(root)
+            .and_then(|suffix| suffix.strip_prefix('/'))
+    }
+}
+
+fn package_completeness_error(
+    component_path: &Path,
+    artifact: &ReleaseArtifact,
+    missing: Vec<String>,
+) -> Result<()> {
     Err(Error::validation_invalid_argument(
         "package",
         format!(
-            "Release package is missing {} tracked runtime file(s): {}",
+            "Release package '{}' is missing {} tracked runtime file(s): {}",
+            artifact.path,
             missing.len(),
             missing.iter().take(20).cloned().collect::<Vec<_>>().join(", ")
         ),
-        Some(format!(
-            "{}",
-            serde_json::json!({
-                "missing": missing,
-                "source": component_path,
-                "checked_artifact_type": "zip"
-            })
-        )),
+        Some(serde_json::json!({
+            "missing": missing,
+            "source": component_path,
+            "artifact": artifact.path,
+            "checked_artifact_type": "zip"
+        }).to_string()),
         Some(vec![
-            "Update the release.package action so the artifact includes every tracked runtime file, or add an explicit release scope exclude for intentional omissions.".to_string(),
+            "Update the release.package action so this artifact includes every mapped tracked runtime file, or add an explicit release scope exclude for intentional omissions.".to_string(),
         ]),
     ))
 }
@@ -233,10 +369,10 @@ fn read_zip_entries(path: &Path) -> Result<BTreeSet<String>> {
     Ok(entries)
 }
 
-fn archive_contains_path(entries: &BTreeSet<String>, path: &str) -> bool {
+fn archive_contains_path(entries: &BTreeSet<String>, path: &str, strict: bool) -> bool {
     entries
         .iter()
-        .any(|entry| entry == path || entry.ends_with(&format!("/{}", path)))
+        .any(|entry| entry == path || (!strict && entry.ends_with(&format!("/{}", path))))
 }
 
 fn normalize_archive_path(path: &str) -> String {
@@ -312,6 +448,237 @@ mod tests {
     }
 
     #[test]
+    fn package_completeness_validates_transformed_source_root_and_direct_config() {
+        let repo = tempfile::tempdir().expect("repo");
+        std::fs::create_dir_all(repo.path().join("source/runtime")).expect("runtime dir");
+        std::fs::write(repo.path().join("source/runtime/main.php"), "<?php\n").expect("main");
+        run_git(repo.path(), &["init"]);
+        run_git(repo.path(), &["add", "source/runtime/main.php"]);
+        let artifact_path = repo.path().join("build/runtime.zip");
+        std::fs::create_dir_all(artifact_path.parent().unwrap()).expect("build dir");
+        write_zip(&artifact_path, &[("bundle/main.php", "<?php\n")]);
+        let mut component = test_component(repo.path());
+        component.release.package_coverage = vec![PackageCoverageConfig {
+            artifact: "build/runtime.zip".to_string(),
+            artifact_match: PackageCoverageArtifactMatch::Exact,
+            source_roots: vec!["source/runtime".to_string()],
+            archive_root: "bundle".to_string(),
+        }];
+
+        validate_package_completeness(&component, repo.path(), &zip_artifacts("build/runtime.zip"))
+            .expect("mapped runtime file should be present at its archive path");
+
+        component.release.package_coverage[0].archive_root = "../bundle".to_string();
+        write_zip(&artifact_path, &[("../bundle/main.php", "<?php\n")]);
+        let error = validate_package_completeness(
+            &component,
+            repo.path(),
+            &zip_artifacts("build/runtime.zip"),
+        )
+        .expect_err("direct traversal must fail before inspecting archive entries");
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(error.message.contains("parent traversal"));
+    }
+
+    #[test]
+    fn package_completeness_rejects_missing_transformed_source_file() {
+        let repo = tempfile::tempdir().expect("repo");
+        std::fs::create_dir_all(repo.path().join("source/runtime")).expect("runtime dir");
+        std::fs::write(repo.path().join("source/runtime/main.php"), "<?php\n").expect("main");
+        std::fs::write(repo.path().join("source/runtime/extra.php"), "<?php\n").expect("extra");
+        run_git(repo.path(), &["init"]);
+        run_git(repo.path(), &["add", "source/runtime"]);
+        let artifact_path = repo.path().join("build/runtime.zip");
+        std::fs::create_dir_all(artifact_path.parent().unwrap()).expect("build dir");
+        write_zip(&artifact_path, &[("bundle/main.php", "<?php\n")]);
+        let mut component = test_component(repo.path());
+        component.release.package_coverage = vec![PackageCoverageConfig {
+            artifact: "build/runtime.zip".to_string(),
+            artifact_match: PackageCoverageArtifactMatch::Exact,
+            source_roots: vec!["source/runtime".to_string()],
+            archive_root: "bundle".to_string(),
+        }];
+
+        let error = validate_package_completeness(
+            &component,
+            repo.path(),
+            &zip_artifacts("build/runtime.zip"),
+        )
+        .expect_err("missing mapped runtime file should fail");
+        assert!(error.message.contains("bundle/extra.php"));
+    }
+
+    #[test]
+    fn package_completeness_does_not_union_zip_entries() {
+        let repo = tempfile::tempdir().expect("repo");
+        std::fs::write(repo.path().join("first.php"), "<?php\n").expect("first");
+        std::fs::write(repo.path().join("second.php"), "<?php\n").expect("second");
+        run_git(repo.path(), &["init"]);
+        run_git(repo.path(), &["add", "first.php", "second.php"]);
+        let first_zip = repo.path().join("build/first.zip");
+        let second_zip = repo.path().join("build/second.zip");
+        std::fs::create_dir_all(first_zip.parent().unwrap()).expect("build dir");
+        write_zip(&first_zip, &[("first.php", "<?php\n")]);
+        write_zip(&second_zip, &[("second.php", "<?php\n")]);
+        let mut first_artifacts = zip_artifacts("build/first.zip");
+        let mut second_artifacts = zip_artifacts("build/second.zip");
+
+        let error = validate_package_completeness(
+            &test_component(repo.path()),
+            repo.path(),
+            &[first_artifacts.remove(0), second_artifacts.remove(0)],
+        )
+        .expect_err("each ZIP must cover its own runtime files");
+        assert!(error.message.contains("build/first.zip"));
+        assert!(error.message.contains("second.php"));
+    }
+
+    #[test]
+    fn package_completeness_preserves_identity_layout_success_and_failure() {
+        let repo = tempfile::tempdir().expect("repo");
+        std::fs::write(repo.path().join("runtime.php"), "<?php\n").expect("runtime");
+        run_git(repo.path(), &["init"]);
+        run_git(repo.path(), &["add", "runtime.php"]);
+        let artifact_path = repo.path().join("build/package.zip");
+        std::fs::create_dir_all(artifact_path.parent().unwrap()).expect("build dir");
+        write_zip(&artifact_path, &[("wrapped/runtime.php", "<?php\n")]);
+        validate_package_completeness(
+            &test_component(repo.path()),
+            repo.path(),
+            &zip_artifacts("build/package.zip"),
+        )
+        .expect("unmapped identity archive should retain wrapped-root support");
+
+        write_zip(&artifact_path, &[("other.php", "<?php\n")]);
+        let error = validate_package_completeness(
+            &test_component(repo.path()),
+            repo.path(),
+            &zip_artifacts("build/package.zip"),
+        )
+        .expect_err("identity archive missing a tracked runtime file should fail");
+        assert!(error.message.contains("runtime.php"));
+    }
+
+    #[test]
+    fn package_completeness_rejects_zero_match_source_root() {
+        let repo = tempfile::tempdir().expect("repo");
+        std::fs::write(repo.path().join("runtime.php"), "<?php\n").expect("runtime");
+        run_git(repo.path(), &["init"]);
+        run_git(repo.path(), &["add", "runtime.php"]);
+        let artifact_path = repo.path().join("build/package.zip");
+        std::fs::create_dir_all(artifact_path.parent().unwrap()).expect("build dir");
+        write_zip(&artifact_path, &[("bundle/runtime.php", "<?php\n")]);
+        let mut component = test_component(repo.path());
+        component.release.package_coverage = vec![PackageCoverageConfig {
+            artifact: "build/package.zip".to_string(),
+            artifact_match: PackageCoverageArtifactMatch::Exact,
+            source_roots: vec!["missing".to_string()],
+            archive_root: "bundle".to_string(),
+        }];
+
+        let error = validate_package_completeness(
+            &component,
+            repo.path(),
+            &zip_artifacts("build/package.zip"),
+        )
+        .expect_err("unmatched source roots must fail closed");
+        assert!(error.message.contains("matches no tracked runtime files"));
+    }
+
+    #[test]
+    fn package_completeness_rejects_archive_path_collisions() {
+        let repo = tempfile::tempdir().expect("repo");
+        for root in ["one", "two"] {
+            std::fs::create_dir_all(repo.path().join(root)).expect("source dir");
+            std::fs::write(repo.path().join(root).join("main.php"), "<?php\n").expect("runtime");
+        }
+        run_git(repo.path(), &["init"]);
+        run_git(repo.path(), &["add", "one", "two"]);
+        let artifact_path = repo.path().join("build/package.zip");
+        std::fs::create_dir_all(artifact_path.parent().unwrap()).expect("build dir");
+        write_zip(&artifact_path, &[("bundle/main.php", "<?php\n")]);
+        let mut component = test_component(repo.path());
+        component.release.package_coverage = vec![PackageCoverageConfig {
+            artifact: "build/package.zip".to_string(),
+            artifact_match: PackageCoverageArtifactMatch::Exact,
+            source_roots: vec!["one".to_string(), "two".to_string()],
+            archive_root: "bundle".to_string(),
+        }];
+
+        let error = validate_package_completeness(
+            &component,
+            repo.path(),
+            &zip_artifacts("build/package.zip"),
+        )
+        .expect_err("colliding mapped archive paths must fail");
+        assert!(error.message.contains("one/main.php"));
+        assert!(error.message.contains("two/main.php"));
+        assert!(error.message.contains("bundle/main.php"));
+    }
+
+    #[test]
+    fn package_completeness_rejects_overlapping_selectors_without_runtime_candidates() {
+        let repo = tempfile::tempdir().expect("repo");
+        run_git(repo.path(), &["init"]);
+        let artifact_path = repo.path().join("build/package.zip");
+        std::fs::create_dir_all(artifact_path.parent().unwrap()).expect("build dir");
+        write_zip(&artifact_path, &[]);
+        let mut component = test_component(repo.path());
+        component.release.package_coverage = vec![
+            PackageCoverageConfig {
+                artifact: "build/package.zip".to_string(),
+                artifact_match: PackageCoverageArtifactMatch::Exact,
+                source_roots: vec![".".to_string()],
+                archive_root: "bundle".to_string(),
+            },
+            PackageCoverageConfig {
+                artifact: "build/*.zip".to_string(),
+                artifact_match: PackageCoverageArtifactMatch::Glob,
+                source_roots: vec![".".to_string()],
+                archive_root: "bundle".to_string(),
+            },
+        ];
+
+        let error = validate_package_completeness(
+            &component,
+            repo.path(),
+            &zip_artifacts("build/package.zip"),
+        )
+        .expect_err("overlapping selectors must fail before runtime coverage is evaluated");
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(error
+            .message
+            .contains("matches multiple package coverage declarations"));
+    }
+
+    #[test]
+    fn package_completeness_rejects_empty_mapped_zip() {
+        let repo = tempfile::tempdir().expect("repo");
+        std::fs::create_dir_all(repo.path().join("source")).expect("source dir");
+        std::fs::write(repo.path().join("source/runtime.php"), "<?php\n").expect("runtime");
+        run_git(repo.path(), &["init"]);
+        run_git(repo.path(), &["add", "source/runtime.php"]);
+        let artifact_path = repo.path().join("build/package.zip");
+        std::fs::create_dir_all(artifact_path.parent().unwrap()).expect("build dir");
+        write_zip(&artifact_path, &[]);
+        let mut component = test_component(repo.path());
+        component.release.package_coverage = vec![PackageCoverageConfig {
+            artifact: "build/package.zip".to_string(),
+            artifact_match: PackageCoverageArtifactMatch::Exact,
+            source_roots: vec!["source".to_string()],
+            archive_root: "bundle".to_string(),
+        }];
+
+        let error = validate_package_completeness(
+            &component,
+            repo.path(),
+            &zip_artifacts("build/package.zip"),
+        )
+        .expect_err("explicit mappings make an empty ZIP incomplete");
+        assert!(error.message.contains("bundle/runtime.php"));
+    }
+
+    #[test]
     fn skip_build_validation_bypasses_package_completeness() {
         // #8189: when the operator passes --skip-build-validation, the
         // package-completeness structure assertion must not run, matching the
@@ -319,6 +686,23 @@ mod tests {
         assert!(!should_validate_package_completeness(true));
         // Default release behavior still enforces completeness.
         assert!(should_validate_package_completeness(false));
+    }
+
+    fn test_component(repo: &Path) -> Component {
+        Component {
+            id: "package".to_string(),
+            local_path: repo.to_string_lossy().to_string(),
+            ..Component::default()
+        }
+    }
+
+    fn zip_artifacts(path: &str) -> Vec<ReleaseArtifact> {
+        vec![ReleaseArtifact {
+            path: path.to_string(),
+            durable_path: None,
+            artifact_type: Some("archive".to_string()),
+            platform: None,
+        }]
     }
 
     fn run_git(repo: &Path, args: &[&str]) {

--- a/docs/reference/schemas/component-schema.md
+++ b/docs/reference/schemas/component-schema.md
@@ -97,6 +97,12 @@ Component configuration defines buildable and deployable units stored in `compon
   - **`enabled`** (boolean): Whether release pipeline is enabled
   - **`steps`** (array): Release step definitions
   - **`settings`** (object): Release pipeline settings
+  - **`package_coverage`** (array): Optional ZIP completeness mappings for transformed archive layouts
+    - **`artifact`** (string): Archive-relative ZIP path or glob pattern, normalized to slash-separated form
+    - **`artifact_match`** (`exact` or `glob`, default `exact`): Selects literal path equality or glob matching explicitly; each declaration must match exactly one emitted ZIP
+    - **`source_roots`** (array): One or more non-overlapping repository-relative source directories
+    - **`archive_root`** (string): Archive-relative directory where each selected source root's contents are packaged
+    - Unmapped ZIP artifacts use the identity-layout completeness check. Mapped archive paths are checked exactly.
 
 ### Runtime Requirements
 
@@ -179,6 +185,14 @@ Setting `local_path` to the same directory as the deploy target is a misconfigur
   },
   "release": {
     "enabled": true,
+    "package_coverage": [
+      {
+        "artifact": "dist/runtime-bundle.zip",
+        "artifact_match": "exact",
+        "source_roots": ["packages/runtime"],
+        "archive_root": "runtime-bundle"
+      }
+    ],
     "steps": [
       {
         "id": "preflight.test",


### PR DESCRIPTION
## Summary
Allow release components to declare generic source-root to archive-root ZIP coverage mappings while validating each ZIP independently.

## What changed
- Added validated release.package\_coverage declarations with explicit exact/glob artifact matching, canonical source roots, and archive roots.
- Changed ZIP completeness validation to isolate artifacts, map transformed paths exactly, reject selector ambiguity, zero-match roots, path collisions, traversal, and incomplete mapped archives.
- Added executable configuration and package regressions for transformed success, missing files, multi-ZIP isolation, identity-layout compatibility, malformed paths, direct construction, collisions, and empty archives.

## How to test
1. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy/target cargo test -p homeboy-core --lib package_completeness`; expect 12 package completeness tests pass..
2. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy/target cargo test -p homeboy-core --lib package_coverage_normalizes_paths_and_rejects_malformed_declarations`; expect The package coverage parsing and direct-construction regression passes..
3. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy/target cargo test -p homeboy-core --lib --no-run`; expect The complete homeboy-core lib-test target compiles..
4. Run `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy/target cargo check -p homeboy-cli`; expect Homeboy CLI compiles against the new generic component schema..
5. Run `cargo fmt --check && git diff --check`; expect Formatting and patch whitespace checks pass..

## Compatibility
Additive generic component schema: configurations without release.package\_coverage retain the shipped identity-layout ZIP validation behavior. Explicit mappings are fail-closed and validate each selected ZIP independently. No product/framework assumptions, extension paths, or existing public fields are removed or renamed.

## Evidence
- CI expected: Audit
- CI expected: Lint
- CI expected: Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8499
- cli-check: Passed
- core-test-compile: Passed
- package-completeness: Passed
- package-coverage-config: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding and review subagents
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the transformed-archive release blocker, implemented the generic package coverage contract and deterministic tests, and iterated through independent review; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8499
