### PR TITLE
refactor: route runner_artifact_content through the evidence hook (runner-decouple)

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/artifact_materialization.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/artifact_materialization.rs
@@ -46,7 +46,11 @@ pub fn materialize_recovered_patch_artifact(
                 &job_id,
                 &record.run_id,
                 &outcome.task_id,
-                |id| crate::runner::runner_artifact_content(&runner_id, &job_id, id),
+                |id| {
+                    crate::observation::runs_service::runner_evidence::with_runner_evidence(|p| {
+                        p.runner_artifact_content(&runner_id, &job_id, id)
+                    })
+                },
             )?;
         }
         let finalized = outcome.artifacts.clone();

--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -64,6 +64,14 @@ pub trait RunnerEvidenceProvider: Send + Sync {
     /// Raw GET against a runner's daemon API.
     fn daemon_api_get(&self, runner_id: &str, path: &str) -> Result<Value>;
 
+    /// Fetch the content of an artifact from a connected runner's job.
+    fn runner_artifact_content(
+        &self,
+        runner_id: &str,
+        job_id: &str,
+        artifact_id: &str,
+    ) -> Result<Value>;
+
     /// Refresh mirrored daemon evidence for a run, returning any mirrored runs.
     fn refresh_mirrored_daemon_evidence(&self, run_id: &str) -> Result<Option<Vec<RunRecord>>>;
 
@@ -94,6 +102,20 @@ impl RunnerEvidenceProvider for NoopRunnerEvidenceProvider {
     }
 
     fn daemon_api_get(&self, _runner_id: &str, _path: &str) -> Result<Value> {
+        Err(Error::validation_invalid_argument(
+            "runner",
+            "no runner evidence provider is registered",
+            None,
+            None,
+        ))
+    }
+
+    fn runner_artifact_content(
+        &self,
+        _runner_id: &str,
+        _job_id: &str,
+        _artifact_id: &str,
+    ) -> Result<Value> {
         Err(Error::validation_invalid_argument(
             "runner",
             "no runner evidence provider is registered",
@@ -202,6 +224,9 @@ mod tests {
                 }]
             }
             fn daemon_api_get(&self, _: &str, _: &str) -> Result<Value> {
+                Ok(Value::Null)
+            }
+            fn runner_artifact_content(&self, _: &str, _: &str, _: &str) -> Result<Value> {
                 Ok(Value::Null)
             }
             fn refresh_mirrored_daemon_evidence(&self, _: &str) -> Result<Option<Vec<RunRecord>>> {

--- a/crates/homeboy-core/src/runner/evidence/provider.rs
+++ b/crates/homeboy-core/src/runner/evidence/provider.rs
@@ -51,6 +51,15 @@ impl RunnerEvidenceProvider for RunnerEvidence {
         super::super::execution::daemon_api_get(runner_id, path)
     }
 
+    fn runner_artifact_content(
+        &self,
+        runner_id: &str,
+        job_id: &str,
+        artifact_id: &str,
+    ) -> Result<Value> {
+        super::super::connection::runner_artifact_content(runner_id, job_id, artifact_id)
+    }
+
     fn refresh_mirrored_daemon_evidence(&self, run_id: &str) -> Result<Option<Vec<RunRecord>>> {
         super::mirror::refresh_mirrored_daemon_evidence(run_id)
     }


### PR DESCRIPTION
## Summary
`agent_task_lifecycle::artifact_materialization` fetched runner artifact content via `crate::runner::runner_artifact_content` directly. That's runner-daemon evidence — the same domain as the `RunnerEvidenceProvider` hook (#8532) — so add it there and route the caller through it, **reusing existing infrastructure**.

Adds `runner_artifact_content(runner_id, job_id, artifact_id) -> Value` to the provider trait; NoopProvider errors clearly (content can't be fetched without a runner); the runner impl delegates to `connection::runner_artifact_content`.

## Impact
Severs the **last cleanly-invertible** core→runner behavior edge in `artifact_materialization`.

## Note
Stacked on #8553 (legacy nuke). The first commit here is #8553; review/merge that first, or merge together.

## Verification
`cargo check` clean for `-p homeboy-core --lib/--tests`; the 4 evidence hook tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)