### PR TITLE
refactor: route failure_recording artifact download through evidence hook (runner-decouple)

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
@@ -685,10 +685,15 @@ pub(crate) fn project_terminal_artifacts(
                                     Some("create controller artifact mirror".to_string()),
                                 )
                             })?;
-                            let download = crate::runners::download_remote_artifact(
-                                &remote_ref,
-                                Some(mirror.path().to_path_buf()),
-                            )?;
+                            let download =
+                                crate::observation::runs_service::runner_evidence::with_runner_evidence(
+                                    |p| {
+                                        p.download_remote_artifact(
+                                            &remote_ref,
+                                            Some(mirror.path().to_path_buf()),
+                                        )
+                                    },
+                                )?;
                             let expected_size = artifact.size_bytes.expect("checked above");
                             let expected_sha256 =
                                 artifact.sha256.as_deref().expect("checked above");


### PR DESCRIPTION
## Summary
`agent_task_lifecycle::failure_recording` called `crate::runners::download_remote_artifact` directly to mirror a controller artifact. That's the **same** remote-artifact download already inverted behind the `RunnerEvidenceProvider` hook (#8532), so this routes the caller through it too — **reusing existing infrastructure** rather than adding a new seam.

It only reads `download.output_path`, which the hook's `RemoteArtifactDownloadInfo` already carries.

## Impact
Severs the `failure_recording` `download_remote_artifact` edge.

## Verification
`cargo check` clean for `-p homeboy-core --lib` and `-p homeboy-cli --lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)