### PR TITLE
Declare shared rig template roots

### DIFF
--- a/crates/homeboy-core/src/rig/discovery.rs
+++ b/crates/homeboy-core/src/rig/discovery.rs
@@ -189,9 +189,10 @@ fn discovered_from_path(
         description: String::new(),
         rig_path: path.to_path_buf(),
     };
-    let effective_source_root =
-        super::install::local_package_source_root_for_dependencies(source_root, &[discovered])?;
-    let mut spec = parse_discovered_rig_spec(path, &effective_source_root)?;
+    // Validate dependency declarations for runner materialization, but keep
+    // template inheritance bounded to the selected package root.
+    super::install::local_package_source_root_for_dependencies(source_root, &[discovered])?;
+    let mut spec = parse_discovered_rig_spec(path, source_root)?;
     if spec.id.is_empty() {
         spec.id = if fallback_id.is_empty() {
             return Err(Error::validation_invalid_argument(

--- a/crates/homeboy-core/src/rig/install.rs
+++ b/crates/homeboy-core/src/rig/install.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 use super::spec::{validate_dependency_materialization_steps, RigSpec};
 
 const EXTENDS_FIELD: &str = "extends";
+const SHARED_TEMPLATES_FIELD: &str = "shared_templates";
 
 pub use super::discovery::{discover_rigs, discover_stacks, DiscoveredRig, DiscoveredStack};
 use super::discovery::{discover_rigs_for_install, select_rigs};
@@ -131,14 +132,14 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
     let mut installed = Vec::new();
     for rig in selected {
         let target = paths::rig_config(&rig.id)?;
-        validate_rig_spec_file(&rig.rig_path, &prepared.source_root, &rig.id)?;
+        validate_rig_spec_file(&rig.rig_path, &prepared.package_path, &rig.id)?;
         if target.exists() || fs::symlink_metadata(&target).is_ok() {
             ensure_rig_refreshable(&rig, &target)?;
             remove_existing_config(&target, "replace rig config link")?;
         }
 
         let materialized =
-            write_rig_config_from_source(&rig.rig_path, &target, &prepared.source_root)?;
+            write_rig_config_from_source(&rig.rig_path, &target, &prepared.package_path)?;
 
         let metadata = RigSourceMetadata {
             source: prepared.source.clone(),
@@ -242,7 +243,14 @@ pub(crate) fn write_rig_config_from_source(
         return Ok(false);
     }
 
-    let value = materialize_rig_spec_value(source, source_root, source_value, &mut Vec::new())?;
+    let shared_template_roots = shared_template_roots(&source_value, source, source_root)?;
+    let value = materialize_rig_spec_value(
+        source,
+        source_root,
+        source_value,
+        &shared_template_roots,
+        &mut Vec::new(),
+    )?;
     let content = serde_json::to_string_pretty(&value).map_err(|e| {
         Error::internal_json(
             e.to_string(),
@@ -295,13 +303,21 @@ pub fn materialize_rig_spec_with_default_source_root(path: &Path) -> Result<serd
 /// `extends` nor array merge directives and uses the install merge semantics.
 pub fn materialize_rig_spec(path: &Path, source_root: &Path) -> Result<serde_json::Value> {
     let value = read_json_value(path)?;
-    materialize_rig_spec_value(path, source_root, value, &mut Vec::new())
+    let shared_template_roots = shared_template_roots(&value, path, source_root)?;
+    materialize_rig_spec_value(
+        path,
+        source_root,
+        value,
+        &shared_template_roots,
+        &mut Vec::new(),
+    )
 }
 
 fn materialize_rig_spec_value(
     path: &Path,
     source_root: &Path,
     mut value: serde_json::Value,
+    shared_template_roots: &[PathBuf],
     stack: &mut Vec<PathBuf>,
 ) -> Result<serde_json::Value> {
     let canonical = path.canonicalize().map_err(|e| {
@@ -320,14 +336,19 @@ fn materialize_rig_spec_value(
     }
     stack.push(canonical);
 
-    let parents = extends_paths(&value, path, source_root)?;
+    let parents = extends_paths(&value, path, source_root, shared_template_roots)?;
     remove_extends(&mut value);
 
     let mut merged = serde_json::Value::Object(serde_json::Map::new());
     for parent in parents {
         let parent_value = read_json_value(&parent)?;
-        let parent_materialized =
-            materialize_rig_spec_value(&parent, source_root, parent_value, stack)?;
+        let parent_materialized = materialize_rig_spec_value(
+            &parent,
+            source_root,
+            parent_value,
+            shared_template_roots,
+            stack,
+        )?;
         merge_json(&mut merged, parent_materialized, &parent, "")?;
     }
     merge_json(&mut merged, value, path, "")?;
@@ -356,6 +377,7 @@ fn extends_paths(
     value: &serde_json::Value,
     path: &Path,
     source_root: &Path,
+    shared_template_roots: &[PathBuf],
 ) -> Result<Vec<PathBuf>> {
     let Some(extends) = value.get(EXTENDS_FIELD) else {
         return Ok(Vec::new());
@@ -413,10 +435,14 @@ fn extends_paths(
                 Some(format!("resolve rig template {}", candidate.display())),
             )
         })?;
-        if !canonical.starts_with(&source_root) {
+        if !canonical.starts_with(&source_root)
+            && !shared_template_roots
+                .iter()
+                .any(|root| canonical.starts_with(root))
+        {
             return Err(Error::validation_invalid_argument(
                 EXTENDS_FIELD,
-                "Rig template extends paths must stay inside the rig package source root",
+                "Rig template extends paths must stay inside the rig package source root or a declared shared template root",
                 Some(raw_path.to_string()),
                 None,
             ));
@@ -426,9 +452,91 @@ fn extends_paths(
     Ok(paths)
 }
 
+fn shared_template_roots(
+    value: &serde_json::Value,
+    path: &Path,
+    package_root: &Path,
+) -> Result<Vec<PathBuf>> {
+    let Some(shared_templates) = value.get(SHARED_TEMPLATES_FIELD) else {
+        return Ok(Vec::new());
+    };
+    let entries = shared_templates.as_array().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            SHARED_TEMPLATES_FIELD,
+            "Rig shared template roots must be an array of relative paths",
+            Some(shared_templates.to_string()),
+            None,
+        )
+    })?;
+    let package_root = package_root.canonicalize().map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!(
+                "resolve rig package root {}",
+                package_root.display()
+            )),
+        )
+    })?;
+    let source_root = git::repo_root(&package_root)
+        .or_else(|| materialized_runner_source_root(&package_root))
+        .unwrap_or_else(|| package_root.clone());
+    let source_root = source_root.canonicalize().map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!(
+                "resolve rig package source root {}",
+                source_root.display()
+            )),
+        )
+    })?;
+    let base = path.parent().unwrap_or_else(|| Path::new("."));
+
+    entries
+        .iter()
+        .map(|entry| {
+            let raw_path = entry.as_str().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    SHARED_TEMPLATES_FIELD,
+                    "Rig shared template roots must be strings",
+                    Some(entry.to_string()),
+                    None,
+                )
+            })?;
+            if raw_path.trim().is_empty() || Path::new(raw_path).is_absolute() {
+                return Err(Error::validation_invalid_argument(
+                    SHARED_TEMPLATES_FIELD,
+                    "Rig shared template roots must be non-empty relative paths",
+                    Some(raw_path.to_string()),
+                    None,
+                ));
+            }
+            let candidate = base.join(raw_path);
+            let canonical = candidate.canonicalize().map_err(|e| {
+                Error::internal_io(
+                    e.to_string(),
+                    Some(format!(
+                        "resolve shared rig template root {}",
+                        candidate.display()
+                    )),
+                )
+            })?;
+            if !canonical.starts_with(&source_root) {
+                return Err(Error::validation_invalid_argument(
+                    SHARED_TEMPLATES_FIELD,
+                    "Rig shared template roots must stay inside the rig package source root",
+                    Some(raw_path.to_string()),
+                    None,
+                ));
+            }
+            Ok(canonical)
+        })
+        .collect()
+}
+
 fn remove_extends(value: &mut serde_json::Value) {
     if let Some(object) = value.as_object_mut() {
         object.remove(EXTENDS_FIELD);
+        object.remove(SHARED_TEMPLATES_FIELD);
     }
 }
 

