### PR TITLE
Restore recovery overlay before release finalization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -780,6 +780,10 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
 
+      - name: Restore recovery cargo-dist overlay
+        if: needs.prepare.outputs.recovery-release == 'true'
+        run: git restore --source=HEAD -- Cargo.toml
+
       - name: Upload dist-manifest.json
         uses: actions/upload-artifact@v4
         with:

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -432,7 +432,12 @@ fn release_recovery_propagates_dist_opt_in_and_dirty_allowance_through_all_dist_
     assert!(prepare.contains("RECOVERY_RELEASE=\"${{ needs.check.outputs.recovery-release }}\""));
     assert!(prepare.contains("echo \"recovery-release=${RECOVERY_RELEASE}\" >> \"$GITHUB_OUTPUT\""));
 
-    for job in ["plan", "build-local-artifacts", "build-global-artifacts", "host"] {
+    for job in [
+        "plan",
+        "build-local-artifacts",
+        "build-global-artifacts",
+        "host",
+    ] {
         let section = job_section(workflow, job);
         let opt_in = section
             .find("grep -Fqx '[package.metadata.dist]' Cargo.toml")
@@ -467,6 +472,33 @@ fn release_recovery_propagates_dist_opt_in_and_dirty_allowance_through_all_dist_
     }
 
     assert!(cargo_manifest().contains("[package.metadata.dist]\ndist = true"));
+}
+
+#[test]
+fn release_recovery_restores_only_the_cargo_dist_overlay_before_finalization() {
+    let host = job_section(release_workflow(), "host");
+    let cargo_dist_upload = host
+        .find("dist host --tag=${{ needs.prepare.outputs['release-tag'] }} --steps=upload")
+        .expect("host must upload artifacts with cargo-dist");
+    let restore = host
+        .find("- name: Restore recovery cargo-dist overlay")
+        .expect("host must clean up the recovery cargo-dist overlay");
+    let finalize = host
+        .find("- name: Finish Homeboy release pipeline at tag")
+        .expect("host must finalize the Homeboy release pipeline");
+
+    assert!(
+        host.contains("if: needs.prepare.outputs.recovery-release == 'true'"),
+        "only recovery releases may restore the cargo-dist overlay"
+    );
+    assert!(
+        host.contains("run: git restore --source=HEAD -- Cargo.toml"),
+        "cleanup must restore only the intentional Cargo.toml overlay"
+    );
+    assert!(
+        cargo_dist_upload < restore && restore < finalize,
+        "recovery overlay cleanup must follow cargo-dist upload and precede Homeboy finalization"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Restore the intentional historical recovery Cargo.toml overlay before the final Homeboy release action validates the working tree.

## What changed
- Add a recovery-only host step that restores Cargo.toml after cargo-dist upload and before Homeboy finalization.
- Add ordering and scope coverage to the release workflow contract tests.

## How to test
1. Run `cargo test --test release_workflow_test`; expect All 22 release workflow tests pass..
2. Run `rustfmt --check tests/release_workflow_test.rs`; expect The affected test file is formatted..
3. Run `git diff --check`; expect The patch has no whitespace errors..

## Compatibility
No backwards-compatibility impact. Fresh releases are unchanged; recovery still permits only the intentional cargo-dist overlay and the existing dirty-tree guard remains fail-closed for unexpected changes.

## Evidence
- Base advanced after verification: verified main at f277d8760781f37b4d49c63a77008052ca6dd557; publication observed 6e23bcdb0d9083b9faf414da626170b2ae307694. Candidate ancestry was validated against the verified snapshot.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/actions/runs/29552119121
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8657
- Verified finalization base: main at f277d8760781f37b4d49c63a77008052ca6dd557
- diff-check: Passed
- release-workflow-tests: Passed
- scoped-rustfmt: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the release recovery boundary and drafted the workflow fix and deterministic tests; Chris reviewed and owns the change.

## Source relationships
- Closes #8657
