### PR TITLE
Resume agent tasks through their pinned runtime

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1,5 +1,6 @@
 use clap::{ArgMatches, Command};
 use std::io::IsTerminal;
+use std::process::Command as ProcessCommand;
 use std::sync::OnceLock;
 
 use crate::cli_surface::{
@@ -266,6 +267,15 @@ impl CliRuntime {
             }
         }
 
+        match delegate_agent_task_lifecycle_to_pinned_runtime(&cli, &normalized) {
+            Ok(Some(exit_code)) => return std::process::ExitCode::from(exit_code_to_u8(exit_code)),
+            Ok(None) => {}
+            Err(err) => {
+                output_runtime::emit_json_result(Err(err), output_file.as_deref(), 2);
+                return std::process::ExitCode::from(2);
+            }
+        }
+
         // Capture controller pressure once before placement routing. The route
         // and persisted evidence reuse this preflight decision rather than
         // probing the host a second time.
@@ -334,6 +344,44 @@ impl CliRuntime {
         self.extension_discovery
             .get_or_init(collect_extension_cli_info)
     }
+}
+
+/// Durable lifecycle mutations remain owned by the runtime that admitted the
+/// record. Re-exec before Lab routing so recovery cannot create a replacement
+/// handoff under the promoted controller.
+fn delegate_agent_task_lifecycle_to_pinned_runtime(
+    cli: &Cli,
+    normalized_args: &[String],
+) -> homeboy::core::Result<Option<i32>> {
+    let run_id = match &cli.command {
+        Commands::AgentTask(agent_task) => match &agent_task.command {
+            crate::commands::agent_task::AgentTaskCommand::Run(args) => Some(&args.run_id),
+            crate::commands::agent_task::AgentTaskCommand::Resume(args) => Some(&args.run_id),
+            crate::commands::agent_task::AgentTaskCommand::Retry(args) => Some(&args.run_id),
+            _ => None,
+        },
+        _ => None,
+    };
+    let Some(run_id) = run_id else {
+        return Ok(None);
+    };
+    let Some(pinned) = crate::core::agent_tasks::lifecycle::pinned_runtime_for_mutation(run_id)?
+    else {
+        return Ok(None);
+    };
+    let status = ProcessCommand::new(&pinned)
+        .args(&normalized_args[1..])
+        .status()
+        .map_err(|error| {
+            homeboy::core::Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "execute pinned controller runtime {}",
+                    pinned.display()
+                )),
+            )
+        })?;
+    Ok(Some(status.code().unwrap_or(1)))
 }
 
 fn run_raw_agent_tool_dispatch(command: &Commands) -> Option<i32> {

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -340,6 +340,17 @@ pub fn load_controller_plan(run_id: &str) -> Result<AgentTaskPlan> {
     store::read_controller_plan(&run_id)
 }
 
+/// Return the immutable controller executable that owns a lifecycle mutation
+/// when this process is not the originating runtime. The pin is verified before
+/// it is returned so callers fail closed rather than launching an untrusted path.
+pub fn pinned_runtime_for_mutation(run_id: &str) -> Result<Option<std::path::PathBuf>> {
+    let record = store::read_record(&resolve_run_id(run_id)?)?;
+    crate::controller_runtime::pinned_executable_for_mutation(
+        &record.metadata,
+        &crate::build_identity::current().display,
+    )
+}
+
 /// Load a durable plan for a scheduler or provider execution. This is the only
 /// read path allowed to upgrade a legacy execution-budget envelope.
 pub fn load_plan_for_execution(run_id: &str) -> Result<AgentTaskPlan> {

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -176,6 +176,40 @@ fn active_pinned_run_does_not_block_controller_promotion() {
 }
 
 #[test]
+fn pinned_runtime_recovery_retains_the_existing_lab_proxy_identity() {
+    with_isolated_home(|_| {
+        record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "runtime-a-lab-proxy",
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace",
+            remote_command: &[
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "run".to_string(),
+            ],
+            durable_plan: None,
+        })
+        .expect("runtime A created proxy");
+        rewrite_record_for_test("runtime-a-lab-proxy", |record| {
+            record.metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
+                ["originating"]["build_identity"] = json!("homeboy runtime-a");
+        })
+        .expect("record runtime A provenance");
+
+        let pinned = pinned_runtime_for_mutation("runtime-a-lab-proxy")
+            .expect("runtime B resolves the verified runtime A pin")
+            .expect("runtime B delegates to runtime A");
+        let record = status("runtime-a-lab-proxy").expect("same durable proxy remains");
+
+        assert!(pinned.is_file());
+        assert_eq!(record.run_id, "runtime-a-lab-proxy");
+        assert_eq!(record.state, AgentTaskRunState::Queued);
+        assert_eq!(list_records().expect("one durable record").len(), 1);
+        assert!(record.provider_handles.is_empty());
+    });
+}
+
+#[test]
 fn detached_lab_handoff_persists_inspectable_running_record() {
     with_isolated_home(|_| {
         for (run_id, handoff) in [

--- a/crates/homeboy-core/src/agent_tasks.rs
+++ b/crates/homeboy-core/src/agent_tasks.rs
@@ -249,8 +249,9 @@ pub mod lifecycle {
     pub use super::super::agent_task_lifecycle::{
         aggregate_source, artifacts, cancel, cancel_run, claim_next_queued_run,
         cook_attempt_run_id, cook_index, list_records, load_controller_plan, load_plan, logs,
-        mark_resuming, mark_running, materialize_recovered_patch_artifact, reconcile_record_health,
-        record_completed_run, record_cook_attempt, record_detached_lab_run, record_health_summary,
+        mark_resuming, mark_running, materialize_recovered_patch_artifact,
+        pinned_runtime_for_mutation, reconcile_record_health, record_completed_run,
+        record_cook_attempt, record_detached_lab_run, record_health_summary,
         record_lab_offload_phase, record_lab_offload_planned, record_pre_dispatch_failure,
         record_pre_execution_failure, record_promotion, record_remote_dispatch_failure,
         record_run_aggregate, retry, run_id_for_aggregate_path, run_record_exists, run_status,

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -119,9 +119,12 @@ pub(crate) fn activate_current_generation() -> Result<Value> {
     result
 }
 
-pub(crate) fn validate_for_mutation(metadata: &Value, current_identity: &str) -> Result<()> {
+pub(crate) fn pinned_executable_for_mutation(
+    metadata: &Value,
+    current_identity: &str,
+) -> Result<Option<PathBuf>> {
     let Some(runtime) = metadata.get(CONTROLLER_RUNTIME_METADATA_KEY) else {
-        return Ok(());
+        return Ok(None);
     };
     validate_pin(runtime)?;
     let originating = runtime
@@ -129,12 +132,24 @@ pub(crate) fn validate_for_mutation(metadata: &Value, current_identity: &str) ->
         .and_then(Value::as_str)
         .unwrap_or_default();
     if originating.is_empty() || originating == current_identity {
-        return Ok(());
+        return Ok(None);
     }
     let pinned = runtime
         .pointer("/originating/pinned_executable")
         .and_then(Value::as_str)
         .unwrap_or("<pinned-controller-runtime>");
+    Ok(Some(PathBuf::from(pinned)))
+}
+
+pub(crate) fn validate_for_mutation(metadata: &Value, current_identity: &str) -> Result<()> {
+    let Some(pinned) = pinned_executable_for_mutation(metadata, current_identity)? else {
+        return Ok(());
+    };
+    let originating = metadata
+        .get(CONTROLLER_RUNTIME_METADATA_KEY)
+        .and_then(|runtime| runtime.pointer("/originating/build_identity"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
     Err(Error::validation_invalid_argument(
         "controller_runtime",
         format!(
@@ -142,7 +157,8 @@ pub(crate) fn validate_for_mutation(metadata: &Value, current_identity: &str) ->
         ),
         Some(current_identity.to_string()),
         Some(vec![format!(
-            "Run the lifecycle mutation through the pinned compatible runtime: {pinned} <original homeboy arguments>"
+            "Run the lifecycle mutation through the pinned compatible runtime: {} <original homeboy arguments>",
+            pinned.display()
         )]),
     ))
 }
@@ -316,6 +332,35 @@ mod tests {
         assert!(error.details["tried"][0]
             .as_str()
             .is_some_and(|command| command.contains("homeboy-origin")));
+    }
+
+    #[test]
+    fn identity_mismatch_resolves_the_verified_pinned_executable() {
+        let temporary = tempfile::tempdir().expect("temporary runtime directory");
+        let pinned = temporary.path().join("homeboy-origin");
+        fs::write(&pinned, b"origin").expect("write pinned executable");
+        make_executable_read_only(&pinned).expect("seal executable");
+        let metadata = json!({
+            "controller_runtime": {
+                "originating": {
+                    "build_identity": "homeboy 1.0.0+origin",
+                    "pinned_executable": pinned,
+                    "sha256": executable_digest(&pinned).expect("hash executable"),
+                }
+            }
+        });
+
+        assert_eq!(
+            pinned_executable_for_mutation(&metadata, "homeboy 1.0.0+replacement")
+                .expect("verified pin")
+                .as_deref(),
+            Some(pinned.as_path())
+        );
+        assert!(
+            pinned_executable_for_mutation(&metadata, "homeboy 1.0.0+origin")
+                .expect("origin runtime")
+                .is_none()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- resolve the immutable originating runtime before Lab routing for agent-task run, resume, and retry
- re-exec lifecycle mutations through the verified pinned executable after controller or runner promotion
- preserve fail-closed pin validation and the existing durable run identity

Closes #8549.

## How to test
1. Run cargo test -p homeboy-core pinned_runtime_recovery_retains_the_existing_lab_proxy_identity --lib.
2. Run cargo test -p homeboy-core controller_runtime --lib.
3. Run cargo test -p homeboy-cli controller_proxy_run_uses_transport_recovery_without_provider_dispatch --lib.
4. Run cargo check -p homeboy-core.
5. Run cargo check -p homeboy-cli.
6. Create a queued Lab agent task with runtime A, promote the runner to runtime B, then invoke agent-task run from runtime B and confirm Homeboy delegates to the verified runtime-A pin while retaining one durable run ID.

## Compatibility
This changes only lifecycle recovery when the current build identity differs from a verified immutable controller-runtime pin. Same-runtime mutations are unchanged. Missing or altered pins continue to fail closed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** OpenAI gpt-5.6-sol
- **Used for:** Diagnosed the runtime-promotion handoff failure, implemented the repair and deterministic tests, and prepared verification evidence; Chris reviewed and owns the change.