### PR TITLE
refactor: make code_audit self-contained for log_status and is_zero

### DIFF
--- a/crates/homeboy-core/src/code_audit/audit_log.rs
+++ b/crates/homeboy-core/src/code_audit/audit_log.rs
@@ -1,0 +1,18 @@
+//! Audit-local status logging.
+//!
+//! The audit engine emits prefixed progress lines to stderr (only when stderr is
+//! a terminal). It defines its own `log_status!` here rather than depending on a
+//! crate-root macro so `code_audit` stays self-contained — a prerequisite for
+//! extracting it into its own crate. The macro is identical in behavior to the
+//! shared one used elsewhere in the workspace.
+
+/// Prefixed status logging to stderr, emitted only when stderr is a terminal.
+///
+/// Usage: `log_status!("audit", "Scanning {}...", path);`
+macro_rules! log_status {
+    ($prefix:expr, $($arg:tt)*) => {
+        if ::std::io::IsTerminal::is_terminal(&::std::io::stderr()) {
+            eprintln!(concat!("[", $prefix, "] {}"), format_args!($($arg)*));
+        }
+    };
+}

--- a/crates/homeboy-core/src/code_audit/docs_audit/mod.rs
+++ b/crates/homeboy-core/src/code_audit/docs_audit/mod.rs
@@ -16,7 +16,12 @@ use std::path::Path;
 pub use claims::{Claim, ClaimConfidence, ClaimType};
 pub use verify::VerifyResult;
 
-use crate::is_zero;
+/// Serde helper for `#[serde(skip_serializing_if = "is_zero")]` on `usize`
+/// fields. Defined locally so `code_audit` does not depend on a crate-root
+/// helper (extraction-prep).
+fn is_zero(v: &usize) -> bool {
+    *v == 0
+}
 
 /// A doc that needs content review due to referenced files changing.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/homeboy-core/src/code_audit/mod.rs
+++ b/crates/homeboy-core/src/code_audit/mod.rs
@@ -11,6 +11,8 @@
 //! 5. Producing actionable findings for outliers
 //! 6. Analyzing structural complexity (god files, high item counts)
 
+#[macro_use]
+mod audit_log;
 pub mod baseline;
 pub mod baseline_merge;
 mod checks;

--- a/crates/homeboy-core/src/code_audit/run.rs
+++ b/crates/homeboy-core/src/code_audit/run.rs
@@ -208,7 +208,7 @@ fn run_audit(args: &AuditRunWorkflowArgs) -> crate::Result<Option<AuditWithAnaly
     if let Some(ref git_ref) = args.changed_since {
         let changed = changed_files_for_scope(args, git_ref)?;
         if changed.is_empty() {
-            crate::log_status!("audit", "No files changed since {}", git_ref);
+            log_status!("audit", "No files changed since {}", git_ref);
             return Ok(None);
         }
         Ok(Some(code_audit::audit_path_scoped_with_plan_and_analysis(
@@ -253,13 +253,13 @@ fn run_baseline_save(
     let saved = if let Some(ref git_ref) = args.changed_since {
         let changed = changed_files_for_scope(args, git_ref)?;
         if changed.is_empty() {
-            crate::log_status!(
+            log_status!(
                 "baseline",
                 "No files changed since {} — baseline unchanged",
                 git_ref
             );
         } else {
-            crate::log_status!(
+            log_status!(
                 "baseline",
                 "Scoped baseline update: {} file(s) in scope",
                 changed.len()


### PR DESCRIPTION
## Summary
Removes two `code_audit -> homeboy-core` crate-root downward edges by giving `code_audit` its own tiny copies:
- **`log_status!`** — a `code_audit::audit_log` module-local macro (identical behavior), brought into the `code_audit` module tree via `#[macro_use]`. The 3 `crate::log_status!` call sites in `run.rs` become bare `log_status!`; the ~30 bare call sites (engine/reference/conventions/descriptor_runtime) now resolve to the audit-local macro.
- **`is_zero`** — a local `fn is_zero` in `docs_audit` instead of `use crate::is_zero`.

## Why local copies (not a relocation)
`log_status!` is used bare (via `#[macro_export]` + crate-root textual scoping) in **~55 files** across deploy/release/server/refactor/extension. Relocating it to a base crate would break that ambient availability and force `use` statements into all 55 files — a huge, noisy, cross-cutting diff. A `code_audit`-local copy (5-line macro) is the surgical extraction-prep move with **zero blast radius outside `code_audit`**. Same for `is_zero` — a 3-line serde helper that's cleaner kept private to the module that uses it.

## Extraction-prep for #8425
After this, `code_audit`'s remaining downward deps on `homeboy-core` are:
- `product_identity` — already its own crate; zero prep (dep-swap at extraction).
- `defaults::extension_provided_detector_profile`, `plan::{HomeboyPlan,...}` — entangled, each its own careful cut.

## Verification
- `cargo check -p homeboy-core --lib` — 0 errors, no new warnings.
- `cargo check --workspace --tests --locked` (topology guard) — **passes**.
- `cargo test -p homeboy-core --lib code_audit::` — **769 passed, 0 failed**.
- `grep` confirms zero `crate::log_status` / `crate::is_zero` refs left in `code_audit`.

Refs #8425