### PR TITLE
Project recovered Lab artifacts during reconciliation

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
@@ -1,6 +1,6 @@
 use super::*;
 use sha2::Digest;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub fn record_pre_execution_failure(
     run_id: &str,
@@ -611,6 +611,7 @@ pub(crate) fn project_terminal_artifacts(
     })?;
 
     let mut used_ids = std::collections::BTreeSet::new();
+    let mut projection_error = None;
     for outcome in &aggregate.outcomes {
         for artifact in &outcome.artifacts {
             let Some(path) = artifact.path.as_deref() else {
@@ -655,29 +656,61 @@ pub(crate) fn project_terminal_artifacts(
                         None,
                     ));
                 }
-                // The producing runner owns finalized bytes. Controller-side
-                // reconciliation indexes its canonical runner token instead of
-                // attempting to copy a runner-local filesystem path.
-                store.import_artifact(&crate::observation::ArtifactRecord {
-                    id: artifact_id,
-                    run_id: record.run_id.clone(),
-                    kind: artifact.kind.clone(),
-                    artifact_type: "remote_file".to_string(),
-                    path: crate::execution_contract::EXECUTION_CONTRACT
-                        .artifacts
-                        .runner_artifact_ref(runner_id, &record.run_id, &logical_id),
-                    url: None,
-                    public_url: None,
-                    viewer_url: None,
-                    viewer_links: Vec::new(),
-                    sha256: artifact.sha256.clone(),
-                    size_bytes: artifact
-                        .size_bytes
-                        .and_then(|value| i64::try_from(value).ok()),
-                    mime: artifact.mime.clone(),
-                    metadata_json: metadata,
-                    created_at: chrono::Utc::now().to_rfc3339(),
-                })?;
+                match controller_finalized_artifact_path(artifact)? {
+                    Some(path) => {
+                        let mut controller_hash = sha2::Sha256::new();
+                        sha2::Digest::update(&mut controller_hash, b"controller");
+                        sha2::Digest::update(&mut controller_hash, [0]);
+                        sha2::Digest::update(&mut controller_hash, artifact_id.as_bytes());
+                        let controller_artifact_id =
+                            format!("agent-task-{:x}", controller_hash.finalize());
+                        let mut metadata = metadata;
+                        metadata["agent_task"]["projection"] = json!("controller_finalized");
+                        store.record_artifact_with_id(
+                            &record.run_id,
+                            &artifact.kind,
+                            path,
+                            &controller_artifact_id,
+                            metadata,
+                        )?;
+                    }
+                    None => {
+                        // Keep the remote reference available for existing Lab
+                        // retrieval flows, but leave an actionable lifecycle
+                        // marker because it cannot satisfy local promotion.
+                        store.import_artifact(&crate::observation::ArtifactRecord {
+                            id: artifact_id,
+                            run_id: record.run_id.clone(),
+                            kind: artifact.kind.clone(),
+                            artifact_type: "remote_file".to_string(),
+                            path: crate::execution_contract::EXECUTION_CONTRACT
+                                .artifacts
+                                .runner_artifact_ref(runner_id, &record.run_id, &logical_id),
+                            url: None,
+                            public_url: None,
+                            viewer_url: None,
+                            viewer_links: Vec::new(),
+                            sha256: artifact.sha256.clone(),
+                            size_bytes: artifact
+                                .size_bytes
+                                .and_then(|value| i64::try_from(value).ok()),
+                            mime: artifact.mime.clone(),
+                            metadata_json: metadata,
+                            created_at: chrono::Utc::now().to_rfc3339(),
+                        })?;
+                        projection_error.get_or_insert_with(|| {
+                            Error::validation_invalid_argument(
+                                "artifact.path",
+                                format!(
+                                    "controller-finalized bytes for run '{}', task '{}', and artifact '{}' were not found with the aggregate SHA-256 and size",
+                                    record.run_id, outcome.task_id, logical_id
+                                ),
+                                Some(artifact.id.clone()),
+                                None,
+                            )
+                        });
+                    }
+                }
             } else {
                 store.record_artifact_with_id(
                     &record.run_id,
@@ -687,6 +720,71 @@ pub(crate) fn project_terminal_artifacts(
                     metadata,
                 )?;
             }
+        }
+    }
+    projection_error.map_or(Ok(()), Err)
+}
+
+/// Find finalized bytes already copied into the controller artifact root. Lab
+/// aggregate paths describe runner provenance and are never read after recovery.
+fn controller_finalized_artifact_path(artifact: &AgentTaskArtifact) -> Result<Option<PathBuf>> {
+    let Some(expected_sha256) = artifact.sha256.as_deref() else {
+        return Ok(None);
+    };
+    let Some(expected_size) = artifact.size_bytes else {
+        return Ok(None);
+    };
+    let root = crate::paths::artifact_root()?.join("executor-finalized");
+    if !root.is_dir() {
+        return Ok(None);
+    }
+    let mut matches = Vec::new();
+    collect_matching_finalized_artifacts(&root, expected_sha256, expected_size, &mut matches)?;
+    matches.sort();
+    Ok(matches.into_iter().next())
+}
+
+fn collect_matching_finalized_artifacts(
+    directory: &Path,
+    expected_sha256: &str,
+    expected_size: u64,
+    matches: &mut Vec<PathBuf>,
+) -> Result<()> {
+    for entry in std::fs::read_dir(directory).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "read controller finalized artifact directory {}",
+                directory.display()
+            )),
+        )
+    })? {
+        let entry = entry.map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("read controller finalized artifact entry".to_string()),
+            )
+        })?;
+        let path = entry.path();
+        let metadata = std::fs::symlink_metadata(&path).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "inspect controller finalized artifact {}",
+                    path.display()
+                )),
+            )
+        })?;
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
+        if metadata.is_dir() {
+            collect_matching_finalized_artifacts(&path, expected_sha256, expected_size, matches)?;
+        } else if metadata.is_file()
+            && metadata.len() == expected_size
+            && crate::artifact_metadata::sha256_file(&path)? == expected_sha256
+        {
+            matches.push(path);
         }
     }
     Ok(())

