### PR TITLE
refactor: move contract-producer + materialization-source types to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/manifest.rs
+++ b/crates/homeboy-core/src/extension/manifest.rs
@@ -6,6 +6,13 @@ pub use homeboy_audit_contract::test_mapping::{
     TestVacuityPolicy,
 };
 use homeboy_audit_contract::AuditConfig;
+pub use homeboy_extension_contract::extension_contract_producer::{
+    ExtensionContractProducer, ExtensionContractProducerInvocation,
+    ExtensionContractProducerOutput, ExtensionContractProducerOutputKind,
+    ExtensionContractProducerPhase, ExtensionMaterializationHelperManifestRef,
+    ExtensionMaterializationSourceContract, ExtensionMaterializationSourceKind,
+    EXTENSION_CONTRACT_PRODUCER_SCHEMA, EXTENSION_MATERIALIZATION_SOURCE_SCHEMA,
+};
 pub use homeboy_extension_contract::manifest_capability_config::{
     AgentRuntimeManifestConfig, ComponentEnvConfig, DiscoveryMarkerConfig, DocTarget,
     ExtensionToolDiagnosticDeclaration, FeatureContextRule, ProvidesConfig, ReleasePreflightConfig,
@@ -14,10 +21,6 @@ pub use homeboy_extension_contract::manifest_capability_config::{
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
-
-pub const EXTENSION_MATERIALIZATION_SOURCE_SCHEMA: &str =
-    "homeboy/extension-materialization-source/v1";
-pub const EXTENSION_CONTRACT_PRODUCER_SCHEMA: &str = "homeboy/extension-contract-producer/v1";
 
 // Keep broad manifest wiring here while leaf config structs live in focused files.
 pub use super::manifest_config::{
@@ -223,110 +226,6 @@ impl ExtensionDiagnosticsConfig {
 pub struct AgentTaskPolicyConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_backend: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum ExtensionMaterializationSourceKind {
-    Git,
-    Archive,
-    LocalPath,
-    Generated,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ExtensionMaterializationHelperManifestRef {
-    pub id: String,
-    pub path: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub schema: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub purpose: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ExtensionMaterializationSourceContract {
-    #[serde(default = "default_extension_materialization_source_schema")]
-    pub schema: String,
-    pub source_kind: ExtensionMaterializationSourceKind,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub revision: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub runner_archive_url: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub runner_archive_sha256: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub runner_ref: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub helper_manifest_refs: Vec<ExtensionMaterializationHelperManifestRef>,
-    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub extra: BTreeMap<String, serde_json::Value>,
-}
-
-fn default_extension_materialization_source_schema() -> String {
-    EXTENSION_MATERIALIZATION_SOURCE_SCHEMA.to_string()
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum ExtensionContractProducerPhase {
-    Discovery,
-    Planning,
-    Handoff,
-    Result,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum ExtensionContractProducerOutputKind {
-    Capability,
-    ExecutionPlan,
-    MaterializationPlan,
-    SecretPlan,
-    RunnerEnvelopeAddition,
-    Artifact,
-    Status,
-    Evidence,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct ExtensionContractProducerOutput {
-    pub kind: ExtensionContractProducerOutputKind,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub schema: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct ExtensionContractProducerInvocation {
-    pub script: String,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub args: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub env: Vec<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub input_schema: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub output_schema: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct ExtensionContractProducer {
-    #[serde(default = "default_extension_contract_producer_schema")]
-    pub schema: String,
-    pub id: String,
-    pub phase: ExtensionContractProducerPhase,
-    pub invocation: ExtensionContractProducerInvocation,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub produces: Vec<ExtensionContractProducerOutput>,
-}
-
-fn default_extension_contract_producer_schema() -> String {
-    EXTENSION_CONTRACT_PRODUCER_SCHEMA.to_string()
 }
 
 /// Unified extension manifest decomposed into capability groups.

--- a/crates/homeboy-extension-contract/src/extension_contract_producer.rs
+++ b/crates/homeboy-extension-contract/src/extension_contract_producer.rs
@@ -1,0 +1,113 @@
+//! Extension contract-producer and materialization-source contract types.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub const EXTENSION_MATERIALIZATION_SOURCE_SCHEMA: &str =
+    "homeboy/extension-materialization-source/v1";
+
+pub const EXTENSION_CONTRACT_PRODUCER_SCHEMA: &str = "homeboy/extension-contract-producer/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionMaterializationSourceKind {
+    Git,
+    Archive,
+    LocalPath,
+    Generated,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionMaterializationHelperManifestRef {
+    pub id: String,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionMaterializationSourceContract {
+    #[serde(default = "default_extension_materialization_source_schema")]
+    pub schema: String,
+    pub source_kind: ExtensionMaterializationSourceKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_archive_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_archive_sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub helper_manifest_refs: Vec<ExtensionMaterializationHelperManifestRef>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, serde_json::Value>,
+}
+
+fn default_extension_materialization_source_schema() -> String {
+    EXTENSION_MATERIALIZATION_SOURCE_SCHEMA.to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionContractProducerPhase {
+    Discovery,
+    Planning,
+    Handoff,
+    Result,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionContractProducerOutputKind {
+    Capability,
+    ExecutionPlan,
+    MaterializationPlan,
+    SecretPlan,
+    RunnerEnvelopeAddition,
+    Artifact,
+    Status,
+    Evidence,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExtensionContractProducerOutput {
+    pub kind: ExtensionContractProducerOutputKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExtensionContractProducerInvocation {
+    pub script: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_schema: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExtensionContractProducer {
+    #[serde(default = "default_extension_contract_producer_schema")]
+    pub schema: String,
+    pub id: String,
+    pub phase: ExtensionContractProducerPhase,
+    pub invocation: ExtensionContractProducerInvocation,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub produces: Vec<ExtensionContractProducerOutput>,
+}
+
+fn default_extension_contract_producer_schema() -> String {
+    EXTENSION_CONTRACT_PRODUCER_SCHEMA.to_string()
+}

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod action_types;
 pub mod core_compat;
 pub mod exec_context;
+pub mod extension_contract_producer;
 pub mod manifest_action_config;
 pub mod manifest_capability_config;
 pub mod manifest_deploy_config;


### PR DESCRIPTION
## Summary
Seventh sub-cut of the **extension crate extraction campaign** (Stage 1, wiki id 12840). Extracts two self-contained pure-type clusters from `manifest.rs` into a new `extension_contract_producer` contract module.

## What moved
- **Contract-producer cluster:** `ExtensionContractProducer`, `ExtensionContractProducerInvocation`, `ExtensionContractProducerOutput`, `ExtensionContractProducerOutputKind`, `ExtensionContractProducerPhase`
- **Materialization-source cluster:** `ExtensionMaterializationSourceContract`, `ExtensionMaterializationHelperManifestRef`, `ExtensionMaterializationSourceKind`
- Their two `#[serde(default = ...)]` helper fns and the two schema constants `EXTENSION_CONTRACT_PRODUCER_SCHEMA` / `EXTENSION_MATERIALIZATION_SOURCE_SCHEMA` (referenced by extension tests + the CLI command-contract registry, so they had to travel with the types).

All types are **impl-free with self-closed field dependencies** (each cluster references only primitives and its own members).

## Zero downstream churn
`manifest.rs` re-exports the whole cluster with `pub use`, so the `pub use manifest::{...}` surface in `mod.rs` is unchanged and every `crate::extension::*` consumer — including the schema-const references — resolves as before.

## Note on DeployCapability
While scoping, confirmed the `DeployCapability` sub-tree (`DeployVerification`/`DeployOverride`/etc.) lives in `manifest_config.rs`, which is blocked by a `LifecycleContract` dependency (chains through core `artifact_contract` → `artifact_ref`/`observation`). That's genuine core-infra, deferred rather than forced. This cut took the two cleanly-closed clusters instead.

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-issues`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)