### PR TITLE
refactor: import code_audit's component config types direct from the contract (#8425)

### DIFF
--- a/crates/homeboy-core/src/code_audit/descriptor_runtime.rs
+++ b/crates/homeboy-core/src/code_audit/descriptor_runtime.rs
@@ -14,7 +14,8 @@ use super::{
     time_audit_detector, AuditExecutionPlan, AuditTiming, DetectorDescriptor, DetectorRuntime,
     Finding, FingerprintDetectorRunner, GenericDetectorRunner, RootDetectorRunner,
 };
-use crate::component::{self, AuditConfig};
+use crate::component;
+use homeboy_audit_contract::AuditConfig;
 use homeboy_engine_primitives::codebase_scan::CodebaseSnapshot;
 use std::path::Path;
 

--- a/crates/homeboy-core/src/code_audit/detectors/artifact_portability.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/artifact_portability.rs
@@ -2,9 +2,9 @@ use std::path::Path;
 
 use crate::code_audit::conventions::AuditFinding;
 use crate::code_audit::findings::{Finding, Severity};
-use crate::component::ArtifactPortabilityConfig;
 use crate::execution_contract::EXECUTION_CONTRACT;
 use crate::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
+use homeboy_audit_contract::ArtifactPortabilityConfig;
 use serde_json::Value;
 
 pub(crate) const DEFAULT_OBSERVATION_RUN_WINDOW: usize = 1000;

--- a/crates/homeboy-core/src/code_audit/detectors/command_status_contracts.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/command_status_contracts.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use crate::component::{CommandStatusContractConfig, CommandStatusContractScenario};
+use homeboy_audit_contract::{CommandStatusContractConfig, CommandStatusContractScenario};
 
 use super::super::{AuditFinding, Finding, Severity};
 

--- a/crates/homeboy-core/src/code_audit/detectors/config_key_usage.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/config_key_usage.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use regex::Regex;
 
-use crate::component::{ConfigKeyUsagePattern, ConfigKeyUsageRule};
+use homeboy_audit_contract::{ConfigKeyUsagePattern, ConfigKeyUsageRule};
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};

--- a/crates/homeboy-core/src/code_audit/detectors/deprecation_age.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/deprecation_age.rs
@@ -24,7 +24,7 @@ use semver::Version;
 use super::conventions::{AuditFinding, Language};
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
-use crate::component::{DetectorProfileConfig, VersionSource};
+use homeboy_audit_contract::{DetectorProfileConfig, VersionSource};
 
 /// Default age threshold: flag when the current minor is more than
 /// this many minors ahead of the deprecated version on the same major,

--- a/crates/homeboy-core/src/code_audit/detectors/requested_detectors.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/requested_detectors.rs
@@ -4,7 +4,7 @@ use regex::{Captures, Regex};
 use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 
-use crate::component::{
+use homeboy_audit_contract::{
     AuditConfig, RequestedDetectorRule, RequestedDetectorRuleBody, RequiredRegexScope,
 };
 

--- a/crates/homeboy-core/src/code_audit/detectors/source_policy.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/source_policy.rs
@@ -4,7 +4,7 @@ use regex::{Captures, Regex};
 use std::collections::HashMap;
 use std::str::FromStr;
 
-use crate::component::{
+use homeboy_audit_contract::{
     SourcePolicyMatchMode, SourcePolicyRule, SourcePolicyRuleBody, SourcePolicyTerm,
 };
 

--- a/crates/homeboy-core/src/code_audit/detectors/test_wiring.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/test_wiring.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 
 use super::conventions::unwired_test_file_finding;
 use super::findings::{Finding, Severity};
-use crate::component::{AuditConfig, TestWiringPolicy};
+use homeboy_audit_contract::{AuditConfig, TestWiringPolicy};
 
 pub(crate) fn run(root: &Path, audit_config: &AuditConfig) -> Vec<Finding> {
     let mut findings = Vec::new();

--- a/crates/homeboy-core/src/code_audit/requirements.rs
+++ b/crates/homeboy-core/src/code_audit/requirements.rs
@@ -21,11 +21,11 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use crate::component::{
+use homeboy_audit_contract::KnownSymbolSourceScanConfig;
+use homeboy_audit_contract::{
     AuditConfig, KnownSymbolEntry, KnownSymbolHeaderVersionProvider, KnownSymbolKind,
     KnownSymbolVersionedEntry,
 };
-use homeboy_audit_contract::KnownSymbolSourceScanConfig;
 
 /// Symbols guaranteed to be defined at runtime given the plugin's declared
 /// requirements and its explicit bootstrap wiring.


### PR DESCRIPTION
## Summary

Mirrors the engine repoint (#8558). `code_audit` was still importing its config schema — `AuditConfig`, `DetectorProfileConfig`, `SourcePolicy*`, `KnownSymbol*`, `CommandStatusContract*`, `ConfigKeyUsage*`, `RequestedDetector*`, `TestWiringPolicy`, `VersionSource`, `ArtifactPortabilityConfig` — via `crate::component::*`, through component's back-compat re-export rather than `homeboy-audit-contract` where those types now live. Several were grouped `use crate::component::{...}` imports the earlier per-type repoints didn't reach.

Repoint them all to `homeboy_audit_contract::`. `descriptor_runtime` splits its grouped import (`component::load` stays, `AuditConfig` → contract).

## Result

`code_audit → component` real edges drop to the **two irreducible ones**: `scope` (component scope resolution) and `Component` (the model). Every audit config type now comes straight from the contract crate.

## Where the campaign stands — the finish line

`code_audit`'s upward edges are now:
- **engine: 0**, **component: 2** (`scope`, `Component`), **extension: 4** (3 test-only + `ExtensionPhaseTiming`), **observation: 1** (production)

The **only** genuinely non-trivial remaining blocker is the `observation` dep — the `artifact_portability` detector reads `ObservationStore` in production to check recorded run artifacts. That needs a provider hook (like the manifest-provider hook #8557). After that, `code_audit` (43k LOC) can physically move to `homeboy-audit`.

## Verification

- `cargo check -p homeboy-core --lib` — clean
- `cargo check --workspace --tests --locked` — **green**

Refs #8425