### PR TITLE
Make controller runtime pins immutable and recoverable

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -37,7 +37,7 @@ pub use args::{
     CompileLoopArgs, ContractArgs, ContractFormat, DiagnoseArgs, EvidenceArgs, FinalizePrArgs,
     GateFeedbackArgs, LatestArgs, ListArgs, PromoteArgs, PromotionProviderArgs, ProvidersArgs,
     ReconcileRecordsArgs, ReplayProviderBoundaryArgs, RetryArgs, ReviewArgs, RunPlanArgs,
-    StatusArgs, SubmitArgs, VerifyGateArgs,
+    RuntimeRecoverArgs, RuntimeValidateArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
 };
 pub(crate) use status::diagnostic_summary_from_aggregate;
 
@@ -71,6 +71,8 @@ pub fn run(args: AgentTaskArgs, _global: &GlobalArgs) -> CmdResult<Value> {
         AgentTaskCommand::Artifacts(status_args) => status::artifacts(status_args),
         AgentTaskCommand::Evidence(evidence_args) => status::evidence(evidence_args),
         AgentTaskCommand::Diagnose(diagnose_args) => status::diagnose(diagnose_args),
+        AgentTaskCommand::RuntimeRecover(args) => status::recover_runtime(args),
+        AgentTaskCommand::RuntimeValidate(args) => status::validate_runtime(args),
         AgentTaskCommand::ReplayProviderBoundary(replay_args) => {
             status::replay_provider_boundary(replay_args)
         }

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -7,8 +7,8 @@ use super::cook::{AgentTaskCookArgs, AgentTaskLoopArgs, PromotionProviderArgs};
 use super::fanout::AgentTaskFanoutArgs;
 use super::lifecycle::{
     CancelArgs, DiagnoseArgs, EvidenceArgs, FinalizePrArgs, GateFeedbackArgs, PromoteArgs,
-    ReplayProviderBoundaryArgs, RetryArgs, ReviewArgs, RunArgs, RunPlanArgs, StatusArgs,
-    SubmitArgs,
+    ReplayProviderBoundaryArgs, RetryArgs, ReviewArgs, RunArgs, RunPlanArgs, RuntimeRecoverArgs,
+    RuntimeValidateArgs, StatusArgs, SubmitArgs,
 };
 
 pub use super::super::auth::{
@@ -49,6 +49,10 @@ pub enum AgentTaskCommand {
     Artifacts(StatusArgs),
     Evidence(EvidenceArgs),
     Diagnose(DiagnoseArgs),
+    /// Recover a missing or corrupted immutable controller runtime pin.
+    RuntimeRecover(RuntimeRecoverArgs),
+    /// Validate controller runtime eligibility without executing provider work.
+    RuntimeValidate(RuntimeValidateArgs),
     ReplayProviderBoundary(ReplayProviderBoundaryArgs),
     Cancel(CancelArgs),
     Resume(StatusArgs),

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -50,6 +50,79 @@ pub struct DiagnoseArgs {
     pub run_id: String,
 }
 #[derive(Args, Debug)]
+pub struct RuntimeRecoverArgs {
+    /// Durable run whose exact controller executable should be rematerialized.
+    pub run_id: String,
+    /// Trusted source checkout used to rebuild the recorded runtime revision.
+    #[arg(
+        long,
+        value_name = "PATH",
+        required_unless_present = "artifact",
+        conflicts_with = "artifact"
+    )]
+    pub source: Option<String>,
+    /// Exact prebuilt controller executable. Its hash and self identity must match the durable pin.
+    #[arg(
+        long,
+        value_name = "PATH",
+        required_unless_present = "source",
+        conflicts_with = "source"
+    )]
+    pub artifact: Option<String>,
+}
+#[derive(Args, Debug)]
+pub struct RuntimeValidateArgs {
+    /// Durable run to validate without executing its provider lifecycle.
+    pub run_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use crate::{
+        cli_surface::{Cli, Commands},
+        commands::agent_task::AgentTaskCommand,
+    };
+
+    #[test]
+    fn runtime_recovery_requires_one_trusted_input() {
+        assert!(
+            Cli::try_parse_from(["homeboy", "agent-task", "runtime-recover", "run-a"]).is_err()
+        );
+        assert!(Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "runtime-recover",
+            "run-a",
+            "--artifact",
+            "/trusted/homeboy",
+            "--source",
+            "/trusted/source",
+        ])
+        .is_err());
+
+        let cli = Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "runtime-recover",
+            "run-a",
+            "--artifact",
+            "/trusted/homeboy",
+        ])
+        .expect("artifact recovery parses");
+        let Commands::AgentTask(agent_task) = cli.command else {
+            panic!("expected agent-task command");
+        };
+        let AgentTaskCommand::RuntimeRecover(args) = agent_task.command else {
+            panic!("expected runtime recovery command");
+        };
+        assert_eq!(args.run_id, "run-a");
+        assert_eq!(args.artifact.as_deref(), Some("/trusted/homeboy"));
+        assert!(args.source.is_none());
+    }
+}
+#[derive(Args, Debug)]
 pub struct ReplayProviderBoundaryArgs {
     pub run_id: String,
     #[arg(long = "task", value_name = "TASK_ID")]

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -16,7 +16,10 @@ use homeboy::core::agent_tasks::service as agent_task_service;
 use homeboy::core::agent_tasks::{AgentTaskEvidenceRef, AgentTaskOutcomeStatus};
 
 use super::super::CmdResult;
-use super::args::{CancelArgs, DiagnoseArgs, EvidenceArgs, ReplayProviderBoundaryArgs, StatusArgs};
+use super::args::{
+    CancelArgs, DiagnoseArgs, EvidenceArgs, ReplayProviderBoundaryArgs, RuntimeRecoverArgs,
+    RuntimeValidateArgs, StatusArgs,
+};
 use crate::commands::utils::response::{
     CommandActionableMetadata, CommandAgentTaskRef, CommandNextAction, CommandNextActionKind,
     CommandResultRefs, ACTIONABLE_METADATA_KEY,
@@ -481,6 +484,26 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
             "hydrated_evidence": hydrated_evidence,
             "next_commands": next_commands,
         }),
+        0,
+    ))
+}
+
+pub(super) fn recover_runtime(args: RuntimeRecoverArgs) -> CmdResult<Value> {
+    let recovered = homeboy::core::agent_task_lifecycle::recover_controller_runtime(
+        &args.run_id,
+        args.artifact.as_deref().map(std::path::Path::new),
+        args.source.as_deref().map(std::path::Path::new),
+    )?;
+    Ok((
+        json!({ "schema": "homeboy/controller-runtime-recovery/v1", "run_id": args.run_id, "recovered": recovered }),
+        0,
+    ))
+}
+
+pub(super) fn validate_runtime(args: RuntimeValidateArgs) -> CmdResult<Value> {
+    let record = homeboy::core::agent_task_lifecycle::validate_controller_runtime(&args.run_id)?;
+    Ok((
+        json!({ "schema": "homeboy/controller-runtime-validation/v1", "run_id": record.run_id, "state": record.state, "executable": true }),
         0,
     ))
 }

--- a/crates/homeboy-cli/src/commands/infra/runtime.rs
+++ b/crates/homeboy-cli/src/commands/infra/runtime.rs
@@ -31,6 +31,12 @@ enum RuntimeCommand {
     },
     /// Explicitly archive a proven dead or expired runtime-promotion lease.
     PromotionTakeover,
