### PR TITLE
Fix stale runner daemon recovery loop

### DIFF
--- a/crates/homeboy-core/src/runner/connection.rs
+++ b/crates/homeboy-core/src/runner/connection.rs
@@ -842,6 +842,9 @@ pub(super) fn active_jobs_before_daemon_replacement(
     if !report.connected {
         return Ok(Vec::new());
     }
+    if authoritative_zero_active_jobs(&report) {
+        return Ok(Vec::new());
+    }
     if report.active_job_state != RunnerActiveJobState::Available {
         let mut error = Error::validation_invalid_argument(
             "reconnect",
@@ -854,7 +857,27 @@ pub(super) fn active_jobs_before_daemon_replacement(
         error.details["active_job_state"] = serde_json::json!(report.active_job_state);
         return Err(error);
     }
+    if let Some(error) = &report.active_job_error {
+        return Err(Error::validation_invalid_argument(
+            "reconnect",
+            format!(
+                "runner `{runner_id}` has an inconsistent active daemon job view ({}); refusing to replace the daemon",
+                error.message
+            ),
+            Some(runner_id.to_string()),
+            Some(vec![format!("homeboy runner status {}", shell::quote_arg(runner_id))]),
+        ));
+    }
     Ok(report.active_jobs)
+}
+
+/// A daemon freshness report is the daemon's own job count. Only a restartable
+/// daemon which reports zero jobs can replace an unavailable typed `/jobs` view.
+pub(crate) fn authoritative_zero_active_jobs(report: &RunnerStatusReport) -> bool {
+    report
+        .daemon_freshness
+        .as_ref()
+        .is_some_and(|freshness| freshness.restartable && freshness.active_jobs == 0)
 }
 
 fn runner_daemon_freshness(

--- a/crates/homeboy-core/src/runner/connection_daemon.rs
+++ b/crates/homeboy-core/src/runner/connection_daemon.rs
@@ -402,7 +402,9 @@ fn daemon_freshness_report(
     Ok(DaemonFreshnessReport {
         fresh: mismatch.is_none(),
         stale_reason_code: mismatch.map(|_| DaemonStaleReasonCode::VersionMismatch),
-        restartable: true,
+        // A legacy version response has no daemon-owned job count, so it cannot
+        // authorize replacement while the typed job endpoint is unavailable.
+        restartable: false,
         lease_id: daemon_lease_id_from_body(&body).map(ToString::to_string),
         pid: None,
         recovery_evidence: None,

--- a/crates/homeboy-core/src/runner/execution/mod.rs
+++ b/crates/homeboy-core/src/runner/execution/mod.rs
@@ -809,7 +809,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
             ),
             Some(runner_id.to_string()),
             Some(vec![format!(
-                "Drain or recover known jobs. An explicit `homeboy runner refresh-homeboy {runner_id} --ref <version> --reconnect` can rotate this daemon only after `homeboy runner status {runner_id}` reports `active_job_count: 0` and `active_job_state: available`."
+                "Drain or recover known jobs. An explicit `homeboy runner refresh-homeboy {runner_id} --ref <version> --reconnect` can rotate this daemon only after `homeboy runner status {runner_id}` reports an authoritative zero active-job count."
             )]),
         ));
     }
@@ -892,17 +892,19 @@ fn allows_idle_stale_daemon_refresh(
     options: &RunnerExecOptions,
     status: &RunnerStatusReport,
 ) -> bool {
-    // A refresh replaces the daemon immediately after this command. Require both
-    // a successful /jobs poll and the daemon's authoritative zero-job count.
+    // A refresh replaces the daemon immediately after this command. A successful
+    // typed /jobs poll or the daemon's restartable freshness report may prove it
+    // is drained; every other state remains fail-closed.
     options
         .capability_preflight
         .as_ref()
         .is_some_and(|preflight| preflight.command == "runner.refresh-homeboy")
-        && status.active_job_state == RunnerActiveJobState::Available
-        && status.active_job_source == Some(RunnerActiveJobSource::DirectDaemon)
-        && status.active_job_count == 0
-        && status.active_jobs.is_empty()
-        && status.active_job_error.is_none()
+        && (crate::runner::connection::authoritative_zero_active_jobs(status)
+            || (status.active_job_state == RunnerActiveJobState::Available
+                && status.active_job_source == Some(RunnerActiveJobSource::DirectDaemon)
+                && status.active_job_count == 0
+                && status.active_jobs.is_empty()
+                && status.active_job_error.is_none()))
 }
 
 fn apply_explicit_runner_exec_run_id_env(

--- a/crates/homeboy-core/src/runner/execution/tests/exec.rs
+++ b/crates/homeboy-core/src/runner/execution/tests/exec.rs
@@ -11,7 +11,14 @@ use serde_json::json;
 
 #[test]
 fn explicit_refresh_allows_an_idle_stale_daemon_after_reconnect() {
-    let status = stale_direct_daemon_status();
+    let mut status = stale_direct_daemon_status();
+    status.active_job_state = RunnerActiveJobState::Unavailable;
+    status.active_job_source = None;
+    status.active_job_error = Some(crate::runner::RunnerActiveJobError {
+        code: "jobs_unavailable".to_string(),
+        message: "typed jobs endpoint belongs to the stale daemon".to_string(),
+    });
+    status.daemon_freshness = Some(authoritative_drained_freshness());
 
     assert!(allows_idle_stale_daemon_refresh(
         &explicit_refresh_options(),
@@ -24,11 +31,35 @@ fn explicit_refresh_keeps_active_or_uncertain_stale_daemons_protected() {
     let options = explicit_refresh_options();
     let mut active = stale_direct_daemon_status();
     active.active_job_count = 1;
+    active.daemon_freshness = Some(crate::daemon::DaemonFreshnessReport {
+        active_jobs: 1,
+        ..authoritative_drained_freshness()
+    });
     let mut unavailable = stale_direct_daemon_status();
     unavailable.active_job_state = RunnerActiveJobState::Unavailable;
 
     assert!(!allows_idle_stale_daemon_refresh(&options, &active));
     assert!(!allows_idle_stale_daemon_refresh(&options, &unavailable));
+}
+
+fn authoritative_drained_freshness() -> crate::daemon::DaemonFreshnessReport {
+    crate::daemon::DaemonFreshnessReport {
+        fresh: false,
+        stale_reason_code: Some(crate::daemon::DaemonStaleReasonCode::VersionMismatch),
+        restartable: true,
+        lease_id: Some("lease-stale".to_string()),
+        pid: Some(4242),
+        recovery_evidence: None,
+        ownership_evidence: None,
+        adoption_command: None,
+        binary_hash: None,
+        daemon_version: Some("0.288.8".to_string()),
+        daemon_build_identity: Some("homeboy 0.288.8+stale".to_string()),
+        runtime_paths: None,
+        active_jobs: 0,
+        termination_evidence: None,
+        repair_plan: Vec::new(),
+    }
 }
 
 fn explicit_refresh_options() -> RunnerExecOptions {

--- a/crates/homeboy-core/src/runner/lab/preparation_tests.rs
+++ b/crates/homeboy-core/src/runner/lab/preparation_tests.rs
@@ -198,7 +198,10 @@ fn lab_runner_preparation_falls_back_for_stale_default_runtime_paths() {
     assert_eq!(
         prepared,
         LabRunnerPreparation::FallBackLocal {
-            reason: "connected runner `lab` daemon runtime is stale after runner-side rebuilds or path changes; restart the active daemon with `homeboy runner disconnect lab && homeboy runner connect lab`".to_string()
+            reason: format!(
+                "connected runner `lab` daemon runtime is stale after runner-side rebuilds or path changes; restart the active daemon with `homeboy runner refresh-homeboy lab --ref v{} --reconnect`",
+                homeboy_product_identity::product_version()
+            )
         }
     );
 }
@@ -245,7 +248,7 @@ fn lab_runner_preparation_errors_for_explicit_stale_daemon_version() {
     assert!(err.message.contains("homeboy 0.219.0"));
     assert!(err
         .message
-        .contains("homeboy runner disconnect lab && homeboy runner connect lab"));
+        .contains("homeboy runner refresh-homeboy lab --ref v"));
     assert!(err
         .message
         .contains("malformed or misleading provider output"));
@@ -257,8 +260,7 @@ fn lab_runner_preparation_errors_for_explicit_stale_daemon_version() {
         .flatten()
         .any(|suggestion| suggestion
             .as_str()
-            .is_some_and(|value| value
-                .contains("homeboy runner disconnect lab && homeboy runner connect lab"))));
+            .is_some_and(|value| value.contains("homeboy runner refresh-homeboy lab --ref v"))));
 }
 
 #[test]

--- a/crates/homeboy-core/src/runner/session.rs
+++ b/crates/homeboy-core/src/runner/session.rs
@@ -589,11 +589,12 @@ impl RunnerStaleDaemonWarning {
         self.stale_runtime_paths = stale_runtime_paths;
         self.changed_runtime_paths = changed_runtime_paths;
         if !self.stale_runtime_paths.is_empty() || !self.changed_runtime_paths.is_empty() {
-            self.message = "connected runner daemon runtime paths are stale; run recovery_commands in order to restart the active daemon after runner-side rebuilds or path changes".to_string();
-            self.recovery_commands = vec![
-                format!("homeboy runner disconnect {}", runner_id),
-                format!("homeboy runner connect {}", runner_id),
-            ];
+            self.message = "connected runner daemon runtime paths are stale; run recovery_commands after active jobs are drained to replace the active daemon with the configured runtime paths".to_string();
+            self.recovery_commands = vec![format!(
+                "homeboy runner refresh-homeboy {} --ref v{} --reconnect",
+                shell::quote_arg(runner_id),
+                homeboy_product_identity::product_version()
+            )];
         }
         self
     }


### PR DESCRIPTION
## Summary
Allow an explicitly refreshed, authoritatively drained stale runner daemon to be replaced while preserving fail-closed behavior for active or unverifiable jobs.

## What changed
- Use restartable daemon freshness with zero active jobs as authoritative replacement evidence, mark legacy version-only freshness non-restartable, and provide convergent recovery guidance.

## How to test
1. Run `cargo test -p homeboy-core runner::execution`; expect all 22 focused execution tests pass.
2. Run `cargo test -p homeboy-core runner::lab::preparation_tests`; expect all 14 focused Lab preparation tests pass.

## Compatibility
No command or schema break. Active and unverifiable runner work remains protected; only explicitly restartable zero-job stale daemons become replaceable.

## Evidence
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8605
- focused-execution-tests: Passed
- lab-preparation-tests: Passed
- rustfmt: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the stale-daemon recovery deadlock, implemented the fix and deterministic tests, and prepared verification evidence.

## Source relationships
- Closes #8605
