### PR TITLE
Recover terminal phantom runner activity

### DIFF
--- a/crates/homeboy-core/src/api_jobs/store.rs
+++ b/crates/homeboy-core/src/api_jobs/store.rs
@@ -500,6 +500,58 @@ impl JobStore {
         )
     }
 
+    /// Reconcile only jobs whose linked durable run has already reached a
+    /// terminal state. This deliberately does not inspect, stop, or alter live
+    /// children, so it is safe when a daemon's aggregate count includes both
+    /// stale handoffs and genuine work.
+    pub fn reconcile_terminal_linked_daemon_jobs(&self) -> Result<Vec<Uuid>> {
+        self.reconcile_terminal_linked_daemon_jobs_with_resolver(
+            recovered_terminal_agent_task_result,
+        )
+    }
+
+    pub(super) fn reconcile_terminal_linked_daemon_jobs_with_resolver(
+        &self,
+        resolve_terminal: impl Fn(&StoredJob) -> Option<RecoveredTerminalJob>,
+    ) -> Result<Vec<Uuid>> {
+        let terminal = {
+            let inner = self.inner.lock().expect("job store mutex poisoned");
+            inner
+                .jobs
+                .values()
+                .filter(|stored| {
+                    matches!(stored.job.status, JobStatus::Queued | JobStatus::Running)
+                })
+                .filter_map(|stored| resolve_terminal(stored).map(|result| (stored.job.id, result)))
+                .collect::<Vec<_>>()
+        };
+
+        let mut reconciled = Vec::with_capacity(terminal.len());
+        for (job_id, result) in terminal {
+            let now = timestamp_ms();
+            let mut inner = self.inner.lock().expect("job store mutex poisoned");
+            let stored = inner.jobs.get_mut(&job_id).expect("terminal job exists");
+            stored.job.status = result.status;
+            stored.job.updated_at_ms = now;
+            stored.job.finished_at_ms = Some(now);
+            stored.job.stale_reason = None;
+            for artifact in result.artifacts {
+                if !stored
+                    .job
+                    .artifacts
+                    .iter()
+                    .any(|existing| existing.id == artifact.id)
+                {
+                    stored.job.artifacts.push(artifact);
+                }
+            }
+            drop(inner);
+            self.persist()?;
+            reconciled.push(job_id);
+        }
+        Ok(reconciled)
+    }
+
     #[cfg(test)]
     pub(super) fn reconcile_dead_daemon_lease_jobs_with_confirmed_no_pid_jobs(
         &self,

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -71,6 +71,59 @@ fn terminal_linked_run_is_authoritative_for_confirmed_recovery() {
 }
 
 #[test]
+fn terminal_linked_reconciliation_preserves_live_jobs_and_is_idempotent() {
+    let store = JobStore::default().with_daemon_lease("lease-live".to_string());
+    let first = store.create("runner.exec");
+    store.start(first.id).expect("start first terminal handoff");
+    let second = store.create("runner.exec");
+    store
+        .start(second.id)
+        .expect("start second terminal handoff");
+    let live = store.create("runner.exec");
+    store.start(live.id).expect("start live job");
+
+    let mut first_pass = store
+        .reconcile_terminal_linked_daemon_jobs_with_resolver(|stored| match stored.job.id {
+            id if id == first.id => Some(RecoveredTerminalJob::test_result(
+                JobStatus::Cancelled,
+                "run-cancelled",
+                json!({ "status": "cancelled" }),
+                Vec::new(),
+            )),
+            id if id == second.id => Some(RecoveredTerminalJob::test_result(
+                JobStatus::Failed,
+                "run-failed",
+                json!({ "status": "failed" }),
+                Vec::new(),
+            )),
+            _ => None,
+        })
+        .expect("reconcile terminal handoffs");
+    first_pass.sort();
+    let mut expected = vec![first.id, second.id];
+    expected.sort();
+    assert_eq!(first_pass, expected);
+    assert_eq!(
+        store.get(first.id).expect("first").status,
+        JobStatus::Cancelled
+    );
+    assert_eq!(
+        store.get(second.id).expect("second").status,
+        JobStatus::Failed
+    );
+    assert_eq!(store.get(live.id).expect("live").status, JobStatus::Running);
+
+    let repeated = store
+        .reconcile_terminal_linked_daemon_jobs_with_resolver(|_| None)
+        .expect("repeat reconciliation");
+    assert!(repeated.is_empty());
+    assert_eq!(
+        store.get(live.id).expect("live remains protected").status,
+        JobStatus::Running
+    );
+}
+
+#[test]
 fn reused_pid_with_a_different_start_identity_is_terminalized() {
     let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
     let job = store.create("runner.exec");

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -1352,6 +1352,19 @@ where
             Ok(body) => daemon_endpoint_response("jobs.exec", body),
             Err(err) => error_response(400, err),
         },
+        ("POST", "/jobs/reconcile-terminal") => {
+            match job_store.reconcile_terminal_linked_daemon_jobs() {
+                Ok(reconciled) => daemon_endpoint_response(
+                    "jobs.reconcile_terminal",
+                    json!({
+                        "reconciled_job_ids": reconciled,
+                        "reconciled_count": reconciled.len(),
+                        "policy": "linked durable runs already terminalized; live and unresolved jobs are preserved",
+                    }),
+                ),
+                Err(err) => error_response(400, err),
+            }
+        }
         ("POST", "/lifecycle/stop") => match lifecycle_stop_request(body)
             .and_then(|request| validate_lifecycle_stop_request(&request).map(|_| request))
         {
@@ -1377,7 +1390,7 @@ where
             Ok(body) => daemon_endpoint_response("files.download", body),
             Err(err) => remote_runner::auth_or_bad_request(err),
         },
-        ("GET", "/exec") => HttpResponse {
+        ("GET", "/exec") | ("GET", "/jobs/reconcile-terminal") => HttpResponse {
             status_code: 405,
             body: json!({ "error": "method_not_allowed" }),
             artifact: None,

--- a/crates/homeboy-runner/src/connection.rs
+++ b/crates/homeboy-runner/src/connection.rs
@@ -25,11 +25,11 @@ use homeboy_core::server::{self, Server, SshClient};
 
 use super::broker_http;
 use super::session::{
-    ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource, RunnerActiveJobState,
-    RunnerChangedRuntimePath, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
-    RunnerLeaselessRecoveryContract, RunnerLeaselessRecoveryEvidence, RunnerSession,
-    RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport,
-    RunnerTunnelMode,
+    ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobRecoveryEvidence,
+    RunnerActiveJobSource, RunnerActiveJobState, RunnerChangedRuntimePath, RunnerConnectReport,
+    RunnerDisconnectReport, RunnerFailureKind, RunnerLeaselessRecoveryContract,
+    RunnerLeaselessRecoveryEvidence, RunnerSession, RunnerSessionRole, RunnerSessionState,
+    RunnerStaleDaemonWarning, RunnerStatusReport, RunnerTunnelMode,
 };
 use super::{load, remote_runner_homeboy_path, Runner, RunnerKind};
 use homeboy_core::broker_auth;
@@ -734,7 +734,7 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
     let state = session_state(session.as_ref());
     let connected = state == RunnerSessionState::Connected;
     let stale_daemon = stale_daemon_warning(&runner, session.as_ref(), connected)?;
-    let daemon_freshness = runner_daemon_freshness(&runner, session.as_ref(), connected)?
+    let mut daemon_freshness = runner_daemon_freshness(&runner, session.as_ref(), connected)?
         .or_else(|| remote_daemon_recovery_freshness(runner_id, &runner));
     let active_job_source = session.as_ref().and_then(active_runner_job_source);
     let direct_daemon_active_jobs =
@@ -792,6 +792,19 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
             None,
         )
     };
+    let (active_jobs, stale_jobs, direct_daemon_active_jobs, active_job_recovery_evidence) =
+        reconcile_terminal_phantom_activity(
+            runner_id,
+            session.as_ref(),
+            active_jobs,
+            stale_jobs,
+            direct_daemon_active_jobs,
+        );
+    if let (Some(freshness), Some(active_jobs)) =
+        (daemon_freshness.as_mut(), direct_daemon_active_jobs)
+    {
+        freshness.active_jobs = active_jobs;
+    }
     let active_job_count = direct_daemon_active_jobs.unwrap_or(active_jobs.len());
     let active_job_error = match (active_job_error, direct_daemon_active_jobs) {
         (Some(error), _) => Some(error),
@@ -799,7 +812,7 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
             Some(RunnerActiveJobError {
                 code: "active_job_view_inconsistent".to_string(),
                 message: format!(
-                    "direct daemon freshness reports {authoritative_count} active job(s), but /jobs exposed {} typed runner job(s); freshness is authoritative and orphan recovery is suppressed until the views converge",
+                    "direct daemon freshness reports {authoritative_count} active job(s), but /jobs exposed {} typed runner job(s); freshness is authoritative and terminal-only reconciliation found no durable terminal handoffs",
                     active_jobs.len()
                 ),
             })
@@ -824,8 +837,99 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
         active_job_state,
         active_job_source,
         active_job_error,
+        active_job_recovery_evidence,
         session_path: session_path.display().to_string(),
     })
