### PR TITLE
Mark terminal agent-task liveness accurately

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -1089,7 +1089,7 @@ fn compact_status_summary(record: &Value, run_id: &str) -> Value {
         "execution_location": execution_location(record),
         "queue_visibility": queue_visibility(record),
         "execution_budget": plan.as_ref().map(|plan| &plan.options.execution_budget),
-        "liveness": liveness_summary(record),
+        "liveness": liveness_summary(record, run_id),
         "full_command": format!("homeboy agent-task status {run_id} --full"),
     });
 
@@ -1126,7 +1126,7 @@ fn compact_status_summary(record: &Value, run_id: &str) -> Value {
     summary
 }
 
-fn liveness_summary(record: &Value) -> Value {
+fn liveness_summary(record: &Value, run_id: &str) -> Value {
     let metadata = record.get("metadata").unwrap_or(&Value::Null);
     let provider_handle_count = record
         .get("provider_handles")
@@ -1140,9 +1140,13 @@ fn liveness_summary(record: &Value) -> Value {
         .get("runner_job_id")
         .and_then(Value::as_str)
         .filter(|job_id| !job_id.trim().is_empty());
+    let terminal = record
+        .get("state")
+        .and_then(Value::as_str)
+        .is_some_and(|state| matches!(state, "succeeded" | "failed" | "cancelled"));
 
     json!({
-        "status": if stale { "stale" } else { "active" },
+        "status": if terminal { "terminal" } else if stale { "stale" } else { "active" },
         "heartbeat_last_seen_at": record.pointer("/lifecycle/heartbeat/last_seen_at"),
         "runner_job_status": metadata.get("runner_job_status"),
         "runner_job_last_seen_at": metadata.get("runner_job_last_seen_at"),
@@ -1152,10 +1156,12 @@ fn liveness_summary(record: &Value) -> Value {
             "runner_job_id": runner_job_id,
         },
         "stale_reason": metadata.get("stale_running_reason"),
-        "next_action": if stale {
-            "homeboy agent-task active --reconcile"
+        "next_action": if terminal {
+            format!("homeboy agent-task review {run_id}")
+        } else if stale {
+            "homeboy agent-task active --reconcile".to_string()
         } else {
-            "homeboy agent-task status <run-id> --full"
+            "homeboy agent-task status <run-id> --full".to_string()
         },
     })
 }
@@ -1719,6 +1725,11 @@ mod tests {
         assert_eq!(
             summary["queue_visibility"]["commands"][0],
             "homeboy agent-task list"
+        );
+        assert_eq!(summary["liveness"]["status"], "terminal");
+        assert_eq!(
+            summary["liveness"]["next_action"],
+            "homeboy agent-task review agent-task-run-1"
         );
         assert!(summary["queue_visibility"]["concurrency_note"]
             .as_str()


### PR DESCRIPTION
## Summary
Report terminal liveness for completed agent-task runs instead of presenting succeeded work as still active.

## What changed
- Project terminal lifecycle state into status liveness and expose the appropriate review follow-up action.

## How to test
1. Run `cargo test -p homeboy-cli agent_task::status --no-default-features`; expect All eight agent-task status tests pass..
2. Run `git diff --check`; expect No whitespace errors are present..

## Compatibility
Status JSON becomes more accurate for terminal runs; active-run behavior and execution contracts are unchanged.

## Evidence
- Base unchanged since verification: main remains at 4dd03157102e31827b7e3156ede26c86c34a98b5.
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8659
- Verified finalization base: main at 4dd03157102e31827b7e3156ede26c86c34a98b5
- diff-check: Passed
- status-tests: Passed
- touched-format: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding task via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Reproduced the stale liveness projection, implemented the terminal mapping, and added deterministic coverage; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8659
