### PR TITLE
Materialize recovered Lab artifacts before promotion

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -137,6 +137,11 @@ impl From<FinalizePrEvidenceArgs> for AgentTaskPrEvidence {
 
 pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
     let record = agent_task_lifecycle::status(&args.run_id)?;
+    // A review that names a target worktree is preparing a promotion handoff.
+    // Materialize recovered runner artifacts before rendering its command.
+    if args.to_worktree.is_some() {
+        agent_task_lifecycle::materialize_recovered_patch_artifact(&record.run_id, None, None)?;
+    }
     let log = agent_task_lifecycle::logs(&args.run_id)?;
     let artifacts = agent_task_lifecycle::artifacts(&args.run_id)?;
     let aggregate_source = completed_run_aggregate_source(&args.run_id).transpose()?;
@@ -196,7 +201,7 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
 
 pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
     let to_worktree = args.to_worktree.clone();
-    let (raw, source_path) = read_promotion_source(&args.source)?;
+    let (_raw, source_path) = read_promotion_source(&args.source)?;
     let source_run_id = match agent_task_lifecycle::status(&args.source) {
         Ok(record) => Some(record.run_id),
         Err(_) => match source_path.as_deref() {
@@ -204,6 +209,14 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
             None => None,
         },
     };
+    if let Some(run_id) = source_run_id.as_deref() {
+        agent_task_lifecycle::materialize_recovered_patch_artifact(
+            run_id,
+            args.task_id.as_deref(),
+            args.artifact_id.as_deref(),
+        )?;
+    }
+    let (raw, source_path) = read_promotion_source(&args.source)?;
     let promotion_options = AgentTaskPromotionOptions {
         source: raw,
         source_run_id: source_run_id.clone(),

--- a/crates/homeboy-core/src/agent_task_lifecycle/artifact_materialization.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/artifact_materialization.rs
@@ -1,0 +1,428 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use base64::Engine;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+use crate::agent_task::AgentTaskArtifact;
+use crate::{Error, Result};
+
+use super::{apply_aggregate_to_record, status, store};
+
+/// Materialize a recovered reverse-runner patch into controller-owned storage.
+/// The aggregate is updated atomically with the durable run record, making a
+/// replay reuse the verified local file instead of contacting the runner again.
+pub fn materialize_recovered_patch_artifact(
+    run_id: &str,
+    task_id: Option<&str>,
+    artifact_id: Option<&str>,
+) -> Result<bool> {
+    let mut record = status(run_id)?;
+    let Some(runner_id) = record.runner_id().filter(|value| !value.trim().is_empty()) else {
+        return Ok(false);
+    };
+    let Some(job_id) = record
+        .runner_job_id()
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return Ok(false);
+    };
+    let mut aggregate = store::read_aggregate(&record.run_id)?;
+    let mut changed = false;
+    for outcome in &mut aggregate.outcomes {
+        if task_id.is_some_and(|expected| expected != outcome.task_id) {
+            continue;
+        }
+        for artifact in &mut outcome.artifacts {
+            if artifact_id.is_some_and(|expected| expected != artifact.id)
+                || !matches!(artifact.kind.as_str(), "patch" | "diff" | "workspace_patch")
+            {
+                continue;
+            }
+            let typed_path = outcome.typed_artifacts.iter().find_map(|typed| {
+                let typed_artifact = typed.artifact.as_ref()?;
+                (typed_artifact.id == artifact.id
+                    && typed_artifact.size_bytes == artifact.size_bytes
+                    && typed_artifact.sha256 == artifact.sha256)
+                    .then(|| {
+                        typed_artifact.path.clone().or_else(|| {
+                            typed
+                                .payload
+                                .get("path")
+                                .and_then(serde_json::Value::as_str)
+                                .map(str::to_string)
+                        })
+                    })
+                    .flatten()
+            });
+            changed |= materialize_artifact(
+                artifact,
+                &runner_id,
+                &job_id,
+                &record.run_id,
+                &outcome.task_id,
+                |id| crate::runner::runner_artifact_content(&runner_id, &job_id, id),
+                typed_path.as_deref(),
+            )?;
+        }
+        let finalized = outcome.artifacts.clone();
+        for typed in &mut outcome.typed_artifacts {
+            if let Some(artifact) = &mut typed.artifact {
+                if let Some(finalized) = finalized.iter().find(|value| value.id == artifact.id) {
+                    *artifact = finalized.clone();
+                }
+            }
+        }
+    }
+    if changed {
+        let aggregate_path = store::aggregate_path(&record.run_id)?.display().to_string();
+        let plan = super::load_plan(&record.run_id)?;
+        apply_aggregate_to_record(&mut record, &plan, &aggregate, aggregate_path);
+        store::write_aggregate_and_record(&record, &aggregate)?;
+    }
+    Ok(changed)
+}
+
+fn materialize_artifact(
+    artifact: &mut AgentTaskArtifact,
+    runner_id: &str,
+    job_id: &str,
+    run_id: &str,
+    task_id: &str,
+    fetch: impl FnOnce(&str) -> Result<serde_json::Value>,
+    typed_path: Option<&str>,
+) -> Result<bool> {
+    if let Some(path) = artifact
+        .path
+        .as_deref()
+        .map(PathBuf::from)
+        .filter(|path| path.is_file())
+    {
+        validate_bytes(artifact, &fs::read(&path).map_err(io_error(&path))?)?;
+        return Ok(false);
+    }
+    let expected_size = artifact
+        .size_bytes
+        .ok_or_else(|| unavailable(artifact, "missing durable byte size"))?;
+    let expected_sha = artifact
+        .sha256
+        .as_deref()
+        .ok_or_else(|| unavailable(artifact, "missing durable SHA-256"))?;
+    let path = materialized_path(run_id, task_id, &artifact.id, expected_sha)?;
+    if path.is_file() {
+        validate_bytes(artifact, &fs::read(&path).map_err(io_error(&path))?)?;
+        artifact.path = Some(path.display().to_string());
+        return Ok(false);
+    }
+    let response = match fetch(&artifact.id) {
+        Ok(response) => response,
+        Err(error) => match typed_path {
+            Some(path) => legacy_direct_typed_artifact_content(runner_id, artifact, path)?,
+            None => return Err(error),
+        },
+    };
+    let encoded = response
+        .get("content_base64")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            unavailable(
+                artifact,
+                "runner job result has no mirrored artifact content",
+            )
+        })?;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|error| {
+            Error::validation_invalid_argument(
+                "artifact",
+                format!("runner artifact content is not valid base64: {error}"),
+                None,
+                None,
+            )
+        })?;
+    validate_bytes(artifact, &bytes)?;
+    fs::create_dir_all(path.parent().expect("materialized artifact parent"))
+        .map_err(io_error(path.parent().unwrap()))?;
+    let temporary = path.with_extension(format!("tmp-{}", uuid::Uuid::new_v4()));
+    fs::write(&temporary, &bytes).map_err(io_error(&temporary))?;
+    fs::rename(&temporary, &path).map_err(io_error(&path))?;
+    artifact.path = Some(path.display().to_string());
+    if !artifact.metadata.is_object() {
+        artifact.metadata = json!({});
+    }
+    artifact.metadata["controller_artifact_materialization"] = json!({
+        "runner_id": runner_id,
+        "runner_job_id": job_id,
+        "artifact_id": artifact.id,
+        "source": "runner_terminal_artifact_content",
+        "verified_size_bytes": expected_size,
+        "verified_sha256": expected_sha,
+    });
+    Ok(true)
+}
+
+/// Legacy Lab terminal results can describe finalized files only in their typed
+/// aggregate. Capture those files through the managed `runs artifact attach`
+/// source primitive after checking the remote path against runner-owned roots.
+fn legacy_direct_typed_artifact_content(
+    runner_id: &str,
+    artifact: &AgentTaskArtifact,
+    path: &str,
+) -> Result<serde_json::Value> {
+    let status = crate::runner::status(runner_id)?;
+    if status.session.as_ref().map(|session| &session.mode)
+        != Some(&crate::runner::RunnerTunnelMode::DirectSsh)
+    {
+        return Err(Error::validation_invalid_argument(
+            "artifact.path",
+            "legacy typed artifact fallback is only available through a direct runner session",
+            Some(path.to_string()),
+            None,
+        ));
+    }
+    let runner = crate::runner::load(runner_id)?;
+    authorize_legacy_runner_path(&runner, artifact, path)?;
+    let source =
+        crate::observation::runner_artifact_attach::copy_runner_artifact_source(&runner, path)?;
+    let bytes = fs::read(&source.path).map_err(io_error(&source.path))?;
+    crate::observation::runner_artifact_attach::cleanup_runner_attach_source(&source);
+    Ok(json!({
+        "command": "runs.artifact.attach.legacy_typed_path",
+        "content_base64": base64::engine::general_purpose::STANDARD.encode(bytes),
+    }))
+}
+
+fn authorize_legacy_runner_path(
+    runner: &crate::runner::Runner,
+    artifact: &AgentTaskArtifact,
+    path: &str,
+) -> Result<()> {
+    let mut roots = runner
+        .workspace_root
+        .iter()
+        .chain(runner.policy.workspace_roots.iter())
+        .map(|root| crate::paths::normalize_remote_root(root))
+        .collect::<Vec<_>>();
+    if let Some(root) = runner.env.get("HOMEBOY_ARTIFACT_ROOT") {
+        roots.push(crate::paths::normalize_remote_root(root));
+    }
+    if let Some(root) = finalized_artifact_root(artifact, path) {
+        roots.push(root);
+    }
+    roots.sort();
+    roots.dedup();
+    crate::paths::authorize_remote_artifact_path(
+        Path::new(path),
+        &roots,
+        crate::paths::RemotePathRootContainment::RemoteString,
+    )
+    .map_err(|error| Error::validation_invalid_argument(
+        "artifact.path",
+        format!("legacy typed runner artifact path is not authorized: {error:?}"),
+        Some(path.to_string()),
+        Some(vec!["The path must be absolute, traversal-free, and beneath a configured runner workspace or HOMEBOY_ARTIFACT_ROOT.".to_string()]),
+    ))
+}
+
+fn finalized_artifact_root(artifact: &AgentTaskArtifact, path: &str) -> Option<String> {
+    let path = Path::new(path);
+    let file = path.file_name()?.to_str()?;
+    let parent = path.parent()?;
+    let finalized = parent.parent()?;
+    let artifacts = finalized.parent()?;
+    if finalized.file_name()?.to_str()? != "executor-finalized"
+        || artifacts.file_name()?.to_str()? != "artifacts"
+        || uuid::Uuid::parse_str(parent.file_name()?.to_str()?).is_err()
+    {
+        return None;
+    }
+    let mut hash = Sha256::new();
+    hash.update(artifact.kind.as_bytes());
+    hash.update([0]);
+    hash.update(artifact.id.as_bytes());
+    (file == format!("artifact-{:x}", hash.finalize())).then(|| artifacts.display().to_string())
+}
+
+fn materialized_path(
+    run_id: &str,
+    task_id: &str,
+    artifact_id: &str,
+    sha256: &str,
+) -> Result<PathBuf> {
+    crate::agent_task_provider::artifact_finalization::validate_token("artifact.id", artifact_id)?;
+    Ok(crate::paths::artifact_root()?
+        .join("recovered-runner-artifacts")
+        .join(crate::paths::sanitize_path_segment(run_id))
+        .join(crate::paths::sanitize_path_segment(task_id))
+        .join(format!("{artifact_id}-{sha256}")))
+}
+
+fn validate_bytes(artifact: &AgentTaskArtifact, bytes: &[u8]) -> Result<()> {
+    let actual_size = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+    if artifact.size_bytes != Some(actual_size) {
+        return Err(Error::validation_invalid_argument(
+            "artifact",
+            format!(
+                "recovered artifact size mismatch: expected {:?}, got {actual_size}",
+                artifact.size_bytes
+            ),
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+    let actual_sha = format!("{:x}", Sha256::digest(bytes));
+    if artifact.sha256.as_deref() != Some(actual_sha.as_str()) {
+        return Err(Error::validation_invalid_argument(
+            "artifact",
+            format!(
+                "recovered artifact SHA-256 mismatch: expected {:?}, got {actual_sha}",
+                artifact.sha256
+            ),
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn unavailable(artifact: &AgentTaskArtifact, reason: &str) -> Error {
+    Error::validation_invalid_argument(
+        "artifact",
+        format!("recovered runner artifact `{}` cannot be materialized: {reason}", artifact.id),
+        Some(artifact.id.clone()),
+        Some(vec!["The source runner/job must retain mirrored artifact bytes; inspect `homeboy runner job artifacts <runner-id> <job-id> <artifact-id>`.".to_string()]),
+    )
+}
+
+fn io_error(path: &std::path::Path) -> impl FnOnce(std::io::Error) -> Error + '_ {
+    move |error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("materialize recovered artifact {}", path.display())),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn artifact_root_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn artifact(bytes: &[u8]) -> AgentTaskArtifact {
+        AgentTaskArtifact {
+            schema: "homeboy/agent-task-artifact/v1".to_string(),
+            id: "patch".to_string(),
+            kind: "patch".to_string(),
+            name: None,
+            label: None,
+            role: None,
+            semantic_key: None,
+            path: None,
+            url: None,
+            mime: None,
+            size_bytes: Some(bytes.len() as u64),
+            sha256: Some(format!("{:x}", Sha256::digest(bytes))),
+            metadata: json!({}),
+        }
+    }
+
+    #[test]
+    fn materializes_valid_runner_bytes_and_replays_without_fetching() {
+        let _lock = artifact_root_lock().lock().expect("artifact root lock");
+        let root = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HOMEBOY_ARTIFACT_ROOT", root.path());
+        let bytes = b"patch bytes";
+        let mut value = artifact(bytes);
+        assert!(materialize_artifact(
+            &mut value,
+            "lab",
+            "job",
+            "run",
+            "task",
+            |_| Ok(
+                json!({ "content_base64": base64::engine::general_purpose::STANDARD.encode(bytes) })
+            ),
+            None
+        )
+        .expect("materialize"));
+        assert!(!materialize_artifact(
+            &mut value,
+            "lab",
+            "job",
+            "run",
+            "task",
+            |_| panic!("must reuse controller artifact"),
+            None
+        )
+        .expect("replay"));
+        std::env::remove_var("HOMEBOY_ARTIFACT_ROOT");
+    }
+
+    #[test]
+    fn rejects_runner_bytes_with_wrong_integrity_metadata() {
+        let _lock = artifact_root_lock().lock().expect("artifact root lock");
+        let root = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HOMEBOY_ARTIFACT_ROOT", root.path());
+        let mut value = artifact(b"expected");
+        let error = materialize_artifact(&mut value, "lab", "job", "run", "task", |_| Ok(json!({ "content_base64": base64::engine::general_purpose::STANDARD.encode(b"wrong") })), None).expect_err("integrity failure");
+        assert!(error.message.contains("mismatch"));
+        std::env::remove_var("HOMEBOY_ARTIFACT_ROOT");
+    }
+
+    #[test]
+    fn preserves_an_existing_local_provider_artifact() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let source = root.path().join("patch");
+        std::fs::write(&source, b"local patch").expect("patch");
+        let mut value = artifact(b"local patch");
+        value.path = Some(source.display().to_string());
+
+        assert!(!materialize_artifact(
+            &mut value,
+            "lab",
+            "job",
+            "run",
+            "task",
+            |_| panic!("must preserve a usable local artifact"),
+            None
+        )
+        .expect("local artifact"));
+        assert_eq!(value.path.as_deref(), source.to_str());
+    }
+
+    #[test]
+    fn recognizes_a_legacy_finalized_typed_artifact_path() {
+        let value = artifact(b"patch");
+        let mut hash = Sha256::new();
+        hash.update(b"patch\0patch");
+        let path = format!(
+            "/home/runner/.local/share/homeboy/artifacts/executor-finalized/41e5fcb2-fbc4-4a55-b745-377684e3e16f/artifact-{:x}",
+            hash.finalize()
+        );
+        assert_eq!(
+            finalized_artifact_root(&value, &path).as_deref(),
+            Some("/home/runner/.local/share/homeboy/artifacts")
+        );
+    }
+
+    #[test]
+    fn rejects_traversal_or_noncanonical_finalized_typed_paths() {
+        let value = artifact(b"patch");
+        assert!(finalized_artifact_root(
+            &value,
+            "/home/runner/.local/share/homeboy/artifacts/executor-finalized/../secret"
+        )
+        .is_none());
+        assert!(finalized_artifact_root(
+            &value,
+            "/tmp/artifacts/executor-finalized/41e5fcb2-fbc4-4a55-b745-377684e3e16f/artifact-forged"
+        )
+        .is_none());
+    }
+}

--- a/crates/homeboy-core/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/mod.rs
@@ -29,6 +29,7 @@ mod lifecycle_store;
 
 use lifecycle_store as store;
 
+mod artifact_materialization;
 mod cancellation;
 mod conversion;
 mod failure_recording;
@@ -37,6 +38,7 @@ mod lifecycle_ops;
 mod lifecycle_record_ops;
 mod records;
 
+pub use artifact_materialization::*;
 pub use cancellation::*;
 pub use failure_recording::*;
 pub use health::*;

--- a/crates/homeboy-core/src/agent_tasks.rs
+++ b/crates/homeboy-core/src/agent_tasks.rs
@@ -249,8 +249,8 @@ pub mod lifecycle {
     pub use super::super::agent_task_lifecycle::{
         aggregate_source, artifacts, cancel, cancel_run, claim_next_queued_run,
         cook_attempt_run_id, cook_index, list_records, load_controller_plan, load_plan, logs,
-        mark_resuming, mark_running, reconcile_record_health, record_completed_run,
-        record_cook_attempt, record_detached_lab_run, record_health_summary,
+        mark_resuming, mark_running, materialize_recovered_patch_artifact, reconcile_record_health,
+        record_completed_run, record_cook_attempt, record_detached_lab_run, record_health_summary,
         record_lab_offload_phase, record_lab_offload_planned, record_pre_dispatch_failure,
         record_pre_execution_failure, record_promotion, record_remote_dispatch_failure,
         record_run_aggregate, retry, run_id_for_aggregate_path, run_record_exists, run_status,

--- a/crates/homeboy-core/src/runner/connection.rs
+++ b/crates/homeboy-core/src/runner/connection.rs
@@ -9,7 +9,10 @@ use reqwest::blocking::Client;
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::api_jobs::{ActiveRunnerJobSummary, JobClaimMetadata, JobStatus, RunnerJobSource};
+use crate::api_jobs::{
+    ActiveRunnerJobSummary, JobClaimMetadata, JobEventKind, JobStatus, RemoteRunnerJobResult,
+    RunnerJobSource,
+};
 use crate::daemon::{
     DaemonFreshnessReport, DaemonLeaselessRecoveryResult, DaemonStaleReasonCode,
     DaemonStateLossRecoveryResult,
@@ -1105,6 +1108,153 @@ pub fn reverse_broker_artifact(runner_id: &str, job_id: &str, artifact_id: &str)
         "lookup reverse runner broker artifact",
         broker_auth::broker_submit_token_for_runner(runner_id)?.as_deref(),
     )
+}
+
+/// Fetch bytes that a reverse runner mirrored into its terminal job result.
+/// Callers must still validate the returned content against durable metadata.
+pub fn reverse_broker_artifact_content(
+    runner_id: &str,
+    job_id: &str,
+    artifact_id: &str,
+) -> Result<Value> {
+    let broker_url = reverse_broker_url(runner_id)?;
+    let artifact_id = crate::execution_contract::encode_uri_component(artifact_id);
+    let client = broker_client("build broker artifact content client")?;
+    broker_http::get_json(
+        &client,
+        &broker_url,
+        &format!("/runner/jobs/{job_id}/artifacts/{artifact_id}/content"),
+        "fetch reverse runner broker artifact content",
+        broker_auth::broker_submit_token_for_runner(runner_id)?.as_deref(),
+    )
+}
+
+/// Retrieve terminal job artifact bytes through the runner's active managed
+/// transport. Direct sessions read the daemon's persisted job result; reverse
+/// sessions use the broker content endpoint.
+pub fn runner_artifact_content(runner_id: &str, job_id: &str, artifact_id: &str) -> Result<Value> {
+    let report = status(runner_id)?;
+    let Some(session) = report.session.filter(|_| report.connected) else {
+        return Err(Error::validation_invalid_argument(
+            "runner_id",
+            format!("runner `{runner_id}` is not connected"),
+            Some(runner_id.to_string()),
+            None,
+        ));
+    };
+    match artifact_content_transport(&session)? {
+        RunnerArtifactContentTransport::DirectDaemon => {
+            direct_daemon_job_artifact_content(runner_id, job_id, artifact_id)
+        }
+        RunnerArtifactContentTransport::ReverseBroker => {
+            reverse_broker_artifact_content(runner_id, job_id, artifact_id)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RunnerArtifactContentTransport {
+    DirectDaemon,
+    ReverseBroker,
+}
+
+fn artifact_content_transport(session: &RunnerSession) -> Result<RunnerArtifactContentTransport> {
+    match session.mode {
+        RunnerTunnelMode::DirectSsh if session.local_url.is_some() => {
+            Ok(RunnerArtifactContentTransport::DirectDaemon)
+        }
+        RunnerTunnelMode::Reverse if session.broker_url.is_some() => {
+            Ok(RunnerArtifactContentTransport::ReverseBroker)
+        }
+        RunnerTunnelMode::DirectSsh => Err(Error::validation_invalid_argument(
+            "runner_id",
+            format!(
+                "direct runner `{}` has no managed daemon endpoint for artifact retrieval",
+                session.runner_id
+            ),
+            Some(session.runner_id.clone()),
+            Some(vec![
+                "Reconnect the direct runner so its local daemon URL is available, then retry the review or promotion."
+                    .to_string(),
+            ]),
+        )),
+        RunnerTunnelMode::Reverse => Err(Error::validation_invalid_argument(
+            "runner_id",
+            format!(
+                "reverse runner `{}` has no broker endpoint for artifact retrieval",
+                session.runner_id
+            ),
+            Some(session.runner_id.clone()),
+            Some(vec![
+                "Reconnect the reverse runner with its broker URL, then retry the review or promotion."
+                    .to_string(),
+            ]),
+        )),
+    }
+}
+
+fn direct_daemon_job_artifact_content(
+    runner_id: &str,
+    job_id: &str,
+    artifact_id: &str,
+) -> Result<Value> {
+    let snapshot = super::runner_job_log_snapshot(runner_id, job_id)?;
+    let result = snapshot
+        .events
+        .iter()
+        .rev()
+        .find(|event| event.kind == JobEventKind::Result)
+        .and_then(|event| event.data.clone())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "artifact_id",
+                format!("runner job `{job_id}` has no terminal result containing artifact bytes"),
+                Some(artifact_id.to_string()),
+                None,
+            )
+        })?;
+    let result: RemoteRunnerJobResult = serde_json::from_value(result).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("parse direct runner terminal job result for artifact retrieval".to_string()),
+        )
+    })?;
+    let artifact = result
+        .artifacts
+        .iter()
+        .chain(result.artifact_refs.iter())
+        .find(|artifact| artifact.id == artifact_id)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "artifact_id",
+                format!("direct runner job `{job_id}` has no artifact `{artifact_id}`"),
+                Some(artifact_id.to_string()),
+                None,
+            )
+        })?;
+    let content_base64 = artifact.content_base64.clone().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "artifact_id",
+            format!(
+                "direct runner job `{job_id}` did not retain bytes for artifact `{artifact_id}`"
+            ),
+            Some(artifact_id.to_string()),
+            Some(vec![
+                "Only artifacts mirrored in the direct runner terminal result can be materialized."
+                    .to_string(),
+            ]),
+        )
+    })?;
+    Ok(serde_json::json!({
+        "command": "runner.jobs.artifacts.direct_daemon_content",
+        "job_id": job_id,
+        "artifact_id": artifact_id,
+        "content_base64": content_base64,
+        "filename": artifact.name,
+        "mime": artifact.mime,
+        "size_bytes": artifact.size_bytes,
+        "sha256": artifact.sha256,
+    }))
 }
 
 fn reverse_broker_url(runner_id: &str) -> Result<String> {

--- a/crates/homeboy-core/src/runner/connection/tests/mod.rs
+++ b/crates/homeboy-core/src/runner/connection/tests/mod.rs
@@ -75,6 +75,38 @@ pub(super) fn reverse_controller_session() -> RunnerSession {
     }
 }
 
