### PR TITLE
Recover legacy controller runtime pins

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -24,7 +24,7 @@ fn fake_controller_artifact(path: &std::path::Path, identity: &str, marker: &str
     std::fs::write(
         path,
         format!(
-            "#!/bin/sh\n# {marker}\nif [ \"$1\" = self ] && [ \"$2\" = identity ]; then\n  printf '%s\\n' '{{\"data\":{{\"display\":{identity}}}}}'\n  exit 0\nfi\nexit 1\n"
+            "#!/bin/sh\n# {marker}\nif [ \"$1\" = self ] && [ \"$2\" = identity ]; then\n  printf '%s\\n' '{{\"data\":{{\"display\":{identity}}}}}'\n  exit 0\nfi\nif [ \"$1\" = self ] && [ \"$2\" = status ]; then\n  printf '%s\\n' '{{\"data\":{{\"active_build_identity\":{{\"display\":{identity}}}}}}}'\n  exit 0\nfi\nexit 1\n"
         ),
     )
     .expect("write fake controller artifact");
@@ -199,33 +199,66 @@ fn artifact_recovery_rejects_wrong_hash_and_identity_without_record_mutation() {
 
 #[cfg(unix)]
 #[test]
-fn legacy_pin_migration_failure_leaves_durable_record_unchanged() {
+fn legacy_v1_pin_migration_failures_leave_durable_record_unchanged() {
     with_isolated_home(|_| {
+        use std::os::unix::fs::PermissionsExt;
+
         let temporary = tempfile::tempdir().expect("temporary fake controller directory");
         let identity = crate::build_identity::current().display;
-        let legacy = temporary.path().join("legacy-homeboy");
-        let digest = fake_controller_artifact(&legacy, &identity, "legacy artifact");
         let record = submit_plan(&test_plan(), Some("migration-failure")).expect("submit");
-        rewrite_record_for_test(&record.run_id, |record| {
-            record.metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = json!({
-                "originating": {
-                    "build_identity": identity,
-                    "pinned_executable": legacy,
-                    "sha256": format!("{digest}00"),
+        let cases = [
+            (
+                "missing",
+                temporary.path().join("missing-homeboy"),
+                None,
+                "missing",
+            ),
+            (
+                "non-executable",
+                temporary.path().join("non-executable-homeboy"),
+                Some(identity.clone()),
+                "not executable",
+            ),
+            (
+                "identity-mismatch",
+                temporary.path().join("wrong-identity-homeboy"),
+                Some("homeboy test+wrong".to_string()),
+                "build identity mismatch",
+            ),
+        ];
+
+        for (name, legacy, artifact_identity, expected_error) in cases {
+            if let Some(artifact_identity) = artifact_identity {
+                fake_controller_artifact(&legacy, &artifact_identity, name);
+                if name == "non-executable" {
+                    std::fs::set_permissions(&legacy, std::fs::Permissions::from_mode(0o600))
+                        .expect("remove executable permission");
                 }
-            });
-        })
-        .expect("project invalid legacy pin");
-        let before = status(&record.run_id).expect("record before migration");
+            }
+            rewrite_record_for_test(&record.run_id, |record| {
+                record.metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = json!({
+                    "originating": {
+                        "build_identity": identity,
+                        "pinned_executable": legacy,
+                    }
+                });
+            })
+            .expect("project v1 legacy pin");
+            let before = status(&record.run_id).expect("record before migration");
 
-        let error =
-            validate_controller_runtime(&record.run_id).expect_err("migration fails closed");
+            let error = validate_controller_runtime(&record.run_id)
+                .expect_err("legacy migration fails closed");
 
-        assert!(error.message.contains("hash mismatch"));
-        assert_eq!(
-            status(&record.run_id).expect("record after migration"),
-            before
-        );
+            assert!(
+                error.message.contains(expected_error),
+                "{name}: {}",
+                error.message
+            );
+            assert_eq!(
+                status(&record.run_id).expect("record after migration"),
+                before
+            );
+        }
     });
 }
 

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -1216,6 +1216,7 @@ mod tests {
             let temporary = tempfile::tempdir().expect("temporary runtime directory");
             let legacy = temporary.path().join("legacy-homeboy");
             let identity = "homeboy test+legacy";
+            fake_controller(&legacy, identity, "legacy");
             let runtime = json!({ "originating": {
                 "build_identity": identity,
                 "pinned_executable": legacy,

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -329,19 +329,43 @@ pub(crate) fn validate_for_mutation(metadata: &Value, current_identity: &str) ->
     ))
 }
 
-/// Move a valid legacy v2 pin into its immutable content-addressed location.
+/// Upgrade a legacy pin into the immutable content-addressed v2 format.
 /// The caller persists the returned metadata only after this has completed.
 pub(crate) fn migrate_legacy_pin(runtime: &Value) -> Result<Value> {
     let identity =
         required_runtime_string(runtime, "/originating/build_identity", "build identity")?;
-    let digest = required_runtime_string(runtime, "/originating/sha256", "content digest")?;
-    let destination = pinned_path(identity, digest)?;
     let current = required_runtime_string(
         runtime,
         "/originating/pinned_executable",
         "immutable executable",
     )?;
-    if Path::new(current) == destination {
+    let current = Path::new(current);
+
+    // v1 pins predate a content digest. The retained executable is the only
+    // trusted migration source; never substitute the current binary or a checkout.
+    if runtime.pointer("/originating/sha256").is_none() {
+        verify_executable(current, "legacy controller runtime")?;
+        verify_self_status_identity(current, identity)?;
+        let digest = executable_digest(current)?;
+        let destination = pinned_path(identity, &digest)?;
+        publish_pin(current, &destination, &digest)?;
+
+        let mut migrated = runtime.clone();
+        migrated["schema"] = json!("homeboy/controller-runtime-pin/v2");
+        migrated["originating"]["sha256"] = json!(digest);
+        migrated["originating"]["pinned_executable"] = json!(destination);
+        for field in ["requested", "current", "executed"] {
+            if migrated.get(field).is_none() || migrated[field].is_null() {
+                migrated[field] = json!(identity);
+            }
+        }
+        validate_pin(&migrated)?;
+        return Ok(migrated);
+    }
+
+    let digest = required_runtime_string(runtime, "/originating/sha256", "content digest")?;
+    let destination = pinned_path(identity, digest)?;
+    if current == destination {
         validate_pin(runtime)?;
         return Ok(runtime.clone());
     }
@@ -349,7 +373,7 @@ pub(crate) fn migrate_legacy_pin(runtime: &Value) -> Result<Value> {
     // Validation includes the digest, executable bit, and advertised identity.
     // Never update durable metadata until the no-clobber publication succeeds.
     validate_pin(runtime)?;
-    publish_pin(Path::new(current), &destination, digest)?;
+    publish_pin(current, &destination, digest)?;
     let mut migrated = runtime.clone();
     migrated["originating"]["pinned_executable"] = json!(destination);
     validate_pin(&migrated)?;
@@ -659,6 +683,52 @@ fn verify_self_identity(path: &Path, expected: &str) -> Result<()> {
     ))
 }
 
+/// v1 records have no digest, so require the historical executable's full
+/// status report to advertise the identity retained by the durable record.
+fn verify_self_status_identity(path: &Path, expected: &str) -> Result<()> {
+    let output = Command::new(path)
+        .args(["self", "status"])
+        .output()
+        .map_err(|error| {
+            Error::validation_invalid_argument(
+                "controller_runtime",
+                format!("legacy controller runtime status check failed: {error}"),
+                Some(path.display().to_string()),
+                None,
+            )
+        })?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let actual = serde_json::from_str::<Value>(&stdout)
+        .ok()
+        .and_then(|value| {
+            value
+                .pointer("/data/active_build_identity/display")
+                .or_else(|| value.pointer("/active_build_identity/display"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        });
+    if !output.status.success() || actual.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "controller_runtime",
+            format!("legacy controller runtime status check returned invalid output: {stdout}"),
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+    let actual = actual.expect("status identity was checked above");
+    if actual == expected {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "controller_runtime",
+        format!(
+            "legacy controller runtime build identity mismatch: expected {expected}, found {actual}"
+        ),
+        Some(path.display().to_string()),
+        None,
+    ))
+}
+
 fn executable_identity(path: &Path) -> Result<String> {
     #[cfg(test)]
     if std::env::current_exe().ok().is_some_and(|current| {
@@ -913,7 +983,7 @@ mod tests {
         fs::write(
             path,
             format!(
-                "#!/bin/sh\n# {marker}\nif [ \"$1\" = self ] && [ \"$2\" = identity ]; then\n  printf '%s\\n' '{{\"data\":{{\"display\":{identity}}}}}'\n  exit 0\nfi\nexit 1\n"
+                "#!/bin/sh\n# {marker}\nif [ \"$1\" = self ] && [ \"$2\" = identity ]; then\n  printf '%s\\n' '{{\"data\":{{\"display\":{identity}}}}}'\n  exit 0\nfi\nif [ \"$1\" = self ] && [ \"$2\" = status ]; then\n  printf '%s\\n' '{{\"data\":{{\"active_build_identity\":{{\"display\":{identity}}}}}}}'\n  exit 0\nfi\nexit 1\n"
             ),
         )
         .expect("write fake controller");
@@ -1141,16 +1211,14 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn legacy_pin_migration_publishes_before_returning_updated_metadata() {
+    fn legacy_v1_pin_migration_publishes_before_returning_updated_metadata() {
         crate::test_support::with_isolated_home(|_| {
             let temporary = tempfile::tempdir().expect("temporary runtime directory");
             let legacy = temporary.path().join("legacy-homeboy");
             let identity = "homeboy test+legacy";
-            let digest = fake_controller(&legacy, identity, "legacy");
             let runtime = json!({ "originating": {
                 "build_identity": identity,
                 "pinned_executable": legacy,
-                "sha256": digest,
             }});
 
             let migrated = migrate_legacy_pin(&runtime).expect("migrate legacy pin");
@@ -1162,6 +1230,10 @@ mod tests {
             assert_ne!(destination, legacy);
             assert!(legacy.exists());
             assert!(destination.is_file());
+            assert_eq!(migrated["schema"], "homeboy/controller-runtime-pin/v2");
+            assert_eq!(migrated["requested"], identity);
+            assert_eq!(migrated["current"], identity);
+            assert_eq!(migrated["executed"], identity);
             validate_pin(&migrated).expect("migrated pin validates");
         });
     }


### PR DESCRIPTION
## Summary
Upgrade historical digestless controller runtime pins from their retained executable so compatible lifecycle mutations can resume safely.

## What changed
- Verify the retained historical executable and exact advertised build identity before computing its SHA-256.
- Publish a content-addressed immutable v2 pin and persist lifecycle metadata only after complete validation.
- Fail closed without record mutation for missing, non-executable, unreadable, or identity-mismatched legacy binaries.

## How to test
1. Run `cargo test -p homeboy-core legacy_v1_pin_migration --lib -- --test-threads=1`; expect success and fail-closed migration tests pass.
2. Run `cargo check --workspace --tests --locked`; expect all workspace test targets compile.
3. Run `rustfmt --edition 2021 --check crates/homeboy-core/src/controller_runtime.rs crates/homeboy-core/src/agent_task_lifecycle/tests.rs`; expect changed files are formatted.
4. Run `git diff --check origin/main...HEAD`; expect no whitespace errors.

## Compatibility
Backwards-compatible recovery for historical v1 runtime records. Existing digest-bearing v2 validation and immutable recovery remain unchanged.

## Evidence
- Base advanced after verification: verified main at ba5462da89072dd005fac74e307c112366e3783c; publication observed 1bac7742051e7cc1df52c434b608abce9de4964e. Candidate ancestry was validated against the verified snapshot.
- CI expected: Repository pull-request CI
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8635
- Verified finalization base: main at ba5462da89072dd005fac74e307c112366e3783c
- changed-file-format: Passed
- diff-check: Passed
- legacy-pin-tests: Passed
- workspace-tests-compile: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed v1 runtime-pin incompatibility, implemented verified content-addressed migration, added fail-closed lifecycle coverage, and ran deterministic verification.

## Source relationships
- Closes #8635