--- a/crates/homeboy-core/src/agent_task_promotion/tests.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/tests.rs
@@ -28,11 +28,13 @@ use crate::agent_task::{
 use crate::agent_task_gate::{
     AgentTaskGateReport, AgentTaskGateRevealPolicy, AgentTaskGateVisibility, VerifyGateOptions,
 };
+use crate::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
 use crate::command_invocation::CommandInvocation;
 use crate::defaults::{
     HomeboyConfig, WorktreeProviderCommands, WorktreeProviderConfig, WorktreeProviderKind,
     WorktreeProviderListResultMapping,
 };
+use crate::lab_contract::AgentTaskDispatchIdentity;
 use crate::{Error, Result};
 
 const VALID_PATCH: &str = "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
@@ -193,6 +195,196 @@ fn recovered_runner_aggregate(
         }]
     })
     .to_string()
+}
+
+#[test]
+fn bridge_reconciliation_projects_recovered_finalized_bytes_for_local_promotion_idempotently() {
+    crate::test_support::with_isolated_home(|_| {
+        let run_id = "recovered-typed-lab-run";
+        let task_id = "implement";
+        let artifact_id = "patch";
+        let plan = AgentTaskPlan::new("recovered-typed-lab-plan", Vec::new());
+        crate::agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submit plan");
+        let finalized = crate::paths::artifact_root()
+            .expect("artifact root")
+            .join("executor-finalized")
+            .join("recovered-run")
+            .join("patch");
+        std::fs::create_dir_all(finalized.parent().expect("finalized parent"))
+            .expect("create finalized parent");
+        std::fs::write(&finalized, VALID_PATCH).expect("write controller finalized patch");
+        let aggregate: AgentTaskAggregate = serde_json::from_str(
+            &serde_json::json!({
+                "schema": "homeboy/agent-task-aggregate/v1",
+                "plan_id": "recovered-typed-lab-plan",
+                "status": "succeeded",
+                "totals": { "skipped": 0, "succeeded": 1 },
+                "outcomes": [{
+                    "schema": AGENT_TASK_OUTCOME_SCHEMA,
+                    "task_id": task_id,
+                    "status": "succeeded",
+                    "artifacts": [{
+                        "schema": AGENT_TASK_ARTIFACT_SCHEMA,
+                        "id": artifact_id,
+                        "kind": "patch",
+                        "path": "/home/runner/.homeboy/executor-finalized/patch.diff",
+                        "url": "homeboy://agent-task/run/recovered-typed-lab-run/artifacts#task=implement&artifact=patch",
+                        "size_bytes": VALID_PATCH.len(),
+                        "sha256": sha256_hex(VALID_PATCH),
+                        "metadata": {
+                            "executor_artifact_finalized": true,
+                            "source_provenance": { "runner_id": "homeboy-lab" }
+                        }
+                    }],
+                    "typed_artifacts": [{
+                        "name": "patch",
+                        "artifact_type": "file",
+                        "payload": {
+                            "artifact_id": artifact_id,
+                            "kind": "patch",
+                            "path": "/home/runner/.homeboy/executor-finalized/patch.diff",
+                            "sha256": sha256_hex(VALID_PATCH),
+                            "size_bytes": VALID_PATCH.len(),
+                            "url": "homeboy://agent-task/run/recovered-typed-lab-run/artifacts#task=implement&artifact=patch"
+                        },
+                        "artifact": {
+                            "schema": AGENT_TASK_ARTIFACT_SCHEMA,
+                            "id": artifact_id,
+                            "kind": "patch",
+                            "path": "/home/runner/.homeboy/executor-finalized/patch.diff",
+                            "size_bytes": VALID_PATCH.len(),
+                            "sha256": sha256_hex(VALID_PATCH),
+                            "metadata": { "executor_artifact_finalized": true }
+                        }
+                    }]
+                }]
+            })
+            .to_string(),
+        )
+        .expect("recovered aggregate");
+        let identity = AgentTaskDispatchIdentity {
+            runner_id: "homeboy-lab".to_string(),
+            runner_job_id: "job-recovered".to_string(),
+            ..Default::default()
+        };
+
+        crate::runner::mirror_agent_task_run_plan_aggregate(
+            "@runner-plan.json",
+            run_id,
+            aggregate.clone(),
+            None,
+            Some(&identity),
+        )
+        .expect("bridge reconciliation");
+        crate::runner::mirror_agent_task_run_plan_aggregate(
+            "@runner-plan.json",
+            run_id,
+            aggregate.clone(),
+            None,
+            Some(&identity),
+        )
+        .expect("idempotent bridge reconciliation");
+
+        let store = crate::observation::ObservationStore::open_initialized().expect("store");
+        let artifacts = store.list_artifacts(run_id).expect("projected artifacts");
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].artifact_type, "file");
+        assert_eq!(artifacts[0].metadata_json["agent_task"]["task_id"], task_id);
+        assert_eq!(
+            artifacts[0].metadata_json["agent_task"]["logical_artifact_id"],
+            artifact_id
+        );
+
+        let temp = tempfile::tempdir().expect("promotion tempdir");
+        let mut provider = FakePromotionWorkspaceProvider {
+            workspace_path: Some(temp.path().join("target")),
+            ..Default::default()
+        };
+        let report = promote_with_provider(
+            AgentTaskPromotionOptions {
+                source: serde_json::to_string(&aggregate).expect("aggregate json"),
+                source_run_id: Some(run_id.to_string()),
+                source_path: None,
+                source_worktree_path: None,
+                base_ref: None,
+                task_base_sha: None,
+                to_worktree: "homeboy@recovered-promotion".to_string(),
+                task_id: Some(task_id.to_string()),
+                artifact_id: Some(artifact_id.to_string()),
+                dry_run: false,
+                gates: VerifyGateOptions::default(),
+                provider_command: None,
+                provider_invocation: None,
+            },
+            &mut provider,
+        )
+        .expect("promote recovered controller projection");
+        assert_eq!(report.patch_artifact.path, artifacts[0].path);
+        assert_eq!(
+            provider.applied_patch_contents,
+            vec![VALID_PATCH.to_string()]
+        );
+    });
+}
+
+#[test]
+fn bridge_reconciliation_marks_missing_or_mismatched_finalized_bytes_pending() {
+    crate::test_support::with_isolated_home(|_| {
+        for (run_id, contents) in [
+            ("recovered-missing-finalized", None),
+            (
+                "recovered-mismatched-finalized",
+                Some("different patch bytes"),
+            ),
+        ] {
+            let plan = AgentTaskPlan::new("recovered-lab-plan", Vec::new());
+            crate::agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submit plan");
+            if let Some(contents) = contents {
+                let finalized = crate::paths::artifact_root()
+                    .expect("artifact root")
+                    .join("executor-finalized")
+                    .join(run_id)
+                    .join("patch");
+                std::fs::create_dir_all(finalized.parent().expect("finalized parent"))
+                    .expect("create finalized parent");
+                std::fs::write(finalized, contents).expect("write mismatched finalized bytes");
+            }
+            let aggregate: AgentTaskAggregate = serde_json::from_str(&recovered_runner_aggregate(
+                "implement",
+                "patch",
+                &sha256_hex(VALID_PATCH),
+                VALID_PATCH.len(),
+            ))
+            .expect("recovered aggregate");
+            let identity = AgentTaskDispatchIdentity {
+                runner_id: "homeboy-lab".to_string(),
+                runner_job_id: format!("job-{run_id}"),
+                ..Default::default()
+            };
+
+            crate::runner::mirror_agent_task_run_plan_aggregate(
+                "@runner-plan.json",
+                run_id,
+                aggregate,
+                None,
+                Some(&identity),
+            )
+            .expect("bridge preserves aggregate while surfacing pending projection");
+
+            let record = crate::agent_task_lifecycle::status(run_id).expect("lifecycle status");
+            assert_eq!(record.metadata["artifact_projection"]["status"], "pending");
+            assert!(record.metadata["artifact_projection"]["error"]
+                .as_str()
+                .expect("actionable error")
+                .contains("controller-finalized bytes"));
+            let artifacts = crate::observation::ObservationStore::open_initialized()
+                .expect("store")
+                .list_artifacts(run_id)
+                .expect("artifact references");
+            assert_eq!(artifacts.len(), 1);
+            assert_eq!(artifacts[0].artifact_type, "remote_file");
+        }
+    });
 }
 
 #[test]

