### PR TITLE
Verify exact-ref deployment artifacts

### DIFF
--- a/crates/homeboy-core/src/deploy/orchestration/mod.rs
+++ b/crates/homeboy-core/src/deploy/orchestration/mod.rs
@@ -158,6 +158,15 @@ pub(super) fn deploy_components(
         checkout.verify()?;
         checkout.hydrate_dependencies(config.skip_deps_hydration)?;
     }
+    if let Some(artifact) = config.prepared_artifact.as_ref() {
+        for checkout in &exact_ref_checkouts {
+            artifact.validate_exact_source(
+                &checkout.component.id,
+                config.expected_version.as_deref(),
+                &checkout.identity.resolved_sha,
+            )?;
+        }
+    }
     let components = if exact_ref_checkouts.is_empty() {
         components
     } else {

--- a/crates/homeboy-core/src/deploy/orchestration/modes.rs
+++ b/crates/homeboy-core/src/deploy/orchestration/modes.rs
@@ -117,6 +117,13 @@ pub(super) fn run_dry_run_mode(
                 .with_source_identity(c, config.head);
             if let Some(requested_ref) = config.requested_ref.as_deref() {
                 let identity = resolve_exact_ref(c, requested_ref)?;
+                if let Some(artifact) = config.prepared_artifact.as_ref() {
+                    artifact.validate_exact_source(
+                        &c.id,
+                        config.expected_version.as_deref(),
+                        &identity.resolved_sha,
+                    )?;
+                }
                 result = result.with_exact_ref_identity(
                     &identity.requested_ref,
                     &identity.resolved_sha,
@@ -165,6 +172,16 @@ fn with_dry_run_artifact_plan(
     let is_file_deploy = deploy_config.is_file_deploy();
     if is_git_deploy || is_file_deploy {
         return result;
+    }
+
+    if let Some(artifact) = config.prepared_artifact.as_ref() {
+        result.warnings.push(format!(
+            "artifact source: verified prepared artifact from commit {}; build phase: skipped; deploy phase: would upload prepared artifact",
+            artifact.source_commit
+        ));
+        return result
+            .with_artifact_path(Some(artifact.effective_path().to_string()))
+            .with_artifact_source(DeployArtifactSource::Prepared);
     }
 
     match release_artifact_plan(component, config, is_git_deploy, is_file_deploy) {
@@ -258,6 +275,7 @@ fn latest_deploy_tag(component: &Component, expected_version: Option<&str>) -> R
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::deploy::PreparedDeployArtifact;
     use std::path::Path;
     use std::process::Command;
 
@@ -337,6 +355,81 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn exact_ref_dry_run_reports_verified_prepared_artifact_strategy() {
+        let repo = tempfile::tempdir().expect("repo");
+        git(repo.path(), &["init", "-q"]);
+        git(repo.path(), &["config", "user.name", "Homeboy Test"]);
+        git(
+            repo.path(),
+            &["config", "user.email", "homeboy@example.test"],
+        );
+        std::fs::write(repo.path().join("payload.txt"), "reviewed\n").expect("payload");
+        git(repo.path(), &["add", "payload.txt"]);
+        git(repo.path(), &["commit", "-q", "-m", "reviewed"]);
+        let sha = git_output(repo.path(), &["rev-parse", "HEAD"]);
+        let artifact_path = repo.path().join("fixture.zip");
+        std::fs::write(&artifact_path, "prepared bytes").expect("artifact");
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: repo.path().to_string_lossy().to_string(),
+            remote_path: "components/fixture".to_string(),
+            build_artifact: Some("build/fixture.zip".to_string()),
+            ..Component::default()
+        };
+        let mut config = DeployConfig {
+            component_ids: vec!["fixture".to_string()],
+            all: false,
+            outdated: false,
+            behind_upstream: false,
+            dry_run: true,
+            check: false,
+            force: false,
+            skip_build: false,
+            keep_deps: false,
+            skip_deps_hydration: false,
+            expected_version: None,
+            no_pull: false,
+            allow_stale_source: false,
+            allow_downgrade: false,
+            head: false,
+            requested_ref: Some(sha.clone()),
+            tagged: false,
+            prepared_artifact: None,
+            resume_run_id: None,
+        };
+        config.prepared_artifact = Some(PreparedDeployArtifact {
+            component_id: "fixture".to_string(),
+            path: artifact_path.display().to_string(),
+            durable_path: artifact_path.display().to_string(),
+            size_bytes: "prepared bytes".len() as u64,
+            sha256: crate::deploy::sha256_file(&artifact_path).expect("sha"),
+            version: String::new(),
+            tag: "prepared".to_string(),
+            source_commit: sha,
+        });
+
+        let result = run_dry_run_mode(
+            std::slice::from_ref(&component),
+            &HashMap::new(),
+            &HashMap::new(),
+            &Project::default(),
+            "/srv/site",
+            &config,
+        )
+        .expect("dry-run plan");
+        let evidence = &result.results[0];
+
+        assert_eq!(
+            evidence.artifact_source,
+            Some(DeployArtifactSource::Prepared)
+        );
+        assert!(evidence
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("verified prepared artifact")));
     }
 
     #[test]

--- a/crates/homeboy-core/src/deploy/orchestration/prepared_payloads.rs
+++ b/crates/homeboy-core/src/deploy/orchestration/prepared_payloads.rs
@@ -56,8 +56,9 @@ pub(super) fn prepare_component_deployments(
                 let mut preparation_config = effective_config.clone();
                 // The existing detached checkout is the authoritative exact-ref source.
                 preparation_config.requested_ref = None;
-                let request =
+                let mut request =
                     ComponentPayloadPreparationRequest::new(&component, &preparation_config);
+                request.config.exact_ref_materialized = config.requested_ref.is_some();
                 if let Some(lease) = release_artifacts.get(&component.id).cloned() {
                     if let Err(error) = payloads.insert(request.clone(), Some(lease)) {
                         failures.push(ComponentDeployResult::failed(

--- a/crates/homeboy-core/src/deploy/preparation.rs
+++ b/crates/homeboy-core/src/deploy/preparation.rs
@@ -221,6 +221,9 @@ pub(crate) struct PreparationConfig {
     pub requested_ref: Option<String>,
     pub tagged: bool,
     pub prepared_artifact: Option<PreparedDeployArtifact>,
+    /// An exact-ref checkout was materialized by the caller and is the only
+    /// eligible local source for this payload.
+    pub exact_ref_materialized: bool,
 }
 
 impl From<&DeployConfig> for PreparationConfig {
@@ -236,6 +239,7 @@ impl From<&DeployConfig> for PreparationConfig {
             requested_ref: config.requested_ref.clone(),
             tagged: config.tagged,
             prepared_artifact: config.prepared_artifact.clone(),
+            exact_ref_materialized: false,
         }
     }
 }
@@ -457,21 +461,34 @@ fn prepare_payload(
         .unwrap_or(component);
     let exact_ref = checkout.as_ref().map(|checkout| checkout.identity.clone());
 
-    let release_artifact = match release_artifact_plan(
-        &component,
-        &DeployConfig::from_preparation(request),
-        false,
-        false,
-    ) {
-        ReleaseArtifactPlan::Reuse { tag, .. } => Some(match retained_release_artifact {
-            Some(artifact) => artifact,
-            None => resolve_planned_release_artifact(&component, &tag, release_artifacts).map_err(
-                |message| {
-                    Error::validation_invalid_argument("releaseArtifact", message, None, None)
-                },
-            )?,
-        }),
-        ReleaseArtifactPlan::LocalBuild { .. } => None,
+    // A successful extension build is not proof that it overwrote an artifact
+    // already present in the selected source tree. Remove every local candidate
+    // first: the build must produce exact-ref bytes, or preparation fails closed.
+    if exact_ref.is_some() || request.config.exact_ref_materialized {
+        remove_exact_ref_artifacts(&component)?;
+    }
+
+    let release_artifact = if request.config.exact_ref_materialized {
+        // `requested_ref` is intentionally cleared after materialization so the
+        // prepared payload does not create another worktree. Keep its source
+        // policy explicit: an exact ref cannot fall back to a release asset.
+        None
+    } else {
+        match release_artifact_plan(
+            &component,
+            &DeployConfig::from_preparation(request),
+            false,
+            false,
+        ) {
+            ReleaseArtifactPlan::Reuse { tag, .. } => Some(match retained_release_artifact {
+                Some(artifact) => artifact,
+                None => resolve_planned_release_artifact(&component, &tag, release_artifacts)
+                    .map_err(|message| {
+                        Error::validation_invalid_argument("releaseArtifact", message, None, None)
+                    })?,
+            }),
+            ReleaseArtifactPlan::LocalBuild { .. } => None,
+        }
     };
     let mut generated_source_artifact = None;
     if release_artifact.is_none() && !request.config.skip_build {
@@ -626,6 +643,85 @@ fn artifact_path(component: &Component) -> Result<PathBuf> {
                 None,
             )
         })
+}
+
+fn remove_exact_ref_artifacts(component: &Component) -> Result<()> {
+    let artifact = component.build_artifact.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "build_artifact",
+            "Component has no build artifact to prepare",
+            None,
+            None,
+        )
+    })?;
+    let source_root = Path::new(&component.local_path);
+    let pattern = if Path::new(artifact).is_absolute() {
+        PathBuf::from(artifact)
+    } else {
+        source_root.join(artifact)
+    };
+    let candidates = if artifact.contains(['*', '?', '[', ']']) {
+        glob::glob(&pattern.to_string_lossy())
+            .map_err(|error| {
+                Error::validation_invalid_argument(
+                    "build_artifact",
+                    format!("Invalid build artifact pattern '{}': {error}", artifact),
+                    Some(artifact.to_string()),
+                    None,
+                )
+            })?
+            .filter_map(std::result::Result::ok)
+            .collect()
+    } else {
+        vec![pattern]
+    };
+    for candidate in candidates {
+        if !candidate.starts_with(source_root) {
+            return Err(Error::validation_invalid_argument(
+                "build_artifact",
+                format!(
+                    "Exact-ref artifact '{}' is outside verified source tree '{}'; refusing to reuse unverified package bytes",
+                    candidate.display(),
+                    source_root.display()
+                ),
+                Some(candidate.display().to_string()),
+                None,
+            ));
+        }
+        let metadata = match std::fs::symlink_metadata(&candidate) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(Error::internal_io(
+                    format!("Failed to inspect exact-ref artifact: {error}"),
+                    Some(candidate.display().to_string()),
+                ));
+            }
+        };
+        let result = if metadata.file_type().is_symlink() || metadata.is_file() {
+            // Unlink symlinks rather than following them outside the materialized tree.
+            std::fs::remove_file(&candidate)
+        } else if metadata.is_dir() {
+            std::fs::remove_dir_all(&candidate)
+        } else {
+            return Err(Error::validation_invalid_argument(
+                "build_artifact",
+                format!(
+                    "Exact-ref artifact '{}' has an unsupported filesystem type",
+                    candidate.display()
+                ),
+                Some(candidate.display().to_string()),
+                None,
+            ));
+        };
+        result.map_err(|error| {
+            Error::internal_io(
+                format!("Failed to invalidate exact-ref artifact: {error}"),
+                Some(candidate.display().to_string()),
+            )
+        })?;
+    }
+    Ok(())
 }
 
 impl DeployConfig {
@@ -1319,5 +1415,128 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn exact_ref_default_extension_build_replaces_stale_artifact_and_records_source_commit() {
+        crate::test_support::with_isolated_home(|home| {
+            fn git(path: &Path, args: &[&str]) -> String {
+                let output = std::process::Command::new("git")
+                    .args(args)
+                    .current_dir(path)
+                    .output()
+                    .expect("run git");
+                assert!(output.status.success(), "git {:?}: {:?}", args, output);
+                String::from_utf8(output.stdout)
+                    .expect("git output")
+                    .trim()
+                    .to_string()
+            }
+
+            let extension_dir = home
+                .path()
+                .join(".config/homeboy/extensions/fixture-packager");
+            std::fs::create_dir_all(&extension_dir).expect("extension directory");
+            std::fs::write(
+                extension_dir.join("fixture-packager.json"),
+                r#"{"name":"fixture-packager","version":"1.0.0","build":{"extension_script":"build.sh"}}"#,
+            )
+            .expect("extension manifest");
+            std::fs::write(
+                extension_dir.join("build.sh"),
+                "mkdir -p build\n[ -f build/fixture.zip ] || cat payload.txt > build/fixture.zip\n",
+            )
+            .expect("extension build script");
+
+            let repo = tempfile::tempdir().expect("repo");
+            git(repo.path(), &["init", "-q"]);
+            git(
+                repo.path(),
+                &["config", "user.email", "homeboy@example.test"],
+            );
+            git(repo.path(), &["config", "user.name", "Homeboy Test"]);
+            std::fs::write(repo.path().join("payload.txt"), "stale source\n")
+                .expect("stale payload");
+            std::fs::create_dir_all(repo.path().join("build")).expect("build directory");
+            std::fs::write(repo.path().join("build/fixture.zip"), "stale artifact\n")
+                .expect("stale artifact");
+            git(repo.path(), &["add", "."]);
+            git(repo.path(), &["commit", "-q", "-m", "stale artifact"]);
+
+            std::fs::write(repo.path().join("payload.txt"), "requested source\n")
+                .expect("requested payload");
+            git(repo.path(), &["commit", "-am", "requested source", "-q"]);
+            git(repo.path(), &["branch", "requested"]);
+            let requested_sha = git(repo.path(), &["rev-parse", "requested"]);
+
+            std::fs::write(repo.path().join("payload.txt"), "configured source\n")
+                .expect("configured payload");
+            git(repo.path(), &["commit", "-am", "configured source", "-q"]);
+
+            let mut component = component();
+            component.local_path = repo.path().display().to_string();
+            component.build_artifact = Some("build/fixture.zip".to_string());
+            component.remote_url = Some("https://github.com/example/fixture".to_string());
+            component.extensions = Some(HashMap::from([(
+                "fixture-packager".to_string(),
+                ScopedExtensionConfig::default(),
+            )]));
+            let mut deploy_config = config();
+            deploy_config.requested_ref = Some("requested".to_string());
+            deploy_config.skip_deps_hydration = true;
+            let request = ComponentPayloadPreparationRequest::new(&component, &deploy_config);
+            let mut collection = PreparedPayloadCollection::default();
+            let payload = collection
+                .prepare(request, &mut ReleaseArtifactStore::default())
+                .expect("prepare exact ref");
+
+            assert_eq!(
+                std::fs::read_to_string(payload.artifact.effective_path()).expect("payload bytes"),
+                "requested source\n"
+            );
+            assert_eq!(payload.source_commit, requested_sha);
+            assert_eq!(payload.artifact.source_commit, requested_sha);
+        });
+    }
+
+    #[test]
+    fn exact_ref_invalidation_removes_in_source_directories_and_unlinks_symlinks() {
+        let source = tempfile::tempdir().expect("source");
+        let artifact = source.path().join("build/artifact");
+        std::fs::create_dir_all(&artifact).expect("artifact directory");
+        std::fs::write(artifact.join("stale.txt"), "stale").expect("stale directory artifact");
+
+        let mut component = component();
+        component.local_path = source.path().display().to_string();
+        component.build_artifact = Some("build/artifact".to_string());
+        remove_exact_ref_artifacts(&component).expect("remove directory artifact");
+        assert!(
+            !artifact.exists(),
+            "exact-ref preparation must invalidate stale directory artifacts"
+        );
+
+        #[cfg(unix)]
+        {
+            let external = tempfile::tempdir().expect("external");
+            let external_artifact = external.path().join("artifact");
+            std::fs::create_dir_all(&external_artifact).expect("external artifact directory");
+            std::fs::write(external_artifact.join("preserved.txt"), "external")
+                .expect("external artifact content");
+            let symlink = source.path().join("build/artifact-link");
+            std::fs::create_dir_all(symlink.parent().expect("symlink parent"))
+                .expect("symlink parent directory");
+            std::os::unix::fs::symlink(&external_artifact, &symlink).expect("directory symlink");
+
+            component.build_artifact = Some("build/artifact-link".to_string());
+            remove_exact_ref_artifacts(&component).expect("unlink directory symlink");
+            assert!(
+                std::fs::symlink_metadata(&symlink).is_err(),
+                "exact-ref preparation must remove the in-source symlink"
+            );
+            assert!(
+                external_artifact.join("preserved.txt").is_file(),
+                "exact-ref preparation must not traverse or delete an external symlink target"
+            );
+        }
     }
 }

--- a/crates/homeboy-core/src/deploy/types.rs
+++ b/crates/homeboy-core/src/deploy/types.rs
@@ -216,6 +216,29 @@ impl PreparedDeployArtifact {
         }
         Ok(())
     }
+
+    /// An exact ref can reuse a prepared artifact only when its immutable source
+    /// identity was recorded at that same commit.
+    pub(crate) fn validate_exact_source(
+        &self,
+        component_id: &str,
+        expected_version: Option<&str>,
+        resolved_sha: &str,
+    ) -> Result<()> {
+        self.validate(component_id, expected_version)?;
+        if self.source_commit != resolved_sha {
+            return Err(crate::error::Error::validation_invalid_argument(
+                "prepared_artifact.source_commit",
+                format!(
+                    "Prepared artifact source commit '{}' does not match exact ref commit '{}'",
+                    self.source_commit, resolved_sha
+                ),
+                None,
+                None,
+            ));
+        }
+        Ok(())
+    }
 }
 
 pub(crate) fn sha256_file(path: &Path) -> Result<String> {
@@ -1132,6 +1155,12 @@ mod tests {
 
         assert!(artifact.validate("fixture", Some("1.2.3")).is_ok());
         assert!(artifact.validate("fixture", Some("1.2.4")).is_err());
+        assert!(artifact
+            .validate_exact_source("fixture", Some("1.2.3"), "0123456789abcdef")
+            .is_ok());
+        assert!(artifact
+            .validate_exact_source("fixture", Some("1.2.3"), "fedcba9876543210")
+            .is_err());
 
         std::fs::write(&artifact_path, "changed bytes").expect("changed artifact");
         assert!(artifact.validate("fixture", Some("1.2.3")).is_err());


### PR DESCRIPTION
## Summary
Bind exact-ref deployments to artifacts proven or rebuilt from the requested immutable source commit.

## What changed
- Invalidate stale file and directory artifact candidates inside exact-ref materializations before build/package; safely unlink symlinks without traversing targets.
- Prevent materialized exact refs from falling back to release assets and require prepared artifact source\_commit to equal resolved\_sha.
- Align dry-run reporting with verified prepared-artifact acquisition and add high-signal regression coverage.

## How to test
1. Run `cargo test -p homeboy-core exact_ref_default_extension_build_replaces_stale_artifact_and_records_source_commit --lib`; expect The stale artifact is replaced with requested-ref bytes and provenance records the requested commit..
2. Run `cargo test -p homeboy-core exact_ref_invalidation_removes_in_source_directories_and_unlinks_symlinks --lib`; expect Directory artifacts are invalidated and symlink targets remain untouched..
3. Run `cargo test -p homeboy-core exact_ref_dry_run_reports_verified_prepared_artifact_strategy --lib`; expect Dry-run reports the verified prepared strategy..
4. Run `cargo test -p homeboy-core prepared_artifact_rejects_changed_bytes_and_version_before_deploy --lib`; expect Prepared artifact identity mismatches fail before deployment..
5. Run `rustfmt --check --edition 2021 crates/homeboy-core/src/deploy/preparation.rs crates/homeboy-core/src/deploy/orchestration/prepared_payloads.rs crates/homeboy-core/src/deploy/orchestration/mod.rs crates/homeboy-core/src/deploy/orchestration/modes.rs crates/homeboy-core/src/deploy/types.rs`; expect Changed Rust files are formatted..
6. Run `git diff --check origin/main...HEAD`; expect The committed diff has no whitespace errors..

## Compatibility
Verified release-asset reuse remains unchanged. Exact-ref deploys now rebuild/package from detached source or fail closed when artifact identity cannot be proven, replacing unsafe stale-artifact reuse.

## Evidence
- Base unchanged since verification: main remains at 4dd03157102e31827b7e3156ede26c86c34a98b5.
- CI expected: Audit
- CI expected: Lint
- CI expected: Test
- Reviewer-resolvable source evidence: https://github.com/Automattic/markdown-database-integration/pull/121
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8662
- Verified finalization base: main at 4dd03157102e31827b7e3156ede26c86c34a98b5
- diff-check: Passed
- directory-symlink: Passed
- dry-run-strategy: Passed
- exact-ref-file: Passed
- prepared-identity: Passed
- scoped-format: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy and OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed false exact-ref deployment provenance, prepared the generic owning-layer repair and deterministic regressions, and verified focused deploy gates; Chris reviews and owns the change.

## Source relationships
- Closes #8662