+fn direct_controller_session() -> RunnerSession {
+    let mut session = reverse_controller_session();
+    session.mode = RunnerTunnelMode::DirectSsh;
+    session.broker_url = None;
+    session.local_url = Some("http://127.0.0.1:9877".to_string());
+    session
+}
+
+#[test]
+fn artifact_content_transport_routes_direct_sessions_to_the_daemon() {
+    assert_eq!(
+        artifact_content_transport(&direct_controller_session()).expect("direct transport"),
+        RunnerArtifactContentTransport::DirectDaemon
+    );
+}
+
+#[test]
+fn artifact_content_transport_routes_reverse_sessions_to_the_broker() {
+    assert_eq!(
+        artifact_content_transport(&reverse_controller_session()).expect("reverse transport"),
+        RunnerArtifactContentTransport::ReverseBroker
+    );
+}
+
+#[test]
+fn artifact_content_transport_rejects_sessions_without_a_managed_endpoint() {
+    let mut session = direct_controller_session();
+    session.local_url = None;
+    let error = artifact_content_transport(&session).expect_err("missing endpoint");
+    assert!(error.message.contains("no managed daemon endpoint"));
+}
+
 pub(super) fn sample_run_summary(id: &str) -> RunSummary {
     RunSummary {
         id: id.to_string(),

--- a/crates/homeboy-core/src/runner/mod.rs
+++ b/crates/homeboy-core/src/runner/mod.rs
@@ -93,7 +93,8 @@ pub(crate) use connection::disconnect_with_force;
 pub use connection::{
     connect, connect_reverse, connect_with_leaseless_orphan_reconciliation,
     connect_with_orphan_adoption, connect_with_recovery, disconnect, reverse_broker_artifact,
-    reverse_broker_reconcile, status, statuses,
+    reverse_broker_artifact_content, reverse_broker_reconcile, runner_artifact_content, status,
+    statuses,
 };
 pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
 pub use evidence::runner_artifact_store_token;

--- a/crates/homeboy-core/src/runners.rs
+++ b/crates/homeboy-core/src/runners.rs
@@ -28,9 +28,9 @@ pub use super::runner::{
     apply_change_artifact, apply_workspace_patch, broker_auth_store_path,
     broker_submit_token_for_runner, broker_token_from_env, connect,
     connect_with_leaseless_orphan_reconciliation, connect_with_orphan_adoption,
-    connect_with_recovery, reverse_broker_artifact, reverse_broker_reconcile, BrokerAuthGrant,
-    BrokerAuthStore, BrokerCredential, BrokerScope, MintedCredential, BROKER_TOKEN_ENV,
-    BROKER_TOKEN_HEADER,
+    connect_with_recovery, reverse_broker_artifact, reverse_broker_artifact_content,
+    reverse_broker_reconcile, runner_artifact_content, BrokerAuthGrant, BrokerAuthStore,
+    BrokerCredential, BrokerScope, MintedCredential, BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
 };
 pub use super::runner::{
     connect_reverse, disconnect, download_remote_artifact,


### PR DESCRIPTION
## Summary

- materialize recovered Lab patch artifacts into controller-owned storage before review handoff or promotion
- route artifact retrieval through direct SSH or reverse-broker runner sessions
- verify declared SHA-256 and byte size, persist provenance, and reuse verified artifacts idempotently
- safely recover legacy finalized typed-artifact paths through Homeboy managed artifact capture

Closes #8505.

## How to test

1. Run `cargo test -p homeboy-core agent_task_lifecycle::artifact_materialization::tests --lib`.
2. Run `cargo test -p homeboy-core runner::connection::tests::artifact_content_transport --lib`.
3. Run `cargo check -p homeboy-cli` and `cargo fmt --check`.
4. Complete a Lab agent-task, remove its controller-local patch path while retaining its durable runner artifact provenance, then run `homeboy agent-task review <run-id> --to-worktree <clean-worktree>`. Verify Homeboy materializes a controller-owned patch whose hash and size match the aggregate.
5. Run `homeboy agent-task promote <aggregate-or-run-id> --task-id <task-id> --artifact-id <artifact-id> --to-worktree <clean-worktree> --dry-run`. Verify promotion passes artifact-path validation without applying changes.
6. Repeat steps 4 and 5. Verify Homeboy reuses the verified local artifact without a second runner transfer.

## Verification

- Five materialization, integrity, legacy-path, traversal-rejection, and idempotency tests passed.
- Three direct/reverse/unavailable transport-routing tests passed.
- `cargo check -p homeboy-cli`, `cargo fmt --check`, and `git diff --check` passed.
- Homeboy audit and lint reported no introduced findings.
- Live direct-SSH recovery materialized a 683,500-byte retained patch with its declared SHA-256; promotion dry-run then reached the expected clean-worktree safety gate.
- The changed-file umbrella selected a Rust module path matching zero tests and failed its zero-test guard; the exact focused suites above executed eight tests successfully.

## Compatibility impact

No extension paths or existing local-provider artifact behavior change. Recovered Lab promotion now performs managed network transfer and persists a controller-local artifact path. Invalid, unavailable, out-of-root, or integrity-mismatched artifacts fail closed with explicit diagnostics.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause analysis, implementation, tests, and live lifecycle verification under human direction.