### PR TITLE
refactor: continue controller actions through Lab replay (#8515)

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/controller.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/controller.rs
@@ -1332,6 +1332,24 @@ where
             request,
             &self.defaults.to_overrides(),
         )?;
+        if let Some(runner_id) = request
+            .get("runner")
+            .or_else(|| request.get("runner_id"))
+            .or_else(|| request.get("lab_runner_id"))
+            .and_then(Value::as_str)
+        {
+            let run_id = command.run_id.clone().ok_or_else(|| {
+                homeboy::core::Error::internal_unexpected(
+                    "controller dispatch did not inject a durable run identity",
+                )
+            })?;
+            let mut dispatch_request = dispatch_service::resolve_dispatch_request(command)?;
+            let plan = dispatch_service::build_controller_dispatch_plan(&mut dispatch_request)?;
+            let handoff = crate::commands::infra::route::dispatch_controller_plan_to_lab(
+                plan, &run_id, runner_id,
+            )?;
+            return Ok((handoff, 0));
+        }
         dispatch_service::run_dispatch_command(command, self.executor.clone())
     }
 }

--- a/crates/homeboy-cli/src/commands/agent_task/tests/controller_run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/controller_run.rs
@@ -77,6 +77,46 @@ fn controller_run_next_executes_spawn_task_plan_and_records_dedupe_lineage() {
 }
 
 #[test]
