### PR TITLE
Keep Lab plans controller-owned after handoff

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -460,14 +460,21 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     let resolved_run_id = resolve_run_id(run_id)?;
     let _ = reconcile_deferred_candidate(&resolved_run_id)?;
     let mut record = store::read_record(&resolved_run_id)?;
+    let controller_plan = store::read_controller_plan(&record.run_id)?;
+    let controller_plan_path = store::controller_plan_path(&record.run_id)?
+        .display()
+        .to_string();
+    if record.plan_path != controller_plan_path {
+        record.plan_path = controller_plan_path;
+        store::write_record(&record)?;
+    }
     if !is_terminal_run_state(record.state) {
         if let Ok(aggregate) = store::read_aggregate(&record.run_id) {
-            let plan = store::read_controller_plan(&record.run_id)?;
             let aggregate_path = store::aggregate_path(&record.run_id)
                 .map(|path| path.display().to_string())
                 .unwrap_or_else(|_| "aggregate.json".to_string());
             let mut reconciled = record.clone();
-            let projection_plan = aggregate_projection_plan(&plan, &aggregate);
+            let projection_plan = aggregate_projection_plan(&controller_plan, &aggregate);
             apply_aggregate_to_record(
                 &mut reconciled,
                 &projection_plan,
@@ -1617,6 +1624,7 @@ fn record_lab_offload_proxy(
             return Err(error);
         }
     }
+    record.plan_path = store::controller_plan_path(&run_id)?.display().to_string();
     let metadata = record.ensure_metadata_object();
     metadata.insert("kind".to_string(), json!("lab_offload_controller_proxy"));
     // This record is the controller's durable projection of a runner handoff.

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -565,6 +565,40 @@ fn retry_uses_controller_plan_when_runner_projection_replaces_plan_path() {
 }
 
 #[test]
+fn status_repairs_runner_plan_projection_and_missing_controller_plan_fails_closed() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        let record =
+            submit_plan(&plan, Some("runner-projected-status")).expect("controller plan submitted");
+        rewrite_record_for_test(&record.run_id, |projected| {
+            projected.plan_path =
+                "/runner/agent-task-runs/runner-projected-status/plan.json".to_string();
+        })
+        .expect("runner transport path projected");
+
+        assert_eq!(
+            status(&record.run_id).expect("controller status").plan_path,
+            record.plan_path
+        );
+        assert_eq!(
+            store::read_record(&record.run_id)
+                .expect("repaired record")
+                .plan_path,
+            record.plan_path
+        );
+
+        std::fs::remove_file(&record.plan_path).expect("remove controller plan");
+        let error = status(&record.run_id).expect_err("missing controller plan fails closed");
+        assert_eq!(error.code, ErrorCode::InternalIoError);
+        let diagnostic = error.details["error"]
+            .as_str()
+            .expect("structured ownership diagnostic");
+        assert!(diagnostic.contains("authoritative controller-owned plan"));
+        assert!(diagnostic.contains("runner execution transport"));
+    });
+}
+
+#[test]
 fn cook_lab_handoff_controller_reads_ignore_runner_plan_projection() {
     with_isolated_home(|_| {
         let plan = test_plan();

--- a/crates/homeboy-core/src/lifecycle_store.rs
+++ b/crates/homeboy-core/src/lifecycle_store.rs
@@ -39,22 +39,23 @@ pub(super) fn read_plan_path(path: &str) -> Result<AgentTaskPlan> {
 }
 
 pub(super) fn read_controller_plan(run_id: &str) -> Result<AgentTaskPlan> {
-    let path = run_dir(run_id)?.join("plan.json");
+    let path = controller_plan_path(run_id)?;
     let plan = read_json(&path).map_err(|error| {
-        if error.code == ErrorCode::InternalIoError {
-            Error::internal_io(
-                format!(
-                    "controller-owned durable plan is unavailable for run `{run_id}`: {}",
-                    error.message
-                ),
-                Some(path.display().to_string()),
-            )
-        } else {
-            error
-        }
+        Error::internal_io(
+            format!(
+                "authoritative controller-owned plan for agent-task run `{run_id}` is unavailable at {}; lifecycle record plan_path is runner execution transport and cannot be used for controller readback: {}",
+                path.display(),
+                error.message
+            ),
+            Some(path.display().to_string()),
+        )
     })?;
     validate_execution_budget(&plan)?;
     Ok(plan)
+}
+
+pub(super) fn controller_plan_path(run_id: &str) -> Result<PathBuf> {
+    Ok(run_dir(run_id)?.join("plan.json"))
 }
 
 /// Controller lifecycle operations resolve the plan from their durable run
@@ -62,7 +63,7 @@ pub(super) fn read_controller_plan(run_id: &str) -> Result<AgentTaskPlan> {
 /// evidence after a Lab projection and is never controller execution authority.
 pub(super) fn read_controller_plan_for_execution(run_id: &str) -> Result<AgentTaskPlan> {
     crate::config::with_config_lock(|| {
-        let path = run_dir(run_id)?.join("plan.json");
+        let path = controller_plan_path(run_id)?;
         let mut plan = read_controller_plan(run_id)?;
         if migrate_execution_budget(&mut plan)? {
             write_private_json(&path, &plan)?;

--- a/crates/homeboy-core/src/runner/lab/agent_task_bridge/tests/tail_tests.rs
+++ b/crates/homeboy-core/src/runner/lab/agent_task_bridge/tests/tail_tests.rs
@@ -297,6 +297,31 @@ fn materializes_inline_agent_task_cook_tasks_json() {
 }
 
 #[test]
+fn materializes_inline_cook_attempt_plan_only_for_runner_execution() {
+    let plan = r#"{"schema":"homeboy/agent-task-plan/v1","plan_id":"controller-plan","tasks":[]}"#;
+    let args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+        "--attempt-plan".to_string(),
+        plan.to_string(),
+    ];
+
+    let (rewritten, entry) = materialize_inline_agent_task_tasks_arg_with(&args, |spec| {
+        assert_eq!(spec, plan);
+        Ok(Some(fake_synced_file(
+            "@/remote/input/agent-task-attempt-plan.json",
+            "agent_task_attempt_plan_remapped",
+        )))
+    })
+    .expect("rewrite attempt plan");
+
+    assert_eq!(rewritten[4], "@/remote/input/agent-task-attempt-plan.json");
+    assert!(!rewritten.contains(&plan.to_string()));
+    assert_eq!(entry.expect("mapping entry").remote_path(), "/remote/input");
+}
+
+#[test]
 fn leaves_agent_task_tasks_file_specs_in_argv() {
     let args = vec![
         "homeboy".to_string(),


### PR DESCRIPTION
## Summary
Keep authoritative agent-task plans in the controller run directory across Lab handoff.

## What changed
- Canonicalize controller plan readback, repair stale projected plan paths, and fail with an ownership diagnostic when the controller plan is missing.
- Add deterministic controller-readback and runner attempt-plan remapping tests.

## How to test
1. Run `cargo test -p homeboy-core --lib status_repairs_runner_plan_projection_and_missing_controller_plan_fails_closed`; expect The controller readback test passes..
2. Run `cargo test -p homeboy-core --lib materializes_inline_cook_attempt_plan_only_for_runner_execution`; expect The runner remapping test passes..
3. Run `cargo check -p homeboy-core --lib`; expect The library compiles successfully..

## Compatibility
Internal lifecycle ownership fix; local execution and detached Lab behavior remain unchanged.

## Evidence
- CI expected: Audit
- CI expected: Lint
- CI expected: Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8494
- focused-controller-plan-test: Passed
- format-and-check: Passed
- runner-remapping-test: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab plan ownership regression, prepared the recovery patch, and added deterministic coverage; Chris reviews and owns the change.

## Source relationships
- Closes #8494
