### PR TITLE
Fix persistence for admission failures

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
@@ -91,14 +91,25 @@ pub fn record_pre_execution_failure(
         },
     };
     let mut failed_record = record_aggregate(&mut record, plan, &aggregate)?;
+    let runner_id = failed_record.runner_id().map(str::to_string);
     let metadata = failed_record.ensure_metadata_object();
     metadata.insert(
         "pre_execution_failure".to_string(),
         json!({
             "phase": phase,
             "error_code": error.code.as_str(),
+            "failure_code": error.details.get("field").cloned().unwrap_or_else(|| json!(error.code.as_str())),
             "message": error.message,
+            "details": error.details.clone(),
             "hints": error.hints.iter().map(|hint| hint.message.as_str()).collect::<Vec<_>>(),
+            "provider_executions_consumed": 0,
+            "controller_identity": crate::build_identity::current().display,
+            "runner_id": runner_id,
+            "task_linkage": plan.tasks.iter().map(|task| json!({
+                "task_id": task.task_id,
+                "workspace": task.workspace,
+                "source_refs": task.source_refs,
+            })).collect::<Vec<_>>(),
         }),
     );
     store::write_record(&failed_record)?;

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -264,21 +264,55 @@ pub fn submit_plan(
     plan: &AgentTaskPlan,
     requested_run_id: Option<&str>,
 ) -> Result<AgentTaskRunRecord> {
+    submit_plan_with_runtime_admission(
+        plan,
+        requested_run_id,
+        crate::controller_runtime::admit_current,
+    )
+}
+
+pub(crate) trait RuntimeAdmissionEvidence {
+    fn runtime(&self) -> Value;
+}
+
+impl RuntimeAdmissionEvidence for crate::controller_runtime::RuntimeAdmission {
+    fn runtime(&self) -> Value {
+        self.runtime.clone()
+    }
+}
+
+#[cfg(test)]
+impl RuntimeAdmissionEvidence for Value {
+    fn runtime(&self) -> Value {
+        self.clone()
+    }
+}
+
+/// Persist the run identity before controller admission so an admission failure
+/// remains inspectable and retryable through the normal lifecycle commands.
+pub(crate) fn submit_plan_with_runtime_admission<F, A>(
+    plan: &AgentTaskPlan,
+    requested_run_id: Option<&str>,
+    admit_runtime: F,
+) -> Result<AgentTaskRunRecord>
+where
+    F: FnOnce() -> Result<A>,
+    A: RuntimeAdmissionEvidence,
+{
     let run_id = requested_run_id
         .map(sanitize_run_id)
         .unwrap_or_else(default_run_id);
     let plan_path = store::write_plan(&run_id, plan)?;
 
-    let admission = crate::controller_runtime::admit_current()?;
     let mut metadata = json!({
         "task_count": plan.tasks.len(),
         "max_concurrency": plan.options.max_concurrency,
         "provider_run_ids": [],
+        "provider_executions_consumed": 0,
+        "controller_identity": crate::build_identity::current().display,
         "lifecycle_schema": RUN_LIFECYCLE_RECORD_SCHEMA,
         "note": "submitted tasks are durable; provider run ids are recorded after an executor returns them as generic artifacts or evidence refs"
     });
-    metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
-        admission.runtime.clone();
     if let Ok(runner_id) = std::env::var(homeboy_runner_contract::RUNNER_ID_ENV) {
         if !runner_id.trim().is_empty() {
             metadata["runner_id"] = json!(runner_id);
@@ -288,9 +322,9 @@ pub fn submit_plan(
         route.insert_into_metadata(&mut metadata);
     }
 
-    let record = AgentTaskRunRecord {
+    let mut record = AgentTaskRunRecord {
         schema: schemas::RUN.to_string(),
-        run_id,
+        run_id: run_id.clone(),
         plan_id: plan.plan_id.clone(),
         state: AgentTaskRunState::Queued,
         submitted_at: now_timestamp(),
@@ -306,6 +340,18 @@ pub fn submit_plan(
         metadata,
     };
     store::write_record(&record)?;
+
+    match admit_runtime() {
+        Ok(admission) => {
+            record.metadata[crate::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
+                admission.runtime();
+            store::write_record(&record)?;
+        }
+        Err(error) => {
+            record_pre_execution_failure(&run_id, plan, "controller_admission", &error)?;
+            return Err(error);
+        }
+    }
     Ok(record)
 }
 

--- a/crates/homeboy-core/src/agent_task_service/cook.rs
+++ b/crates/homeboy-core/src/agent_task_service/cook.rs
@@ -1692,6 +1692,34 @@ mod tests {
         fail: bool,
     }
 
+    #[derive(Debug)]
+    struct AdmissionFailingAttemptDispatcher {
+        message: &'static str,
+    }
+
+    impl AgentTaskCookAttemptDispatcher for AdmissionFailingAttemptDispatcher {
+        fn durable_recipe(&self) -> Result<Value> {
+            Ok(serde_json::json!({ "kind": "test-admission-failure" }))
+        }
+
+        fn dispatch_attempt(
+            &self,
+            plan: AgentTaskPlan,
+            run_id: &str,
+            _derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+        ) -> Result<()> {
+            agent_task_lifecycle::submit_plan_with_runtime_admission(&plan, Some(run_id), || {
+                Err::<Value, _>(Error::validation_invalid_argument(
+                    "controller_admission",
+                    self.message,
+                    Some("fixture controller diagnostics".to_string()),
+                    None,
+                ))
+            })?;
+            Ok(())
+        }
+    }
+
     impl AgentTaskCookAttemptDispatcher for BatchAttemptDispatcher {
         fn durable_recipe(&self) -> Result<Value> {
             Ok(serde_json::json!({ "kind": "test-batch" }))
@@ -1782,6 +1810,111 @@ mod tests {
             attempt_dispatcher: Some(dispatcher),
             harvest_context: Default::default(),
         }
+    }
+
+    #[test]
+    fn cook_persists_controller_admission_timeout_before_provider_execution() {
+        crate::test_support::with_isolated_home(|_| {
+            let cook_id = "cook-admission-timeout";
+            let run_id = "cook-admission-timeout-attempt-1";
+            let mut options = batch_cook_options(
+                cook_id,
+                Arc::new(AdmissionFailingAttemptDispatcher {
+                    message: "timed out waiting for controller generation admission",
+                }),
+            );
+            options.provider_command = Some("fixture-provider".to_string());
+            let result = run_cook(
+                AgentTaskCookServiceOptions {
+                    initial_run_id: run_id.to_string(),
+                    ..options
+                },
+                UnusedExecutor,
+            )
+            .expect("cook returns the persisted dispatch failure");
+
+            assert_eq!(result.exit_code, 1);
+            assert_eq!(result.value.latest_run_id.as_deref(), Some(run_id));
+            assert_eq!(result.value.history_run_ids, vec![run_id]);
+            let record =
+                agent_task_lifecycle::status(run_id).expect("returned attempt is resolvable");
+            let logs =
+                agent_task_lifecycle::logs(run_id).expect("failed attempt logs are resolvable");
+            let retry = agent_task_lifecycle::retry(run_id, Some("cook-admission-timeout-retry"))
+                .expect("failed admission attempt is retryable");
+
+            assert_eq!(
+                record.state,
+                agent_task_lifecycle::AgentTaskRunState::Failed
+            );
+            assert!(record.provider_handles.is_empty());
+            assert_eq!(record.metadata["provider_executions_consumed"], 0);
+            assert_eq!(
+                record.metadata["pre_execution_failure"]["phase"],
+                "controller_admission"
+            );
+            assert_eq!(
+                record.metadata["pre_execution_failure"]["failure_code"],
+                "controller_admission"
+            );
+            assert!(record.metadata["pre_execution_failure"]["message"]
+                .as_str()
+                .expect("failure message")
+                .contains("timed out waiting for controller generation admission"));
+            assert_eq!(
+                record.metadata["pre_execution_failure"]["details"]["id"],
+                "fixture controller diagnostics"
+            );
+            assert_eq!(
+                record.metadata["pre_execution_failure"]["provider_executions_consumed"],
+                0
+            );
+            assert_eq!(
+                logs.events.last().map(|event| event.state),
+                Some(AgentTaskState::Failed)
+            );
+            assert_eq!(retry.metadata["retry_of"], run_id);
+            assert_eq!(
+                retry.metadata["retry_origin"]["pre_execution_failure"]["phase"],
+                "controller_admission"
+            );
+        });
+    }
+
+    #[test]
+    fn cook_persists_controller_runtime_mismatch_before_provider_execution() {
+        crate::test_support::with_isolated_home(|_| {
+            let run_id = "cook-runtime-mismatch-attempt-1";
+            let mut options = batch_cook_options(
+                "cook-runtime-mismatch",
+                Arc::new(AdmissionFailingAttemptDispatcher {
+                    message: "pinned controller executable hash mismatch: expected fixture, found replacement",
+                }),
+            );
+            options.provider_command = Some("fixture-provider".to_string());
+            let result = run_cook(
+                AgentTaskCookServiceOptions {
+                    initial_run_id: run_id.to_string(),
+                    ..options
+                },
+                UnusedExecutor,
+            )
+            .expect("cook returns the persisted runtime mismatch");
+
+            let record =
+                agent_task_lifecycle::status(run_id).expect("runtime mismatch attempt exists");
+            assert_eq!(result.exit_code, 1);
+            assert_eq!(
+                record.state,
+                agent_task_lifecycle::AgentTaskRunState::Failed
+            );
+            assert!(record.provider_handles.is_empty());
+            assert_eq!(record.metadata["provider_executions_consumed"], 0);
+            assert!(record.metadata["pre_execution_failure"]["message"]
+                .as_str()
+                .expect("failure message")
+                .contains("hash mismatch"));
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- persist the queued agent-task record before controller runtime admission
- terminalize admission failures with structured pre-execution evidence and zero consumed provider executions
- keep returned cook attempt IDs available to status, logs, diagnose, and linked retry flows
- cover controller admission timeout and immutable runtime mismatch before provider dispatch

Fixes #8656.

## Root cause

`submit_plan` persisted the plan, attempted controller runtime admission, and only wrote the lifecycle record after admission succeeded. A timeout or runtime mismatch therefore returned an attempt ID that did not exist in the durable lifecycle store.

## How to test

1. Run `cargo test -p homeboy-core agent_task_service::cook::tests::cook_persists_controller -- --test-threads=1`.
2. Confirm both admission-timeout and runtime-mismatch tests pass.
3. Run `cargo test -p homeboy-core failed_lab_handoff_retry_recovers_the_materialized_user_plan -- --test-threads=1`.
4. Confirm the existing retry test still passes and preserves the original pre-execution failure evidence.
5. Run `git diff --check origin/main...HEAD`.

## Verification

- Focused admission tests: 2 passed.
- Existing linked-retry lifecycle test: 1 passed.
- Release binary build: passed.
- `git diff --check`: passed.

The full lifecycle-filtered suite exceeded 25 minutes under local machine contention. The broader cook test scope also contains an existing batch fixture failure before dispatch because no workspace provider is configured. Strict crate Clippy is currently blocked by an unrelated `homeboy-cli-contract` derivable-impl finding.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode and Homeboy
- **Used for:** Reproduced the lifecycle failure, drafted the implementation and deterministic tests, and reviewed verification evidence; Chris reviewed and owns the change.