+}
+
+fn reconcile_terminal_phantom_activity(
+    runner_id: &str,
+    session: Option<&RunnerSession>,
+    active_jobs: Vec<ActiveRunnerJobSummary>,
+    stale_jobs: Vec<ActiveRunnerJobSummary>,
+    direct_daemon_active_jobs: Option<usize>,
+) -> (
+    Vec<ActiveRunnerJobSummary>,
+    Vec<ActiveRunnerJobSummary>,
+    Option<usize>,
+    Option<RunnerActiveJobRecoveryEvidence>,
+) {
+    let Some(authoritative_count) = direct_daemon_active_jobs else {
+        return (active_jobs, stale_jobs, direct_daemon_active_jobs, None);
+    };
+    if authoritative_count == active_jobs.len() {
+        return (active_jobs, stale_jobs, direct_daemon_active_jobs, None);
+    }
+    let Some(local_url) = session.and_then(|session| session.local_url.as_deref()) else {
+        return (active_jobs, stale_jobs, direct_daemon_active_jobs, None);
+    };
+    let Ok(client) = Client::builder().timeout(Duration::from_secs(10)).build() else {
+        return (active_jobs, stale_jobs, direct_daemon_active_jobs, None);
+    };
+    let Ok(response) = client
+        .post(format!(
+            "{}/jobs/reconcile-terminal",
+            local_url.trim_end_matches('/')
+        ))
+        .send()
+    else {
+        return (active_jobs, stale_jobs, direct_daemon_active_jobs, None);
+    };
+    if !response.status().is_success() {
+        return (active_jobs, stale_jobs, direct_daemon_active_jobs, None);
+    }
+    let Ok(body) = response.json::<Value>() else {
+        return (active_jobs, stale_jobs, direct_daemon_active_jobs, None);
+    };
+    let reconciled = body
+        .pointer("/body/reconciled_count")
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+    let reconciled_job_ids = body
+        .pointer("/body/reconciled_job_ids")
+        .and_then(Value::as_array)
+        .map(|ids| {
+            ids.iter()
+                .filter_map(Value::as_str)
+                .take(100)
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if reconciled == 0
+        || reconciled_job_ids.is_empty()
+        || usize::try_from(reconciled).ok() != Some(reconciled_job_ids.len())
+    {
+        return (active_jobs, stale_jobs, direct_daemon_active_jobs, None);
+    }
+    let Ok((refreshed_active_jobs, refreshed_stale_jobs)) =
+        runner_jobs(runner_id, session.expect("local URL requires session"))
+    else {
+        return (active_jobs, stale_jobs, direct_daemon_active_jobs, None);
+    };
+    let Some(refreshed_count) = daemon_http_freshness(
+        local_url,
+        &session.expect("local URL requires session").homeboy_version,
+        session
+            .expect("local URL requires session")
+            .homeboy_build_identity
+            .as_deref()
+            .unwrap_or(""),
+    )
+    .ok()
+    .map(|freshness| freshness.active_jobs) else {
+        return (active_jobs, stale_jobs, direct_daemon_active_jobs, None);
+    };
+    (
+        refreshed_active_jobs,
+        refreshed_stale_jobs,
+        Some(refreshed_count),
+        Some(RunnerActiveJobRecoveryEvidence {
+            reconciled_job_ids,
+            prior_active_job_count: authoritative_count,
+            active_job_count: refreshed_count,
+        }),
+    )
 }
 
 fn should_infer_child_run_orphans(

--- a/crates/homeboy-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-runner/src/connection/tests/session.rs
@@ -318,6 +318,191 @@ fn routine_disconnect_refuses_an_unbound_session_without_executing_a_configured_
 }
 
 #[test]
+fn terminal_phantom_reconciliation_is_fail_soft_for_an_unreachable_stale_session() {
+    let mut session = direct_ssh_session("lease-live");
+    session.local_url = Some("http://127.0.0.1:1".to_string());
+    let active_jobs = vec![sample_active_job(None, "runner job")];
+
+    let (active, stale, count, evidence) = reconcile_terminal_phantom_activity(
+        "homeboy-lab",
+        Some(&session),
+        active_jobs.clone(),
+        Vec::new(),
+        Some(2),
+    );
+
+    assert_eq!(active, active_jobs);
+    assert!(stale.is_empty());
+    assert_eq!(count, Some(2));
+    assert!(evidence.is_none());
+}
+
+#[test]
+fn terminal_phantom_reconciliation_ignores_non_success_responses() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+    let address = listener.local_addr().expect("address");
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("request");
+        let mut request = [0; 4096];
+        let length = stream.read(&mut request).expect("read request");
+        let request = String::from_utf8(request[..length].to_vec()).expect("request text");
+        assert!(request.starts_with("POST /jobs/reconcile-terminal HTTP/1.1"));
+        stream
+            .write_all(b"HTTP/1.1 409 Conflict\r\nContent-Length: 25\r\nConnection: close\r\n\r\n{\"body\":{\"reconciled_count\":9}}")
+            .expect("response");
+    });
+    let mut session = direct_ssh_session("lease-live");
+    session.local_url = Some(format!("http://{address}"));
+
+    let (active, _, count, evidence) = reconcile_terminal_phantom_activity(
+        "homeboy-lab",
+        Some(&session),
+        Vec::new(),
+        Vec::new(),
+        Some(1),
+    );
+
+    server.join().expect("server");
+    assert!(active.is_empty());
+    assert_eq!(count, Some(1));
+    assert!(evidence.is_none());
+}
+
+#[test]
+fn terminal_phantom_reconciliation_refreshes_counts_and_exposes_bounded_evidence() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+    let address = listener.local_addr().expect("address");
+    let mut active = sample_active_job(Some("run-live"), "live runner job");
+    active.source = "daemon".to_string();
+    let mut stale = sample_active_job(Some("run-stale"), "stale runner job");
+    stale.source = "daemon".to_string();
+    stale.status = JobStatus::Failed;
+    stale.stale_reason = Some("terminal durable run".to_string());
+    let active_body = serde_json::to_value(vec![active.clone()]).expect("active jobs");
+    let stale_body = serde_json::to_value(vec![stale.clone()]).expect("stale jobs");
+    let server = std::thread::spawn(move || {
+        for (expected_path, body) in [
+            (
+                "POST /jobs/reconcile-terminal HTTP/1.1",
+                serde_json::json!({
+                    "body": {
+                        "reconciled_count": 2,
+                        "reconciled_job_ids": ["phantom-1", "phantom-2"],
+                    }
+                }),
+            ),
+            (
+                "GET /jobs HTTP/1.1",
+                serde_json::json!({
+                    "success": true,
+                    "data": { "body": {
+                        "active_runner_jobs": active_body,
+                        "stale_runner_jobs": stale_body,
+                    }}
+                }),
+            ),
+            (
+                "GET /version HTTP/1.1",
+                serde_json::json!({
+                    "version": "test",
+                    "build_identity": { "display": "homeboy test+abc123" },
+                    "lease": { "lease_id": "lease-live" },
+                    "freshness": {
+                        "fresh": true,
+                        "restartable": false,
+                        "active_jobs": 1,
+                        "repair_plan": [],
+                    }
+                }),
+            ),
+        ] {
+            let (mut stream, _) = listener.accept().expect("request");
+            let mut request = [0; 4096];
+            let length = stream.read(&mut request).expect("read request");
+            let request = String::from_utf8(request[..length].to_vec()).expect("request text");
+            assert!(request.starts_with(expected_path), "{request}");
+            let body = body.to_string();
+            stream
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    )
+                    .as_bytes(),
+                )
+                .expect("response");
+        }
+    });
+    let mut session = direct_ssh_session("lease-live");
+    session.local_url = Some(format!("http://{address}"));
+
+    let (refreshed_active, refreshed_stale, count, evidence) = reconcile_terminal_phantom_activity(
+        "homeboy-lab",
+        Some(&session),
+        Vec::new(),
+        Vec::new(),
+        Some(3),
+    );
+
+    server.join().expect("server");
+    assert_eq!(count, Some(1));
+    assert_eq!(refreshed_active, vec![active]);
+    assert_eq!(refreshed_stale, vec![stale]);
+    let evidence = evidence.expect("recovery evidence");
+    assert_eq!(evidence.prior_active_job_count, 3);
+    assert_eq!(evidence.active_job_count, 1);
+    assert_eq!(evidence.reconciled_job_ids, ["phantom-1", "phantom-2"]);
+
+    let (_, _, repeated_count, repeated_evidence) = reconcile_terminal_phantom_activity(
+        "homeboy-lab",
+        Some(&session),
+        refreshed_active,
+        refreshed_stale,
+        count,
+    );
+    assert_eq!(repeated_count, Some(1));
+    assert!(repeated_evidence.is_none());
+}
+
+#[test]
+fn terminal_phantom_reconciliation_rejects_mismatched_count_and_ids() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+    let address = listener.local_addr().expect("address");
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("request");
+        let mut request = [0; 4096];
+        let length = stream.read(&mut request).expect("read request");
+        assert!(String::from_utf8(request[..length].to_vec())
+            .expect("request text")
+            .starts_with("POST /jobs/reconcile-terminal HTTP/1.1"));
+        let body = r#"{"body":{"reconciled_count":2,"reconciled_job_ids":["phantom-1"]}}"#;
+        stream
+            .write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                )
+                .as_bytes(),
+            )
+            .expect("response");
+    });
+    let mut session = direct_ssh_session("lease-live");
+    session.local_url = Some(format!("http://{address}"));
+
+    let (_, _, count, evidence) = reconcile_terminal_phantom_activity(
+        "homeboy-lab",
+        Some(&session),
+        Vec::new(),
+        Vec::new(),
+        Some(2),
+    );
+
+    server.join().expect("server");
+    assert_eq!(count, Some(2));
+    assert!(evidence.is_none());
+}
+
+#[test]
 fn routine_disconnect_posts_the_exact_live_lease_to_the_daemon_tunnel() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
     let address = listener.local_addr().expect("address");

