### PR TITLE
refactor: route daemon /exec runner process driver through a hook

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -135,6 +135,10 @@ impl CliRuntime {
         // can reconcile and resume runs dispatched to a remote runner without
         // core depending on runner behavior.
         crate::core::runner::register_runner_continuation_provider();
+        // Register the runner daemon-exec driver so the daemon's /exec endpoint
+        // can prepare and run a runner job as a local child without core
+        // depending on runner process-execution behavior.
+        crate::core::runner::register_runner_daemon_exec_driver();
         // Register the runner-upgrade provider so the core upgrade flow can
         // refresh configured runners without depending on runner behavior.
         crate::core::upgrade::register_runner_upgrade();

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -23,10 +23,7 @@ use crate::paths;
 use crate::process::{
     pid_has_environment_value, pid_is_running, terminate_pid_with_sigterm_and_wait,
 };
-use crate::runner::{
-    execute_runner_process_until_cancelled_with_progress, prepare_daemon_local_process,
-    BrokerScope, Runner, RunnerProcessRequest,
-};
+use crate::runner::BrokerScope;
 use crate::runner_execution_envelope::PathMaterializationPlan;
 use crate::secret_env_plan::SecretEnvPlan;
 use crate::source_snapshot::SourceSnapshot;
@@ -38,6 +35,7 @@ mod completion_tracker;
 mod control;
 mod patch_capture;
 mod remote_runner;
+pub mod runner_exec_driver;
 pub use artifact_download::ArtifactDownload;
 pub use broker_config::{render_broker_config, BrokerConfig, BrokerConfigOptions, ServiceIdentity};
 pub use control::{
@@ -370,7 +368,7 @@ pub struct HttpResponse {
 struct ExecRequest {
     runner_id: String,
     #[serde(default)]
-    runner: Option<Runner>,
+    runner: Option<serde_json::Value>,
     #[serde(default)]
     project_id: Option<String>,
     #[serde(default)]
@@ -1729,7 +1727,7 @@ fn enqueue_exec_job(
             request.capture_patch,
         )
     })?;
-    let plan = prepare_daemon_local_process(RunnerProcessRequest {
+    let plan = runner_exec_driver::prepare_exec(runner_exec_driver::RunnerExecPrepareRequest {
         runner_id: request.runner_id,
         runner: request.runner,
         cwd: request.cwd,
@@ -1737,7 +1735,9 @@ fn enqueue_exec_job(
         command: request.command,
         env: request.env,
         secret_env_names: request.secret_env_names,
-        secret_env_plan: Some(secret_env_plan),
+        secret_env_plan: Some(
+            serde_json::to_value(&secret_env_plan).unwrap_or(serde_json::Value::Null),
+        ),
         capture_patch: request.capture_patch,
         raw_exec: request.raw_exec,
         source_snapshot: request.source_snapshot,
@@ -1771,7 +1771,7 @@ fn enqueue_exec_job(
             .durable_run_id = Some(durable_run_id);
     }
     let summary = json!({
-        "runner_id": plan.runner.id,
+        "runner_id": plan.runner_id,
         "cwd": plan.cwd,
         "command": plan.command,
         "capture_patch": request.capture_patch,
@@ -1787,7 +1787,7 @@ fn enqueue_exec_job(
     )
     .unwrap_or_else(|| json!({}));
     run_ref_metadata["runner_job_projection"] = json!({
-        "runner_id": plan.runner.id,
+        "runner_id": plan.runner_id,
         "command": crate::redaction::redact_argv_display(&plan.command),
         "cwd": plan.cwd,
         "source": lifecycle.as_ref().and_then(|lifecycle| lifecycle.source.clone()).unwrap_or_else(|| "runner-daemon".to_string()),
@@ -1801,7 +1801,7 @@ fn enqueue_exec_job(
             Some(run_ref_metadata),
             path_materialization_plan.clone(),
             Some(LocalRunnerJob {
-                runner_id: plan.runner.id.clone(),
+                runner_id: plan.runner_id.clone(),
                 command: plan.command.clone(),
                 cwd: Some(plan.cwd.clone()),
                 lifecycle: lifecycle.clone(),
@@ -1831,9 +1831,10 @@ fn enqueue_exec_job(
                     started_job.start_with_reserved_child_identity(pid, process_group_id, discriminator)?;
                     Ok(())
                 });
-                let process_output = execute_runner_process_until_cancelled_with_progress(
+                let cancel_job = job.clone();
+                let process_output = runner_exec_driver::execute_exec(
                     &plan,
-                    || job.is_cancelled(),
+                    Box::new(move || cancel_job.is_cancelled()),
                     Some(progress_sink),
                     true,
                     Some(child_started),
@@ -1850,7 +1851,7 @@ fn enqueue_exec_job(
                         "metrics": metrics.clone(),
                     }));
                     return Ok(json!({
-                        "runner_id": plan.runner.id.clone(),
+                        "runner_id": plan.runner_id.clone(),
                         "cwd": plan.cwd.clone(),
                         "command": plan.command.clone(),
                         "exit_code": exit_code,
@@ -1877,7 +1878,7 @@ fn enqueue_exec_job(
                 let patch = if let Some(baseline) = baseline {
                     Some(capture_patch_report(
                         job.job_id(),
-                        &plan.runner.id,
+                        &plan.runner_id,
                         &plan.cwd,
                         &plan.command,
                         source_snapshot.as_ref(),
@@ -1888,7 +1889,7 @@ fn enqueue_exec_job(
                     None
                 };
                 let result = json!({
-                    "runner_id": plan.runner.id,
+                    "runner_id": plan.runner_id,
                     "cwd": plan.cwd,
                     "command": plan.command,
                     "exit_code": exit_code,
@@ -1909,7 +1910,7 @@ fn enqueue_exec_job(
                         stderr,
                         target: TargetDetails {
                             project_id: None,
-                            server_id: Some(plan.runner.id.clone()),
+                            server_id: Some(plan.runner_id.clone()),
                             host: None,
                         },
                     }));

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -2022,6 +2022,7 @@ mod tests {
 
     #[test]
     fn daemon_exec_projects_metadata_run_id_through_jobs_and_runs_without_read_side_growth() {
+        crate::runner::register_runner_daemon_exec_driver();
         with_isolated_home(|_| {
             let workspace = tempfile::tempdir().expect("workspace");
             let store = JobStore::default();

--- a/crates/homeboy-core/src/daemon/runner_exec_driver.rs
+++ b/crates/homeboy-core/src/daemon/runner_exec_driver.rs
@@ -1,0 +1,201 @@
+//! Runner exec-driver hook.
+//!
+//! The daemon's `/exec` endpoint runs a runner job as a local child process:
+//! it prepares a process plan (resolving the runner, cwd, command, and secret
+//! environment) and then executes that child with the daemon's job callbacks
+//! (cancellation, progress, child-identity acknowledgement, output capture).
+//!
+//! That prepare+execute path is the ONLY runner-specific behavior left in the
+//! otherwise-general daemon (which also serves health, lifecycle, file, and
+//! code-analysis job endpoints). It is inverted behind this driver trait so the
+//! daemon stays in `homeboy-core` while the optional runner crate supplies the
+//! process-execution implementation.
+//!
+//! With no driver registered (single-machine install with no runner) the
+//! [`NoopRunnerExecDriver`] errors clearly — the `/exec` endpoint is only
+//! reached when a runner job was actually dispatched.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use serde_json::Value;
+
+use crate::error::{Error, Result};
+use crate::source_snapshot::SourceSnapshot;
+
+/// Everything the driver needs to build a runner process plan. Mirrors the
+/// daemon's `ExecRequest`, but carries the runner descriptor as raw JSON so no
+/// runner type crosses the core boundary.
+pub struct RunnerExecPrepareRequest {
+    pub runner_id: String,
+    /// The optional inline runner descriptor from the exec request body,
+    /// deserialized by the driver on the runner side.
+    pub runner: Option<Value>,
+    pub project_id: Option<String>,
+    pub cwd: Option<String>,
+    pub command: Vec<String>,
+    pub env: HashMap<String, String>,
+    pub secret_env_names: Vec<String>,
+    /// The already-computed secret-env plan, serialized. `None` when default.
+    pub secret_env_plan: Option<Value>,
+    pub capture_patch: bool,
+    pub raw_exec: bool,
+    pub source_snapshot: Option<SourceSnapshot>,
+    pub require_paths: Vec<String>,
+    pub validate_require_paths_on_host: bool,
+}
+
+/// A prepared runner process, slimmed to the fields the daemon reads while it
+/// drives the child. The runner descriptor itself stays inside the driver.
+#[derive(Debug, Clone)]
+pub struct PreparedDaemonExec {
+    pub runner_id: String,
+    pub cwd: String,
+    pub command: Vec<String>,
+    pub env: HashMap<String, String>,
+    pub secret_env_names: Vec<String>,
+    pub source_snapshot: SourceSnapshot,
+    pub require_paths: Vec<String>,
+    /// Opaque driver-owned plan handle carried back into `execute`. The daemon
+    /// never inspects it; it exists so the driver can reconstruct the full
+    /// runner process without re-preparing.
+    plan_token: Arc<dyn std::any::Any + Send + Sync>,
+}
+
+impl PreparedDaemonExec {
+    /// Construct a prepared exec. `plan_token` is the driver's private full
+    /// plan; the daemon-visible fields are the process descriptor.
+    pub fn new(
+        runner_id: String,
+        cwd: String,
+        command: Vec<String>,
+        env: HashMap<String, String>,
+        secret_env_names: Vec<String>,
+        source_snapshot: SourceSnapshot,
+        require_paths: Vec<String>,
+        plan_token: Arc<dyn std::any::Any + Send + Sync>,
+    ) -> Self {
+        Self {
+            runner_id,
+            cwd,
+            command,
+            env,
+            secret_env_names,
+            source_snapshot,
+            require_paths,
+            plan_token,
+        }
+    }
+
+    /// The driver-owned opaque plan handle.
+    pub fn plan_token(&self) -> &Arc<dyn std::any::Any + Send + Sync> {
+        &self.plan_token
+    }
+}
+
+/// The output of running a runner child, slimmed to what the daemon serializes.
+#[derive(Debug, Clone, Default)]
+pub struct DaemonExecOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+    /// Serialized `RunnerResourceMetrics`, if any.
+    pub metrics: Option<Value>,
+    /// Serialized command-capture metadata, if any.
+    pub capture: Option<Value>,
+}
+
+/// A cancellation probe the driver polls while the child runs.
+pub type ExecCancellationProbe = Box<dyn FnMut() -> bool + Send>;
+/// A progress sink the driver invokes with structured progress events.
+pub type ExecProgressSink = Arc<dyn Fn(Value) -> Result<()> + Send + Sync + 'static>;
+/// A child-started acknowledgement callback invoked with the child pid.
+pub type ExecChildStarted = Arc<dyn Fn(u32) -> Result<()> + Send + Sync + 'static>;
+
+/// The runner process prepare+execute contract the daemon depends on.
+pub trait RunnerExecDriver: Send + Sync {
+    /// Prepare a runner process plan from the exec request.
+    fn prepare(&self, request: RunnerExecPrepareRequest) -> Result<PreparedDaemonExec>;
+
+    /// Execute a prepared runner child, driving it with the daemon's
+    /// cancellation, progress, and child-identity callbacks.
+    ///
+    /// The daemon may mutate `prepared.env` (e.g. to inject the child
+    /// reservation id) between `prepare` and `execute`, so implementations MUST
+    /// honor `prepared.env` rather than any environment captured at prepare
+    /// time.
+    fn execute(
+        &self,
+        prepared: &PreparedDaemonExec,
+        is_cancelled: ExecCancellationProbe,
+        progress_sink: Option<ExecProgressSink>,
+        require_child_identity_acknowledgement: bool,
+        child_started: Option<ExecChildStarted>,
+    ) -> Result<DaemonExecOutput>;
+}
+
+/// Default driver used when no runner layer is registered.
+struct NoopRunnerExecDriver;
+
+const NO_DRIVER: &str = "runner subsystem is unavailable: cannot execute a runner exec job";
+
+impl RunnerExecDriver for NoopRunnerExecDriver {
+    fn prepare(&self, _request: RunnerExecPrepareRequest) -> Result<PreparedDaemonExec> {
+        Err(Error::internal_unexpected(NO_DRIVER))
+    }
+
+    fn execute(
+        &self,
+        _prepared: &PreparedDaemonExec,
+        _is_cancelled: ExecCancellationProbe,
+        _progress_sink: Option<ExecProgressSink>,
+        _require_child_identity_acknowledgement: bool,
+        _child_started: Option<ExecChildStarted>,
+    ) -> Result<DaemonExecOutput> {
+        Err(Error::internal_unexpected(NO_DRIVER))
+    }
+}
+
+fn driver_slot() -> &'static Mutex<Option<Arc<dyn RunnerExecDriver>>> {
+    static DRIVER: Mutex<Option<Arc<dyn RunnerExecDriver>>> = Mutex::new(None);
+    &DRIVER
+}
+
+/// Resolve the active driver, cloning the `Arc` so the registry lock is not
+/// held while a (potentially long-running) child process executes.
+fn active_driver() -> Arc<dyn RunnerExecDriver> {
+    let slot = driver_slot().lock().expect("runner exec driver lock");
+    match slot.as_ref() {
+        Some(driver) => Arc::clone(driver),
+        None => Arc::new(NoopRunnerExecDriver),
+    }
+}
+
+/// Register the runner exec driver. Called once at startup by the runner layer.
+pub fn register_runner_exec_driver(driver: Arc<dyn RunnerExecDriver>) {
+    let mut slot = driver_slot().lock().expect("runner exec driver lock");
+    *slot = Some(driver);
+}
+
+/// Prepare a runner process via the registered driver (or the no-op driver).
+pub(crate) fn prepare_exec(request: RunnerExecPrepareRequest) -> Result<PreparedDaemonExec> {
+    active_driver().prepare(request)
+}
+
+/// Execute a prepared runner child via the registered driver. The registry lock
+/// is released before the child runs.
+pub(crate) fn execute_exec(
+    prepared: &PreparedDaemonExec,
+    is_cancelled: ExecCancellationProbe,
+    progress_sink: Option<ExecProgressSink>,
+    require_child_identity_acknowledgement: bool,
+    child_started: Option<ExecChildStarted>,
+) -> Result<DaemonExecOutput> {
+    active_driver().execute(
+        prepared,
+        is_cancelled,
+        progress_sink,
+        require_child_identity_acknowledgement,
+        child_started,
+    )
+}

--- a/crates/homeboy-core/src/runner/daemon_exec_driver.rs
+++ b/crates/homeboy-core/src/runner/daemon_exec_driver.rs
@@ -1,0 +1,131 @@
+//! Runner-side implementation of core's `RunnerExecDriver` hook.
+//!
+//! Core's daemon `/exec` endpoint prepares and runs a runner job as a local
+//! child. This adapter builds the runner process plan and drives the child,
+//! keeping runner types (`Runner`, `PreparedRunnerProcess`, `ProcessOutput`)
+//! inside the runner layer while the daemon sees only slim core types.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use crate::daemon::runner_exec_driver::{
+    DaemonExecOutput, ExecCancellationProbe, ExecChildStarted, ExecProgressSink,
+    PreparedDaemonExec, RunnerExecDriver, RunnerExecPrepareRequest,
+};
+use crate::error::Result;
+use crate::secret_env_plan::SecretEnvPlan;
+
+use super::execution::{
+    execute_runner_process_until_cancelled_with_progress, prepare_daemon_local_process,
+    PreparedRunnerProcess, RunnerProcessRequest,
+};
+use super::Runner;
+
+/// The runner layer's `RunnerExecDriver`. Registered with core at startup.
+pub struct RunnerDaemonExecDriver;
+
+impl RunnerExecDriver for RunnerDaemonExecDriver {
+    fn prepare(&self, request: RunnerExecPrepareRequest) -> Result<PreparedDaemonExec> {
+        let runner: Option<Runner> = match request.runner {
+            Some(value) => Some(serde_json::from_value(value).map_err(|err| {
+                crate::error::Error::validation_invalid_argument(
+                    "runner",
+                    format!("invalid runner descriptor in exec request: {err}"),
+                    None,
+                    None,
+                )
+            })?),
+            None => None,
+        };
+        let secret_env_plan: Option<SecretEnvPlan> = match request.secret_env_plan {
+            Some(Value::Null) | None => None,
+            Some(value) => Some(serde_json::from_value(value).map_err(|err| {
+                crate::error::Error::validation_invalid_argument(
+                    "secret_env_plan",
+                    format!("invalid secret env plan in exec request: {err}"),
+                    None,
+                    None,
+                )
+            })?),
+        };
+
+        let plan = prepare_daemon_local_process(RunnerProcessRequest {
+            runner_id: request.runner_id,
+            runner,
+            cwd: request.cwd,
+            project_id: request.project_id,
+            command: request.command,
+            env: request.env,
+            secret_env_names: request.secret_env_names,
+            secret_env_plan,
+            capture_patch: request.capture_patch,
+            raw_exec: request.raw_exec,
+            source_snapshot: request.source_snapshot,
+            require_paths: request.require_paths,
+            validate_require_paths_on_host: request.validate_require_paths_on_host,
+        })?;
+
+        Ok(PreparedDaemonExec::new(
+            plan.runner.id.clone(),
+            plan.cwd.clone(),
+            plan.command.clone(),
+            plan.env.clone(),
+            plan.secret_env_names.clone(),
+            plan.source_snapshot.clone(),
+            plan.require_paths.clone(),
+            Arc::new(plan),
+        ))
+    }
+
+    fn execute(
+        &self,
+        prepared: &PreparedDaemonExec,
+        is_cancelled: ExecCancellationProbe,
+        progress_sink: Option<ExecProgressSink>,
+        require_child_identity_acknowledgement: bool,
+        child_started: Option<ExecChildStarted>,
+    ) -> Result<DaemonExecOutput> {
+        let base = prepared
+            .plan_token()
+            .downcast_ref::<PreparedRunnerProcess>()
+            .ok_or_else(|| {
+                crate::error::Error::internal_unexpected(
+                    "runner exec driver received a plan it did not prepare",
+                )
+            })?;
+
+        // The daemon may have mutated `prepared.env` (e.g. injecting the child
+        // reservation id) between prepare and execute, so run with that env.
+        let mut plan = base.clone();
+        plan.env = prepared.env.clone();
+
+        let mut is_cancelled = is_cancelled;
+        let output = execute_runner_process_until_cancelled_with_progress(
+            &plan,
+            || is_cancelled(),
+            progress_sink,
+            require_child_identity_acknowledgement,
+            child_started,
+        )?;
+
+        Ok(DaemonExecOutput {
+            stdout: output.stdout,
+            stderr: output.stderr,
+            exit_code: output.exit_code,
+            metrics: output
+                .metrics
+                .and_then(|metrics| serde_json::to_value(metrics).ok()),
+            capture: output
+                .capture
+                .and_then(|capture| serde_json::to_value(capture).ok()),
+        })
+    }
+}
+
+/// Register the runner daemon-exec driver with core. Called once at startup.
+pub fn register() {
+    crate::daemon::runner_exec_driver::register_runner_exec_driver(Arc::new(
+        RunnerDaemonExecDriver,
+    ));
+}

--- a/crates/homeboy-core/src/runner/execution/tests/handoff.rs
+++ b/crates/homeboy-core/src/runner/execution/tests/handoff.rs
@@ -1156,6 +1156,10 @@ fn reverse_broker_exec_submits_job_and_polls_result() {
 }
 
 fn allow_unauthenticated_loopback_broker() {
+    // The in-process daemon's /exec endpoint drives runner processes through the
+    // RunnerExecDriver hook; register the runner-side driver so these end-to-end
+    // handoff tests can run the child (production wires this at CLI startup).
+    crate::runner::register_runner_daemon_exec_driver();
     // Skip hashing the (multi-hundred-MB debug) test binary during in-process
     // daemon startup, which otherwise blocks `serve_listener` past the client's
     // connect timeout and makes the mock broker appear unreachable.

--- a/crates/homeboy-core/src/runner/mod.rs
+++ b/crates/homeboy-core/src/runner/mod.rs
@@ -33,6 +33,7 @@ pub use cli_resolver::{
 mod command_path;
 mod connection;
 mod continuation_provider;
+mod daemon_exec_driver;
 mod daemon_health;
 mod daemon_http_get;
 mod evidence;
@@ -108,6 +109,7 @@ pub use connection::{
     statuses,
 };
 pub use continuation_provider::register as register_runner_continuation_provider;
+pub use daemon_exec_driver::register as register_runner_daemon_exec_driver;
 pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
 pub use evidence::register_runner_evidence_provider;
 pub use evidence::runner_artifact_store_token;


### PR DESCRIPTION
## Summary
- Inverts the core runner-exec behavior edge in the daemon. The `/exec` endpoint prepared and ran a runner job as a local child by calling `crate::runner::{prepare_daemon_local_process, execute_runner_process_until_cancelled_with_progress}` directly; that prepare+execute path now goes through a new `RunnerExecDriver` hook.
- Core owns the daemon and its job loop and drives the child through slim core types (`PreparedDaemonExec`, `DaemonExecOutput`); the runner layer supplies the process-execution impl (registered at CLI startup). The runner descriptor crosses the boundary as raw JSON (`ExecRequest.runner: Option<Value>`), so no runner type reaches the daemon.

## Design notes
- The prepared plan is carried back into `execute` as an opaque driver-owned handle (`Arc<dyn Any>`); the daemon's env mutation (child reservation id) is honored via the slim `env` field, documented as a contract on `execute`.
- The driver `Arc` is cloned out of the registry **before** the child runs, so the registry lock is never held across a (potentially long) process execution.
- No-op driver errors clearly when no runner is registered (single-machine install).
- The daemon is a shared local broker (health, lifecycle, file, code-analysis endpoints too), so it stays in core; only the runner-exec driver is inverted. Remaining daemon->runner edges (`BrokerScope`, `extract_bearer_token` for the broker/file API) are a smaller follow-up.

## Testing
- `cargo check -p homeboy-core --lib` / `--tests` and `-p homeboy-cli --lib` — clean
- `cargo test -p homeboy-core --lib`: `daemon_exec_projects_metadata_run_id...` passes; handoff exec suite 25 pass. Two detached-handoff tests (`reverse_broker_exec_detached_surfaces_persisted_run_id`, `direct_daemon_detached_handoff_returns_...`) fail identically on clean `origin/main` (pre-existing `agent-task run record not found` fixture gap) — not introduced here.
- Full `--workspace` suite via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)