### PR TITLE
Preserve explicit agent runtime identity

### DIFF
--- a/crates/homeboy-core/src/agent_task_dispatch_service.rs
+++ b/crates/homeboy-core/src/agent_task_dispatch_service.rs
@@ -314,8 +314,32 @@ pub fn resolve_dispatch_request(
 pub fn controller_resolved_execution_policy(
     request: &AgentTaskDispatchRequest,
 ) -> ResolvedAgentTaskProviderPolicy {
-    let rotation = crate::defaults::load_config().agent_task.rotation;
     let runtime_identity = selected_runtime_identity(request);
+    let explicit_backend = request
+        .backend_selection
+        .as_ref()
+        .is_some_and(|selection| selection.source == BackendSelectionSource::Cli);
+    let rotation = crate::defaults::load_config()
+        .agent_task
+        .rotation
+        .map(|mut rotation| {
+            if explicit_backend {
+                // A controller pin describes one immutable runtime. Global fallback
+                // entries for another runtime must not replace an explicit choice.
+                rotation.entries.retain(|entry| {
+                    entry
+                        .backend
+                        .as_deref()
+                        .is_none_or(|backend| backend == request.backend)
+                        && entry.selector.as_deref().is_none_or(|selector| {
+                            runtime_identity
+                                .as_ref()
+                                .is_some_and(|identity| identity.provider_id == selector)
+                        })
+                });
+            }
+            rotation
+        });
     ResolvedAgentTaskProviderPolicy {
         backend: request.backend.clone(),
         selector: request.selector.clone(),
@@ -328,7 +352,9 @@ pub fn controller_resolved_execution_policy(
             .as_ref()
             .and_then(|policy| policy.liveness_timeout_ms),
         rotation,
-        rotation_starts_with_first_entry: true,
+        // An explicit CLI backend/model is the first attempt. Default policy
+        // rotation retains its existing first-entry selection behavior.
+        rotation_starts_with_first_entry: !explicit_backend,
         runtime_identity,
     }
 }
@@ -582,5 +608,84 @@ mod tests {
         assert_eq!(selection.source, BackendSelectionSource::Policy);
         // Default-policy selections never count as an explicit override.
         assert!(!selection.overrides_default);
+    }
+
+    #[test]
+    fn explicit_backend_keeps_its_runtime_pin_when_default_rotation_targets_another_backend() {
+        crate::test_support::with_isolated_home(|home| {
+            let runtimes = home.path().join(".config/homeboy/agent-runtimes");
+            for (runtime_id, provider_id, backend) in [
+                ("opencode", "opencode.agent-task-executor", "opencode"),
+                ("codex", "codex.agent-task-executor", "codex"),
+            ] {
+                let runtime = runtimes.join(runtime_id);
+                std::fs::create_dir_all(&runtime).expect("runtime directory");
+                std::fs::write(
+                    runtime.join(format!("{runtime_id}.json")),
+                    serde_json::json!({
+                        "schema": crate::agent_runtime_manifest::AGENT_RUNTIME_MANIFEST_SCHEMA,
+                        "id": runtime_id,
+                        "source_revision": "0123456789abcdef0123456789abcdef01234567",
+                        "agent_task_executors": [{
+                            "schema": crate::agent_task_provider::AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
+                            "id": provider_id,
+                            "backend": backend,
+                            "invocation": { "argv": ["provider"] }
+                        }]
+                    })
+                    .to_string(),
+                )
+                .expect("runtime manifest");
+                for args in [
+                    vec!["init"],
+                    vec!["add", "."],
+                    vec![
+                        "-c",
+                        "user.name=Homeboy Test",
+                        "-c",
+                        "user.email=homeboy-test@example.com",
+                        "commit",
+                        "-m",
+                        "runtime manifest",
+                    ],
+                ] {
+                    let status = std::process::Command::new("git")
+                        .args(args)
+                        .current_dir(&runtime)
+                        .status()
+                        .expect("run git");
+                    assert!(status.success(), "initialize runtime source");
+                }
+            }
+
+            let mut config = crate::defaults::load_config();
+            config.agent_task.default_backend = Some("opencode".to_string());
+            config.agent_task.rotation = Some(AgentTaskProviderRotationPolicy {
+                entries: vec![
+                    crate::agent_task_scheduler::AgentTaskProviderRotationEntry {
+                        backend: Some("opencode".to_string()),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            });
+            crate::defaults::save_config(&config).expect("save config");
+
+            let request = resolve_dispatch_request_with_default_and_config(
+                command_with_backend(Some("codex")),
+                |_| Ok(Some("opencode".to_string())),
+                || Some("opencode".to_string()),
+            )
+            .expect("explicit Codex request");
+            let policy = controller_resolved_execution_policy(&request);
+
+            assert_eq!(policy.backend, "codex");
+            assert!(!policy.rotation_starts_with_first_entry);
+            assert!(policy.rotation.expect("rotation").entries.is_empty());
+            let identity = policy.runtime_identity.expect("Codex runtime identity");
+            assert_eq!(identity.runtime_id, "codex");
+            assert_eq!(identity.provider_id, "codex.agent-task-executor");
+            assert_eq!(identity.provider["backend"], "codex");
+        });
     }
 }

--- a/crates/homeboy-runner/src/lab/provider_preflight.rs
+++ b/crates/homeboy-runner/src/lab/provider_preflight.rs
@@ -809,6 +809,35 @@ mod tests {
     }
 
     #[test]
+    fn controller_identity_rejects_provider_backend_mismatch() {
+        let selection = AgentTaskProviderSelection {
+            backend: "codex".to_string(),
+            selector: None,
+            runtime_identity: None,
+        };
+        let identity = homeboy_core::agent_task_config::ResolvedAgentTaskRuntimeIdentity {
+            runtime_id: "opencode".to_string(),
+            provider_id: "opencode.agent-task-executor".to_string(),
+            source_selector: "extension:opencode".to_string(),
+            source_revision: "0123456789abcdef0123456789abcdef01234567".to_string(),
+            freshness:
+                homeboy_core::agent_task_config::ResolvedAgentTaskRuntimeFreshness::Unverifiable,
+            provider: serde_json::json!({
+                "id": "opencode.agent-task-executor",
+                "backend": "opencode"
+            }),
+            materialization_plan: serde_json::Value::Null,
+        };
+
+        let error = validate_controller_runtime_identity(&identity, &selection)
+            .expect_err("mismatched provider identity must fail");
+
+        assert!(error
+            .message
+            .contains("does not match the requested provider"));
+    }
+
+    #[test]
     fn runner_provider_output_parser_accepts_cli_envelope_with_chatter() {
         let stdout = concat!(
             "Preparing runtime...\n",


### PR DESCRIPTION
## Summary
- preserve an explicit CLI backend as the first provider execution even when another backend is configured as the global default
- exclude incompatible global rotation entries when the controller runtime is explicitly pinned
- retain default OpenCode rotation behavior for non-explicit dispatches
- keep genuine provider/backend mismatches fail-closed

Addresses #8732.

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-core agent_task_dispatch_service::tests --lib` and confirm all five tests pass.
3. Run `cargo test -p homeboy-runner controller_identity --lib` and confirm all three tests pass.
4. Run `homeboy review audit --changed-since origin/main --profile pr --json-summary` and confirm there are no introduced findings.
5. Dispatch a clean test worktree with an OpenCode default and explicit `--backend codex`; confirm the first attempt remains Codex and its controller runtime pin uses `codex.agent-task-executor`.

## Verification
- `cargo fmt --check`: passed.
- Dispatch policy tests: 5 passed.
- Controller identity tests: 3 passed.
- Homeboy PR audit: zero introduced findings.
- Local Homeboy lint was deferred because release policy requires the configured Lab route; hosted CI is the authoritative lint gate.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with `openai/gpt-5.6-sol`
- **Used for:** Diagnosed the explicit Codex/OpenCode identity conflict, implemented the generic runtime-pin fix and deterministic coverage, and verified the candidate with Chris.