### PR TITLE
refactor: invert api_jobs→runner job-preparation via provider hook (runner-decouple)

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -103,6 +103,10 @@ impl CliRuntime {
         // core depending on runner behavior. (Runner is still in-crate today;
         // this registration is the seam that lets it become its own crate.)
         crate::core::runner::register_runner_evidence_provider();
+        // Register the runner job-preparation provider so api_jobs can compute
+        // the secret-env plan and validate workload dispatch for remote-runner
+        // jobs without core depending on runner behavior.
+        crate::core::runner::register_runner_job_preparation_provider();
         // Register the command-label resolver so core::runner can map dispatched
         // argv to a hot-command label without depending on the full CLI parser.
         crate::core::runner::set_command_label_resolver(|argv| {

--- a/crates/homeboy-core/src/api_jobs/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/mod.rs
@@ -1,5 +1,6 @@
 mod persistence;
 mod remote_runner;
+mod runner_job_preparation;
 mod store;
 mod summary;
 mod types;
@@ -7,6 +8,10 @@ mod types;
 pub use remote_runner::{
     JobArtifactMetadata, RemoteRunnerJobClaim, RemoteRunnerJobRequest, RemoteRunnerJobResult,
     RunnerJobLifecycleMetadata,
+};
+pub(crate) use runner_job_preparation::with_runner_job_preparation;
+pub use runner_job_preparation::{
+    register_runner_job_preparation_provider, RunnerJobPreparationProvider,
 };
 pub(crate) use store::LocalChildStartDiscriminator;
 pub(crate) use store::LocalRunnerJob;

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -103,13 +103,15 @@ impl RemoteRunnerJobRequest {
             }
         }
 
-        let secret_env_plan = crate::runner::runner_exec_secret_env_plan(
-            &self.command,
-            None,
-            &self.secret_env_names,
-            &self.env,
-            base_plan,
-        );
+        let secret_env_plan = super::with_runner_job_preparation(|p| {
+            p.runner_exec_secret_env_plan(
+                &self.command,
+                None,
+                &self.secret_env_names,
+                &self.env,
+                base_plan,
+            )
+        });
         self.secret_env_names = secret_env_plan.secret_env_names();
         self.secret_env_plan = secret_env_plan.clone();
         secret_env_plan
@@ -341,14 +343,16 @@ impl JobStore {
             ));
         }
         let secret_env_plan = request.normalize();
