### PR TITLE
refactor: import HomeboyFinding direct from the homeboy-finding crate (#8425)

### DIFF
--- a/crates/homeboy-core/src/code_audit/findings.rs
+++ b/crates/homeboy-core/src/code_audit/findings.rs
@@ -2,7 +2,7 @@
 
 use super::checks::{CheckResult, CheckStatus};
 use super::conventions::AuditFinding;
-use crate::finding::{FindingSource, HomeboyFinding};
+use homeboy_finding::{FindingSource, HomeboyFinding};
 use regex::Regex;
 use serde::{Deserializer, Serializer};
 use serde_json::Value;

--- a/crates/homeboy-core/src/code_audit/report.rs
+++ b/crates/homeboy-core/src/code_audit/report.rs
@@ -12,7 +12,7 @@ use crate::code_audit::{
     FindingConfidence, Severity,
 };
 use crate::extension::ExtensionPhaseTiming;
-use crate::finding::HomeboyFinding;
+use homeboy_finding::HomeboyFinding;
 use serde::Serialize;
 use serde_json::Value;
 


### PR DESCRIPTION
## Summary

`code_audit` imported `HomeboyFinding` / `FindingSource` via `crate::finding`, which is just core's `pub use homeboy_finding as finding` re-export bridge. Point the two audit call sites (`findings.rs`, `report.rs`) straight at `homeboy_finding::` — the crate where those types live — instead of routing through core.

## Context — and an honest note on the audit-crate goal

This is a small cleanup toward decoupling `code_audit` from core internals. But while chasing the `homeboy-audit` crate extraction, I confirmed it is **not viable**, and shouldn't be forced:

- `refactor` depends on `code_audit` **bidirectionally by design** — 31 use-statements (`AuditFinding` 18×, `CodeAuditResult`, `walker`, `conventions`, `fingerprint`…). The refactor engine consumes audit findings to drive fixes: audit finds, refactor fixes. That's two halves of one loop, not incidental coupling.
- `code_audit` also depends on core-internal utilities (`git`, `plan`, `execution_contract`). With `core → audit` (via refactor) already true, `audit → core` would be a Cargo crate cycle.

**Verdict: audit correctly stays a core module.** The valuable campaign work stands — audit is now decoupled from the *feature layers* (component/extension/observation) via `homeboy-audit-contract` + provider hooks, which is the right architecture. A separate crate is not.

## Verification

- `cargo check -p homeboy-core --lib` — clean

Refs #8425