### PR TITLE
refactor: relocate remote-shell env helpers into engine-primitives

### DIFF
--- a/crates/homeboy-core/src/runner/command_path.rs
+++ b/crates/homeboy-core/src/runner/command_path.rs
@@ -64,24 +64,6 @@ fn prepend_path_entry(env: &mut HashMap<String, String>, entry: &str) {
     }
 }
 
-pub(crate) fn remote_shell_path_preamble() -> &'static str {
-    concat!(
-        "export PATH=\"$HOME/.local/bin:$HOME/.",
-        "car",
-        "go/bin:$HOME/.kimaki/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}\"; ",
-        "for d in \"$HOME\"/.local/opt/node-*/bin \"$HOME\"/.nvm/versions/node/*/bin; do ",
-        "[ -d \"$d\" ] && PATH=\"$d:$PATH\"; done; export PATH"
-    )
-}
-
-pub(crate) fn quote_runner_env_value(key: &str, value: &str) -> String {
-    if key == "PATH" {
-        return format!("\"{}\"", escape_double_quoted_env_value(value));
-    }
-
-    crate::engine::shell::quote_arg(value)
-}
-
 /// Explicit path-translation preflight for a remote dispatch argv.
 ///
 /// Rejects any argument that still embeds the controller-local source-checkout
@@ -569,13 +551,6 @@ fn arg_embeds_untranslated_local_path(arg: &str, local_root: &str, remote_cwd: &
     true
 }
 
