### PR TITLE
refactor: import audit config schema directly from homeboy-audit-contract (#8425)

### DIFF
--- a/crates/homeboy-core/src/code_audit/comment_hygiene.rs
+++ b/crates/homeboy-core/src/code_audit/comment_hygiene.rs
@@ -8,7 +8,7 @@ use super::conventions::{AuditFinding, Language};
 use super::detectors::upstream_workaround;
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
-use crate::component::DetectorProfileConfig;
+use homeboy_audit_contract::DetectorProfileConfig;
 
 const TODO_MARKERS: &[&str] = &["TODO", "FIXME", "HACK", "XXX"];
 const LEGACY_MARKERS: &[&str] = &[
@@ -183,7 +183,7 @@ mod tests {
     use super::*;
     use crate::code_audit::conventions::Language;
     use crate::code_audit::fingerprint::FileFingerprint;
-    use crate::component::DetectorProfileConfig;
+    use homeboy_audit_contract::DetectorProfileConfig;
 
     fn make_fp(path: &str, lang: Language, content: &str) -> FileFingerprint {
         FileFingerprint {

--- a/crates/homeboy-core/src/code_audit/convention_membership.rs
+++ b/crates/homeboy-core/src/code_audit/convention_membership.rs
@@ -1,6 +1,6 @@
 use super::conventions::{AuditFinding, Deviation};
 use super::fingerprint::FileFingerprint;
-use crate::component::AuditConfig;
+use homeboy_audit_contract::AuditConfig;
 
 const GENERIC_UTILITY_SUFFIXES: &[&str] = &[
     "Base",

--- a/crates/homeboy-core/src/code_audit/conventions/mod.rs
+++ b/crates/homeboy-core/src/code_audit/conventions/mod.rs
@@ -15,7 +15,7 @@ use super::fingerprint::FileFingerprint;
 use super::import_matching::has_import_with_context;
 use super::naming::{detect_naming_suffix, suffix_matches};
 use super::signatures::{compute_signature_skeleton, tokenize_signature};
-use crate::component::AuditConfig;
+use homeboy_audit_contract::AuditConfig;
 
 /// `Language` now lives in `crate::engine::language` — the foundation layer,
 /// since it is a source-file primitive with no audit dependencies. Re-exported

--- a/crates/homeboy-core/src/code_audit/dead_code.rs
+++ b/crates/homeboy-core/src/code_audit/dead_code.rs
@@ -12,7 +12,7 @@ use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
 use super::import_matching::{blank_comments_and_strings, contains_word_in_code};
 use super::walker::is_test_path;
-use crate::component::AuditConfig;
+use homeboy_audit_contract::AuditConfig;
 
 /// A cross-file caller record: which files call a function and with how many args.
 struct CallerRecord {

--- a/crates/homeboy-core/src/code_audit/detectors/command_status_contracts.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/command_status_contracts.rs
@@ -391,7 +391,7 @@ fn json_value_label(value: &serde_json::Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::component::CommandStatusContractScenario;
+    use homeboy_audit_contract::CommandStatusContractScenario;
     use std::collections::BTreeMap;
 
     #[test]

--- a/crates/homeboy-core/src/code_audit/detectors/config_key_usage.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/config_key_usage.rs
@@ -248,7 +248,7 @@ fn finding_for(rule: &ConfigKeyUsageRule, key: &str, evidence: &KeyEvidence) -> 
 
 #[cfg(test)]
 mod tests {
-    use crate::component::ConfigKeyUsagePattern;
+    use homeboy_audit_contract::ConfigKeyUsagePattern;
 
     use super::*;
 

--- a/crates/homeboy-core/src/code_audit/detectors/dead_guard.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/dead_guard.rs
@@ -21,7 +21,7 @@ use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
 use super::requirements::{known_available_symbols, KnownSymbols};
 use super::source_locations::line_of_offset;
-use crate::component::AuditConfig;
+use homeboy_audit_contract::AuditConfig;
 
 /// Kinds of guards we detect.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/homeboy-core/src/code_audit/detectors/mutating_resource_access.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/mutating_resource_access.rs
@@ -1,6 +1,6 @@
 use regex::Regex;
 
-use crate::component::MutatingResourceAccessConfig;
+use homeboy_audit_contract::MutatingResourceAccessConfig;
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};

--- a/crates/homeboy-core/src/code_audit/detectors/public_registry_exposure.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/public_registry_exposure.rs
@@ -2,7 +2,7 @@
 
 use regex::Regex;
 
-use crate::component::PublicRegistryExposureConfig;
+use homeboy_audit_contract::PublicRegistryExposureConfig;
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};

--- a/crates/homeboy-core/src/code_audit/detectors/redirect_validation.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/redirect_validation.rs
@@ -4,7 +4,7 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
-use crate::component::RedirectValidationConfig;
+use homeboy_audit_contract::RedirectValidationConfig;
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};

--- a/crates/homeboy-core/src/code_audit/detectors/remote_execution_preflight.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/remote_execution_preflight.rs
@@ -6,7 +6,7 @@
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
-use crate::component::audit::RemoteExecutionSafetyConfig;
+use homeboy_audit_contract::RemoteExecutionSafetyConfig;
 
 pub(in crate::code_audit) fn run(
     fingerprints: &[&FileFingerprint],

--- a/crates/homeboy-core/src/code_audit/detectors/requested_detectors/config_roundtrip_keys.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/requested_detectors/config_roundtrip_keys.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
 
-use crate::component::RequestedDetectorRule;
+use homeboy_audit_contract::RequestedDetectorRule;
 
 use super::super::conventions::AuditFinding;
 use super::super::findings::Finding;

--- a/crates/homeboy-core/src/code_audit/detectors/source_policy.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/source_policy.rs
@@ -497,8 +497,8 @@ mod tests { const PACKAGE: &str = "widget-package.json"; }
     // generic engine. These tests pin the preset's behavior end to end.
     // ------------------------------------------------------------------------
 
-    fn core_boundary_config() -> crate::component::CoreBoundaryLeakConfig {
-        crate::component::CoreBoundaryLeakConfig {
+    fn core_boundary_config() -> homeboy_audit_contract::CoreBoundaryLeakConfig {
+        homeboy_audit_contract::CoreBoundaryLeakConfig {
             terms: vec!["florpstack".to_string(), "florp-run".to_string()],
             scan_path_contains: vec!["src/core/".to_string()],
             allow_path_contains: vec!["src/core/fixtures/allowed".to_string()],
@@ -509,7 +509,7 @@ mod tests { const PACKAGE: &str = "widget-package.json"; }
 
     fn run_core_boundary(
         fingerprints: &[&FileFingerprint],
-        config: &crate::component::CoreBoundaryLeakConfig,
+        config: &homeboy_audit_contract::CoreBoundaryLeakConfig,
     ) -> Vec<Finding> {
         run(fingerprints, &config.to_source_policy_rules())
     }
@@ -518,10 +518,11 @@ mod tests { const PACKAGE: &str = "widget-package.json"; }
     fn core_boundary_default_config_emits_nothing() {
         let fp = rust_fp("src/core/engine.rs", "fn dispatch() {}");
 
-        assert!(
-            run_core_boundary(&[&fp], &crate::component::CoreBoundaryLeakConfig::default())
-                .is_empty()
-        );
+        assert!(run_core_boundary(
+            &[&fp],
+            &homeboy_audit_contract::CoreBoundaryLeakConfig::default()
+        )
+        .is_empty());
     }
 
     #[test]

--- a/crates/homeboy-core/src/code_audit/detectors/test_wiring.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/test_wiring.rs
@@ -162,7 +162,7 @@ fn normalize_path(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::component::TestWiringConfig;
+    use homeboy_audit_contract::TestWiringConfig;
     use tempfile::TempDir;
 
     fn write(path: &Path, content: &str) {

--- a/crates/homeboy-core/src/code_audit/detectors/thin_command_adapter.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/thin_command_adapter.rs
@@ -21,8 +21,8 @@ use std::path::Path;
 
 use regex::Regex;
 
-use crate::component::ThinCommandAdapterConfig;
 use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use homeboy_audit_contract::ThinCommandAdapterConfig;
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};

--- a/crates/homeboy-core/src/code_audit/detectors/upstream_workaround.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/upstream_workaround.rs
@@ -29,7 +29,7 @@ use super::comment_blocks;
 use super::conventions::{builtin_tracker_reference_regexes, AuditFinding, Language};
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
-use crate::component::DetectorProfileConfig;
+use homeboy_audit_contract::DetectorProfileConfig;
 
 // ============================================================================
 // Tier A — marker + tracker reference catalogues

--- a/crates/homeboy-core/src/code_audit/discovery.rs
+++ b/crates/homeboy-core/src/code_audit/discovery.rs
@@ -8,8 +8,8 @@ use super::fingerprint::{fingerprint_content, normalize_convention_tags, FileFin
 use super::walker::{
     extension_provided_file_extensions, is_extension_provided_source_file, is_test_path,
 };
-use crate::component::AuditConfig;
 use crate::engine::codebase_scan::CodebaseSnapshot;
+use homeboy_audit_contract::AuditConfig;
 
 type DiscoveryGroupKey = (String, Language, bool, Vec<String>);
 
@@ -322,7 +322,7 @@ mod tests {
             ..Default::default()
         };
         let audit_config = AuditConfig {
-            convention_tag_globs: vec![crate::component::ConventionTagGlob {
+            convention_tag_globs: vec![homeboy_audit_contract::ConventionTagGlob {
                 tag: "component:generated".to_string(),
                 globs: vec!["src/generated/*".to_string()],
             }],

--- a/crates/homeboy-core/src/code_audit/duplication.rs
+++ b/crates/homeboy-core/src/code_audit/duplication.rs
@@ -19,7 +19,7 @@ use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
 use super::idiomatic::is_trivial_method;
 use super::walker::is_test_path;
-use crate::component::DuplicationDetectorConfig;
+use homeboy_audit_contract::DuplicationDetectorConfig;
 
 mod intra_method;
 

--- a/crates/homeboy-core/src/code_audit/entry.rs
+++ b/crates/homeboy-core/src/code_audit/entry.rs
@@ -11,8 +11,8 @@ use super::execution_plan::AuditExecutionPlan;
 use super::findings::Finding;
 use super::types::{AuditWithAnalysis, CodeAuditResult};
 use super::{fingerprint, walker};
-use crate::component::AuditConfig;
 use crate::{component, Result};
+use homeboy_audit_contract::AuditConfig;
 
 /// Audit a registered component by ID.
 pub fn audit_component(component_id: &str) -> Result<CodeAuditResult> {

--- a/crates/homeboy-core/src/code_audit/mod.rs
+++ b/crates/homeboy-core/src/code_audit/mod.rs
@@ -98,7 +98,7 @@ mod tests {
     use super::reference::fingerprint_component_reference_files;
     use super::types::{time_audit_detector, ScopedAuditExecution};
     use super::*;
-    use crate::component::AuditConfig;
+    use homeboy_audit_contract::AuditConfig;
     use std::fs;
 
     #[test]

--- a/crates/homeboy-core/src/code_audit/requirements.rs
+++ b/crates/homeboy-core/src/code_audit/requirements.rs
@@ -21,11 +21,11 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use crate::component::audit::KnownSymbolSourceScanConfig;
 use crate::component::{
     AuditConfig, KnownSymbolEntry, KnownSymbolHeaderVersionProvider, KnownSymbolKind,
     KnownSymbolVersionedEntry,
 };
+use homeboy_audit_contract::KnownSymbolSourceScanConfig;
 
 /// Symbols guaranteed to be defined at runtime given the plugin's declared
 /// requirements and its explicit bootstrap wiring.


### PR DESCRIPTION
## Summary

**Stage 3 of the `homeboy-audit` extraction.** After stage 1 (#8540) moved the audit config schema into `homeboy-audit-contract`, `code_audit` was still importing those types via `crate::component::{AuditConfig, DetectorProfileConfig, SourcePolicyRule, ...}` — bouncing through component's back-compat re-export instead of the crate where the types now live.

Repoint all ~24 such imports across **21 code_audit files** from `crate::component::<ConfigType>` → `homeboy_audit_contract::<ConfigType>` (and the `component::audit::*` namespace refs straight to the crate root). Pure import change; identical types, sourced from their real home.

## Result

`code_audit → component` real edges drop to only the **two genuine ones**: `Component` (the model) and `scope`. The entire config-schema coupling between audit and component is gone — both now depend on the shared contract, neither on the other for config types.

## Verification

- `cargo check -p homeboy-core --lib` — clean
- Depends on the pre-existing homeboy-cli fix (separate PR) for the full workspace guard to go green — that break is unrelated (a missing `ErrorCode::RuntimePromotionContended` match arm).

Refs #8425