### PR TITLE
Mirror detached artifacts for promotion

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
@@ -675,17 +675,71 @@ pub(crate) fn project_terminal_artifacts(
                         )?;
                     }
                     None => {
-                        // Keep the remote reference available for existing Lab
-                        // retrieval flows, but leave an actionable lifecycle
-                        // marker because it cannot satisfy local promotion.
+                        let remote_ref = crate::execution_contract::EXECUTION_CONTRACT
+                            .artifacts
+                            .runner_artifact_ref(runner_id, &record.run_id, &logical_id);
+                        let mirror_result = (|| -> Result<()> {
+                            let mirror = tempfile::NamedTempFile::new().map_err(|error| {
+                                Error::internal_io(
+                                    error.to_string(),
+                                    Some("create controller artifact mirror".to_string()),
+                                )
+                            })?;
+                            let download = crate::runners::download_remote_artifact(
+                                &remote_ref,
+                                Some(mirror.path().to_path_buf()),
+                            )?;
+                            let expected_size = artifact.size_bytes.expect("checked above");
+                            let expected_sha256 =
+                                artifact.sha256.as_deref().expect("checked above");
+                            let actual_size = std::fs::metadata(&download.output_path)
+                                .map_err(|error| {
+                                    Error::internal_io(
+                                        error.to_string(),
+                                        Some("inspect controller artifact mirror".to_string()),
+                                    )
+                                })?
+                                .len();
+                            let actual_sha256 =
+                                crate::artifact_metadata::sha256_file(&download.output_path)?;
+                            if actual_size != expected_size || actual_sha256 != expected_sha256 {
+                                return Err(Error::validation_invalid_argument(
+                                    "artifact_id",
+                                    format!(
+                                        "runner artifact mirror for run '{}', task '{}', and artifact '{}' does not match the aggregate SHA-256 and size",
+                                        record.run_id, outcome.task_id, artifact.id
+                                    ),
+                                    Some(artifact.id.clone()),
+                                    None,
+                                ));
+                            }
+                            let mut controller_hash = sha2::Sha256::new();
+                            sha2::Digest::update(&mut controller_hash, b"controller");
+                            sha2::Digest::update(&mut controller_hash, [0]);
+                            sha2::Digest::update(&mut controller_hash, artifact_id.as_bytes());
+                            let controller_artifact_id =
+                                format!("agent-task-{:x}", controller_hash.finalize());
+                            let mut controller_metadata = metadata.clone();
+                            controller_metadata["agent_task"]["projection"] =
+                                json!("runner_mirrored");
+                            store.record_artifact_with_id(
+                                &record.run_id,
+                                &artifact.kind,
+                                &download.output_path,
+                                &controller_artifact_id,
+                                controller_metadata,
+                            )?;
+                            Ok(())
+                        })();
+
+                        // Preserve the canonical runner retrieval alias even when
+                        // the controller also materializes verified bytes.
                         store.import_artifact(&crate::observation::ArtifactRecord {
                             id: artifact_id,
                             run_id: record.run_id.clone(),
                             kind: artifact.kind.clone(),
                             artifact_type: "remote_file".to_string(),
-                            path: crate::execution_contract::EXECUTION_CONTRACT
-                                .artifacts
-                                .runner_artifact_ref(runner_id, &record.run_id, &logical_id),
+                            path: remote_ref,
                             url: None,
                             public_url: None,
                             viewer_url: None,
@@ -698,17 +752,9 @@ pub(crate) fn project_terminal_artifacts(
                             metadata_json: metadata,
                             created_at: chrono::Utc::now().to_rfc3339(),
                         })?;
-                        projection_error.get_or_insert_with(|| {
-                            Error::validation_invalid_argument(
-                                "artifact.path",
-                                format!(
-                                    "controller-finalized bytes for run '{}', task '{}', and artifact '{}' were not found with the aggregate SHA-256 and size",
-                                    record.run_id, outcome.task_id, logical_id
-                                ),
-                                Some(artifact.id.clone()),
-                                None,
-                            )
-                        });
+                        if let Err(error) = mirror_result {
+                            projection_error.get_or_insert(error);
+                        }
                     }
                 }
             } else {

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -1860,12 +1860,25 @@ fn controller_leaves_runner_artifact_projection_pending_when_it_cannot_mirror_by
             .as_str()
             .is_some_and(|error| !error.is_empty()));
         let store = crate::observation::ObservationStore::open_initialized().expect("store");
