### PR TITLE
Flag signature-only and discarded-call tests as vacuous

### DIFF
--- a/crates/homeboy-core/src/code_audit/detectors/test_vacuity.rs
+++ b/crates/homeboy-core/src/code_audit/detectors/test_vacuity.rs
@@ -142,6 +142,19 @@ fn classify_vacuous_test(
     );
 
     if has_product_ref {
+        // A product symbol appearing in the body is not enough: naming a product
+        // function in a type-signature binding (`let f: fn(..) = product_fn;`) or
+        // calling it only to discard the result (`let _ = product_fn(..);`) proves
+        // nothing at runtime beyond what the compiler already guarantees. Such
+        // tests reference product code without exercising it, so they slip past
+        // the reference check above. Flag them when there is no assertion and the
+        // body contains nothing but signature-bindings / discarded calls.
+        if !has_assertion && is_signature_or_discard_only(&uncommented) {
+            return Some(
+                "it only names product code in a signature binding or discarded call without asserting on behavior"
+                    .to_string(),
+            );
+        }
         return None;
     }
 
@@ -197,6 +210,54 @@ fn contains_word_call(haystack: &str, needle: &str) -> bool {
     Regex::new(&pattern)
         .ok()
         .is_some_and(|re| re.is_match(haystack))
+}
+
+/// Return true when a comment-stripped test body only *names* product code
+/// without observing any outcome from it.
+///
+/// This recognizes the two no-op shapes that reference a product symbol yet
+/// prove nothing at runtime:
+///
+/// * a function-pointer signature binding — `let f: fn(..) [-> ..] = product_fn;`
+///   followed by an optional `let _ = f;` discard, and
+/// * a discarded call — `let _ = product_fn(..);` (result never inspected).
+///
+/// It is deliberately conservative: any statement that is not one of those
+/// no-op shapes (a real `let name = value;` binding whose value is later used, a
+/// method chain, a control-flow construct, etc.) makes the body non-vacuous so
+/// legitimate tests are never flagged. The caller only reaches this after
+/// confirming the body has no assertion.
+fn is_signature_or_discard_only(body: &str) -> bool {
+    let statements: Vec<&str> = body
+        .split(';')
+        .map(str::trim)
+        .filter(|stmt| !stmt.is_empty())
+        .collect();
+
+    if statements.is_empty() {
+        return false;
+    }
+
+    let fn_pointer_binding = Regex::new(r"^let\s+\w+\s*:\s*fn\s*\(").unwrap();
+    let discard_binding = Regex::new(r"^let\s+_\w*\s*=").unwrap();
+
+    let mut saw_no_op_reference = false;
+    for stmt in statements {
+        if fn_pointer_binding.is_match(stmt) {
+            saw_no_op_reference = true;
+            continue;
+        }
+        if discard_binding.is_match(stmt) {
+            // `let _ = something(..);` or `let _ = ident;` — result discarded.
+            saw_no_op_reference = true;
+            continue;
+        }
+        // Any other statement (real binding, chained call, control flow) means
+        // the test does more than name product code; leave it alone.
+        return false;
+    }
+
+    saw_no_op_reference
 }
 
 /// Collect product symbols imported from the resolved package via `use` lines.
