### PR TITLE
refactor: relocate artifact-ref URI schemes into homeboy-engine-primitives

### DIFF
--- a/crates/homeboy-core/src/artifact_ref.rs
+++ b/crates/homeboy-core/src/artifact_ref.rs
@@ -8,9 +8,13 @@ use crate::observation::ArtifactRecord;
 
 pub const ARTIFACT_REF_SCHEMA: &str = "homeboy/artifact-ref/v1";
 pub const EVIDENCE_REF_SCHEMA: &str = "homeboy/evidence-ref/v1";
-pub const HOMEBOY_REF_SCHEME: &str = "homeboy://";
-pub const RUNNER_ARTIFACT_REF_SCHEME: &str = "runner-artifact://";
-pub const METADATA_ONLY_REF_SCHEME: &str = "metadata-only:";
+// The artifact-ref URI schemes live in homeboy-engine-primitives (the slim
+// shared base) so the audit engine and CLI command contract can check them
+// without depending on this module. Re-exported here to preserve existing
+// crate::artifact_ref::{HOMEBOY_REF_SCHEME, ...} call sites.
+pub use homeboy_engine_primitives::artifact_ref_scheme::{
+    HOMEBOY_REF_SCHEME, METADATA_ONLY_REF_SCHEME, RUNNER_ARTIFACT_REF_SCHEME,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReviewerFacingArtifactRefError {

--- a/crates/homeboy-core/src/code_audit/detectors/artifact_portability.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/artifact_portability.rs
@@ -2,8 +2,10 @@ use std::path::Path;
 
 use crate::code_audit::conventions::AuditFinding;
 use crate::code_audit::findings::{Finding, Severity};
-use crate::execution_contract::EXECUTION_CONTRACT;
 use homeboy_audit_contract::ArtifactPortabilityConfig;
+use homeboy_engine_primitives::artifact_ref_scheme::{
+    is_metadata_only_ref, is_runner_artifact_ref,
+};
 use serde_json::Value;
 
 pub(crate) const DEFAULT_OBSERVATION_RUN_WINDOW: usize = 1000;
@@ -91,9 +93,7 @@ fn artifact_path_is_portable(
     artifact_root: Option<&Path>,
     config: &ArtifactPortabilityConfig,
 ) -> bool {
-    if EXECUTION_CONTRACT.artifacts.is_runner_artifact_ref(path)
-        || EXECUTION_CONTRACT.artifacts.is_metadata_only_ref(path)
-    {
+    if is_runner_artifact_ref(path) || is_metadata_only_ref(path) {
         return true;
     }
     let path_ref = Path::new(path);
@@ -261,7 +261,7 @@ fn looks_like_local_absolute_path(
     artifact_root: Option<&Path>,
     _config: &ArtifactPortabilityConfig,
 ) -> bool {
-    if is_runner_artifact_ref(path) || EXECUTION_CONTRACT.artifacts.is_metadata_only_ref(path) {
+    if is_runner_artifact_ref(path) || is_metadata_only_ref(path) {
         return false;
     }
     let path_ref = Path::new(path);
@@ -274,10 +274,6 @@ fn looks_like_local_absolute_path(
         }
     }
     true
-}
-
-fn is_runner_artifact_ref(path: &str) -> bool {
-    EXECUTION_CONTRACT.artifacts.is_runner_artifact_ref(path)
 }
 
 fn metadata_promises_cleanup(value: &Value) -> bool {

--- a/crates/homeboy-engine-primitives/src/artifact_ref_scheme.rs
+++ b/crates/homeboy-engine-primitives/src/artifact_ref_scheme.rs
@@ -1,0 +1,53 @@
+//! Artifact-reference URI schemes.
+//!
+//! The stable string schemes that identify how an artifact path should be
+//! interpreted across process boundaries:
+//!
+//! - `homeboy://` — a homeboy-native artifact reference.
+//! - `runner-artifact://` — an artifact held by a runner (fetched on demand).
+//! - `metadata-only:` — a reference that carries only metadata, no payload.
+//!
+//! These are protocol constants shared by the runner/Lab/daemon execution
+//! surface (`homeboy-core::artifact_ref` / `execution_contract`), the CLI command
+//! contract, and the audit engine's artifact-portability detector. They live in
+//! `homeboy-engine-primitives` — the slim shared base — so consumers depend on
+//! the primitives layer rather than reaching up into `homeboy-core` (or each
+//! other) for a handful of scheme strings and prefix checks.
+
+/// Scheme for homeboy-native artifact references.
+pub const HOMEBOY_REF_SCHEME: &str = "homeboy://";
+
+/// Scheme for artifacts held by a runner (materialized on demand).
+pub const RUNNER_ARTIFACT_REF_SCHEME: &str = "runner-artifact://";
+
+/// Scheme for references that carry only metadata (no payload).
+pub const METADATA_ONLY_REF_SCHEME: &str = "metadata-only:";
+
+/// Whether `path` is a runner-artifact reference (`runner-artifact://…`).
+pub fn is_runner_artifact_ref(path: &str) -> bool {
+    path.starts_with(RUNNER_ARTIFACT_REF_SCHEME)
+}
+
+/// Whether `path` is a metadata-only reference (`metadata-only:…`).
+pub fn is_metadata_only_ref(path: &str) -> bool {
+    path.starts_with(METADATA_ONLY_REF_SCHEME)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_runner_artifact_refs() {
+        assert!(is_runner_artifact_ref("runner-artifact://r/run/a"));
+        assert!(!is_runner_artifact_ref("metadata-only:label"));
+        assert!(!is_runner_artifact_ref("/abs/path"));
+    }
+
+    #[test]
+    fn recognizes_metadata_only_refs() {
+        assert!(is_metadata_only_ref("metadata-only:label"));
+        assert!(!is_metadata_only_ref("runner-artifact://r/run/a"));
+        assert!(!is_metadata_only_ref("/abs/path"));
+    }
+}

--- a/crates/homeboy-engine-primitives/src/lib.rs
+++ b/crates/homeboy-engine-primitives/src/lib.rs
@@ -6,6 +6,7 @@
 //! own crate so they compile as an independent unit and are re-exported under
 //! `crate::core::engine::*` in the main binary for source compatibility.
 
+pub mod artifact_ref_scheme;
 pub mod baseline;
 pub mod codebase_scan;
 pub mod command;


### PR DESCRIPTION
## Summary
- Moves the artifact-ref URI schemes (`homeboy://`, `runner-artifact://`, `metadata-only:`) plus slim `is_runner_artifact_ref` / `is_metadata_only_ref` prefix predicates from `homeboy-core`'s `artifact_ref` into `homeboy-engine-primitives::artifact_ref_scheme`.
- Re-exported from `artifact_ref` so existing `crate::artifact_ref::{HOMEBOY_REF_SCHEME, ...}` call sites are unaffected.

## Why (extraction-prep for #8425)
This severs `code_audit`'s **last heavy downward edge**. The artifact-portability detector reached `crate::execution_contract::EXECUTION_CONTRACT` just to call `.artifacts.is_runner_artifact_ref(path)` / `.is_metadata_only_ref(path)` — two trivial `starts_with` checks. But `execution_contract` is mutually entangled with `artifact_ref`, which itself drags `observation::ArtifactRecord`. So a one-line predicate was pulling `code_audit` into a whole cluster of core internals.

The detector now calls the primitives predicates directly, so **`code_audit` no longer depends on `execution_contract` or `artifact_ref` at all**. The schemes are protocol constants that belong in the slim shared base anyway — the runner/Lab/daemon surface, the CLI command contract, and the audit detector all check them.

## What's left before the crate git-mv
After this, `code_audit`'s remaining downward deps on `homeboy-core` are all small leaves:
- `product_identity` — already its own crate (`homeboy-product-identity`), just a dep-swap at extraction; zero prep.
- `is_zero` — a 3-line serde helper; trivially localized.
- `defaults::extension_provided_detector_profile`, `plan::{HomeboyPlan,...}` — entangled, each its own careful cut.
- `log_status!` macro.

## Verification
- `cargo check -p homeboy-engine-primitives --lib`, `-p homeboy-core --lib` — 0 errors, no new warnings (removed the now-redundant local `is_runner_artifact_ref` wrapper).
- `cargo check --workspace --tests --locked` (topology guard) — **passes** (cli command-contract + core scheme consumers resolve via the re-export).
- `cargo test -p homeboy-core --lib code_audit::detectors::artifact_portability` — **12 passed**; `homeboy-engine-primitives --lib artifact_ref_scheme` — **2 passed**.
- Confirmed `grep` shows zero `execution_contract` references left in `code_audit`.

Refs #8425