### PR TITLE
refactor: import Language from primitives, not via code_audit::conventions (#8425)

### DIFF
--- a/crates/homeboy-core/src/extension/manifest.rs
+++ b/crates/homeboy-core/src/extension/manifest.rs
@@ -1,4 +1,3 @@
-use homeboy_audit_contract::AuditConfig;
 use crate::config::ConfigEntity;
 use crate::error::{Error, Result};
 use crate::paths;
@@ -6,6 +5,7 @@ pub use homeboy_audit_contract::test_mapping::{
     BehaviorScenarioNames, IncludeWrapperPolicy, PackageNameSource, TestMappingConfig,
     TestVacuityPolicy,
 };
+use homeboy_audit_contract::AuditConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;

--- a/crates/homeboy-core/src/refactor/plan/generate/convention_fixes.rs
+++ b/crates/homeboy-core/src/refactor/plan/generate/convention_fixes.rs
@@ -1,7 +1,7 @@
-use crate::code_audit::conventions::Language;
 use crate::code_audit::naming::{detect_naming_suffix, suffix_matches};
 use crate::code_audit::{AuditFinding, CodeAuditResult};
 use crate::refactor::auto::{Fix, InsertionKind, SkippedFile};
+use homeboy_engine_primitives::language::Language;
 
 use regex::Regex;
 use std::collections::HashMap;

--- a/crates/homeboy-core/src/refactor/plan/generate/duplicate_fixes.rs
+++ b/crates/homeboy-core/src/refactor/plan/generate/duplicate_fixes.rs
@@ -1,6 +1,6 @@
-use crate::code_audit::conventions::Language;
 use crate::code_audit::{AuditFinding, CodeAuditResult, DuplicateGroup};
 use crate::refactor::auto::{Fix, InsertionKind, NewFile, SkippedFile};
+use homeboy_engine_primitives::language::Language;
 
 use regex::Regex;
 use std::collections::HashSet;

--- a/crates/homeboy-core/src/refactor/plan/generate/signatures.rs
+++ b/crates/homeboy-core/src/refactor/plan/generate/signatures.rs
@@ -1,4 +1,4 @@
-use crate::code_audit::conventions::Language;
+use homeboy_engine_primitives::language::Language;
 use regex::Regex;
 
 /// Full method signature extracted from a conforming file.


### PR DESCRIPTION
## Summary

`refactor` imported `Language` via `crate::code_audit::conventions::Language` — but `Language` has lived in `homeboy-engine-primitives` since #8433; `code_audit` just re-exports it. Point refactor's imports straight at `homeboy_engine_primitives::language::Language`.

Removes 3 `refactor → code_audit` edges that were **never real audit coupling** — just a primitive routed through audit's re-export.

## Context

Part of demonstrating that `refactor ↔ audit` is contract-able types + shared primitives, **not by-design behavioral coupling** (my earlier claim, which Chubes correctly challenged). Independent of the AuditFinding move (#8580).

## Verification
- `cargo check -p homeboy-core --lib` — clean
- `cargo check --workspace --tests --locked` — green

Refs #8425