+fn controller_cli_hook_blocks_unavailable_required_runner_without_local_fallback() {
+    with_temp_home(|| {
+        let mut controller = agent_task_loop_controller::create_controller(
+            "loop-cli-runner-unavailable",
+            "repair",
+            "v1",
+        )
+        .expect("controller created");
+        controller.record_action(
+            AgentTaskLoopPolicyAction::SpawnTask {
+                dedupe_key: "runner:required".to_string(),
+                entity_id: None,
+                request: json!({
+                    "mode": "dispatch",
+                    "runner": "missing-lab-runner",
+                    "local_fallback": false,
+                    "dispatch": { "prompt": "This must not run locally.", "backend": "fixture" },
+                }),
+            },
+            "runner required",
+        );
+        agent_task_loop_controller::write_controller(&controller).expect("controller written");
+
+        let (value, exit_code) = controller_run_next_with_executor(
+            "loop-cli-runner-unavailable".to_string(),
+            CapturingExecutor::default(),
+        )
+        .expect("controller reports policy block");
+        assert_eq!(exit_code, 1, "{value:#}");
+        assert_eq!(value["status"], "blocked_runner_unavailable");
+        let loaded = agent_task_loop_controller::load_controller("loop-cli-runner-unavailable")
+            .expect("controller loaded");
+        assert_eq!(
+            loaded.next_actions[0].status,
+            AgentTaskLoopActionStatus::BlockedRunnerUnavailable
+        );
+    });
+}
+
+#[test]
 fn controller_dispatch_runtime_component_contracts_reach_spawned_agent_task_request() {
     with_temp_home(|| {
         let component = tempfile::tempdir().expect("agents-api checkout");

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -659,6 +659,47 @@ fn lab_cook_attempt_args(serialized_plan: String, run_id: &str) -> Vec<String> {
     ]
 }
 
+/// Dispatch one controller-owned plan through the canonical Lab attempt
+/// transport. The durable run record is created before handoff and receives the
+/// typed runner/job identity as soon as the daemon accepts it.
+pub(crate) fn dispatch_controller_plan_to_lab(
+    plan: homeboy::core::agent_tasks::scheduler::AgentTaskPlan,
+    run_id: &str,
+    runner_id: &str,
+) -> homeboy::core::Result<serde_json::Value> {
+    let source_path = plan
+        .tasks
+        .first()
+        .and_then(|task| task.workspace.root.as_ref())
+        .map(PathBuf::from);
+    let dispatcher = LabCookAttemptDispatcher {
+        runner_id: runner_id.to_string(),
+        allow_local_fallback: false,
+        allow_dirty_lab_workspace: false,
+        skip_deps_hydration: false,
+        // Controller actions yield after the daemon accepts the child. The
+        // persisted run is the reconnect and terminal-event replay boundary.
+        detach_after_handoff: true,
+        source_path,
+        job_overrides: runners::LabJobOverrides::default(),
+    };
+    <LabCookAttemptDispatcher as crate::core::agent_task_service::AgentTaskCookAttemptDispatcher>::prepare_for_cook(&dispatcher)?;
+    <LabCookAttemptDispatcher as crate::core::agent_task_service::AgentTaskCookAttemptDispatcher>::dispatch_attempt(
+        &dispatcher,
+        plan,
+        run_id,
+        None,
+    )?;
+    let record = agent_task_lifecycle::status(run_id)?;
+    Ok(serde_json::json!({
+        "schema": "homeboy/agent-task-controller-lab-handoff/v1",
+        "run_id": run_id,
+        "runner_id": runner_id,
+        "identity": record.metadata.get("runner_handoff").and_then(|handoff| handoff.get("identity")).cloned(),
+        "run": record,
+    }))
+}
+
 /// Transfer the exact controller-compiled cook plan rather than asking the
 /// runner to rebuild it from command-line inputs after the durable handoff.
 fn inject_agent_task_cook_attempt_plan(

--- a/crates/homeboy-core/src/agent_task_controller_service/actions.rs
+++ b/crates/homeboy-core/src/agent_task_controller_service/actions.rs
@@ -58,6 +58,24 @@ where
 
     match execute_claimed_controller_action(record, &action, executor, dispatch) {
         Ok((execution, exit_code)) => {
+            if let Some(identity) = accepted_runner_handoff_identity(&execution)? {
+                bind_controller_action_runner_handoff(record, action_id, identity, &execution)?;
+                controller::write_controller(record)?;
+                return Ok(AgentTaskRunResult {
+                    value: ControllerActionReport {
+                        schema: ACTION_RESULT_SCHEMA,
+                        loop_id: record.loop_id.clone(),
+                        claimed: true,
+                        action_id: Some(action_id.to_string()),
+                        status: Some("waiting_for_runner".to_string()),
+                        failure_summary: None,
+                        runtime_evidence: controller_action_runtime_evidence(&execution),
+                        execution: Some(execution),
+                        controller: record.clone(),
+                    },
+                    exit_code: 0,
+                });
+            }
             let mut exit_code = exit_code;
             let missing_required_artifacts = if exit_code == 0 {
                 validate_required_action_artifacts(&action, &execution)
@@ -208,46 +226,6 @@ where
         }));
     }
 
-    if let Some(AgentTaskLoopRunnerExecutionTarget::Runner(runner)) = decision.target {
-        let diagnostic = AgentTaskLoopActionDiagnostic {
-            code: "runner_action_dispatch_unimplemented".to_string(),
-            message: format!(
-                "controller action '{}' targets runner `{runner}`, but controller runner dispatch is not implemented; refusing local fallback",
-                action.action_id
-            ),
-            runner: Some(runner.clone()),
-            details: serde_json::json!({
-                "action_id": action.action_id,
-                "dedupe_key": action.dedupe_key,
-            }),
-        };
-        let execution = serde_json::json!({
-            "mode": "runner_policy",
-            "status": "failed",
-            "target": "runner",
-            "runner": runner,
-            "diagnostics": [diagnostic],
-        });
-        complete_controller_action(record, action_id, &execution, 1)?;
-        controller::write_controller(record)?;
-        return Ok(Some(AgentTaskRunResult {
-            value: ControllerActionReport {
-                schema: ACTION_RESULT_SCHEMA,
-                loop_id: record.loop_id.clone(),
-                claimed: true,
-                action_id: Some(action_id.to_string()),
-                status: Some("failed".to_string()),
-                failure_summary: Some(controller_action_failure_summary(
-                    record, action, &execution,
-                )),
-                runtime_evidence: controller_action_runtime_evidence(&execution),
-                execution: Some(execution),
-                controller: record.clone(),
-            },
-            exit_code: 1,
-        }));
-    }
-
     Ok(None)
 }
 
@@ -275,17 +253,129 @@ fn controller_runner_availability(runner_id: &str) -> AgentTaskLoopRunnerAvailab
     }
 }
 
