### PR TITLE
refactor: invert audit compiler-warning detection behind a provider hook

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -112,6 +112,10 @@ impl CliRuntime {
         // engine can load extension-shipped grammars without resolving them
         // through the extension registry directly.
         crate::core::extension::audit_grammar_source_provider::register();
+        // Register the compiler-warning provider so code_audit's compiler-warnings
+        // detector can run extension compiler/checker scripts without depending on
+        // the extension script runner.
+        crate::core::extension::audit_compiler_warning_provider::register();
         // Register the audit recorded-artifact provider so the artifact-portability
         // detector can read past runs' artifacts from the observation store without
         // code_audit depending on observation — the last seam before audit becomes

--- a/crates/homeboy-core/src/code_audit/compiler_warning_provider.rs
+++ b/crates/homeboy-core/src/code_audit/compiler_warning_provider.rs
@@ -1,0 +1,93 @@
+//! Extension-provided compiler warnings for the audit engine, inverted behind a
+//! provider.
+//!
+//! The `compiler_warnings` detector surfaces compiler/checker warnings (dead
+//! code, unused imports, unused variables) as audit findings. It gets those
+//! warnings by running extension-owned compiler-warning scripts. Audit used to
+//! do that by calling `crate::extension::{extensions_for_compiler_warning_contract,
+//! run_compiler_warning_contract_script}` directly, coupling `code_audit` to the
+//! extension script runner and its manifest types.
+//!
+//! Instead, audit defines the slim view it needs (a root directory → a list of
+//! warnings) plus a provider trait; the extension layer registers an
+//! implementation at startup that finds the extensions declaring a
+//! compiler-warning script, runs them, and parses their output (same pattern as
+//! the fingerprint-script / grammar-source / component / fixability /
+//! extension-manifest / runner-evidence provider hooks). When no provider is
+//! registered — e.g. audit running standalone — the no-op provider yields no
+//! warnings, so the detector produces no findings (exactly as when no extension
+//! ships a compiler-warning script).
+
+use std::path::Path;
+use std::sync::Mutex;
+
+/// One compiler warning surfaced by an extension's compiler-warning script,
+/// reduced to the fields the audit detector maps into a finding.
+#[derive(Debug, Clone)]
+pub struct AuditCompilerWarning {
+    /// Warning code, e.g. `unused_imports`.
+    pub code: String,
+    /// Human-readable warning message.
+    pub message: String,
+    /// Component-relative file the warning applies to.
+    pub file: String,
+    /// Optional remediation suggestion.
+    pub suggestion: Option<String>,
+}
+
+/// The compiler-warning contract the audit engine depends on. Implemented by the
+/// extension layer and registered at startup; audit calls it without depending
+/// on the extension script runner.
+pub trait CompilerWarningProvider: Send + Sync {
+    /// Run the compiler-warning scripts of every extension declaring one for the
+    /// component rooted at `root`, returning their warnings. Returns an empty
+    /// vec when no extension ships such a script.
+    fn compiler_warnings(&self, root: &Path) -> Vec<AuditCompilerWarning>;
+}
+
+/// Default provider used when no extension layer is registered: no warnings, so
+/// the detector produces no findings (exactly as when no extension ships a
+/// compiler-warning script).
+struct NoopProvider;
+
+impl CompilerWarningProvider for NoopProvider {
+    fn compiler_warnings(&self, _root: &Path) -> Vec<AuditCompilerWarning> {
+        Vec::new()
+    }
+}
+
+static PROVIDER: Mutex<Option<Box<dyn CompilerWarningProvider>>> = Mutex::new(None);
+
+/// Register the compiler-warning provider. Called once at binary startup by the
+/// extension layer (via the CLI). Replaces any previously registered provider.
+pub fn register_compiler_warning_provider(provider: Box<dyn CompilerWarningProvider>) {
+    let mut guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = Some(provider);
+}
+
+/// Collect compiler warnings for `root` via the registered provider.
+pub(crate) fn compiler_warnings_for_root(root: &Path) -> Vec<AuditCompilerWarning> {
+    with_provider(|p| p.compiler_warnings(root))
+}
+
+fn with_provider<T>(f: impl FnOnce(&dyn CompilerWarningProvider) -> T) -> T {
+    let guard = PROVIDER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    match guard.as_ref() {
+        Some(provider) => f(provider.as_ref()),
+        None => f(&NoopProvider),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_provider_yields_no_warnings() {
+        assert!(NoopProvider.compiler_warnings(Path::new("/tmp")).is_empty());
+    }
+}

--- a/crates/homeboy-core/src/code_audit/compiler_warnings.rs
+++ b/crates/homeboy-core/src/code_audit/compiler_warnings.rs
@@ -7,44 +7,19 @@
 
 use std::path::Path;
 
+use super::compiler_warning_provider::AuditCompilerWarning;
 use super::{AuditFinding, Finding, Severity};
-use crate::extension::{
-    extensions_for_compiler_warning_contract, run_compiler_warning_contract_script,
-    CompilerWarningContract, ExtensionManifest,
-};
-
-#[derive(Debug, Clone, serde::Deserialize)]
-struct CompilerWarning {
-    code: String,
-    message: String,
-    file: String,
-    #[serde(rename = "line")]
-    _line: usize,
-    #[serde(default)]
-    suggestion: Option<String>,
-}
-
-#[derive(Debug, Clone, serde::Deserialize)]
-struct CompilerWarningEnvelope {
-    #[serde(default)]
-    warnings: Vec<CompilerWarning>,
-}
 
 /// Run compiler checks and return findings for any warnings detected.
 pub fn run(root: &Path) -> Vec<Finding> {
-    extensions_for_compiler_warning_contract(root, CompilerWarningContract::Warnings)
-        .into_iter()
-        .flat_map(|extension| run_extension_compiler_warnings(&extension, root))
-        .collect()
+    warnings_to_findings(super::compiler_warning_provider::compiler_warnings_for_root(root))
 }
 
-fn run_extension_compiler_warnings(extension: &ExtensionManifest, root: &Path) -> Vec<Finding> {
-    let Some(envelope) = run_compiler_warning_script(extension, root) else {
-        return Vec::new();
-    };
-
-    envelope
-        .warnings
+/// Map the raw compiler warnings from the provider into audit findings, dropping
+/// warnings with empty or absolute file paths (which can't be attributed to a
+/// component-relative source file).
+fn warnings_to_findings(warnings: Vec<AuditCompilerWarning>) -> Vec<Finding> {
+    warnings
         .into_iter()
         .filter(|warning| !warning.file.is_empty() && !warning.file.starts_with('/'))
         .map(|warning| Finding {
@@ -60,90 +35,54 @@ fn run_extension_compiler_warnings(extension: &ExtensionManifest, root: &Path) -
         .collect()
 }
 
-fn run_compiler_warning_script(
-    extension: &ExtensionManifest,
-    root: &Path,
-) -> Option<CompilerWarningEnvelope> {
-    let input = serde_json::json!({
-        "root": root,
-    });
-    let stdout = match run_compiler_warning_contract_script(
-        extension,
-        CompilerWarningContract::Warnings,
-        root,
-        &input,
-    ) {
-        Ok(Some(stdout)) => stdout,
-        Ok(None) => return None,
-        Err(error) => {
-            crate::log_status!("audit", "{}", error);
-            return None;
-        }
-    };
-    serde_json::from_str(&stdout).ok()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
-    use tempfile::TempDir;
 
-    fn write_executable(path: &Path, content: &str) {
-        fs::write(path, content).unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(path).unwrap().permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(path, perms).unwrap();
+    fn warning(
+        code: &str,
+        message: &str,
+        file: &str,
+        suggestion: Option<&str>,
+    ) -> AuditCompilerWarning {
+        AuditCompilerWarning {
+            code: code.to_string(),
+            message: message.to_string(),
+            file: file.to_string(),
+            suggestion: suggestion.map(str::to_string),
         }
     }
 
     #[test]
-    fn run_uses_extension_compiler_warning_script() {
-        crate::test_support::with_isolated_home(|home| {
-            let extension_dir = home.path().join(".config/homeboy/extensions/example");
-            fs::create_dir_all(extension_dir.join("scripts")).unwrap();
-            fs::write(
-                extension_dir.join("example.json"),
-                r#"{
-                    "name": "Example",
-                    "version": "1.0.0",
-                    "scripts": { "compiler_warnings": "scripts/warnings.sh" }
-                }"#,
-            )
-            .unwrap();
-            write_executable(
-                &extension_dir.join("scripts/warnings.sh"),
-                r#"#!/usr/bin/env bash
-cat >/dev/null
-printf '{"warnings":[{"code":"unused_imports","message":"unused import","file":"src/lib.rs","line":3,"suggestion":"Remove import"}]}'
-"#,
-            );
+    fn maps_provider_warnings_into_findings() {
+        let findings = warnings_to_findings(vec![warning(
+            "unused_imports",
+            "unused import",
+            "src/lib.rs",
+            Some("Remove import"),
+        )]);
 
-            let root = TempDir::new().expect("temp dir");
-            let findings = run(root.path());
-
-            assert_eq!(findings.len(), 1);
-            assert_eq!(findings[0].file, "src/lib.rs");
-            assert_eq!(findings[0].kind, AuditFinding::CompilerWarning);
-            assert_eq!(findings[0].description, "[unused_imports] unused import");
-            assert_eq!(findings[0].suggestion, "Remove import");
-        });
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].file, "src/lib.rs");
+        assert_eq!(findings[0].kind, AuditFinding::CompilerWarning);
+        assert_eq!(findings[0].severity, Severity::Warning);
+        assert_eq!(findings[0].description, "[unused_imports] unused import");
+        assert_eq!(findings[0].suggestion, "Remove import");
     }
 
     #[test]
-    fn run_returns_no_findings_without_extension_contract() {
-        crate::test_support::with_isolated_home(|_| {
-            let dir = TempDir::new().expect("temp dir");
-            fs::write(
-                dir.path().join("Cargo.toml"),
-                "[package]\nname = \"test-warn\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
-            )
-            .unwrap();
+    fn drops_absolute_and_empty_paths_and_defaults_suggestion() {
+        let findings = warnings_to_findings(vec![
+            warning("abs", "absolute path", "/etc/passwd", None),
+            warning("empty", "empty path", "", None),
+            warning("dead_code", "never used", "src/x.rs", None),
+        ]);
 
-            assert!(run(dir.path()).is_empty());
-        });
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].file, "src/x.rs");
+        assert_eq!(
+            findings[0].suggestion,
+            "Address compiler warning: dead_code"
+        );
     }
 }

--- a/crates/homeboy-core/src/code_audit/mod.rs
+++ b/crates/homeboy-core/src/code_audit/mod.rs
@@ -18,6 +18,7 @@ pub mod codebase_map;
 mod comment_blocks;
 mod comment_hygiene;
 pub mod compare;
+pub mod compiler_warning_provider;
 mod compiler_warnings;
 pub mod component_provider;
 mod convention_membership;

--- a/crates/homeboy-core/src/extension/audit_compiler_warning_provider.rs
+++ b/crates/homeboy-core/src/extension/audit_compiler_warning_provider.rs
@@ -1,0 +1,166 @@
+//! Extension-side implementation of the audit compiler-warning provider.
+//!
+//! The audit engine (`code_audit`) defines `CompilerWarningProvider` and calls it
+//! to collect compiler/checker warnings for a component, without depending on the
+//! extension script runner. This module implements that trait by finding the
+//! extensions that declare a compiler-warning script, running them, and parsing
+//! their JSON envelopes into the slim `AuditCompilerWarning` view the audit
+//! engine consumes. It is registered at binary startup by the CLI, mirroring the
+//! fingerprint-script / grammar-source / component / fixability /
+//! extension-manifest / runner-evidence provider hooks.
+
+use std::path::Path;
+
+use crate::code_audit::compiler_warning_provider::{
+    register_compiler_warning_provider, AuditCompilerWarning, CompilerWarningProvider,
+};
+
+use super::compiler_warning_contract::{
+    extensions_for_compiler_warning_contract, run_compiler_warning_contract_script,
+    CompilerWarningContract,
+};
+use super::ExtensionManifest;
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct CompilerWarning {
+    code: String,
+    message: String,
+    file: String,
+    #[serde(rename = "line")]
+    _line: usize,
+    #[serde(default)]
+    suggestion: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct CompilerWarningEnvelope {
+    #[serde(default)]
+    warnings: Vec<CompilerWarning>,
+}
+
+struct ExtensionCompilerWarningProvider;
+
+impl CompilerWarningProvider for ExtensionCompilerWarningProvider {
+    fn compiler_warnings(&self, root: &Path) -> Vec<AuditCompilerWarning> {
+        extensions_for_compiler_warning_contract(root, CompilerWarningContract::Warnings)
+            .into_iter()
+            .flat_map(|extension| run_extension_compiler_warnings(&extension, root))
+            .collect()
+    }
+}
+
+fn run_extension_compiler_warnings(
+    extension: &ExtensionManifest,
+    root: &Path,
+) -> Vec<AuditCompilerWarning> {
+    let Some(envelope) = run_compiler_warning_script(extension, root) else {
+        return Vec::new();
+    };
+
+    envelope
+        .warnings
+        .into_iter()
+        .map(|warning| AuditCompilerWarning {
+            code: warning.code,
+            message: warning.message,
+            file: warning.file,
+            suggestion: warning.suggestion,
+        })
+        .collect()
+}
+
+fn run_compiler_warning_script(
+    extension: &ExtensionManifest,
+    root: &Path,
+) -> Option<CompilerWarningEnvelope> {
+    let input = serde_json::json!({
+        "root": root,
+    });
+    let stdout = match run_compiler_warning_contract_script(
+        extension,
+        CompilerWarningContract::Warnings,
+        root,
+        &input,
+    ) {
+        Ok(Some(stdout)) => stdout,
+        Ok(None) => return None,
+        Err(error) => {
+            crate::log_status!("audit", "{}", error);
+            return None;
+        }
+    };
+    serde_json::from_str(&stdout).ok()
+}
+
+/// Register the extension-backed compiler-warning provider. Called once at binary
+/// startup by the CLI.
+pub fn register() {
+    register_compiler_warning_provider(Box::new(ExtensionCompilerWarningProvider));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_executable(path: &Path, content: &str) {
+        fs::write(path, content).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(path).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(path, perms).unwrap();
+        }
+    }
+
+    #[test]
+    fn provider_uses_extension_compiler_warning_script() {
+        crate::test_support::with_isolated_home(|home| {
+            let extension_dir = home.path().join(".config/homeboy/extensions/example");
+            fs::create_dir_all(extension_dir.join("scripts")).unwrap();
+            fs::write(
+                extension_dir.join("example.json"),
+                r#"{
+                    "name": "Example",
+                    "version": "1.0.0",
+                    "scripts": { "compiler_warnings": "scripts/warnings.sh" }
+                }"#,
+            )
+            .unwrap();
+            write_executable(
+                &extension_dir.join("scripts/warnings.sh"),
+                r#"#!/usr/bin/env bash
+cat >/dev/null
+printf '{"warnings":[{"code":"unused_imports","message":"unused import","file":"src/lib.rs","line":3,"suggestion":"Remove import"}]}'
+"#,
+            );
+
+            let root = TempDir::new().expect("temp dir");
+            let warnings = ExtensionCompilerWarningProvider.compiler_warnings(root.path());
+
+            assert_eq!(warnings.len(), 1);
+            assert_eq!(warnings[0].code, "unused_imports");
+            assert_eq!(warnings[0].message, "unused import");
+            assert_eq!(warnings[0].file, "src/lib.rs");
+            assert_eq!(warnings[0].suggestion.as_deref(), Some("Remove import"));
+        });
+    }
+
+    #[test]
+    fn provider_returns_no_warnings_without_extension_contract() {
+        crate::test_support::with_isolated_home(|_| {
+            let dir = TempDir::new().expect("temp dir");
+            fs::write(
+                dir.path().join("Cargo.toml"),
+                "[package]\nname = \"test-warn\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+            )
+            .unwrap();
+
+            assert!(ExtensionCompilerWarningProvider
+                .compiler_warnings(dir.path())
+                .is_empty());
+        });
+    }
+}

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -1,3 +1,4 @@
+pub mod audit_compiler_warning_provider;
 pub mod audit_fingerprint_script_provider;
 pub mod audit_grammar_source_provider;
 pub mod audit_manifest_provider;


### PR DESCRIPTION
## Summary
- `code_audit`'s `compiler_warnings` detector ran extension-owned compiler/checker scripts directly (`extensions_for_compiler_warning_contract` + `run_compiler_warning_contract_script`) and used the extension manifest types — the **last `code_audit -> extension` prod edge**.
- Invert it behind a `CompilerWarningProvider` hook, mirroring the fingerprint-script / grammar-source / component / fixability / extension-manifest / runner-evidence provider hooks.

## Design
- `code_audit::compiler_warning_provider` owns the trait, a slim owned view (`AuditCompilerWarning { code, message, file, suggestion }`), and a no-op provider that yields no warnings.
- `extension::audit_compiler_warning_provider` implements it — finds the extensions declaring a compiler-warning script, runs them, parses their JSON envelopes — and the CLI registers it at startup. The extension-protocol deserialize structs (`CompilerWarning`/`CompilerWarningEnvelope`) move to the extension side with the script runner, so `code_audit` no longer knows the script wire format.
- `code_audit` keeps the finding mapping, factored into a pure `warnings_to_findings` that's unit-tested directly against the slim view (drops empty/absolute paths, defaults the suggestion). The full extension-script end-to-end tests move to the extension provider impl.

## Behavior parity
When no provider is registered (audit running standalone), the no-op provider returns no warnings, so the detector produces no findings — exactly as it does today when no extension ships a compiler-warning script. Same graceful-degradation contract as the other audit hooks.

## #8425 — code_audit is now extractable
This removes the **last** `code_audit -> extension` prod edge. Combined with the already-inverted refactor/component/observation/review/issues edges and the grammar-source (#8660) and `ExtensionPhaseTiming` (#8654) work, `code_audit` has **zero upward feature-layer prod edges**. Remaining `crate::extension` refs in `code_audit` are test-only (a manifest-provider fixture test that registers the provider hook).

## Verification
- `cargo check -p homeboy-core --lib`, `-p homeboy-cli --lib` — 0 errors, no new warnings.
- `cargo check --workspace --tests --locked` (topology guard) — **passes**.
- `cargo test -p homeboy-core --lib code_audit::` — **769 passed, 0 failed**.
- `cargo test -p homeboy-core --lib extension::audit_compiler_warning_provider` — 2 passed (the moved end-to-end tests); `code_audit::compiler_warnings` — 2 passed (the new mapping tests).

Note: builds on the same edge-inversion campaign as #8654 and #8660 (both independent, all based on `main`, not stacked).

Refs #8425