### PR TITLE
refactor: self-register Runner as a config entity

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -147,6 +147,10 @@ impl CliRuntime {
         // resolve a runner's configured workspace_root without core depending on
         // the runner config registry.
         crate::core::runner::register_runner_workspace_root_provider();
+        // Register Runner as a config entity so it participates in config
+        // id/alias collision detection, mirroring how feature crates register
+        // their own entities (moves into the runner crate once extracted).
+        crate::core::runner::register_runner_config_entity();
         // Register the runner-upgrade provider so the core upgrade flow can
         // refresh configured runners without depending on runner behavior.
         crate::core::upgrade::register_runner_upgrade();

--- a/crates/homeboy-core/src/config.rs
+++ b/crates/homeboy-core/src/config.rs
@@ -205,9 +205,6 @@ fn config_entity_registry() -> Vec<ConfigEntityMetadata> {
     let mut registry = vec![
         entity_metadata::<crate::project::Project>(),
         entity_metadata::<crate::server::Server>(),
-        // Runner is still core-owned (not yet extracted); when the runner crate
-        // lands it should register itself via `register_config_entity` instead.
-        entity_metadata::<crate::runner::Runner>(),
         entity_metadata::<crate::extension::ExtensionManifest>(),
         entity_metadata::<crate::fleet::Fleet>(),
     ];

--- a/crates/homeboy-core/src/runner/mod.rs
+++ b/crates/homeboy-core/src/runner/mod.rs
@@ -370,6 +370,14 @@ impl ConfigEntity for Runner {
     }
 }
 
+/// Register `Runner` as a config entity so it participates in config-id/alias
+/// collision detection. Called once at startup, mirroring how feature crates
+/// (e.g. the tunnel crate) register their own entities; when the runner crate
+/// is extracted this call moves into that crate's startup registration.
+pub fn register_runner_config_entity() {
+    config::register_config_entity::<Runner>();
+}
+
 pub fn load(id: &str) -> Result<Runner> {
     if id == "local" {
         return Ok(builtin_local_runner());
@@ -977,6 +985,24 @@ fn validate_server_runner(server_id: &str, runner: &ServerRunner) -> Result<()> 
 mod tests {
     use super::*;
     use crate::test_support;
+
+    #[test]
+    fn register_runner_config_entity_participates_in_collision_detection() {
+        // Runner is no longer hard-coded into core's config-entity seed; it
+        // self-registers. Guard the collision invariant: after registration the
+        // runner entity type is present, and registration is idempotent.
+        register_runner_config_entity();
+        register_runner_config_entity();
+        let registered = crate::config::registered_config_entity_types();
+        assert_eq!(
+            registered
+                .iter()
+                .filter(|entity_type| **entity_type == Runner::ENTITY_TYPE)
+                .count(),
+            1,
+            "runner entity type must be registered exactly once, got: {registered:?}"
+        );
+    }
 
     fn default_lab_candidate(
         id: &str,


### PR DESCRIPTION
## Summary
- Removes `Runner` from core's hard-coded config-entity seed (`config_entity_registry`) and registers it via `register_config_entity::<Runner>()` at startup instead — mirroring how feature crates register their own entities (the tunnel crate registers `ServiceTunnel` the same way).
- Adds `runner::register_runner_config_entity()`, wired into CLI startup next to the other runner registrations, plus a guard test asserting the runner entity type is registered exactly once (idempotent).

## Why
The config-entity keystone (from the tunnel extraction, #8488) lets a feature layer register its own config entity for id/alias collision detection without core hard-coding it. This applies that pattern to `Runner` so that when the runner crate is extracted, its self-registration call simply moves into the runner crate's startup — no change to core.

Final prep step before the wholesale runner `git mv`.

## Testing
- `cargo check -p homeboy-core --lib` / `--tests` and `-p homeboy-cli --lib` — clean
- `cargo test -p homeboy-core --lib`: `config::tests` (6), `collision` (6), and the new `register_runner_config_entity_participates_in_collision_detection` guard test — all pass
- Full `--workspace` suite via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)