@@ -552,6 +613,69 @@ fn parse_json() {
     #[test]
     fn classify_vacuous_test_accepts_product_reference_marker() {
         let body = "let result = crate::run();\nassert!(result);";
+        assert_eq!(
+            classify_vacuous_test(body, &HashSet::new(), &HashSet::new(), &policy(), None),
+            None
+        );
+    }
+
+    #[test]
+    fn classify_vacuous_test_flags_fn_pointer_signature_binding() {
+        let body = r#"
+            let edit_fn: fn(&str, &str, usize, &str) -> Result<EditResult> = crate::edit_replace_line;
+            let _ = edit_fn;
+        "#;
+        assert_eq!(
+            classify_vacuous_test(body, &HashSet::new(), &HashSet::new(), &policy(), None),
+            Some(
+                "it only names product code in a signature binding or discarded call without asserting on behavior"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn classify_vacuous_test_flags_discarded_product_call() {
+        let body = "let _ = crate::login(credentials);";
+        assert_eq!(
+            classify_vacuous_test(body, &HashSet::new(), &HashSet::new(), &policy(), None),
+            Some(
+                "it only names product code in a signature binding or discarded call without asserting on behavior"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn classify_vacuous_test_keeps_discarded_call_when_it_asserts() {
+        // A test that discards one call but still asserts on behavior is real.
+        let body = "let _ = crate::warm_cache();\nlet value = crate::run();\nassert_eq!(value, 1);";
+        assert_eq!(
+            classify_vacuous_test(body, &HashSet::new(), &HashSet::new(), &policy(), None),
+            None
+        );
+    }
+
+    #[test]
+    fn classify_vacuous_test_keeps_real_product_call_with_bound_result() {
+        // Binds the result of a product call and inspects it — not a no-op even
+        // though it shares the `let name = ...` shape.
+        let body = "let value = crate::run();\nassert_eq!(value, 1);";
+        assert_eq!(
+            classify_vacuous_test(body, &HashSet::new(), &HashSet::new(), &policy(), None),
+            None
+        );
+    }
+
+    #[test]
+    fn classify_vacuous_test_keeps_fn_pointer_binding_that_invokes_it() {
+        // Signature binding is fine when the bound pointer is actually called and
+        // its outcome asserted.
+        let body = r#"
+            let edit_fn: fn(&str) -> Result<()> = crate::edit_replace_line;
+            let result = edit_fn("x");
+            assert!(result.is_ok());
+        "#;
         assert_eq!(
             classify_vacuous_test(body, &HashSet::new(), &HashSet::new(), &policy(), None),
             None


### PR DESCRIPTION
## Summary

Closes #8709. Teaches the `test_vacuity` detector to distinguish **naming** a product symbol from **exercising** it, so signature-only no-op tests stop slipping past the audit.

Previously, `classify_vacuous_test` treated any product symbol appearing in a test body as proof the test exercises product code and short-circuited to non-vacuous. That let a whole class of no-op tests pass:

```rust
#[test]
fn test_edit_replace_line() {
    let edit_fn: fn(&str, &str, usize, &str) -> Result<EditResult> = edit_replace_line;
    let _ = edit_fn;   // the entire test — proves nothing at runtime
}
```

The symbol `edit_replace_line` reads as a "product reference" even though the test only re-proves a type signature the compiler already enforces. The same gap let discarded calls (`let _ = login(credentials);` with no assertion) pass.

## Change

- `classify_vacuous_test` now flags a body when **all** of the following hold:
  1. it has no assertion (`assert*` / `panic!`), and
  2. every statement is either a function-pointer signature binding (`let f: fn(..) [-> ..] = ...`) or a discarded `let _ = ...;` binding.
- New helper `is_signature_or_discard_only` is deliberately conservative — any real binding (`let value = run();`), chained call, or control-flow construct keeps the test, so legitimate behavior tests are never flagged. It is only consulted after the caller confirms there is no assertion, so a signature binding that is later invoked and asserted stays valid.

## Tests

Added fixtures covering both flagged shapes and the negatives that must **not** flag:
- flags: fn-pointer signature binding, discarded product call
- keeps: discarded call that still asserts, real product call with bound+asserted result, fn-pointer binding that is invoked and asserted

## Impact

Surfaces the 18 signature-only no-op tests currently in the repo (9 in `project/files/edit.rs`, 5 in `project/files.rs`, plus `extension/registry.rs`, `refactor/plan/sources.rs`, `extension/maintenance.rs`) and the `server/auth.rs` `let _ = ...` cluster — the highest-signal test cruft the detector was green-lighting. Those tests are left in place; this PR makes the detector report them so they can be cleaned up (or turned into real tests) in follow-up.

Verified with `cargo fmt` + `cargo check -p homeboy-core --lib` (clean); classification logic cross-checked against the real `edit.rs` bodies and the negative cases. Full test run left to CI.