### PR TITLE
refactor: route hygiene workspace snapshot through a hook

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -129,6 +129,10 @@ impl CliRuntime {
         // Register the runner-upgrade provider so the core upgrade flow can
         // refresh configured runners without depending on runner behavior.
         crate::core::upgrade::register_runner_upgrade();
+        // Register the workspace-snapshot provider so core's hygiene subsystem
+        // can materialize an isolated validation-dependency workspace without
+        // depending on runner behavior.
+        crate::core::runner::register_workspace_snapshot_provider();
         // Register the command-label resolver so core::runner can map dispatched
         // argv to a hot-command label without depending on the full CLI parser.
         crate::core::runner::set_command_label_resolver(|argv| {

--- a/crates/homeboy-core/src/hygiene.rs
+++ b/crates/homeboy-core/src/hygiene.rs
@@ -631,7 +631,7 @@ fn run_validation_dependency_lifecycle_isolated(component: &Component, path: &Pa
         .into_iter()
         .map(str::to_string)
         .collect::<Vec<_>>();
-    crate::runner::copy_snapshot_to_directory(path, &prepared_path, &excludes)?;
+    crate::workspace_snapshot::copy_snapshot_to_directory(path, &prepared_path, &excludes)?;
 
     let mut prepared = component.clone();
     prepared.local_path = prepared_path.display().to_string();
@@ -906,6 +906,13 @@ mod tests {
         git(path, &["commit", "-m", "initial"]);
     }
 
+    /// Register the runner-backed workspace-snapshot provider so tests that run
+    /// an isolated validation-dependency lifecycle can materialize the snapshot.
+    /// Production wires this at CLI startup; core tests wire it explicitly.
+    fn ensure_snapshot_provider() {
+        crate::runner::register_workspace_snapshot_provider();
+    }
+
     fn init_repo_with_upstream(path: &Path) -> tempfile::TempDir {
         let remote = tempfile::tempdir().unwrap();
         init_repo(path);
@@ -920,6 +927,7 @@ mod tests {
 
     #[test]
     fn dependency_hygiene_fast_forwards_validation_dependency_behind_upstream() {
+        ensure_snapshot_provider();
         let local = tempfile::tempdir().unwrap();
         let remote = tempfile::tempdir().unwrap();
         let writer = tempfile::tempdir().unwrap();
@@ -1006,6 +1014,7 @@ mod tests {
 
     #[test]
     fn dependency_hygiene_allows_stale_with_explicit_opt_in() {
+        ensure_snapshot_provider();
         let local = tempfile::tempdir().unwrap();
         init_repo(local.path());
         fs::write(local.path().join("dirty.txt"), "dirty\n").unwrap();
@@ -1115,6 +1124,7 @@ mod tests {
 
     #[test]
     fn dependency_hygiene_runs_validation_dependency_lifecycle() {
+        ensure_snapshot_provider();
         crate::test_support::with_isolated_home(|_| {
             let workspace_parent = tempfile::tempdir().unwrap();
             let source = workspace_parent.path().join("source");
@@ -1170,6 +1180,7 @@ mod tests {
 
     #[test]
     fn dependency_hygiene_uses_manifest_id_for_runtime_path_dependency_lifecycle() {
+        ensure_snapshot_provider();
         crate::test_support::with_isolated_home(|_| {
             let source = tempfile::tempdir().unwrap();
             let dependency = tempfile::tempdir().unwrap();

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -230,6 +230,7 @@ pub mod test_support;
 pub mod update_check_cache;
 pub mod upgrade;
 pub mod validation_progress;
+pub mod workspace_snapshot;
 pub mod worktree;
 pub mod worktree_providers;
 

--- a/crates/homeboy-core/src/runner/mod.rs
+++ b/crates/homeboy-core/src/runner/mod.rs
@@ -76,6 +76,7 @@ mod worker;
 pub(crate) mod workload;
 mod workspace;
 pub(crate) use workspace::copy_snapshot_to_directory;
+pub use workspace::register_workspace_snapshot_provider;
 // Only test code (extension::trace::canonicality) still calls verify_lab_workspace
 // directly; production goes through the LabWorkspaceProvenanceProvider hook.
 #[cfg(test)]

--- a/crates/homeboy-core/src/runner/workspace/mod.rs
+++ b/crates/homeboy-core/src/runner/workspace/mod.rs
@@ -12,6 +12,7 @@ mod materializer;
 mod provenance;
 mod pull;
 mod snapshot;
+mod snapshot_provider;
 mod sync;
 mod types;
 mod util;
@@ -41,6 +42,7 @@ pub(crate) use provenance::{
     materialize_verified_lab_snapshot_git_baseline, verify_lab_workspace,
     verify_lab_workspace_from_env, verify_lab_workspace_git_root, VerifiedLabWorkspaceProvenance,
 };
+pub use snapshot_provider::register as register_workspace_snapshot_provider;
 pub(crate) use snapshot::{
     copy_snapshot_to_directory, effective_snapshot_excludes, local_snapshot_stats,
     materialize_snapshot, materialize_snapshot_git, snapshot_identity, workspace_content_hash,

--- a/crates/homeboy-core/src/runner/workspace/snapshot_provider.rs
+++ b/crates/homeboy-core/src/runner/workspace/snapshot_provider.rs
@@ -1,0 +1,33 @@
+//! Runner-side implementation of core's `WorkspaceSnapshotProvider` hook.
+//!
+//! Core's hygiene subsystem materializes a local directory snapshot when
+//! running validation-dependency lifecycles in isolation. That copy is the
+//! runner's tar-pipe snapshot machinery, so this adapter delegates to
+//! `snapshot::copy_snapshot_to_directory` without core depending on runner
+//! behavior directly.
+
+use std::path::Path;
+
+use crate::error::Result;
+use crate::workspace_snapshot::WorkspaceSnapshotProvider;
+
+/// The runner layer's `WorkspaceSnapshotProvider`. Registered with core at startup.
+pub struct RunnerWorkspaceSnapshot;
+
+impl WorkspaceSnapshotProvider for RunnerWorkspaceSnapshot {
+    fn copy_snapshot_to_directory(
+        &self,
+        local_path: &Path,
+        destination: &Path,
+        excludes: &[String],
+    ) -> Result<()> {
+        super::snapshot::copy_snapshot_to_directory(local_path, destination, excludes)
+    }
+}
+
+/// Register the runner workspace-snapshot provider with core. Called once at startup.
+pub fn register() {
+    crate::workspace_snapshot::register_workspace_snapshot_provider(Box::new(
+        RunnerWorkspaceSnapshot,
+    ));
+}

--- a/crates/homeboy-core/src/workspace_snapshot.rs
+++ b/crates/homeboy-core/src/workspace_snapshot.rs
@@ -1,0 +1,74 @@
+//! Workspace-snapshot hook.
+//!
+//! Materializing a local directory snapshot into a prepared directory (an
+//! archive-and-extract copy that honors exclude globs) is runner-workspace
+//! machinery: it shares the runner's tar-pipe materializer with SSH/local
+//! offload. Core's hygiene subsystem needs the same local-copy operation to
+//! run validation-dependency lifecycles in an isolated workspace, so instead
+//! of depending on the runner subsystem directly it calls this provider.
+//!
+//! When the runner subsystem is absent no provider is registered and the
+//! [`NoopProvider`] errors clearly.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use crate::error::{Error, Result};
+
+/// Local workspace-snapshot materialization the hygiene subsystem depends on.
+pub trait WorkspaceSnapshotProvider: Send + Sync {
+    /// Archive the directory at `local_path` and extract it into `destination`,
+    /// honoring the given exclude globs.
+    fn copy_snapshot_to_directory(
+        &self,
+        local_path: &Path,
+        destination: &Path,
+        excludes: &[String],
+    ) -> Result<()>;
+}
+
+/// Default provider used when the runner subsystem is not present.
+struct NoopProvider;
+
+impl WorkspaceSnapshotProvider for NoopProvider {
+    fn copy_snapshot_to_directory(
+        &self,
+        _local_path: &Path,
+        _destination: &Path,
+        _excludes: &[String],
+    ) -> Result<()> {
+        Err(Error::internal_unexpected(
+            "runner subsystem is unavailable: cannot materialize a local workspace snapshot",
+        ))
+    }
+}
+
+fn provider_slot() -> &'static Mutex<Option<Box<dyn WorkspaceSnapshotProvider>>> {
+    static PROVIDER: Mutex<Option<Box<dyn WorkspaceSnapshotProvider>>> = Mutex::new(None);
+    &PROVIDER
+}
+
+/// Register the workspace-snapshot provider. Called once at startup by the
+/// runner subsystem when it is present.
+pub fn register_workspace_snapshot_provider(provider: Box<dyn WorkspaceSnapshotProvider>) {
+    let mut slot = provider_slot()
+        .lock()
+        .expect("workspace snapshot provider lock");
+    *slot = Some(provider);
+}
+
+/// Copy a local directory snapshot into `destination`, delegating to the
+/// registered provider (or erroring via the no-op provider when absent).
+pub(crate) fn copy_snapshot_to_directory(
+    local_path: &Path,
+    destination: &Path,
+    excludes: &[String],
+) -> Result<()> {
+    let slot = provider_slot()
+        .lock()
+        .expect("workspace snapshot provider lock");
+    match slot.as_deref() {
+        Some(provider) => provider.copy_snapshot_to_directory(local_path, destination, excludes),
+        None => NoopProvider.copy_snapshot_to_directory(local_path, destination, excludes),
+    }
+}


### PR DESCRIPTION
## Summary
- Inverts the **last production `core -> runner` edge in the hygiene subsystem** behind a new `WorkspaceSnapshotProvider` hook. `hygiene` materialized an isolated validation-dependency workspace by calling `crate::runner::copy_snapshot_to_directory` directly; that call now goes through a registered provider (runner-side impl registered at CLI startup). `hygiene` is now free of runner references.
- Adds `crate::workspace_snapshot` (trait + registry + no-op provider) in core, and `runner/workspace/snapshot_provider.rs` (runner-side impl delegating to the existing tar-pipe `snapshot::copy_snapshot_to_directory`).

## Why
Part of the staged runner-subsystem extraction. This is a behavior-inversion (hook), not a relocation: the tar-pipe snapshot copy is genuine runner-workspace machinery — it shares the runner's `WorkspaceMaterializer` with SSH/local offload and is used by `git.rs` too — so it stays in runner and hygiene delegates. On a single-machine install no provider is registered; the no-op provider errors clearly if an isolated validation-dependency lifecycle is attempted.

## Testing
- `cargo check -p homeboy-core --lib` / `--tests` — clean
- `cargo check -p homeboy-cli --lib` — clean
- `cargo test -p homeboy-core --lib 'hygiene::tests'` — 21 passed (the 4 validation-dependency-lifecycle tests register the runner provider in-test, matching the established hook pattern)
- Full `--workspace` suite via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)