### PR TITLE
refactor: import extension's engine primitives direct from the crate (#8425)

### DIFF
--- a/crates/homeboy-core/src/extension/bench/baseline.rs
+++ b/crates/homeboy-core/src/extension/bench/baseline.rs
@@ -21,8 +21,8 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::engine::baseline::{self as generic, BaselineConfig};
 use crate::error::Result;
+use homeboy_engine_primitives::baseline::{self as generic, BaselineConfig};
 
 use super::metrics::{resolve_metric_policies, MetricDelta};
 use super::parsing::{BenchResults, BenchScenario};

--- a/crates/homeboy-core/src/extension/bench/failure_diagnostic.rs
+++ b/crates/homeboy-core/src/extension/bench/failure_diagnostic.rs
@@ -85,8 +85,8 @@ fn text_after<'a>(text: &'a str, start: &str) -> Option<&'a str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::baseline::BaselineFlags;
     use crate::extension::bench::parsing::BenchRunExecution;
+    use homeboy_engine_primitives::baseline::BaselineFlags;
 
     #[test]
     fn test_bench_failure_stderr_tail() {

--- a/crates/homeboy-core/src/extension/bench/run/list.rs
+++ b/crates/homeboy-core/src/extension/bench/run/list.rs
@@ -3,12 +3,12 @@
 use std::path::{Path, PathBuf};
 
 use crate::component::Component;
-use crate::engine::baseline::BaselineFlags;
 use crate::engine::invocation::InvocationRequirements;
 use crate::engine::run_dir::{self, RunDir};
 use crate::error::{Error, Result};
 use crate::extension::bench::parsing::{self, BenchRunExecution};
 use crate::extension::{resolve_execution_context, ExtensionCapability};
+use homeboy_engine_primitives::baseline::BaselineFlags;
 
 use super::runner::build_runner;
 use super::scenario::{apply_scenario_filter, normalize_workload_json_scenario_ids};

--- a/crates/homeboy-core/src/extension/bench/run/mod.rs
+++ b/crates/homeboy-core/src/extension/bench/run/mod.rs
@@ -31,7 +31,6 @@ mod tests {
     use super::types::{BenchListWorkflowArgs, BenchListWorkflowResult, BenchRunWorkflowArgs};
     use super::workflow::bench_component_script_env;
     use crate::component::Component;
-    use crate::engine::baseline::BaselineFlags;
     use crate::engine::invocation::InvocationRequirements;
     use crate::engine::resource::{
         self, ChildProcessIdentity, ExtensionChildProcessSample, ExtensionChildResourceSample,
@@ -42,6 +41,7 @@ mod tests {
     use crate::extension::bench::responsiveness::BenchResponsivenessSummary;
     use crate::extension::bench::test_support::{results_with_scenarios, scenario_with_iterations};
     use crate::extension::path_list_env_value;
+    use homeboy_engine_primitives::baseline::BaselineFlags;
     use std::collections::BTreeMap;
     use std::fs;
     use std::path::PathBuf;

--- a/crates/homeboy-core/src/extension/bench/run/types.rs
+++ b/crates/homeboy-core/src/extension/bench/run/types.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
-use crate::engine::baseline::BaselineFlags;
 use crate::engine::invocation::InvocationRequirements;
 use crate::extension::bench::baseline::BenchBaselineComparison;
 use crate::extension::bench::diagnostic::BenchDiagnostic;
@@ -15,6 +14,7 @@ use crate::extension::bench::responsiveness::{
     BenchFailureMemorySample, BenchResponsivenessSummary,
 };
 use crate::gate::HomeboyGateResult;
+use homeboy_engine_primitives::baseline::BaselineFlags;
 
 #[derive(Debug, Clone)]
 pub struct BenchRunWorkflowArgs {

--- a/crates/homeboy-core/src/extension/bench/run_metadata.rs
+++ b/crates/homeboy-core/src/extension/bench/run_metadata.rs
@@ -166,10 +166,10 @@ fn source_revision_at(path: &Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::baseline::BaselineFlags;
     use crate::engine::invocation::InvocationRequirements;
     use crate::extension::bench::parsing::{self, BenchRunExecution};
     use crate::extension::ExtensionCapability;
+    use homeboy_engine_primitives::baseline::BaselineFlags;
 
     #[test]
     fn run_metadata_captures_reproducible_bench_context() {

--- a/crates/homeboy-core/src/extension/build/mod.rs
+++ b/crates/homeboy-core/src/extension/build/mod.rs
@@ -6,9 +6,7 @@ use crate::artifact_inputs::{self, ResolvedArtifactInput};
 use crate::component::{self, Component};
 use crate::config::{is_json_input, parse_bulk_ids};
 use crate::deploy::permissions;
-use crate::engine::command::CapturedOutput;
 use crate::engine::run_dir::RunDir;
-use crate::engine::shell;
 use crate::error::{Error, Result};
 use crate::extension::{
     self, exec_context, ExtensionCapability, ExtensionExecutionContext, ExtensionPhaseTiming,
@@ -16,6 +14,8 @@ use crate::extension::{
 use crate::output::{BulkResult, BulkResultBuilder};
 use crate::paths;
 use crate::server::execute_local_command_in_dir;
+use homeboy_engine_primitives::command::CapturedOutput;
+use homeboy_engine_primitives::shell;
 
 const DEFAULT_BUILD_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 const BUILD_TIMEOUT_ENV: &str = "HOMEBOY_BUILD_TIMEOUT_SECS";
@@ -738,7 +738,11 @@ fn command_with_args(command: &str, args: &[String]) -> String {
         return command.to_string();
     }
 
-    format!("{} {}", command, crate::engine::shell::quote_args(args))
+    format!(
+        "{} {}",
+        command,
+        homeboy_engine_primitives::shell::quote_args(args)
+    )
 }
 
 fn apply_artifact_inputs(comp: &Component) -> Result<Vec<ResolvedArtifactInput>> {

--- a/crates/homeboy-core/src/extension/compiler_warning_contract.rs
+++ b/crates/homeboy-core/src/extension/compiler_warning_contract.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::engine::command::{wait_with_bounded_output, DEFAULT_CAPTURE_LIMIT_BYTES};
+use homeboy_engine_primitives::command::{wait_with_bounded_output, DEFAULT_CAPTURE_LIMIT_BYTES};
 
 use super::ExtensionManifest;
 

--- a/crates/homeboy-core/src/extension/component_script.rs
+++ b/crates/homeboy-core/src/extension/component_script.rs
@@ -278,7 +278,7 @@ fn command_with_args(command: &str, script_args: &[String]) -> String {
     format!(
         "{} {}",
         command,
-        crate::engine::shell::quote_args(script_args)
+        homeboy_engine_primitives::shell::quote_args(script_args)
     )
 }
 

--- a/crates/homeboy-core/src/extension/env_provider.rs
+++ b/crates/homeboy-core/src/extension/env_provider.rs
@@ -1,7 +1,7 @@
-use crate::engine::shell;
 use crate::error::{Error, Result};
 use crate::extension::manifest::ExtensionManifest;
 use crate::server::execute_local_command_in_dir;
+use homeboy_engine_primitives::shell;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 

--- a/crates/homeboy-core/src/extension/execution.rs
+++ b/crates/homeboy-core/src/extension/execution.rs
@@ -1,6 +1,4 @@
 use crate::component::{self, Component};
-use crate::engine::command::CapturedOutput;
-use crate::engine::shell;
 use crate::engine::{template, validation};
 use crate::error::{Error, Result};
 use crate::project::{self, Project};
@@ -11,6 +9,8 @@ use crate::server::{
     execute_local_command_passthrough_with_timeout, execute_local_command_stderr_passthrough,
     execute_local_command_stderr_passthrough_with_timeout, CommandOutput,
 };
+use homeboy_engine_primitives::command::CapturedOutput;
+use homeboy_engine_primitives::shell;
 use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
@@ -665,8 +665,10 @@ pub(super) fn build_action_env(
     project_base_path: Option<&str>,
 ) -> Vec<(String, String)> {
     let settings_json = payload.to_string();
-    let component_id = crate::engine::text::json_path_str(payload, &["release", "component_id"]);
-    let component_path = crate::engine::text::json_path_str(payload, &["release", "local_path"]);
+    let component_id =
+        homeboy_engine_primitives::text::json_path_str(payload, &["release", "component_id"]);
+    let component_path =
+        homeboy_engine_primitives::text::json_path_str(payload, &["release", "local_path"]);
 
     let mut env = build_exec_env(
         extension_id,
@@ -679,7 +681,7 @@ pub(super) fn build_action_env(
         component_path,
     );
     if let Some(source_path) =
-        crate::engine::text::json_path_str(payload, &["release", "source_path"])
+        homeboy_engine_primitives::text::json_path_str(payload, &["release", "source_path"])
     {
         env.push((
             "HOMEBOY_RELEASE_SOURCE_PATH".to_string(),

--- a/crates/homeboy-core/src/extension/execution/action.rs
+++ b/crates/homeboy-core/src/extension/execution/action.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
-use crate::engine::validation;
 use crate::error::{Error, Result};
 use crate::project;
 use crate::server::http::ApiClient;
+use homeboy_engine_primitives::validation;
 
 use super::{
     build_action_env, execute_extension_command, load_extension, ExtensionExecutionMode,
@@ -126,7 +126,7 @@ pub(crate) fn execute_action(
                 .and_then(|proj| proj.base_path.clone());
 
             let working_dir =
-                crate::engine::text::json_path_str(&payload, &["release", "local_path"])
+                homeboy_engine_primitives::text::json_path_str(&payload, &["release", "local_path"])
                     .unwrap_or(extension_path);
 
             let env = build_action_env(

--- a/crates/homeboy-core/src/extension/execution/readiness.rs
+++ b/crates/homeboy-core/src/extension/execution/readiness.rs
@@ -1,8 +1,8 @@
 use serde::Serialize;
 
-use crate::engine::template;
 use crate::project::Project;
 use crate::server::execute_local_command_in_dir;
+use homeboy_engine_primitives::template;
 
 use super::{load_extension, ExtensionManifest};
 

--- a/crates/homeboy-core/src/extension/execution/settings.rs
+++ b/crates/homeboy-core/src/extension/execution/settings.rs
@@ -1,5 +1,5 @@
-use crate::engine::local_files;
 use crate::error::{Error, Result};
+use homeboy_engine_primitives::local_files;
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/crates/homeboy-core/src/extension/fingerprint.rs
+++ b/crates/homeboy-core/src/extension/fingerprint.rs
@@ -1,5 +1,5 @@
 use super::manifest::ExtensionManifest;
-use crate::engine::command::{wait_with_bounded_output, DEFAULT_CAPTURE_LIMIT_BYTES};
+use homeboy_engine_primitives::command::{wait_with_bounded_output, DEFAULT_CAPTURE_LIMIT_BYTES};
 
 // The fingerprint output schema moved to the homeboy-audit-contract crate
 // (#8425) — it's audit's data model, not extension behavior. Re-exported here

--- a/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
@@ -10,10 +10,10 @@ use std::path::Path;
 
 use crate::agent_runtime_manifest::validate_installed_extension_agent_runtime_provider_discovery;
 use crate::config::{self, from_str};
-use crate::engine::local_files;
 use crate::error::{Error, Result};
 use crate::git;
 use crate::paths;
+use homeboy_engine_primitives::local_files;
 
 use super::super::execution::run_setup;
 use super::super::load_extension;

--- a/crates/homeboy-core/src/extension/lifecycle/mod.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/mod.rs
@@ -1,7 +1,7 @@
-use crate::engine::identifier;
 use crate::error::{Error, Result};
 use crate::git;
 use crate::paths;
+use homeboy_engine_primitives::identifier;
 use std::path::{Path, PathBuf};
 
 use super::load_extension;

--- a/crates/homeboy-core/src/extension/lint/baseline.rs
+++ b/crates/homeboy-core/src/extension/lint/baseline.rs
@@ -7,9 +7,9 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::engine::baseline::{self as generic, BaselineConfig, Fingerprintable};
 use crate::finding::{FindingSource, HomeboyFinding};
 use crate::structured_sidecar;
+use homeboy_engine_primitives::baseline::{self as generic, BaselineConfig, Fingerprintable};
 
 const BASELINE_KEY: &str = "lint";
 

--- a/crates/homeboy-core/src/extension/lint/run/hints.rs
+++ b/crates/homeboy-core/src/extension/lint/run/hints.rs
@@ -2,7 +2,7 @@
 //! refactor --from lint --write` CTAs while preserving the active scope flags.
 
 use super::types::LintRunWorkflowArgs;
-use crate::engine::shell;
+use homeboy_engine_primitives::shell;
 
 pub(super) fn build_autofix_hint(args: &LintRunWorkflowArgs) -> String {
     let lint_command = lint_autofix_command(args);

--- a/crates/homeboy-core/src/extension/lint/run/tests/mod.rs
+++ b/crates/homeboy-core/src/extension/lint/run/tests/mod.rs
@@ -2,9 +2,9 @@
 
 use super::types::{LintRunWorkflowArgs, LintSniffFilters};
 use crate::component::Component;
-use crate::engine::baseline::BaselineFlags;
 use crate::extension::LintChangedFileRoute;
 use crate::finding::HomeboyFinding;
+use homeboy_engine_primitives::baseline::BaselineFlags;
 
 mod exit_code;
 mod findings;

--- a/crates/homeboy-core/src/extension/lint/run/types.rs
+++ b/crates/homeboy-core/src/extension/lint/run/types.rs
@@ -1,11 +1,11 @@
 //! Shared workflow types — args, results, and summary structures.
 
-use crate::engine::baseline::BaselineFlags;
 use crate::extension::lint::baseline as lint_baseline;
 use crate::extension::self_check::SelfCheckCaptureMetadata;
 use crate::extension::ExtensionPhaseTiming;
 use crate::finding::{FindingProducerSummary, HomeboyFinding};
 use crate::refactor::AppliedRefactor;
+use homeboy_engine_primitives::baseline::BaselineFlags;
 use serde::Serialize;
 use std::collections::BTreeMap;
 

--- a/crates/homeboy-core/src/extension/manifest_config.rs
+++ b/crates/homeboy-core/src/extension/manifest_config.rs
@@ -1,5 +1,5 @@
-use crate::engine::output_parse::ParseSpec;
 use crate::lifecycle::LifecycleContract;
+use homeboy_engine_primitives::output_parse::ParseSpec;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/crates/homeboy-core/src/extension/refactor_protocol.rs
+++ b/crates/homeboy-core/src/extension/refactor_protocol.rs
@@ -1,5 +1,5 @@
 use super::manifest::ExtensionManifest;
-use crate::engine::command::{wait_with_bounded_output, DEFAULT_CAPTURE_LIMIT_BYTES};
+use homeboy_engine_primitives::command::{wait_with_bounded_output, DEFAULT_CAPTURE_LIMIT_BYTES};
 
 #[derive(Debug, Clone)]
 pub struct RefactorScriptFailure {

--- a/crates/homeboy-core/src/extension/repair.rs
+++ b/crates/homeboy-core/src/extension/repair.rs
@@ -1,9 +1,9 @@
 use crate::agent_runtime_manifest::validate_installed_extension_agent_runtime_provider_discovery;
 use crate::config::{self, from_str};
-use crate::engine::local_files;
 use crate::error::{Error, Result};
 use crate::git;
 use crate::paths;
+use homeboy_engine_primitives::local_files;
 use std::path::{Path, PathBuf};
 
 use super::execution::run_setup;

--- a/crates/homeboy-core/src/extension/runner.rs
+++ b/crates/homeboy-core/src/extension/runner.rs
@@ -5,10 +5,10 @@ use crate::component::Component;
 use crate::engine::invocation::{InvocationGuard, InvocationRequirements};
 use crate::engine::resource::{self, ExtensionChildResourceSummary};
 use crate::engine::run_dir::{self, RunDir};
-use crate::engine::shell;
 use crate::error::{Error, Result};
 use crate::extension::{ExtensionCapability, ExtensionPhaseTiming};
 use crate::server::CommandOutput;
+use homeboy_engine_primitives::shell;
 use serde_json::json;
 
 const STRICT_VALIDATION_DEPENDENCIES_ENV: &str = "HOMEBOY_STRICT_VALIDATION_DEPENDENCIES";

--- a/crates/homeboy-core/src/extension/runtime_helper.rs
+++ b/crates/homeboy-core/src/extension/runtime_helper.rs
@@ -1,6 +1,6 @@
-use crate::engine::local_files;
 use crate::error::{Error, Result};
 use crate::paths;
+use homeboy_engine_primitives::local_files;
 use serde::Deserialize;
 use std::env;
 use std::fs;

--- a/crates/homeboy-core/src/extension/setup_env.rs
+++ b/crates/homeboy-core/src/extension/setup_env.rs
@@ -17,9 +17,9 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-use crate::engine::local_files;
 use crate::error::Result;
 use crate::paths;
+use homeboy_engine_primitives::local_files;
 
 /// Schema marker for the persisted setup-env document.
 const SETUP_ENV_SCHEMA: &str = "homeboy/extension-setup-env/v1";

--- a/crates/homeboy-core/src/extension/test/baseline.rs
+++ b/crates/homeboy-core/src/extension/test/baseline.rs
@@ -9,8 +9,8 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::engine::baseline::{self as generic, BaselineConfig};
 use crate::error::Result;
+use homeboy_engine_primitives::baseline::{self as generic, BaselineConfig};
 
 const BASELINE_KEY: &str = "test";
 

--- a/crates/homeboy-core/src/extension/test/drift.rs
+++ b/crates/homeboy-core/src/extension/test/drift.rs
@@ -576,7 +576,7 @@ pub fn is_source_relevant_change(opts: &DriftOptions, path: &str) -> bool {
 
 /// Collect test files in the repo using extension-declared glob patterns.
 fn collect_test_files(root: &Path, test_patterns: &[String]) -> Vec<PathBuf> {
-    use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+    use homeboy_engine_primitives::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
     let config = ScanConfig {
         extensions: ExtensionFilter::All,

--- a/crates/homeboy-core/src/extension/test/parsing.rs
+++ b/crates/homeboy-core/src/extension/test/parsing.rs
@@ -1,11 +1,11 @@
 use serde::{Deserialize, Serialize};
 
-use crate::engine::local_files;
-use crate::engine::output_parse::{Aggregate, DeriveRule, ParseRule, ParseSpec};
 use crate::error::Result;
 use crate::extension::test::analyze::{TestAnalysis, TestAnalysisInput, TestFailure};
 use crate::extension::test::TestCounts;
 use crate::structured_sidecar;
+use homeboy_engine_primitives::local_files;
+use homeboy_engine_primitives::output_parse::{Aggregate, DeriveRule, ParseRule, ParseSpec};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CoverageOutput {

--- a/crates/homeboy-core/src/extension/test/run.rs
+++ b/crates/homeboy-core/src/extension/test/run.rs
@@ -1,7 +1,4 @@
 use crate::component::Component;
-use crate::engine::baseline::BaselineFlags;
-use crate::engine::local_files;
-use crate::engine::output_parse::ParseSpec;
 use crate::engine::run_dir::{self, RunDir};
 use crate::error::{Error, ErrorCode};
 use crate::extension::runner::tail_lines;
@@ -18,6 +15,9 @@ use crate::finding::HomeboyFinding;
 use crate::observation::homeboy_findings_from_test_analysis_input;
 use crate::refactor::AppliedRefactor;
 use crate::validation_progress::{write_command_artifact, ValidationProgressRecorder};
+use homeboy_engine_primitives::baseline::BaselineFlags;
+use homeboy_engine_primitives::local_files;
+use homeboy_engine_primitives::output_parse::ParseSpec;
 use serde::Serialize;
 use std::path::Path;
 
@@ -809,10 +809,11 @@ fn run_declared_result_parser(
         },
     )?;
     if !output.success {
-        let mut command = crate::engine::shell::quote_path(&resolved_script.to_string_lossy());
+        let mut command =
+            homeboy_engine_primitives::shell::quote_path(&resolved_script.to_string_lossy());
         if !args.is_empty() {
             command.push(' ');
-            command.push_str(&crate::engine::shell::quote_args(&args));
+            command.push_str(&homeboy_engine_primitives::shell::quote_args(&args));
         }
         return Err(declared_result_parser_error(
             component,

--- a/crates/homeboy-core/src/extension/trace/baseline.rs
+++ b/crates/homeboy-core/src/extension/trace/baseline.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::engine::baseline::{self as generic, BaselineConfig};
 use crate::error::Result;
+use homeboy_engine_primitives::baseline::{self as generic, BaselineConfig};
 
 use super::parsing::{TraceAssertion, TraceAssertionStatus, TraceResults};
 

--- a/crates/homeboy-core/src/extension/trace/canonicality.rs
+++ b/crates/homeboy-core/src/extension/trace/canonicality.rs
@@ -608,10 +608,10 @@ fn parse_ahead_behind(value: &str) -> Option<(Option<u32>, Option<u32>)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::baseline::BaselineFlags;
     use crate::engine::run_dir::RunDir;
     use crate::extension::trace::run::{run_trace_workflow, TraceRunnerInputs};
     use crate::extension::ExtensionCapability;
+    use homeboy_engine_primitives::baseline::BaselineFlags;
     use std::path::Path;
 
     #[test]

--- a/crates/homeboy-core/src/extension/trace/overlay.rs
+++ b/crates/homeboy-core/src/extension/trace/overlay.rs
@@ -4,9 +4,9 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::engine::detail_output::{bounded_items, DEFAULT_DETAIL_ITEM_LIMIT};
 use crate::engine::run_dir::RunDir;
 use crate::error::{Error, Result};
+use homeboy_engine_primitives::detail_output::{bounded_items, DEFAULT_DETAIL_ITEM_LIMIT};
 
 use super::overlay_lock;
 

--- a/crates/homeboy-core/src/extension/trace/report.rs
+++ b/crates/homeboy-core/src/extension/trace/report.rs
@@ -15,9 +15,9 @@ use super::span_summary::{
     format_span_summary_metadata, format_span_summary_status, trace_span_summaries,
     TraceSpanSummaryOutput,
 };
-use crate::engine::detail_output::{bounded_items, DEFAULT_DETAIL_ITEM_LIMIT};
 use crate::execution_contract::is_reportable_artifact_evidence_path;
 use crate::rig::RigStateSnapshot;
+use homeboy_engine_primitives::detail_output::{bounded_items, DEFAULT_DETAIL_ITEM_LIMIT};
 
 pub use aggregate_types::*;
 pub use builders::*;
@@ -858,7 +858,7 @@ mod markdown {
     fn push_omitted_detail_line(
         out: &mut String,
         label: &str,
-        metadata: &crate::engine::detail_output::DetailOutputMetadata,
+        metadata: &homeboy_engine_primitives::detail_output::DetailOutputMetadata,
     ) {
         if metadata.truncated {
             out.push_str(&format!(
@@ -875,7 +875,7 @@ mod markdown {
     fn push_indented_omitted_detail_line(
         out: &mut String,
         label: &str,
-        metadata: &crate::engine::detail_output::DetailOutputMetadata,
+        metadata: &homeboy_engine_primitives::detail_output::DetailOutputMetadata,
     ) {
         if metadata.truncated {
             out.push_str(&format!(

--- a/crates/homeboy-core/src/extension/trace/run/list.rs
+++ b/crates/homeboy-core/src/extension/trace/run/list.rs
@@ -1,10 +1,10 @@
 //! Trace scenario discovery (list-only) workflow.
 
 use crate::component::Component;
-use crate::engine::baseline::BaselineFlags;
 use crate::engine::run_dir::{self, RunDir};
 use crate::error::{Error, Result};
 use crate::extension::{resolve_execution_context, ExtensionCapability, RunnerOutput};
+use homeboy_engine_primitives::baseline::BaselineFlags;
 
 use super::super::canonicality::TraceCanonicalPolicy;
 use super::super::parsing::{parse_trace_list_str, TraceList};

--- a/crates/homeboy-core/src/extension/trace/run/tests/extension.rs
+++ b/crates/homeboy-core/src/extension/trace/run/tests/extension.rs
@@ -6,7 +6,6 @@ use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 
 use crate::component::{Component, ScopedExtensionConfig};
-use crate::engine::baseline::BaselineFlags;
 use crate::engine::invocation::InvocationRequirements;
 use crate::engine::run_dir::RunDir;
 use crate::error::{Error, ErrorCode};
@@ -19,6 +18,7 @@ use crate::extension::trace::overlay::{apply_trace_overlays, TraceOverlayRequest
 use crate::extension::trace::probes::TraceProbeConfig;
 use crate::extension::{ExtensionCapability, ExtensionExecutionContext, RunnerOutput};
 use crate::test_support::{exec_capable_tempdir, with_isolated_home};
+use homeboy_engine_primitives::baseline::BaselineFlags;
 
 use super::super::runner::{build_trace_runner, failure_from_output, trace_is_unclaimed};
 use super::super::types::{TraceRunWorkflowArgs, TraceRunnerInputs};

--- a/crates/homeboy-core/src/extension/trace/run/tests/workflow.rs
+++ b/crates/homeboy-core/src/extension/trace/run/tests/workflow.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use crate::component::Component;
-use crate::engine::baseline::BaselineFlags;
 use crate::engine::run_dir::RunDir;
 use crate::error::{Error, ErrorCode};
 use crate::extension::trace::attach::TraceAttachment;
@@ -13,6 +12,7 @@ use crate::extension::trace::canonicality::TraceCanonicalPolicy;
 use crate::extension::trace::parsing::{TraceGitProvenance, TraceResults, TraceStatus};
 use crate::extension::trace::probes::TraceProbeConfig;
 use crate::extension::{ExtensionCapability, ExtensionExecutionContext, RunnerOutput};
+use homeboy_engine_primitives::baseline::BaselineFlags;
 
 use super::super::list::run_trace_list_workflow;
 use super::super::provenance::{

--- a/crates/homeboy-core/src/extension/trace/run/types.rs
+++ b/crates/homeboy-core/src/extension/trace/run/types.rs
@@ -3,10 +3,10 @@
 use serde::Serialize;
 use std::path::PathBuf;
 
-use crate::engine::baseline::BaselineFlags;
 use crate::engine::invocation::InvocationRequirements;
 use crate::extension::trace::baseline::TraceBaselineComparison;
 use crate::rig::TraceDependencySpec;
+use homeboy_engine_primitives::baseline::BaselineFlags;
 
 use super::super::attach::TraceAttachment;
 use super::super::canonicality::TraceCanonicalPolicy;


### PR DESCRIPTION
## Summary

Cuts the largest remaining core cycle. `extension → engine` was **88** real use-statements — but ~40 of them were modules that **already live in `homeboy-engine-primitives`** (`baseline`, `shell`, `local_files`, `command`, `text`, `detail_output`, `output_parse`, `validation`, `template`, `codebase_scan`, `grammar`, `language`, `identifier`, `edit_op*`, `symbol_graph`), routed through core's engine re-export bridge rather than the crate where they live.

Repoint them to `homeboy_engine_primitives::`.

## Result

`extension → engine` real edges drop **88 → 56**, and the remaining 56 are **only** the three test-coupled engine primitives (`run_dir`, `invocation`, `resource`) that can't move while `test_support` stays core-bound. No behavior change — same modules, sourced from their real crate.

## Context: extension stays in core (like audit)

While assessing whether extension deserves its own crate, I confirmed it doesn't — it's a **cross-cutting concern**, not a clean domain. Everything (`release`, `refactor`, `deploy`, `audit`, `rig`) reads extension manifests, and extension reaches back into `engine`/`component`/`refactor`/`observation`. A crate would create cycles in 4+ directions. Extension belongs in core; the untangling is real and worthwhile in place. This is the highest-leverage piece of it.

## Verification

- `cargo check -p homeboy-core --lib` — clean
- `cargo check --workspace --tests --locked` — **green**

Refs #8425