--- a/crates/homeboy-core/src/runner/lab.rs
+++ b/crates/homeboy-core/src/runner/lab.rs
@@ -41,4 +41,7 @@ pub use offload::{
 };
 
 #[cfg(test)]
+pub(crate) use agent_task_plan_projection::mirror_agent_task_run_plan_aggregate;
+
+#[cfg(test)]
 mod preparation_tests;

--- a/crates/homeboy-core/src/runner/lab/agent_task_plan_projection.rs
+++ b/crates/homeboy-core/src/runner/lab/agent_task_plan_projection.rs
@@ -5,7 +5,7 @@ use crate::lab_contract::AgentTaskDispatchIdentity;
 use crate::notification_route::NotificationRoute;
 use crate::{config, Error, Result};
 
-pub(super) fn mirror_agent_task_run_plan_aggregate(
+pub(crate) fn mirror_agent_task_run_plan_aggregate(
     plan_spec: &str,
     run_id: &str,
     aggregate: AgentTaskAggregate,
@@ -36,12 +36,14 @@ pub(super) fn mirror_agent_task_run_plan_aggregate(
     if !controller_owned {
         agent_task_lifecycle::mark_running(run_id)?;
     }
-    agent_task_lifecycle::record_run_aggregate(run_id, &plan, &aggregate)?;
     if let Some(identity) = dispatch_identity.filter(|identity| {
         !identity.runner_id.trim().is_empty() && !identity.runner_job_id.trim().is_empty()
     }) {
         record_runner_job_identity(run_id, &identity.runner_id, &identity.runner_job_id)?;
     }
+    // Artifact projection needs the runner identity while reconciling the
+    // aggregate so it can distinguish runner provenance from controller bytes.
+    agent_task_lifecycle::record_run_aggregate(run_id, &plan, &aggregate)?;
     Ok(())
 }
 

--- a/crates/homeboy-core/src/runner/mod.rs
+++ b/crates/homeboy-core/src/runner/mod.rs
@@ -37,6 +37,8 @@ mod extension_materialization;
 mod git_dependency_materialization;
 mod homeboy_refresh;
 mod lab;
+#[cfg(test)]
+pub(crate) use lab::mirror_agent_task_run_plan_aggregate;
 mod lab_apply;
 mod lab_args;
 mod lab_capabilities;


### PR DESCRIPTION
## Summary
Complete recovered Lab artifact promotion by projecting verified controller-finalized bytes during bridge reconciliation.

## What changed
- Record runner identity before aggregate reconciliation, then match recovered artifacts to controller-finalized bytes by SHA-256 and size and persist an idempotent local observation projection.
- Keep remote retrieval references and mark projection pending with actionable evidence when verified controller bytes are missing or mismatched.

## How to test
1. Run `cargo test -p homeboy-core recovered --lib`; expect Six recovered-run tests pass, including bridge reconciliation and local promotion..
2. Run `cargo test -p homeboy-core bridge_reconciliation_marks_missing_or_mismatched_finalized_bytes_pending --lib`; expect Missing and mismatched controller bytes remain pending with actionable lifecycle evidence..
3. Run `cargo check -p homeboy-core`; expect Changed production code and dependencies compile..
4. Run `cargo fmt --check`; expect Formatting is clean..
5. Run `git diff --check`; expect The patch has no whitespace errors..

## Compatibility
Preserves existing local and remote artifact behavior. Historical recovered Lab artifacts become locally promotable only when controller-finalized bytes match the aggregate hash and size; otherwise remote references remain available and promotion stays blocked.

## Evidence
- CI expected: GitHub Actions repository checks
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8507
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/pull/8513
- core-check: Passed
- diff-check: Passed
- format: Passed
- projection-failure-test: Passed
- recovered-tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Validated #8513 against the preserved real run, traced the missing bridge projection, implemented lifecycle reconciliation, and added integration coverage; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8507
