### PR TITLE
refactor: route trace canonicality lab-workspace check through the provenance hook

### DIFF
--- a/crates/homeboy-core/src/agent_task_scheduler/lab_workspace_provenance.rs
+++ b/crates/homeboy-core/src/agent_task_scheduler/lab_workspace_provenance.rs
@@ -51,6 +51,15 @@ pub trait LabWorkspaceProvenanceProvider: Send + Sync {
         snapshot: SourceSnapshot,
         lab: serde_json::Value,
     ) -> std::result::Result<String, String>;
+
+    /// Verify a lab-materialized workspace using the lab-offload and
+    /// source-snapshot metadata carried in the process environment (the
+    /// `verify_lab_workspace_from_env` check used by trace canonicality).
+    fn verify_lab_workspace_from_env(
+        &self,
+        expected_remote_component_path: &str,
+        materialized_workspace_path: &Path,
+    ) -> std::result::Result<LabWorkspaceProvenanceInfo, String>;
 }
 
 /// Default provider used when no runner layer is registered. The verification
@@ -80,6 +89,14 @@ impl LabWorkspaceProvenanceProvider for NoopLabWorkspaceProvenanceProvider {
         _snapshot: SourceSnapshot,
         _lab: serde_json::Value,
     ) -> std::result::Result<String, String> {
+        Err(NO_PROVIDER.to_string())
+    }
+
+    fn verify_lab_workspace_from_env(
+        &self,
+        _expected_remote_component_path: &str,
+        _materialized_workspace_path: &Path,
+    ) -> std::result::Result<LabWorkspaceProvenanceInfo, String> {
         Err(NO_PROVIDER.to_string())
     }
 }

--- a/crates/homeboy-core/src/extension/trace/canonicality.rs
+++ b/crates/homeboy-core/src/extension/trace/canonicality.rs
@@ -5,9 +5,11 @@ use crate::component::Component;
 use crate::error::{ErrorCode, Result};
 use crate::extension::manifest_config::TraceToolchainProvenanceConfig;
 use crate::extension::ExtensionExecutionContext;
+use crate::agent_task_scheduler::lab_workspace_provenance::{
+    with_lab_workspace_provenance, LabWorkspaceProvenanceInfo,
+};
 #[cfg(test)]
 use crate::runner::verify_lab_workspace;
-use crate::runner::verify_lab_workspace_from_env;
 #[cfg(test)]
 use crate::source_snapshot::SourceSnapshot;
 
@@ -409,12 +411,10 @@ fn check_managed_lab_snapshot(
     reasons: &mut Vec<String>,
 ) -> Option<TraceCanonicalCheck> {
     let expected_remote_component_path = expected_remote_component_path?;
-    verified_lab_snapshot_check(
-        target,
-        path,
-        verify_lab_workspace_from_env(expected_remote_component_path, path),
-        reasons,
-    )
+    let provenance = with_lab_workspace_provenance(|provider| {
+        provider.verify_lab_workspace_from_env(expected_remote_component_path, path)
+    });
+    verified_lab_snapshot_check(target, path, provenance, reasons)
 }
 
 #[cfg(test)]
@@ -426,18 +426,22 @@ fn validate_managed_lab_snapshot(
     lab: serde_json::Value,
     reasons: &mut Vec<String>,
 ) -> Option<TraceCanonicalCheck> {
-    verified_lab_snapshot_check(
-        target,
-        path,
-        verify_lab_workspace(expected_remote_component_path, path, snapshot, lab),
-        reasons,
-    )
+    let provenance = verify_lab_workspace(expected_remote_component_path, path, snapshot, lab).map(
+        |provenance| LabWorkspaceProvenanceInfo {
+            source_revision: provenance.source_revision,
+            materialization_mode: provenance.materialization_mode,
+            runner_id: provenance.runner_id,
+            workspace_identity: provenance.workspace_identity,
+            snapshot_hash: provenance.snapshot_hash,
+        },
+    );
+    verified_lab_snapshot_check(target, path, provenance, reasons)
 }
 
 fn verified_lab_snapshot_check(
     target: &str,
     path: &Path,
-    provenance: std::result::Result<crate::runner::VerifiedLabWorkspaceProvenance, String>,
+    provenance: std::result::Result<LabWorkspaceProvenanceInfo, String>,
     reasons: &mut Vec<String>,
 ) -> Option<TraceCanonicalCheck> {
     match provenance {
@@ -1027,6 +1031,7 @@ mod tests {
 
     #[test]
     fn canonical_trace_accepts_lab_dispatch_environment_for_remapped_workspace() {
+        crate::runner::register_lab_workspace_provenance_provider();
         let (_source, remote, snapshot, lab) = lab_snapshot_fixture();
         let mut env = crate::runner::build_lab_offload_env(&lab);
         env.insert(

--- a/crates/homeboy-core/src/runner/lab_workspace_provenance_provider.rs
+++ b/crates/homeboy-core/src/runner/lab_workspace_provenance_provider.rs
@@ -60,6 +60,24 @@ impl LabWorkspaceProvenanceProvider for LabWorkspaceProvenance {
             lab,
         )
     }
+
+    fn verify_lab_workspace_from_env(
+        &self,
+        expected_remote_component_path: &str,
+        materialized_workspace_path: &Path,
+    ) -> std::result::Result<LabWorkspaceProvenanceInfo, String> {
+        let provenance = super::workspace::verify_lab_workspace_from_env(
+            expected_remote_component_path,
+            materialized_workspace_path,
+        )?;
+        Ok(LabWorkspaceProvenanceInfo {
+            source_revision: provenance.source_revision,
+            materialization_mode: provenance.materialization_mode,
+            runner_id: provenance.runner_id,
+            workspace_identity: provenance.workspace_identity,
+            snapshot_hash: provenance.snapshot_hash,
+        })
+    }
 }
 
 /// Register the lab-workspace provenance provider with core. Called once at


### PR DESCRIPTION
## Summary
- Clears the last production `core -> runner` behavior edge in `extension/trace`. Trace canonicality verified a lab-materialized workspace by calling `crate::runner::verify_lab_workspace_from_env` directly; it now goes through the existing `LabWorkspaceProvenanceProvider` hook.
- Extends that hook with a `verify_lab_workspace_from_env` method (Noop errors clearly), maps the full runner provenance onto the slim `LabWorkspaceProvenanceInfo` the check already consumes, and repoints `verified_lab_snapshot_check` to the slim type.

## Why
Part of the staged runner-subsystem extraction. This is a behavior-inversion (hook) reusing the provenance provider already registered at CLI startup, so no new registration is needed. One canonicality test that exercises the prod path registers the runner provider in-test.

## Testing
- `cargo check -p homeboy-core --lib` / `--tests` — clean
- `cargo check -p homeboy-cli --lib` — clean
- `cargo test -p homeboy-core --lib` for `extension::trace::canonicality` (20 passed) and `lab_workspace_provenance` (2 passed)
- Full `--workspace` suite via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)