### PR TITLE
Preserve direct SSH sessions through Cook handoff

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -344,7 +344,7 @@ pub fn connect_with_orphan_adoption(
         mode: RunnerTunnelMode::DirectSsh,
         role: RunnerSessionRole::Controller,
         server_id: Some(server_id),
-        controller_id: None,
+        controller_id: Some(controller_id()),
         broker_url: None,
         remote_daemon_address: Some(daemon.address),
         local_port: Some(local_port),
@@ -730,7 +730,10 @@ fn register_reverse_session_with_broker(broker_url: &str, session: &RunnerSessio
 pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
     let runner = load(runner_id)?;
     let session_path = session_path(runner_id)?;
-    let session = read_session(runner_id)?;
+    // A Cook handoff can cross controller identities after readiness accepted a
+    // direct SSH tunnel. Reuse that still-live tunnel rather than treating the
+    // controller-local record lookup as a daemon disconnect.
+    let session = read_session_or_live_peer(runner_id)?;
     let state = session_state(session.as_ref());
     let connected = state == RunnerSessionState::Connected;
     let stale_daemon = stale_daemon_warning(&runner, session.as_ref(), connected)?;
@@ -1434,7 +1437,7 @@ pub(crate) fn local_live_session(
     runner_id: &str,
     timeout: Duration,
 ) -> Result<Option<RunnerSession>> {
-    let Some(session) = read_session(runner_id)? else {
+    let Some(session) = read_session_or_live_peer(runner_id)? else {
         return Ok(None);
     };
     Ok(session_is_live_with_timeout(&session, timeout).then_some(session))

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -2,6 +2,9 @@ use super::*;
 use homeboy_core::daemon::{DaemonFreshnessReport, DaemonRecoveryEvidence};
 use std::time::Duration;
 
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+
 pub(super) const REMOTE_DAEMON_STATUS_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub(super) fn resolve_ssh_runner(runner: &Runner) -> Result<Option<(String, Server, SshClient)>> {
@@ -129,12 +132,13 @@ pub(super) fn open_loopback_tunnel(
         format!("{}@{}", server.user, server.host),
     ]);
 
-    let child = std::process::Command::new("ssh")
+    let mut command = std::process::Command::new("ssh");
+    command
         .args(&args)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn();
+        .stderr(std::process::Stdio::null());
+    let child = spawn_tunnel_process(&mut command);
     match child {
         Ok(child) => SshTunnelOutput {
             pid: Some(child.id()),
@@ -147,6 +151,22 @@ pub(super) fn open_loopback_tunnel(
             success: false,
         },
     }
+}
+
+pub(super) fn spawn_tunnel_process(
+    command: &mut std::process::Command,
+) -> std::io::Result<std::process::Child> {
+    #[cfg(unix)]
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setpgid(0, 0) == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::last_os_error())
+            }
+        });
+    }
+    command.spawn()
 }
 
 #[derive(Debug, Clone)]

--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -98,6 +98,20 @@ pub(super) fn read_session(runner_id: &str) -> Result<Option<RunnerSession>> {
     read_session_for_controller(runner_id, &controller_id())
 }
 
