### PR TITLE
Fix Windows dependency ownership before release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,24 @@ jobs:
           path: target/release/homeboy
           retention-days: 1
 
+  # The artifact matrix includes Windows, so compile the complete workspace on
+  # its native target before preparation creates a release tag.
+  gate-windows-build:
+    name: Windows Build
+    needs: check
+    if: needs.check.outputs.should-release == 'true'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Compile Windows workspace
+        run: cargo build --workspace --locked
+
   # ── Step 3: Quality checks (parallel read-only checks + advisory repair) ──
   # Release preparation is gated by release-quality-policy, not by raw job
   # failures. Commands opt in to release blocking through RELEASE_BLOCKING_COMMANDS
@@ -358,10 +376,11 @@ jobs:
     needs:
       - check
       - gate-build
+      - gate-windows-build
       - gate-audit
       - gate-lint
       - gate-test
-    if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.check.outputs.recovery-release != 'true' && needs.gate-build.result == 'success' }}
+    if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.check.outputs.recovery-release != 'true' && needs.gate-build.result == 'success' && needs.gate-windows-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout workflow event commit
@@ -384,8 +403,9 @@ jobs:
     needs:
       - check
       - gate-build
+      - gate-windows-build
       - release-quality-policy
-    if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.gate-build.result == 'success' && (needs.check.outputs.recovery-release == 'true' || inputs.release_tag != '' || needs.release-quality-policy.result == 'success') }}
+    if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.gate-build.result == 'success' && needs.gate-windows-build.result == 'success' && (needs.check.outputs.recovery-release == 'true' || inputs.release_tag != '' || needs.release-quality-policy.result == 'success') }}
     runs-on: ubuntu-latest
     outputs:
       release-version: ${{ steps.outputs.outputs['release-version'] }}
@@ -889,6 +909,7 @@ jobs:
     needs:
       - check
       - gate-build
+      - gate-windows-build
       - gate-audit
       - gate-lint
       - gate-test
@@ -919,6 +940,7 @@ jobs:
     needs:
       - check
       - gate-build
+      - gate-windows-build
       - gate-audit
       - gate-lint
       - gate-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,7 +735,6 @@ dependencies = [
  "tempfile",
  "toml",
  "uuid",
- "windows-sys 0.61.2",
  "zip",
 ]
 
@@ -869,6 +868,7 @@ dependencies = [
  "tempfile",
  "toml",
  "uuid",
+ "windows-sys 0.61.2",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,9 +87,6 @@ clap = { version = "4.5", features = ["derive", "string"] }
 toml = "1.0.3"
 sha2 = "0.10.9"
 
-[target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_IO"] }
-
 [dev-dependencies]
 # Enable homeboy-core's shared hermetic test fixtures for this crate's test build
 # (integration tests reach them via `homeboy::test_support`).

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -62,5 +62,8 @@ clap = { version = "4.5", features = ["derive", "string"] }
 toml = "1.0.3"
 sha2 = "0.10.9"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_IO"] }
+
 [dev-dependencies]
 homeboy-code-audit = { version = "0.1.0", path = "../homeboy-code-audit", features = ["test-support"] }

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -266,6 +266,32 @@ fn release_preflight_validates_the_private_workspace_build_before_mutating_relea
 }
 
 #[test]
+fn release_blocks_preparation_and_publication_on_a_native_windows_workspace_build() {
+    let windows_build = job_section(release_workflow(), "gate-windows-build");
+    let quality_policy = job_section(release_workflow(), "release-quality-policy");
+    let prepare = job_section(release_workflow(), "prepare");
+
+    assert!(windows_build.contains("runs-on: windows-latest"));
+    assert!(windows_build.contains("run: cargo build --workspace --locked"));
+    assert!(
+        quality_policy.contains("- gate-windows-build"),
+        "the release quality policy must wait for the native Windows build"
+    );
+    assert!(
+        quality_policy.contains("needs.gate-windows-build.result == 'success'"),
+        "the release quality policy must fail closed when the native Windows build fails"
+    );
+    assert!(
+        prepare.contains("- gate-windows-build"),
+        "release preparation must wait for the native Windows build"
+    );
+    assert!(
+        prepare.contains("needs.gate-windows-build.result == 'success'"),
+        "a failed native Windows build must prevent tag preparation and publication"
+    );
+}
+
+#[test]
 fn release_workflow_publishes_binary_channels_not_crates_io() {
     let workflow = release_workflow();
     let host = job_section(workflow, "host");


### PR DESCRIPTION
## Summary
Move the Windows-only dependency to homeboy-core and block release preparation on a native Windows workspace build.

## What changed
- Declare windows-sys in the crate that imports it, remove the obsolete root declaration, and add a native Windows release gate with contract coverage.

## How to test
1. Run `cargo test --test release_workflow_test --locked`; expect All release workflow contract tests pass..
2. Run `cargo check --workspace --tests --locked`; expect The full workspace test targets compile..
3. Run `Dispatch the Release workflow on this branch with dry-run=true`; expect Windows Build passes and no tag or GitHub Release is created..

## Compatibility
No backwards-compatibility impact. This corrects internal dependency ownership and adds a fail-closed pre-release compile gate.

## Evidence
- Base advanced after verification: verified main at 5bdf8435e86574294732d1a6d5c89fda8477fb7d; publication observed 1ecb7f2f935d390a6a26dd3f0177e9450e08d207. Candidate ancestry was validated against the verified snapshot.
- CI expected: CI / Audit
- CI expected: CI / Lint
- CI expected: CI / Test
- CI expected: CI / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/actions/runs/29580890315
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/actions/runs/29580890315/job/87914339472
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8742
- Verified finalization base: main at 5bdf8435e86574294732d1a6d5c89fda8477fb7d
- diff-check: Passed
- format: Passed
- release-contract: Passed
- workspace-check: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed release evidence, prepared the dependency/workflow repair, and verified it through Homeboy Lab; Chris reviewed and owns the change.

## Source relationships
- Closes #8742
- Relates to #8748