+    /// Plan or apply pruning for unreferenced immutable controller runtimes.
+    ControllerPrune {
+        /// Delete pins not retained by nonterminal durable runs or the active generation.
+        #[arg(long)]
+        apply: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -52,6 +58,7 @@ pub enum RuntimeOutput {
     HelperPath(RuntimeHelperPathOutput),
     RuntimePackageRefresh(RuntimePackageRefreshOutput),
     RuntimePromotionTakeover(RuntimePromotionTakeoverOutput),
+    ControllerPrune(ControllerRuntimePruneOutput),
 }
 
 #[derive(Serialize)]
@@ -81,6 +88,15 @@ pub struct RuntimePromotionTakeoverOutput {
     archived_path: String,
 }
 
+#[derive(Serialize)]
+pub struct ControllerRuntimePruneOutput {
+    command: String,
+    apply: bool,
+    retained: Vec<String>,
+    eligible: Vec<String>,
+    removed: Vec<String>,
+}
+
 pub fn run(args: RuntimeArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<RuntimeOutput> {
     match args.command {
         RuntimeCommand::Helper { command } => match command {
@@ -92,6 +108,7 @@ pub fn run(args: RuntimeArgs, _global: &crate::commands::GlobalArgs) -> CmdResul
             revision,
         } => refresh_runtime_package(&runtime_id, &source, revision.as_deref()),
         RuntimeCommand::PromotionTakeover => promotion_takeover(),
+        RuntimeCommand::ControllerPrune { apply } => controller_prune(apply),
     }
 }
 
@@ -100,7 +117,9 @@ pub fn is_plain_mode(args: &RuntimeArgs) -> bool {
         RuntimeCommand::Helper { command } => match command {
             RuntimeHelperCommand::Path { plain, .. } => *plain,
         },
-        RuntimeCommand::Refresh { .. } | RuntimeCommand::PromotionTakeover => false,
+        RuntimeCommand::Refresh { .. }
+        | RuntimeCommand::PromotionTakeover
+        | RuntimeCommand::ControllerPrune { .. } => false,
     }
 }
 
@@ -118,10 +137,32 @@ pub fn run_plain_text(args: RuntimeArgs) -> homeboy::core::Result<(String, i32)>
                 Ok((format!("{}\n", path.to_string_lossy()), 0))
             }
         },
-        RuntimeCommand::Refresh { .. } | RuntimeCommand::PromotionTakeover => {
+        RuntimeCommand::Refresh { .. }
+        | RuntimeCommand::PromotionTakeover
+        | RuntimeCommand::ControllerPrune { .. } => {
             unreachable!("runtime mutation has no plain mode")
         }
     }
