### PR TITLE
Reconcile stale daemon lease stops

### DIFF
--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -836,14 +836,9 @@ pub fn force_stop_for_lease(expected_lease_id: &str) -> Result<DaemonStopResult>
     {
         return Err(corrupt_daemon_lease_error(&path, validation.stale_reason));
     }
-    let state = validation.state.ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "lease_id",
-            "forced daemon stop requires a persisted live daemon lease",
-            Some(expected_lease_id.to_string()),
-            None,
-        )
-    })?;
+    let Some(state) = validation.state else {
+        return reconcile_absent_lease_stop(expected_lease_id, state_path_display);
+    };
     if state.lease_id != expected_lease_id {
         return Err(Error::validation_invalid_argument(
             "lease_id",
@@ -936,14 +931,14 @@ fn stop_with_force_for_lease(expected_lease_id: &str, force: bool) -> Result<Dae
     let _lock = acquire_daemon_operation_lock()?;
     let path = state_path()?;
     let validation = validate_lease_file(&path)?;
-    let state = validation.state.ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "lease_id",
-            "daemon lifecycle stop requires a live recorded lease",
-            Some(expected_lease_id.to_string()),
-            None,
-        )
-    })?;
+    if validation.invalid_pid.is_some()
+        || (validation.state.is_none() && validation.stale_reason.is_some() && path.exists())
+    {
+        return Err(corrupt_daemon_lease_error(&path, validation.stale_reason));
+    }
+    let Some(state) = validation.state else {
+        return reconcile_absent_lease_stop(expected_lease_id, path.display().to_string());
+    };
     if state.lease_id != expected_lease_id {
         return Err(Error::validation_invalid_argument(
             "lease_id",
@@ -956,6 +951,42 @@ fn stop_with_force_for_lease(expected_lease_id: &str, force: bool) -> Result<Dae
         ));
     }
     stop_unlocked_with_force(force)
+}
+
+/// A lease-bound stop can be replayed after a previous stop removed a dead
+/// lease. It never signals a process without persisted ownership evidence.
+fn reconcile_absent_lease_stop(
+    expected_lease_id: &str,
+    state_path: String,
+) -> Result<DaemonStopResult> {
+    let active_job_ids = active_daemon_job_ids()?;
+    if !active_job_ids.is_empty() {
+        let mut error = Error::validation_invalid_argument(
+            "daemon_stop",
+            format!(
+                "refusing daemon stop for missing lease `{expected_lease_id}` while active durable jobs exist: {}",
+                active_job_ids
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            ),
+            Some(expected_lease_id.to_string()),
+            Some(vec![
+                "Inspect `homeboy daemon status` and reconcile the active durable jobs before replacing this daemon."
+                    .to_string(),
+            ]),
+        );
+        error.details["active_job_ids"] = serde_json::json!(active_job_ids);
+        error.details["lifecycle_mutation"] = serde_json::json!("stop");
+        return Err(error);
+    }
+    Ok(DaemonStopResult {
+        stopped: false,
+        pid: None,
+        state_path,
+        termination_evidence: None,
+    })
 }
 
 fn stop_unlocked() -> Result<DaemonStopResult> {

--- a/crates/homeboy-core/src/runner/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-core/src/runner/connection_stop_transport_recovery.rs
@@ -281,6 +281,12 @@ fn confirm_remote_daemon_stopped_after_transport_error(
             daemon.pid.map(|pid| pid.to_string()).as_deref().unwrap_or("unavailable")
         ));
     }
+    if status.stale_reason_code == Some(DaemonStaleReasonCode::LeaseMissing) && !status.reachable {
+        // A lease-bound stop can already have removed a dead lease. With no
+        // active work, reconnect may continue to ensure-running, which still
+        // reattaches any demonstrably live owner instead of replacing it.
+        return Ok(());
+    }
     let clean_stop = status
         .termination_evidence
         .as_ref()
