### PR TITLE
refactor: move RunnerArtifactRef to runner-contract (runner-decouple)

### DIFF
--- a/crates/homeboy-core/src/observation/runs_service/mod.rs
+++ b/crates/homeboy-core/src/observation/runs_service/mod.rs
@@ -31,9 +31,9 @@ use super::{
 use crate::artifact_links::{cached_validated_viewer_links, public_artifact_url};
 use crate::engine::temp::CleanupSizeTotals;
 use crate::execution_contract::EXECUTION_CONTRACT;
-use crate::runners::RunnerArtifactRef;
 use crate::Error;
 use crate::Result;
+use homeboy_runner_contract::RunnerArtifactRef;
 
 /// Output of a successful artifact byte retrieval (whether the bytes came
 /// from a locally-recorded file or from a remote runner).

--- a/crates/homeboy-core/src/run_outcome_envelope.rs
+++ b/crates/homeboy-core/src/run_outcome_envelope.rs
@@ -3,8 +3,9 @@ use serde_json::Value;
 
 use crate::api_jobs::JobArtifactMetadata;
 use crate::artifact_ref::{artifact_uri, ArtifactRef, EvidenceRef, ARTIFACT_REF_SCHEMA};
-use crate::runner::{RunnerArtifactRef, RunnerHandoff};
+use crate::runner::RunnerHandoff;
 use crate::runner_execution_envelope::{RunnerExecutionArtifactRef, RunnerExecutionRecord};
+use homeboy_runner_contract::RunnerArtifactRef;
 
 pub const RUN_OUTCOME_ENVELOPE_SCHEMA: &str = "homeboy/run-outcome-envelope/v1";
 pub const RUN_OUTCOME_ENVELOPE_FILE: &str = "run-outcome-envelope.json";

--- a/crates/homeboy-core/src/runner/session.rs
+++ b/crates/homeboy-core/src/runner/session.rs
@@ -240,24 +240,12 @@ impl RunnerSession {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunnerArtifactRef {
-    pub artifact_id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub path: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub mime: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub size_bytes: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sha256: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub transport: Option<String>,
-}
+// RunnerArtifactRef is behavior-free data; it now lives in the shared
+// runner-contract crate so core can name it without a core -> runner edge.
+// Re-exported so internal/CLI call sites resolve unchanged. The
+// From<&JobArtifactMetadata> impl stays below (orphan rule: JobArtifactMetadata
+// is core-owned).
+pub use homeboy_runner_contract::RunnerArtifactRef;
 
 impl From<&JobArtifactMetadata> for RunnerArtifactRef {
     fn from(artifact: &JobArtifactMetadata) -> Self {

--- a/crates/homeboy-runner-contract/src/lib.rs
+++ b/crates/homeboy-runner-contract/src/lib.rs
@@ -17,6 +17,28 @@ pub enum RunnerKind {
     Ssh,
 }
 
+/// A reference to an artifact produced by a runner job. Plain data describing
+/// where/how to fetch the artifact; behavior-free so core can name it without a
+/// core -> runner edge.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerArtifactRef {
+    pub artifact_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
+}
+
 /// How a runner workspace is synced before a job runs.
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
## Summary
Moves the plain-data `RunnerArtifactRef` into `homeboy-runner-contract` so core can name it without a core→runner edge. The `From<&JobArtifactMetadata>` impl stays in core (orphan rule: `JobArtifactMetadata` is core-owned).

Re-exported from `runner::session` so internal/CLI call sites resolve unchanged; external consumers (observation/runs_service, run_outcome_envelope) repointed to `homeboy_runner_contract::`.

## Why now
This **unblocks the upcoming runner-evidence hook** — `download_remote_artifact` returns a `RemoteArtifactDownload` whose `artifact_ref` is a `RunnerArtifactRef`, and `ArtifactFetchOutcome` carries `Option<RunnerArtifactRef>`. Both are now nameable in core without a runner edge, so the hook can return them cleanly.

## Context
Part of the staged runner extraction. The next PR builds the `RunnerEvidenceProvider` hook (design in wiki: runner-evidence-hook-design) to invert the fattest behavior cluster (observation/runs_service → runner daemon evidence).

## Verification
`cargo check` clean for `-p homeboy-runner-contract`, `-p homeboy-core --lib`, `-p homeboy-cli --lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)