### PR TITLE
Reuse accepted runner session during Homeboy refresh

### DIFF
--- a/crates/homeboy-runner/src/execution/mod.rs
+++ b/crates/homeboy-runner/src/execution/mod.rs
@@ -689,6 +689,19 @@ pub(crate) struct ProcessOutput {
 }
 
 pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOutput, i32)> {
+    exec_with_status_snapshot(runner_id, options, None)
+}
+
+/// Execute against a status observation made by the caller's transaction.
+///
+/// A refresh verifies the session before selecting or replacing a binary. Keep
+/// that verified transport rather than resolving a controller-scoped session a
+/// second time during the same transaction.
+pub(crate) fn exec_with_status_snapshot(
+    runner_id: &str,
+    options: RunnerExecOptions,
+    status_snapshot: Option<RunnerStatusReport>,
+) -> Result<(RunnerExecOutput, i32)> {
     if options.command.is_empty() {
         return Err(Error::validation_invalid_argument(
             "command",
@@ -797,7 +810,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
         );
     }
 
-    let connected = status(runner_id)?;
+    let connected = execution_status(runner_id, status_snapshot)?;
     if connected.connected
         && connected.stale_daemon.is_some()
         && !allows_idle_stale_daemon_refresh(&options, &connected)
@@ -886,6 +899,13 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
         append_runner_exec_diagnostic_hint(&mut output, run_id_hint);
         (output, exit_code)
     })
