### PR TITLE
Fix runner refresh reconnect transaction

### DIFF
--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -29,6 +29,8 @@ pub(super) use super::{extension_materialization, Runner};
 const DEFAULT_HOMEBOY_REMOTE: &str = "https://github.com/Extra-Chill/homeboy.git";
 const DEFAULT_HOMEBOY_REF: &str = "main";
 const DISCONNECTED_SSH_REFRESH_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+const RECONNECT_VERIFICATION_WINDOW: Duration = Duration::from_secs(3);
+const RECONNECT_VERIFICATION_RETRY_INTERVAL: Duration = Duration::from_millis(50);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HomeboyBinaryRefreshMode {
@@ -432,7 +434,7 @@ pub fn refresh_homeboy_binary(
             }
         };
         let daemon_identity_verification = (connect_exit_code == 0)
-            .then(|| verify_refreshed_daemon_identity(&plan.runner_id))
+            .then(|| verify_refreshed_daemon_identity(&plan.runner_id, &identity))
             .transpose()
             .map_err(|error| error.message);
         daemon_refreshed = daemon_identity_verification.is_ok();
@@ -442,9 +444,11 @@ pub fn refresh_homeboy_binary(
             } else {
                 connect_exit_code
             };
-            if let Err(rollback_error) =
-                restore_runner_homeboy_path(&plan.runner_id, previous_homeboy_path.as_deref())
-            {
+            if let Err(rollback_error) = rollback_refreshed_daemon(
+                &plan.runner_id,
+                previous_homeboy_path.as_deref(),
+                options.force,
+            ) {
                 return Err(reconnect_rollback_error(&report, rollback_error));
             }
             return Ok((
@@ -554,20 +558,81 @@ fn refresh_verification_failure(
     failure
 }
 
-fn verify_refreshed_daemon_identity(runner_id: &str) -> Result<()> {
-    let status = super::status(runner_id)?;
-    if !status.connected {
+fn verify_refreshed_daemon_identity(runner_id: &str, identity: &Value) -> Result<()> {
+    let expected_commit = identity
+        .get("data")
+        .unwrap_or(identity)
+        .get("git_commit")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "runner `{runner_id}` refreshed binary did not report a git commit"
+            ))
+        })?;
+    verify_refreshed_daemon_identity_with(
+        runner_id,
+        expected_commit,
+        || super::status(runner_id),
+        || std::thread::sleep(RECONNECT_VERIFICATION_RETRY_INTERVAL),
+    )
+}
+
+fn verify_refreshed_daemon_identity_with<Status, Wait>(
+    runner_id: &str,
+    expected_commit: &str,
+    mut status: Status,
+    mut wait: Wait,
+) -> Result<()>
+where
+    Status: FnMut() -> Result<super::RunnerStatusReport>,
+    Wait: FnMut(),
+{
+    let deadline = Instant::now() + RECONNECT_VERIFICATION_WINDOW;
+    loop {
+        match verify_refreshed_daemon_status(runner_id, expected_commit, &status()?) {
+            Ok(()) => return Ok(()),
+            Err(_) if Instant::now() < deadline => wait(),
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn verify_refreshed_daemon_status(
+    runner_id: &str,
+    expected_commit: &str,
+    status: &super::RunnerStatusReport,
+) -> Result<()> {
+    if !status.is_connected() {
         return Err(Error::internal_unexpected(format!(
             "runner `{runner_id}` reconnect did not persist an active daemon session"
         )));
     }
-    if let Some(stale_daemon) = status.stale_daemon {
+    if let Some(stale_daemon) = &status.stale_daemon {
         return Err(Error::internal_unexpected(format!(
             "runner `{runner_id}` reconnect retained a stale daemon: {}",
             stale_daemon.message
         )));
     }
+    let actual_identity = status
+        .session
+        .as_ref()
+        .and_then(|session| session.homeboy_build_identity.as_deref())
+        .ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "runner `{runner_id}` reconnect did not persist a daemon build identity"
+            ))
+        })?;
+    if build_identity_commit(actual_identity) != Some(expected_commit) {
+        return Err(Error::internal_unexpected(format!(
+            "runner `{runner_id}` reconnect started daemon `{actual_identity}`, expected commit `{expected_commit}`"
+        )));
+    }
     Ok(())
+}
+
+fn build_identity_commit(identity: &str) -> Option<&str> {
+    let (_, commit) = identity.strip_prefix("homeboy ")?.split_once('+')?;
+    Some(commit.strip_suffix("-dirty").unwrap_or(commit))
 }
 
 fn refresh_execution_options(
@@ -1068,6 +1133,51 @@ fn restore_runner_homeboy_path(runner_id: &str, homeboy_path: Option<&str>) -> R
             MergeOutput::Single(_) | MergeOutput::Bulk(_) => Ok(()),
         }
     })
