### PR TITLE
refactor: invert controller-runtime pin-reference edge behind a hook

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -166,6 +166,12 @@ impl CliRuntime {
         // can materialize an isolated validation-dependency workspace without
         // depending on runner behavior.
         crate::runner::register_workspace_snapshot_provider();
+        // Register the agent-task controller pin-reference provider so core's
+        // controller-runtime retention report can discover which pinned
+        // executables are still referenced by nonterminal durable agent-task
+        // records without core depending on the agent-task subsystem. (This is
+        // the seam that lets agent-task become its own crate.)
+        crate::core::agent_task_lifecycle::controller_pin_reference_provider::register();
         // Register the command-label resolver so core::runner can map dispatched
         // argv to a hot-command label without depending on the full CLI parser.
         crate::runner::set_command_label_resolver(|argv| {

--- a/crates/homeboy-core/src/agent_task_lifecycle/controller_pin_reference_provider.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/controller_pin_reference_provider.rs
@@ -1,0 +1,66 @@
+//! Agent-task implementation of the controller pin-reference hook.
+//!
+//! Core's controller-runtime retention logic asks which pinned executables are
+//! still referenced by a nonterminal durable agent-task record. That query is
+//! agent-task behavior — it reads the lifecycle store and inspects each record's
+//! state and metadata — so it is provided to core through the
+//! `ControllerPinReferenceProvider` hook instead of core calling the agent-task
+//! subsystem directly.
+
+use std::path::PathBuf;
+
+use serde_json::Value;
+
+use crate::agent_task_lifecycle::{list_records_with_health, AgentTaskRunState};
+use crate::controller_pin_reference::{
+    register_controller_pin_reference_provider, ControllerPinReferenceProvider,
+};
+use crate::Result;
+
+/// JSON pointer to a record's originating controller-runtime pinned executable.
+/// Mirrors core's `CONTROLLER_RUNTIME_METADATA_KEY` layout.
+const PINNED_EXECUTABLE_POINTER: &str = "/controller_runtime/originating/pinned_executable";
+
+struct AgentTaskControllerPinReferenceProvider;
+
+impl ControllerPinReferenceProvider for AgentTaskControllerPinReferenceProvider {
+    fn referenced_controller_pins(&self) -> Result<Vec<PathBuf>> {
+        let (records, _) = list_records_with_health()?;
+        let mut referenced = Vec::new();
+        for record in records {
+            if !state_retains_pin(record.state) {
+                continue;
+            }
+            if let Some(path) = record
+                .metadata
+                .pointer(PINNED_EXECUTABLE_POINTER)
+                .and_then(Value::as_str)
+                .map(PathBuf::from)
+            {
+                referenced.push(path);
+            }
+        }
+        Ok(referenced)
+    }
+}
+
+/// A record whose state can still operate on its pin retains it: queued,
+/// running, and recoverable-partial records may be re-run by lifecycle
+/// recovery, so their originating pinned executable must survive pruning.
+fn state_retains_pin(state: AgentTaskRunState) -> bool {
+    matches!(
+        state,
+        AgentTaskRunState::Queued
+            | AgentTaskRunState::Running
+            | AgentTaskRunState::CandidateRecoverable
+            | AgentTaskRunState::PartialRecoverable
+            | AgentTaskRunState::PartialFailure
+    )
+}
+
+/// Register the agent-task controller pin-reference provider. Called once at
+/// startup so core's controller-runtime retention report can discover
+/// still-referenced pins without depending on the agent-task subsystem.
+pub fn register() {
+    register_controller_pin_reference_provider(Box::new(AgentTaskControllerPinReferenceProvider));
+}

--- a/crates/homeboy-core/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/mod.rs
@@ -32,6 +32,7 @@ use lifecycle_store as store;
 pub mod agent_task_lifecycle_event;
 mod artifact_materialization;
 mod cancellation;
+pub mod controller_pin_reference_provider;
 mod conversion;
 mod failure_recording;
 mod health;

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -266,6 +266,10 @@ fn legacy_v1_pin_migration_failures_leave_durable_record_unchanged() {
 #[test]
 fn controller_runtime_retention_keeps_mutable_runs_and_reports_terminal_pins_eligible() {
     with_isolated_home(|_| {
+        // Controller-runtime retention discovers referenced pins through the
+        // agent-task pin-reference provider hook; register it so the report can
+        // see this test's durable records.
+        super::controller_pin_reference_provider::register();
         let temporary = tempfile::tempdir().expect("temporary fake controller directory");
         let identity = crate::build_identity::current().display;
         let active_artifact = temporary.path().join("active-homeboy");

--- a/crates/homeboy-core/src/controller_pin_reference.rs
+++ b/crates/homeboy-core/src/controller_pin_reference.rs
@@ -1,0 +1,68 @@
+//! Controller-runtime pin-reference hook.
+//!
+//! Controller runtime pins (immutable homeboy executables) are retained while a
+//! durable agent-task record can still operate on them — a queued, running, or
+//! recoverable-partial record keeps its originating pinned executable alive so
+//! lifecycle recovery does not lose the binary it must re-run.
+//!
+//! Discovering which pins are still referenced requires reading the agent-task
+//! lifecycle store and inspecting each record's state and metadata, which is
+//! agent-task behavior. It is inverted behind this provider so the controller
+//! runtime's retention logic (pin classification, disk scan, pruning) stays in
+//! core without core depending on the agent-task subsystem.
+//!
+//! With no provider registered (no agent-task subsystem present) the no-op
+//! provider reports zero referenced pins. That is safe for the read-only
+//! retention report, and pruning is always an explicit caller opt-in.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use crate::Result;
+
+/// Supplies the controller-runtime pin paths still referenced by nonterminal
+/// durable agent-task records.
+pub trait ControllerPinReferenceProvider: Send + Sync {
+    /// Return every pinned-executable path referenced by an agent-task record
+    /// whose state still retains its pin (queued, running, or recoverable).
+    /// Returned paths are raw record references; the caller filters them to the
+    /// content-addressed pins it owns.
+    fn referenced_controller_pins(&self) -> Result<Vec<PathBuf>>;
+}
+
+struct NoopProvider;
+
+impl ControllerPinReferenceProvider for NoopProvider {
+    fn referenced_controller_pins(&self) -> Result<Vec<PathBuf>> {
+        Ok(Vec::new())
+    }
+}
+
+fn provider_slot() -> &'static Mutex<Option<Box<dyn ControllerPinReferenceProvider>>> {
+    static PROVIDER: Mutex<Option<Box<dyn ControllerPinReferenceProvider>>> = Mutex::new(None);
+    &PROVIDER
+}
+
+/// Register the controller pin-reference provider. Called once at startup by the
+/// agent-task layer.
+pub fn register_controller_pin_reference_provider(
+    provider: Box<dyn ControllerPinReferenceProvider>,
+) {
+    let mut slot = provider_slot()
+        .lock()
+        .expect("controller pin reference provider lock");
+    *slot = Some(provider);
+}
+
+/// The controller-runtime pins still referenced by nonterminal agent-task
+/// records, via the registered provider (or an empty set when the agent-task
+/// subsystem is absent).
+pub(crate) fn referenced_controller_pins() -> Result<Vec<PathBuf>> {
+    let slot = provider_slot()
+        .lock()
+        .expect("controller pin reference provider lock");
+    match slot.as_deref() {
+        Some(provider) => provider.referenced_controller_pins(),
+        None => NoopProvider.referenced_controller_pins(),
+    }
+}

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -49,22 +49,11 @@ pub struct ControllerRuntimePruneResult {
 /// still operate on them. The active admission generation is retained as well.
 pub fn retention_report() -> Result<ControllerRuntimeRetentionReport> {
     let root = runtime_root()?;
-    let (records, _) = crate::agent_task_lifecycle::list_records_with_health()?;
+    let referenced = crate::controller_pin_reference::referenced_controller_pins()?;
     let mut retained = BTreeSet::new();
 
-    for record in records {
-        if !state_retains_pin(record.state) {
-            continue;
-        }
-        if let Some(path) = record
-            .metadata
-            .pointer(&format!(
-                "/{CONTROLLER_RUNTIME_METADATA_KEY}/originating/pinned_executable"
-            ))
-            .and_then(Value::as_str)
-            .map(PathBuf::from)
-            .filter(|path| content_addressed_pin_path(&root, path))
-        {
+    for path in referenced {
+        if content_addressed_pin_path(&root, &path) {
             retained.insert(path);
         }
     }
@@ -123,17 +112,6 @@ pub fn prune_pins(apply: bool) -> Result<ControllerRuntimePruneResult> {
         eligible: report.eligible,
         removed,
     })
-}
-
-fn state_retains_pin(state: crate::agent_task_lifecycle::AgentTaskRunState) -> bool {
-    matches!(
-        state,
-        crate::agent_task_lifecycle::AgentTaskRunState::Queued
-            | crate::agent_task_lifecycle::AgentTaskRunState::Running
-            | crate::agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
-            | crate::agent_task_lifecycle::AgentTaskRunState::PartialRecoverable
-            | crate::agent_task_lifecycle::AgentTaskRunState::PartialFailure
-    )
 }
 
 fn content_addressed_pin_path(root: &Path, path: &Path) -> bool {

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -112,6 +112,7 @@ pub mod command_execution_plan;
 pub mod command_invocation;
 pub mod component;
 pub mod context;
+pub mod controller_pin_reference;
 pub(crate) mod controller_runtime;
 pub mod controller_scratch;
 pub mod daemon;


### PR DESCRIPTION
## Summary
First prep-PR of the **homeboy-agents crate extraction** campaign (wiki: `homeboy-agents-crate-extraction-plan`). Severs the heaviest `core -> agent_task` upward edge so the ~83k-LOC agent-task subsystem can eventually leave core.

`controller_runtime::retention_report()` called `agent_task_lifecycle::list_records_with_health()` directly to find which pinned executables are still referenced by nonterminal durable records — 7 references in `controller_runtime.rs`, the single biggest agent-task leak in a non-agent core file.

## What changed
- New `controller_pin_reference` hook in core: `ControllerPinReferenceProvider` trait + `NoopProvider` (returns zero references) + registry, mirroring the established runner-availability/continuation provider pattern.
- `retention_report()` now asks the hook for referenced pins and filters them through core's own `content_addressed_pin_path`. Core keeps pin classification, the disk scan, and pruning; the agent-task layer owns the record scan + state filter + metadata-pointer extraction (`state_retains_pin` moved to the agent side).
- Agent-side impl `agent_task_lifecycle::controller_pin_reference_provider`, registered at startup in `cli_runtime.rs` next to the runner provider block.
- In-test registration for the retention test (provider-static pattern from the runner campaign).

## Effect
- `controller_runtime.rs`: 7 agent-task refs -> **0** (edge fully severed).
- Core upward-edge files: 17 -> 16.
- No behavior change: the retention report still retains active/recoverable pins and marks terminal pins eligible. On a no-agent install the no-op returns empty, which is safe for the read-only report (pruning is always an explicit caller opt-in).

## Verification
- `cargo check -p homeboy-core --lib` / `--tests`, `-p homeboy-cli --lib`: clean.
- `cargo test -p homeboy-core --lib controller_runtime_retention_keeps_mutable_runs...`: passes.
- `cargo fmt`: clean.

(Heavy build/test left to CI per repo convention.)