### PR TITLE
Make extension lifecycle deterministic and fail closed

### DIFF
--- a/crates/homeboy-core/src/engine/hooks.rs
+++ b/crates/homeboy-core/src/engine/hooks.rs
@@ -48,19 +48,22 @@ pub enum HookFailureMode {
 /// Resolve all hooks for a given event by merging extension-level and component-level hooks.
 ///
 /// Execution order:
-/// 1. Extension hooks (platform behavior) — from all linked extensions, in extension iteration order
+/// 1. Extension hooks (platform behavior) — from all linked extensions, sorted by extension ID
 /// 2. Component hooks (user customization)
 ///
-pub fn resolve_hooks(component: &Component, event: &str) -> Vec<String> {
+/// A configured extension is part of the component's declared behavior. Failing
+/// to load it must fail hook resolution rather than silently changing the plan.
+pub fn resolve_hooks(component: &Component, event: &str) -> Result<Vec<String>> {
     let mut commands = Vec::new();
 
     // Extension hooks first
     if let Some(ref extensions) = component.extensions {
-        for extension_id in extensions.keys() {
-            if let Ok(manifest) = extension::load_extension(extension_id) {
-                if let Some(extension_commands) = manifest.hooks.get(event) {
-                    commands.extend(extension_commands.clone());
-                }
+        let mut extension_ids: Vec<_> = extensions.keys().collect();
+        extension_ids.sort();
+        for extension_id in extension_ids {
+            let manifest = extension::load_extension(extension_id)?;
+            if let Some(extension_commands) = manifest.hooks.get(event) {
+                commands.extend(extension_commands.clone());
             }
         }
     }
@@ -70,7 +73,7 @@ pub fn resolve_hooks(component: &Component, event: &str) -> Vec<String> {
         commands.extend(component_commands.clone());
     }
 
-    commands
+    Ok(commands)
 }
 
 /// Run all hooks for a given event.
@@ -82,7 +85,7 @@ pub fn run_hooks(
     event: &str,
     failure_mode: HookFailureMode,
 ) -> Result<HookRunResult> {
-    let commands = resolve_hooks(component, event);
+    let commands = resolve_hooks(component, event)?;
     run_commands(&commands, &component.local_path, event, failure_mode)
 }
 
@@ -149,7 +152,7 @@ pub(crate) fn run_hooks_remote(
     failure_mode: HookFailureMode,
     vars: &HashMap<String, String>,
 ) -> Result<HookRunResult> {
-    let commands = resolve_hooks(component, event);
+    let commands = resolve_hooks(component, event)?;
     let expanded: Vec<String> = commands
         .iter()
         .map(|c| template::render_map(c, vars))
@@ -223,6 +226,22 @@ pub mod events {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::component::ScopedExtensionConfig;
+    use crate::test_support::with_isolated_home;
+    use std::collections::HashMap;
+
+    fn write_extension_with_hook(home: &std::path::Path, id: &str, command: &str) {
+        let extension_dir = home.join(".config/homeboy/extensions").join(id);
+        std::fs::create_dir_all(&extension_dir).unwrap();
+        std::fs::write(
+            extension_dir.join(format!("{id}.json")),
+            format!(
+                r#"{{"name":"{id}","version":"1.0.0","hooks":{{"{}": ["{command}"]}}}}"#,
+                events::PRE_VERSION_BUMP
+            ),
+        )
+        .unwrap();
+    }
 
     #[test]
     fn resolve_hooks_returns_empty_when_no_hooks() {
@@ -232,7 +251,7 @@ mod tests {
             "".to_string(),
             None,
         );
-        let commands = resolve_hooks(&component, events::PRE_VERSION_BUMP);
+        let commands = resolve_hooks(&component, events::PRE_VERSION_BUMP).unwrap();
         assert!(commands.is_empty());
     }
 
@@ -248,7 +267,7 @@ mod tests {
             events::PRE_VERSION_BUMP.to_string(),
             vec!["echo hello".to_string()],
         );
-        let commands = resolve_hooks(&component, events::PRE_VERSION_BUMP);
+        let commands = resolve_hooks(&component, events::PRE_VERSION_BUMP).unwrap();
         assert_eq!(commands, vec!["echo hello".to_string()]);
     }
 
@@ -264,8 +283,38 @@ mod tests {
             events::POST_DEPLOY.to_string(),
             vec!["echo deploy".to_string()],
         );
-        let commands = resolve_hooks(&component, events::PRE_VERSION_BUMP);
+        let commands = resolve_hooks(&component, events::PRE_VERSION_BUMP).unwrap();
         assert!(commands.is_empty());
+    }
+
+    #[test]
+    fn resolve_hooks_sorts_extensions_and_rejects_missing_configured_extension() {
+        with_isolated_home(|home| {
+            write_extension_with_hook(home.path(), "zebra", "echo zebra");
+            write_extension_with_hook(home.path(), "alpha", "echo alpha");
+            let mut component = Component::new(
+                "test".to_string(),
+                "/tmp/test".to_string(),
+                "".to_string(),
+                None,
+            );
+            component.extensions = Some(HashMap::from([
+                ("zebra".to_string(), ScopedExtensionConfig::default()),
+                ("alpha".to_string(), ScopedExtensionConfig::default()),
+            ]));
+
+            assert_eq!(
+                resolve_hooks(&component, events::PRE_VERSION_BUMP).unwrap(),
+                vec!["echo alpha", "echo zebra"]
+            );
+
+            component
+                .extensions
+                .as_mut()
+                .unwrap()
+                .insert("missing".to_string(), ScopedExtensionConfig::default());
+            assert!(resolve_hooks(&component, events::PRE_VERSION_BUMP).is_err());
+        });
     }
 
     #[test]

--- a/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
@@ -16,7 +16,6 @@ use crate::paths;
 use homeboy_engine_primitives::local_files;
 
 use super::super::execution::run_setup;
-use super::super::load_extension;
 use super::super::manifest::ExtensionManifest;
 use super::{
     derive_id_from_url, manifest_path_for_extension, slugify_id, write_source_metadata,
@@ -144,20 +143,14 @@ pub(super) fn install_from_url(
     let extension_id = result?;
 
     // Write source metadata so it survives even when .git is discarded.
-    if let Some(ref rev) = source_revision {
-        let _ = std::fs::write(extension_dir.join(".source-revision"), rev);
-    }
-    let _ = std::fs::write(extension_dir.join(".source-url"), url);
+    write_source_metadata(&extension_dir, url, source_revision.clone());
+    super::write_requested_source_ref(&extension_dir, revision);
 
-    // Auto-run setup if extension defines a setup_command
-    // Setup is best-effort: install succeeds even if setup fails
-    if let Ok(extension) = load_extension(&extension_id) {
-        if extension
-            .runtime()
-            .is_some_and(|r| r.setup_command.is_some())
-        {
-            let _ = run_setup(&extension_id);
-        }
+    // A successful install is ready for use. Do not report a successful install
+    // if the declared setup command failed.
+    if let Err(err) = run_setup(&extension_id) {
+        let _ = std::fs::remove_dir_all(&extension_dir);
+        return Err(err);
     }
 
     let manifest_path = paths::extension_manifest(&extension_id)?;
@@ -544,6 +537,11 @@ pub(super) fn install_from_path(
         &source.to_string_lossy(),
         source_revision.clone(),
     );
+    super::write_requested_source_ref(&extension_dir, revision);
+    if let Err(err) = run_setup(&extension_id) {
+        let _ = std::fs::remove_file(&extension_dir);
+        return Err(err);
+    }
     let manifest_path = paths::extension_manifest(&extension_id)?;
     if let Err(err) = validate_installed_extension_agent_runtime_provider_discovery(&extension_id) {
         let _ = std::fs::remove_file(&extension_dir);

--- a/crates/homeboy-core/src/extension/lifecycle/mod.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/mod.rs
@@ -323,6 +323,7 @@ pub(crate) use install_sources::{
 mod update;
 #[cfg(test)]
 use update::is_extension_update_workdir_clean;
+pub(crate) use update::write_requested_source_ref;
 pub(crate) use update::write_source_metadata;
 pub use update::{
     check_update_available, read_source_revision, read_source_url, update, UpdateAvailable,
@@ -1407,6 +1408,29 @@ exec '{}' "$@"
     }
 
     #[test]
+    fn install_fails_when_setup_fails_and_removes_unready_extension() {
+        with_isolated_home(|home| {
+            let source = home.path().join("source-repo");
+            let extension_dir = source.join("wordpress");
+            fs::create_dir_all(&extension_dir).expect("extension dir");
+            fs::write(
+                extension_dir.join("wordpress.json"),
+                r#"{"name":"wordpress","version":"1.0.0","executable":{"runtime":{"setup_command":"exit 23"}}}"#,
+            )
+            .expect("extension manifest");
+
+            let _err = install(&extension_dir.to_string_lossy(), Some("wordpress"))
+                .expect_err("failed setup must fail installation");
+
+            assert!(
+                std::fs::symlink_metadata(home.path().join(".config/homeboy/extensions/wordpress"))
+                    .is_err(),
+                "failed setup must not leave an installed-but-unready extension"
+            );
+        });
+    }
+
+    #[test]
     fn test_install_with_revision() {
         with_isolated_home(|home| {
             let home = home.path();
@@ -1478,6 +1502,45 @@ exec '{}' "$@"
             assert_eq!(
                 result.source_revision.as_deref(),
                 Some(branch_revision.as_str())
+            );
+        });
+    }
+
+    #[test]
+    fn extracted_update_preserves_requested_commit_pin() {
+        with_isolated_home(|home| {
+            let source = home.path().join("source-repo");
+            fs::create_dir_all(&source).expect("source repo");
+            let remote = match prepare_git_extension_repo(&source, "wordpress") {
+                Some(remote) => remote,
+                None => return,
+            };
+            let pinned_revision = match git_output(&source, &["rev-parse", "--short", "HEAD"]) {
+                Some(revision) => revision,
+                None => return,
+            };
+            write_extension_fixture_with_version(&source, "wordpress", "2.0.0");
+            assert!(commit_all(&source, "default branch update"));
+            assert!(run_git(&source, &["push", "origin", "HEAD"]));
+            let remote_url = remote.path().join("extension.git");
+
+            install_with_revision(
+                &remote_url.to_string_lossy(),
+                Some("wordpress"),
+                Some(&pinned_revision),
+            )
+            .expect("install pinned extracted extension");
+            update("wordpress", false).expect("update pinned extracted extension");
+
+            assert_eq!(load_extension("wordpress").unwrap().version, "1.0.0");
+            assert_eq!(
+                fs::read_to_string(
+                    home.path()
+                        .join(".config/homeboy/extensions/wordpress/.source-requested-ref"),
+                )
+                .unwrap()
+                .trim(),
+                pinned_revision
             );
         });
     }
@@ -1565,6 +1628,10 @@ exec '{}' "$@"
                 Some("fixture-b"),
             )
             .expect("install linked fixture-b extension");
+            // Install now runs setup, so restore the fixture checkout to the
+            // clean state required by this update-path test.
+            fs::remove_file(source.join("fixture-a/setup-count.txt")).expect("clear setup output");
+            fs::remove_file(source.join("fixture-b/setup-count.txt")).expect("clear setup output");
 
             let bin_dir = home.join("bin");
             let pull_count_file = home.join("pull-count");

--- a/crates/homeboy-core/src/extension/lifecycle/update.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/update.rs
@@ -55,7 +55,7 @@ pub fn update(extension_id: &str, force: bool) -> Result<UpdateResult> {
             git::short_head_revision(&extension_dir),
         );
 
-        run_setup_if_configured(extension_id);
+        run_setup_if_configured(extension_id)?;
 
         return Ok(UpdateResult {
             extension_id: extension_id.to_string(),
@@ -70,8 +70,6 @@ pub fn update(extension_id: &str, force: bool) -> Result<UpdateResult> {
     }
 
     update_extracted_extension(extension_id, &extension_dir, &source_url)?;
-
-    run_setup_if_configured(extension_id);
 
     Ok(UpdateResult {
         extension_id: extension_id.to_string(),
@@ -106,7 +104,8 @@ fn update_extracted_extension(
         }
     }
 
-    git::clone_repo(source_url, &clone_dir)?;
+    let requested_ref = read_source_requested_ref(extension_dir);
+    git::clone_repo_at_ref(source_url, &clone_dir, requested_ref.as_deref())?;
     let source_revision = git::short_head_revision(&clone_dir);
 
     let result = resolve_cloned_extension(&clone_dir, extension_id, &staged_dir, source_url);
@@ -116,9 +115,16 @@ fn update_extracted_extension(
     result?;
 
     write_source_metadata(&staged_dir, source_url, source_revision);
+    write_requested_source_ref(&staged_dir, requested_ref.as_deref());
 
     rename_dir(extension_dir, &backup_dir)?;
     if let Err(err) = rename_dir(&staged_dir, extension_dir) {
+        let _ = rename_dir(&backup_dir, extension_dir);
+        return Err(err);
+    }
+
+    if let Err(err) = run_setup_if_configured(extension_id) {
+        let _ = std::fs::remove_dir_all(extension_dir);
         let _ = rename_dir(&backup_dir, extension_dir);
         return Err(err);
     }
@@ -146,6 +152,26 @@ pub(crate) fn write_source_metadata(
         metadata_dir.join(source_metadata_file(extension_dir, "url")),
         source_url,
     );
+}
+
+/// Persist the user-requested source ref separately from the resolved revision.
+/// Extracted monorepo installs discard `.git`, so this is the only durable
+/// input that lets a later update preserve a branch, tag, or commit pin.
+pub(crate) fn write_requested_source_ref(extension_dir: &Path, requested_ref: Option<&str>) {
+    let path = source_metadata_dir(extension_dir)
+        .join(source_metadata_file(extension_dir, "requested-ref"));
+    match requested_ref.filter(|value| !value.trim().is_empty()) {
+        Some(value) => {
+            let _ = std::fs::write(path, value);
+        }
+        None => {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+pub(crate) fn read_source_requested_ref(extension_dir: &Path) -> Option<String> {
+    read_source_metadata_value(extension_dir, "requested-ref")
 }
 
 pub fn read_source_url(extension_dir: &Path) -> Option<String> {
@@ -243,15 +269,15 @@ fn is_generated_extension_metadata_path(path: &str, extension_rel: Option<&str>)
     })
 }
 
-pub(crate) fn run_setup_if_configured(extension_id: &str) {
-    if let Ok(extension) = load_extension(extension_id) {
-        if extension
-            .runtime()
-            .is_some_and(|r| r.setup_command.is_some())
-        {
-            let _ = super::super::execution::run_setup(extension_id);
-        }
+pub(crate) fn run_setup_if_configured(extension_id: &str) -> Result<()> {
+    let extension = load_extension(extension_id)?;
+    if extension
+        .runtime()
+        .is_some_and(|r| r.setup_command.is_some())
+    {
+        super::super::execution::run_setup(extension_id)?;
     }
+    Ok(())
 }
 
 fn update_linked_extension(
@@ -322,7 +348,7 @@ fn update_linked_extension(
         }
     };
     install_linked_shared_assets(&source_dir, extension_dir, None)?;
-    run_setup_if_configured(extension_id);
+    run_setup_if_configured(extension_id)?;
     let url = format!("linked:{}", source_dir.display());
     let new_branch = git::current_branch(&git_root);
     let new_source_revision = git::short_head_revision(&git_root);

--- a/crates/homeboy-core/src/extension/repair.rs
+++ b/crates/homeboy-core/src/extension/repair.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use super::execution::run_setup;
 use super::lifecycle::{
     derive_id_from_url, install_linked_shared_assets, is_git_url, rename_dir,
-    resolve_cloned_extension, slugify_id, write_source_metadata,
+    resolve_cloned_extension, slugify_id, write_requested_source_ref, write_source_metadata,
 };
 use super::manifest::ExtensionManifest;
 
@@ -89,6 +89,7 @@ fn replace_from_url(
     result?;
 
     write_source_metadata(&staged_dir, url, source_revision.clone());
+    write_requested_source_ref(&staged_dir, revision);
 
     let old_path = installed_source_path(&extension_dir);
     move_existing_install(&extension_dir, &backup_dir)?;
@@ -165,6 +166,7 @@ fn replace_from_path(
         let _ = restore_existing_install(&backup_dir, &extension_dir);
         return Err(err);
     }
+    write_requested_source_ref(&extension_dir, requested_revision);
 
     run_setup_or_restore(&extension_id, &extension_dir, &backup_dir)?;
     validate_agent_runtime_discovery_or_restore(&extension_id, &extension_dir, &backup_dir)?;

--- a/crates/homeboy-core/src/release/plan_steps/release.rs
+++ b/crates/homeboy-core/src/release/plan_steps/release.rs
@@ -32,7 +32,7 @@ pub(in crate::release) fn build_release_steps(
     add_release_extension_diagnostics(component, extensions, &publish_targets, options, warnings);
 
     if options.pipeline.head {
-        return Ok(build_head_release_steps(
+        return build_head_release_steps(
             component,
             extensions,
             new_version,
@@ -40,7 +40,7 @@ pub(in crate::release) fn build_release_steps(
             release_scope,
             &publish_targets,
             warnings,
-        ));
+        );
     }
 
     if !publish_targets.is_empty() && !has_package_capability(extensions) {
@@ -193,7 +193,7 @@ pub(in crate::release) fn build_release_steps(
     }
 
     let post_release_hooks =
-        crate::engine::hooks::resolve_hooks(component, crate::engine::hooks::events::POST_RELEASE);
+        crate::engine::hooks::resolve_hooks(component, crate::engine::hooks::events::POST_RELEASE)?;
     if !post_release_hooks.is_empty() {
         let post_release_needs = if !options.pipeline.skip_publish && !publish_targets.is_empty() {
             if options.pipeline.deploy {
@@ -243,7 +243,7 @@ fn build_head_release_steps(
     release_scope: &ReleaseScope,
     publish_targets: &[String],
     warnings: &mut Vec<String>,
-) -> Vec<PlanStep> {
+) -> Result<Vec<PlanStep>> {
     let mut steps = Vec::new();
     let mut artifact_need = "preflight.remote_sync".to_string();
 
@@ -323,7 +323,7 @@ fn build_head_release_steps(
     }
 
     let post_release_hooks =
-        crate::engine::hooks::resolve_hooks(component, crate::engine::hooks::events::POST_RELEASE);
+        crate::engine::hooks::resolve_hooks(component, crate::engine::hooks::events::POST_RELEASE)?;
     if !post_release_hooks.is_empty() {
         let post_release_needs = if !options.pipeline.skip_publish && !publish_targets.is_empty() {
             if options.pipeline.deploy {
@@ -366,7 +366,7 @@ fn build_head_release_steps(
         ));
     }
 
-    steps
+    Ok(steps)
 }
 
 fn add_package_preflight_step(


### PR DESCRIPTION
## Summary
Make configured extension hooks, setup, updates, and requested source refs deterministic and fail closed.

## What changed
- Sort extension hook execution, surface load failures, preserve extracted source pins, and roll back failed setup updates.

## How to test
1. Run `cargo test -p homeboy-core extension::lifecycle --lib`; expect 41 lifecycle tests pass..
2. Run `cargo check --workspace`; expect Workspace compiles..

## Compatibility
Configured missing extensions and failed setup now surface errors instead of being silently ignored; manifest shapes are unchanged.

## Evidence
- Base unchanged since verification: main remains at 4dd03157102e31827b7e3156ede26c86c34a98b5.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8643
- Verified finalization base: main at 4dd03157102e31827b7e3156ede26c86c34a98b5
- extension-lifecycle: Passed
- workspace-check: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent
- **Model:** openai/gpt-5.6-sol
- **Used for:** Implemented deterministic extension lifecycle behavior and tests; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8643
