### PR TITLE
refactor: invert audit component resolution behind a provider hook

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -113,6 +113,11 @@ impl CliRuntime {
         // fixable its findings are without calling up into the refactor engine's
         // fix planner — the seam that removes the last code_audit->refactor edge.
         crate::core::refactor::audit_fixability_provider::register();
+        // Register the audit component provider so code_audit can resolve the
+        // component under audit (path, extension ids, audit rules, scope excludes)
+        // without depending on the component layer — the last cross-layer seam
+        // before audit becomes its own crate.
+        crate::core::component::audit_provider::register();
         // Register the runner-evidence provider so observation::runs_service can
         // enrich run/artifact lookups with live runner + daemon evidence without
         // core depending on runner behavior. (Runner is still in-crate today;

--- a/crates/homeboy-core/src/code_audit/codebase_map.rs
+++ b/crates/homeboy-core/src/code_audit/codebase_map.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use serde::Serialize;
 
 use crate::code_audit::fingerprint::{self, FileFingerprint};
-use crate::{component, extension, Error};
+use crate::{extension, Error};
 use homeboy_engine_primitives::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
 // ============================================================================
@@ -108,7 +108,7 @@ pub struct MapConfig<'a> {
 /// Scans source directories for files, fingerprints each one, and groups
 /// results into modules by directory. Builds class hierarchy and hook summaries.
 pub fn build_map(config: &MapConfig) -> Result<CodebaseMap, Error> {
-    let comp = component::resolve_effective(Some(config.component_id), None, None)?;
+    let comp = super::component_provider::resolve_effective(config.component_id)?;
     let root = Path::new(&comp.local_path);
 
     // Determine which directories to scan

--- a/crates/homeboy-core/src/code_audit/component_provider.rs
+++ b/crates/homeboy-core/src/code_audit/component_provider.rs
@@ -1,0 +1,129 @@
+//! Component resolution for the audit engine, inverted behind a provider.
+//!
+//! The audit engine needs a little data about the component it is auditing —
+//! the resolved on-disk source path, the installed extension ids, the
+//! component's own audit detector rules, and the audit-scope exclude globs. It
+//! used to reach that by calling `crate::component::{load, resolve_effective,
+//! discover_from_portable, validate_local_path}` and `component::scope::*`
+//! directly, which coupled `code_audit` to the `component` feature layer and was
+//! the last cross-layer blocker to extracting audit into its own crate.
+//!
+//! Instead, audit defines the slim view it needs (`AuditComponentInfo`) plus a
+//! provider trait; the component layer registers an implementation at startup
+//! (same pattern as the extension-manifest / fixability / runner-evidence /
+//! tunnel provider hooks). When no provider is registered — e.g. audit running
+//! standalone — the no-op provider resolves nothing, which every call site
+//! already tolerates (path audits fall back to the raw path; config/doc lookups
+//! contribute no component-derived rules).
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use homeboy_audit_contract::AuditConfig;
+
+use crate::Result;
+
+/// The slim, owned view of a component that the audit engine needs.
+///
+/// Owning the data (rather than borrowing a `Component`) keeps the provider
+/// boundary clean: the audit engine never sees the full component type.
+#[derive(Debug, Clone, Default)]
+pub struct AuditComponentInfo {
+    /// Resolved absolute on-disk source path (the component's `local_path`).
+    pub local_path: String,
+    /// Ids of extensions installed for this component.
+    pub extension_ids: Vec<String>,
+    /// The component's own audit detector rules, if it declares any.
+    pub audit_rules: Option<AuditConfig>,
+    /// Audit-scope exclude globs (from the component's effective `audit` scope).
+    pub audit_scope_excludes: Vec<String>,
+}
+
+/// The component-resolution contract the audit engine depends on. Implemented by
+/// the component layer and registered at startup; audit calls it without
+/// depending on component behavior.
+pub trait AuditComponentProvider: Send + Sync {
+    /// Resolve a registered component by id (like `component::load`). Returns
+    /// `None` when the component is not registered.
+    fn resolve_by_id(&self, component_id: &str) -> Option<AuditComponentInfo>;
+
+    /// Resolve a component's effective config by id and validate its local path
+    /// (like `component::resolve_effective` + `validate_local_path`). Errors when
+    /// the component cannot be resolved or its path is invalid.
+    fn resolve_effective(&self, component_id: &str) -> Result<AuditComponentInfo>;
+
+    /// Discover a component from a portable `homeboy.json` at `root` (like
+    /// `component::discover_from_portable`). Returns `None` when absent/invalid.
+    fn discover_from_portable(&self, root: &Path) -> Option<AuditComponentInfo>;
+}
+
+/// Default provider used when no component layer is registered: resolves
+/// nothing. Every audit call site treats a missing component as "no
+/// component-derived configuration", so behavior degrades to a raw-path audit.
+struct NoopProvider;
+
+impl AuditComponentProvider for NoopProvider {
+    fn resolve_by_id(&self, _component_id: &str) -> Option<AuditComponentInfo> {
+        None
+    }
+
+    fn resolve_effective(&self, component_id: &str) -> Result<AuditComponentInfo> {
+        Err(crate::Error::internal_unexpected(format!(
+            "no audit component provider registered; cannot resolve component `{component_id}`"
+        )))
+    }
+
+    fn discover_from_portable(&self, _root: &Path) -> Option<AuditComponentInfo> {
+        None
+    }
+}
+
+static PROVIDER: Mutex<Option<Box<dyn AuditComponentProvider>>> = Mutex::new(None);
+
+/// Register the audit component provider. Called once at binary startup by the
+/// component layer (via the CLI). Replaces any previously registered provider.
+pub fn register_audit_component_provider(provider: Box<dyn AuditComponentProvider>) {
+    let mut guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = Some(provider);
+}
+
+/// Resolve a registered component by id via the registered provider.
+pub(crate) fn resolve_by_id(component_id: &str) -> Option<AuditComponentInfo> {
+    with_provider(|p| p.resolve_by_id(component_id))
+}
+
+/// Resolve + validate a component's effective config by id via the provider.
+pub(crate) fn resolve_effective(component_id: &str) -> Result<AuditComponentInfo> {
+    with_provider(|p| p.resolve_effective(component_id))
+}
+
+/// Discover a component from a portable config at `root` via the provider.
+pub(crate) fn discover_from_portable(root: &Path) -> Option<AuditComponentInfo> {
+    with_provider(|p| p.discover_from_portable(root))
+}
+
+fn with_provider<T>(f: impl FnOnce(&dyn AuditComponentProvider) -> T) -> T {
+    let guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    match guard.as_ref() {
+        Some(provider) => f(provider.as_ref()),
+        None => f(&NoopProvider),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_provider_resolves_nothing() {
+        assert!(NoopProvider.resolve_by_id("anything").is_none());
+        assert!(NoopProvider
+            .discover_from_portable(Path::new("/nope"))
+            .is_none());
+        assert!(NoopProvider.resolve_effective("anything").is_err());
+    }
+}

--- a/crates/homeboy-core/src/code_audit/descriptor_runtime.rs
+++ b/crates/homeboy-core/src/code_audit/descriptor_runtime.rs
@@ -14,7 +14,6 @@ use super::{
     time_audit_detector, AuditExecutionPlan, AuditTiming, DetectorDescriptor, DetectorRuntime,
     Finding, FingerprintDetectorRunner, GenericDetectorRunner, RootDetectorRunner,
 };
-use crate::component;
 use homeboy_audit_contract::AuditConfig;
 use homeboy_engine_primitives::codebase_scan::CodebaseSnapshot;
 use std::path::Path;
@@ -178,13 +177,10 @@ fn run_dead_code(context: &DetectorRunContext<'_>) -> Vec<Finding> {
 /// that declares a `test_mapping` for the component, matching the prior
 /// hand-wired loop's "first extension wins, then stop" behavior.
 fn run_test_coverage(context: &DetectorRunContext<'_>) -> Vec<Finding> {
-    let Ok(comp) = component::load(context.component_id) else {
+    let Some(comp) = super::component_provider::resolve_by_id(context.component_id) else {
         return Vec::new();
     };
-    let Some(extensions) = comp.extensions else {
-        return Vec::new();
-    };
-    for ext_id in extensions.keys() {
+    for ext_id in &comp.extension_ids {
         if let Some(ext_manifest) = super::extension_manifests::load_audit_manifest(ext_id) {
             if let Some(test_mapping) = &ext_manifest.test_mapping {
                 return test_coverage::run(context.root, context.all_fingerprints, test_mapping);

--- a/crates/homeboy-core/src/code_audit/doc_drift.rs
+++ b/crates/homeboy-core/src/code_audit/doc_drift.rs
@@ -7,7 +7,6 @@ use std::path::Path;
 use super::conventions::AuditFinding;
 use super::docs_audit;
 use super::findings::{Finding, Severity};
-use crate::component;
 
 pub(super) fn detect_doc_drift(root: &Path, component_id: &str) -> Vec<Finding> {
     use docs_audit::claims::ClaimConfidence;
@@ -29,15 +28,14 @@ pub(super) fn detect_doc_drift(root: &Path, component_id: &str) -> Vec<Finding> 
         return findings;
     };
 
-    let doc_excludes = if let Ok(comp) = component::load(component_id) {
-        crate::component::scope::resolve_component_scope(
-            &comp,
-            crate::component::scope::ScopeCommand::Audit,
-        )
-        .exclude
-    } else {
-        Vec::new()
-    };
+    // Resolve the component's audit-scope excludes and extension ids once, via
+    // the provider hook (no direct dependency on the component layer).
+    let component = super::component_provider::resolve_by_id(component_id);
+
+    let doc_excludes = component
+        .as_ref()
+        .map(|c| c.audit_scope_excludes.clone())
+        .unwrap_or_default();
 
     let doc_files = docs_audit::find_doc_files(&docs_path, &doc_excludes);
     if doc_files.is_empty() {
@@ -45,11 +43,10 @@ pub(super) fn detect_doc_drift(root: &Path, component_id: &str) -> Vec<Finding> 
     }
 
     // Load extension-configured ignore patterns if component is registered
-    let ignore_patterns = if let Ok(comp) = component::load(component_id) {
-        docs_audit::collect_extension_ignore_patterns(&comp)
-    } else {
-        Vec::new()
-    };
+    let ignore_patterns = component
+        .as_ref()
+        .map(|c| docs_audit::collect_extension_ignore_patterns(&c.extension_ids))
+        .unwrap_or_default();
 
     for relative_doc in &doc_files {
         let abs_doc = docs_path.join(relative_doc);

--- a/crates/homeboy-core/src/code_audit/docs_audit/mod.rs
+++ b/crates/homeboy-core/src/code_audit/docs_audit/mod.rs
@@ -16,7 +16,6 @@ use std::path::Path;
 pub use claims::{Claim, ClaimConfidence, ClaimType};
 pub use verify::VerifyResult;
 
-use crate::component;
 use crate::is_zero;
 
 /// A doc that needs content review due to referenced files changing.
@@ -156,15 +155,13 @@ pub(crate) fn find_doc_files(docs_path: &Path, excluded_targets: &[String]) -> V
 }
 
 /// Collect audit ignore patterns from all linked extensions.
-pub(crate) fn collect_extension_ignore_patterns(comp: &component::Component) -> Vec<String> {
+pub(crate) fn collect_extension_ignore_patterns(extension_ids: &[String]) -> Vec<String> {
     let mut patterns = Vec::new();
-    if let Some(ref extensions) = comp.extensions {
-        for extension_id in extensions.keys() {
-            if let Some(manifest) =
-                crate::code_audit::extension_manifests::load_audit_manifest(extension_id)
-            {
-                patterns.extend(manifest.audit_ignore_claim_patterns);
-            }
+    for extension_id in extension_ids {
+        if let Some(manifest) =
+            crate::code_audit::extension_manifests::load_audit_manifest(extension_id)
+        {
+            patterns.extend(manifest.audit_ignore_claim_patterns);
         }
     }
     patterns

--- a/crates/homeboy-core/src/code_audit/entry.rs
+++ b/crates/homeboy-core/src/code_audit/entry.rs
@@ -11,13 +11,12 @@ use super::execution_plan::AuditExecutionPlan;
 use super::findings::Finding;
 use super::types::{AuditWithAnalysis, CodeAuditResult};
 use super::{fingerprint, walker};
-use crate::{component, Result};
+use crate::Result;
 use homeboy_audit_contract::AuditConfig;
 
 /// Audit a registered component by ID.
 pub fn audit_component(component_id: &str) -> Result<CodeAuditResult> {
-    let comp = component::resolve_effective(Some(component_id), None, None)?;
-    component::validate_local_path(&comp)?;
+    let comp = super::component_provider::resolve_effective(component_id)?;
     audit_path_with_id(component_id, &comp.local_path)
 }
 
@@ -175,24 +174,20 @@ pub(super) fn audit_config_for(
     root: &Path,
     extension_overrides: &[String],
 ) -> AuditConfig {
-    let component =
-        component::discover_from_portable(root).or_else(|| component::load(component_id).ok());
+    let component = super::component_provider::discover_from_portable(root)
+        .or_else(|| super::component_provider::resolve_by_id(component_id));
     let mut audit_config = AuditConfig::default();
 
     if let Some(component) = &component {
-        if let Some(extensions) = &component.extensions {
-            for extension_id in extensions.keys() {
-                if let Some(manifest) =
-                    super::extension_manifests::load_audit_manifest(extension_id)
-                {
-                    if let Some(rules) = &manifest.audit_detector_rules {
-                        audit_config.merge(rules);
-                    }
+        for extension_id in &component.extension_ids {
+            if let Some(manifest) = super::extension_manifests::load_audit_manifest(extension_id) {
+                if let Some(rules) = &manifest.audit_detector_rules {
+                    audit_config.merge(rules);
                 }
             }
         }
 
-        if let Some(component_rules) = &component.audit {
+        if let Some(component_rules) = &component.audit_rules {
             audit_config.merge(component_rules);
         }
     }

--- a/crates/homeboy-core/src/code_audit/mod.rs
+++ b/crates/homeboy-core/src/code_audit/mod.rs
@@ -19,6 +19,7 @@ mod comment_blocks;
 mod comment_hygiene;
 pub mod compare;
 mod compiler_warnings;
+pub mod component_provider;
 mod convention_membership;
 pub(crate) mod conventions;
 pub(crate) mod core_fingerprint;

--- a/crates/homeboy-core/src/component/audit_provider.rs
+++ b/crates/homeboy-core/src/component/audit_provider.rs
@@ -1,0 +1,56 @@
+//! Component-side implementation of the audit component provider.
+//!
+//! The audit engine (`code_audit`) defines `AuditComponentProvider` and calls it
+//! to resolve the component under audit without depending on the component
+//! layer. This module implements that trait by resolving real `Component`s
+//! (`load` / `resolve_effective` + `validate_local_path` / `discover_from_portable`)
+//! and projecting each into the slim `AuditComponentInfo` view audit needs. It is
+//! registered at binary startup by the CLI, mirroring the extension-manifest /
+//! fixability / runner-evidence / tunnel provider hooks.
+
+use std::path::Path;
+
+use super::model::Component;
+use super::scope::{resolve_component_scope, ScopeCommand};
+use crate::code_audit::component_provider::{
+    register_audit_component_provider, AuditComponentInfo, AuditComponentProvider,
+};
+use crate::Result;
+
+/// Project a resolved `Component` into the audit-relevant view.
+fn project(component: &Component) -> AuditComponentInfo {
+    AuditComponentInfo {
+        local_path: component.local_path.clone(),
+        extension_ids: component
+            .extensions
+            .as_ref()
+            .map(|extensions| extensions.keys().cloned().collect())
+            .unwrap_or_default(),
+        audit_rules: component.audit.clone(),
+        audit_scope_excludes: resolve_component_scope(component, ScopeCommand::Audit).exclude,
+    }
+}
+
+struct ComponentAuditProvider;
+
+impl AuditComponentProvider for ComponentAuditProvider {
+    fn resolve_by_id(&self, component_id: &str) -> Option<AuditComponentInfo> {
+        super::load(component_id).ok().map(|c| project(&c))
+    }
+
+    fn resolve_effective(&self, component_id: &str) -> Result<AuditComponentInfo> {
+        let component = super::resolve_effective(Some(component_id), None, None)?;
+        super::validate_local_path(&component)?;
+        Ok(project(&component))
+    }
+
+    fn discover_from_portable(&self, root: &Path) -> Option<AuditComponentInfo> {
+        super::discover_from_portable(root).map(|c| project(&c))
+    }
+}
+
+/// Register the component-backed audit component provider. Called once at binary
+/// startup by the CLI.
+pub fn register() {
+    register_audit_component_provider(Box::new(ComponentAuditProvider));
+}

--- a/crates/homeboy-core/src/component/mod.rs
+++ b/crates/homeboy-core/src/component/mod.rs
@@ -1,4 +1,5 @@
 pub mod artifacts;
+pub mod audit_provider;
 // The audit config schema was extracted to the homeboy-audit-contract crate
 // (#8425) so it no longer couples component <-> code_audit through the core
 // module tree. Re-exported as `component::audit` so existing

--- a/tests/core/code_audit/audit_runtime_regression_test.rs
+++ b/tests/core/code_audit/audit_runtime_regression_test.rs
@@ -122,6 +122,11 @@ fn fixture_workflow_args() -> AuditRunWorkflowArgs {
 /// Run the fixture audit through the CI entry point and return the workflow
 /// result.
 fn run_fixture_audit() -> AuditRunWorkflowResult {
+    // Audit resolves the component under audit (here, the portable fixture's
+    // homeboy.json) through a provider the CLI registers at startup; a core lib
+    // test never runs the CLI, so register the component-backed provider so the
+    // fixture's audit config is discovered.
+    crate::component::audit_provider::register();
     run_main_audit_workflow(fixture_workflow_args())
         .expect("audit workflow runs on the fixture tree")
 }


### PR DESCRIPTION
## Summary
- The audit engine needs a little data about the component it audits — the resolved on-disk **source path**, the installed **extension ids**, the component's own **audit detector rules**, and the **audit-scope exclude globs**. It reached that by calling `crate::component::{load, resolve_effective, discover_from_portable, validate_local_path}` and `component::scope::*` directly, coupling `code_audit` to the `component` feature layer — the **last cross-layer blocker** to extracting audit into its own crate.
- Invert it behind a provider hook (same pattern as the extension-manifest, fixability, runner-evidence, and tunnel hooks).

## This removes ALL `code_audit → component` production edges
`code_audit`'s upward feature-layer edges are now:

| layer | prod edges |
|---|---|
| component | **0** ✅ |
| refactor | 0 ✅ |
| observation | 0 ✅ |
| review | 0 ✅ |
| issues | 0 ✅ |
| extension | a handful (value types `ExtensionPhaseTiming`/`HookRef` + the `find_extension_for_file_ext`/`run_fingerprint_script` fingerprint-script fallback) |

Audit is now genuinely within reach of its own crate — only the extension value-type/fingerprint-script edges remain (separate follow-ups).

## Design
- `code_audit::component_provider`: defines `AuditComponentProvider` + a slim owned `AuditComponentInfo { local_path, extension_ids, audit_rules, audit_scope_excludes }`. Audit never sees the full `Component` type. No-op provider (unregistered) resolves `None`/`Err`, which every call site already tolerates — path audits fall back to the raw path; config/doc lookups contribute no component-derived rules.
- `component::audit_provider`: implements the trait by resolving real `Component`s (`load` / `resolve_effective` + `validate_local_path` / `discover_from_portable`) and projecting each (including `resolve_component_scope(.., Audit).exclude`). `component::audit` is already `homeboy_audit_contract`, so `audit_rules` carries the contract type with no new coupling.
- CLI registers it at startup alongside the other audit provider hooks.
- Repointed 5 call sites across `entry.rs`, `codebase_map.rs`, `doc_drift.rs`, `docs_audit/mod.rs`, `descriptor_runtime.rs`; `collect_extension_ignore_patterns` now takes `&[String]` extension ids instead of `&Component`.

## Verification
- `cargo check -p homeboy-core --lib` — 0 errors, no new warnings.
- `grep` confirms **zero** `code_audit -> component` production refs remain.
- `cargo test -p homeboy-core --lib code_audit::` — **766 passed, 0 failed** (hook degrades gracefully; no default-tier test needed real resolution).
- `cargo test -p homeboy-core --lib component_provider` — noop provider test passes.
- `cargo check --workspace --tests --locked` (topology guard) — passes; slow tier compiles.
- The slow-tier fixture regression test registers the provider explicitly. (It still fails on a bare host lacking a rust fingerprinting extension — the pre-existing env issue documented in #8600, unrelated to this change.)
- 11 files; reverted unrelated `cargo fmt` drift.

Refs #8425