### PR TITLE
refactor: import code_audit's engine primitives direct from the crate (#8425)

### DIFF
--- a/crates/homeboy-core/src/code_audit/baseline.rs
+++ b/crates/homeboy-core/src/code_audit/baseline.rs
@@ -7,7 +7,7 @@
 use std::collections::BTreeSet;
 use std::path::Path;
 
-use crate::engine::baseline::{self as generic, BaselineConfig, Fingerprintable};
+use homeboy_engine_primitives::baseline::{self as generic, BaselineConfig, Fingerprintable};
 
 use super::conventions::AuditFinding as AuditFindingKind;
 use super::findings::{normalized_finding_description_for_fingerprint, Finding};

--- a/crates/homeboy-core/src/code_audit/codebase_map.rs
+++ b/crates/homeboy-core/src/code_audit/codebase_map.rs
@@ -12,8 +12,8 @@ use std::path::Path;
 use serde::Serialize;
 
 use crate::code_audit::fingerprint::{self, FileFingerprint};
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
 use crate::{component, extension, Error};
+use homeboy_engine_primitives::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
 // ============================================================================
 // Types

--- a/crates/homeboy-core/src/code_audit/conventions/mod.rs
+++ b/crates/homeboy-core/src/code_audit/conventions/mod.rs
@@ -17,10 +17,10 @@ use super::naming::{detect_naming_suffix, suffix_matches};
 use super::signatures::{compute_signature_skeleton, tokenize_signature};
 use homeboy_audit_contract::AuditConfig;
 
-/// `Language` now lives in `crate::engine::language` — the foundation layer,
+/// `Language` now lives in `homeboy_engine_primitives::language` — the foundation layer,
 /// since it is a source-file primitive with no audit dependencies. Re-exported
 /// here so existing `code_audit::conventions::Language` paths keep resolving.
-pub use crate::engine::language::Language;
+pub use homeboy_engine_primitives::language::Language;
 
 /// Generic, framework-agnostic tracker-reference regex defaults shipped with
 /// Homeboy core. These match issue/PR/ticket URL shapes that are not tied to

--- a/crates/homeboy-core/src/code_audit/descriptor_runtime.rs
+++ b/crates/homeboy-core/src/code_audit/descriptor_runtime.rs
@@ -15,7 +15,7 @@ use super::{
     Finding, FingerprintDetectorRunner, GenericDetectorRunner, RootDetectorRunner,
 };
 use crate::component::{self, AuditConfig};
-use crate::engine::codebase_scan::CodebaseSnapshot;
+use homeboy_engine_primitives::codebase_scan::CodebaseSnapshot;
 use std::path::Path;
 
 /// Inputs shared by every data-driven detector. The descriptor table dispatches

--- a/crates/homeboy-core/src/code_audit/detectors/enum_dispatch_contracts.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/enum_dispatch_contracts.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use crate::engine::codebase_scan::CodebaseSnapshot;
+use homeboy_engine_primitives::codebase_scan::CodebaseSnapshot;
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
@@ -654,7 +654,7 @@ mod tests {
         )
         .expect("write fixture");
 
-        use crate::engine::codebase_scan::{ExtensionFilter, ScanConfig};
+        use homeboy_engine_primitives::codebase_scan::{ExtensionFilter, ScanConfig};
         let snapshot = CodebaseSnapshot::build(
             dir.path(),
             &ScanConfig {

--- a/crates/homeboy-core/src/code_audit/detectors/layer_ownership.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/layer_ownership.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 use glob_match::glob_match;
 
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use homeboy_engine_primitives::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};

--- a/crates/homeboy-core/src/code_audit/detectors/test_topology.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/test_topology.rs
@@ -8,8 +8,8 @@ use std::path::Path;
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
-use crate::engine::command::{wait_with_bounded_output, DEFAULT_CAPTURE_LIMIT_BYTES};
+use homeboy_engine_primitives::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use homeboy_engine_primitives::command::{wait_with_bounded_output, DEFAULT_CAPTURE_LIMIT_BYTES};
 
 #[path = "../test_quality.rs"]
 mod test_quality;

--- a/crates/homeboy-core/src/code_audit/detectors/thin_command_adapter.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/thin_command_adapter.rs
@@ -21,8 +21,8 @@ use std::path::Path;
 
 use regex::Regex;
 
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
 use homeboy_audit_contract::ThinCommandAdapterConfig;
+use homeboy_engine_primitives::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};

