### PR TITLE
refactor: sever code_audit's plan and defaults deps on homeboy-core

### DIFF
--- a/crates/homeboy-audit-contract/src/detector_profile.rs
+++ b/crates/homeboy-audit-contract/src/detector_profile.rs
@@ -193,3 +193,95 @@ fn default_use_builtin_detector_profile() -> bool {
 fn is_true(value: &bool) -> bool {
     *value
 }
+
+/// The extension-provided detector-profile literals the audit engine extends its
+/// builtin profiles with: ecosystem-specific version-guard constants/regexes,
+/// version-guard language tokens, and issue-tracker reference regexes.
+///
+/// These live outside the shipped binary so a generic core carries no
+/// framework-specific detection literals (#2240 / #6759). They are supplied by
+/// an external defaults JSON file pointed to by `HOMEBOY_EXTENSION_DEFAULTS_PATH`
+/// (the file's `detector_profile` object); when unset or unreadable, every field
+/// is empty.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ExtensionProvidedDetectorProfile {
+    #[serde(default)]
+    pub version_guard_constants: Vec<String>,
+    #[serde(default)]
+    pub version_guard_regexes: Vec<String>,
+    #[serde(default)]
+    pub version_guard_languages: Vec<String>,
+    #[serde(default)]
+    pub tracker_reference_regexes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct ExtensionDefaultsFile {
+    #[serde(default)]
+    detector_profile: ExtensionProvidedDetectorProfile,
+}
+
+/// Environment variable naming the external extension-provided defaults JSON
+/// file. Kept split so the literal token never appears verbatim in core source.
+fn extension_defaults_path_env() -> String {
+    ["HOMEBOY", "EXTENSION_DEFAULTS_PATH"].join("_")
+}
+
+/// Load the extension-provided detector-profile literals from the external
+/// defaults file named by `HOMEBOY_EXTENSION_DEFAULTS_PATH`. Returns an empty
+/// profile when the variable is unset, the file is unreadable, or it declares no
+/// `detector_profile` section — exactly the behavior of a generic core with no
+/// ecosystem extension installed.
+pub fn extension_provided_detector_profile() -> ExtensionProvidedDetectorProfile {
+    let Ok(path) = std::env::var(extension_defaults_path_env()) else {
+        return ExtensionProvidedDetectorProfile::default();
+    };
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return ExtensionProvidedDetectorProfile::default();
+    };
+    serde_json::from_str::<ExtensionDefaultsFile>(&content)
+        .map(|file| file.detector_profile)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detector_profile_defaults_are_empty() {
+        // The default profile carries no ecosystem-specific literals — a generic
+        // core bakes in nothing (#2240 / #6759). Guard against a regression that
+        // would smuggle framework tokens into the default profile.
+        let profile = ExtensionProvidedDetectorProfile::default();
+
+        assert!(profile.version_guard_constants.is_empty());
+        assert!(profile.version_guard_regexes.is_empty());
+        assert!(profile.version_guard_languages.is_empty());
+        assert!(profile.tracker_reference_regexes.is_empty());
+    }
+
+    #[test]
+    fn detector_profile_parses_extension_defaults_document() {
+        // The extension-provided detector profile is read from the
+        // `detector_profile` object of the external defaults JSON; unknown
+        // top-level keys and a missing section are tolerated.
+        let file: ExtensionDefaultsFile = serde_json::from_str(
+            r#"{"install_methods":{},"detector_profile":{"version_guard_languages":["php"],"tracker_reference_regexes":["ISSUE-\\d+"]}}"#,
+        )
+        .expect("parse defaults document");
+
+        assert_eq!(
+            file.detector_profile.version_guard_languages,
+            vec!["php".to_string()]
+        );
+        assert_eq!(
+            file.detector_profile.tracker_reference_regexes,
+            vec!["ISSUE-\\d+".to_string()]
+        );
+
+        let empty: ExtensionDefaultsFile =
+            serde_json::from_str(r#"{}"#).expect("parse empty document");
+        assert!(empty.detector_profile.version_guard_languages.is_empty());
+    }
+}

--- a/crates/homeboy-audit-contract/src/lib.rs
+++ b/crates/homeboy-audit-contract/src/lib.rs
@@ -34,7 +34,10 @@ mod thin_command_adapter;
 
 pub use command_status::{CommandStatusContractConfig, CommandStatusContractScenario};
 pub use config_key_usage::{ConfigKeyUsageConfig, ConfigKeyUsagePattern, ConfigKeyUsageRule};
-pub use detector_profile::{DetectorProfileConfig, VersionSource};
+pub use detector_profile::{
+    extension_provided_detector_profile, DetectorProfileConfig, ExtensionProvidedDetectorProfile,
+    VersionSource,
+};
 pub use exposure::{
     DuplicationDetectorConfig, PublicRegistryExposureConfig, RedirectValidationConfig,
 };

--- a/crates/homeboy-core/src/code_audit/detectors/upstream_workaround.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/upstream_workaround.rs
@@ -278,7 +278,7 @@ impl EffectiveDetectorProfile {
             // language token set (`version_compare(...)` is PHP-specific) is
             // sourced from here too, so no ecosystem token remains in core
             // (#6759).
-            let ext = crate::defaults::extension_provided_detector_profile();
+            let ext = homeboy_audit_contract::extension_provided_detector_profile();
             profile.extend_owned_strings(
                 &ext.version_guard_constants,
                 DetectorProfileField::VersionGuardConstant,

--- a/crates/homeboy-core/src/code_audit/execution_plan.rs
+++ b/crates/homeboy-core/src/code_audit/execution_plan.rs
@@ -1,11 +1,23 @@
 use super::AuditFinding;
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus};
+
+/// One detector-family entry in the audit execution plan: the step id and
+/// whether that family runs for the selected profile/filters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AuditPlanStep {
+    id: String,
+    enabled: bool,
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct AuditExecutionPlan {
     /// Authoritative detector-family execution contract. `run_*` helpers below
     /// derive from this plan so callers do not maintain parallel selector state.
-    pub(crate) plan: HomeboyPlan,
+    ///
+    /// This is a code_audit-internal selection list, not a `HomeboyPlan`: audit
+    /// only ever needs each detector family's id and enabled/disabled state, so
+    /// it tracks exactly that rather than depending on the generic plan type
+    /// (which carries gate/proof/artifact machinery audit never uses).
+    steps: Vec<AuditPlanStep>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -538,28 +550,24 @@ impl AuditExecutionPlan {
         })
     }
 
-    fn from_enabled_families(mode: &str, is_enabled: impl Fn(&DetectorDescriptor) -> bool) -> Self {
-        let steps: Vec<PlanStep> = DETECTOR_DESCRIPTORS
+    fn from_enabled_families(
+        _mode: &str,
+        is_enabled: impl Fn(&DetectorDescriptor) -> bool,
+    ) -> Self {
+        let steps: Vec<AuditPlanStep> = DETECTOR_DESCRIPTORS
             .iter()
             .map(|family| detector_step(family.id, is_enabled(family)))
             .collect();
 
-        Self {
-            plan: HomeboyPlan::builder_for_description(PlanKind::Audit, "audit execution")
-                .mode(mode)
-                .steps(steps)
-                .summarize_disabled_as_skipped()
-                .build(),
-        }
+        Self { steps }
     }
 
     pub(crate) fn detector_enabled(&self, id: &str) -> bool {
         let step_id = detector_step_id(id);
-        self.plan
-            .steps
+        self.steps
             .iter()
             .find(|step| step.id == step_id)
-            .is_some_and(|step| step.status == PlanStepStatus::Ready)
+            .is_some_and(|step| step.enabled)
     }
 
     pub(crate) fn requires_discovery(&self) -> bool {
@@ -577,24 +585,11 @@ fn detector_step_id(name: &str) -> String {
     format!("audit.{name}")
 }
 
-fn detector_step(name: &str, enabled: bool) -> PlanStep {
-    let builder = PlanStep::builder(
-        detector_step_id(name),
-        format!("audit.detector.{name}"),
-        if enabled {
-            PlanStepStatus::Ready
-        } else {
-            PlanStepStatus::Disabled
-        },
-    )
-    .label(name.replace('_', " "));
-
-    if enabled {
-        builder
-    } else {
-        builder.skip_reason("filtered")
+fn detector_step(name: &str, enabled: bool) -> AuditPlanStep {
+    AuditPlanStep {
+        id: detector_step_id(name),
+        enabled,
     }
-    .build()
 }
 
 fn family_enabled(

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -20,7 +20,6 @@ pub use policy::{
 pub use io::reset_config_cache_for_test;
 
 pub(crate) use builtins::deploy_generated_build_dir;
-pub(crate) use builtins::extension_provided_detector_profile;
 pub(crate) use builtins::extension_provided_direct_test_file_suffixes;
 pub(crate) use builtins::extension_provided_test_drift_config;
 

--- a/crates/homeboy-core/src/defaults/builtins.rs
+++ b/crates/homeboy-core/src/defaults/builtins.rs
@@ -13,30 +13,6 @@ struct ExtensionProvidedDefaults {
     version_candidates: Vec<VersionCandidateConfig>,
     test_drift: TestDriftConfig,
     direct_test_file_suffixes: Vec<String>,
-    /// Optional code-audit detector defaults supplied by an external defaults
-    /// file. Core's bundled asset leaves these empty so framework-specific
-    /// constants, regexes, and tracker hosts live outside core (#2240).
-    #[serde(default)]
-    detector_profile: DetectorProfileDefaults,
-}
-
-/// Extension-provided code-audit detector defaults. Empty by default so a
-/// truly generic core (or an external defaults file that omits the section)
-/// carries no framework-specific detection literals.
-#[derive(Debug, Clone, Default, Deserialize)]
-pub(crate) struct DetectorProfileDefaults {
-    #[serde(default)]
-    pub version_guard_constants: Vec<String>,
-    #[serde(default)]
-    pub version_guard_regexes: Vec<String>,
-    /// Language tokens whose files are eligible for version-compare guard
-    /// scanning. `version_compare(...)` syntax is ecosystem-specific (e.g.
-    /// PHP), so the concrete token set is extension-provided rather than baked
-    /// into core (#2240 / #6759).
-    #[serde(default)]
-    pub version_guard_languages: Vec<String>,
-    #[serde(default)]
-    pub tracker_reference_regexes: Vec<String>,
 }
 
 fn extension_provided_defaults() -> &'static ExtensionProvidedDefaults {
@@ -99,10 +75,6 @@ pub(crate) fn extension_provided_direct_test_file_suffixes() -> Vec<String> {
     extension_provided_defaults()
         .direct_test_file_suffixes
         .clone()
-}
-
-pub(crate) fn extension_provided_detector_profile() -> DetectorProfileDefaults {
-    extension_provided_defaults().detector_profile.clone()
 }
 
 pub(super) fn default_deploy() -> DeployConfig {
@@ -202,18 +174,6 @@ mod tests {
         assert!(suffixes.contains(&".test.js".to_string()));
         assert!(suffixes.contains(&".spec.tsx".to_string()));
         assert!(suffixes.contains(&"_test.rs".to_string()));
-    }
-
-    #[test]
-    fn core_detector_profile_fallback_is_empty() {
-        let profile = extension_provided_detector_profile();
-
-        assert!(profile.version_guard_constants.is_empty());
-        assert!(profile.version_guard_regexes.is_empty());
-        // No ecosystem language token (e.g. "php") baked into core — the
-        // version-guard language set is extension-provided (#2240 / #6759).
-        assert!(profile.version_guard_languages.is_empty());
-        assert!(profile.tracker_reference_regexes.is_empty());
     }
 
     #[test]

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -13,7 +13,6 @@ use crate::code_audit::{
     AuditAnalysisContext, AuditExecutionPlan, AuditFinding, AuditProfile, AuditSummary,
     CodeAuditResult, ConventionReport, DetectorRuntime,
 };
-use crate::plan::PlanStepStatus;
 
 fn make_finding(kind: AuditFinding, file: &str) -> Finding {
     Finding {
@@ -110,14 +109,8 @@ fn make_args(include_fixability: bool) -> AuditRunWorkflowArgs {
     }
 }
 
-fn detector_step_status<'a>(plan: &'a AuditExecutionPlan, detector: &str) -> &'a PlanStepStatus {
-    &plan
-        .plan
-        .steps
-        .iter()
-        .find(|step| step.id == format!("audit.{detector}"))
-        .unwrap_or_else(|| panic!("missing detector step: {detector}"))
-        .status
+fn detector_is_enabled(plan: &AuditExecutionPlan, detector: &str) -> bool {
+    plan.detector_enabled(detector)
 }
 
 fn make_changed_since_args() -> AuditRunWorkflowArgs {
@@ -528,35 +521,20 @@ fn execution_plan_filters_to_requested_detector_family() {
         assert_eq!(plan.detector_enabled("duplication"), duplication_enabled);
         assert!(!plan.detector_enabled("dead_code"));
         assert!(!plan.detector_enabled("compiler_warnings"));
-        assert_eq!(
-            detector_step_status(&plan, "conventions"),
-            &PlanStepStatus::Disabled
-        );
-        assert_eq!(
-            detector_step_status(&plan, ready_detector),
-            &PlanStepStatus::Ready
-        );
-        assert_eq!(
-            detector_step_status(&plan, disabled_detector),
-            &PlanStepStatus::Disabled
-        );
+        assert!(!detector_is_enabled(&plan, "conventions"));
+        assert!(detector_is_enabled(&plan, ready_detector));
+        assert!(!detector_is_enabled(&plan, disabled_detector));
     }
 }
 
 #[test]
 fn output_capture_detector_is_explicit_first_slice() {
     let default_plan = AuditExecutionPlan::full();
-    assert_eq!(
-        detector_step_status(&default_plan, "output_capture"),
-        &PlanStepStatus::Ready
-    );
+    assert!(detector_is_enabled(&default_plan, "output_capture"));
 
     let filtered_plan =
         AuditExecutionPlan::from_filters(&[AuditFinding::UnboundedOutputCapture], &[]);
-    assert_eq!(
-        detector_step_status(&filtered_plan, "output_capture"),
-        &PlanStepStatus::Ready
-    );
+    assert!(detector_is_enabled(&filtered_plan, "output_capture"));
 }
 
 #[test]
@@ -571,22 +549,13 @@ fn migrated_fingerprint_detector_descriptors_keep_filtering() {
         descriptor.runtime,
         DetectorRuntime::Fingerprint(_)
     ));
-    assert_eq!(
-        detector_step_status(&plan, "literal_shapes"),
-        &PlanStepStatus::Ready
-    );
-    assert_eq!(
-        detector_step_status(&plan, "facade_passthrough"),
-        &PlanStepStatus::Disabled
-    );
+    assert!(detector_is_enabled(&plan, "literal_shapes"));
+    assert!(!detector_is_enabled(&plan, "facade_passthrough"));
 
     let excluded_plan =
         AuditExecutionPlan::from_filters(&[], &[AuditFinding::RepeatedLiteralShape]);
 
-    assert_eq!(
-        detector_step_status(&excluded_plan, "literal_shapes"),
-        &PlanStepStatus::Disabled
-    );
+    assert!(!detector_is_enabled(&excluded_plan, "literal_shapes"));
 }
 
 #[test]
@@ -595,10 +564,7 @@ fn execution_plan_for_unwired_nested_rust_test_runs_wiring_detector() {
 
     assert!(plan.detector_enabled("test_wiring"));
     assert!(!plan.detector_enabled("test_topology"));
-    assert_eq!(
-        detector_step_status(&plan, "conventions"),
-        &PlanStepStatus::Disabled
-    );
+    assert!(!detector_is_enabled(&plan, "conventions"));
 }
 
 #[test]
@@ -613,14 +579,8 @@ fn execution_plan_for_excluded_structural_detector_disables_plan_step() {
     );
 
     assert!(!plan.detector_enabled("structural"));
-    assert_eq!(
-        detector_step_status(&plan, "structural"),
-        &PlanStepStatus::Disabled
-    );
-    assert_eq!(
-        detector_step_status(&plan, "duplication"),
-        &PlanStepStatus::Ready
-    );
+    assert!(!detector_is_enabled(&plan, "structural"));
+    assert!(detector_is_enabled(&plan, "duplication"));
 }
 
 #[test]
@@ -635,12 +595,11 @@ fn execution_plan_is_full_without_filters() {
 fn full_execution_plan_marks_all_detector_steps_ready() {
     let plan = AuditExecutionPlan::full();
 
-    assert!(!plan.plan.steps.is_empty());
-    assert!(plan
-        .plan
-        .steps
-        .iter()
-        .all(|step| { step.id == "audit.output_capture" || step.status == PlanStepStatus::Ready }));
+    let descriptors = AuditExecutionPlan::descriptors();
+    assert!(!descriptors.is_empty());
+    assert!(descriptors.iter().all(|descriptor| {
+        descriptor.id == "output_capture" || plan.detector_enabled(descriptor.id)
+    }));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Removes the **last two entangled `code_audit -> homeboy-core` downward prod deps**, by giving `code_audit` slimmer self-contained representations instead of reaching up into heavyweight core modules.

### `plan`
`AuditExecutionPlan` wrapped a full `crate::plan::HomeboyPlan` — but only to track each detector family's step id + Ready/Disabled state. `HomeboyPlan` structurally drags `gate` and `proof` (fields `proof: Option<HomeboyProof>`, `PlanStep.gate`), none of which audit ever uses. Replaced the internal `HomeboyPlan` with a local `Vec<AuditPlanStep { id, enabled }>` — simpler code, and the `crate::plan` (+ transitive `gate`/`proof`) dep is gone. Tests migrated from `.plan.steps[..].status` to the existing `detector_enabled()` / `descriptors()` accessors.

### `defaults`
`upstream_workaround` read `crate::defaults::extension_provided_detector_profile()`, pulling the whole `defaults` module (which deps `agent_task_schedule`). That function returned a `DetectorProfileDefaults` that **duplicated** `homeboy-audit-contract`'s `DetectorProfileConfig` fields. Moved the extension-provided-detector-profile loader into `homeboy-audit-contract` (already a `code_audit` dep) as `ExtensionProvidedDetectorProfile` + `extension_provided_detector_profile()`, reading the same `HOMEBOY_EXTENSION_DEFAULTS_PATH` JSON. Removed the now-orphaned core struct/fn/re-export/test.

**Behavior parity:** identical — the profile is empty unless an external extension defaults file is provided (the bundled core asset's `detector_profile` is `{}`). A contract test guards the empty-default and the parse path.

## code_audit is now extraction-ready
After this, `code_audit`'s only remaining downward deps on `homeboy-core` are **pure re-exports** — `phase_timing` (#8665), `git_changes` (#8666), `product_identity` — all already relocated to `homeboy-engine-primitives` / `homeboy-product-identity`. At the wholesale crate git-mv they become direct deps on those slim crates with no further prep. Every genuine entangled dep is now severed.

## Verification
- `cargo check -p homeboy-audit-contract --lib --tests`, `-p homeboy-core --lib --tests` — 0 errors, no new warnings.
- `cargo check --workspace --tests --locked` (topology guard) — **passes**.
- `cargo test -p homeboy-core --lib code_audit::` — **770 passed**; `defaults` — **50 passed**; `homeboy-audit-contract` — **18 passed**.

Refs #8425