### PR TITLE
ci(release): fail loudly when a prepared release does not publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -772,6 +772,31 @@ jobs:
           release-from-artifacts: artifacts
           release-skip-publish: 'true'
 
+  # ── Step 5b: Fail loudly if a prepared release did not publish ──
+  # Skipped jobs do not fail a run, so a broken publish chain (e.g. `plan`
+  # or `host` skipped) would otherwise land a tag with no GitHub Release
+  # while the overall run still reports success — exactly the regression
+  # fixed in #8567. This guard turns that silent gap into a red run: once a
+  # release is actually prepared (`prepared == 'true'`), `host` MUST succeed.
+  verify-published:
+    name: Verify GitHub Release published
+    needs:
+      - prepare
+      - host
+    if: ${{ always() && needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce publish completed
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
+          HOST_RESULT: ${{ needs.host.result }}
+        run: |
+          if [ "${HOST_RESULT}" != "success" ]; then
+            echo "::error::Release ${RELEASE_TAG} was prepared and tagged but the Create GitHub Release job did not succeed (result: ${HOST_RESULT}). The tag exists with no GitHub Release. Investigate the plan/build/host publish chain; recover with a workflow_dispatch run using release_tag=${RELEASE_TAG}."
+            exit 1
+          fi
+          echo "::notice::Release ${RELEASE_TAG} published successfully."
+
   announce:
     needs:
       - plan
@@ -800,6 +825,7 @@ jobs:
       - build-local-artifacts
       - build-global-artifacts
       - host
+      - verify-published
       - announce
     if: ${{ always() && github.event_name == 'push' && needs.check.outputs.should-release == 'true' && contains(toJson(needs), '"result":"failure"') }}
     runs-on: ubuntu-latest
@@ -829,6 +855,7 @@ jobs:
       - build-local-artifacts
       - build-global-artifacts
       - host
+      - verify-published
       - announce
     if: ${{ always() && github.event_name == 'push' && needs.check.outputs.should-release == 'true' && !contains(toJson(needs), '"result":"failure"') && !contains(toJson(needs), '"result":"cancelled"') }}
     runs-on: ubuntu-latest

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -334,6 +334,38 @@ fn release_prepare_uses_prepared_output_to_unlock_publish_jobs() {
 }
 
 #[test]
+fn release_fails_loudly_when_prepared_release_does_not_publish() {
+    let verify = job_section(release_workflow(), "verify-published");
+
+    // The guard must run whenever a release was actually prepared, even if
+    // the publish chain skipped (so it uses always() + the prepared output).
+    assert!(
+        verify.contains("always()"),
+        "verify-published must use always() so a skipped host does not skip the guard"
+    );
+    assert!(verify.contains("needs.prepare.outputs.prepared == 'true'"));
+    assert!(verify.contains("needs.prepare.outputs['release-tag'] != ''"));
+
+    // It must fail the run when host did not succeed.
+    assert!(verify.contains("needs.host.result"));
+    assert!(
+        verify.contains("!= \"success\""),
+        "verify-published must fail unless host succeeded"
+    );
+    assert!(
+        verify.contains("exit 1"),
+        "verify-published must exit non-zero to fail the run"
+    );
+
+    // A failed guard must be treated as a release failure by the bookkeeping
+    // jobs so the broken commit is recorded and not silently retried.
+    let record_failure = job_section(release_workflow(), "record-failure");
+    let clear_failure = job_section(release_workflow(), "clear-failure");
+    assert!(record_failure.contains("- verify-published"));
+    assert!(clear_failure.contains("- verify-published"));
+}
+
+#[test]
 fn release_recovery_bypasses_quality_gates_and_still_prepares() {
     let check = job_section(release_workflow(), "check");
     let gate_audit = job_section(release_workflow(), "gate-audit");


### PR DESCRIPTION
## Summary
Follow-up to #8567. That fix restored the recovery publish path, but the deeper hazard remains: **skipped jobs don't fail a run**, so any future break in the `plan → build → host` publish chain would again land a tag with **no GitHub Release** while the run reports green. That's why the original regression went unnoticed across ~40 tags (v0.286.7 → v0.288.8).

## What this adds
A `verify-published` guard job that:
- Runs whenever a release was **actually prepared** (`needs.prepare.outputs.prepared == 'true'`), using `always()` so a skipped/failed `host` can't skip the guard itself.
- **Fails the run** (`exit 1` + `::error::`) if `host` (Create GitHub Release) did not succeed, with a message pointing at the recovery path (`workflow_dispatch` + `release_tag=vX.Y.Z`).
- Is exempt for non-releasable pushes (no prepare → `prepared` empty → guard skipped).

It's wired into `record-failure` / `clear-failure` so a failed guard records the broken SHA (and isn't silently retried on the same commit until new commits land).

## Test
Adds `release_fails_loudly_when_prepared_release_does_not_publish` asserting the guard uses `always()` + the prepared output, fails unless `host` succeeded, and is referenced by both bookkeeping jobs.

## Verification
- `release.yml` validates as YAML; `cargo fmt --check` clean on the test file.
- Simulated the test's `job_section` extraction + all assertions against the workflow — all pass.