### PR TITLE
refactor: reuse generic cook batch scheduler (#8519)

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -3,13 +3,10 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
-use std::sync::{mpsc, Arc, Mutex};
 
 use homeboy::core::agent_task_provider::AgentTaskProviderProfileDeclaration;
 use homeboy::core::agent_tasks::batch;
-use homeboy::core::agent_tasks::dispatch_service::{
-    self, AgentTaskDispatchCommand, DispatchCoreInputs,
-};
+use homeboy::core::agent_tasks::dispatch_service::{AgentTaskDispatchCommand, DispatchCoreInputs};
 use homeboy::core::agent_tasks::gate::{AgentTaskGateRevealPolicy, VerifyGateOptions};
 use homeboy::core::agent_tasks::lifecycle as agent_task_lifecycle;
 use homeboy::core::agent_tasks::provider::{self, AgentTaskProviderCatalog};
@@ -132,17 +129,17 @@ where
     if let Some(record_run_id) = args.record_run_id {
         plan.fanout_id = record_run_id;
     }
-    run_batch_cook_fanout_plan_with_terminal(plan, None, move |mut options| {
-        options.attempt_dispatcher = Some(attempt_dispatcher(&options));
-        let result = agent_task_service::run_cook(
-            options,
-            provider::ExtensionProviderAgentTaskExecutor::discover(),
-        )?;
-        Ok(serde_json::json!({
-            "exit_code": result.exit_code,
-            "result": serde_json::to_value(result.value).unwrap_or(Value::Null),
-        }))
-    })
+    let result = agent_task_service::run_cook_batch(
+        agent_task_service::AgentTaskCookBatchOptions {
+            batch_id: plan.fanout_id.clone(),
+            cooks: compile_batch_cooks(&plan, |options| {
+                options.attempt_dispatcher = Some(attempt_dispatcher(options));
+            })?,
+            max_concurrency: batch_worker_limit(&plan),
+        },
+        provider::ExtensionProviderAgentTaskExecutor::discover(),
+    )?;
+    Ok(batch_cook_result(&plan, result))
 }
 
 fn run_batch_cook_fanout_plan(plan: BatchCookFanoutPlan) -> CmdResult<Value> {
@@ -157,15 +154,17 @@ fn run_batch_cook_fanout_plan_with_executor<E>(
     executor: E,
 ) -> CmdResult<Value>
 where
-    E: homeboy::core::agent_tasks::scheduler::AgentTaskExecutorAdapter + Clone,
+    E: homeboy::core::agent_tasks::scheduler::AgentTaskExecutorAdapter + Clone + Send,
 {
-    run_batch_cook_fanout_plan_with_terminal(plan, None, move |options| {
-        let result = agent_task_service::run_cook(options, executor.clone())?;
-        Ok(serde_json::json!({
-            "exit_code": result.exit_code,
-            "result": serde_json::to_value(result.value).unwrap_or(Value::Null),
-        }))
-    })
+    let result = agent_task_service::run_cook_batch(
+        agent_task_service::AgentTaskCookBatchOptions {
+            batch_id: plan.fanout_id.clone(),
+            cooks: compile_batch_cooks(&plan, |_| {})?,
+            max_concurrency: batch_worker_limit(&plan),
+        },
+        executor,
+    )?;
+    Ok(batch_cook_result(&plan, result))
 }
 
 fn batch_harvest_context() -> Result<homeboy::core::agent_task_scheduler::HarvestExecutionContext> {
@@ -176,117 +175,66 @@ fn batch_harvest_context() -> Result<homeboy::core::agent_task_scheduler::Harves
     }
 }
 
