### PR TITLE
refactor: move update_output + SourceMetadataRepair to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/lifecycle/source_metadata.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/source_metadata.rs
@@ -2,12 +2,7 @@ use super::{load_extension, read_source_revision, read_source_url, write_source_
 use crate::error::{Error, Result};
 use crate::paths;
 
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct SourceMetadataRepair {
-    pub source_url: String,
-    pub reason: String,
-    pub repair_command: String,
-}
+pub use homeboy_extension_contract::source_metadata_repair::SourceMetadataRepair;
 
 #[derive(Debug)]
 pub struct SourceMetadataResolution {

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -36,7 +36,6 @@ mod summary;
 pub mod test;
 pub mod trace;
 pub mod update_check;
-mod update_output;
 mod validation;
 
 pub use capability::{
@@ -72,6 +71,10 @@ pub use homeboy_extension_contract::runner_contract::{
     phase_failure_category_from_exit_code, phase_status_from_exit_code, ExtensionPhaseTiming,
     PhaseFailure, PhaseFailureCategory, PhaseReport, PhaseStatus, RunnerStepFilter,
     VerificationPhase, GENERIC_INFRASTRUCTURE_FAILURE_MARKERS,
+};
+pub use homeboy_extension_contract::update_output::{
+    ExtensionSourceUpdate, SourceMetadataRepairEntry, UpdateAllResult, UpdateEntry,
+    UpdateSkippedEntry,
 };
 pub use homeboy_extension_contract::version::{parse_extension_version, VersionConstraint};
 pub use homeboy_extension_contract::{DeployArchiveInstallPolicy, DeployRequiredHeader};
@@ -126,15 +129,13 @@ pub use runtime_helper::{
 };
 pub use scope::ExtensionScope;
 pub use summary::{list_summaries, ActionSummary, ExtensionSummary};
-pub use update_output::{
-    ExtensionSourceUpdate, SourceMetadataRepairEntry, UpdateAllResult, UpdateEntry,
-    UpdateSkippedEntry,
-};
 pub use validation::{
     extension_provides_build, validate_extension_requirements, validate_required_extensions,
 };
 
-pub use homeboy_extension_contract::{core_compat, exec_context, runner_contract, version};
+pub use homeboy_extension_contract::{
+    core_compat, exec_context, runner_contract, source_metadata_repair, update_output, version,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -14,6 +14,8 @@ pub mod exec_context;
 pub mod manifest_deploy_config;
 pub mod manifest_test_config;
 pub mod runner_contract;
+pub mod source_metadata_repair;
+pub mod update_output;
 pub mod version;
 
 pub use core_compat::{

--- a/crates/homeboy-extension-contract/src/source_metadata_repair.rs
+++ b/crates/homeboy-extension-contract/src/source_metadata_repair.rs
@@ -1,0 +1,14 @@
+//! Source-metadata repair contract type.
+//!
+//! Pure data describing a repair that reconciled an extension's on-disk source
+//! metadata with its manifest. The behavior that produces it (resolving source
+//! URLs, rewriting metadata files) lives in `homeboy_core::extension`; only the
+//! serializable result shape lives here so it can travel through update/report
+//! contract types without dragging that behavior into the leaf crate.
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SourceMetadataRepair {
+    pub source_url: String,
+    pub reason: String,
+    pub repair_command: String,
+}

--- a/crates/homeboy-extension-contract/src/update_output.rs
+++ b/crates/homeboy-extension-contract/src/update_output.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use super::SourceMetadataRepair;
+use crate::source_metadata_repair::SourceMetadataRepair;
 
 /// Result of updating all extensions.
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## Summary
Third sub-cut of the **extension crate extraction campaign** (Stage 1, wiki id 12840), following the keystone (#8716) and exec/version/compat cut (#8722).

This one is an **untangle-then-move**: it separates a pure data type from its behavior-heavy home so a dependent module can follow it into the contract crate.

## The untangle
`update_output` was blocked from moving only because it referenced `SourceMetadataRepair` — which lived in `extension/lifecycle/source_metadata.rs`, a module full of behavior (loading extensions, reading source revisions, rewriting on-disk metadata files).

But `SourceMetadataRepair` itself is a **pure 3-field serde struct** (`source_url`, `reason`, `repair_command`). So:
1. Moved just that struct into `homeboy-extension-contract` (new `source_metadata_repair` module). The resolving *behavior* (`resolve_source_url`, `SourceMetadataResolution`) stays in core; `source_metadata.rs` re-exports the type.
2. With the dep severed, `update_output` (`UpdateAllResult`, `UpdateEntry`, `ExtensionSourceUpdate`, `SourceMetadataRepairEntry`, `UpdateSkippedEntry`) is now serde-only and moves into the contract crate too.

## Zero downstream churn
Core's `extension` module re-exports both moved modules and their types (including the module paths, so `super::update_output::*` in `maintenance.rs` resolves). All existing `crate::extension::*` / `homeboy::core::extension::SourceMetadataRepair` call sites keep working unchanged.

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-runner` + bin clean on `--lib`.
- Heavy build/test left to CI per repo policy.

## Campaign progress
Contract crate now holds 8 modules. Remaining Stage-1 candidates need bigger untangles: `manifest_action_config` (needs `manifest::{ActionType, BuiltinAction, HttpMethod}`), `manifest_sidecar` (needs `engine::run_dir`), `manifest_config` (29 types, chained through `manifest`/`lifecycle`/`DepsConfig`). See wiki 12840.

🤖 Generated with [Claude Code](https://claude.com/claude-code)