### PR TITLE
Preserve detached runner artifact provenance

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -864,6 +864,16 @@ pub(crate) fn reconcile_runner_job_snapshot(
         }
         return Ok(());
     }
+    if matches!(
+        snapshot.job.status,
+        crate::api_jobs::JobStatus::Succeeded
+            | crate::api_jobs::JobStatus::Failed
+            | crate::api_jobs::JobStatus::Cancelled
+    ) {
+        if let Some(event) = terminal_runner_lifecycle_event(record, snapshot)? {
+            preserve_terminal_runner_identity(record, &event)?;
+        }
+    }
     validate_runner_job_snapshot(record, snapshot)?;
     let mut reconciled = record.clone();
     reconciled.record_runner_reachable();
@@ -938,6 +948,7 @@ fn project_terminal_runner_lifecycle_event(
     snapshot: &crate::runner::RunnerJobLogSnapshot,
     event: &crate::agent_task_lifecycle::agent_task_lifecycle_event::AgentTaskRunPlanLifecycleEvent,
 ) -> Result<()> {
+    preserve_terminal_runner_identity(record, event)?;
     validate_runner_job_snapshot(record, snapshot)?;
     validate_terminal_child_identity(record, snapshot, event)?;
     let projection_plan = aggregate_projection_plan_from_outcomes(&event.aggregate);
@@ -950,6 +961,37 @@ fn project_terminal_runner_lifecycle_event(
     record_runner_job_terminal_metadata(record, snapshot.job.status, &snapshot.events);
     store::write_aggregate_and_record(record, &event.aggregate)?;
     crate::agent_task_lifecycle::record_terminal_artifact_projection(record, &event.aggregate)
+}
+
+fn preserve_terminal_runner_identity(
+    record: &mut AgentTaskRunRecord,
+    event: &crate::runner::agent_task_lifecycle_event::AgentTaskRunPlanLifecycleEvent,
+) -> Result<()> {
+    let identity = &event.identity;
+    if identity.runner_id.trim().is_empty()
+        || identity.runner_job_id.trim().is_empty()
+        || identity.run_id.as_deref() != Some(record.run_id.as_str())
+        || identity.persisted_run_id.as_deref() != Some(record.run_id.as_str())
+    {
+        return Ok(());
+    }
+
+    let metadata = record.ensure_metadata_object();
+    if metadata
+        .get("runner_id")
+        .and_then(Value::as_str)
+        .is_none_or(str::is_empty)
+    {
+        metadata.insert("runner_id".to_string(), json!(identity.runner_id));
+    }
+    if metadata
+        .get("runner_job_id")
+        .and_then(Value::as_str)
+        .is_none_or(str::is_empty)
+    {
+        metadata.insert("runner_job_id".to_string(), json!(identity.runner_job_id));
+    }
+    Ok(())
 }
 
 fn merge_live_provider_handles(

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -14,6 +14,7 @@ use crate::agent_task_scheduler::{
 };
 use crate::api_jobs::{JobEvent, JobEventKind};
 use crate::test_support::with_isolated_home;
+use sha2::Digest;
 
 #[test]
 fn provider_run_result_reads_declared_output_alias() {
@@ -1568,6 +1569,95 @@ fn transport_proxy_snapshot_reconciliation_advances_queued_lifecycle() {
         assert_eq!(
             record.metadata["runner_execution_record"]["status"],
             "succeeded"
+        );
+    });
+}
+
+#[test]
+fn recovery_preserves_terminal_runner_identity_before_projecting_runner_artifacts() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let run_id = "agent-task-recovered-runner-artifact";
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id,
+            runner_id: "runner/a:lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("detached handoff");
+        record.ensure_metadata_object().remove("runner_id");
+        record.ensure_metadata_object().remove("runner_job_id");
+
+        let patch = "runner patch";
+        let finalized = crate::paths::artifact_root()
+            .expect("artifact root")
+            .join("executor-finalized")
+            .join(run_id)
+            .join("patch.diff");
+        std::fs::create_dir_all(finalized.parent().expect("finalized parent"))
+            .expect("create finalized parent");
+        std::fs::write(&finalized, patch).expect("write finalized patch");
+        let mut aggregate = succeeded_aggregate(&test_plan());
+        aggregate.outcomes[0].artifacts.push(AgentTaskArtifact {
+            schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+            id: "patch".to_string(),
+            kind: "patch".to_string(),
+            name: None,
+            label: None,
+            role: None,
+            semantic_key: None,
+            path: Some("/home/runner/.homeboy/executor-finalized/patch.diff".to_string()),
+            url: None,
+            mime: Some("text/x-patch".to_string()),
+            size_bytes: Some(patch.len() as u64),
+            sha256: Some(format!("{:x}", sha2::Sha256::digest(patch.as_bytes()))),
+            metadata: json!({ "executor_artifact_finalized": true }),
+        });
+        let mut snapshot = terminal_child_snapshot(&aggregate);
+        snapshot.events[0].data.as_mut().expect("event data")["identity"]["runner_id"] =
+            json!("runner/a:lab");
+        snapshot.events[0].data.as_mut().expect("event data")["identity"]["run_id"] = json!(run_id);
+        snapshot.events[0].data.as_mut().expect("event data")["identity"]["persisted_run_id"] =
+            json!(run_id);
+        let event = crate::runner::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_job_events(
+            Some(&snapshot.events),
+        )
+        .expect("terminal lifecycle event");
+        assert_eq!(event.identity.runner_id, "runner/a:lab");
+        assert_eq!(
+            event.identity.runner_job_id,
+            "00000000-0000-0000-0000-000000000123"
+        );
+        assert_eq!(event.identity.run_id.as_deref(), Some(run_id));
+        assert_eq!(event.identity.persisted_run_id.as_deref(), Some(run_id));
+
+        reconcile_runner_job_snapshot(&mut record, &snapshot).expect("terminal recovery");
+
+        assert_eq!(record.metadata["runner_id"], "runner/a:lab");
+        assert_eq!(
+            record.metadata["runner_job_id"],
+            "00000000-0000-0000-0000-000000000123"
+        );
+        assert_eq!(record.metadata["artifact_projection"]["status"], "complete");
+        let artifacts = crate::observation::ObservationStore::open_initialized()
+            .expect("store")
+            .list_artifacts(run_id)
+            .expect("artifact projections");
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].artifact_type, "file");
+        let projected = verified_controller_artifact_projection_path(
+            run_id,
+            &aggregate.outcomes[0].task_id,
+            &aggregate.outcomes[0].artifacts[0],
+        );
+        assert_eq!(
+            projected.expect("verify projection"),
+            Some(std::path::PathBuf::from(&artifacts[0].path))
+        );
+        assert_ne!(
+            artifacts[0].path,
+            "/home/runner/.homeboy/executor-finalized/patch.diff"
         );
     });
 }


### PR DESCRIPTION
## Summary
Preserve validated runner identity before detached terminal evidence is projected on the controller.

## What changed
- Carry terminal lifecycle runner\_id and runner\_job\_id into the controller record before validation and artifact projection.
- Cover recovered finalized bytes through bridge reconciliation and verified local promotion.

## How to test
1. Run `cargo test -p homeboy-core recovery_preserves_terminal_runner_identity_before_projecting_runner_artifacts`; expect The detached recovery test passes..
2. Run `cargo test -p homeboy-core bridge_reconciliation_projects_recovered_finalized_bytes_for_local_promotion_idempotently`; expect The bridge-to-local-promotion test passes..
3. Run `cargo fmt --check`; expect Formatting is clean..

## Compatibility
No public interface or extension-path compatibility changes; this corrects detached Lab lifecycle provenance and preserves fail-closed artifact verification.

## Evidence
- CI expected: GitHub Actions
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8548
- bridge-promotion-test: Passed
- focused-lifecycle-test: Passed
- formatting: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the live detached-run failure and drafted the implementation and regression tests; Chris owns and reviews the change.

## Source relationships
- Closes Extra-Chill/homeboy#8548
