### PR TITLE
test: remove worthless call-and-discard smoke tests in git::changes

### DIFF
--- a/crates/homeboy-core/src/git/changes.rs
+++ b/crates/homeboy-core/src/git/changes.rs
@@ -323,12 +323,6 @@ pub fn get_range_diff(path: &str, baseline_ref: &str) -> Result<String> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_get_uncommitted_changes_default_path() {
-        let path = "";
-        let _result = get_uncommitted_changes(path);
-    }
-
     /// Regression: get_uncommitted_changes runs `git update-index --refresh`
     /// before reading status so stale stat info from upstream tooling
     /// (build steps, git pull, extension setup) doesn't surface as
@@ -470,73 +464,5 @@ mod tests {
             assert_eq!(changed, vec!["new name.txt", "old name.txt"]);
             assert!(untracked.is_empty());
         }
-    }
-
-    #[test]
-    fn test_get_uncommitted_changes_has_expected_effects() {
-        // Expected effects: mutation
-        let path = "";
-        let _ = get_uncommitted_changes(path);
-    }
-
-    #[test]
-    fn test_get_files_changed_since_default_path() {
-        let path = "";
-        let git_ref = "";
-        let _result = get_files_changed_since(path, git_ref);
-    }
-
-    #[test]
-    fn test_get_files_changed_since_default_path_2() {
-        let path = "";
-        let git_ref = "";
-        let _result = get_files_changed_since(path, git_ref);
-    }
-
-    #[test]
-    fn test_get_files_changed_since_has_expected_effects() {
-        // Expected effects: logging
-        let path = "";
-        let git_ref = "";
-        let _ = get_files_changed_since(path, git_ref);
-    }
-
-    #[test]
-    fn test_get_dirty_files_default_path() {
-        let path = "";
-        let _result = get_dirty_files(path);
-    }
-
-    #[test]
-    fn test_get_dirty_files_has_expected_effects() {
-        // Expected effects: mutation
-        let path = "";
-        let _ = get_dirty_files(path);
-    }
-
-    #[test]
-    fn test_get_diff_default_path() {
-        let path = "";
-        let _result = get_diff(path);
-    }
-
-    #[test]
-    fn test_get_diff_default_path_2() {
-        let path = "";
-        let _result = get_diff(path);
-    }
-
-    #[test]
-    fn test_get_diff_has_expected_effects() {
-        // Expected effects: mutation
-        let path = "";
-        let _ = get_diff(path);
-    }
-
-    #[test]
-    fn test_get_range_diff_default_path() {
-        let path = "";
-        let baseline_ref = "";
-        let _result = get_range_diff(path, baseline_ref);
     }
 }


### PR DESCRIPTION
## Summary
Removes **11 zero-value tests** in `git::changes` that called functions with empty-string paths and discarded the result with no assertions:

```rust
#[test]
fn test_get_files_changed_since_default_path() {
    let path = "";
    let git_ref = "";
    let _result = get_files_changed_since(path, git_ref);   // no assert
}
```

- **Zero coverage value** — no `assert`, no `expect`, no `unwrap`, nothing verified.
- **Actively slow** — each spawns a real `git` subprocess (`get_files_changed_since`, `get_dirty_files`, `get_diff`, `get_range_diff`, `get_uncommitted_changes`), so they add subprocess-spawn latency to the suite for nothing.
- Two pairs were **exact duplicates** (`_default_path` / `_default_path_2`).

The file keeps its 3 real behavior tests: stat-only-touch clean detection, rename-path reporting, and porcelain rename/copy parsing.

## Why
Part of trimming excessive/low-value tests to cut CI test-suite wall-clock. These are the safest possible cut — mechanically verifiable as assertion-free, subprocess-spawning, and partially duplicated. No behavior coverage is lost.

## Verification
- `cargo check -p homeboy-core --lib --tests` — 0 errors, no new warnings.
- `cargo test -p homeboy-core --lib git::changes` — **3 passed** (the real tests), 0 failed.
- 74 lines deleted, 0 added.