### PR TITLE
Expose canonical rig materialization for package validation

### DIFF
--- a/crates/homeboy-cli/src/command_contract/public_variants.rs
+++ b/crates/homeboy-cli/src/command_contract/public_variants.rs
@@ -256,6 +256,13 @@ pub const PUBLIC_OUTPUT_VARIANT_CONTRACTS: &[PublicOutputVariantContract] = &[
     },
     PublicOutputVariantContract {
         command: "rig",
+        variant: "materialize",
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("materialize"),
+        golden_fixture: None,
+    },
+    PublicOutputVariantContract {
+        command: "rig",
         variant: "up",
         discriminator_field: Some("variant"),
         discriminator_value: Some("up"),

--- a/crates/homeboy-cli/src/command_contract/spec.rs
+++ b/crates/homeboy-cli/src/command_contract/spec.rs
@@ -514,7 +514,7 @@ const PROJECT_MUTATING_PATHS: &[&str] = &[
 ];
 const COMPONENT_MUTATING_PATHS: &[&str] = &["create", "set", "delete", "rename", "setup"];
 const COMPONENT_GUARDED_PATHS: &[&str] = &["reconcile", "artifacts"];
-const RIG_STATIC_LINT_PATHS: &[&str] = &["lint", "package lint"];
+const RIG_STATIC_LINT_PATHS: &[&str] = &["lint", "package lint", "materialize"];
 
 const DEPS_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[paths_safety(
     DEPS_MUTATING_PATHS,

--- a/crates/homeboy-cli/src/commands/rig/mod.rs
+++ b/crates/homeboy-cli/src/commands/rig/mod.rs
@@ -13,9 +13,9 @@ use homeboy::core::runners;
 
 use self::output::{
     RigAppOutput, RigCheckOutput, RigDownOutput, RigInstallOutput, RigInstalledStackSummary,
-    RigInstalledSummary, RigListOutput, RigReleaseLockOutput, RigRepairOutput, RigRunOutput,
-    RigShowOutput, RigSourceSummary, RigStatusOutput, RigSummary, RigSyncOutput, RigUpOutput,
-    RigUpPlanOutput, RigUpPlanStep, RigUpdateOutput,
+    RigInstalledSummary, RigListOutput, RigMaterializeOutput, RigReleaseLockOutput,
+    RigRepairOutput, RigRunOutput, RigShowOutput, RigSourceSummary, RigStatusOutput, RigSummary,
+    RigSyncOutput, RigUpOutput, RigUpPlanOutput, RigUpPlanStep, RigUpdateOutput,
 };
 use super::bench::RigRunBenchOptions;
 use super::utils::args::SettingArgs;
@@ -131,6 +131,14 @@ enum RigCommand {
     Show {
         /// Rig ID
         rig_id: String,
+    },
+    /// Read and normalize a rig spec, resolving its local inheritance chain.
+    Materialize {
+        /// Path to a rig.json file
+        rig_path: std::path::PathBuf,
+        /// Directory that inherited templates must remain within. Defaults to the package root for rigs/<id>/rig.json, otherwise the rig directory.
+        #[arg(long)]
+        source_root: Option<std::path::PathBuf>,
     },
     /// Materialize a rig: run its `up` pipeline
     Up {
@@ -349,6 +357,10 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
     match args.command {
         RigCommand::List => list(),
         RigCommand::Show { rig_id } => show(&rig_id),
+        RigCommand::Materialize {
+            rig_path,
+            source_root,
+        } => materialize(&rig_path, source_root.as_deref()),
         RigCommand::Up { rig_id, dry_run } => up(&rig_id, dry_run),
         RigCommand::Check { target, id, path } => check(&target, id.as_deref(), path.as_deref()),
         RigCommand::Lint {
@@ -377,6 +389,23 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Sources { command } => sources::run(command),
         RigCommand::App { command } => app(command),
     }
+}
+
+fn materialize(
+    rig_path: &std::path::Path,
+    source_root: Option<&std::path::Path>,
+) -> CmdResult<RigCommandOutput> {
+    let rig = match source_root {
+        Some(source_root) => rig::materialize_rig_spec(rig_path, source_root)?,
+        None => rig::materialize_rig_spec_with_default_source_root(rig_path)?,
+    };
+    Ok((
+        RigCommandOutput::Materialize(RigMaterializeOutput {
+            command: "rig.materialize",
+            rig,
+        }),
+        0,
+    ))
 }
 
 fn package(command: RigPackageCommand) -> CmdResult<RigCommandOutput> {
@@ -1285,6 +1314,55 @@ mod tests {
         assert_eq!(id.as_deref(), Some("alpha"));
         assert!(!all);
         assert_eq!(format, None);
+    }
+
+    #[test]
+    fn materialize_defaults_to_the_package_root_for_standard_rig_layouts() {
+        let package = tempfile::TempDir::new().expect("package");
+        let rig_path = package.path().join("rigs/example/rig.json");
+        fs::create_dir_all(rig_path.parent().expect("rig directory"))
+            .expect("create rig directory");
+        fs::create_dir_all(package.path().join("templates")).expect("create templates");
+        fs::write(
+            package.path().join("templates/base.json"),
+            r#"{ "settings": { "inherited": true } }"#,
+        )
+        .expect("write template");
+        fs::write(
+            &rig_path,
+            r#"{ "extends": "../../templates/base.json", "id": "example" }"#,
+        )
+        .expect("write rig");
+
+        assert_eq!(
+            rig::default_materialize_source_root(&rig_path),
+            package.path()
+        );
+        let (output, exit_code) = materialize(&rig_path, None).expect("materialize rig");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(
+            serde_json::to_value(output).expect("serialize output"),
+            serde_json::json!({
+                "variant": "materialize",
+                "payload": {
+                    "command": "rig.materialize",
+                    "rig": {
+                        "id": "example",
+                        "settings": { "inherited": true }
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn materialize_defaults_to_the_rig_directory_for_non_package_paths() {
+        let rig_path = std::path::Path::new("custom/rig.json");
+        assert_eq!(
+            rig::default_materialize_source_root(rig_path),
+            std::path::PathBuf::from("custom")
+        );
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/rig/output.rs
+++ b/crates/homeboy-cli/src/commands/rig/output.rs
@@ -15,6 +15,7 @@ use homeboy::core::rig::{self, RigResourcesSpec, RigSpec};
 pub enum RigCommandOutput {
     List(RigListOutput),
     Show(RigShowOutput),
+    Materialize(RigMaterializeOutput),
     Up(RigUpOutput),
     UpPlan(RigUpPlanOutput),
     Check(RigCheckOutput),
@@ -80,6 +81,13 @@ pub struct RigShowOutput {
     pub rig: RigSpec,
     #[serde(skip_serializing_if = "RigResourcesSpec::is_empty")]
     pub resources: RigResourcesSpec,
+}
+
+/// Canonical, inheritance-resolved rig JSON for package tooling.
+#[derive(Serialize)]
+pub struct RigMaterializeOutput {
+    pub command: &'static str,
+    pub rig: serde_json::Value,
 }
 
 pub type RigUpOutput = CommandReport<rig::UpReport>;
@@ -207,5 +215,24 @@ mod tests {
         assert!(json.contains("/Users/user/Developer/studio"));
         assert!(json.contains("studio-runtime"));
         assert!(json.contains("wordpress-server-child.mjs"));
+    }
+
+    #[test]
+    fn rig_materialize_output_uses_the_machine_readable_variant() {
+        let output = RigCommandOutput::Materialize(RigMaterializeOutput {
+            command: "rig.materialize",
+            rig: serde_json::json!({ "id": "example" }),
+        });
+
+        assert_eq!(
+            serde_json::to_value(output).expect("serialize"),
+            serde_json::json!({
+                "variant": "materialize",
+                "payload": {
+                    "command": "rig.materialize",
+                    "rig": { "id": "example" }
+                }
+            })
+        );
     }
 }

--- a/crates/homeboy-core/src/rig/discovery.rs
+++ b/crates/homeboy-core/src/rig/discovery.rs
@@ -219,24 +219,9 @@ fn discovered_from_path(
 /// (`{ "$append": [...] }` / `{ "$merge_by": "label", "entries": [...] }`).
 /// Validating the raw child against the full schema would reject those, so when
 /// a spec declares `extends` we materialize it first (merging templates and
-/// stripping directives) and validate the resolved spec. Specs without
-/// `extends` keep the identical raw-parse schema gate so malformed specs still
-/// fail discovery with the same error shape.
+/// stripping directives) and validate the resolved spec.
 fn parse_discovered_rig_spec(path: &Path, source_root: &Path) -> Result<super::RigSpec> {
-    let value = match super::install::materialize_rig_spec(path, source_root)? {
-        Some(materialized) => materialized,
-        None => {
-            let content = fs::read_to_string(path)
-                .map_err(|e| Error::internal_io(e.to_string(), Some("read rig spec".into())))?;
-            serde_json::from_str(&content).map_err(|e| {
-                Error::validation_invalid_json(
-                    e,
-                    Some(format!("parse rig spec {}", path.display())),
-                    Some(content.chars().take(200).collect()),
-                )
-            })?
-        }
-    };
+    let value = super::install::materialize_rig_spec(path, source_root)?;
 
     serde_json::from_value(value).map_err(|e| {
         Error::validation_invalid_argument(

--- a/crates/homeboy-core/src/rig/install.rs
+++ b/crates/homeboy-core/src/rig/install.rs
@@ -202,24 +202,7 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
 }
 
 fn validate_rig_spec_file(path: &Path, source_root: &Path, rig_id: &str) -> Result<()> {
-    let value = match materialize_rig_spec(path, source_root)? {
-        Some(value) => value,
-        None => {
-            let content = fs::read_to_string(path).map_err(|e| {
-                Error::internal_io(
-                    e.to_string(),
-                    Some(format!("read rig spec {}", path.display())),
-                )
-            })?;
-            serde_json::from_str(&content).map_err(|e| {
-                Error::validation_invalid_json(
-                    e,
-                    Some(format!("parse rig spec {}", path.display())),
-                    Some(content.chars().take(200).collect()),
-                )
-            })?
-        }
-    };
+    let value = materialize_rig_spec(path, source_root)?;
     let mut spec: RigSpec = serde_json::from_value(value).map_err(|e| {
         Error::rig_schema_unsupported(
             e.to_string(),
@@ -253,35 +236,66 @@ pub(crate) fn write_rig_config_from_source(
     target: &Path,
     source_root: &Path,
 ) -> Result<bool> {
-    match materialize_rig_spec(source, source_root)? {
-        Some(value) => {
-            let content = serde_json::to_string_pretty(&value).map_err(|e| {
-                Error::internal_json(
-                    e.to_string(),
-                    Some("serialize materialized rig spec".into()),
-                )
-            })?;
-            fs::write(target, format!("{}\n", content)).map_err(|e| {
-                Error::internal_io(e.to_string(), Some("write materialized rig spec".into()))
-            })?;
-            Ok(true)
-        }
-        None => {
-            link_or_copy_file(source, target)?;
-            Ok(false)
-        }
+    let source_value = read_json_value(source)?;
+    if source_value.get(EXTENDS_FIELD).is_none() {
+        link_or_copy_file(source, target)?;
+        return Ok(false);
     }
+
+    let value = materialize_rig_spec_value(source, source_root, source_value, &mut Vec::new())?;
+    let content = serde_json::to_string_pretty(&value).map_err(|e| {
+        Error::internal_json(
+            e.to_string(),
+            Some("serialize materialized rig spec".into()),
+        )
+    })?;
+    fs::write(target, format!("{}\n", content)).map_err(|e| {
+        Error::internal_io(e.to_string(), Some("write materialized rig spec".into()))
+    })?;
+    Ok(true)
 }
 
-pub(crate) fn materialize_rig_spec(
-    path: &Path,
-    source_root: &Path,
-) -> Result<Option<serde_json::Value>> {
-    let value = read_json_value(path)?;
-    if value.get(EXTENDS_FIELD).is_none() {
-        return Ok(None);
+/// Return the default boundary for a standalone rig materialization request.
+///
+/// The conventional `rigs/<id>/rig.json` layout inherits templates from its
+/// package root. Other layouts are bounded by the rig directory.
+pub fn default_materialize_source_root(path: &Path) -> PathBuf {
+    if path.file_name().map_or(true, |name| name != "rig.json") {
+        return path.parent().unwrap_or(path).to_path_buf();
     }
-    materialize_rig_spec_value(path, source_root, value, &mut Vec::new()).map(Some)
+    let Some(rig_directory) = path.parent() else {
+        return path.to_path_buf();
+    };
+    let Some(rigs_directory) = rig_directory.parent() else {
+        return rig_directory.to_path_buf();
+    };
+    if rigs_directory
+        .file_name()
+        .is_some_and(|name| name == "rigs")
+    {
+        return rigs_directory
+            .parent()
+            .unwrap_or(rigs_directory)
+            .to_path_buf();
+    }
+    rig_directory.to_path_buf()
+}
+
+/// Read and normalize a rig spec using the conventional source-root boundary.
+///
+/// Downstream package tooling should use this entry point unless it has an
+/// explicit source-root policy of its own.
+pub fn materialize_rig_spec_with_default_source_root(path: &Path) -> Result<serde_json::Value> {
+    materialize_rig_spec(path, &default_materialize_source_root(path))
+}
+
+/// Read and normalize a rig spec, resolving its local `extends` chain.
+///
+/// `source_root` bounds inherited template paths. The result contains neither
+/// `extends` nor array merge directives and uses the install merge semantics.
+pub fn materialize_rig_spec(path: &Path, source_root: &Path) -> Result<serde_json::Value> {
+    let value = read_json_value(path)?;
+    materialize_rig_spec_value(path, source_root, value, &mut Vec::new())
 }
 
 fn materialize_rig_spec_value(
@@ -599,8 +613,16 @@ fn merge_json(
 ) -> Result<()> {
     match overlay {
         serde_json::Value::Object(overlay) => {
-            if target.is_array() && overlay.keys().any(|key| key.starts_with('$')) {
-                merge_array_directive(target, overlay, source_path, field_path)?;
+            if overlay.keys().any(|key| key.starts_with('$')) {
+                if target.is_array() {
+                    merge_array_directive(target, overlay, source_path, field_path)?;
+                } else {
+                    return Err(extends_merge_error(
+                        source_path,
+                        field_path,
+                        "Rig extends array merge directives must override an inherited array",
+                    ));
+                }
             } else if let serde_json::Value::Object(target) = target {
                 for (key, value) in overlay {
                     let child_path = if field_path.is_empty() {
@@ -611,6 +633,16 @@ fn merge_json(
                     match target.get_mut(&key) {
                         Some(existing) => merge_json(existing, value, source_path, &child_path)?,
                         None => {
+                            if value
+                                .as_object()
+                                .is_some_and(|value| value.keys().any(|key| key.starts_with('$')))
+                            {
+                                return Err(extends_merge_error(
+                                    source_path,
+                                    &child_path,
+                                    "Rig extends array merge directives must override an inherited array",
+                                ));
+                            }
                             target.insert(key, value);
                         }
                     }

--- a/crates/homeboy-core/src/rig/mod.rs
+++ b/crates/homeboy-core/src/rig/mod.rs
@@ -51,9 +51,10 @@ pub use capabilities::{
 };
 pub use component_resolution::{component_ref, resolve_component, resolve_component_path};
 pub use install::{
-    discover_rigs, discover_stacks, install, read_source_metadata, read_stack_source_metadata,
-    DiscoveredRig, DiscoveredStack, InstalledStack, RigInstallResult, RigSourceMetadata,
-    StackSourceMetadata,
+    default_materialize_source_root, discover_rigs, discover_stacks, install, materialize_rig_spec,
+    materialize_rig_spec_with_default_source_root, read_source_metadata,
+    read_stack_source_metadata, DiscoveredRig, DiscoveredStack, InstalledStack, RigInstallResult,
+    RigSourceMetadata, StackSourceMetadata,
 };
 pub use lease::{
     acquire_active_run_lease, acquire_active_run_lease_with_settings, active_run_leases,
@@ -358,24 +359,7 @@ fn read_spec_from_path(
     package_root: &Path,
     source_root: &Path,
 ) -> Result<RigSpec> {
-    let value = match install::materialize_rig_spec(path, source_root)? {
-        Some(value) => value,
-        None => {
-            let content = fs::read_to_string(path).map_err(|e| {
-                Error::internal_io(
-                    e.to_string(),
-                    Some(format!("read rig spec {}", path.display())),
-                )
-            })?;
-            serde_json::from_str(&content).map_err(|e| {
-                Error::validation_invalid_json(
-                    e,
-                    Some(format!("parse rig spec {}", path.display())),
-                    Some(content.chars().take(200).collect()),
-                )
-            })?
-        }
-    };
+    let value = install::materialize_rig_spec(path, source_root)?;
     let mut spec: RigSpec = serde_json::from_value(value.clone())
         .map_err(|e| rig_spec_parse_error(e, path, Some(&value), None))?;
     if spec.id.is_empty() {

--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -60,7 +60,7 @@ are extension hooks. See `docs/architecture/lifecycle-contracts.md`.
 
 ## Templates And Variants
 
-Rig package specs may declare `extends` to derive a concrete installed rig from one or more JSON templates in the same package source root. Homeboy resolves each parent relative to the declaring file, materializes the merged JSON during `homeboy rig install` / `rig sources update`, and writes the installed rig without the `extends` field. Runtime commands continue to load ordinary rig JSON.
+Rig package specs may declare `extends` to derive a concrete installed rig from one or more JSON templates in the same package source root. Homeboy resolves each parent relative to the declaring file, materializes the merged JSON during `homeboy rig install` / `rig sources update`, and writes the installed rig without the `extends` field. Runtime commands continue to load ordinary rig JSON. Package tools can consume the same canonical result with `homeboy rig materialize <rig.json>`; see [`rig materialize`](rig.md#materialize) for its machine-readable contract and source-root behavior.
 
 Merge rules are intentionally generic:
 

--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -33,6 +33,7 @@ rig package / local spec
 |---|---|
 | `list` | List declared rigs. |
 | `show <id>` | Print one rig spec as JSON. |
+| `materialize <rig.json>` | Resolve a rig's local inheritance chain as machine-readable JSON. |
 | `up <id>` | Run the rig's `up` pipeline and materialize the environment. |
 | `check <id>` | Run the rig's `check` pipeline and report all failures. |
 | `lint <target>` | Lint a rig ID, package path, or `rig.json` without touching the environment. |
@@ -68,6 +69,40 @@ homeboy rig show studio
 ```
 
 Prints the resolved rig spec. This is the fastest way to inspect a package-installed rig without opening the linked source file manually.
+
+### `materialize`
+
+```sh
+homeboy rig materialize ./packages/example/rigs/example/rig.json
+homeboy rig materialize ./custom/rig.json --source-root ./custom
+```
+
+`materialize` is the public read-only contract for package tooling that needs
+Homeboy's canonical inheritance behavior. Its JSON result has this stable shape:
+
+```json
+{
+  "variant": "materialize",
+  "payload": {
+    "command": "rig.materialize",
+    "rig": { "id": "example" }
+  }
+}
+```
+
+`payload.rig` is normalized JSON after recursive `extends`, deep object merge,
+`$append`, and `$merge_by` processing. It has no `extends` field or merge
+directives. The default source root for the standard `rigs/<id>/rig.json`
+package layout is the package root, so package-level templates resolve without
+an extra flag. For any other layout, the default is the `rig.json` directory;
+pass `--source-root` to select a wider permitted boundary. Inherited templates
+must stay inside that source root.
+
+Library consumers can use `homeboy::core::rig::materialize_rig_spec_with_default_source_root`
+for the same default-root policy, or `materialize_rig_spec` when their caller
+supplies an explicit boundary. The CLI JSON envelope is the public
+machine-readable interchange contract; downstream rig-package tooling still
+needs to migrate to this command or core API.
 
 ### `up`
 

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -2,7 +2,8 @@
 
 use crate::rig::install::local_package_source_root_for_dependencies;
 use crate::rig::{
-    declared_id, discover_rigs, install, list, list_ids, load, load_local_source,
+    declared_id, default_materialize_source_root, discover_rigs, install, list, list_ids, load,
+    load_local_source, materialize_rig_spec, materialize_rig_spec_with_default_source_root,
     read_source_metadata, read_stack_source_metadata, run_check, run_lint,
 };
 use crate::test_support::HomeGuard;
@@ -79,6 +80,213 @@ mod discovery {
         let metadata = read_source_metadata("alpha").expect("metadata");
         assert!(metadata.linked);
         assert_eq!(metadata.rig_path, source.to_string_lossy());
+    }
+}
+
+mod materialization {
+    use super::*;
+
+    #[test]
+    fn materialize_resolves_inheritance_append_merge_by_and_serializes_deterministically() {
+        let package = tempfile::tempdir().expect("package");
+        fs::create_dir_all(package.path().join("templates")).expect("templates");
+        fs::create_dir_all(package.path().join("rigs/child")).expect("rig dir");
+        fs::write(
+            package.path().join("templates/base.json"),
+            r#"{
+                "settings": { "base": true, "shared": "parent" },
+                "appendable": ["base"],
+                "steps": [
+                    { "id": "build", "command": "make build", "metadata": { "retries": 1 } },
+                    { "id": "test", "command": "make test" }
+                ]
+            }"#,
+        )
+        .expect("base template");
+        let child = package.path().join("rigs/child/rig.json");
+        fs::write(
+            &child,
+            r#"{
+                "extends": "../../templates/base.json",
+                "id": "child",
+                "settings": { "shared": "child" },
+                "appendable": { "$append": ["child"] },
+                "steps": {
+                    "$merge_by": "id",
+                    "entries": [
+                        { "id": "build", "command": "make build-fast", "metadata": { "timeout": 60 } },
+                        { "id": "lint", "command": "make lint" }
+                    ]
+                }
+            }"#,
+        )
+        .expect("child rig");
+
+        let materialized = materialize_rig_spec(&child, package.path()).expect("materialize");
+        assert_eq!(materialized["id"], "child");
+        assert_eq!(materialized["settings"]["base"], true);
+        assert_eq!(materialized["settings"]["shared"], "child");
+        assert_eq!(
+            materialized["appendable"],
+            serde_json::json!(["base", "child"])
+        );
+        assert_eq!(materialized["steps"][0]["command"], "make build-fast");
+        assert_eq!(
+            materialized["steps"][0]["metadata"],
+            serde_json::json!({ "retries": 1, "timeout": 60 })
+        );
+        assert_eq!(materialized["steps"][2]["id"], "lint");
+        assert!(materialized.get("extends").is_none());
+
+        let first = serde_json::to_string(&materialized).expect("serialize");
+        let second = serde_json::to_string(
+            &materialize_rig_spec(&child, package.path()).expect("materialize again"),
+        )
+        .expect("serialize again");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn materialize_default_source_root_resolves_package_templates() {
+        let package = tempfile::tempdir().expect("package");
+        let rig = package.path().join("rigs/example/rig.json");
+        fs::create_dir_all(rig.parent().expect("rig directory")).expect("rig directory");
+        fs::create_dir_all(package.path().join("templates")).expect("template directory");
+        fs::write(
+            package.path().join("templates/base.json"),
+            r#"{ "settings": { "inherited": true } }"#,
+        )
+        .expect("template");
+        fs::write(
+            &rig,
+            r#"{ "extends": "../../templates/base.json", "id": "example" }"#,
+        )
+        .expect("rig");
+
+        assert_eq!(default_materialize_source_root(&rig), package.path());
+        assert_eq!(
+            materialize_rig_spec_with_default_source_root(&rig).expect("materialize"),
+            serde_json::json!({ "id": "example", "settings": { "inherited": true } })
+        );
+    }
+
+    #[test]
+    fn materialize_default_source_root_keeps_non_standard_files_narrow() {
+        assert_eq!(
+            default_materialize_source_root(Path::new("rigs/example/template.json")),
+            std::path::PathBuf::from("rigs/example")
+        );
+    }
+
+    #[test]
+    fn materialize_matches_generic_representative_fixture() {
+        let package = tempfile::tempdir().expect("package");
+        let templates = package.path().join("templates");
+        let rig = package.path().join("rigs/representative/rig.json");
+        fs::create_dir_all(&templates).expect("template directory");
+        fs::create_dir_all(rig.parent().expect("rig directory")).expect("rig directory");
+        fs::write(
+            templates.join("base.json"),
+            include_str!("../../fixtures/rig-materialize/templates/base.json"),
+        )
+        .expect("base fixture");
+        fs::write(
+            &rig,
+            include_str!("../../fixtures/rig-materialize/rigs/representative/rig.json"),
+        )
+        .expect("rig fixture");
+
+        let expected: serde_json::Value =
+            serde_json::from_str(include_str!("../../fixtures/rig-materialize/expected.json"))
+                .expect("expected fixture");
+        assert_eq!(
+            materialize_rig_spec_with_default_source_root(&rig).expect("materialize"),
+            expected
+        );
+    }
+
+    #[test]
+    fn materialize_rejects_inheritance_cycles() {
+        let package = tempfile::tempdir().expect("package");
+        let first = package.path().join("first.json");
+        let second = package.path().join("second.json");
+        fs::write(&first, r#"{ "extends": "second.json" }"#).expect("first template");
+        fs::write(&second, r#"{ "extends": "first.json" }"#).expect("second template");
+
+        let error = materialize_rig_spec(&first, package.path()).expect_err("cycle rejected");
+        assert_eq!(error.details["field"], "extends");
+        assert!(error.message.contains("cycle"));
+    }
+
+    #[test]
+    fn materialize_rejects_array_directives_without_an_inherited_array() {
+        let package = tempfile::tempdir().expect("package");
+        let rig = package.path().join("rig.json");
+        fs::write(&rig, r#"{ "items": { "$append": ["unexpected"] } }"#).expect("rig");
+
+        let error = materialize_rig_spec(&rig, package.path()).expect_err("directive rejected");
+        assert_eq!(error.details["field"], "items");
+        assert!(error.message.contains("inherited array"));
+    }
+
+    #[test]
+    fn materialize_rejects_unknown_array_directives() {
+        let package = tempfile::tempdir().expect("package");
+        let base = package.path().join("base.json");
+        let rig = package.path().join("rig.json");
+        fs::write(&base, r#"{ "items": ["base"] }"#).expect("base");
+        fs::write(
+            &rig,
+            r#"{ "extends": "base.json", "items": { "$unknown": [] } }"#,
+        )
+        .expect("rig");
+
+        let error = materialize_rig_spec(&rig, package.path()).expect_err("directive rejected");
+        assert_eq!(error.details["field"], "items");
+        assert!(error
+            .message
+            .contains("Unknown rig extends array merge directive"));
+    }
+
+    #[test]
+    fn materialize_rejects_malformed_array_directives() {
+        let package = tempfile::tempdir().expect("package");
+        let base = package.path().join("base.json");
+        fs::write(&base, r#"{ "items": [{ "id": "base" }] }"#).expect("base");
+
+        for (name, directive, message) in [
+            (
+                "mixed",
+                r#"{ "$append": [], "$merge_by": "id", "entries": [] }"#,
+                "either '$append' or '$merge_by'",
+            ),
+            (
+                "append-extra",
+                r#"{ "$append": [], "entries": [] }"#,
+                "must only contain '$append'",
+            ),
+            (
+                "merge-missing",
+                r#"{ "$merge_by": "id" }"#,
+                "must include an 'entries' array",
+            ),
+            (
+                "merge-empty",
+                r#"{ "$merge_by": "", "entries": [] }"#,
+                "non-empty key field",
+            ),
+        ] {
+            let rig = package.path().join(format!("{name}.json"));
+            fs::write(
+                &rig,
+                format!(r#"{{ "extends": "base.json", "items": {directive} }}"#),
+            )
+            .expect("rig");
+
+            let error = materialize_rig_spec(&rig, package.path()).expect_err("directive rejected");
+            assert_eq!(error.details["field"], "items", "{name}");
+            assert!(error.message.contains(message), "{name}: {}", error.message);
+        }
     }
 }
 

--- a/tests/fixtures/rig-materialize/expected.json
+++ b/tests/fixtures/rig-materialize/expected.json
@@ -1,0 +1,26 @@
+{
+  "id": "representative",
+  "labels": ["base", "derived"],
+  "settings": {
+    "base": true,
+    "mode": "derived"
+  },
+  "steps": [
+    {
+      "command": "build-fast",
+      "id": "build",
+      "metadata": {
+        "retries": 1,
+        "timeout": 60
+      }
+    },
+    {
+      "command": "test",
+      "id": "test"
+    },
+    {
+      "command": "lint",
+      "id": "lint"
+    }
+  ]
+}

--- a/tests/fixtures/rig-materialize/rigs/representative/rig.json
+++ b/tests/fixtures/rig-materialize/rigs/representative/rig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../templates/base.json",
+  "id": "representative",
+  "settings": {
+    "mode": "derived"
+  },
+  "labels": {
+    "$append": ["derived"]
+  },
+  "steps": {
+    "$merge_by": "id",
+    "entries": [
+      {
+        "id": "build",
+        "command": "build-fast",
+        "metadata": { "timeout": 60 }
+      },
+      {
+        "id": "lint",
+        "command": "lint"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/rig-materialize/templates/base.json
+++ b/tests/fixtures/rig-materialize/templates/base.json
@@ -1,0 +1,18 @@
+{
+  "settings": {
+    "base": true,
+    "mode": "base"
+  },
+  "labels": ["base"],
+  "steps": [
+    {
+      "id": "build",
+      "command": "build",
+      "metadata": { "retries": 1 }
+    },
+    {
+      "id": "test",
+      "command": "test"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Provide one canonical rig materialization contract for package validation instead of caller-specific inheritance handling.

## What changed
- Add canonical materialization types and validation, deterministic fixtures, and package-facing documentation for resolved rig inheritance.

## How to test
1. Run `cargo test -p homeboy-core rig::material --lib`; expect Canonical rig materialization tests pass..

## Compatibility
The contract is additive. Existing rig declarations remain valid; package validation gains a canonical resolved representation without changing extension paths.

## Evidence
- Base advanced after verification: verified main at 4f33eea4aeb8529a21c267d7b269c75b1e93c5e1; publication observed 16d294bf6292063e5bf684da5d14b7c14e15a744. Candidate ancestry was validated against the verified snapshot.
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8518
- Verified finalization base: main at 4f33eea4aeb8529a21c267d7b269c75b1e93c5e1
- diff-check: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Prepared the canonical rig materialization contract, rebased it onto current main, and opened review with Chris.

## Source relationships
- Closes Extra-Chill/homeboy#8518
