### PR TITLE
refactor: break core↔runner type cycles ahead of runner extraction (stage 1)

### DIFF
--- a/crates/homeboy-core/src/extension/dev_run.rs
+++ b/crates/homeboy-core/src/extension/dev_run.rs
@@ -11,13 +11,13 @@ use crate::lab_contract::{
     RunnerWorkloadWorkspaceMappings, RUNNER_WORKLOAD_SCHEMA,
 };
 use crate::resource_lifecycle_index::ResourceCleanupPolicy;
-use crate::runner::RunnerWorkspaceLease;
 use crate::runner_execution_envelope::RunnerExecutionProjection;
 use crate::runners::{
     self, RunnerCapabilityPreflight, RunnerExecOptions, RunnerExecOutput, RunnerWorkspaceSyncMode,
     RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 use crate::source_snapshot::SourceSnapshot;
+use homeboy_runner_contract::RunnerWorkspaceLease;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ExtensionDevRunPlan {
@@ -661,10 +661,10 @@ mod tests {
     use std::fs;
 
     use super::*;
-    use crate::runner::{
+    use crate::runner_execution_envelope::RunnerExecutionRecord;
+    use homeboy_runner_contract::{
         ByteFileCounts, RunnerLifecycleOwner, RunnerWorkspaceCurrentSummary, RunnerWorkspaceLease,
     };
-    use crate::runner_execution_envelope::RunnerExecutionRecord;
     use tempfile::TempDir;
 
     #[test]

--- a/crates/homeboy-core/src/run_outcome_envelope.rs
+++ b/crates/homeboy-core/src/run_outcome_envelope.rs
@@ -3,7 +3,6 @@ use serde_json::Value;
 
 use crate::api_jobs::JobArtifactMetadata;
 use crate::artifact_ref::{artifact_uri, ArtifactRef, EvidenceRef, ARTIFACT_REF_SCHEMA};
-use crate::runner::RunnerHandoff;
 use crate::runner_execution_envelope::{RunnerExecutionArtifactRef, RunnerExecutionRecord};
 use homeboy_runner_contract::RunnerArtifactRef;
 
@@ -123,15 +122,21 @@ impl RunOutcomeEnvelope {
         }
     }
 
-    pub fn add_handoff(&mut self, handoff: &RunnerHandoff) {
+    /// Record a runner handoff. Takes the already-extracted primitive fields
+    /// (rather than the runner-owned `RunnerHandoff` type) so this core envelope
+    /// does not depend on runner.
+    pub fn add_handoff(
+        &mut self,
+        runner_id: String,
+        transport: String,
+        lifecycle_owner: String,
+        job_id: Option<String>,
+    ) {
         self.handoffs.push(RunOutcomeHandoffRef {
-            runner_id: handoff.runner_id.clone(),
-            transport: handoff.transport.clone(),
-            lifecycle_owner: serde_json::to_value(&handoff.lifecycle_owner)
-                .ok()
-                .and_then(|value| value.as_str().map(ToString::to_string))
-                .unwrap_or_else(|| "unknown".to_string()),
-            job_id: handoff.job.as_ref().map(|job| job.job_id.clone()),
+            runner_id,
+            transport,
+            lifecycle_owner,
+            job_id,
         });
     }
 

--- a/crates/homeboy-core/src/runner/session.rs
+++ b/crates/homeboy-core/src/runner/session.rs
@@ -12,25 +12,11 @@ use crate::api_jobs::{ActiveRunnerJobSummary, Job, JobArtifactMetadata, JobStatu
 mod session_enums {
     use super::*;
 
-    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-    #[serde(rename_all = "snake_case")]
-    pub enum RunnerLifecycleOwner {
-        Controller,
-        Runner,
-        Broker,
-        Local,
-    }
-
-    impl RunnerLifecycleOwner {
-        pub fn as_str(&self) -> &'static str {
-            match self {
-                Self::Controller => "controller",
-                Self::Runner => "runner",
-                Self::Broker => "broker",
-                Self::Local => "local",
-            }
-        }
-    }
+    // RunnerLifecycleOwner now lives in the shared runner-contract crate so core
+    // (dev_run, run_outcome_envelope, and the types that reference it) can name it
+    // without a core -> runner edge. Re-exported so runner-internal call sites
+    // resolve unchanged.
+    pub use homeboy_runner_contract::RunnerLifecycleOwner;
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
     #[serde(rename_all = "snake_case")]
@@ -375,21 +361,9 @@ impl RunnerJob {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunnerWorkspaceLease {
-    pub runner_id: String,
-    pub local_path: String,
-    pub remote_path: String,
-    pub sync_mode: String,
-    pub materialized: bool,
-    pub lifecycle_owner: RunnerLifecycleOwner,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source_commit: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source_ref: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source_dirty: Option<bool>,
-}
+// RunnerWorkspaceLease now lives in the shared runner-contract crate (core's
+// dev_run names it). Re-exported so runner-internal call sites resolve.
+pub use homeboy_runner_contract::RunnerWorkspaceLease;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RunnerNamedWorkspaceLease {

--- a/crates/homeboy-core/src/runner/worker/result.rs
+++ b/crates/homeboy-core/src/runner/worker/result.rs
@@ -90,7 +90,16 @@ pub(super) fn remote_runner_result_from_exec_output(
             outcome.with_result(serde_json::to_value(result).unwrap_or(serde_json::Value::Null));
     }
     if let Some(handoff) = exec_output.handoff.as_ref() {
-        outcome.add_handoff(handoff);
+        let lifecycle_owner = serde_json::to_value(&handoff.lifecycle_owner)
+            .ok()
+            .and_then(|value| value.as_str().map(ToString::to_string))
+            .unwrap_or_else(|| "unknown".to_string());
+        outcome.add_handoff(
+            handoff.runner_id.clone(),
+            handoff.transport.clone(),
+            lifecycle_owner,
+            handoff.job.as_ref().map(|job| job.job_id.clone()),
+        );
     }
     data["outcome"] = serde_json::to_value(outcome).unwrap_or(serde_json::Value::Null);
     let artifacts = mirror_file_artifact_content(exec_output.artifacts, &exec_output.remote_cwd);

--- a/crates/homeboy-core/src/runner/workspace/types.rs
+++ b/crates/homeboy-core/src/runner/workspace/types.rs
@@ -406,40 +406,18 @@ pub(super) struct RunnerWorkspaceMetadata {
     pub resource_lifecycle: Option<ResourceLifecycleRecord>,
 }
 
-#[derive(Debug, Clone, Serialize)]
-pub struct RunnerWorkspaceCurrentSummary {
-    pub local_path: String,
-    pub remote_path: String,
-    pub sync_mode: RunnerWorkspaceSyncMode,
-    pub materialized: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source_commit: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source_ref: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source_dirty: Option<bool>,
-    /// Commit SHA of the synthetic git checkout created for a `snapshot-git`
-    /// sync, so write-capable agent-task dispatches can trace the dirty
-    /// controller-side worktree back to the synthetic commit that carries it
-    /// into the runner workspace. `None` for plain `snapshot`/`git` syncs.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub synthetic_checkout_commit: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub synthetic_checkout_ref: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub synthetic_checkout_tree: Option<String>,
-}
+// RunnerWorkspaceCurrentSummary now lives in the shared runner-contract crate
+// (core's dev_run names it). Re-exported so runner-internal call sites resolve.
+pub use homeboy_runner_contract::RunnerWorkspaceCurrentSummary;
 
 /// File + byte counts for a synced/snapshotted workspace tree.
 ///
 /// Shared across the workspace-sync and git-dependency materialization outputs
 /// so the `files` / `bytes` pair is declared once. Serialized flat via
 /// `#[serde(flatten)]` to preserve the historical top-level JSON keys.
-#[derive(Debug, Clone, Copy, Default, Serialize, PartialEq, Eq)]
-pub struct ByteFileCounts {
-    pub files: usize,
-    pub bytes: u64,
-}
+// ByteFileCounts now lives in the shared runner-contract crate (core's dev_run
+// names it). Re-exported so runner-internal call sites resolve.
+pub use homeboy_runner_contract::ByteFileCounts;
 
 pub(super) type SnapshotStats = ByteFileCounts;
 

--- a/crates/homeboy-runner-contract/src/lib.rs
+++ b/crates/homeboy-runner-contract/src/lib.rs
@@ -17,6 +17,76 @@ pub enum RunnerKind {
     Ssh,
 }
 
+/// Which side of a runner exchange owns a lifecycle resource.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerLifecycleOwner {
+    Controller,
+    Runner,
+    Broker,
+    Local,
+}
+
+impl RunnerLifecycleOwner {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Controller => "controller",
+            Self::Runner => "runner",
+            Self::Broker => "broker",
+            Self::Local => "local",
+        }
+    }
+}
+
+/// File + byte counts for a workspace sync.
+#[derive(Debug, Clone, Copy, Default, Serialize, PartialEq, Eq)]
+pub struct ByteFileCounts {
+    pub files: usize,
+    pub bytes: u64,
+}
+
+/// A lease describing a runner's materialized workspace.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerWorkspaceLease {
+    pub runner_id: String,
+    pub local_path: String,
+    pub remote_path: String,
+    pub sync_mode: String,
+    pub materialized: bool,
+    pub lifecycle_owner: RunnerLifecycleOwner,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_commit: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_dirty: Option<bool>,
+}
+
+/// A summary of a runner's current workspace materialization.
+#[derive(Debug, Clone, Serialize)]
+pub struct RunnerWorkspaceCurrentSummary {
+    pub local_path: String,
+    pub remote_path: String,
+    pub sync_mode: RunnerWorkspaceSyncMode,
+    pub materialized: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_commit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_dirty: Option<bool>,
+    /// Commit SHA of the synthetic git checkout created for a `snapshot-git`
+    /// sync, so write-capable agent-task dispatches can trace the dirty
+    /// controller-side worktree back to the synthetic commit that carries it
+    /// into the runner workspace. `None` for plain `snapshot`/`git` syncs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub synthetic_checkout_commit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub synthetic_checkout_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub synthetic_checkout_tree: Option<String>,
+}
+
 /// A reference to an artifact produced by a runner job. Plain data describing
 /// where/how to fetch the artifact; behavior-free so core can name it without a
 /// core -> runner edge.


### PR DESCRIPTION
## Summary
**Stage 1** of the wholesale `homeboy-runner` extraction — sever the last core→runner **type** cycles so the runner subsystem can move to its own crate without a `core ↔ homeboy-runner` dependency cycle.

The two core files that named runner types (outside the `upgrade/runners` cluster) were `dev_run` and `run_outcome_envelope`:

- **Moved the plain-data types `dev_run` needs** into `homeboy-runner-contract`: `RunnerLifecycleOwner` (+ `as_str`), `ByteFileCounts`, `RunnerWorkspaceLease`, `RunnerWorkspaceCurrentSummary`. Re-exported from their old runner paths so runner-internal call sites resolve unchanged; `dev_run` now names them via the contract.
- **`run_outcome_envelope::add_handoff`** took a runner-owned `&RunnerHandoff` but only read four primitive fields. Changed it to take those directly; its one caller (`runner/worker/result.rs`) extracts them. `RunnerHandoff` (and its `RunnerJob` graph) now stays entirely in runner — no graph move needed.

## Result
After this, the only remaining non-upgrade core→runner reference is the `Runner` ConfigEntity registration in `config.rs`, which the `register_config_entity` keystone handles when runner becomes its own crate.

## Next stages
2. Invert the `upgrade/helpers → upgrade/runners` boundary + move `upgrade/runners` with runner.
3. The wholesale `git mv crates/homeboy-core/src/runner → crates/homeboy-runner` — core drops ~80k LOC.

## Verification
`cargo check` clean for `-p homeboy-runner-contract`, `-p homeboy-core --lib/--tests`, `-p homeboy-cli --lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)