### PR TITLE
fix(release): publish GitHub Release on recovery path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -510,7 +510,13 @@ jobs:
   plan:
     name: Plan Build Matrix
     needs: prepare
-    if: needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != ''
+    # Recovery releases (HEAD already tagged, GitHub Release missing) reach
+    # `prepare` through its `always()` gate while the quality-policy job is
+    # skipped. Without `always()` here, GitHub propagates that skipped
+    # ancestor down the `needs` chain and skips `plan` too — so the tag lands
+    # with no GitHub Release. Gate on prepare's result + outputs explicitly,
+    # mirroring the `host` job, so both fresh and recovery paths publish.
+    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != '' }}
     runs-on: ubuntu-22.04
     outputs:
       val: ${{ steps.plan.outputs.manifest }}

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -315,6 +315,22 @@ fn release_prepare_uses_prepared_output_to_unlock_publish_jobs() {
     assert!(plan.contains("needs.prepare.outputs['release-tag'] != ''"));
     assert!(plan.contains("needs.prepare.outputs['release-tag']"));
     assert!(!plan.contains("needs.prepare.outputs.released == 'true'"));
+
+    // Regression guard: recovery releases reach `prepare` through its
+    // `always()` gate while the quality-policy job is skipped. If `plan`
+    // relied on the implicit `success()`, that skipped ancestor would
+    // propagate down the `needs` chain and skip `plan` too — landing the
+    // tag with no GitHub Release. `plan` must gate explicitly on
+    // `always()` + `prepare.result == 'success'` so the recovery path
+    // still publishes.
+    assert!(
+        plan.contains("always()"),
+        "plan must use always() so a skipped quality-policy ancestor does not skip publish"
+    );
+    assert!(
+        plan.contains("needs.prepare.result == 'success'"),
+        "plan must gate on prepare's result explicitly instead of the implicit success()"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Fixes the regression where `homeboy release` creates git tags but **no GitHub Release** is published. Every tag from **v0.286.7 → v0.288.8** landed without a GitHub Release.
- Root cause is a GitHub Actions skip-propagation bug on the recovery path, not the multi-crate split.

## Root cause
Local `homeboy release` now prepares, tags, and pushes the release commit in one shot. CI then runs in **recovery mode** to publish the GitHub Release + cross-platform binaries for the already-existing tag (this is the intended design — see `prepared_tag_publish_recovery_decision` in `release/workflow.rs`).

In recovery mode:
- `release-quality-policy` is **skipped** (gates are bypassed for an already-prepared tag).
- `prepare` still runs because it uses `if: always() && …` and sets `prepared=true` + `release-tag`.
- **`plan` relied on the implicit `success()`** (no `always()`). GitHub propagates the skipped `release-quality-policy` ancestor down the `needs` chain, so `plan` — and therefore `build-*` and `host` (`Create GitHub Release`) — were all **skipped**.
- The whole run still reported `success` because skipped jobs don't fail, so the missing release went unnoticed.

Confirmed by comparing runs: a fresh release (quality-policy = success) publishes; every recovery release (quality-policy = skipped) skips `plan` → `host`.

## Fix
Gate `plan` on `always() && needs.prepare.result == 'success'` plus the existing `prepared`/`release-tag` output checks — mirroring the `host` job's already-correct idiom. This breaks the skip propagation so both the fresh and recovery paths publish. Downstream `build-*` and `host` unblock automatically once `plan` runs.

Added a regression guard to `release_workflow_test.rs` asserting `plan` uses `always()` + `needs.prepare.result == 'success'`.

## Verification
- `release.yml` validates as YAML; `cargo fmt --check` clean on the test file.
- Simulated the test's `job_section` extraction + assertions against the workflow — all pass.
- No backfill of the missing v0.286.7–v0.288.8 releases (per request); the next release will publish normally. Existing tags can still be recovered manually via `workflow_dispatch` with `release_tag=vX.Y.Z` if desired.