### PR TITLE
Make runtime catalog identity authoritative

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
@@ -351,6 +351,7 @@ mod tests {
             rotation_starts_with_first_entry: false,
             retry: Default::default(),
             liveness_timeout_ms: None,
+            runtime_identity: None,
         });
 
         let request = dispatch_service::resolve_dispatch_request_with_default(args.into(), |_| {

--- a/crates/homeboy-core/src/agent_runtime_manifest.rs
+++ b/crates/homeboy-core/src/agent_runtime_manifest.rs
@@ -61,6 +61,8 @@ pub struct AgentRuntimeManifest {
     pub extension_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
     #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra: BTreeMap<String, Value>,
 }
@@ -245,6 +247,14 @@ pub struct AgentRuntimeMaterializationPlan {
     /// identity rather than repeating ambient runtime discovery.
     #[serde(default)]
     pub selected_identity: AgentRuntimeSelectedIdentity,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub provider_id: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub source_selector: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
+    #[serde(default)]
+    pub freshness: AgentRuntimeFreshness,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_path: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -281,8 +291,22 @@ fn default_runtime_freshness() -> String {
     "unverifiable".to_string()
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRuntimeFreshness {
+    Pinned,
+    Unverifiable,
+}
+
+impl Default for AgentRuntimeFreshness {
+    fn default() -> Self {
+        Self::Unverifiable
+    }
+}
+
 pub(crate) fn runtime_materialization_plan(
     manifest: &AgentRuntimeManifest,
+    provider_id: impl Into<String>,
 ) -> AgentRuntimeMaterializationPlan {
     let mut env_passthrough = manifest.materialization.env_passthrough.clone();
     env_passthrough.sort();
@@ -320,6 +344,12 @@ pub(crate) fn runtime_materialization_plan(
             revision,
             freshness: freshness.to_string(),
         },
+        provider_id: provider_id.into(),
+        source_selector: runtime_source_description(manifest),
+        source_revision: manifest.source_revision.clone(),
+        // A controller-selected revision is not freshness evidence. Only a
+        // materializer that verifies the selected object may report it current.
+        freshness: AgentRuntimeFreshness::Unverifiable,
         runtime_path: manifest.runtime_path.clone(),
         source_roots,
         dependencies: manifest.materialization.dependencies.clone(),
@@ -528,6 +558,15 @@ fn load_standalone_agent_runtime_manifest(
     manifest.extension_id = None;
     manifest.extension_path = None;
     manifest.runtime_path = Some(path.to_string_lossy().to_string());
+    manifest.source_revision = crate::git::head_sha(path);
+    if let Some(diagnostic) = mutable_runtime_source_diagnostic(
+        &manifest.id,
+        None,
+        manifest.runtime_path.as_deref(),
+        &manifest.materialization,
+    ) {
+        return StandaloneAgentRuntimeManifestLoad::Invalid(diagnostic);
+    }
     if let Some(diagnostic) = agent_runtime_core_incompatible_diagnostic(
         &manifest.id,
         None,
@@ -560,6 +599,23 @@ pub(crate) fn discover_agent_runtime_catalog_from_extensions(
                 diagnostics.push(diagnostic);
                 continue;
             }
+            let materialization: AgentRuntimeMaterializationContract = serde_json::from_value(
+                runtime
+                    .extra
+                    .get("materialization")
+                    .cloned()
+                    .unwrap_or(Value::Null),
+            )
+            .unwrap_or_default();
+            if let Some(diagnostic) = mutable_runtime_source_diagnostic(
+                &runtime.id,
+                Some(&extension.id),
+                extension.extension_path.as_deref(),
+                &materialization,
+            ) {
+                diagnostics.push(diagnostic);
+                continue;
+            }
             let provider_catalog = parse_agent_task_executor_provider_catalog(
                 &runtime.agent_task_executors,
                 &runtime.id,
@@ -577,18 +633,13 @@ pub(crate) fn discover_agent_runtime_catalog_from_extensions(
                 label: runtime.label.clone(),
                 agent_task_executors: providers,
                 config_path_fields: runtime.config_path_fields.clone(),
-                materialization: serde_json::from_value(
-                    runtime
-                        .extra
-                        .get("materialization")
-                        .cloned()
-                        .unwrap_or(Value::Null),
-                )
-                .unwrap_or_default(),
+                materialization,
                 extension_id: Some(extension.id.clone()),
                 requires: runtime_requires(runtime, extension),
                 extension_path: extension.extension_path.clone(),
                 runtime_path: extension.extension_path.clone(),
+                source_revision: extension::read_source_revision(&extension.id)
+                    .filter(|revision| is_immutable_revision(revision)),
                 extra: runtime
                     .extra
                     .clone()
@@ -602,6 +653,37 @@ pub(crate) fn discover_agent_runtime_catalog_from_extensions(
         manifests: runtime_manifests,
         diagnostics,
     }
+}
+
+fn mutable_runtime_source_diagnostic(
+    runtime_id: &str,
+    extension_id: Option<&str>,
+    path: Option<&str>,
+    materialization: &AgentRuntimeMaterializationContract,
+) -> Option<AgentRuntimeDiscoveryDiagnostic> {
+    let source = materialization.source_roots.iter().find(|source| {
+        source
+            .git_ref
+            .as_deref()
+            .is_some_and(|git_ref| !is_immutable_revision(git_ref))
+    })?;
+    Some(AgentRuntimeDiscoveryDiagnostic {
+        class: "agent_runtime_manifest.mutable_ref".to_string(),
+        message: format!(
+            "Agent runtime '{}' source '{}' declares mutable git_ref '{}'. Materialization requires an immutable commit revision.",
+            runtime_id,
+            source.id,
+            source.git_ref.as_deref().unwrap_or_default(),
+        ),
+        runtime_id: Some(runtime_id.to_string()),
+        extension_id: extension_id.map(str::to_string),
+        path: path.map(str::to_string),
+    })
+}
+
+pub(crate) fn is_immutable_revision(value: &str) -> bool {
+    let value = value.trim();
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn runtime_requires(
@@ -666,37 +748,12 @@ pub(crate) fn discover_agent_task_executor_providers() -> Vec<AgentTaskExecutorP
 pub(crate) fn discover_agent_task_executor_provider_catalog(
 ) -> AgentTaskExecutorProviderDiscoveryCatalog {
     let catalog = discover_agent_runtime_catalog();
-    let mut providers = agent_task_executor_providers_from_runtime_manifests(catalog.manifests);
     let mut diagnostics = catalog.diagnostics;
-    providers.sort_by(|left, right| left.id.cmp(&right.id));
-    let mut selected = Vec::new();
-    let mut candidates = providers.into_iter().peekable();
-    while let Some(provider) = candidates.next() {
-        let id = provider.id.clone();
-        let mut collisions = vec![provider];
-        while candidates
-            .peek()
-            .is_some_and(|candidate| candidate.id == id)
-        {
-            collisions.push(candidates.next().expect("peeked provider candidate"));
-        }
-        if collisions.len() == 1 {
-            selected.push(collisions.pop().expect("single provider candidate"));
-            continue;
-        }
-        diagnostics.push(AgentRuntimeDiscoveryDiagnostic {
-            class: "agent_task_executor_provider.conflict".to_string(),
-            message: format!(
-                "Provider id '{id}' is declared by multiple runtime sources: {}. Select one source explicitly before dispatching.",
-                collisions.iter().map(|provider| format!("{}:{}", provider.runtime_id.as_deref().unwrap_or("unknown"), provider.extension_id.as_deref().unwrap_or("standalone"))).collect::<Vec<_>>().join(", ")
-            ),
-            runtime_id: None,
-            extension_id: None,
-            path: None,
-        });
-    }
     AgentTaskExecutorProviderDiscoveryCatalog {
-        providers: selected,
+        providers: reject_duplicate_provider_ids(
+            agent_task_executor_providers_from_runtime_manifests(catalog.manifests),
+            &mut diagnostics,
+        ),
         diagnostics,
     }
 }
@@ -713,8 +770,7 @@ fn agent_task_executor_providers_from_runtime_manifests(
 ) -> Vec<AgentTaskExecutorProvider> {
     let mut providers = Vec::new();
     for runtime_manifest in runtime_manifests {
-        let materialization_plan = runtime_materialization_plan(&runtime_manifest);
-        for mut provider in runtime_manifest.agent_task_executors {
+        for mut provider in runtime_manifest.agent_task_executors.clone() {
             normalize_agent_task_executor_provider_invocation(&mut provider);
             provider.extension_id = runtime_manifest.extension_id.clone();
             provider.extension_path = runtime_manifest.extension_path.clone();
@@ -723,6 +779,8 @@ fn agent_task_executor_providers_from_runtime_manifests(
             }
             provider.runtime_id = Some(runtime_manifest.id.clone());
             provider.runtime_path = runtime_manifest.runtime_path.clone();
+            let materialization_plan =
+                runtime_materialization_plan(&runtime_manifest, &provider.id);
             if let Ok(value) = serde_json::to_value(&materialization_plan) {
                 provider
                     .extra
@@ -732,6 +790,50 @@ fn agent_task_executor_providers_from_runtime_manifests(
         }
     }
     providers
+}
+
+fn reject_duplicate_provider_ids(
+    providers: Vec<AgentTaskExecutorProvider>,
+    diagnostics: &mut Vec<AgentRuntimeDiscoveryDiagnostic>,
+) -> Vec<AgentTaskExecutorProvider> {
+    let mut by_id = BTreeMap::<String, Vec<AgentTaskExecutorProvider>>::new();
+    for provider in providers {
+        by_id.entry(provider.id.clone()).or_default().push(provider);
+    }
+
+    by_id
+        .into_iter()
+        .filter_map(|(id, providers)| {
+            if providers.len() == 1 {
+                return providers.into_iter().next();
+            }
+            let sources = providers
+                .iter()
+                .map(|provider| {
+                    format!(
+                        "runtime:{} source:{}",
+                        provider.runtime_id.as_deref().unwrap_or("<unknown>"),
+                        provider
+                            .extension_id
+                            .as_deref()
+                            .unwrap_or("standalone")
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            diagnostics.push(AgentRuntimeDiscoveryDiagnostic {
+                class: "agent_task_executor_provider.id_conflict".to_string(),
+                message: format!(
+                    "Agent-task provider id '{}' is declared by multiple sources: {}. Select one source explicitly before dispatching this provider.",
+                    id, sources
+                ),
+                runtime_id: None,
+                extension_id: None,
+                path: None,
+            });
+            None
+        })
+        .collect()
 }
 
 fn normalize_agent_task_executor_provider_invocation(provider: &mut AgentTaskExecutorProvider) {
@@ -945,7 +1047,7 @@ mod tests {
                         "label": "Example Runtime Source",
                         "path": "~/.cache/homeboy/example-runtime",
                         "remote_url": "https://example.com/runtime.git",
-                        "git_ref": "main"
+                        "git_ref": "0123456789abcdef0123456789abcdef01234567"
                     }],
                     "dependencies": [{
                         "id": "example-runtime-package",
@@ -1003,7 +1105,7 @@ mod tests {
         );
         assert_eq!(manifests[0].agent_task_executors[0].backend, "example");
         assert!(!manifests[0].extra.contains_key("materialization"));
-        let materialization_plan = runtime_materialization_plan(&manifests[0]);
+        let materialization_plan = runtime_materialization_plan(&manifests[0], "example.default");
         assert_eq!(
             materialization_plan.schema,
             AGENT_RUNTIME_MATERIALIZATION_PLAN_SCHEMA
@@ -1049,6 +1151,13 @@ mod tests {
             manifests[0].runtime_path.as_deref(),
             Some("/extensions/runtime-extension")
         );
+        let providers = agent_task_executor_providers_from_runtime_manifests(manifests.clone());
+        let provider_plan: AgentRuntimeMaterializationPlan =
+            serde_json::from_value(providers[0].extra["runtime_materialization_plan"].clone())
+                .expect("provider materialization plan");
+        assert_eq!(provider_plan.runtime_id, "example-runtime");
+        assert_eq!(provider_plan.provider_id, "example.default");
+        assert_eq!(provider_plan.freshness, AgentRuntimeFreshness::Unverifiable);
         assert_eq!(manifests[0].extra["runtime_metadata"]["owner"], "extension");
         assert_eq!(
             serde_json::to_value(&manifests[0]).expect("runtime export")["runtime_metadata"]
@@ -1151,7 +1260,8 @@ mod tests {
                 provider.provider_defaults["example-provider"]["secret_env"][0],
                 "EXAMPLE_RUNTIME_REFRESH_TOKEN"
             );
-            let materialization_plan = runtime_materialization_plan(&manifests[0]);
+            let materialization_plan =
+                runtime_materialization_plan(&manifests[0], "standalone-example.default");
             assert_eq!(
                 materialization_plan.env_passthrough,
                 vec!["STANDALONE_RUNTIME_HOME".to_string()]
@@ -1489,19 +1599,84 @@ mod tests {
     }
 
     #[test]
+    fn duplicate_provider_ids_fail_closed_with_source_diagnostics() {
+        let first: AgentTaskExecutorProvider =
+            serde_json::from_value(provider_json("shared", "one")).expect("first provider");
+        let second: AgentTaskExecutorProvider =
+            serde_json::from_value(provider_json("shared", "two")).expect("second provider");
+        let mut diagnostics = Vec::new();
+
+        let providers = reject_duplicate_provider_ids(vec![first, second], &mut diagnostics);
+
+        assert!(providers.is_empty());
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].class,
+            "agent_task_executor_provider.id_conflict"
+        );
+        assert!(diagnostics[0].message.contains("shared"));
+    }
+
+    #[test]
+    fn mutable_runtime_source_ref_is_rejected() {
+        let mut extension = extension("runtime-extension");
+        extension.agent_runtimes.push(
+            serde_json::from_value(json!({
+                "id": "example-runtime",
+                "materialization": {
+                    "source_roots": [{
+                        "id": "example-source",
+                        "label": "Example source",
+                        "path": "/tmp/example-source",
+                        "git_ref": "main"
+                    }]
+                },
+                "agent_task_executors": [provider_json("example.default", "example")]
+            }))
+            .expect("runtime manifest"),
+        );
+
+        let catalog = discover_agent_runtime_catalog_from_extensions(&[extension]);
+
+        assert!(catalog.manifests.is_empty());
+        assert_eq!(
+            catalog.diagnostics[0].class,
+            "agent_runtime_manifest.mutable_ref"
+        );
+        assert!(catalog.diagnostics[0].message.contains("main"));
+    }
+
+    #[test]
+    fn existing_materialization_plans_deserialize_as_unverifiable() {
+        let plan: AgentRuntimeMaterializationPlan = serde_json::from_value(json!({
+            "schema": AGENT_RUNTIME_MATERIALIZATION_PLAN_SCHEMA,
+            "runtime_id": "existing-runtime"
+        }))
+        .expect("existing materialization plan");
+
+        assert!(plan.provider_id.is_empty());
+        assert_eq!(plan.freshness, AgentRuntimeFreshness::Unverifiable);
+    }
+
+    #[test]
     fn sample_runtime_materialization_fixture_is_plain_data() {
         let manifest: AgentRuntimeManifest = serde_json::from_str(include_str!(
             "../../../tests/fixtures/sample_runtime_materialization_manifest.json"
         ))
         .expect("sample runtime fixture parses");
 
-        let materialization_plan = runtime_materialization_plan(&manifest);
+        let materialization_plan = runtime_materialization_plan(&manifest, "sample.default");
 
         assert_eq!(manifest.id, "sample-runtime");
         assert_eq!(materialization_plan.runtime_id, "sample-runtime");
         assert_eq!(
             materialization_plan.selected_identity.freshness,
             "unverifiable"
+        );
+        assert_eq!(materialization_plan.provider_id, "sample.default");
+        assert_eq!(
+            materialization_plan.freshness,
+            AgentRuntimeFreshness::Unverifiable
         );
         assert_eq!(materialization_plan.source_roots[0].id, "sample-runtime");
         assert_eq!(

--- a/crates/homeboy-core/src/agent_task_dispatch_plan.rs
+++ b/crates/homeboy-core/src/agent_task_dispatch_plan.rs
@@ -173,12 +173,28 @@ pub fn build_dispatch_plan_with_provider_requirements(
                 backend: policy_backend.clone(),
                 selector: policy_selector.clone(),
                 runtime_selection: Some(AgentTaskRuntimeSelection {
-                    runtime_id: None,
+                    runtime_id: request
+                        .core
+                        .resolved_provider_policy
+                        .as_ref()
+                        .and_then(|policy| policy.runtime_identity.as_ref())
+                        .map(|identity| identity.runtime_id.clone()),
                     executor_backend: Some(policy_backend.clone()),
-                    executor_provider_id: policy_selector.clone(),
+                    executor_provider_id: request
+                        .core
+                        .resolved_provider_policy
+                        .as_ref()
+                        .and_then(|policy| policy.runtime_identity.as_ref())
+                        .map(|identity| identity.provider_id.clone())
+                        .or_else(|| policy_selector.clone()),
                     ai_provider_id: config_string(&provider_config, "provider"),
                     model: policy_model.clone(),
-                    substrate_ref: None,
+                    substrate_ref: request
+                        .core
+                        .resolved_provider_policy
+                        .as_ref()
+                        .and_then(|policy| policy.runtime_identity.as_ref())
+                        .map(|identity| identity.source_revision.clone()),
                 }),
                 required_capabilities: request.required_capabilities.clone(),
                 secret_env: secret_env.clone(),
@@ -238,6 +254,9 @@ pub fn build_dispatch_plan_with_provider_requirements(
                 "dispatch": "agent-task cook",
                 "required_capabilities": request.required_capabilities,
                 "runtime_dependency_graph": runtime_dependency_graph_evidence,
+                "resolved_runtime_identity": request.core.resolved_provider_policy
+                    .as_ref()
+                    .and_then(|policy| policy.runtime_identity.as_ref()),
             }),
         });
     }
@@ -1114,6 +1133,7 @@ mod tests {
                                 ..Default::default()
                             },
                             liveness_timeout_ms: Some(45_000),
+                            runtime_identity: None,
                         },
                     ),
                     ..DispatchCoreInputs::default()
@@ -1199,6 +1219,7 @@ mod tests {
                                 ..Default::default()
                             },
                             liveness_timeout_ms: None,
+                            runtime_identity: None,
                         },
                     ),
                     ..DispatchCoreInputs::default()
@@ -1240,6 +1261,7 @@ mod tests {
                             ..Default::default()
                         },
                         liveness_timeout_ms: None,
+                        runtime_identity: None,
                     },
                 ),
                 ..DispatchCoreInputs::default()
@@ -1329,6 +1351,7 @@ mod tests {
                     rotation_starts_with_first_entry: false,
                     retry: AgentTaskRetryPolicy::default(),
                     liveness_timeout_ms: None,
+                    runtime_identity: None,
                 };
             let mut request = dispatch_request(DispatchRequestOverrides {
                 prompt: Some("Cook with the submitted model.".to_string()),

--- a/crates/homeboy-core/src/agent_task_dispatch_service.rs
+++ b/crates/homeboy-core/src/agent_task_dispatch_service.rs
@@ -16,7 +16,7 @@ use crate::agent_task_lifecycle::{AgentTaskRunRecord, AgentTaskRunState};
 use crate::agent_task_provider::{
     apply_provider_runner_secret_env_contracts, default_backend_for_component,
     enforce_runtime_preflight_checks_for_plan, preflight_plan_provider_config_with_providers,
-    AgentTaskProviderCatalog,
+    resolve_provider_for_backend, AgentTaskProviderCatalog, ProviderResolution,
 };
 use crate::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskProviderRotationPolicy,
@@ -315,6 +315,7 @@ pub fn controller_resolved_execution_policy(
     request: &AgentTaskDispatchRequest,
 ) -> ResolvedAgentTaskProviderPolicy {
     let rotation = crate::defaults::load_config().agent_task.rotation;
+    let runtime_identity = selected_runtime_identity(request);
     ResolvedAgentTaskProviderPolicy {
         backend: request.backend.clone(),
         selector: request.selector.clone(),
@@ -328,7 +329,45 @@ pub fn controller_resolved_execution_policy(
             .and_then(|policy| policy.liveness_timeout_ms),
         rotation,
         rotation_starts_with_first_entry: true,
+        runtime_identity,
     }
+}
+
+fn selected_runtime_identity(
+    request: &AgentTaskDispatchRequest,
+) -> Option<crate::agent_task_config::ResolvedAgentTaskRuntimeIdentity> {
+    let catalog = AgentTaskProviderCatalog::discover();
+    let ProviderResolution::Resolved(provider) = resolve_provider_for_backend(
+        catalog.providers(),
+        &request.backend,
+        request.selector.as_deref(),
+    ) else {
+        return None;
+    };
+    let plan = provider.extra.get("runtime_materialization_plan")?;
+    let plan: crate::agent_runtime_manifest::AgentRuntimeMaterializationPlan =
+        serde_json::from_value(plan.clone()).ok()?;
+    let source_revision = plan.source_revision.clone()?;
+    if !crate::agent_runtime_manifest::is_immutable_revision(&source_revision) {
+        return None;
+    }
+    let materialization_plan = serde_json::to_value(&plan).ok()?;
+    Some(crate::agent_task_config::ResolvedAgentTaskRuntimeIdentity {
+        runtime_id: plan.runtime_id,
+        provider_id: plan.provider_id,
+        source_selector: plan.source_selector,
+        source_revision,
+        freshness: match plan.freshness {
+            crate::agent_runtime_manifest::AgentRuntimeFreshness::Pinned => {
+                crate::agent_task_config::ResolvedAgentTaskRuntimeFreshness::Pinned
+            }
+            crate::agent_runtime_manifest::AgentRuntimeFreshness::Unverifiable => {
+                crate::agent_task_config::ResolvedAgentTaskRuntimeFreshness::Unverifiable
+            }
+        },
+        provider: serde_json::to_value(provider).ok()?,
+        materialization_plan,
+    })
 }
 
 /// Build a controller-owned plan with a durable execution policy when the

--- a/crates/homeboy-core/src/agent_task_provider/executor.rs
+++ b/crates/homeboy-core/src/agent_task_provider/executor.rs
@@ -1,6 +1,7 @@
 use super::command_runner::{failure_outcome, run_materialized_provider_command};
 use super::fixtures::run_fixture_provider;
 use super::*;
+use std::borrow::Cow;
 
 impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
     fn execute(
@@ -36,17 +37,30 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
             return run_repo_local_gate_task(&request);
         }
 
-        let provider = match resolve_provider_for_backend(
-            self.providers(),
-            &request.executor.backend,
-            request.executor.selector.as_deref(),
-        ) {
-            ProviderResolution::Resolved(provider) => provider,
-            resolution => {
-                return provider_resolution_failure_outcome(
+        let provider = match resolved_provider_from_request(&request) {
+            Ok(Some(provider)) => Cow::Owned(provider),
+            Ok(None) => match resolve_provider_for_backend(
+                self.providers(),
+                &request.executor.backend,
+                request.executor.selector.as_deref(),
+            ) {
+                ProviderResolution::Resolved(provider) => Cow::Borrowed(provider),
+                resolution => {
+                    return provider_resolution_failure_outcome(
+                        &request,
+                        resolution,
+                        self.diagnostics(),
+                    )
+                }
+            },
+            Err(message) => {
+                return failure_outcome(
                     &request,
-                    resolution,
-                    self.diagnostics(),
+                    AgentTaskOutcomeStatus::ProviderError,
+                    AgentTaskFailureClassification::Provider,
+                    "agent_task.runtime_identity_invalid",
+                    message,
+                    Value::Null,
                 )
             }
         };
@@ -73,8 +87,39 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
             );
         }
 
-        run_materialized_provider_command(&request, provider, context.run_id.as_deref())
+        run_materialized_provider_command(&request, &provider, context.run_id.as_deref())
     }
+}
+
+fn resolved_provider_from_request(
+    request: &AgentTaskExecutorRequest,
+) -> std::result::Result<Option<AgentTaskExecutorProvider>, String> {
+    let Some(identity) = request
+        .request
+        .metadata
+        .get("resolved_runtime_identity")
+        .filter(|identity| !identity.is_null())
+    else {
+        return Ok(None);
+    };
+    let identity: crate::agent_task_config::ResolvedAgentTaskRuntimeIdentity =
+        serde_json::from_value(identity.clone())
+            .map_err(|error| format!("invalid controller runtime identity: {error}"))?;
+    if !crate::agent_runtime_manifest::is_immutable_revision(&identity.source_revision) {
+        return Err(format!(
+            "controller runtime identity for provider '{}' has a non-immutable source revision '{}'",
+            identity.provider_id, identity.source_revision
+        ));
+    }
+    let provider: AgentTaskExecutorProvider = serde_json::from_value(identity.provider)
+        .map_err(|error| format!("invalid controller-selected provider: {error}"))?;
+    if provider.id != identity.provider_id || provider.backend != request.request.executor.backend {
+        return Err(format!(
+            "controller runtime identity does not match requested provider backend '{}' and id '{}'",
+            request.request.executor.backend, identity.provider_id
+        ));
+    }
+    Ok(Some(provider))
 }
 
 fn materialize_executor_request(

--- a/crates/homeboy-core/src/extension/lifecycle/update.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/update.rs
@@ -439,7 +439,7 @@ pub fn read_source_revision(extension_id: &str) -> Option<String> {
     }
 
     // Try .git first (single-extension repos and linked extensions)
-    if let Some(rev) = git::short_head_revision(&extension_dir) {
+    if let Some(rev) = git::head_sha(&extension_dir) {
         return Some(rev);
     }
 

--- a/crates/homeboy-core/src/runner/lab/agent_task_bridge.rs
+++ b/crates/homeboy-core/src/runner/lab/agent_task_bridge.rs
@@ -1246,6 +1246,7 @@ mod tests {
                         rotation_starts_with_first_entry: true,
                         retry: Default::default(),
                         liveness_timeout_ms: None,
+                        runtime_identity: None,
                     },
                 ),
                 dispatch_kind: crate::lab_contract::RunnerWorkloadAgentTaskDispatchKind::RunPlan,

--- a/crates/homeboy-core/src/runner/lab/provider_preflight.rs
+++ b/crates/homeboy-core/src/runner/lab/provider_preflight.rs
@@ -24,6 +24,7 @@ use super::offload::runner_homeboy_daemon_display;
 struct AgentTaskProviderSelection {
     backend: String,
     selector: Option<String>,
+    runtime_identity: Option<crate::agent_task_config::ResolvedAgentTaskRuntimeIdentity>,
 }
 
 const PROVIDER_SESSION_REFRESH_RETRY_ATTEMPTS: usize = 20;
@@ -46,6 +47,9 @@ pub(super) fn preflight_agent_task_provider_on_runner(
     let Some(selection) = agent_task_provider_selection_from_args(args)? else {
         return Ok(());
     };
+    if let Some(identity) = selection.runtime_identity.as_ref() {
+        return validate_controller_runtime_identity(identity, &selection);
+    }
 
     let mut command = command_prefix.to_vec();
     command.extend([
@@ -359,6 +363,7 @@ fn agent_task_provider_selection_from_args(
     let mut backend = None;
     let mut selector = None;
     let mut repo = None;
+    let mut resolved_provider_policy = None;
     let mut iter = args.iter().skip(action_index + 1);
     while let Some(arg) = iter.next() {
         if arg == "--" {
@@ -368,6 +373,7 @@ fn agent_task_provider_selection_from_args(
             "--backend" => backend = iter.next().cloned(),
             "--selector" => selector = iter.next().cloned(),
             "--repo" => repo = iter.next().cloned(),
+            "--resolved-provider-policy" => resolved_provider_policy = iter.next().cloned(),
             _ => {
                 if let Some(value) = arg.strip_prefix("--backend=") {
                     backend = Some(value.to_string());
@@ -375,6 +381,8 @@ fn agent_task_provider_selection_from_args(
                     selector = Some(value.to_string());
                 } else if let Some(value) = arg.strip_prefix("--repo=") {
                     repo = Some(value.to_string());
+                } else if let Some(value) = arg.strip_prefix("--resolved-provider-policy=") {
+                    resolved_provider_policy = Some(value.to_string());
                 }
             }
         }
@@ -385,7 +393,63 @@ fn agent_task_provider_selection_from_args(
         None => default_backend_for_component(repo.as_deref())?,
     };
 
-    Ok(backend.map(|backend| AgentTaskProviderSelection { backend, selector }))
+    let runtime_identity = resolved_provider_policy
+        .map(|policy| {
+            serde_json::from_str::<crate::agent_task_config::ResolvedAgentTaskProviderPolicy>(
+                &policy,
+            )
+            .map(|policy| policy.runtime_identity)
+            .map_err(|error| {
+                Error::validation_invalid_argument(
+                    "resolved-provider-policy",
+                    "Lab received an invalid controller provider policy",
+                    Some(error.to_string()),
+                    None,
+                )
+            })
+        })
+        .transpose()?
+        .flatten();
+    Ok(backend.map(|backend| AgentTaskProviderSelection {
+        backend,
+        selector,
+        runtime_identity,
+    }))
+}
+
+fn validate_controller_runtime_identity(
+    identity: &crate::agent_task_config::ResolvedAgentTaskRuntimeIdentity,
+    selection: &AgentTaskProviderSelection,
+) -> Result<()> {
+    if !crate::agent_runtime_manifest::is_immutable_revision(&identity.source_revision) {
+        return Err(Error::validation_invalid_argument(
+            "resolved-provider-policy",
+            "Lab requires a full immutable runtime source revision from the controller",
+            Some(identity.source_revision.clone()),
+            None,
+        ));
+    }
+    let provider: AgentTaskExecutorProvider = serde_json::from_value(identity.provider.clone())
+        .map_err(|error| {
+            Error::validation_invalid_argument(
+                "resolved-provider-policy",
+                "Lab received an invalid controller-selected provider",
+                Some(error.to_string()),
+                None,
+            )
+        })?;
+    if provider.id != identity.provider_id || provider.backend != selection.backend {
+        return Err(Error::validation_invalid_argument(
+            "resolved-provider-policy",
+            "Lab controller runtime identity does not match the requested provider",
+            Some(format!(
+                "identity provider '{}' backend '{}'; request backend '{}'",
+                identity.provider_id, provider.backend, selection.backend
+            )),
+            None,
+        ));
+    }
+    Ok(())
 }
 
 fn parse_agent_task_providers_output(
@@ -667,6 +731,83 @@ mod tests {
     }
 
     #[test]
+    fn controller_identity_bypasses_runner_discovery_with_full_selected_provider() {
+        let policy = crate::agent_task_config::ResolvedAgentTaskProviderPolicy {
+            backend: "controller-backend".to_string(),
+            selector: Some("controller-source".to_string()),
+            model: None,
+            rotation: None,
+            rotation_starts_with_first_entry: false,
+            retry: Default::default(),
+            liveness_timeout_ms: None,
+            runtime_identity: Some(crate::agent_task_config::ResolvedAgentTaskRuntimeIdentity {
+                runtime_id: "controller-runtime".to_string(),
+                provider_id: "controller-provider".to_string(),
+                source_selector: "extension:controller-source".to_string(),
+                source_revision: "0123456789abcdef0123456789abcdef01234567".to_string(),
+                freshness:
+                    crate::agent_task_config::ResolvedAgentTaskRuntimeFreshness::Unverifiable,
+                provider: serde_json::json!({
+                    "id": "controller-provider",
+                    "backend": "controller-backend",
+                    "argv": ["controller-provider"]
+                }),
+                materialization_plan: serde_json::json!({"runtime_id": "controller-runtime"}),
+            }),
+        };
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--backend".to_string(),
+            "controller-backend".to_string(),
+            "--resolved-provider-policy".to_string(),
+            serde_json::to_string(&policy).expect("policy"),
+        ];
+
+        let selection = agent_task_provider_selection_from_args(&args)
+            .expect("selection")
+            .expect("agent task selection");
+
+        assert_eq!(
+            selection
+                .runtime_identity
+                .as_ref()
+                .expect("identity")
+                .provider_id,
+            "controller-provider"
+        );
+        validate_controller_runtime_identity(
+            selection.runtime_identity.as_ref().expect("identity"),
+            &selection,
+        )
+        .expect("controller identity is sufficient without runner discovery");
+    }
+
+    #[test]
+    fn controller_identity_rejects_short_source_revision() {
+        let selection = AgentTaskProviderSelection {
+            backend: "controller-backend".to_string(),
+            selector: None,
+            runtime_identity: None,
+        };
+        let identity = crate::agent_task_config::ResolvedAgentTaskRuntimeIdentity {
+            runtime_id: "runtime".to_string(),
+            provider_id: "provider".to_string(),
+            source_selector: "extension:source".to_string(),
+            source_revision: "0123456".to_string(),
+            freshness: crate::agent_task_config::ResolvedAgentTaskRuntimeFreshness::Unverifiable,
+            provider: serde_json::json!({"id": "provider", "backend": "controller-backend"}),
+            materialization_plan: serde_json::Value::Null,
+        };
+
+        let error = validate_controller_runtime_identity(&identity, &selection)
+            .expect_err("short revision must fail");
+
+        assert!(error.message.contains("full immutable"));
+    }
+
+    #[test]
     fn runner_provider_output_parser_accepts_cli_envelope_with_chatter() {
         let stdout = concat!(
             "Preparing runtime...\n",
@@ -693,6 +834,7 @@ mod tests {
         let mut selection = AgentTaskProviderSelection {
             backend: "extension-a".to_string(),
             selector: None,
+            runtime_identity: None,
         };
         assert!(runner_provider_unavailable_reason(&providers, &selection).is_none());
         assert!(provider_available(
@@ -731,6 +873,7 @@ mod tests {
         let selection = AgentTaskProviderSelection {
             backend: "primary".to_string(),
             selector: None,
+            runtime_identity: None,
         };
         let runner_homeboy = serde_json::json!({
             "refresh_commands": [
@@ -782,6 +925,7 @@ mod tests {
         let selection = AgentTaskProviderSelection {
             backend: "primary".to_string(),
             selector: None,
+            runtime_identity: None,
         };
         let runner_homeboy = serde_json::json!({
             "active_daemon_build_identity": "homeboy 0.0.0+old",
@@ -825,6 +969,7 @@ mod tests {
         let selection = AgentTaskProviderSelection {
             backend: "opencode".to_string(),
             selector: Some("opencode.agent-task-executor".to_string()),
+            runtime_identity: None,
         };
         let runner_homeboy = serde_json::json!({
             "refresh_commands": [

--- a/crates/homeboy-lab-contract/src/agent_task_config.rs
+++ b/crates/homeboy-lab-contract/src/agent_task_config.rs
@@ -336,6 +336,36 @@ pub struct ResolvedAgentTaskProviderPolicy {
     pub retry: AgentTaskRetryPolicy,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub liveness_timeout_ms: Option<u64>,
+    /// Controller-selected runtime identity. Lab consumes this opaque identity
+    /// instead of reapplying local extension discovery precedence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_identity: Option<ResolvedAgentTaskRuntimeIdentity>,
+}
+
+/// Immutable runtime identity selected by the controller for an agent-task
+/// provider. `source_selector` is deliberately explicit so a collision is
+/// observable in handoff evidence rather than hidden by local precedence.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedAgentTaskRuntimeIdentity {
+    pub runtime_id: String,
+    pub provider_id: String,
+    pub source_selector: String,
+    pub source_revision: String,
+    pub freshness: ResolvedAgentTaskRuntimeFreshness,
+    /// Controller-resolved provider definition. This opaque payload prevents a
+    /// Lab runner from applying its own extension discovery precedence.
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub provider: Value,
+    /// Controller-resolved materialization contract for the selected provider.
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub materialization_plan: Value,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResolvedAgentTaskRuntimeFreshness {
+    Pinned,
+    Unverifiable,
 }
 
 /// One rotation target: executor selector overrides and/or nested provider


### PR DESCRIPTION
## Summary
Carry the controller-resolved runtime/provider identity into Lab materialization instead of rediscovering ambient runtime state.

## What changed
- Add provider and source identity plus fail-closed freshness to the runtime materialization plan, preserve the newer selected\_identity contract, and reject ambiguous runtime/provider catalogs with source diagnostics.

## How to test
1. Run `cargo test -p homeboy-core agent_runtime_manifest --lib`; expect Runtime catalog identity, conflict, and materialization tests pass..

## Compatibility
Adds serialized runtime materialization identity fields while preserving defaults for existing plans. Ambiguous duplicate runtime or provider ids now fail closed instead of relying on discovery order.

## Evidence
- Base advanced after verification: verified main at 4f33eea4aeb8529a21c267d7b269c75b1e93c5e1; publication observed 16d294bf6292063e5bf684da5d14b7c14e15a744. Candidate ancestry was validated against the verified snapshot.
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8514
- Verified finalization base: main at 4f33eea4aeb8529a21c267d7b269c75b1e93c5e1
- diff-check: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Prepared the authoritative runtime catalog implementation, resolved current-main contract overlap, and opened the review with Chris.

## Source relationships
- Closes Extra-Chill/homeboy#8514
