### PR TITLE
Require complete assets in release recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -524,6 +524,7 @@ jobs:
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag-flag: ${{ format('--tag={0}', needs.prepare.outputs['release-tag']) }}
+      expected-assets: ${{ steps.plan.outputs.expected-assets }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -557,6 +558,12 @@ jobs:
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+          EXPECTED_ASSETS="$(jq -c '[.releases[].artifacts[]? | split("/") | last] | unique' plan-dist-manifest.json)"
+          if [ "$(jq 'length' <<< "${EXPECTED_ASSETS}")" -eq 0 ]; then
+            echo "::error::cargo-dist planned no release assets"
+            exit 1
+          fi
+          echo "expected-assets=${EXPECTED_ASSETS}" >> "$GITHUB_OUTPUT"
 
       - name: Upload dist-manifest.json
         uses: actions/upload-artifact@v4
@@ -569,7 +576,7 @@ jobs:
     needs:
       - prepare
       - plan
-    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null }}
+    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != '' && needs.plan.result == 'success' && fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
@@ -646,6 +653,7 @@ jobs:
       - prepare
       - plan
       - build-local-artifacts
+    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != '' && needs.plan.result == 'success' && (fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include == null || needs.build-local-artifacts.result == 'success') }}
     runs-on: ubuntu-22.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -735,7 +743,7 @@ jobs:
       - plan
       - build-local-artifacts
       - build-global-artifacts