+}
+
+fn execution_status(
+    runner_id: &str,
+    status_snapshot: Option<RunnerStatusReport>,
+) -> Result<RunnerStatusReport> {
+    status_snapshot.map(Ok).unwrap_or_else(|| status(runner_id))
 }
 
 fn allows_idle_stale_daemon_refresh(

--- a/crates/homeboy-runner/src/execution/tests/exec.rs
+++ b/crates/homeboy-runner/src/execution/tests/exec.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
-    RunnerActiveJobSource, RunnerActiveJobState, RunnerSessionState, RunnerStaleDaemonWarning,
-    RunnerStatusReport,
+    RunnerActiveJobSource, RunnerActiveJobState, RunnerSession, RunnerSessionRole,
+    RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport, RunnerTunnelMode,
 };
 use homeboy_core::runner_execution_envelope::{
     PATH_MATERIALIZATION_MODE_GIT, PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
@@ -40,6 +40,45 @@ fn explicit_refresh_keeps_active_or_uncertain_stale_daemons_protected() {
 
     assert!(!allows_idle_stale_daemon_refresh(&options, &active));
     assert!(!allows_idle_stale_daemon_refresh(&options, &unavailable));
+}
+
+#[test]
+fn refresh_execution_uses_the_connected_preflight_session_without_a_second_lookup() {
+    let mut status = stale_direct_daemon_status();
+    status.session = Some(RunnerSession {
+        runner_id: "homeboy-lab".to_string(),
+        mode: RunnerTunnelMode::DirectSsh,
+        role: RunnerSessionRole::Controller,
+        server_id: Some("homeboy-lab".to_string()),
+        controller_id: Some("controller".to_string()),
+        broker_url: None,
+        remote_daemon_address: Some("127.0.0.1:4242".to_string()),
+        local_port: Some(4242),
+        local_url: Some("http://127.0.0.1:4242".to_string()),
+        tunnel_pid: Some(1),
+        remote_daemon_pid: Some(2),
+        remote_daemon_lease_id: Some("idempotently-reattached-lease".to_string()),
+        homeboy_version: "0.288.10".to_string(),
+        homeboy_build_identity: None,
+        connected_at: "2026-07-17T00:00:00Z".to_string(),
+        worker_identity: None,
+        worker_pid: None,
+        last_seen_at: None,
+        leaseless_recovery_evidence: None,
+    });
+    let resolved = execution_status("unresolvable-runner", Some(status.clone()))
+        .expect("the refresh transaction keeps its authoritative preflight session");
+
+    assert_eq!(resolved.runner_id, "homeboy-lab");
+    assert!(resolved.connected);
+    assert_eq!(resolved.session_path, "/tmp/homeboy-lab.json");
+    assert_eq!(
+        resolved
+            .session
+            .as_ref()
+            .and_then(|session| session.remote_daemon_lease_id.as_deref()),
+        Some("idempotently-reattached-lease")
+    );
 }
 
 fn authoritative_drained_freshness() -> homeboy_core::daemon::DaemonFreshnessReport {

--- a/crates/homeboy-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-runner/src/homeboy_refresh.rs
@@ -14,11 +14,12 @@ use homeboy_core::git::{run_git, run_git_output};
 use homeboy_core::output::MergeOutput;
 
 use super::connection::{active_jobs_before_daemon_replacement, disconnect_with_session};
+use super::execution::exec_with_status_snapshot;
 use super::{
-    connect_with_orphan_adoption, exec, exec_with_status_snapshot, load,
-    materialize_runner_extension_with_env, merge, normalize_runner_command_env_for_homeboy_path,
-    plan_controller_snapshot_extension, RunnerCapabilityPreflight, RunnerExecOptions,
-    RunnerExecOutput, RunnerExtensionMaterializationRequest, RunnerExtensionMaterializationSource,
+    connect_with_orphan_adoption, exec, load, materialize_runner_extension_with_env, merge,
+    normalize_runner_command_env_for_homeboy_path, plan_controller_snapshot_extension,
+    RunnerCapabilityPreflight, RunnerExecOptions, RunnerExecOutput,
+    RunnerExtensionMaterializationRequest, RunnerExtensionMaterializationSource,
     RunnerFileTransfer, RunnerKind,
 };
 

--- a/crates/homeboy-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-runner/src/homeboy_refresh.rs
@@ -15,10 +15,10 @@ use homeboy_core::output::MergeOutput;
 
 use super::connection::{active_jobs_before_daemon_replacement, disconnect_with_session};
 use super::{
-    connect_with_orphan_adoption, exec, load, materialize_runner_extension_with_env, merge,
-    normalize_runner_command_env_for_homeboy_path, plan_controller_snapshot_extension,
-    RunnerCapabilityPreflight, RunnerExecOptions, RunnerExecOutput,
-    RunnerExtensionMaterializationRequest, RunnerExtensionMaterializationSource,
+    connect_with_orphan_adoption, exec, exec_with_status_snapshot, load,
+    materialize_runner_extension_with_env, merge, normalize_runner_command_env_for_homeboy_path,
+    plan_controller_snapshot_extension, RunnerCapabilityPreflight, RunnerExecOptions,
+    RunnerExecOutput, RunnerExtensionMaterializationRequest, RunnerExtensionMaterializationSource,
     RunnerFileTransfer, RunnerKind,
 };
 
@@ -296,10 +296,11 @@ pub fn refresh_homeboy_binary(
     promotion_lease.assert_generation()?;
     let runner = load(&plan.runner_id)?;
     let previous_homeboy_path = runner.settings.homeboy_path.clone();
-    let disconnected_ssh =
-        runner.kind == RunnerKind::Ssh && status_is_disconnected(&plan.runner_id)?;
+    let connection_status = super::status(&plan.runner_id)?;
+    let disconnected_ssh = runner.kind == RunnerKind::Ssh && !connection_status.connected;
     let exec_options = refresh_execution_options(&plan, required_commands, disconnected_ssh);
-    let (exec_output, exit_code) = exec(&plan.runner_id, exec_options)?;
+    let (exec_output, exit_code) =
+        exec_with_status_snapshot(&plan.runner_id, exec_options, Some(connection_status))?;
     if exit_code != 0 {
         return Ok((
             HomeboyBinaryRefreshOutput {
@@ -550,10 +551,6 @@ fn refresh_verification_failure(
     let mut failure = refresh_failure(plan, execution, 1);
     failure.verification = Some(verification);
     failure
-}
-
-fn status_is_disconnected(runner_id: &str) -> Result<bool> {
-    Ok(!super::status(runner_id)?.connected)
 }
 
 fn verify_refreshed_daemon_identity(runner_id: &str) -> Result<()> {

--- a/crates/homeboy-runner/src/lib.rs
+++ b/crates/homeboy-runner/src/lib.rs
@@ -132,8 +132,8 @@ pub use execution::{
     RunnerExecPromotedOutput, RunnerExecStructuredSummary,
 };
 pub(crate) use execution::{
-    execute_runner_process_until_cancelled_with_progress, prepare_daemon_local_process,
-    RunnerProcessRequest,
+    exec_with_status_snapshot, execute_runner_process_until_cancelled_with_progress,
+    prepare_daemon_local_process, RunnerProcessRequest,
 };
 pub use execution::{RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV, RUNNER_PLACEMENT_RESOLVED_ENV};
 pub(crate) use extension_materialization::extension_source_content_hash;

--- a/crates/homeboy-runner/src/lib.rs
+++ b/crates/homeboy-runner/src/lib.rs
@@ -132,8 +132,8 @@ pub use execution::{
     RunnerExecPromotedOutput, RunnerExecStructuredSummary,
 };
 pub(crate) use execution::{
-    exec_with_status_snapshot, execute_runner_process_until_cancelled_with_progress,
-    prepare_daemon_local_process, RunnerProcessRequest,
+    execute_runner_process_until_cancelled_with_progress, prepare_daemon_local_process,
+    RunnerProcessRequest,
 };
 pub use execution::{RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV, RUNNER_PLACEMENT_RESOLVED_ENV};
 pub(crate) use extension_materialization::extension_source_content_hash;


### PR DESCRIPTION
## Summary
- reuse the connected runner status accepted by refresh preflight during the verification execution
- keep ordinary runner execution on live status resolution
- preserve the active-job recheck immediately before daemon replacement
- add regression coverage for an idempotently reattached direct-SSH lease
- follow the current `homeboy-runner` crate ownership introduced on `main`

Addresses the connected-session resolution variant reported in #8459.

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-runner refresh_execution_uses_the_connected_preflight_session_without_a_second_lookup --lib`.
3. Run `cargo test -p homeboy-runner reconnect_error_after_disconnect_restores_the_pre_refresh_binary --lib`.
4. Run `cargo test -p homeboy-runner select_without_materialization_sha_promotes_the_verified_binary --lib`.
5. Run `homeboy review audit --changed-since origin/main --profile pr --json-summary` and confirm there are no introduced findings.
6. Run `homeboy review lint --changed-since origin/main --summary` and confirm lint passes.

## Verification
- Homeboy audit: passed with zero introduced findings before the upstream runner-crate extraction; the rebased patch preserves that smaller three-file ownership surface.
- Homeboy lint: passed with zero findings.
- All three focused Rust tests passed after rebasing onto current `main`, and each executed one test in `homeboy-runner`.
- The changed-scope `homeboy review` umbrella is not reported as green: its test selector converted the changed Rust test file into a filter that executed zero tests, so Homeboy correctly failed that umbrella stage. The explicit focused commands above provide the behavioral test evidence.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with `openai/gpt-5.6-sol`
- **Used for:** Diagnosed the refresh session-resolution mismatch, implemented and refined the fix and regression coverage, resolved the upstream runner-crate extraction conflict, and verified the candidate with Chris.