### PR TITLE
Activate the installed controller generation after upgrade

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -390,51 +390,6 @@ fn active_pinned_run_does_not_block_controller_promotion() {
     });
 }
 
-#[cfg(unix)]
-#[test]
-fn post_install_generation_switch_pins_new_cooks_to_b_and_retains_a() {
-    use std::os::unix::fs::PermissionsExt;
-
-    with_isolated_home(|_| {
-        let temporary = tempfile::tempdir().expect("temporary executable directory");
-        let generation_a = temporary.path().join("homeboy-a");
-        let generation_b = temporary.path().join("homeboy-b");
-        for (path, identity) in [
-            (&generation_a, "homeboy 0.1.0+generation-a"),
-            (&generation_b, "homeboy 0.1.0+generation-b"),
-        ] {
-            std::fs::write(path, format!("#!/bin/sh\nprintf '{identity}\\n'\n"))
-                .expect("write generation executable");
-            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
-                .expect("make generation executable");
-        }
-
-        crate::controller_runtime::activate_installed_generation(&generation_a)
-            .expect("activate installed generation A");
-        let record_a = submit_plan(&test_plan(), Some("generation-a-cook"))
-            .expect("generation A cook is admitted");
-
-        crate::controller_runtime::activate_installed_generation(&generation_b)
-            .expect("activate installed generation B");
-        let record_b = submit_plan(&test_plan(), Some("generation-b-cook"))
-            .expect("generation B cook is admitted");
-
-        assert_eq!(
-            record_a.metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
-                ["originating"]["build_identity"],
-            "homeboy 0.1.0+generation-a"
-        );
-        assert_eq!(
-            record_b.metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
-                ["originating"]["build_identity"],
-            "homeboy 0.1.0+generation-b"
-        );
-        assert!(pinned_runtime_for_mutation(&record_a.run_id)
-            .expect("generation A runtime remains verified")
-            .is_some());
-    });
-}
-
 #[test]
 fn pinned_runtime_recovery_retains_the_existing_lab_proxy_identity() {
     with_isolated_home(|_| {

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -390,6 +390,51 @@ fn active_pinned_run_does_not_block_controller_promotion() {
     });
 }
 
+#[cfg(unix)]
+#[test]
+fn post_install_generation_switch_pins_new_cooks_to_b_and_retains_a() {
+    use std::os::unix::fs::PermissionsExt;
+
+    with_isolated_home(|_| {
+        let temporary = tempfile::tempdir().expect("temporary executable directory");
+        let generation_a = temporary.path().join("homeboy-a");
+        let generation_b = temporary.path().join("homeboy-b");
+        for (path, identity) in [
+            (&generation_a, "homeboy 0.1.0+generation-a"),
+            (&generation_b, "homeboy 0.1.0+generation-b"),
+        ] {
+            std::fs::write(path, format!("#!/bin/sh\nprintf '{identity}\\n'\n"))
+                .expect("write generation executable");
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+                .expect("make generation executable");
+        }
+
+        crate::controller_runtime::activate_installed_generation(&generation_a)
+            .expect("activate installed generation A");
+        let record_a = submit_plan(&test_plan(), Some("generation-a-cook"))
+            .expect("generation A cook is admitted");
+
+        crate::controller_runtime::activate_installed_generation(&generation_b)
+            .expect("activate installed generation B");
+        let record_b = submit_plan(&test_plan(), Some("generation-b-cook"))
+            .expect("generation B cook is admitted");
+
+        assert_eq!(
+            record_a.metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
+                ["originating"]["build_identity"],
+            "homeboy 0.1.0+generation-a"
+        );
+        assert_eq!(
+            record_b.metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
+                ["originating"]["build_identity"],
+            "homeboy 0.1.0+generation-b"
+        );
+        assert!(pinned_runtime_for_mutation(&record_a.run_id)
+            .expect("generation A runtime remains verified")
+            .is_some());
+    });
+}
+
 #[test]
 fn pinned_runtime_recovery_retains_the_existing_lab_proxy_identity() {
     with_isolated_home(|_| {

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -214,11 +214,17 @@ pub(crate) fn pin_current() -> Result<Value> {
 }
 
 fn pin_executable(executable: &Path, identity: &str) -> Result<Value> {
-    let digest = executable_digest(&executable)?;
+    let digest = executable_digest(executable)?;
     let pinned_path = pinned_path(identity, &digest)?;
     publish_pin(executable, &pinned_path, &digest)?;
 
-    Ok(json!({
+    let runtime = runtime_pin(&identity, executable, &pinned_path, &digest);
+    validate_pin(&runtime)?;
+    Ok(runtime)
+}
+
+fn runtime_pin(identity: &str, executable: &Path, pinned_path: &Path, digest: &str) -> Value {
+    json!({
         "schema": "homeboy/controller-runtime-pin/v2",
         "requested": identity,
         "originating": {
@@ -230,7 +236,7 @@ fn pin_executable(executable: &Path, identity: &str) -> Result<Value> {
         },
         "current": identity,
         "executed": identity,
-    }))
+    })
 }
 
 /// Pin the process submitting a durable run while serializing admission. The
@@ -253,17 +259,24 @@ pub(crate) fn admit_current() -> Result<RuntimeAdmission> {
 /// Publish the current executable as the generation selected for future
 /// admissions. Existing records retain their own pinned runtime metadata.
 pub(crate) fn activate_current_generation() -> Result<Value> {
+    let executable = std::env::current_exe().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("resolve controller executable".to_string()),
+        )
+    })?;
+    activate_installed_generation(&executable)
+}
+
+/// Publish the executable that installation just verified. This intentionally
+/// does not use the upgrading process's executable: after an on-disk swap that
+/// process can still be running the previous generation.
+pub(crate) fn activate_installed_generation(executable: &Path) -> Result<Value> {
     let root = runtime_root()?;
     let lock_path = root.join(ADMISSION_LOCK_DIR);
     acquire_admission_lock(&lock_path)?;
     let result = (|| {
-        let executable = std::env::current_exe().map_err(|error| {
-            Error::internal_io(
-                error.to_string(),
-                Some("resolve activated controller executable".to_string()),
-            )
-        })?;
-        let runtime = pin_executable(&executable, &activated_executable_identity(&executable)?)?;
+        let runtime = pin_executable(executable, &activated_executable_identity(executable)?)?;
         validate_pin(&runtime)?;
         write_active_generation(&root.join(ACTIVE_GENERATION_FILE), &runtime)?;
         Ok(runtime)
@@ -648,14 +661,15 @@ fn verify_self_identity(path: &Path, expected: &str) -> Result<()> {
 
 fn executable_identity(path: &Path) -> Result<String> {
     #[cfg(test)]
-    if std::env::current_exe()
-        .ok()
-        .zip(fs::canonicalize(path).ok())
-        .is_some_and(|(current, candidate)| current == candidate)
-    {
+    if std::env::current_exe().ok().is_some_and(|current| {
+        executable_digest(&current)
+            .ok()
+            .zip(executable_digest(path).ok())
+            .is_some_and(|(current, candidate)| current == candidate)
+    }) {
         // Unit tests run inside the libtest executable, not the Homeboy CLI.
-        // Keep lifecycle fixtures hermetic while artifact tests still execute
-        // their explicit fake controller binaries.
+        // Pins are byte-identical copies, so accept them without recursively
+        // launching the test harness. Explicit fake controllers still execute.
         return Ok(build_identity::current().display);
     }
     let output = Command::new(path)
@@ -692,14 +706,6 @@ fn executable_identity(path: &Path) -> Result<String> {
 }
 
 fn activated_executable_identity(path: &Path) -> Result<String> {
-    #[cfg(test)]
-    {
-        // Core unit tests run a Rust test harness rather than the Homeboy CLI.
-        // Production activation always reads the freshly installed executable.
-        let _ = path;
-        return Ok(build_identity::current().display);
-    }
-    #[cfg(not(test))]
     executable_identity(path)
 }
 

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -1000,6 +1000,63 @@ mod tests {
         assert!(validate_pin(&runtime).is_err());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn installed_generation_switch_publishes_b_and_retains_a_pin() {
+        use std::os::unix::fs::PermissionsExt;
+
+        crate::test_support::with_isolated_home(|_| {
+            let temporary = tempfile::tempdir().expect("temporary executable directory");
+            let generation_a = temporary.path().join("homeboy-a");
+            let generation_b = temporary.path().join("homeboy-b");
+            for (path, identity) in [
+                (&generation_a, "homeboy 0.1.0+generation-a"),
+                (&generation_b, "homeboy 0.1.0+generation-b"),
+            ] {
+                let identity = serde_json::to_string(identity).expect("serialize identity");
+                fs::write(
+                    path,
+                    format!(
+                        "#!/bin/sh\nif [ \"$1\" = self ] && [ \"$2\" = identity ]; then\n  printf '%s\\n' '{{\"data\":{{\"display\":{identity}}}}}'\n  exit 0\nfi\nexit 1\n"
+                    ),
+                )
+                .expect("write generation executable");
+                fs::set_permissions(path, fs::Permissions::from_mode(0o755))
+                    .expect("make generation executable");
+            }
+
+            let runtime_a = activate_installed_generation(&generation_a)
+                .expect("activate installed generation A");
+            let runtime_b = activate_installed_generation(&generation_b)
+                .expect("activate installed generation B");
+
+            assert_eq!(
+                runtime_a["originating"]["build_identity"],
+                "homeboy 0.1.0+generation-a"
+            );
+            assert_eq!(
+                runtime_b["originating"]["build_identity"],
+                "homeboy 0.1.0+generation-b"
+            );
+            validate_pin(&runtime_a).expect("generation A pin remains valid");
+            validate_pin(&runtime_b).expect("generation B pin is valid");
+
+            let active: Value = serde_json::from_str(
+                &fs::read_to_string(
+                    runtime_root()
+                        .expect("runtime root")
+                        .join(ACTIVE_GENERATION_FILE),
+                )
+                .expect("read active generation"),
+            )
+            .expect("parse active generation");
+            assert_eq!(
+                active["originating"]["build_identity"],
+                "homeboy 0.1.0+generation-b"
+            );
+        });
+    }
+
     #[test]
     fn admission_replaces_a_stale_active_generation_with_the_submitting_runtime() {
         crate::test_support::with_isolated_home(|_| {

--- a/crates/homeboy-core/src/upgrade/execution.rs
+++ b/crates/homeboy-core/src/upgrade/execution.rs
@@ -919,7 +919,7 @@ fn command_output_with_timeout(
     }
 }
 
-fn active_binary_path() -> Result<PathBuf> {
+pub(crate) fn active_binary_path() -> Result<PathBuf> {
     if let Some(path) = resolve_binary_on_path() {
         return Ok(path);
     }

--- a/crates/homeboy-core/src/upgrade/helpers.rs
+++ b/crates/homeboy-core/src/upgrade/helpers.rs
@@ -246,7 +246,8 @@ pub fn run_upgrade_with_method(
     if upgrade_completed {
         // This is deliberately a short switch, not a drain: records admitted
         // before it retain their immutable runtime pin and remain executable.
-        crate::controller_runtime::activate_current_generation()?;
+        let installed_executable = super::execution::active_binary_path()?;
+        crate::controller_runtime::activate_installed_generation(&installed_executable)?;
     }
 
     // Auto-update all installed extensions after the upgrade command completes.


### PR DESCRIPTION
## Summary
Activate the exact installed Homeboy executable after upgrades so new durable work pins the new controller generation instead of the replaced upgrader process.

## What changed
- Derive and validate the installed executable identity and digest, publish its immutable runtime pin atomically, and route all upgrade methods through that activation contract.
- Add deterministic controller-runtime coverage proving generation B becomes active while generation A's immutable pin remains valid.

## How to test
1. Run `cargo test -p homeboy-core controller_runtime::tests::installed_generation_switch_publishes_b_and_retains_a_pin -- --exact`; expect The generation switch test passes..
2. Run `cargo test -p homeboy-core controller_runtime::tests:: -- --test-threads=1`; expect All controller runtime tests pass..
3. Run `cargo check -p homeboy-core`; expect The core crate compiles successfully..

## Compatibility
No external CLI or extension contract changes. Existing durable runs retain their historical immutable runtime pins; only post-upgrade activation for new work changes.

## Evidence
- Base advanced after verification: verified main at a47a24b717ebddaabefb6c6db08eb7cfda8b6059; publication observed 5d134c7210faa48064b28fbfdbe65a37e844dd92. Candidate ancestry was validated against the verified snapshot.
- CI expected: Homeboy CI
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8585
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8610
- Verified finalization base: main at a47a24b717ebddaabefb6c6db08eb7cfda8b6059
- cargo-check: Passed
- controller-runtime-suite: Passed
- diff-check: Passed
- focused-controller-runtime-tests: Passed
- formatting: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the post-upgrade generation bug, implemented the repair and deterministic tests, resolved the #8597 rebase, and verified the result with Chris.

## Source relationships
- Closes #8585
- Relates to #8610
