### PR TITLE
refactor: route daemon exec-prep + job cancellation through runner hooks (runner-extraction prep)

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/cancellation.rs
@@ -214,7 +214,9 @@ fn cancel_runner_job(
         return result;
     }
 
-    crate::runners::runner_job_cancel(runner_id, runner_job_id)
+    crate::observation::runs_service::runner_evidence::with_runner_evidence(|p| {
+        p.runner_job_cancel(runner_id, runner_job_id)
+    })
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -1677,23 +1677,27 @@ fn enqueue_exec_job(
             base_plan = Some(request.secret_env_plan.clone());
         }
     }
-    let secret_env_plan = crate::runner::runner_exec_secret_env_plan(
-        &request.command,
-        None,
-        &request.secret_env_names,
-        &request.env,
-        base_plan,
-    );
+    let secret_env_plan = crate::api_jobs::with_runner_job_preparation(|p| {
+        p.runner_exec_secret_env_plan(
+            &request.command,
+            None,
+            &request.secret_env_names,
+            &request.env,
+            base_plan,
+        )
+    });
     request.secret_env_names = secret_env_plan.secret_env_names();
     request.secret_env_plan = secret_env_plan.clone();
-    crate::runner::workload::validate_runner_workload_dispatch(
-        request.runner_workload.as_ref(),
-        &request.runner_id,
-        request.cwd.as_deref(),
-        &request.command,
-        &secret_env_plan,
-        request.capture_patch,
-    )?;
+    crate::api_jobs::with_runner_job_preparation(|p| {
+        p.validate_runner_workload_dispatch(
+            request.runner_workload.as_ref(),
+            &request.runner_id,
+            request.cwd.as_deref(),
+            &request.command,
+            &secret_env_plan,
+            request.capture_patch,
+        )
+    })?;
     let plan = prepare_daemon_local_process(RunnerProcessRequest {
         runner_id: request.runner_id,
         runner: request.runner,

--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -72,6 +72,14 @@ pub trait RunnerEvidenceProvider: Send + Sync {
         artifact_id: &str,
     ) -> Result<Value>;
 
+    /// Cancel a job running on a runner, returning the terminal job record and
+    /// its events.
+    fn runner_job_cancel(
+        &self,
+        runner_id: &str,
+        job_id: &str,
+    ) -> Result<(crate::api_jobs::Job, Vec<crate::api_jobs::JobEvent>)>;
+
     /// Refresh mirrored daemon evidence for a run, returning any mirrored runs.
     fn refresh_mirrored_daemon_evidence(&self, run_id: &str) -> Result<Option<Vec<RunRecord>>>;
 
@@ -116,6 +124,19 @@ impl RunnerEvidenceProvider for NoopRunnerEvidenceProvider {
         _job_id: &str,
         _artifact_id: &str,
     ) -> Result<Value> {
+        Err(Error::validation_invalid_argument(
+            "runner",
+            "no runner evidence provider is registered",
+            None,
+            None,
+        ))
+    }
+
+    fn runner_job_cancel(
+        &self,
+        _runner_id: &str,
+        _job_id: &str,
+    ) -> Result<(crate::api_jobs::Job, Vec<crate::api_jobs::JobEvent>)> {
         Err(Error::validation_invalid_argument(
             "runner",
             "no runner evidence provider is registered",
@@ -228,6 +249,13 @@ mod tests {
             }
             fn runner_artifact_content(&self, _: &str, _: &str, _: &str) -> Result<Value> {
                 Ok(Value::Null)
+            }
+            fn runner_job_cancel(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<(crate::api_jobs::Job, Vec<crate::api_jobs::JobEvent>)> {
+                unreachable!()
             }
             fn refresh_mirrored_daemon_evidence(&self, _: &str) -> Result<Option<Vec<RunRecord>>> {
                 Ok(None)

--- a/crates/homeboy-core/src/runner/evidence/provider.rs
+++ b/crates/homeboy-core/src/runner/evidence/provider.rs
@@ -60,6 +60,14 @@ impl RunnerEvidenceProvider for RunnerEvidence {
         super::super::connection::runner_artifact_content(runner_id, job_id, artifact_id)
     }
 
+    fn runner_job_cancel(
+        &self,
+        runner_id: &str,
+        job_id: &str,
+    ) -> Result<(crate::api_jobs::Job, Vec<crate::api_jobs::JobEvent>)> {
+        super::super::execution::runner_job_cancel(runner_id, job_id)
+    }
+
     fn refresh_mirrored_daemon_evidence(&self, run_id: &str) -> Result<Option<Vec<RunRecord>>> {
         super::mirror::refresh_mirrored_daemon_evidence(run_id)
     }

--- a/crates/homeboy-core/src/runner/mod.rs
+++ b/crates/homeboy-core/src/runner/mod.rs
@@ -126,7 +126,7 @@ pub use execution::{
 };
 pub(crate) use execution::{
     execute_runner_process_until_cancelled_with_progress, prepare_daemon_local_process,
-    runner_exec_secret_env_plan, RunnerProcessRequest,
+    RunnerProcessRequest,
 };
 pub use execution::{RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV, RUNNER_PLACEMENT_RESOLVED_ENV};
 pub(crate) use extension_materialization::extension_source_content_hash;


### PR DESCRIPTION
## Summary
Prep for the runner extraction, severing **3 more core→runner edges**:

- **`daemon.rs`'s** remote-runner exec path called `runner_exec_secret_env_plan` and `workload::validate_runner_workload_dispatch` directly. These are already inverted behind the `RunnerJobPreparationProvider` hook (#8536, same code as `remote_runner.rs`), so this routes daemon through it too via `api_jobs::with_runner_job_preparation`. Dropped the now-unused runner-level re-export.

- **`cancellation::cancel_runner_job`** called `runners::runner_job_cancel` directly (cancel a job on a *remote* runner = genuine runner behavior). Added `runner_job_cancel` to the `RunnerEvidenceProvider` hook (returns core `Job`/`JobEvent` types); the runner impl delegates to `execution::runner_job_cancel`. Its existing `#[cfg(test)] test_cancel_hook` still short-circuits tests.

## Verification
`cargo check` clean for `-p homeboy-core --lib/--tests`, `-p homeboy-cli --lib`; cancellation + evidence-hook tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)