### PR TITLE
fix(observation): add runner_job_cancel to the test FakeProvider

### DIFF
--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -343,6 +343,13 @@ mod tests {
             fn runner_artifact_content(&self, _: &str, _: &str, _: &str) -> Result<Value> {
                 Ok(Value::Null)
             }
+            fn runner_job_cancel(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<(crate::api_jobs::Job, Vec<crate::api_jobs::JobEvent>)> {
+                unreachable!()
+            }
             fn refresh_mirrored_daemon_evidence(
                 &self,
                 run_id: &str,


### PR DESCRIPTION
## Summary

`RunnerEvidenceProvider` gained a `runner_job_cancel` method, but the **second** `FakeProvider` in `runner_evidence`'s tests (there are two) wasn't updated — breaking the `homeboy-core` test target on current main with **E0046** (missing trait item). The other `FakeProvider` and the `NoopProvider` already had it.

Mirror the existing impl (`unreachable!()` — this fake is never asked to cancel).

## How it was found

Surfaced by `cargo check --workspace --tests` (the topology guard #8509 pattern) while working on an unrelated audit refactor. Reproduced on clean main to confirm it's pre-existing — the differentially-scoped `review test` gate missed it.

## Verification

- `cargo check -p homeboy-core --tests` — clean (was E0046-broken on main)