-fn escape_double_quoted_env_value(value: &str) -> String {
-    value
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('`', "\\`")
-}
-
 fn local_runner_command_path() -> Option<OsString> {
     let home = std::env::var_os("HOME").map(PathBuf::from);
     let existing_path = std::env::var_os("PATH");
@@ -702,31 +677,6 @@ mod tests {
         normalize_runner_command_env(&mut env);
 
         assert_eq!(env.get("PATH").map(String::as_str), Some("/custom/bin"));
-    }
-
-    #[test]
-    fn remote_shell_path_preamble_includes_local_opt_node_glob() {
-        let preamble = remote_shell_path_preamble();
-
-        assert!(preamble.contains("$HOME/.local/bin"));
-        assert!(preamble.contains("$HOME\"/.local/opt/node-*/bin"));
-        assert!(preamble.contains("$HOME\"/.nvm/versions/node/*/bin"));
-    }
-
-    #[test]
-    fn path_env_value_allows_existing_path_expansion() {
-        assert_eq!(
-            quote_runner_env_value("PATH", "$PATH:/custom/bin"),
-            "\"$PATH:/custom/bin\""
-        );
-    }
-
-    #[test]
-    fn non_path_env_value_uses_shell_quoting() {
-        assert_eq!(
-            quote_runner_env_value("TOKEN", "hello world"),
-            "'hello world'"
-        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/runner/mod.rs
+++ b/crates/homeboy-core/src/runner/mod.rs
@@ -96,11 +96,8 @@ pub use capabilities::{
     PreparedLabRunnerCapability, RunnerCapabilityPreflight, RunnerRequiredTool,
     RunnerToolCapabilityRequirement,
 };
+pub(crate) use command_path::normalize_runner_command_env_for_homeboy_path;
 pub use command_path::preflight_remote_argv_path_translation;
-pub(crate) use command_path::{
-    normalize_runner_command_env_for_homeboy_path, quote_runner_env_value,
-    remote_shell_path_preamble,
-};
 pub(crate) use connection::daemon_endpoint_identity;
 pub(crate) use connection::disconnect_with_force;
 pub(crate) use connection::local_live_session;
@@ -110,8 +107,8 @@ pub use connection::{
     reverse_broker_artifact_content, reverse_broker_reconcile, runner_artifact_content, status,
     statuses,
 };
-pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
 pub use continuation_provider::register as register_runner_continuation_provider;
+pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
 pub use evidence::register_runner_evidence_provider;
 pub use evidence::runner_artifact_store_token;
 pub use evidence::{

--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -5,8 +5,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::engine::shell;
+use crate::engine::shell::{quote_runner_env_value, remote_shell_path_preamble};
 use crate::error::{Error, Result};
-use crate::runner::{quote_runner_env_value, remote_shell_path_preamble};
 
 use super::super::session::ensure_control_path_parent;
 use super::super::ssh_args::{client_ssh_args, SshArgOptions, SshPortFlag};

--- a/crates/homeboy-engine-primitives/src/shell.rs
+++ b/crates/homeboy-engine-primitives/src/shell.rs
@@ -77,3 +77,65 @@ fn split_respecting_quotes(input: &str) -> Vec<String> {
 pub fn quote_path(path: &str) -> String {
     format!("'{}'", escape_single_quote_content(path))
 }
+
+/// Shell preamble that normalizes `PATH` for a remote (SSH) command so common
+/// user/tool bin directories and versioned Node installs are discoverable
+/// before the dispatched command runs. Pure shell-string construction shared by
+/// remote-dispatch callers; contains no runner-specific behavior.
+pub fn remote_shell_path_preamble() -> &'static str {
+    concat!(
+        "export PATH=\"$HOME/.local/bin:$HOME/.",
+        "car",
+        "go/bin:$HOME/.kimaki/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}\"; ",
+        "for d in \"$HOME\"/.local/opt/node-*/bin \"$HOME\"/.nvm/versions/node/*/bin; do ",
+        "[ -d \"$d\" ] && PATH=\"$d:$PATH\"; done; export PATH"
+    )
+}
+
+/// Quote an environment-variable value for inclusion in a remote `export`
+/// statement. `PATH` is quoted with double quotes so `$PATH` expansion is
+/// preserved; every other value is shell-quoted normally.
+pub fn quote_runner_env_value(key: &str, value: &str) -> String {
+    if key == "PATH" {
+        return format!("\"{}\"", escape_double_quoted_env_value(value));
+    }
+
+    quote_arg(value)
+}
+
+fn escape_double_quoted_env_value(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('`', "\\`")
+}
+
+#[cfg(test)]
+mod remote_env_tests {
+    use super::*;
+
+    #[test]
+    fn remote_shell_path_preamble_includes_local_opt_node_glob() {
+        let preamble = remote_shell_path_preamble();
+
+        assert!(preamble.contains("$HOME/.local/bin"));
+        assert!(preamble.contains("$HOME\"/.local/opt/node-*/bin"));
+        assert!(preamble.contains("$HOME\"/.nvm/versions/node/*/bin"));
+    }
+
+    #[test]
+    fn path_env_value_allows_existing_path_expansion() {
+        assert_eq!(
+            quote_runner_env_value("PATH", "$PATH:/custom/bin"),
+            "\"$PATH:/custom/bin\""
+        );
+    }
+
+    #[test]
+    fn non_path_env_value_uses_shell_quoting() {
+        assert_eq!(
+            quote_runner_env_value("TOKEN", "hello world"),
+            "'hello world'"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Moves `remote_shell_path_preamble` and `quote_runner_env_value` (plus the private `escape_double_quoted_env_value` helper) out of `runner/command_path.rs` and into `homeboy-engine-primitives::shell`, alongside the existing `quote_arg`/`quote_args`/`quote_path` primitives.
- Repoints the one non-runner caller, `server/client/ssh_client.rs`, at `crate::engine::shell` — **severing a core→runner dependency edge**.
- The moved unit tests come with them.

## Why
These two functions are pure shell-command construction (a static PATH-export preamble and env-value quoting), not runner-specific behavior. Their old home forced `ssh_client.rs` — a core server module — to `use crate::runner::…`. That's an edge that has to go before the runner subsystem can be extracted into its own crate.

This is the "it's actually a core concern, not runner behavior" edge-elimination pattern: no hook, no type-drag, no behavior change — just relocating primitives to where they belong. One more edge off the runner-extraction blocker list.

## Verification
- `cargo fmt` clean.
- `ssh_client.rs` now has zero `crate::runner` references; it no longer appears in the core→runner edge inventory.
- `command_path.rs` / `runner/mod.rs` no longer reference the moved symbols.

_Left heavy `cargo build`/`test` to CI per repo policy._

🤖 Generated with [Claude Code](https://claude.com/claude-code)