### PR TITLE
refactor: invert code_audit's extension-manifest loading behind a provider hook (#8425)

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -98,6 +98,11 @@ impl CliRuntime {
         // IDs/aliases participate in cross-entity collision detection. Core owns
         // the collision invariant but must not depend on these optional features.
         homeboy_tunnel::register();
+        // Register the audit manifest provider so code_audit can read extension
+        // manifests (detector rules, test mappings, provided extensions) without
+        // depending on the extension layer's loader — the seam that lets audit
+        // become its own crate.
+        crate::core::extension::audit_manifest_provider::register();
         // Register the runner-evidence provider so observation::runs_service can
         // enrich run/artifact lookups with live runner + daemon evidence without
         // core depending on runner behavior. (Runner is still in-crate today;

--- a/crates/homeboy-core/src/code_audit/descriptor_runtime.rs
+++ b/crates/homeboy-core/src/code_audit/descriptor_runtime.rs
@@ -184,8 +184,8 @@ fn run_test_coverage(context: &DetectorRunContext<'_>) -> Vec<Finding> {
         return Vec::new();
     };
     for ext_id in extensions.keys() {
-        if let Ok(ext_manifest) = crate::extension::load_extension(ext_id) {
-            if let Some(test_mapping) = ext_manifest.test_mapping() {
+        if let Some(ext_manifest) = super::extension_manifests::load_audit_manifest(ext_id) {
+            if let Some(test_mapping) = &ext_manifest.test_mapping {
                 return test_coverage::run(context.root, context.all_fingerprints, test_mapping);
             }
         }

--- a/crates/homeboy-core/src/code_audit/detectors/test_topology.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/test_topology.rs
@@ -10,7 +10,6 @@ use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
 use crate::engine::command::{wait_with_bounded_output, DEFAULT_CAPTURE_LIMIT_BYTES};
-use crate::extension::{self, ExtensionManifest};
 
 #[path = "../test_quality.rs"]
 mod test_quality;
@@ -84,8 +83,8 @@ fn analyze_test_topology(root: &Path) -> Vec<Finding> {
     let severity = parse_severity(rules.severity.as_deref());
     let mut findings = Vec::new();
 
-    for extension in extension::load_all_extensions().unwrap_or_default() {
-        let Some(script_rel) = extension.topology_script() else {
+    for extension in crate::code_audit::extension_manifests::load_all_audit_manifests() {
+        let Some(script_rel) = extension.topology_script.clone() else {
             continue;
         };
 
@@ -119,7 +118,7 @@ fn analyze_test_topology(root: &Path) -> Vec<Finding> {
                 content,
             };
 
-            let artifacts = run_topology_script(&extension, script_rel, &input);
+            let artifacts = run_topology_script(&extension, &script_rel, &input);
             for artifact in artifacts {
                 apply_policy(
                     &artifact,
@@ -175,7 +174,7 @@ fn apply_policy(
 }
 
 fn run_topology_script(
-    extension: &ExtensionManifest,
+    extension: &crate::code_audit::extension_manifests::AuditExtensionManifest,
     script_rel: &str,
     input: &TopologyInput,
 ) -> Vec<TopologyArtifact> {
@@ -358,52 +357,11 @@ JSON
             std::fs::set_permissions(&script_path, perms).expect("script should become executable");
         }
 
-        let extension = ExtensionManifest {
+        let extension = crate::code_audit::extension_manifests::AuditExtensionManifest {
             id: "test-ext".to_string(),
-            name: "Test Extension".to_string(),
-            version: "0.1.0".to_string(),
-            provides: None,
-            scripts: Some(crate::extension::ScriptsConfig {
-                topology: Some(script_rel.to_string()),
-                ..Default::default()
-            }),
-            icon: None,
-            description: None,
-            author: None,
-            homepage: None,
-            source_url: None,
-            deploy: None,
-            audit: None,
-            executable: None,
-            platform: None,
-            component_env: None,
-            env_provider: None,
-            ci: None,
-            source_snapshot: None,
-            diagnostics: Default::default(),
-            notification_transports: Vec::new(),
-            runtime: None,
-            cli: None,
-            build: None,
-            deps: None,
-            lint: None,
-            test: None,
-            bench: None,
-            fuzz: None,
-            trace: None,
-            structured_sidecars: std::collections::BTreeMap::new(),
-            materialization_source: None,
-            contract_producers: vec![],
-            release_preflights: vec![],
-            agent_runtimes: vec![],
-            agent_task: None,
-            actions: vec![],
-            hooks: std::collections::HashMap::new(),
-            settings: vec![],
-            requires: None,
-            autofix_verify: None,
-            extra: std::collections::HashMap::new(),
             extension_path: Some(dir.path().to_string_lossy().to_string()),
+            topology_script: Some(script_rel.to_string()),
+            ..Default::default()
         };
 
         let artifacts = run_topology_script(

--- a/crates/homeboy-core/src/code_audit/docs_audit/mod.rs
+++ b/crates/homeboy-core/src/code_audit/docs_audit/mod.rs
@@ -16,8 +16,8 @@ use std::path::Path;
 pub use claims::{Claim, ClaimConfidence, ClaimType};
 pub use verify::VerifyResult;
 
+use crate::component;
 use crate::is_zero;
-use crate::{component, extension};
 
 /// A doc that needs content review due to referenced files changing.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -160,8 +160,10 @@ pub(crate) fn collect_extension_ignore_patterns(comp: &component::Component) -> 
     let mut patterns = Vec::new();
     if let Some(ref extensions) = comp.extensions {
         for extension_id in extensions.keys() {
-            if let Ok(manifest) = extension::load_extension(extension_id) {
-                patterns.extend(manifest.audit_ignore_claim_patterns().to_vec());
+            if let Some(manifest) =
+                crate::code_audit::extension_manifests::load_audit_manifest(extension_id)
+            {
+                patterns.extend(manifest.audit_ignore_claim_patterns);
             }
         }
     }

--- a/crates/homeboy-core/src/code_audit/entry.rs
+++ b/crates/homeboy-core/src/code_audit/entry.rs
@@ -182,8 +182,10 @@ pub(super) fn audit_config_for(
     if let Some(component) = &component {
         if let Some(extensions) = &component.extensions {
             for extension_id in extensions.keys() {
-                if let Ok(manifest) = crate::extension::load_extension(extension_id) {
-                    if let Some(rules) = manifest.audit_detector_rules() {
+                if let Some(manifest) =
+                    super::extension_manifests::load_audit_manifest(extension_id)
+                {
+                    if let Some(rules) = &manifest.audit_detector_rules {
                         audit_config.merge(rules);
                     }
                 }
@@ -196,8 +198,8 @@ pub(super) fn audit_config_for(
     }
 
     for extension_id in extension_overrides {
-        if let Ok(manifest) = crate::extension::load_extension(extension_id) {
-            if let Some(rules) = manifest.audit_detector_rules() {
+        if let Some(manifest) = super::extension_manifests::load_audit_manifest(extension_id) {
+            if let Some(rules) = &manifest.audit_detector_rules {
                 audit_config.merge(rules);
             }
         }

--- a/crates/homeboy-core/src/code_audit/extension_manifests.rs
+++ b/crates/homeboy-core/src/code_audit/extension_manifests.rs
@@ -1,0 +1,114 @@
+//! Extension-manifest access for the audit engine, inverted behind a provider.
+//!
+//! The audit engine needs a little data from installed extension manifests —
+//! provided file extensions, the audit detector rules, test-mapping config,
+//! doc-claim ignore patterns, the topology script, and the extension path. It
+//! used to reach that by calling `crate::extension::{load_extension,
+//! load_all_extensions}` directly, which coupled `code_audit` to the
+//! `extension` feature layer and blocked extracting audit into its own crate.
+//!
+//! Instead, audit defines the slim view it needs (`AuditExtensionManifest`) plus
+//! a provider trait; the extension layer registers an implementation at startup
+//! (same pattern as the runner-evidence / tunnel provider hooks). When no
+//! provider is registered — e.g. audit running standalone — the no-op provider
+//! yields no manifests, which every call site already treats as "no extension
+//! contributed anything".
+
+use std::sync::Mutex;
+
+use homeboy_audit_contract::AuditConfig;
+
+use crate::extension::TestMappingConfig;
+
+/// The slim, owned view of an extension manifest that the audit engine needs.
+///
+/// Owning the data (rather than borrowing an `ExtensionManifest`) keeps the
+/// provider boundary clean: the audit engine never sees the full extension type.
+#[derive(Debug, Clone, Default)]
+pub struct AuditExtensionManifest {
+    /// Extension id.
+    pub id: String,
+    /// Absolute path to the extension directory, if installed on disk.
+    pub extension_path: Option<String>,
+    /// File extensions this extension can fingerprint/handle.
+    pub provided_file_extensions: Vec<String>,
+    /// Per-detector audit configuration the extension ships, if any.
+    pub audit_detector_rules: Option<AuditConfig>,
+    /// Test source/mapping configuration, if the extension declares one.
+    pub test_mapping: Option<TestMappingConfig>,
+    /// Prose doc-claim patterns the extension asks doc-drift to ignore.
+    pub audit_ignore_claim_patterns: Vec<String>,
+    /// Relative path to the extension's test-topology script, if any.
+    pub topology_script: Option<String>,
+}
+
+/// The manifest-access contract the audit engine depends on. Implemented by the
+/// extension layer and registered at startup; audit calls it without depending
+/// on extension behavior.
+pub trait AuditExtensionManifestProvider: Send + Sync {
+    /// Load every installed extension's audit view.
+    fn load_all(&self) -> Vec<AuditExtensionManifest>;
+
+    /// Load a single extension's audit view by id.
+    fn load(&self, id: &str) -> Option<AuditExtensionManifest>;
+}
+
+/// Default provider used when no extension layer is registered: no extensions,
+/// so the audit engine behaves exactly as it does on a component with no
+/// installed extensions.
+struct NoopProvider;
+
+impl AuditExtensionManifestProvider for NoopProvider {
+    fn load_all(&self) -> Vec<AuditExtensionManifest> {
+        Vec::new()
+    }
+
+    fn load(&self, _id: &str) -> Option<AuditExtensionManifest> {
+        None
+    }
+}
+
+static PROVIDER: Mutex<Option<Box<dyn AuditExtensionManifestProvider>>> = Mutex::new(None);
+
+/// Register the audit manifest provider. Called once at binary startup by the
+/// extension layer (via the CLI). Replaces any previously registered provider.
+pub fn register_audit_extension_manifest_provider(
+    provider: Box<dyn AuditExtensionManifestProvider>,
+) {
+    let mut guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = Some(provider);
+}
+
+/// Load every installed extension's audit view via the registered provider.
+pub(crate) fn load_all_audit_manifests() -> Vec<AuditExtensionManifest> {
+    with_provider(|p| p.load_all())
+}
+
+/// Load a single extension's audit view via the registered provider.
+pub(crate) fn load_audit_manifest(id: &str) -> Option<AuditExtensionManifest> {
+    with_provider(|p| p.load(id))
+}
+
+fn with_provider<T>(f: impl FnOnce(&dyn AuditExtensionManifestProvider) -> T) -> T {
+    let guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    match guard.as_ref() {
+        Some(provider) => f(provider.as_ref()),
+        None => f(&NoopProvider),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_provider_yields_no_manifests() {
+        let noop = NoopProvider;
+        assert!(noop.load_all().is_empty());
+        assert!(noop.load("anything").is_none());
+    }
+}

--- a/crates/homeboy-core/src/code_audit/mod.rs
+++ b/crates/homeboy-core/src/code_audit/mod.rs
@@ -29,6 +29,7 @@ mod discovery;
 pub mod docs_audit;
 mod duplication;
 mod execution_plan;
+pub mod extension_manifests;
 mod findings;
 pub mod fingerprint;
 mod idiomatic;

--- a/crates/homeboy-core/src/code_audit/walker.rs
+++ b/crates/homeboy-core/src/code_audit/walker.rs
@@ -37,10 +37,9 @@ pub(crate) fn is_index_file(path: &Path) -> bool {
 
 /// Collect all file extensions that installed extensions can handle.
 pub(crate) fn extension_provided_file_extensions() -> Vec<String> {
-    crate::extension::load_all_extensions()
-        .unwrap_or_default()
+    super::extension_manifests::load_all_audit_manifests()
         .into_iter()
-        .flat_map(|m| m.provided_file_extensions().to_vec())
+        .flat_map(|m| m.provided_file_extensions)
         .collect()
 }
 

--- a/crates/homeboy-core/src/extension/audit_manifest_provider.rs
+++ b/crates/homeboy-core/src/extension/audit_manifest_provider.rs
@@ -1,0 +1,49 @@
+//! Extension-side implementation of the audit manifest provider.
+//!
+//! The audit engine (`code_audit`) defines `AuditExtensionManifestProvider` and
+//! calls it without depending on extension behavior. This module implements that
+//! trait by loading real `ExtensionManifest`s and projecting each into the slim
+//! `AuditExtensionManifest` view audit needs. It is registered at binary startup
+//! by the CLI, mirroring the runner-evidence / tunnel provider hooks.
+
+use super::manifest::ExtensionManifest;
+use super::registry::{load_all_extensions, load_extension};
+use crate::code_audit::extension_manifests::{
+    register_audit_extension_manifest_provider, AuditExtensionManifest,
+    AuditExtensionManifestProvider,
+};
+
+/// Project a loaded `ExtensionManifest` into the audit-relevant view.
+fn project(manifest: &ExtensionManifest) -> AuditExtensionManifest {
+    AuditExtensionManifest {
+        id: manifest.id.clone(),
+        extension_path: manifest.extension_path.clone(),
+        provided_file_extensions: manifest.provided_file_extensions().to_vec(),
+        audit_detector_rules: manifest.audit_detector_rules().cloned(),
+        test_mapping: manifest.test_mapping().cloned(),
+        audit_ignore_claim_patterns: manifest.audit_ignore_claim_patterns().to_vec(),
+        topology_script: manifest.topology_script().map(str::to_string),
+    }
+}
+
+struct ExtensionManifestProvider;
+
+impl AuditExtensionManifestProvider for ExtensionManifestProvider {
+    fn load_all(&self) -> Vec<AuditExtensionManifest> {
+        load_all_extensions()
+            .unwrap_or_default()
+            .iter()
+            .map(project)
+            .collect()
+    }
+
+    fn load(&self, id: &str) -> Option<AuditExtensionManifest> {
+        load_extension(id).ok().map(|m| project(&m))
+    }
+}
+
+/// Register the extension-backed audit manifest provider. Called once at binary
+/// startup by the CLI.
+pub fn register() {
+    register_audit_extension_manifest_provider(Box::new(ExtensionManifestProvider));
+}

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -1,3 +1,4 @@
+pub mod audit_manifest_provider;
 pub mod bench;
 pub mod build;
 mod capability;


### PR DESCRIPTION
## Summary

**The last production behavior edge from `code_audit` into the extension layer** — the real final blocker to extracting audit into its own crate.

Audit called `crate::extension::{load_extension, load_all_extensions}` in 6 sites (walker, entry, docs_audit, test_topology, descriptor_runtime) to read detector rules, test mappings, provided file extensions, doc-ignore patterns, and topology scripts off `ExtensionManifest`. That coupled audit to extension *behavior*.

## The inversion (mirrors the runner-evidence / tunnel provider hooks)

- **`code_audit::extension_manifests`** defines a slim owned view (`AuditExtensionManifest`) + an `AuditExtensionManifestProvider` trait + a registry with a `NoopProvider` default. No-op yields no manifests — which every call site already treats as "no extension contributed anything", so audit standalone behaves exactly like a component with no installed extensions.
- **`extension::audit_manifest_provider`** implements the trait, loading real `ExtensionManifest`s and projecting each into the slim view.
- The **CLI registers it at startup** next to the other provider hooks.
- All 6 call sites now go through `load_all_audit_manifests` / `load_audit_manifest`.

## Result

- **Zero production `load_extension` / `load_all_extensions` calls** from code_audit.
- Bonus: the topology test's 47-line `ExtensionManifest` fixture collapses to a 5-line `AuditExtensionManifest`.
- Remaining `code_audit → extension` refs are type imports (`TestMappingConfig` etc. for the slim-view fields) + test-fixture behavior (`save_manifest`, `bench::test_support`) — production behavior coupling is severed.

## Verification

- core + cli + test targets compile clean
- provider test + **26 topology tests pass**
- `cargo check --workspace --tests --locked` — **green**

## Campaign status

With this, `code_audit`'s upward coupling is essentially resolved: config + fingerprint schemas in `homeboy-audit-contract`, grammar/language in primitives, is_test_path primitive, and now manifest loading behind a hook. The path to physically moving `code_audit` into `homeboy-audit` is clear — remaining is a config-type mop-up (`TestMappingConfig`/`TestVacuityPolicy` cascade into the contract).

Refs #8425