### PR TITLE
Document why keychain/auth integration tests are ignored

### DIFF
--- a/crates/homeboy-core/src/keychain.rs
+++ b/crates/homeboy-core/src/keychain.rs
@@ -360,7 +360,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live OS keychain / secret store; run locally with `cargo test -- --ignored`"]
     fn test_set() {
         let project_id = "homeboy-keychain-test-set";
         let variable_name = "token";
@@ -377,7 +377,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live OS keychain / secret store; run locally with `cargo test -- --ignored`"]
     fn test_get() {
         let project_id = "homeboy-keychain-test-get";
         let variable_name = "token";
@@ -398,7 +398,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live OS keychain / secret store; run locally with `cargo test -- --ignored`"]
     fn test_remove() {
         let project_id = "homeboy-keychain-test-remove";
         let variable_name = "token";
@@ -412,7 +412,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live OS keychain / secret store; run locally with `cargo test -- --ignored`"]
     fn test_exists() {
         let project_id = "homeboy-keychain-test-exists";
         let variable_name = "token";
@@ -425,7 +425,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live OS keychain / secret store; run locally with `cargo test -- --ignored`"]
     fn test_remove_many() {
         let project_id = "homeboy-keychain-test-remove-many";
         let variables = vec!["token".to_string(), "refresh".to_string()];
@@ -441,7 +441,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live OS keychain / secret store; run locally with `cargo test -- --ignored`"]
     fn stores_reads_and_removes_keychain_value() {
         let project_id = "homeboy-keychain-test";
         let variable_name = "token";

--- a/crates/homeboy-core/src/server/auth.rs
+++ b/crates/homeboy-core/src/server/auth.rs
@@ -423,20 +423,20 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live authenticated server; run locally with `cargo test -- --ignored`"]
     fn test_login() {
         let credentials = HashMap::new();
         let _ = login("homeboy-auth-test", credentials);
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live authenticated server; run locally with `cargo test -- --ignored`"]
     fn test_logout() {
         let _ = logout("homeboy-auth-test");
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live OS keychain / secret store; run locally with `cargo test -- --ignored`"]
     fn test_set() {
         let result = set("homeboy-auth-test", "token", "secret-value").expect("store value");
 
@@ -447,7 +447,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live OS keychain / secret store; run locally with `cargo test -- --ignored`"]
     fn test_get() {
         set("homeboy-auth-test", "token", "secret-value").expect("store value");
         let result = get("homeboy-auth-test", "token", true).expect("read value");
@@ -458,7 +458,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live OS keychain / secret store; run locally with `cargo test -- --ignored`"]
     fn test_remove() {
         set("homeboy-auth-test", "token", "secret-value").expect("store value");
         let result = remove("homeboy-auth-test", "token").expect("remove value");
@@ -467,7 +467,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live authenticated server; run locally with `cargo test -- --ignored`"]
     fn test_status() {
         let _ = status("homeboy-auth-test");
     }

--- a/crates/homeboy-core/src/server/auth_profiles.rs
+++ b/crates/homeboy-core/src/server/auth_profiles.rs
@@ -145,7 +145,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live OS keychain / secret store; run locally with `cargo test -- --ignored`"]
     fn test_set_profile_basic() {
         let profile = "homeboy-auth-profile-basic-test";
         let _ = remove_profile(profile);
@@ -158,7 +158,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live OS keychain / secret store; run locally with `cargo test -- --ignored`"]
     fn test_set_profile_bearer() {
         let profile = "homeboy-auth-profile-bearer-test";
         let _ = remove_profile(profile);
@@ -171,7 +171,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live OS keychain / secret store; run locally with `cargo test -- --ignored`"]
     fn test_profile_status() {
         let profile = "homeboy-auth-profile-status-test";
         let _ = remove_profile(profile);
@@ -185,7 +185,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live OS keychain / secret store; run locally with `cargo test -- --ignored`"]
     fn test_profile_authorization_header() {
         let profile = "homeboy-auth-profile-header-test";
         let _ = remove_profile(profile);
@@ -198,7 +198,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Requires a live OS keychain / secret store; run locally with `cargo test -- --ignored`"]
     fn test_remove_profile() {
         let profile = "homeboy-auth-profile-remove-test";
         set_profile_bearer(profile, "token").expect("store bearer profile");


### PR DESCRIPTION
## Summary

Adds reason strings to the 17 bare `#[ignore]` attributes flagged by the `IgnoredTestWithoutReason` detector (#8717). The tests stay ignored; they just stop being silently skipped. Test-only, no behavior change.

## Why they're ignored (now documented)

- **Live OS keychain / secret store** (14): all 6 in `keychain.rs`, the `test_set`/`test_get`/`test_remove` trio in `server/auth.rs`, and all 5 in `server/auth_profiles.rs`. These call `set`/`get`/`remove` / `set_profile_*` which persist to the real OS keychain (macOS Keychain, Linux secret service) — not available or isolatable in CI.
- **Live authenticated server** (3): `test_login`/`test_logout`/`test_status` in `server/auth.rs` hit a real auth endpoint.

Each attribute now reads e.g.:

```rust
#[ignore = "Requires a live OS keychain / secret store; run locally with `cargo test -- --ignored`"]
```

matching the documented-form examples already in the tree (`#[ignore = "Requires PHP extension..."]`).

## Result

Zero bare `#[ignore]` remain in the codebase — the `IgnoredTestWithoutReason` detector is now clean. Verified with `cargo fmt` + `cargo check -p homeboy-core --lib --tests` (clean); confirmed 0 remaining bare attributes and 17 documented (6 + 6 + 5).