### PR TITLE
Fix external release artifact recovery

### DIFF
--- a/crates/homeboy-core/src/release/execution_dispatch.rs
+++ b/crates/homeboy-core/src/release/execution_dispatch.rs
@@ -175,8 +175,12 @@ pub(super) fn execute_release_plan_step(
             .map(Some)
         }
         "github.release" => Ok(Some(
-            executor::run_github_release(context.component, &context.state)
-                .unwrap_or_else(|err| failed_result("github.release", "github.release", err)),
+            executor::run_github_release(
+                context.component,
+                &context.state,
+                context.options.pipeline.from_artifacts.is_some(),
+            )
+            .unwrap_or_else(|err| failed_result("github.release", "github.release", err)),
         )),
         "cleanup" => {
             if context.publish_failed {

--- a/crates/homeboy-core/src/release/executor.rs
+++ b/crates/homeboy-core/src/release/executor.rs
@@ -911,13 +911,53 @@ mod tests {
             ..ReleaseState::default()
         };
 
-        let error = super::run_github_release(&component, &state)
+        let error = super::run_github_release(&component, &state, false)
             .expect_err("missing declared artifact must block GitHub publication");
 
         assert!(error
             .message
             .contains("absent from the GitHub Release assets"));
         assert!(!error.message.contains("no remote_url"));
+    }
+
+    #[test]
+    fn external_cargo_dist_artifacts_do_not_require_raw_deploy_artifact() {
+        let artifact_dir = tempfile::tempdir().expect("artifact tempdir");
+        let archive = artifact_dir
+            .path()
+            .join("homeboy-x86_64-unknown-linux-gnu.tar.xz");
+        let checksum = artifact_dir
+            .path()
+            .join("homeboy-x86_64-unknown-linux-gnu.tar.xz.sha256");
+        let manifest = artifact_dir.path().join("dist-manifest.json");
+        std::fs::write(&archive, "archive").expect("write archive");
+        std::fs::write(&checksum, "checksum").expect("write checksum");
+        std::fs::write(
+            &manifest,
+            r#"{"artifacts":[{"path":"homeboy-x86_64-unknown-linux-gnu.tar.xz"},{"path":"homeboy-x86_64-unknown-linux-gnu.tar.xz.sha256"}]}"#,
+        )
+        .expect("write manifest");
+
+        let mut state = ReleaseState {
+            tag: Some("v1.2.3".to_string()),
+            ..ReleaseState::default()
+        };
+        super::artifacts::run_artifact_inventory(
+            &mut state,
+            &artifact_dir.path().to_string_lossy(),
+        )
+        .expect("inventory external artifacts");
+        let component = Component {
+            id: "homeboy".to_string(),
+            local_path: artifact_dir.path().to_string_lossy().to_string(),
+            build_artifact: Some("target/release/homeboy".to_string()),
+            ..Component::default()
+        };
+
+        let error = super::run_github_release(&component, &state, true)
+            .expect_err("missing remote should stop after asset validation");
+        assert!(error.message.contains("no remote_url"));
+        assert!(!error.message.contains("build_artifact"));
     }
 
     fn release_package_extension(id: &str, command: &str) -> ExtensionManifest {

--- a/crates/homeboy-core/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-core/src/release/executor/github_release/gh_cli.rs
@@ -110,13 +110,22 @@ pub(crate) fn github_release_asset_paths(state: &ReleaseState) -> Result<Vec<Str
         .filter(|path| !path_is_file(path))
         .map(|path| release_asset_name(path))
         .collect::<Vec<_>>();
-    if missing.is_empty() {
-        Ok(paths)
-    } else {
+    if !missing.is_empty() {
         Err(format!(
             "release assets declared by dist-manifest.json are missing: {}. Run the package step again, then resume with `homeboy release --head --from-artifacts <artifact-dir>`.",
             missing.join(", ")
         ))
+    } else if let Some(path) = paths.iter().find(|path| {
+        std::fs::metadata(path)
+            .map(|metadata| metadata.len() == 0)
+            .unwrap_or(false)
+    }) {
+        Err(format!(
+            "release asset '{}' is empty",
+            release_asset_name(path)
+        ))
+    } else {
+        Ok(paths)
     }
 }
 
@@ -520,6 +529,28 @@ mod tests {
                 manifest.display().to_string(),
                 archive.display().to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn release_assets_reject_zero_byte_external_artifacts() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let archive = dir.path().join("homeboy-x86_64-unknown-linux-gnu.tar.xz");
+        std::fs::write(&archive, []).expect("write empty archive");
+        let state = ReleaseState {
+            artifacts: vec![crate::release::types::ReleaseArtifact {
+                path: archive.display().to_string(),
+                durable_path: None,
+                artifact_type: None,
+                platform: None,
+            }],
+            ..ReleaseState::default()
+        };
+
+        let error = github_release_asset_paths(&state).expect_err("empty archive");
+        assert_eq!(
+            error,
+            "release asset 'homeboy-x86_64-unknown-linux-gnu.tar.xz' is empty"
         );
     }
 

--- a/crates/homeboy-core/src/release/executor/github_release/run.rs
+++ b/crates/homeboy-core/src/release/executor/github_release/run.rs
@@ -43,13 +43,14 @@ use super::{
 pub(crate) fn run_github_release(
     component: &Component,
     state: &ReleaseState,
+    external_artifacts: bool,
 ) -> Result<ReleaseStepResult> {
     let tag = state.tag.clone().ok_or_else(|| {
         Error::internal_unexpected(
             "github.release: tag state not set (git.tag must run first)".to_string(),
         )
     })?;
-    validate_declared_build_artifact(component, state)?;
+    validate_declared_build_artifact(component, state, external_artifacts)?;
     let local_path = &component.local_path;
 
     let remote_url = component
@@ -414,9 +415,16 @@ pub(crate) fn run_github_release(
     ))
 }
 
-/// A configured deploy artifact is part of the release contract, including
-/// `--head --from-artifacts` recovery where `release.package` is not run.
-fn validate_declared_build_artifact(component: &Component, state: &ReleaseState) -> Result<()> {
+/// Package-owned releases must include the component deploy artifact. Externally
+/// supplied release assets have their own validated inventory contract.
+pub(crate) fn validate_declared_build_artifact(
+    component: &Component,
+    state: &ReleaseState,
+    external_artifacts: bool,
+) -> Result<()> {
+    if external_artifacts {
+        return Ok(());
+    }
     let Some(declared_build_artifact) = component
         .build_artifact
         .as_deref()


### PR DESCRIPTION
## Summary

- Treat artifacts explicitly supplied through `release --head --from-artifacts` as the authoritative GitHub Release inventory.
- Preserve declared `build_artifact` collection and validation for normal package-owned releases.
- Reject zero-byte release assets before draft creation/upload while preserving draft-first manifest completeness, size, and digest verification.

## Root cause

GitHub Release finalization applied the component deploy-artifact contract to both normal package output and externally packaged recovery assets. Homeboy declares `target/release/homeboy` as its deploy artifact, while cargo-dist transforms that binary into platform archives and checksums. Recovery therefore rejected a valid external inventory because it did not contain a raw asset named `homeboy`.

The release executor now receives explicit external-artifact context from `ReleaseOptions.pipeline.from_artifacts`. Only that path bypasses the raw deploy filename assertion; its supplied inventory remains subject to the existing GitHub Release asset validation.

## How to test

1. Run `cargo test -p homeboy-core release::executor::github_release:: --lib`; expect 33 tests to pass, including cargo-dist recovery and zero-byte rejection coverage.
2. Run `cargo test --test release_workflow_test`; expect 24 release workflow contract tests to pass.
3. Run `cargo check -p homeboy-core`; expect the core crate to compile.
4. Run `cargo fmt --check`; expect no formatting drift.
5. Run `git diff --check origin/main...HEAD`; expect no whitespace errors.

## Compatibility

Normal package-owned releases are unchanged: components declaring `build_artifact` must still produce and upload that artifact. External `--head --from-artifacts` recovery no longer requires the original raw deploy artifact filename when the supplied release inventory contains transformed archives. This intentionally fixes the external recovery contract; components relying on implicit upload of a raw deploy artifact during external recovery must include it explicitly in the supplied artifact directory/manifest.

## Evidence

- Failing Homeboy release run: https://github.com/Extra-Chill/homeboy/actions/runs/29563575998
- Source issue: https://github.com/Extra-Chill/homeboy/issues/8691
- Prior draft-first complete-asset publication repair: https://github.com/Extra-Chill/homeboy/pull/8693

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding task
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the release artifact contract, implemented the generic recovery fix and deterministic tests, rebased the candidate, and prepared verification and PR materials; Chris reviews and owns the change.

Closes #8691