+/// Resolve this controller's session, or borrow a peer's live direct-SSH
+/// tunnel for an in-process handoff. Borrowing never writes a controller
+/// record, so only the original controller may later tear down that tunnel.
+pub(super) fn read_session_or_live_peer(runner_id: &str) -> Result<Option<RunnerSession>> {
+    let session = read_session(runner_id)?;
+    if session.as_ref().is_some_and(session_is_live) {
+        return Ok(session);
+    }
+
+    let directory = paths::runner_sessions_dir()?.join(runner_id);
+    let peer = live_peer_session_in(&directory, None, session_is_live)?;
+    Ok(peer.or(session))
+}
+
 pub(super) fn read_session_for_controller(
     runner_id: &str,
     controller_id: &str,
@@ -218,10 +232,60 @@ pub(super) fn has_live_peer_session(session: &RunnerSession) -> Result<bool> {
     Ok(false)
 }
 
+fn live_peer_session_in(
+    directory: &PathBuf,
+    controller_id: Option<&str>,
+    is_live: impl Fn(&RunnerSession) -> bool,
+) -> Result<Option<RunnerSession>> {
+    let entries = match std::fs::read_dir(directory) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(Error::internal_io(
+                error.to_string(),
+                Some("read runner controller sessions".to_string()),
+            ))
+        }
+    };
+    let mut live_peer: Option<RunnerSession> = None;
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("read runner controller session".to_string()),
+            )
+        })?;
+        let Some(peer) = read_session_at(&entry.path())? else {
+            continue;
+        };
+        if controller_id
+            .is_none_or(|controller_id| peer.controller_id.as_deref() != Some(controller_id))
+            && peer.mode == RunnerTunnelMode::DirectSsh
+            && is_live(&peer)
+        {
+            if let Some(existing) = &live_peer {
+                if existing.remote_daemon_address != peer.remote_daemon_address
+                    || existing.remote_daemon_lease_id != peer.remote_daemon_lease_id
+                    || existing.remote_daemon_pid != peer.remote_daemon_pid
+                {
+                    // Two live sessions for this runner disagree on daemon
+                    // identity. Refuse an ambiguous handoff rather than route
+                    // a Cook job to an arbitrary peer tunnel.
+                    return Ok(None);
+                }
+            } else {
+                live_peer = Some(peer);
+            }
+        }
+    }
+    Ok(live_peer)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{RunnerSessionRole, RunnerTunnelMode};
+    use tempfile::TempDir;
 
     fn session(controller_id: &str, lease_id: &str) -> RunnerSession {
         RunnerSession {
@@ -268,6 +332,27 @@ mod tests {
             stale.remote_daemon_lease_id,
             replacement.remote_daemon_lease_id
         );
+    }
+
+    #[test]
+    fn cook_handoff_adopts_a_live_peer_direct_ssh_session_without_claiming_it() {
+        let root = TempDir::new().expect("session directory");
+        let peer = session("cook-readiness", "lease-accepted");
+        write_session_at(&root.path().join("cook-readiness.json"), &peer)
+            .expect("write readiness session");
+
+        let adopted =
+            live_peer_session_in(&root.path().to_path_buf(), Some("cook-handoff"), |_| true)
+                .expect("read live peer")
+                .expect("accepted session");
+
+        assert_eq!(
+            adopted.remote_daemon_lease_id.as_deref(),
+            Some("lease-accepted")
+        );
+        assert_eq!(adopted.controller_id.as_deref(), Some("cook-readiness"));
+        assert!(root.path().join("cook-readiness.json").exists());
+        assert!(!root.path().join("cook-handoff.json").exists());
     }
 }
 

--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -354,6 +354,91 @@ mod tests {
         assert!(root.path().join("cook-readiness.json").exists());
         assert!(!root.path().join("cook-handoff.json").exists());
     }
+
+    #[test]
+    fn fresh_peer_session_survives_repeated_cook_preflight_and_handoff_reads() {
+        let root = TempDir::new().expect("session directory");
+        let peer = session("cook-readiness", "lease-accepted");
+        let path = root.path().join("cook-readiness.json");
+        write_session_at(&path, &peer).expect("write readiness session");
+
+        let preflight = live_peer_session_in(&root.path().to_path_buf(), Some("cook"), |_| true)
+            .expect("read preflight session")
+            .expect("live preflight session");
+        let handoff = live_peer_session_in(&root.path().to_path_buf(), Some("cook"), |_| true)
+            .expect("read handoff session")
+            .expect("live handoff session");
+
+        assert_eq!(preflight, peer);
+        assert_eq!(handoff, peer);
+        assert_eq!(
+            read_session_at(&path).expect("read stored session"),
+            Some(peer)
+        );
+    }
+
+    #[test]
+    fn concurrent_status_observers_do_not_mutate_a_borrowed_session() {
+        use std::sync::{Arc, Barrier};
+
+        let root = TempDir::new().expect("session directory");
+        let peer = session("cook-readiness", "lease-accepted");
+        let path = root.path().join("cook-readiness.json");
+        write_session_at(&path, &peer).expect("write readiness session");
+        let directory = Arc::new(root.path().to_path_buf());
+        let barrier = Arc::new(Barrier::new(3));
+
+        let observers: Vec<_> = ["status-a", "status-b"]
+            .into_iter()
+            .map(|controller| {
+                let directory = Arc::clone(&directory);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    live_peer_session_in(&directory, Some(controller), |_| true)
+                        .expect("observe peer session")
+                        .expect("live peer session")
+                })
+            })
+            .collect();
+
+        barrier.wait();
+        for observer in observers {
+            assert_eq!(observer.join().expect("status observer"), peer);
+        }
+        assert_eq!(
+            read_session_at(&path).expect("read stored session"),
+            Some(peer)
+        );
+    }
+
+    #[test]
+    fn repeated_peer_handoffs_reject_ambiguous_daemon_ownership_without_mutation() {
+        let root = TempDir::new().expect("session directory");
+        let accepted = session("cook-readiness", "lease-accepted");
+        let conflicting = session("other-controller", "lease-other");
+        let accepted_path = root.path().join("cook-readiness.json");
+        let conflicting_path = root.path().join("other-controller.json");
+        write_session_at(&accepted_path, &accepted).expect("write accepted session");
+        write_session_at(&conflicting_path, &conflicting).expect("write conflicting session");
+
+        for _ in 0..2 {
+            assert!(
+                live_peer_session_in(&root.path().to_path_buf(), Some("cook"), |_| true)
+                    .expect("read peer sessions")
+                    .is_none()
+            );
+        }
+
+        assert_eq!(
+            read_session_at(&accepted_path).expect("read accepted session"),
+            Some(accepted)
+        );
+        assert_eq!(
+            read_session_at(&conflicting_path).expect("read conflicting session"),
+            Some(conflicting)
+        );
+    }
 }
 
 pub(super) fn failed_connect(
@@ -438,6 +523,11 @@ pub(super) fn terminate_pid(pid: u32) {
     }
     #[cfg(unix)]
     unsafe {
-        let _ = libc::kill(pid as libc::pid_t, libc::SIGTERM);
+        // Direct SSH tunnels lead their own group so Cook's command cleanup
+        // cannot tear them down. Stop that whole group on explicit disconnect,
+        // with a root-PID fallback for sessions recorded before isolation.
+        if libc::kill(-(pid as libc::pid_t), libc::SIGTERM) != 0 {
+            let _ = libc::kill(pid as libc::pid_t, libc::SIGTERM);
+        }
     }
 }

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -631,6 +631,25 @@ fn test_open_loopback_tunnel_noops_for_local_runner() {
     assert_eq!(tunnel.stderr, "");
 }
 
