### PR TITLE
fix: scope release recovery concurrency by tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ env:
 # after the first finishes and its check job exits in seconds because
 # HEAD is already tagged — zero wasted work.
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.release_tag || github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -203,6 +203,13 @@ fn release_ci_disables_homeboy_update_checks() {
 }
 
 #[test]
+fn release_concurrency_scopes_recovery_runs_to_the_requested_tag() {
+    assert!(release_workflow().contains(
+        "concurrency:\n  group: release-${{ inputs.release_tag || github.ref }}\n  cancel-in-progress: false"
+    ));
+}
+
+#[test]
 fn release_test_gate_does_not_repeat_separate_lint_gate() {
     let gate_test = job_section(release_workflow(), "gate-test");
 


### PR DESCRIPTION
Closes #8584

## Summary
- Scope existing-tag recovery dispatches to `inputs.release_tag`.
- Retain `github.ref` for ordinary push-triggered releases.
- Add an exact workflow contract assertion for the concurrency identity and non-cancellation policy.

## Evidence
- Source relationship: #8584 identifies recovery dispatches from `main` sharing `release-refs/heads/main` with normal releases, allowing later pushes to replace pending recovery work.
- Change kind: one workflow concurrency expression plus one deterministic source-contract test.
- Verification capability: `cargo test --test release_workflow_test` passes (20 tests).
- Scope: `inputs.release_tag || github.ref` is the workflow's existing recovery-versus-push discriminator, already used by release checkouts. Applying it only to the concurrency key serializes duplicate recoveries of one tag, isolates distinct tags, and leaves normal `main` serialization unchanged.

## AI Assistance Disclosure
Assisted by OpenAI GPT-5.6 Sol using Homeboy/OpenCode.