-        assert!(crate::observation::runs_service::resolve_artifact_for_run(
+        let remote_alias = crate::observation::runs_service::resolve_artifact_for_run(
             &store,
             &submitted.run_id,
             "patch",
         )
-        .is_err());
+        .expect("runner artifact alias remains available");
+        assert_eq!(remote_alias.artifact_type, "remote_file");
+        assert!(crate::execution_contract::is_remote_runner_artifact_path(
+            &remote_alias.path
+        ));
+        assert_eq!(
+            verified_controller_artifact_projection_path(
+                &submitted.run_id,
+                &aggregate.outcomes[0].task_id,
+                &aggregate.outcomes[0].artifacts[0],
+            )
+            .expect("verify controller projection"),
+            None,
+        );
     });
 }
 

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -1707,7 +1707,113 @@ fn terminal_executor_artifacts_are_projected_under_logical_ids() {
 }
 
 #[test]
-fn controller_projects_runner_artifact_aliases_with_encoded_retrieval_tokens() {
+fn controller_mirrors_verified_detached_runner_artifact_into_a_local_projection() {
+    with_isolated_home(|_| {
+        use sha2::Digest;
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let patch = b"patch bytes";
+        let sha256 = format!("{:x}", sha2::Sha256::digest(patch));
+        let response_sha256 = sha256.clone();
+        let listener = TcpListener::bind("127.0.0.1:0").expect("runner daemon listener");
+        let address = listener.local_addr().expect("runner daemon address");
+        std::thread::spawn(move || {
+            for _ in 0..5 {
+                let (mut stream, _) = listener.accept().expect("runner daemon request");
+                let mut request = [0; 1024];
+                let read = stream.read(&mut request).expect("read runner request");
+                if read == 0 {
+                    continue;
+                }
+                let request = String::from_utf8_lossy(&request[..read]);
+                if request.starts_with("GET /runs/detached-run/artifacts/patch/content ") {
+                    write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nX-Homeboy-Artifact-Sha256: {response_sha256}\r\nConnection: close\r\n\r\n{}",
+                        patch.len(),
+                        String::from_utf8_lossy(patch),
+                    )
+                    .expect("write artifact response");
+                } else {
+                    write!(
+                        stream,
+                        "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    )
+                    .expect("write jobs response");
+                }
+            }
+        });
+        let session = crate::runner::RunnerSession {
+            runner_id: "local".to_string(),
+            mode: crate::runner::RunnerTunnelMode::DirectSsh,
+            role: crate::runner::RunnerSessionRole::Controller,
+            server_id: None,
+            controller_id: None,
+            broker_url: None,
+            remote_daemon_address: None,
+            local_port: Some(address.port()),
+            local_url: Some(format!("http://{address}")),
+            tunnel_pid: None,
+            remote_daemon_pid: None,
+            remote_daemon_lease_id: None,
+            homeboy_version: "test".to_string(),
+            homeboy_build_identity: None,
+            connected_at: now_timestamp(),
+            worker_identity: None,
+            worker_pid: None,
+            last_seen_at: None,
+            leaseless_recovery_evidence: None,
+        };
+        let session_path = crate::paths::runner_session_file("local").expect("session path");
+        std::fs::create_dir_all(session_path.parent().expect("session parent"))
+            .expect("create session parent");
+        std::fs::write(
+            session_path,
+            serde_json::to_string(&session).expect("session JSON"),
+        )
+        .expect("write session");
+
+        let plan = test_plan();
+        let mut aggregate = succeeded_aggregate(&plan);
+        aggregate.outcomes[0].artifacts.push(AgentTaskArtifact {
+            schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+            id: "patch".to_string(),
+            kind: "patch".to_string(),
+            name: None,
+            label: None,
+            role: None,
+            semantic_key: None,
+            path: Some("/home/runner/.homeboy/executor-finalized/patch.diff".to_string()),
+            url: None,
+            mime: Some("text/x-patch".to_string()),
+            size_bytes: Some(patch.len() as u64),
+            sha256: Some(sha256),
+            metadata: json!({ "executor_artifact_finalized": true }),
+        });
+        submit_plan(&plan, Some("detached-run")).expect("submit");
+        record_runner_job_identity("detached-run", "local", "job-1").expect("runner identity");
+        record_run_aggregate("detached-run", &plan, &aggregate).expect("reconcile aggregate");
+
+        let record = status("detached-run").expect("status");
+        assert_eq!(record.metadata["artifact_projection"]["status"], "complete");
+        let store = crate::observation::ObservationStore::open_initialized().expect("store");
+        let artifact = crate::observation::runs_service::resolve_artifact_for_run(
+            &store,
+            "detached-run",
+            "patch",
+        )
+        .expect("controller projection");
+        assert_eq!(artifact.artifact_type, "file");
+        assert_eq!(
+            std::fs::read(artifact.path).expect("projection bytes"),
+            patch
+        );
+    });
+}
+
+#[test]
+fn controller_leaves_runner_artifact_projection_pending_when_it_cannot_mirror_bytes() {
     with_isolated_home(|_| {
         let plan = test_plan();
         let mut aggregate = succeeded_aggregate(&plan);
@@ -1748,32 +1854,18 @@ fn controller_projects_runner_artifact_aliases_with_encoded_retrieval_tokens() {
             .expect("runner identity");
         record_run_aggregate(&submitted.run_id, &plan, &aggregate).expect("controller projection");
 
+        let record = status(&submitted.run_id).expect("status");
+        assert_eq!(record.metadata["artifact_projection"]["status"], "pending");
+        assert!(record.metadata["artifact_projection"]["error"]
+            .as_str()
+            .is_some_and(|error| !error.is_empty()));
         let store = crate::observation::ObservationStore::open_initialized().expect("store");
-        let patch = crate::observation::runs_service::resolve_artifact_for_run(
+        assert!(crate::observation::runs_service::resolve_artifact_for_run(
             &store,
             &submitted.run_id,
             "patch",
         )
-        .expect("patch alias");
-        let report = crate::observation::runs_service::resolve_artifact_for_run(
-            &store,
-            &submitted.run_id,
-            "task-a-patch",
-        )
-        .expect("duplicate alias");
-        assert_eq!(patch.artifact_type, "remote_file");
-        assert_eq!(
-            patch.path,
-            crate::execution_contract::EXECUTION_CONTRACT
-                .artifacts
-                .runner_artifact_ref("runner/a:lab", &submitted.run_id, "patch")
-        );
-        assert_eq!(
-            report.path,
-            crate::execution_contract::EXECUTION_CONTRACT
-                .artifacts
-                .runner_artifact_ref("runner/a:lab", &submitted.run_id, "task-a-patch")
-        );
+        .is_err());
     });
 }
 


### PR DESCRIPTION
## Summary

- mirror detached runner artifacts into the controller artifact store during reconciliation
- verify downloaded bytes against recorded SHA-256 and size before marking projection complete
- keep projection pending when retrieval or integrity validation fails
- preserve remote artifact aliases while requiring verified controller-owned files for promotion

Fixes the remaining promotion failure documented in https://github.com/Extra-Chill/homeboy/issues/8508#issuecomment-4994823159

## How to test

1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-core controller_mirrors_verified_detached_runner_artifact_into_a_local_projection --lib`.
3. Run `cargo test -p homeboy-core controller_leaves_runner_artifact_projection_pending_when_it_cannot_mirror_bytes --lib`.
4. Run `cargo test -p homeboy-core promotion_uses_verified_controller_projection_for_recovered_runner_aggregate_sources --lib`.
5. Run `cargo test -p homeboy-core promotion_rejects_missing_or_mismatched_recovered_controller_projection --lib`.
6. Run `git diff --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed the controller/runner artifact ownership gap, implemented verified mirroring and fail-closed coverage, resolved upstream rebase changes, and verified the repair with Chris.