### PR TITLE
Pin verified base snapshots across finalization

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -88,6 +88,9 @@ pub struct PromoteArgs {
     pub source: String,
     #[arg(long, value_name = "HANDLE")]
     pub to_worktree: String,
+    /// Declared base branch resolved immediately before promotion gates run.
+    #[arg(long, default_value = "main", value_name = "BRANCH")]
+    pub base: String,
     #[arg(long, value_name = "COMMAND")]
     pub provider_command: Option<String>,
     #[arg(
@@ -113,6 +116,9 @@ pub struct FinalizePrArgs {
     pub path: String,
     #[arg(long, default_value = "main", value_name = "BRANCH")]
     pub base: String,
+    /// Immutable base commit SHA recorded before the declared verification gates ran.
+    #[arg(long, value_name = "SHA")]
+    pub verified_base_sha: Option<String>,
     #[arg(long, value_name = "BRANCH")]
     pub head: Option<String>,
     #[arg(long, value_name = "TEXT")]

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -222,7 +222,7 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
         source_run_id: source_run_id.clone(),
         source_path,
         source_worktree_path: None,
-        base_ref: None,
+        base_ref: Some(args.base),
         task_base_sha: None,
         to_worktree: args.to_worktree,
         task_id: args.task_id,
@@ -395,6 +395,7 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
         path: args.path,
         run_id: args.run_id,
         base: args.base,
+        verified_base_sha: args.verified_base_sha,
         head: args.head,
         title: args.title,
         commit_message: args.commit_message,
@@ -772,6 +773,7 @@ fn promotion_handoff(report: &AgentTaskPromotionReport, to_worktree: &str) -> Va
         .get("worktree_path")
         .and_then(Value::as_str)
         .unwrap_or(to_worktree);
+    let verified_base = report.verified_base.as_ref();
     let mut next_actions = Vec::new();
     if report.status.gate_failed() {
         next_actions.push(
@@ -795,9 +797,10 @@ fn promotion_handoff(report: &AgentTaskPromotionReport, to_worktree: &str) -> Va
             "pr_opened": false
         },
         "boundary": report.status.handoff_boundary(),
-        "finalize_command": format!(
-            "homeboy agent-task finalize-pr --run-id <run-id> --path {finalize_path} --title <title> --commit-message <message>"
-        ),
+        "finalize_command": verified_base.map(|verified_base| format!(
+            "homeboy agent-task finalize-pr --run-id <run-id> --path {finalize_path} --base {} --verified-base-sha {} --title <title> --commit-message <message>",
+            verified_base.base, verified_base.sha
+        )),
         "next_actions": next_actions
     })
 }
@@ -1002,6 +1005,12 @@ mod tests {
             command_evidence: Vec::<AgentTaskPromotionCommandReport>::new(),
             deterministic_gates: Vec::new(),
             gate_results: Vec::new(),
+            verified_base: Some(
+                homeboy::core::agent_tasks::promotion::AgentTaskPromotionVerifiedBase {
+                    base: "release".to_string(),
+                    sha: "0123456789012345678901234567890123456789".to_string(),
+                },
+            ),
             provenance: serde_json::json!({ "worktree_path": "/Users/user/Developer/homeboy@fix-runtime" }),
             operator_notification: AgentTaskPromotionNotification {
                 status: "completed".to_string(),
@@ -1021,6 +1030,12 @@ mod tests {
             .as_str()
             .expect("finalize command")
             .contains("--path /Users/user/Developer/homeboy@fix-runtime"));
+        assert!(handoff["finalize_command"]
+            .as_str()
+            .expect("finalize command")
+            .contains(
+                "--base release --verified-base-sha 0123456789012345678901234567890123456789"
+            ));
     }
 
     #[test]

--- a/crates/homeboy-core/src/agent_task_cook_loop.rs
+++ b/crates/homeboy-core/src/agent_task_cook_loop.rs
@@ -736,6 +736,7 @@ mod tests {
             command_evidence: Vec::new(),
             deterministic_gates,
             gate_results: Vec::new(),
+            verified_base: None,
             provenance: json!({ "worktree_path": "/tmp/homeboy@fix-3676" }),
             operator_notification: AgentTaskPromotionNotification {
                 status: if status == AgentTaskPromotionStatus::Applied {

--- a/crates/homeboy-core/src/agent_task_finalization.rs
+++ b/crates/homeboy-core/src/agent_task_finalization.rs
@@ -68,16 +68,6 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     }
     validate_green_gates(&options.normalized_gate_results)?;
     options.review_dossier.apply_overrides()?;
-    enrich_dossier(
-        &mut options.review_dossier,
-        &options.evidence.source_refs,
-        &options.evidence.artifact_refs,
-        &options.normalized_gate_results,
-        &options.evidence.verification.ci_expected,
-        options.evidence.lifecycle.as_ref(),
-    );
-    options.review_dossier.validate(&options.review_profile)?;
-    let proof = build_finalization_proof(&options, options.normalized_gate_results.clone());
     let current_branch = backend.current_branch(&options.path)?;
     let head = options
         .head
@@ -93,7 +83,15 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     }
     refuse_protected_head(&head, &options.protected_branches)?;
 
-    let base = backend.resolve_base(&options.path, &options.base)?;
+    let verified_base_sha = options.verified_base_sha.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "verified_base_sha",
+            "finalization requires the immutable base SHA recorded before declared gates ran",
+            None,
+            None,
+        )
+    })?;
+    let base = backend.resolve_verified_base(&options.path, verified_base_sha)?;
     let candidate = backend.candidate_state(&options.path, &base, &head)?;
     let (mut changed_files, commit_required, push_required) = match candidate {
         AgentTaskPrCandidateState::Dirty { changed_files } => (changed_files, true, true),
@@ -118,7 +116,33 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     }
     changed_files.sort();
     changed_files.dedup();
