### PR TITLE
Reconcile accepted Lab jobs and portable patch artifacts

### DIFF
--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -1778,7 +1778,7 @@ fn enqueue_exec_job(
                     job.local_child_reservation_id()?,
                 );
                 let baseline = if request.capture_patch {
-                    Some(capture_baseline(&plan.cwd)?)
+                    Some(capture_baseline(&plan.cwd, source_snapshot.as_ref())?)
                 } else {
                     None
                 };

--- a/crates/homeboy-core/src/daemon/patch_capture.rs
+++ b/crates/homeboy-core/src/daemon/patch_capture.rs
@@ -14,6 +14,7 @@ use crate::source_snapshot::SourceSnapshot;
 
 const PATCH_CAPTURE_EXCLUDES: &[&str] = &[
     ".git",
+    ".homeboy",
     "node_modules",
     "target",
     "vendor",
@@ -27,6 +28,7 @@ const PATCH_CAPTURE_EXCLUDES: &[&str] = &[
 pub(super) struct BaselineCapture {
     _scratch: ScratchDir,
     path: PathBuf,
+    excludes: Vec<String>,
 }
 
 struct ScratchDir {
@@ -63,7 +65,10 @@ struct PatchRunInput<'a> {
     exit_code: i32,
 }
 
-pub(super) fn capture_baseline(cwd: &str) -> Result<BaselineCapture> {
+pub(super) fn capture_baseline(
+    cwd: &str,
+    source_snapshot: Option<&SourceSnapshot>,
+) -> Result<BaselineCapture> {
     let cwd_path = Path::new(cwd);
     if !cwd_path.is_dir() {
         return Err(Error::validation_invalid_argument(
@@ -75,10 +80,14 @@ pub(super) fn capture_baseline(cwd: &str) -> Result<BaselineCapture> {
     }
     let scratch = create_scratch_dir("baseline")?;
     let baseline_path = scratch.path.join("baseline");
-    copy_dir_filtered(cwd_path, &baseline_path)?;
+    let excludes = source_snapshot
+        .map(|snapshot| snapshot.sync_excludes.clone())
+        .unwrap_or_default();
+    copy_dir_filtered(cwd_path, &baseline_path, cwd_path, &excludes)?;
     Ok(BaselineCapture {
         _scratch: scratch,
         path: baseline_path,
+        excludes,
     })
 }
 
@@ -93,7 +102,8 @@ pub(super) fn capture_patch_report(
 ) -> Result<PatchCaptureReport> {
     let after_scratch = create_scratch_dir("after")?;
     let after_path = after_scratch.path.join("after");
-    copy_dir_filtered(Path::new(cwd), &after_path)?;
+    let cwd_path = Path::new(cwd);
+    copy_dir_filtered(cwd_path, &after_path, cwd_path, &baseline.excludes)?;
 
     let patch = normalized_no_index_diff(&baseline.path, &after_path)?;
     let modified_files = no_index_modified_files(&baseline.path, &after_path)?;
@@ -294,7 +304,7 @@ fn normalize_patch_paths(patch: &str, baseline: &Path, after: &Path) -> String {
         .replace(after.as_ref(), "b")
 }
 
-fn copy_dir_filtered(source: &Path, target: &Path) -> Result<()> {
+fn copy_dir_filtered(source: &Path, target: &Path, root: &Path, excludes: &[String]) -> Result<()> {
     fs::create_dir_all(target).map_err(|err| {
         Error::internal_io(
             err.to_string(),
@@ -311,7 +321,8 @@ fn copy_dir_filtered(source: &Path, target: &Path) -> Result<()> {
         let Some(name_str) = name.to_str() else {
             continue;
         };
-        if PATCH_CAPTURE_EXCLUDES.contains(&name_str) {
+        let relative = source_path_relative(root, &entry.path());
+        if PATCH_CAPTURE_EXCLUDES.contains(&name_str) || is_excluded(&relative, excludes) {
             continue;
         }
         let source_path = entry.path();
@@ -323,7 +334,7 @@ fn copy_dir_filtered(source: &Path, target: &Path) -> Result<()> {
             )
         })?;
         if metadata.is_dir() {
-            copy_dir_filtered(&source_path, &target_path)?;
+            copy_dir_filtered(&source_path, &target_path, root, excludes)?;
         } else if metadata.is_file() {
             fs::copy(&source_path, &target_path).map_err(|err| {
                 Error::internal_io(
@@ -334,6 +345,25 @@ fn copy_dir_filtered(source: &Path, target: &Path) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn source_path_relative(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn is_excluded(path: &str, excludes: &[String]) -> bool {
+    excludes.iter().any(|pattern| {
+        let pattern = pattern.trim_matches('/');
+        !pattern.is_empty()
+            && (path == pattern
+                || path
+                    .strip_prefix(pattern)
+                    .is_some_and(|suffix| suffix.starts_with('/'))
+                || glob_match::glob_match(pattern, path))
+    })
 }
 
 #[cfg(test)]
@@ -353,7 +383,8 @@ mod tests {
         )
         .expect("ignored file");
 
-        let baseline = capture_baseline(&workspace.path().display().to_string()).expect("baseline");
+        let baseline =
+            capture_baseline(&workspace.path().display().to_string(), None).expect("baseline");
 
         assert!(baseline.path.join("file.txt").exists());
         assert!(!baseline.path.join("target").exists());
@@ -364,7 +395,8 @@ mod tests {
         let _home = HomeGuard::new();
         let workspace = tempfile::tempdir().expect("workspace");
         fs::write(workspace.path().join("file.txt"), "before\n").expect("before");
-        let baseline = capture_baseline(&workspace.path().display().to_string()).expect("baseline");
+        let baseline =
+            capture_baseline(&workspace.path().display().to_string(), None).expect("baseline");
         fs::write(workspace.path().join("file.txt"), "after\n").expect("after");
         let job_id = uuid::Uuid::new_v4();
         let command = vec!["sh".to_string(), "-c".to_string(), "true".to_string()];
@@ -385,6 +417,43 @@ mod tests {
         let patch_body = fs::read_to_string(artifact_path).expect("patch body");
         assert!(patch_body.contains("-before"));
         assert!(patch_body.contains("+after"));
+    }
+
+    #[test]
+    fn capture_patch_report_excludes_runner_metadata_and_staged_excludes() {
+        let _home = HomeGuard::new();
+        let workspace = tempfile::tempdir().expect("workspace");
+        fs::create_dir_all(workspace.path().join(".homeboy")).expect("runner metadata");
+        fs::create_dir_all(workspace.path().join("docs")).expect("docs");
+        fs::write(workspace.path().join("tracked.txt"), "before\n").expect("tracked");
+        fs::write(workspace.path().join("docs/superpowers"), "before\n").expect("excluded");
+        let snapshot = SourceSnapshot::existing_remote("lab", "/runner/workspace", None);
+        let snapshot = SourceSnapshot {
+            sync_excludes: vec!["docs/superpowers".to_string()],
+            ..snapshot
+        };
+        let baseline = capture_baseline(&workspace.path().display().to_string(), Some(&snapshot))
+            .expect("baseline");
+        fs::write(workspace.path().join("tracked.txt"), "after\n").expect("tracked change");
+        fs::write(
+            workspace.path().join(".homeboy/runner-workspace.json"),
+            "removed later\n",
+        )
+        .expect("runner metadata");
+        fs::write(workspace.path().join("docs/superpowers"), "after\n").expect("excluded change");
+
+        let report = capture_patch_report(
+            uuid::Uuid::new_v4(),
+            "lab",
+            &workspace.path().display().to_string(),
+            &["true".to_string()],
+            Some(&snapshot),
+            &baseline,
+            0,
+        )
+        .expect("patch report");
+
+        assert_eq!(report.modified_files, vec!["tracked.txt".to_string()]);
     }
 
     #[test]
@@ -442,7 +511,7 @@ mod tests {
                 Some(String::new())
             );
 
-            let baseline = capture_baseline(&sync.remote_path).expect("capture baseline");
+            let baseline = capture_baseline(&sync.remote_path, None).expect("capture baseline");
             fs::write(remote.join("tracked.txt"), "after\n").expect("modify tracked file");
             let report = capture_patch_report(
                 uuid::Uuid::new_v4(),

--- a/crates/homeboy-core/src/runner/evidence/mirror.rs
+++ b/crates/homeboy-core/src/runner/evidence/mirror.rs
@@ -1,5 +1,3 @@
-use std::fs;
-
 use serde_json::{json, Value};
 
 use crate::api_jobs::{Job, JobArtifactMetadata, JobEvent, JobStatus};
@@ -19,7 +17,7 @@ use super::detail::{
     explicit_observation_run_ids, remote_detail_artifacts, remote_detail_to_run_record,
     remote_run_matches_job_window,
 };
-use super::tokens::is_retrievable_runner_artifact;
+use super::tokens::{is_retrievable_runner_artifact, runner_artifact_token};
 use super::util::{
     job_status_as_run_status, local_job_run_id, ms_to_rfc3339, result_summary,
     runner_exec_run_label, runner_metadata, source_snapshot_from_result,
@@ -292,23 +290,16 @@ pub(super) fn mirrored_patch_result(
             ))
         })?;
 
-    let accessible = is_retrievable_runner_artifact(&artifact.path)
-        || fs::metadata(&artifact.path)
-            .map(|metadata| metadata.is_file())
-            .unwrap_or(false);
-    if !accessible {
-        return Err(Error::internal_unexpected(format!(
-            "runner capture-patch artifact {artifact_id} was mirrored for runner {}, but its mirrored path is not accessible: {}",
-            runner.id, artifact.path
-        )));
-    }
-
     let mut patched = patch.clone();
     if let Some(object) = patched.as_object_mut() {
-        object.insert(
-            "patch_artifact_path".to_string(),
-            Value::String(artifact.path),
-        );
+        // The controller cannot rely on the runner-local artifact path. Keep
+        // the patch on the daemon artifact route so promotion can fetch it.
+        let path = if is_retrievable_runner_artifact(&artifact.path) {
+            artifact.path
+        } else {
+            runner_artifact_token(&runner.id, &expected_run_id, artifact_id)
+        };
+        object.insert("patch_artifact_path".to_string(), Value::String(path));
     }
     Ok(Some(patched))
 }

--- a/crates/homeboy-core/src/runner/evidence/tests/mod.rs
+++ b/crates/homeboy-core/src/runner/evidence/tests/mod.rs
@@ -489,6 +489,11 @@ fn test_mirrored_patch_result_reports_accessible_artifact_token() {
             .expect("patch");
 
         assert_eq!(mirrored["patch_artifact_path"], token);
+        assert!(is_retrievable_runner_artifact(
+            mirrored["patch_artifact_path"]
+                .as_str()
+                .expect("projected patch artifact token")
+        ));
     });
 }
 

--- a/crates/homeboy-core/src/runner/lab/offload/inner.rs
+++ b/crates/homeboy-core/src/runner/lab/offload/inner.rs
@@ -421,6 +421,20 @@ pub(crate) fn exec_lab_context(
             if let Some(workspace) = context.materialized_workspace.as_mut() {
                 workspace.preserve();
             }
+            if let Some(run_id) = context.agent_task_run_id.as_deref() {
+                if let Some(job_id) = accepted_runner_job_id(runner_id, run_id) {
+                    return in_flight_daemon_disconnect_outcome(
+                        context.plan,
+                        runner_id,
+                        &job_id,
+                        run_id,
+                        &remote_cwd,
+                        &context.remote_command,
+                        "daemon accepted the durable job before the exec response was lost",
+                        &err,
+                    );
+                }
+            }
             let health = runner_daemon_health_failure(&err);
             let in_flight_job_id = health
                 .as_ref()
@@ -733,6 +747,35 @@ pub(crate) fn exec_lab_context(
         exit_code,
         output_file_content,
     })
+}
+
+/// `/exec` is not an idempotent operation. When its response is lost, query the
+/// daemon's durable active-job projection by the preassigned run ID rather than
+/// submitting the workload again.
+fn accepted_runner_job_id(runner_id: &str, run_id: &str) -> Option<String> {
+    accepted_runner_job_id_with(runner_id, run_id, || crate::runner::status(runner_id))
+}
+
+pub(crate) fn accepted_runner_job_id_with<F>(
+    runner_id: &str,
+    run_id: &str,
+    status: F,
+) -> Option<String>
+where
+    F: FnOnce() -> Result<crate::runner::RunnerStatusReport>,
+{
+    let status = status().ok()?;
+    if status.runner_id != runner_id {
+        return None;
+    }
+    let mut matching = status
+        .active_runner_jobs
+        .into_iter()
+        .filter(|job| job.durable_run_id.as_deref() == Some(run_id))
+        .map(|job| job.job_id)
+        .collect::<Vec<_>>();
+    matching.sort();
+    (matching.len() == 1).then(|| matching.remove(0))
 }
 
 fn promotion_handoff_intent(args: &[String], stdout: &str) -> Result<Option<PromotionPatchIntent>> {

--- a/crates/homeboy-core/src/runner/lab/offload/mod.rs
+++ b/crates/homeboy-core/src/runner/lab/offload/mod.rs
@@ -116,6 +116,9 @@ use super::super::{
     RunnerWorkspaceSyncOutput, WorkspaceCleanupPolicy,
 };
 
+#[cfg(test)]
+pub(super) use inner::accepted_runner_job_id_with;
+
 use super::super::workload::{
     build_runner_workload_for_dispatched_command, runner_workload_agent_task_from_command,
     RunnerWorkloadBuildInput,

--- a/crates/homeboy-core/src/runner/lab/offload/tests/exec_errors.rs
+++ b/crates/homeboy-core/src/runner/lab/offload/tests/exec_errors.rs
@@ -20,6 +20,74 @@ fn apply_patch_step_accepts_noop_mutation_return() {
 }
 
 #[test]
+fn lost_exec_response_reconciles_the_single_accepted_durable_job() {
+    crate::test_support::with_isolated_home(|_| {
+        let run_id = "cook-8525-attempt-1";
+        crate::agent_task_lifecycle::record_lab_offload_phase(
+            run_id,
+            "homeboy-lab",
+            "dispatching",
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("record controller proxy before daemon acceptance");
+        let mut status = reverse_status("homeboy-lab");
+        status.active_runner_jobs.push(crate::runner::RunnerJob {
+            runner_id: "homeboy-lab".to_string(),
+            job_id: "job-8525".to_string(),
+            operation: "runner.exec".to_string(),
+            status: crate::api_jobs::JobStatus::Running,
+            command: "homeboy agent-task cook".to_string(),
+            cwd: Some("/runner/workspace".to_string()),
+            source: "runner-daemon".to_string(),
+            lifecycle_owner: crate::runner::RunnerLifecycleOwner::Controller,
+            lifecycle: None,
+            started_at_ms: Some(1),
+            updated_at_ms: Some(1),
+            elapsed_ms: Some(1),
+            heartbeat_age_ms: Some(1),
+            claim: Default::default(),
+            claim_expires_in_ms: None,
+            durable_run_id: Some(run_id.to_string()),
+            stale_reason: None,
+            lifecycle_state: Some("running".to_string()),
+            retryable: Some(false),
+            artifact_refs: Vec::new(),
+        });
+
+        let response_error = Error::internal_unexpected("/exec response connection reset");
+        let job_id = accepted_runner_job_id_with("homeboy-lab", run_id, || Ok(status))
+            .expect("reconcile exactly one accepted daemon job");
+        let outcome = in_flight_daemon_disconnect_outcome(
+            base_lab_plan(Some(&portable_lab_command("agent-task cook"))),
+            "homeboy-lab",
+            &job_id,
+            run_id,
+            "/runner/workspace",
+            &[
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+            ],
+            "daemon accepted the durable job before the exec response was lost",
+            &response_error,
+        )
+        .expect("accepted job must become an in-flight outcome");
+
+        assert!(matches!(outcome, LabOffloadOutcome::InFlight { .. }));
+        let record = crate::agent_task_lifecycle::status(run_id).expect("controller record");
+        assert_eq!(
+            record.state,
+            crate::agent_task_lifecycle::AgentTaskRunState::Running
+        );
+        assert_eq!(record.runner_job_id(), Some("job-8525"));
+        assert!(record.metadata.get("pre_execution_failure").is_none());
+    });
+}
+
+#[test]
 fn lab_remote_dispatch_preflight_requires_configured_homeboy_path() {
     let runner = crate::runner::Runner {
         id: "lab-default".to_string(),


### PR DESCRIPTION
## Summary
Reconcile accepted Lab jobs after lost responses and keep runner-owned files out of portable patches.

## What changed
- Recognize a uniquely accepted durable daemon job before recording pre-execution failure.
- Apply staged sync exclusions and .homeboy exclusion during before/after patch capture.
- Project runner-local patch paths to retrievable runner-artifact tokens for promotion.

## How to test
1. Run `cargo test -p homeboy-core runner::lab::offload::tests::exec_errors::lost_exec_response_reconciles_the_single_accepted_durable_job --lib`; expect The accepted durable job remains in flight without a pre-execution failure..
2. Run `cargo test -p homeboy-core runner::evidence::tests::test_mirrored_patch_result_reports_accessible_artifact_token --lib`; expect The projected patch address is retrievable through runner-artifact..
3. Run `cargo test -p homeboy-core daemon::patch_capture::tests::capture_patch_report_excludes_runner_metadata_and_staged_excludes --lib`; expect Only intended source changes appear in the captured patch..
4. Run `cargo check -p homeboy-core && cargo fmt --check`; expect The core crate compiles and formatting is clean..

## Compatibility
No public CLI flags or schemas change. Lost-response handling now preserves an accepted in-flight job, and patch artifacts omit runner-owned/excluded files.

## Evidence
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8525
- cargo\_check: Passed
- format: Passed
- targeted\_tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Reproduced the Lab handoff and promotion failures, implemented generic reconciliation and patch-capture fixes, and added deterministic coverage; Chris reviewed and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8525
