### PR TITLE
Make detached artifact reconciliation idempotent

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
@@ -823,6 +823,9 @@ pub(crate) fn project_terminal_artifacts(
                     "runner_provenance": artifact.metadata,
                 }
             });
+            if reusable_terminal_artifact(&store, &record.run_id, artifact, &artifact_id)? {
+                continue;
+            }
             if let Some(runner_id) = record.runner_id().filter(|runner_id| {
                 std::env::var(homeboy_runner_contract::RUNNER_ID_ENV)
                     .ok()
@@ -974,6 +977,50 @@ pub(crate) fn project_terminal_artifacts(
         }
     }
     projection_error.map_or(Ok(()), Err)
+}
+
+/// A direct artifact import can retain the same deterministic lifecycle id
+/// before terminal reconciliation. Reuse it only when its controller-local
+/// bytes prove it belongs to this artifact projection.
+fn reusable_terminal_artifact(
+    store: &crate::observation::ObservationStore,
+    run_id: &str,
+    artifact: &AgentTaskArtifact,
+    artifact_id: &str,
+) -> Result<bool> {
+    let Some(existing) = store.get_artifact(artifact_id)? else {
+        return Ok(false);
+    };
+    if existing.artifact_type != "file" {
+        return Ok(false);
+    }
+
+    let expected_size = i64::try_from(artifact.size_bytes.expect("checked above")).ok();
+    let expected_sha256 = artifact.sha256.as_deref().expect("checked above");
+    let matches = existing.run_id == run_id
+        && existing.size_bytes == expected_size
+        && existing.sha256.as_deref() == Some(expected_sha256)
+        && std::fs::metadata(&existing.path)
+            .map(|metadata| {
+                metadata.is_file() && i64::try_from(metadata.len()).ok() == expected_size
+            })
+            .unwrap_or(false)
+        && crate::artifact_metadata::sha256_file(Path::new(&existing.path))
+            .ok()
+            .as_deref()
+            == Some(expected_sha256);
+    if matches {
+        return Ok(true);
+    }
+
+    Err(Error::validation_invalid_argument(
+        "artifact_id",
+        format!(
+            "existing artifact record conflicts with terminal artifact projection: {artifact_id}"
+        ),
+        Some(artifact_id.to_string()),
+        None,
+    ))
 }
 
 /// Find finalized bytes already copied into the controller artifact root. Lab

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -2129,6 +2129,144 @@ fn terminal_executor_artifacts_are_projected_under_logical_ids() {
 }
 
 #[test]
