### PR TITLE
Verify stale runner daemon rotation

### DIFF
--- a/crates/homeboy-core/src/runner/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-core/src/runner/connection_stop_transport_recovery.rs
@@ -135,7 +135,7 @@ pub(super) fn disconnect_remote_daemon(
             response_body_excerpt(&body)
         ));
     }
-    Ok(())
+    verify_remote_daemon_stopped(session)
 }
 
 fn response_body_excerpt(body: &str) -> String {
@@ -154,36 +154,25 @@ pub(super) fn recover_remote_daemon_stop_after_transport_error(
     session: &RunnerSession,
     transport_error: &str,
 ) -> std::result::Result<(), String> {
-    let runner = load(&session.runner_id).map_err(|error| {
-        format!(
-            "re-probe runner after stop transport error: {}",
-            error.message
-        )
-    })?;
-    let homeboy =
-        remote_runner_homeboy_path(&runner, "runner disconnect re-probe").map_err(|error| {
-            format!(
-                "re-probe daemon after stop transport error: {}",
-                error.message
-            )
-        })?;
+    verify_remote_daemon_stopped(session).map_err(|error| format!("{transport_error}; {error}"))
+}
+
+/// A lifecycle stop acknowledgement alone is not proof that the daemon exited.
+/// Verify the exact recorded owner before reconnect can create a new session,
+/// otherwise it could reattach the stale lease it was meant to rotate.
+fn verify_remote_daemon_stopped(session: &RunnerSession) -> std::result::Result<(), String> {
+    let runner = load(&session.runner_id)
+        .map_err(|error| format!("re-probe runner after daemon stop: {}", error.message))?;
+    let homeboy = remote_runner_homeboy_path(&runner, "runner disconnect stop verification")
+        .map_err(|error| format!("re-probe daemon after stop: {}", error.message))?;
     let lease_id = session.remote_daemon_lease_id.as_deref().ok_or_else(|| {
-        "re-probe daemon after stop transport error: persisted daemon lease is unavailable"
-            .to_string()
+        "re-probe daemon after stop: persisted daemon lease is unavailable".to_string()
     })?;
     let (_, _, client) = remote_daemon::resolve_ssh_runner(&runner)
-        .map_err(|error| {
-            format!(
-                "re-probe daemon after stop transport error: {}",
-                error.message
-            )
-        })?
-        .ok_or_else(|| {
-            "re-probe daemon after stop transport error: runner is not SSH-backed".to_string()
-        })?;
-    let status = remote_daemon::remote_daemon_status(&client, homeboy).map_err(|error| {
-        format!("{transport_error}; authoritative daemon re-probe failed: {error}")
-    })?;
+        .map_err(|error| format!("re-probe daemon after stop: {}", error.message))?
+        .ok_or_else(|| "re-probe daemon after stop: runner is not SSH-backed".to_string())?;
+    let status = remote_daemon::remote_daemon_status(&client, homeboy)
+        .map_err(|error| format!("authoritative daemon re-probe after stop failed: {error}"))?;
     let fallback_command =
         remote_lease_bound_stop_recovery_command(session, runner.server_id.as_deref(), homeboy);
 
@@ -193,7 +182,7 @@ pub(super) fn recover_remote_daemon_stop_after_transport_error(
         || execute_remote_lease_bound_daemon_stop(&client, homeboy, lease_id),
         || remote_daemon::remote_daemon_status(&client, homeboy),
     )
-    .map_err(|error| format!("{transport_error}; {error}. Recovery: {fallback_command}"))
+    .map_err(|error| format!("{error}. Recovery: {fallback_command}"))
 }
 
 pub(super) fn complete_stop_transport_recovery<Stop, Probe>(
@@ -427,11 +416,17 @@ mod tests {
                 stop_called = true;
                 Ok(())
             },
-            || Ok(stopped),
+            || Ok(stopped.clone()),
         )
         .expect("exact live owner is stopped through bounded SSH fallback");
 
         assert!(stop_called);
+        assert_eq!(
+            remote_daemon::remote_daemon_connect_action(Some(&session), &stopped)
+                .expect("the stopped lease is replaced on reconnect"),
+            remote_daemon::RemoteDaemonConnectAction::Start,
+            "refresh must start a replacement rather than reattach the stale lease"
+        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/runner/homeboy_refresh.rs
+++ b/crates/homeboy-core/src/runner/homeboy_refresh.rs
@@ -427,8 +427,17 @@ pub fn refresh_homeboy_binary(
                 )
             }
         };
