### PR TITLE
refactor: invert proof loop-spec-validation edge behind a hook

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -172,6 +172,10 @@ impl CliRuntime {
         // records without core depending on the agent-task subsystem. (This is
         // the seam that lets agent-task become its own crate.)
         crate::core::agent_task_lifecycle::controller_pin_reference_provider::register();
+        // Register the loop-spec validation provider so core's proof validator
+        // can validate a materialized agent-task loop-spec artifact without
+        // depending on the agent-task subsystem.
+        crate::core::agent_task_controller_service::loop_spec_validation_provider::register();
         // Register the command-label resolver so core::runner can map dispatched
         // argv to a hot-command label without depending on the full CLI parser.
         crate::runner::set_command_label_resolver(|argv| {

--- a/crates/homeboy-core/src/agent_task_controller_service/loop_spec_validation_provider.rs
+++ b/crates/homeboy-core/src/agent_task_controller_service/loop_spec_validation_provider.rs
@@ -1,0 +1,52 @@
+//! Agent-task implementation of the loop-spec proof-validation hook.
+//!
+//! Proof validation for a materialized loop-spec artifact must confirm the
+//! embedded `spec` deserializes to the agent-task loop-spec schema and passes
+//! the loop-spec and artifact-reference validators. That is agent-task
+//! behavior, provided to core's proof validator through the
+//! `LoopSpecValidationProvider` hook so proof validation does not depend on the
+//! agent-task subsystem directly.
+
+use serde_json::Value;
+
+use crate::agent_task_controller_service::{validate_loop_spec, AgentTaskRepoLoopSpec};
+use crate::agent_task_repo_loop_compile::validate_repo_loop_artifact_references;
+use crate::proof::loop_spec_validation::{
+    register_loop_spec_validation_provider, LoopSpecValidationDiagnostic,
+    LoopSpecValidationProvider,
+};
+
+struct AgentTaskLoopSpecValidationProvider;
+
+impl LoopSpecValidationProvider for AgentTaskLoopSpecValidationProvider {
+    fn validate_materialized_loop_spec(&self, spec: &Value) -> Vec<LoopSpecValidationDiagnostic> {
+        let Ok(spec) = serde_json::from_value::<AgentTaskRepoLoopSpec>(spec.clone()) else {
+            return vec![LoopSpecValidationDiagnostic {
+                code: "invalid_loop_spec_json".to_string(),
+                message: "materialized controller spec does not match the loop spec schema"
+                    .to_string(),
+            }];
+        };
+        let mut diagnostics = Vec::new();
+        if let Err(error) = validate_loop_spec(&spec) {
+            diagnostics.push(LoopSpecValidationDiagnostic {
+                code: "invalid_controller_loop_spec".to_string(),
+                message: error.message,
+            });
+        }
+        if let Err(error) = validate_repo_loop_artifact_references(&spec) {
+            diagnostics.push(LoopSpecValidationDiagnostic {
+                code: "invalid_artifact_references".to_string(),
+                message: error.message,
+            });
+        }
+        diagnostics
+    }
+}
+
+/// Register the agent-task loop-spec validation provider. Called once at startup
+/// so core's proof validator can validate materialized loop-spec artifacts
+/// without depending on the agent-task subsystem.
+pub fn register() {
+    register_loop_spec_validation_provider(Box::new(AgentTaskLoopSpecValidationProvider));
+}

--- a/crates/homeboy-core/src/agent_task_controller_service/mod.rs
+++ b/crates/homeboy-core/src/agent_task_controller_service/mod.rs
@@ -57,6 +57,7 @@ mod action_state;
 mod actions;
 mod artifacts;
 mod dispatch_defaults;
+pub mod loop_spec_validation_provider;
 mod pr_ownership;
 mod proof;
 mod reports;

--- a/crates/homeboy-core/src/proof.rs
+++ b/crates/homeboy-core/src/proof.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::gate::HomeboyGateResult;
 
+pub mod loop_spec_validation;
 mod validation;
 pub use validation::{
     gate_scope_label, gate_status_label, is_ci_equivalent_gate, proof_runner_label,
@@ -484,6 +485,7 @@ mod tests {
 
     #[test]
     fn proof_validation_accepts_successful_command_envelope_data() {
+        crate::agent_task_controller_service::loop_spec_validation_provider::register();
         let report = validate_proof_value(json!({
             "success": true,
             "data": valid_materialized_spec()
@@ -495,6 +497,7 @@ mod tests {
 
     #[test]
     fn proof_validation_accepts_successful_command_envelope_value() {
+        crate::agent_task_controller_service::loop_spec_validation_provider::register();
         let report = validate_proof_value(json!({
             "success": true,
             "value": valid_materialized_spec()
@@ -531,6 +534,9 @@ mod tests {
 
     #[test]
     fn proof_validation_accepts_materialized_controller_gates_and_metrics() {
+        // Loop-spec validation runs through the agent-task provider hook; register
+        // it so proof validation can validate the materialized spec.
+        crate::agent_task_controller_service::loop_spec_validation_provider::register();
         let report = validate_proof_value(json!({
             "schema": "homeboy/agent-task-loop-spec-materialization/v1",
             "spec": {
@@ -563,6 +569,9 @@ mod tests {
 
     #[test]
     fn proof_validation_rejects_undeclared_materialized_controller_gate() {
+        // Loop-spec validation runs through the agent-task provider hook; register
+        // it so proof validation can validate the materialized spec.
+        crate::agent_task_controller_service::loop_spec_validation_provider::register();
         let report = validate_proof_value(json!({
             "schema": "homeboy/agent-task-loop-spec-materialization/v1",
             "spec": {

--- a/crates/homeboy-core/src/proof/loop_spec_validation.rs
+++ b/crates/homeboy-core/src/proof/loop_spec_validation.rs
@@ -1,0 +1,69 @@
+//! Loop-spec proof-validation hook.
+//!
+//! Proof validation accepts a materialized agent-task loop-spec artifact
+//! (`homeboy/agent-task-loop-spec-materialization/v1`) and must confirm the
+//! embedded `spec` deserializes to the loop-spec schema and passes the
+//! agent-task loop-spec + artifact-reference validators. That validation is
+//! agent-task behavior — it owns the `AgentTaskRepoLoopSpec` schema and its
+//! rules — so it is inverted behind this provider: core owns proof dispatch and
+//! diagnostic reporting, the agent-task layer owns loop-spec validation.
+//!
+//! With no provider registered (no agent-task subsystem present) the no-op
+//! provider reports that the loop-spec schema cannot be validated, so a proof
+//! carrying that schema is flagged rather than silently accepted.
+
+use std::sync::Mutex;
+
+use serde_json::Value;
+
+/// A single loop-spec validation finding: a stable diagnostic code and a
+/// human-readable message. The caller attaches the JSON path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoopSpecValidationDiagnostic {
+    pub code: String,
+    pub message: String,
+}
+
+/// Validates a materialized agent-task loop-spec `spec` value.
+pub trait LoopSpecValidationProvider: Send + Sync {
+    /// Validate the embedded loop-spec `spec` JSON, returning one diagnostic per
+    /// problem found. An empty vec means the spec is valid.
+    fn validate_materialized_loop_spec(&self, spec: &Value) -> Vec<LoopSpecValidationDiagnostic>;
+}
+
+struct NoopProvider;
+
+impl LoopSpecValidationProvider for NoopProvider {
+    fn validate_materialized_loop_spec(&self, _spec: &Value) -> Vec<LoopSpecValidationDiagnostic> {
+        vec![LoopSpecValidationDiagnostic {
+            code: "loop_spec_validation_unavailable".to_string(),
+            message: "agent-task loop-spec validation is not available: the agent-task subsystem is not present".to_string(),
+        }]
+    }
+}
+
+fn provider_slot() -> &'static Mutex<Option<Box<dyn LoopSpecValidationProvider>>> {
+    static PROVIDER: Mutex<Option<Box<dyn LoopSpecValidationProvider>>> = Mutex::new(None);
+    &PROVIDER
+}
+
+/// Register the loop-spec validation provider. Called once at startup by the
+/// agent-task layer.
+pub fn register_loop_spec_validation_provider(provider: Box<dyn LoopSpecValidationProvider>) {
+    let mut slot = provider_slot()
+        .lock()
+        .expect("loop spec validation provider lock");
+    *slot = Some(provider);
+}
+
+/// Validate a materialized loop-spec `spec` value via the registered provider
+/// (or the no-op provider when the agent-task subsystem is absent).
+pub(crate) fn validate_materialized_loop_spec(spec: &Value) -> Vec<LoopSpecValidationDiagnostic> {
+    let slot = provider_slot()
+        .lock()
+        .expect("loop spec validation provider lock");
+    match slot.as_deref() {
+        Some(provider) => provider.validate_materialized_loop_spec(spec),
+        None => NoopProvider.validate_materialized_loop_spec(spec),
+    }
+}

--- a/crates/homeboy-core/src/proof/validation.rs
+++ b/crates/homeboy-core/src/proof/validation.rs
@@ -1,7 +1,5 @@
 use serde_json::Value;
 
-use crate::agent_task_controller_service::{validate_loop_spec, AgentTaskRepoLoopSpec};
-use crate::agent_task_repo_loop_compile::validate_repo_loop_artifact_references;
 use crate::artifact_address::validated_public_url;
 use crate::gate::{HomeboyGateResult, HomeboyGateStatus};
 
@@ -214,27 +212,11 @@ fn validate_materialized_loop_spec(
         ));
         return;
     };
-    let Ok(spec) = serde_json::from_value::<AgentTaskRepoLoopSpec>(spec.clone()) else {
-        diagnostics.push(diagnostic(
-            "invalid_loop_spec_json",
-            "materialized controller spec does not match the loop spec schema",
-            path("/spec"),
-        ));
-        return;
-    };
-    if let Err(error) = validate_loop_spec(&spec) {
-        diagnostics.push(diagnostic(
-            "invalid_controller_loop_spec",
-            error.message,
-            path("/spec"),
-        ));
-    }
-    if let Err(error) = validate_repo_loop_artifact_references(&spec) {
-        diagnostics.push(diagnostic(
-            "invalid_artifact_references",
-            error.message,
-            path("/spec"),
-        ));
+    // Loop-spec schema + rule validation is agent-task behavior, delegated
+    // through the loop-spec validation hook so proof validation does not depend
+    // on the agent-task subsystem.
+    for finding in crate::proof::loop_spec_validation::validate_materialized_loop_spec(spec) {
+        diagnostics.push(diagnostic(finding.code, finding.message, path("/spec")));
     }
 }
 


### PR DESCRIPTION
## Summary
Second prep-PR of the **homeboy-agents crate extraction** campaign (wiki: `homeboy-agents-crate-extraction-plan`). Stacked on #8753.

`proof::validation` validated a materialized agent-task loop-spec artifact (`homeboy/agent-task-loop-spec-materialization/v1`) by deserializing the embedded `spec` to `AgentTaskRepoLoopSpec` and running the agent-task validators — a `core -> agent_task` upward edge in `proof/validation.rs`.

## What changed
- New `proof::loop_spec_validation` hook: `LoopSpecValidationProvider` trait + `LoopSpecValidationDiagnostic` + `NoopProvider` + registry.
- `validate_materialized_loop_spec` in `proof/validation.rs` now delegates spec deserialization + validation to the hook and attaches the returned diagnostics at `/spec`. Core keeps proof dispatch, the diagnostic type, and reporting.
- Agent-side impl `agent_task_controller_service::loop_spec_validation_provider`, registered at startup in `cli_runtime.rs`. Reproduces the exact original diagnostic codes: `invalid_loop_spec_json`, `invalid_controller_loop_spec`, `invalid_artifact_references`.
- In-test registration for the four proof tests that exercise the materialized-loop-spec path (provider-static pattern).

## Effect
- `proof/validation.rs`: 2 agent-task refs -> **0** (edge fully severed).
- No behavior change: valid specs stay valid, invalid specs produce the same codes/messages. On a no-agent install the no-op flags the loop-spec schema as unvalidatable rather than silently accepting it.

## Verification
- `cargo check -p homeboy-core --lib` / `--tests`, `-p homeboy-cli --lib`: clean.
- `cargo test -p homeboy-core --lib proof::tests`: 21 passed.
- `cargo fmt`: clean.

(Heavy build/test left to CI per repo convention.)

> Note: stacked on #8753 — review/merge that first, or this rebases cleanly onto main once it lands.