### PR TITLE
refactor: move CodeAuditResult schema into homeboy-audit-contract

### DIFF
--- a/crates/homeboy-audit-contract/src/lib.rs
+++ b/crates/homeboy-audit-contract/src/lib.rs
@@ -5,10 +5,15 @@ pub mod finding_kind;
 pub use finding::{finding_confidence, Finding, FindingConfidence, Severity};
 pub use finding_kind::AuditFinding;
 pub mod fingerprint;
+pub mod result;
 pub mod test_mapping;
 pub use fingerprint::{
     AggregateConstructionSeam, AggregateLiteral, CallSite, DeadCodeMarker, FingerprintOutput,
     HookRef, UnusedParam,
+};
+pub use result::{
+    AuditSummary, CheckStatus, CodeAuditResult, ConventionReport, Deviation, DirectoryConvention,
+    DirectoryOutlier, DuplicateGroup, Outlier,
 };
 pub use test_mapping::{
     BehaviorScenarioNames, IncludeWrapperPolicy, PackageNameSource, TestMappingConfig,

--- a/crates/homeboy-audit-contract/src/result.rs
+++ b/crates/homeboy-audit-contract/src/result.rs
@@ -1,0 +1,150 @@
+//! Audit result value types — the shared schema that both the audit engine
+//! (which produces it) and the refactor engine (which consumes and reconstructs
+//! it) depend on. These are pure serde value types with no behavior; timing and
+//! internal analysis state stay in the audit engine.
+
+use serde::{Deserialize, Serialize};
+
+use crate::finding::Finding;
+use crate::finding_kind::AuditFinding;
+
+fn is_zero(value: &usize) -> bool {
+    *value == 0
+}
+
+/// Summary counts for the audit report.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditSummary {
+    pub files_scanned: usize,
+    pub conventions_detected: usize,
+    #[serde(skip_serializing_if = "is_zero", default)]
+    pub outliers_found: usize,
+    /// Overall alignment score (0.0 = total chaos, 1.0 = perfect consistency).
+    /// Null when no files could be fingerprinted (score would be meaningless).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub alignment_score: Option<f32>,
+    /// Source files found but not fingerprinted (no extension provides fingerprinting).
+    #[serde(skip_serializing_if = "is_zero", default)]
+    pub files_skipped: usize,
+    /// Warnings about the audit (e.g., unsupported file types).
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub warnings: Vec<String>,
+}
+
+/// Complete result of auditing a component's code conventions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodeAuditResult {
+    pub component_id: String,
+    pub source_path: String,
+    pub summary: AuditSummary,
+    pub conventions: Vec<ConventionReport>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub directory_conventions: Vec<DirectoryConvention>,
+    pub findings: Vec<Finding>,
+    /// Grouped duplications for the fixer — each group has a canonical file and removal targets.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub duplicate_groups: Vec<DuplicateGroup>,
+}
+
+/// A cross-directory convention: a pattern that sibling subdirectories share.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DirectoryConvention {
+    /// Parent directory path (e.g., "inc/Abilities").
+    pub parent: String,
+    /// Expected methods that most subdirectories' conventions share.
+    pub expected_methods: Vec<String>,
+    /// Expected registrations that most subdirectories share.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub expected_registrations: Vec<String>,
+    /// Subdirectories that conform.
+    pub conforming_dirs: Vec<String>,
+    /// Subdirectories that deviate.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub outlier_dirs: Vec<DirectoryOutlier>,
+    /// How many subdirectories were analyzed.
+    pub total_dirs: usize,
+    /// Confidence score.
+    pub confidence: f32,
+}
+
+/// A subdirectory that deviates from the cross-directory convention.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DirectoryOutlier {
+    /// Subdirectory name.
+    pub dir: String,
+    /// What's missing compared to sibling conventions.
+    pub missing_methods: Vec<String>,
+    /// Missing registrations.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub missing_registrations: Vec<String>,
+}
+
+/// A convention as reported to the user (includes check status).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConventionReport {
+    pub name: String,
+    pub glob: String,
+    pub status: CheckStatus,
+    pub expected_methods: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub expected_registrations: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub expected_interfaces: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub expected_namespace: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub expected_imports: Vec<String>,
+    pub conforming: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub outliers: Vec<Outlier>,
+    pub total_files: usize,
+    pub confidence: f32,
+}
+
+/// Status of a convention check.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckStatus {
+    /// All files conform.
+    Clean,
+    /// Some files deviate.
+    Drift,
+    /// Less than half conform — convention may be wrong or split.
+    Fragmented,
+}
+
+/// A file that deviates from a convention.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Outlier {
+    /// Relative file path.
+    pub file: String,
+    /// Whether this outlier appears to be helper/utility drift rather than a real member.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub noisy: bool,
+    /// What's missing or different.
+    pub deviations: Vec<Deviation>,
+}
+
+/// A specific deviation from the convention.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Deviation {
+    /// What kind of deviation.
+    pub kind: AuditFinding,
+    /// Human-readable description.
+    pub description: String,
+    /// Suggested fix.
+    pub suggestion: String,
+}
+
+/// A group of files containing an identical function.
+///
+/// The fixer uses this to keep the canonical copy and remove the rest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DuplicateGroup {
+    /// The duplicated function name.
+    pub function_name: String,
+    /// File chosen to keep the function (canonical location).
+    pub canonical_file: String,
+    /// Files where the duplicate should be removed and replaced with an import.
+    pub remove_from: Vec<String>,
+}

