### PR TITLE
Apply canonical Rust formatting

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1128,8 +1128,10 @@ mod tests {
 
         assert_eq!(cooks.len(), 2);
         assert!(cooks.iter().all(|cook| cook.initial_plan.tasks.len() == 1));
-        assert!(cooks.iter().all(|cook| format!("{:?}", cook.harvest_context)
-            == "HarvestExecutionContext { source_snapshot: None, lab_offload: None }"));
+        assert!(cooks
+            .iter()
+            .all(|cook| format!("{:?}", cook.harvest_context)
+                == "HarvestExecutionContext { source_snapshot: None, lab_offload: None }"));
     }
 
     fn args() -> AgentTaskFanoutInputArgs {

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -15,6 +15,7 @@ use crate::api_jobs::{
     DaemonActiveJobRecoveryEvidence, JobStatus, JobStore, LocalRunnerJob,
     RunnerJobLifecycleMetadata,
 };
+use crate::broker_auth::BrokerScope;
 use crate::build_identity;
 use crate::error::{Error, RemoteCommandFailedDetails, Result, TargetDetails};
 use crate::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnalysisJobRunner};
@@ -23,7 +24,6 @@ use crate::paths;
 use crate::process::{
     pid_has_environment_value, pid_is_running, terminate_pid_with_sigterm_and_wait,
 };
-use crate::broker_auth::BrokerScope;
 use crate::runner_execution_envelope::PathMaterializationPlan;
 use crate::secret_env_plan::SecretEnvPlan;
 use crate::source_snapshot::SourceSnapshot;

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -6,9 +6,9 @@ use super::{daemon_endpoint_response, error_response, HttpResponse};
 use crate::api_jobs::{
     JobArtifactMetadata, JobEventKind, JobStore, RemoteRunnerJobRequest, RemoteRunnerJobResult,
 };
+use crate::broker_auth::{BrokerAuthStore, BrokerScope};
 use crate::error::{Error, Result};
 use crate::paths;
-use crate::broker_auth::{BrokerAuthStore, BrokerScope};
 use crate::runner::{self, RunnerSession, RunnerSessionRole, RunnerTunnelMode};
 
 /// Per-request broker authentication context extracted from the network layer.

--- a/crates/homeboy-core/src/extension/trace/canonicality.rs
+++ b/crates/homeboy-core/src/extension/trace/canonicality.rs
@@ -1,13 +1,13 @@
 use std::path::Path;
 use std::process::Command;
 
+use crate::agent_task_scheduler::lab_workspace_provenance::{
+    with_lab_workspace_provenance, LabWorkspaceProvenanceInfo,
+};
 use crate::component::Component;
 use crate::error::{ErrorCode, Result};
 use crate::extension::manifest_config::TraceToolchainProvenanceConfig;
 use crate::extension::ExtensionExecutionContext;
-use crate::agent_task_scheduler::lab_workspace_provenance::{
-    with_lab_workspace_provenance, LabWorkspaceProvenanceInfo,
-};
 #[cfg(test)]
 use crate::runner::verify_lab_workspace;
 #[cfg(test)]

--- a/crates/homeboy-core/src/runner/mod.rs
+++ b/crates/homeboy-core/src/runner/mod.rs
@@ -33,7 +33,6 @@ mod command_path;
 mod connection;
 mod continuation_provider;
 mod daemon_exec_driver;
-mod workspace_root_provider;
 mod daemon_health;
 mod daemon_http_get;
 mod evidence;
@@ -44,6 +43,7 @@ mod homeboy_refresh;
 mod job_preparation;
 mod lab;
 mod lab_workspace_provenance_provider;
+mod workspace_root_provider;
 #[cfg(test)]
 pub(crate) use lab::mirror_agent_task_run_plan_aggregate;
 mod lab_apply;
@@ -110,7 +110,6 @@ pub use connection::{
 };
 pub use continuation_provider::register as register_runner_continuation_provider;
 pub use daemon_exec_driver::register as register_runner_daemon_exec_driver;
-pub use workspace_root_provider::register as register_runner_workspace_root_provider;
 pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
 pub use evidence::register_runner_evidence_provider;
 pub use evidence::runner_artifact_store_token;
@@ -199,6 +198,7 @@ pub(crate) use workspace::{
     workspace_content_manifest_for_policy, VerifiedLabWorkspaceProvenance,
     WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
 };
+pub use workspace_root_provider::register as register_runner_workspace_root_provider;
 
 // RunnerKind now lives in the shared runner-contract crate so core code can
 // name it without a core -> runner edge. Re-exported here so the many

--- a/crates/homeboy-core/src/runner/workspace/mod.rs
+++ b/crates/homeboy-core/src/runner/workspace/mod.rs
@@ -42,13 +42,13 @@ pub(crate) use provenance::{
     materialize_verified_lab_snapshot_git_baseline, verify_lab_workspace,
     verify_lab_workspace_from_env, verify_lab_workspace_git_root, VerifiedLabWorkspaceProvenance,
 };
-pub use snapshot_provider::register as register_workspace_snapshot_provider;
 pub(crate) use snapshot::{
     copy_snapshot_to_directory, effective_snapshot_excludes, local_snapshot_stats,
     materialize_snapshot, materialize_snapshot_git, snapshot_identity, workspace_content_hash,
     workspace_content_hash_algorithm, workspace_content_manifest_for_policy,
     WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
 };
+pub use snapshot_provider::register as register_workspace_snapshot_provider;
 pub(crate) use types::{canonical_workspace_path, DEFAULT_EXCLUDES};
 pub(crate) use util::{
     git_output, parent_remote_path, run_shell_capture, run_shell_command, sanitize_path_segment,


### PR DESCRIPTION
## Summary
Restore a green cargo fmt --check gate by applying canonical rustfmt output to the drifted files on current main.

## What changed
- Apply formatting-only changes with no semantic edits, rebased after the functional session and rig-template changes.

## How to test
1. Run `cargo fmt --check`; expect The full workspace formatting gate passed before the conflict-free rebase..
2. Run `cargo check`; expect The workspace compiled with existing warnings only before the conflict-free rebase..
3. Run `git diff --check origin/main...HEAD`; expect The rebased formatting patch has no whitespace errors..

## Compatibility
No runtime or extension compatibility impact; this is formatting-only.

## Evidence
- Base unchanged since verification: main remains at 9d660cff5e540ab107c9e58b6903688db1e622d8.
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8664
- Verified finalization base: main at 9d660cff5e540ab107c9e58b6903688db1e622d8
- post-rebase-diff-check: Passed
- pre-rebase-cargo-check: Passed
- pre-rebase-fmt-check: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding task via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Reproduced formatting drift, applied canonical rustfmt output, verified formatting and compilation, and rebased cleanly after functional merges; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8664
