### PR TITLE
refactor: route daemon file-API workspace-root lookup through a hook

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -143,6 +143,10 @@ impl CliRuntime {
         // can prepare and run a runner job as a local child without core
         // depending on runner process-execution behavior.
         crate::core::runner::register_runner_daemon_exec_driver();
+        // Register the runner workspace-root provider so the daemon file API can
+        // resolve a runner's configured workspace_root without core depending on
+        // the runner config registry.
+        crate::core::runner::register_runner_workspace_root_provider();
         // Register the runner-upgrade provider so the core upgrade flow can
         // refresh configured runners without depending on runner behavior.
         crate::core::upgrade::register_runner_upgrade();

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -36,6 +36,7 @@ mod control;
 mod patch_capture;
 mod remote_runner;
 pub mod runner_exec_driver;
+pub mod runner_workspace_root;
 pub use artifact_download::ArtifactDownload;
 pub use broker_config::{render_broker_config, BrokerConfig, BrokerConfigOptions, ServiceIdentity};
 pub use control::{
@@ -1572,12 +1573,12 @@ fn resolve_runner_workspace_path(
     requested_path: &str,
     request_workspace_root: Option<&str>,
 ) -> Result<PathBuf> {
-    let loaded_runner;
+    let resolved_root;
     let workspace_root = match request_workspace_root.filter(|root| !root.trim().is_empty()) {
         Some(root) => root,
         None => {
-            loaded_runner = crate::runner::load(runner_id)?;
-            loaded_runner.workspace_root.as_deref().ok_or_else(|| {
+            resolved_root = runner_workspace_root::runner_workspace_root(runner_id);
+            resolved_root.as_deref().ok_or_else(|| {
                 Error::validation_invalid_argument(
                     "workspace_root",
                     format!("runner `{runner_id}` file API requires workspace_root"),

--- a/crates/homeboy-core/src/daemon/runner_workspace_root.rs
+++ b/crates/homeboy-core/src/daemon/runner_workspace_root.rs
@@ -1,0 +1,52 @@
+//! Runner workspace-root lookup hook.
+//!
+//! The daemon's runner file API (`/files/mkdir|upload|download`) resolves a
+//! path against a runner's configured `workspace_root` when the request does
+//! not carry one. That lookup loads the runner config, which is runner-owned,
+//! so it is inverted behind this small provider: core's daemon asks for the
+//! workspace root, the runner layer supplies it from the runner registry.
+//!
+//! With no provider registered the daemon simply has no configured root to fall
+//! back on, so the caller reports the same "requires workspace_root" error it
+//! would for a runner without one.
+
+use std::sync::Mutex;
+
+/// Looks up a runner's configured workspace root by id.
+pub trait RunnerWorkspaceRootProvider: Send + Sync {
+    /// The configured `workspace_root` for `runner_id`, if any.
+    fn runner_workspace_root(&self, runner_id: &str) -> Option<String>;
+}
+
+struct NoopProvider;
+
+impl RunnerWorkspaceRootProvider for NoopProvider {
+    fn runner_workspace_root(&self, _runner_id: &str) -> Option<String> {
+        None
+    }
+}
+
+fn provider_slot() -> &'static Mutex<Option<Box<dyn RunnerWorkspaceRootProvider>>> {
+    static PROVIDER: Mutex<Option<Box<dyn RunnerWorkspaceRootProvider>>> = Mutex::new(None);
+    &PROVIDER
+}
+
+/// Register the runner workspace-root provider. Called once at startup by the
+/// runner layer.
+pub fn register_runner_workspace_root_provider(provider: Box<dyn RunnerWorkspaceRootProvider>) {
+    let mut slot = provider_slot()
+        .lock()
+        .expect("runner workspace root provider lock");
+    *slot = Some(provider);
+}
+
+/// Resolve a runner's configured workspace root via the registered provider.
+pub(crate) fn runner_workspace_root(runner_id: &str) -> Option<String> {
+    let slot = provider_slot()
+        .lock()
+        .expect("runner workspace root provider lock");
+    match slot.as_deref() {
+        Some(provider) => provider.runner_workspace_root(runner_id),
+        None => NoopProvider.runner_workspace_root(runner_id),
+    }
+}

--- a/crates/homeboy-core/src/runner/mod.rs
+++ b/crates/homeboy-core/src/runner/mod.rs
@@ -33,6 +33,7 @@ mod command_path;
 mod connection;
 mod continuation_provider;
 mod daemon_exec_driver;
+mod workspace_root_provider;
 mod daemon_health;
 mod daemon_http_get;
 mod evidence;
@@ -109,6 +110,7 @@ pub use connection::{
 };
 pub use continuation_provider::register as register_runner_continuation_provider;
 pub use daemon_exec_driver::register as register_runner_daemon_exec_driver;
+pub use workspace_root_provider::register as register_runner_workspace_root_provider;
 pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
 pub use evidence::register_runner_evidence_provider;
 pub use evidence::runner_artifact_store_token;

--- a/crates/homeboy-core/src/runner/workspace_root_provider.rs
+++ b/crates/homeboy-core/src/runner/workspace_root_provider.rs
@@ -1,0 +1,22 @@
+//! Runner-side implementation of core's `RunnerWorkspaceRootProvider` hook.
+//!
+//! Core's daemon file API asks for a runner's configured workspace root; this
+//! adapter loads the runner config and returns its `workspace_root`.
+
+use crate::daemon::runner_workspace_root::RunnerWorkspaceRootProvider;
+
+/// The runner layer's `RunnerWorkspaceRootProvider`. Registered with core at startup.
+pub struct RunnerWorkspaceRoot;
+
+impl RunnerWorkspaceRootProvider for RunnerWorkspaceRoot {
+    fn runner_workspace_root(&self, runner_id: &str) -> Option<String> {
+        super::load(runner_id).ok()?.workspace_root
+    }
+}
+
+/// Register the runner workspace-root provider with core. Called once at startup.
+pub fn register() {
+    crate::daemon::runner_workspace_root::register_runner_workspace_root_provider(Box::new(
+        RunnerWorkspaceRoot,
+    ));
+}


### PR DESCRIPTION
## Summary
- Clears the **last production daemon->runner behavior edge**. The daemon's runner file API (`/files/mkdir|upload|download`) resolved a request path against a runner's configured `workspace_root` by calling `crate::runner::load` directly; it now goes through a small `RunnerWorkspaceRootProvider` hook.
- Adds `daemon/runner_workspace_root.rs` (trait + registry + no-op returning `None`) and `runner/workspace_root_provider.rs` (runner-side impl delegating to `load(runner_id).workspace_root`), registered at CLI startup.

## Why
Part of the staged runner extraction. `daemon.rs` is now free of production runner references — the only remaining daemon->runner refs are runner-type imports (`RunnerSession`, etc.) that leave with the runner crate. With this + the merged broker-auth relocation (#8638) and exec-driver hook (#8632), the daemon is ready for the wholesale runner `git mv`.

## Behavior
With no provider registered the daemon has no configured root to fall back on, so the caller reports the same "requires workspace_root" error it would for a runner without one (unchanged for the request-supplied-root path).

## Testing
- `cargo check -p homeboy-core --lib` / `--tests` and `-p homeboy-cli --lib` — clean
- `cargo test -p homeboy-core --lib 'daemon::remote_runner'` — 6 passed
- Full `--workspace` suite via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)