-/// Runs one controller-owned batch. The controller captures one immutable Lab
-/// process context; each cell receives a clone after its dispatch plan and cook
-/// options have been constructed. Batch cook specs currently have no per-cell
-/// runner or placement field, so they cannot request mixed local/Lab routing.
-fn run_batch_cook_fanout_plan_with_terminal<F>(
-    plan: BatchCookFanoutPlan,
-    worker_limit: Option<usize>,
-    terminal: F,
-) -> CmdResult<Value>
-where
-    F: Fn(AgentTaskCookServiceOptions) -> Result<Value> + Clone + Send,
-{
+fn compile_batch_cooks(
+    plan: &BatchCookFanoutPlan,
+    configure: impl Fn(&mut AgentTaskCookServiceOptions),
+) -> Result<Vec<AgentTaskCookServiceOptions>> {
     let harvest_context = batch_harvest_context()?;
-    let workers = worker_limit.unwrap_or_else(|| {
-        plan.cooks
-            .len()
-            .min(std::thread::available_parallelism().map_or(1, usize::from))
-    });
-    run_batch_cook_fanout_plan_with_terminal_and_workers(plan, harvest_context, workers, terminal)
+    plan.cooks
+        .iter()
+        .map(|cook| {
+            let invocation = cook.to_cook_invocation(plan)?;
+            let mut options =
+                agent_task_service::compile_cook_attempt(invocation.options, invocation.dispatch)?;
+            options.harvest_context = harvest_context.clone();
+            configure(&mut options);
+            Ok(options)
+        })
+        .collect()
 }
 
-fn run_batch_cook_fanout_plan_with_terminal_and_workers<F>(
-    plan: BatchCookFanoutPlan,
-    harvest_context: homeboy::core::agent_task_scheduler::HarvestExecutionContext,
-    workers: usize,
-    terminal: F,
-) -> CmdResult<Value>
-where
-    F: Fn(AgentTaskCookServiceOptions) -> Result<Value> + Clone + Send,
-{
-    let total = plan.cooks.len();
-    let workers = workers.min(total);
-    let plan = Arc::new(plan);
-    let next = Arc::new(Mutex::new(0usize));
-    let (tx, rx) = mpsc::channel();
-    std::thread::scope(|scope| {
-        for _ in 0..workers {
-            let plan = Arc::clone(&plan);
-            let next = Arc::clone(&next);
-            let tx = tx.clone();
-            let terminal = terminal.clone();
-            let harvest_context = harvest_context.clone();
-            scope.spawn(move || loop {
-                let index = {
-                    let mut next = next.lock().expect("batch cook work queue");
-                    if *next == plan.cooks.len() {
-                        return;
-                    }
-                    let index = *next;
-                    *next += 1;
-                    index
-                };
-                let cook = &plan.cooks[index];
-                let cell = (|| -> Result<Value> {
-                    let invocation = cook.to_cook_invocation(&plan)?;
-                    let run_id = invocation.options.initial_run_id.clone();
-                    let request =
-                        dispatch_service::resolve_dispatch_request(invocation.dispatch.into())?;
-                    let initial_plan = dispatch_service::build_dispatch_plan(&request)?;
-                    let mut options = invocation.options;
-                    options.initial_run_id = run_id;
-                    options.initial_plan = initial_plan;
-                    options.harvest_context = harvest_context.clone();
-                    terminal(options)
-                })();
-                let _ = tx.send((index, cell));
-            });
-        }
-    });
-    drop(tx);
+fn batch_worker_limit(plan: &BatchCookFanoutPlan) -> usize {
+    plan.cooks
+        .len()
+        .min(std::thread::available_parallelism().map_or(1, usize::from))
+}
 
-    let mut results = (0..total).map(|_| None).collect::<Vec<Option<Value>>>();
-    for (index, cell) in rx {
-        let cook = &plan.cooks[index];
-        let cell = match cell {
-            Ok(cell) => cell,
-            Err(error) => serde_json::json!({
-                "exit_code": 1,
-                "result": { "error": error.to_string() },
-            }),
-        };
-        results[index] = Some(serde_json::json!({
-            "cook_id": cook.cook_id,
-            "run_id": cook.run_id(),
-            "worktree": cook.to_worktree,
-            "head": cook.head,
-            "workspace_materialization": cook.workspace_materialization,
-            "exit_code": cell["exit_code"],
-            "result": cell["result"],
-        }));
-    }
-    let results = results.into_iter().flatten().collect::<Vec<_>>();
-    let failed = results
+fn batch_cook_result(
+    plan: &BatchCookFanoutPlan,
+    result: agent_task_service::AgentTaskRunResult<agent_task_service::AgentTaskCookBatchReport>,
+) -> (Value, i32) {
+    let report = result.value;
+    let cooks = report
+        .cooks
         .iter()
-        .filter(|result| result["exit_code"].as_i64() != Some(0))
-        .count();
-
-    Ok((
+        .zip(&plan.cooks)
+        .map(|(cell, cook)| {
+            let cell_result = cell
+                .result
+                .as_ref()
+                .map(|result| serde_json::to_value(result).unwrap_or(Value::Null))
+                .unwrap_or_else(|| serde_json::json!({ "error": cell.error }));
+            serde_json::json!({
+                "cook_id": cook.cook_id,
+                "run_id": cook.run_id(),
+                "worktree": cook.to_worktree,
+                "head": cook.head,
+                "workspace_materialization": cook.workspace_materialization,
+                "exit_code": cell.exit_code,
+                "result": cell_result,
+            })
+        })
+        .collect::<Vec<_>>();
+    (
         serde_json::json!({
             "schema": AGENT_TASK_BATCH_COOK_FANOUT_RUN_SCHEMA,
             "fanout_id": plan.fanout_id,
-            "status": if failed == 0 { "succeeded" } else { "failed" },
-            "summary": {
-                "total": results.len(),
-                "succeeded": results.len() - failed,
-                "failed": failed,
-            },
-            "cooks": results,
+            "status": report.status,
+            "summary": { "total": report.total, "succeeded": report.succeeded, "failed": report.failed },
+            "cooks": cooks,
         }),
-        if failed == 0 { 0 } else { 1 },
-    ))
+        result.exit_code,
+    )
 }
 
 fn cook_batch(mut args: AgentTaskFanoutCookBatchArgs) -> CmdResult<Value> {

--- a/crates/homeboy-core/src/agent_task_service/cook.rs
+++ b/crates/homeboy-core/src/agent_task_service/cook.rs
@@ -6,12 +6,14 @@ use serde_json::Value;
 use sha2::Digest;
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::Arc;
+use std::sync::{mpsc, Arc, Mutex};
 
 use crate::agent_task::AgentTaskExecutor;
 use crate::agent_task_cook_loop::{
     evaluate_cook_loop, AgentTaskCookLoopOptions, AgentTaskCookLoopReport, AgentTaskCookLoopStatus,
 };
+use crate::agent_task_dispatch_plan::build_dispatch_plan;
+use crate::agent_task_dispatch_service::{self, AgentTaskDispatchCommand};
 use crate::agent_task_finalization::{
     finalize_pr_with_backend, AgentTaskPrEvidence, AgentTaskPrFinalizationBackend,
     AgentTaskPrFinalizationOptions, AgentTaskPrRuntimeGuardrails, AgentTaskPrSourceRelationship,
@@ -105,6 +107,137 @@ pub struct AgentTaskCookReport {
     pub finalization: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_reason: Option<String>,
+}
+
+/// A bounded collection of independently durable cooks. Each cook retains the
+/// same dispatch, retry, promotion, and lifecycle path as `run_cook`.
+#[derive(Debug, Clone)]
+pub struct AgentTaskCookBatchOptions {
+    pub batch_id: String,
+    pub cooks: Vec<AgentTaskCookServiceOptions>,
+    pub max_concurrency: usize,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AgentTaskCookBatchCellReport {
+    pub cook_id: String,
+    pub initial_run_id: String,
+    pub exit_code: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<AgentTaskCookReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AgentTaskCookBatchReport {
+    pub schema: &'static str,
+    pub batch_id: String,
+    pub status: String,
+    pub total: usize,
+    pub succeeded: usize,
+    pub failed: usize,
+    pub cooks: Vec<AgentTaskCookBatchCellReport>,
+}
+
+/// Resolves a generic dispatch command once, before a typed cook is scheduled.
+/// Callers compile workflow policy into the command and cook options; this
+/// routine owns the shared dispatch compilation boundary.
+pub fn compile_cook_attempt(
+    mut options: AgentTaskCookServiceOptions,
+    dispatch: AgentTaskDispatchCommand,
+) -> Result<AgentTaskCookServiceOptions> {
+    let request = agent_task_dispatch_service::resolve_dispatch_request(dispatch.into())?;
+    options.initial_plan = build_dispatch_plan(&request)?;
+    Ok(options)
+}
+
+/// Runs independently durable cooks with bounded concurrency while preserving
+/// input order for callers that join their own metadata onto the results.
+/// Batch-cook fanout is the first caller; other cook coordinators can migrate
+/// by compiling their own `AgentTaskCookServiceOptions` and using this runner.
+pub fn run_cook_batch<E>(
+    options: AgentTaskCookBatchOptions,
+    executor: E,
+) -> Result<AgentTaskRunResult<AgentTaskCookBatchReport>>
+where
+    E: AgentTaskExecutorAdapter + Clone + Send,
+{
+    let total = options.cooks.len();
+    if total == 0 {
+        return Err(Error::validation_invalid_argument(
+            "cooks",
+            "agent-task cook batch requires at least one cook",
+            Some(options.batch_id),
+            None,
+        ));
+    }
+
+    let workers = options.max_concurrency.max(1).min(total);
+    let cooks = Arc::new(options.cooks);
+    let next = Arc::new(Mutex::new(0usize));
+    let (tx, rx) = mpsc::channel();
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            let cooks = Arc::clone(&cooks);
+            let next = Arc::clone(&next);
+            let tx = tx.clone();
+            let executor = executor.clone();
+            scope.spawn(move || loop {
+                let index = {
+                    let mut next = next.lock().expect("cook batch work queue");
+                    if *next == cooks.len() {
+                        return;
+                    }
+                    let index = *next;
+                    *next += 1;
+                    index
+                };
+                let cook = cooks[index].clone();
+                let cell = match run_cook(cook.clone(), executor.clone()) {
+                    Ok(result) => AgentTaskCookBatchCellReport {
+                        cook_id: cook.cook_id,
+                        initial_run_id: cook.initial_run_id,
+                        exit_code: result.exit_code,
+                        result: Some(result.value),
+                        error: None,
+                    },
+                    Err(error) => AgentTaskCookBatchCellReport {
+                        cook_id: cook.cook_id,
+                        initial_run_id: cook.initial_run_id,
+                        exit_code: 1,
+                        result: None,
+                        error: Some(error.to_string()),
+                    },
+                };
+                let _ = tx.send((index, cell));
+            });
+        }
+    });
+    drop(tx);
+
+    let mut cells = (0..total).map(|_| None).collect::<Vec<_>>();
+    for (index, cell) in rx {
+        cells[index] = Some(cell);
+    }
+    let cooks = cells.into_iter().flatten().collect::<Vec<_>>();
+    let failed = cooks.iter().filter(|cell| cell.exit_code != 0).count();
+    Ok(AgentTaskRunResult {
+        exit_code: if failed == 0 { 0 } else { 1 },
+        value: AgentTaskCookBatchReport {
+            schema: "homeboy/agent-task-cook-batch/v1",
+            batch_id: options.batch_id,
+            status: if failed == 0 {
+                "succeeded".to_string()
+            } else {
+                "failed".to_string()
+            },
+            total,
+            succeeded: total - failed,
+            failed,
+            cooks,
+        },
+    })
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -1343,6 +1476,8 @@ mod tests {
         ProviderRuntimeLifecycle, ProviderRuntimeState, RunExecutionLifecycle, RunExecutionState,
         RunLifecycleRecord,
     };
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Barrier;
 
     #[test]
     fn cook_service_retry_uses_the_same_passed_context_after_ambient_mutation() {
@@ -1408,6 +1543,166 @@ mod tests {
         ) -> crate::agent_task::AgentTaskOutcome {
             panic!("accepted detached attempts must remain daemon-owned")
         }
+    }
+
+    #[derive(Debug)]
+    struct BatchAttemptDispatcher {
+        barrier: Arc<Barrier>,
+        entered: Arc<AtomicUsize>,
+        fail: bool,
+    }
+
+    impl AgentTaskCookAttemptDispatcher for BatchAttemptDispatcher {
+        fn durable_recipe(&self) -> Result<Value> {
+            Ok(serde_json::json!({ "kind": "test-batch" }))
+        }
+
+        fn dispatch_attempt(
+            &self,
+            plan: AgentTaskPlan,
+            run_id: &str,
+            _derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+        ) -> Result<()> {
+            self.entered.fetch_add(1, Ordering::SeqCst);
+            self.barrier.wait();
+            if self.fail {
+                return Err(Error::validation_invalid_argument(
+                    "dispatch",
+                    "fixture dispatch failure",
+                    None,
+                    None,
+                ));
+            }
+            agent_task_lifecycle::submit_plan(&plan, Some(run_id))?;
+            agent_task_lifecycle::record_detached_lab_run(
+                agent_task_lifecycle::DetachedLabRunRecord {
+                    run_id,
+                    runner_id: "fixture-lab",
+                    runner_job_id: "fixture-job",
+                    remote_workspace: "/runner/workspace",
+                    remote_command: &["homeboy".to_string(), "agent-task".to_string()],
+                },
+            )?;
+            Ok(())
+        }
+    }
+
+    fn batch_cook_options(
+        cook_id: &str,
+        dispatcher: Arc<dyn AgentTaskCookAttemptDispatcher>,
+    ) -> AgentTaskCookServiceOptions {
+        AgentTaskCookServiceOptions {
+            cook_id: cook_id.to_string(),
+            initial_run_id: format!("{cook_id}-run"),
+            initial_plan: AgentTaskPlan::new(
+                cook_id,
+                vec![AgentTaskRequest {
+                    schema: crate::agent_task::AGENT_TASK_REQUEST_SCHEMA.to_string(),
+                    task_id: "provider".to_string(),
+                    group_key: None,
+                    parent_plan_id: None,
+                    executor: AgentTaskExecutor {
+                        backend: "fixture".to_string(),
+                        selector: None,
+                        runtime_selection: None,
+                        required_capabilities: Vec::new(),
+                        secret_env: Vec::new(),
+                        model: None,
+                        config: Value::Null,
+                    },
+                    instructions: "complete the task".to_string(),
+                    inputs: Value::Null,
+                    source_refs: Vec::new(),
+                    workspace: AgentTaskWorkspace::default(),
+                    component_contracts: Vec::new(),
+                    policy: AgentTaskPolicy::default(),
+                    limits: AgentTaskLimits::default(),
+                    expected_artifacts: Vec::new(),
+                    artifact_declarations: Vec::new(),
+                    metadata: Value::Null,
+                }],
+            ),
+            to_worktree: format!("fixture@{cook_id}"),
+            source_worktree_path: None,
+            provider_command: None,
+            provider_invocation: None,
+            gates: VerifyGateOptions::default(),
+            max_attempts: 1,
+            no_finalize: true,
+            base: "main".to_string(),
+            task_base_sha: None,
+            head: None,
+            title: "Batch cook".to_string(),
+            commit_message: "test".to_string(),
+            source_refs: Vec::new(),
+            protected_branches: Vec::new(),
+            ai_tool: "test".to_string(),
+            ai_model: None,
+            ai_used_for: "test".to_string(),
+            attempt_dispatcher: Some(dispatcher),
+            harvest_context: Default::default(),
+        }
+    }
+
+    #[test]
+    fn cook_batch_preserves_order_concurrency_and_failure_isolation() {
+        crate::test_support::with_isolated_home(|_| {
+            let barrier = Arc::new(Barrier::new(2));
+            let entered = Arc::new(AtomicUsize::new(0));
+            let result = run_cook_batch(
+                AgentTaskCookBatchOptions {
+                    batch_id: "fixture-batch".to_string(),
+                    cooks: vec![
+                        batch_cook_options(
+                            "first",
+                            Arc::new(BatchAttemptDispatcher {
+                                barrier: Arc::clone(&barrier),
+                                entered: Arc::clone(&entered),
+                                fail: true,
+                            }),
+                        ),
+                        batch_cook_options(
+                            "second",
+                            Arc::new(BatchAttemptDispatcher {
+                                barrier,
+                                entered: Arc::clone(&entered),
+                                fail: false,
+                            }),
+                        ),
+                    ],
+                    max_concurrency: 2,
+                },
+                UnusedExecutor,
+            )
+            .expect("batch completes despite an individual cook failure");
+
+            assert_eq!(entered.load(Ordering::SeqCst), 2);
+            assert_eq!(result.exit_code, 1);
+            assert_eq!(result.value.status, "failed");
+            assert_eq!(result.value.total, 2);
+            assert_eq!(result.value.succeeded, 1);
+            assert_eq!(result.value.failed, 1);
+            assert_eq!(result.value.cooks[0].cook_id, "first");
+            assert_eq!(result.value.cooks[0].exit_code, 1);
+            assert_eq!(
+                result.value.cooks[0]
+                    .result
+                    .as_ref()
+                    .expect("failed cook report")
+                    .status,
+                "provider_failure"
+            );
+            assert_eq!(result.value.cooks[1].cook_id, "second");
+            assert_eq!(result.value.cooks[1].exit_code, 0);
+            assert_eq!(
+                result.value.cooks[1]
+                    .result
+                    .as_ref()
+                    .expect("successful cook report")
+                    .status,
+                "in_flight"
+            );
+        });
     }
 
     #[test]

--- a/crates/homeboy-core/src/agent_tasks.rs
+++ b/crates/homeboy-core/src/agent_tasks.rs
@@ -371,16 +371,17 @@ pub mod secrets {
 /// High-level service entry points combining lifecycle and scheduling.
 pub mod service {
     pub use super::super::agent_task_service::{
-        aggregate_exit_code, ai_model_from_tool, artifacts, cancel, discover_runs,
-        evidence_ref_task_id, hydrate_evidence_ref, hydrate_evidence_summary, logs,
+        aggregate_exit_code, ai_model_from_tool, artifacts, cancel, compile_cook_attempt,
+        discover_runs, evidence_ref_task_id, hydrate_evidence_ref, hydrate_evidence_summary, logs,
         normalize_plan_workspaces, offloaded_status_remediation,
         persist_provider_boundary_replay_evidence, promotion_source, read_plan,
-        reconcile_terminal_artifact_projection, resume, retry, run_cook, run_loaded_plan, run_next,
-        run_next_with_cook_dispatcher, run_status, run_submitted, run_submitted_with_timeout,
-        source_worktree_path, status, submit_plan_spec, AgentTaskCookAttemptReport,
-        AgentTaskCookReport, AgentTaskCookServiceOptions, AgentTaskDiscoveryCommands,
-        AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter, AgentTaskDiscoveryReport,
-        AgentTaskDiscoveryRun, AgentTaskHydratedEvidence, AgentTaskRetryServiceResult,
-        AgentTaskRunResult,
+        reconcile_terminal_artifact_projection, resume, retry, run_cook, run_cook_batch,
+        run_loaded_plan, run_next, run_next_with_cook_dispatcher, run_status, run_submitted,
+        run_submitted_with_timeout, source_worktree_path, status, submit_plan_spec,
+        AgentTaskCookAttemptReport, AgentTaskCookBatchCellReport, AgentTaskCookBatchOptions,
+        AgentTaskCookBatchReport, AgentTaskCookReport, AgentTaskCookServiceOptions,
+        AgentTaskDiscoveryCommands, AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter,
+        AgentTaskDiscoveryReport, AgentTaskDiscoveryRun, AgentTaskHydratedEvidence,
+        AgentTaskRetryServiceResult, AgentTaskRunResult,
     };
 }


### PR DESCRIPTION
## Summary
- Consolidates the **fanout and batch cook** paths onto a single generic cook batch scheduler (`run_cook_batch` + `AgentTaskCookBatch{Options,Report,CellReport}` in `agent_task_service/cook.rs`), removing the divergent bespoke scheduling logic in `agent_task/fanout.rs`.
- Re-exports the new batch scheduler surface through `agent_tasks::service`.

## Why
Closes #8519 — "Consolidate fanout and batch cook onto the generic cook scheduler." Fanout previously reimplemented batch scheduling; this reuses one generic scheduler so both paths share behavior.

## Notes
- Was stranded ~30min with no PR. Rebased onto latest `main` — resolved **one conflict** in `agent_tasks.rs::service`: it was a `pub use` re-export list where main had added `reconcile_terminal_artifact_projection` and this branch added `run_cook_batch` + the batch report types. Resolution is the **union** of both (verified both symbols resolve: `run_cook_batch`/batch types in `cook.rs`, `reconcile_terminal_artifact_projection` in `execution.rs`).
- `cargo fmt` clean.
- Left heavy `cargo build`/`test` to CI per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)