### PR TITLE
Fix runner doctor probe watchdog cleanup

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
@@ -601,6 +601,13 @@ fn runtime_relative_path(runtime_root: &Path, value: &str) -> Option<String> {
 pub(super) fn provider_executor_resolution_remote_shell(
     entrypoint: &RemoteProviderExecutorEntrypoint,
 ) -> String {
+    provider_executor_resolution_remote_shell_with_timeout(entrypoint, 20)
+}
+
+pub(super) fn provider_executor_resolution_remote_shell_with_timeout(
+    entrypoint: &RemoteProviderExecutorEntrypoint,
+    timeout_seconds: u64,
+) -> String {
     let runtime_root = format!(
         "runtime_root=\"$HOME/.config/homeboy/agent-runtimes\"/{}",
         common::shell_word(&entrypoint.runtime_id)
@@ -616,15 +623,15 @@ pub(super) fn provider_executor_resolution_remote_shell(
     argv.push(common::shell_word("--provider-contract"));
     let invocation = argv.join(" ");
     let invocation = if let Some(cwd) = &entrypoint.cwd {
-        format!("cd {} && {invocation}", runner_path(cwd))
+        format!("cd {} && exec {invocation}", runner_path(cwd))
     } else {
-        invocation
+        format!("exec {invocation}")
     };
 
     // Keep the remote SSH command bounded even if an executor ignores the
     // dry-load flag and waits for input. Stdin is closed and stderr is captured.
     format!(
-        "{runtime_root}; tmp=$(mktemp 2>/dev/null || printf '/tmp/homeboy-provider-probe-$$'); ({invocation}) </dev/null >/dev/null 2>\"$tmp\" & pid=$!; (sleep 20; kill \"$pid\" 2>/dev/null) & killer=$!; wait \"$pid\"; rc=$?; kill \"$killer\" 2>/dev/null; cat \"$tmp\" >&2; rm -f \"$tmp\"; exit \"$rc\""
+        "{runtime_root}; tmp=$(mktemp 2>/dev/null || printf '/tmp/homeboy-provider-probe-$$'); ({invocation}) </dev/null >/dev/null 2>\"$tmp\" & pid=$!; (trap 'kill \"$sleeper\" 2>/dev/null; wait \"$sleeper\" 2>/dev/null; exit' TERM; sleep {timeout_seconds} & sleeper=$!; wait \"$sleeper\"; kill \"$pid\" 2>/dev/null) & killer=$!; wait \"$pid\"; rc=$?; kill \"$killer\" 2>/dev/null; wait \"$killer\" 2>/dev/null; cat \"$tmp\" >&2; rm -f \"$tmp\"; exit \"$rc\""
     )
 }
 

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/provider.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/provider.rs
@@ -5,6 +5,8 @@ use homeboy::core::agent_tasks::provider::{
 use serde_json::json;
 use std::collections::BTreeMap;
 use std::io::Write;
+use std::process::Command;
+use std::time::{Duration, Instant};
 use types::RunnerDoctorStatus;
 
 #[test]
@@ -244,19 +246,73 @@ fn remote_executor_probe_keeps_missing_runner_local_dependency_actionable() {
     assert!(entrypoint
         .display()
         .contains("<runtime:test-runtime>/scripts/executor.cjs"));
-    let runner_root = tempfile::tempdir().expect("runner root");
-    let script = runner_root.path().join("scripts/executor.cjs");
+    let home = tempfile::tempdir().expect("runner home");
+    let runner_root = home
+        .path()
+        .join(".config/homeboy/agent-runtimes/test-runtime");
+    let script = runner_root.join("scripts/executor.cjs");
     std::fs::create_dir_all(script.parent().expect("script parent")).expect("create scripts");
     std::fs::write(&script, "require('./missing-runner-local-package');\n")
         .expect("write runner executor");
-    let output = std::process::Command::new("node")
-        .arg(runner_root.path().join("scripts/executor.cjs"))
-        .arg("--provider-contract")
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(probes::provider_executor_resolution_remote_shell(
+            &entrypoint,
+        ))
+        .env("HOME", home.path())
         .output()
-        .expect("run runner-local probe");
+        .expect("run runner shell probe");
 
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr).contains("Cannot find module"));
+}
+
+#[test]
+fn remote_executor_probe_shell_returns_promptly_after_success() {
+    let shell = probes::provider_executor_resolution_remote_shell_with_timeout(
+        &shell_entrypoint("exit 0"),
+        1,
+    );
+    let started = Instant::now();
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(shell)
+        .output()
+        .expect("run successful runner shell probe");
+
+    assert!(output.status.success());
+    assert!(started.elapsed() < Duration::from_secs(1));
+}
+
+#[test]
+fn remote_executor_probe_shell_bounds_and_terminates_hanging_executor() {
+    let shell = probes::provider_executor_resolution_remote_shell_with_timeout(
+        &shell_entrypoint("while :; do :; done"),
+        1,
+    );
+    let started = Instant::now();
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(shell)
+        .output()
+        .expect("run hanging runner shell probe");
+    let elapsed = started.elapsed();
+
+    assert!(!output.status.success());
+    assert!(elapsed >= Duration::from_millis(750));
+    assert!(elapsed < Duration::from_secs(3));
+}
+
+fn shell_entrypoint(script: &str) -> probes::RemoteProviderExecutorEntrypoint {
+    probes::RemoteProviderExecutorEntrypoint {
+        runtime_id: "test-runtime".to_string(),
+        program: probes::RemoteProviderExecutorEntrypointPart::Literal("sh".to_string()),
+        args: vec![
+            probes::RemoteProviderExecutorEntrypointPart::Literal("-c".to_string()),
+            probes::RemoteProviderExecutorEntrypointPart::Literal(script.to_string()),
+        ],
+        cwd: None,
+    }
 }
 
 fn node_provider(id: &str, backend: &str, script: &std::path::Path) -> AgentTaskExecutorProvider {


### PR DESCRIPTION
## Summary

- terminate and reap the remote provider-probe watchdog without orphaning its sleeper
- execute provider probes directly inside their subshell so timeout signals reach the executor
- exercise the generated shell for immediate success, bounded hangs, and actionable missing dependencies

Closes #8697.

## How to test

1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-cli commands::runner::doctor::tests::provider`.
3. Configure an SSH runner with agent runtimes and run `homeboy runner doctor <runner-id> --scope lab-offload`.
4. Confirm healthy `agent_task.provider_executor_resolution.*` checks return promptly instead of timing out after 20 seconds.

## Compatibility

- No public command or data-contract changes.
- The remote probe remains POSIX-shell based and preserves the existing 20-second bound and missing-module diagnostics.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause analysis, implementation, deterministic regression tests, and verification.