### PR TITLE
Keep durable promotion on the controller

### DIFF
--- a/crates/homeboy-cli/src/commands/contract_lab_routing.rs
+++ b/crates/homeboy-cli/src/commands/contract_lab_routing.rs
@@ -13,6 +13,7 @@ use crate::command_contract::{
     RUNTIME_REFRESH_LAB_LABEL,
 };
 use crate::commands::{adapter, agent_task};
+use crate::core::agent_tasks::lifecycle as agent_task_lifecycle;
 use crate::core::agent_tasks::provider::{default_backend, provider_requires_cwd_git_checkout};
 use crate::core::engine::execution_context::{self, ResolveOptions};
 use crate::core::extension::ExtensionCapability;
@@ -26,6 +27,8 @@ const AGENT_TASK_COOK_MISSING_VERIFY_GATE_REASON: &str =
     "agent-task cook requires at least one deterministic --verify or --private-verify gate";
 pub(crate) const AGENT_TASK_COOK_COORDINATOR_CONTROLLER_REASON: &str =
     "agent-task cook is a controller-owned coordinator: it resolves the managed target, ingests provider artifacts, promotes candidates, runs deterministic gates, and finalizes. Offload the materialized agent-task run-plan provider attempt instead.";
+pub(crate) const AGENT_TASK_PROMOTION_RUN_CONTROLLER_REASON: &str =
+    "agent-task promote with a durable run id is controller-owned: it resolves authoritative lifecycle state and finalized artifact projections on the controller.";
 const AGENT_TASK_FANOUT_COOK_BATCH_DRY_RUN_CONTROLLER_REASON: &str =
     "agent-task fanout cook-batch --dry-run is controller-local planning; it does not execute cooks and should not offload or materialize the controller cwd";
 pub(crate) const AGENT_TASK_FANOUT_COORDINATOR_CONTROLLER_REASON: &str =
@@ -72,6 +75,14 @@ impl Commands {
                 LAB_NO_EXTRA_CAPABILITIES,
             )
             .with_secret_env_sources(LAB_AGENT_TASK_SECRET_ENV_SOURCES),
+            Commands::AgentTask(agent_task::AgentTaskArgs {
+                command: agent_task::AgentTaskCommand::Promote(args),
+            }) if agent_task_promotion_source_is_controller_owned(&args.source) => {
+                LabCommandContract::local_only(
+                    AGENT_TASK_PROMOTE_LAB_LABEL,
+                    AGENT_TASK_PROMOTION_RUN_CONTROLLER_REASON,
+                )
+            }
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command: agent_task::AgentTaskCommand::Promote(_),
             }) => LabCommandContract::portable(
@@ -298,6 +309,13 @@ fn agent_task_fanout_local_only_contract(
     reason: &'static str,
 ) -> LabCommandContract {
     LabCommandContract::local_only(label, reason)
+}
+
+/// A durable run id is resolved through the controller lifecycle store, whose
+/// aggregate and finalized artifact projections are not portable path inputs.
+/// Other promotion source forms retain their existing runner-local behavior.
+fn agent_task_promotion_source_is_controller_owned(source: &str) -> bool {
+    agent_task_lifecycle::status(source).is_ok()
 }
 
 pub(crate) fn agent_task_controller_materializes_worktree(

--- a/crates/homeboy-cli/src/commands/contract_lab_routing_tests.rs
+++ b/crates/homeboy-cli/src/commands/contract_lab_routing_tests.rs
@@ -3,8 +3,10 @@
 use clap::Parser;
 
 use crate::cli_surface::{Cli, Commands};
+use crate::core::agent_tasks::{lifecycle as agent_task_lifecycle, AgentTaskPlan};
 
 use crate::command_contract::{LabCommandPortability, LabSourcePathMode, LabWorkspaceModePolicy};
+use crate::test_support::with_isolated_home;
 
 fn parsed_command(args: &[&str]) -> Commands {
     Cli::try_parse_from(args)
@@ -178,6 +180,34 @@ fn agent_task_promote_with_runner_only_source_remains_lab_portable() {
     );
     assert!(contract.capture_mutation_patch);
     assert!(!command.lab_offload_captures_mutation_patch());
+}
+
+#[test]
+fn agent_task_promote_with_controller_run_id_stays_with_finalized_artifacts() {
+    with_isolated_home(|_| {
+        let run_id = "controller-finalized-run";
+        agent_task_lifecycle::submit_plan(&AgentTaskPlan::new("fixture", Vec::new()), Some(run_id))
+            .expect("persist controller-owned run");
+
+        let command = parsed_command(&[
+            "homeboy",
+            "agent-task",
+            "promote",
+            run_id,
+            "--to-worktree",
+            "homeboy@fix-8511",
+        ]);
+
+        let contract = command.lab_contract().expect("promote contract");
+
+        assert_eq!(
+            contract.portability,
+            LabCommandPortability::LocalOnly(
+                crate::commands::contract_lab_routing::AGENT_TASK_PROMOTION_RUN_CONTROLLER_REASON
+            )
+        );
+        assert!(!contract.routing_policy.default_lab_offload);
+    });
 }
 
 #[test]

--- a/crates/homeboy-core/src/agent_task_promotion/tests.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/tests.rs
@@ -360,6 +360,20 @@ fn aggregate_promotion_forwards_canonical_gate_feedback_baseline() {
     });
     let source = serde_json::json!({
         "schema": "homeboy/agent-task-aggregate/v1",
+        "plan_id": "follow-up-plan",
+        "status": "succeeded",
+        "totals": {
+            "queued": 0,
+            "running": 0,
+            "blocked": 0,
+            "skipped": 0,
+            "succeeded": 1,
+            "candidate_recoverable": 0,
+            "recoverable_candidates": 0,
+            "failed": 0,
+            "cancelled": 0,
+            "timed_out": 0
+        },
         "outcomes": [{
             "schema": AGENT_TASK_OUTCOME_SCHEMA,
             "task_id": "follow-up",


### PR DESCRIPTION
## Summary
Keep promotion by durable run id on the controller where authoritative lifecycle state and finalized artifact projections are resolvable.

## What changed
- Added a lifecycle-aware routing predicate that marks known durable run-id promotion local-only while preserving existing routing for other source forms.

## How to test
1. Run `cargo test -p homeboy-cli commands::contract_lab_routing_tests --lib`; expect Durable run ids remain controller-local and runner-only sources remain Lab-portable..
2. Run `cargo test -p homeboy-core agent_task_promotion::tests --lib`; expect Recovered artifact projection, integrity validation, and actual patch application remain green..
3. Run `Run homeboy agent-task promote <durable-run-id> --to-worktree <handle> while Lab is available`; expect Promotion executes on the controller and resolves the finalized patch without cross-host absolute paths..

## Compatibility
No public API or extension-path compatibility change. Existing inline JSON, local file, runner-resident source, dry-run, gate, and promotion provenance behavior is preserved.

## Evidence
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8490
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8511
- cli-check: Passed
- core-check: Passed
- diff-check: Passed
- format: Passed
- promotion-tests: Passed
- routing-tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy recovery workflow
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed cross-host promotion routing, implemented the controller-owned durable-run boundary, rebased against complementary artifact projection repairs, and added deterministic coverage; Chris reviews and owns the change.

## Source relationships
- Closes #8511
- Relates to #8490
- Relates to #8513
