### PR TITLE
refactor: relocate validation_dependency_ids from runner into core hygiene (runner-extraction prep)

### DIFF
--- a/crates/homeboy-core/src/hygiene.rs
+++ b/crates/homeboy-core/src/hygiene.rs
@@ -292,8 +292,61 @@ fn validation_dependency_ids_from_value(value: &serde_json::Value) -> Vec<String
         .collect()
 }
 
-fn validation_dependency_ids(source_path: &Path) -> Result<Vec<String>> {
-    crate::runner::validation_dependency_ids(source_path)
+const PORTABLE_CONFIG_FILE: &str = concat!("homeboy", ".json");
+
+/// Collect the declared `validation_dependencies` extension IDs from a portable
+/// homeboy.json manifest. Pure single-machine manifest parsing (no runner) — a
+/// component's validation deps are the same whether or not a runner is present.
+pub(crate) fn validation_dependency_ids(local_path: &Path) -> Result<Vec<String>> {
+    let manifest_path = local_path.join(PORTABLE_CONFIG_FILE);
+    let Ok(content) = fs::read_to_string(&manifest_path) else {
+        return Ok(Vec::new());
+    };
+    let manifest: serde_json::Value = serde_json::from_str(&content).map_err(|err| {
+        Error::validation_invalid_argument(
+            PORTABLE_CONFIG_FILE,
+            format!("failed to parse {}: {err}", manifest_path.display()),
+            None,
+            None,
+        )
+    })?;
+
+    let mut ids = Vec::new();
+    let Some(extensions) = manifest
+        .get("extensions")
+        .and_then(|value| value.as_object())
+    else {
+        return Ok(ids);
+    };
+
+    for extension in extensions.values() {
+        collect_validation_dependency_ids(extension, &mut ids);
+        if let Some(settings) = extension.get("settings") {
+            collect_validation_dependency_ids(settings, &mut ids);
+        }
+    }
+
+    ids.sort();
+    ids.dedup();
+    Ok(ids)
+}
+
+fn collect_validation_dependency_ids(value: &serde_json::Value, ids: &mut Vec<String>) {
+    let Some(dependencies) = value
+        .get("validation_dependencies")
+        .and_then(|value| value.as_array())
+    else {
+        return;
+    };
+
+    ids.extend(
+        dependencies
+            .iter()
+            .filter_map(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+    );
 }
 
 fn resolve_validation_dependency_path(source_path: &Path, dependency: &str) -> Result<PathBuf> {

--- a/crates/homeboy-core/src/runner/mod.rs
+++ b/crates/homeboy-core/src/runner/mod.rs
@@ -70,7 +70,6 @@ mod source_materialization;
 mod tool_registry;
 mod transport;
 mod validation_dependencies;
-pub(crate) use validation_dependencies::validation_dependency_ids;
 pub use validation_dependencies::RunnerValidationDependencySyncOutput;
 mod worker;
 pub(crate) mod workload;

--- a/crates/homeboy-core/src/runner/validation_dependencies.rs
+++ b/crates/homeboy-core/src/runner/validation_dependencies.rs
@@ -66,7 +66,7 @@ fn validation_dependency_workspaces(
     local_path: &Path,
     excludes: &[String],
 ) -> Result<Vec<PreparedValidationDependencyWorkspace>> {
-    let dependency_ids = validation_dependency_ids(local_path)?;
+    let dependency_ids = crate::hygiene::validation_dependency_ids(local_path)?;
     if dependency_ids.is_empty() {
         return Ok(Vec::new());
     }
@@ -83,57 +83,9 @@ fn validation_dependency_workspaces(
         .collect()
 }
 
-pub(crate) fn validation_dependency_ids(local_path: &Path) -> Result<Vec<String>> {
-    let manifest_path = local_path.join(PORTABLE_CONFIG_FILE);
-    let Ok(content) = fs::read_to_string(&manifest_path) else {
-        return Ok(Vec::new());
-    };
-    let manifest: serde_json::Value = serde_json::from_str(&content).map_err(|err| {
-        Error::validation_invalid_argument(
-            PORTABLE_CONFIG_FILE,
-            format!("failed to parse {}: {err}", manifest_path.display()),
-            None,
-            None,
-        )
-    })?;
-
-    let mut ids = Vec::new();
-    let Some(extensions) = manifest
-        .get("extensions")
-        .and_then(|value| value.as_object())
-    else {
-        return Ok(ids);
-    };
-
-    for extension in extensions.values() {
-        collect_validation_dependency_ids(extension, &mut ids);
-        if let Some(settings) = extension.get("settings") {
-            collect_validation_dependency_ids(settings, &mut ids);
-        }
-    }
-
-    ids.sort();
-    ids.dedup();
-    Ok(ids)
-}
-
-fn collect_validation_dependency_ids(value: &serde_json::Value, ids: &mut Vec<String>) {
-    let Some(dependencies) = value
-        .get("validation_dependencies")
-        .and_then(|value| value.as_array())
-    else {
-        return;
-    };
-
-    ids.extend(
-        dependencies
-            .iter()
-            .filter_map(|value| value.as_str())
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string),
-    );
-}
+// validation_dependency_ids (+ its collector) is pure single-machine manifest
+// parsing; it now lives in core's hygiene module. Called here via
+// crate::hygiene::validation_dependency_ids.
 
 fn canonicalize_dependency_path(path: &Path, dependency_id: &str) -> Result<PathBuf> {
     path.canonicalize().map_err(|err| {


### PR DESCRIPTION
## Summary
Prep for the runner extraction, applying the **"single-machine core vs runner feature"** lens: a component's declared `validation_dependencies` come from its portable `homeboy.json` manifest and are the same whether or not a runner is present. `validation_dependency_ids` (+ its collector) is pure manifest parsing that was mis-filed under runner.

Moved both functions into core's `hygiene` module (which already wrapped it and was the sole external consumer). Runner's own internal caller now uses `crate::hygiene::validation_dependency_ids`; the runner re-export is dropped.

## Impact
Severs one of `hygiene`'s two core→runner edges. (`copy_snapshot_to_directory`, which is woven into runner's snapshot machinery, remains for a later stage.)

## Verification
`cargo check` clean for `-p homeboy-core --lib/--tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)