--- a/crates/homeboy-core/src/rig/lint.rs
+++ b/crates/homeboy-core/src/rig/lint.rs
@@ -130,6 +130,7 @@ const KNOWN_RIG_TOP_LEVEL_FIELDS: &[&str] = &[
     "requirements",
     "resources",
     "services",
+    "shared_templates",
     "shared_paths",
     "symlinks",
     "trace",
@@ -482,7 +483,13 @@ fn template_source_root(root: &Path, file: &Path) -> Result<PathBuf> {
         description: String::new(),
         rig_path: file.to_path_buf(),
     };
-    super::install::local_package_source_root_for_dependencies(root, &[rig])
+    super::install::local_package_source_root_for_dependencies(root, &[rig])?;
+    root.canonicalize().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("resolve rig package root {}", root.display())),
+        )
+    })
 }
 
 fn portability_failures(root: &Path, files: &[PathBuf]) -> Result<Vec<String>> {
@@ -1126,7 +1133,7 @@ mod tests {
             rig_dir.join("rig.json"),
             r#"{
                 "id": "browser-coverage",
-                "package_dependencies": ["../../shared/wordpress-plugin"],
+                "shared_templates": ["../../../../shared/wordpress-plugin"],
                 "extends": "../../../../shared/wordpress-plugin/browser-coverage.base.json",
                 "trace_profiles": { "smoke": { "scenario": "browser-coverage" } }
             }"#,

--- a/crates/homeboy-core/src/rig/mod.rs
+++ b/crates/homeboy-core/src/rig/mod.rs
@@ -357,9 +357,9 @@ fn read_spec_from_path(
     path: &Path,
     id_hint: Option<&str>,
     package_root: &Path,
-    source_root: &Path,
+    _source_root: &Path,
 ) -> Result<RigSpec> {
-    let value = install::materialize_rig_spec(path, source_root)?;
+    let value = install::materialize_rig_spec(path, package_root)?;
     let mut spec: RigSpec = serde_json::from_value(value.clone())
         .map_err(|e| rig_spec_parse_error(e, path, Some(&value), None))?;
     if spec.id.is_empty() {

--- a/crates/homeboy-core/src/rig/source.rs
+++ b/crates/homeboy-core/src/rig/source.rs
@@ -322,7 +322,7 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
         }
 
         let config_path = PathBuf::from(&rig.config_path);
-        super::install::materialize_rig_spec(&rig_path, Path::new(&source.source_root))?;
+        super::install::materialize_rig_spec(&rig_path, Path::new(&source.package_path))?;
         if config_path.exists() || fs::symlink_metadata(&config_path).is_ok() {
             fs::remove_file(&config_path).map_err(|e| {
                 Error::internal_io(e.to_string(), Some("replace rig config link".into()))

--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -40,6 +40,7 @@ touching component checkouts.
 | `services` | object | No | Map of service ID to `ServiceSpec`. |
 | `symlinks` | array | No | List of `SymlinkSpec` entries. |
 | `shared_paths` | array | No | List of dependency paths the rig may borrow from another checkout. |
+| `shared_templates` | array | No | Template roots, relative to this `rig.json`, this rig may inherit from outside its selected package root. |
 | `package_dependencies` | array | No | Install-time package-relative paths that must materialize with the package, for nested package imports that cross the selected package root. |
 | `resources` | object | No | Resource declarations used by active-run leases. |
 | `pipeline` | object | No | Map of pipeline name to `PipelineStep[]`. |
@@ -70,7 +71,7 @@ Merge rules are intentionally generic:
 - A child field whose inherited value is an array can opt into array merge semantics by using an object directive instead of a plain array:
   - `{ "$append": [...] }` appends entries after the inherited array.
   - `{ "$merge_by": "<key>", "entries": [...] }` merges array objects by a key field such as `id` or `label`; matching entries deep-merge with the same object rules, and new keyed entries append.
-- `extends` paths must be non-empty relative paths that stay inside the rig package source root.
+- `extends` paths must be non-empty relative paths that stay inside the rig package source root, or inside a root explicitly declared in `shared_templates`.
 
 Example:
 
@@ -100,6 +101,20 @@ Example:
 ```
 
 The installed rig keeps the base `pipeline.check` and `components.app.branch`, while replacing `components.app.path`.
+
+### Shared Templates
+
+Packages nested inside a repository can reuse a repository-level template by declaring its directory in `shared_templates`. The declaration and every resolved template are canonicalized, must remain inside the containing repository (or materialized runner snapshot), and authorize only that declared root. This keeps package-local templates working as before while rejecting undeclared traversal and symlink escapes.
+
+```jsonc
+// Automattic/jetpack/rigs/browser-coverage/rig.json
+{
+  "shared_templates": ["../../../../shared/wordpress-plugin"],
+  "extends": "../../../../shared/wordpress-plugin/browser-coverage.base.json"
+}
+```
+
+For runner installation, declare the same repository-level directory in `package_dependencies` when it must travel with a selected package snapshot.
 
 Array merge example:
 

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -171,6 +171,82 @@ mod materialization {
     }
 
     #[test]
+    fn materialize_allows_declared_shared_template_root() {
+        let repo = tempfile::tempdir().expect("repo");
+        let package = repo.path().join("packages/app");
+        let rig = package.join("rigs/example/rig.json");
+        let shared = repo.path().join("shared/templates");
+        fs::create_dir_all(rig.parent().expect("rig directory")).expect("rig directory");
+        fs::create_dir_all(&shared).expect("shared directory");
+        fs::write(
+            shared.join("base.json"),
+            r#"{ "settings": { "shared": true } }"#,
+        )
+        .expect("shared template");
+        fs::write(
+            &rig,
+            r#"{
+                "id": "example",
+                "shared_templates": ["../../../../shared/templates"],
+                "extends": "../../../../shared/templates/base.json"
+            }"#,
+        )
+        .expect("rig");
+        GitFixture::init(repo.path()).commit("shared template");
+
+        assert_eq!(
+            materialize_rig_spec(&rig, &package).expect("materialize"),
+            serde_json::json!({ "id": "example", "settings": { "shared": true } })
+        );
+    }
+
+    #[test]
+    fn materialize_rejects_undeclared_template_outside_package_root() {
+        let repo = tempfile::tempdir().expect("repo");
+        let package = repo.path().join("packages/app");
+        let rig = package.join("rigs/example/rig.json");
+        let shared = repo.path().join("shared/templates");
+        fs::create_dir_all(rig.parent().expect("rig directory")).expect("rig directory");
+        fs::create_dir_all(&shared).expect("shared directory");
+        fs::write(shared.join("base.json"), r#"{}"#).expect("shared template");
+        fs::write(
+            &rig,
+            r#"{ "extends": "../../../../shared/templates/base.json" }"#,
+        )
+        .expect("rig");
+        GitFixture::init(repo.path()).commit("undeclared shared template");
+
+        let error = materialize_rig_spec(&rig, &package).expect_err("undeclared template rejected");
+        assert_eq!(error.details["field"], "extends");
+        assert!(error.message.contains("declared shared template root"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn materialize_rejects_shared_template_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let package = tempfile::tempdir().expect("package");
+        let outside = tempfile::tempdir().expect("outside");
+        let rig = package.path().join("rigs/example/rig.json");
+        fs::create_dir_all(rig.parent().expect("rig directory")).expect("rig directory");
+        fs::write(outside.path().join("base.json"), r#"{}"#).expect("outside template");
+        symlink(outside.path(), package.path().join("shared")).expect("shared symlink");
+        fs::write(
+            &rig,
+            r#"{
+                "shared_templates": ["../../shared"],
+                "extends": "../../shared/base.json"
+            }"#,
+        )
+        .expect("rig");
+
+        let error = materialize_rig_spec(&rig, package.path()).expect_err("symlink rejected");
+        assert_eq!(error.details["field"], "shared_templates");
+        assert!(error.message.contains("must stay inside"));
+    }
+
+    #[test]
     fn materialize_default_source_root_keeps_non_standard_files_narrow() {
         assert_eq!(
             default_materialize_source_root(Path::new("rigs/example/template.json")),


### PR DESCRIPTION
## Summary
Add an explicit shared\_templates contract so nested rig packages can reuse declared repository templates without allowing arbitrary package-root escape.

## What changed
- Separate template authorization from package dependency transport, canonicalize declared shared roots, and preserve package-local extends behavior.

## How to test
1. Run `cargo test -p homeboy-core --lib rig::install::install_test`; expect All 51 rig installation tests pass..
2. Run `cargo test -p homeboy-core --lib rig::lint::tests::package_lint_materializes_extends_from_declared_repo_shared_root`; expect Declared shared-root materialization passes..
3. Run `cargo check -p homeboy-core`; expect The touched core crate compiles..

## Compatibility
Existing package-local extends behavior is unchanged. The new optional shared\_templates field is an extension-path contract; runner snapshots still declare matching package\_dependencies for transported shared files.

## Evidence
- Base unchanged since verification: main remains at 4dd03157102e31827b7e3156ede26c86c34a98b5.
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8658
- Verified finalization base: main at 4dd03157102e31827b7e3156ede26c86c34a98b5
- core-check: Passed
- diff-check: Passed
- rig-install-tests: Passed
- shared-root-lint-test: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding task via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Designed and implemented the declared shared-template contract and deterministic tests; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8658
