### PR TITLE
refactor: invert runs_service→runner evidence via provider hook (runner-decouple)

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -98,6 +98,11 @@ impl CliRuntime {
         // IDs/aliases participate in cross-entity collision detection. Core owns
         // the collision invariant but must not depend on these optional features.
         homeboy_tunnel::register();
+        // Register the runner-evidence provider so observation::runs_service can
+        // enrich run/artifact lookups with live runner + daemon evidence without
+        // core depending on runner behavior. (Runner is still in-crate today;
+        // this registration is the seam that lets it become its own crate.)
+        crate::core::runner::register_runner_evidence_provider();
         // Register the command-label resolver so core::runner can map dispatched
         // argv to a hot-command label without depending on the full CLI parser.
         crate::core::runner::set_command_label_resolver(|argv| {

--- a/crates/homeboy-core/src/observation/runs_service/artifact_links.rs
+++ b/crates/homeboy-core/src/observation/runs_service/artifact_links.rs
@@ -38,14 +38,15 @@ pub fn related_lab_artifacts_for_runner_job(
     if run.kind != "runner-exec" {
         return Ok(Vec::new());
     }
-    let Some(job_id) = crate::runners::mirrored_runner_job_identity(run)
-        .map(|(_runner_id, job_id)| job_id)
-        .or_else(|| {
-            run.metadata_json
-                .pointer("/lab/remote_job_id")
-                .and_then(Value::as_str)
-                .map(str::to_string)
-        })
+    let Some(job_id) =
+        runner_evidence::with_runner_evidence(|p| p.mirrored_runner_job_identity(run))
+            .map(|(_runner_id, job_id)| job_id)
+            .or_else(|| {
+                run.metadata_json
+                    .pointer("/lab/remote_job_id")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
     else {
         return Ok(Vec::new());
     };

--- a/crates/homeboy-core/src/observation/runs_service/artifact_resolve.rs
+++ b/crates/homeboy-core/src/observation/runs_service/artifact_resolve.rs
@@ -176,7 +176,9 @@ pub fn download_remote_artifact(
     artifact: ArtifactRecord,
     output: Option<PathBuf>,
 ) -> Result<ArtifactFetchOutcome> {
-    let download = crate::runners::download_remote_artifact(&artifact.path, output)?;
+    let download = runner_evidence::with_runner_evidence(|p| {
+        p.download_remote_artifact(&artifact.path, output)
+    })?;
     Ok(ArtifactFetchOutcome {
         run_id: artifact.run_id,
         artifact_id: artifact.id,

--- a/crates/homeboy-core/src/observation/runs_service/mod.rs
+++ b/crates/homeboy-core/src/observation/runs_service/mod.rs
@@ -161,12 +161,17 @@ mod artifact_resolve;
 mod persisted_cleanup;
 mod run_lookup;
 mod runner_downloads;
+pub mod runner_evidence;
 
 pub use artifact_links::*;
 pub use artifact_resolve::*;
 pub use persisted_cleanup::*;
 pub use run_lookup::*;
 pub use runner_downloads::*;
+pub use runner_evidence::{
+    register_runner_evidence_provider, RemoteArtifactDownloadInfo, RunnerConnectionInfo,
+    RunnerEvidenceProvider, StaleRunnerJobInfo,
+};
 
 /// Safe, bounded retention of terminal observation rows. Artifact byte cleanup
 /// remains a separate explicit operation because artifact roots may have their

--- a/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
+++ b/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
@@ -6,7 +6,9 @@ pub fn require_run(store: &ObservationStore, run_id: &str) -> Result<RunRecord> 
     if let Some(run) = store.get_run(run_id)? {
         return Ok(run);
     }
-    if let Ok(Some(run)) = crate::runners::mirror_connected_runner_run(run_id) {
+    if let Ok(Some(run)) =
+        runner_evidence::with_runner_evidence(|p| p.mirror_connected_runner_run(run_id))
+    {
         return Ok(run);
     }
     if let Some(run) = resolve_run_label(store, run_id)? {
@@ -21,12 +23,13 @@ fn resolve_run_label(store: &ObservationStore, label: &str) -> Result<Option<Run
         ..Default::default()
     })?;
     let mut matches = matching_run_labels(&runs, label);
-    for report in crate::runners::statuses()
-        .unwrap_or_default()
-        .into_iter()
-        .filter(|report| report.connected)
-    {
-        let Ok(data) = crate::runners::daemon_api_get(&report.runner_id, "/runs?limit=200") else {
+    let connected_runners: Vec<RunnerConnectionInfo> = runner_evidence::with_runner_evidence(|p| {
+        p.statuses().into_iter().filter(|r| r.connected).collect()
+    });
+    for report in connected_runners {
+        let Ok(data) = runner_evidence::with_runner_evidence(|p| {
+            p.daemon_api_get(&report.runner_id, "/runs?limit=200")
+        }) else {
             continue;
         };
         let runs: Vec<RunRecord> =
@@ -128,12 +131,13 @@ fn missing_run_error(run_id: &str) -> Error {
 
 fn missing_run_guidance(run_id: &str) -> Vec<String> {
     let mut hints = Vec::new();
-    let connected = crate::runners::statuses()
-        .unwrap_or_default()
-        .into_iter()
-        .filter(|report| report.connected)
-        .map(|report| report.runner_id)
-        .collect::<Vec<_>>();
+    let connected = runner_evidence::with_runner_evidence(|p| {
+        p.statuses()
+            .into_iter()
+            .filter(|report| report.connected)
+            .map(|report| report.runner_id)
+            .collect::<Vec<_>>()
+    });
 
     if connected.is_empty() {
         hints.push(
@@ -175,7 +179,9 @@ pub(crate) fn missing_run_guidance_for_runner_ids(
 /// historical CLI behavior so the `runs show` / `runs artifacts` commands
 /// keep emitting the same stderr text on failures.
 pub fn refresh_mirrored_daemon_evidence_best_effort(run_id: &str) {
-    if let Err(err) = crate::runners::refresh_mirrored_daemon_evidence(run_id) {
+    if let Err(err) =
+        runner_evidence::with_runner_evidence(|p| p.refresh_mirrored_daemon_evidence(run_id))
+    {
         eprintln!(
             "Warning: could not refresh mirrored Lab runner evidence for `{run_id}`: {}",
             err.message
@@ -190,7 +196,8 @@ pub fn refresh_mirrored_daemon_evidence_best_effort(run_id: &str) {
 /// observation store converge on the daemon's terminal state without requiring
 /// operators to know and run `runs show <mirror-run-id>` first.
 pub fn refresh_running_mirrored_daemon_evidence_best_effort(store: &ObservationStore) {
-    for report in crate::runners::statuses().unwrap_or_default() {
+    let statuses = runner_evidence::with_runner_evidence(|p| p.statuses());
+    for report in statuses {
         for job in report.stale_runner_jobs {
             finish_stale_runner_child_run(store, &job);
         }
@@ -205,13 +212,14 @@ pub fn refresh_running_mirrored_daemon_evidence_best_effort(store: &ObservationS
         .unwrap_or_default();
 
     for run in runs {
-        if crate::runners::mirrored_runner_job_identity(&run).is_some() {
+        if runner_evidence::with_runner_evidence(|p| p.mirrored_runner_job_identity(&run)).is_some()
+        {
             refresh_mirrored_daemon_evidence_best_effort(&run.id);
         }
     }
 }
 
-fn finish_stale_runner_child_run(store: &ObservationStore, job: &crate::runners::RunnerJob) {
+fn finish_stale_runner_child_run(store: &ObservationStore, job: &StaleRunnerJobInfo) {
     let Some(run_id) = job.durable_run_id.as_deref() else {
         return;
     };
@@ -245,9 +253,7 @@ fn finish_stale_runner_child_run(store: &ObservationStore, job: &crate::runners:
 #[cfg(test)]
 mod stale_runner_tests {
     use super::*;
-    use crate::api_jobs::{JobClaimMetadata, JobStatus};
     use crate::observation::{NewRunRecord, ObservationStore};
-    use crate::runners::{RunnerJob, RunnerLifecycleOwner};
 
     #[test]
     fn stale_runner_child_finalizes_matching_running_observation() {
@@ -257,27 +263,14 @@ mod stale_runner_tests {
                 .start_run(NewRunRecord::builder("bench").build())
                 .expect("run");
             let run_id = started.id;
-            let job = RunnerJob {
+            let job = StaleRunnerJobInfo {
+                durable_run_id: Some(run_id.clone()),
                 runner_id: "homeboy-lab".to_string(),
                 job_id: "orphaned-child-run-run-1".to_string(),
-                operation: "child-run".to_string(),
-                status: JobStatus::Failed,
-                command: "homeboy bench".to_string(),
-                cwd: None,
-                source: "runner-observation".to_string(),
-                lifecycle_owner: RunnerLifecycleOwner::Controller,
-                lifecycle: None,
-                started_at_ms: None,
-                updated_at_ms: None,
-                elapsed_ms: None,
-                heartbeat_age_ms: None,
-                claim: JobClaimMetadata::default(),
-                claim_expires_in_ms: None,
-                durable_run_id: Some(run_id.clone()),
-                stale_reason: Some("child_run_running_without_active_runner_job".to_string()),
+                status: "failed".to_string(),
                 lifecycle_state: Some("stale".to_string()),
+                stale_reason: Some("child_run_running_without_active_runner_job".to_string()),
                 retryable: Some(true),
-                artifact_refs: Vec::new(),
             };
 
             finish_stale_runner_child_run(&store, &job);

--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -1,0 +1,234 @@
+//! Runner-evidence provider hook.
+//!
+//! `runs_service` enriches run/artifact lookups with live runner + daemon
+//! evidence (mirrored runs, connected-runner status, remote artifact
+//! downloads). Runner is an optional Lab-offload feature, so core must not
+//! depend on runner *behavior* to do this. Instead, core defines the
+//! [`RunnerEvidenceProvider`] contract here and the runner layer registers an
+//! implementation at startup. When no provider is registered (runner absent),
+//! the [`NoopRunnerEvidenceProvider`] returns empty evidence — which is exactly
+//! how the callers already behave when no runner is connected.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use homeboy_runner_contract::RunnerArtifactRef;
+use serde_json::Value;
+
+use crate::error::{Error, Result};
+use crate::observation::RunRecord;
+
+/// A connected runner's status, slimmed to the fields `runs_service` needs.
+#[derive(Debug, Clone, Default)]
+pub struct RunnerConnectionInfo {
+    pub runner_id: String,
+    pub connected: bool,
+    pub stale_runner_jobs: Vec<StaleRunnerJobInfo>,
+}
+
+/// A stale runner job, slimmed to the fields `runs_service` reconciles. Field
+/// types mirror the runner-side job record so the reconciled `runner_terminal
+/// _evidence` JSON is byte-for-byte identical to the pre-hook behavior.
+#[derive(Debug, Clone, Default)]
+pub struct StaleRunnerJobInfo {
+    pub durable_run_id: Option<String>,
+    pub runner_id: String,
+    pub job_id: String,
+    pub status: String,
+    pub lifecycle_state: Option<String>,
+    pub stale_reason: Option<String>,
+    pub retryable: Option<bool>,
+}
+
+/// The result of downloading a remote runner artifact, slimmed to what
+/// `runs_service` surfaces in an `ArtifactFetchOutcome`.
+#[derive(Debug)]
+pub struct RemoteArtifactDownloadInfo {
+    pub output_path: PathBuf,
+    pub content_type: Option<String>,
+    pub size_bytes: Option<i64>,
+    pub sha256: Option<String>,
+    pub artifact_ref: RunnerArtifactRef,
+}
+
+/// The runner-evidence contract `runs_service` depends on. Implemented by the
+/// runner layer and registered at startup; core calls it without depending on
+/// runner behavior.
+pub trait RunnerEvidenceProvider: Send + Sync {
+    /// Mirror the run from a connected runner, if one owns it.
+    fn mirror_connected_runner_run(&self, run_id: &str) -> Result<Option<RunRecord>>;
+
+    /// Status of all known runners (connected or not).
+    fn statuses(&self) -> Vec<RunnerConnectionInfo>;
+
+    /// Raw GET against a runner's daemon API.
+    fn daemon_api_get(&self, runner_id: &str, path: &str) -> Result<Value>;
+
+    /// Refresh mirrored daemon evidence for a run, returning any mirrored runs.
+    fn refresh_mirrored_daemon_evidence(&self, run_id: &str) -> Result<Option<Vec<RunRecord>>>;
+
+    /// The `(runner_id, job_id)` identity mirrored onto a run record, if any.
+    fn mirrored_runner_job_identity(&self, run: &RunRecord) -> Option<(String, String)>;
+
+    /// Download a remote runner artifact to `output` (or a temp path).
+    fn download_remote_artifact(
+        &self,
+        path: &str,
+        output: Option<PathBuf>,
+    ) -> Result<RemoteArtifactDownloadInfo>;
+}
+
+/// Default provider used when no runner layer is registered. Returns empty
+/// evidence for the best-effort methods; the one non-degradable method
+/// (`download_remote_artifact`) errors clearly, since a remote artifact cannot
+/// be resolved without a runner.
+struct NoopRunnerEvidenceProvider;
+
+impl RunnerEvidenceProvider for NoopRunnerEvidenceProvider {
+    fn mirror_connected_runner_run(&self, _run_id: &str) -> Result<Option<RunRecord>> {
+        Ok(None)
+    }
+
+    fn statuses(&self) -> Vec<RunnerConnectionInfo> {
+        Vec::new()
+    }
+
+    fn daemon_api_get(&self, _runner_id: &str, _path: &str) -> Result<Value> {
+        Err(Error::validation_invalid_argument(
+            "runner",
+            "no runner evidence provider is registered",
+            None,
+            None,
+        ))
+    }
+
+    fn refresh_mirrored_daemon_evidence(&self, _run_id: &str) -> Result<Option<Vec<RunRecord>>> {
+        Ok(None)
+    }
+
+    fn mirrored_runner_job_identity(&self, _run: &RunRecord) -> Option<(String, String)> {
+        None
+    }
+
+    fn download_remote_artifact(
+        &self,
+        _path: &str,
+        _output: Option<PathBuf>,
+    ) -> Result<RemoteArtifactDownloadInfo> {
+        Err(Error::validation_invalid_argument(
+            "artifact",
+            "cannot download a remote runner artifact without a registered runner evidence provider",
+            None,
+            None,
+        ))
+    }
+}
+
+static PROVIDER: Mutex<Option<Box<dyn RunnerEvidenceProvider>>> = Mutex::new(None);
+
+/// Register the runner-evidence provider. Called once at binary startup by the
+/// runner layer (via the CLI). Replaces any previously registered provider.
+pub fn register_runner_evidence_provider(provider: Box<dyn RunnerEvidenceProvider>) {
+    let mut guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = Some(provider);
+}
+
+/// Whether a runner-evidence provider is currently registered.
+pub fn has_runner_evidence_provider() -> bool {
+    PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .is_some()
+}
+
+/// Run `f` against the registered provider, or the no-op provider if none is
+/// registered. Keeps the lock held only for the duration of the call.
+pub(crate) fn with_runner_evidence<T>(f: impl FnOnce(&dyn RunnerEvidenceProvider) -> T) -> T {
+    let guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    match guard.as_ref() {
+        Some(provider) => f(provider.as_ref()),
+        None => f(&NoopRunnerEvidenceProvider),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Guards graceful degradation: the best-effort evidence methods must return
+    /// empty (not error, not panic) when no provider is registered. runs_service
+    /// callers already treat "no runner connected" as empty; the no-op provider
+    /// must preserve that so run-lookup keeps working with runner absent.
+    #[test]
+    fn noop_provider_degrades_gracefully() {
+        let noop = NoopRunnerEvidenceProvider;
+        assert!(noop.statuses().is_empty());
+        assert!(noop.mirror_connected_runner_run("run-x").unwrap().is_none());
+        assert!(noop
+            .refresh_mirrored_daemon_evidence("run-x")
+            .unwrap()
+            .is_none());
+    }
+
+    /// The one non-degradable method (a remote artifact genuinely can't be
+    /// resolved without a runner) must surface a clear error rather than a
+    /// silent empty result.
+    #[test]
+    fn noop_provider_download_errors_clearly() {
+        let noop = NoopRunnerEvidenceProvider;
+        let err = noop
+            .download_remote_artifact("runner-artifact://x", None)
+            .expect_err("download must error without a provider");
+        assert!(err.message.contains("runner evidence provider"));
+    }
+
+    /// A registered provider is used in place of the no-op default.
+    #[test]
+    fn registered_provider_is_used() {
+        struct FakeProvider;
+        impl RunnerEvidenceProvider for FakeProvider {
+            fn mirror_connected_runner_run(&self, _: &str) -> Result<Option<RunRecord>> {
+                Ok(None)
+            }
+            fn statuses(&self) -> Vec<RunnerConnectionInfo> {
+                vec![RunnerConnectionInfo {
+                    runner_id: "fake".to_string(),
+                    connected: true,
+                    stale_runner_jobs: Vec::new(),
+                }]
+            }
+            fn daemon_api_get(&self, _: &str, _: &str) -> Result<Value> {
+                Ok(Value::Null)
+            }
+            fn refresh_mirrored_daemon_evidence(&self, _: &str) -> Result<Option<Vec<RunRecord>>> {
+                Ok(None)
+            }
+            fn mirrored_runner_job_identity(&self, _: &RunRecord) -> Option<(String, String)> {
+                None
+            }
+            fn download_remote_artifact(
+                &self,
+                _: &str,
+                _: Option<PathBuf>,
+            ) -> Result<RemoteArtifactDownloadInfo> {
+                unreachable!()
+            }
+        }
+
+        register_runner_evidence_provider(Box::new(FakeProvider));
+        let statuses = with_runner_evidence(|p| p.statuses());
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0].runner_id, "fake");
+
+        // Reset so the registered fake doesn't leak into other tests sharing the
+        // process-global provider.
+        PROVIDER
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+    }
+}

--- a/crates/homeboy-core/src/runner/evidence/mod.rs
+++ b/crates/homeboy-core/src/runner/evidence/mod.rs
@@ -1,8 +1,11 @@
 mod detail;
 mod download;
 mod mirror;
+mod provider;
 mod tokens;
 mod util;
+
+pub use provider::register as register_runner_evidence_provider;
 
 #[cfg(test)]
 mod tests;

--- a/crates/homeboy-core/src/runner/evidence/provider.rs
+++ b/crates/homeboy-core/src/runner/evidence/provider.rs
@@ -1,0 +1,81 @@
+//! Runner-side implementation of core's `RunnerEvidenceProvider` hook.
+//!
+//! Core's `observation::runs_service` calls this contract to enrich run/artifact
+//! lookups with live runner + daemon evidence, without depending on runner
+//! behavior directly. This adapter delegates to the runner evidence functions
+//! and maps runner types onto the slim core-facing types.
+
+use std::path::PathBuf;
+
+use serde_json::Value;
+
+use crate::error::Result;
+use crate::observation::runs_service::{
+    RemoteArtifactDownloadInfo, RunnerConnectionInfo, RunnerEvidenceProvider, StaleRunnerJobInfo,
+};
+use crate::observation::RunRecord;
+
+/// The runner layer's `RunnerEvidenceProvider`. Registered with core at startup.
+pub struct RunnerEvidence;
+
+impl RunnerEvidenceProvider for RunnerEvidence {
+    fn mirror_connected_runner_run(&self, run_id: &str) -> Result<Option<RunRecord>> {
+        super::mirror::mirror_connected_runner_run(run_id)
+    }
+
+    fn statuses(&self) -> Vec<RunnerConnectionInfo> {
+        super::super::connection::statuses()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|report| RunnerConnectionInfo {
+                runner_id: report.runner_id,
+                connected: report.connected,
+                stale_runner_jobs: report
+                    .stale_runner_jobs
+                    .into_iter()
+                    .map(|job| StaleRunnerJobInfo {
+                        durable_run_id: job.durable_run_id,
+                        runner_id: job.runner_id,
+                        job_id: job.job_id,
+                        status: job.status.daemon_status_label().to_string(),
+                        lifecycle_state: job.lifecycle_state,
+                        stale_reason: job.stale_reason,
+                        retryable: job.retryable,
+                    })
+                    .collect(),
+            })
+            .collect()
+    }
+
+    fn daemon_api_get(&self, runner_id: &str, path: &str) -> Result<Value> {
+        super::super::execution::daemon_api_get(runner_id, path)
+    }
+
+    fn refresh_mirrored_daemon_evidence(&self, run_id: &str) -> Result<Option<Vec<RunRecord>>> {
+        super::mirror::refresh_mirrored_daemon_evidence(run_id)
+    }
+
+    fn mirrored_runner_job_identity(&self, run: &RunRecord) -> Option<(String, String)> {
+        super::mirror::mirrored_runner_job_identity(run)
+    }
+
+    fn download_remote_artifact(
+        &self,
+        path: &str,
+        output: Option<PathBuf>,
+    ) -> Result<RemoteArtifactDownloadInfo> {
+        let download = super::download::download_remote_artifact(path, output)?;
+        Ok(RemoteArtifactDownloadInfo {
+            output_path: download.output_path,
+            content_type: download.content_type,
+            size_bytes: download.size_bytes,
+            sha256: download.sha256,
+            artifact_ref: download.artifact_ref,
+        })
+    }
+}
+
+/// Register the runner evidence provider with core. Called once at startup.
+pub fn register() {
+    crate::observation::runs_service::register_runner_evidence_provider(Box::new(RunnerEvidence));
+}

--- a/crates/homeboy-core/src/runner/mod.rs
+++ b/crates/homeboy-core/src/runner/mod.rs
@@ -99,6 +99,7 @@ pub use connection::{
     statuses,
 };
 pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
+pub use evidence::register_runner_evidence_provider;
 pub use evidence::runner_artifact_store_token;
 pub use evidence::{
     download_remote_artifact, is_remote_runner_artifact_path, is_reportable_artifact_evidence_path,


### PR DESCRIPTION
## Summary
Inverts the **fattest core→runner behavioral cluster**. `observation::runs_service` called 6 runner functions to enrich run/artifact lookups with live runner + daemon evidence. Runner is an optional Lab-offload feature — core must not depend on runner behavior for this.

This is the first **behavioral hook** in the runner campaign (vs. the type-moves so far), and it's the pattern that actually clears whole files toward lifting runner out.

## Design — RunnerEvidenceProvider hook (tunnel/fuzz keystone pattern)
- **Core** owns the trait + registry + slim core-facing types (`RunnerConnectionInfo`, `StaleRunnerJobInfo`, `RemoteArtifactDownloadInfo`) in `observation/runs_service/runner_evidence.rs`. A `NoopRunnerEvidenceProvider` returns empty evidence when no runner is registered.
- The **runner layer** implements it (`runner/evidence/provider.rs`), mapping runner types → slim core types, and registers at CLI startup alongside `homeboy_tunnel::register()`.
- `runs_service` calls the provider via `with_runner_evidence(...)` instead of `crate::runners::*`.

## Why graceful degradation is correct
All 6 call sites were **already best-effort** (`if-let-Ok` / `unwrap_or_default` / `eprintln-on-err`), so "no provider registered" behaves exactly like "no runner connected" today. The one non-degradable method (`download_remote_artifact`) errors clearly.

## Safety
3 guard tests: no-op degrades gracefully, no-op download errors clearly, registered provider is used. The existing stale-runner reconciliation test is updated to the slim type (byte-identical terminal-evidence JSON).

## Impact
Severs **all 6** runs_service runner-evidence edges. Reverse-edge file count: **33 → 30**.

## Verification
`cargo check` clean for `-p homeboy-core --lib/--tests` and `-p homeboy-cli --lib`; the 20 runs_service tests (incl. 3 new guards) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)