-        daemon_refreshed = connect_exit_code == 0;
+        let daemon_identity_verification = (connect_exit_code == 0)
+            .then(|| verify_refreshed_daemon_identity(&plan.runner_id))
+            .transpose()
+            .map_err(|error| error.message);
+        daemon_refreshed = daemon_identity_verification.is_ok();
         if !daemon_refreshed {
+            let reconnect_exit_code = if connect_exit_code == 0 {
+                1
+            } else {
+                connect_exit_code
+            };
             if let Err(rollback_error) =
                 restore_runner_homeboy_path(&plan.runner_id, previous_homeboy_path.as_deref())
             {
@@ -448,10 +457,15 @@ pub fn refresh_homeboy_binary(
                     selected_binary_path: plan.binary_path.clone(),
                     reconnect_required: true,
                     followup_commands: plan.followup_commands.clone(),
-                    failure: Some(refresh_reconnect_failure(&plan, &exec_output, &report)),
+                    failure: Some(refresh_reconnect_failure(
+                        &plan,
+                        &exec_output,
+                        &report,
+                        daemon_identity_verification.err().as_deref(),
+                    )),
                     bootstrap_provenance: None,
                 },
-                connect_exit_code,
+                reconnect_exit_code,
             ));
         }
     } else {
@@ -538,6 +552,22 @@ fn refresh_verification_failure(
 
 fn status_is_disconnected(runner_id: &str) -> Result<bool> {
     Ok(!super::status(runner_id)?.connected)
+}
+
+fn verify_refreshed_daemon_identity(runner_id: &str) -> Result<()> {
+    let status = super::status(runner_id)?;
+    if !status.connected {
+        return Err(Error::internal_unexpected(format!(
+            "runner `{runner_id}` reconnect did not persist an active daemon session"
+        )));
+    }
+    if let Some(stale_daemon) = status.stale_daemon {
+        return Err(Error::internal_unexpected(format!(
+            "runner `{runner_id}` reconnect retained a stale daemon: {}",
+            stale_daemon.message
+        )));
+    }
+    Ok(())
 }
 
 fn refresh_execution_options(
@@ -1105,6 +1135,7 @@ fn refresh_reconnect_failure(
     plan: &HomeboyBinaryRefreshPlan,
     execution: &RunnerExecOutput,
     report: &super::RunnerConnectReport,
+    daemon_identity_verification: Option<&str>,
 ) -> HomeboyBinaryRefreshFailure {
     let mut failure = refresh_failure(plan, execution.clone(), 1);
     failure.verification = Some(format!(
@@ -1112,6 +1143,7 @@ fn refresh_reconnect_failure(
         report
             .failure_message
             .as_deref()
+            .or(daemon_identity_verification)
             .unwrap_or("runner connect returned a non-zero exit code")
     ));
     failure


### PR DESCRIPTION
## Summary
Make explicit runner refresh replace the proven-idle stale daemon and verify the new active identity before reporting success.

## What changed
- Verify the exact stale lease and PID terminate after lifecycle stop, use bounded transport recovery only for a direct zero-job owner, require the reconnected daemon identity to match the selected binary, and restore the prior binary when verification fails.

## How to test
1. Run `CARGO_TARGET_DIR=/tmp/homeboy-8601-rotation-target cargo test -p homeboy-core transport_drop_uses_bounded_ssh_stop_for_exact_live_owner`; expect The exact stale owner is stopped and reconnect selects a replacement daemon..
2. Run `CARGO_TARGET_DIR=/tmp/homeboy-8601-rotation-target cargo check -p homeboy-core -p homeboy-cli`; expect The core and CLI crates compile..

## Compatibility
Explicit idle stale-daemon refresh now fails closed unless the old exact owner exits and the replacement identity matches the selected binary. Active and uncertain jobs remain protected; ordinary fresh runner connections are unchanged.

## Evidence
- Base unchanged since verification: main remains at a47a24b717ebddaabefb6c6db08eb7cfda8b6059.
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8601
- Verified finalization base: main at a47a24b717ebddaabefb6c6db08eb7cfda8b6059
- cargo-check: Passed
- diff-check: Passed
- focused-test: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Ran live post-merge verification, found the incomplete daemon rotation, implemented the exact-owner stop and identity proof, and orchestrated deterministic coverage with Chris.

## Source relationships
- Closes Extra-Chill/homeboy#8601
