### PR TITLE
fix(cli): map ErrorCode::RuntimePromotionContended in exit_code_for_error

### DIFF
--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -422,7 +422,11 @@ fn exit_code_for_error(code: ErrorCode) -> i32 {
         | ErrorCode::DeployUploadFailed
         | ErrorCode::GitCommandFailed => 20,
 
-        ErrorCode::InternalIoError
+        // A contended runtime promotion (another owner holds the lease) is a
+        // transient "busy" condition, not a hard failure — map it to the
+        // general error code alongside the other internal/unexpected states.
+        ErrorCode::RuntimePromotionContended
+        | ErrorCode::InternalIoError
         | ErrorCode::InternalJsonError
         | ErrorCode::InternalUnexpected => 1,
     }


### PR DESCRIPTION
## Summary

`exit_code_for_error` in `commands/utils/response.rs` had no match arm for `ErrorCode::RuntimePromotionContended` (added with the runtime-promotion lease work), breaking the **homeboy-cli build on current main** with a non-exhaustive-patterns error (E0004).

A contended runtime promotion is a transient "another owner holds the lease" condition, so it maps to exit code 1 alongside the other internal/unexpected states.

## How it was found

Surfaced by the `cargo check --workspace --tests` topology guard (#8509) while working on an unrelated audit refactor — the guard compiles every crate's targets, so this pre-existing cli lib break (which the differentially-scoped `review` gate had missed) showed up. Reproduced on clean main to confirm it's pre-existing.

## Verification

- `cargo check -p homeboy-cli --lib` — clean (was E0004-broken on main)