### PR TITLE
refactor: invert audit fixability planning behind a provider hook

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -109,6 +109,10 @@ impl CliRuntime {
         // code_audit depending on observation — the last seam before audit becomes
         // its own crate.
         crate::core::observation::audit_artifact_provider::register();
+        // Register the audit fixability provider so code_audit can report how
+        // fixable its findings are without calling up into the refactor engine's
+        // fix planner — the seam that removes the last code_audit->refactor edge.
+        crate::core::refactor::audit_fixability_provider::register();
         // Register the runner-evidence provider so observation::runs_service can
         // enrich run/artifact lookups with live runner + daemon evidence without
         // core depending on runner behavior. (Runner is still in-crate today;

--- a/crates/homeboy-core/src/code_audit/fixability_provider.rs
+++ b/crates/homeboy-core/src/code_audit/fixability_provider.rs
@@ -1,0 +1,124 @@
+//! Fix-plan access for the audit engine, inverted behind a provider.
+//!
+//! Audit reports a *fixability* summary (how many findings an automated fixer
+//! could address) alongside its findings. Computing that requires planning the
+//! actual fixes — which is the refactor engine's job. Audit used to call
+//! `crate::refactor::plan::generate::*` and `crate::refactor::auto::*` directly,
+//! which coupled `code_audit` up to the `refactor` feature layer and formed a
+//! `code_audit`↔`refactor` cycle (refactor already depends on audit for the
+//! `CodeAuditResult` it fixes).
+//!
+//! Instead, audit defines the slim view it needs (a per-finding automation
+//! verdict) plus a provider trait; the refactor layer registers an
+//! implementation at startup (same pattern as the extension-manifest /
+//! runner-evidence / tunnel provider hooks). When no provider is registered —
+//! e.g. audit running standalone — the no-op provider yields no fixes, which the
+//! caller already treats as "not fixable / fixability unavailable".
+
+use std::sync::Mutex;
+
+use super::fingerprint::FileFingerprint;
+use super::CodeAuditResult;
+use homeboy_audit_contract::AuditFinding;
+
+/// One planned fix's automation verdict, projected for audit's fixability tally.
+///
+/// Audit never sees the refactor engine's `FixResult` / insertion types; it only
+/// needs, per planned fix, which finding it addresses and whether an automated
+/// fixer could apply it unattended.
+#[derive(Debug, Clone)]
+pub struct FixabilityVerdict {
+    /// The audit finding this planned fix addresses.
+    pub finding: AuditFinding,
+    /// Whether an automated fixer could apply this fix without human review.
+    pub auto_apply: bool,
+}
+
+/// The fix-planning contract the audit engine depends on. Implemented by the
+/// refactor layer and registered at startup; audit calls it without depending
+/// on refactor behavior.
+pub trait AuditFixabilityProvider: Send + Sync {
+    /// Plan the fixes for an audit result and project each into a verdict.
+    ///
+    /// `fingerprints` is the audit run's already-computed fingerprint set (empty
+    /// when unavailable); providers may use it to avoid re-fingerprinting.
+    /// Returns the per-fix verdicts (empty when nothing is planned).
+    fn plan(
+        &self,
+        result: &CodeAuditResult,
+        source_path: &str,
+        fingerprints: &[FileFingerprint],
+    ) -> Vec<FixabilityVerdict>;
+}
+
+/// Default provider used when no refactor layer is registered: no fixes, so the
+/// audit engine reports no fixability (exactly as it does when the refactor
+/// engine is unavailable).
+struct NoopProvider;
+
+impl AuditFixabilityProvider for NoopProvider {
+    fn plan(
+        &self,
+        _result: &CodeAuditResult,
+        _source_path: &str,
+        _fingerprints: &[FileFingerprint],
+    ) -> Vec<FixabilityVerdict> {
+        Vec::new()
+    }
+}
+
+static PROVIDER: Mutex<Option<Box<dyn AuditFixabilityProvider>>> = Mutex::new(None);
+
+/// Register the audit fixability provider. Called once at binary startup by the
+/// refactor layer (via the CLI). Replaces any previously registered provider.
+pub fn register_audit_fixability_provider(provider: Box<dyn AuditFixabilityProvider>) {
+    let mut guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = Some(provider);
+}
+
+/// Plan fixability verdicts for an audit result via the registered provider.
+pub(crate) fn plan_fixability(
+    result: &CodeAuditResult,
+    source_path: &str,
+    fingerprints: &[FileFingerprint],
+) -> Vec<FixabilityVerdict> {
+    with_provider(|p| p.plan(result, source_path, fingerprints))
+}
+
+fn with_provider<T>(f: impl FnOnce(&dyn AuditFixabilityProvider) -> T) -> T {
+    let guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    match guard.as_ref() {
+        Some(provider) => f(provider.as_ref()),
+        None => f(&NoopProvider),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_provider_plans_nothing() {
+        let result = CodeAuditResult {
+            component_id: "c".into(),
+            source_path: "/nonexistent".into(),
+            summary: homeboy_audit_contract::AuditSummary {
+                files_scanned: 0,
+                conventions_detected: 0,
+                outliers_found: 0,
+                alignment_score: None,
+                files_skipped: 0,
+                warnings: Vec::new(),
+            },
+            conventions: Vec::new(),
+            directory_conventions: Vec::new(),
+            findings: Vec::new(),
+            duplicate_groups: Vec::new(),
+        };
+        assert!(NoopProvider.plan(&result, "/nonexistent", &[]).is_empty());
+    }
+}

--- a/crates/homeboy-core/src/code_audit/mod.rs
+++ b/crates/homeboy-core/src/code_audit/mod.rs
@@ -32,6 +32,7 @@ mod execution_plan;
 pub mod extension_manifests;
 pub(crate) mod findings;
 pub mod fingerprint;
+pub mod fixability_provider;
 mod idiomatic;
 pub(crate) mod impact;
 pub(crate) mod import_matching;

--- a/crates/homeboy-core/src/code_audit/report.rs
+++ b/crates/homeboy-core/src/code_audit/report.rs
@@ -368,40 +368,29 @@ fn compute_fixability_impl(
         return None;
     }
 
-    // Generate fix plan (dry-run — never writes)
-    let fix_policy = crate::refactor::auto::FixPolicy::default();
-    let mut fix_result = match analysis {
-        Some(analysis) if !analysis.fingerprints.is_empty() => {
-            crate::refactor::plan::generate::generate_audit_fixes_with_fingerprints(
-                result,
-                source_path,
-                &fix_policy,
-                &analysis.fingerprints,
-            )
-        }
-        _ => {
-            crate::refactor::plan::generate::generate_audit_fixes(result, source_path, &fix_policy)
-        }
-    };
+    // Plan the fixes and project each into an automation verdict. The refactor
+    // engine owns the planning (generate + policy annotation); audit only needs
+    // the per-fix (finding, auto_apply) tally. When no refactor provider is
+    // registered, this yields no verdicts and fixability is unavailable.
+    let fingerprints = analysis
+        .map(|analysis| analysis.fingerprints.as_slice())
+        .unwrap_or(&[]);
+    let verdicts = super::fixability_provider::plan_fixability(
+        result,
+        &source_path.to_string_lossy(),
+        fingerprints,
+    );
 
-    if fix_result.fixes.is_empty() && fix_result.new_files.is_empty() {
+    if verdicts.is_empty() {
         return None;
     }
-
-    // Apply policy annotation (dry-run mode: write=false, no filtering)
-    let policy = crate::refactor::auto::FixPolicy {
-        only: None,
-        exclude: Vec::new(),
-    };
-    let _ = source_path;
-    crate::refactor::auto::apply_fix_policy(&mut fix_result, false, &policy);
 
     // Count by automation eligibility
     let mut automated_count = 0usize;
     let mut manual_only = 0usize;
     let mut by_kind: BTreeMap<String, FixabilityKindBreakdown> = BTreeMap::new();
-    let mut count_fixability = |finding: &AuditFinding, auto_apply: bool| {
-        let kind_key = finding_kind_key(finding);
+    for verdict in &verdicts {
+        let kind_key = finding_kind_key(&verdict.finding);
         let entry = by_kind.entry(kind_key).or_insert(FixabilityKindBreakdown {
             total: 0,
             automated: 0,
@@ -409,23 +398,13 @@ fn compute_fixability_impl(
         });
         entry.total += 1;
 
-        if auto_apply {
+        if verdict.auto_apply {
             automated_count += 1;
             entry.automated += 1;
         } else {
             manual_only += 1;
             entry.manual_only += 1;
         }
-    };
-
-    for fix in &fix_result.fixes {
-        for insertion in &fix.insertions {
-            count_fixability(&insertion.finding, insertion.auto_apply);
-        }
-    }
-
-    for new_file in &fix_result.new_files {
-        count_fixability(&new_file.finding, new_file.auto_apply);
     }
 
     let fixable_count = automated_count + manual_only;

--- a/crates/homeboy-core/src/refactor/audit_fixability_provider.rs
+++ b/crates/homeboy-core/src/refactor/audit_fixability_provider.rs
@@ -1,0 +1,79 @@
+//! Refactor-side implementation of the audit fixability provider.
+//!
+//! The audit engine (`code_audit`) defines `AuditFixabilityProvider` and calls
+//! it to compute its fixability summary without depending on refactor behavior.
+//! This module implements that trait by running the real fix planner
+//! (`plan::generate::generate_audit_fixes*`), applying the dry-run policy
+//! annotation (`auto::apply_fix_policy`), and projecting each planned insertion
+//! and new file into the slim `(finding, auto_apply)` verdict audit needs. It is
+//! registered at binary startup by the CLI, mirroring the extension-manifest /
+//! runner-evidence / tunnel provider hooks.
+
+use crate::code_audit::fingerprint::FileFingerprint;
+use crate::code_audit::fixability_provider::{
+    register_audit_fixability_provider, AuditFixabilityProvider, FixabilityVerdict,
+};
+use crate::code_audit::CodeAuditResult;
+
+struct RefactorFixabilityProvider;
+
+impl AuditFixabilityProvider for RefactorFixabilityProvider {
+    fn plan(
+        &self,
+        result: &CodeAuditResult,
+        source_path: &str,
+        fingerprints: &[FileFingerprint],
+    ) -> Vec<FixabilityVerdict> {
+        let path = std::path::Path::new(source_path);
+
+        // Generate the fix plan (dry-run — never writes). Reuse the audit run's
+        // fingerprints when present to avoid re-fingerprinting.
+        let fix_policy = crate::refactor::auto::FixPolicy::default();
+        let mut fix_result = if fingerprints.is_empty() {
+            crate::refactor::plan::generate::generate_audit_fixes(result, path, &fix_policy)
+        } else {
+            crate::refactor::plan::generate::generate_audit_fixes_with_fingerprints(
+                result,
+                path,
+                &fix_policy,
+                fingerprints,
+            )
+        };
+
+        if fix_result.fixes.is_empty() && fix_result.new_files.is_empty() {
+            return Vec::new();
+        }
+
+        // Apply policy annotation (dry-run mode: write=false, no filtering) so
+        // each insertion/new file carries its automation verdict.
+        let policy = crate::refactor::auto::FixPolicy {
+            only: None,
+            exclude: Vec::new(),
+        };
+        crate::refactor::auto::apply_fix_policy(&mut fix_result, false, &policy);
+
+        let mut verdicts = Vec::new();
+        for fix in &fix_result.fixes {
+            for insertion in &fix.insertions {
+                verdicts.push(FixabilityVerdict {
+                    finding: insertion.finding.clone(),
+                    auto_apply: insertion.auto_apply,
+                });
+            }
+        }
+        for new_file in &fix_result.new_files {
+            verdicts.push(FixabilityVerdict {
+                finding: new_file.finding.clone(),
+                auto_apply: new_file.auto_apply,
+            });
+        }
+
+        verdicts
+    }
+}
+
+/// Register the refactor-backed audit fixability provider. Called once at binary
+/// startup by the CLI.
+pub fn register() {
+    register_audit_fixability_provider(Box::new(RefactorFixabilityProvider));
+}

--- a/crates/homeboy-core/src/refactor/mod.rs
+++ b/crates/homeboy-core/src/refactor/mod.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use std::path::PathBuf;
 
 pub mod add;
+pub mod audit_fixability_provider;
 pub mod auto;
 pub mod decompose;
 pub mod edit_op_tagged;

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -1,8 +1,10 @@
 use crate::code_audit::report::{
-    build_audit_summary, build_changed_since_summary, compute_fixability,
-    compute_fixability_with_analysis, finding_kind_key, from_main_workflow,
-    AuditChangedSinceSummary, AuditCommandOutput,
+    build_audit_summary, build_changed_since_summary, compute_fixability, finding_kind_key,
+    from_main_workflow, AuditChangedSinceSummary, AuditCommandOutput,
 };
+// Only used by the slow-tier `test_compute_fixability_with_analysis`.
+#[cfg(feature = "slow-tests")]
+use crate::code_audit::report::compute_fixability_with_analysis;
 use crate::code_audit::test_helpers::{empty_result, make_finding};
 use crate::code_audit::{AuditFinding, Finding, FindingConfidence, Severity};
 
@@ -274,6 +276,11 @@ fn test_compute_fixability_skips_structural_only_results() {
 #[test]
 fn test_compute_fixability_counts_fixes_from_real_audit() {
     use std::fs;
+
+    // Fixability planning is inverted behind a provider the CLI registers at
+    // startup; a core lib test never runs the CLI, so register the refactor-backed
+    // provider explicitly — otherwise fixability is always unavailable (None).
+    crate::refactor::audit_fixability_provider::register();
 
     let dir = tempfile::tempdir().expect("temp dir");
     let root = dir.path();


### PR DESCRIPTION
## Summary
- Audit reports a *fixability* summary (how many findings an automated fixer could address), which requires **planning the actual fixes** — the refactor engine's job. `compute_fixability_impl` called `crate::refactor::plan::generate::*` and `crate::refactor::auto::*` directly, coupling `code_audit` **up** to the refactor feature layer and forming a `code_audit`↔`refactor` cycle (refactor already depends on audit for the `CodeAuditResult` it fixes).
- Invert it behind a provider hook — the same pattern as the extension-manifest, runner-evidence, and tunnel hooks.

## This removes the LAST `code_audit → refactor` edge
`code_audit` now has **zero** references to `refactor` (verified by grep — the only remaining match is a doc-comment mention). Combined with #8607 (signature extraction) and #8591 (CodeAuditResult schema), the audit engine is now fully decoupled from refactor in the production direction.

## Design
- `code_audit::fixability_provider`: defines `AuditFixabilityProvider` + a slim `FixabilityVerdict { finding, auto_apply }`. Audit never sees refactor's `FixResult`/insertion types — only the per-fix automation verdict it tallies. No-op provider (unregistered) yields no verdicts → fixability unavailable, exactly as before when refactor was absent.
- `refactor::audit_fixability_provider`: implements the trait by running the real planner (`generate_audit_fixes[_with_fingerprints]`) + the dry-run policy annotation (`apply_fix_policy`) and projecting each insertion/new-file into a verdict.
- CLI registers it at startup alongside the other audit provider hooks.
- Audit keeps its own output type (`AuditFixability`) and the aggregation/guards (`source_path.is_dir()`, structural-only skip). Only the planning it genuinely cannot do without refactor is inverted.

## Verification
- `cargo check -p homeboy-core --lib` — 0 errors, no new warnings (also cfg-gated a now-slow-only import so the default build stays warning-free).
- `cargo test -p homeboy-core --lib code_audit::report` — 18 passed (all `compute_fixability*` default tests green).
- `cargo test -p homeboy-core --lib fixability_provider` — noop provider test passes.
- `cargo test -p homeboy-core --lib --features slow-tests test_compute_fixability_counts_fixes_from_real_audit` — **passes end-to-end** with the real refactor provider registered (proves the hook wiring).
- `cargo check --workspace --tests --locked` (topology guard) — passes.
- 7 files; reverted unrelated `cargo fmt` drift in `runner/workspace/mod.rs`.

Refs #8425