-fn action_status_report_label(status: AgentTaskLoopActionStatus) -> &'static str {
+pub(super) fn action_status_report_label(status: AgentTaskLoopActionStatus) -> &'static str {
     match status {
         AgentTaskLoopActionStatus::Pending => "pending",
         AgentTaskLoopActionStatus::Running => "running",
+        AgentTaskLoopActionStatus::WaitingForRunner => "waiting_for_runner",
         AgentTaskLoopActionStatus::AlreadySatisfied => "already_satisfied",
         AgentTaskLoopActionStatus::Completed => "completed",
         AgentTaskLoopActionStatus::Failed => "failed",
+        AgentTaskLoopActionStatus::Cancelled => "cancelled",
         AgentTaskLoopActionStatus::BlockedRunnerUnavailable => "blocked_runner_unavailable",
         AgentTaskLoopActionStatus::BlockedRemoteMaterialization => "blocked_remote_materialization",
         AgentTaskLoopActionStatus::BlockedLocalFallbackDenied => "blocked_local_fallback_denied",
     }
+}
+
+pub(super) fn accepted_runner_handoff_identity(execution: &Value) -> Result<Option<Value>> {
+    // Spawn-task dispatch results are wrapped with their controller mode and
+    // request artifacts. The Lab handoff itself remains the typed result.
+    let handoff = execution.get("result").unwrap_or(execution);
+    if handoff.get("schema").and_then(Value::as_str)
+        != Some("homeboy/agent-task-controller-lab-handoff/v1")
+    {
+        return Ok(None);
+    }
+
+    let identity = handoff.get("identity").cloned().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "controller runner handoff",
+            "Lab accepted the controller action without a typed runner identity",
+            None,
+            None,
+        )
+    })?;
+    let run_id = identity
+        .get("run_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "controller runner handoff identity.run_id",
+                "Lab handoff identity requires a persisted run id",
+                Some(identity.to_string()),
+                None,
+            )
+        })?;
+    let runner_id = identity
+        .get("runner_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "controller runner handoff identity.runner_id",
+                "Lab handoff identity requires a runner id",
+                Some(identity.to_string()),
+                None,
+            )
+        })?;
+    let runner_job_id = identity
+        .get("runner_job_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "controller runner handoff identity.runner_job_id",
+                "Lab handoff identity requires a runner job id",
+                Some(identity.to_string()),
+                None,
+            )
+        })?;
+    if handoff.get("run_id").and_then(Value::as_str) != Some(run_id) {
+        return Err(Error::validation_invalid_argument(
+            "controller runner handoff run_id",
+            "Lab handoff run id does not match its typed identity",
+            Some(identity.to_string()),
+            None,
+        ));
+    }
+
+    let persisted = lifecycle::status(run_id)?;
+    if persisted.runner_id() != Some(runner_id) || persisted.runner_job_id() != Some(runner_job_id)
+    {
+        return Err(Error::validation_invalid_argument(
+            "controller runner handoff identity",
+            "Lab handoff identity does not match the persisted run/runner/job binding",
+            Some(identity.to_string()),
+            None,
+        ));
+    }
+    Ok(Some(identity))
+}
+
+fn bind_controller_action_runner_handoff(
+    record: &mut AgentTaskLoopControllerRecord,
+    action_id: &str,
+    identity: Value,
+    execution: &Value,
+) -> Result<()> {
+    let action = record
+        .next_actions
+        .iter_mut()
+        .find(|action| action.action_id == action_id)
+        .ok_or_else(|| Error::internal_unexpected("claimed controller action disappeared"))?;
+    action.status = AgentTaskLoopActionStatus::WaitingForRunner;
+    action
+        .diagnostics
+        .retain(|diagnostic| diagnostic.code != "runner_handoff");
+    action.diagnostics.push(AgentTaskLoopActionDiagnostic {
+        code: "runner_handoff".to_string(),
+        message: "Lab accepted this controller action; waiting for the authoritative runner terminal result".to_string(),
+        runner: identity
+            .get("runner_id")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        details: serde_json::json!({
+            "schema": "homeboy/agent-task-controller-runner-handoff/v1",
+            "identity": identity,
+            "execution": execution,
+        }),
+    });
+    push_controller_history(
+        record,
+        "controller.action.runner_handoff_accepted",
+        None,
+        serde_json::json!({ "action_id": action_id, "execution": execution }),
+    );
+    Ok(())
 }
 
 fn controller_action_failure_summary(

--- a/crates/homeboy-core/src/agent_task_controller_service/mod.rs
+++ b/crates/homeboy-core/src/agent_task_controller_service/mod.rs
@@ -25,9 +25,9 @@ use crate::agent_task_loop_controller::{
     AgentTaskLoopControllerState, AgentTaskLoopEntity, AgentTaskLoopExternalEvent,
     AgentTaskLoopGateStatus, AgentTaskLoopHistoryEvent, AgentTaskLoopPolicy,
     AgentTaskLoopPolicyAction, AgentTaskLoopPolicyActionRecord, AgentTaskLoopProvenanceRef,
-    AgentTaskLoopRunRef, AgentTaskLoopRunnerAvailability, AgentTaskLoopRunnerExecutionTarget,
-    AgentTaskLoopTaskLineage, AgentTaskLoopTerminalStatus, AgentTaskLoopTransition,
-    AgentTaskPrOwnershipRequest, AgentTaskPrOwnershipState, AgentTaskPrOwnershipStatusUpdate,
+    AgentTaskLoopRunRef, AgentTaskLoopRunnerAvailability, AgentTaskLoopTaskLineage,
+    AgentTaskLoopTerminalStatus, AgentTaskLoopTransition, AgentTaskPrOwnershipRequest,
+    AgentTaskPrOwnershipState, AgentTaskPrOwnershipStatusUpdate,
 };
 use crate::agent_task_scheduler::{AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan};
 use crate::agent_task_service::{self, AgentTaskRunResult};
@@ -556,6 +556,14 @@ pub fn mark_human_ready(
 /// Apply an external event to the controller and return the resulting actions.
 pub fn apply_event(request: ControllerApplyEventRequest) -> Result<ControllerEventReport> {
     let mut record = controller::load_controller(&request.loop_id)?;
+    if replay_runner_terminal_event(&mut record, &request)? {
+        controller::write_controller(&record)?;
+        return Ok(ControllerEventReport {
+            schema: APPLY_EVENT_RESULT_SCHEMA,
+            controller: record,
+            actions: Vec::new(),
+        });
+    }
     let event_id = request
         .event_id
         .unwrap_or_else(|| format!("event-{}", record.history.len() + 1));
@@ -574,6 +582,149 @@ pub fn apply_event(request: ControllerApplyEventRequest) -> Result<ControllerEve
     })
 }
 