@@ -509,6 +515,24 @@ mod tests {
 
         confirm_remote_daemon_stopped_after_transport_error(&session, &status)
             .expect("the exact already-dead owner is safe to disconnect");
+    }
+
+    #[test]
+    fn transport_drop_reconciles_missing_lease_after_idempotent_stop() {
+        let session = direct_ssh_session("lease-removed");
+        let status = remote_daemon::RemoteDaemonStatus {
+            daemon: None,
+            stale_reason: None,
+            stale_reason_code: Some(DaemonStaleReasonCode::LeaseMissing),
+            fresh: false,
+            reachable: false,
+            active_jobs: 0,
+            endpoint_probe_error: None,
+            termination_evidence: None,
+        };
+
+        confirm_remote_daemon_stopped_after_transport_error(&session, &status)
+            .expect("missing lease after a zero-job stop is idempotently reconciled");
     }
 
     #[test]

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -845,6 +845,39 @@ fn force_stop_default_non_force_behavior_remains_unchanged() {
 }
 
 #[test]
+fn lease_bound_stop_reconciles_an_absent_lease_idempotently_without_jobs() {
+    let _home = HomeGuard::new();
+
+    let normal = stop_for_lease("stale-lease").expect("normal stop reconciles missing lease");
+    let forced = force_stop_for_lease("stale-lease").expect("forced stop replays safely");
+
+    assert!(!normal.stopped);
+    assert!(!forced.stopped);
+    assert_eq!(normal.pid, None);
+    assert_eq!(forced.pid, None);
+}
+
+#[test]
+fn lease_bound_stop_keeps_active_jobs_protected_when_lease_is_absent() {
+    let _home = HomeGuard::new();
+    let store = JobStore::open_without_reconciliation(
+        &crate::paths::daemon_jobs_file().expect("jobs path"),
+    )
+    .expect("store")
+    .with_daemon_lease("stale-lease".to_string());
+    let job = store.create("runner.exec");
+    store.start(job.id).expect("start job");
+
+    for result in [
+        stop_for_lease("stale-lease"),
+        force_stop_for_lease("stale-lease"),
+    ] {
+        let error = result.expect_err("active job blocks missing-lease reconciliation");
+        assert_eq!(error.details["active_job_ids"], serde_json::json!([job.id]));
+    }
+}
+
+#[test]
 fn stop_reports_corrupt_lease_without_signalling_pid() {
     let _home = HomeGuard::new();
     let path = state_path().expect("state path");


### PR DESCRIPTION
## Summary
- make lease-bound normal and forced daemon stops idempotent after a dead lease has already disappeared
- preserve fail-closed protection when active durable jobs exist or lease evidence is corrupt
- allow reconnect to accept an unreachable, zero-job LeaseMissing state after transport loss

Closes #8571.

## How to test
1. Run cargo test -p homeboy-core --lib lease_bound_stop.
2. Run cargo test -p homeboy-core --lib runner::connection_stop_transport_recovery::tests::transport_drop_reconciles_missing_lease_after_idempotent_stop.
3. Run cargo check -p homeboy-core.
4. Run cargo check -p homeboy.
5. Refresh a connected runner to a newer binary, interrupt transport after the old daemon lease disappears, and confirm reconnect safely proceeds when no active jobs remain.

## Verification
- cargo fmt --check passed.
- git diff --check origin/main...HEAD passed.
- The focused test-build blocker from FakeProvider was resolved upstream in #8574.
- Final focused test compilation was interrupted before completion; CI is expected to run the complete suite.

## Compatibility
Live daemons, active durable jobs, mismatched leases, and corrupt lease evidence remain protected. The change only reconciles an absent lease when no active jobs exist.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** OpenAI gpt-5.6-sol
- **Used for:** Diagnosed the contradictory daemon lease state, implemented idempotent recovery and regression tests, and prepared verification evidence; Chris reviewed and owns the change.