### PR TITLE
Keep activity reads state neutral

### DIFF
--- a/crates/homeboy-cli/src/commands/activity.rs
+++ b/crates/homeboy-cli/src/commands/activity.rs
@@ -5,7 +5,6 @@ use serde::Serialize;
 
 use homeboy::core::activity::{self, ActivityItem, ActivityReport, ActivityScope, ActivityState};
 use homeboy::core::notify::{self, NotifyEvent, NotifyOutcome};
-use homeboy::core::observation::ObservationStore;
 use homeboy::core::{Error, Result};
 
 use super::utils::response::{
@@ -180,7 +179,6 @@ pub fn render_activity_summary(payload: &serde_json::Value) -> Option<String> {
 }
 
 fn list(args: ActivityListArgs) -> CmdResult<ActivityOutput> {
-    reconcile_runs_best_effort();
     let scope = if args.all {
         ActivityScope::All
     } else {
@@ -195,7 +193,6 @@ fn list(args: ActivityListArgs) -> CmdResult<ActivityOutput> {
 }
 
 fn show(id: &str) -> CmdResult<ActivityOutput> {
-    reconcile_runs_best_effort();
     let report = activity::show_activity(id)?;
     let actionable = actionable_for_activity_report(&report);
     Ok((
@@ -211,7 +208,6 @@ fn watch(args: ActivityWatchArgs) -> CmdResult<ActivityOutput> {
     let mut poll_count = 0;
 
     loop {
-        reconcile_runs_best_effort();
         let item = activity::resolve_activity(&args.id)?;
         poll_count += 1;
         eprintln!(
@@ -239,12 +235,6 @@ fn watch(args: ActivityWatchArgs) -> CmdResult<ActivityOutput> {
             }
         }
         std::thread::sleep(interval);
-    }
-}
-
-fn reconcile_runs_best_effort() {
-    if let Ok(store) = ObservationStore::open_initialized() {
-        let _ = crate::commands::runs::reconcile::reconcile_owned_stale_running_runs(&store, 1000);
     }
 }
 
@@ -488,6 +478,8 @@ fn truncate(value: &str, width: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
+    use homeboy::test_support::with_isolated_home;
     use serde_json::json;
 
     #[test]
@@ -506,5 +498,49 @@ mod tests {
             parse_duration("2s").expect("duration"),
             Duration::from_secs(2)
         );
+    }
+
+    #[test]
+    fn activity_reads_do_not_reconcile_stale_running_records() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(
+                    NewRunRecord::builder("activity-read-test")
+                        .metadata(json!({ "owner_pid": 999_999 }))
+                        .build(),
+                )
+                .expect("running run");
+            let before = store
+                .get_run(&run.id)
+                .expect("read run")
+                .expect("run exists");
+
+            list(ActivityListArgs {
+                limit: 1,
+                all: false,
+            })
+            .expect("list activity");
+            show(&run.id).expect("show activity");
+            watch(ActivityWatchArgs {
+                id: run.id.clone(),
+                timeout: Some("0s".to_string()),
+                interval: "0s".to_string(),
+                notify: false,
+            })
+            .expect("watch activity");
+            list(ActivityListArgs {
+                limit: 1,
+                all: false,
+            })
+            .expect("repeat list activity");
+
+            let after = store
+                .get_run(&run.id)
+                .expect("read run")
+                .expect("run exists");
+            assert_eq!(after, before);
+            assert_eq!(after.status, RunStatus::Running.as_str());
+        });
     }
 }

--- a/crates/homeboy-core/src/activity.rs
+++ b/crates/homeboy-core/src/activity.rs
@@ -132,13 +132,9 @@ pub struct ActivityReport {
 }
 
 pub fn activity_report(scope: ActivityScope, limit: usize) -> Result<ActivityReport> {
-    // Agent-task lifecycle is authoritative over the runner/session mirrors.
-    // Refresh accepted daemon handoffs first so controller wait expiry is not
-    // projected as a terminal local failure.
-    let _ = agent_task_lifecycle::reconcile_active_runner_handoffs();
     let mut collector = ActivityCollector::default();
     observation::collect(&mut collector, limit)?;
-    agent_tasks::collect(&mut collector, limit)?;
+    agent_tasks::collect(&mut collector)?;
     daemon_jobs::collect(&mut collector)?;
     runner_sessions::collect(&mut collector);
     let mut report = report_from_items(collector.items(scope, limit), "activity");
@@ -427,10 +423,22 @@ mod observation {
 
     pub(super) fn collect(collector: &mut ActivityCollector, limit: usize) -> Result<()> {
         let store = ObservationStore::open_initialized()?;
-        let records = store.list_runs(RunListFilter {
+        let mut records = store.list_runs(RunListFilter {
             limit: Some(limit as i64),
             ..Default::default()
         })?;
+        let listed_ids = records
+            .iter()
+            .map(|record| record.id.clone())
+            .collect::<BTreeSet<_>>();
+        // Recent terminal records are bounded for display, but active work is
+        // always included before the canonical report applies its final limit.
+        records.extend(
+            store
+                .list_active_runs()?
+                .into_iter()
+                .filter(|record| !listed_ids.contains(&record.id)),
+        );
         for run in records {
             collector.insert(item_from_run(&store, run)?);
         }
@@ -514,11 +522,8 @@ mod observation {
 mod agent_tasks {
     use super::*;
 
-    pub(super) fn collect(collector: &mut ActivityCollector, limit: usize) -> Result<()> {
-        for record in agent_task_lifecycle::list_records()?
-            .into_iter()
-            .take(limit)
-        {
+    pub(super) fn collect(collector: &mut ActivityCollector) -> Result<()> {
+        for record in agent_task_lifecycle::list_records()? {
             collector.insert(item_from_agent_task(record));
         }
         Ok(())
@@ -785,6 +790,7 @@ mod tests {
         status, AgentTaskRunState, LabOffloadProxyPlan,
     };
     use crate::api_jobs::JobStatus;
+    use crate::observation::NewRunRecord;
     use crate::test_support::with_isolated_home;
 
     fn item(id: &str, state: ActivityState) -> ActivityItem {
@@ -1023,6 +1029,28 @@ mod tests {
                     .state,
                 AgentTaskRunState::Cancelled
             );
+        });
+    }
+
+    #[test]
+    fn observation_collection_keeps_active_runs_outside_the_recent_source_limit() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let active = store
+                .start_run(NewRunRecord::builder("active").build())
+                .expect("active run");
+            let recent_terminal = store
+                .start_run(NewRunRecord::builder("terminal").build())
+                .expect("terminal run");
+            store
+                .finish_run(&recent_terminal.id, RunStatus::Pass, None)
+                .expect("finish terminal run");
+
+            let mut collector = ActivityCollector::default();
+            observation::collect(&mut collector, 1).expect("collect activity");
+            let items = collector.items(ActivityScope::All, 10);
+
+            assert!(items.iter().any(|item| item.id == active.id));
         });
     }
 

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -256,6 +256,28 @@ impl ObservationStore {
         collect_rows(rows, "collect run records")
     }
 
+    /// List every currently running run so callers can retain active work when
+    /// applying a separate display limit to recent history.
+    pub fn list_active_runs(&self) -> Result<Vec<RunRecord>> {
+        let mut statement = self
+            .connection
+            .prepare(
+                r#"
+                SELECT id, kind, component_id, started_at, finished_at, status, command, cwd,
+                       homeboy_version, git_sha, rig_id, metadata_json
+                FROM runs
+                WHERE status = ?1
+                ORDER BY started_at DESC, id DESC
+                "#,
+            )
+            .map_err(sqlite_error("prepare list active run records"))?;
+        let rows = statement
+            .query_map([RunStatus::Running.as_str()], row_to_run_record)
+            .map_err(sqlite_error("list active run records"))?;
+
+        collect_rows(rows, "collect active run records")
+    }
+
     pub fn latest_run(&self, mut filter: RunListFilter) -> Result<Option<RunRecord>> {
         filter.limit = Some(1);
         Ok(self.list_runs(filter)?.into_iter().next())

--- a/docs/commands/activity.md
+++ b/docs/commands/activity.md
@@ -28,4 +28,4 @@ Human output is a compact table followed by next-action command lines per item.
 
 ## Scope
 
-This is a local read model only. It does not create a daemon, event bus, or offloaded job, and the Lab contract marks it local-only.
+This is a local read model only. List, show, and watch do not reconcile or otherwise mutate persisted state. Use the structured `reconcile` actions when shown, such as `homeboy runs reconcile` or `homeboy agent-task active --reconcile`, to invoke the existing explicit reconciliation services. It does not create a daemon, event bus, or offloaded job, and the Lab contract marks it local-only.


### PR DESCRIPTION
## Summary
Make activity list, show, and watch strictly read-only while preserving active work before display limiting.

## What changed
- Removed implicit reconciliation from read paths and retained explicit reconciliation commands as actionable operations.

## How to test
1. Run `cargo test -p homeboy-core activity::tests --lib`; expect 12 tests pass..
2. Run `cargo test -p homeboy-cli commands::activity::tests --lib`; expect 3 tests pass..

## Compatibility
Activity schema and source provenance remain unchanged; reads no longer mutate lifecycle state.

## Evidence
- Base unchanged since verification: main remains at 4dd03157102e31827b7e3156ede26c86c34a98b5.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8646
- Verified finalization base: main at 4dd03157102e31827b7e3156ede26c86c34a98b5
- activity-cli: Passed
- activity-core: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent
- **Model:** openai/gpt-5.6-sol
- **Used for:** Removed implicit activity mutation, corrected active-record limiting, and added deterministic tests; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8646
