### PR TITLE
refactor: import AuditConfig direct from the contract in extension manifest (#8425)

### DIFF
--- a/crates/homeboy-core/src/extension/manifest.rs
+++ b/crates/homeboy-core/src/extension/manifest.rs
@@ -1,4 +1,4 @@
-use crate::component::AuditConfig;
+use homeboy_audit_contract::AuditConfig;
 use crate::config::ConfigEntity;
 use crate::error::{Error, Result};
 use crate::paths;


### PR DESCRIPTION
## Summary

`extension/manifest.rs` imported `AuditConfig` via `crate::component::AuditConfig`, but that type lives in `homeboy-audit-contract` now (component just re-exports it). Point it straight at the crate — one fewer `extension → component` edge routed through a bridge.

## Verification
- `cargo check -p homeboy-core --lib` — clean
- `cargo check --workspace --tests --locked` — green

Refs #8425