### PR TITLE
Restore runtime manifest compilation

### DIFF
--- a/crates/homeboy-core/src/agent_runtime_manifest.rs
+++ b/crates/homeboy-core/src/agent_runtime_manifest.rs
@@ -1587,7 +1587,9 @@ mod tests {
                 resolved.diagnostics[0].class,
                 "agent_runtime_catalog.conflict"
             );
-            assert!(resolved.diagnostics[0].message.contains("stale-cache"));
+            assert!(resolved.diagnostics[0]
+                .message
+                .contains(runtime_dir.to_str().expect("runtime dir utf-8")));
             assert!(resolved.diagnostics[0]
                 .message
                 .contains("sample-runtime-extension"));

--- a/crates/homeboy-core/src/agent_runtime_manifest.rs
+++ b/crates/homeboy-core/src/agent_runtime_manifest.rs
@@ -369,10 +369,6 @@ fn runtime_source_revision(path: &Path) -> Option<String> {
     })
 }
 
-fn is_immutable_revision(revision: &str) -> bool {
-    matches!(revision.len(), 40 | 64) && revision.bytes().all(|byte| byte.is_ascii_hexdigit())
-}
-
 pub fn discover_agent_runtime_catalog() -> AgentRuntimeDiscoveryCatalog {
     let standalone = discover_standalone_agent_runtime_catalog();
     let extensions = load_all_extensions().unwrap_or_default();
@@ -1659,6 +1655,13 @@ mod tests {
     }
 
     #[test]
+    fn immutable_revision_requires_a_full_git_sha() {
+        assert!(is_immutable_revision(&"a".repeat(40)));
+        assert!(!is_immutable_revision(&"a".repeat(64)));
+        assert!(!is_immutable_revision("main"));
+    }
+
+    #[test]
     fn sample_runtime_materialization_fixture_is_plain_data() {
         let manifest: AgentRuntimeManifest = serde_json::from_str(include_str!(
             "../../../tests/fixtures/sample_runtime_materialization_manifest.json"
@@ -1728,10 +1731,11 @@ mod tests {
             extension_id: None,
             extension_path: None,
             runtime_path: Some(root.path().display().to_string()),
+            source_revision: Some(revision.clone()),
             extra: BTreeMap::new(),
         };
 
-        let controller_plan = runtime_materialization_plan(&manifest);
+        let controller_plan = runtime_materialization_plan(&manifest, "parity.default");
         let lab_plan: AgentRuntimeMaterializationPlan =
             serde_json::from_value(serde_json::to_value(&controller_plan).expect("handoff"))
                 .expect("lab plan");
@@ -1742,6 +1746,15 @@ mod tests {
             Some(revision.as_str())
         );
         assert_eq!(controller_plan.selected_identity.freshness, "current");
+        assert_eq!(controller_plan.provider_id, "parity.default");
+        assert_eq!(
+            controller_plan.source_revision.as_deref(),
+            Some(revision.as_str())
+        );
+        assert_eq!(
+            controller_plan.freshness,
+            AgentRuntimeFreshness::Unverifiable
+        );
         assert_eq!(
             controller_plan.source_roots[0].git_ref.as_deref(),
             Some(revision.as_str())
@@ -1774,12 +1787,15 @@ mod tests {
             extension_id: None,
             extension_path: None,
             runtime_path: Some(root.path().display().to_string()),
+            source_revision: None,
             extra: BTreeMap::new(),
         };
 
-        let plan = runtime_materialization_plan(&manifest);
+        let plan = runtime_materialization_plan(&manifest, "extracted.default");
 
         assert_eq!(plan.selected_identity.freshness, "unverifiable");
+        assert_eq!(plan.provider_id, "extracted.default");
+        assert!(plan.source_revision.is_none());
         assert_eq!(plan.source_roots[0].git_ref.as_deref(), Some("main"));
     }
 }


### PR DESCRIPTION
## Summary
Restore current-main compilation after runtime catalog identity changes.

## What changed
- Remove the duplicate immutable revision predicate and retain one canonical 40-character Git SHA contract.
- Update runtime materialization fixtures for source revision and provider identity fields.

## How to test
1. Run `cargo test -p homeboy-core immutable_revision_requires_a_full_git_sha --lib`; expect focused immutable revision test passes.
2. Run `cargo check -p homeboy-cli`; expect Homeboy CLI and core compile successfully.
3. Run `git diff --check`; expect no whitespace errors.

## Compatibility
No compatibility impact. The change restores the intended immutable full Git SHA contract and updates tests to the current materialization API.

## Evidence
- Base unchanged since verification: main remains at 433c16554b96443a26cac09bc12b68e8e6314195.
- CI expected: Repository pull-request CI
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8639
- Verified finalization base: main at 433c16554b96443a26cac09bc12b68e8e6314195
- cargo-check: Passed
- diff-check: Passed
- immutable-revision-test: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the current-main compile regression, prepared and reviewed the canonical immutable-revision fix, updated stale fixtures, and ran deterministic verification.

## Source relationships
- Closes #8639
