### PR TITLE
Unify scheduler attempt cleanup ownership

### DIFF
--- a/crates/homeboy-core/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-core/src/agent_task_scheduler/attempt_workspace.rs
@@ -1,9 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
+use std::sync::Arc;
 
 use sha2::{Digest, Sha256};
 
@@ -79,7 +76,6 @@ pub(super) struct AttemptWorkspace {
     source_root: PathBuf,
     root: PathBuf,
     base_sha: String,
-    retain: AtomicBool,
 }
 
 impl AttemptWorkspace {
@@ -87,13 +83,25 @@ impl AttemptWorkspace {
         &self.base_sha
     }
 
-    pub(super) fn retain_for_diagnostics(&self) {
-        self.retain.store(true, Ordering::Release);
-    }
-
     pub(super) fn cleanup(&self) -> Result<(), String> {
+        let status = git_output(&self.root, &["status", "--porcelain=v1"])
+            .map_err(|error| format!("cannot inspect attempt workspace state: {error:?}"))?;
+        if !status.trim().is_empty() {
+            return Err("attempt workspace has uncommitted changes".to_string());
+        }
+        let unpushed = git_output(
+            &self.root,
+            &["rev-list", "--count", &format!("{}..HEAD", self.base_sha)],
+        )
+        .map_err(|error| format!("cannot inspect attempt workspace commits: {error:?}"))?;
+        if unpushed.trim() != "0" {
+            return Err(format!(
+                "attempt workspace has {} commit(s) beyond its base",
+                unpushed.trim()
+            ));
+        }
         let remove = Command::new("git")
-            .args(["worktree", "remove", "--force"])
+            .args(["worktree", "remove"])
             .arg(&self.root)
             .current_dir(&self.source_root)
             .status()
@@ -101,23 +109,7 @@ impl AttemptWorkspace {
         if !remove.success() {
             return Err(format!("git worktree remove exited {remove}"));
         }
-        self.retain.store(true, Ordering::Release);
         Ok(())
-    }
-}
-
-impl Drop for AttemptWorkspace {
-    fn drop(&mut self) {
-        if self.retain.load(Ordering::Acquire) {
-            return;
-        }
-        // This is a scheduler-created detached checkout, never the caller's
-        // managed task workspace. Drop runs after the executor thread exits.
-        let _ = Command::new("git")
-            .args(["worktree", "remove", "--force"])
-            .arg(&self.root)
-            .current_dir(&self.source_root)
-            .status();
     }
 }
 
@@ -369,6 +361,7 @@ pub(super) fn prepare_attempt_workspace(
     request: &mut AgentTaskRequest,
     base: Option<&str>,
     candidate_baseline: Option<&CandidateBaseline>,
+    scratch_root: &Path,
 ) -> Result<Option<Arc<AttemptWorkspace>>, HarvestError> {
     let Some(root) = request.workspace.root.as_deref().map(PathBuf::from) else {
         return Ok(None);
@@ -376,13 +369,10 @@ pub(super) fn prepare_attempt_workspace(
     let Some(base) = base else {
         return Ok(None);
     };
-    let parent = std::env::temp_dir().join("homeboy-agent-task-attempts");
-    std::fs::create_dir_all(&parent).map_err(|error| HarvestError::ArtifactDirectory {
-        path: parent.clone(),
-        message: error.to_string(),
-    })?;
     let identity = format!("attempt-{}", uuid::Uuid::new_v4());
-    let attempt_root = parent.join(&identity);
+    // The attempt checkout is a child of the scheduler's durably registered
+    // scratch lease, never an untracked system-temporary worktree.
+    let attempt_root = scratch_root.join("workspace");
     let attempt_root_string = attempt_root.display().to_string();
     git_output(
         &root,
@@ -393,7 +383,6 @@ pub(super) fn prepare_attempt_workspace(
         source_root: root.clone(),
         root: attempt_root.clone(),
         base_sha: base.to_string(),
-        retain: AtomicBool::new(false),
     });
     let adoption = request
         .workspace

--- a/crates/homeboy-core/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-core/src/agent_task_scheduler/engine.rs
@@ -393,42 +393,6 @@ where
                     .or(harvest_preflight.base_sha.clone());
                 let source_workspace_root = request.workspace.root.clone();
                 let source_provenance = harvest_preflight.source_provenance;
-                let attempt_workspace = match prepare_attempt_workspace(
-                    &mut request,
-                    task_base_sha.as_deref(),
-                    harvest_preflight.candidate_baseline.as_ref(),
-                ) {
-                    Ok(workspace) => workspace,
-                    Err(error) => {
-                        record_harvest_setup_failure(
-                            &task_id,
-                            scheduled.attempt,
-                            error,
-                            &mut completed_by_task,
-                            &mut outcomes,
-                            &mut events,
-                        );
-                        continue;
-                    }
-                };
-                let task_base_sha = attempt_workspace
-                    .as_ref()
-                    .map(|workspace| workspace.base_sha().to_string())
-                    .or(task_base_sha);
-                if let Some(adoption) = scheduled.adoption.as_ref() {
-                    if let Err(mut outcome) = validate_and_apply_candidate_adoption(
-                        &request,
-                        adoption,
-                        task_base_sha.as_deref(),
-                    ) {
-                        outcome.task_id = task_id.clone();
-                        record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
-                        continue;
-                    }
-                }
-                if let Some(root) = request.workspace.root.as_deref() {
-                    request.executor.remap_workspace_root(root);
-                }
                 #[cfg(test)]
                 let scratch_allocation = crate::controller_scratch::allocate_test_attempt;
                 #[cfg(not(test))]
@@ -453,6 +417,48 @@ where
                         continue;
                     }
                 };
+                let attempt_workspace = match prepare_attempt_workspace(
+                    &mut request,
+                    task_base_sha.as_deref(),
+                    harvest_preflight.candidate_baseline.as_ref(),
+                    &scratch.path,
+                ) {
+                    Ok(workspace) => workspace,
+                    Err(error) => {
+                        let outcome = committed_harvest_failure(
+                            committed_harvest_preflight_outcome(task_id.clone()),
+                            error,
+                        );
+                        release_scratch(&scratch, "attempt_workspace_setup_failed", &outcome);
+                        events.push(event(
+                            &task_id,
+                            AgentTaskState::Failed,
+                            scheduled.attempt,
+                            outcome.summary.clone(),
+                        ));
+                        record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
+                        continue;
+                    }
+                };
+                let task_base_sha = attempt_workspace
+                    .as_ref()
+                    .map(|workspace| workspace.base_sha().to_string())
+                    .or(task_base_sha);
+                if let Some(adoption) = scheduled.adoption.as_ref() {
+                    if let Err(mut outcome) = validate_and_apply_candidate_adoption(
+                        &request,
+                        adoption,
+                        task_base_sha.as_deref(),
+                    ) {
+                        outcome.task_id = task_id.clone();
+                        release_scratch(&scratch, "candidate_adoption_failed", &outcome);
+                        record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
+                        continue;
+                    }
+                }
+                if let Some(root) = request.workspace.root.as_deref() {
+                    request.executor.remap_workspace_root(root);
+                }
                 request
                     .executor
                     .set_runtime_tmpdir(scratch.path.to_string_lossy().as_ref());
@@ -590,9 +596,6 @@ where
                     if let Err(error) = harvest_uncommitted_patch(&mut outcome, &running_task)
                         .and_then(|_| harvest_committed_patch(&mut outcome, &running_task))
                     {
-                        if let Some(workspace) = &running_task._attempt_workspace {
-                            workspace.retain_for_diagnostics();
-                        }
                         outcome = committed_harvest_failure(outcome, error);
                     }
                     finalize_candidate_artifacts(&mut outcome, &running_task);
@@ -649,6 +652,7 @@ where
                         retry_budget_used,
                         &plan.options.retry.retryable_failure_classifications,
                     ) {
+                        cleanup_attempt_workspace(&mut outcome, &running_task);
                         release_scratch(&result.scratch, "retry", &outcome);
                         retry_budget_used += 1;
                         let retry_evidence = retry_attempt_evidence(&outcome, &running_task);
@@ -695,6 +699,7 @@ where
                             execution_budget.max_provider_executions,
                             execution_budget.max_provider_rotations,
                         ) {
+                            cleanup_attempt_workspace(&mut outcome, &running_task);
                             release_scratch(&result.scratch, "provider_rotation", &outcome);
                             let mut rotation_attempts = running_task.rotation_attempts.clone();
                             rotation_attempts.push(
@@ -784,6 +789,7 @@ where
                         }
                     }
                     let mut outcome = outcome;
+                    cleanup_attempt_workspace(&mut outcome, &running_task);
                     append_unique_artifacts(
                         &mut outcome.artifacts,
                         running_task.candidate_artifacts,
@@ -1067,6 +1073,25 @@ pub(super) fn release_scratch(
         "outcome": outcome,
     });
     let _ = crate::controller_scratch::release_attempt(allocation, reason, evidence);
+}
+
+/// A clean attempt is unregistered from Git before its enclosing scratch lease
+/// is released. Dirty, unpushed, and indeterminate checkouts remain registered
+/// for lifecycle cleanup instead of being force-removed.
+fn cleanup_attempt_workspace(outcome: &mut AgentTaskOutcome, running: &RunningTask) {
+    let Some(workspace) = &running._attempt_workspace else {
+        return;
+    };
+    if let Err(error) = workspace.cleanup() {
+        outcome.diagnostics.push(AgentTaskDiagnostic {
+            class: "agent_task.attempt_workspace_retained".to_string(),
+            message: format!("attempt workspace retained for lifecycle cleanup: {error}"),
+            data: serde_json::json!({
+                "path": running.request.workspace.root,
+                "reason": "dirty_unpushed_or_unknown",
+            }),
+        });
+    }
 }
 
 fn terminal_reason(outcome: &AgentTaskOutcome, cancelled: bool) -> &'static str {

