### PR TITLE
Publish GitHub releases after asset verification

### DIFF
--- a/crates/homeboy-core/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-core/src/release/executor/github_release/gh_cli.rs
@@ -74,6 +74,98 @@ pub(crate) fn github_release_artifact_paths(state: &ReleaseState) -> Vec<String>
         .collect()
 }
 
+/// Resolve every local asset required to publish a release. A cargo-dist
+/// manifest is itself an uploadable asset, but it also declares the archives
+/// that must exist before the release can become public.
+pub(crate) fn github_release_asset_paths(state: &ReleaseState) -> Result<Vec<String>, String> {
+    let mut paths = github_release_artifact_paths(state);
+    let manifests = paths
+        .iter()
+        .filter(|path| {
+            std::path::Path::new(path)
+                .file_name()
+                .and_then(|name| name.to_str())
+                == Some("dist-manifest.json")
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+
+    for manifest in manifests {
+        let contents = std::fs::read_to_string(&manifest).map_err(|error| {
+            format!("could not read distribution manifest '{manifest}': {error}")
+        })?;
+        let value: serde_json::Value = serde_json::from_str(&contents).map_err(|error| {
+            format!("could not parse distribution manifest '{manifest}': {error}")
+        })?;
+        let manifest_dir = std::path::Path::new(&manifest)
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."));
+        collect_manifest_assets(&value, manifest_dir, &mut paths);
+    }
+
+    paths.sort();
+    paths.dedup();
+    let missing = paths
+        .iter()
+        .filter(|path| !path_is_file(path))
+        .map(|path| release_asset_name(path))
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        Ok(paths)
+    } else {
+        Err(format!(
+            "release assets declared by dist-manifest.json are missing: {}. Run the package step again, then resume with `homeboy release --head --from-artifacts <artifact-dir>`.",
+            missing.join(", ")
+        ))
+    }
+}
+
+fn collect_manifest_assets(
+    value: &serde_json::Value,
+    manifest_dir: &std::path::Path,
+    paths: &mut Vec<String>,
+) {
+    match value {
+        serde_json::Value::Object(object) => {
+            // cargo-dist artifacts use a path/name pair. Require a distributable
+            // filename so unrelated manifest metadata is never treated as an asset.
+            if let Some(path) = object.get("path").and_then(serde_json::Value::as_str) {
+                let candidate = std::path::Path::new(path);
+                if is_release_archive(candidate) {
+                    paths.push(manifest_dir.join(candidate).display().to_string());
+                }
+            }
+            for value in object.values() {
+                collect_manifest_assets(value, manifest_dir, paths);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_manifest_assets(value, manifest_dir, paths);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_release_archive(path: &std::path::Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            [".tar.xz", ".tar.gz", ".tar.zst", ".zip", ".sha256"]
+                .iter()
+                .any(|suffix| name.ends_with(suffix))
+        })
+}
+
+fn release_asset_name(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(path)
+        .to_string()
+}
+
 pub(crate) fn github_release_upload_timeout() -> Duration {
     std::env::var(GITHUB_RELEASE_UPLOAD_TIMEOUT_ENV)
         .ok()
@@ -374,6 +466,74 @@ mod tests {
         assert_eq!(
             github_release_artifact_paths(&state),
             vec![durable.display().to_string()]
+        );
+    }
+
+    #[test]
+    fn manifest_only_release_fails_with_the_missing_target_archive() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manifest = dir.path().join("dist-manifest.json");
+        std::fs::write(
+            &manifest,
+            r#"{"artifacts":[{"path":"homeboy-x86_64-unknown-linux-gnu.tar.xz"}]}"#,
+        )
+        .expect("write manifest");
+        let state = ReleaseState {
+            artifacts: vec![crate::release::types::ReleaseArtifact {
+                path: manifest.display().to_string(),
+                durable_path: None,
+                artifact_type: None,
+                platform: None,
+            }],
+            ..ReleaseState::default()
+        };
+
+        let error = github_release_asset_paths(&state).expect_err("missing archive");
+        assert!(error.contains("homeboy-x86_64-unknown-linux-gnu.tar.xz"));
+        assert!(error.contains("homeboy release --head --from-artifacts"));
+    }
+
+    #[test]
+    fn manifest_declared_archives_are_uploaded_with_the_manifest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manifest = dir.path().join("dist-manifest.json");
+        let archive = dir.path().join("homeboy-x86_64-unknown-linux-gnu.tar.xz");
+        std::fs::write(&archive, b"archive").expect("write archive");
+        std::fs::write(
+            &manifest,
+            r#"{"artifacts":[{"path":"homeboy-x86_64-unknown-linux-gnu.tar.xz"}]}"#,
+        )
+        .expect("write manifest");
+        let state = ReleaseState {
+            artifacts: vec![crate::release::types::ReleaseArtifact {
+                path: manifest.display().to_string(),
+                durable_path: None,
+                artifact_type: None,
+                platform: None,
+            }],
+            ..ReleaseState::default()
+        };
+
+        assert_eq!(
+            github_release_asset_paths(&state).expect("assets"),
+            vec![
+                manifest.display().to_string(),
+                archive.display().to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn verification_names_the_missing_uploaded_archive() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("homeboy-x86_64-unknown-linux-gnu.tar.xz");
+        std::fs::write(&path, b"archive").expect("write archive");
+
+        let error = verify_release_assets(&[path.display().to_string()], &[])
+            .expect_err("remote archive is absent");
+        assert_eq!(
+            error,
+            "GitHub Release is missing uploaded asset 'homeboy-x86_64-unknown-linux-gnu.tar.xz'"
         );
     }
 }

--- a/crates/homeboy-core/src/release/executor/github_release/mod.rs
+++ b/crates/homeboy-core/src/release/executor/github_release/mod.rs
@@ -46,4 +46,6 @@ pub(crate) use repair::{
     github_release_repair_commands_with_proxy, GitHubReleaseRepairCommands,
 };
 #[cfg(test)]
-pub(crate) use results::{create_failed_result, not_created_result, upload_failed_result};
+pub(crate) use results::{
+    create_failed_result, not_created_result, upload_failed_result, upload_success_result,
+};

--- a/crates/homeboy-core/src/release/executor/github_release/results.rs
+++ b/crates/homeboy-core/src/release/executor/github_release/results.rs
@@ -162,7 +162,7 @@ pub(crate) fn upload_failed_result(
     )
 }
 
-pub(super) fn upload_success_result(
+pub(crate) fn upload_success_result(
     tag: &str,
     github: &GitHubRepo,
     artifact_count: usize,

--- a/crates/homeboy-core/src/release/executor/github_release/run.rs
+++ b/crates/homeboy-core/src/release/executor/github_release/run.rs
@@ -7,7 +7,7 @@ use crate::release::types::{ReleaseState, ReleaseStepResult};
 use super::super::step_success;
 use super::gh_cli::{
     gh_command, gh_is_authenticated, gh_is_available, gh_release_exists,
-    github_release_artifact_paths,
+    github_release_artifact_paths, github_release_asset_paths,
 };
 use super::notes::{
     build_github_release_body, github_changelog_url, github_release_notes_start_tag,
@@ -85,7 +85,8 @@ pub(crate) fn run_github_release(
     // single API call — keeping the github.release step responsible for
     // the full Release lifecycle (entry + assets) instead of requiring a
     // separate publish.<target> step.
-    let artifact_paths = github_release_artifact_paths(state);
+    let artifact_paths = github_release_asset_paths(state)
+        .map_err(|error| Error::validation_invalid_argument("release assets", error, None, None))?;
     let has_artifacts = !artifact_paths.is_empty();
     // Single repair-command builder for every failure path. The persisted
     // exact-body file only exists after `persist_release_body` runs below, so
@@ -279,6 +280,9 @@ pub(crate) fn run_github_release(
         artifact_paths.len()
     );
 
+    // Create a draft first. A public release immediately becomes eligible for
+    // GitHub's latest-download endpoint, so it must not be visible until its
+    // manifest-declared assets have been read back and verified.
     // Build args dynamically so we can append artifact paths as positional
     // arguments — `gh release create <tag> [files...]` attaches each file
     // as a Release asset in the same API call.
@@ -290,6 +294,7 @@ pub(crate) fn run_github_release(
         &tag,
         "--notes",
         &release_notes,
+        "--draft",
         "-R",
         &repo_flag,
     ];
@@ -340,9 +345,53 @@ pub(crate) fn run_github_release(
         ));
     }
 
-    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    log_status!("release", "Created GitHub Release: {}", url);
+    let metadata = match gh_release_metadata(&github, &component.github, &tag, &repo_flag) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            return Ok(upload_failed_result(
+                &tag,
+                &github,
+                String::new(),
+                error,
+                None,
+                false,
+                artifact_paths.len(),
+                repair_commands(notes_start_tag.as_deref(), persisted_notes_path.as_deref()),
+            ))
+        }
+    };
+    if let Err(error) = verify_release_assets(&artifact_paths, &metadata.assets) {
+        return Ok(upload_failed_result(
+            &tag,
+            &github,
+            String::new(),
+            error,
+            None,
+            false,
+            artifact_paths.len(),
+            repair_commands(notes_start_tag.as_deref(), persisted_notes_path.as_deref()),
+        ));
+    }
+    let publish_args = ["release", "edit", &tag, "--draft=false", "-R", &repo_flag];
+    let publish_output = run_gh_command(
+        gh_command(&github, &component.github, &publish_args),
+        github_release_upload_timeout(),
+    );
+    if publish_output.timed_out || publish_output.exit_code != Some(0) {
+        return Ok(upload_failed_result(
+            &tag,
+            &github,
+            publish_output.stdout,
+            publish_output.stderr,
+            publish_output.exit_code,
+            publish_output.timed_out,
+            artifact_paths.len(),
+            repair_commands(notes_start_tag.as_deref(), persisted_notes_path.as_deref()),
+        ));
+    }
 
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    log_status!("release", "Published verified GitHub Release: {}", url);
     Ok(step_success(
         "github.release",
         "github.release",
@@ -354,14 +403,9 @@ pub(crate) fn run_github_release(
             "url": url,
             "artifact_count": artifact_paths.len(),
             "generated_notes": generated_notes_ok,
-            // The changelog URL embedded in the release body footer, read back
-            // from the single body builder so step metadata and the posted body
-            // can never disagree (issue #3508).
+            "published": true,
             "changelog_url": body.changelog_url,
             "notes_start_tag": notes_start_tag,
-            // The exact GitHub Release body Homeboy posted, plus a persisted
-            // copy on disk, so manual recovery reproduces the identical body
-            // without reconstructing it from source (issue #3508).
             "release_body": release_notes,
             "release_body_source": body.source_label(),
             "release_body_file": persisted_notes_path,

--- a/crates/homeboy-core/src/release/executor/github_release/tests/result_builders.rs
+++ b/crates/homeboy-core/src/release/executor/github_release/tests/result_builders.rs
@@ -2,7 +2,9 @@
 
 use crate::release::types::ReleaseStepStatus;
 
-use super::super::{create_failed_result, not_created_result, upload_failed_result};
+use super::super::{
+    create_failed_result, not_created_result, upload_failed_result, upload_success_result,
+};
 use super::{data_bool, data_str, test_body, test_repair, test_repo};
 
 #[test]
@@ -136,4 +138,20 @@ fn upload_timeout_is_classified_and_preserves_empty_stderr() {
         Some(124)
     );
     assert!(result.error.as_deref().unwrap().contains("timed out"));
+}
+
+#[test]
+fn verified_upload_result_is_successful_only_after_publication() {
+    let result = upload_success_result("v0.10.6", &test_repo(), 2);
+
+    assert_eq!(result.status, ReleaseStepStatus::Success);
+    assert_eq!(data_str(&result, "action"), Some("github.release.upload"));
+    assert_eq!(
+        result
+            .data
+            .as_ref()
+            .and_then(|data| data.get("artifact_count"))
+            .and_then(|value| value.as_u64()),
+        Some(2)
+    );
 }


### PR DESCRIPTION
## Summary
Keep new GitHub releases in draft state until every manifest-declared archive is uploaded and its name, size, and digest are verified.

## What changed
- Create releases as drafts, expand distribution-manifest archive declarations, fail closed with recovery diagnostics for incomplete assets, and publish only after complete verification.

## How to test
1. Run `cargo test -p homeboy-core release::executor::github_release:: --lib`; expect All 32 GitHub release executor tests pass..
2. Run `cargo check -p homeboy-core`; expect The touched core crate compiles..
3. Run `git diff --check origin/main...HEAD`; expect The rebased patch has no whitespace errors..

## Compatibility
Restores the external releases/latest/download/homeboy-\<target\>.tar.xz consumer contract without changing archive names. Release timing changes intentionally: incomplete releases remain drafts instead of becoming public/latest.

## Evidence
- Base unchanged since verification: main remains at 9503f9be07cedf33d572d31d40001c4b72136d15.
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8687
- Reviewer-resolvable source evidence: https://github.com/chubes4/homeboy-rigs/pull/682
- Verified finalization base: main at 9503f9be07cedf33d572d31d40001c4b72136d15
- core-check: Passed
- post-rebase-diff-check: Passed
- release-tests: Passed
- touched-format: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding task via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed manifest-only publication, implemented draft-first complete-asset verification, and added deterministic release tests; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8687
