### PR TITLE
Fix Lab cook child placement forwarding

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -559,15 +559,7 @@ impl crate::core::agent_task_service::AgentTaskCookAttemptDispatcher for LabCook
                 Some("serialize Lab cook attempt plan".to_string()),
             )
         })?;
-        let provider_args = vec![
-            "homeboy".to_string(),
-            "agent-task".to_string(),
-            "run-plan".to_string(),
-            "--plan".to_string(),
-            serialized_plan,
-            "--record-run-id".to_string(),
-            run_id.to_string(),
-        ];
+        let provider_args = lab_cook_attempt_args(serialized_plan, run_id);
         let provider_cli = Cli::try_parse_from(&provider_args).map_err(|error| {
             Error::validation_invalid_argument(
                 "agent-task cook",
@@ -649,6 +641,22 @@ impl crate::core::agent_task_service::AgentTaskCookAttemptDispatcher for LabCook
             LabRouteOutcome::InFlight(_) => Ok(()),
         }
     }
+}
+
+/// Build the runner-side child invocation after the controller has consumed
+/// Lab selection. The accepted runner workspace is the child's local context.
+fn lab_cook_attempt_args(serialized_plan: String, run_id: &str) -> Vec<String> {
+    vec![
+        "homeboy".to_string(),
+        "--placement".to_string(),
+        "local".to_string(),
+        "agent-task".to_string(),
+        "run-plan".to_string(),
+        "--plan".to_string(),
+        serialized_plan,
+        "--record-run-id".to_string(),
+        run_id.to_string(),
+    ]
 }
 
 /// Transfer the exact controller-compiled cook plan rather than asking the

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -73,6 +73,28 @@ fn lab_cook_dispatcher_recipe_round_trips_exact_transport() {
 }
 
 #[test]
+fn lab_cook_child_invocation_consumes_controller_runner_placement() {
+    let args = lab_cook_attempt_args("{\"tasks\":[]}".to_string(), "cook-attempt-1");
+
+    assert_eq!(
+        args,
+        vec![
+            "homeboy",
+            "--placement",
+            "local",
+            "agent-task",
+            "run-plan",
+            "--plan",
+            "{\"tasks\":[]}",
+            "--record-run-id",
+            "cook-attempt-1",
+        ]
+    );
+    assert!(!args.iter().any(|arg| arg == "--runner"));
+    assert!(!args.iter().any(|arg| arg.starts_with("--runner=")));
+}
+
+#[test]
 fn non_lab_command_continues_local_dispatch() {
     // route_after_parse mutates the process-global LAB_OFFLOAD_METADATA_ENV,
     // so hold the env lock to serialize against tests that assert on it.


### PR DESCRIPTION
## Summary
- consume Lab runner selection at the controller handoff boundary
- force the accepted runner-side child to execute with `--placement local`
- preserve the serialized plan and durable run identity without forwarding controller-only runner flags

Fixes #8583.

## How to test
1. Run `cargo test -p homeboy-cli --lib lab_cook_child_invocation_consumes_controller_runner_placement`.
2. Run `cargo fmt --check`.
3. Run `git diff --check origin/main...HEAD`.
4. Connect a Lab runner and execute an `agent-task cook --placement lab --runner <id>` task; confirm provider execution starts in the accepted remote workspace rather than failing runner lookup during preacceptance.

## Verification
- focused regression: 1 passed, 0 failed
- `cargo fmt --check`: passed
- `cargo clippy`: passed through `homeboy review`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.6-sol)
- **Used for:** Diagnosed the Lab handoff failure, implemented the generic boundary fix and regression coverage, and verified the change with Chris.
