### PR TITLE
refactor: move action-type enums + manifest_action_config to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/manifest.rs
+++ b/crates/homeboy-core/src/extension/manifest.rs
@@ -15,9 +15,6 @@ pub const EXTENSION_MATERIALIZATION_SOURCE_SCHEMA: &str =
 pub const EXTENSION_CONTRACT_PRODUCER_SCHEMA: &str = "homeboy/extension-contract-producer/v1";
 
 // Keep broad manifest wiring here while leaf config structs live in focused files.
-pub use super::manifest_action_config::{
-    ActionConfig, InputConfig, RuntimeConfig, SelectOption, SettingConfig,
-};
 pub use super::manifest_config::{
     AutofixVerifyConfig, BenchConfig, BuildConfig, CliAutoFlag, CliAutoFlagCondition, CliConfig,
     CliHelpConfig, DatabaseCliConfig, DatabaseConfig, DeployOverride, DeployOwnerHint,
@@ -29,6 +26,9 @@ pub use super::manifest_config::{
     TraceBrowserMetricAliasConfig, TraceBrowserSummaryAliasConfig, TraceConfig,
     VersionPatternConfig,
 };
+pub use homeboy_extension_contract::manifest_action_config::{
+    ActionConfig, InputConfig, RuntimeConfig, SelectOption, SettingConfig,
+};
 mod ci_config;
 pub use super::manifest_sidecar::{StructuredSidecarContract, StructuredSidecarDeclaration};
 pub use ci_config::{
@@ -37,36 +37,7 @@ pub use ci_config::{
 pub use homeboy_extension_contract::DeployArchiveInstallPolicy;
 pub use homeboy_extension_contract::{TestPassthroughFilter, TestPassthroughFilterStrategy};
 
-/// Type of action that can be executed by a extension.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum ActionType {
-    Api,
-    Command,
-    Builtin,
-}
-
-/// Builtin action types for Desktop app (copy, export operations).
-/// CLI parses these but does not execute them - Desktop implements the behavior.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
-pub enum BuiltinAction {
-    CopyColumn,
-    ExportCsv,
-    CopyJson,
-}
-
-/// HTTP method for API actions.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum HttpMethod {
-    #[default]
-    Get,
-    Post,
-    Put,
-    Patch,
-    Delete,
-}
+pub use homeboy_extension_contract::action_types::{ActionType, BuiltinAction, HttpMethod};
 
 // ============================================================================
 // Capability Groups

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -21,7 +21,6 @@ mod lifecycle;
 pub mod lint;
 mod maintenance;
 mod manifest;
-mod manifest_action_config;
 mod manifest_config;
 mod manifest_sidecar;
 mod refactor_protocol;

--- a/crates/homeboy-extension-contract/src/action_types.rs
+++ b/crates/homeboy-extension-contract/src/action_types.rs
@@ -1,0 +1,37 @@
+//! Action-type contract enums for extension manifests.
+//!
+//! Pure serde enums describing the shape of manifest-declared actions. The CLI
+//! parses these; execution behavior lives in `homeboy_core::extension`.
+
+use serde::{Deserialize, Serialize};
+
+/// Type of action that can be executed by a extension.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ActionType {
+    Api,
+    Command,
+    Builtin,
+}
+
+/// Builtin action types for Desktop app (copy, export operations).
+/// CLI parses these but does not execute them - Desktop implements the behavior.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum BuiltinAction {
+    CopyColumn,
+    ExportCsv,
+    CopyJson,
+}
+
+/// HTTP method for API actions.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum HttpMethod {
+    #[default]
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+}

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -9,8 +9,10 @@
 //! Modules and types are re-exported from `homeboy_core::extension` so existing
 //! `crate::extension::*` call sites keep working unchanged.
 
+pub mod action_types;
 pub mod core_compat;
 pub mod exec_context;
+pub mod manifest_action_config;
 pub mod manifest_deploy_config;
 pub mod manifest_test_config;
 pub mod runner_contract;

--- a/crates/homeboy-extension-contract/src/manifest_action_config.rs
+++ b/crates/homeboy-extension-contract/src/manifest_action_config.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use super::manifest::{ActionType, BuiltinAction, HttpMethod};
+use crate::action_types::{ActionType, BuiltinAction, HttpMethod};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuntimeConfig {


### PR DESCRIPTION
## Summary
Fourth sub-cut of the **extension crate extraction campaign** (Stage 1, wiki id 12840) — and the **first cut into `manifest.rs` itself**, the woven heart of the extension type model.

## The untangle
`manifest_action_config` was blocked from moving only because it imported `manifest::{ActionType, BuiltinAction, HttpMethod}`. Those three are **pure serde enums** (no methods, no dependencies) that just happened to live inside the big `manifest.rs` file.

1. Lifted the 3 enums into a new `action_types` module in `homeboy-extension-contract`. `manifest.rs` re-imports them from the contract crate, so every in-file reference resolves unchanged.
2. With the dep severed, `manifest_action_config` (`RuntimeConfig`, `InputConfig`, `SelectOption`, `ActionConfig`, `SettingConfig`) is now serde-only and moves into the contract crate too.

## Zero downstream churn
`manifest.rs` already re-exported the action-config types via `pub use super::manifest_action_config::{...}`, which `mod.rs` re-exports through its `pub use manifest::{...}` block. Repointing that one re-import to the contract crate keeps the entire `crate::extension::*` surface intact — `ActionType`, `HttpMethod`, `ActionConfig`, etc. all resolve exactly as before.

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-runner`, `homeboy-tunnel`, bin clean on `--lib`.
- Heavy build/test left to CI per repo policy.

## Campaign progress
Contract crate now holds 10 modules. This proves the manifest.rs enums can be peeled cleanly — the next cuts (`manifest_sidecar` needs `engine::run_dir`; `manifest_config`'s 29 types chain through `manifest`/`lifecycle`/`DepsConfig`; then the woven `ExtensionManifest`/`Capability` themselves) get progressively deeper. See wiki 12840.

🤖 Generated with [Claude Code](https://claude.com/claude-code)