### PR TITLE
fix: add active_job_recovery_evidence to RunnerStatusReport test initializers

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -1258,6 +1258,7 @@ mod tests {
                 active_job_state: RunnerActiveJobState::NotQueried,
                 active_job_source: None,
                 active_job_error: None,
+                active_job_recovery_evidence: None,
                 session_path: "/tmp/lab.json".to_string(),
             };
 

--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -1193,6 +1193,7 @@ mod tests {
             active_job_state: RunnerActiveJobState::Available,
             active_job_source: None,
             active_job_error: None,
+            active_job_recovery_evidence: None,
             session_path: "/tmp/homeboy-lab.json".to_string(),
         }
     }

--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -127,6 +127,7 @@ fn reverse_runner_status_commands_include_lifecycle_operations() {
         active_job_state: RunnerActiveJobState::Available,
         active_job_source: Some(RunnerActiveJobSource::ReverseBroker),
         active_job_error: None,
+        active_job_recovery_evidence: None,
         session_path: "/tmp/session.json".to_string(),
     };
 
@@ -214,6 +215,7 @@ fn disconnected_split_view_status_exposes_bounded_reconciliation_command() {
             code: "active_job_view_inconsistent".to_string(),
             message: "freshness has one job while /jobs has none".to_string(),
         }),
+        active_job_recovery_evidence: None,
         session_path: "/tmp/session.json".to_string(),
     };
 
@@ -600,6 +602,7 @@ fn runner_status_artifact_diagnostics_surface_controller_runner_checks_and_drift
         active_job_state: RunnerActiveJobState::Available,
         active_job_source: Some(RunnerActiveJobSource::ReverseBroker),
         active_job_error: None,
+        active_job_recovery_evidence: None,
         session_path: "/tmp/session.json".to_string(),
     };
 
@@ -661,6 +664,7 @@ fn runner_homeboy_status_distinguishes_daemon_and_job_binary_roles() {
         active_job_state: RunnerActiveJobState::Available,
         active_job_source: Some(RunnerActiveJobSource::DirectDaemon),
         active_job_error: None,
+        active_job_recovery_evidence: None,
         session_path: "/tmp/session.json".to_string(),
     };
 


### PR DESCRIPTION
## Summary
A recent runner change added the `active_job_recovery_evidence: Option<RunnerActiveJobRecoveryEvidence>` field to `RunnerStatusReport`, but three CLI test/helper initializers were not updated — breaking `homeboy-cli --tests` on `main` with `E0063: missing field active_job_recovery_evidence`.

Adds the field (`None`) to all six affected initializers:
- `commands/runner/status.rs` (1)
- `commands/runner/tests/status.rs` (4)
- `commands/cleanup.rs` (1)

## Verification
- `homeboy-cli --tests` now compiles clean (was 6 errors on `main`).
- Pure test-fixture fix; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)