### PR TITLE
Recover runner patches from mixed artifact aggregates

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
@@ -551,20 +551,7 @@ pub(crate) fn record_terminal_artifact_projection(
     record: &mut AgentTaskRunRecord,
     aggregate: &AgentTaskAggregate,
 ) -> Result<()> {
-    if record.runner_id().is_none()
-        && aggregate
-            .outcomes
-            .iter()
-            .flat_map(|outcome| &outcome.artifacts)
-            .any(|artifact| {
-                artifact
-                    .path
-                    .as_deref()
-                    .is_some_and(|path| Path::new(path).is_absolute())
-                    && artifact.size_bytes.is_some()
-                    && artifact.sha256.is_some()
-            })
-    {
+    if record.runner_id().is_none() && aggregate_has_unresolved_actionable_patch(aggregate) {
         match runner_id_from_artifact_provenance(aggregate) {
             Ok(runner_id) => {
                 record
@@ -597,16 +584,16 @@ pub(crate) fn record_terminal_artifact_projection(
     store::write_record(record)
 }
 
-/// Recover the only runner identity trusted by legacy aggregate artifact
-/// provenance. Every unresolved absolute artifact must agree so controller
-/// reconciliation cannot treat a runner path as a local file.
+/// Recover the runner identity for canonical legacy patch artifacts. Diagnostic
+/// artifacts can share an aggregate without participating in promotion.
 fn runner_id_from_artifact_provenance(aggregate: &AgentTaskAggregate) -> Result<String> {
     let runner_ids = aggregate
         .outcomes
         .iter()
         .flat_map(|outcome| &outcome.artifacts)
         .filter(|artifact| {
-            artifact.path.as_deref().is_some_and(|path| Path::new(path).is_absolute())
+            crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(artifact)
+                && artifact.path.as_deref().is_some_and(|path| Path::new(path).is_absolute())
                 && artifact.size_bytes.is_some()
                 && artifact.sha256.is_some()
         })
@@ -638,13 +625,32 @@ fn runner_id_from_artifact_provenance(aggregate: &AgentTaskAggregate) -> Result<
     }
 }
 
+fn aggregate_has_unresolved_actionable_patch(aggregate: &AgentTaskAggregate) -> bool {
+    aggregate
+        .outcomes
+        .iter()
+        .flat_map(|outcome| &outcome.artifacts)
+        .any(|artifact| {
+            crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(artifact)
+                && artifact
+                    .path
+                    .as_deref()
+                    .is_some_and(|path| Path::new(path).is_absolute())
+                && artifact.size_bytes.is_some()
+                && artifact.sha256.is_some()
+        })
+}
+
 pub(crate) fn terminal_artifact_projection_is_verified(
     record: &AgentTaskRunRecord,
     aggregate: &AgentTaskAggregate,
 ) -> Result<bool> {
     for outcome in &aggregate.outcomes {
         for artifact in &outcome.artifacts {
-            if artifact.path.is_some() && artifact.size_bytes.is_some() && artifact.sha256.is_some()
+            if crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(artifact)
+                && artifact.path.is_some()
+                && artifact.size_bytes.is_some()
+                && artifact.sha256.is_some()
             {
                 if verified_controller_artifact_projection_path(
                     &record.run_id,
@@ -665,11 +671,11 @@ pub(crate) fn terminal_artifact_projection_is_verified(
 mod tests {
     use super::*;
 
-    fn artifact(runner_id: Option<&str>) -> AgentTaskArtifact {
+    fn artifact(id: &str, kind: &str, runner_id: Option<&str>) -> AgentTaskArtifact {
         AgentTaskArtifact {
             schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-            id: "patch".to_string(),
-            kind: "patch".to_string(),
+            id: id.to_string(),
+            kind: kind.to_string(),
             name: None,
             label: None,
             role: None,
@@ -687,7 +693,7 @@ mod tests {
     }
 
     #[test]
-    fn legacy_runner_provenance_requires_one_consistent_value() {
+    fn legacy_runner_provenance_uses_only_actionable_patch_artifacts() {
         let mut aggregate = AgentTaskAggregate {
             schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
             plan_id: "plan".to_string(),
@@ -706,7 +712,12 @@ mod tests {
             status: AgentTaskOutcomeStatus::Succeeded,
             summary: None,
             failure_classification: None,
-            artifacts: vec![artifact(Some("runner-a")), artifact(Some("runner-b"))],
+            artifacts: vec![
+                artifact("patch", "patch", Some("runner-a")),
+                artifact("transcript", "transcript", None),
+                artifact("result", "result", None),
+                artifact("runtime-log", "runtime-log", None),
+            ],
             typed_artifacts: Vec::new(),
             evidence_refs: Vec::new(),
             diagnostics: Vec::new(),
@@ -716,13 +727,13 @@ mod tests {
             metadata: Value::Null,
         });
 
-        assert!(runner_id_from_artifact_provenance(&aggregate).is_err());
-        aggregate.outcomes[0].artifacts[1] = artifact(Some("runner-a"));
         assert_eq!(
             runner_id_from_artifact_provenance(&aggregate).expect("consistent provenance"),
             "runner-a"
         );
-        aggregate.outcomes[0].artifacts[1] = artifact(None);
+        aggregate.outcomes[0]
+            .artifacts
+            .push(artifact("second-patch", "patch", Some("runner-b")));
         assert!(runner_id_from_artifact_provenance(&aggregate).is_err());
     }
 }
@@ -837,14 +848,21 @@ pub(crate) fn project_terminal_artifacts(
                         let remote_ref = crate::execution_contract::EXECUTION_CONTRACT
                             .artifacts
                             .runner_artifact_ref(runner_id, &record.run_id, &logical_id);
-                        let mirror_result = (|| -> Result<()> {
-                            let mirror = tempfile::NamedTempFile::new().map_err(|error| {
-                                Error::internal_io(
-                                    error.to_string(),
-                                    Some("create controller artifact mirror".to_string()),
-                                )
-                            })?;
-                            let download =
+                        let mirror_result =
+                            if crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(
+                                artifact,
+                            ) {
+                                (|| -> Result<()> {
+                                    let mirror =
+                                        tempfile::NamedTempFile::new().map_err(|error| {
+                                            Error::internal_io(
+                                                error.to_string(),
+                                                Some(
+                                                    "create controller artifact mirror".to_string(),
+                                                ),
+                                            )
+                                        })?;
+                                    let download =
                                 crate::observation::runs_service::runner_evidence::with_runner_evidence(
                                     |p| {
                                         p.download_remote_artifact(
@@ -853,21 +871,27 @@ pub(crate) fn project_terminal_artifacts(
                                         )
                                     },
                                 )?;
-                            let expected_size = artifact.size_bytes.expect("checked above");
-                            let expected_sha256 =
-                                artifact.sha256.as_deref().expect("checked above");
-                            let actual_size = std::fs::metadata(&download.output_path)
-                                .map_err(|error| {
-                                    Error::internal_io(
-                                        error.to_string(),
-                                        Some("inspect controller artifact mirror".to_string()),
-                                    )
-                                })?
-                                .len();
-                            let actual_sha256 =
-                                crate::artifact_metadata::sha256_file(&download.output_path)?;
-                            if actual_size != expected_size || actual_sha256 != expected_sha256 {
-                                return Err(Error::validation_invalid_argument(
+                                    let expected_size = artifact.size_bytes.expect("checked above");
+                                    let expected_sha256 =
+                                        artifact.sha256.as_deref().expect("checked above");
+                                    let actual_size = std::fs::metadata(&download.output_path)
+                                        .map_err(|error| {
+                                            Error::internal_io(
+                                                error.to_string(),
+                                                Some(
+                                                    "inspect controller artifact mirror"
+                                                        .to_string(),
+                                                ),
+                                            )
+                                        })?
+                                        .len();
+                                    let actual_sha256 = crate::artifact_metadata::sha256_file(
+                                        &download.output_path,
+                                    )?;
+                                    if actual_size != expected_size
+                                        || actual_sha256 != expected_sha256
+                                    {
+                                        return Err(Error::validation_invalid_argument(
                                     "artifact_id",
                                     format!(
                                         "runner artifact mirror for run '{}', task '{}', and artifact '{}' does not match the aggregate SHA-256 and size",
@@ -876,25 +900,31 @@ pub(crate) fn project_terminal_artifacts(
                                     Some(artifact.id.clone()),
                                     None,
                                 ));
-                            }
-                            let mut controller_hash = sha2::Sha256::new();
-                            sha2::Digest::update(&mut controller_hash, b"controller");
-                            sha2::Digest::update(&mut controller_hash, [0]);
-                            sha2::Digest::update(&mut controller_hash, artifact_id.as_bytes());
-                            let controller_artifact_id =
-                                format!("agent-task-{:x}", controller_hash.finalize());
-                            let mut controller_metadata = metadata.clone();
-                            controller_metadata["agent_task"]["projection"] =
-                                json!("runner_mirrored");
-                            store.record_artifact_with_id(
-                                &record.run_id,
-                                &artifact.kind,
-                                &download.output_path,
-                                &controller_artifact_id,
-                                controller_metadata,
-                            )?;
-                            Ok(())
-                        })();
+                                    }
+                                    let mut controller_hash = sha2::Sha256::new();
+                                    sha2::Digest::update(&mut controller_hash, b"controller");
+                                    sha2::Digest::update(&mut controller_hash, [0]);
+                                    sha2::Digest::update(
+                                        &mut controller_hash,
+                                        artifact_id.as_bytes(),
+                                    );
+                                    let controller_artifact_id =
+                                        format!("agent-task-{:x}", controller_hash.finalize());
+                                    let mut controller_metadata = metadata.clone();
+                                    controller_metadata["agent_task"]["projection"] =
+                                        json!("runner_mirrored");
+                                    store.record_artifact_with_id(
+                                        &record.run_id,
+                                        &artifact.kind,
+                                        &download.output_path,
+                                        &controller_artifact_id,
+                                        controller_metadata,
+                                    )?;
+                                    Ok(())
+                                })()
+                            } else {
+                                Ok(())
+                            };
 
                         // Preserve the canonical runner retrieval alias even when
                         // the controller also materializes verified bytes.

--- a/crates/homeboy-core/src/agent_task_promotion/tests.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/tests.rs
@@ -222,7 +222,7 @@ fn recovered_runner_aggregate(
 }
 
 #[test]
-fn bridge_reconciliation_projects_recovered_finalized_bytes_for_local_promotion_idempotently() {
+fn bridge_reconciliation_recovers_mixed_runner_artifacts_for_local_promotion_idempotently() {
     crate::test_support::with_isolated_home(|_| {
         let run_id = "recovered-typed-lab-run";
         let task_id = "implement";
@@ -259,6 +259,30 @@ fn bridge_reconciliation_projects_recovered_finalized_bytes_for_local_promotion_
                             "executor_artifact_finalized": true,
                             "source_provenance": { "runner_id": "homeboy-lab" }
                         }
+                    }, {
+                        "schema": AGENT_TASK_ARTIFACT_SCHEMA,
+                        "id": "transcript",
+                        "kind": "transcript",
+                        "path": "/home/runner/.homeboy/executor-finalized/transcript.json",
+                        "size_bytes": 10,
+                        "sha256": "a".repeat(64),
+                        "metadata": { "executor_artifact_finalized": true }
+                    }, {
+                        "schema": AGENT_TASK_ARTIFACT_SCHEMA,
+                        "id": "result",
+                        "kind": "result",
+                        "path": "/home/runner/.homeboy/executor-finalized/result.json",
+                        "size_bytes": 10,
+                        "sha256": "b".repeat(64),
+                        "metadata": { "executor_artifact_finalized": true }
+                    }, {
+                        "schema": AGENT_TASK_ARTIFACT_SCHEMA,
+                        "id": "runtime-log",
+                        "kind": "runtime-log",
+                        "path": "/home/runner/.homeboy/executor-finalized/runtime.log",
+                        "size_bytes": 10,
+                        "sha256": "c".repeat(64),
+                        "metadata": { "executor_artifact_finalized": true }
                     }],
                     "typed_artifacts": [{
                         "name": "patch",
@@ -286,18 +310,12 @@ fn bridge_reconciliation_projects_recovered_finalized_bytes_for_local_promotion_
             .to_string(),
         )
         .expect("recovered aggregate");
-        let identity = AgentTaskDispatchIdentity {
-            runner_id: "homeboy-lab".to_string(),
-            runner_job_id: "job-recovered".to_string(),
-            ..Default::default()
-        };
-
         crate::runner::mirror_agent_task_run_plan_aggregate(
             "@runner-plan.json",
             run_id,
             aggregate.clone(),
             None,
-            Some(&identity),
+            None,
         )
         .expect("bridge reconciliation");
         crate::runner::mirror_agent_task_run_plan_aggregate(
@@ -305,19 +323,25 @@ fn bridge_reconciliation_projects_recovered_finalized_bytes_for_local_promotion_
             run_id,
             aggregate.clone(),
             None,
-            Some(&identity),
+            None,
         )
         .expect("idempotent bridge reconciliation");
 
         let store = crate::observation::ObservationStore::open_initialized().expect("store");
         let artifacts = store.list_artifacts(run_id).expect("projected artifacts");
-        assert_eq!(artifacts.len(), 1);
-        assert_eq!(artifacts[0].artifact_type, "file");
-        assert_eq!(artifacts[0].metadata_json["agent_task"]["task_id"], task_id);
+        assert_eq!(artifacts.len(), 4);
+        let patch = artifacts
+            .iter()
+            .find(|artifact| artifact.artifact_type == "file")
+            .expect("projected patch");
+        assert_eq!(patch.metadata_json["agent_task"]["task_id"], task_id);
         assert_eq!(
-            artifacts[0].metadata_json["agent_task"]["logical_artifact_id"],
+            patch.metadata_json["agent_task"]["logical_artifact_id"],
             artifact_id
         );
+        let record = crate::agent_task_lifecycle::status(run_id).expect("recovered status");
+        assert_eq!(record.metadata["runner_id"], "homeboy-lab");
+        assert_eq!(record.metadata["artifact_projection"]["status"], "complete");
 
         let temp = tempfile::tempdir().expect("promotion tempdir");
         let mut provider = FakePromotionWorkspaceProvider {
@@ -343,7 +367,7 @@ fn bridge_reconciliation_projects_recovered_finalized_bytes_for_local_promotion_
             &mut provider,
         )
         .expect("promote recovered controller projection");
-        assert_eq!(report.patch_artifact.path, artifacts[0].path);
+        assert_eq!(report.patch_artifact.path, patch.path);
         assert_eq!(
             provider.applied_patch_contents,
             vec![VALID_PATCH.to_string()]


### PR DESCRIPTION
## Summary
Recover detached Lab patch candidates from realistic mixed-artifact aggregates without weakening provenance checks.

## What changed
- Derive legacy runner identity only from actionable absolute patch artifacts selected for promotion.
- Mirror actionable patches to verified controller storage while preserving non-actionable evidence as runner retrieval aliases.
- Keep multiple actionable patches with conflicting runner identities fail-closed.
- Add a mixed patch/transcript/result/runtime-log regression fixture matching the live #8548 failure.

## How to test
1. Run `cargo test -p homeboy-core agent_task_promotion::tests::bridge_reconciliation_recovers_mixed_runner_artifacts_for_local_promotion_idempotently --lib -- --exact`; expect Passes after #8637 restores current-main compilation..
2. Run `cargo test -p homeboy-core agent_task_lifecycle::failure_recording::tests::legacy_runner_provenance_uses_only_actionable_patch_artifacts --lib -- --exact`; expect Accepts provenance-free diagnostic artifacts and rejects conflicting actionable patch provenance..

## Compatibility
No public API or extension-path compatibility change. Recovery is narrowed to promotable patch artifacts; ambiguous actionable provenance remains blocked.

## Evidence
- Base advanced after verification: verified main at 433c16554b96443a26cac09bc12b68e8e6314195; publication observed 4753a877357dce54095b901d0bfca7eba6f1b595. Candidate ancestry was validated against the verified snapshot.
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8548
- Verified finalization base: main at 433c16554b96443a26cac09bc12b68e8e6314195
- conflicting-actionable-provenance: Passed
- mixed-artifact-promotion: Passed
- targeted-rustfmt: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the live mixed-artifact projection failure, implemented scoped actionable-patch recovery, and added deterministic regression coverage; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8548
