### PR TITLE
Flag bare #[ignore] attributes that carry no reason

### DIFF
--- a/crates/homeboy-audit-contract/src/finding_kind.rs
+++ b/crates/homeboy-audit-contract/src/finding_kind.rs
@@ -58,6 +58,9 @@ pub enum AuditFinding {
     /// re-running that test for no added coverage — usually a leftover rename
     /// shim.
     RedundantTestWrapper,
+    /// Test is disabled with a bare skip attribute that carries no reason,
+    /// leaving no record of why it is skipped or when it should run again.
+    IgnoredTestWithoutReason,
     /// Comment starts with TODO/FIXME/HACK/XXX marker.
     TodoMarker,
     /// Comment starts with stale or legacy phrasing.
@@ -217,6 +220,7 @@ impl AuditFinding {
             "orphaned_test",
             "vacuous_test",
             "redundant_test_wrapper",
+            "ignored_test_without_reason",
             "todo_marker",
             "legacy_comment",
             "layer_ownership_violation",

--- a/crates/homeboy-core/src/code_audit/execution_plan.rs
+++ b/crates/homeboy-core/src/code_audit/execution_plan.rs
@@ -269,6 +269,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
             AuditFinding::ScatteredTestFile,
             AuditFinding::VacuousTest,
             AuditFinding::RedundantTestWrapper,
+            AuditFinding::IgnoredTestWithoutReason,
         ],
         access: DetectorAccess::RootOnly,
         runtime: DetectorRuntime::Root(RootDetectorRunner::TestTopology),

--- a/crates/homeboy-core/src/code_audit/test_quality.rs
+++ b/crates/homeboy-core/src/code_audit/test_quality.rs
@@ -38,6 +38,7 @@ pub(super) fn run(root: &Path) -> Vec<Finding> {
         };
 
         findings.extend(detect_vacuous_tests(&relative, &content));
+        findings.extend(detect_ignored_without_reason(&relative, &content));
         for site in detect_env_mutations(&relative, &content) {
             env_mutations
                 .entry(site.var.clone())
@@ -559,6 +560,134 @@ fn extract_fn_name(line: &str) -> Option<String> {
         .split(|c: char| !c.is_alphanumeric() && c != '_')
         .next()?;
     (!name.is_empty()).then(|| name.to_string())
+}
+
+/// Flag `#[ignore]` attributes that carry no reason string.
+///
+/// An ignored test with no rationale leaves no record of *why* it is skipped or
+/// what would re-enable it, so it tends to rot into permanently-dead weight.
+/// The documented form `#[ignore = "..."]` keeps the skip self-explaining; this
+/// check nudges bare `#[ignore]` toward it.
+///
+/// Detection is line-oriented (rustfmt always places attributes on their own
+/// line). String and raw-string literals are blanked first so `#[ignore]` text
+/// embedded in test fixtures is never mistaken for a real attribute. A line
+/// whose trimmed text is exactly `#[ignore]` is flagged.
+fn detect_ignored_without_reason(file: &str, content: &str) -> Vec<Finding> {
+    let masked = blank_string_literals(content);
+    masked
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| line.trim() == "#[ignore]")
+        .map(|(index, _)| Finding {
+            convention: "test_quality".to_string(),
+            severity: Severity::Info,
+            file: file.to_string(),
+            description: format!(
+                "Test at line {} is disabled with a bare `#[ignore]` that gives no reason",
+                index + 1
+            ),
+            suggestion:
+                "Use `#[ignore = \"<why it is skipped / when it should run>\"]` so the skip is self-documenting"
+                    .to_string(),
+            kind: AuditFinding::IgnoredTestWithoutReason,
+        })
+        .collect()
+}
+
+/// Replace the contents of Rust string literals (regular `"..."` and raw
+/// `r#"..."#`) with spaces while preserving newlines, so line-oriented scans
+/// see the code skeleton but not literal payloads such as test fixtures.
+///
+/// Operates purely on bytes (never slicing `&str` at an arbitrary offset) so it
+/// is safe on files containing multi-byte UTF-8 characters. Every non-newline
+/// byte inside a literal is replaced by a single space; because ASCII spaces
+/// and newlines are one byte each, the output preserves line boundaries and
+/// column-agnostic line numbers.
+fn blank_string_literals(content: &str) -> String {
+    let bytes = content.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+
+    let blank = |byte: u8| if byte == b'\n' { b'\n' } else { b' ' };
+
+    while i < bytes.len() {
+        let byte = bytes[i];
+
+        // Raw string: r"...", r#"..."#, r##"..."##, ...
+        if byte == b'r' {
+            let mut j = i + 1;
+            let mut hashes = 0;
+            while j < bytes.len() && bytes[j] == b'#' {
+                hashes += 1;
+                j += 1;
+            }
+            if j < bytes.len() && bytes[j] == b'"' {
+                out.push(b'r');
+                out.extend(std::iter::repeat_n(b'#', hashes));
+                out.push(b'"');
+                j += 1;
+                // Closing delimiter is `"` followed by `hashes` `#` bytes.
+                loop {
+                    if j >= bytes.len() {
+                        break;
+                    }
+                    let is_close = bytes[j] == b'"'
+                        && bytes[j + 1..]
+                            .iter()
+                            .take(hashes)
+                            .filter(|b| **b == b'#')
+                            .count()
+                            == hashes;
+                    if is_close {
+                        out.push(b'"');
+                        out.extend(std::iter::repeat_n(b'#', hashes));
+                        j += 1 + hashes;
+                        break;
+                    }
+                    out.push(blank(bytes[j]));
+                    j += 1;
+                }
+                i = j;
+                continue;
+            }
+        }
+
+        // Regular string: "...", honoring backslash escapes.
+        if byte == b'"' {
+            out.push(b'"');
+            let mut j = i + 1;
+            while j < bytes.len() {
+                match bytes[j] {
+                    b'\\' => {
+                        out.push(b' ');
+                        if j + 1 < bytes.len() {
+                            out.push(blank(bytes[j + 1]));
+                        }
+                        j += 2;
+                    }
+                    b'"' => {
+                        out.push(b'"');
+                        j += 1;
+                        break;
+                    }
+                    other => {
+                        out.push(blank(other));
+                        j += 1;
+                    }
+                }
+            }
+            i = j;
+            continue;
+        }
+
+        out.push(byte);
+        i += 1;
+    }
+
+    // Every replaced byte is ASCII (space/newline) and untouched bytes retain
+    // their original UTF-8 sequences, so the result is always valid UTF-8.
+    String::from_utf8(out).unwrap_or_else(|_| content.to_string())
 }
 
 #[derive(Debug, Clone)]
@@ -1167,5 +1296,60 @@ fn with_isolated_home() { std::env::set_var("HOME", "/tmp/a"); }
             ],
         );
         assert!(detect_inconsistent_env_guards(shared).is_empty());
