### PR TITLE
fix: recover cargo-dist releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,6 +392,7 @@ jobs:
       release-tag: ${{ steps.outputs.outputs['release-tag'] }}
       prepared: ${{ steps.outputs.outputs.prepared }}
       released: ${{ steps.outputs.outputs.released }}
+      recovery-release: ${{ steps.outputs.outputs.recovery-release }}
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -500,11 +501,13 @@ jobs:
           RELEASE_TAG="${{ steps.recovery.outputs['release-tag'] || steps.release.outputs['release-tag'] }}"
           PREPARED="${{ steps.recovery.outputs.prepared || steps.prepared.outputs.prepared }}"
           RELEASED="${{ steps.recovery.outputs.released || steps.release.outputs.released }}"
+          RECOVERY_RELEASE="${{ needs.check.outputs.recovery-release }}"
 
           echo "release-version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "release-tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
           echo "prepared=${PREPARED}" >> "$GITHUB_OUTPUT"
           echo "released=${RELEASED}" >> "$GITHUB_OUTPUT"
+          echo "recovery-release=${RECOVERY_RELEASE}" >> "$GITHUB_OUTPUT"
 
   # ── Step 4: Build cross-platform binaries ──
   plan:
@@ -542,7 +545,15 @@ jobs:
 
       - id: plan
         run: |
-          dist host --steps=create --tag=${{ needs.prepare.outputs['release-tag'] }} --output-format=json > plan-dist-manifest.json
+          if ! grep -Fqx '[package.metadata.dist]' Cargo.toml; then
+            printf '\n[package.metadata.dist]\ndist = true\n' >> Cargo.toml
+          fi
+          if [ "${{ needs.prepare.outputs.recovery-release }}" = "true" ]; then
+            DIST_ALLOW_DIRTY="--allow-dirty"
+          else
+            DIST_ALLOW_DIRTY=""
+          fi
+          dist host --steps=create --tag=${{ needs.prepare.outputs['release-tag'] }} --output-format=json ${DIST_ALLOW_DIRTY} > plan-dist-manifest.json
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -602,7 +613,15 @@ jobs:
 
       - name: Build artifacts
         run: |
-          dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
+          if ! grep -Fqx '[package.metadata.dist]' Cargo.toml; then
+            printf '\n[package.metadata.dist]\ndist = true\n' >> Cargo.toml
+          fi
+          if [ "${{ needs.prepare.outputs.recovery-release }}" = "true" ]; then
+            DIST_ALLOW_DIRTY="--allow-dirty"
+          else
+            DIST_ALLOW_DIRTY=""
+          fi
+          dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} ${DIST_ALLOW_DIRTY} > dist-manifest.json
           echo "dist ran successfully"
 
       - id: cargo-dist
@@ -685,7 +704,15 @@ jobs:
       - id: cargo-dist
         shell: bash
         run: |
-          dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" > dist-manifest.json
+          if ! grep -Fqx '[package.metadata.dist]' Cargo.toml; then
+            printf '\n[package.metadata.dist]\ndist = true\n' >> Cargo.toml
+          fi
+          if [ "${{ needs.prepare.outputs.recovery-release }}" = "true" ]; then
+            DIST_ALLOW_DIRTY="--allow-dirty"
+          else
+            DIST_ALLOW_DIRTY=""
+          fi
+          dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" ${DIST_ALLOW_DIRTY} > dist-manifest.json
           echo "dist ran successfully"
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
           jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
@@ -740,7 +767,15 @@ jobs:
       - id: host
         shell: bash
         run: |
