### PR TITLE
refactor: move TestDriftConfig to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/manifest.rs
+++ b/crates/homeboy-core/src/extension/manifest.rs
@@ -68,22 +68,7 @@ pub struct DeployCapability {
 }
 
 /// Test mapping convention: how source files map to test files.
-
-/// Test drift convention: how source and test files are selected for drift scans.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct TestDriftConfig {
-    /// Source directories to scan (relative to component root).
-    pub source_dirs: Vec<String>,
-    /// Test directories to scan (relative to component root).
-    pub test_dirs: Vec<String>,
-    /// File extensions to include when building source/test glob patterns.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub file_extensions: Vec<String>,
-    /// Whether the language supports inline tests. Stored for consumers that
-    /// need it; drift scanning still uses source/test glob patterns.
-    #[serde(default)]
-    pub inline_tests: bool,
-}
+pub use homeboy_extension_contract::test_drift::TestDriftConfig;
 
 /// Docs audit: ignore patterns and feature detection patterns.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -17,6 +17,7 @@ pub mod manifest_deploy_config;
 pub mod manifest_test_config;
 pub mod runner_contract;
 pub mod source_metadata_repair;
+pub mod test_drift;
 pub mod update_output;
 pub mod version;
 
@@ -32,4 +33,5 @@ pub use runner_contract::{
     PhaseFailure, PhaseFailureCategory, PhaseReport, PhaseStatus, RunnerStepFilter,
     VerificationPhase, GENERIC_INFRASTRUCTURE_FAILURE_MARKERS,
 };
+pub use test_drift::TestDriftConfig;
 pub use version::{parse_extension_version, VersionConstraint};

--- a/crates/homeboy-extension-contract/src/test_drift.rs
+++ b/crates/homeboy-extension-contract/src/test_drift.rs
@@ -1,0 +1,19 @@
+//! Test-drift convention contract type.
+
+use serde::{Deserialize, Serialize};
+
+/// Test drift convention: how source and test files are selected for drift scans.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TestDriftConfig {
+    /// Source directories to scan (relative to component root).
+    pub source_dirs: Vec<String>,
+    /// Test directories to scan (relative to component root).
+    pub test_dirs: Vec<String>,
+    /// File extensions to include when building source/test glob patterns.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub file_extensions: Vec<String>,
+    /// Whether the language supports inline tests. Stored for consumers that
+    /// need it; drift scanning still uses source/test glob patterns.
+    #[serde(default)]
+    pub inline_tests: bool,
+}


### PR DESCRIPTION
## Summary
Fifth sub-cut of the **extension crate extraction campaign** (Stage 1, wiki id 12840).

`TestDriftConfig` is a **fully pure serde struct** — every field is `Vec<String>` or `bool`, zero type dependencies — that lived inside the woven `manifest.rs`. Moves it into a new contract `test_drift` module. `manifest.rs` re-imports it, so all six consumers (`manifest_config`, `test/drift`, `test/mod`, `defaults/builtins`, and the mod.rs re-export) keep working through the unchanged `crate::extension::TestDriftConfig` path.

This also **partially unblocks a future `manifest_config` cut** — `TestDriftConfig` was one of its two blocking deps (the other, `LifecycleContract`, stays in core for now).

## Zero downstream churn
Single-purpose type move + re-import. No behavior changes.

## Tests
- `homeboy-extension-contract`, `homeboy-core` clean on `--lib` and `--tests`; `homeboy-cli`, `homeboy-runner`, bin clean on `--lib`.

> Note: `homeboy-cli --tests` currently has a **pre-existing, unrelated failure on `main`** — three `RunnerStatusReport { ... }` initializers (`commands/runner/status.rs`, `commands/runner/tests/status.rs`, `commands/cleanup.rs`) are missing the `active_job_recovery_evidence` field added by a recent runner change. This is not touched by or caused by this PR (verified: my diff is 3 files — `manifest.rs`, contract `lib.rs`, new `test_drift.rs`). Flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)