--- a/crates/homeboy-core/src/code_audit/checks.rs
+++ b/crates/homeboy-core/src/code_audit/checks.rs
@@ -5,6 +5,10 @@
 
 use super::conventions::{Convention, Outlier};
 
+// `CheckStatus` now lives in the shared audit contract; re-exported so existing
+// `code_audit::checks::CheckStatus` and `code_audit::CheckStatus` paths resolve.
+pub use homeboy_audit_contract::CheckStatus;
+
 /// Result of checking a set of conventions.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct CheckResult {
@@ -18,17 +22,6 @@ pub struct CheckResult {
     pub total_count: usize,
     /// Outliers found.
     pub outliers: Vec<Outlier>,
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CheckStatus {
-    /// All files conform.
-    Clean,
-    /// Some files deviate.
-    Drift,
-    /// Less than half conform — convention may be wrong or split.
-    Fragmented,
 }
 
 /// Run checks on all discovered conventions.

--- a/crates/homeboy-core/src/code_audit/conventions/mod.rs
+++ b/crates/homeboy-core/src/code_audit/conventions/mod.rs
@@ -65,28 +65,10 @@ pub struct Convention {
     pub confidence: f32,
 }
 
-/// A file that deviates from a convention.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct Outlier {
-    /// Relative file path.
-    pub file: String,
-    /// Whether this outlier appears to be helper/utility drift rather than a real member.
-    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
-    pub noisy: bool,
-    /// What's missing or different.
-    pub deviations: Vec<Deviation>,
-}
-
-/// A specific deviation from the convention.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct Deviation {
-    /// What kind of deviation.
-    pub kind: AuditFinding,
-    /// Human-readable description.
-    pub description: String,
-    /// Suggested fix.
-    pub suggestion: String,
-}
+// `Outlier` and `Deviation` now live in the shared audit contract; re-exported
+// so existing `code_audit::conventions::{Outlier, Deviation}` and
+// `code_audit::{Outlier, Deviation}` paths resolve.
+pub use homeboy_audit_contract::{Deviation, Outlier};
 
 pub(crate) fn unwired_test_file_finding() -> AuditFinding {
     AuditFinding::UnwiredNestedRustTest

--- a/crates/homeboy-core/src/code_audit/duplication.rs
+++ b/crates/homeboy-core/src/code_audit/duplication.rs
@@ -21,6 +21,11 @@ use super::idiomatic::is_trivial_method;
 use super::walker::is_test_path;
 use homeboy_audit_contract::DuplicationDetectorConfig;
 
+// `DuplicateGroup` now lives in the shared audit contract; re-exported so
+// existing `code_audit::duplication::DuplicateGroup` and `code_audit::DuplicateGroup`
+// paths resolve.
+pub use homeboy_audit_contract::DuplicateGroup;
+
 mod intra_method;
 
 pub(crate) use intra_method::detect_intra_method_duplicates;
@@ -29,19 +34,6 @@ use intra_method::{has_logic_signal, is_scaffolding_line};
 
 /// Minimum number of locations for a function to count as duplicated.
 const MIN_DUPLICATE_LOCATIONS: usize = 2;
-
-/// A group of files containing an identical function.
-///
-/// The fixer uses this to keep the canonical copy and remove the rest.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct DuplicateGroup {
-    /// The duplicated function name.
-    pub function_name: String,
-    /// File chosen to keep the function (canonical location).
-    pub canonical_file: String,
-    /// Files where the duplicate should be removed and replaced with an import.
-    pub remove_from: Vec<String>,
-}
 
 /// Build grouped duplication data from fingerprints.
 ///

--- a/crates/homeboy-core/src/code_audit/types.rs
+++ b/crates/homeboy-core/src/code_audit/types.rs
@@ -6,46 +6,15 @@
 use std::collections::HashSet;
 use std::time::Duration;
 
-use super::checks::CheckStatus;
-use super::conventions::Outlier;
-use super::duplication;
-use super::findings::Finding;
 use super::fingerprint;
-use crate::is_zero;
 
