### PR TITLE
Fix managed Lab runner handoff routing

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -26,15 +26,12 @@ pub fn route_after_parse(
     normalized_args: &[String],
     output_file: Option<&str>,
 ) -> homeboy::core::Result<Option<i32>> {
-    // A managed runner executes the controller-selected command once. A
-    // materialized run-plan is the one explicit-placement exception: it is the
-    // controller's provider handoff, not a new dispatch from the runner.
+    // A managed runner executes the controller-selected command once. Its argv
+    // retains the controller's explicit placement for provenance, but must not
+    // recursively route back through a runner-side controller daemon.
     let managed_runner_placement =
         crate::commands::utils::resource_policy::is_managed_runner_placement_context();
-    if (cli.placement == homeboy::cli_surface::Placement::Auto
-        && (lab_routing::is_lab_offload_subprocess() || managed_runner_placement))
-        || (managed_runner_placement && is_managed_agent_task_run_plan(cli))
-    {
+    if lab_routing::is_lab_offload_subprocess() || managed_runner_placement {
         return Ok(None);
     }
 
@@ -257,15 +254,6 @@ pub fn route_after_parse(
             Ok(Some(output.exit_code))
         }
     }
-}
-
-fn is_managed_agent_task_run_plan(cli: &Cli) -> bool {
-    matches!(
-        &cli.command,
-        Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
-            command: crate::commands::agent_task::AgentTaskCommand::RunPlan(_),
-        })
-    )
 }
 
 /// Fanout keeps durable batch state, worktree ownership, artifact ingestion,

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -26,12 +26,14 @@ pub fn route_after_parse(
     normalized_args: &[String],
     output_file: Option<&str>,
 ) -> homeboy::core::Result<Option<i32>> {
-    // A managed runner executes the controller-selected command once. Explicit
-    // placement is never skipped: it must still enforce Lab routing and local
-    // safety gates even if a caller has inherited marker-like environment.
-    if cli.placement == homeboy::cli_surface::Placement::Auto
-        && (lab_routing::is_lab_offload_subprocess()
-            || crate::commands::utils::resource_policy::is_managed_runner_placement_context())
+    // A managed runner executes the controller-selected command once. A
+    // materialized run-plan is the one explicit-placement exception: it is the
+    // controller's provider handoff, not a new dispatch from the runner.
+    let managed_runner_placement =
+        crate::commands::utils::resource_policy::is_managed_runner_placement_context();
+    if (cli.placement == homeboy::cli_surface::Placement::Auto
+        && (lab_routing::is_lab_offload_subprocess() || managed_runner_placement))
+        || (managed_runner_placement && is_managed_agent_task_run_plan(cli))
     {
         return Ok(None);
     }
@@ -255,6 +257,15 @@ pub fn route_after_parse(
             Ok(Some(output.exit_code))
         }
     }
+}
+
+fn is_managed_agent_task_run_plan(cli: &Cli) -> bool {
+    matches!(
+        &cli.command,
+        Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+            command: crate::commands::agent_task::AgentTaskCommand::RunPlan(_),
+        })
+    )
 }
 
 /// Fanout keeps durable batch state, worktree ownership, artifact ingestion,

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -522,6 +522,38 @@ fn managed_run_plan_handoff_does_not_require_a_second_controller_session() {
 }
 
 #[test]