+#[cfg(unix)]
+#[test]
+fn direct_ssh_tunnel_process_isolated_from_cook_command_cleanup() {
+    let mut command = std::process::Command::new("sh");
+    command.args(["-c", "sleep 60"]);
+    let mut tunnel = super::super::remote_daemon::spawn_tunnel_process(&mut command)
+        .expect("spawn tunnel process");
+    let pid = tunnel.id() as libc::pid_t;
+
+    unsafe {
+        assert_eq!(libc::getpgid(pid), pid);
+        assert_ne!(libc::getpgid(0), pid);
+    }
+    assert!(homeboy_core::process::pid_is_running(tunnel.id()));
+
+    super::terminate_pid(tunnel.id());
+    let _ = tunnel.wait();
+}
+
 #[test]
 fn connect_reports_local_runner_as_unsupported() {
     test_support::with_isolated_home(|_| {


### PR DESCRIPTION
## Summary
Preserve a fresh direct-SSH Lab session across Cook readiness and handoff without transferring teardown ownership or invalidating the shared tunnel.

## What changed
- Record controller identity for direct-SSH sessions and allow later Cook phases to borrow an identical live peer session without rewriting it.
- Reject ambiguous peer daemon ownership while preserving the original session and live-job safety.
- Place SSH tunnels in an isolated process group so Cook command cleanup cannot terminate them; explicit disconnect still terminates the tunnel group.

## How to test
1. Run `cargo test -p homeboy-lab-runner peer_ --lib -- --test-threads=1`; expect Live peer sessions are reused idempotently without ownership mutation, while ambiguous peers are rejected..
2. Run `cargo test -p homeboy-lab-runner direct_ssh_tunnel_process_isolated_from_cook_command_cleanup --lib -- --test-threads=1`; expect The SSH tunnel survives Cook command cleanup and remains explicitly terminable..
3. Run `cargo test -p homeboy-lab-runner lab::preparation_tests -- --test-threads=1`; expect All Lab handoff preparation and reconnect contention tests pass..

## Compatibility
No public contract or extension-path changes. Existing direct-SSH sessions gain cross-controller read-only reuse; explicit disconnect behavior remains compatible.

## Evidence
- Base advanced after verification: verified main at 9c88ee2ce0728e72cb607e0f861d9e6ea61ff895; publication observed 5db22e6c6bd14ec3d3329dd309962029ab75caaa. Candidate ancestry was validated against the verified snapshot.
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8728
- Verified finalization base: main at 9c88ee2ce0728e72cb607e0f861d9e6ea61ff895
- cli-check: Passed
- diff-check: Passed
- format: Passed
- lab-preparation: Passed
- peer-session-regressions: Passed
- runner-check: Passed
- tunnel-isolation-regression: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed controller-local direct-SSH session invalidation, completed peer-session borrowing and tunnel isolation, and verified runner handoff behavior.

## Source relationships
- Closes Extra-Chill/homeboy#8728
