### PR TITLE
refactor: move ExtensionPhaseTiming value type into the audit contract

### DIFF
--- a/crates/homeboy-audit-contract/src/lib.rs
+++ b/crates/homeboy-audit-contract/src/lib.rs
@@ -5,6 +5,8 @@ pub mod finding_kind;
 pub use finding::{finding_confidence, Finding, FindingConfidence, Severity};
 pub use finding_kind::AuditFinding;
 pub mod fingerprint;
+pub mod phase_timing;
+pub use phase_timing::ExtensionPhaseTiming;
 pub mod result;
 pub mod test_mapping;
 pub use fingerprint::{

--- a/crates/homeboy-audit-contract/src/phase_timing.rs
+++ b/crates/homeboy-audit-contract/src/phase_timing.rs
@@ -1,0 +1,28 @@
+//! Extension runner phase-timing value type.
+//!
+//! A pure serde value type describing one phase of an extension runner's work
+//! (build/lint/test), with duration, an opaque provider-declared status, a
+//! human-readable message, artifacts, and free-form metadata. Core treats every
+//! field as opaque data — it never infers tool-specific behavior from `status`
+//! or `message`. `extension::runner_contract` re-exports this and owns the
+//! runners that produce it; `code_audit` consumes it in its report output.
+
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ExtensionPhaseTiming {
+    pub name: String,
+    pub duration_ms: u64,
+    /// Provider-declared generic state for this phase, for example `running`,
+    /// `waiting`, `blocked`, `queued`, `passed`, or `failed`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// Human-readable provider summary for the phase. Core treats this as
+    /// opaque text and does not infer tool-specific behavior from it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}

--- a/crates/homeboy-core/src/code_audit/core_fingerprint/mod.rs
+++ b/crates/homeboy-core/src/code_audit/core_fingerprint/mod.rs
@@ -37,9 +37,9 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::Path;
 
-use crate::extension::{
-    self, AggregateConstructionSeam, AggregateLiteral, CallSite, DeadCodeMarker, HookRef,
-    UnusedParam,
+use crate::extension;
+use homeboy_audit_contract::{
+    AggregateConstructionSeam, AggregateLiteral, CallSite, DeadCodeMarker, HookRef, UnusedParam,
 };
 use homeboy_engine_primitives::grammar::{self, AggregateSeamConfig, Grammar, Symbol};
 

--- a/crates/homeboy-core/src/code_audit/dead_code.rs
+++ b/crates/homeboy-core/src/code_audit/dead_code.rs
@@ -478,7 +478,7 @@ fn classify_unused_param(
 mod tests {
     use super::*;
     use crate::code_audit::conventions::Language;
-    use crate::extension::{DeadCodeMarker, UnusedParam};
+    use homeboy_audit_contract::{DeadCodeMarker, UnusedParam};
     use std::collections::HashMap;
 
     fn make_fingerprint(

--- a/crates/homeboy-core/src/code_audit/detectors/aggregate_construction.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/aggregate_construction.rs
@@ -132,7 +132,7 @@ fn detect_direct_aggregate_construction(fingerprints: &[&FileFingerprint]) -> Ve
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension::{AggregateConstructionSeam, AggregateLiteral};
+    use homeboy_audit_contract::{AggregateConstructionSeam, AggregateLiteral};
 
     fn file(
         path: &str,

--- a/crates/homeboy-core/src/code_audit/report.rs
+++ b/crates/homeboy-core/src/code_audit/report.rs
@@ -12,7 +12,7 @@ use crate::code_audit::{
     baseline, AuditFinding, CodeAuditResult, ConventionReport, DirectoryConvention,
     FindingConfidence, Severity,
 };
-use crate::extension::ExtensionPhaseTiming;
+use homeboy_audit_contract::ExtensionPhaseTiming;
 use homeboy_finding::HomeboyFinding;
 use serde::Serialize;
 use serde_json::Value;

--- a/crates/homeboy-core/src/extension/runner_contract.rs
+++ b/crates/homeboy-core/src/extension/runner_contract.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
 
@@ -65,23 +65,12 @@ pub struct PhaseFailure {
     pub summary: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ExtensionPhaseTiming {
-    pub name: String,
-    pub duration_ms: u64,
-    /// Provider-declared generic state for this phase, for example `running`,
-    /// `waiting`, `blocked`, `queued`, `passed`, or `failed`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub status: Option<String>,
-    /// Human-readable provider summary for the phase. Core treats this as
-    /// opaque text and does not infer tool-specific behavior from it.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub message: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub artifacts: Vec<serde_json::Value>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub metadata: BTreeMap<String, serde_json::Value>,
-}
+// `ExtensionPhaseTiming` is a pure serde value type that both the extension
+// runners (which produce it) and `code_audit` (which reports it) consume. It
+// lives in `homeboy-audit-contract` so `code_audit` never reaches up into the
+// extension layer for it; this re-export keeps the existing
+// `extension::runner_contract::ExtensionPhaseTiming` path working.
+pub use homeboy_audit_contract::ExtensionPhaseTiming;
 
 pub fn phase_status_from_exit_code(exit_code: i32) -> PhaseStatus {
     if exit_code == 0 {


### PR DESCRIPTION
## Summary
- Moves `ExtensionPhaseTiming` — a pure serde value type — from `extension::runner_contract` into `homeboy-audit-contract`, severing the last `code_audit -> extension` **type** edge in `report.rs`.
- Re-exports it from `extension::runner_contract` so all 10 extension-layer consumers (build/lint/test/runner/review) compile unchanged; `code_audit::report` imports it directly from the contract.
- Also repoints `code_audit`'s remaining contract-owned fingerprint type imports (`HookRef`, `CallSite`, `DeadCodeMarker`, `UnusedParam`, `AggregateConstructionSeam`, `AggregateLiteral`) from the `crate::extension` re-export to `homeboy_audit_contract` directly, matching #8618/#8636.

## Honest edge status for #8425
This clears the `ExtensionPhaseTiming` type edge that #8636's PR body called "the last edge." On fresh `main` there are still **two genuine `code_audit -> extension` behavior edges** remaining, which this PR intentionally does **not** touch (they need hook inversion, not a type move):

1. `code_audit::compiler_warnings` — runs extension compiler/checker scripts (`extensions_for_compiler_warning_contract`, `run_compiler_warning_contract_script`).
2. `code_audit::core_fingerprint::load_grammar_for_ext` — calls `extension::find_extension_for_file_ext` to locate a grammar.

Those are follow-ups (same provider-hook pattern as fingerprint-script/component/fixability). This PR is the clean type-relocation slice.

## Design
- New `homeboy-audit-contract::phase_timing` module holds `ExtensionPhaseTiming` (needs only `serde`/`serde_json`/`BTreeMap`, all already available in the contract). No behavior, no new deps.
- `extension::runner_contract` becomes `pub use homeboy_audit_contract::ExtensionPhaseTiming;` — path-preserving for existing consumers.

## Verification
- `cargo check -p homeboy-audit-contract --lib`, `-p homeboy-core --lib` — 0 errors, no new warnings (dropped the now-unused `BTreeMap` import in `runner_contract`).
- `cargo check --workspace --tests --locked` (topology guard) — **passes**.
- `cargo test -p homeboy-core --lib code_audit::` — **767 passed, 0 failed**.
- One pre-existing unrelated failure (`extension::test::tests::changed_source_without_selected_tests_flags_false_green`, a git-scope test) reproduces on clean `main` and is untouched by this diff.

Refs #8425