### PR TITLE
refactor: invert agent-task-scheduler→runner lab-workspace verify via hook (runner-decouple)

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -107,6 +107,10 @@ impl CliRuntime {
         // the secret-env plan and validate workload dispatch for remote-runner
         // jobs without core depending on runner behavior.
         crate::core::runner::register_runner_job_preparation_provider();
+        // Register the lab-workspace provenance provider so the agent-task
+        // scheduler can verify lab-materialized workspaces without core depending
+        // on runner behavior.
+        crate::core::runner::register_lab_workspace_provenance_provider();
         // Register the command-label resolver so core::runner can map dispatched
         // argv to a hot-command label without depending on the full CLI parser.
         crate::core::runner::set_command_label_resolver(|argv| {

--- a/crates/homeboy-core/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-core/src/agent_task_scheduler/attempt_workspace.rs
@@ -164,16 +164,21 @@ pub(super) fn prepare_committed_harvest(
             "parent_snapshot": capability.parent_snapshot(),
         }))
     } else if snapshot_signaled {
-        let provenance = crate::runner::verify_lab_workspace(
-            &root.display().to_string(),
-            root,
-            context.source_snapshot()?,
-            context.lab_offload()?,
-        )
+        let source_snapshot = context.source_snapshot()?;
+        let lab_offload = context.lab_offload()?;
+        let provenance = lab_workspace_provenance::with_lab_workspace_provenance(|p| {
+            p.verify_lab_workspace(
+                &root.display().to_string(),
+                root,
+                source_snapshot,
+                lab_offload,
+                is_repository,
+            )
+        })
         .map_err(snapshot_harvest_error)?;
         if is_repository {
-            crate::runner::verify_lab_workspace_git_root(root, &provenance)
-                .map_err(snapshot_harvest_error)?;
+            // git-root verification is folded into verify_lab_workspace above via
+            // require_git_root = is_repository.
         } else {
             if provenance.materialization_mode == "git" {
                 return Err(snapshot_harvest_error(
@@ -217,12 +222,16 @@ pub(super) fn prepare_committed_harvest(
         None
     };
     if !is_repository {
-        crate::runner::materialize_verified_lab_snapshot_git_baseline(
-            &root.display().to_string(),
-            root,
-            context.source_snapshot()?,
-            context.lab_offload()?,
-        )
+        let source_snapshot = context.source_snapshot()?;
+        let lab_offload = context.lab_offload()?;
+        lab_workspace_provenance::with_lab_workspace_provenance(|p| {
+            p.materialize_verified_lab_snapshot_git_baseline(
+                &root.display().to_string(),
+                root,
+                source_snapshot,
+                lab_offload,
+            )
+        })
         .map_err(|message| HarvestError::Git {
             command: "materialize verified Lab snapshot Git baseline".to_string(),
             message,

--- a/crates/homeboy-core/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-core/src/agent_task_scheduler/harvest.rs
@@ -839,6 +839,10 @@ mod committed_harvest_tests {
 
     #[test]
     fn authorized_dirty_lab_snapshot_preflight_materializes_a_provider_ready_attempt_workspace() {
+        // Exercises lab-workspace provenance verification, which lives behind the
+        // LabWorkspaceProvenanceProvider hook. Register the runner provider
+        // (normally done at CLI startup) so verification runs.
+        crate::runner::register_lab_workspace_provenance_provider();
         let _guard = LAB_ENV_LOCK
             .get_or_init(|| Mutex::new(()))
             .lock()

--- a/crates/homeboy-core/src/agent_task_scheduler/lab_workspace_provenance.rs
+++ b/crates/homeboy-core/src/agent_task_scheduler/lab_workspace_provenance.rs
@@ -1,0 +1,146 @@
+//! Lab-workspace provenance provider hook.
+//!
+//! When the agent-task scheduler harvests a cook attempt's workspace it must
+//! verify the lab-materialized workspace's provenance (and, for git-mode,
+//! synthesize a baseline). That verification is coupled to the runner's
+//! workspace-snapshot machinery, but runner is an optional Lab-offload feature,
+//! so core defines the [`LabWorkspaceProvenanceProvider`] contract here and the
+//! runner layer registers an implementation at startup.
+//!
+//! With no provider registered there is no lab workspace to verify, so the
+//! [`NoopLabWorkspaceProvenanceProvider`] reports a clear error — this path is
+//! only reached when a snapshot was actually signaled by a runner.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use crate::source_snapshot::SourceSnapshot;
+
+/// The verified provenance of a lab-materialized workspace, slimmed to the
+/// fields the scheduler records. The full provenance stays runner-internal.
+#[derive(Debug, Clone, Default)]
+pub struct LabWorkspaceProvenanceInfo {
+    pub source_revision: String,
+    pub materialization_mode: String,
+    pub runner_id: String,
+    pub workspace_identity: String,
+    pub snapshot_hash: String,
+}
+
+/// The lab-workspace provenance contract the agent-task scheduler depends on.
+/// Implemented by the runner layer and registered at startup.
+pub trait LabWorkspaceProvenanceProvider: Send + Sync {
+    /// Verify a materialized lab workspace and return its provenance. When
+    /// `require_git_root` is set, also verify the workspace's git-root metadata
+    /// (the paired `verify_lab_workspace_git_root` check).
+    fn verify_lab_workspace(
+        &self,
+        expected_remote_component_path: &str,
+        materialized_workspace_path: &Path,
+        snapshot: SourceSnapshot,
+        lab: serde_json::Value,
+        require_git_root: bool,
+    ) -> std::result::Result<LabWorkspaceProvenanceInfo, String>;
+
+    /// Materialize a synthetic Git baseline for a verified snapshot workspace,
+    /// returning the baseline commit.
+    fn materialize_verified_lab_snapshot_git_baseline(
+        &self,
+        expected_remote_component_path: &str,
+        materialized_workspace_path: &Path,
+        snapshot: SourceSnapshot,
+        lab: serde_json::Value,
+    ) -> std::result::Result<String, String>;
+}
+
+/// Default provider used when no runner layer is registered. The verification
+/// path is only reached after a runner signaled a snapshot, so without a
+/// provider there is nothing to verify and both methods report a clear error.
+struct NoopLabWorkspaceProvenanceProvider;
+
+const NO_PROVIDER: &str =
+    "no runner is registered to verify the lab-materialized workspace provenance";
+
+impl LabWorkspaceProvenanceProvider for NoopLabWorkspaceProvenanceProvider {
+    fn verify_lab_workspace(
+        &self,
+        _expected_remote_component_path: &str,
+        _materialized_workspace_path: &Path,
+        _snapshot: SourceSnapshot,
+        _lab: serde_json::Value,
+        _require_git_root: bool,
+    ) -> std::result::Result<LabWorkspaceProvenanceInfo, String> {
+        Err(NO_PROVIDER.to_string())
+    }
+
+    fn materialize_verified_lab_snapshot_git_baseline(
+        &self,
+        _expected_remote_component_path: &str,
+        _materialized_workspace_path: &Path,
+        _snapshot: SourceSnapshot,
+        _lab: serde_json::Value,
+    ) -> std::result::Result<String, String> {
+        Err(NO_PROVIDER.to_string())
+    }
+}
+
+static PROVIDER: Mutex<Option<Box<dyn LabWorkspaceProvenanceProvider>>> = Mutex::new(None);
+
+/// Register the lab-workspace provenance provider. Called once at startup by the
+/// runner layer (via the CLI).
+pub fn register_lab_workspace_provenance_provider(
+    provider: Box<dyn LabWorkspaceProvenanceProvider>,
+) {
+    let mut guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = Some(provider);
+}
+
+/// Run `f` against the registered provider, or the no-op provider if none is
+/// registered.
+pub(crate) fn with_lab_workspace_provenance<T>(
+    f: impl FnOnce(&dyn LabWorkspaceProvenanceProvider) -> T,
+) -> T {
+    let guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    match guard.as_ref() {
+        Some(provider) => f(provider.as_ref()),
+        None => f(&NoopLabWorkspaceProvenanceProvider),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_verify_errors_clearly() {
+        let noop = NoopLabWorkspaceProvenanceProvider;
+        let err = noop
+            .verify_lab_workspace(
+                "path",
+                Path::new("/tmp/x"),
+                SourceSnapshot::default(),
+                serde_json::Value::Null,
+                false,
+            )
+            .expect_err("must error without a provider");
+        assert!(err.contains("no runner is registered"));
+    }
+
+    #[test]
+    fn noop_materialize_errors_clearly() {
+        let noop = NoopLabWorkspaceProvenanceProvider;
+        let err = noop
+            .materialize_verified_lab_snapshot_git_baseline(
+                "path",
+                Path::new("/tmp/x"),
+                SourceSnapshot::default(),
+                serde_json::Value::Null,
+            )
+            .expect_err("must error without a provider");
+        assert!(err.contains("no runner is registered"));
+    }
+}

--- a/crates/homeboy-core/src/agent_task_scheduler/mod.rs
+++ b/crates/homeboy-core/src/agent_task_scheduler/mod.rs
@@ -7,6 +7,7 @@ mod attempt_workspace;
 mod candidate_adoption;
 mod engine;
 mod harvest;
+pub mod lab_workspace_provenance;
 mod outcome;
 mod outcome_artifacts;
 mod outcome_status;

--- a/crates/homeboy-core/src/runner/lab_workspace_provenance_provider.rs
+++ b/crates/homeboy-core/src/runner/lab_workspace_provenance_provider.rs
@@ -1,0 +1,71 @@
+//! Runner-side implementation of core's `LabWorkspaceProvenanceProvider` hook.
+//!
+//! Core's agent-task scheduler calls this contract to verify a lab-materialized
+//! workspace's provenance without depending on runner behavior. This adapter
+//! delegates to the runner's workspace-provenance functions and maps the full
+//! runner provenance onto the slim core-facing type.
+
+use std::path::Path;
+
+use crate::agent_task_scheduler::lab_workspace_provenance::{
+    LabWorkspaceProvenanceInfo, LabWorkspaceProvenanceProvider,
+};
+use crate::source_snapshot::SourceSnapshot;
+
+/// The runner layer's `LabWorkspaceProvenanceProvider`. Registered with core at
+/// startup.
+pub struct LabWorkspaceProvenance;
+
+impl LabWorkspaceProvenanceProvider for LabWorkspaceProvenance {
+    fn verify_lab_workspace(
+        &self,
+        expected_remote_component_path: &str,
+        materialized_workspace_path: &Path,
+        snapshot: SourceSnapshot,
+        lab: serde_json::Value,
+        require_git_root: bool,
+    ) -> std::result::Result<LabWorkspaceProvenanceInfo, String> {
+        let provenance = super::workspace::verify_lab_workspace(
+            expected_remote_component_path,
+            materialized_workspace_path,
+            snapshot,
+            lab,
+        )?;
+        if require_git_root {
+            super::workspace::verify_lab_workspace_git_root(
+                materialized_workspace_path,
+                &provenance,
+            )?;
+        }
+        Ok(LabWorkspaceProvenanceInfo {
+            source_revision: provenance.source_revision,
+            materialization_mode: provenance.materialization_mode,
+            runner_id: provenance.runner_id,
+            workspace_identity: provenance.workspace_identity,
+            snapshot_hash: provenance.snapshot_hash,
+        })
+    }
+
+    fn materialize_verified_lab_snapshot_git_baseline(
+        &self,
+        expected_remote_component_path: &str,
+        materialized_workspace_path: &Path,
+        snapshot: SourceSnapshot,
+        lab: serde_json::Value,
+    ) -> std::result::Result<String, String> {
+        super::workspace::materialize_verified_lab_snapshot_git_baseline(
+            expected_remote_component_path,
+            materialized_workspace_path,
+            snapshot,
+            lab,
+        )
+    }
+}
+
+/// Register the lab-workspace provenance provider with core. Called once at
+/// startup.
+pub fn register() {
+    crate::agent_task_scheduler::lab_workspace_provenance::register_lab_workspace_provenance_provider(
+        Box::new(LabWorkspaceProvenance),
+    );
+}

--- a/crates/homeboy-core/src/runner/mod.rs
+++ b/crates/homeboy-core/src/runner/mod.rs
@@ -38,6 +38,7 @@ mod git_dependency_materialization;
 mod homeboy_refresh;
 mod job_preparation;
 mod lab;
+mod lab_workspace_provenance_provider;
 #[cfg(test)]
 pub(crate) use lab::mirror_agent_task_run_plan_aggregate;
 mod lab_apply;
@@ -72,9 +73,13 @@ mod worker;
 pub(crate) mod workload;
 mod workspace;
 pub(crate) use workspace::copy_snapshot_to_directory;
+// Only test code (extension::trace::canonicality) still calls verify_lab_workspace
+// directly; production goes through the LabWorkspaceProvenanceProvider hook.
+#[cfg(test)]
+pub(crate) use workspace::verify_lab_workspace;
 #[cfg(test)]
 pub(crate) use workspace::workspace_resource_lifecycle;
-pub(crate) use workspace::{materialize_verified_lab_snapshot_git_baseline, verify_lab_workspace};
+
 pub(crate) use workspace::{MaterializedWorkspace, WorkspaceCleanupPolicy};
 
 pub use apply::{
@@ -144,6 +149,7 @@ pub use lab::{
 #[cfg(test)]
 pub(crate) use lab_env::build_lab_offload_env;
 pub use lab_selection::prepare_explicit_lab_runner_for_offload;
+pub use lab_workspace_provenance_provider::register as register_lab_workspace_provenance_provider;
 pub use offload_changed_since::{
     lab_offload_changed_since_ref, preflight_lab_offload_changed_since,
     prepare_git_lab_offload_changed_since,
@@ -182,9 +188,9 @@ pub use workspace::{
     RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 pub(crate) use workspace::{
-    verify_lab_workspace_from_env, verify_lab_workspace_git_root, workspace_content_hash,
-    workspace_content_hash_algorithm, workspace_content_manifest_for_policy,
-    VerifiedLabWorkspaceProvenance, WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+    verify_lab_workspace_from_env, workspace_content_hash, workspace_content_hash_algorithm,
+    workspace_content_manifest_for_policy, VerifiedLabWorkspaceProvenance,
+    WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
 };
 
 // RunnerKind now lives in the shared runner-contract crate so core code can

--- a/crates/homeboy-core/src/source_snapshot.rs
+++ b/crates/homeboy-core/src/source_snapshot.rs
@@ -73,7 +73,7 @@ impl Default for SourceSnapshotPolicy {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SourceSnapshot {
     pub runner_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary
Third behavioral hook in the runner campaign (after evidence #8532 and job-preparation #8536). `agent_task_scheduler::attempt_workspace` called three runner functions to verify a lab-materialized cook workspace (`verify_lab_workspace`, `verify_lab_workspace_git_root`, `materialize_verified_lab_snapshot_git_baseline`). That verification is coupled to the runner's workspace-snapshot machinery — runner is an optional Lab-offload feature, so core must not depend on it.

## Design — LabWorkspaceProvenanceProvider hook
- **Core** owns the trait + registry + `NoopProvider` + a slim `LabWorkspaceProvenanceInfo` type (the 5 provenance fields the scheduler records) in `agent_task_scheduler/lab_workspace_provenance.rs`. The full runner provenance stays runner-internal.
- The **runner layer** implements it (`runner/lab_workspace_provenance_provider.rs`), folding the always-paired `verify` + `verify_git_root` into one call (`require_git_root` flag), and registers at CLI startup.
- `attempt_workspace` calls the provider via `with_lab_workspace_provenance(...)`.

## NoopProvider semantics
Errors clearly — this path is only reached after a runner signaled a snapshot, so without a provider there is genuinely nothing to verify.

## Notes
- Derives `Default` on `SourceSnapshot` (all-optional plain data) for test construction.
- Two tests exercising the real verification path (`harvest::authorized_dirty...`, `extension::trace::canonicality` via a test-only re-export) register the runner provider first, as CLI startup does.

## Impact
Severs **all three** attempt_workspace lab-workspace edges.

## Verification
`cargo check` clean for `-p homeboy-core --lib/--tests` and `-p homeboy-cli --lib`; hook + harvest + canonicality tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)