### PR TITLE
Preserve SSH snapshot failure evidence

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -756,7 +756,9 @@ fn detached_cook_preacceptance_failure_terminalizes_attempt_proxy() {
             attempt_run_id,
             &plan,
             "lab_workspace_stage",
-            &Error::internal_unexpected("workspace materialization failed"),
+            &Error::internal_unexpected("workspace materialization failed").with_hint(format!(
+                "Retry: homeboy agent-task retry {attempt_run_id} --run"
+            )),
         )
         .expect("terminal staging failure");
 
@@ -766,6 +768,12 @@ fn detached_cook_preacceptance_failure_terminalizes_attempt_proxy() {
             record.metadata["pre_execution_failure"]["phase"],
             "lab_workspace_stage"
         );
+        assert!(record.metadata["pre_execution_failure"]["hints"]
+            .as_array()
+            .expect("failure hints")
+            .iter()
+            .any(|hint| hint
+                == "Retry: homeboy agent-task retry cook-7970-attempt-1-staging-failure --run"));
         assert!(record.metadata.get("runner_job_id").is_none());
     });
 }

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1182,6 +1182,11 @@ pub(crate) fn run_lab_offload_inner(
     ) {
         Ok(stage) => stage,
         Err(error) => {
+            let error = if let Some(run_id) = pre_acceptance_run_id.as_deref() {
+                error.with_hint(format!("Retry: homeboy agent-task retry {run_id} --run"))
+            } else {
+                error
+            };
             if let Some(run_id) = pre_acceptance_run_id.as_deref() {
                 if let Ok(plan) = agent_task_lifecycle::load_plan(run_id) {
                     // Staging is still controller-side. Make a failed handoff

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -105,6 +105,58 @@ use crate::workspace::util::git_output;
 static PATH_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 #[test]
+fn snapshot_command_failure_keeps_exit_status_and_silent_transport_cause() {
+    let error =
+        super::super::util::run_shell_command("exit 23", "materialize SSH workspace snapshot")
+            .expect_err("silent command failure must be actionable");
+
+    assert_eq!(
+        error.message,
+        "materialize SSH workspace snapshot failed during command execution (exit status 23): the command exited without stdout or stderr"
+    );
+}
+
+#[test]
+fn snapshot_command_failure_preserves_bounded_transport_output() {
+    let error = super::super::util::run_shell_command(
+        "printf stdout-evidence; printf stderr-evidence >&2; exit 24",
+        "materialize SSH workspace snapshot",
+    )
+    .expect_err("transport output must be retained");
+
+    assert!(error.message.contains("exit status 24"));
+    assert!(error.message.contains("stdout: stdout-evidence"));
+    assert!(error.message.contains("stderr: stderr-evidence"));
+}
+
+#[test]
+fn snapshot_command_failure_bounds_transport_output() {
+    let error = super::super::util::run_shell_command(
+        "head -c 5000 /dev/zero | tr '\\0' x; exit 25",
+        "materialize SSH workspace snapshot",
+    )
+    .expect_err("large transport output must be bounded");
+
+    assert!(error.message.contains("exit status 25"));
+    assert!(error.message.ends_with("... [truncated]"));
+    assert!(error.message.len() < 4_300);
+}
+
+#[test]
+fn snapshot_command_failure_bounds_multibyte_output_at_a_character_boundary() {
+    let error = super::super::util::run_shell_command(
+        "head -c 4095 /dev/zero | tr '\\0' Z; printf '\\342\\202\\254'; exit 26",
+        "materialize SSH workspace snapshot",
+    )
+    .expect_err("multibyte transport output must not panic while truncating");
+
+    assert!(error.message.contains("exit status 26"));
+    assert_eq!(error.message.matches('Z').count(), 4095);
+    assert!(!error.message.contains('\u{20ac}'));
+    assert!(error.message.ends_with("... [truncated]"));
+}
+
+#[test]
 fn runner_snapshot_includes_override_generated_output_excludes() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let source = tempfile::tempdir().expect("source tempdir");

--- a/crates/homeboy-lab-runner/src/workspace/util.rs
+++ b/crates/homeboy-lab-runner/src/workspace/util.rs
@@ -119,10 +119,40 @@ pub(crate) fn run_shell_command(command: &str, action: &str) -> Result<()> {
     if output.status.success() {
         return Ok(());
     }
+    let stdout = bounded_command_output(&output.stdout);
+    let stderr = bounded_command_output(&output.stderr);
+    let evidence = match (stdout.is_empty(), stderr.is_empty()) {
+        (true, true) => "the command exited without stdout or stderr".to_string(),
+        (false, true) => format!("stdout: {stdout}"),
+        (true, false) => format!("stderr: {stderr}"),
+        (false, false) => format!("stdout: {stdout}; stderr: {stderr}"),
+    };
     Err(Error::internal_unexpected(format!(
-        "{action} failed: {}",
-        String::from_utf8_lossy(&output.stderr)
+        "{action} failed during command execution (exit status {}): {evidence}",
+        output.status.code().unwrap_or(-1),
     )))
+}
+
+const COMMAND_FAILURE_OUTPUT_LIMIT: usize = 4 * 1024;
+
+fn bounded_command_output(output: &[u8]) -> String {
+    if output.len() <= COMMAND_FAILURE_OUTPUT_LIMIT {
+        return String::from_utf8_lossy(output).trim().to_string();
+    }
+
+    let prefix = match std::str::from_utf8(output) {
+        Ok(output) => {
+            let end = output
+                .char_indices()
+                .map(|(index, _)| index)
+                .take_while(|index| *index <= COMMAND_FAILURE_OUTPUT_LIMIT)
+                .last()
+                .unwrap_or(0);
+            output[..end].to_string()
+        }
+        Err(_) => String::from_utf8_lossy(&output[..COMMAND_FAILURE_OUTPUT_LIMIT]).into_owned(),
+    };
+    format!("{}... [truncated]", prefix.trim())
 }
 
 pub(crate) fn shell_command_for_runner(runner: &Runner, command: &str) -> Result<String> {


### PR DESCRIPTION
## Summary
Preserve actionable evidence when SSH snapshot materialization commands fail before provider execution.

## What changed
- Capture exit status plus bounded stdout/stderr, report silent failures explicitly, and persist a runnable retry hint in pre-acceptance lifecycle evidence.

## How to test
1. Run `cargo test -p homeboy-lab-runner snapshot_command_failure --lib`; expect Four focused failure-evidence tests pass.
2. Run `cargo test -p homeboy-core detached_cook_preacceptance_failure_terminalizes_attempt_proxy --lib -- --test-threads=1`; expect Lifecycle retry evidence test passes.
3. Run `cargo fmt --check`; expect Formatting passes.

## Compatibility
No command or success-path behavior changes; failure diagnostics gain bounded evidence and retry guidance.

## Evidence
- Base advanced after verification: verified main at 1ecb7f2f935d390a6a26dd3f0177e9450e08d207; publication observed d203829a506a484c340de4e5c602bc29fc9f9cae. Candidate ancestry was validated against the verified snapshot.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8737
- Verified finalization base: main at 1ecb7f2f935d390a6a26dd3f0177e9450e08d207
- diff-check: Passed
- focused-tests: Passed
- format: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab snapshot evidence loss, implemented bounded diagnostics and lifecycle retry coverage, and reviewed the candidate; Chris reviews and owns the change.

## Source relationships
- Closes #8737
