### PR TITLE
Make Lab batch handoff durable

### DIFF
--- a/crates/homeboy-core/src/agent_task_batch.rs
+++ b/crates/homeboy-core/src/agent_task_batch.rs
@@ -18,6 +18,19 @@ pub fn submit_plan_batch(
     plan: &AgentTaskPlan,
     requested_batch_id: Option<&str>,
 ) -> Result<AgentTaskBatchRecord> {
+    submit_plan_batch_with(plan, requested_batch_id, |child_plan, run_id| {
+        agent_task_lifecycle::submit_plan(child_plan, Some(run_id))
+    })
+}
+
+fn submit_plan_batch_with<F>(
+    plan: &AgentTaskPlan,
+    requested_batch_id: Option<&str>,
+    mut submit_child: F,
+) -> Result<AgentTaskBatchRecord>
+where
+    F: FnMut(&AgentTaskPlan, &str) -> Result<crate::agent_task_lifecycle::AgentTaskRunRecord>,
+{
     if plan.tasks.is_empty() {
         return Err(Error::validation_invalid_argument(
             "input",
@@ -70,19 +83,9 @@ pub fn submit_plan_batch(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    let mut child_runs = Vec::with_capacity(plan.tasks.len());
-    for task in &plan.tasks {
-        let child_run_id = child_run_ids[child_runs.len()].clone();
-        let child_plan = child_plan(plan, task.clone(), &batch_id);
-        let record = agent_task_lifecycle::submit_plan(&child_plan, Some(&child_run_id))?;
-        child_runs.push(AgentTaskBatchChildRun {
-            task_id: task.task_id.clone(),
-            run_id: record.run_id,
-            state: record.state,
-        });
-    }
-
-    let record = AgentTaskBatchRecord {
+    // Persist the batch boundary before creating children. A later submission
+    // failure must still leave an inspectable batch identity for recovery.
+    let mut record = AgentTaskBatchRecord {
         schema: AGENT_TASK_BATCH_SCHEMA.to_string(),
         batch_id,
         plan_id: plan.plan_id.clone(),
@@ -90,10 +93,31 @@ pub fn submit_plan_batch(
         submitted_at: now_timestamp(),
         updated_at: None,
         task_count: plan.tasks.len(),
-        child_runs,
+        child_runs: plan
+            .tasks
+            .iter()
+            .zip(&child_run_ids)
+            .map(|(task, run_id)| AgentTaskBatchChildRun {
+                task_id: task.task_id.clone(),
+                run_id: run_id.clone(),
+                state: AgentTaskRunState::Queued,
+            })
+            .collect(),
         metadata: batch_metadata(plan),
     };
     write_batch(&record)?;
+
+    for (index, task) in plan.tasks.iter().enumerate() {
+        let child_run_id = child_run_ids[index].clone();
+        let child_plan = child_plan(plan, task.clone(), &record.batch_id);
+        let child_record = submit_child(&child_plan, &child_run_id)?;
+        let child = &mut record.child_runs[index];
+        child.run_id = child_record.run_id;
+        child.state = child_record.state;
+        record.updated_at = Some(now_timestamp());
+        write_batch(&record)?;
+    }
+
     Ok(record)
 }
 
@@ -416,6 +440,29 @@ mod tests {
         let status = status("batch/audit").expect("batch status");
         assert_eq!(status.totals.queued, 2);
         assert_eq!(status.commands.run_next, "homeboy agent-task run-next");
+    }
+
+    #[test]
+    fn batch_identity_is_persisted_before_the_first_child_submission() {
+        let _home = crate::test_support::HomeGuard::new();
+        let plan = AgentTaskPlan::new("fanout/pre-submit", vec![request("a"), request("b")]);
+        let mut observed = false;
+
+        let batch = submit_plan_batch_with(&plan, Some("batch/pre-submit"), |child, run_id| {
+            let persisted = read_batch("batch/pre-submit").expect("persisted batch identity");
+            assert_eq!(persisted.batch_id, "batch_pre-submit");
+            assert_eq!(persisted.child_runs.len(), 2);
+            assert!(persisted
+                .child_runs
+                .iter()
+                .all(|child| child.state == AgentTaskRunState::Queued));
+            observed = true;
+            agent_task_lifecycle::submit_plan(child, Some(run_id))
+        })
+        .expect("batch submitted");
+
+        assert!(observed);
+        assert_eq!(batch.child_runs.len(), 2);
     }
 
     #[test]

--- a/crates/homeboy-core/src/runner/execution/broker.rs
+++ b/crates/homeboy-core/src/runner/execution/broker.rs
@@ -126,6 +126,15 @@ pub(super) fn exec_via_reverse_broker(
         &cwd,
         &command,
     )?;
+    if let Some(run_id) = run_id.as_deref() {
+        // Match daemon handoff behavior: the accepted remote job must be bound
+        // to its controller lifecycle before a detached response is returned.
+        crate::agent_task_lifecycle::record_runner_job_identity(
+            run_id,
+            &runner.id,
+            &job.id.to_string(),
+        )?;
+    }
     let persisted_run_id = mirror_evidence
         .then(|| persist_lab_offload_handoff_run(runner, &cwd, &command, &job, run_id.as_deref()))
         .flatten();
@@ -139,6 +148,7 @@ pub(super) fn exec_via_reverse_broker(
             job,
             path_materialization_plan,
             require_paths,
+            run_id,
             persisted_run_id,
         ));
     }

--- a/crates/homeboy-core/src/runner/execution/daemon.rs
+++ b/crates/homeboy-core/src/runner/execution/daemon.rs
@@ -169,6 +169,7 @@ pub(super) fn exec_via_daemon(
             job,
             path_materialization_plan,
             require_paths,
+            run_id,
             persisted_run_id,
         ));
     }
@@ -398,6 +399,7 @@ pub(super) fn detached_handoff_output(
     job: Job,
     path_materialization_plan: Option<PathMaterializationPlan>,
     require_paths: Vec<String>,
+    accepted_run_id: Option<String>,
     mirror_run_id: Option<String>,
 ) -> (RunnerExecOutput, i32) {
     let job_id = job.id.to_string();
@@ -416,6 +418,7 @@ pub(super) fn detached_handoff_output(
         &job_id,
         cwd.clone(),
         record_path_materialization_plan.clone(),
+        accepted_run_id,
         mirror_run_id.clone(),
         job_timestamp_ms_to_rfc3339(job.updated_at_ms),
     );

--- a/crates/homeboy-core/src/runner/execution/tests/handoff.rs
+++ b/crates/homeboy-core/src/runner/execution/tests/handoff.rs
@@ -742,11 +742,12 @@ fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
             None,
             Vec::new(),
             Some("agent-task-run-6454".to_string()),
+            Some("mirrored-run-6454".to_string()),
         );
 
         assert_eq!(exit_code, 0);
         assert_eq!(output.job_id.as_deref(), Some(job_id.as_str()));
-        assert_eq!(output.mirror_run_id.as_deref(), Some("agent-task-run-6454"));
+        assert_eq!(output.mirror_run_id.as_deref(), Some("mirrored-run-6454"));
         assert_eq!(
             output
                 .execution_record
@@ -825,7 +826,7 @@ fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
             envelope.run_location_index.follow_commands.job_logs,
             format!("homeboy runner job logs lab {job_id} --follow")
         );
-        assert_eq!(envelope.evidence.status, "running");
+        assert_eq!(envelope.evidence.status, "accepted");
         assert_eq!(envelope.evidence.runner_id, "lab");
         assert_eq!(envelope.evidence.runner_job_id, job_id);
         assert_eq!(
@@ -859,10 +860,7 @@ fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
             envelope.persisted_run_id.as_deref(),
             Some("agent-task-run-6454")
         );
-        assert_eq!(
-            envelope.mirror_run_id.as_deref(),
-            Some("agent-task-run-6454")
-        );
+        assert_eq!(envelope.mirror_run_id.as_deref(), Some("mirrored-run-6454"));
         assert_eq!(json["status"], "running");
         assert_eq!(json["identity"]["runner_id"], "lab");
         assert_eq!(json["identity"]["runner_job_id"], job_id);
@@ -924,6 +922,7 @@ fn runner_handoff_envelope_omits_agent_task_followups_without_run_id() {
         "lab",
         "job-123",
         "/srv/homeboy/project".to_string(),
+        None,
         None,
         None,
         "2026-06-30T15:58:00Z".to_string(),

--- a/crates/homeboy-lab-contract/src/lab/handoff.rs
+++ b/crates/homeboy-lab-contract/src/lab/handoff.rs
@@ -115,6 +115,7 @@ impl RunnerHandoffEnvelope {
         job_id: &str,
         remote_cwd: String,
         path_materialization_plan: Option<PathMaterializationPlan>,
+        accepted_run_id: Option<String>,
         mirror_run_id: Option<String>,
         liveness_heartbeat_timestamp: String,
     ) -> Self {
@@ -145,7 +146,8 @@ impl RunnerHandoffEnvelope {
                 command: job_cancel_command.clone(),
             },
         ];
-        if let Some(run_id) = mirror_run_id.as_ref() {
+        let actionable_run_id = accepted_run_id.as_ref().or(mirror_run_id.as_ref());
+        if let Some(run_id) = actionable_run_id {
             next_commands.extend([
                 RunnerHandoffNextCommand {
                     label: "run_status".to_string(),
@@ -181,20 +183,20 @@ impl RunnerHandoffEnvelope {
         let follow_commands = RunnerHandoffFollowCommands {
             job_logs: format!("homeboy runner job logs {runner_id} {job_id} --follow"),
             job_cancel: format!("homeboy runner job cancel {runner_id} {job_id}"),
-            status: mirror_run_id
+            status: actionable_run_id
                 .as_ref()
                 .map(|run_id| format!("homeboy agent-task status {run_id}")),
-            logs: mirror_run_id
+            logs: actionable_run_id
                 .as_ref()
                 .map(|run_id| format!("homeboy agent-task logs {run_id}")),
-            artifacts: mirror_run_id
+            artifacts: actionable_run_id
                 .as_ref()
                 .map(|run_id| format!("homeboy agent-task artifacts {run_id}")),
         };
         let run_location_index = RunLocationIndex {
             schema: RUN_LOCATION_INDEX_SCHEMA.to_string(),
-            run_id: mirror_run_id
-                .clone()
+            run_id: actionable_run_id
+                .cloned()
                 .unwrap_or_else(|| format!("runner:{runner_id}:job:{job_id}")),
             controller_location: "controller:local".to_string(),
             runner_id: runner_id.to_string(),
@@ -206,11 +208,13 @@ impl RunnerHandoffEnvelope {
         };
         let evidence = RunnerHandoffEvidence {
             schema: "homeboy/runner-handoff-evidence/v1".to_string(),
-            status: "running".to_string(),
+            // The daemon has accepted this job even though its execution remains
+            // in flight. Keep that acceptance distinct from terminal state.
+            status: "accepted".to_string(),
             runner_id: runner_id.to_string(),
             runner_job_id: job_id.to_string(),
-            run_id: mirror_run_id.clone(),
-            persisted_run_id: mirror_run_id.clone(),
+            run_id: actionable_run_id.cloned(),
+            persisted_run_id: accepted_run_id.clone(),
             mirror_run_id: mirror_run_id.clone(),
             remote_cwd: remote_cwd.clone(),
             artifact_manifest: artifact_manifest.clone(),
@@ -237,14 +241,14 @@ impl RunnerHandoffEnvelope {
             identity: AgentTaskDispatchIdentity {
                 runner_id: runner_id.to_string(),
                 runner_job_id: job_id.to_string(),
-                persisted_run_id: mirror_run_id.clone(),
-                run_id: mirror_run_id.clone(),
+                persisted_run_id: accepted_run_id.clone(),
+                run_id: actionable_run_id.cloned(),
                 handoff_id: Some(format!("runner:{runner_id}:job:{job_id}")),
             },
             runner_id: runner_id.to_string(),
             job_id: job_id.to_string(),
-            durable_run_id: mirror_run_id.clone(),
-            persisted_run_id: mirror_run_id.clone(),
+            durable_run_id: accepted_run_id.clone(),
+            persisted_run_id: accepted_run_id,
             mirror_run_id,
             artifact_manifest,
             run_location_index,


### PR DESCRIPTION
## Summary
Persist the batch boundary before child submission and keep accepted durable run identity distinct from controller mirror identity.

## What changed
- Persist batch identity before creating child runs and update it after each accepted child.
- Carry accepted run and mirror run identities separately through detached Lab handoff evidence.

## How to test
1. Run `cargo test -p homeboy-core batch_identity_is_persisted_before_the_first_child_submission`; expect The targeted batch durability test passes..
2. Run `cargo test -p homeboy-core detached_handoff_output_includes_runner_job_and_agent_task_followups`; expect The detached handoff identity assertions pass..
3. Run `cargo test -p homeboy-core runner_handoff_envelope_omits_agent_task_followups_without_run_id`; expect The no-run-id handoff assertions pass..
4. Run `cargo check -p homeboy-lab-contract`; expect The Lab contract compiles..

## Compatibility
Additive internal handoff metadata refinement; no extension-facing API removal.

## Evidence
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8528
- batch-durability: Passed
- detached-handoff: Passed
- handoff-without-run-id: Passed
- lab-contract-check: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Prepared the implementation and targeted tests; Chris reviewed and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8528
