### PR TITLE
Fix committed NoOp candidate finalization

### DIFF
--- a/crates/homeboy-core/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/promote.rs
@@ -271,12 +271,14 @@ pub(super) fn promote_with_provider_and_checkpoint(
 
     if !matches!(
         outcome.status,
-        AgentTaskOutcomeStatus::Succeeded | AgentTaskOutcomeStatus::CandidateRecoverable
+        AgentTaskOutcomeStatus::Succeeded
+            | AgentTaskOutcomeStatus::CandidateRecoverable
+            | AgentTaskOutcomeStatus::NoOp
     ) {
         return Err(Error::validation_invalid_argument(
             "source",
             format!(
-                "promotion requires a succeeded or recoverable-candidate outcome; task {} has status {:?}",
+                "promotion requires a succeeded, recoverable-candidate, or no-op outcome; task {} has status {:?}",
                 outcome.task_id, outcome.status
             ),
             None,
@@ -298,6 +300,26 @@ pub(super) fn promote_with_provider_and_checkpoint(
             None,
             None,
         ));
+    }
+
+    if outcome.status == AgentTaskOutcomeStatus::NoOp {
+        let committed_patch = committed_changes_patch(&options)?.ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "source",
+                "no-op promotion requires an audited committed candidate after the task base",
+                None,
+                None,
+            )
+        })?;
+        return promote_committed_changes(
+            &options,
+            provider,
+            checkpoint,
+            &source_kind,
+            &outcome,
+            None,
+            committed_patch,
+        );
     }
 
     let artifact = match select_patch_artifact(&outcome, options.artifact_id.as_deref()) {
@@ -753,6 +775,16 @@ fn promote_committed_changes(
     };
     let (gates, verified_base) = verified_base;
     let operator_notification = promotion_notification(gates.status, &target);
+    let candidate = if gates.status == AgentTaskPromotionStatus::Applied {
+        applied_worktree_path
+            .as_deref()
+            .map(|path| {
+                crate::agent_task_promotion::candidate_fingerprint(&path.display().to_string())
+            })
+            .transpose()?
+    } else {
+        None
+    };
 
     Ok(AgentTaskPromotionReport {
         schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
@@ -780,6 +812,7 @@ fn promote_committed_changes(
             "base_ref": committed_patch.base_ref,
             "commit_range": committed_patch.commit_range,
             "commits": committed_patch.commits,
+            "candidate": candidate,
         }),
         operator_notification,
     })

--- a/crates/homeboy-core/src/agent_task_promotion/tests.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/tests.rs
@@ -1215,6 +1215,134 @@ fn promote_reports_no_changes_for_empty_patch_metadata() {
 }
 
 #[test]
+fn promote_no_op_outcome_uses_audited_committed_candidate() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir(&repo).expect("create repo");
+    git(&repo, &["init"]);
+    git(&repo, &["config", "user.email", "agent@example.test"]);
+    git(&repo, &["config", "user.name", "Agent"]);
+    git(&repo, &["checkout", "-b", "main"]);
+    std::fs::write(repo.join("lib.rs"), "base\n").expect("write base");
+    git(&repo, &["add", "lib.rs"]);
+    git(&repo, &["commit", "-m", "base"]);
+    let base = git_head(&repo, "HEAD");
+    std::fs::write(repo.join("lib.rs"), "candidate\n").expect("write candidate");
+    git(&repo, &["commit", "-am", "agent candidate"]);
+
+    let source_path = temp.path().join("outcome.json");
+    let mut outcome = serde_json::json!({
+        "schema": AGENT_TASK_OUTCOME_SCHEMA,
+        "task_id": "task",
+        "status": "succeeded",
+        "artifacts": []
+    });
+    outcome["status"] = Value::String("no_op".to_string());
+    let source = outcome.to_string();
+    std::fs::write(&source_path, &source).expect("write mutated outcome");
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(repo.clone()),
+        ..Default::default()
+    };
+
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("run".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: Some(repo.clone()),
+            base_ref: None,
+            task_base_sha: Some(base.clone()),
+            to_worktree: "repo@promotion".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["true".to_string()],
+                private_verify: Vec::new(),
+                private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+            },
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+    )
+    .expect("audited committed candidate promotes");
+
+    assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
+    assert_eq!(report.patch_artifact.id, "committed-changes");
+    assert_eq!(report.provenance["change_source"], "local_commits");
+    assert_eq!(report.provenance["base_ref"], base);
+    assert_eq!(report.provenance["candidate"]["kind"], "git");
+    assert_eq!(
+        report.provenance["candidate"]["fingerprint"]["head"],
+        git_head(&repo, "HEAD")
+    );
+    assert_eq!(report.provenance["candidate"]["fingerprint"]["base"], base);
+    assert_eq!(report.deterministic_gates.len(), 1);
+    assert_eq!(provider.apply_calls.len(), 1);
+    assert_eq!(provider.verify_calls.len(), 1);
+}
+
+#[test]
+fn promote_no_op_outcome_without_committed_candidate_rejects_before_apply() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir(&repo).expect("create repo");
+    git(&repo, &["init"]);
+    git(&repo, &["config", "user.email", "agent@example.test"]);
+    git(&repo, &["config", "user.name", "Agent"]);
+    std::fs::write(repo.join("lib.rs"), "base\n").expect("write base");
+    git(&repo, &["add", "lib.rs"]);
+    git(&repo, &["commit", "-m", "base"]);
+    let base = git_head(&repo, "HEAD");
+
+    let source_path = temp.path().join("outcome.json");
+    let source = serde_json::json!({
+        "schema": AGENT_TASK_OUTCOME_SCHEMA,
+        "task_id": "task",
+        "status": "no_op",
+        "artifacts": []
+    })
+    .to_string();
+    std::fs::write(&source_path, &source).expect("write no-op outcome");
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(repo.clone()),
+        ..Default::default()
+    };
+
+    let error = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("run".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: Some(repo),
+            base_ref: None,
+            task_base_sha: Some(base),
+            to_worktree: "repo@promotion".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["true".to_string()],
+                private_verify: Vec::new(),
+                private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+            },
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+    )
+    .expect_err("no-op without an audited candidate is rejected");
+
+    assert!(error
+        .message
+        .contains("no-op promotion requires an audited committed candidate"));
+    assert!(provider.apply_calls.is_empty());
+    assert!(provider.verify_calls.is_empty());
+}
+
+#[test]
 fn promote_exports_committed_changes_when_patch_artifact_is_empty() {
     let temp = tempfile::tempdir().expect("tempdir");
     let repo = temp.path().join("repo");


### PR DESCRIPTION
## Summary
Allow successful NoOp reviews to preserve and finalize an existing audited committed candidate.

## What changed
- Route NoOp promotion through the existing committed-changes path, record the post-gate candidate fingerprint, and cover acceptance and rejection paths.

## How to test
1. Run `cargo test -p homeboy-core agent_task_finalization`; expect All focused agent-task finalization tests pass..

## Compatibility
No extension-path or backwards-compatibility impact. True NoOp outcomes without a committed candidate retain their existing rejection behavior.

## Evidence
- Base advanced after verification: verified main at ba5462da89072dd005fac74e307c112366e3783c; publication observed 1bac7742051e7cc1df52c434b608abce9de4964e. Candidate ancestry was validated against the verified snapshot.
- CI expected: Audit
- CI expected: Lint
- CI expected: Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8610
- Verified finalization base: main at ba5462da89072dd005fac74e307c112366e3783c
- focused-tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Implemented the committed-candidate NoOp promotion fix and regression coverage; Chris reviewed and owns the change.

## Source relationships
- Closes #8610
