### PR TITLE
fix: green the default code_audit test tier

### DIFF
--- a/crates/homeboy-core/src/code_audit/mod.rs
+++ b/crates/homeboy-core/src/code_audit/mod.rs
@@ -185,6 +185,11 @@ mod tests {
 
     #[test]
     fn audit_config_includes_explicit_extension_overrides() {
+        // Audit reads extension manifests through the provider hook, which the
+        // CLI registers at startup. In a core lib test the CLI never runs, so
+        // register the extension-backed provider explicitly — otherwise the
+        // no-op provider is used and no saved manifest is ever seen.
+        crate::extension::audit_manifest_provider::register();
         crate::test_support::with_isolated_home(|home| {
             let mut manifest: crate::extension::ExtensionManifest =
                 serde_json::from_value(serde_json::json!({

--- a/tests/core/code_audit/audit_runtime_regression_test.rs
+++ b/tests/core/code_audit/audit_runtime_regression_test.rs
@@ -78,8 +78,14 @@ const FIXTURE_COMPONENT_ID: &str = "audit-runtime-fixture";
 
 /// Absolute path to the fixture component tree, derived from the crate root so
 /// the test is independent of the current working directory.
+///
+/// The fixture data lives at the repository-root `tests/fixtures/` tree (shared
+/// with the other `tests/core/**` harnesses that are `#[path]`-included into
+/// this crate), so we walk up from `crates/homeboy-core` (`CARGO_MANIFEST_DIR`)
+/// to the workspace root before descending into `tests/fixtures/audit_runtime`.
 fn fixture_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
         .join("tests")
         .join("fixtures")
         .join("audit_runtime")
@@ -154,6 +160,13 @@ const EXPECTED_FINDINGS: &[&str] = &[
     "unreferenced_export::src/policy_violation.rs",
 ];
 
+// Runs the full audit workflow against the fixture tree, which requires a
+// fingerprinting extension for the fixture's source language to be installed in
+// the resolved config home. That makes it a broad-machinery / real-checkout
+// test in the sense of `docs/internals/test-tiers.md`, so it lives in the slow
+// tier next to `audit_runtime_regression_is_deterministic` rather than the
+// hermetic default gate.
+#[cfg(feature = "slow-tests")]
 #[test]
 fn audit_runtime_regression_matches_snapshot() {
     let root = fixture_root();

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -319,6 +319,11 @@ fn test_compute_fixability_counts_fixes_from_real_audit() {
     // enough conventions — that's acceptable for this test.
 }
 
+// Runs the full audit-with-analysis pipeline (walk + fingerprint + detectors +
+// fixability planning) over a fixture tree, matching the broad-machinery slow
+// tier described in `docs/internals/test-tiers.md` — the same tier its sibling
+// `test_compute_fixability_counts_fixes_from_real_audit` already lives in.
+#[cfg(feature = "slow-tests")]
 #[test]
 fn test_compute_fixability_with_analysis() {
     use std::fs;


### PR DESCRIPTION
## Summary
Three `code_audit` tests failed in the default (hermetic) unit gate on a clean checkout — the ones I flagged while landing #8591. Each is root-caused and fixed distinctly, not blanket-gated.

## The three failures

**1. `audit_config_includes_explicit_extension_overrides` — real test bug (fixed).**
The audit engine now loads extension manifests through a provider hook (the same inversion pattern as the runner-evidence / tunnel hooks) that the **CLI registers at startup**. This is a core *lib* test — the CLI never runs, so the no-op provider was used and the saved fixture manifest was never seen → the merged config was empty. Fix: register the extension-backed provider explicitly in the test.

**2. `audit_runtime_regression_matches_snapshot` — latent path bug + wrong tier.**
`fixture_root()` resolved `tests/fixtures/` relative to `CARGO_MANIFEST_DIR`, which became `crates/homeboy-core` after the crate split (#8434) — so the fixture tree (still at the **repository root**) was never found (`root.is_dir()` panicked). Fix: walk up to the workspace root (`../..`), matching the existing `artifact_portability.rs` precedent. The test *also* requires a fingerprinting extension for the fixture language to be installed in the resolved config home, which makes it a broad-machinery / real-checkout test per `docs/internals/test-tiers.md` — so it's gated under `slow-tests` next to its already-gated sibling `audit_runtime_regression_is_deterministic`.

**3. `test_compute_fixability_with_analysis` — wrong tier.**
Same broad-machinery profile (full walk + fingerprint + detectors + fixability planning). Gated under `slow-tests` to match its sibling `test_compute_fixability_counts_fixes_from_real_audit`, which was already gated.

## Why gate #2 and #1 instead of forcing hermetic
`docs/internals/test-tiers.md` explicitly reserves the slow tier for "full-pipeline audit/refactor regressions that intentionally run broad audit machinery… not part of the default unit gate because they scan real fixture/checkouts." These two are exactly that, and their direct siblings were already gated — the tiering commit (`8c3dcf5f`) simply missed them. This keeps the default gate hermetic and green without deleting regression coverage (the tests still run in `--features slow-tests`).

## Verification
- `cargo test -p homeboy-core --lib code_audit::` — **764 passed, 0 failed** (was 763 / 3 failed).
- `cargo test -p homeboy-core --lib --features slow-tests --no-run` — slow tier still **compiles clean**.
- `cargo check --workspace --tests --locked` (topology guard) — **passes**.
- `cargo fmt` clean; 3 files, +23 lines.