-    let intent = build_pr_publication_intent(&options, &head, &changed_files, proof.clone());
+    enrich_dossier(
+        &mut options.review_dossier,
+        &options.evidence.source_refs,
+        &options.evidence.artifact_refs,
+        &options.normalized_gate_results,
+        &options.evidence.verification.ci_expected,
+        options.evidence.lifecycle.as_ref(),
+    );
+    options.review_dossier.evidence.push(
+        crate::agent_task_review_dossier::AgentTaskReviewEvidence {
+            summary: format!(
+                "Verified finalization base: {} at {}",
+                options.base, base.sha
+            ),
+            url: None,
+        },
+    );
+    options.review_dossier.evidence.sort_by(|left, right| {
+        left.summary
+            .cmp(&right.summary)
+            .then(left.url.cmp(&right.url))
+    });
+    options.review_dossier.evidence.dedup();
+    options.review_dossier.validate(&options.review_profile)?;
+    let proof = build_finalization_proof(&options, options.normalized_gate_results.clone());
+    let mut intent =
+        build_pr_publication_intent(&options, &head, &changed_files, proof.clone(), &base);
     validate_publication_intent(&intent)?;
 
     if changed_files.is_empty() {
@@ -146,8 +170,36 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     if push_required {
         backend.push_branch(&options.path, &head)?;
     }
-    let body = render_review_dossier(&options.review_dossier, &options.review_profile);
     let existing = backend.find_open_pr(&options.path, &options.base, &head)?;
+    let publication_base_sha = backend.publication_base_sha(&options.path, &options.base)?;
+    intent.target.publication_base_sha = publication_base_sha.clone();
+    let base_observation = match publication_base_sha {
+        Some(publication_base_sha) if publication_base_sha == base.sha => format!(
+            "Base unchanged since verification: {} remains at {}.",
+            options.base, base.sha
+        ),
+        Some(publication_base_sha) => format!(
+            "Base advanced after verification: verified {} at {}; publication observed {}. Candidate ancestry was validated against the verified snapshot.",
+            options.base, base.sha, publication_base_sha
+        ),
+        None => format!(
+            "Base observation unavailable immediately before publication; candidate ancestry was validated against verified {} at {}.",
+            options.base, base.sha
+        ),
+    };
+    options.review_dossier.evidence.push(
+        crate::agent_task_review_dossier::AgentTaskReviewEvidence {
+            summary: base_observation,
+            url: None,
+        },
+    );
+    options.review_dossier.evidence.sort_by(|left, right| {
+        left.summary
+            .cmp(&right.summary)
+            .then(left.url.cmp(&right.url))
+    });
+    options.review_dossier.evidence.dedup();
+    let body = render_review_dossier(&options.review_dossier, &options.review_profile);
     let (action, pr) = match existing {
         Some(existing) => (
             "updated",
@@ -351,6 +403,7 @@ fn build_pr_publication_intent(
     head: &str,
     changed_files: &[String],
     proof: HomeboyProof,
+    base: &AgentTaskPrResolvedBase,
 ) -> AgentTaskPublicationIntent {
     AgentTaskPublicationIntent {
         schema: AGENT_TASK_PUBLICATION_INTENT_SCHEMA.to_string(),
@@ -361,6 +414,8 @@ fn build_pr_publication_intent(
             adapter: Some("github_pull_request".to_string()),
             path: Some(options.path.clone()),
             base: Some(options.base.clone()),
+            verified_base_sha: Some(base.sha.clone()),
+            publication_base_sha: None,
             head: Some(head.to_string()),
             url: None,
         },

--- a/crates/homeboy-core/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-core/src/agent_task_finalization/backend.rs
@@ -95,6 +95,104 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
         Ok(AgentTaskPrResolvedBase { reference, sha })
     }
 
+    fn resolve_verified_base(
+        &mut self,
+        path: &str,
+        verified_base_sha: &str,
+    ) -> Result<AgentTaskPrResolvedBase> {
+        if !is_git_object_id(verified_base_sha) {
+            return Err(Error::validation_invalid_argument(
+                "verified_base_sha",
+                "verified base snapshot must be a full Git object ID",
+                Some(verified_base_sha.to_string()),
+                None,
+            ));
+        }
+        let sha = git_output(
+            path,
+            &[
+                "rev-parse",
+                "--verify",
+                &format!("{verified_base_sha}^{{commit}}"),
+            ],
+        )
+        .or_else(|_| {
+            let fetch = std::process::Command::new("git")
+                .args([
+                    "fetch",
+                    "--no-tags",
+                    "--no-write-fetch-head",
+                    "origin",
+                    verified_base_sha,
+                ])
+                .current_dir(path)
+                .output()
+                .map_err(|error| Error::git_command_failed(error.to_string()))?;
+            if !fetch.status.success() {
+                return Err(Error::validation_invalid_argument(
+                    "verified_base_sha",
+                    format!(
+                        "verified base snapshot is unavailable locally and origin could not materialize exact commit `{verified_base_sha}`; retry from a worktree with origin access: {}",
+                        String::from_utf8_lossy(&fetch.stderr).trim()
+                    ),
+                    Some(verified_base_sha.to_string()),
+                    None,
+                ));
+            }
+            git_output(
+                path,
+                &[
+                    "rev-parse",
+                    "--verify",
+                    &format!("{verified_base_sha}^{{commit}}"),
+                ],
+            )
+            .map_err(|_| {
+                Error::validation_invalid_argument(
+                    "verified_base_sha",
+                    "origin did not materialize the persisted verified base snapshot as a commit",
+                    Some(verified_base_sha.to_string()),
+                    None,
+                )
+            })
+        })?;
+        if sha != verified_base_sha {
+            return Err(Error::validation_invalid_argument(
+                "verified_base_sha",
+                "verified base snapshot did not resolve to the supplied immutable Git object ID",
+                Some(verified_base_sha.to_string()),
+                None,
+            ));
+        }
+        Ok(AgentTaskPrResolvedBase {
+            reference: verified_base_sha.to_string(),
+            sha,
+        })
+    }
+
+    fn publication_base_sha(&mut self, path: &str, base: &str) -> Result<Option<String>> {
+        let output = std::process::Command::new("git")
+            .args([
+                "ls-remote",
+                "--heads",
+                "origin",
+                &format!("refs/heads/{base}"),
+            ])
+            .current_dir(path)
+            .output()
+            .map_err(|error| Error::git_command_failed(error.to_string()))?;
+        if !output.status.success() {
+            return Err(Error::git_command_failed(format!(
+                "could not observe live origin base `{base}` before publication: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .split_whitespace()
+            .next()
+            .map(str::to_string))
+    }
+
     fn candidate_state(
         &mut self,
         path: &str,
@@ -306,6 +404,10 @@ fn git_output(path: &str, args: &[&str]) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+fn is_git_object_id(value: &str) -> bool {
+    matches!(value.len(), 40 | 64) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
 #[cfg(test)]
 mod remote_base_tests {
     use super::*;
@@ -497,6 +599,123 @@ mod remote_base_tests {
 
         assert_eq!(resolved.sha, remote_head.trim());
         assert_eq!(resolved.reference, "refs/homeboy/finalization/base/main");
+    }
+
+    #[test]
+    fn resolve_verified_base_rejects_malformed_and_unresolvable_snapshots() {
+        let repo = repo();
+        for snapshot in ["not-a-sha", &"f".repeat(40)] {
+            let error = RealAgentTaskPrFinalizationBackend
+                .resolve_verified_base(repo.path().to_str().unwrap(), snapshot)
+                .expect_err("invalid snapshot is rejected");
+            assert_eq!(error.code, crate::ErrorCode::ValidationInvalidArgument);
+        }
+    }
+
+    #[test]
+    fn resolve_verified_base_rematerializes_only_the_persisted_snapshot() {
+        let repo = repo();
+        let remote = tempfile::tempdir().unwrap();
+        git(remote.path(), &["init", "--bare"]);
+        git(
+            repo.path(),
+            &["remote", "add", "origin", remote.path().to_str().unwrap()],
+        );
+        git(repo.path(), &["push", "-u", "origin", "main"]);
+        git(repo.path(), &["checkout", "-b", "snapshot"]);
+        std::fs::write(repo.path().join("snapshot.txt"), "snapshot").unwrap();
+        git(repo.path(), &["add", "snapshot.txt"]);
+        git(repo.path(), &["commit", "-m", "verified snapshot"]);
+        let snapshot = git_output(repo.path().to_str().unwrap(), &["rev-parse", "HEAD"]).unwrap();
+        git(repo.path(), &["push", "origin", "snapshot"]);
+
+        let clone = tempfile::tempdir().unwrap();
+        assert!(Command::new("git")
+            .args([
+                "clone",
+                "--no-local",
+                "--single-branch",
+                "--branch",
+                "main",
+                remote.path().to_str().unwrap(),
+                clone.path().to_str().unwrap(),
+            ])
+            .status()
+            .unwrap()
+            .success());
+        assert!(git_output(
+            clone.path().to_str().unwrap(),
+            &["cat-file", "-e", &format!("{snapshot}^{{commit}}")],
+        )
+        .is_err());
+
+        let resolved = RealAgentTaskPrFinalizationBackend
+            .resolve_verified_base(clone.path().to_str().unwrap(), &snapshot)
+            .expect("exact snapshot rematerialized");
+        assert_eq!(resolved.sha, snapshot);
+        assert!(git_output(
+            clone.path().to_str().unwrap(),
+            &["cat-file", "-e", &format!("{}^{{commit}}", resolved.sha)],
+        )
+        .is_ok());
+
+        let unavailable = "f".repeat(40);
+        let error = RealAgentTaskPrFinalizationBackend
+            .resolve_verified_base(clone.path().to_str().unwrap(), &unavailable)
+            .expect_err("unavailable exact snapshot is rejected");
+        assert_eq!(error.code, crate::ErrorCode::ValidationInvalidArgument);
+    }
+
+    #[test]
+    fn captured_base_survives_remote_advance_while_newer_snapshot_rejects_stale_candidate() {
+        let repo = repo();
+        let remote = tempfile::tempdir().unwrap();
+        git(remote.path(), &["init", "--bare"]);
+        git(
+            repo.path(),
+            &["remote", "add", "origin", remote.path().to_str().unwrap()],
+        );
+        git(repo.path(), &["push", "-u", "origin", "main"]);
+        let captured_base = git_output(repo.path().to_str().unwrap(), &["rev-parse", "HEAD"])
+            .expect("captured declared base");
+
+        git(repo.path(), &["checkout", "-b", "feature"]);
+        std::fs::write(repo.path().join("feature.txt"), "feature").unwrap();
+        git(repo.path(), &["add", "feature.txt"]);
+        git(
+            repo.path(),
+            &["commit", "-m", "candidate verified by gates"],
+        );
+
+        git(repo.path(), &["checkout", "main"]);
+        std::fs::write(repo.path().join("main.txt"), "advance").unwrap();
+        git(repo.path(), &["add", "main.txt"]);
+        git(repo.path(), &["commit", "-m", "remote advance after gates"]);
+        git(repo.path(), &["push", "origin", "main"]);
+        let advanced_base = git_output(repo.path().to_str().unwrap(), &["rev-parse", "HEAD"])
+            .expect("advanced base");
+        git(repo.path(), &["checkout", "feature"]);
+
+        let published = RealAgentTaskPrFinalizationBackend
+            .candidate_state(
+                repo.path().to_str().unwrap(),
+                &base(&captured_base, &captured_base),
+                "feature",
+            )
+            .expect("captured base validates candidate");
+        assert!(matches!(
+            published,
+            AgentTaskPrCandidateState::Committed { .. }
+        ));
+
+        let stale = RealAgentTaskPrFinalizationBackend
+            .candidate_state(
+                repo.path().to_str().unwrap(),
+                &base(&advanced_base, &advanced_base),
+                "feature",
+            )
+            .expect("newer snapshot compares candidate");
+        assert!(matches!(stale, AgentTaskPrCandidateState::Invalid { .. }));
     }
 }
 

--- a/crates/homeboy-core/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-core/src/agent_task_finalization/tests.rs
@@ -23,6 +23,11 @@ struct MockBackend {
     branch: String,
     changed_files: Vec<String>,
     candidate_state: Option<AgentTaskPrCandidateState>,
+    resolved_base: Option<AgentTaskPrResolvedBase>,
+    publication_base_sha: Option<String>,
+    candidate_base_sha: Option<String>,
+    pr_lookup_complete: bool,
+    publication_observed_after_pr_lookup: bool,
     existing_pr: Option<AgentTaskPrRef>,
     create_error: bool,
     push_error: bool,
@@ -113,9 +118,10 @@ impl AgentTaskPrFinalizationBackend for MockBackend {
     fn candidate_state(
         &mut self,
         _path: &str,
-        _base: &AgentTaskPrResolvedBase,
+        base: &AgentTaskPrResolvedBase,
         _head: &str,
     ) -> Result<AgentTaskPrCandidateState> {
+        self.candidate_base_sha = Some(base.sha.clone());
         Ok(self.candidate_state.clone().unwrap_or_else(|| {
             if self.changed_files.is_empty() {
                 AgentTaskPrCandidateState::Equivalent
@@ -125,6 +131,35 @@ impl AgentTaskPrFinalizationBackend for MockBackend {
                 }
             }
         }))
+    }
+
+    fn resolve_base(&mut self, _path: &str, base: &str) -> Result<AgentTaskPrResolvedBase> {
+        Ok(self
+            .resolved_base
+            .clone()
+            .unwrap_or_else(|| AgentTaskPrResolvedBase {
+                reference: base.to_string(),
+                sha: String::new(),
+            }))
+    }
+
+    fn resolve_verified_base(
+        &mut self,
+        _path: &str,
+        verified_base_sha: &str,
+    ) -> Result<AgentTaskPrResolvedBase> {
+        Ok(self
+            .resolved_base
+            .clone()
+            .unwrap_or_else(|| AgentTaskPrResolvedBase {
+                reference: verified_base_sha.to_string(),
+                sha: verified_base_sha.to_string(),
+            }))
+    }
+
+    fn publication_base_sha(&mut self, _path: &str, _base: &str) -> Result<Option<String>> {
+        self.publication_observed_after_pr_lookup = self.pr_lookup_complete;
+        Ok(self.publication_base_sha.clone())
     }
 
     fn commit_all(&mut self, _path: &str, _message: &str) -> Result<()> {
@@ -148,6 +183,7 @@ impl AgentTaskPrFinalizationBackend for MockBackend {
         _base: &str,
         _head: &str,
     ) -> Result<Option<AgentTaskPrRef>> {
+        self.pr_lookup_complete = true;
         Ok(self.existing_pr.clone())
     }
 
@@ -255,6 +291,145 @@ fn creates_new_pr_after_green_gates() {
     assert!(report.finalization_outcome.committed);
     assert!(report.finalization_outcome.pushed);
     assert!(report.finalization_outcome.published);
+}
+
+#[test]
+fn finalization_pins_verified_base_when_base_advances_before_publication() {
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        resolved_base: Some(AgentTaskPrResolvedBase {
+            reference: "refs/homeboy/finalization/base/main".to_string(),
+            sha: "verified-base".to_string(),
+        }),
+        publication_base_sha: Some("advanced-base".to_string()),
+        ..Default::default()
+    };
+
+    let report = finalize_pr_with_backend(options(), &mut backend).expect("finalized");
+
+    assert_eq!(backend.candidate_base_sha.as_deref(), Some("verified-base"));
+    assert!(backend.created);
+    assert!(backend.publication_observed_after_pr_lookup);
+    assert_eq!(
+        report
+            .publication_intent
+            .target
+            .verified_base_sha
+            .as_deref(),
+        Some("verified-base")
+    );
+    assert_eq!(
+        report
+            .publication_intent
+            .target
+            .publication_base_sha
+            .as_deref(),
+        Some("advanced-base")
+    );
+    assert!(backend
+        .last_body
+        .contains("Verified finalization base: main at verified-base"));
+    assert!(backend
+        .last_body
+        .contains("Base advanced after verification"));
+    assert!(backend
+        .last_body
+        .contains("publication observed advanced-base"));
+}
+
+#[test]
+fn finalization_records_unchanged_live_base_before_publication() {
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        resolved_base: Some(AgentTaskPrResolvedBase {
+            reference: "refs/homeboy/finalization/base/main".to_string(),
+            sha: "verified-base".to_string(),
+        }),
+        publication_base_sha: Some("verified-base".to_string()),
+        ..Default::default()
+    };
+
+    let report = finalize_pr_with_backend(options(), &mut backend).expect("finalized");
+
+    assert!(backend.publication_observed_after_pr_lookup);
+    assert_eq!(
+        report
+            .publication_intent
+            .target
+            .verified_base_sha
+            .as_deref(),
+        Some("verified-base")
+    );
+    assert_eq!(
+        report
+            .publication_intent
+            .target
+            .publication_base_sha
+            .as_deref(),
+        Some("verified-base")
+    );
+    assert!(backend
+        .last_body
+        .contains("Base unchanged since verification: main remains at verified-base."));
+}
+
+#[test]
+fn finalization_reports_unavailable_live_base_observation() {
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        resolved_base: Some(AgentTaskPrResolvedBase {
+            reference: "refs/homeboy/finalization/base/main".to_string(),
+            sha: "verified-base".to_string(),
+        }),
+        ..Default::default()
+    };
+
+    let report = finalize_pr_with_backend(options(), &mut backend).expect("finalized");
+
+    assert!(backend.publication_observed_after_pr_lookup);
+    assert_eq!(report.publication_intent.target.publication_base_sha, None);
+    assert!(backend
+        .last_body
+        .contains("Base observation unavailable immediately before publication"));
+}
+
+#[test]
+fn finalization_rejects_candidate_behind_pinned_base_before_publication() {
+    let mut backend = MockBackend {
+        resolved_base: Some(AgentTaskPrResolvedBase {
+            reference: "refs/homeboy/finalization/base/main".to_string(),
+            sha: "verified-base".to_string(),
+        }),
+        publication_base_sha: Some("advanced-base".to_string()),
+        candidate_state: Some(AgentTaskPrCandidateState::Invalid {
+            diagnostic: "HEAD is behind the pinned base".to_string(),
+        }),
+        ..Default::default()
+    };
+
+    let error = finalize_pr_with_backend(options(), &mut backend).expect_err("behind candidate");
+
+    assert!(error.message.contains("behind the pinned base"));
+    assert_eq!(backend.candidate_base_sha.as_deref(), Some("verified-base"));
+    assert!(!backend.committed);
+    assert!(!backend.pushed);
+    assert!(!backend.created);
+}
+
+#[test]
+fn finalization_requires_an_explicit_verified_base_snapshot() {
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        ..Default::default()
+    };
+    let mut finalization_options = options();
+    finalization_options.verified_base_sha = None;
+
+    let error = finalize_pr_with_backend(finalization_options, &mut backend)
+        .expect_err("missing snapshot is rejected");
+
+    assert!(error.message.contains("immutable base SHA"));
+    assert!(!backend.created);
 }
 
 #[test]
@@ -1222,6 +1397,7 @@ fn options() -> AgentTaskPrFinalizationOptions {
         path: "/repo".to_string(),
         run_id: "cook-3678".to_string(),
         base: "main".to_string(),
+        verified_base_sha: Some("verified-base".to_string()),
         head: None,
         title: "Cook issue #3678".to_string(),
         commit_message: "finalize cook loop PR plumbing".to_string(),

--- a/crates/homeboy-core/src/agent_task_finalization/types.rs
+++ b/crates/homeboy-core/src/agent_task_finalization/types.rs
@@ -84,6 +84,12 @@ pub struct AgentTaskPublicationTarget {
     pub path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base: Option<String>,
+    /// Immutable base snapshot used to verify the candidate before publication.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verified_base_sha: Option<String>,
+    /// Live base SHA observed immediately before publication, if available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub publication_base_sha: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub head: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -197,6 +203,8 @@ pub struct AgentTaskPrFinalizationOptions {
     pub path: String,
     pub run_id: String,
     pub base: String,
+    /// Immutable commit SHA recorded before the declared verification gates ran.
+    pub verified_base_sha: Option<String>,
     pub head: Option<String>,
     pub title: String,
     pub commit_message: String,
@@ -262,6 +270,20 @@ pub trait AgentTaskPrFinalizationBackend {
             reference: base.to_string(),
             sha: String::new(),
         })
+    }
+    fn resolve_verified_base(
+        &mut self,
+        _path: &str,
+        verified_base_sha: &str,
+    ) -> Result<AgentTaskPrResolvedBase> {
+        Ok(AgentTaskPrResolvedBase {
+            reference: verified_base_sha.to_string(),
+            sha: verified_base_sha.to_string(),
+        })
+    }
+    /// Observes the live base without updating the immutable finalization snapshot.
+    fn publication_base_sha(&mut self, _path: &str, _base: &str) -> Result<Option<String>> {
+        Ok(None)
     }
     fn candidate_state(
         &mut self,

--- a/crates/homeboy-core/src/agent_task_promotion/mod.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/mod.rs
@@ -28,7 +28,7 @@ pub use types::{
     AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandCapture,
     AgentTaskPromotionCommandReport, AgentTaskPromotionNotification, AgentTaskPromotionOptions,
     AgentTaskPromotionReport, AgentTaskPromotionSource, AgentTaskPromotionStatus,
-    AgentTaskPromotionTarget, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
+    AgentTaskPromotionTarget, AgentTaskPromotionVerifiedBase, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
 };
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/promote.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use serde_json::{json, Value};
 
@@ -23,7 +24,8 @@ pub(crate) use super::patch::{normalize_promotion_patch, validate_artifact_conte
 use super::types::{
     AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandReport, AgentTaskPromotionNotification,
     AgentTaskPromotionOptions, AgentTaskPromotionReport, AgentTaskPromotionSource,
-    AgentTaskPromotionStatus, AgentTaskPromotionTarget, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
+    AgentTaskPromotionStatus, AgentTaskPromotionTarget, AgentTaskPromotionVerifiedBase,
+    AGENT_TASK_PROMOTION_REPORT_SCHEMA,
 };
 
 mod gate_run;
@@ -96,6 +98,7 @@ pub fn resume_promoted_patch(
         &normalized_patch.content,
     )?];
     let mut provider = ExternalPromotionWorkspaceProvider::from_options(&options);
+    let verified_base = capture_declared_base(target_path, options.base_ref.as_deref())?;
     let gates = run_promotion_gates(&options, &mut provider, target_path)?;
     let target =
         AgentTaskPromotionTarget::from_worktree(options.to_worktree.clone(), Some(target_path));
@@ -122,6 +125,7 @@ pub fn resume_promoted_patch(
         command_evidence,
         deterministic_gates: gates.deterministic_gates,
         gate_results: gates.gate_results,
+        verified_base,
         provenance: json!({
             "source_schema": outcome.schema,
             "artifact_metadata": artifact.metadata,
@@ -371,6 +375,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
             command_evidence: Vec::new(),
             deterministic_gates: Vec::new(),
             gate_results: Vec::new(),
+            verified_base: None,
             provenance: json!({
                 "source_schema": outcome.schema,
                 "artifact_metadata": artifact.metadata,
@@ -431,11 +436,16 @@ pub(super) fn promote_with_provider_and_checkpoint(
             artifact.metadata.clone(),
         ))?;
     }
-    let gates = if let Some(worktree_path) = applied_worktree_path.as_deref() {
-        run_promotion_gates(&options, provider, worktree_path)?
+    let verified_base = if let Some(worktree_path) = applied_worktree_path.as_deref() {
+        let verified_base = capture_declared_base(worktree_path, options.base_ref.as_deref())?;
+        (
+            run_promotion_gates(&options, provider, worktree_path)?,
+            verified_base,
+        )
     } else {
-        PromotionGateRun::without_gates(options.dry_run)
+        (PromotionGateRun::without_gates(options.dry_run), None)
     };
+    let (gates, verified_base) = verified_base;
     let operator_notification = promotion_notification(gates.status, &target);
     let candidate = if gates.status == AgentTaskPromotionStatus::Applied {
         applied_worktree_path
@@ -464,6 +474,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
         command_evidence,
         deterministic_gates: gates.deterministic_gates,
         gate_results: gates.gate_results,
+        verified_base,
         provenance: json!({
             "source_schema": outcome.schema,
             "artifact_metadata": artifact.metadata,
@@ -608,6 +619,72 @@ fn valid_sha256(value: &str) -> bool {
     value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
+#[cfg(test)]
+mod declared_base_tests {
+    use super::*;
+
+    fn git(path: &Path, args: &[&str]) {
+        assert!(Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .status()
+            .expect("git runs")
+            .success());
+    }
+
+    fn git_output(path: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("git runs");
+        assert!(output.status.success());
+        String::from_utf8(output.stdout).unwrap().trim().to_string()
+    }
+
+    #[test]
+    fn declared_base_capture_is_immune_to_unrelated_fetch_head_activity() {
+        let repo = tempfile::tempdir().unwrap();
+        git(repo.path(), &["init", "-b", "main"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test"]);
+        std::fs::write(repo.path().join("base"), "base").unwrap();
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "main"]);
+        let remote = tempfile::tempdir().unwrap();
+        git(remote.path(), &["init", "--bare"]);
+        git(
+            repo.path(),
+            &["remote", "add", "origin", remote.path().to_str().unwrap()],
+        );
+        git(repo.path(), &["push", "-u", "origin", "main"]);
+        let main_sha = git_output(repo.path(), &["rev-parse", "HEAD"]);
+        git(repo.path(), &["checkout", "-b", "other"]);
+        std::fs::write(repo.path().join("other"), "other").unwrap();
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "other"]);
+        git(repo.path(), &["push", "origin", "other"]);
+        git(repo.path(), &["checkout", "main"]);
+
+        let captured = capture_declared_base(repo.path(), Some("main"))
+            .expect("capture main")
+            .expect("declared base");
+        git(repo.path(), &["fetch", "origin", "refs/heads/other"]);
+
+        assert_eq!(captured.base, "main");
+        assert_eq!(captured.sha, main_sha);
+        assert!(git_output(
+            repo.path(),
+            &[
+                "for-each-ref",
+                "--format=%(refname)",
+                "refs/homeboy/promotion/base"
+            ],
+        )
+        .is_empty());
+    }
+}
+
 fn promote_committed_changes(
     options: &AgentTaskPromotionOptions,
     provider: &mut impl AgentTaskPromotionWorkspaceProvider,
@@ -668,11 +745,13 @@ fn promote_committed_changes(
                 .unwrap_or(Value::Null),
         ))?;
     }
-    let gates = if let Some(path) = applied_worktree_path.as_deref() {
-        run_promotion_gates(options, provider, path)?
+    let verified_base = if let Some(path) = applied_worktree_path.as_deref() {
+        let verified_base = capture_declared_base(path, options.base_ref.as_deref())?;
+        (run_promotion_gates(options, provider, path)?, verified_base)
     } else {
-        PromotionGateRun::without_gates(options.dry_run)
+        (PromotionGateRun::without_gates(options.dry_run), None)
     };
+    let (gates, verified_base) = verified_base;
     let operator_notification = promotion_notification(gates.status, &target);
 
     Ok(AgentTaskPromotionReport {
@@ -691,6 +770,7 @@ fn promote_committed_changes(
         command_evidence,
         deterministic_gates: gates.deterministic_gates,
         gate_results: gates.gate_results,
+        verified_base,
         provenance: json!({
             "source_schema": outcome.schema,
             "artifact_metadata": artifact.map(|artifact| artifact.metadata.clone()).unwrap_or(Value::Null),
@@ -836,6 +916,82 @@ fn promotion_source(
     }
 }
 
+fn capture_declared_base(
+    worktree_path: &Path,
+    base_ref: Option<&str>,
+) -> Result<Option<AgentTaskPromotionVerifiedBase>> {
+    let Some(base_ref) = base_ref.filter(|value| !value.trim().is_empty()) else {
+        return Ok(None);
+    };
+    let observed = Command::new("git")
+        .args([
+            "ls-remote",
+            "--heads",
+            "origin",
+            &format!("refs/heads/{base_ref}"),
+        ])
+        .current_dir(worktree_path)
+        .output()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    if !observed.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "base_ref",
+            format!(
+                "could not capture declared base `{base_ref}` before promotion gates: {}",
+                String::from_utf8_lossy(&observed.stderr).trim()
+            ),
+            None,
+            None,
+        ));
+    }
+    let sha = String::from_utf8_lossy(&observed.stdout)
+        .split_whitespace()
+        .next()
+        .filter(|sha| !sha.is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "base_ref",
+                format!(
+                    "declared base `{base_ref}` was not found on origin before promotion gates"
+                ),
+                None,
+                None,
+            )
+        })?
+        .to_string();
+    let fetch = Command::new("git")
+        .args([
+            "fetch",
+            "--no-tags",
+            "--no-write-fetch-head",
+            "origin",
+            &sha,
+        ])
+        .current_dir(worktree_path)
+        .output()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    if !fetch.status.success() {
+        return Err(Error::validation_invalid_argument("base_ref", format!("could not materialize observed declared base `{base_ref}` at {sha}; retry promotion: {}", String::from_utf8_lossy(&fetch.stderr).trim()), None, None));
+    }
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", &format!("{sha}^{{commit}}")])
+        .current_dir(worktree_path)
+        .output()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "base_ref",
+            format!("could not resolve declared base `{base_ref}` before promotion gates"),
+            None,
+            None,
+        ));
+    }
+    Ok(Some(AgentTaskPromotionVerifiedBase {
+        base: base_ref.to_string(),
+        sha: String::from_utf8_lossy(&output.stdout).trim().to_string(),
+    }))
+}
+
 fn status_for_report(dry_run: bool, has_gate_failure: bool) -> AgentTaskPromotionStatus {
     if dry_run {
         AgentTaskPromotionStatus::DryRun
@@ -861,13 +1017,11 @@ fn promotion_notification(
         AgentTaskPromotionStatus::Applied => AgentTaskPromotionNotification {
             status: "completed".to_string(),
             message: format!(
-                "patch promoted into {}; verify and finalize from {}",
+                "patch promoted into {}; finalize from {} using the verified_base_sha recorded in this promotion report",
                 target.worktree, target_path
             ),
             resumable_blocker: None,
-            next_command: Some(format!(
-                "homeboy agent-task finalize-pr --run-id <run-id> --path {target_path} --title <title> --commit-message <message>"
-            )),
+            next_command: None,
         },
         AgentTaskPromotionStatus::GateFailed => AgentTaskPromotionNotification {
             status: "blocked".to_string(),
@@ -920,6 +1074,7 @@ fn post_apply_report(
         command_evidence,
         deterministic_gates: Vec::new(),
         gate_results: Vec::new(),
+        verified_base: None,
         provenance: json!({
             "source_schema": source_schema,
             "artifact_metadata": artifact_metadata,

--- a/crates/homeboy-core/src/agent_task_promotion/tests.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/tests.rs
@@ -2116,6 +2116,7 @@ fn promotion_report_serializes_generic_command_evidence() {
         ])],
         deterministic_gates: Vec::new(),
         gate_results: Vec::new(),
+        verified_base: None,
         provenance: Value::Null,
         operator_notification: AgentTaskPromotionNotification {
             status: "completed".to_string(),

--- a/crates/homeboy-core/src/agent_task_promotion/types.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/types.rs
@@ -61,9 +61,18 @@ pub struct AgentTaskPromotionReport {
     pub deterministic_gates: Vec<AgentTaskGateReport>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub gate_results: Vec<HomeboyGateResult>,
+    /// Declared base branch snapshot captured immediately before promotion gates.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verified_base: Option<AgentTaskPromotionVerifiedBase>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub provenance: Value,
     pub operator_notification: AgentTaskPromotionNotification,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPromotionVerifiedBase {
+    pub base: String,
+    pub sha: String,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/homeboy-core/src/agent_task_service/cook.rs
+++ b/crates/homeboy-core/src/agent_task_service/cook.rs
@@ -1175,6 +1175,18 @@ fn finalize_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
         )))
         .collect();
     let artifact_refs = std::iter::once(promotion.patch_artifact.path.clone()).collect();
+    let verified_base = promotion
+        .verified_base
+        .as_ref()
+        .filter(|base| base.base == options.base && !base.sha.trim().is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "promotion.verified_base",
+                "cook finalization requires the typed declared base snapshot captured before promotion gates; rerun promotion against the configured base before finalizing",
+                None,
+                None,
+            )
+        })?;
     crate::agent_task_lifecycle::record_promotion(
         successful_run_id,
         serde_json::to_value(promotion).unwrap_or(Value::Null),
@@ -1184,6 +1196,7 @@ fn finalize_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
             path: path.clone(),
             run_id: successful_run_id.to_string(),
             base: options.base.clone(),
+            verified_base_sha: Some(verified_base.sha.clone()),
             head: options.head.clone(),
             title: options.title.clone(),
             commit_message: options.commit_message.clone(),
@@ -1542,6 +1555,7 @@ mod tests {
             "changed_files": ["src/lib.rs"],
             "gate_results": [{"id": "gate", "name": "cargo test --locked agent_task_promotion --lib", "kind": "command", "status": "passed"}],
             "operator_notification": {"status": "completed", "message": "complete"},
+            "verified_base": {"base": "main", "sha": "verified-base"},
             "provenance": {"worktree_path": "/repo"}
         })).unwrap()
     }
@@ -1603,7 +1617,7 @@ mod tests {
                 max_attempts: 1,
                 no_finalize: false,
                 base: "main".to_string(),
-                task_base_sha: None,
+                task_base_sha: Some("task-candidate-base".to_string()),
                 head: Some("fix/8058".to_string()),
                 title: "Close #8058".to_string(),
                 commit_message: "test".to_string(),
@@ -1626,6 +1640,7 @@ mod tests {
                 "## Evidence",
                 "## AI assistance",
                 "openai/gpt-5.6-terra",
+                "Verified finalization base: main at verified-base",
                 "1. Run `cargo test --locked agent_task_promotion --lib`; expect passes.",
             ] {
                 assert!(

--- a/crates/homeboy-core/src/agent_tasks.rs
+++ b/crates/homeboy-core/src/agent_tasks.rs
@@ -303,7 +303,8 @@ pub mod promotion {
         promote, promote_with_checkpoint, resume_promoted_patch, AgentTaskPromotionArtifactRef,
         AgentTaskPromotionCommandReport, AgentTaskPromotionNotification, AgentTaskPromotionOptions,
         AgentTaskPromotionReport, AgentTaskPromotionSource, AgentTaskPromotionStatus,
-        AgentTaskPromotionTarget, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
+        AgentTaskPromotionTarget, AgentTaskPromotionVerifiedBase,
+        AGENT_TASK_PROMOTION_REPORT_SCHEMA,
     };
 }
 


### PR DESCRIPTION
## Summary
Carry one immutable declared-base snapshot from promotion through gates and finalization so later remote movement is reported rather than forcing repeated rebases.

## What changed
- Capture the exact declared remote base before deterministic promotion gates without shared FETCH\_HEAD state, persist a typed base-and-SHA binding, and require finalization to validate candidate ancestry against that snapshot.
- Propagate the binding through cook, promotion reports, generated handoffs, publication intent, and reviewer evidence; rematerialize only the persisted SHA when local Git GC removed it.
- Add deterministic temporary-repository coverage for unrelated concurrent fetches, remote advancement during the gate window, stale-candidate rejection, exact-SHA recovery, cook integration, and non-default-base handoffs.

## How to test
1. Run `cargo check --workspace --tests --locked`; expect Every workspace test target compiles against the captured base snapshot.
2. Run `cargo test -p homeboy-core agent_task_finalization --no-fail-fast`; expect All focused finalization tests pass, including gate-window advancement and fail-closed snapshot validation.
3. Run `cargo test -p homeboy-core declared_base_capture_is_immune_to_unrelated_fetch_head_activity --no-fail-fast`; expect Concurrent unrelated fetch activity cannot change the captured declared-base SHA and no private refs leak.
4. Run `cargo test -p homeboy-core resolve_verified_base_rematerializes_only_the_persisted_snapshot --no-fail-fast`; expect A missing local object is rematerialized by exact SHA without substituting the current branch tip.
5. Run `cargo test -p homeboy-core cook_successful_concrete_attempt_publishes_reviewer_body --no-fail-fast`; expect Cook carries promotion snapshot provenance into finalization evidence.
6. Run `cargo test -p homeboy-cli promotion_handoff --no-fail-fast`; expect Generated handoffs include both declared base and verified SHA.
7. Run `git diff --name-only origin/main...HEAD -- '*.rs' | xargs rustfmt --edition 2021 --check && git diff --check`; expect Every changed Rust file is formatted and the patch contains no whitespace errors.

## Compatibility
The finalize-pr command now requires an explicit verified-base-sha captured before declared gates, and promotion reports add optional typed verified-base provenance. Generated Homeboy handoffs and cook flows supply the new contract. Persisted older promotion reports remain readable but fail closed before new finalization when no trustworthy snapshot exists.

## Evidence
- Base unchanged since verification: main remains at d4a306a8569265105e7b46b394c6bb1120729d0e.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8483
- Verified finalization base: main at d4a306a8569265105e7b46b394c6bb1120729d0e
- changed-file-format: Passed
- cook-integration: Passed
- diff-check: Passed
- finalization-tests: Passed
- handoff: Passed
- snapshot-capture: Passed
- snapshot-rematerialization: Passed
- workspace-tests-compile: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Implemented and repeatedly reviewed the gate-time base snapshot contract, promotion/cook propagation, exact-SHA durability, and deterministic race coverage with Chris.

## Source relationships
- Closes #8483