-/// Summary counts for the audit report.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct AuditSummary {
-    pub files_scanned: usize,
-    pub conventions_detected: usize,
-    #[serde(skip_serializing_if = "is_zero", default)]
-    pub outliers_found: usize,
-    /// Overall alignment score (0.0 = total chaos, 1.0 = perfect consistency).
-    /// Null when no files could be fingerprinted (score would be meaningless).
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub alignment_score: Option<f32>,
-    /// Source files found but not fingerprinted (no extension provides fingerprinting).
-    #[serde(skip_serializing_if = "is_zero", default)]
-    pub files_skipped: usize,
-    /// Warnings about the audit (e.g., unsupported file types).
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub warnings: Vec<String>,
-}
-
-/// Complete result of auditing a component's code conventions.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct CodeAuditResult {
-    pub component_id: String,
-    pub source_path: String,
-    pub summary: AuditSummary,
-    pub conventions: Vec<ConventionReport>,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub directory_conventions: Vec<DirectoryConvention>,
-    pub findings: Vec<Finding>,
-    /// Grouped duplications for the fixer — each group has a canonical file and removal targets.
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub duplicate_groups: Vec<duplication::DuplicateGroup>,
-}
+// Audit result value types now live in the shared audit contract so both the
+// audit engine (producer) and the refactor engine (consumer/reconstructor) can
+// depend on them without a cross-engine edge. Re-exported here so existing
+// `code_audit::types::X` and `code_audit::X` paths keep resolving.
+pub use homeboy_audit_contract::{
+    AuditSummary, CodeAuditResult, ConventionReport, DirectoryConvention, DirectoryOutlier,
+};
 
 /// Shared analysis state built during an audit run and reused by downstream
 /// consumers that would otherwise re-walk and re-fingerprint the codebase.
@@ -185,61 +154,6 @@ pub(crate) fn time_audit_detector<T>(
         timing.push_skipped(id);
         skipped()
     }
-}
-
-/// A cross-directory convention: a pattern that sibling subdirectories share.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct DirectoryConvention {
-    /// Parent directory path (e.g., "inc/Abilities").
-    pub parent: String,
-    /// Expected methods that most subdirectories' conventions share.
-    pub expected_methods: Vec<String>,
-    /// Expected registrations that most subdirectories share.
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub expected_registrations: Vec<String>,
-    /// Subdirectories that conform.
-    pub conforming_dirs: Vec<String>,
-    /// Subdirectories that deviate.
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub outlier_dirs: Vec<DirectoryOutlier>,
-    /// How many subdirectories were analyzed.
-    pub total_dirs: usize,
-    /// Confidence score.
-    pub confidence: f32,
-}
-
-/// A subdirectory that deviates from the cross-directory convention.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct DirectoryOutlier {
-    /// Subdirectory name.
-    pub dir: String,
-    /// What's missing compared to sibling conventions.
-    pub missing_methods: Vec<String>,
-    /// Missing registrations.
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub missing_registrations: Vec<String>,
-}
-
-/// A convention as reported to the user (includes check status).
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct ConventionReport {
-    pub name: String,
-    pub glob: String,
-    pub status: CheckStatus,
-    pub expected_methods: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub expected_registrations: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub expected_interfaces: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub expected_namespace: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub expected_imports: Vec<String>,
-    pub conforming: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub outliers: Vec<Outlier>,
-    pub total_files: usize,
-    pub confidence: f32,
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Moves the audit **result schema** — `CodeAuditResult`, `AuditSummary`, `ConventionReport`, `DirectoryConvention`, `DirectoryOutlier`, `Outlier`, `Deviation`, `DuplicateGroup`, `CheckStatus` — out of `homeboy-core`'s `code_audit` module into the shared `homeboy-audit-contract` crate.
- These types are the shared audit-output vocabulary that **both** the audit engine (producer) and the refactor engine (consumer — which also *reconstructs* `CodeAuditResult` in its plan sources) depend on. Housing them in the contract removes another class of cross-engine coupling and is a prerequisite for extracting the audit engine into its own crate.

## Scope discipline
- **Pure serde value types only.** Behavior stays in `code_audit`: `AuditTiming`/`AuditTimingSpan` (they carry `impl From<PhaseSpan>` + `phase_timing` core impls), `AuditAnalysisContext`, `AuditWithAnalysis`, `ScopedAuditExecution`, and the audit execution helpers.
- The full closure bottoms out at `AuditFinding`/`Finding`, which already live in the contract (#8580, #8586). No deeper cascade.
- All moved types are **re-exported from their original modules** (`code_audit::types`, `::checks`, `::conventions`, `::duplication`) so every `code_audit::X` path resolves unchanged. **Zero consumer edits** — refactor/review/observation/issues/extension untouched.
- No new crate deps (core and the contract already had everything needed); `Cargo.lock` unchanged.

## Verification
- `cargo check -p homeboy-audit-contract --lib` — clean.
- `cargo check -p homeboy-core --lib --tests` — 0 errors (refactor's `CodeAuditResult` constructions compile against the contract type).
- `cargo check --workspace --tests --locked` (the topology guard) — **passes**, 0 errors.
- `cargo test -p homeboy-core --lib code_audit::` — identical result to `origin/main` (763 passed; same 3 pre-existing failures, see note).
- `cargo fmt` clean; diff is 6 files, net ~-114 lines from core.

## Note — 3 pre-existing test failures on main
`audit_runtime_regression_matches_snapshot`, `test_compute_fixability_with_analysis`, and `audit_config_includes_explicit_extension_overrides` **already fail on clean `origin/main`** (verified by stashing this change). They are unrelated to this refactor (fingerprint retention / extension-config / snapshot fixtures) and slipped past the topology guard because that guard is a `--tests` *compile* check, not a run. Flagging for a separate fix.

Refs #8425