+    }
+
+    #[test]
+    fn flags_bare_ignore_attribute() {
+        let findings = detect_ignored_without_reason(
+            "src/server/auth.rs",
+            r#"
+    #[test]
+    #[ignore]
+    fn test_login() {
+        let _ = login("fixture");
+    }
+"#,
+        );
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, AuditFinding::IgnoredTestWithoutReason);
+        assert!(findings[0].description.contains("bare `#[ignore]`"));
+    }
+
+    #[test]
+    fn keeps_ignore_attribute_with_reason() {
+        let findings = detect_ignored_without_reason(
+            "src/code_audit/mod.rs",
+            r#"
+    #[test]
+    #[ignore = "Requires PHP extension with fingerprint script installed"]
+    fn integration_only() {
+        run();
+    }
+"#,
+        );
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn ignores_bare_ignore_text_inside_string_fixtures() {
+        // The literal `#[ignore]` here is test-input data, not an attribute
+        // position: nothing that looks like a test item follows it.
+        let findings = detect_ignored_without_reason(
+            "src/code_audit/detectors/test_vacuity.rs",
+            r#"
+    fn fixture() {
+        let sample = "\
+#[test]
+#[ignore]
+fn generated() {}
+";
+        assert!(sample.contains("ignore"));
+    }
+"#,
+        );
+
+        assert!(findings.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Closes #8711. Adds a `test_quality` consistency lint for `#[ignore]` attributes used without a reason string. A bare `#[ignore]` leaves no record of *why* a test is skipped or when it should run again, so it tends to rot into permanently-dead weight. The repo is already inconsistent: 4 sites use the documented `#[ignore = "..."]` form, 17 use bare `#[ignore]`.

## Change

- New `AuditFinding::IgnoredTestWithoutReason` finding kind (in `homeboy-audit-contract`), wired into the `test_topology` detector descriptor that drives `test_quality`.
- New `detect_ignored_without_reason` in `test_quality.rs`, called per file in `run`. It flags any line whose trimmed text is exactly `#[ignore]` (rustfmt always puts attributes on their own line).
- Robustness: string and raw-string literals (`"..."`, `r#"..."#`) are blanked to spaces first — **byte-safe** and newline-preserving — so `#[ignore]` text embedded in test fixtures (this detector's own tests, grammar fixtures, etc.) is never mistaken for a real attribute, and line numbers stay accurate. The blanker operates on bytes and never slices `&str` at an arbitrary offset, so it is safe on files with multi-byte UTF-8.

## Tests

- flags: a bare `#[ignore]`
- keeps: `#[ignore = "..."]` with a reason
- keeps: `#[ignore]` that appears inside a string fixture (not a real attribute)

## Impact

Surfaces 17 undocumented skips today (`keychain.rs` ×6, `server/auth.rs` ×6, `server/auth_profiles.rs` ×5 — all real integration tests that hit a live OS keychain and can't run in CI). The *ignoring* is legitimate; the lint just asks each to say why. The 4 existing `#[ignore = "..."]` sites are correctly left alone.

Verified with `cargo fmt` + `cargo check -p homeboy-core --lib` + `-p homeboy-audit-contract --lib` (clean). The literal-blanking + flag logic was cross-checked by compiling the exact function against the real repo (17 prod hits, zero fixture false-positives) and against a UTF-8 file that previously would have panicked a naive `&str`-slicing implementation. Full test run left to CI.