-          dist host --tag=${{ needs.prepare.outputs['release-tag'] }} --steps=upload --output-format=json > dist-manifest.json
+          if ! grep -Fqx '[package.metadata.dist]' Cargo.toml; then
+            printf '\n[package.metadata.dist]\ndist = true\n' >> Cargo.toml
+          fi
+          if [ "${{ needs.prepare.outputs.recovery-release }}" = "true" ]; then
+            DIST_ALLOW_DIRTY="--allow-dirty"
+          else
+            DIST_ALLOW_DIRTY=""
+          fi
+          dist host --tag=${{ needs.prepare.outputs['release-tag'] }} --steps=upload --output-format=json ${DIST_ALLOW_DIRTY} > dist-manifest.json
           echo "artifacts uploaded successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ homepage = "https://github.com/Extra-Chill/homeboy"
 exclude = ["/artifacts/"]
 publish = false
 
+[package.metadata.dist]
+dist = true
+
 [lib]
 name = "homeboy"
 path = "src/lib.rs"

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -424,6 +424,52 @@ fn release_finish_head_pipeline_uses_homeboy_action_head_inputs() {
 }
 
 #[test]
+fn release_recovery_propagates_dist_opt_in_and_dirty_allowance_through_all_dist_phases() {
+    let workflow = release_workflow();
+    let prepare = job_section(workflow, "prepare");
+
+    assert!(prepare.contains("recovery-release: ${{ steps.outputs.outputs.recovery-release }}"));
+    assert!(prepare.contains("RECOVERY_RELEASE=\"${{ needs.check.outputs.recovery-release }}\""));
+    assert!(prepare.contains("echo \"recovery-release=${RECOVERY_RELEASE}\" >> \"$GITHUB_OUTPUT\""));
+
+    for job in ["plan", "build-local-artifacts", "build-global-artifacts", "host"] {
+        let section = job_section(workflow, job);
+        let opt_in = section
+            .find("grep -Fqx '[package.metadata.dist]' Cargo.toml")
+            .unwrap_or_else(|| panic!("{job} must use fixed-string exact-line matching"));
+        let dist = section
+            .find("\n          dist ")
+            .unwrap_or_else(|| panic!("{job} must execute cargo-dist"));
+
+        assert!(
+            opt_in < dist,
+            "{job} must append the dist opt-in before executing cargo-dist"
+        );
+        assert!(
+            section.contains("printf '\\n[package.metadata.dist]\\ndist = true\\n' >> Cargo.toml"),
+            "{job} must append the literal root package dist opt-in when it is absent"
+        );
+        assert!(
+            section.contains(
+                "if [ \"${{ needs.prepare.outputs.recovery-release }}\" = \"true\" ]; then\n            DIST_ALLOW_DIRTY=\"--allow-dirty\""
+            ),
+            "{job} must allow a dirty manifest only in recovery mode"
+        );
+        assert!(
+            section.contains("else\n            DIST_ALLOW_DIRTY=\"\""),
+            "{job} must preserve a clean fresh-release cargo-dist invocation"
+        );
+        assert_eq!(
+            section.matches("--allow-dirty").count(),
+            1,
+            "{job} must not pass --allow-dirty outside the recovery branch"
+        );
+    }
+
+    assert!(cargo_manifest().contains("[package.metadata.dist]\ndist = true"));
+}
+
+#[test]
 fn release_prepare_and_publish_preflight_runner_disk() {
     let workflow = release_workflow();
 


### PR DESCRIPTION
Closes #8617.

## Summary
- Opt the private root package into cargo-dist.
- Propagate recovery mode from prepare and add an ephemeral, fixed-string-guarded metadata overlay before all four cargo-dist phases.
- Pass `--allow-dirty` only for recovery runs and lock that contract with workflow tests.

## Evidence
- Source relationship: implements the recovery failure documented in #8617 for tags from v0.287.0 onward.
- Change kind: release-workflow compatibility fix plus deterministic workflow coverage.
- Scope: the runtime overlay only applies when a checked-out historical tag lacks the exact root opt-in; fresh release manifests already contain it, and their cargo-dist invocations stay clean.

## Verification
- `cargo test --test release_workflow_test`
- `git diff --check`

AI disclosure: OpenAI GPT-5.6 Sol and Homeboy/OpenCode.