-        crate::runner::workload::validate_runner_workload_dispatch(
-            request.runner_workload.as_ref(),
-            &request.runner_id,
-            request.cwd.as_deref(),
-            &request.command,
-            &secret_env_plan,
-            request.capture_patch,
-        )?;
+        super::with_runner_job_preparation(|p| {
+            p.validate_runner_workload_dispatch(
+                request.runner_workload.as_ref(),
+                &request.runner_id,
+                request.cwd.as_deref(),
+                &request.command,
+                &secret_env_plan,
+                request.capture_patch,
+            )
+        })?;
 
         let now = timestamp_ms();
         let job = Job {

--- a/crates/homeboy-core/src/api_jobs/runner_job_preparation.rs
+++ b/crates/homeboy-core/src/api_jobs/runner_job_preparation.rs
@@ -1,0 +1,159 @@
+//! Runner job-preparation provider hook.
+//!
+//! When `api_jobs` prepares a remote-runner job it needs two runner-domain
+//! computations: the secret-env plan (which folds in runner/lab-declared secret
+//! env names) and workload-dispatch validation. Runner is an optional Lab-
+//! offload feature, so core defines the [`RunnerJobPreparationProvider`]
+//! contract here and the runner layer registers an implementation at startup.
+//!
+//! When no provider is registered, the [`NoopRunnerJobPreparationProvider`]
+//! builds a secret-env plan from the explicitly-declared names only (skipping
+//! the runner/lab-specific augmentation) and performs no workload validation —
+//! the correct behavior when there is no runner to dispatch to.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use crate::lab_contract::RunnerWorkload;
+use crate::secret_env_plan::SecretEnvPlan;
+use homeboy_runner_contract::RunnerCapabilityPreflight;
+
+use crate::error::Result;
+
+/// The runner job-preparation contract `api_jobs` depends on. Implemented by the
+/// runner layer and registered at startup; core prepares remote-runner jobs
+/// without depending on runner behavior.
+pub trait RunnerJobPreparationProvider: Send + Sync {
+    /// Compute the secret-env plan for a runner exec, folding in any
+    /// runner/lab-declared secret env names.
+    fn runner_exec_secret_env_plan(
+        &self,
+        command: &[String],
+        preflight: Option<&RunnerCapabilityPreflight>,
+        explicit_names: &[String],
+        env: &HashMap<String, String>,
+        base_plan: Option<SecretEnvPlan>,
+    ) -> SecretEnvPlan;
+
+    /// Validate that a workload may be dispatched to the given runner.
+    fn validate_runner_workload_dispatch(
+        &self,
+        workload: Option<&RunnerWorkload>,
+        runner_id: &str,
+        cwd: Option<&str>,
+        command: &[String],
+        secret_env_plan: &SecretEnvPlan,
+        capture_patch: bool,
+    ) -> Result<()>;
+}
+
+/// Default provider used when no runner layer is registered.
+struct NoopRunnerJobPreparationProvider;
+
+impl RunnerJobPreparationProvider for NoopRunnerJobPreparationProvider {
+    fn runner_exec_secret_env_plan(
+        &self,
+        _command: &[String],
+        preflight: Option<&RunnerCapabilityPreflight>,
+        explicit_names: &[String],
+        _env: &HashMap<String, String>,
+        base_plan: Option<SecretEnvPlan>,
+    ) -> SecretEnvPlan {
+        if let Some(plan) = base_plan {
+            return plan;
+        }
+        let mut names: Vec<String> = explicit_names.to_vec();
+        if let Some(preflight) = preflight {
+            names.extend(preflight.required_env.iter().cloned());
+        }
+        SecretEnvPlan::from_secret_env_names(names)
+    }
+
+    fn validate_runner_workload_dispatch(
+        &self,
+        _workload: Option<&RunnerWorkload>,
+        _runner_id: &str,
+        _cwd: Option<&str>,
+        _command: &[String],
+        _secret_env_plan: &SecretEnvPlan,
+        _capture_patch: bool,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
+static PROVIDER: Mutex<Option<Box<dyn RunnerJobPreparationProvider>>> = Mutex::new(None);
+
+/// Register the runner job-preparation provider. Called once at binary startup
+/// by the runner layer (via the CLI).
+pub fn register_runner_job_preparation_provider(provider: Box<dyn RunnerJobPreparationProvider>) {
+    let mut guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = Some(provider);
+}
+
+/// Run `f` against the registered provider, or the no-op provider if none is
+/// registered.
+pub(crate) fn with_runner_job_preparation<T>(
+    f: impl FnOnce(&dyn RunnerJobPreparationProvider) -> T,
+) -> T {
+    let guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    match guard.as_ref() {
+        Some(provider) => f(provider.as_ref()),
+        None => f(&NoopRunnerJobPreparationProvider),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_secret_env_plan_uses_explicit_names() {
+        let noop = NoopRunnerJobPreparationProvider;
+        let plan = noop.runner_exec_secret_env_plan(
+            &["cmd".to_string()],
+            None,
+            &["EXPLICIT_SECRET".to_string()],
+            &HashMap::new(),
+            None,
+        );
+        assert!(plan
+            .secret_env_names()
+            .contains(&"EXPLICIT_SECRET".to_string()));
+    }
+
+    #[test]
+    fn noop_secret_env_plan_prefers_base_plan() {
+        let noop = NoopRunnerJobPreparationProvider;
+        let base = SecretEnvPlan::from_secret_env_names(vec!["BASE_SECRET".to_string()]);
+        let plan = noop.runner_exec_secret_env_plan(
+            &["cmd".to_string()],
+            None,
+            &["EXPLICIT_SECRET".to_string()],
+            &HashMap::new(),
+            Some(base),
+        );
+        let names = plan.secret_env_names();
+        assert!(names.contains(&"BASE_SECRET".to_string()));
+    }
+
+    #[test]
+    fn noop_workload_validation_passes() {
+        let noop = NoopRunnerJobPreparationProvider;
+        let plan = SecretEnvPlan::from_secret_env_names(Vec::<String>::new());
+        assert!(noop
+            .validate_runner_workload_dispatch(
+                None,
+                "runner",
+                None,
+                &["cmd".to_string()],
+                &plan,
+                false
+            )
+            .is_ok());
+    }
+}

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -14,6 +14,10 @@ use uuid::Uuid;
 
 #[test]
 fn remote_runner_job_submit_derives_implicit_command_secret_names() {
+    // This test exercises runner-augmented secret-env derivation, which lives
+    // behind the RunnerJobPreparationProvider hook. Register the runner provider
+    // (normally done at CLI startup) so the augmentation runs.
+    crate::runner::register_runner_job_preparation_provider();
     let store = JobStore::default();
     let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
     request.command = vec![
@@ -787,6 +791,10 @@ fn remote_runner_jobs_persist_request_and_claim_state() {
 
 #[test]
 fn remote_runner_request_compiles_canonical_execution_envelope() {
+    // Exercises runner-augmented secret-env derivation via the
+    // RunnerJobPreparationProvider hook; register the runner provider (normally
+    // done at CLI startup) so the augmentation runs.
+    crate::runner::register_runner_job_preparation_provider();
     let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
     request.command = vec!["sh".to_string(), "-c".to_string(), "printf ok".to_string()];
     request

--- a/crates/homeboy-core/src/runner/job_preparation.rs
+++ b/crates/homeboy-core/src/runner/job_preparation.rs
@@ -1,0 +1,62 @@
+//! Runner-side implementation of core's `RunnerJobPreparationProvider` hook.
+//!
+//! Core's `api_jobs` calls this contract when preparing remote-runner jobs, so
+//! it can compute the secret-env plan and validate workload dispatch without
+//! depending on runner behavior directly.
+
+use std::collections::HashMap;
+
+use crate::lab_contract::RunnerWorkload;
+use crate::secret_env_plan::SecretEnvPlan;
+use homeboy_runner_contract::RunnerCapabilityPreflight;
+
+use crate::api_jobs::RunnerJobPreparationProvider;
+use crate::error::Result;
+
+/// The runner layer's `RunnerJobPreparationProvider`. Registered with core at
+/// startup.
+pub struct RunnerJobPreparation;
+
+impl RunnerJobPreparationProvider for RunnerJobPreparation {
+    fn runner_exec_secret_env_plan(
+        &self,
+        command: &[String],
+        preflight: Option<&RunnerCapabilityPreflight>,
+        explicit_names: &[String],
+        env: &HashMap<String, String>,
+        base_plan: Option<SecretEnvPlan>,
+    ) -> SecretEnvPlan {
+        super::execution::runner_exec_secret_env_plan(
+            command,
+            preflight,
+            explicit_names,
+            env,
+            base_plan,
+        )
+    }
+
+    fn validate_runner_workload_dispatch(
+        &self,
+        workload: Option<&RunnerWorkload>,
+        runner_id: &str,
+        cwd: Option<&str>,
+        command: &[String],
+        secret_env_plan: &SecretEnvPlan,
+        capture_patch: bool,
+    ) -> Result<()> {
+        super::workload::validate_runner_workload_dispatch(
+            workload,
+            runner_id,
+            cwd,
+            command,
+            secret_env_plan,
+            capture_patch,
+        )
+    }
+}
+
+/// Register the runner job-preparation provider with core. Called once at
+/// startup.
+pub fn register() {
+    crate::api_jobs::register_runner_job_preparation_provider(Box::new(RunnerJobPreparation));
+}

--- a/crates/homeboy-core/src/runner/mod.rs
+++ b/crates/homeboy-core/src/runner/mod.rs
@@ -36,6 +36,7 @@ mod execution;
 mod extension_materialization;
 mod git_dependency_materialization;
 mod homeboy_refresh;
+mod job_preparation;
 mod lab;
 #[cfg(test)]
 pub(crate) use lab::mirror_agent_task_run_plan_aggregate;
@@ -135,6 +136,7 @@ pub use homeboy_refresh::{
     HomeboyBinaryRefreshOptions, HomeboyBinaryRefreshOutput, HomeboyBinaryRefreshPlan,
     RunnerDevSyncExtensionProvenance, RunnerDevSyncOptions, RunnerDevSyncOutput, RunnerDevSyncPlan,
 };
+pub use job_preparation::register as register_runner_job_preparation_provider;
 pub use lab::{
     execute_lab_offload, LabJobOverrides, LabOffloadCommand, LabOffloadOutcome, LabOffloadRequest,
     LabOffloadSourcePathMode, LabOffloadWorkspaceModePolicy, LabRunnerSelectionSource,


### PR DESCRIPTION
## Summary
Second behavioral hook in the runner campaign (after the evidence hook #8532). `api_jobs::remote_runner` called two runner functions when preparing remote-runner jobs: `runner_exec_secret_env_plan` (folds in runner/lab-declared secret env names) and `validate_runner_workload_dispatch`. Runner is an optional Lab-offload feature — core must not depend on runner behavior for this.

## Design — RunnerJobPreparationProvider hook
- **Core** owns the trait + registry + `NoopProvider` in `api_jobs/runner_job_preparation.rs`. All signature types are **already contract types** (`RunnerCapabilityPreflight` in runner-contract; `SecretEnvPlan` + `RunnerWorkload` in lab-contract), so no new slim types are needed.
- The **runner layer** implements it (`runner/job_preparation.rs`), delegating to the real functions, and registers at CLI startup next to the evidence provider.
- `remote_runner` calls the provider via `with_runner_job_preparation(...)`.

## NoopProvider semantics
Builds a secret-env plan from explicit names + preflight `required_env` only (skips the runner/lab augmentation), and performs no workload validation — correct when there's no runner to dispatch to.

## Safety
3 new unit tests (noop uses explicit names, prefers base plan, workload validation passes). Two existing `part_c` tests that assert runner-augmented secret derivation now register the runner provider first (as CLI startup does) — confirming the full behavior is preserved. This actually **caught** the degradation semantics: without registration those tests correctly fell back to the noop.

## Impact
Severs **both** remote_runner runner-behavior edges.

## Verification
`cargo check` clean for `-p homeboy-core --lib/--tests` and `-p homeboy-cli --lib`; all 83 api_jobs tests + 3 new hook tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)