### PR TITLE
refactor: invert audit grammar-source resolution behind a provider hook

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -108,6 +108,10 @@ impl CliRuntime {
         // extension fingerprint scripts (for files the core grammar engine can't
         // handle) without depending on the extension script runner.
         crate::core::extension::audit_fingerprint_script_provider::register();
+        // Register the grammar-source provider so code_audit's core fingerprint
+        // engine can load extension-shipped grammars without resolving them
+        // through the extension registry directly.
+        crate::core::extension::audit_grammar_source_provider::register();
         // Register the audit recorded-artifact provider so the artifact-portability
         // detector can read past runs' artifacts from the observation store without
         // code_audit depending on observation — the last seam before audit becomes

--- a/crates/homeboy-core/src/code_audit/core_fingerprint/mod.rs
+++ b/crates/homeboy-core/src/code_audit/core_fingerprint/mod.rs
@@ -37,7 +37,6 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::Path;
 
-use crate::extension;
 use homeboy_audit_contract::{
     AggregateConstructionSeam, AggregateLiteral, CallSite, DeadCodeMarker, HookRef, UnusedParam,
 };
@@ -278,16 +277,15 @@ pub fn fingerprint_from_grammar(
 /// Searches installed extensions for a grammar.toml that handles the given
 /// file extension.
 pub fn load_grammar_for_ext(ext: &str) -> Option<Grammar> {
-    let matched = extension::find_extension_for_file_ext(ext, "fingerprint")?;
-    let extension_path = matched.extension_path.as_deref()?;
+    let grammar_dir = super::grammar_source_provider::grammar_dir_for_ext(ext)?;
 
     // Try grammar.toml first, then grammar.json
-    let grammar_path = Path::new(extension_path).join("grammar.toml");
+    let grammar_path = grammar_dir.join("grammar.toml");
     if grammar_path.exists() {
         return grammar::load_grammar(&grammar_path).ok();
     }
 
-    let grammar_json_path = Path::new(extension_path).join("grammar.json");
+    let grammar_json_path = grammar_dir.join("grammar.json");
     if grammar_json_path.exists() {
         return grammar::load_grammar_json(&grammar_json_path).ok();
     }

--- a/crates/homeboy-core/src/code_audit/detectors/test_coverage.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/test_coverage.rs
@@ -721,7 +721,7 @@ fn is_include_wrapper_for_test_path(
 mod tests {
     use super::*;
     use crate::code_audit::conventions::Language;
-    use crate::extension::{BehaviorScenarioNames, IncludeWrapperPolicy};
+    use homeboy_audit_contract::{BehaviorScenarioNames, IncludeWrapperPolicy};
 
     fn make_config() -> TestMappingConfig {
         TestMappingConfig {

--- a/crates/homeboy-core/src/code_audit/detectors/test_vacuity.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/test_vacuity.rs
@@ -16,7 +16,7 @@ use regex::Regex;
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
-use crate::extension::{PackageNameSource, TestVacuityPolicy};
+use homeboy_audit_contract::{PackageNameSource, TestVacuityPolicy};
 
 /// Resolve a package name from a config-declared manifest source.
 ///

--- a/crates/homeboy-core/src/code_audit/grammar_source_provider.rs
+++ b/crates/homeboy-core/src/code_audit/grammar_source_provider.rs
@@ -1,0 +1,80 @@
+//! Extension-provided grammar sources for the audit engine, inverted behind a
+//! provider.
+//!
+//! The core grammar engine fingerprints a file by loading a grammar
+//! (`grammar.toml`/`grammar.json`) shipped by the extension that handles the
+//! file's extension. Audit used to resolve that by calling
+//! `crate::extension::find_extension_for_file_ext` directly and reading the
+//! matched manifest's `extension_path`, coupling `code_audit` to the extension
+//! registry.
+//!
+//! Instead, audit defines the slim view it needs (file extension → the directory
+//! that holds the grammar) plus a provider trait; the extension layer registers
+//! an implementation at startup (same pattern as the fingerprint-script /
+//! extension-manifest / component / fixability / runner-evidence / tunnel
+//! provider hooks). When no provider is registered — e.g. audit running
+//! standalone — the no-op provider yields no directory, so audit simply loads no
+//! extension grammar (exactly as it does when no such extension is installed)
+//! and falls back to its built-in grammars / extension fingerprint scripts.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+/// The grammar-source contract the audit engine depends on. Implemented by the
+/// extension layer and registered at startup; audit calls it without depending
+/// on the extension registry.
+pub trait GrammarSourceProvider: Send + Sync {
+    /// Return the directory holding the grammar for files with `file_extension`
+    /// (without leading dot), i.e. the extension path of the extension
+    /// registered to fingerprint that file type. Returns `None` when no
+    /// extension handles the file extension or it declares no path on disk.
+    fn grammar_dir(&self, file_extension: &str) -> Option<PathBuf>;
+}
+
+/// Default provider used when no extension layer is registered: no directory, so
+/// audit loads no extension grammar (exactly as when no such extension is
+/// installed).
+struct NoopProvider;
+
+impl GrammarSourceProvider for NoopProvider {
+    fn grammar_dir(&self, _file_extension: &str) -> Option<PathBuf> {
+        None
+    }
+}
+
+static PROVIDER: Mutex<Option<Box<dyn GrammarSourceProvider>>> = Mutex::new(None);
+
+/// Register the grammar-source provider. Called once at binary startup by the
+/// extension layer (via the CLI). Replaces any previously registered provider.
+pub fn register_grammar_source_provider(provider: Box<dyn GrammarSourceProvider>) {
+    let mut guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = Some(provider);
+}
+
+/// Resolve the grammar directory for `file_extension` via the registered
+/// provider.
+pub(crate) fn grammar_dir_for_ext(file_extension: &str) -> Option<PathBuf> {
+    with_provider(|p| p.grammar_dir(file_extension))
+}
+
+fn with_provider<T>(f: impl FnOnce(&dyn GrammarSourceProvider) -> T) -> T {
+    let guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    match guard.as_ref() {
+        Some(provider) => f(provider.as_ref()),
+        None => f(&NoopProvider),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_provider_yields_no_directory() {
+        assert!(NoopProvider.grammar_dir("rs").is_none());
+    }
+}

--- a/crates/homeboy-core/src/code_audit/mod.rs
+++ b/crates/homeboy-core/src/code_audit/mod.rs
@@ -35,6 +35,7 @@ pub(crate) mod findings;
 pub mod fingerprint;
 pub mod fingerprint_script_provider;
 pub mod fixability_provider;
+pub mod grammar_source_provider;
 mod idiomatic;
 pub(crate) mod impact;
 pub(crate) mod import_matching;

--- a/crates/homeboy-core/src/extension/audit_grammar_source_provider.rs
+++ b/crates/homeboy-core/src/extension/audit_grammar_source_provider.rs
@@ -1,0 +1,31 @@
+//! Extension-side implementation of the audit grammar-source provider.
+//!
+//! The audit engine (`code_audit`) defines `GrammarSourceProvider` and calls it
+//! to locate the directory holding the grammar for a file type, without
+//! depending on the extension registry. This module implements that trait by
+//! finding the extension registered to fingerprint the file extension and
+//! returning its on-disk path (which holds `grammar.toml`/`grammar.json`). It is
+//! registered at binary startup by the CLI, mirroring the fingerprint-script /
+//! extension-manifest / component / fixability / runner-evidence / tunnel
+//! provider hooks.
+
+use std::path::PathBuf;
+
+use crate::code_audit::grammar_source_provider::{
+    register_grammar_source_provider, GrammarSourceProvider,
+};
+
+struct ExtensionGrammarSourceProvider;
+
+impl GrammarSourceProvider for ExtensionGrammarSourceProvider {
+    fn grammar_dir(&self, file_extension: &str) -> Option<PathBuf> {
+        let matched = super::find_extension_for_file_ext(file_extension, "fingerprint")?;
+        matched.extension_path.map(PathBuf::from)
+    }
+}
+
+/// Register the extension-backed grammar-source provider. Called once at binary
+/// startup by the CLI.
+pub fn register() {
+    register_grammar_source_provider(Box::new(ExtensionGrammarSourceProvider));
+}

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -1,4 +1,5 @@
 pub mod audit_fingerprint_script_provider;
+pub mod audit_grammar_source_provider;
 pub mod audit_manifest_provider;
 pub mod bench;
 pub mod build;


### PR DESCRIPTION
## Summary
- `code_audit`'s core fingerprint engine (`core_fingerprint::load_grammar_for_ext`) loaded extension-shipped grammars by calling `crate::extension::find_extension_for_file_ext` directly and reading the matched manifest's `extension_path` — a `code_audit -> extension` **behavior** edge.
- Invert it behind a `GrammarSourceProvider` hook, mirroring the fingerprint-script / component / fixability / extension-manifest / runner-evidence provider hooks: `code_audit` owns the trait + a slim view (file extension → grammar directory) + a no-op provider; the extension layer implements it; the CLI registers it at startup.
- `load_grammar_for_ext` keeps the `grammar.toml`/`grammar.json` resolution + parsing (via `homeboy_engine_primitives::grammar`, core-owned) — only the *extension lookup* moves behind the hook.
- Also repoints two more contract-owned type imports to `homeboy_audit_contract` directly (`PackageNameSource`/`TestVacuityPolicy` in `test_vacuity`; `BehaviorScenarioNames`/`IncludeWrapperPolicy` in `test_coverage`).

## Behavior parity
When no provider is registered (audit running standalone), the no-op provider returns no directory, so `load_grammar_for_ext` loads no extension grammar and audit falls back to its built-in grammars / extension fingerprint scripts — exactly as it does when no such extension is installed. This matches the graceful-degradation contract of the other audit provider hooks.

## #8425 status
After this, the **only** remaining `code_audit -> extension` prod edge is the `compiler_warnings` detector (it runs extension compiler/checker scripts — `extensions_for_compiler_warning_contract` / `run_compiler_warning_contract_script`). That's the last follow-up before `code_audit` is extractable, and gets the same hook treatment.

## Verification
- `cargo check -p homeboy-core --lib`, `-p homeboy-cli --lib` — 0 errors, no new warnings (dropped the now-unused `use crate::extension;` in `core_fingerprint`).
- `cargo check --workspace --tests --locked` (topology guard) — **passes**.
- `cargo test -p homeboy-core --lib code_audit::` — **768 passed, 0 failed** (incl. the new no-op grammar-provider test).

Refs #8425