### PR TITLE
Persist recoverable promotion checkpoints

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -8,8 +8,8 @@ use homeboy::core::agent_tasks::finalization::{
 };
 use homeboy::core::agent_tasks::lifecycle as agent_task_lifecycle;
 use homeboy::core::agent_tasks::promotion::{
-    promote, resume_promoted_patch, AgentTaskPromotionOptions, AgentTaskPromotionReport,
-    AgentTaskPromotionStatus,
+    promote_with_checkpoint, resume_promoted_patch, AgentTaskPromotionOptions,
+    AgentTaskPromotionReport, AgentTaskPromotionStatus,
 };
 use homeboy::core::agent_tasks::provider::{
     AgentTaskExecutorProvider, AgentTaskProviderCatalog, ExtensionProviderAgentTaskExecutor,
@@ -240,9 +240,12 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
             .ok()
             .and_then(|record| record.metadata.get("latest_promotion").cloned())
     });
-    let report = if let Some(previous) = previous_promotion
-        .filter(|previous| previous.get("status").and_then(Value::as_str) == Some("gate_failed"))
-    {
+    let report = if let Some(previous) = previous_promotion.filter(|previous| {
+        matches!(
+            previous.get("status").and_then(Value::as_str),
+            Some("gate_failed" | "verification_pending")
+        )
+    }) {
         let target_path = previous
             .pointer("/target/path")
             .and_then(Value::as_str)
@@ -260,7 +263,21 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
             &previous,
         )?
     } else {
-        promote(promotion_options)?
+        let checkpoint_run_id = (!args.dry_run).then(|| source_run_id.clone()).flatten();
+        promote_with_checkpoint(promotion_options, |checkpoint| {
+            if let Some(run_id) = checkpoint_run_id.as_deref() {
+                agent_task_lifecycle::record_promotion(
+                    run_id,
+                    serde_json::to_value(checkpoint).map_err(|error| {
+                        homeboy::core::Error::internal_json(
+                            error.to_string(),
+                            Some("serialize pending agent-task promotion report".to_string()),
+                        )
+                    })?,
+                )?;
+            }
+            Ok(())
+        })?
     };
     let exit_code = if report.status == AgentTaskPromotionStatus::GateFailed {
         1

--- a/crates/homeboy-core/src/agent_task_promotion/mod.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/mod.rs
@@ -22,6 +22,7 @@ pub use fingerprint::{
 };
 pub(crate) use patch::{normalize_promotion_patch, validate_artifact_content};
 pub use promote::promote;
+pub use promote::promote_with_checkpoint;
 pub use promote::resume_promoted_patch;
 pub use types::{
     AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandCapture,

--- a/crates/homeboy-core/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/promote.rs
@@ -31,8 +31,17 @@ mod gate_run;
 use gate_run::PromotionGateRun;
 
 pub fn promote(options: AgentTaskPromotionOptions) -> Result<AgentTaskPromotionReport> {
+    promote_with_checkpoint(options, |_| Ok(()))
+}
+
+/// Promote a patch while recording the recoverable post-apply boundary before
+/// dependency materialization or verification is attempted.
+pub fn promote_with_checkpoint(
+    options: AgentTaskPromotionOptions,
+    mut checkpoint: impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
+) -> Result<AgentTaskPromotionReport> {
     let mut provider = ExternalPromotionWorkspaceProvider::from_options(&options);
-    let mut report = promote_with_provider(options, &mut provider)?;
+    let mut report = promote_with_provider_and_checkpoint(options, &mut provider, &mut checkpoint)?;
     if let Some(provenance) = provider.provenance() {
         report.provenance["worktree_provider"] = provenance.clone();
     }
@@ -50,9 +59,9 @@ pub fn promote(options: AgentTaskPromotionOptions) -> Result<AgentTaskPromotionR
     Ok(report)
 }
 
-/// Rebuild a full proof for a clean candidate that was already applied before
-/// its deterministic gates failed. The reverse apply check proves the original
-/// artifact remains in the candidate before any gate result is trusted.
+/// Rebuild a full proof for a clean candidate from a durable post-apply report.
+/// The reverse apply check proves the original artifact remains in the candidate
+/// before any gate result is trusted.
 pub fn resume_promoted_patch(
     options: AgentTaskPromotionOptions,
     target_path: &Path,
@@ -119,7 +128,7 @@ pub fn resume_promoted_patch(
             "worktree_path": target_path,
             "dependencies_materialized": gates.dependencies_materialized,
             "candidate": candidate,
-            "resumed_from_gate_failed_promotion": true,
+            "resumed_post_apply_promotion": true,
         }),
         operator_notification: promotion_notification(gates.status, &target),
     };
@@ -134,10 +143,13 @@ fn validate_resume_provenance(
     target_path: &Path,
     previous: &Value,
 ) -> Result<()> {
-    if previous.get("status").and_then(Value::as_str) != Some("gate_failed") {
+    if !matches!(
+        previous.get("status").and_then(Value::as_str),
+        Some("gate_failed" | "verification_pending")
+    ) {
         return Err(Error::validation_invalid_argument(
             "promotion",
-            "promotion resume requires a durable gate-failed promotion",
+            "promotion resume requires a durable post-apply promotion",
             None,
             None,
         ));
@@ -149,7 +161,7 @@ fn validate_resume_provenance(
     if previous_run != options.source_run_id.as_deref() {
         return Err(Error::validation_invalid_argument(
             "promotion",
-            "promotion resume source run does not match the durable gate-failed promotion",
+            "promotion resume source run does not match the durable post-apply promotion",
             None,
             None,
         ));
@@ -162,7 +174,7 @@ fn validate_resume_provenance(
     {
         return Err(Error::validation_invalid_argument(
             "promotion",
-            "promotion resume target does not match the durable gate-failed promotion",
+            "promotion resume target does not match the durable post-apply promotion",
             None,
             None,
         ));
@@ -234,6 +246,14 @@ pub(crate) fn promote_with_provider(
     options: AgentTaskPromotionOptions,
     provider: &mut impl AgentTaskPromotionWorkspaceProvider,
 ) -> Result<AgentTaskPromotionReport> {
+    promote_with_provider_and_checkpoint(options, provider, &mut |_| Ok(()))
+}
+
+pub(super) fn promote_with_provider_and_checkpoint(
+    options: AgentTaskPromotionOptions,
+    provider: &mut impl AgentTaskPromotionWorkspaceProvider,
+    checkpoint: &mut impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
+) -> Result<AgentTaskPromotionReport> {
     validate_workspace_handle(&options.to_worktree)?;
     let source_value: Value = serde_json::from_str(&options.source).map_err(|error| {
         Error::validation_invalid_json(
@@ -283,6 +303,7 @@ pub(crate) fn promote_with_provider(
                 return promote_committed_changes(
                     &options,
                     provider,
+                    checkpoint,
                     &source_kind,
                     &outcome,
                     None,
@@ -323,6 +344,7 @@ pub(crate) fn promote_with_provider(
             return promote_committed_changes(
                 &options,
                 provider,
+                checkpoint,
                 &source_kind,
                 &outcome,
                 Some(&artifact),
@@ -386,15 +408,34 @@ pub(crate) fn promote_with_provider(
         }
     }
 
+    let target = AgentTaskPromotionTarget::from_worktree(
+        options.to_worktree.clone(),
+        applied_worktree_path.as_deref(),
+    );
+    if let Some(worktree_path) = applied_worktree_path.as_deref() {
+        checkpoint(&post_apply_report(
+            &options,
+            &source_kind,
+            &outcome,
+            AgentTaskPromotionArtifactRef {
+                id: artifact.id.clone(),
+                kind: artifact.kind.clone(),
+                path: patch_path.display().to_string(),
+                sha256: artifact.sha256.clone(),
+            },
+            changed_files.clone(),
+            command_evidence.clone(),
+            target.clone(),
+            worktree_path,
+            &outcome.schema,
+            artifact.metadata.clone(),
+        ))?;
+    }
     let gates = if let Some(worktree_path) = applied_worktree_path.as_deref() {
         run_promotion_gates(&options, provider, worktree_path)?
     } else {
         PromotionGateRun::without_gates(options.dry_run)
     };
-    let target = AgentTaskPromotionTarget::from_worktree(
-        options.to_worktree.clone(),
-        applied_worktree_path.as_deref(),
-    );
     let operator_notification = promotion_notification(gates.status, &target);
     let candidate = if gates.status == AgentTaskPromotionStatus::Applied {
         applied_worktree_path
@@ -570,6 +611,7 @@ fn valid_sha256(value: &str) -> bool {
 fn promote_committed_changes(
     options: &AgentTaskPromotionOptions,
     provider: &mut impl AgentTaskPromotionWorkspaceProvider,
+    checkpoint: &mut impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
     source_kind: &str,
     outcome: &AgentTaskOutcome,
     artifact: Option<&AgentTaskArtifact>,
@@ -601,15 +643,36 @@ fn promote_committed_changes(
     })?;
     command_evidence.extend(target.command_evidence);
     let applied_worktree_path = (!options.dry_run).then_some(target.path);
+    let target = AgentTaskPromotionTarget::from_worktree(
+        options.to_worktree.clone(),
+        applied_worktree_path.as_deref(),
+    );
+    if let Some(path) = applied_worktree_path.as_deref() {
+        checkpoint(&post_apply_report(
+            options,
+            source_kind,
+            outcome,
+            AgentTaskPromotionArtifactRef {
+                id: "committed-changes".to_string(),
+                kind: "patch".to_string(),
+                path: committed_patch.patch_path.display().to_string(),
+                sha256: Some(committed_patch.sha256.clone()),
+            },
+            normalized_patch.changed_files.clone(),
+            command_evidence.clone(),
+            target.clone(),
+            path,
+            &outcome.schema,
+            artifact
+                .map(|artifact| artifact.metadata.clone())
+                .unwrap_or(Value::Null),
+        ))?;
+    }
     let gates = if let Some(path) = applied_worktree_path.as_deref() {
         run_promotion_gates(options, provider, path)?
     } else {
         PromotionGateRun::without_gates(options.dry_run)
     };
-    let target = AgentTaskPromotionTarget::from_worktree(
-        options.to_worktree.clone(),
-        applied_worktree_path.as_deref(),
-    );
     let operator_notification = promotion_notification(gates.status, &target);
 
     Ok(AgentTaskPromotionReport {
@@ -789,6 +852,12 @@ fn promotion_notification(
 ) -> AgentTaskPromotionNotification {
     let target_path = target.path.as_deref().unwrap_or(target.worktree.as_str());
     match status {
+        AgentTaskPromotionStatus::VerificationPending => AgentTaskPromotionNotification {
+            status: "blocked".to_string(),
+            message: "patch promoted; deterministic verification is pending".to_string(),
+            resumable_blocker: Some("rerun promotion to resume verification without reapplying the patch".to_string()),
+            next_command: None,
+        },
         AgentTaskPromotionStatus::Applied => AgentTaskPromotionNotification {
             status: "completed".to_string(),
             message: format!(
@@ -823,6 +892,42 @@ fn promotion_notification(
             resumable_blocker: None,
             next_command: None,
         },
+    }
+}
+
+fn post_apply_report(
+    options: &AgentTaskPromotionOptions,
+    source_kind: &str,
+    outcome: &AgentTaskOutcome,
+    patch_artifact: AgentTaskPromotionArtifactRef,
+    changed_files: Vec<String>,
+    command_evidence: Vec<AgentTaskPromotionCommandReport>,
+    target: AgentTaskPromotionTarget,
+    worktree_path: &Path,
+    source_schema: &str,
+    artifact_metadata: Value,
+) -> AgentTaskPromotionReport {
+    let status = AgentTaskPromotionStatus::VerificationPending;
+    let operator_notification = promotion_notification(status, &target);
+    AgentTaskPromotionReport {
+        schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
+        status,
+        source: promotion_source(source_kind, outcome, options),
+        to_worktree: options.to_worktree.clone(),
+        target,
+        patch_artifact,
+        changed_files,
+        command_evidence,
+        deterministic_gates: Vec::new(),
+        gate_results: Vec::new(),
+        provenance: json!({
+            "source_schema": source_schema,
+            "artifact_metadata": artifact_metadata,
+            "worktree_path": worktree_path,
+            "dependencies_materialized": false,
+            "post_apply": true,
+        }),
+        operator_notification,
     }
 }
 

--- a/crates/homeboy-core/src/agent_task_promotion/tests.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/tests.rs
@@ -12,8 +12,9 @@ use super::apply::{
     AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA, AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
 };
 use super::promote::{
-    normalize_promotion_patch, promote, promote_with_provider, resume_promoted_patch,
-    select_patch_artifact, validate_artifact_content,
+    normalize_promotion_patch, promote, promote_with_provider,
+    promote_with_provider_and_checkpoint, resume_promoted_patch, select_patch_artifact,
+    validate_artifact_content,
 };
 use super::types::{
     AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandCapture,
@@ -51,6 +52,7 @@ struct FakePromotionWorkspaceProvider {
         AgentTaskGateRevealPolicy,
     )>,
     verify_exit_code: i32,
+    verify_transport_error: bool,
 }
 
 impl AgentTaskPromotionWorkspaceProvider for FakePromotionWorkspaceProvider {
@@ -93,6 +95,12 @@ impl AgentTaskPromotionWorkspaceProvider for FakePromotionWorkspaceProvider {
             visibility,
             reveal_policy,
         ));
+        if self.verify_transport_error {
+            return Err(Error::internal_io(
+                "simulated verification transport interruption",
+                Some("promotion gate transport".to_string()),
+            ));
+        }
         Ok(AgentTaskGateReport::new(
             format!("gate-{index}"),
             vec!["sh".to_string(), "-lc".to_string(), command.to_string()],
@@ -1719,7 +1727,65 @@ fn promote_verification_failure_keeps_the_applied_target_recoverable() {
 }
 
 #[test]
-fn resume_promoted_patch_rebuilds_green_proof_for_clean_committed_candidate() {
+fn promotion_checkpoints_applied_target_before_gate_transport_failure() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let worktree_path = temp.path().join("managed-target");
+    std::fs::create_dir(&worktree_path).expect("create target");
+    git(&worktree_path, &["init"]);
+    let (source_path, source) = write_patch_source(&temp);
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(worktree_path.clone()),
+        verify_transport_error: true,
+        ..Default::default()
+    };
+    let mut checkpoints = Vec::new();
+
+    let error = promote_with_provider_and_checkpoint(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("restartable-run".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            to_worktree: "homeboy@restartable".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["true".to_string()],
+                private_verify: Vec::new(),
+                private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+            },
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+        &mut |report| {
+            checkpoints.push(report.clone());
+            Ok(())
+        },
+    )
+    .expect_err("gate transport failure propagates after checkpoint");
+
+    assert!(!error.message.is_empty());
+    assert_eq!(provider.apply_calls.len(), 1);
+    assert_eq!(provider.verify_calls.len(), 1);
+    assert_eq!(checkpoints.len(), 1);
+    assert_eq!(
+        checkpoints[0].status,
+        AgentTaskPromotionStatus::VerificationPending
+    );
+    assert!(checkpoints[0].status.patch_promoted());
+    assert_eq!(
+        checkpoints[0].target.path.as_deref(),
+        worktree_path.to_str()
+    );
+    assert_eq!(checkpoints[0].provenance["post_apply"], true);
+}
+
+#[test]
+fn resume_promoted_patch_rebuilds_green_proof_from_pending_post_apply_checkpoint() {
     let temp = tempfile::tempdir().expect("tempdir");
     let target = temp.path().join("target");
     std::fs::create_dir(&target).expect("target");
@@ -1754,8 +1820,8 @@ fn resume_promoted_patch_rebuilds_green_proof_for_clean_committed_candidate() {
         provider_invocation: None,
     };
     let previous = serde_json::json!({
-        "schema": "homeboy/agent-task-promotion-status/v1",
-        "status": "gate_failed",
+        "schema": "homeboy/agent-task-promotion-report/v1",
+        "status": "verification_pending",
         "source_run_id": "run-8307",
         "to_worktree": "repo@fix-8307",
         "target": { "worktree": "repo@fix-8307", "path": target },
@@ -1773,11 +1839,9 @@ fn resume_promoted_patch_rebuilds_green_proof_for_clean_committed_candidate() {
         report.gate_results[0].status,
         crate::gate::HomeboyGateStatus::Passed
     );
-    assert_eq!(
-        report.provenance["resumed_from_gate_failed_promotion"],
-        true
-    );
+    assert_eq!(report.provenance["resumed_post_apply_promotion"], true);
     assert!(report.provenance["candidate"].is_object());
+    assert_eq!(report.provenance["resumed_post_apply_promotion"], true);
 }
 
 #[test]

--- a/crates/homeboy-core/src/agent_task_promotion/types.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/types.rs
@@ -70,6 +70,9 @@ pub struct AgentTaskPromotionReport {
 #[serde(rename_all = "snake_case")]
 pub enum AgentTaskPromotionStatus {
     DryRun,
+    /// The provider applied the patch and its target is durable, but verification
+    /// has not completed. Retrying must resume verification, not apply again.
+    VerificationPending,
     Applied,
     GateFailed,
     NoChanges,
@@ -79,7 +82,10 @@ impl AgentTaskPromotionStatus {
     /// Whether a patch was actually promoted into the target worktree for this
     /// status (true for both clean applies and gate-failed applies).
     pub fn patch_promoted(self) -> bool {
-        matches!(self, Self::Applied | Self::GateFailed)
+        matches!(
+            self,
+            Self::VerificationPending | Self::Applied | Self::GateFailed
+        )
     }
 
     /// Whether deterministic gates failed after the patch was promoted.
@@ -90,6 +96,7 @@ impl AgentTaskPromotionStatus {
     /// Stable handoff boundary identifier for this promotion status.
     pub fn handoff_boundary(self) -> &'static str {
         match self {
+            Self::VerificationPending => "patch_promoted_verification_pending",
             Self::Applied => "patch_promoted_no_pr",
             Self::GateFailed => "patch_promoted_gates_failed",
             Self::DryRun => "patch_not_promoted_dry_run",

--- a/crates/homeboy-core/src/agent_task_service/cook.rs
+++ b/crates/homeboy-core/src/agent_task_service/cook.rs
@@ -20,8 +20,8 @@ use crate::agent_task_finalization::{
 use crate::agent_task_gate::VerifyGateOptions;
 use crate::agent_task_lifecycle;
 use crate::agent_task_promotion::{
-    normalize_promotion_patch, promote, AgentTaskPromotionOptions, AgentTaskPromotionReport,
-    AgentTaskPromotionStatus,
+    normalize_promotion_patch, promote_with_checkpoint, AgentTaskPromotionOptions,
+    AgentTaskPromotionReport, AgentTaskPromotionStatus,
 };
 use crate::agent_task_review_dossier::{
     resolve_review_profile, AgentTaskReviewAiAssistance, AgentTaskReviewDossier,
@@ -1031,21 +1031,35 @@ fn promote_attempt(
     run_id: &str,
 ) -> Result<AgentTaskPromotionReport> {
     let (source, source_path) = promotion_source(run_id)?;
-    promote(AgentTaskPromotionOptions {
-        source,
-        source_run_id: Some(run_id.to_string()),
-        source_path,
-        source_worktree_path: options.source_worktree_path.clone(),
-        base_ref: Some(options.base.clone()),
-        task_base_sha: options.task_base_sha.clone(),
-        to_worktree: options.to_worktree.clone(),
-        task_id: None,
-        artifact_id: None,
-        dry_run: false,
-        gates: options.gates.clone(),
-        provider_command: options.provider_command.clone(),
-        provider_invocation: options.provider_invocation.clone(),
-    })
+    promote_with_checkpoint(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some(run_id.to_string()),
+            source_path,
+            source_worktree_path: options.source_worktree_path.clone(),
+            base_ref: Some(options.base.clone()),
+            task_base_sha: options.task_base_sha.clone(),
+            to_worktree: options.to_worktree.clone(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: options.gates.clone(),
+            provider_command: options.provider_command.clone(),
+            provider_invocation: options.provider_invocation.clone(),
+        },
+        |checkpoint| {
+            agent_task_lifecycle::record_promotion(
+                run_id,
+                serde_json::to_value(checkpoint).map_err(|error| {
+                    Error::internal_json(
+                        error.to_string(),
+                        Some("serialize pending cook promotion".to_string()),
+                    )
+                })?,
+            )?;
+            Ok(())
+        },
+    )
 }
 
 /// Promotion is the durable boundary between a terminal provider result and

--- a/crates/homeboy-core/src/agent_tasks.rs
+++ b/crates/homeboy-core/src/agent_tasks.rs
@@ -300,7 +300,7 @@ pub mod loop_definition {
 /// Promotion reports and entry point.
 pub mod promotion {
     pub use super::super::agent_task_promotion::{
-        promote, resume_promoted_patch, AgentTaskPromotionArtifactRef,
+        promote, promote_with_checkpoint, resume_promoted_patch, AgentTaskPromotionArtifactRef,
         AgentTaskPromotionCommandReport, AgentTaskPromotionNotification, AgentTaskPromotionOptions,
         AgentTaskPromotionReport, AgentTaskPromotionSource, AgentTaskPromotionStatus,
         AgentTaskPromotionTarget, AGENT_TASK_PROMOTION_REPORT_SCHEMA,


### PR DESCRIPTION
## Summary
Persist the recoverable post-apply boundary before dependency hydration or verification can be interrupted.

## What changed
- Record a verification-pending promotion checkpoint immediately after patch application.
- Resume verification from durable pending or gate-failed checkpoints without reapplying the patch.

## How to test
1. Run `cargo test -p homeboy-core promotion_checkpoints_applied_target_before_gate_transport_failure`; expect The post-apply checkpoint survives a simulated verification transport interruption..
2. Run `cargo test -p homeboy-core resume_promoted_patch_rebuilds_green_proof_from_pending_post_apply_checkpoint`; expect Promotion resumes from the persisted checkpoint without reapplying..

## Compatibility
Internal promotion lifecycle refinement; existing applied and gate-failed promotion records remain accepted.

## Evidence
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8516
- post-apply-checkpoint: Passed
- promotion-resume: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Prepared the implementation and targeted tests; Chris reviewed and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8516
