### PR TITLE
Fail audits when configured source roots disappear

### DIFF
--- a/crates/homeboy-core/src/code_audit/detectors/source_policy.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/source_policy.rs
@@ -28,6 +28,38 @@ pub(in crate::code_audit) fn run(
     findings
 }
 
+/// Reject configured source roots that would otherwise silently disable a rule.
+pub(in crate::code_audit) fn validate_source_roots(
+    fingerprints: &[&FileFingerprint],
+    rules: &[SourcePolicyRule],
+) -> crate::Result<()> {
+    let missing = rules
+        .iter()
+        .flat_map(|rule| {
+            rule.include_path_contains.iter().filter_map(|root| {
+                (!fingerprints
+                    .iter()
+                    .any(|fingerprint| fingerprint.relative_path.contains(root)))
+                .then(|| format!("{}: {root}", rule.id))
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    Err(crate::Error::validation_invalid_argument(
+        "audit.source_policies",
+        format!(
+            "configured source root(s) matched zero files: {}. Update the configured path or remove the stale source root.",
+            missing.join(", ")
+        ),
+        None,
+        None,
+    ))
+}
+
 fn run_rule(rule: &SourcePolicyRule, fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
     match &rule.rule {
         SourcePolicyRuleBody::ForbiddenTerms {
@@ -489,6 +521,22 @@ mod tests { const PACKAGE: &str = "widget-package.json"; }
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].file, "src/commands/new_feature.rs");
         assert!(findings[0].description.contains("direct process execution"));
+    }
+
+    #[test]
+    fn rejects_configured_source_roots_that_match_zero_files() {
+        let fp = rust_fp("crates/homeboy-core/src/engine.rs", "fn dispatch() {}");
+        let mut rule = rule();
+        rule.include_path_contains = vec![
+            "crates/homeboy-core/src/".to_string(),
+            "crates/renamed-core/src/".to_string(),
+        ];
+
+        let error = validate_source_roots(&[&fp], &[rule]).expect_err("missing root must fail");
+
+        assert!(error.to_string().contains("synthetic-source-boundary"));
+        assert!(error.to_string().contains("crates/renamed-core/src/"));
+        assert!(error.to_string().contains("matched zero files"));
     }
 
     // ------------------------------------------------------------------------

--- a/crates/homeboy-core/src/code_audit/engine.rs
+++ b/crates/homeboy-core/src/code_audit/engine.rs
@@ -15,7 +15,7 @@ use std::collections::HashSet;
 use std::path::Path;
 
 use super::descriptor_runtime::{run_descriptor_detectors, DetectorRunContext};
-use super::detectors::artifact_portability;
+use super::detectors::{artifact_portability, source_policy};
 use super::entry::audit_config_for;
 use super::execution_plan::AuditExecutionPlan;
 use super::findings;
@@ -193,6 +193,14 @@ pub(super) fn audit_internal(
         .iter()
         .flat_map(|(_, _, fps)| fps.iter())
         .collect();
+
+    if plan.detector_enabled("core_boundary_leaks") {
+        let rules = audit_config.core_boundary_leaks.to_source_policy_rules();
+        source_policy::validate_source_roots(&all_fingerprints, &rules)?;
+    }
+    if plan.detector_enabled("source_policy") {
+        source_policy::validate_source_roots(&all_fingerprints, &audit_config.source_policies)?;
+    }
 
     // Build convention method set ONCE — used by duplication, near-duplicate, and parallel detectors.
     // Convention-expected methods are excluded from duplication/parallel findings because identical

--- a/crates/homeboy-core/src/code_audit/entry.rs
+++ b/crates/homeboy-core/src/code_audit/entry.rs
@@ -96,6 +96,8 @@ pub fn source_policy_findings_for_path(
         .collect::<Vec<_>>();
     let fingerprint_refs = fingerprints.iter().collect::<Vec<_>>();
 
+    source_policy::validate_source_roots(&fingerprint_refs, &audit_config.source_policies)?;
+
     Ok(source_policy::run(
         &fingerprint_refs,
         &audit_config.source_policies,

--- a/homeboy.json
+++ b/homeboy.json
@@ -131,36 +131,34 @@
         "default_match": "token",
         "description": "Core boundary leak (core-agnostic-source) configured ecosystem term `{term}` appears at line {line} in {classification} context `{context}`",
         "exclude_path_contains": [
-          "src/core/execution_contract.rs",
-          "src/core/product_identity.rs",
-          "src/core/code_audit/conventions/",
-          "src/core/code_audit/comment_blocks.rs",
-          "src/core/code_audit/comment_hygiene.rs",
-          "src/core/code_audit/core_fingerprint/mod.rs",
-          "src/core/code_audit/core_fingerprint/relationships.rs",
-          "src/core/code_audit/detectors/test_coverage.rs",
-          "src/core/code_audit/detectors/global_env_guard.rs",
-          "src/core/runner/tool_registry.rs",
-          "src/core/cleanup.rs",
-          "src/core/cleanup/self_artifacts.rs",
-          "src/core/runner/lab_args/tests.rs",
-          "src/core/release/executor/lockfile_guard.rs",
-          "src/core/triage/tests",
-          "src/core/extension/bench/baseline.rs"
+          "crates/homeboy-core/src/execution_contract.rs",
+          "crates/homeboy-core/src/code_audit/conventions/",
+          "crates/homeboy-core/src/code_audit/comment_blocks.rs",
+          "crates/homeboy-core/src/code_audit/comment_hygiene.rs",
+          "crates/homeboy-core/src/code_audit/core_fingerprint/mod.rs",
+          "crates/homeboy-core/src/code_audit/core_fingerprint/relationships.rs",
+          "crates/homeboy-core/src/code_audit/detectors/test_coverage.rs",
+          "crates/homeboy-core/src/code_audit/detectors/global_env_guard.rs",
+          "crates/homeboy-core/src/runner/tool_registry.rs",
+          "crates/homeboy-core/src/cleanup.rs",
+          "crates/homeboy-core/src/cleanup/self_artifacts.rs",
+          "crates/homeboy-core/src/runner/lab_args/tests.rs",
+          "crates/homeboy-core/src/release/executor/lockfile_guard.rs",
+          "crates/homeboy-core/src/extension/bench/baseline.rs"
         ],
         "id": "core-agnostic-source",
         "ignore_after_line_equals": [
           "#[cfg(test)]"
         ],
         "include_path_contains": [
-          "src/core",
-          "src/commands/component.rs",
-          "src/commands/extension.rs",
-          "src/commands/lint.rs",
-          "src/commands/report.rs",
-          "src/commands/resources/mod.rs",
-          "src/commands/review/mod.rs",
-          "src/commands/test.rs"
+          "crates/homeboy-core/src/",
+          "crates/homeboy-cli/src/commands/component.rs",
+          "crates/homeboy-cli/src/commands/extension.rs",
+          "crates/homeboy-cli/src/commands/lint.rs",
+          "crates/homeboy-cli/src/commands/report.rs",
+          "crates/homeboy-cli/src/commands/resources/",
+          "crates/homeboy-cli/src/commands/review/",
+          "crates/homeboy-cli/src/commands/test.rs"
         ],
         "kind": "core_boundary_leak",
         "suggestion": "Move ecosystem-specific behavior into extension metadata/rules, or add an explicit audit allowlist for intentional examples.",
@@ -278,15 +276,15 @@
         "default_match": "token",
         "description": "Core boundary leak (detector-agnostic-source) configured ecosystem term `{term}` appears at line {line} in {classification} context `{context}`",
         "exclude_path_contains": [
-          "src/core/code_audit/detectors/test_coverage.rs",
-          "src/core/code_audit/detectors/global_env_guard.rs"
+          "crates/homeboy-core/src/code_audit/detectors/test_coverage.rs",
+          "crates/homeboy-core/src/code_audit/detectors/global_env_guard.rs"
         ],
         "id": "detector-agnostic-source",
         "ignore_after_line_equals": [
           "#[cfg(test)]"
         ],
         "include_path_contains": [
-          "src/core/code_audit/detectors"
+          "crates/homeboy-core/src/code_audit/detectors/"
         ],
         "kind": "core_boundary_leak",
         "suggestion": "Move ecosystem-specific behavior into extension metadata/rules, or add an explicit audit allowlist for intentional examples.",


### PR DESCRIPTION
## Summary
Make source-policy audits fail when configured roots match no files and point Homeboy's boundary policy at the current crate tree.

## What changed
- Added source-root validation and migrated obsolete src/core policy paths to crates/homeboy-core/src.

## How to test
1. Run `cargo test -p homeboy-core rejects_configured_source_roots_that_match_zero_files --lib`; expect Regression test passes..
2. Run `cargo check -p homeboy-core`; expect Core compiles..

## Compatibility
Invalid stale audit configurations now fail with actionable errors instead of producing false-green results.

## Evidence
- Base unchanged since verification: main remains at 4dd03157102e31827b7e3156ede26c86c34a98b5.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8644
- Verified finalization base: main at 4dd03157102e31827b7e3156ede26c86c34a98b5
- core-check: Passed
- zero-match-regression: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent
- **Model:** openai/gpt-5.6-sol
- **Used for:** Repaired current core-boundary policy paths and added zero-match regression coverage; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8644
