### PR TITLE
Allow idle stale runner daemon refresh

### DIFF
--- a/crates/homeboy-core/src/runner/connection/tests/session.rs
+++ b/crates/homeboy-core/src/runner/connection/tests/session.rs
@@ -155,7 +155,7 @@ fn parses_self_identity_json_envelope() {
 }
 
 #[test]
-fn stale_daemon_warning_includes_ordered_restart_recovery_commands() {
+fn stale_daemon_warning_includes_explicit_refresh_recovery_command() {
     let warning = RunnerStaleDaemonWarning::new(
         "homeboy-lab",
         "homeboy 0.201.3".to_string(),
@@ -189,7 +189,7 @@ fn stale_daemon_warning_includes_ordered_restart_recovery_commands() {
     assert_eq!(
         warning.refresh_command,
         format!(
-            "homeboy runner refresh-homeboy homeboy-lab --ref v{} --reconnect && homeboy runner disconnect homeboy-lab && homeboy runner connect homeboy-lab",
+            "homeboy runner refresh-homeboy homeboy-lab --ref v{} --reconnect",
             homeboy_product_identity::product_version()
         )
     );
@@ -198,14 +198,10 @@ fn stale_daemon_warning_includes_ordered_restart_recovery_commands() {
     assert!(warning.message.contains("active jobs are drained"));
     assert_eq!(
         warning.recovery_commands,
-        vec![
-            format!(
-                "homeboy runner refresh-homeboy homeboy-lab --ref v{} --reconnect",
-                homeboy_product_identity::product_version()
-            ),
-            "homeboy runner disconnect homeboy-lab".to_string(),
-            "homeboy runner connect homeboy-lab".to_string(),
-        ]
+        vec![format!(
+            "homeboy runner refresh-homeboy homeboy-lab --ref v{} --reconnect",
+            homeboy_product_identity::product_version()
+        )]
     );
 }
 

--- a/crates/homeboy-core/src/runner/execution/mod.rs
+++ b/crates/homeboy-core/src/runner/execution/mod.rs
@@ -28,8 +28,9 @@ use crate::source_snapshot::SourceSnapshot;
 
 use super::resource_metrics::RunnerResourceMetrics;
 use super::{
-    select_runner_transport, status, Runner, RunnerCapabilityPreflight, RunnerHandoff, RunnerJob,
-    RunnerKind, RunnerMutationArtifacts, RunnerResult, RunnerSession, RunnerTransport,
+    select_runner_transport, status, Runner, RunnerActiveJobSource, RunnerActiveJobState,
+    RunnerCapabilityPreflight, RunnerHandoff, RunnerJob, RunnerKind, RunnerMutationArtifacts,
+    RunnerResult, RunnerSession, RunnerStatusReport, RunnerTransport,
 };
 
 const DEFAULT_RUNNER_EXEC_WAIT_TIMEOUT_SECS: u64 = 20 * 60;
@@ -797,7 +798,10 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
     }
 
     let connected = status(runner_id)?;
-    if connected.connected && connected.stale_daemon.is_some() {
+    if connected.connected
+        && connected.stale_daemon.is_some()
+        && !allows_idle_stale_daemon_refresh(&options, &connected)
+    {
         return Err(Error::validation_invalid_argument(
             "runner",
             format!(
@@ -805,7 +809,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
             ),
             Some(runner_id.to_string()),
             Some(vec![format!(
-                "Drain or recover known jobs, then refresh explicitly with `homeboy runner disconnect {runner_id} && homeboy runner connect {runner_id}`."
+                "Drain or recover known jobs. An explicit `homeboy runner refresh-homeboy {runner_id} --ref <version> --reconnect` can rotate this daemon only after `homeboy runner status {runner_id}` reports `active_job_count: 0` and `active_job_state: available`."
             )]),
         ));
     }
@@ -882,6 +886,23 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
         append_runner_exec_diagnostic_hint(&mut output, run_id_hint);
         (output, exit_code)
     })
+}
+
+fn allows_idle_stale_daemon_refresh(
+    options: &RunnerExecOptions,
+    status: &RunnerStatusReport,
+) -> bool {
+    // A refresh replaces the daemon immediately after this command. Require both
+    // a successful /jobs poll and the daemon's authoritative zero-job count.
+    options
+        .capability_preflight
+        .as_ref()
+        .is_some_and(|preflight| preflight.command == "runner.refresh-homeboy")
+        && status.active_job_state == RunnerActiveJobState::Available
+        && status.active_job_source == Some(RunnerActiveJobSource::DirectDaemon)
+        && status.active_job_count == 0
+        && status.active_jobs.is_empty()
+        && status.active_job_error.is_none()
 }
 
 fn apply_explicit_runner_exec_run_id_env(

--- a/crates/homeboy-core/src/runner/execution/tests/exec.rs
+++ b/crates/homeboy-core/src/runner/execution/tests/exec.rs
@@ -1,9 +1,70 @@
 use super::*;
+use crate::runner::{
+    RunnerActiveJobSource, RunnerActiveJobState, RunnerSessionState, RunnerStaleDaemonWarning,
+    RunnerStatusReport,
+};
 use crate::runner_execution_envelope::{
     PATH_MATERIALIZATION_MODE_GIT, PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
     PATH_MATERIALIZATION_STATUS_MATERIALIZED,
 };
 use serde_json::json;
+
+#[test]
+fn explicit_refresh_allows_an_idle_stale_daemon_after_reconnect() {
+    let status = stale_direct_daemon_status();
+
+    assert!(allows_idle_stale_daemon_refresh(
+        &explicit_refresh_options(),
+        &status,
+    ));
+}
+
+#[test]
+fn explicit_refresh_keeps_active_or_uncertain_stale_daemons_protected() {
+    let options = explicit_refresh_options();
+    let mut active = stale_direct_daemon_status();
+    active.active_job_count = 1;
+    let mut unavailable = stale_direct_daemon_status();
+    unavailable.active_job_state = RunnerActiveJobState::Unavailable;
+
+    assert!(!allows_idle_stale_daemon_refresh(&options, &active));
+    assert!(!allows_idle_stale_daemon_refresh(&options, &unavailable));
+}
+
+fn explicit_refresh_options() -> RunnerExecOptions {
+    RunnerExecOptions::raw_command(vec!["bash".to_string()]).with_capability_preflight(
+        RunnerCapabilityPreflight {
+            command: "runner.refresh-homeboy".to_string(),
+            ..Default::default()
+        },
+    )
+}
+
+fn stale_direct_daemon_status() -> RunnerStatusReport {
+    RunnerStatusReport {
+        runner_id: "homeboy-lab".to_string(),
+        connected: true,
+        state: RunnerSessionState::Connected,
+        session: None,
+        stale_daemon: Some(RunnerStaleDaemonWarning::new(
+            "homeboy-lab",
+            "homeboy 0.288.8".to_string(),
+            "homeboy 0.288.9".to_string(),
+            None,
+            None,
+        )),
+        daemon_freshness: None,
+        active_jobs: Vec::new(),
+        active_runner_jobs: Vec::new(),
+        stale_runner_jobs: Vec::new(),
+        active_job_count: 0,
+        stale_runner_job_count: 0,
+        active_job_state: RunnerActiveJobState::Available,
+        active_job_source: Some(RunnerActiveJobSource::DirectDaemon),
+        active_job_error: None,
+        session_path: "/tmp/homeboy-lab.json".to_string(),
+    }
+}
 
 #[test]
 fn runner_execution_record_uses_dispatched_path_materialization_plan() {

--- a/crates/homeboy-core/src/runner/lab/offload/tests/capability_metadata.rs
+++ b/crates/homeboy-core/src/runner/lab/offload/tests/capability_metadata.rs
@@ -973,11 +973,10 @@ fn runner_homeboy_metadata_carries_stale_daemon_details() {
         metadata["stale_daemon"]["job_command_binary_build_identity"],
         "homeboy 0.229.11+new"
     );
-    // The stale-daemon refresh command now leads with a version-pinned
-    // `refresh-homeboy --ref v<current> --reconnect` step before the
-    // disconnect/connect fallback (matching the connection.rs contract).
+    // The explicit refresh owns the reconnect, so the recovery command avoids
+    // a redundant disconnect/connect loop.
     let expected_refresh = format!(
-        "homeboy runner refresh-homeboy lab --ref v{} --reconnect && homeboy runner disconnect lab && homeboy runner connect lab",
+        "homeboy runner refresh-homeboy lab --ref v{} --reconnect",
         homeboy_product_identity::product_version()
     );
     assert_eq!(

--- a/crates/homeboy-core/src/runner/session.rs
+++ b/crates/homeboy-core/src/runner/session.rs
@@ -557,15 +557,11 @@ impl RunnerStaleDaemonWarning {
         session_homeboy_build_identity: Option<String>,
         current_homeboy_build_identity: Option<String>,
     ) -> Self {
-        let recovery_commands = vec![
-            format!(
-                "homeboy runner refresh-homeboy {} --ref v{} --reconnect",
-                shell::quote_arg(runner_id),
-                homeboy_product_identity::product_version()
-            ),
-            format!("homeboy runner disconnect {}", shell::quote_arg(runner_id)),
-            format!("homeboy runner connect {}", shell::quote_arg(runner_id)),
-        ];
+        let recovery_commands = vec![format!(
+            "homeboy runner refresh-homeboy {} --ref v{} --reconnect",
+            shell::quote_arg(runner_id),
+            homeboy_product_identity::product_version()
+        )];
         Self {
             severity: "warning",
             active_daemon_control_plane_version: session_homeboy_version.clone(),


### PR DESCRIPTION
## Summary
Allow explicit runner refresh to recover an idle stale daemon without weakening active-job protection.

## What changed
- Permit runner.refresh-homeboy through the stale-session preflight only when a direct daemon poll proves zero active jobs, and replace looping disconnect/reconnect guidance with the explicit refresh command.

## How to test
1. Run `CARGO_TARGET_DIR=/tmp/homeboy-8601-target cargo test -p homeboy-core runner::execution::tests::exec::explicit_refresh`; expect Both idle-refresh and protected-state tests pass..
2. Run `CARGO_TARGET_DIR=/tmp/homeboy-8601-target cargo test -p homeboy-core runner::connection::tests::session::stale_daemon_warning_includes_explicit_refresh_recovery_command`; expect The recovery-command test passes..
3. Run `CARGO_TARGET_DIR=/tmp/homeboy-8601-target cargo check -p homeboy-core`; expect The core crate compiles..

## Compatibility
Behavior changes only for an explicitly requested stale-daemon refresh after direct evidence proves zero active jobs. Active, unavailable, inconsistent, and non-direct job evidence remains fail-closed.

## Evidence
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8601
- cargo-check: Passed
- diff-check: Passed
- focused-tests: Passed
- format: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Reproduced the runner refresh deadlock, implemented the owning-layer repair and deterministic tests, and orchestrated verification with Chris.

## Source relationships
- Closes Extra-Chill/homeboy#8601