+}
+
+fn controller_prune(apply: bool) -> CmdResult<RuntimeOutput> {
+    let result = homeboy::core::agent_tasks::lifecycle::prune_controller_runtime_pins(apply)?;
+    let stringify = |paths: Vec<std::path::PathBuf>| {
+        paths
+            .into_iter()
+            .map(|path| path.to_string_lossy().to_string())
+            .collect()
+    };
+    Ok((
+        RuntimeOutput::ControllerPrune(ControllerRuntimePruneOutput {
+            command: "runtime.controller_prune".to_string(),
+            apply,
+            retained: stringify(result.retained),
+            eligible: stringify(result.eligible),
+            removed: stringify(result.removed),
+        }),
+        0,
+    ))
 }
 
 fn promotion_takeover() -> CmdResult<RuntimeOutput> {

--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -406,6 +406,7 @@ fn exit_code_for_error(code: ErrorCode) -> i32 {
         | ErrorCode::RigResourceConflict
         | ErrorCode::RunnerLabTransportFailure
         | ErrorCode::RunnerControllerDisconnected
+        | ErrorCode::RuntimePromotionContended
         | ErrorCode::StackApplyConflict
         | ErrorCode::DependencyStepFailed
         | ErrorCode::DependencyOutputMissing => 20,

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -358,8 +358,88 @@ pub fn load_plan_for_execution(run_id: &str) -> Result<AgentTaskPlan> {
     store::read_controller_plan_for_execution(&run_id)
 }
 
+/// Validate a queued lifecycle's pinned controller without scheduling provider work.
+pub fn validate_controller_runtime(run_id: &str) -> Result<AgentTaskRunRecord> {
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    migrate_record_controller_runtime(&mut record)?;
+    crate::controller_runtime::validate(
+        record
+            .metadata
+            .get(crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY)
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "controller_runtime",
+                    "durable run has no controller runtime pin",
+                    Some(record.run_id.clone()),
+                    None,
+                )
+            })?,
+    )?;
+    Ok(record)
+}
+
+/// Resolve the compatible immutable executable for a lifecycle mutation.
+/// Legacy pins are migrated atomically before returning a path for re-exec.
+pub fn pinned_runtime_for_mutation(run_id: &str) -> Result<Option<std::path::PathBuf>> {
+    let mut record = store::read_record(&resolve_run_id(run_id)?)?;
+    migrate_record_controller_runtime(&mut record)?;
+    crate::controller_runtime::pinned_executable_for_mutation(
+        &record.metadata,
+        &crate::build_identity::current().display,
+    )
+}
+
+/// Prune immutable controller pins through the durable lifecycle ownership
+/// boundary so nonterminal records remain authoritative retention roots.
+pub fn prune_controller_runtime_pins(
+    apply: bool,
+) -> Result<crate::controller_runtime::ControllerRuntimePruneResult> {
+    crate::controller_runtime::prune_pins(apply)
+}
+
+fn migrate_record_controller_runtime(record: &mut AgentTaskRunRecord) -> Result<()> {
+    let Some(runtime) = record
+        .metadata
+        .get(crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY)
+    else {
+        return Ok(());
+    };
+    let migrated = crate::controller_runtime::migrate_legacy_pin(runtime)?;
+    if &migrated != runtime {
+        record.metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = migrated;
+        store::write_record(record)?;
+    }
+    Ok(())
+}
+
+/// Repair only the executable artifact named by durable controller provenance.
+pub fn recover_controller_runtime(
+    run_id: &str,
+    artifact: Option<&std::path::Path>,
+    source: Option<&std::path::Path>,
+) -> Result<Value> {
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let runtime = record
+        .metadata
+        .get(crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "controller_runtime",
+                "durable run has no controller runtime pin",
+                Some(record.run_id.clone()),
+                None,
+            )
+        })?;
+    let recovered = crate::controller_runtime::recover_pin(runtime, artifact, source)?;
+    // The new pin is verified before this single-record durable mutation.
+    record.metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = recovered.clone();
+    store::write_record(&record)?;
+    Ok(recovered)
+}
+
 pub fn mark_running(run_id: &str) -> Result<AgentTaskRunRecord> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    migrate_record_controller_runtime(&mut record)?;
     crate::controller_runtime::validate_for_mutation(
         &record.metadata,
         &crate::build_identity::current().display,

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -340,17 +340,6 @@ pub fn load_controller_plan(run_id: &str) -> Result<AgentTaskPlan> {
     store::read_controller_plan(&run_id)
 }
 
-/// Return the immutable controller executable that owns a lifecycle mutation
-/// when this process is not the originating runtime. The pin is verified before
-/// it is returned so callers fail closed rather than launching an untrusted path.
-pub fn pinned_runtime_for_mutation(run_id: &str) -> Result<Option<std::path::PathBuf>> {
-    let record = store::read_record(&resolve_run_id(run_id)?)?;
-    crate::controller_runtime::pinned_executable_for_mutation(
-        &record.metadata,
-        &crate::build_identity::current().display,
-    )
-}
-
 /// Load a durable plan for a scheduler or provider execution. This is the only
 /// read path allowed to upgrade a legacy execution-budget envelope.
 pub fn load_plan_for_execution(run_id: &str) -> Result<AgentTaskPlan> {

--- a/crates/homeboy-core/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/mod.rs
@@ -48,9 +48,7 @@ pub use health::*;
 pub use lifecycle_ops::*;
 pub use lifecycle_record_ops::cook_attempt_run_id;
 pub use records::*;
-pub use runner_continuation::{
-    register_runner_continuation_provider, RunnerContinuationProvider,
-};
+pub use runner_continuation::{register_runner_continuation_provider, RunnerContinuationProvider};
 
 pub(crate) use conversion::*;
 pub(crate) use lifecycle_record_ops::*;

--- a/crates/homeboy-core/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/mod.rs
@@ -40,6 +40,7 @@ mod lifecycle_record_ops;
 mod records;
 pub mod runner_continuation;
 
+pub use crate::controller_runtime::ControllerRuntimePruneResult;
 pub use artifact_materialization::*;
 pub use cancellation::*;
 pub use failure_recording::*;

--- a/crates/homeboy-core/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/runner_continuation.rs
@@ -21,8 +21,11 @@ use crate::error::{Error, Result};
 /// resuming a run that was handed off to a remote runner.
 pub trait RunnerContinuationProvider: Send + Sync {
     /// Durable snapshot (job + event log) for a runner job.
-    fn runner_job_log_snapshot(&self, runner_id: &str, job_id: &str)
-        -> Result<RunnerJobLogSnapshot>;
+    fn runner_job_log_snapshot(
+        &self,
+        runner_id: &str,
+        job_id: &str,
+    ) -> Result<RunnerJobLogSnapshot>;
 
     /// Whether the runner currently reports a live connection.
     fn is_runner_connected(&self, runner_id: &str) -> bool;
@@ -83,10 +86,10 @@ fn provider_slot() -> &'static Mutex<Option<Box<dyn RunnerContinuationProvider>>
 
 /// Register the runner-continuation provider. Called once at startup by the
 /// runner subsystem when it is present.
-pub fn register_runner_continuation_provider(
-    provider: Box<dyn RunnerContinuationProvider>,
-) {
-    let mut slot = provider_slot().lock().expect("runner continuation provider lock");
+pub fn register_runner_continuation_provider(provider: Box<dyn RunnerContinuationProvider>) {
+    let mut slot = provider_slot()
+        .lock()
+        .expect("runner continuation provider lock");
     *slot = Some(provider);
 }
 
@@ -95,7 +98,9 @@ pub fn register_runner_continuation_provider(
 pub(crate) fn with_runner_continuation<R>(
     f: impl FnOnce(&dyn RunnerContinuationProvider) -> R,
 ) -> R {
-    let slot = provider_slot().lock().expect("runner continuation provider lock");
+    let slot = provider_slot()
+        .lock()
+        .expect("runner continuation provider lock");
     match slot.as_deref() {
         Some(provider) => f(provider),
         None => f(&NoopProvider),

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -14,7 +14,27 @@ use crate::agent_task_scheduler::{
 };
 use crate::api_jobs::{JobEvent, JobEventKind};
 use crate::test_support::with_isolated_home;
-use sha2::Digest;
+use sha2::{Digest, Sha256};
+
+#[cfg(unix)]
+fn fake_controller_artifact(path: &std::path::Path, identity: &str, marker: &str) -> String {
+    use std::os::unix::fs::PermissionsExt;
+
+    let identity = serde_json::to_string(identity).expect("serialize fake controller identity");
+    std::fs::write(
+        path,
+        format!(
+            "#!/bin/sh\n# {marker}\nif [ \"$1\" = self ] && [ \"$2\" = identity ]; then\n  printf '%s\\n' '{{\"data\":{{\"display\":{identity}}}}}'\n  exit 0\nfi\nexit 1\n"
+        ),
+    )
+    .expect("write fake controller artifact");
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+        .expect("make fake controller artifact executable");
+    format!(
+        "{:x}",
+        Sha256::digest(std::fs::read(path).expect("read fake controller artifact"))
+    )
+}
 
 #[test]
 fn provider_run_result_reads_declared_output_alias() {
@@ -78,6 +98,201 @@ fn submit_plan_persists_queued_status() {
             loaded.tasks[0].provider_ref.as_deref(),
             Some("test:fixture")
         );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn artifact_recovery_replaces_only_the_recorded_legacy_pin() {
+    with_isolated_home(|_| {
+        let temporary = tempfile::tempdir().expect("temporary fake controller directory");
+        let identity = crate::build_identity::current().display;
+        let artifact = temporary.path().join("exact-homeboy");
+        let digest = fake_controller_artifact(&artifact, &identity, "exact artifact");
+        let legacy = temporary.path().join("legacy-homeboy");
+        std::fs::write(&legacy, b"corrupted legacy bytes").expect("write corrupted legacy pin");
+        let record = submit_plan(&test_plan(), Some("recover-exact-artifact")).expect("submit");
+        rewrite_record_for_test(&record.run_id, |record| {
+            record.metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = json!({
+                "originating": {
+                    "build_identity": identity,
+                    "pinned_executable": legacy,
+                    "sha256": digest,
+                }
+            });
+        })
+        .expect("project legacy pin");
+
+        let recovered = recover_controller_runtime(&record.run_id, Some(&artifact), None)
+            .expect("recover exact artifact");
+        let pinned = std::path::PathBuf::from(
+            recovered["originating"]["pinned_executable"]
+                .as_str()
+                .expect("recovered pin path"),
+        );
+        assert_ne!(pinned, legacy);
+        assert!(pinned.is_file());
+        assert_eq!(
+            std::fs::read(&legacy).expect("legacy bytes retained"),
+            b"corrupted legacy bytes"
+        );
+        assert_eq!(
+            status(&record.run_id).expect("recovered record").metadata
+                [crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY],
+            recovered
+        );
+        validate_controller_runtime(&record.run_id).expect("recovered runtime validates");
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn artifact_recovery_rejects_wrong_hash_and_identity_without_record_mutation() {
+    with_isolated_home(|_| {
+        let temporary = tempfile::tempdir().expect("temporary fake controller directory");
+        let identity = crate::build_identity::current().display;
+        let artifact = temporary.path().join("exact-homeboy");
+        let digest = fake_controller_artifact(&artifact, &identity, "exact artifact");
+        let legacy = temporary.path().join("legacy-homeboy");
+        std::fs::write(&legacy, b"corrupted legacy bytes").expect("write corrupted legacy pin");
+        let record = submit_plan(&test_plan(), Some("recover-reject-artifact")).expect("submit");
+
+        rewrite_record_for_test(&record.run_id, |record| {
+            record.metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = json!({
+                "originating": {
+                    "build_identity": identity,
+                    "pinned_executable": legacy,
+                    "sha256": "00",
+                }
+            });
+        })
+        .expect("project wrong hash pin");
+        let before_hash = status(&record.run_id).expect("record before wrong hash");
+        let hash_error = recover_controller_runtime(&record.run_id, Some(&artifact), None)
+            .expect_err("wrong hash rejected");
+        assert!(hash_error.message.contains("hash mismatch"));
+        assert_eq!(
+            status(&record.run_id).expect("record after wrong hash"),
+            before_hash
+        );
+
+        rewrite_record_for_test(&record.run_id, |record| {
+            record.metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = json!({
+                "originating": {
+                    "build_identity": "homeboy test+wrong-identity",
+                    "pinned_executable": legacy,
+                    "sha256": digest,
+                }
+            });
+        })
+        .expect("project wrong identity pin");
+        let before_identity = status(&record.run_id).expect("record before wrong identity");
+        let identity_error = recover_controller_runtime(&record.run_id, Some(&artifact), None)
+            .expect_err("wrong identity rejected");
+        assert!(identity_error.message.contains("build identity mismatch"));
+        assert_eq!(
+            status(&record.run_id).expect("record after wrong identity"),
+            before_identity
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn legacy_pin_migration_failure_leaves_durable_record_unchanged() {
+    with_isolated_home(|_| {
+        let temporary = tempfile::tempdir().expect("temporary fake controller directory");
+        let identity = crate::build_identity::current().display;
+        let legacy = temporary.path().join("legacy-homeboy");
+        let digest = fake_controller_artifact(&legacy, &identity, "legacy artifact");
+        let record = submit_plan(&test_plan(), Some("migration-failure")).expect("submit");
+        rewrite_record_for_test(&record.run_id, |record| {
+            record.metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = json!({
+                "originating": {
+                    "build_identity": identity,
+                    "pinned_executable": legacy,
+                    "sha256": format!("{digest}00"),
+                }
+            });
+        })
+        .expect("project invalid legacy pin");
+        let before = status(&record.run_id).expect("record before migration");
+
+        let error =
+            validate_controller_runtime(&record.run_id).expect_err("migration fails closed");
+
+        assert!(error.message.contains("hash mismatch"));
+        assert_eq!(
+            status(&record.run_id).expect("record after migration"),
+            before
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn controller_runtime_retention_keeps_mutable_runs_and_reports_terminal_pins_eligible() {
+    with_isolated_home(|_| {
+        let temporary = tempfile::tempdir().expect("temporary fake controller directory");
+        let identity = crate::build_identity::current().display;
+        let active_artifact = temporary.path().join("active-homeboy");
+        let terminal_artifact = temporary.path().join("terminal-homeboy");
+        let active_digest =
+            fake_controller_artifact(&active_artifact, &identity, "active artifact");
+        let terminal_digest =
+            fake_controller_artifact(&terminal_artifact, &identity, "terminal artifact");
+
+        let active = submit_plan(&test_plan(), Some("retention-active")).expect("submit active");
+        let terminal =
+            submit_plan(&test_plan(), Some("retention-terminal")).expect("submit terminal");
+        for (record, artifact, digest) in [
+            (&active, &active_artifact, &active_digest),
+            (&terminal, &terminal_artifact, &terminal_digest),
+        ] {
+            let legacy = temporary.path().join(format!("{}-legacy", record.run_id));
+            std::fs::write(&legacy, b"corrupted legacy bytes").expect("write legacy pin");
+            rewrite_record_for_test(&record.run_id, |record| {
+                record.metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = json!({
+                    "originating": {
+                        "build_identity": identity,
+                        "pinned_executable": legacy,
+                        "sha256": digest,
+                    }
+                });
+            })
+            .expect("project legacy pin");
+            recover_controller_runtime(&record.run_id, Some(artifact), None).expect("recover pin");
+        }
+        rewrite_record_for_test(&terminal.run_id, |record| {
+            record.state = AgentTaskRunState::Succeeded;
+        })
+        .expect("make terminal");
+
+        let active_pin = std::path::PathBuf::from(
+            status(&active.run_id).expect("active record").metadata
+                [crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]["originating"]
+                ["pinned_executable"]
+                .as_str()
+                .expect("active pin"),
+        );
+        let terminal_pin = std::path::PathBuf::from(
+            status(&terminal.run_id).expect("terminal record").metadata
+                [crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]["originating"]
+                ["pinned_executable"]
+                .as_str()
+                .expect("terminal pin"),
+        );
+        let report = crate::controller_runtime::retention_report().expect("retention report");
+        assert!(report.retained.contains(&active_pin));
+        assert!(report.eligible.contains(&terminal_pin));
+        let dry_run = prune_controller_runtime_pins(false).expect("plan pin pruning");
+        assert!(dry_run.retained.contains(&active_pin));
+        assert!(dry_run.eligible.contains(&terminal_pin));
+        assert!(dry_run.removed.is_empty());
+        let applied = prune_controller_runtime_pins(true).expect("prune terminal pin");
+        assert!(applied.removed.contains(&terminal_pin));
+        assert!(active_pin.exists());
+        assert!(!terminal_pin.exists());
     });
 }
 

--- a/crates/homeboy-core/src/agent_tasks.rs
+++ b/crates/homeboy-core/src/agent_tasks.rs
@@ -250,8 +250,8 @@ pub mod lifecycle {
         aggregate_source, artifacts, cancel, cancel_run, claim_next_queued_run,
         cook_attempt_run_id, cook_index, list_records, load_controller_plan, load_plan, logs,
         mark_resuming, mark_running, materialize_recovered_patch_artifact,
-        pinned_runtime_for_mutation, reconcile_record_health, record_completed_run,
-        record_cook_attempt, record_detached_lab_run, record_health_summary,
+        pinned_runtime_for_mutation, prune_controller_runtime_pins, reconcile_record_health,
+        record_completed_run, record_cook_attempt, record_detached_lab_run, record_health_summary,
         record_lab_offload_phase, record_lab_offload_planned, record_pre_dispatch_failure,
         record_pre_execution_failure, record_promotion, record_remote_dispatch_failure,
         record_run_aggregate, retry, run_id_for_aggregate_path, run_record_exists, run_status,
@@ -261,7 +261,7 @@ pub mod lifecycle {
         AgentTaskRecordReconciliationItem, AgentTaskRecordReconciliationReport,
         AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts, AgentTaskRunLog,
         AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState, AgentTaskRunStatus,
-        AgentTaskRunTask, DetachedLabRunRecord, LabOffloadProxyPlan,
+        AgentTaskRunTask, ControllerRuntimePruneResult, DetachedLabRunRecord, LabOffloadProxyPlan,
     };
 }
 

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -648,7 +648,11 @@ fn verify_self_identity(path: &Path, expected: &str) -> Result<()> {
 
 fn executable_identity(path: &Path) -> Result<String> {
     #[cfg(test)]
-    if std::env::current_exe().ok().as_deref() == Some(path) {
+    if std::env::current_exe()
+        .ok()
+        .zip(fs::canonicalize(path).ok())
+        .is_some_and(|(current, candidate)| current == candidate)
+    {
         // Unit tests run inside the libtest executable, not the Homeboy CLI.
         // Keep lifecycle fixtures hermetic while artifact tests still execute
         // their explicit fake controller binaries.

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -943,17 +943,18 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn identity_mismatch_resolves_the_verified_pinned_executable() {
         let temporary = tempfile::tempdir().expect("temporary runtime directory");
         let pinned = temporary.path().join("homeboy-origin");
-        fs::write(&pinned, b"origin").expect("write pinned executable");
+        let digest = fake_controller(&pinned, "homeboy 1.0.0+origin", "origin");
         make_executable_read_only(&pinned).expect("seal executable");
         let metadata = json!({
             "controller_runtime": {
                 "originating": {
                     "build_identity": "homeboy 1.0.0+origin",
                     "pinned_executable": pinned,
-                    "sha256": executable_digest(&pinned).expect("hash executable"),
+                    "sha256": digest,
                 }
             }
         });

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -2,8 +2,10 @@
 
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use crate::{build_identity, paths, Error, Result};
 
@@ -11,6 +13,180 @@ pub(crate) const CONTROLLER_RUNTIME_METADATA_KEY: &str = "controller_runtime";
 
 const ACTIVE_GENERATION_FILE: &str = "active.json";
 const ADMISSION_LOCK_DIR: &str = "admission.lock";
+
+/// Report-only retention inventory for immutable controller runtime pins.
+///
+/// No current cleanup command deletes controller runtime pins. This report is
+/// intentionally the eligibility primitive for a future narrowly-scoped pruner;
+/// callers must retain every path in `retained` and may consider only `eligible`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControllerRuntimeRetentionReport {
+    pub retained: Vec<PathBuf>,
+    pub eligible: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControllerRuntimePruneResult {
+    pub retained: Vec<PathBuf>,
+    pub eligible: Vec<PathBuf>,
+    pub removed: Vec<PathBuf>,
+}
+
+/// Discover pin references through the durable lifecycle store and classify the
+/// content-addressed pins currently present on disk. Queued, running, and
+/// recoverable partial records retain their pins because lifecycle recovery can
+/// still operate on them. The active admission generation is retained as well.
+pub fn retention_report() -> Result<ControllerRuntimeRetentionReport> {
+    let root = runtime_root()?;
+    let (records, _) = crate::agent_task_lifecycle::list_records_with_health()?;
+    let mut retained = BTreeSet::new();
+
+    for record in records {
+        if !state_retains_pin(record.state) {
+            continue;
+        }
+        if let Some(path) = record
+            .metadata
+            .pointer(&format!(
+                "/{CONTROLLER_RUNTIME_METADATA_KEY}/originating/pinned_executable"
+            ))
+            .and_then(Value::as_str)
+            .map(PathBuf::from)
+            .filter(|path| content_addressed_pin_path(&root, path))
+        {
+            retained.insert(path);
+        }
+    }
+
+    let active = root.join(ACTIVE_GENERATION_FILE);
+    if active.exists() {
+        let value = fs::read_to_string(&active).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("read active controller generation".to_string()),
+            )
+        })?;
+        let runtime: Value = serde_json::from_str(&value).map_err(|error| {
+            Error::validation_invalid_json(
+                error,
+                Some("parse active controller generation".to_string()),
+                None,
+            )
+        })?;
+        if let Some(path) = runtime
+            .pointer("/originating/pinned_executable")
+            .and_then(Value::as_str)
+            .map(PathBuf::from)
+            .filter(|path| content_addressed_pin_path(&root, path))
+        {
+            retained.insert(path);
+        }
+    }
+
+    let pins = discover_pin_paths(&root)?;
+    let eligible = pins.difference(&retained).cloned().collect();
+    Ok(ControllerRuntimeRetentionReport {
+        retained: retained.into_iter().collect(),
+        eligible,
+    })
+}
+
+/// Remove only content-addressed pins not referenced by a nonterminal durable
+/// record or the active generation. The caller chooses mutation explicitly.
+pub fn prune_pins(apply: bool) -> Result<ControllerRuntimePruneResult> {
+    let report = retention_report()?;
+    let mut removed = Vec::new();
+    if apply {
+        for path in &report.eligible {
+            fs::remove_file(path).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("prune unreferenced controller runtime pin".to_string()),
+                )
+            })?;
+            removed.push(path.clone());
+        }
+    }
+    Ok(ControllerRuntimePruneResult {
+        retained: report.retained,
+        eligible: report.eligible,
+        removed,
+    })
+}
+
+fn state_retains_pin(state: crate::agent_task_lifecycle::AgentTaskRunState) -> bool {
+    matches!(
+        state,
+        crate::agent_task_lifecycle::AgentTaskRunState::Queued
+            | crate::agent_task_lifecycle::AgentTaskRunState::Running
+            | crate::agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
+            | crate::agent_task_lifecycle::AgentTaskRunState::PartialRecoverable
+            | crate::agent_task_lifecycle::AgentTaskRunState::PartialFailure
+    )
+}
+
+fn content_addressed_pin_path(root: &Path, path: &Path) -> bool {
+    let Ok(relative) = path.strip_prefix(root) else {
+        return false;
+    };
+    let components = relative.components().collect::<Vec<_>>();
+    let primary_pin = matches!(
+        components.as_slice(),
+        [generation, executable]
+            if generation.as_os_str() != "active.json" && executable.as_os_str() == "homeboy"
+    );
+    let recovered_pin = matches!(
+        components.as_slice(),
+        [generation, recovery, executable]
+            if generation.as_os_str() != "active.json"
+                && recovery.as_os_str().to_string_lossy().starts_with("recovery-")
+                && executable.as_os_str() == "homeboy"
+    );
+    primary_pin || recovered_pin
+}
+
+fn discover_pin_paths(root: &Path) -> Result<BTreeSet<PathBuf>> {
+    let mut pins = BTreeSet::new();
+    for entry in fs::read_dir(root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("list controller runtime pins".to_string()),
+        )
+    })? {
+        let entry = entry.map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("read controller runtime pin".to_string()),
+            )
+        })?;
+        let path = entry.path();
+        let direct_pin = path.join("homeboy");
+        if content_addressed_pin_path(root, &direct_pin) && direct_pin.is_file() {
+            pins.insert(direct_pin);
+        }
+        if !path.is_dir() {
+            continue;
+        }
+        for recovery in fs::read_dir(&path).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("list recovered controller runtime pins".to_string()),
+            )
+        })? {
+            let recovery = recovery.map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("read recovered controller runtime pin".to_string()),
+                )
+            })?;
+            let recovered_pin = recovery.path().join("homeboy");
+            if content_addressed_pin_path(root, &recovered_pin) && recovered_pin.is_file() {
+                pins.insert(recovered_pin);
+            }
+        }
+    }
+    Ok(pins)
+}
 
 /// Holds the short admission critical section.  Keeping selection and durable
 /// record creation together prevents a submission from observing A after B is
@@ -34,37 +210,26 @@ pub(crate) fn pin_current() -> Result<Value> {
             Some("resolve controller executable".to_string()),
         )
     })?;
-    let pinned_path = pinned_path(&identity.display)?;
-    if !pinned_path.exists() {
-        let parent = pinned_path.parent().expect("pinned runtime has parent");
-        std::fs::create_dir_all(parent).map_err(|error| {
-            Error::internal_io(
-                error.to_string(),
-                Some("create controller runtime pin".to_string()),
-            )
-        })?;
-        std::fs::copy(&executable, &pinned_path).map_err(|error| {
-            Error::internal_io(
-                error.to_string(),
-                Some("pin controller executable".to_string()),
-            )
-        })?;
-        make_executable_read_only(&pinned_path)?;
-    }
+    pin_executable(&executable, &identity.display)
+}
 
-    let digest = executable_digest(&pinned_path)?;
+fn pin_executable(executable: &Path, identity: &str) -> Result<Value> {
+    let digest = executable_digest(&executable)?;
+    let pinned_path = pinned_path(identity, &digest)?;
+    publish_pin(executable, &pinned_path, &digest)?;
 
     Ok(json!({
         "schema": "homeboy/controller-runtime-pin/v2",
-        "requested": identity.display,
+        "requested": identity,
         "originating": {
-            "build_identity": identity.display,
+            "build_identity": identity,
             "executable": executable,
             "pinned_executable": pinned_path,
             "sha256": digest,
+            "source": source_provenance(),
         },
-        "current": identity.display,
-        "executed": identity.display,
+        "current": identity,
+        "executed": identity,
     }))
 }
 
@@ -92,7 +257,13 @@ pub(crate) fn activate_current_generation() -> Result<Value> {
     let lock_path = root.join(ADMISSION_LOCK_DIR);
     acquire_admission_lock(&lock_path)?;
     let result = (|| {
-        let runtime = pin_current()?;
+        let executable = std::env::current_exe().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("resolve activated controller executable".to_string()),
+            )
+        })?;
+        let runtime = pin_executable(&executable, &activated_executable_identity(&executable)?)?;
         validate_pin(&runtime)?;
         write_active_generation(&root.join(ACTIVE_GENERATION_FILE), &runtime)?;
         Ok(runtime)
@@ -143,6 +314,175 @@ pub(crate) fn validate_for_mutation(metadata: &Value, current_identity: &str) ->
             pinned.display()
         )]),
     ))