-    if: ${{ always() && needs.plan.result == 'success' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != '' && needs.plan.result == 'success' && needs.build-global-artifacts.result == 'success' && (fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include == null || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -746,6 +754,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.prepare.outputs['release-tag'] }}
+          fetch-depth: 0
           persist-credentials: false
           submodules: recursive
 
@@ -821,20 +830,44 @@ jobs:
     name: Verify GitHub Release published
     needs:
       - prepare
+      - plan
       - host
     if: ${{ always() && needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != '' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Enforce publish completed
+      - name: Verify planned release assets
         env:
           RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
           HOST_RESULT: ${{ needs.host.result }}
+          EXPECTED_ASSETS: ${{ needs.plan.outputs.expected-assets }}
         run: |
           if [ "${HOST_RESULT}" != "success" ]; then
             echo "::error::Release ${RELEASE_TAG} was prepared and tagged but the Create GitHub Release job did not succeed (result: ${HOST_RESULT}). The tag exists with no GitHub Release. Investigate the plan/build/host publish chain; recover with a workflow_dispatch run using release_tag=${RELEASE_TAG}."
             exit 1
           fi
-          echo "::notice::Release ${RELEASE_TAG} published successfully."
+
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" > release.json
+          missing=()
+          invalid=()
+          while IFS= read -r asset; do
+            matches="$(jq -c --arg name "${asset}" '[.assets[] | select(.name == $name)]' release.json)"
+            if [ "${matches}" = "[]" ]; then
+              missing+=("${asset}")
+            elif ! jq -e --arg name "${asset}" '.assets[] | select(.name == $name and .state == "uploaded" and .size > 0)' release.json >/dev/null; then
+              invalid+=("${asset}: $(jq -c --arg name "${asset}" '[.assets[] | select(.name == $name) | {state, size}]' release.json)")
+            fi
+          done < <(jq -r '.[]' <<< "${EXPECTED_ASSETS}")
+
+          if [ "${#missing[@]}" -gt 0 ] || [ "${#invalid[@]}" -gt 0 ]; then
+            [ "${#missing[@]}" -eq 0 ] || echo "::error::Release ${RELEASE_TAG} is missing planned assets: ${missing[*]}"
+            [ "${#invalid[@]}" -eq 0 ] || echo "::error::Release ${RELEASE_TAG} has planned assets that are not uploaded or are zero bytes: ${invalid[*]}"
+            exit 1
+          fi
+          echo "::notice::Release ${RELEASE_TAG} contains every planned asset."
 
   announce:
     needs:

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -342,6 +342,7 @@ fn release_prepare_uses_prepared_output_to_unlock_publish_jobs() {
 
 #[test]
 fn release_fails_loudly_when_prepared_release_does_not_publish() {
+    let plan = job_section(release_workflow(), "plan");
     let verify = job_section(release_workflow(), "verify-published");
 
     // The guard must run whenever a release was actually prepared, even if
@@ -352,6 +353,16 @@ fn release_fails_loudly_when_prepared_release_does_not_publish() {
     );
     assert!(verify.contains("needs.prepare.outputs.prepared == 'true'"));
     assert!(verify.contains("needs.prepare.outputs['release-tag'] != ''"));
+    assert!(verify.contains("- plan"));
+    assert!(verify.contains("contents: read"));
+    assert!(verify.contains("GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}"));
+    assert!(plan.contains("expected-assets: ${{ steps.plan.outputs.expected-assets }}"));
+    assert!(plan.contains(".releases[].artifacts[]? | split(\"/\") | last"));
+    assert!(plan.contains("cargo-dist planned no release assets"));
+    assert!(verify.contains("EXPECTED_ASSETS: ${{ needs.plan.outputs.expected-assets }}"));
+    assert!(verify.contains("gh api \"repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}\""));
+    assert!(verify.contains(".state == \"uploaded\" and .size > 0"));
+    assert!(verify.contains("missing planned assets"));
 
     // It must fail the run when host did not succeed.
     assert!(verify.contains("needs.host.result"));
@@ -370,6 +381,46 @@ fn release_fails_loudly_when_prepared_release_does_not_publish() {
     let clear_failure = job_section(release_workflow(), "clear-failure");
     assert!(record_failure.contains("- verify-published"));
     assert!(clear_failure.contains("- verify-published"));
+}
+
+#[test]
+fn release_artifact_builds_survive_recovery_skips_but_fail_closed_on_required_builds() {
+    let workflow = release_workflow();
+    let local = job_section(workflow, "build-local-artifacts");
+    let global = job_section(workflow, "build-global-artifacts");
+    let host = job_section(workflow, "host");
+
+    for section in [local, global, host] {
+        assert!(section.contains("always()"));
+        assert!(section.contains("needs.prepare.result == 'success'"));
+        assert!(section.contains("needs.plan.result == 'success'"));
+        assert!(section.contains("needs.prepare.outputs.prepared == 'true'"));
+    }
+
+    assert!(local.contains("artifacts_matrix.include != null"));
+    assert!(global.contains(
+        "artifacts_matrix.include == null || needs.build-local-artifacts.result == 'success'"
+    ));
+    assert!(host.contains("needs.build-global-artifacts.result == 'success'"));
+    assert!(host.contains(
+        "artifacts_matrix.include == null || needs.build-local-artifacts.result == 'success'"
+    ));
+    assert!(!host.contains("needs.build-global-artifacts.result == 'skipped'"));
+    assert!(!host.contains("needs.build-local-artifacts.result == 'skipped'"));
+}
+
+#[test]
+fn release_host_checkout_fetches_full_history_for_finalizer_ancestry_validation() {
+    let host = job_section(release_workflow(), "host");
+    let checkout = host
+        .find("uses: actions/checkout@v4")
+        .expect("host must check out the release tag");
+    let finalizer = host
+        .find("Finish Homeboy release pipeline at tag")
+        .expect("host must finalize the release");
+
+    assert!(checkout < finalizer);
+    assert!(host[checkout..finalizer].contains("fetch-depth: 0"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Make existing-tag recovery build every planned artifact, validate the complete planned asset set, and provide full ancestry to Homeboy finalization.

## What changed
- Propagate recovery through local/global build jobs with explicit success gates and require required builds before host publication.
- Export the generic cargo-dist expected asset set and fail verification on missing, incomplete, or zero-byte planned assets.
- Fetch full tag/default-branch history in the host job so remote-sync can distinguish reachable historical tags from divergent tags.

## How to test
1. Run `cargo test --test release_workflow_test`; expect All 24 release workflow contract tests pass..
2. Run `rustfmt --check tests/release_workflow_test.rs`; expect The affected Rust test is formatted..
3. Run `git diff --check`; expect The patch has no whitespace errors..

## Compatibility
No backwards-compatibility impact to Homeboy CLI consumers. Release recovery becomes stricter: workflows that previously reported success with skipped required builds or incomplete assets now fail closed. Immutable tag handling and fresh-release behavior remain unchanged.

## Evidence
- Base unchanged since verification: main remains at 4dd03157102e31827b7e3156ede26c86c34a98b5.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/actions/runs/29554150061
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/actions/runs/29554150061/artifacts/8396946911
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/actions/runs/29554152037
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8668
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8669
- Verified finalization base: main at 4dd03157102e31827b7e3156ede26c86c34a98b5
- diff-check: Passed
- real-manifest-extraction: Passed
- release-workflow-tests: Passed
- scoped-rustfmt: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed skipped recovery builds and shallow ancestry validation, then drafted and reviewed the fail-closed workflow repair and tests; Chris reviewed and owns the change.

## Source relationships
- Closes #8668
- Closes #8669