+fn managed_promotion_handoff_does_not_require_runner_side_artifact_hydration() {
+    let _env = EnvGuard::set_many(&[
+        (homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV, None),
+        (homeboy::core::runner::RUNNER_HOSTED_EXEC_ENV, Some("1")),
+        (
+            homeboy::core::runner::RUNNER_PLACEMENT_RESOLVED_ENV,
+            Some("1"),
+        ),
+        (homeboy::core::runner::RUNNER_ID_ENV, Some("homeboy-lab")),
+    ]);
+    let normalized = vec![
+        "homeboy".to_string(),
+        "--runner".to_string(),
+        "homeboy-lab".to_string(),
+        "--placement".to_string(),
+        "lab".to_string(),
+        "agent-task".to_string(),
+        "promote".to_string(),
+        "agent-task-preserved-run".to_string(),
+        "--to-worktree".to_string(),
+        "homeboy@fix-preserved-candidate".to_string(),
+    ];
+    let cli = Cli::parse_from(&normalized);
+
+    assert_eq!(
+        route_after_parse(&cli, &normalized, None)
+            .expect("managed promotion must execute on its authorized runner"),
+        None
+    );
+}
+
+#[test]
 fn unmanaged_explicit_lab_handoff_keeps_runner_connection_requirements() {
     let _env = EnvGuard::set_many(&[
         (homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV, None),

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -492,6 +492,65 @@ fn managed_runner_context_bypasses_auto_routing_once() {
 }
 
 #[test]
+fn managed_run_plan_handoff_does_not_require_a_second_controller_session() {
+    let _env = EnvGuard::set_many(&[
+        (homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV, None),
+        (homeboy::core::runner::RUNNER_HOSTED_EXEC_ENV, Some("1")),
+        (
+            homeboy::core::runner::RUNNER_PLACEMENT_RESOLVED_ENV,
+            Some("1"),
+        ),
+        (homeboy::core::runner::RUNNER_ID_ENV, Some("homeboy-lab")),
+    ]);
+    let normalized = vec![
+        "homeboy".to_string(),
+        "--runner".to_string(),
+        "homeboy-lab".to_string(),
+        "--placement".to_string(),
+        "lab".to_string(),
+        "agent-task".to_string(),
+        "run-plan".to_string(),
+        "--plan".to_string(),
+        r#"{"plan_id":"handoff","tasks":[]}"#.to_string(),
+    ];
+    let cli = Cli::parse_from(&normalized);
+
+    assert_eq!(
+        route_after_parse(&cli, &normalized, None).expect("managed handoff stays local"),
+        None
+    );
+}
+
+#[test]
+fn unmanaged_explicit_lab_handoff_keeps_runner_connection_requirements() {
+    let _env = EnvGuard::set_many(&[
+        (homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV, None),
+        (homeboy::core::runner::RUNNER_HOSTED_EXEC_ENV, None),
+        (homeboy::core::runner::RUNNER_PLACEMENT_RESOLVED_ENV, None),
+        (homeboy::core::runner::RUNNER_ID_ENV, None),
+    ]);
+    let normalized = vec![
+        "homeboy".to_string(),
+        "--runner".to_string(),
+        "disconnected-lab".to_string(),
+        "--placement".to_string(),
+        "lab".to_string(),
+        "agent-task".to_string(),
+        "run-plan".to_string(),
+        "--plan".to_string(),
+        r#"{"plan_id":"handoff","tasks":[]}"#.to_string(),
+    ];
+    let cli = Cli::parse_from(&normalized);
+
+    let error = crate::test_support::with_isolated_home(|_| {
+        route_after_parse(&cli, &normalized, None)
+            .expect_err("unmanaged run-plan must still require a Lab runner")
+    });
+
+    assert_eq!(error.code.as_str(), "runner.not_found");
+}
+
+#[test]
 fn agent_task_doctor_runner_option_routes_locally() {
     let _env = EnvGuard::remove(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV);
     let normalized = vec![

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -543,6 +543,10 @@ fn managed_promotion_handoff_does_not_require_runner_side_artifact_hydration() {
         "agent-task-preserved-run".to_string(),
         "--to-worktree".to_string(),
         "homeboy@fix-preserved-candidate".to_string(),
+        "--task-id".to_string(),
+        "task-preserved-artifact".to_string(),
+        "--artifact-id".to_string(),
+        "patch-preserved-artifact".to_string(),
     ];
     let cli = Cli::parse_from(&normalized);
 


### PR DESCRIPTION
Closes #8577

## Summary
- Let a child with the complete managed-runner transport context execute its controller-selected command locally once, even when preserved argv requests explicit Lab placement.
- Preserve fail-closed behavior for unmanaged explicit Lab invocations.
- Cover managed run-plan and artifact-identified promotion routing deterministically.

## Evidence
- Source relationship: extends the existing #8577 managed Lab run-plan repair and the established complete three-marker managed-runner boundary.
- Change kind: narrowly scoped control-plane routing correction plus route-level behavioral coverage.
- Verification capability: `cargo test -p homeboy-cli commands::infra::route::tests::dispatch`, `cargo test -p homeboy-cli managed_`, `cargo check -p homeboy-cli`, `cargo fmt --check`, and `git diff --check` pass.
- Runtime scope: no new placement policy or artifact behavior is introduced; the early return only consumes a fully prepared managed-runner context, while absent or partial context continues through normal explicit-Lab validation.

## AI Disclosure
Prepared with OpenCode using `openai/gpt-5.6-sol`; human review remains required.