### PR TITLE
refactor: invert upgrade→runners boundary via provider hook (runner-extraction stage 2)

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -116,6 +116,9 @@ impl CliRuntime {
         // scheduler can verify lab-materialized workspaces without core depending
         // on runner behavior.
         crate::core::runner::register_lab_workspace_provenance_provider();
+        // Register the runner-upgrade provider so the core upgrade flow can
+        // refresh configured runners without depending on runner behavior.
+        crate::core::upgrade::register_runner_upgrade();
         // Register the command-label resolver so core::runner can map dispatched
         // argv to a hot-command label without depending on the full CLI parser.
         crate::core::runner::set_command_label_resolver(|argv| {

--- a/crates/homeboy-core/src/upgrade/helpers.rs
+++ b/crates/homeboy-core/src/upgrade/helpers.rs
@@ -7,7 +7,6 @@ use std::process::Command;
 
 use super::constants::{GITHUB_RELEASES_API, VERSION};
 use super::execution::{execute_upgrade, resolve_source_workspace};
-use super::runners;
 use super::services;
 use super::types::*;
 use super::validation::check_for_updates;
@@ -184,14 +183,16 @@ pub fn run_upgrade_with_method(
             let (runners_updated, runners_skipped) = if skip_runners {
                 (vec![], vec![])
             } else {
-                runners::upgrade_configured_runners_with_explicit_source_path(
-                    force,
-                    runner_method_override,
-                    source_upgrade_path.as_deref(),
-                    source_path.is_some(),
-                    runner_targets,
-                    &extensions_updated,
-                )?
+                super::with_runner_upgrade(|p| {
+                    p.upgrade_configured_runners_with_explicit_source_path(
+                        force,
+                        runner_method_override,
+                        source_upgrade_path.as_deref(),
+                        source_path.is_some(),
+                        runner_targets,
+                        &extensions_updated,
+                    )
+                })?
             };
             let source_drift = same_version_source_checkout_drift(
                 previous_build_identity.as_deref(),
@@ -261,14 +262,16 @@ pub fn run_upgrade_with_method(
     promotion_lease.assert_generation()?;
     let (runners_updated, runners_skipped) = if upgrade_completed && !skip_runners {
         upgrade_phase("refreshing configured runners");
-        runners::upgrade_configured_runners_with_explicit_source_path(
-            force,
-            runner_method_override,
-            source_upgrade_path.as_deref(),
-            source_path.is_some(),
-            runner_targets,
-            &extensions_updated,
-        )?
+        super::with_runner_upgrade(|p| {
+            p.upgrade_configured_runners_with_explicit_source_path(
+                force,
+                runner_method_override,
+                source_upgrade_path.as_deref(),
+                source_path.is_some(),
+                runner_targets,
+                &extensions_updated,
+            )
+        })?
     } else {
         (vec![], vec![])
     };
@@ -699,7 +702,8 @@ fn same_version_source_checkout_drift(
     skip_services: bool,
 ) -> Option<SourceCheckoutDriftWarning> {
     let checkout = resolve_source_workspace(source_path).ok()?;
-    let source_identity = runners::source_checkout_build_identity(&checkout)?;
+    let source_identity =
+        super::with_runner_upgrade(|p| p.source_checkout_build_identity(&checkout))?;
     if active_build_identity == Some(source_identity.as_str()) {
         return None;
     }
@@ -806,6 +810,10 @@ version = "0.0.0"
 
     #[test]
     fn same_version_source_checkout_drift_reports_recovery_command() {
+        // Exercises source_checkout_build_identity, which lives behind the
+        // RunnerUpgradeProvider hook. Register the provider (normally done at CLI
+        // startup) so build-identity detection runs.
+        crate::upgrade::register_runner_upgrade();
         let dir = tempdir().unwrap();
         std::fs::write(dir.path().join("homeboy.json"), r#"{"id":"homeboy"}"#).unwrap();
         std::fs::write(

--- a/crates/homeboy-core/src/upgrade/mod.rs
+++ b/crates/homeboy-core/src/upgrade/mod.rs
@@ -2,6 +2,7 @@ mod constants;
 mod execution;
 mod helpers;
 mod planning;
+mod runner_upgrade_provider;
 mod runners;
 mod services;
 mod types;
@@ -14,6 +15,9 @@ pub use helpers::{
     run_upgrade_with_method,
 };
 pub use planning::resolve_binary_on_path;
+pub(crate) use runner_upgrade_provider::with_runner_upgrade;
+pub use runner_upgrade_provider::{register_runner_upgrade_provider, RunnerUpgradeProvider};
+pub use runners::register as register_runner_upgrade;
 pub use types::{
     ExtensionUpgradeEntry, InstallMethod, RunnerUpgradeEntry, ServiceRestartEntry, UpgradeResult,
     VersionCheck,

--- a/crates/homeboy-core/src/upgrade/runner_upgrade_provider.rs
+++ b/crates/homeboy-core/src/upgrade/runner_upgrade_provider.rs
@@ -1,0 +1,81 @@
+//! Runner-upgrade provider hook.
+//!
+//! The core upgrade flow (`upgrade::helpers`) upgrades configured runners as
+//! part of `homeboy upgrade`. That orchestration is runner-domain — runner is an
+//! optional Lab-offload feature — so core defines the [`RunnerUpgradeProvider`]
+//! contract here and the runner layer registers an implementation at startup.
+//!
+//! With no provider registered there are no runners to upgrade, so the
+//! [`NoopRunnerUpgradeProvider`] reports no upgrades and no build identity.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use crate::error::Result;
+use crate::upgrade::{ExtensionUpgradeEntry, InstallMethod, RunnerUpgradeEntry};
+
+/// The runner-upgrade contract the core upgrade flow depends on. Implemented by
+/// the runner layer and registered at startup.
+pub trait RunnerUpgradeProvider: Send + Sync {
+    /// Upgrade the configured runners from an explicit source checkout,
+    /// returning `(upgraded, skipped)` entries.
+    #[allow(clippy::too_many_arguments)]
+    fn upgrade_configured_runners_with_explicit_source_path(
+        &self,
+        force: bool,
+        method_override: Option<InstallMethod>,
+        source_path: Option<&Path>,
+        explicit_source_path: bool,
+        runner_targets: &[String],
+        extension_updates: &[ExtensionUpgradeEntry],
+    ) -> Result<(Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>)>;
+
+    /// A short build-identity string for a source checkout (commit + dirty
+    /// marker), or `None` if it can't be identified.
+    fn source_checkout_build_identity(&self, source_path: &Path) -> Option<String>;
+}
+
+/// Default provider used when no runner layer is registered: no runners to
+/// upgrade, no build identity.
+struct NoopRunnerUpgradeProvider;
+
+impl RunnerUpgradeProvider for NoopRunnerUpgradeProvider {
+    fn upgrade_configured_runners_with_explicit_source_path(
+        &self,
+        _force: bool,
+        _method_override: Option<InstallMethod>,
+        _source_path: Option<&Path>,
+        _explicit_source_path: bool,
+        _runner_targets: &[String],
+        _extension_updates: &[ExtensionUpgradeEntry],
+    ) -> Result<(Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>)> {
+        Ok((Vec::new(), Vec::new()))
+    }
+
+    fn source_checkout_build_identity(&self, _source_path: &Path) -> Option<String> {
+        None
+    }
+}
+
+static PROVIDER: Mutex<Option<Box<dyn RunnerUpgradeProvider>>> = Mutex::new(None);
+
+/// Register the runner-upgrade provider. Called once at startup by the runner
+/// layer (via the CLI).
+pub fn register_runner_upgrade_provider(provider: Box<dyn RunnerUpgradeProvider>) {
+    let mut guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = Some(provider);
+}
+
+/// Run `f` against the registered provider, or the no-op provider if none is
+/// registered.
+pub(crate) fn with_runner_upgrade<T>(f: impl FnOnce(&dyn RunnerUpgradeProvider) -> T) -> T {
+    let guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    match guard.as_ref() {
+        Some(provider) => f(provider.as_ref()),
+        None => f(&NoopRunnerUpgradeProvider),
+    }
+}

--- a/crates/homeboy-core/src/upgrade/runners/mod.rs
+++ b/crates/homeboy-core/src/upgrade/runners/mod.rs
@@ -27,5 +27,47 @@ pub(super) use reporting::*;
 pub(super) use source_checkout::*;
 pub(super) use version::*;
 
+use std::path::Path;
+
+use crate::error::Result;
+use crate::upgrade::{
+    ExtensionUpgradeEntry, InstallMethod, RunnerUpgradeEntry, RunnerUpgradeProvider,
+};
+
+/// The runner layer's `RunnerUpgradeProvider`, delegating to this cluster's
+/// upgrade orchestration. Registered with core at startup.
+pub struct RunnerUpgrade;
+
+impl RunnerUpgradeProvider for RunnerUpgrade {
+    fn upgrade_configured_runners_with_explicit_source_path(
+        &self,
+        force: bool,
+        method_override: Option<InstallMethod>,
+        source_path: Option<&Path>,
+        explicit_source_path: bool,
+        runner_targets: &[String],
+        extension_updates: &[ExtensionUpgradeEntry],
+    ) -> Result<(Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>)> {
+        upgrade_configured_runners_with_explicit_source_path(
+            force,
+            method_override,
+            source_path,
+            explicit_source_path,
+            runner_targets,
+            extension_updates,
+        )
+    }
+
+    fn source_checkout_build_identity(&self, source_path: &Path) -> Option<String> {
+        source_checkout_build_identity(source_path)
+    }
+}
+
+/// Register this cluster's runner-upgrade provider with core. Called once at
+/// startup.
+pub fn register() {
+    crate::upgrade::register_runner_upgrade_provider(Box::new(RunnerUpgrade));
+}
+
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary
**Stage 2** of the wholesale `homeboy-runner` extraction. The core upgrade flow (`upgrade::helpers`) called into the `upgrade/runners` cluster via two functions: `upgrade_configured_runners_with_explicit_source_path` and `source_checkout_build_identity`. That cluster is runner-upgrade orchestration (runner-domain), so this inverts the boundary behind a `RunnerUpgradeProvider` hook.

## Design
- **Core** owns the trait + registry + `NoopProvider` in `upgrade/runner_upgrade_provider.rs`. All signature types (`InstallMethod`, `ExtensionUpgradeEntry`, `RunnerUpgradeEntry`) already live in `upgrade/types.rs`, so no new types are needed. NoopProvider reports no runner upgrades and no build identity (correct when there's no runner).
- The `upgrade/runners` cluster implements it (`RunnerUpgrade` in `runners/mod.rs`), delegating to its existing functions, and registers at CLI startup.
- `helpers.rs` now calls the provider via `with_runner_upgrade(...)` and **no longer imports `super::runners`**.

## Why this matters
After this, `upgrade/runners` is only reached through the hook — so it can move into the runner crate with the wholesale `git mv` (stage 3) without core's upgrade flow depending on it.

## Verification
`cargo check` clean for `-p homeboy-core --lib/--tests`, `-p homeboy-cli --lib`; all 111 upgrade tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)