### PR TITLE
Recover legacy artifacts through mirrored runner evidence

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/artifact_materialization.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/artifact_materialization.rs
@@ -10,6 +10,12 @@ use crate::{Error, Result};
 
 use super::{apply_aggregate_to_record, status, store};
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct RunnerArtifactRoute {
+    runner_id: String,
+    job_id: String,
+}
+
 /// Materialize a recovered reverse-runner patch into controller-owned storage.
 /// The aggregate is updated atomically with the durable run record, making a
 /// replay reuse the verified local file instead of contacting the runner again.
@@ -19,15 +25,6 @@ pub fn materialize_recovered_patch_artifact(
     artifact_id: Option<&str>,
 ) -> Result<bool> {
     let mut record = status(run_id)?;
-    let Some(runner_id) = record.runner_id().filter(|value| !value.trim().is_empty()) else {
-        return Ok(false);
-    };
-    let Some(job_id) = record
-        .runner_job_id()
-        .filter(|value| !value.trim().is_empty())
-    else {
-        return Ok(false);
-    };
     let mut aggregate = store::read_aggregate(&record.run_id)?;
     let mut changed = false;
     for outcome in &mut aggregate.outcomes {
@@ -40,15 +37,16 @@ pub fn materialize_recovered_patch_artifact(
             {
                 continue;
             }
+            let route = resolve_runner_artifact_route(&record, artifact)?;
             changed |= materialize_artifact(
                 artifact,
-                &runner_id,
-                &job_id,
+                &route.runner_id,
+                &route.job_id,
                 &record.run_id,
                 &outcome.task_id,
                 |id| {
                     crate::observation::runs_service::runner_evidence::with_runner_evidence(|p| {
-                        p.runner_artifact_content(&runner_id, &job_id, id)
+                        p.runner_artifact_content(&route.runner_id, &route.job_id, id)
                     })
                 },
             )?;
@@ -69,6 +67,31 @@ pub fn materialize_recovered_patch_artifact(
         store::write_aggregate_and_record(&record, &aggregate)?;
     }
     Ok(changed)
+}
+
+fn resolve_runner_artifact_route(
+    record: &super::AgentTaskRunRecord,
+    artifact: &AgentTaskArtifact,
+) -> Result<RunnerArtifactRoute> {
+    let mut routes =
+        if let (Some(runner_id), Some(job_id)) = (record.runner_id(), record.runner_job_id()) {
+            vec![RunnerArtifactRoute {
+                runner_id: runner_id.to_string(),
+                job_id: job_id.to_string(),
+            }]
+        } else {
+            crate::observation::runs_service::mirrored_runner_job_identities(&record.run_id)?
+                .into_iter()
+                .map(|(runner_id, job_id)| RunnerArtifactRoute { runner_id, job_id })
+                .collect()
+        };
+    routes.sort();
+    routes.dedup();
+    match routes.as_slice() {
+        [route] => Ok(route.clone()),
+        [] => Err(unavailable(artifact, "no authenticated runner/job binding exists in lifecycle or mirrored runner evidence")),
+        _ => Err(unavailable(artifact, "multiple conflicting authenticated runner/job bindings exist in lifecycle or mirrored runner evidence")),
+    }
 }
 
 fn materialize_artifact(

--- a/crates/homeboy-core/src/agent_task_lifecycle/artifact_materialization.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/artifact_materialization.rs
@@ -73,18 +73,34 @@ fn resolve_runner_artifact_route(
     record: &super::AgentTaskRunRecord,
     artifact: &AgentTaskArtifact,
 ) -> Result<RunnerArtifactRoute> {
-    let mut routes =
-        if let (Some(runner_id), Some(job_id)) = (record.runner_id(), record.runner_job_id()) {
-            vec![RunnerArtifactRoute {
+    let lifecycle_route =
+        record
+            .runner_id()
+            .zip(record.runner_job_id())
+            .map(|(runner_id, job_id)| RunnerArtifactRoute {
                 runner_id: runner_id.to_string(),
                 job_id: job_id.to_string(),
-            }]
-        } else {
-            crate::observation::runs_service::mirrored_runner_job_identities(&record.run_id)?
-                .into_iter()
-                .map(|(runner_id, job_id)| RunnerArtifactRoute { runner_id, job_id })
-                .collect()
-        };
+            });
+    let mirrored_identities = if lifecycle_route.is_none() {
+        crate::observation::runs_service::mirrored_runner_job_identities(&record.run_id)?
+    } else {
+        Vec::new()
+    };
+    resolve_runner_artifact_route_from_identities(artifact, lifecycle_route, mirrored_identities)
+}
+
+fn resolve_runner_artifact_route_from_identities(
+    artifact: &AgentTaskArtifact,
+    lifecycle_route: Option<RunnerArtifactRoute>,
+    mirrored_identities: Vec<(String, String)>,
+) -> Result<RunnerArtifactRoute> {
+    let mut routes = lifecycle_route.into_iter().collect::<Vec<_>>();
+    if routes.is_empty() {
+        routes = mirrored_identities
+            .into_iter()
+            .map(|(runner_id, job_id)| RunnerArtifactRoute { runner_id, job_id })
+            .collect();
+    }
     routes.sort();
     routes.dedup();
     match routes.as_slice() {
@@ -251,6 +267,103 @@ mod tests {
             sha256: Some(format!("{:x}", Sha256::digest(bytes))),
             metadata: json!({}),
         }
+    }
+
+    #[test]
+    fn route_selection_prefers_lifecycle_and_fails_closed_for_missing_or_ambiguous_mirrors() {
+        let value = artifact(b"patch bytes");
+        let lifecycle = RunnerArtifactRoute {
+            runner_id: "lifecycle-runner".to_string(),
+            job_id: "lifecycle-job".to_string(),
+        };
+        assert_eq!(
+            resolve_runner_artifact_route_from_identities(
+                &value,
+                Some(lifecycle.clone()),
+                vec![("mirror-runner".to_string(), "mirror-job".to_string())],
+            )
+            .expect("lifecycle route wins"),
+            lifecycle
+        );
+        assert_eq!(
+            resolve_runner_artifact_route_from_identities(
+                &value,
+                None,
+                vec![("mirror-runner".to_string(), "mirror-job".to_string())],
+            )
+            .expect("single mirror route"),
+            RunnerArtifactRoute {
+                runner_id: "mirror-runner".to_string(),
+                job_id: "mirror-job".to_string(),
+            }
+        );
+
+        let missing = resolve_runner_artifact_route_from_identities(&value, None, Vec::new())
+            .expect_err("missing route fails closed");
+        assert_eq!(missing.code, crate::ErrorCode::ValidationInvalidArgument);
+        assert!(missing
+            .message
+            .contains("no authenticated runner/job binding"));
+
+        let ambiguous = resolve_runner_artifact_route_from_identities(
+            &value,
+            None,
+            vec![
+                ("runner-a".to_string(), "job-a".to_string()),
+                ("runner-b".to_string(), "job-b".to_string()),
+            ],
+        )
+        .expect_err("ambiguous routes fail closed");
+        assert_eq!(ambiguous.code, crate::ErrorCode::ValidationInvalidArgument);
+        assert!(ambiguous
+            .message
+            .contains("multiple conflicting authenticated runner/job bindings"));
+    }
+
+    #[test]
+    fn selected_mirrored_route_materializes_verified_controller_bytes() {
+        let _lock = artifact_root_lock().lock().expect("artifact root lock");
+        let root = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HOMEBOY_ARTIFACT_ROOT", root.path());
+        let bytes = b"mirrored patch bytes";
+        let mut value = artifact(bytes);
+        let route = resolve_runner_artifact_route_from_identities(
+            &value,
+            None,
+            vec![("mirror-runner".to_string(), "mirror-job".to_string())],
+        )
+        .expect("select mirrored route");
+
+        assert!(materialize_artifact(
+            &mut value,
+            &route.runner_id,
+            &route.job_id,
+            "run",
+            "task",
+            |_| Ok(
+                json!({ "content_base64": base64::engine::general_purpose::STANDARD.encode(bytes) })
+            ),
+        )
+        .expect("materialize mirrored artifact"));
+        let path = PathBuf::from(value.path.as_deref().expect("controller path"));
+        assert_eq!(std::fs::read(path).expect("controller bytes"), bytes);
+        assert_eq!(
+            value.metadata["controller_artifact_materialization"]["runner_id"],
+            "mirror-runner"
+        );
+        assert_eq!(
+            value.metadata["controller_artifact_materialization"]["runner_job_id"],
+            "mirror-job"
+        );
+        assert_eq!(
+            value.metadata["controller_artifact_materialization"]["verified_size_bytes"],
+            bytes.len()
+        );
+        assert_eq!(
+            value.metadata["controller_artifact_materialization"]["verified_sha256"],
+            value.sha256.as_deref().expect("SHA")
+        );
+        std::env::remove_var("HOMEBOY_ARTIFACT_ROOT");
     }
 
     #[test]

--- a/crates/homeboy-core/src/observation/runs_service/mod.rs
+++ b/crates/homeboy-core/src/observation/runs_service/mod.rs
@@ -169,8 +169,8 @@ pub use persisted_cleanup::*;
 pub use run_lookup::*;
 pub use runner_downloads::*;
 pub use runner_evidence::{
-    register_runner_evidence_provider, RemoteArtifactDownloadInfo, RunnerConnectionInfo,
-    RunnerEvidenceProvider, StaleRunnerJobInfo,
+    mirrored_runner_job_identities, register_runner_evidence_provider, RemoteArtifactDownloadInfo,
+    RunnerConnectionInfo, RunnerEvidenceProvider, StaleRunnerJobInfo,
 };
 
 /// Safe, bounded retention of terminal observation rows. Artifact byte cleanup

--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -157,6 +157,22 @@ pub fn register_runner_evidence_provider(provider: Box<dyn RunnerEvidenceProvide
     *guard = Some(provider);
 }
 
+/// Refresh runner-owned evidence and return its authenticated runner/job
+/// identities without exposing runner-specific metadata to consumers.
+pub fn mirrored_runner_job_identities(run_id: &str) -> Result<Vec<(String, String)>> {
+    let mut identities = with_runner_evidence(|provider| -> Result<Vec<(String, String)>> {
+        Ok(provider
+            .refresh_mirrored_daemon_evidence(run_id)?
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|run| provider.mirrored_runner_job_identity(run))
+            .collect())
+    })?;
+    identities.sort();
+    identities.dedup();
+    Ok(identities)
+}
+
 /// Whether a runner-evidence provider is currently registered.
 pub fn has_runner_evidence_provider() -> bool {
     PROVIDER

--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -196,6 +196,29 @@ pub(crate) fn with_runner_evidence<T>(f: impl FnOnce(&dyn RunnerEvidenceProvider
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::OnceLock;
+
+    fn provider_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn run(id: &str) -> RunRecord {
+        RunRecord {
+            id: id.to_string(),
+            kind: "agent-task".to_string(),
+            component_id: None,
+            started_at: "2026-07-16T00:00:00Z".to_string(),
+            finished_at: None,
+            status: "running".to_string(),
+            command: None,
+            cwd: None,
+            homeboy_version: None,
+            git_sha: None,
+            rig_id: None,
+            metadata_json: Value::Null,
+        }
+    }
 
     /// Guards graceful degradation: the best-effort evidence methods must return
     /// empty (not error, not panic) when no provider is registered. runs_service
@@ -227,6 +250,7 @@ mod tests {
     /// A registered provider is used in place of the no-op default.
     #[test]
     fn registered_provider_is_used() {
+        let _lock = provider_lock().lock().expect("provider lock");
         struct FakeProvider;
         impl RunnerEvidenceProvider for FakeProvider {
             fn mirror_connected_runner_run(&self, _: &str) -> Result<Option<RunRecord>> {
@@ -267,6 +291,74 @@ mod tests {
 
         // Reset so the registered fake doesn't leak into other tests sharing the
         // process-global provider.
+        PROVIDER
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+    }
+
+    #[test]
+    fn mirrored_runner_job_identities_deduplicates_and_preserves_ambiguity() {
+        let _lock = provider_lock().lock().expect("provider lock");
+        struct FakeProvider;
+
+        impl RunnerEvidenceProvider for FakeProvider {
+            fn mirror_connected_runner_run(&self, _: &str) -> Result<Option<RunRecord>> {
+                Ok(None)
+            }
+            fn statuses(&self) -> Vec<RunnerConnectionInfo> {
+                Vec::new()
+            }
+            fn daemon_api_get(&self, _: &str, _: &str) -> Result<Value> {
+                Ok(Value::Null)
+            }
+            fn runner_artifact_content(&self, _: &str, _: &str, _: &str) -> Result<Value> {
+                Ok(Value::Null)
+            }
+            fn refresh_mirrored_daemon_evidence(
+                &self,
+                run_id: &str,
+            ) -> Result<Option<Vec<RunRecord>>> {
+                Ok(Some(match run_id {
+                    "duplicates" => vec![run("same"), run("same")],
+                    "none" => vec![run("no-identity")],
+                    "distinct" => vec![run("first"), run("second")],
+                    _ => Vec::new(),
+                }))
+            }
+            fn mirrored_runner_job_identity(&self, run: &RunRecord) -> Option<(String, String)> {
+                match run.id.as_str() {
+                    "same" => Some(("runner".to_string(), "job".to_string())),
+                    "first" => Some(("runner-a".to_string(), "job-a".to_string())),
+                    "second" => Some(("runner-b".to_string(), "job-b".to_string())),
+                    _ => None,
+                }
+            }
+            fn download_remote_artifact(
+                &self,
+                _: &str,
+                _: Option<PathBuf>,
+            ) -> Result<RemoteArtifactDownloadInfo> {
+                unreachable!()
+            }
+        }
+
+        register_runner_evidence_provider(Box::new(FakeProvider));
+        assert_eq!(
+            mirrored_runner_job_identities("duplicates").expect("duplicate identities"),
+            vec![("runner".to_string(), "job".to_string())]
+        );
+        assert!(mirrored_runner_job_identities("none")
+            .expect("no identity")
+            .is_empty());
+        assert_eq!(
+            mirrored_runner_job_identities("distinct").expect("distinct identities"),
+            vec![
+                ("runner-a".to_string(), "job-a".to_string()),
+                ("runner-b".to_string(), "job-b".to_string()),
+            ]
+        );
+
         PROVIDER
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())


### PR DESCRIPTION
## Summary
Recover legacy Lab patch artifacts through the generic runner evidence contract when lifecycle records lack top-level runner/job identity.

## What changed
- Added a deduplicated mirrored runner/job identity query and used it only as the legacy fallback before existing job-backed artifact retrieval and SHA/size verification.

## How to test
1. Run `cargo test -p homeboy-core agent_task_lifecycle::artifact_materialization --lib`; expect Five tests prove modern identity precedence, unique mirrored fallback, fail-closed ambiguity, integrity verification, and controller-owned bytes..
2. Run `cargo test -p homeboy-core observation::runs_service::runner_evidence --lib`; expect Four tests prove provider refresh, identity extraction, deduplication, and ambiguity preservation..
3. Run `cargo test -p homeboy-core agent_task_promotion::tests::promotion_uses_verified_controller_projection_for_recovered_runner_aggregate_sources --lib -- --exact`; expect The verified controller projection applies the actual recovered patch..

## Compatibility
No public API or extension-path compatibility change. Modern run recovery is unchanged; legacy runs gain a fail-closed authenticated fallback through existing generic evidence hooks.

## Evidence
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8490
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8537
- core-check: Passed
- diff-check: Passed
- format: Passed
- materialization-tests: Passed
- promotion-test: Passed
- runner-evidence-tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy recovery workflow
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed legacy lifecycle evidence gaps, aligned recovery with the generic RunnerEvidenceProvider architecture, implemented unique mirrored runner/job resolution, and added deterministic integrity and promotion coverage; Chris reviews and owns the change.

## Source relationships
- Closes #8537
- Relates to #8490
- Relates to #8553
- Relates to #8555