+}
+
+fn rollback_refreshed_daemon(
+    runner_id: &str,
+    previous_homeboy_path: Option<&str>,
+    force: bool,
+) -> Result<()> {
+    // Stop the newly selected daemon before restoring configuration so all
+    // persisted state converges on the previous binary before it reconnects.
+    rollback_refreshed_daemon_with(
+        previous_homeboy_path,
+        || disconnect_with_session(runner_id, None, force).map(|_| ()),
+        |homeboy_path| restore_runner_homeboy_path(runner_id, homeboy_path),
+        |_| {
+            let (report, exit_code) =
+                connect_with_orphan_adoption(runner_id, None, &[], false, None, None, None)?;
+            if exit_code != 0 || !report.connected {
+                return Err(Error::validation_invalid_argument(
+                    "reconnect",
+                    report.failure_message.unwrap_or_else(|| {
+                        "rollback reconnect did not persist an active daemon session".to_string()
+                    }),
+                    Some(runner_id.to_string()),
+                    None,
+                ));
+            }
+            Ok(())
+        },
+    )
+}
+
+fn rollback_refreshed_daemon_with<Stop, Restore, Reconnect>(
+    previous_homeboy_path: Option<&str>,
+    stop: Stop,
+    restore: Restore,
+    reconnect: Reconnect,
+) -> Result<()>
+where
+    Stop: FnOnce() -> Result<()>,
+    Restore: FnOnce(Option<&str>) -> Result<()>,
+    Reconnect: FnOnce(Option<&str>) -> Result<()>,
+{
+    stop()?;
+    restore(previous_homeboy_path)?;
+    reconnect(previous_homeboy_path)
 }
 
 fn rollback_refresh_error<T>(

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use super::*;
+use crate::{RunnerActiveJobState, RunnerSessionState, RunnerStatusReport};
 use crate::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};
 use homeboy_core::test_support;
 
