### PR TITLE
Allow hot controllers to coordinate Lab cook batches

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
@@ -19,7 +19,7 @@ pub enum AgentTaskFanoutCommand {
     RunPlan(AgentTaskFanoutRunPlanArgs),
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 pub struct AgentTaskFanoutCookBatchArgs {
     #[arg(value_name = "ISSUE_URL", required = true)]
     pub issues: Vec<String>,

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -43,6 +43,21 @@ pub(super) fn fanout(args: AgentTaskFanoutArgs) -> CmdResult<Value> {
     }
 }
 
+type CookAttemptDispatcherFactory = dyn Fn(
+        &AgentTaskCookServiceOptions,
+    ) -> std::sync::Arc<dyn crate::core::agent_task_service::AgentTaskCookAttemptDispatcher>
+    + Send
+    + Sync;
+
+/// Runs controller-owned cook-batch coordination while dispatching its typed
+/// provider attempts through the caller-selected transport.
+pub(crate) fn cook_batch_with_attempt_dispatcher(
+    args: AgentTaskFanoutCookBatchArgs,
+    attempt_dispatcher: &CookAttemptDispatcherFactory,
+) -> CmdResult<Value> {
+    cook_batch_inner(args, Some(attempt_dispatcher))
+}
+
 fn submit_batch_cook_fanout(args: AgentTaskFanoutSubmitArgs) -> CmdResult<Value> {
     let mut plan = load_batch_cook_fanout_plan(&args.input)?;
     if let Some(run_id) = args.run_id {
@@ -112,23 +127,21 @@ fn run_batch_cook_fanout(args: AgentTaskFanoutRunPlanArgs) -> CmdResult<Value> {
 
 /// Keeps durable batch coordination on the controller while routing each
 /// independent provider attempt through the selected transport.
-pub(crate) fn run_batch_cook_fanout_with_attempt_dispatcher<F>(
+pub(crate) fn run_batch_cook_fanout_with_attempt_dispatcher(
     args: AgentTaskFanoutRunPlanArgs,
-    attempt_dispatcher: F,
-) -> CmdResult<Value>
-where
-    F: Fn(
-            &AgentTaskCookServiceOptions,
-        )
-            -> std::sync::Arc<dyn crate::core::agent_task_service::AgentTaskCookAttemptDispatcher>
-        + Clone
-        + Send
-        + Sync,
-{
+    attempt_dispatcher: &CookAttemptDispatcherFactory,
+) -> CmdResult<Value> {
     let mut plan = load_batch_cook_fanout_plan(&args.input)?;
     if let Some(record_run_id) = args.record_run_id {
         plan.fanout_id = record_run_id;
     }
+    run_batch_cook_fanout_plan_with_attempt_dispatcher(plan, attempt_dispatcher)
+}
+
+fn run_batch_cook_fanout_plan_with_attempt_dispatcher(
+    plan: BatchCookFanoutPlan,
+    attempt_dispatcher: &CookAttemptDispatcherFactory,
+) -> CmdResult<Value> {
     let result = agent_task_service::run_cook_batch(
         agent_task_service::AgentTaskCookBatchOptions {
             batch_id: plan.fanout_id.clone(),
@@ -237,7 +250,14 @@ fn batch_cook_result(
     )
 }
 
-fn cook_batch(mut args: AgentTaskFanoutCookBatchArgs) -> CmdResult<Value> {
+fn cook_batch(args: AgentTaskFanoutCookBatchArgs) -> CmdResult<Value> {
+    cook_batch_inner(args, None)
+}
+
+fn cook_batch_inner(
+    mut args: AgentTaskFanoutCookBatchArgs,
+    attempt_dispatcher: Option<&CookAttemptDispatcherFactory>,
+) -> CmdResult<Value> {
     if !args.gates.has_deterministic_gate() {
         return Err(invalid_fanout(
             "agent-task fanout cook-batch requires --verify or --private-verify",
@@ -272,7 +292,12 @@ fn cook_batch(mut args: AgentTaskFanoutCookBatchArgs) -> CmdResult<Value> {
             .iter()
             .all(|row| matches!(row.status, worktree::WorktreeQueueCreateStatus::Created));
     let run_result = if args.run_plan && can_run {
-        let (value, exit_code) = run_batch_cook_fanout_plan(plan.clone())?;
+        let (value, exit_code) = match attempt_dispatcher {
+            Some(dispatcher) => {
+                run_batch_cook_fanout_plan_with_attempt_dispatcher(plan.clone(), dispatcher)?
+            }
+            None => run_batch_cook_fanout_plan(plan.clone())?,
+        };
         Some(serde_json::json!({ "exit_code": exit_code, "result": value }))
     } else {
         None

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -112,7 +112,9 @@ pub fn route_after_parse(
         return Ok(Some(exit_code));
     }
 
-    if let Some(exit_code) = run_split_placement_fanout(cli, output_file, cli.runner.as_deref())? {
+    if let Some(exit_code) =
+        run_split_placement_fanout(cli, output_file, inferred_runner_id.as_deref())?
+    {
         return Ok(Some(exit_code));
     }
 
@@ -270,18 +272,6 @@ fn run_split_placement_fanout(
     let Some(runner_id) = runner_id else {
         return Ok(None);
     };
-    let Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
-        command:
-            crate::commands::agent_task::AgentTaskCommand::Fanout(
-                crate::commands::agent_task::AgentTaskFanoutArgs {
-                    command: crate::commands::agent_task::AgentTaskFanoutCommand::RunPlan(args),
-                },
-            ),
-    }) = &cli.command
-    else {
-        return Ok(None);
-    };
-
     let dispatcher = LabCookAttemptDispatcher {
         runner_id: runner_id.to_string(),
         allow_local_fallback: false,
@@ -291,20 +281,46 @@ fn run_split_placement_fanout(
         source_path: None,
         job_overrides: lab_job_overrides(cli)?,
     };
-    let (value, exit_code) =
-        crate::commands::agent_task::fanout::run_batch_cook_fanout_with_attempt_dispatcher(
+    let attempt_dispatcher =
+        move |options: &crate::core::agent_task_service::AgentTaskCookServiceOptions| {
+            let mut dispatcher = dispatcher.clone();
+            dispatcher.source_path = options
+                .initial_plan
+                .tasks
+                .first()
+                .and_then(|task| task.workspace.root.as_ref())
+                .map(PathBuf::from);
+            Arc::new(dispatcher)
+                as Arc<dyn crate::core::agent_task_service::AgentTaskCookAttemptDispatcher>
+        };
+    let (value, exit_code) = match &cli.command {
+        Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+            command:
+                crate::commands::agent_task::AgentTaskCommand::Fanout(
+                    crate::commands::agent_task::AgentTaskFanoutArgs {
+                        command: crate::commands::agent_task::AgentTaskFanoutCommand::RunPlan(args),
+                    },
+                ),
+        }) => crate::commands::agent_task::fanout::run_batch_cook_fanout_with_attempt_dispatcher(
             args.clone(),
-            move |options| {
-                let mut dispatcher = dispatcher.clone();
-                dispatcher.source_path = options
-                    .initial_plan
-                    .tasks
-                    .first()
-                    .and_then(|task| task.workspace.root.as_ref())
-                    .map(PathBuf::from);
-                Arc::new(dispatcher)
-            },
-        )?;
+            &attempt_dispatcher,
+        )?,
+        Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+            command:
+                crate::commands::agent_task::AgentTaskCommand::Fanout(
+                    crate::commands::agent_task::AgentTaskFanoutArgs {
+                        command:
+                            crate::commands::agent_task::AgentTaskFanoutCommand::CookBatch(args),
+                    },
+                ),
+        }) if args.run_plan => {
+            crate::commands::agent_task::fanout::cook_batch_with_attempt_dispatcher(
+                args.clone(),
+                &attempt_dispatcher,
+            )?
+        }
+        _ => return Ok(None),
+    };
     let stdout = serde_json::to_string_pretty(&value).map_err(|error| {
         Error::internal_json(
             error.to_string(),

--- a/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
@@ -722,6 +722,9 @@ fn agent_task_fanout_cook_batch_run_plan_keeps_cook_coordinators_local() {
     assert_eq!(command.hot_label, "agent-task fanout cook-batch");
     assert!(!command.is_portable());
     assert!(!command.routing_policy.default_lab_offload);
+    // Controller coordination stays local while typed child attempts retain
+    // the selected Lab runner and its normal placement enforcement (#8519).
+    assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/utils/resource_policy.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy.rs
@@ -143,7 +143,10 @@ fn severity_str(recommendation: ResourceRecommendation) -> &'static str {
 }
 
 pub fn hot_command(command: &Commands) -> Option<HotCommand> {
-    if is_plan_only_command(command) || is_read_only_agent_task(command) {
+    if is_plan_only_command(command)
+        || is_controller_owned_fanout_coordination(command)
+        || is_read_only_agent_task(command)
+    {
         return None;
     }
 
@@ -178,6 +181,19 @@ pub fn hot_command(command: &Commands) -> Option<HotCommand> {
             Some(HotCommand::local_only(contract.hot_label, Some(reason)))
         }
     }
+}
+
+fn is_controller_owned_fanout_coordination(command: &Commands) -> bool {
+    matches!(
+        command,
+        Commands::AgentTask(agent_task::AgentTaskArgs {
+            command: agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
+                command: agent_task::AgentTaskFanoutCommand::CookBatch(
+                    agent_task::AgentTaskFanoutCookBatchArgs { run_plan: true, .. },
+                ),
+            }),
+        })
+    )
 }
 
 fn is_plan_only_command(command: &Commands) -> bool {
@@ -544,6 +560,24 @@ mod tests {
             "cargo build -j 3",
             "--dry-run",
             "https://github.com/Extra-Chill/homeboy/issues/7796",
+        ]);
+
+        assert!(hot_command(&cli.command).is_none());
+    }
+
+    #[test]
+    fn controller_owned_cook_batch_coordination_skips_hot_resource_refusal() {
+        let cli = Cli::parse_from([
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "cook-batch",
+            "--repo",
+            "homeboy",
+            "--verify",
+            "cargo test --lib",
+            "--run-plan",
+            "https://github.com/Extra-Chill/homeboy/issues/8519",
         ]);
 
         assert!(hot_command(&cli.command).is_none());


### PR DESCRIPTION
## Summary
Allow lightweight controller-owned cook-batch coordination under hot resource pressure while retaining normal Lab placement and resource enforcement for provider attempts.

## What changed
- Route cook-batch run-plan cells through the existing LabCookAttemptDispatcher and exempt only lightweight controller coordination from hot-command refusal.

## How to test
1. Run `cargo check -p homeboy-cli --lib`; expect Homeboy CLI compiles..
2. Run `Run cook-batch --run-plan on a hot controller with connected Lab`; expect Controller coordination remains local and provider attempts use Lab placement..

## Compatibility
No command or serialized contract changes. Existing local coordination remains local; execution cells now honor selected/default Lab placement.

## Evidence
- Base unchanged since verification: main remains at 4dd03157102e31827b7e3156ede26c86c34a98b5.
- CI expected: cargo check --workspace --tests --locked
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8519
- Verified finalization base: main at 4dd03157102e31827b7e3156ede26c86c34a98b5
- diff-hygiene: Passed
- homeboy-cli-compile: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode recovery subagent
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the hot-controller fanout deadlock, implemented the typed Lab dispatch repair, and verified the focused library build; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8519
