### PR TITLE
refactor: move signature extraction into code_audit to break refactor cycle

### DIFF
--- a/crates/homeboy-core/src/code_audit/conventions/mod.rs
+++ b/crates/homeboy-core/src/code_audit/conventions/mod.rs
@@ -450,7 +450,7 @@ pub fn check_signature_consistency(
                 Err(_) => continue,
             };
 
-            let sigs = crate::refactor::plan::generate::extract_signatures(&content, &lang);
+            let sigs = super::signature_extraction::extract_signatures(&content, &lang);
             for sig in &sigs {
                 if conv.expected_methods.contains(&sig.name) {
                     method_sigs

--- a/crates/homeboy-core/src/code_audit/mod.rs
+++ b/crates/homeboy-core/src/code_audit/mod.rs
@@ -41,6 +41,7 @@ pub mod report;
 mod requirements;
 pub mod run;
 mod shadow_modules;
+pub(crate) mod signature_extraction;
 mod signatures;
 mod source_locations;
 mod structural;

--- a/crates/homeboy-core/src/code_audit/signature_extraction.rs
+++ b/crates/homeboy-core/src/code_audit/signature_extraction.rs
@@ -1,0 +1,118 @@
+//! Grammar-driven method-signature extraction.
+//!
+//! This is a source-parsing primitive: given file content and a language, it
+//! uses the audit fingerprinting grammar (`core_fingerprint`) to pull out each
+//! method's name, declaration line, and body. It lives in `code_audit` next to
+//! the grammar engine it depends on. Both the convention detector (which
+//! compares method skeletons across conforming files) and the refactor
+//! convention-fix generator (which stubs missing methods from a conforming
+//! peer) consume it — refactor imports it *down* from here rather than audit
+//! reaching *up* into refactor, which previously formed a `code_audit`↔
+//! `refactor` cycle.
+
+use homeboy_engine_primitives::language::Language;
+
+/// Full method signature extracted from a conforming file.
+#[derive(Debug, Clone)]
+pub(crate) struct MethodSignature {
+    /// Method name.
+    pub(crate) name: String,
+    /// Full signature line (e.g., "public function execute(array $config): array").
+    pub(crate) signature: String,
+    /// The language this was extracted from.
+    pub(crate) language: Language,
+    /// Full method body (between braces), extracted from the conforming file.
+    /// None if the body couldn't be extracted.
+    pub(crate) body: Option<String>,
+}
+
+pub(crate) fn extract_signatures_from_items(
+    content: &str,
+    language: &Language,
+) -> Vec<MethodSignature> {
+    let file_ext = match language {
+        Language::Php => "php",
+        Language::Rust => "rs",
+        Language::JavaScript => "js",
+        Language::TypeScript => "ts",
+        Language::Unknown => return Vec::new(),
+    };
+
+    let Some(grammar) = super::core_fingerprint::load_grammar_for_ext(file_ext) else {
+        return Vec::new();
+    };
+
+    let symbols = crate::extension::grammar::extract(content, &grammar);
+    let lines: Vec<&str> = content.lines().collect();
+
+    symbols
+        .into_iter()
+        .filter(|symbol| {
+            matches!(
+                symbol.concept.as_str(),
+                "function" | "free_function" | "method"
+            )
+        })
+        .filter_map(|symbol| {
+            let name = symbol.name()?.to_string();
+            let line_idx = symbol.line.checked_sub(1)?;
+            let signature = lines
+                .get(line_idx)
+                .map(|line| line.trim().to_string())
+                .filter(|line| !line.is_empty())
+                .unwrap_or_else(|| name.clone());
+
+            let body = extract_method_body(&lines, line_idx);
+
+            Some(MethodSignature {
+                name,
+                signature,
+                language: language.clone(),
+                body,
+            })
+        })
+        .collect()
+}
+
+/// Extract the body of a method from source lines, starting from the
+/// declaration line. Finds the opening `{` and walks to the matching `}`,
+/// returning the lines between them (the body content).
+fn extract_method_body(lines: &[&str], start_line: usize) -> Option<String> {
+    let mut brace_depth = 0i32;
+    let mut found_open = false;
+    let mut body_start_line = start_line + 1;
+
+    for i in start_line..lines.len() {
+        let line = lines[i];
+        for ch in line.chars() {
+            if ch == '{' {
+                if !found_open {
+                    found_open = true;
+                    // Body starts on the NEXT line after the opening brace.
+                    body_start_line = i + 1;
+                }
+                brace_depth += 1;
+            } else if ch == '}' {
+                brace_depth -= 1;
+                if found_open && brace_depth == 0 {
+                    // Collect body lines (between opening { line and closing } line).
+                    if body_start_line > i {
+                        return None; // empty body: `{ }`
+                    }
+                    let body_lines = &lines[body_start_line..i];
+                    let body = body_lines.join("\n");
+                    if body.trim().is_empty() {
+                        return None;
+                    }
+                    return Some(body);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+pub(crate) fn extract_signatures(content: &str, language: &Language) -> Vec<MethodSignature> {
+    extract_signatures_from_items(content, language)
+}

--- a/crates/homeboy-core/src/refactor/plan/generate/mod.rs
+++ b/crates/homeboy-core/src/refactor/plan/generate/mod.rs
@@ -30,9 +30,8 @@ pub(crate) use duplicate_fixes::{
 };
 pub(crate) use module_surface::{FileRole, ModuleSurfaceIndex};
 pub(crate) use signatures::{
-    extract_signatures, extract_signatures_from_items, find_parsed_item_by_name,
-    generate_fallback_signature, generate_method_stub, parse_items_for_dedup,
-    primary_type_name_from_declaration,
+    extract_signatures_from_items, find_parsed_item_by_name, generate_fallback_signature,
+    generate_method_stub, parse_items_for_dedup, primary_type_name_from_declaration,
 };
 
 pub fn generate_audit_fixes(

--- a/crates/homeboy-core/src/refactor/plan/generate/signatures.rs
+++ b/crates/homeboy-core/src/refactor/plan/generate/signatures.rs
@@ -1,19 +1,13 @@
 use homeboy_engine_primitives::language::Language;
 use regex::Regex;
 
-/// Full method signature extracted from a conforming file.
-#[derive(Debug, Clone)]
-pub(crate) struct MethodSignature {
-    /// Method name.
-    pub(crate) name: String,
-    /// Full signature line (e.g., "public function execute(array $config): array").
-    pub(crate) signature: String,
-    /// The language this was extracted from.
-    pub(crate) language: Language,
-    /// Full method body (between braces), extracted from the conforming file.
-    /// None if the body couldn't be extracted.
-    pub(crate) body: Option<String>,
-}
+// Grammar-driven signature extraction (`MethodSignature`, `extract_signatures*`)
+// lives in `code_audit::signatures`, next to the fingerprinting grammar it
+// depends on. Refactor's convention-fix codegen consumes it from there, which
+// keeps the dependency pointing refactor -> code_audit (no cycle).
+pub(crate) use crate::code_audit::signature_extraction::{
+    extract_signatures_from_items, MethodSignature,
+};
 
 pub(crate) fn generate_method_stub(sig: &MethodSignature) -> String {
     // Use the real body from a conforming peer when available.
@@ -152,95 +146,4 @@ pub(crate) fn parse_items_for_dedup(
     crate::extension::run_refactor_script(&manifest, &parse_cmd)
         .and_then(|value| value.get("items").cloned())
         .and_then(|value| serde_json::from_value(value).ok())
-}
-
-pub(crate) fn extract_signatures_from_items(
-    content: &str,
-    language: &Language,
-) -> Vec<MethodSignature> {
-    let file_ext = match language {
-        Language::Php => "php",
-        Language::Rust => "rs",
-        Language::JavaScript => "js",
-        Language::TypeScript => "ts",
-        Language::Unknown => return Vec::new(),
-    };
-
-    let Some(grammar) = crate::code_audit::core_fingerprint::load_grammar_for_ext(file_ext) else {
-        return Vec::new();
-    };
-
-    let symbols = crate::extension::grammar::extract(content, &grammar);
-    let lines: Vec<&str> = content.lines().collect();
-
-    symbols
-        .into_iter()
-        .filter(|symbol| {
-            matches!(
-                symbol.concept.as_str(),
-                "function" | "free_function" | "method"
-            )
-        })
-        .filter_map(|symbol| {
-            let name = symbol.name()?.to_string();
-            let line_idx = symbol.line.checked_sub(1)?;
-            let signature = lines
-                .get(line_idx)
-                .map(|line| line.trim().to_string())
-                .filter(|line| !line.is_empty())
-                .unwrap_or_else(|| name.clone());
-
-            let body = extract_method_body(&lines, line_idx);
-
-            Some(MethodSignature {
-                name,
-                signature,
-                language: language.clone(),
-                body,
-            })
-        })
-        .collect()
-}
-
-/// Extract the body of a method from source lines, starting from the
-/// declaration line. Finds the opening `{` and walks to the matching `}`,
-/// returning the lines between them (the body content).
-fn extract_method_body(lines: &[&str], start_line: usize) -> Option<String> {
-    let mut brace_depth = 0i32;
-    let mut found_open = false;
-    let mut body_start_line = start_line + 1;
-
-    for i in start_line..lines.len() {
-        let line = lines[i];
-        for ch in line.chars() {
-            if ch == '{' {
-                if !found_open {
-                    found_open = true;
-                    // Body starts on the NEXT line after the opening brace.
-                    body_start_line = i + 1;
-                }
-                brace_depth += 1;
-            } else if ch == '}' {
-                brace_depth -= 1;
-                if found_open && brace_depth == 0 {
-                    // Collect body lines (between opening { line and closing } line).
-                    if body_start_line > i {
-                        return None; // empty body: `{ }`
-                    }
-                    let body_lines = &lines[body_start_line..i];
-                    let body = body_lines.join("\n");
-                    if body.trim().is_empty() {
-                        return None;
-                    }
-                    return Some(body);
-                }
-            }
-        }
-    }
-
-    None
-}
-
-pub(crate) fn extract_signatures(content: &str, language: &Language) -> Vec<MethodSignature> {
-    extract_signatures_from_items(content, language)
 }


### PR DESCRIPTION
## Summary
- Grammar-driven method-signature extraction (`MethodSignature`, `extract_signatures`, `extract_signatures_from_items`, `extract_method_body`) lived in `refactor::plan::generate::signatures`, but `code_audit`'s convention detector called **up** into it — while the extraction itself calls **down** into `code_audit::core_fingerprint`. That formed a `code_audit`↔`refactor` production cycle around the same neighborhood.
- Extraction is fundamentally a source-parsing primitive over the audit fingerprinting grammar, so it belongs in `code_audit`. Moved into a new `code_audit::signature_extraction` module (next to `core_fingerprint`, which it already depends on).

## Result
- The convention detector now calls the local module (`super::signature_extraction::extract_signatures`).
- Refactor's convention-fix codegen imports `MethodSignature` / `extract_signatures_from_items` **down** from `code_audit`, so the dependency points refactor → code_audit (natural direction, no cycle).
- Codegen helpers (`generate_method_stub`, `generate_fallback_signature`, `parse_items_for_dedup`, `find_parsed_item_by_name`, `primary_type_name_from_declaration`) stay in refactor.
- **Removes the `code_audit::conventions -> refactor` edge.** The remaining `code_audit -> refactor` edges (audit fixability planning in `report.rs`, which invokes the refactor fix-planner) are a separate, larger cluster for a follow-up.

## Verification
- `cargo check -p homeboy-core --lib` — 0 errors, no new warnings in touched files.
- `cargo test -p homeboy-core --lib signature` — 32 passed; `conventions::` — 34 passed. Behavior preserved.
- `cargo check --workspace --tests --locked` (topology guard) — passes.
- 5 files; reverted unrelated `cargo fmt` drift in `agent_task_lifecycle/*` and `runner/*`.

Refs #8425