--- a/crates/homeboy-runner/src/execution/tests/exec.rs
+++ b/crates/homeboy-runner/src/execution/tests/exec.rs
@@ -132,6 +132,7 @@ fn stale_direct_daemon_status() -> RunnerStatusReport {
         active_job_state: RunnerActiveJobState::Available,
         active_job_source: Some(RunnerActiveJobSource::DirectDaemon),
         active_job_error: None,
+        active_job_recovery_evidence: None,
         session_path: "/tmp/homeboy-lab.json".to_string(),
     }
 }

--- a/crates/homeboy-runner/src/lab/offload/tests/mod.rs
+++ b/crates/homeboy-runner/src/lab/offload/tests/mod.rs
@@ -93,6 +93,7 @@ pub(super) fn reverse_status(runner_id: &str) -> RunnerStatusReport {
         active_job_state: RunnerActiveJobState::Available,
         active_job_source: Some(RunnerActiveJobSource::ReverseBroker),
         active_job_error: None,
+        active_job_recovery_evidence: None,
         session_path: "/tmp/lab.json".to_string(),
     }
 }

--- a/crates/homeboy-runner/src/lab/preparation_tests.rs
+++ b/crates/homeboy-runner/src/lab/preparation_tests.rs
@@ -35,6 +35,7 @@ fn lab_runner_preparation_falls_back_for_unreachable_default_runner() {
                 active_job_state: RunnerActiveJobState::NotQueried,
                 active_job_source: None,
                 active_job_error: None,
+                active_job_recovery_evidence: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
@@ -105,6 +106,7 @@ fn lab_runner_preparation_uses_already_connected_runner() {
                 active_job_state: RunnerActiveJobState::NotQueried,
                 active_job_source: None,
                 active_job_error: None,
+                active_job_recovery_evidence: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
@@ -144,6 +146,7 @@ fn lab_runner_preparation_falls_back_for_stale_default_daemon_version_without_re
                 active_job_state: RunnerActiveJobState::NotQueried,
                 active_job_source: None,
                 active_job_error: None,
+                active_job_recovery_evidence: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
@@ -186,6 +189,7 @@ fn lab_runner_preparation_falls_back_for_stale_default_runtime_paths() {
                 active_job_state: RunnerActiveJobState::NotQueried,
                 active_job_source: None,
                 active_job_error: None,
+                active_job_recovery_evidence: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
@@ -233,6 +237,7 @@ fn lab_runner_preparation_errors_for_explicit_stale_daemon_version() {
                 active_job_state: RunnerActiveJobState::NotQueried,
                 active_job_source: None,
                 active_job_error: None,
+                active_job_recovery_evidence: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
@@ -303,6 +308,7 @@ fn concurrent_stale_handoffs_preserve_the_shared_tunnel() {
                             active_job_state: RunnerActiveJobState::Available,
                             active_job_source: None,
                             active_job_error: None,
+                            active_job_recovery_evidence: None,
                             session_path: "/tmp/lab.json".to_string(),
                         })
                     },
@@ -465,6 +471,7 @@ fn lab_runner_preparation_falls_back_for_stale_default_direct_session_without_da
                 active_job_state: RunnerActiveJobState::NotQueried,
                 active_job_source: None,
                 active_job_error: None,
+                active_job_recovery_evidence: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
@@ -506,6 +513,7 @@ fn lab_runner_preparation_errors_for_explicit_direct_session_without_daemon_url(
                 active_job_state: RunnerActiveJobState::NotQueried,
                 active_job_source: None,
                 active_job_error: None,
+                active_job_recovery_evidence: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
@@ -552,6 +560,7 @@ fn lab_runner_preparation_connects_disconnected_runner() {
                 active_job_state: RunnerActiveJobState::NotQueried,
                 active_job_source: None,
                 active_job_error: None,
+                active_job_recovery_evidence: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
@@ -614,6 +623,7 @@ fn lab_runner_preparation_errors_for_unreachable_explicit_runner() {
                 active_job_state: RunnerActiveJobState::NotQueried,
                 active_job_source: None,
                 active_job_error: None,
+                active_job_recovery_evidence: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
@@ -700,6 +710,7 @@ fn unreachable_health_status(runner_id: &str, connected: bool) -> RunnerStatusRe
         active_job_state: RunnerActiveJobState::Unavailable,
         active_job_source: None,
         active_job_error: None,
+        active_job_recovery_evidence: None,
         session_path: "/tmp/lab-unreachable-health.json".to_string(),
     }
 }

--- a/crates/homeboy-runner/src/runtime_materialization_status.rs
+++ b/crates/homeboy-runner/src/runtime_materialization_status.rs
@@ -266,6 +266,7 @@ mod tests {
             active_job_state: RunnerActiveJobState::Available,
             active_job_source: None,
             active_job_error: None,
+            active_job_recovery_evidence: None,
             session_path: "/tmp/session.json".to_string(),
         }
     }

--- a/crates/homeboy-runner/src/session.rs
+++ b/crates/homeboy-runner/src/session.rs
@@ -135,6 +135,14 @@ pub struct RunnerActiveJobError {
     pub message: String,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunnerActiveJobRecoveryEvidence {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reconciled_job_ids: Vec<String>,
+    pub prior_active_job_count: usize,
+    pub active_job_count: usize,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RunnerLeaselessRecoveryContract {
@@ -424,6 +432,8 @@ pub struct RunnerStatusReport {
     pub active_job_source: Option<RunnerActiveJobSource>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active_job_error: Option<RunnerActiveJobError>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_job_recovery_evidence: Option<RunnerActiveJobRecoveryEvidence>,
     pub session_path: String,
 }
 

--- a/crates/homeboy-runner/src/transport.rs
+++ b/crates/homeboy-runner/src/transport.rs
@@ -542,6 +542,7 @@ mod tests {
             active_job_state: RunnerActiveJobState::NotQueried,
             active_job_source: None,
             active_job_error: None,
+            active_job_recovery_evidence: None,
             session_path: "/tmp/session.json".to_string(),
         }
     }

--- a/crates/homeboy-runner/src/upgrade_runners/tests.rs
+++ b/crates/homeboy-runner/src/upgrade_runners/tests.rs
@@ -1477,6 +1477,7 @@ fn runner_status(runner_id: &str) -> Result<RunnerStatusReport> {
         active_job_state: RunnerActiveJobState::NotQueried,
         active_job_source: None,
         active_job_error: None,
+        active_job_recovery_evidence: None,
         session_path: "/tmp/homeboy-runner-session.json".to_string(),
     })
 }
@@ -1503,6 +1504,7 @@ fn stale_runner_status(runner_id: &str) -> Result<RunnerStatusReport> {
         active_job_state: RunnerActiveJobState::NotQueried,
         active_job_source: None,
         active_job_error: None,
+        active_job_recovery_evidence: None,
         session_path: "/tmp/homeboy-runner-session.json".to_string(),
     })
 }


