### PR TITLE
Detect redundant test wrappers that only re-run another test

### DIFF
--- a/crates/homeboy-audit-contract/src/finding_kind.rs
+++ b/crates/homeboy-audit-contract/src/finding_kind.rs
@@ -54,6 +54,10 @@ pub enum AuditFinding {
     OrphanedTest,
     /// Test method has a placeholder/no-op body that does not exercise product code.
     VacuousTest,
+    /// Test method's entire body is a call to another test in the same file,
+    /// re-running that test for no added coverage — usually a leftover rename
+    /// shim.
+    RedundantTestWrapper,
     /// Comment starts with TODO/FIXME/HACK/XXX marker.
     TodoMarker,
     /// Comment starts with stale or legacy phrasing.
@@ -212,6 +216,7 @@ impl AuditFinding {
             "missing_test_method",
             "orphaned_test",
             "vacuous_test",
+            "redundant_test_wrapper",
             "todo_marker",
             "legacy_comment",
             "layer_ownership_violation",

--- a/crates/homeboy-core/src/code_audit/execution_plan.rs
+++ b/crates/homeboy-core/src/code_audit/execution_plan.rs
@@ -268,6 +268,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
             AuditFinding::InlineTestModule,
             AuditFinding::ScatteredTestFile,
             AuditFinding::VacuousTest,
+            AuditFinding::RedundantTestWrapper,
         ],
         access: DetectorAccess::RootOnly,
         runtime: DetectorRuntime::Root(RootDetectorRunner::TestTopology),

--- a/crates/homeboy-core/src/code_audit/test_quality.rs
+++ b/crates/homeboy-core/src/code_audit/test_quality.rs
@@ -97,6 +97,7 @@ fn detect_vacuous_tests(file: &str, content: &str) -> Vec<Finding> {
         .collect::<Vec<_>>();
 
     findings.extend(detect_duplicate_test_names(&file_path, &tests));
+    findings.extend(detect_redundant_test_wrappers(&file_path, &tests));
     if !inline_source_file {
         findings.extend(detect_unused_product_imports(
             &file_path,
@@ -236,6 +237,61 @@ fn detect_duplicate_test_names(file: &str, tests: &[TestFunction]) -> Vec<Findin
     }
 
     findings
+}
+
+/// Flag a test whose entire body is a bare call to another `#[test]` in the
+/// same file.
+///
+/// Such a wrapper re-runs the target test verbatim, adding no coverage — it is
+/// almost always a rename shim left behind when a test was renamed but the old
+/// name was kept as a forwarding stub. The target already executes on its own,
+/// so the wrapper just doubles the work (and doubles any flakiness for
+/// expensive tests that bind sockets, spawn threads, or touch the filesystem).
+///
+/// The check is deliberately narrow: it only fires when the body, after
+/// stripping comments, is exactly one statement of the form `other_name();`
+/// where `other_name` is another test in the same file. A wrapper that passes
+/// arguments, asserts, or does any additional work is a legitimate helper and
+/// is left alone.
+fn detect_redundant_test_wrappers(file: &str, tests: &[TestFunction]) -> Vec<Finding> {
+    let test_names: BTreeSet<&str> = tests.iter().map(|test| test.name.as_str()).collect();
+    let call_pattern = regex::Regex::new(r"^([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*\)\s*;?$").unwrap();
+
+    tests
+        .iter()
+        .filter_map(|test| {
+            let body = strip_comments(&test.body);
+            let statements: Vec<&str> = body
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .collect();
+            if statements.len() != 1 {
+                return None;
+            }
+
+            let captures = call_pattern.captures(statements[0])?;
+            let target = captures.get(1)?.as_str();
+            if target == test.name || !test_names.contains(target) {
+                return None;
+            }
+
+            Some(Finding {
+                convention: "test_quality".to_string(),
+                severity: Severity::Info,
+                file: file.to_string(),
+                description: format!(
+                    "Redundant test `{}` at line {} only calls another test `{}` in the same file, re-running it for no added coverage",
+                    test.name, test.line, target
+                ),
+                suggestion: format!(
+                    "Delete `{}` (the target `{}` already runs), or give it distinct arguments and assertions",
+                    test.name, target
+                ),
+                kind: AuditFinding::RedundantTestWrapper,
+            })
+        })
+        .collect()
 }
 
 fn detect_unused_product_imports(
@@ -786,6 +842,119 @@ fn duplicate_behavior() {
         assert!(findings.iter().any(|finding| finding
             .description
             .contains("Duplicate test name `duplicate_behavior`")));
+    }
+
+    #[test]
+    fn flags_test_that_only_calls_another_test_in_same_file() {
+        let findings = detect_vacuous_tests(
+            "tests/core/wiring_test.rs",
+            r#"
+#[test]
+fn test_run() {
+    real_behavior_test();
+}
+
+#[test]
+fn real_behavior_test() {
+    crate::thing::run();
+    assert!(true);
+}
+"#,
+        );
+
+        assert!(findings.iter().any(|finding| {
+            finding.kind == AuditFinding::RedundantTestWrapper
+                && finding.description.contains("Redundant test `test_run`")
+                && finding.description.contains("`real_behavior_test`")
+        }));
+    }
+
+    #[test]
+    fn keeps_test_that_calls_a_non_test_helper() {
+        // Calling a shared helper (not itself a #[test]) is a normal fixture
+        // pattern, not a redundant wrapper.
+        let findings = detect_vacuous_tests(
+            "tests/core/wiring_test.rs",
+            r#"
+#[test]
+fn exercises_behavior() {
+    run_shared_fixture();
+}
+"#,
+        );
+
+        assert!(findings
+            .iter()
+            .all(|finding| finding.kind != AuditFinding::RedundantTestWrapper));
+    }
+
+    #[test]
+    fn keeps_test_that_delegates_with_arguments() {
+        // A one-liner that passes arguments to another test is doing real work
+        // (a parameterized case), not blindly re-running it.
+        let findings = detect_vacuous_tests(
+            "tests/core/wiring_test.rs",
+            r#"
+#[test]
+fn cold_start() {
+    shared_case("cold");
+}
+
+#[test]
+fn shared_case(mode: &str) {
+    crate::thing::run(mode);
+}
+"#,
+        );
+
+        assert!(findings
+            .iter()
+            .all(|finding| finding.kind != AuditFinding::RedundantTestWrapper));
+    }
+
+    #[test]
+    fn flags_redundant_wrapper_directly() {
+        let tests = extract_test_functions(
+            r#"
+#[test]
+fn test_run() {
+    get_returns_status_headers_and_json_body();
+}
+
+#[test]
+fn get_returns_status_headers_and_json_body() {
+    crate::http::run();
+    assert!(true);
+}
+"#,
+        );
+        let findings = detect_redundant_test_wrappers("src/http_request.rs", &tests);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, AuditFinding::RedundantTestWrapper);
+        assert!(findings[0]
+            .description
+            .contains("only calls another test `get_returns_status_headers_and_json_body`"));
+    }
+
+    #[test]
+    fn keeps_multi_statement_test_that_starts_with_a_call() {
+        let tests = extract_test_functions(
+            r#"
+#[test]
+fn setup_then_assert() {
+    helper_test();
+    assert_eq!(1, 1);
+}
+
+#[test]
+fn helper_test() {
+    crate::thing::run();
+}
+"#,
+        );
+
+        assert!(detect_redundant_test_wrappers("tests/core/wiring_test.rs", &tests).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #8710. Adds a `test_quality` lint for tests whose entire body is a bare call to another `#[test]` in the same file — a shim that re-runs the target verbatim for zero added coverage.

Example this catches (real, in `http_request.rs`):

```rust
#[test]
fn test_run() {
    get_returns_status_headers_and_json_body();   // itself a #[test]
}

#[test]
fn get_returns_status_headers_and_json_body() {
    // real test: binds a TcpListener, spawns a server thread, asserts status/body/headers
}
```

`test_run` re-runs a network-binding test with no variation — a leftover rename shim that just doubles the work (and any flakiness).

## Change

- New `AuditFinding::RedundantTestWrapper` finding kind (in `homeboy-audit-contract`), wired into the `test_topology` detector descriptor (which drives `test_quality`).
- New `detect_redundant_test_wrappers` in `test_quality.rs`, called alongside the existing `detect_duplicate_test_names`. It reuses the file's already-extracted `#[test]` set + bodies.
- Deliberately narrow: fires only when the comment-stripped body is exactly one statement `other_name();` where `other_name` is another test in the same file. Any arguments (`shared_case("cold")`), assertions, method chains, or extra statements keep the test — so parameterized delegations and setup-then-assert helpers are never flagged.

## Tests

Added fixtures for both the flag path and the negatives that must NOT flag:
- flags: test that only calls another same-file test (via the public per-file entry and the detector directly)
- keeps: calls a non-test helper, delegates with arguments, multi-statement body starting with a call

## Impact

Low volume (1 clear instance today) but cheap to detect and doubles as a rename-shim guard. The offending test is left in place; the detector now reports it for cleanup.

Verified with `cargo fmt` + `cargo check -p homeboy-core --lib` + `-p homeboy-audit-contract --lib` (clean); the match regex was cross-checked against arg/chain/assert/path-call cases. Full test run left to CI.