### PR TITLE
Unify resolved extension invocation context

### DIFF
--- a/crates/homeboy-core/src/extension/capability.rs
+++ b/crates/homeboy-core/src/extension/capability.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use super::manifest::ExtensionManifest;
 use super::registry::{extension_path, load_extension};
 use super::runner::ExtensionRunner;
+use super::ResolvedExtensionInvocationContext;
 
 pub(crate) fn stderr_tail(stderr: &str) -> String {
     const MAX_LINES: usize = 20;
@@ -428,7 +429,7 @@ pub fn resolve_execution_context(
     capability: ExtensionCapability,
 ) -> Result<ExtensionExecutionContext> {
     let extension_id = resolve_extension_for_capability(component, capability)?;
-    execution_context_for_extension(component, capability, extension_id)
+    execution_context_for_extension(component, None, capability, extension_id)
 }
 
 /// Resolve an execution context when a linked extension provides `capability`.
@@ -442,11 +443,24 @@ pub(crate) fn resolve_execution_context_if_available(
     else {
         return Ok(None);
     };
-    execution_context_for_extension(component, capability, extension_id).map(Some)
+    execution_context_for_extension(component, None, capability, extension_id).map(Some)
+}
+
+/// Resolve a capability against a project attachment, retaining the project
+/// settings and attachment path for the runner environment.
+pub fn resolve_execution_context_for_project(
+    project: &crate::project::Project,
+    component_id: &str,
+    capability: ExtensionCapability,
+) -> Result<ExtensionExecutionContext> {
+    let component = crate::project::resolve_project_component(project, component_id)?;
+    let extension_id = resolve_extension_for_capability(&component, capability)?;
+    execution_context_for_extension(&component, Some(project.clone()), capability, extension_id)
 }
 
 fn execution_context_for_extension(
     component: &Component,
+    project: Option<crate::project::Project>,
     capability: ExtensionCapability,
     extension_id: String,
 ) -> Result<ExtensionExecutionContext> {
@@ -490,13 +504,21 @@ fn execution_context_for_extension(
         ));
     }
 
+    let invocation = ResolvedExtensionInvocationContext::for_component(
+        &extension_id,
+        project,
+        component.clone(),
+    )?;
+
     Ok(ExtensionExecutionContext {
-        component: component.clone(),
+        component: invocation
+            .component
+            .expect("capability invocation has component"),
         capability,
         extension_id: extension_id.clone(),
         extension_path,
         script_path,
-        settings: extract_component_extension_settings(component, &extension_id),
+        settings: invocation.settings.into_iter().collect(),
         accepted_setting_keys: manifest.accepted_setting_keys(),
     })
 }
@@ -581,6 +603,70 @@ mod tests {
             let err = resolve_extension_for_capability(&component, ExtensionCapability::Deps)
                 .expect_err("selected extension must provide selected capability");
             assert!(err.message.contains("does not provide it"));
+        });
+    }
+
+    #[test]
+    fn project_capability_context_applies_project_component_and_cli_settings() {
+        crate::test_support::with_isolated_home(|home| {
+            let component_dir = tempfile::tempdir().expect("component");
+            std::fs::write(
+                component_dir.path().join("homeboy.json"),
+                r#"{"id":"consumer","extensions":{"fixture":{"settings":{"winner":"component"}}}}"#,
+            )
+            .expect("portable component");
+            write_extension_manifest(home.path(), "fixture", "test");
+            let extension_dir = home.path().join(".config/homeboy/extensions/fixture");
+            let script = extension_dir.join("test.sh");
+            std::fs::write(
+                &script,
+                "#!/bin/sh\nprintf '%s' \"$HOMEBOY_SETTINGS_JSON\"\n",
+            )
+            .expect("test script");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut permissions = std::fs::metadata(&script)
+                    .expect("script metadata")
+                    .permissions();
+                permissions.set_mode(0o755);
+                std::fs::set_permissions(&script, permissions).expect("make script executable");
+            }
+            let project = crate::project::Project {
+                id: "site".to_string(),
+                extensions: Some(std::collections::HashMap::from([(
+                    "fixture".to_string(),
+                    crate::component::ScopedExtensionConfig {
+                        settings: std::collections::HashMap::from([(
+                            "winner".to_string(),
+                            serde_json::json!("project"),
+                        )]),
+                        ..Default::default()
+                    },
+                )])),
+                components: vec![crate::project::ProjectComponentAttachment {
+                    id: "consumer".to_string(),
+                    local_path: component_dir.path().to_string_lossy().to_string(),
+                    remote_path: None,
+                }],
+                ..Default::default()
+            };
+
+            let context = resolve_execution_context_for_project(
+                &project,
+                "consumer",
+                ExtensionCapability::Test,
+            )
+            .expect("project capability context");
+            let output = ExtensionRunner::for_context(context)
+                .settings(&[("winner".to_string(), "cli".to_string())])
+                .passthrough(false)
+                .run()
+                .expect("capability run");
+            let settings: serde_json::Value =
+                serde_json::from_str(&output.stdout).expect("settings JSON");
+
+            assert_eq!(settings["winner"], "cli");
         });
     }
 }

