### PR TITLE
refactor: invert code_audit's observation-store reads behind a provider hook (#8425)

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -103,6 +103,11 @@ impl CliRuntime {
         // depending on the extension layer's loader — the seam that lets audit
         // become its own crate.
         crate::core::extension::audit_manifest_provider::register();
+        // Register the audit recorded-artifact provider so the artifact-portability
+        // detector can read past runs' artifacts from the observation store without
+        // code_audit depending on observation — the last seam before audit becomes
+        // its own crate.
+        crate::core::observation::audit_artifact_provider::register();
         // Register the runner-evidence provider so observation::runs_service can
         // enrich run/artifact lookups with live runner + daemon evidence without
         // core depending on runner behavior. (Runner is still in-crate today;

--- a/crates/homeboy-core/src/code_audit/detectors/artifact_portability.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/artifact_portability.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use crate::code_audit::conventions::AuditFinding;
 use crate::code_audit::findings::{Finding, Severity};
 use crate::execution_contract::EXECUTION_CONTRACT;
-use crate::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
 use homeboy_audit_contract::ArtifactPortabilityConfig;
 use serde_json::Value;
 
@@ -47,26 +46,16 @@ pub(crate) fn run_report_with_config(
         run_window,
         ..Default::default()
     };
-    let Ok(store) = ObservationStore::open_initialized() else {
-        return report;
-    };
-    let Ok(runs) = store.list_runs(RunListFilter {
-        kind: None,
-        component_id: Some(component_id.to_string()),
-        status: None,
-        rig_id: None,
-        limit: Some(run_window as i64),
-    }) else {
-        return report;
-    };
+    let runs = crate::code_audit::recorded_artifacts::recent_recorded_runs(
+        component_id,
+        run_window as usize,
+    );
     let artifact_root = crate::artifact_root().ok();
     let path_policy = config.with_generic_defaults();
 
     for run in runs {
         report.runs_scanned += 1;
-        let Ok(artifacts) = store.list_artifacts(&run.id) else {
-            continue;
-        };
+        let artifacts = &run.artifacts;
         report.artifacts_scanned += artifacts.len();
         let artifact_paths: Vec<String> = artifacts
             .iter()
@@ -116,7 +105,10 @@ fn artifact_path_is_portable(
     !path_ref.is_absolute() && !looks_like_runtime_temp_path(path, config)
 }
 
-fn artifact_path_finding(run: &RunRecord, artifact: &ArtifactRecord) -> Finding {
+fn artifact_path_finding(
+    run: &crate::code_audit::recorded_artifacts::AuditRecordedRun,
+    artifact: &crate::code_audit::recorded_artifacts::AuditRecordedArtifact,
+) -> Finding {
     portability_finding(
         run,
         "artifact.path",
@@ -130,7 +122,7 @@ fn artifact_path_finding(run: &RunRecord, artifact: &ArtifactRecord) -> Finding 
 }
 
 fn metadata_path_findings(
-    run: &RunRecord,
+    run: &crate::code_audit::recorded_artifacts::AuditRecordedRun,
     artifact_paths: &[String],
     artifact_root: Option<&Path>,
     config: &ArtifactPortabilityConfig,
@@ -190,7 +182,7 @@ struct MetadataPathScan {
 }
 
 fn portability_finding(
-    run: &RunRecord,
+    run: &crate::code_audit::recorded_artifacts::AuditRecordedRun,
     field: &str,
     observed_path: &str,
     description: String,
@@ -326,7 +318,7 @@ fn looks_like_runtime_temp_path(path: &str, config: &ArtifactPortabilityConfig) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::observation::{ArtifactRecord, NewRunRecord};
+    use crate::observation::{ArtifactRecord, NewRunRecord, ObservationStore};
     use crate::test_support::with_isolated_home;
 
     #[test]
@@ -362,6 +354,7 @@ mod tests {
                 })
                 .expect("artifact");
 
+            crate::observation::audit_artifact_provider::register();
             let findings = super::run("demo");
 
             assert_eq!(findings.len(), 1);
@@ -402,6 +395,7 @@ mod tests {
                 .finish_run(&run_record.id, crate::observation::RunStatus::Pass, None)
                 .expect("finish");
 
+            crate::observation::audit_artifact_provider::register();
             let findings = super::run("demo");
 
             assert_eq!(findings.len(), 1);
@@ -435,6 +429,7 @@ mod tests {
                 .finish_run(&run_record.id, crate::observation::RunStatus::Pass, None)
                 .expect("finish");
 
+            crate::observation::audit_artifact_provider::register();
             let findings = super::run("demo");
 
             assert_eq!(findings.len(), 1);
@@ -486,6 +481,7 @@ mod tests {
                 .finish_run(&run_record.id, crate::observation::RunStatus::Pass, None)
                 .expect("finish");
 
+            crate::observation::audit_artifact_provider::register();
             let findings = super::run("demo");
 
             assert!(findings.is_empty());
@@ -520,6 +516,7 @@ mod tests {
                 .finish_run(&run_record.id, crate::observation::RunStatus::Pass, None)
                 .expect("finish");
 
+            crate::observation::audit_artifact_provider::register();
             let findings = super::run("demo");
 
             assert!(findings.is_empty());
@@ -677,6 +674,7 @@ mod tests {
                     .expect("finish");
             }
 
+            crate::observation::audit_artifact_provider::register();
             let report = super::run_report_with_config(
                 "demo",
                 &ArtifactPortabilityConfig {

--- a/crates/homeboy-core/src/code_audit/mod.rs
+++ b/crates/homeboy-core/src/code_audit/mod.rs
@@ -36,6 +36,7 @@ mod idiomatic;
 pub(crate) mod impact;
 pub(crate) mod import_matching;
 pub(crate) mod naming;
+pub mod recorded_artifacts;
 pub mod report;
 mod requirements;
 pub mod run;

--- a/crates/homeboy-core/src/code_audit/recorded_artifacts.rs
+++ b/crates/homeboy-core/src/code_audit/recorded_artifacts.rs
@@ -1,0 +1,89 @@
+//! Recorded-run artifact access for the audit engine, inverted behind a
+//! provider.
+//!
+//! The `artifact_portability` detector checks that artifacts recorded by past
+//! runs use portable (relative / root-anchored) paths. It reads the recorded
+//! runs + their artifacts from the observation store — which coupled
+//! `code_audit` to the `observation` subsystem and blocked extracting audit
+//! into its own crate.
+//!
+//! Instead, audit defines the slim view it needs (`AuditRecordedRun` +
+//! `AuditRecordedArtifact`) plus a provider trait; the observation layer
+//! registers an implementation at startup (same pattern as the manifest / runner
+//! evidence provider hooks). When no provider is registered — e.g. audit running
+//! standalone — the no-op provider yields no runs, which the detector already
+//! treats as "nothing recorded to check".
+
+use std::sync::Mutex;
+
+/// A recorded artifact, projected to what the portability detector needs.
+#[derive(Debug, Clone, Default)]
+pub struct AuditRecordedArtifact {
+    pub id: String,
+    pub kind: String,
+    pub artifact_type: String,
+    pub path: String,
+}
+
+/// A recorded run plus its artifacts, projected for the portability detector.
+#[derive(Debug, Clone, Default)]
+pub struct AuditRecordedRun {
+    pub id: String,
+    pub command: Option<String>,
+    pub metadata_json: serde_json::Value,
+    pub artifacts: Vec<AuditRecordedArtifact>,
+}
+
+/// The recorded-artifact contract the audit engine depends on. Implemented by
+/// the observation layer and registered at startup; audit calls it without
+/// depending on observation behavior.
+pub trait AuditRecordedArtifactProvider: Send + Sync {
+    /// Return the most recent recorded runs (with their artifacts) for a
+    /// component, newest first, up to `limit`.
+    fn recent_runs(&self, component_id: &str, limit: usize) -> Vec<AuditRecordedRun>;
+}
+
+/// Default provider used when no observation layer is registered: no recorded
+/// runs, so the portability detector reports nothing — exactly as it does today
+/// when the observation store can't be opened.
+struct NoopProvider;
+
+impl AuditRecordedArtifactProvider for NoopProvider {
+    fn recent_runs(&self, _component_id: &str, _limit: usize) -> Vec<AuditRecordedRun> {
+        Vec::new()
+    }
+}
+
+static PROVIDER: Mutex<Option<Box<dyn AuditRecordedArtifactProvider>>> = Mutex::new(None);
+
+/// Register the recorded-artifact provider. Called once at binary startup by the
+/// observation layer (via the CLI). Replaces any previously registered provider.
+pub fn register_audit_recorded_artifact_provider(provider: Box<dyn AuditRecordedArtifactProvider>) {
+    let mut guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = Some(provider);
+}
+
+/// Recent recorded runs (with artifacts) for a component via the registered
+/// provider.
+pub(crate) fn recent_recorded_runs(component_id: &str, limit: usize) -> Vec<AuditRecordedRun> {
+    let guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    match guard.as_ref() {
+        Some(provider) => provider.recent_runs(component_id, limit),
+        None => NoopProvider.recent_runs(component_id, limit),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_provider_yields_no_runs() {
+        let noop = NoopProvider;
+        assert!(noop.recent_runs("any", 10).is_empty());
+    }
+}

--- a/crates/homeboy-core/src/observation/audit_artifact_provider.rs
+++ b/crates/homeboy-core/src/observation/audit_artifact_provider.rs
@@ -1,0 +1,61 @@
+//! Observation-side implementation of the audit recorded-artifact provider.
+//!
+//! The audit engine (`code_audit`) defines `AuditRecordedArtifactProvider` and
+//! calls it without depending on the observation store. This module implements
+//! that trait by opening the store, listing a component's recent runs and their
+//! artifacts, and projecting each into the slim view audit's portability
+//! detector needs. It is registered at binary startup by the CLI, mirroring the
+//! manifest / runner-evidence provider hooks.
+
+use crate::code_audit::recorded_artifacts::{
+    register_audit_recorded_artifact_provider, AuditRecordedArtifact,
+    AuditRecordedArtifactProvider, AuditRecordedRun,
+};
+use crate::observation::{ObservationStore, RunListFilter};
+
+struct StoreArtifactProvider;
+
+impl AuditRecordedArtifactProvider for StoreArtifactProvider {
+    fn recent_runs(&self, component_id: &str, limit: usize) -> Vec<AuditRecordedRun> {
+        let Ok(store) = ObservationStore::open_initialized() else {
+            return Vec::new();
+        };
+        let Ok(runs) = store.list_runs(RunListFilter {
+            kind: None,
+            component_id: Some(component_id.to_string()),
+            status: None,
+            rig_id: None,
+            limit: Some(limit as i64),
+        }) else {
+            return Vec::new();
+        };
+
+        runs.into_iter()
+            .map(|run| {
+                let artifacts = store
+                    .list_artifacts(&run.id)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|artifact| AuditRecordedArtifact {
+                        id: artifact.id,
+                        kind: artifact.kind,
+                        artifact_type: artifact.artifact_type,
+                        path: artifact.path,
+                    })
+                    .collect();
+                AuditRecordedRun {
+                    id: run.id,
+                    command: run.command,
+                    metadata_json: run.metadata_json,
+                    artifacts,
+                }
+            })
+            .collect()
+    }
+}
+
+/// Register the observation-backed recorded-artifact provider. Called once at
+/// binary startup by the CLI.
+pub fn register() {
+    register_audit_recorded_artifact_provider(Box::new(StoreArtifactProvider));
+}

--- a/crates/homeboy-core/src/observation/mod.rs
+++ b/crates/homeboy-core/src/observation/mod.rs
@@ -5,6 +5,7 @@
 //! generated artifacts. This module only provides the storage substrate.
 
 pub mod artifact_preview;
+pub mod audit_artifact_provider;
 mod budget_findings;
 pub mod bundle;
 pub mod context;


### PR DESCRIPTION
## Summary

**The last production behavior edge** from `code_audit` into another core subsystem — the final non-trivial blocker to extracting audit.

The `artifact_portability` detector opened `ObservationStore` directly and read a component's recent runs + their artifacts to check that recorded artifact paths are portable. That coupled `code_audit` to `observation`.

## The inversion (mirrors the manifest / runner-evidence hooks)

- **`code_audit::recorded_artifacts`** defines slim owned views (`AuditRecordedRun` + `AuditRecordedArtifact`) + an `AuditRecordedArtifactProvider` trait + a registry with a `NoopProvider` default (yields no runs — exactly what the detector does today when the store can't be opened).
- **`observation::audit_artifact_provider`** implements it, opening the store and projecting `RunRecord`/`ArtifactRecord` into the slim views.
- The **CLI registers it at startup** next to the manifest provider.
- The detector's `run()` now calls `recent_recorded_runs()`; its finding helpers take the slim types; the production observation import is gone. The detector's tests seed the store then register the store-backed provider before invoking `run()`.

## Result — the finish line

**Zero production `crate::observation` references from `code_audit`.**

`code_audit`'s remaining upward edges are now only:
- **component** — `scope` + `Component` (the model). Irreducible.
- **extension** — test-only fixtures (`save_manifest`, `bench`) + `ExtensionPhaseTiming`.

Every real behavior/config/type coupling is resolved. The path to physically moving `code_audit` (43k LOC) into `homeboy-audit` is clear.

## Verification

- core + cli compile clean
- **12 artifact_portability + provider tests pass**
- `cargo check --workspace --tests --locked` — **green**

Refs #8425