### PR TITLE
refactor: move FuzzConfig/FuzzWorkloadConfig to homeboy-extension-contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,6 +902,7 @@ dependencies = [
  "homeboy-audit-contract",
  "homeboy-engine-primitives",
  "homeboy-error",
+ "homeboy-lifecycle-contract",
  "homeboy-product-identity",
  "semver",
  "serde",

--- a/crates/homeboy-core/src/extension/manifest.rs
+++ b/crates/homeboy-core/src/extension/manifest.rs
@@ -24,10 +24,10 @@ use std::path::PathBuf;
 
 // Keep broad manifest wiring here while leaf config structs live in focused files.
 pub use super::manifest_config::{
-    AutofixVerifyConfig, FuzzConfig, FuzzWorkloadConfig, TraceBrowserArtifactMapConfig,
-    TraceBrowserEvidenceAdapterConfig, TraceBrowserMetricAliasConfig,
-    TraceBrowserSummaryAliasConfig, TraceConfig,
+    AutofixVerifyConfig, TraceBrowserArtifactMapConfig, TraceBrowserEvidenceAdapterConfig,
+    TraceBrowserMetricAliasConfig, TraceBrowserSummaryAliasConfig, TraceConfig,
 };
+pub use homeboy_extension_contract::fuzz_config::{FuzzConfig, FuzzWorkloadConfig};
 pub use homeboy_extension_contract::manifest_action_config::{
     ActionConfig, InputConfig, RuntimeConfig, SelectOption, SettingConfig,
 };

--- a/crates/homeboy-core/src/extension/manifest_config.rs
+++ b/crates/homeboy-core/src/extension/manifest_config.rs
@@ -1,7 +1,3 @@
-use crate::lifecycle::LifecycleContract;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-
 mod autofix_config;
 pub use autofix_config::AutofixVerifyConfig;
 pub use homeboy_extension_contract::trace_config::{
@@ -19,39 +15,4 @@ mod tests {
         let config: DepsConfig = serde_json::from_str(r#"{"extension_script":"deps.sh"}"#).unwrap();
         assert_eq!(config.extension_script.as_deref(), Some("deps.sh"));
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
-pub struct FuzzConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub extension_script: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub env: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub workloads: Vec<FuzzWorkloadConfig>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub case_artifact: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub corpus_artifacts: Vec<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub seed: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub replay_command: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub minimize_command: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub result_schema: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub artifact_retention: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct FuzzWorkloadConfig {
-    pub id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub label: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub lifecycle: Option<LifecycleContract>,
 }

--- a/crates/homeboy-extension-contract/Cargo.toml
+++ b/crates/homeboy-extension-contract/Cargo.toml
@@ -17,6 +17,7 @@ homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
 homeboy-audit-contract = { version = "0.1.0", path = "../homeboy-audit-contract" }
 homeboy-product-identity = { version = "0.1.0", path = "../homeboy-product-identity" }
 homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
+homeboy-lifecycle-contract = { version = "0.1.0", path = "../homeboy-lifecycle-contract" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 semver = "1.0"

--- a/crates/homeboy-extension-contract/src/fuzz_config.rs
+++ b/crates/homeboy-extension-contract/src/fuzz_config.rs
@@ -1,0 +1,39 @@
+//! Fuzz workload manifest config types.
+
+use homeboy_lifecycle_contract::LifecycleContract;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct FuzzConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extension_script: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub workloads: Vec<FuzzWorkloadConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub case_artifact: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub corpus_artifacts: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replay_command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minimize_command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_schema: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_retention: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FuzzWorkloadConfig {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lifecycle: Option<LifecycleContract>,
+}

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -13,6 +13,7 @@ pub mod action_types;
 pub mod core_compat;
 pub mod exec_context;
 pub mod extension_contract_producer;
+pub mod fuzz_config;
 pub mod manifest_action_config;
 pub mod manifest_capability_config;
 pub mod manifest_deploy_config;


### PR DESCRIPTION
## Summary
Tenth sub-cut of the **extension crate extraction campaign** (Stage 1, wiki id 12840) — collects the payoff of the lifecycle-contract extraction (#8752).

`FuzzConfig` and `FuzzWorkloadConfig` were the **last two types stuck in `manifest_config.rs`**, deferred in cut 8 because `FuzzWorkloadConfig` carries an `Option<LifecycleContract>` field, and `LifecycleContract` was buried in core behind the `observation` dependency chain.

Now that #8752 moved `LifecycleContract` into the leaf `homeboy-lifecycle-contract` crate, the extension-contract crate can depend on it and pull these two pure serde types in cleanly.

## Result
`manifest_config.rs` is now **fully drained of data types** — only re-exports of `autofix_config`/`trace_config` submodules and a test remain. `manifest.rs` re-exports the two Fuzz types from the contract crate, keeping the `crate::extension::*` surface stable.

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-issues`, `homeboy-fuzz`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)