### PR DESCRIPTION
## Summary
Restore direct-SSH Lab availability by reconciling only daemon jobs whose linked durable agent-task runs are authoritatively terminal, while preserving live and unresolved jobs.

## What changed
- Add a daemon endpoint that terminalizes queued/running jobs only from durable terminal run evidence.
- Make runner status attempt fail-soft terminal reconciliation when freshness and typed job views diverge, then refresh both views.
- Expose bounded structured recovery evidence and cover successful, unreachable, non-2xx, malformed, idempotent, and live-job cases.

## How to test
1. Run `cargo test -p homeboy-runner terminal_phantom_reconciliation --lib -- --test-threads=1`; expect All successful and fail-soft phantom reconciliation regressions pass..
2. Run `cargo test -p homeboy-runner connection:: --lib`; expect All runner connection tests pass..
3. Run `cargo test -p homeboy-core api_jobs::tests::part_b::terminal_linked_reconciliation_preserves_live_jobs_and_is_idempotent -- --exact`; expect Terminal phantom jobs reconcile idempotently while live jobs remain running..

## Compatibility
Adds an internal daemon endpoint and an optional runner-status evidence field. Existing runner commands and public behavior remain compatible.

## Evidence
- Base advanced after verification: verified main at 42a65b49e8a36d7054c462c9364c250202cef984; publication observed 4f9811e6a6eab03e7031228ce67722b061b092b1. Candidate ancestry was validated against the verified snapshot.
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8713
- Verified finalization base: main at 42a65b49e8a36d7054c462c9364c250202cef984
- diff-check: Passed
- format: Passed
- phantom-reconciliation-regressions: Passed
- runner-check: Passed
- runner-connection-suite: Passed
- terminal-ownership-regression: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed direct-SSH runner split-view recovery, implemented terminal-only reconciliation, and added core plus connection-layer regression coverage.

## Source relationships
- Closes Extra-Chill/homeboy#8713