--- a/crates/homeboy-core/src/extension/execution.rs
+++ b/crates/homeboy-core/src/extension/execution.rs
@@ -1,7 +1,7 @@
 use crate::component::{self, Component};
 use crate::engine::{template, validation};
 use crate::error::{Error, Result};
-use crate::project::{self, Project};
+use crate::project::Project;
 use crate::rig::toolchain;
 use crate::server::{
     execute_local_command_in_dir, execute_local_command_in_dir_with_timeout,
@@ -26,7 +26,7 @@ use super::manifest::{ExtensionManifest, RuntimeConfig};
 use super::read_source_revision;
 use super::runner_contract::RunnerStepFilter;
 use super::runtime_helper;
-use super::scope::ExtensionScope;
+use super::ResolvedExtensionInvocationContext;
 
 pub(crate) use action::execute_action;
 pub use readiness::{extension_ready_status, is_extension_compatible, ExtensionReadyStatus};
@@ -59,14 +59,6 @@ pub enum ExtensionExecutionMode {
 /// Result of running extension setup.
 pub struct ExtensionSetupResult {
     pub exit_code: i32,
-}
-
-struct ExtensionExecutionContext {
-    extension_id: String,
-    project_id: Option<String>,
-    component_id: Option<String>,
-    project: Option<Project>,
-    settings: HashMap<String, serde_json::Value>,
 }
 
 /// Run a extension's setup command (if defined).
@@ -236,75 +228,6 @@ fn build_args_string(
     }
     argv.extend(args);
     argv.join(" ")
-}
-
-fn resolve_extension_context(
-    extension: &ExtensionManifest,
-    extension_id: &str,
-    project_id: Option<&str>,
-    component_id: Option<&str>,
-    run_command: &str,
-) -> Result<ExtensionExecutionContext> {
-    let requires_project = extension.requires.is_some()
-        || template::is_present(run_command, "projectId")
-        || template::is_present(run_command, "sitePath")
-        || template::is_present(run_command, "cliPath")
-        || template::is_present(run_command, "domain");
-
-    let mut project = None;
-    let mut component = None;
-    let mut resolved_project_id = None;
-    let mut resolved_component_id = None;
-
-    // Handle component-only execution (no project required)
-    if let Some(cid) = component_id {
-        if let Ok(loaded_component) = component::resolve_effective(Some(cid), None, None) {
-            component = Some(loaded_component);
-            resolved_component_id = Some(cid.to_string());
-        }
-    }
-
-    if requires_project {
-        let pid = project_id.ok_or_else(|| {
-            Error::config(format!(
-                "Extension {} requires a project context, but no project ID was provided",
-                extension.id
-            ))
-        })?;
-
-        let loaded_project = project::load(pid)?;
-        ExtensionScope::validate_project_compatibility(extension, &loaded_project)?;
-
-        resolved_component_id =
-            ExtensionScope::resolve_component_scope(extension, &loaded_project, component_id)?;
-
-        if let Some(ref comp_id) = resolved_component_id {
-            component = Some(
-                component::resolve_effective(Some(comp_id), None, Some(&loaded_project)).map_err(
-                    |_| {
-                        Error::config(format!(
-                            "Component {} required by extension {} is not configured",
-                            comp_id, &extension.id
-                        ))
-                    },
-                )?,
-            );
-        }
-
-        resolved_project_id = Some(pid.to_string());
-        project = Some(loaded_project);
-    }
-
-    let settings =
-        ExtensionScope::effective_settings(extension_id, project.as_ref(), component.as_ref())?;
-
-    Ok(ExtensionExecutionContext {
-        extension_id: extension_id.to_string(),
-        project_id: resolved_project_id,
-        component_id: resolved_component_id,
-        project,
-        settings,
-    })
 }
 
 pub(crate) fn validate_capability_script_exists(
@@ -626,7 +549,7 @@ fn build_template_vars<'a>(
 
 fn build_runtime_env(
     runtime: &RuntimeConfig,
-    context: &ExtensionExecutionContext,
+    context: &ResolvedExtensionInvocationContext,
     vars: &[(&str, &str)],
     settings_json: &str,
     extension_path: &str,
@@ -639,12 +562,18 @@ fn build_runtime_env(
     let mut env = build_exec_env(
         &context.extension_id,
         context.project_id.as_deref(),
-        context.component_id.as_deref(),
+        context
+            .component
+            .as_ref()
+            .map(|component| component.id.as_str()),
         settings_json,
         Some(extension_path),
         project_base_path,
         Some(&context.settings),
-        None, // no path override in runtime context
+        context
+            .component
+            .as_ref()
+            .map(|component| component.local_path.as_str()),
     );
 
     if let Some(ref extension_env) = runtime.env {
@@ -768,7 +697,7 @@ fn execute_extension_runtime(
     )?;
 
     let args_str = build_args_string(&extension, inputs, args);
-    let context = resolve_extension_context(
+    let context = ResolvedExtensionInvocationContext::resolve_runtime(
         &extension,
         extension_id,
         project_id,
@@ -898,6 +827,114 @@ mod tests {
     use super::*;
     use crate::component::Component;
     use crate::extension::extract_component_extension_settings;
+
+    fn make_executable(path: &Path) {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = std::fs::metadata(path)
+                .expect("script metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(path, permissions).expect("make script executable");
+        }
+    }
+
+    fn write_extension(home: &Path, id: &str, manifest: serde_json::Value, script: &str) {
+        let dir = home.join(".config/homeboy/extensions").join(id);
+        std::fs::create_dir_all(&dir).expect("extension dir");
+        std::fs::write(dir.join(format!("{id}.json")), manifest.to_string()).expect("manifest");
+        let script_path = dir.join("run.sh");
+        std::fs::write(&script_path, script).expect("script");
+        make_executable(&script_path);
+    }
+
+    #[test]
+    fn extension_run_preserves_project_attachment_component_path() {
+        crate::test_support::with_isolated_home(|home| {
+            let attachment = tempfile::tempdir().expect("attachment");
+            std::fs::write(
+                attachment.path().join("homeboy.json"),
+                r#"{"id":"fixture","extensions":{"fixture-extension":{"settings":{"source":"component"}}}}"#,
+            )
+            .expect("portable component");
+            write_extension(
+                home.path(),
+                "fixture-extension",
+                serde_json::json!({
+                    "name": "fixture-extension", "version": "1.0.0",
+                    "requires": { "components": ["fixture"] },
+                    "executable": { "runtime": { "run_command": "sh {{extension_path}}/run.sh" } }
+                }),
+                "#!/bin/sh\nprintf '%s' \"$HOMEBOY_COMPONENT_PATH\"\n",
+            );
+            crate::project::save(&crate::project::Project {
+                id: "site".to_string(),
+                components: vec![crate::project::ProjectComponentAttachment {
+                    id: "fixture".to_string(),
+                    local_path: attachment.path().to_string_lossy().to_string(),
+                    remote_path: None,
+                }],
+                ..Default::default()
+            })
+            .expect("project");
+
+            let result = run_extension(
+                "fixture-extension",
+                Some("site"),
+                Some("fixture"),
+                vec![],
+                vec![],
+                ExtensionExecutionMode::Captured,
+                ExtensionStepFilter::default(),
+            )
+            .expect("extension run");
+
+            assert_eq!(
+                result.output.expect("output").stdout,
+                attachment.path().to_string_lossy()
+            );
+        });
+    }
+
+    #[test]
+    fn extension_run_with_component_exports_component_identity_and_path() {
+        crate::test_support::with_isolated_home(|home| {
+            let component = tempfile::tempdir().expect("component");
+            crate::component::write_standalone_component_config(&Component::new(
+                "fixture".to_string(),
+                component.path().to_string_lossy().to_string(),
+                "fixture-extension".to_string(),
+                None,
+            ))
+            .expect("component config");
+            write_extension(
+                home.path(),
+                "fixture-extension",
+                serde_json::json!({
+                    "name": "fixture-extension", "version": "1.0.0",
+                    "executable": { "runtime": { "run_command": "sh {{extension_path}}/run.sh" } }
+                }),
+                "#!/bin/sh\nprintf '%s|%s' \"$HOMEBOY_COMPONENT_ID\" \"$HOMEBOY_COMPONENT_PATH\"\n",
+            );
+
+            let result = run_extension(
+                "fixture-extension",
+                None,
+                Some("fixture"),
+                vec![],
+                vec![],
+                ExtensionExecutionMode::Captured,
+                ExtensionStepFilter::default(),
+            )
+            .expect("extension run");
+
+            assert_eq!(
+                result.output.expect("output").stdout,
+                format!("fixture|{}", component.path().to_string_lossy()),
+            );
+        });
+    }
 
     #[test]
     fn build_exec_env_includes_runtime_runner_helper_paths() {

--- a/crates/homeboy-core/src/extension/execution/action.rs
+++ b/crates/homeboy-core/src/extension/execution/action.rs
@@ -5,11 +5,9 @@ use crate::project;
 use crate::server::http::ApiClient;
 use homeboy_engine_primitives::validation;
 
-use super::{
-    build_action_env, execute_extension_command, load_extension, ExtensionExecutionMode,
-    ExtensionScope,
-};
+use super::{build_action_env, execute_extension_command, load_extension, ExtensionExecutionMode};
 use crate::extension::manifest::{ActionConfig, ActionType, HttpMethod};
+use crate::extension::ExtensionScope;
 
 pub(crate) fn execute_action(
     extension_id: &str,

--- a/crates/homeboy-core/src/extension/invocation_context.rs
+++ b/crates/homeboy-core/src/extension/invocation_context.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+
+use crate::component::{self, Component};
+use crate::engine::template;
+use crate::error::{Error, Result};
+use crate::project::{self, Project};
+
+use super::{ExtensionManifest, ExtensionScope};
+
+/// The resolved project/component/settings identity for one extension invocation.
+///
+/// Resolve this once at the command boundary. Execution code must use the retained
+/// component instead of resolving its ID again, because a project attachment can
+/// deliberately differ from the globally registered component path.
+#[derive(Debug, Clone)]
+pub struct ResolvedExtensionInvocationContext {
+    pub extension_id: String,
+    pub project_id: Option<String>,
+    pub project: Option<Project>,
+    pub component: Option<Component>,
+    pub settings: HashMap<String, serde_json::Value>,
+}
+
+impl ResolvedExtensionInvocationContext {
+    pub fn for_component(
+        extension_id: &str,
+        project: Option<Project>,
+        component: Component,
+    ) -> Result<Self> {
+        let settings =
+            ExtensionScope::effective_settings(extension_id, project.as_ref(), Some(&component))?;
+
+        Ok(Self {
+            extension_id: extension_id.to_string(),
+            project_id: project.as_ref().map(|project| project.id.clone()),
+            project,
+            component: Some(component),
+            settings,
+        })
+    }
+
+    pub fn resolve_runtime(
+        extension: &ExtensionManifest,
+        extension_id: &str,
+        project_id: Option<&str>,
+        component_id: Option<&str>,
+        run_command: &str,
+    ) -> Result<Self> {
+        let requires_project = extension.requires.is_some()
+            || template::is_present(run_command, "projectId")
+            || template::is_present(run_command, "sitePath")
+            || template::is_present(run_command, "cliPath")
+            || template::is_present(run_command, "domain");
+
+        let project = if requires_project {
+            let project_id = project_id.ok_or_else(|| {
+                Error::config(format!(
+                    "Extension {} requires a project context, but no project ID was provided",
+                    extension.id
+                ))
+            })?;
+            let project = project::load(project_id)?;
+            ExtensionScope::validate_project_compatibility(extension, &project)?;
+            Some(project)
+        } else {
+            None
+        };
+
+        let component_id = match project.as_ref() {
+            Some(project) => {
+                ExtensionScope::resolve_component_scope(extension, project, component_id)?
+            }
+            None => component_id.map(str::to_string),
+        };
+        let component = component_id
+            .as_deref()
+            .map(|component_id| {
+                component::resolve_effective(Some(component_id), None, project.as_ref())
+            })
+            .transpose()?;
+
+        let settings =
+            ExtensionScope::effective_settings(extension_id, project.as_ref(), component.as_ref())?;
+
+        Ok(Self {
+            extension_id: extension_id.to_string(),
+            project_id: project.as_ref().map(|project| project.id.clone()),
+            project,
+            component,
+            settings,
+        })
+    }
+}

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -12,6 +12,7 @@ mod dev_run;
 mod env_provider;
 mod execution;
 mod fingerprint;
+mod invocation_context;
 // The grammar parsing engine is a language-agnostic primitive; it now lives in
 // homeboy-engine-primitives. Re-exported here so existing
 // `crate::extension::grammar` / `crate::extension::grammar_items` paths keep
@@ -78,6 +79,7 @@ pub use fingerprint::{
     run_fingerprint_script, AggregateConstructionSeam, AggregateLiteral, CallSite, DeadCodeMarker,
     FingerprintOutput, HookRef, UnusedParam,
 };
+pub use invocation_context::ResolvedExtensionInvocationContext;
 pub(crate) use lifecycle::source_metadata::resolve_source_url;
 pub use lifecycle::source_metadata::SourceMetadataRepair;
 pub use lifecycle::{

--- a/crates/homeboy-core/src/extension/runner.rs
+++ b/crates/homeboy-core/src/extension/runner.rs
@@ -224,7 +224,9 @@ impl ExtensionRunner {
     pub fn run(&self) -> Result<RunnerOutput> {
         let prepared = super::execution::prepare_capability_run(
             &self.execution_context,
-            self.pre_loaded_component.as_ref(),
+            self.pre_loaded_component
+                .as_ref()
+                .or(Some(&self.execution_context.component)),
             self.path_override.as_deref(),
             &self.settings_overrides,
             &self.settings_json_overrides,


### PR DESCRIPTION
## Summary
Carry one resolved extension invocation context through direct and capability execution.

## What changed
- Preserve project attachment paths, component-only environment identity, and project/component/CLI settings precedence without re-resolving components by ID.

## How to test
1. Run `Run the project attachment path regression test`; expect Attachment-specific component path is exported..
2. Run `Run component-only and capability settings regression tests`; expect Identity and precedence are preserved..

## Compatibility
Environment variable names and manifest shapes are unchanged; documented context is now consistently delivered.

## Evidence
- Base unchanged since verification: main remains at 4dd03157102e31827b7e3156ede26c86c34a98b5.
- CI expected: cargo test -p homeboy-core --lib
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8645
- Verified finalization base: main at 4dd03157102e31827b7e3156ede26c86c34a98b5
- invocation-context: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent
- **Model:** openai/gpt-5.6-sol
- **Used for:** Unified project, component, path, and settings resolution and added regression tests; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8645