@@ -66,6 +67,112 @@ fn refresh_preserves_only_its_direct_controller_lease_for_orphan_recovery() {
     assert_eq!(
         refresh_owned_lease(session),
         Some("lease-refresh".to_string())
+    );
+}
+
+fn refreshed_daemon_status(connected: bool, identity: Option<&str>) -> RunnerStatusReport {
+    RunnerStatusReport {
+        runner_id: "lab".to_string(),
+        connected,
+        state: if connected {
+            RunnerSessionState::Connected
+        } else {
+            RunnerSessionState::Disconnected
+        },
+        session: identity.map(|homeboy_build_identity| RunnerSession {
+            runner_id: "lab".to_string(),
+            mode: RunnerTunnelMode::DirectSsh,
+            role: RunnerSessionRole::Controller,
+            server_id: None,
+            controller_id: None,
+            broker_url: None,
+            remote_daemon_address: None,
+            local_port: None,
+            local_url: None,
+            tunnel_pid: None,
+            remote_daemon_pid: None,
+            remote_daemon_lease_id: None,
+            homeboy_version: "test".to_string(),
+            homeboy_build_identity: Some(homeboy_build_identity.to_string()),
+            connected_at: "2026-01-01T00:00:00Z".to_string(),
+            worker_identity: None,
+            worker_pid: None,
+            last_seen_at: None,
+            leaseless_recovery_evidence: None,
+        }),
+        stale_daemon: None,
+        daemon_freshness: None,
+        active_jobs: Vec::new(),
+        active_runner_jobs: Vec::new(),
+        stale_runner_jobs: Vec::new(),
+        active_job_count: 0,
+        stale_runner_job_count: 0,
+        active_job_state: RunnerActiveJobState::NotQueried,
+        active_job_source: None,
+        active_job_error: None,
+        active_job_recovery_evidence: None,
+        session_path: String::new(),
+    }
+}
+
+#[test]
+fn refreshed_daemon_verification_accepts_the_post_start_health_window() {
+    let not_ready = refreshed_daemon_status(false, Some("homeboy 0.1.0+06bbf46013cf"));
+    let ready = refreshed_daemon_status(true, Some("homeboy 0.1.0+06bbf46013cf"));
+    let mut statuses = [not_ready, ready].into_iter();
+    let mut retries = 0;
+
+    verify_refreshed_daemon_identity_with(
+        "lab",
+        "06bbf46013cf",
+        || Ok(statuses.next().expect("post-start status probe")),
+        || retries += 1,
+    )
+    .expect("the persisted connected session identifies the requested daemon commit");
+    assert_eq!(retries, 1, "the initial tunnel health race is retried once");
+}
+
+#[test]
+fn refreshed_daemon_verification_rejects_commit_substring_mismatch() {
+    let status = refreshed_daemon_status(true, Some("homeboy 0.1.0+x06bbf46013cf"));
+
+    let error = verify_refreshed_daemon_status("lab", "06bbf46013cf", &status)
+        .expect_err("the daemon commit component must match exactly");
+    assert!(error.message.contains("expected commit `06bbf46013cf`"));
+}
+
+#[test]
+fn refreshed_daemon_rollback_stops_restores_and_reconnects_the_previous_binary() {
+    let operations = std::cell::RefCell::new(Vec::new());
+
+    rollback_refreshed_daemon_with(
+        Some("/stable/homeboy"),
+        || {
+            operations.borrow_mut().push("stop new daemon".to_string());
+            Ok(())
+        },
+        |path| {
+            operations
+                .borrow_mut()
+                .push(format!("restore {}", path.expect("previous binary")));
+            Ok(())
+        },
+        |path| {
+            operations
+                .borrow_mut()
+                .push(format!("reconnect {}", path.expect("previous binary")));
+            Ok(())
+        },
+    )
+    .expect("rollback converges on the previous binary");
+
+    assert_eq!(
+        operations.into_inner(),
+        [
+            "stop new daemon",
+            "restore /stable/homeboy",
+            "reconnect /stable/homeboy",
+        ]
     );
 }
 


### PR DESCRIPTION
## Summary

- tolerate the bounded post-start health window before declaring a refreshed runner disconnected
- verify the connected daemon reports the exact requested Homeboy commit
- make failed refresh rollback stop the new daemon, restore the previous binary, and reconnect coherently

Fixes #8740.

## How to test

1. Run `cargo fmt --check`.
2. Run `git diff --check origin/main...HEAD`.
3. Run `cargo test -p homeboy-lab-runner 'homeboy_refresh::tests::part_a::refreshed_daemon_'`.\n4. Confirm all three focused tests pass: post-start health retry, exact commit rejection, and coherent rollback sequencing.\n\n## Test results\n\n- `cargo fmt --check`: passed\n- `git diff --check origin/main...HEAD`: passed\n- focused reconnect tests: 3 passed, 0 failed\n- broader `homeboy_refresh::tests::part_a`: 22 passed, 1 pre-existing fixture failure because the test tries to copy a nonexistent `crates/homeboy-lab-runner/build.rs`\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode\n- **Used for:** Runtime diagnosis, implementation, regression tests, and review under Chris Huber's direction.