### PR TITLE
refactor: import grammar directly from engine-primitives in audit signature extraction

### DIFF
--- a/crates/homeboy-core/src/code_audit/signature_extraction.rs
+++ b/crates/homeboy-core/src/code_audit/signature_extraction.rs
@@ -42,7 +42,7 @@ pub(crate) fn extract_signatures_from_items(
         return Vec::new();
     };
 
-    let symbols = crate::extension::grammar::extract(content, &grammar);
+    let symbols = homeboy_engine_primitives::grammar::extract(content, &grammar);
     let lines: Vec<&str> = content.lines().collect();
 
     symbols


### PR DESCRIPTION
## Summary
- `code_audit::signature_extraction` called `crate::extension::grammar::extract`, but `extension::grammar` is just a re-export of `homeboy_engine_primitives::grammar` (the foundation crate where the grammar engine actually lives). Import it directly — matching how `core_fingerprint` and `engine::symbol_graph` already reference it.
- Removes an incidental `code_audit -> extension` edge that routed a foundation-layer primitive through the extension re-export.

## Context (audit-crate extraction)
After this, `code_audit`'s remaining upward production edges are down to:
- **extension**: 1 (`ExtensionPhaseTiming`, a shared serde value type in `report.rs` output; the rest — `ExtensionManifest`, `save_manifest`, `audit_manifest_provider` — are test-only, already handled by the provider hook in prod).
- **component**: 2 (`scope::resolve_component_scope`, `scope::ScopeCommand::Audit`).
- **refactor / observation / review / issues**: 0.

Those remaining boundary types deserve their own considered cuts (a shared value type + component scope), tracked separately.

## Verification
- `cargo check -p homeboy-core --lib` — 0 errors.
- `grep` confirms zero `code_audit -> extension::grammar` refs remain.
- `cargo check --workspace --tests --locked` (topology guard) — passes.
- 1 file, 1 line; reverted unrelated `cargo fmt` drift.

Refs #8425