+fn terminal_reconciliation_reuses_verified_directly_imported_artifact() {
+    with_isolated_home(|home| {
+        let patch = b"patch bytes";
+        let source = home.path().join("imported.patch");
+        std::fs::write(&source, patch).expect("write imported patch");
+        let plan = test_plan();
+        let mut aggregate = succeeded_aggregate(&plan);
+        aggregate.outcomes[0].artifacts.push(AgentTaskArtifact {
+            schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+            id: "patch".to_string(),
+            kind: "patch".to_string(),
+            name: None,
+            label: None,
+            role: Some("patch".to_string()),
+            semantic_key: None,
+            path: Some("/runner/private/patch.diff".to_string()),
+            url: None,
+            mime: Some("text/x-patch".to_string()),
+            size_bytes: Some(patch.len() as u64),
+            sha256: Some(format!("{:x}", sha2::Sha256::digest(patch))),
+            metadata: json!({ "executor_artifact_finalized": true }),
+        });
+        let submitted = submit_plan(&plan, Some("direct-import-reconciliation")).expect("submit");
+        record_runner_job_identity(&submitted.run_id, "homeboy-lab", "job-1")
+            .expect("runner identity");
+
+        let mut hash = sha2::Sha256::new();
+        sha2::Digest::update(&mut hash, submitted.run_id.as_bytes());
+        sha2::Digest::update(&mut hash, [0]);
+        sha2::Digest::update(&mut hash, aggregate.outcomes[0].task_id.as_bytes());
+        sha2::Digest::update(&mut hash, [0]);
+        sha2::Digest::update(&mut hash, b"patch");
+        let artifact_id = format!("agent-task-{:x}", hash.finalize());
+        let store = crate::observation::ObservationStore::open_initialized().expect("store");
+        store
+            .import_artifact(&crate::observation::ArtifactRecord {
+                id: artifact_id,
+                run_id: submitted.run_id.clone(),
+                kind: "patch".to_string(),
+                artifact_type: "file".to_string(),
+                path: source.display().to_string(),
+                url: None,
+                public_url: None,
+                viewer_url: None,
+                viewer_links: Vec::new(),
+                sha256: Some(format!("{:x}", sha2::Sha256::digest(patch))),
+                size_bytes: Some(patch.len() as i64),
+                mime: Some("text/x-patch".to_string()),
+                metadata_json: json!({ "name": "patch" }),
+                created_at: chrono::Utc::now().to_rfc3339(),
+            })
+            .expect("direct artifact import");
+
+        record_run_aggregate(&submitted.run_id, &plan, &aggregate)
+            .expect("terminal reconciliation");
+        reconcile_terminal_artifact_projection(&submitted.run_id).expect("repeated reconciliation");
+
+        let record = store::read_record(&submitted.run_id).expect("terminal record");
+        assert_eq!(record.metadata["artifact_projection"]["status"], "complete");
+        let artifact = crate::observation::runs_service::resolve_artifact_for_run(
+            &store,
+            &submitted.run_id,
+            "patch",
+        )
+        .expect("actionable imported patch");
+        let output = home.path().join("recovered.patch");
+        crate::observation::runs_service::copy_local_file_artifact(artifact, Some(output.clone()))
+            .expect("recover patch without runner");
+        assert_eq!(std::fs::read(output).expect("recovered patch bytes"), patch);
+    });
+}
+
+#[test]
+fn terminal_reconciliation_rejects_conflicting_directly_imported_artifact() {
+    with_isolated_home(|home| {
+        let patch = b"patch bytes";
+        let conflicting = b"other bytes";
+        let source = home.path().join("conflicting.patch");
+        std::fs::write(&source, conflicting).expect("write conflicting patch");
+        let plan = test_plan();
+        let mut aggregate = succeeded_aggregate(&plan);
+        aggregate.outcomes[0].artifacts.push(AgentTaskArtifact {
+            schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+            id: "patch".to_string(),
+            kind: "patch".to_string(),
+            name: None,
+            label: None,
+            role: Some("patch".to_string()),
+            semantic_key: None,
+            path: Some("/runner/private/patch.diff".to_string()),
+            url: None,
+            mime: Some("text/x-patch".to_string()),
+            size_bytes: Some(patch.len() as u64),
+            sha256: Some(format!("{:x}", sha2::Sha256::digest(patch))),
+            metadata: json!({ "executor_artifact_finalized": true }),
+        });
+        let submitted = submit_plan(&plan, Some("direct-import-conflict")).expect("submit");
+        record_runner_job_identity(&submitted.run_id, "homeboy-lab", "job-1")
+            .expect("runner identity");
+
+        let mut hash = sha2::Sha256::new();
+        sha2::Digest::update(&mut hash, submitted.run_id.as_bytes());
+        sha2::Digest::update(&mut hash, [0]);
+        sha2::Digest::update(&mut hash, aggregate.outcomes[0].task_id.as_bytes());
+        sha2::Digest::update(&mut hash, [0]);
+        sha2::Digest::update(&mut hash, b"patch");
+        let artifact_id = format!("agent-task-{:x}", hash.finalize());
+        let store = crate::observation::ObservationStore::open_initialized().expect("store");
+        store
+            .import_artifact(&crate::observation::ArtifactRecord {
+                id: artifact_id,
+                run_id: submitted.run_id.clone(),
+                kind: "patch".to_string(),
+                artifact_type: "file".to_string(),
+                path: source.display().to_string(),
+                url: None,
+                public_url: None,
+                viewer_url: None,
+                viewer_links: Vec::new(),
+                sha256: Some(format!("{:x}", sha2::Sha256::digest(conflicting))),
+                size_bytes: Some(conflicting.len() as i64),
+                mime: Some("text/x-patch".to_string()),
+                metadata_json: json!({ "name": "patch" }),
+                created_at: chrono::Utc::now().to_rfc3339(),
+            })
+            .expect("conflicting direct artifact import");
+
+        record_run_aggregate(&submitted.run_id, &plan, &aggregate)
+            .expect("terminal state is persisted");
+        let record = store::read_record(&submitted.run_id).expect("terminal record");
+        assert_eq!(record.metadata["artifact_projection"]["status"], "pending");
+        assert!(record.metadata["artifact_projection"]["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("conflicts with terminal artifact projection")));
+    });
+}
+
+#[test]
 fn status_backfills_legacy_runner_provenance_and_mirrors_a_verified_projection_idempotently() {
     with_isolated_home(|_| {
         use sha2::Digest;


### PR DESCRIPTION
## Summary
Allow detached terminal reconciliation to reuse a directly imported deterministic artifact only when controller-local bytes, run ownership, SHA-256, and size all match.

## What changed
- Detect an existing deterministic terminal artifact before attempting another import.
- Reuse only verified controller-local file records owned by the same run; reject ownership, metadata, or byte conflicts.
- Cover equivalent pre-import reuse, repeated reconciliation, offline actionability, and conflicting pre-import rejection.

## How to test
1. Run `cargo fmt --check`; expect Formatting passes..
2. Run `cargo test -p homeboy-core agent_task_lifecycle::tests::terminal_reconciliation_reuses_verified_directly_imported_artifact --lib -- --exact --test-threads=1`; expect Equivalent directly imported artifacts are reused and remain actionable without a runner..
3. Run `cargo test -p homeboy-core agent_task_lifecycle::tests::terminal_reconciliation_rejects_conflicting_directly_imported_artifact --lib -- --exact --test-threads=1`; expect Conflicting imported artifacts remain pending and fail closed..

## Compatibility
No public API or extension-path contract changes. Reconciliation behavior changes only for equivalent controller-local records; strict conflict rejection is preserved.

## Evidence
- Base unchanged since verification: main remains at c28086d4eb434b9c7e313d35119250e5000a0603.
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8625
- Verified finalization base: main at c28086d4eb434b9c7e313d35119250e5000a0603
- conflicting-import-regression: Passed
- diff-check: Passed
- equivalent-import-regression: Passed
- format: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the deterministic artifact-record conflict, implemented strict equivalent-record reuse, and added positive and negative regression coverage.

## Source relationships
- Closes Extra-Chill/homeboy#8625
