### PR TITLE
Recover legacy patches through canonical runner artifacts

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/artifact_materialization.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/artifact_materialization.rs
@@ -1,7 +1,6 @@
 use std::fs;
 use std::path::PathBuf;
 
-use base64::Engine;
 use serde_json::json;
 use sha2::{Digest, Sha256};
 
@@ -9,12 +8,6 @@ use crate::agent_task::AgentTaskArtifact;
 use crate::{Error, Result};
 
 use super::{apply_aggregate_to_record, status, store};
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct RunnerArtifactRoute {
-    runner_id: String,
-    job_id: String,
-}
 
 /// Materialize a recovered reverse-runner patch into controller-owned storage.
 /// The aggregate is updated atomically with the durable run record, making a
@@ -37,16 +30,30 @@ pub fn materialize_recovered_patch_artifact(
             {
                 continue;
             }
-            let route = resolve_runner_artifact_route(&record, artifact)?;
-            changed |= materialize_artifact(
-                artifact,
-                &route.runner_id,
-                &route.job_id,
+            let runner_id = record.runner_id().ok_or_else(|| {
+                unavailable(
+                    artifact,
+                    "no validated source-provenance runner is recorded for the aggregate",
+                )
+            })?;
+            let remote_ref = canonical_runner_artifact_ref(
+                runner_id,
                 &record.run_id,
                 &outcome.task_id,
-                |id| {
+                artifact,
+            )?;
+            changed |= materialize_artifact(
+                artifact,
+                runner_id,
+                &remote_ref,
+                &record.run_id,
+                &outcome.task_id,
+                |remote_ref| {
                     crate::observation::runs_service::runner_evidence::with_runner_evidence(|p| {
-                        p.runner_artifact_content(&route.runner_id, &route.job_id, id)
+                        p.download_remote_artifact(remote_ref, None)
+                    })
+                    .and_then(|download| {
+                        fs::read(&download.output_path).map_err(io_error(&download.output_path))
                     })
                 },
             )?;
@@ -69,54 +76,38 @@ pub fn materialize_recovered_patch_artifact(
     Ok(changed)
 }
 
-fn resolve_runner_artifact_route(
-    record: &super::AgentTaskRunRecord,
+fn canonical_runner_artifact_ref(
+    runner_id: &str,
+    run_id: &str,
+    task_id: &str,
     artifact: &AgentTaskArtifact,
-) -> Result<RunnerArtifactRoute> {
-    let lifecycle_route =
-        record
-            .runner_id()
-            .zip(record.runner_job_id())
-            .map(|(runner_id, job_id)| RunnerArtifactRoute {
-                runner_id: runner_id.to_string(),
-                job_id: job_id.to_string(),
-            });
-    let mirrored_identities = if lifecycle_route.is_none() {
-        crate::observation::runs_service::mirrored_runner_job_identities(&record.run_id)?
-    } else {
-        Vec::new()
-    };
-    resolve_runner_artifact_route_from_identities(artifact, lifecycle_route, mirrored_identities)
-}
+) -> Result<String> {
+    use crate::execution_contract::encode_uri_component;
 
-fn resolve_runner_artifact_route_from_identities(
-    artifact: &AgentTaskArtifact,
-    lifecycle_route: Option<RunnerArtifactRoute>,
-    mirrored_identities: Vec<(String, String)>,
-) -> Result<RunnerArtifactRoute> {
-    let mut routes = lifecycle_route.into_iter().collect::<Vec<_>>();
-    if routes.is_empty() {
-        routes = mirrored_identities
-            .into_iter()
-            .map(|(runner_id, job_id)| RunnerArtifactRoute { runner_id, job_id })
-            .collect();
+    let canonical_url = format!(
+        "homeboy://agent-task/run/{}/artifacts#task={}&artifact={}",
+        encode_uri_component(run_id),
+        encode_uri_component(task_id),
+        encode_uri_component(&artifact.id),
+    );
+    if artifact.url.as_deref() != Some(canonical_url.as_str()) {
+        return Err(unavailable(
+            artifact,
+            "aggregate does not retain its canonical agent-task artifact route",
+        ));
     }
-    routes.sort();
-    routes.dedup();
-    match routes.as_slice() {
-        [route] => Ok(route.clone()),
-        [] => Err(unavailable(artifact, "no authenticated runner/job binding exists in lifecycle or mirrored runner evidence")),
-        _ => Err(unavailable(artifact, "multiple conflicting authenticated runner/job bindings exist in lifecycle or mirrored runner evidence")),
-    }
+    Ok(crate::execution_contract::EXECUTION_CONTRACT
+        .artifacts
+        .runner_artifact_ref(runner_id, run_id, &artifact.id))
 }
 
 fn materialize_artifact(
     artifact: &mut AgentTaskArtifact,
     runner_id: &str,
-    job_id: &str,
+    remote_ref: &str,
     run_id: &str,
     task_id: &str,
-    fetch: impl FnOnce(&str) -> Result<serde_json::Value>,
+    fetch: impl FnOnce(&str) -> Result<Vec<u8>>,
 ) -> Result<bool> {
     if let Some(path) = artifact
         .path
@@ -140,26 +131,7 @@ fn materialize_artifact(
         artifact.path = Some(path.display().to_string());
         return Ok(false);
     }
-    let response = fetch(&artifact.id)?;
-    let encoded = response
-        .get("content_base64")
-        .and_then(serde_json::Value::as_str)
-        .ok_or_else(|| {
-            unavailable(
-                artifact,
-                "runner job result has no mirrored artifact content",
-            )
-        })?;
-    let bytes = base64::engine::general_purpose::STANDARD
-        .decode(encoded)
-        .map_err(|error| {
-            Error::validation_invalid_argument(
-                "artifact",
-                format!("runner artifact content is not valid base64: {error}"),
-                None,
-                None,
-            )
-        })?;
+    let bytes = fetch(remote_ref)?;
     validate_bytes(artifact, &bytes)?;
     fs::create_dir_all(path.parent().expect("materialized artifact parent"))
         .map_err(io_error(path.parent().unwrap()))?;
@@ -172,9 +144,9 @@ fn materialize_artifact(
     }
     artifact.metadata["controller_artifact_materialization"] = json!({
         "runner_id": runner_id,
-        "runner_job_id": job_id,
         "artifact_id": artifact.id,
-        "source": "runner_terminal_artifact_content",
+        "source": "runner_canonical_artifact_content",
+        "source_ref": remote_ref,
         "verified_size_bytes": expected_size,
         "verified_sha256": expected_sha,
     });
@@ -270,54 +242,22 @@ mod tests {
     }
 
     #[test]
-    fn route_selection_prefers_lifecycle_and_fails_closed_for_missing_or_ambiguous_mirrors() {
+    fn canonical_route_requires_the_aggregate_artifact_identity() {
         let value = artifact(b"patch bytes");
-        let lifecycle = RunnerArtifactRoute {
-            runner_id: "lifecycle-runner".to_string(),
-            job_id: "lifecycle-job".to_string(),
-        };
         assert_eq!(
-            resolve_runner_artifact_route_from_identities(
-                &value,
-                Some(lifecycle.clone()),
-                vec![("mirror-runner".to_string(), "mirror-job".to_string())],
-            )
-            .expect("lifecycle route wins"),
-            lifecycle
+            canonical_runner_artifact_ref("runner", "run", "task", &value)
+                .expect_err("missing canonical route")
+                .message,
+            "Invalid argument 'artifact': recovered runner artifact `patch` cannot be materialized: aggregate does not retain its canonical agent-task artifact route"
         );
+        let mut value = value;
+        value.url =
+            Some("homeboy://agent-task/run/run/artifacts#task=task&artifact=patch".to_string());
         assert_eq!(
-            resolve_runner_artifact_route_from_identities(
-                &value,
-                None,
-                vec![("mirror-runner".to_string(), "mirror-job".to_string())],
-            )
-            .expect("single mirror route"),
-            RunnerArtifactRoute {
-                runner_id: "mirror-runner".to_string(),
-                job_id: "mirror-job".to_string(),
-            }
+            canonical_runner_artifact_ref("runner", "run", "task", &value)
+                .expect("canonical runner ref"),
+            "runner-artifact://runner/run/patch"
         );
-
-        let missing = resolve_runner_artifact_route_from_identities(&value, None, Vec::new())
-            .expect_err("missing route fails closed");
-        assert_eq!(missing.code, crate::ErrorCode::ValidationInvalidArgument);
-        assert!(missing
-            .message
-            .contains("no authenticated runner/job binding"));
-
-        let ambiguous = resolve_runner_artifact_route_from_identities(
-            &value,
-            None,
-            vec![
-                ("runner-a".to_string(), "job-a".to_string()),
-                ("runner-b".to_string(), "job-b".to_string()),
-            ],
-        )
-        .expect_err("ambiguous routes fail closed");
-        assert_eq!(ambiguous.code, crate::ErrorCode::ValidationInvalidArgument);
-        assert!(ambiguous
-            .message
-            .contains("multiple conflicting authenticated runner/job bindings"));
     }
 
     #[test]
@@ -327,22 +267,18 @@ mod tests {
         std::env::set_var("HOMEBOY_ARTIFACT_ROOT", root.path());
         let bytes = b"mirrored patch bytes";
         let mut value = artifact(bytes);
-        let route = resolve_runner_artifact_route_from_identities(
-            &value,
-            None,
-            vec![("mirror-runner".to_string(), "mirror-job".to_string())],
-        )
-        .expect("select mirrored route");
+        value.url =
+            Some("homeboy://agent-task/run/run/artifacts#task=task&artifact=patch".to_string());
+        let remote_ref = canonical_runner_artifact_ref("mirror-runner", "run", "task", &value)
+            .expect("canonical route");
 
         assert!(materialize_artifact(
             &mut value,
-            &route.runner_id,
-            &route.job_id,
+            "mirror-runner",
+            &remote_ref,
             "run",
             "task",
-            |_| Ok(
-                json!({ "content_base64": base64::engine::general_purpose::STANDARD.encode(bytes) })
-            ),
+            |_| Ok(bytes.to_vec()),
         )
         .expect("materialize mirrored artifact"));
         let path = PathBuf::from(value.path.as_deref().expect("controller path"));
@@ -352,8 +288,8 @@ mod tests {
             "mirror-runner"
         );
         assert_eq!(
-            value.metadata["controller_artifact_materialization"]["runner_job_id"],
-            "mirror-job"
+            value.metadata["controller_artifact_materialization"]["source"],
+            "runner_canonical_artifact_content"
         );
         assert_eq!(
             value.metadata["controller_artifact_materialization"]["verified_size_bytes"],
@@ -373,18 +309,24 @@ mod tests {
         std::env::set_var("HOMEBOY_ARTIFACT_ROOT", root.path());
         let bytes = b"patch bytes";
         let mut value = artifact(bytes);
-        assert!(
-            materialize_artifact(&mut value, "lab", "job", "run", "task", |_| Ok(
-                json!({ "content_base64": base64::engine::general_purpose::STANDARD.encode(bytes) })
-            ),)
-            .expect("materialize")
-        );
-        assert!(
-            !materialize_artifact(&mut value, "lab", "job", "run", "task", |_| panic!(
-                "must reuse controller artifact"
-            ),)
-            .expect("replay")
-        );
+        assert!(materialize_artifact(
+            &mut value,
+            "lab",
+            "runner-artifact://lab/run/patch",
+            "run",
+            "task",
+            |_| Ok(bytes.to_vec()),
+        )
+        .expect("materialize"));
+        assert!(!materialize_artifact(
+            &mut value,
+            "lab",
+            "runner-artifact://lab/run/patch",
+            "run",
+            "task",
+            |_| panic!("must reuse controller artifact"),
+        )
+        .expect("replay"));
         std::env::remove_var("HOMEBOY_ARTIFACT_ROOT");
     }
 
@@ -394,7 +336,15 @@ mod tests {
         let root = tempfile::tempdir().expect("tempdir");
         std::env::set_var("HOMEBOY_ARTIFACT_ROOT", root.path());
         let mut value = artifact(b"expected");
-        let error = materialize_artifact(&mut value, "lab", "job", "run", "task", |_| Ok(json!({ "content_base64": base64::engine::general_purpose::STANDARD.encode(b"wrong") }))).expect_err("integrity failure");
+        let error = materialize_artifact(
+            &mut value,
+            "lab",
+            "runner-artifact://lab/run/patch",
+            "run",
+            "task",
+            |_| Ok(b"wrong".to_vec()),
+        )
+        .expect_err("integrity failure");
         assert!(error.message.contains("mismatch"));
         std::env::remove_var("HOMEBOY_ARTIFACT_ROOT");
     }
@@ -407,12 +357,15 @@ mod tests {
         let mut value = artifact(b"local patch");
         value.path = Some(source.display().to_string());
 
-        assert!(
-            !materialize_artifact(&mut value, "lab", "job", "run", "task", |_| panic!(
-                "must preserve a usable local artifact"
-            ),)
-            .expect("local artifact")
-        );
+        assert!(!materialize_artifact(
+            &mut value,
+            "lab",
+            "runner-artifact://lab/run/patch",
+            "run",
+            "task",
+            |_| panic!("must preserve a usable local artifact"),
+        )
+        .expect("local artifact"));
         assert_eq!(value.path.as_deref(), source.to_str());
     }
 }

--- a/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
@@ -551,6 +551,35 @@ pub(crate) fn record_terminal_artifact_projection(
     record: &mut AgentTaskRunRecord,
     aggregate: &AgentTaskAggregate,
 ) -> Result<()> {
+    if record.runner_id().is_none()
+        && aggregate
+            .outcomes
+            .iter()
+            .flat_map(|outcome| &outcome.artifacts)
+            .any(|artifact| {
+                artifact
+                    .path
+                    .as_deref()
+                    .is_some_and(|path| Path::new(path).is_absolute())
+                    && artifact.size_bytes.is_some()
+                    && artifact.sha256.is_some()
+            })
+    {
+        match runner_id_from_artifact_provenance(aggregate) {
+            Ok(runner_id) => {
+                record
+                    .ensure_metadata_object()
+                    .insert("runner_id".to_string(), json!(runner_id));
+            }
+            Err(error) => {
+                record.ensure_metadata_object().insert(
+                    "artifact_projection".to_string(),
+                    json!({ "status": "pending", "error": error.message }),
+                );
+                return store::write_record(record);
+            }
+        }
+    }
     match project_terminal_artifacts(record, aggregate) {
         Ok(()) => {
             record.ensure_metadata_object().insert(
@@ -566,6 +595,136 @@ pub(crate) fn record_terminal_artifact_projection(
         }
     }
     store::write_record(record)
+}
+
+/// Recover the only runner identity trusted by legacy aggregate artifact
+/// provenance. Every unresolved absolute artifact must agree so controller
+/// reconciliation cannot treat a runner path as a local file.
+fn runner_id_from_artifact_provenance(aggregate: &AgentTaskAggregate) -> Result<String> {
+    let runner_ids = aggregate
+        .outcomes
+        .iter()
+        .flat_map(|outcome| &outcome.artifacts)
+        .filter(|artifact| {
+            artifact.path.as_deref().is_some_and(|path| Path::new(path).is_absolute())
+                && artifact.size_bytes.is_some()
+                && artifact.sha256.is_some()
+        })
+        .map(|artifact| {
+            artifact
+                .metadata
+                .pointer("/source_provenance/runner_id")
+                .and_then(Value::as_str)
+                .filter(|runner_id| !runner_id.trim().is_empty())
+                .map(str::to_string)
+                .ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "artifact.metadata.source_provenance.runner_id",
+                        "cannot recover a controller artifact projection without unambiguous runner provenance",
+                        Some(artifact.id.clone()),
+                        None,
+                    )
+                })
+        })
+        .collect::<Result<std::collections::BTreeSet<_>>>()?;
+    match runner_ids.into_iter().collect::<Vec<_>>().as_slice() {
+        [runner_id] => Ok(runner_id.clone()),
+        _ => Err(Error::validation_invalid_argument(
+            "artifact.metadata.source_provenance.runner_id",
+            "cannot recover a controller artifact projection without unambiguous runner provenance",
+            None,
+            None,
+        )),
+    }
+}
+
+pub(crate) fn terminal_artifact_projection_is_verified(
+    record: &AgentTaskRunRecord,
+    aggregate: &AgentTaskAggregate,
+) -> Result<bool> {
+    for outcome in &aggregate.outcomes {
+        for artifact in &outcome.artifacts {
+            if artifact.path.is_some() && artifact.size_bytes.is_some() && artifact.sha256.is_some()
+            {
+                if verified_controller_artifact_projection_path(
+                    &record.run_id,
+                    &outcome.task_id,
+                    artifact,
+                )?
+                .is_none()
+                {
+                    return Ok(false);
+                }
+            }
+        }
+    }
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn artifact(runner_id: Option<&str>) -> AgentTaskArtifact {
+        AgentTaskArtifact {
+            schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+            id: "patch".to_string(),
+            kind: "patch".to_string(),
+            name: None,
+            label: None,
+            role: None,
+            semantic_key: None,
+            path: Some("/runner/patch.diff".to_string()),
+            url: None,
+            mime: None,
+            size_bytes: Some(1),
+            sha256: Some("a".repeat(64)),
+            metadata: runner_id.map_or_else(
+                || json!({}),
+                |runner_id| json!({ "source_provenance": { "runner_id": runner_id } }),
+            ),
+        }
+    }
+
+    #[test]
+    fn legacy_runner_provenance_requires_one_consistent_value() {
+        let mut aggregate = AgentTaskAggregate {
+            schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+            plan_id: "plan".to_string(),
+            status: AgentTaskAggregateStatus::Succeeded,
+            totals: AgentTaskAggregateTotals::default(),
+            outcomes: Vec::new(),
+            events: Vec::new(),
+            artifact_lineage: Vec::new(),
+            child_runs: Vec::new(),
+            artifact_bindings: Vec::new(),
+            queue: AgentTaskQueueStatus::default(),
+        };
+        aggregate.outcomes.push(AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: "task".to_string(),
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: None,
+            failure_classification: None,
+            artifacts: vec![artifact(Some("runner-a")), artifact(Some("runner-b"))],
+            typed_artifacts: Vec::new(),
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            outputs: Value::Null,
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        });
+
+        assert!(runner_id_from_artifact_provenance(&aggregate).is_err());
+        aggregate.outcomes[0].artifacts[1] = artifact(Some("runner-a"));
+        assert_eq!(
+            runner_id_from_artifact_provenance(&aggregate).expect("consistent provenance"),
+            "runner-a"
+        );
+        aggregate.outcomes[0].artifacts[1] = artifact(None);
+        assert!(runner_id_from_artifact_provenance(&aggregate).is_err());
+    }
 }
 
 /// Project finalized executor artifacts into the standard observation registry.

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -520,20 +520,16 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
             );
         }
     }
-    if is_terminal_run_state(record.state)
-        && record
-            .metadata
-            .get("artifact_projection")
-            .and_then(Value::as_object)
-            .and_then(|value| value.get("status"))
-            .and_then(Value::as_str)
-            != Some("complete")
-    {
+    if is_terminal_run_state(record.state) {
         if let Ok(aggregate) = store::read_aggregate(&record.run_id) {
-            crate::agent_task_lifecycle::record_terminal_artifact_projection(
-                &mut record,
-                &aggregate,
-            )?;
+            if !crate::agent_task_lifecycle::terminal_artifact_projection_is_verified(
+                &record, &aggregate,
+            )? {
+                crate::agent_task_lifecycle::record_terminal_artifact_projection(
+                    &mut record,
+                    &aggregate,
+                )?;
+            }
         }
     }
     // Read-side reconciliation only writes the durable continuation signal.

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -1636,7 +1636,10 @@ fn recovery_preserves_terminal_runner_identity_before_projecting_runner_artifact
             role: None,
             semantic_key: None,
             path: Some("/home/runner/.homeboy/executor-finalized/patch.diff".to_string()),
-            url: None,
+            url: Some(
+                "homeboy://agent-task/run/detached-run/artifacts#task=task-a&artifact=patch"
+                    .to_string(),
+            ),
             mime: Some("text/x-patch".to_string()),
             size_bytes: Some(patch.len() as u64),
             sha256: Some(format!("{:x}", sha2::Sha256::digest(patch.as_bytes()))),
@@ -1667,7 +1670,11 @@ fn recovery_preserves_terminal_runner_identity_before_projecting_runner_artifact
             record.metadata["runner_job_id"],
             "00000000-0000-0000-0000-000000000123"
         );
-        assert_eq!(record.metadata["artifact_projection"]["status"], "complete");
+        assert_eq!(
+            record.metadata["artifact_projection"]["status"], "complete",
+            "{:#}",
+            record.metadata
+        );
         let artifacts = crate::observation::ObservationStore::open_initialized()
             .expect("store")
             .list_artifacts(run_id)
@@ -1825,7 +1832,7 @@ fn terminal_executor_artifacts_are_projected_under_logical_ids() {
 }
 
 #[test]
-fn controller_mirrors_verified_detached_runner_artifact_into_a_local_projection() {
+fn status_backfills_legacy_runner_provenance_and_mirrors_a_verified_projection_idempotently() {
     with_isolated_home(|_| {
         use sha2::Digest;
         use std::io::{Read, Write};
@@ -1891,6 +1898,77 @@ fn controller_mirrors_verified_detached_runner_artifact_into_a_local_projection(
             serde_json::to_string(&session).expect("session JSON"),
         )
         .expect("write session");
+        struct FakeRunnerEvidence;
+        impl crate::observation::runs_service::RunnerEvidenceProvider for FakeRunnerEvidence {
+            fn mirror_connected_runner_run(
+                &self,
+                _: &str,
+            ) -> Result<Option<crate::observation::RunRecord>> {
+                Ok(None)
+            }
+            fn statuses(&self) -> Vec<crate::observation::runs_service::RunnerConnectionInfo> {
+                Vec::new()
+            }
+            fn daemon_api_get(&self, _: &str, _: &str) -> Result<Value> {
+                Ok(Value::Null)
+            }
+            fn runner_artifact_content(&self, _: &str, _: &str, _: &str) -> Result<Value> {
+                Ok(Value::Null)
+            }
+            fn runner_job_cancel(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<(crate::api_jobs::Job, Vec<crate::api_jobs::JobEvent>)> {
+                unreachable!()
+            }
+            fn refresh_mirrored_daemon_evidence(
+                &self,
+                _: &str,
+            ) -> Result<Option<Vec<crate::observation::RunRecord>>> {
+                Ok(None)
+            }
+            fn mirrored_runner_job_identity(
+                &self,
+                _: &crate::observation::RunRecord,
+            ) -> Option<(String, String)> {
+                None
+            }
+            fn download_remote_artifact(
+                &self,
+                path: &str,
+                output: Option<std::path::PathBuf>,
+            ) -> Result<crate::observation::runs_service::RemoteArtifactDownloadInfo> {
+                assert_eq!(path, "runner-artifact://local/detached-run/patch");
+                let output_path = output.unwrap_or_else(|| {
+                    crate::paths::artifact_root()
+                        .expect("artifact root")
+                        .join("fake-runner-patch")
+                });
+                std::fs::write(&output_path, b"patch bytes").expect("write fake runner bytes");
+                Ok(
+                    crate::observation::runs_service::RemoteArtifactDownloadInfo {
+                        output_path,
+                        content_type: Some("text/x-patch".to_string()),
+                        size_bytes: Some(11),
+                        sha256: Some(format!("{:x}", sha2::Sha256::digest(b"patch bytes"))),
+                        artifact_ref: homeboy_runner_contract::RunnerArtifactRef {
+                            artifact_id: "patch".to_string(),
+                            name: None,
+                            path: Some(path.to_string()),
+                            url: None,
+                            mime: Some("text/x-patch".to_string()),
+                            size_bytes: Some(11),
+                            sha256: Some(format!("{:x}", sha2::Sha256::digest(b"patch bytes"))),
+                            transport: Some("test".to_string()),
+                        },
+                    },
+                )
+            }
+        }
+        crate::observation::runs_service::register_runner_evidence_provider(Box::new(
+            FakeRunnerEvidence,
+        ));
 
         let plan = test_plan();
         let mut aggregate = succeeded_aggregate(&plan);
@@ -1907,13 +1985,38 @@ fn controller_mirrors_verified_detached_runner_artifact_into_a_local_projection(
             mime: Some("text/x-patch".to_string()),
             size_bytes: Some(patch.len() as u64),
             sha256: Some(sha256),
-            metadata: json!({ "executor_artifact_finalized": true }),
+            metadata: json!({
+                "executor_artifact_finalized": true,
+                "source_provenance": { "runner_id": "local" }
+            }),
         });
         submit_plan(&plan, Some("detached-run")).expect("submit");
-        record_runner_job_identity("detached-run", "local", "job-1").expect("runner identity");
+        record_runner_job_identity("detached-run", "local", "job-1").expect("runner setup");
         record_run_aggregate("detached-run", &plan, &aggregate).expect("reconcile aggregate");
 
+        // Match the pre-#8562 persisted shape: terminal and claimed complete,
+        // but without a controller projection or record-level runner identity.
+        let mut legacy = store::read_record("detached-run").expect("legacy record");
+        legacy.ensure_metadata_object().remove("runner_id");
+        legacy.ensure_metadata_object().remove("runner_job_id");
+        legacy.ensure_metadata_object().insert(
+            "artifact_projection".to_string(),
+            json!({ "status": "complete" }),
+        );
+        store::write_record(&legacy).expect("persist legacy record");
+        let observation =
+            crate::observation::ObservationStore::open_initialized().expect("observation store");
+        for artifact in observation
+            .list_artifacts("detached-run")
+            .expect("existing projections")
+        {
+            observation
+                .delete_artifact_record(&artifact.id)
+                .expect("remove unverified projection");
+        }
+
         let record = status("detached-run").expect("status");
+        assert_eq!(record.metadata["runner_id"], "local");
         assert_eq!(record.metadata["artifact_projection"]["status"], "complete");
         let store = crate::observation::ObservationStore::open_initialized().expect("store");
         let artifact = crate::observation::runs_service::resolve_artifact_for_run(
@@ -1926,6 +2029,19 @@ fn controller_mirrors_verified_detached_runner_artifact_into_a_local_projection(
         assert_eq!(
             std::fs::read(artifact.path).expect("projection bytes"),
             patch
+        );
+        let projection_count = store
+            .list_artifacts("detached-run")
+            .expect("initial projections")
+            .len();
+        let replay = status("detached-run").expect("idempotent status");
+        assert_eq!(replay.metadata, record.metadata);
+        assert_eq!(
+            store
+                .list_artifacts("detached-run")
+                .expect("idempotent projections")
+                .len(),
+            projection_count
         );
     });
 }

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -3946,7 +3946,9 @@ fn test_plan() -> AgentTaskPlan {
     )
 }
 
-fn terminal_child_snapshot(aggregate: &AgentTaskAggregate) -> crate::api_jobs::RunnerJobLogSnapshot {
+fn terminal_child_snapshot(
+    aggregate: &AgentTaskAggregate,
+) -> crate::api_jobs::RunnerJobLogSnapshot {
     let job_id = uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000123").expect("job id");
     crate::api_jobs::RunnerJobLogSnapshot {
         job: crate::api_jobs::Job {


### PR DESCRIPTION
## Summary
Recover pre-fix detached patch artifacts through their canonical aggregate route instead of assuming a mirrored direct job owns the same logical artifact.

## What changed
- Backfill one unambiguous runner identity from retained aggregate provenance and keep conflicting or missing provenance fail-closed.
- Materialize canonical runner artifact bytes into controller storage with existing SHA-256 and size verification.
- Recheck claimed-complete terminal projections and repair them idempotently when verified controller bytes are absent.

## How to test
1. Run `cargo test -p homeboy-core agent_task_lifecycle::artifact_materialization --lib`; expect Five canonical artifact materialization and integrity tests pass..
2. Run `cargo test -p homeboy-core status_backfills_legacy_runner_provenance --lib`; expect The persisted legacy lifecycle shape repairs idempotently..
3. Run `cargo test -p homeboy-core agent_task_promotion::tests::promotion_uses_verified_controller_projection_for_recovered_runner_aggregate_sources --lib -- --exact`; expect Promotion consumes the verified controller projection..
4. Run `rustfmt --edition 2021 --check crates/homeboy-core/src/agent_task_lifecycle/artifact_materialization.rs crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs crates/homeboy-core/src/agent_task_lifecycle/tests.rs`; expect All changed Rust files are formatted..

## Compatibility
No public API or extension-path compatibility change. Persisted detached runs gain a verified recovery path; ambiguous provenance remains blocked.

## Evidence
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8548
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/pull/8569
- artifact-materialization-tests: Passed
- changed-files-formatting: Passed
- diff-check: Passed
- legacy-status-repair-test: Passed
- promotion-test: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the live legacy-promotion failure, implemented canonical runner artifact recovery and deterministic regression coverage; Chris owns and reviews the change.

## Source relationships
- Closes Extra-Chill/homeboy#8548