+/// Reconcile accepted Lab handoffs before selecting the next pending action.
+/// This is the reconnect path: lifecycle status refreshes the authoritative
+/// runner snapshot, then the same typed terminal projection is applied.
+fn reconcile_waiting_runner_actions(record: &mut AgentTaskLoopControllerRecord) -> Result<bool> {
+    let mut changed = false;
+    for action in record
+        .next_actions
+        .clone()
+        .into_iter()
+        .filter(|action| action.status == AgentTaskLoopActionStatus::WaitingForRunner)
+    {
+        let Some(identity) = runner_handoff_identity(&action) else {
+            continue;
+        };
+        let run_id = identity["run_id"].as_str().unwrap_or_default();
+        let run = lifecycle::status(run_id)?;
+        if let Some(status) = terminal_runner_action_status(run.state) {
+            project_runner_terminal_action(record, &action.action_id, &identity, status, None)?;
+            changed = true;
+        }
+    }
+    Ok(changed)
+}
+
+fn replay_runner_terminal_event(
+    record: &mut AgentTaskLoopControllerRecord,
+    request: &ControllerApplyEventRequest,
+) -> Result<bool> {
+    if request.event_type != "agent_task.runner_terminal" {
+        return Ok(false);
+    }
+    let identity = request.payload.get("identity").cloned().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "payload.identity",
+            "runner terminal event requires identity",
+            None,
+            None,
+        )
+    })?;
+    let action = record
+        .next_actions
+        .iter()
+        .find(|action| runner_handoff_identity(action).as_ref() == Some(&identity));
+    let Some(action) = action else {
+        return Err(Error::validation_invalid_argument(
+            "payload.identity",
+            "runner terminal event does not match a controller action handoff identity",
+            Some(identity.to_string()),
+            None,
+        ));
+    };
+    let action_id = action.action_id.clone();
+    let action_status = action.status;
+    if matches!(
+        action_status,
+        AgentTaskLoopActionStatus::Completed
+            | AgentTaskLoopActionStatus::Failed
+            | AgentTaskLoopActionStatus::Cancelled
+    ) {
+        return Ok(true);
+    }
+    if action_status != AgentTaskLoopActionStatus::WaitingForRunner {
+        return Err(Error::validation_invalid_argument(
+            "payload.identity",
+            "runner terminal event matched an action that is not waiting for the runner",
+            Some(action_id.clone()),
+            None,
+        ));
+    }
+    let run_id = identity["run_id"].as_str().unwrap_or_default();
+    let run = lifecycle::status(run_id)?;
+    let status = terminal_runner_action_status(run.state).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "payload.identity",
+            "runner terminal replay requires a terminal persisted run",
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    project_runner_terminal_action(
+        record,
+        &action_id,
+        &identity,
+        status,
+        Some(&request.payload),
+    )?;
+    Ok(true)
+}
+
+fn runner_handoff_identity(action: &AgentTaskLoopPolicyActionRecord) -> Option<Value> {
+    action
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "runner_handoff")?
+        .details
+        .get("identity")
+        .cloned()
+}
+
+fn terminal_runner_action_status(
+    state: lifecycle::AgentTaskRunState,
+) -> Option<AgentTaskLoopActionStatus> {
+    match state {
+        lifecycle::AgentTaskRunState::Succeeded => Some(AgentTaskLoopActionStatus::Completed),
+        lifecycle::AgentTaskRunState::Cancelled => Some(AgentTaskLoopActionStatus::Cancelled),
+        lifecycle::AgentTaskRunState::CandidateRecoverable
+        | lifecycle::AgentTaskRunState::PartialRecoverable
+        | lifecycle::AgentTaskRunState::PartialFailure
+        | lifecycle::AgentTaskRunState::Failed => Some(AgentTaskLoopActionStatus::Failed),
+        _ => None,
+    }
+}
+
+fn project_runner_terminal_action(
+    record: &mut AgentTaskLoopControllerRecord,
+    action_id: &str,
+    identity: &Value,
+    status: AgentTaskLoopActionStatus,
+    replay: Option<&Value>,
+) -> Result<()> {
+    let action = record
+        .next_actions
+        .iter_mut()
+        .find(|action| action.action_id == action_id)
+        .ok_or_else(|| Error::internal_unexpected("runner handoff action disappeared"))?;
+    if action.status != AgentTaskLoopActionStatus::WaitingForRunner {
+        return Ok(());
+    }
+    action.status = status;
+    push_controller_history(
+        record,
+        "controller.action.runner_terminal_projected",
+        None,
+        serde_json::json!({
+            "action_id": action_id,
+            "identity": identity,
+            "status": action_status_report_label(status),
+            "replay": replay,
+        }),
+    );
+    Ok(())
+}
+
 /// Claim and execute the first pending controller action, if any.
 pub fn run_next<E, D>(
     loop_id: &str,
@@ -585,6 +736,9 @@ where
     D: ControllerDispatchHook,
 {
     let mut record = controller::controller_status(loop_id)?;
+    if reconcile_waiting_runner_actions(&mut record)? {
+        controller::write_controller(&record)?;
+    }
     let Some(action_id) = first_pending_action_id(&record) else {
         return Ok(AgentTaskRunResult {
             value: ControllerActionReport {
@@ -650,7 +804,10 @@ where
 {
     let mut results = Vec::new();
     while results.len() < options.max_actions {
-        let record = controller::controller_status(loop_id)?;
+        let mut record = controller::controller_status(loop_id)?;
+        if reconcile_waiting_runner_actions(&mut record)? {
+            controller::write_controller(&record)?;
+        }
         if options.stop_on_terminal && controller_state_is_terminal(record.state) {
             return Ok(AgentTaskRunResult {
                 value: ControllerResumeReport {

--- a/crates/homeboy-core/src/agent_task_controller_service/spec_compile.rs
+++ b/crates/homeboy-core/src/agent_task_controller_service/spec_compile.rs
@@ -158,9 +158,12 @@ pub(super) fn controller_action_plan_step(
         AgentTaskLoopActionStatus::BlockedRunnerUnavailable
         | AgentTaskLoopActionStatus::BlockedRemoteMaterialization
         | AgentTaskLoopActionStatus::BlockedLocalFallbackDenied => PlanStepStatus::Missing,
-        AgentTaskLoopActionStatus::Running => PlanStepStatus::Running,
+        AgentTaskLoopActionStatus::Running | AgentTaskLoopActionStatus::WaitingForRunner => {
+            PlanStepStatus::Running
+        }
         AgentTaskLoopActionStatus::Completed => PlanStepStatus::Success,
         AgentTaskLoopActionStatus::Failed => PlanStepStatus::Failed,
+        AgentTaskLoopActionStatus::Cancelled => PlanStepStatus::Skipped,
     };
     let mut inputs = HashMap::from([
         ("action".to_string(), action_value),

--- a/crates/homeboy-core/src/agent_task_controller_service/tests/dispatch_execute_tests.rs
+++ b/crates/homeboy-core/src/agent_task_controller_service/tests/dispatch_execute_tests.rs
@@ -140,7 +140,7 @@ fn execute_controller_action_marks_blocked_no_local_fallback_policy() {
 }
 
 #[test]
-fn execute_controller_action_fails_closed_for_unimplemented_runner_target() {
+fn execute_controller_action_dispatches_an_available_runner_target() {
     with_isolated_home(|_| {
         let mut record = AgentTaskLoopControllerRecord::new("loop-runner-target", "dispatch", "v1");
         let action = record.record_action(
@@ -168,23 +168,10 @@ fn execute_controller_action_fails_closed_for_unimplemented_runner_target() {
                 AgentTaskLoopRunnerAvailability::Available
             },
         )
-        .expect("runner target fails closed");
+        .expect("runner target dispatches");
 
-        assert_eq!(result.exit_code, 1);
-        assert_eq!(result.value.status.as_deref(), Some("failed"));
-        let execution = result.value.execution.as_ref().expect("execution result");
-        assert_eq!(
-            execution
-                .pointer("/diagnostics/0/code")
-                .and_then(Value::as_str),
-            Some("runner_action_dispatch_unimplemented")
-        );
-        assert_eq!(
-            execution
-                .pointer("/diagnostics/0/runner")
-                .and_then(Value::as_str),
-            Some("homeboy-lab")
-        );
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.value.status.as_deref(), Some("completed"));
         let persisted_action = result
             .value
             .controller
@@ -192,17 +179,29 @@ fn execute_controller_action_fails_closed_for_unimplemented_runner_target() {
             .iter()
             .find(|candidate| candidate.action_id == action.action_id)
             .expect("action persisted");
-        assert_eq!(persisted_action.status, AgentTaskLoopActionStatus::Failed);
+        assert_eq!(
+            persisted_action.status,
+            AgentTaskLoopActionStatus::Completed
+        );
         assert!(executor
             .observed_request
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .is_none());
-        assert!(dispatch
+        let dispatches = dispatch
             .observed_requests
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .is_empty());
+            .clone();
+        assert_eq!(dispatches.len(), 1);
+        assert_eq!(dispatches[0]["runner"], "homeboy-lab");
+        assert!(dispatches[0]
+            .get("dispatch")
+            .unwrap_or(&dispatches[0])
+            .get("run_id")
+            .and_then(Value::as_str)
+            .expect("controller run identity")
+            .starts_with("controller-loop-runner-target-action-1-task_runner"));
     });
 }
 
@@ -249,5 +248,128 @@ fn execute_controller_dispatch_injects_action_scoped_identity() {
         assert!(task_id
             .starts_with("controller-task-loop-dispatch-identity-action-1-workflow_store-idea"));
         assert_eq!(request["dispatch"]["repo"], "wp-site-generator");
+    });
+}
+
+#[test]
+fn accepted_runner_handoff_waits_and_terminal_replay_is_idempotent() {
+    with_isolated_home(|_| {
+        let mut record = AgentTaskLoopControllerRecord::new("loop-runner-replay", "dispatch", "v1");
+        let action = record.record_action(
+            AgentTaskLoopPolicyAction::SpawnTask {
+                dedupe_key: "task:runner-replay".to_string(),
+                entity_id: None,
+                request: json!({
+                    "mode": "dispatch",
+                    "runner": "homeboy-lab",
+                    "local_fallback": false,
+                    "dispatch": { "prompt": "Run remotely." },
+                }),
+            },
+            "policy matched",
+        );
+        let run_id = "controller-loop-runner-replay-action-1-task_runner-replay";
+        lifecycle::submit_plan(&test_plan(), Some(run_id)).expect("persisted run");
+        lifecycle::record_detached_lab_run(lifecycle::DetachedLabRunRecord {
+            run_id,
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-8515",
+            remote_workspace: "/runner/workspace",
+            remote_command: &["homeboy".to_string(), "agent-task".to_string()],
+        })
+        .expect("accepted runner job binds the persisted run");
+
+        let accepted = execute_controller_action_with_runner_availability(
+            &mut record,
+            &action.action_id,
+            CapturingExecutor::default(),
+            &RunnerHandoffDispatchHook,
+            |_| AgentTaskLoopRunnerAvailability::Available,
+        )
+        .expect("runner accepts handoff");
+        assert_eq!(accepted.exit_code, 0);
+        assert_eq!(accepted.value.status.as_deref(), Some("waiting_for_runner"));
+        assert_eq!(
+            accepted.value.controller.next_actions[0].status,
+            AgentTaskLoopActionStatus::WaitingForRunner
+        );
+        assert_eq!(
+            accepted.value.controller.next_actions[0].diagnostics[0].details["identity"]
+                ["runner_job_id"],
+            "job-8515"
+        );
+
+        lifecycle::cancel(run_id).expect("terminal runner run");
+        controller::write_controller(&accepted.value.controller).expect("persist waiting action");
+        let payload = json!({
+            "identity": {
+                "run_id": run_id,
+                "runner_id": "homeboy-lab",
+                "runner_job_id": "job-8515",
+            },
+        });
+        let first = apply_event(ControllerApplyEventRequest {
+            loop_id: "loop-runner-replay".to_string(),
+            event_type: "agent_task.runner_terminal".to_string(),
+            event_id: Some("runner-job-8515-terminal".to_string()),
+            event_key: None,
+            entity_id: None,
+            payload: payload.clone(),
+        })
+        .expect("terminal replay projects cancellation");
+        assert_eq!(
+            first.controller.next_actions[0].status,
+            AgentTaskLoopActionStatus::Cancelled
+        );
+        let projected = first
+            .controller
+            .history
+            .iter()
+            .filter(|event| event.event_type == "controller.action.runner_terminal_projected")
+            .count();
+
+        let duplicate = apply_event(ControllerApplyEventRequest {
+            loop_id: "loop-runner-replay".to_string(),
+            event_type: "agent_task.runner_terminal".to_string(),
+            event_id: Some("runner-job-8515-terminal-duplicate".to_string()),
+            event_key: None,
+            entity_id: None,
+            payload,
+        })
+        .expect("duplicate terminal replay is idempotent");
+        assert_eq!(
+            duplicate.controller.next_actions[0].status,
+            AgentTaskLoopActionStatus::Cancelled
+        );
+        assert_eq!(
+            duplicate
+                .controller
+                .history
+                .iter()
+                .filter(|event| event.event_type == "controller.action.runner_terminal_projected")
+                .count(),
+            projected
+        );
+    });
+}
+
+#[test]
+fn accepted_runner_handoff_rejects_an_unbound_persisted_identity() {
+    with_isolated_home(|_| {
+        let run_id = "controller-unbound-runner-handoff";
+        lifecycle::submit_plan(&test_plan(), Some(run_id)).expect("persisted queued run");
+
+        let error = accepted_runner_handoff_identity(&json!({
+            "schema": "homeboy/agent-task-controller-lab-handoff/v1",
+            "run_id": run_id,
+            "identity": {
+                "run_id": run_id,
+                "runner_id": "homeboy-lab",
+                "runner_job_id": "job-8515",
+            },
+        }))
+        .expect_err("handoff must bind the persisted run to the same runner job");
+
+        assert!(error.message.contains("persisted run/runner/job binding"));
     });
 }

--- a/crates/homeboy-core/src/agent_task_controller_service/tests/mod.rs
+++ b/crates/homeboy-core/src/agent_task_controller_service/tests/mod.rs
@@ -70,6 +70,9 @@ struct CountingFailingDispatchHook {
 struct RuntimeBudgetDispatchHook;
 
 #[derive(Clone, Default)]
+struct RunnerHandoffDispatchHook;
+
+#[derive(Clone, Default)]
 struct EvidenceExecutor;
 
 impl ControllerDispatchHook for CapturingDispatchHook {
@@ -240,6 +243,27 @@ impl ControllerDispatchHook for RuntimeBudgetDispatchHook {
                         }
                     }]
                 }
+            }),
+            0,
+        ))
+    }
+}
+
+impl ControllerDispatchHook for RunnerHandoffDispatchHook {
+    fn dispatch(&self, request: &Value) -> Result<(Value, i32)> {
+        let run_id = request["dispatch"]["run_id"]
+            .as_str()
+            .expect("controller injected run id");
+        Ok((
+            json!({
+                "schema": "homeboy/agent-task-controller-lab-handoff/v1",
+                "run_id": run_id,
+                "runner_id": "homeboy-lab",
+                "identity": {
+                    "run_id": run_id,
+                    "runner_id": "homeboy-lab",
+                    "runner_job_id": "job-8515",
+                },
             }),
             0,
         ))

--- a/crates/homeboy-core/src/agent_task_loop_controller/policy.rs
+++ b/crates/homeboy-core/src/agent_task_loop_controller/policy.rs
@@ -250,9 +250,11 @@ pub enum AgentTaskPrOwnershipState {
 pub enum AgentTaskLoopActionStatus {
     Pending,
     Running,
+    WaitingForRunner,
     AlreadySatisfied,
     Completed,
     Failed,
+    Cancelled,
     BlockedRunnerUnavailable,
     BlockedRemoteMaterialization,
     BlockedLocalFallbackDenied,

--- a/crates/homeboy-core/src/agent_task_loop_controller/service.rs
+++ b/crates/homeboy-core/src/agent_task_loop_controller/service.rs
@@ -159,6 +159,19 @@ fn controller_state_diagnostic(
         };
     }
 
+    if record
+        .next_actions
+        .iter()
+        .any(|action| action.status == AgentTaskLoopActionStatus::WaitingForRunner)
+    {
+        return AgentTaskLoopControllerStateDiagnostic {
+            state: "waiting_for_runner".to_string(),
+            label: "waiting for runner".to_string(),
+            actionable: false,
+            reason: "a Lab runner accepted a controller action and remains authoritative until it reports a terminal result".to_string(),
+        };
+    }
+
     if record.next_actions.iter().any(is_failed_or_blocked_action) {
         return AgentTaskLoopControllerStateDiagnostic {
             state: "running_blocked_failed_action".to_string(),
@@ -215,6 +228,12 @@ fn relevant_action_diagnostic(
             record
                 .next_actions
                 .iter()
+                .find(|action| action.status == AgentTaskLoopActionStatus::WaitingForRunner)
+        })
+        .or_else(|| {
+            record
+                .next_actions
+                .iter()
                 .find(|action| action.status == AgentTaskLoopActionStatus::Pending)
         })?;
     let action_value = action_value(action);
@@ -253,6 +272,9 @@ fn controller_next_commands(
         )],
         "running_active_work" => vec![format!(
             "homeboy agent-task controller status {loop_id}  # active work is still running"
+        )],
+        "waiting_for_runner" => vec![format!(
+            "homeboy agent-task controller status {loop_id}  # Lab owns the accepted action until its terminal result is reconciled"
         )],
         "running_blocked_failed_action" => {
             let mut commands = vec![format!(


### PR DESCRIPTION
## Summary
- Routes controller runner actions through the **canonical Lab offload** path so controller-driven agent-task actions dispatch to an available runner target and reconcile terminal state via replay.
- Adds runner-handoff binding + reconciliation to the loop controller service: `bind_controller_action_runner_handoff`, `reconcile_waiting_runner_actions`, `replay_runner_terminal_event`, `project_runner_terminal_action`, and idempotent terminal-replay handling.
- Adds a `ControllerDispatchHook` (`RunnerHandoffDispatchHook`) so controller dispatch to Lab is inverted through a hook rather than a hard runner dependency, plus `dispatch_controller_plan_to_lab` and an `infra/route` CLI surface.
- Loop-controller policy/service now track accepted runner-handoff identity and wait for terminal replay (idempotent; rejects unbound persisted identities).

## Notes
- Closes #8515.
- Rebased onto latest `main` (was stranded ~15min with no PR); merges cleanly, no conflicts.
- Includes new controller_run / dispatch_execute tests covering dispatch, handoff-wait/terminal-replay idempotency, and unbound-identity rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)