--- a/crates/homeboy-core/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-core/src/agent_task_scheduler/harvest.rs
@@ -640,10 +640,12 @@ mod committed_harvest_tests {
             prepare_committed_harvest(&request, None, &HarvestExecutionContext::default())
                 .expect("recorded promoted candidate is accepted");
         let source_base = preflight.base_sha.expect("source base");
+        let scratch = tempfile::tempdir().expect("attempt scratch");
         let attempt = prepare_attempt_workspace(
             &mut request,
             Some(&source_base),
             preflight.candidate_baseline.as_ref(),
+            scratch.path(),
         )
         .expect("attempt workspace")
         .expect("isolated attempt");
@@ -964,9 +966,11 @@ mod committed_harvest_tests {
             prepare_committed_harvest(&request, None, &context).expect("snapshot retry preflight");
         assert_eq!(retry_preflight.base_sha.as_deref(), Some(baseline.as_str()));
         assert_eq!(source_provenance["source_revision"], "a".repeat(40));
-        let attempt = prepare_attempt_workspace(&mut request, Some(&baseline), None)
-            .expect("provider-ready attempt")
-            .expect("attempt workspace");
+        let scratch = tempfile::tempdir().expect("attempt scratch");
+        let attempt =
+            prepare_attempt_workspace(&mut request, Some(&baseline), None, scratch.path())
+                .expect("provider-ready attempt")
+                .expect("attempt workspace");
         assert_ne!(
             request.workspace.root.as_deref(),
             Some(workspace.path().to_str().unwrap())

--- a/crates/homeboy-core/src/controller_scratch.rs
+++ b/crates/homeboy-core/src/controller_scratch.rs
@@ -306,7 +306,9 @@ fn register_outcome_resources_unlocked(run_id: &str, outcomes: &[AgentTaskOutcom
                 root_bound: root.display().to_string(),
                 owner_pid: std::process::id(),
                 lifecycle_state: "provider_registered".to_string(),
-                lease_id: String::new(),
+                // Provider resources arrive after their materialization, so
+                // assign their lease while adopting them into our index.
+                lease_id: uuid::Uuid::new_v4().to_string(),
                 reconstructable: value
                     .get("reconstructable")
                     .and_then(serde_json::Value::as_bool)
@@ -565,7 +567,6 @@ fn remove_candidate(
     let mut index = read_index_unlocked()?;
     let Some(resource) = index.resources.iter_mut().find(|resource| {
         resource.lease_id == candidate.lease_id
-            && !resource.lease_id.is_empty()
             && resource.path == candidate.path
             && resource.owner_pid == candidate.owner_pid
     }) else {
@@ -1235,6 +1236,9 @@ mod tests {
             run_git(&scratch, &["push", "-u", "origin", "main"]);
             let mut resource = resource(&scratch, root.path());
             resource.lifecycle_state = "released".to_string();
+            // Older provider registrations had no lease. Recovery must still
+            // reconcile that owned resource after the normal safety gates.
+            resource.lease_id.clear();
             write_index(&ControllerScratchIndex {
                 schema: schema(),
                 resources: vec![resource],
@@ -1265,7 +1269,7 @@ mod tests {
                 .expect("index")
                 .resources
                 .into_iter()
-                .find(|resource| resource.lease_id == "test-lease")
+                .find(|resource| resource.path == scratch.display().to_string())
                 .expect("retained lifecycle evidence");
             assert_eq!(retained.lifecycle_state, "released");
             assert_eq!(retained.path, scratch.display().to_string());


### PR DESCRIPTION
## Summary
Put scheduler attempt worktrees under durable scratch ownership and remove them only after clean-state safety checks.

## What changed
- Materialize attempt worktrees inside the scheduler scratch lease instead of untracked system temporary storage.
- Replace force-removal and Drop cleanup with explicit clean, unpushed-state validation and lifecycle retention diagnostics.
- Assign leases when adopting provider resources while preserving recovery for older leaseless records.

## How to test
1. Run `cargo test -p homeboy-core terminal_reconstructable_resource_is_inventoried_and_removed_with_byte_accounting`; expect A released reconstructable resource is inventoried, removed, and byte-accounted..
2. Run `cargo test -p homeboy-core authorized_dirty_lab_snapshot_preflight_materializes_a_provider_ready_attempt_workspace`; expect The authorized snapshot creates a provider-ready attempt workspace under scratch ownership..
3. Run `cargo test -p homeboy-core clean_workspace_without_executor_commits_remains_a_no_patch_success`; expect A clean no-commit attempt remains successful and cleans up safely..

## Compatibility
Internal scheduler resource ownership change; dirty or unpushed attempt worktrees are now retained instead of force-removed.

## Evidence
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8517
- attempt-materialization: Passed
- clean-attempt-cleanup: Passed
- cleanup-accounting: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Prepared the implementation and targeted tests; Chris reviewed and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8517
