### PR TITLE
Run release recovery builds under Bash on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -619,6 +619,7 @@ jobs:
           ${{ matrix.packages_install }}
 
       - name: Build artifacts
+        shell: bash
         run: |
           if ! grep -Fqx '[package.metadata.dist]' Cargo.toml; then
             printf '\n[package.metadata.dist]\ndist = true\n' >> Cargo.toml

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -478,10 +478,22 @@ fn release_finish_head_pipeline_uses_homeboy_action_head_inputs() {
 fn release_recovery_propagates_dist_opt_in_and_dirty_allowance_through_all_dist_phases() {
     let workflow = release_workflow();
     let prepare = job_section(workflow, "prepare");
+    let local_build = job_section(workflow, "build-local-artifacts");
 
     assert!(prepare.contains("recovery-release: ${{ steps.outputs.outputs.recovery-release }}"));
     assert!(prepare.contains("RECOVERY_RELEASE=\"${{ needs.check.outputs.recovery-release }}\""));
     assert!(prepare.contains("echo \"recovery-release=${RECOVERY_RELEASE}\" >> \"$GITHUB_OUTPUT\""));
+
+    let build_step = local_build
+        .find("- name: Build artifacts")
+        .expect("local artifact build step must exist");
+    let post_build = local_build
+        .find("- id: cargo-dist")
+        .expect("local artifact post-build step must exist");
+    assert!(
+        local_build[build_step..post_build].contains("shell: bash"),
+        "recovery syntax must use Bash on every matrix runner, including Windows"
+    );
 
     for job in [
         "plan",


### PR DESCRIPTION
## Summary
Run the Bash-based cargo-dist recovery overlay under Bash on every matrix runner, including Windows.

## What changed
- Declare `shell: bash` on the cross-platform Build artifacts step.
- Pin the shell ordering in the release workflow contract test.

## How to test
1. Run `cargo test --test release_workflow_test`; expect all 24 release workflow tests to pass.
2. Run `rustfmt --check tests/release_workflow_test.rs`; expect the affected test file to be formatted.
3. Run `git diff --check`; expect no whitespace errors.

## Compatibility
No backwards-compatibility impact. The cargo-dist invocation and target matrix are unchanged; Windows now interprets the existing recovery script with its intended shell.

## Evidence
- Windows parser failure: https://github.com/Extra-Chill/homeboy/actions/runs/29576251527/job/87872657168
- Sibling Windows parser failure: https://github.com/Extra-Chill/homeboy/actions/runs/29576255217/job/87872660448
- Sibling Windows parser failure: https://github.com/Extra-Chill/homeboy/actions/runs/29576262215/job/87872603629
- Tracking issue: https://github.com/Extra-Chill/homeboy/issues/8692
- `cargo test --test release_workflow_test`: 24 passed
- `rustfmt --check tests/release_workflow_test.rs`: passed
- `git diff --check`: passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Windows PowerShell parser failure, added the explicit Bash shell contract and deterministic workflow coverage; Chris reviewed and owns the change.

## Source relationships
- Closes #8692