--- a/crates/homeboy-core/src/code_audit/discovery.rs
+++ b/crates/homeboy-core/src/code_audit/discovery.rs
@@ -8,8 +8,8 @@ use super::fingerprint::{fingerprint_content, normalize_convention_tags, FileFin
 use super::walker::{
     extension_provided_file_extensions, is_extension_provided_source_file, is_test_path,
 };
-use crate::engine::codebase_scan::CodebaseSnapshot;
 use homeboy_audit_contract::AuditConfig;
+use homeboy_engine_primitives::codebase_scan::CodebaseSnapshot;
 
 type DiscoveryGroupKey = (String, Language, bool, Vec<String>);
 

--- a/crates/homeboy-core/src/code_audit/docs_audit/mod.rs
+++ b/crates/homeboy-core/src/code_audit/docs_audit/mod.rs
@@ -118,7 +118,7 @@ pub struct AuditResult {
 const DEFAULT_DOC_EXCLUDES: &[&str] = &["changelog.md"];
 
 pub(crate) fn find_doc_files(docs_path: &Path, excluded_targets: &[String]) -> Vec<String> {
-    use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+    use homeboy_engine_primitives::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
     if !docs_path.exists() {
         return Vec::new();

--- a/crates/homeboy-core/src/code_audit/docs_audit/verify.rs
+++ b/crates/homeboy-core/src/code_audit/docs_audit/verify.rs
@@ -7,7 +7,7 @@
 use std::fs;
 use std::path::Path;
 
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig, WalkEntry};
+use homeboy_engine_primitives::codebase_scan::{self, ExtensionFilter, ScanConfig, WalkEntry};
 
 use super::claims::{Claim, ClaimType};
 

--- a/crates/homeboy-core/src/code_audit/engine.rs
+++ b/crates/homeboy-core/src/code_audit/engine.rs
@@ -556,7 +556,9 @@ pub(super) fn audit_internal(
 ///
 /// The snapshot uses structural source extensions so structural checks avoid a
 /// second walk/read of the tree.
-fn build_shared_source_snapshot(root: &Path) -> crate::engine::codebase_scan::CodebaseSnapshot {
+fn build_shared_source_snapshot(
+    root: &Path,
+) -> homeboy_engine_primitives::codebase_scan::CodebaseSnapshot {
     let additional: Vec<String> = structural::source_extensions()
         .iter()
         .map(|ext| (*ext).to_string())

--- a/crates/homeboy-core/src/code_audit/fingerprint.rs
+++ b/crates/homeboy-core/src/code_audit/fingerprint.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use super::conventions::Language;
-use crate::engine::codebase_scan::CodebaseSnapshot;
+use homeboy_engine_primitives::codebase_scan::CodebaseSnapshot;
 
 /// A structural fingerprint extracted from a single source file.
 #[derive(Debug, Clone, Default)]
@@ -274,7 +274,7 @@ impl FingerprintIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::codebase_scan::ScanConfig;
+    use homeboy_engine_primitives::codebase_scan::ScanConfig;
 
     /// Sort a slice of strings into an owned Vec for set-equivalence asserts.
     /// Used because some fingerprint vector fields come from HashMap iteration

--- a/crates/homeboy-core/src/code_audit/impact.rs
+++ b/crates/homeboy-core/src/code_audit/impact.rs
@@ -118,8 +118,11 @@ pub(crate) fn fingerprint_from_git_ref(
 ) -> Option<FileFingerprint> {
     // Get file content from the git ref
     let git_spec = format!("{}:{}", git_ref, relative_path);
-    let content =
-        crate::engine::command::run_in_optional(source_path, "git", &["show", &git_spec])?;
+    let content = homeboy_engine_primitives::command::run_in_optional(
+        source_path,
+        "git",
+        &["show", &git_spec],
+    )?;
 
     let ext = Path::new(relative_path).extension()?.to_str()?;
     super::fingerprint::fingerprint_extension_content(ext, relative_path, &content)

--- a/crates/homeboy-core/src/code_audit/run.rs
+++ b/crates/homeboy-core/src/code_audit/run.rs
@@ -27,7 +27,7 @@ pub struct AuditRunWorkflowArgs {
     pub exclude_labels: Vec<String>,
     pub profile: code_audit::AuditProfile,
     pub extension_overrides: Vec<String>,
-    pub baseline_flags: crate::engine::baseline::BaselineFlags,
+    pub baseline_flags: homeboy_engine_primitives::baseline::BaselineFlags,
     pub changed_since: Option<String>,
     pub precomputed_changed_files: Option<Vec<String>>,
     pub json_summary: bool,

--- a/crates/homeboy-core/src/code_audit/structural.rs
+++ b/crates/homeboy-core/src/code_audit/structural.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::engine::codebase_scan::{CodebaseSnapshot, ExtensionFilter, ScanConfig};
+use homeboy_engine_primitives::codebase_scan::{CodebaseSnapshot, ExtensionFilter, ScanConfig};
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};

--- a/crates/homeboy-core/src/code_audit/test_quality.rs
+++ b/crates/homeboy-core/src/code_audit/test_quality.rs
@@ -7,7 +7,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use homeboy_engine_primitives::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
 use crate::code_audit::conventions::AuditFinding;
 use crate::code_audit::findings::{Finding, Severity};

--- a/crates/homeboy-core/src/code_audit/walker.rs
+++ b/crates/homeboy-core/src/code_audit/walker.rs
@@ -1,10 +1,12 @@
 //! walker — extracted from conventions.rs.
 //!
-//! File walking delegated to `crate::engine::codebase_scan` for consistency.
+//! File walking delegated to `homeboy_engine_primitives::codebase_scan` for consistency.
 
 use std::path::Path;
 
-use crate::engine::codebase_scan::{self, CodebaseSnapshot, ExtensionFilter, ScanConfig};
+use homeboy_engine_primitives::codebase_scan::{
+    self, CodebaseSnapshot, ExtensionFilter, ScanConfig,
+};
 
 // `is_test_path` is a pure path classifier consumed by both code_audit and
 // extension; it now lives in homeboy-engine-primitives so those two feature


### PR DESCRIPTION
## Summary

`code_audit`'s 17 `crate::engine::*` imports were **all** modules that already live in `homeboy-engine-primitives` (`codebase_scan`, `language`, `command`, `baseline`) — routing through core's engine re-export bridge instead of the crate where they live.

Repoint them to `homeboy_engine_primitives::` directly.

## Result

`code_audit → engine` real edges drop from **17 → 0**.

Combined with the earlier config/fingerprint contract extractions, the grammar/language/is_test_path primitive moves, and the manifest-provider hook (#8557), `code_audit`'s only remaining upward edges are now:
- **extension (12)** — `TestMappingConfig` / `TestVacuityPolicy` config types (the cascade to fold into the contract) + a couple test-only (`save_manifest`, `bench`)
- **component (4)** — `scope` (2), `Component` (1), `ArtifactPortabilityConfig` (1, already in contract)
- **observation (2)** — one detector's `ObservationStore` use

That's the crisp remaining blocker list before `code_audit` can physically move to `homeboy-audit`.

## Verification

- `cargo check -p homeboy-core --lib` — clean
- `cargo check --workspace --tests --locked` — **green**

Refs #8425