### PR TITLE
refactor: extract is_test_path primitive, sever the extension→code_audit cycle (#8425)

### DIFF
--- a/crates/homeboy-core/src/code_audit/mod.rs
+++ b/crates/homeboy-core/src/code_audit/mod.rs
@@ -75,9 +75,9 @@ pub(crate) use execution_plan::{
 };
 pub use findings::{homeboy_finding_from_audit, Finding, FindingConfidence, Severity};
 pub use fingerprint::FileFingerprint;
+pub use homeboy_engine_primitives::test_path::is_test_path;
 pub use report::AuditCommandOutput;
 pub use run::{run_main_audit_workflow, AuditRunWorkflowArgs, AuditRunWorkflowResult};
-pub use walker::is_test_path;
 
 pub use entry::{
     audit_component, audit_path, audit_path_scoped, audit_path_with_id,

--- a/crates/homeboy-core/src/code_audit/walker.rs
+++ b/crates/homeboy-core/src/code_audit/walker.rs
@@ -6,6 +6,12 @@ use std::path::Path;
 
 use crate::engine::codebase_scan::{self, CodebaseSnapshot, ExtensionFilter, ScanConfig};
 
+// `is_test_path` is a pure path classifier consumed by both code_audit and
+// extension; it now lives in homeboy-engine-primitives so those two feature
+// layers don't have to depend on each other. Re-exported here so the many
+// `walker::is_test_path` / `code_audit::is_test_path` call sites keep resolving.
+pub use homeboy_engine_primitives::test_path::is_test_path;
+
 /// Extension index/entry-point filenames that should be excluded from convention
 /// sibling detection. These files organize other files rather than being
 /// peers — including them produces false "missing method" findings.
@@ -105,75 +111,6 @@ pub(crate) fn walk_all_source_files_snapshot(root: &Path) -> CodebaseSnapshot {
     CodebaseSnapshot::build(root, &source_scan_config())
 }
 
-/// Check if a relative path points to a test file using heuristic patterns.
-///
-/// Used to separate test files from production code during convention discovery,
-/// preventing test methods (set_up, tear_down) from contaminating production
-/// conventions and preventing production conventions from generating false
-/// positives in test files.
-///
-/// Matches common test file patterns across languages:
-/// - Paths under `tests/`, `Tests/`, `test/`, `__tests__/` directories
-/// - Files named `*_test.rs`, `*Test.php`, `*.test.js`, `*.spec.ts`, etc.
-pub fn is_test_path(relative_path: &str) -> bool {
-    // Directory-based detection
-    let path_lower = relative_path.to_lowercase();
-    if path_lower.starts_with("tests/")
-        || path_lower.starts_with("test/")
-        || path_lower.starts_with("__tests__/")
-        || path_lower.contains("/tests/")
-        || path_lower.contains("/test/")
-        || path_lower.contains("/__tests__/")
-    {
-        return true;
-    }
-
-    // Filename-based detection (case-sensitive for precision)
-    let file_name = relative_path.rsplit('/').next().unwrap_or(relative_path);
-
-    // Rust: foo_test.rs, foo_tests.rs, and bare test.rs / tests.rs modules
-    // (conventionally wired as `#[cfg(test)] mod tests;`). Also cover shared
-    // test-fixture modules — `*_fixture(s).rs` (e.g. test_fixture.rs) — which are
-    // conventionally `#[cfg(test)] mod` fixtures consumed by sibling `*_tests.rs`
-    // files, not production code.
-    if file_name.ends_with("_test.rs")
-        || file_name.ends_with("_tests.rs")
-        || file_name.ends_with("_fixture.rs")
-        || file_name.ends_with("_fixtures.rs")
-        || file_name == "test.rs"
-        || file_name == "tests.rs"
-    {
-        return true;
-    }
-    // PHP: FooTest.php
-    if file_name.ends_with("Test.php") {
-        return true;
-    }
-    // JS/TS: foo.test.js, foo.spec.js, foo.test.ts, foo.spec.ts (and jsx/tsx)
-    for ext in &[
-        ".test.js",
-        ".test.jsx",
-        ".test.ts",
-        ".test.tsx",
-        ".test.mjs",
-        ".spec.js",
-        ".spec.jsx",
-        ".spec.ts",
-        ".spec.tsx",
-        ".spec.mjs",
-    ] {
-        if file_name.ends_with(ext) {
-            return true;
-        }
-    }
-    // Python: test_foo.py
-    if file_name.starts_with("test_") && file_name.ends_with(".py") {
-        return true;
-    }
-
-    false
-}
-
 /// Known source file extensions that may be present even if no extension claims them.
 const COMMON_SOURCE_EXTENSIONS: &[&str] = &[
     "rs", "php", "js", "ts", "py", "go", "java", "rb", "swift", "kt", "c", "cpp", "h",
@@ -195,48 +132,4 @@ pub(crate) fn count_unclaimed_source_files(root: &Path) -> usize {
     };
 
     codebase_scan::walk_files(root, &config).len()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_is_test_path_directory_patterns() {
-        // Directory-based detection
-        assert!(is_test_path("tests/core/audit.rs"));
-        assert!(is_test_path("tests/Unit/FooTest.php"));
-        assert!(is_test_path("test/helpers.js"));
-        assert!(is_test_path("src/__tests__/foo.test.ts"));
-        assert!(is_test_path("inc/Tests/Abilities/FooTest.php"));
-        assert!(is_test_path("some/deep/path/tests/unit/bar.rs"));
-    }
-
-    #[test]
-    fn test_is_test_path_filename_patterns() {
-        // Filename-based detection
-        assert!(is_test_path("src/core/audit_test.rs"));
-        assert!(is_test_path("src/core/audit_tests.rs"));
-        assert!(is_test_path("inc/Abilities/SystemAbilitiesTest.php"));
-        assert!(is_test_path("src/components/Button.test.tsx"));
-        assert!(is_test_path("src/utils/parse.spec.ts"));
-        assert!(is_test_path("lib/test_runner.py"));
-        // Bare `tests.rs` / `test.rs` modules (conventionally `#[cfg(test)] mod tests;`).
-        assert!(is_test_path("src/commands/bench/tests.rs"));
-        assert!(is_test_path("src/core/triage/test.rs"));
-        // Shared `*_fixture(s).rs` test-support modules (conventionally
-        // `#[cfg(test)] mod test_fixture;`), consumed by sibling `*_tests.rs`.
-        assert!(is_test_path("src/commands/trace/test_fixture.rs"));
-        assert!(is_test_path("src/core/runner/exec_fixtures.rs"));
-    }
-
-    #[test]
-    fn test_is_test_path_negative() {
-        // These should NOT be detected as test files
-        assert!(!is_test_path("src/core/audit.rs"));
-        assert!(!is_test_path("inc/Abilities/SystemAbilities.php"));
-        assert!(!is_test_path("src/components/Button.tsx"));
-        assert!(!is_test_path("src/utils/test_helpers.rs")); // helper, not a test
-        assert!(!is_test_path("src/testing/framework.rs")); // "testing" != "tests"
-    }
 }

--- a/crates/homeboy-core/src/extension/manifest.rs
+++ b/crates/homeboy-core/src/extension/manifest.rs
@@ -174,7 +174,7 @@ impl TestMappingConfig {
     /// and builtin defaults without core embedding the literals.
     pub fn effective_trivial_method_names(&self) -> Vec<String> {
         if self.trivial_method_names.is_empty() {
-            crate::code_audit::conventions::Language::builtin_trivial_method_names()
+            homeboy_engine_primitives::language::Language::builtin_trivial_method_names()
                 .iter()
                 .map(|s| s.to_string())
                 .collect()
@@ -188,7 +188,7 @@ impl TestMappingConfig {
     /// declared none.
     pub fn effective_trivial_method_prefixes(&self) -> Vec<String> {
         if self.trivial_method_prefixes.is_empty() {
-            crate::code_audit::conventions::Language::builtin_trivial_method_prefixes()
+            homeboy_engine_primitives::language::Language::builtin_trivial_method_prefixes()
                 .iter()
                 .map(|s| s.to_string())
                 .collect()

--- a/crates/homeboy-core/src/extension/test/drift.rs
+++ b/crates/homeboy-core/src/extension/test/drift.rs
@@ -13,10 +13,10 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::code_audit::walker::is_test_path;
 use crate::error::{Error, Result};
 use crate::extension::TestDriftConfig;
 use crate::git;
+use homeboy_engine_primitives::test_path::is_test_path;
 
 // ============================================================================
 // Models
@@ -571,7 +571,7 @@ fn matches_any_pattern(path: &str, patterns: &[String]) -> bool {
 pub fn is_source_relevant_change(opts: &DriftOptions, path: &str) -> bool {
     matches_any_pattern(path, &opts.source_patterns)
         || matches_any_pattern(path, &opts.test_patterns)
-        || crate::code_audit::walker::is_test_path(path)
+        || is_test_path(path)
 }
 
 /// Collect test files in the repo using extension-declared glob patterns.

--- a/crates/homeboy-engine-primitives/src/lib.rs
+++ b/crates/homeboy-engine-primitives/src/lib.rs
@@ -19,5 +19,6 @@ pub mod local_files;
 pub mod output_parse;
 pub mod shell;
 pub mod template;
+pub mod test_path;
 pub mod text;
 pub mod validation;

--- a/crates/homeboy-engine-primitives/src/test_path.rs
+++ b/crates/homeboy-engine-primitives/src/test_path.rs
@@ -1,0 +1,114 @@
+//! Test-path classification primitive.
+//!
+//! `is_test_path` heuristically classifies whether a relative path points to a
+//! test file (test directories, `*_test.rs` / `*Test.php` / `*.spec.ts`
+//! filenames, etc.). It is a pure, language-agnostic string classifier with no
+//! dependencies, consumed by both `code_audit` and `extension` — so it lives in
+//! the primitives crate to keep those two feature layers off each other.
+
+/// Check if a relative path points to a test file using heuristic patterns.
+///
+/// Used to separate test files from production code during convention discovery,
+/// preventing test methods (set_up, tear_down) from contaminating production
+/// conventions and preventing production conventions from generating false
+/// positives in test files.
+///
+/// Matches common test file patterns across languages:
+/// - Paths under `tests/`, `Tests/`, `test/`, `__tests__/` directories
+/// - Files named `*_test.rs`, `*Test.php`, `*.test.js`, `*.spec.ts`, etc.
+pub fn is_test_path(relative_path: &str) -> bool {
+    // Directory-based detection
+    let path_lower = relative_path.to_lowercase();
+    if path_lower.starts_with("tests/")
+        || path_lower.starts_with("test/")
+        || path_lower.starts_with("__tests__/")
+        || path_lower.contains("/tests/")
+        || path_lower.contains("/test/")
+        || path_lower.contains("/__tests__/")
+    {
+        return true;
+    }
+
+    // Filename-based detection (case-sensitive for precision)
+    let file_name = relative_path.rsplit('/').next().unwrap_or(relative_path);
+
+    // Rust: foo_test.rs, foo_tests.rs, and bare test.rs / tests.rs modules
+    // (conventionally wired as `#[cfg(test)] mod tests;`). Also cover shared
+    // test-fixture modules — `*_fixture(s).rs` (e.g. test_fixture.rs) — which are
+    // conventionally `#[cfg(test)] mod` fixtures consumed by sibling `*_tests.rs`
+    // files, not production code.
+    if file_name.ends_with("_test.rs")
+        || file_name.ends_with("_tests.rs")
+        || file_name.ends_with("_fixture.rs")
+        || file_name.ends_with("_fixtures.rs")
+        || file_name == "test.rs"
+        || file_name == "tests.rs"
+    {
+        return true;
+    }
+    // PHP: FooTest.php
+    if file_name.ends_with("Test.php") {
+        return true;
+    }
+    // JS/TS: foo.test.js, foo.spec.js, foo.test.ts, foo.spec.ts (and jsx/tsx)
+    for ext in &[
+        ".test.js",
+        ".test.jsx",
+        ".test.ts",
+        ".test.tsx",
+        ".test.mjs",
+        ".spec.js",
+        ".spec.jsx",
+        ".spec.ts",
+        ".spec.tsx",
+        ".spec.mjs",
+    ] {
+        if file_name.ends_with(ext) {
+            return true;
+        }
+    }
+    // Python: test_foo.py
+    if file_name.starts_with("test_") && file_name.ends_with(".py") {
+        return true;
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_test_path_directory_patterns() {
+        assert!(is_test_path("tests/core/audit.rs"));
+        assert!(is_test_path("tests/Unit/FooTest.php"));
+        assert!(is_test_path("test/helpers.js"));
+        assert!(is_test_path("src/__tests__/foo.test.ts"));
+        assert!(is_test_path("inc/Tests/Abilities/FooTest.php"));
+        assert!(is_test_path("some/deep/path/tests/unit/bar.rs"));
+    }
+
+    #[test]
+    fn test_is_test_path_filename_patterns() {
+        assert!(is_test_path("src/core/audit_test.rs"));
+        assert!(is_test_path("src/core/audit_tests.rs"));
+        assert!(is_test_path("inc/Abilities/SystemAbilitiesTest.php"));
+        assert!(is_test_path("src/components/Button.test.tsx"));
+        assert!(is_test_path("src/utils/parse.spec.ts"));
+        assert!(is_test_path("lib/test_runner.py"));
+        assert!(is_test_path("src/commands/bench/tests.rs"));
+        assert!(is_test_path("src/core/triage/test.rs"));
+        assert!(is_test_path("src/commands/trace/test_fixture.rs"));
+        assert!(is_test_path("src/core/runner/exec_fixtures.rs"));
+    }
+
+    #[test]
+    fn test_is_test_path_negative() {
+        assert!(!is_test_path("src/core/audit.rs"));
+        assert!(!is_test_path("inc/Abilities/SystemAbilities.php"));
+        assert!(!is_test_path("src/components/Button.tsx"));
+        assert!(!is_test_path("src/utils/test_helpers.rs"));
+        assert!(!is_test_path("src/testing/framework.rs"));
+    }
+}


### PR DESCRIPTION
## Summary

**Keystone for a future `homeboy-audit` extraction.** You asked whether audit-as-a-crate makes sense — it does, and it's closer than expected. `code_audit` is otherwise a clean top-consumer:

```
component → code_audit:  0
engine    → code_audit:  0
extension → code_audit:  1   ← the only cycle edge
```

That single edge turned out to be **three references, all to things that are actually low-level primitives, not audit domain logic** (the recurring misplaced-primitive pattern):

- `extension/test/drift.rs` imported `code_audit::walker::is_test_path` — a pure, zero-dependency test-path classifier — twice (a `use` + an inline fully-qualified call).
- `extension/manifest.rs` called `code_audit::conventions::Language::builtin_*` — but `Language` already lives in `homeboy-engine-primitives` (this campaign); `code_audit::conventions` just re-exports it.

## The cut

- Move `is_test_path` into `homeboy-engine-primitives` as `test_path` (pure string classification, zero deps).
- Re-export it from `code_audit::walker` + the `code_audit` root so the **~18 existing call sites are unchanged**.
- Repoint `extension`'s three refs straight at the primitives crate.

**Result: `extension → code_audit` real edges drop to ZERO.** `code_audit` now sits cleanly above component/extension/engine with no back-edge — the last structural blocker to extracting it as `homeboy-audit`.

## On `homeboy-review`

Investigated it too — `review` (1.8k core + 1.5k cli) is a thin **umbrella that consumes `code_audit`** (renders audit/lint/test output). It sits *above* audit, so it's not the extraction lever; it'd need audit extractable first. Audit is the right target, and this unblocks it.

## Verification

- `cargo check -p homeboy-engine-primitives` + `-p homeboy-core --lib` — clean
- 3 `test_path` tests pass
- `cargo check --workspace --tests --locked` — **green**

Refs #8425