### PR TITLE
refactor: invert audit fingerprint-script fallback behind a provider hook

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -104,6 +104,10 @@ impl CliRuntime {
         // depending on the extension layer's loader — the seam that lets audit
         // become its own crate.
         crate::core::extension::audit_manifest_provider::register();
+        // Register the fingerprint-script provider so code_audit can fall back to
+        // extension fingerprint scripts (for files the core grammar engine can't
+        // handle) without depending on the extension script runner.
+        crate::core::extension::audit_fingerprint_script_provider::register();
         // Register the audit recorded-artifact provider so the artifact-portability
         // detector can read past runs' artifacts from the observation store without
         // code_audit depending on observation — the last seam before audit becomes

--- a/crates/homeboy-core/src/code_audit/codebase_map.rs
+++ b/crates/homeboy-core/src/code_audit/codebase_map.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use serde::Serialize;
 
 use crate::code_audit::fingerprint::{self, FileFingerprint};
-use crate::{extension, Error};
+use crate::Error;
 use homeboy_engine_primitives::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
 // ============================================================================
@@ -60,7 +60,7 @@ pub struct MapClass {
     pub properties: Vec<String>,
     /// Hook references (actions and filters).
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub hooks: Vec<extension::HookRef>,
+    pub hooks: Vec<homeboy_audit_contract::HookRef>,
 }
 
 /// The class hierarchy: parent → children mapping.

--- a/crates/homeboy-core/src/code_audit/fingerprint.rs
+++ b/crates/homeboy-core/src/code_audit/fingerprint.rs
@@ -156,10 +156,8 @@ pub(crate) fn fingerprint_extension_content(
     relative_path: &str,
     content: &str,
 ) -> Option<FileFingerprint> {
-    use crate::extension;
-
-    let matched_extension = extension::find_extension_for_file_ext(ext, "fingerprint")?;
-    let output = extension::run_fingerprint_script(&matched_extension, relative_path, content)?;
+    let output =
+        super::fingerprint_script_provider::fingerprint_via_script(ext, relative_path, content)?;
 
     let language = Language::from_extension(ext);
 

--- a/crates/homeboy-core/src/code_audit/fingerprint_script_provider.rs
+++ b/crates/homeboy-core/src/code_audit/fingerprint_script_provider.rs
@@ -1,0 +1,95 @@
+//! Extension-script fingerprinting for the audit engine, inverted behind a
+//! provider.
+//!
+//! When the core grammar engine cannot fingerprint a file, audit falls back to
+//! an extension-provided fingerprint script: it finds the extension that handles
+//! the file extension and runs its script, getting back a `FingerprintOutput`.
+//! Audit used to do that by calling `crate::extension::{find_extension_for_file_ext,
+//! run_fingerprint_script}` directly, coupling `code_audit` to the extension
+//! layer's script runner.
+//!
+//! Instead, audit defines the slim view it needs (extension → `FingerprintOutput`)
+//! plus a provider trait; the extension layer registers an implementation at
+//! startup (same pattern as the extension-manifest / component / fixability /
+//! runner-evidence / tunnel provider hooks). When no provider is registered —
+//! e.g. audit running standalone — the no-op provider yields no output, so audit
+//! simply produces no fingerprint for files only an extension script could
+//! handle (exactly as it does when no such extension is installed).
+
+use std::sync::Mutex;
+
+use homeboy_audit_contract::FingerprintOutput;
+
+/// The fingerprint-script contract the audit engine depends on. Implemented by
+/// the extension layer and registered at startup; audit calls it without
+/// depending on the extension script runner.
+pub trait FingerprintScriptProvider: Send + Sync {
+    /// Fingerprint a file via the extension script registered for `file_extension`
+    /// (without leading dot). Returns `None` when no extension handles the
+    /// extension or the script produced no output.
+    fn fingerprint(
+        &self,
+        file_extension: &str,
+        relative_path: &str,
+        content: &str,
+    ) -> Option<FingerprintOutput>;
+}
+
+/// Default provider used when no extension layer is registered: no output, so
+/// audit produces no fingerprint for extension-script-only files (exactly as it
+/// does when no such extension is installed).
+struct NoopProvider;
+
+impl FingerprintScriptProvider for NoopProvider {
+    fn fingerprint(
+        &self,
+        _file_extension: &str,
+        _relative_path: &str,
+        _content: &str,
+    ) -> Option<FingerprintOutput> {
+        None
+    }
+}
+
+static PROVIDER: Mutex<Option<Box<dyn FingerprintScriptProvider>>> = Mutex::new(None);
+
+/// Register the fingerprint-script provider. Called once at binary startup by
+/// the extension layer (via the CLI). Replaces any previously registered
+/// provider.
+pub fn register_fingerprint_script_provider(provider: Box<dyn FingerprintScriptProvider>) {
+    let mut guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = Some(provider);
+}
+
+/// Fingerprint a file via the registered extension-script provider.
+pub(crate) fn fingerprint_via_script(
+    file_extension: &str,
+    relative_path: &str,
+    content: &str,
+) -> Option<FingerprintOutput> {
+    with_provider(|p| p.fingerprint(file_extension, relative_path, content))
+}
+
+fn with_provider<T>(f: impl FnOnce(&dyn FingerprintScriptProvider) -> T) -> T {
+    let guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    match guard.as_ref() {
+        Some(provider) => f(provider.as_ref()),
+        None => f(&NoopProvider),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_provider_yields_no_output() {
+        assert!(NoopProvider
+            .fingerprint("rs", "src/lib.rs", "fn x() {}")
+            .is_none());
+    }
+}

--- a/crates/homeboy-core/src/code_audit/mod.rs
+++ b/crates/homeboy-core/src/code_audit/mod.rs
@@ -33,6 +33,7 @@ mod execution_plan;
 pub mod extension_manifests;
 pub(crate) mod findings;
 pub mod fingerprint;
+pub mod fingerprint_script_provider;
 pub mod fixability_provider;
 mod idiomatic;
 pub(crate) mod impact;

--- a/crates/homeboy-core/src/extension/audit_fingerprint_script_provider.rs
+++ b/crates/homeboy-core/src/extension/audit_fingerprint_script_provider.rs
@@ -1,0 +1,35 @@
+//! Extension-side implementation of the audit fingerprint-script provider.
+//!
+//! The audit engine (`code_audit`) defines `FingerprintScriptProvider` and calls
+//! it to fingerprint files that the core grammar engine cannot handle, without
+//! depending on the extension script runner. This module implements that trait
+//! by finding the extension registered for the file extension and running its
+//! fingerprint script. It is registered at binary startup by the CLI, mirroring
+//! the extension-manifest / component / fixability / runner-evidence / tunnel
+//! provider hooks.
+
+use homeboy_audit_contract::FingerprintOutput;
+
+use crate::code_audit::fingerprint_script_provider::{
+    register_fingerprint_script_provider, FingerprintScriptProvider,
+};
+
+struct ExtensionFingerprintScriptProvider;
+
+impl FingerprintScriptProvider for ExtensionFingerprintScriptProvider {
+    fn fingerprint(
+        &self,
+        file_extension: &str,
+        relative_path: &str,
+        content: &str,
+    ) -> Option<FingerprintOutput> {
+        let matched = super::find_extension_for_file_ext(file_extension, "fingerprint")?;
+        super::run_fingerprint_script(&matched, relative_path, content)
+    }
+}
+
+/// Register the extension-backed fingerprint-script provider. Called once at
+/// binary startup by the CLI.
+pub fn register() {
+    register_fingerprint_script_provider(Box::new(ExtensionFingerprintScriptProvider));
+}

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -1,3 +1,4 @@
+pub mod audit_fingerprint_script_provider;
 pub mod audit_manifest_provider;
 pub mod bench;
 pub mod build;


### PR DESCRIPTION
## Summary
- When the core grammar engine can't fingerprint a file, audit falls back to an extension-provided fingerprint script. `fingerprint_extension_content` did this by calling `crate::extension::{find_extension_for_file_ext, run_fingerprint_script}` directly, coupling `code_audit` to the extension script runner.
- Invert it behind a provider hook (same pattern as the extension-manifest, component, fixability, runner-evidence, and tunnel hooks).
- Also repoints `code_audit`'s one `extension::HookRef` reference directly to `homeboy_audit_contract::HookRef` (it was just a re-export of the contract type), matching the grammar fix in #8618.

## code_audit is now ONE edge from extractable
After this, `code_audit`'s only remaining upward feature-layer edge is the `ExtensionPhaseTiming` value type in `report.rs` output. Every **behavior** and **resolution** edge to component/extension/refactor/observation is now inverted or gone:

| layer | prod edges |
|---|---|
| component | 0 (#8628) |
| refactor | 0 |
| observation | 0 |
| review / issues | 0 |
| extension | **1** — just the `ExtensionPhaseTiming` value type (a follow-up value-type move) |

## Design
- `code_audit::fingerprint_script_provider`: defines `FingerprintScriptProvider` returning `Option<FingerprintOutput>` (a contract type — no extension types cross the boundary). No-op provider (unregistered) yields `None`, so audit produces no fingerprint for extension-script-only files — exactly as when no such extension is installed.
- `extension::audit_fingerprint_script_provider`: implements it via `find_extension_for_file_ext` + `run_fingerprint_script`.
- CLI registers it at startup alongside the other audit provider hooks.
- `fingerprint_extension_content` keeps assembling the `FileFingerprint` from the `FingerprintOutput` in `code_audit`; both its callers (`fingerprint.rs` fallback, `impact.rs`) are untouched.

## Verification
- `cargo check -p homeboy-core --lib` and `--tests` — **0 errors**, no new warnings.
- `grep` confirms the only remaining `code_audit -> extension` prod ref is `ExtensionPhaseTiming`.
- `cargo test -p homeboy-core --lib code_audit::` — **767 passed, 0 failed**; `fingerprint` suite 83 passed; noop provider test passes.
- 7 files; reverted unrelated `cargo fmt` drift.

## Note — pre-existing broken `--tests` on main (not this PR)
`cargo check --workspace --tests` currently fails with 20 errors in `homeboy-cli/src/commands/agent_task/fanout.rs` (references to a `run_batch_cook_fanout_plan_with_terminal` fn removed by #8631 + missing `Arc`/`Mutex` imports in that test module). These reproduce identically on clean `origin/main` and are **entirely unrelated** to this change — `homeboy-core --tests` is 0 errors. Fixing separately.

Refs #8425