+}
+
+/// Move a valid legacy v2 pin into its immutable content-addressed location.
+/// The caller persists the returned metadata only after this has completed.
+pub(crate) fn migrate_legacy_pin(runtime: &Value) -> Result<Value> {
+    let identity =
+        required_runtime_string(runtime, "/originating/build_identity", "build identity")?;
+    let digest = required_runtime_string(runtime, "/originating/sha256", "content digest")?;
+    let destination = pinned_path(identity, digest)?;
+    let current = required_runtime_string(
+        runtime,
+        "/originating/pinned_executable",
+        "immutable executable",
+    )?;
+    if Path::new(current) == destination {
+        validate_pin(runtime)?;
+        return Ok(runtime.clone());
+    }
+
+    // Validation includes the digest, executable bit, and advertised identity.
+    // Never update durable metadata until the no-clobber publication succeeds.
+    validate_pin(runtime)?;
+    publish_pin(Path::new(current), &destination, digest)?;
+    let mut migrated = runtime.clone();
+    migrated["originating"]["pinned_executable"] = json!(destination);
+    validate_pin(&migrated)?;
+    Ok(migrated)
+}
+
+pub(crate) fn validate(runtime: &Value) -> Result<()> {
+    validate_pin(runtime)
+}
+
+/// Restore a missing or corrupted pin from one explicitly supplied trusted
+/// artifact or source checkout without changing the durable identity or digest
+/// contract.
+pub(crate) fn recover_pin(
+    runtime: &Value,
+    artifact: Option<&Path>,
+    source: Option<&Path>,
+) -> Result<Value> {
+    let identity =
+        required_runtime_string(runtime, "/originating/build_identity", "build identity")?;
+    let expected = required_runtime_string(runtime, "/originating/sha256", "content digest")?;
+    // Recovery never repairs an existing path in place. A corrupted canonical
+    // path can still be referenced by another durable record, so this record
+    // receives a distinct immutable snapshot after the artifact is verified.
+    let destination = recovered_pinned_path(identity, expected)?;
+    if let Some(artifact) = artifact {
+        verify_artifact(artifact, expected, identity)?;
+        publish_pin(artifact, &destination, expected)?;
+        let mut recovered = runtime.clone();
+        recovered["originating"]["pinned_executable"] = json!(destination);
+        validate_pin(&recovered)?;
+        return Ok(recovered);
+    }
+    let revision = runtime
+        .pointer("/originating/source/revision")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            identity
+                .rsplit_once('+')
+                .map(|(_, revision)| revision.to_string())
+        })
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "controller_runtime",
+                "controller runtime recovery needs recorded source revision",
+                Some(identity.to_string()),
+                None,
+            )
+        })?;
+    let source = source.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "source",
+            "controller runtime recovery requires --artifact or --source",
+            None,
+            None,
+        )
+    })?;
+    let temporary = tempfile::tempdir().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("create controller runtime recovery workspace".to_string()),
+        )
+    })?;
+    let checkout = temporary.path().join("source");
+    run_command(
+        "git",
+        [
+            "-C",
+            &source.display().to_string(),
+            "worktree",
+            "add",
+            "--detach",
+            &checkout.display().to_string(),
+            &revision,
+        ],
+    )?;
+    let build = Command::new("cargo")
+        .args(["build", "--release", "--bin", "homeboy"])
+        .current_dir(&checkout)
+        .status()
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("build controller runtime recovery source".to_string()),
+            )
+        })?;
+    if !build.success() {
+        let _ = run_command(
+            "git",
+            [
+                "-C",
+                &source.display().to_string(),
+                "worktree",
+                "remove",
+                "--force",
+                &checkout.display().to_string(),
+            ],
+        );
+        return Err(Error::validation_invalid_argument(
+            "controller_runtime",
+            "controller runtime recovery build failed",
+            Some(identity.to_string()),
+            None,
+        ));
+    }
+    let built = checkout.join("target/release/homeboy");
+    let actual = executable_digest(&built)?;
+    if actual != expected {
+        let _ = run_command(
+            "git",
+            [
+                "-C",
+                &source.display().to_string(),
+                "worktree",
+                "remove",
+                "--force",
+                &checkout.display().to_string(),
+            ],
+        );
+        return Err(Error::validation_invalid_argument(
+            "controller_runtime",
+            format!(
+                "recovered controller runtime hash does not match durable pin: expected {expected}"
+            ),
+            Some(built.display().to_string()),
+            None,
+        ));
+    }
+    verify_artifact(&built, expected, identity)?;
+    publish_pin(&built, &destination, expected)?;
+    let _ = run_command(
+        "git",
+        [
+            "-C",
+            &source.display().to_string(),
+            "worktree",
+            "remove",
+            "--force",
+            &checkout.display().to_string(),
+        ],
+    );
+    let mut recovered = runtime.clone();
+    recovered["originating"]["pinned_executable"] = json!(destination);
+    validate_pin(&recovered)?;
+    Ok(recovered)
 }
 
 fn runtime_root() -> Result<PathBuf> {
@@ -227,20 +567,136 @@ fn validate_pin(runtime: &Value) -> Result<()> {
     let metadata = fs::metadata(path).map_err(|_| {
         Error::validation_invalid_argument(
             "controller_runtime",
-            format!("pinned controller executable is unavailable: {pinned}"),
+            format!("pinned controller executable is missing: {pinned}"),
             Some(pinned.to_string()),
             None,
         )
     })?;
-    if !metadata.is_file() || !is_executable(&metadata) || executable_digest(path)? != expected {
+    if !metadata.is_file() || !is_executable(&metadata) {
         return Err(Error::validation_invalid_argument(
             "controller_runtime",
-            format!("pinned controller executable is not immutable and available: {pinned}"),
+            format!("pinned controller executable is not executable: {pinned}"),
             Some(pinned.to_string()),
             None,
         ));
     }
+    let actual = executable_digest(path)?;
+    if actual != expected {
+        return Err(Error::validation_invalid_argument(
+            "controller_runtime",
+            format!(
+                "pinned controller executable hash mismatch: expected {expected}, found {actual}"
+            ),
+            Some(pinned.to_string()),
+            None,
+        ));
+    }
+    let identity =
+        required_runtime_string(runtime, "/originating/build_identity", "build identity")?;
+    verify_self_identity(path, identity)?;
     Ok(())
+}
+
+fn verify_artifact(path: &Path, expected: &str, identity: &str) -> Result<()> {
+    verify_executable(path, "recovery artifact")?;
+    let actual = executable_digest(path)?;
+    if actual != expected {
+        return Err(Error::validation_invalid_argument(
+            "controller_runtime",
+            format!("recovery artifact hash mismatch: expected {expected}, found {actual}"),
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+    verify_self_identity(path, identity)
+}
+
+fn verify_executable(path: &Path, label: &str) -> Result<()> {
+    let metadata = fs::metadata(path).map_err(|_| {
+        Error::validation_invalid_argument(
+            "controller_runtime",
+            format!("{label} is missing: {}", path.display()),
+            Some(path.display().to_string()),
+            None,
+        )
+    })?;
+    if !metadata.is_file() || !is_executable(&metadata) {
+        return Err(Error::validation_invalid_argument(
+            "controller_runtime",
+            format!("{label} is not executable: {}", path.display()),
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn verify_self_identity(path: &Path, expected: &str) -> Result<()> {
+    let actual = executable_identity(path)?;
+    if actual == expected {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "controller_runtime",
+        format!(
+            "pinned controller executable build identity mismatch: expected {expected}, found {actual}"
+        ),
+        Some(path.display().to_string()),
+        None,
+    ))
+}
+
+fn executable_identity(path: &Path) -> Result<String> {
+    #[cfg(test)]
+    if std::env::current_exe().ok().as_deref() == Some(path) {
+        // Unit tests run inside the libtest executable, not the Homeboy CLI.
+        // Keep lifecycle fixtures hermetic while artifact tests still execute
+        // their explicit fake controller binaries.
+        return Ok(build_identity::current().display);
+    }
+    let output = Command::new(path)
+        .args(["self", "identity"])
+        .output()
+        .map_err(|error| {
+            Error::validation_invalid_argument(
+                "controller_runtime",
+                format!("pinned controller executable identity check failed: {error}"),
+                Some(path.display().to_string()),
+                None,
+            )
+        })?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let actual = serde_json::from_str::<Value>(&stdout)
+        .ok()
+        .and_then(|value| {
+            value
+                .pointer("/data/display")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        });
+    if !output.status.success() || actual.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "controller_runtime",
+            format!(
+                "pinned controller executable identity check returned invalid output: {stdout}"
+            ),
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+    Ok(actual.expect("identity was checked above"))
+}
+
+fn activated_executable_identity(path: &Path) -> Result<String> {
+    #[cfg(test)]
+    {
+        // Core unit tests run a Rust test harness rather than the Homeboy CLI.
+        // Production activation always reads the freshly installed executable.
+        let _ = path;
+        return Ok(build_identity::current().display);
+    }
+    #[cfg(not(test))]
+    executable_identity(path)
 }
 
 fn executable_digest(path: &Path) -> Result<String> {
@@ -280,29 +736,195 @@ fn is_executable(metadata: &fs::Metadata) -> bool {
     }
 }
 
-fn pinned_path(identity: &str) -> Result<PathBuf> {
+fn pinned_path(identity: &str, digest: &str) -> Result<PathBuf> {
     Ok(paths::homeboy_data()?
         .join("controller-runtimes")
-        .join(paths::sanitize_path_segment(identity))
+        .join(format!(
+            "{}-{}",
+            paths::sanitize_path_segment(identity),
+            digest
+        ))
         .join("homeboy"))
+}
+
+fn recovered_pinned_path(identity: &str, digest: &str) -> Result<PathBuf> {
+    Ok(paths::homeboy_data()?
+        .join("controller-runtimes")
+        .join(format!(
+            "{}-{}",
+            paths::sanitize_path_segment(identity),
+            digest
+        ))
+        .join(format!("recovery-{}", uuid::Uuid::new_v4()))
+        .join("homeboy"))
+}
+
+fn publish_pin(source: &Path, destination: &Path, expected_digest: &str) -> Result<()> {
+    if destination.exists() {
+        let actual = executable_digest(destination)?;
+        if actual == expected_digest {
+            return Ok(());
+        }
+        return Err(Error::validation_invalid_argument(
+            "controller_runtime",
+            format!(
+                "immutable controller runtime path already contains different bytes: {}",
+                destination.display()
+            ),
+            Some(destination.display().to_string()),
+            None,
+        ));
+    }
+    let parent = destination.parent().expect("pinned runtime has parent");
+    fs::create_dir_all(parent).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("create controller runtime pin".to_string()),
+        )
+    })?;
+    let staging = parent.join(format!(
+        ".homeboy-{}-{}",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    fs::copy(source, &staging).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("stage controller runtime pin".to_string()),
+        )
+    })?;
+    let actual = executable_digest(&staging)?;
+    if actual != expected_digest {
+        let _ = fs::remove_file(&staging);
+        return Err(Error::validation_invalid_argument(
+            "controller_runtime",
+            format!(
+                "controller runtime source hash mismatch while publishing: expected {expected_digest}, found {actual}"
+            ),
+            Some(source.display().to_string()),
+            None,
+        ));
+    }
+    make_executable_read_only(&staging)?;
+    match fs::hard_link(&staging, destination) {
+        Ok(()) => {
+            let _ = fs::remove_file(&staging);
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let _ = fs::remove_file(&staging);
+            let actual = executable_digest(destination)?;
+            if actual == expected_digest {
+                Ok(())
+            } else {
+                Err(Error::validation_invalid_argument(
+                    "controller_runtime",
+                    format!(
+                        "immutable controller runtime path already contains different bytes: {}",
+                        destination.display()
+                    ),
+                    Some(destination.display().to_string()),
+                    None,
+                ))
+            }
+        }
+        Err(error) => {
+            let _ = fs::remove_file(&staging);
+            Err(Error::internal_io(
+                error.to_string(),
+                Some("publish controller runtime pin".to_string()),
+            ))
+        }
+    }
+}
+
+fn required_runtime_string<'a>(runtime: &'a Value, pointer: &str, label: &str) -> Result<&'a str> {
+    runtime
+        .pointer(pointer)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "controller_runtime",
+                format!("controller runtime pin has no {label}"),
+                None,
+                None,
+            )
+        })
+}
+
+fn source_provenance() -> Value {
+    let cwd = std::env::current_dir().ok();
+    let revision = cwd
+        .as_ref()
+        .and_then(|path| git_output(path, ["rev-parse", "HEAD"]));
+    let repository = cwd
+        .as_ref()
+        .and_then(|path| git_output(path, ["config", "--get", "remote.origin.url"]));
+    json!({ "revision": revision, "repository": repository, "verification": "observed_from_process_cwd" })
+}
+
+fn git_output(path: &Path, args: impl IntoIterator<Item = &'static str>) -> Option<String> {
+    Command::new("git")
+        .args(["-C", &path.display().to_string()])
+        .args(args)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn run_command<const N: usize>(program: &str, args: [&str; N]) -> Result<()> {
+    let status = Command::new(program)
+        .args(args)
+        .status()
+        .map_err(|error| Error::internal_io(error.to_string(), Some(format!("run {program}"))))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(Error::validation_invalid_argument(
+            "controller_runtime",
+            format!("{program} command failed during runtime recovery"),
+            None,
+            None,
+        ))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    fn fake_controller(path: &Path, identity: &str, marker: &str) -> String {
+        use std::os::unix::fs::PermissionsExt;
+
+        let identity = serde_json::to_string(identity).expect("serialize fake identity");
+        fs::write(
+            path,
+            format!(
+                "#!/bin/sh\n# {marker}\nif [ \"$1\" = self ] && [ \"$2\" = identity ]; then\n  printf '%s\\n' '{{\"data\":{{\"display\":{identity}}}}}'\n  exit 0\nfi\nexit 1\n"
+            ),
+        )
+        .expect("write fake controller");
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .expect("make fake controller executable");
+        executable_digest(path).expect("hash fake controller")
+    }
+
     #[test]
+    #[cfg(unix)]
     fn identity_mismatch_returns_pinned_runtime_recovery_command() {
         let temporary = tempfile::tempdir().expect("temporary runtime directory");
         let pinned = temporary.path().join("homeboy-origin");
-        fs::write(&pinned, b"origin").expect("write pinned executable");
+        let digest = fake_controller(&pinned, "homeboy 1.0.0+origin", "origin");
         make_executable_read_only(&pinned).expect("seal executable");
         let metadata = json!({
             "controller_runtime": {
                 "originating": {
                     "build_identity": "homeboy 1.0.0+origin",
                     "pinned_executable": pinned,
-                    "sha256": executable_digest(&pinned).expect("hash executable"),
+                    "sha256": digest,
                 }
             }
         });
@@ -357,8 +979,6 @@ mod tests {
                 "sha256": executable_digest(&pinned).expect("hash executable")
             }
         });
-        validate_pin(&runtime).expect("sealed pin is valid");
-
         fs::remove_file(
             runtime
                 .pointer("/originating/pinned_executable")
@@ -403,6 +1023,212 @@ mod tests {
             )
             .expect("parse refreshed active generation");
             assert_eq!(active["originating"]["build_identity"], current);
+        });
+    }
+
+    #[test]
+    fn publication_is_no_clobber_and_idempotent() {
+        let temporary = tempfile::tempdir().expect("temporary runtime directory");
+        let source = temporary.path().join("source");
+        let destination = temporary.path().join("runtime/homeboy");
+        fs::write(&source, b"generation-a").expect("write source");
+        let digest = executable_digest(&source).expect("hash source");
+
+        publish_pin(&source, &destination, &digest).expect("publish first pin");
+        publish_pin(&source, &destination, &digest).expect("reuse exact pin");
+        fs::write(&source, b"generation-b").expect("replace source");
+        let error = publish_pin(
+            &source,
+            &destination,
+            &executable_digest(&source).expect("hash replacement"),
+        )
+        .expect_err("different bytes must never replace a pin");
+
+        assert!(error.message.contains("different bytes"));
+        assert_eq!(fs::read(&destination).expect("read pin"), b"generation-a");
+    }
+
+    #[test]
+    fn concurrent_publication_is_no_clobber_and_idempotent() {
+        let temporary = tempfile::tempdir().expect("temporary runtime directory");
+        let source = temporary.path().join("source");
+        let destination = temporary.path().join("runtime/homeboy");
+        fs::write(&source, b"generation-a").expect("write source");
+        let digest = executable_digest(&source).expect("hash source");
+
+        std::thread::scope(|scope| {
+            let mut publications = Vec::new();
+            for _ in 0..8 {
+                publications.push(scope.spawn(|| publish_pin(&source, &destination, &digest)));
+            }
+            for publication in publications {
+                publication
+                    .join()
+                    .expect("publication thread completes")
+                    .expect("concurrent publication succeeds");
+            }
+        });
+        assert_eq!(fs::read(&destination).expect("read pin"), b"generation-a");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn legacy_pin_migration_publishes_before_returning_updated_metadata() {
+        crate::test_support::with_isolated_home(|_| {
+            let temporary = tempfile::tempdir().expect("temporary runtime directory");
+            let legacy = temporary.path().join("legacy-homeboy");
+            let identity = "homeboy test+legacy";
+            let digest = fake_controller(&legacy, identity, "legacy");
+            let runtime = json!({ "originating": {
+                "build_identity": identity,
+                "pinned_executable": legacy,
+                "sha256": digest,
+            }});
+
+            let migrated = migrate_legacy_pin(&runtime).expect("migrate legacy pin");
+            let destination = PathBuf::from(
+                migrated["originating"]["pinned_executable"]
+                    .as_str()
+                    .expect("migrated path"),
+            );
+            assert_ne!(destination, legacy);
+            assert!(legacy.exists());
+            assert!(destination.is_file());
+            validate_pin(&migrated).expect("migrated pin validates");
+        });
+    }
+
+    #[test]
+    fn pin_diagnostics_distinguish_missing_and_hash_mismatch() {
+        let temporary = tempfile::tempdir().expect("temporary runtime directory");
+        let pinned = temporary.path().join("homeboy");
+        fs::write(&pinned, b"generation-a").expect("write pin");
+        make_executable_read_only(&pinned).expect("seal pin");
+        let runtime = json!({ "originating": { "pinned_executable": pinned, "sha256": "00" } });
+        let mismatch = validate_pin(&runtime).expect_err("hash mismatch");
+        assert!(mismatch.message.contains("hash mismatch"));
+        fs::remove_file(
+            runtime
+                .pointer("/originating/pinned_executable")
+                .and_then(Value::as_str)
+                .expect("path"),
+        )
+        .expect("remove pin");
+        let missing = validate_pin(&runtime).expect_err("missing pin");
+        assert!(missing.message.contains("missing"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn artifact_diagnostics_distinguish_missing_non_executable_hash_and_identity() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temporary = tempfile::tempdir().expect("temporary runtime directory");
+        let artifact = temporary.path().join("homeboy");
+        let missing = verify_artifact(&artifact, "00", "homeboy test+one")
+            .expect_err("missing artifact fails");
+        assert!(missing.message.contains("missing"));
+
+        fs::write(&artifact, b"not executable").expect("write artifact");
+        let non_executable = verify_artifact(&artifact, "00", "homeboy test+one")
+            .expect_err("non-executable artifact fails");
+        assert!(non_executable.message.contains("not executable"));
+
+        let digest = fake_controller(&artifact, "homeboy test+one", "artifact");
+        let hash =
+            verify_artifact(&artifact, "00", "homeboy test+one").expect_err("hash mismatch fails");
+        assert!(hash.message.contains("hash mismatch"));
+        let identity = verify_artifact(&artifact, &digest, "homeboy test+two")
+            .expect_err("identity mismatch fails");
+        assert!(identity.message.contains("build identity mismatch"));
+        fs::set_permissions(&artifact, fs::Permissions::from_mode(0o500)).expect("seal artifact");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn durable_pin_rejects_a_matching_hash_with_the_wrong_build_identity() {
+        let temporary = tempfile::tempdir().expect("temporary runtime directory");
+        let pinned = temporary.path().join("homeboy");
+        let digest = fake_controller(&pinned, "homeboy 0.288.4+older", "wrong identity");
+        make_executable_read_only(&pinned).expect("seal executable");
+        let runtime = json!({ "originating": {
+            "build_identity": "homeboy 0.288.6+expected",
+            "pinned_executable": pinned,
+            "sha256": digest,
+        }});
+
+        let error =
+            validate_pin(&runtime).expect_err("identity mismatch must fail after hash validation");
+
+        assert!(error.message.contains("build identity mismatch"));
+        assert!(error.message.contains("homeboy 0.288.6+expected"));
+        assert!(error.message.contains("homeboy 0.288.4+older"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn recovery_preserves_runtime_a_after_generation_b_activation() {
+        use std::os::unix::fs::PermissionsExt;
+
+        crate::test_support::with_isolated_home(|_| {
+            let temporary = tempfile::tempdir().expect("temporary controller directory");
+            let artifact_a = temporary.path().join("homeboy-a");
+            let artifact_b = temporary.path().join("homeboy-b");
+            let identity_a = "homeboy test+runtime-a";
+            let identity_b = "homeboy test+runtime-b";
+            let digest_a = fake_controller(&artifact_a, identity_a, "runtime A");
+            let digest_b = fake_controller(&artifact_b, identity_b, "runtime B");
+            let pin_a = pinned_path(identity_a, &digest_a).expect("runtime A path");
+            let pin_b = pinned_path(identity_b, &digest_b).expect("runtime B path");
+            publish_pin(&artifact_a, &pin_a, &digest_a).expect("publish runtime A");
+            let runtime_a = json!({ "originating": {
+                "build_identity": identity_a,
+                "pinned_executable": pin_a,
+                "sha256": digest_a,
+            }});
+            validate_pin(&runtime_a).expect("runtime A validates before upgrade");
+            let runtime_a_bytes = fs::read(&pin_a).expect("read runtime A");
+
+            publish_pin(&artifact_b, &pin_b, &digest_b).expect("publish runtime B");
+            let runtime_b = json!({ "originating": {
+                "build_identity": identity_b,
+                "pinned_executable": pin_b,
+                "sha256": digest_b,
+            }});
+            write_active_generation(
+                &runtime_root()
+                    .expect("runtime root")
+                    .join(ACTIVE_GENERATION_FILE),
+                &runtime_b,
+            )
+            .expect("activate runtime B");
+            assert_eq!(
+                fs::read(&pin_a).expect("read runtime A after upgrade"),
+                runtime_a_bytes
+            );
+            validate_pin(&runtime_a)
+                .expect("runtime A remains executable after runtime B activation");
+
+            fs::set_permissions(&pin_a, fs::Permissions::from_mode(0o700))
+                .expect("allow test corruption");
+            fs::write(&pin_a, b"corrupted runtime A").expect("corrupt runtime A");
+            let error = validate_pin(&runtime_a).expect_err("corruption fails closed");
+            assert!(error.message.contains("hash mismatch"));
+            assert!(error.message.contains(&digest_a));
+
+            let recovered = recover_pin(&runtime_a, Some(&artifact_a), None)
+                .expect("recover runtime A from trusted artifact");
+            let recovered_pin = PathBuf::from(
+                recovered["originating"]["pinned_executable"]
+                    .as_str()
+                    .expect("recovered runtime A path"),
+            );
+            assert_ne!(recovered_pin, pin_a);
+            assert_eq!(
+                fs::read(&recovered_pin).expect("read recovered runtime A"),
+                runtime_a_bytes
+            );
+            validate_pin(&recovered).expect("recovered runtime A validates");
         });
     }
 }

--- a/crates/homeboy-core/src/runner/mod.rs
+++ b/crates/homeboy-core/src/runner/mod.rs
@@ -110,8 +110,8 @@ pub use connection::{
     reverse_broker_artifact_content, reverse_broker_reconcile, runner_artifact_content, status,
     statuses,
 };
-pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
 pub use continuation_provider::register as register_runner_continuation_provider;
+pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
 pub use evidence::register_runner_evidence_provider;
 pub use evidence::runner_artifact_store_token;
 pub use evidence::{


### PR DESCRIPTION
## Summary

- store controller runtime snapshots at content-addressed, no-clobber paths
- validate pinned bytes and structured build identity before lifecycle mutations
- add explicit trusted recovery plus retention-aware pruning for nonterminal runs
- integrate immutable pins with the existing pinned-runtime resume path

Closes #8544.

## Why

A queued durable run could retain a path and SHA-256 that still resolved successfully while the executable at that path reported a different Homeboy build identity. The active runtime and the suggested pinned runtime then both failed strict lifecycle validation, permanently stranding the run.

## Compatibility

This changes the internal controller-runtime pin layout from identity-only directories to identity-plus-digest directories. Existing durable v2 records are migrated to immutable content-addressed snapshots before mutation. Strict identity validation remains fail-closed. The new `homeboy runtime controller-prune` command retains pins referenced by nonterminal runs and the active generation.

No extension API or provider contract changes.

## How to test

1. Run `cargo fmt --all -- --check`.
2. Run `cargo test -p homeboy-core controller_runtime::tests --lib --no-fail-fast`; expect 10 passing tests.
3. Run `cargo check -p homeboy-cli`.
4. Create runtime A, submit a queued run, and activate runtime B; verify A remains byte-identical and executable.
5. Corrupt A; verify mutation fails with the expected and actual SHA-256 values.
6. Recover A from an explicitly supplied trusted artifact; verify the run validates through a new immutable recovery snapshot.
7. Run `homeboy runtime controller-prune` and verify the queued run pin is retained; terminal unreferenced pins are only removed with `--apply`.

## Evidence

- Reproduction: durable run `agent-task-f3d554f9-36e2-4da7-81a1-fd2e0107b4ed` recorded `homeboy 0.288.6+05f528c22487-dirty`, but its matching-SHA pinned executable reported `homeboy 0.288.4+7a852c093514`.
- Focused controller-runtime suite: 10 passed, 0 failed.
- `cargo check -p homeboy-cli`: passed.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the durable runtime mismatch, completed and rebased the immutable pin implementation, resolved integration conflicts, and verified the focused runtime and CLI checks. Chris reviews and owns the change.