### PR TITLE
Resolve extension artifacts for exact-ref deploys

### DIFF
--- a/crates/homeboy-core/src/deploy/orchestration/mod.rs
+++ b/crates/homeboy-core/src/deploy/orchestration/mod.rs
@@ -1271,6 +1271,93 @@ mod tests {
     }
 
     #[test]
+    fn exact_ref_command_preparation_rebuilds_extension_owned_artifact() {
+        with_isolated_home(|home| {
+            let extension_dir = home
+                .path()
+                .join(".config/homeboy/extensions/fixture-packager");
+            std::fs::create_dir_all(&extension_dir).expect("extension directory");
+            std::fs::write(
+                extension_dir.join("fixture-packager.json"),
+                r#"{"name":"fixture-packager","version":"1.0.0","build":{"extension_script":"build.sh","artifact_pattern":"build/plugin.zip"}}"#,
+            )
+            .expect("extension manifest");
+            std::fs::write(
+                extension_dir.join("build.sh"),
+                "mkdir -p build\n[ -f build/plugin.zip ] || git archive --format=zip --output=build/plugin.zip HEAD\n",
+            )
+            .expect("extension build script");
+
+            let repo = TempDir::new().expect("repo");
+            run_git(repo.path(), &["init", "-q"]);
+            run_git(repo.path(), &["config", "user.email", "test@example.com"]);
+            run_git(repo.path(), &["config", "user.name", "Test"]);
+            std::fs::write(repo.path().join("payload.txt"), "stale\n").expect("stale payload");
+            std::fs::create_dir_all(repo.path().join("build")).expect("build directory");
+            std::fs::write(repo.path().join("build/plugin.zip"), "stale artifact\n")
+                .expect("stale artifact");
+            run_git(repo.path(), &["add", "."]);
+            run_git(repo.path(), &["commit", "-q", "-m", "stale artifact"]);
+
+            std::fs::write(repo.path().join("payload.txt"), "requested\n")
+                .expect("requested payload");
+            run_git(repo.path(), &["commit", "-am", "requested", "-q"]);
+            run_git(repo.path(), &["branch", "requested"]);
+            let requested_sha = git_stdout(repo.path(), &["rev-parse", "requested"]);
+            std::fs::write(repo.path().join("payload.txt"), "configured\n")
+                .expect("configured payload");
+            run_git(repo.path(), &["commit", "-am", "configured", "-q"]);
+
+            let mut component = Component::new(
+                "plugin".to_string(),
+                repo.path().display().to_string(),
+                "plugins/plugin".to_string(),
+                None,
+            );
+            component.extract_command = Some("unzip -o {{artifact}}".to_string());
+            component.extensions = Some(HashMap::from([(
+                "fixture-packager".to_string(),
+                crate::component::ScopedExtensionConfig::default(),
+            )]));
+            let checkout = ExactRefCheckout::materialize(&component, "requested")
+                .expect("materialize requested ref");
+            checkout.verify().expect("verify requested ref");
+
+            let mut config = base_deploy_config();
+            config.requested_ref = Some("requested".to_string());
+            config.force = true;
+            let prepared = prepare_component_deployments(
+                &[checkout.component.clone()],
+                &config,
+                &Project::default(),
+                "/srv/site",
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new(),
+            )
+            .expect("prepare exact-ref extension artifact");
+
+            let artifact = prepared[0].artifact_path.as_ref().expect("artifact path");
+            let file = std::fs::File::open(artifact).expect("open artifact");
+            let mut archive = zip::ZipArchive::new(file).expect("read artifact");
+            assert_eq!(
+                std::io::read_to_string(archive.by_name("payload.txt").expect("payload entry"))
+                    .expect("payload content"),
+                "requested\n"
+            );
+            assert_eq!(
+                prepared[0]
+                    .config
+                    .prepared_artifact
+                    .as_ref()
+                    .expect("prepared artifact")
+                    .source_commit,
+                requested_sha
+            );
+        });
+    }
+
+    #[test]
     fn exact_ref_hydration_fixtures_build_concurrently_without_crossing_worktrees() {
         let _home_env = home_env_guard();
         let barrier = Arc::new(Barrier::new(2));

--- a/crates/homeboy-core/src/deploy/preparation.rs
+++ b/crates/homeboy-core/src/deploy/preparation.rs
@@ -283,7 +283,7 @@ struct GeneratedSourceArtifactCleanup {
 
 impl GeneratedSourceArtifactCleanup {
     fn new(component: &Component) -> Result<Self> {
-        let artifact = artifact_path(component)?;
+        let artifact = configured_artifact_path(component)?;
         let build_dir =
             Path::new(&component.local_path).join(crate::defaults::deploy_generated_build_dir());
         let artifact_parent = artifact.parent().map(Path::to_path_buf);
@@ -623,42 +623,41 @@ fn copy_prepared_artifact(source: &Path) -> Result<(PathBuf, PreparedArtifactCle
 }
 
 fn artifact_path(component: &Component) -> Result<PathBuf> {
-    component
-        .build_artifact
-        .as_ref()
-        .map(|artifact| {
-            let path = Path::new(artifact);
-            Ok(if path.is_absolute() {
-                path.to_path_buf()
-            } else {
-                Path::new(&component.local_path).join(path)
-            })
-        })
-        .transpose()?
-        .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "build_artifact",
-                "Component has no build artifact to prepare",
-                None,
-                None,
-            )
-        })
+    let artifact = artifact_pattern(component)?;
+    crate::extension::build::resolve_artifact_path_from_root(
+        &artifact,
+        Some(Path::new(&component.local_path)),
+    )
 }
 
-fn remove_exact_ref_artifacts(component: &Component) -> Result<()> {
-    let artifact = component.build_artifact.as_deref().ok_or_else(|| {
+fn configured_artifact_path(component: &Component) -> Result<PathBuf> {
+    let artifact = artifact_pattern(component)?;
+    let path = Path::new(&artifact);
+    Ok(if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        Path::new(&component.local_path).join(path)
+    })
+}
+
+fn artifact_pattern(component: &Component) -> Result<String> {
+    crate::component::resolve_artifact(component).ok_or_else(|| {
         Error::validation_invalid_argument(
             "build_artifact",
-            "Component has no build artifact to prepare",
+            "Component has no build artifact configured by itself or a linked extension",
             None,
             None,
         )
-    })?;
+    })
+}
+
+fn remove_exact_ref_artifacts(component: &Component) -> Result<()> {
+    let artifact = artifact_pattern(component)?;
     let source_root = Path::new(&component.local_path);
-    let pattern = if Path::new(artifact).is_absolute() {
-        PathBuf::from(artifact)
+    let pattern = if Path::new(&artifact).is_absolute() {
+        PathBuf::from(&artifact)
     } else {
-        source_root.join(artifact)
+        source_root.join(&artifact)
     };
     let candidates = if artifact.contains(['*', '?', '[', ']']) {
         glob::glob(&pattern.to_string_lossy())
@@ -666,7 +665,7 @@ fn remove_exact_ref_artifacts(component: &Component) -> Result<()> {
                 Error::validation_invalid_argument(
                     "build_artifact",
                     format!("Invalid build artifact pattern '{}': {error}", artifact),
-                    Some(artifact.to_string()),
+                    Some(artifact.clone()),
                     None,
                 )
             })?
@@ -1439,7 +1438,7 @@ mod tests {
             std::fs::create_dir_all(&extension_dir).expect("extension directory");
             std::fs::write(
                 extension_dir.join("fixture-packager.json"),
-                r#"{"name":"fixture-packager","version":"1.0.0","build":{"extension_script":"build.sh"}}"#,
+                r#"{"name":"fixture-packager","version":"1.0.0","build":{"extension_script":"build.sh","artifact_pattern":"build/fixture.zip"}}"#,
             )
             .expect("extension manifest");
             std::fs::write(
@@ -1475,7 +1474,7 @@ mod tests {
 
             let mut component = component();
             component.local_path = repo.path().display().to_string();
-            component.build_artifact = Some("build/fixture.zip".to_string());
+            component.build_artifact = None;
             component.remote_url = Some("https://github.com/example/fixture".to_string());
             component.extensions = Some(HashMap::from([(
                 "fixture-packager".to_string(),


### PR DESCRIPTION
## Summary
- resolve deploy artifact paths through the same component-or-extension contract used by packaging
- invalidate extension-owned stale artifacts before exact-ref builds
- add a command-preparation regression covering the default extension packaging path

## Root cause
PR #8670 correctly validated prepared artifact provenance after preparation, but exact-ref invalidation only inspected `Component.build_artifact`. Components using an extension-provided `build.artifact_pattern` therefore retained an old ZIP in the detached checkout. The extension build reused that ZIP, and the resulting prepared artifact was labeled with the requested commit even though its bytes came from an older commit.

This change makes artifact invalidation, build output acquisition, and prepared-artifact hashing resolve the same effective artifact declaration. Exact-ref deploys now rebuild extension-owned artifacts from the detached requested source before any remote mutation.

Closes #8662.

## How to test
1. Run `cargo test -p homeboy-core exact_ref_command_preparation_rebuilds_extension_owned_artifact --lib`.
2. Run `cargo test -p homeboy-core deploy::preparation::tests --lib`.
3. Confirm the focused regression creates a repository with a committed stale ZIP, configures only an extension-owned `artifact_pattern`, requests a newer commit, and verifies both the ZIP contents and `source_commit` match that requested commit.

## Compatibility
- Non-ref deployments retain their existing artifact strategy.
- Verified release assets remain excluded from local exact-ref invalidation.
- Component-owned `build_artifact` declarations continue to resolve as before.
- Extension-owned artifact paths now receive the same exact-ref safety policy as component-owned paths.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause tracing, implementation, regression tests, and verification in collaboration with Chris Huber.
