### PR TITLE
Queue busy Lab cooks with crash-safe replay

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -1208,9 +1208,14 @@ fn liveness_summary(record: &Value, run_id: &str) -> Value {
         .get("state")
         .and_then(Value::as_str)
         .is_some_and(|state| matches!(state, "succeeded" | "failed" | "cancelled"));
+    let waiting_for_capacity = metadata
+        .get("runner_queue")
+        .and_then(|queue| queue.get("state"))
+        .and_then(Value::as_str)
+        == Some("waiting_for_capacity");
 
     json!({
-        "status": if terminal { "terminal" } else if stale { "stale" } else { "active" },
+        "status": if terminal { "terminal" } else if stale { "stale" } else if waiting_for_capacity { "waiting_for_capacity" } else { "active" },
         "heartbeat_last_seen_at": record.pointer("/lifecycle/heartbeat/last_seen_at"),
         "runner_job_status": metadata.get("runner_job_status"),
         "runner_job_last_seen_at": metadata.get("runner_job_last_seen_at"),
@@ -1220,10 +1225,13 @@ fn liveness_summary(record: &Value, run_id: &str) -> Value {
             "runner_job_id": runner_job_id,
         },
         "stale_reason": metadata.get("stale_running_reason"),
+        "runner_queue": metadata.get("runner_queue"),
         "next_action": if terminal {
             format!("homeboy agent-task review {run_id}")
         } else if stale {
             "homeboy agent-task active --reconcile".to_string()
+        } else if waiting_for_capacity {
+            "await runner completion or reconnect; the runner will claim this FIFO queue entry under its capacity lease".to_string()
         } else {
             "homeboy agent-task status <run-id> --full".to_string()
         },

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -591,9 +591,6 @@ where
 }
 
 pub fn claim_next_queued_run() -> Result<Option<AgentTaskRunRecord>> {
-    // Interactive local `run-next` invocations can race across processes. Keep
-    // their selection and transition atomic without assigning them daemon ownership.
-    let _claim_lock = QueuedRunClaimLock::lock()?;
     let mut queued: Vec<AgentTaskRunRecord> = store::read_records()?
         .into_iter()
         .filter(|record| record.state == AgentTaskRunState::Queued && !is_transport_proxy(record))
@@ -1907,12 +1904,12 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
             "runner_job_id": input.runner_job_id,
         }),
     );
-    metadata.insert("phase".to_string(), json!("waiting_for_capacity"));
+    metadata.insert("phase".to_string(), json!("awaiting_runner_result"));
     metadata.insert(
         "phase_activity".to_string(),
-        json!("runner owns this FIFO queue entry; awaiting a capacity lease"),
+        json!("controller handoff complete; awaiting authoritative runner daemon result"),
     );
-    metadata.insert("provider_state".to_string(), json!("queued"));
+    metadata.insert("provider_state".to_string(), json!("active"));
     let source_snapshot = metadata
         .get("source_checkout")
         .cloned()
@@ -1920,7 +1917,7 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
     metadata.insert(
         "runner_handoff".to_string(),
         json!({
-            "state": "queued",
+            "state": "in_flight",
             "authority": "runner_daemon",
             "identity": {
                 "run_id": run_id,
@@ -1937,15 +1934,6 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
     );
     metadata.insert("runner_id".to_string(), json!(input.runner_id));
     metadata.insert("runner_job_id".to_string(), json!(input.runner_job_id));
-    metadata.insert(
-        "runner_queue".to_string(),
-        json!({
-            "owner_runner_id": input.runner_id,
-            "ordering": "fifo",
-            "dispatch_eligibility": "runner_capacity_lease",
-            "state": "waiting_for_capacity",
-        }),
-    );
     metadata.insert(
         "remote_workspace".to_string(),
         json!(input.remote_workspace),

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1206,12 +1206,36 @@ pub(crate) fn reconcile_runner_job_snapshot(
             metadata.insert("runner_job_status".to_string(), json!(snapshot.job.status));
             metadata.insert("runner_job_last_seen_at".to_string(), json!(last_seen_at));
             metadata.insert("runner_job_events".to_string(), json!(snapshot.events));
-            metadata.insert("phase".to_string(), json!("executing"));
+            let queued = snapshot.job.status == crate::api_jobs::JobStatus::Queued;
+            metadata.insert(
+                "phase".to_string(),
+                json!(if queued {
+                    "waiting_for_capacity"
+                } else {
+                    "executing"
+                }),
+            );
             metadata.insert(
                 "phase_activity".to_string(),
-                json!("provider/executor process is active"),
+                json!(if queued {
+                    "runner owns this FIFO queue entry; awaiting a capacity lease"
+                } else {
+                    "provider/executor process is active"
+                }),
             );
-            metadata.insert("provider_state".to_string(), json!("active"));
+            metadata.insert(
+                "provider_state".to_string(),
+                json!(if queued { "queued" } else { "active" }),
+            );
+            metadata.insert(
+                "runner_queue".to_string(),
+                json!({
+                    "owner_runner_id": snapshot.job.target_runner_id,
+                    "ordering": "fifo",
+                    "dispatch_eligibility": "runner_capacity_lease",
+                    "state": if queued { "waiting_for_capacity" } else { "claimed" },
+                }),
+            );
             if let Some(provider) = metadata
                 .get("provider_rotation")
                 .and_then(|rotation| rotation.get("entries"))
@@ -1883,12 +1907,12 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
             "runner_job_id": input.runner_job_id,
         }),
     );
-    metadata.insert("phase".to_string(), json!("awaiting_runner_result"));
+    metadata.insert("phase".to_string(), json!("waiting_for_capacity"));
     metadata.insert(
         "phase_activity".to_string(),
-        json!("controller handoff complete; awaiting authoritative runner daemon result"),
+        json!("runner owns this FIFO queue entry; awaiting a capacity lease"),
     );
-    metadata.insert("provider_state".to_string(), json!("active"));
+    metadata.insert("provider_state".to_string(), json!("queued"));
     let source_snapshot = metadata
         .get("source_checkout")
         .cloned()
@@ -1896,7 +1920,7 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
     metadata.insert(
         "runner_handoff".to_string(),
         json!({
-            "state": "in_flight",
+            "state": "queued",
             "authority": "runner_daemon",
             "identity": {
                 "run_id": run_id,
@@ -1913,6 +1937,15 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
     );
     metadata.insert("runner_id".to_string(), json!(input.runner_id));
     metadata.insert("runner_job_id".to_string(), json!(input.runner_job_id));
+    metadata.insert(
+        "runner_queue".to_string(),
+        json!({
+            "owner_runner_id": input.runner_id,
+            "ordering": "fifo",
+            "dispatch_eligibility": "runner_capacity_lease",
+            "state": "waiting_for_capacity",
+        }),
+    );
     metadata.insert(
         "remote_workspace".to_string(),
         json!(input.remote_workspace),

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -654,6 +654,46 @@ pub fn record_runner_job_identity(
     Ok(record)
 }
 
+/// Persist redacted submission ownership before a reverse-broker POST. The
+/// command itself is canonical controller provenance; secret values are never
+/// copied here, only the names the runner must hydrate at dispatch.
+pub fn record_lab_offload_submission_intent(
+    run_id: &str,
+    runner_id: &str,
+    remote_workspace: &str,
+    remote_command: &[String],
+    secret_env_names: &[String],
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let _lock = LabHandoffLock::lock(&run_id)?;
+    let mut record = store::read_record(&run_id)?;
+    let submission_key = format!("agent-task:{run_id}");
+    let metadata = record.ensure_metadata_object();
+    metadata.insert(
+        "runner_submission_intent".to_string(),
+        json!({
+            "state": "pending",
+            "submission_key": submission_key,
+            "runner_id": runner_id,
+            "ordering": "broker_fifo",
+            "eligibility": "reverse_runner_detached_durable_handoff",
+            "canonical_workload": {
+                "run_id": run_id,
+                "remote_workspace": remote_workspace,
+                "remote_command": remote_command,
+            },
+            "secret_env_names": secret_env_names,
+        }),
+    );
+    metadata.insert("phase".to_string(), json!("waiting_for_runner_capacity"));
+    metadata.insert(
+        "phase_activity".to_string(),
+        json!("durable broker submission intent recorded; waiting for runner capacity"),
+    );
+    store::write_record(&record)?;
+    Ok(record)
+}
+
 pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     let requested_run_id = sanitize_run_id(run_id);
     let resolved_run_id = resolve_run_id(run_id)?;
@@ -1896,6 +1936,11 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
     let accepted_at = record.updated_at.clone();
     let metadata = record.ensure_metadata_object();
     metadata.insert("kind".to_string(), json!("lab_offload_detached_handoff"));
+    if let Some(intent) = metadata.get_mut("runner_submission_intent") {
+        intent["state"] = json!("accepted");
+        intent["runner_job_id"] = json!(input.runner_job_id);
+        intent["accepted_at"] = json!(accepted_at);
+    }
     metadata.insert(
         "handoff_acceptance".to_string(),
         json!({

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -361,7 +361,7 @@ where
 
     let mut record = AgentTaskRunRecord {
         schema: schemas::RUN.to_string(),
-        run_id: run_id.clone(),
+        run_id,
         plan_id: plan.plan_id.clone(),
         state: AgentTaskRunState::Queued,
         submitted_at: now_timestamp(),
@@ -591,6 +591,9 @@ where
 }
 
 pub fn claim_next_queued_run() -> Result<Option<AgentTaskRunRecord>> {
+    // Interactive local `run-next` invocations can race across processes. Keep
+    // their selection and transition atomic without assigning them daemon ownership.
+    let _claim_lock = QueuedRunClaimLock::lock()?;
     let mut queued: Vec<AgentTaskRunRecord> = store::read_records()?
         .into_iter()
         .filter(|record| record.state == AgentTaskRunState::Queued && !is_transport_proxy(record))

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -669,7 +669,7 @@ pub fn record_lab_offload_submission_intent(
     let run_id = sanitize_run_id(run_id);
     let _lock = LabHandoffLock::lock(&run_id)?;
     let mut record = store::read_record(&run_id)?;
-    let submission_key = format!("agent-task:{run_id}");
+    let submission_key = format!("agent-task:{runner_id}:{run_id}");
     let metadata = record.ensure_metadata_object();
     metadata.insert(
         "runner_submission_intent".to_string(),

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -363,7 +363,7 @@ where
 
     let mut record = AgentTaskRunRecord {
         schema: schemas::RUN.to_string(),
-        run_id,
+        run_id: run_id.clone(),
         plan_id: plan.plan_id.clone(),
         state: AgentTaskRunState::Queued,
         submitted_at: now_timestamp(),

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::api_jobs::{RemoteRunnerJobRequest, RunnerJobLifecycleMetadata};
+use crate::secret_env_plan::SecretEnvPlan;
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 
@@ -699,6 +701,9 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     let resolved_run_id = resolve_run_id(run_id)?;
     let _ = reconcile_deferred_candidate(&resolved_run_id)?;
     let mut record = store::read_record(&resolved_run_id)?;
+    if reconcile_pending_runner_submission_intent(&resolved_run_id)? {
+        record = store::read_record(&resolved_run_id)?;
+    }
     if is_expired_unaccepted_lab_handoff(&record, chrono::Utc::now()) {
         let _ = expire_unaccepted_lab_handoff(&resolved_run_id)?;
         record = store::read_record(&resolved_run_id)?;
@@ -842,6 +847,7 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
 pub fn reconcile_active_lab_runner_handoffs() -> Result<usize> {
     let now = chrono::Utc::now();
     let mut accepted_run_ids = Vec::new();
+    let mut pending_intent_run_ids = Vec::new();
     let mut expired_run_ids = Vec::new();
     // Scan the stored snapshot so this operation owns and reports its expiry
     // mutations. `list_records` refreshes through `status`, which also expires
@@ -852,12 +858,19 @@ pub fn reconcile_active_lab_runner_handoffs() -> Result<usize> {
             && record.runner_job_id().is_some()
         {
             accepted_run_ids.push(record.run_id);
+        } else if has_pending_runner_submission_intent(&record) {
+            pending_intent_run_ids.push(record.run_id);
         } else if is_expired_unaccepted_lab_handoff(&record, now) {
             expired_run_ids.push(record.run_id);
         }
     }
 
     let mut reconciled = 0;
+    for run_id in pending_intent_run_ids {
+        if reconcile_pending_runner_submission_intent(&run_id)? {
+            reconciled += 1;
+        }
+    }
     for run_id in expired_run_ids {
         if expire_unaccepted_lab_handoff(&run_id)? {
             reconciled += 1;
@@ -872,6 +885,137 @@ pub fn reconcile_active_lab_runner_handoffs() -> Result<usize> {
         }
     }
     Ok(reconciled)
+}
+
+fn has_pending_runner_submission_intent(record: &AgentTaskRunRecord) -> bool {
+    record.runner_job_id().is_none()
+        && record
+            .metadata
+            .pointer("/runner_submission_intent/state")
+            .and_then(Value::as_str)
+            == Some("pending")
+}
+
+/// Replay an unacknowledged durable handoff. A broker that already accepted the
+/// original POST returns the same job for its submission key, so this covers
+/// both controller crash boundaries without retaining secret values.
+pub fn reconcile_pending_runner_submission_intent(run_id: &str) -> Result<bool> {
+    let run_id = sanitize_run_id(run_id);
+    let record = store::read_record(&run_id)?;
+    if !has_pending_runner_submission_intent(&record) {
+        return Ok(false);
+    }
+    let intent = record
+        .metadata
+        .get("runner_submission_intent")
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            Error::internal_unexpected("pending runner submission intent is malformed")
+        })?;
+    let string = |key: &str| {
+        intent
+            .get(key)
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string)
+    };
+    let runner_id = string("runner_id").ok_or_else(|| {
+        Error::internal_unexpected("pending runner submission intent has no runner id")
+    })?;
+    let submission_key = string("submission_key").ok_or_else(|| {
+        Error::internal_unexpected("pending runner submission intent has no submission key")
+    })?;
+    let workload = intent
+        .get("canonical_workload")
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            Error::internal_unexpected("pending runner submission intent has no canonical workload")
+        })?;
+    let cwd = workload
+        .get("remote_workspace")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            Error::internal_unexpected("pending runner submission intent has no remote workspace")
+        })?;
+    let command = workload
+        .get("remote_command")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            Error::internal_unexpected("pending runner submission intent has no remote command")
+        })?
+        .iter()
+        .map(|value| {
+            value.as_str().map(str::to_string).ok_or_else(|| {
+                Error::internal_unexpected(
+                    "pending runner submission intent has invalid remote command",
+                )
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let secret_env_names = intent
+        .get("secret_env_names")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let request = RemoteRunnerJobRequest {
+        runner_id: runner_id.clone(),
+        project_id: None,
+        operation: "runner.exec".to_string(),
+        command: command.clone(),
+        cwd: Some(cwd.clone()),
+        env: Default::default(),
+        secret_env_names: secret_env_names.clone(),
+        secret_env_plan: SecretEnvPlan::from_secret_env_names(secret_env_names),
+        env_materialization: None,
+        capture_patch: false,
+        source_snapshot: None,
+        path_materialization_plan: None,
+        require_paths: Vec::new(),
+        runner_workload: None,
+        lifecycle: Some(RunnerJobLifecycleMetadata {
+            source: Some("reverse-broker-reconciliation".to_string()),
+            kind: Some("agent-task".to_string()),
+            durable_run_id: Some(run_id.clone()),
+            active_child_count: None,
+            active_cell_count: None,
+        }),
+        metadata: Some(json!({
+            "submission_key": submission_key,
+            "durable_run_id": run_id,
+            "reconciled_from": "durable_detached_handoff_intent",
+        })),
+    };
+    match runner_continuation::with_runner_continuation(|provider| {
+        provider.submit_reverse_broker_job(&runner_id, request)
+    }) {
+        Ok(job) => {
+            record_detached_lab_run(DetachedLabRunRecord {
+                run_id: &run_id,
+                runner_id: &runner_id,
+                runner_job_id: &job.id.to_string(),
+                remote_workspace: &cwd,
+                remote_command: &command,
+            })?;
+            Ok(true)
+        }
+        Err(error) => {
+            let _ = store::mutate_record(&run_id, |record| {
+                let metadata = record.ensure_metadata_object();
+                metadata["runner_submission_intent"]["last_reconciliation_error"] = json!({
+                    "code": error.code.as_str(),
+                    "message": error.message,
+                    "retryable": true,
+                });
+                true
+            })?;
+            Ok(false)
+        }
+    }
 }
 
 fn is_expired_unaccepted_lab_handoff(

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -976,7 +976,7 @@ pub fn reconcile_pending_runner_submission_intent(run_id: &str) -> Result<bool> 
         source_snapshot: None,
         path_materialization_plan: None,
         require_paths: Vec::new(),
-        runner_workload: None,
+        lab_runner_workload: None,
         lifecycle: Some(RunnerJobLifecycleMetadata {
             source: Some("reverse-broker-reconciliation".to_string()),
             kind: Some("agent-task".to_string()),

--- a/crates/homeboy-core/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/runner_continuation.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Mutex;
 
-use crate::api_jobs::RunnerJobLogSnapshot;
+use crate::api_jobs::{Job, RemoteRunnerJobRequest, RunnerJobLogSnapshot};
 use crate::error::{Error, Result};
 
 /// Runner-side operations the agent-task lifecycle needs when reconciling or
@@ -41,6 +41,13 @@ pub trait RunnerContinuationProvider: Send + Sync {
         command: &[String],
         run_id: &str,
     ) -> Result<i32>;
+
+    /// Submit a replayable reverse-broker request during lifecycle reconciliation.
+    fn submit_reverse_broker_job(
+        &self,
+        runner_id: &str,
+        request: RemoteRunnerJobRequest,
+    ) -> Result<Job>;
 }
 
 /// Default provider used when the runner subsystem is not present. Behaves like
@@ -75,6 +82,16 @@ impl RunnerContinuationProvider for NoopProvider {
     ) -> Result<i32> {
         Err(Error::internal_unexpected(
             "runner subsystem is unavailable: cannot execute runner continuation",
+        ))
+    }
+
+    fn submit_reverse_broker_job(
+        &self,
+        _runner_id: &str,
+        _request: RemoteRunnerJobRequest,
+    ) -> Result<Job> {
+        Err(Error::internal_unexpected(
+            "runner subsystem is unavailable: cannot submit reverse broker job",
         ))
     }
 }

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -706,11 +706,17 @@ impl RunnerContinuationProvider for IntentReplayProvider {
         _runner_id: &str,
         _job_id: &str,
     ) -> Result<crate::api_jobs::RunnerJobLogSnapshot> {
-        Err(Error::internal_unexpected("not used by submission reconciliation"))
+        Err(Error::internal_unexpected(
+            "not used by submission reconciliation",
+        ))
     }
 
-    fn is_runner_connected(&self, _runner_id: &str) -> bool { true }
-    fn runner_exists(&self, _runner_id: &str) -> bool { true }
+    fn is_runner_connected(&self, _runner_id: &str) -> bool {
+        true
+    }
+    fn runner_exists(&self, _runner_id: &str) -> bool {
+        true
+    }
 
     fn run_continuation_exec(
         &self,
@@ -719,7 +725,9 @@ impl RunnerContinuationProvider for IntentReplayProvider {
         _command: &[String],
         _run_id: &str,
     ) -> Result<i32> {
-        Err(Error::internal_unexpected("not used by submission reconciliation"))
+        Err(Error::internal_unexpected(
+            "not used by submission reconciliation",
+        ))
     }
 
     fn submit_reverse_broker_job(
@@ -731,7 +739,9 @@ impl RunnerContinuationProvider for IntentReplayProvider {
         self.submitted.lock().expect("submission log").push(job.id);
         let mut fail = self.fail_after_accept_once.lock().expect("fault flag");
         if std::mem::take(&mut *fail) {
-            return Err(Error::internal_unexpected("injected post-accept pre-ack crash"));
+            return Err(Error::internal_unexpected(
+                "injected post-accept pre-ack crash",
+            ));
         }
         Ok(job)
     }
@@ -748,37 +758,56 @@ fn detached_cook_intent_reconciliation_converges_both_crash_windows_without_secr
             submitted: Arc::clone(&submitted),
             fail_after_accept_once: Arc::clone(&fail_after_accept_once),
         }));
-        let command = vec!["homeboy".to_string(), "agent-task".to_string(), "cook".to_string()];
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
 
-        for (run_id, post_accept_fault) in [("fault-after-intent", false), ("fault-after-post", true)] {
+        for (run_id, post_accept_fault) in
+            [("fault-after-intent", false), ("fault-after-post", true)]
+        {
             record_lab_offload_planned(LabOffloadProxyPlan {
                 run_id,
                 runner_id: "homeboy-lab",
                 remote_workspace: "/runner/workspace/homeboy",
                 remote_command: &command,
                 durable_plan: None,
-            }).expect("record Lab admission");
+            })
+            .expect("record Lab admission");
             record_lab_offload_submission_intent(
                 run_id,
                 "homeboy-lab",
                 "/runner/workspace/homeboy",
                 &command,
                 &["HOMEBOY_TEST_REVERSE_SECRET".to_string()],
-            ).expect("persist redacted pre-submit intent");
+            )
+            .expect("persist redacted pre-submit intent");
 
             if post_accept_fault {
                 *fail_after_accept_once.lock().expect("fault flag") = true;
-                assert!(!reconcile_pending_runner_submission_intent(run_id).expect("fault is retained"));
+                assert!(
+                    !reconcile_pending_runner_submission_intent(run_id).expect("fault is retained")
+                );
             }
             assert!(reconcile_pending_runner_submission_intent(run_id).expect("replay intent"));
             assert!(!reconcile_pending_runner_submission_intent(run_id).expect("duplicate wake"));
             let record = status(run_id).expect("accepted lifecycle");
-            assert_eq!(record.metadata["runner_submission_intent"]["state"], "accepted");
-            assert!(!serde_json::to_string(&record).expect("record JSON").contains("secret-value"));
+            assert_eq!(
+                record.metadata["runner_submission_intent"]["state"],
+                "accepted"
+            );
+            assert!(!serde_json::to_string(&record)
+                .expect("record JSON")
+                .contains("secret-value"));
         }
 
         let submitted = submitted.lock().expect("submission log");
-        assert_eq!(submitted.len(), 3, "post-accept replay reuses the broker submission key");
+        assert_eq!(
+            submitted.len(),
+            3,
+            "post-accept replay reuses the broker submission key"
+        );
         assert_eq!(submitted[1], submitted[2]);
         let persisted = serde_json::to_string(&store.get(submitted[0]).expect("broker job"))
             .expect("broker JSON");

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -635,6 +635,64 @@ fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
 }
 
 #[test]
+fn detached_handoff_persists_redacted_submission_intent_before_broker_ack() {
+    with_isolated_home(|_| {
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+        record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "intent-before-post",
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+            durable_plan: None,
+        })
+        .expect("controller proxy");
+        record_lab_offload_submission_intent(
+            "intent-before-post",
+            "homeboy-lab",
+            "/runner/workspace/repo",
+            &command,
+            &["RUNNER_SECRET_TOKEN".to_string()],
+        )
+        .expect("persist intent");
+
+        let pending = status("intent-before-post").expect("pending intent status");
+        assert_eq!(
+            pending.metadata["runner_submission_intent"]["state"],
+            "pending"
+        );
+        assert_eq!(
+            pending.metadata["runner_submission_intent"]["submission_key"],
+            "agent-task:intent-before-post"
+        );
+        assert_eq!(pending.metadata["phase"], "waiting_for_runner_capacity");
+        assert!(!serde_json::to_string(&pending)
+            .expect("serialize record")
+            .contains("secret-value"));
+
+        let accepted = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "intent-before-post",
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-replayed",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("ack binds intent");
+        assert_eq!(
+            accepted.metadata["runner_submission_intent"]["state"],
+            "accepted"
+        );
+        assert_eq!(
+            accepted.metadata["runner_submission_intent"]["runner_job_id"],
+            "job-replayed"
+        );
+    });
+}
+
+#[test]
 fn status_expires_an_unaccepted_handoff_but_late_runner_acceptance_wins() {
     with_isolated_home(|_| {
         let command = vec![

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -12,9 +12,10 @@ use crate::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
     AGENT_TASK_AGGREGATE_SCHEMA,
 };
-use crate::api_jobs::{JobEvent, JobEventKind};
+use crate::api_jobs::{Job, JobEvent, JobEventKind, JobStore, RemoteRunnerJobRequest};
 use crate::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};
+use std::sync::{Arc, Mutex};
 
 #[cfg(unix)]
 fn fake_controller_artifact(path: &std::path::Path, identity: &str, marker: &str) -> String {
@@ -689,6 +690,99 @@ fn detached_handoff_persists_redacted_submission_intent_before_broker_ack() {
             accepted.metadata["runner_submission_intent"]["runner_job_id"],
             "job-replayed"
         );
+    });
+}
+
+#[derive(Clone)]
+struct IntentReplayProvider {
+    store: JobStore,
+    submitted: Arc<Mutex<Vec<uuid::Uuid>>>,
+    fail_after_accept_once: Arc<Mutex<bool>>,
+}
+
+impl RunnerContinuationProvider for IntentReplayProvider {
+    fn runner_job_log_snapshot(
+        &self,
+        _runner_id: &str,
+        _job_id: &str,
+    ) -> Result<crate::api_jobs::RunnerJobLogSnapshot> {
+        Err(Error::internal_unexpected("not used by submission reconciliation"))
+    }
+
+    fn is_runner_connected(&self, _runner_id: &str) -> bool { true }
+    fn runner_exists(&self, _runner_id: &str) -> bool { true }
+
+    fn run_continuation_exec(
+        &self,
+        _runner_id: &str,
+        _cwd: &str,
+        _command: &[String],
+        _run_id: &str,
+    ) -> Result<i32> {
+        Err(Error::internal_unexpected("not used by submission reconciliation"))
+    }
+
+    fn submit_reverse_broker_job(
+        &self,
+        _runner_id: &str,
+        request: RemoteRunnerJobRequest,
+    ) -> Result<Job> {
+        let job = self.store.submit_remote_runner_job(request)?;
+        self.submitted.lock().expect("submission log").push(job.id);
+        let mut fail = self.fail_after_accept_once.lock().expect("fault flag");
+        if std::mem::take(&mut *fail) {
+            return Err(Error::internal_unexpected("injected post-accept pre-ack crash"));
+        }
+        Ok(job)
+    }
+}
+
+#[test]
+fn detached_cook_intent_reconciliation_converges_both_crash_windows_without_secret_leakage() {
+    with_isolated_home(|_| {
+        let store = JobStore::default();
+        let submitted = Arc::new(Mutex::new(Vec::new()));
+        let fail_after_accept_once = Arc::new(Mutex::new(false));
+        register_runner_continuation_provider(Box::new(IntentReplayProvider {
+            store: store.clone(),
+            submitted: Arc::clone(&submitted),
+            fail_after_accept_once: Arc::clone(&fail_after_accept_once),
+        }));
+        let command = vec!["homeboy".to_string(), "agent-task".to_string(), "cook".to_string()];
+
+        for (run_id, post_accept_fault) in [("fault-after-intent", false), ("fault-after-post", true)] {
+            record_lab_offload_planned(LabOffloadProxyPlan {
+                run_id,
+                runner_id: "homeboy-lab",
+                remote_workspace: "/runner/workspace/homeboy",
+                remote_command: &command,
+                durable_plan: None,
+            }).expect("record Lab admission");
+            record_lab_offload_submission_intent(
+                run_id,
+                "homeboy-lab",
+                "/runner/workspace/homeboy",
+                &command,
+                &["HOMEBOY_TEST_REVERSE_SECRET".to_string()],
+            ).expect("persist redacted pre-submit intent");
+
+            if post_accept_fault {
+                *fail_after_accept_once.lock().expect("fault flag") = true;
+                assert!(!reconcile_pending_runner_submission_intent(run_id).expect("fault is retained"));
+            }
+            assert!(reconcile_pending_runner_submission_intent(run_id).expect("replay intent"));
+            assert!(!reconcile_pending_runner_submission_intent(run_id).expect("duplicate wake"));
+            let record = status(run_id).expect("accepted lifecycle");
+            assert_eq!(record.metadata["runner_submission_intent"]["state"], "accepted");
+            assert!(!serde_json::to_string(&record).expect("record JSON").contains("secret-value"));
+        }
+
+        let submitted = submitted.lock().expect("submission log");
+        assert_eq!(submitted.len(), 3, "post-accept replay reuses the broker submission key");
+        assert_eq!(submitted[1], submitted[2]);
+        let persisted = serde_json::to_string(&store.get(submitted[0]).expect("broker job"))
+            .expect("broker JSON");
+        assert!(!persisted.contains("secret-value"));
     });
 }
 

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -667,7 +667,7 @@ fn detached_handoff_persists_redacted_submission_intent_before_broker_ack() {
         );
         assert_eq!(
             pending.metadata["runner_submission_intent"]["submission_key"],
-            "agent-task:intent-before-post"
+            "agent-task:homeboy-lab:intent-before-post"
         );
         assert_eq!(pending.metadata["phase"], "waiting_for_runner_capacity");
         assert!(!serde_json::to_string(&pending)

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -719,21 +719,13 @@ fn detached_cook_attempt_proxy_advances_after_daemon_acceptance() {
         assert_eq!(accepted.run_id, attempt_run_id);
         assert_eq!(accepted.state, AgentTaskRunState::Running);
         assert_eq!(accepted.metadata["runner_job_id"], "job-7970");
-        assert_eq!(accepted.metadata["phase"], "waiting_for_capacity");
+        assert_eq!(accepted.metadata["phase"], "awaiting_runner_result");
         assert_eq!(
             accepted.metadata["phase_activity"],
-            "runner owns this FIFO queue entry; awaiting a capacity lease"
+            "controller handoff complete; awaiting authoritative runner daemon result"
         );
-        assert_eq!(accepted.metadata["runner_handoff"]["state"], "queued");
-        assert_eq!(
-            accepted.metadata["runner_queue"],
-            json!({
-                "owner_runner_id": "homeboy-lab",
-                "ordering": "fifo",
-                "dispatch_eligibility": "runner_capacity_lease",
-                "state": "waiting_for_capacity",
-            })
-        );
+        assert_eq!(accepted.metadata["runner_handoff"]["state"], "in_flight");
+        assert!(accepted.metadata.get("runner_queue").is_none());
         assert_eq!(
             accepted.metadata["runner_handoff"]["continuation"]["intent"],
             "reconcile_runner_job"

--- a/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/tests.rs
@@ -719,12 +719,21 @@ fn detached_cook_attempt_proxy_advances_after_daemon_acceptance() {
         assert_eq!(accepted.run_id, attempt_run_id);
         assert_eq!(accepted.state, AgentTaskRunState::Running);
         assert_eq!(accepted.metadata["runner_job_id"], "job-7970");
-        assert_eq!(accepted.metadata["phase"], "awaiting_runner_result");
+        assert_eq!(accepted.metadata["phase"], "waiting_for_capacity");
         assert_eq!(
             accepted.metadata["phase_activity"],
-            "controller handoff complete; awaiting authoritative runner daemon result"
+            "runner owns this FIFO queue entry; awaiting a capacity lease"
         );
-        assert_eq!(accepted.metadata["runner_handoff"]["state"], "in_flight");
+        assert_eq!(accepted.metadata["runner_handoff"]["state"], "queued");
+        assert_eq!(
+            accepted.metadata["runner_queue"],
+            json!({
+                "owner_runner_id": "homeboy-lab",
+                "ordering": "fifo",
+                "dispatch_eligibility": "runner_capacity_lease",
+                "state": "waiting_for_capacity",
+            })
+        );
         assert_eq!(
             accepted.metadata["runner_handoff"]["continuation"]["intent"],
             "reconcile_runner_job"
@@ -1342,6 +1351,45 @@ fn reachable_running_child_clears_disconnected_liveness_and_refreshes_heartbeat(
         assert!(record.metadata.get("stale_running_reason").is_none());
         assert!(record.metadata.get("retryable").is_none());
         assert_ne!(record.lifecycle.heartbeat, disconnected_heartbeat);
+    });
+}
+
+#[test]
+fn queued_runner_child_reports_fifo_capacity_ownership_before_its_claim() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-queued-capacity",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("queued proxy");
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        snapshot.job.status = crate::api_jobs::JobStatus::Queued;
+        snapshot.job.target_runner_id = Some("homeboy-lab".to_string());
+        snapshot.events.clear();
+
+        reconcile_runner_job_snapshot(&mut record, &snapshot).expect("queued reconciliation");
+
+        assert_eq!(record.state, AgentTaskRunState::Running);
+        assert_eq!(record.metadata["phase"], "waiting_for_capacity");
+        assert_eq!(record.metadata["provider_state"], "queued");
+        assert_eq!(
+            record.metadata["runner_queue"],
+            json!({
+                "owner_runner_id": "homeboy-lab",
+                "ordering": "fifo",
+                "dispatch_eligibility": "runner_capacity_lease",
+                "state": "waiting_for_capacity",
+            })
+        );
+
+        snapshot.job.status = crate::api_jobs::JobStatus::Running;
+        reconcile_runner_job_snapshot(&mut record, &snapshot).expect("claim reconciliation");
+        assert_eq!(record.metadata["phase"], "executing");
+        assert_eq!(record.metadata["runner_queue"]["state"], "claimed");
     });
 }
 

--- a/crates/homeboy-core/src/api_jobs/persistence.rs
+++ b/crates/homeboy-core/src/api_jobs/persistence.rs
@@ -282,19 +282,11 @@ fn last_known_child_event(event: &JobEvent) -> Value {
 }
 
 fn remote_runner_job_has_unrecoverable_execution_env(stored: &StoredJob) -> bool {
-    let Some(remote_runner) = stored.remote_runner.as_ref() else {
-        return false;
-    };
-    if remote_runner.execution_request.is_some() {
-        return false;
-    }
-    remote_runner.request.secret_env_names.iter().any(|name| {
-        remote_runner
-            .request
-            .env
-            .get(name)
-            .is_some_and(|value| value == "<redacted>")
-    })
+    // Remote runner jobs persist named references rather than execution values.
+    // A restart keeps queued work replayable; dispatch hydrates each name on the
+    // runner and fails closed there if the reference can no longer resolve.
+    let _ = stored;
+    false
 }
 
 /// Recover a terminal job status from a recorded `Result` event when a job was

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -430,6 +430,7 @@ impl JobStore {
         }
         request.validate_command_assets()?;
         let secret_env_plan = request.normalize();
+        reject_inline_durable_secret_env(&request, &secret_env_plan)?;
         super::with_runner_job_preparation(|p| {
             p.validate_lab_runner_workload_dispatch(
                 request.lab_runner_workload.as_ref(),
@@ -823,6 +824,34 @@ impl JobStore {
 
         Ok(())
     }
+}
+
+fn reject_inline_durable_secret_env(
+    request: &RemoteRunnerJobRequest,
+    secret_env_plan: &SecretEnvPlan,
+) -> Result<()> {
+    let inline_secret_names = secret_env_plan
+        .secret_env_names()
+        .into_iter()
+        .filter(|name| {
+            request
+                .env
+                .get(name)
+                .is_some_and(|value| !value.is_empty() && value != "<redacted>")
+        })
+        .collect::<Vec<_>>();
+    if inline_secret_names.is_empty() {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "env",
+        "durable reverse-runner jobs cannot accept inline secret env values",
+        Some("durable_reverse_runner_inline_secret_env".to_string()),
+        Some(vec![
+            format!("Inline secret variables: {}", inline_secret_names.join(", ")),
+            "Configure named runner secret_env or SecretEnvPlan references so the worker can rehydrate secrets after replay.".to_string(),
+        ]),
+    ))
 }
 
 fn default_runner_exec_operation() -> String {

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -19,6 +19,12 @@ use crate::secret_env_plan::SecretEnvPlan;
 use crate::source_snapshot::SourceSnapshot;
 use homeboy_lab_runner_contract::{RunnerMutationArtifacts, RunnerResourceMetrics};
 
+/// Broker metadata is durable queue input. Keep command-file payloads bounded
+/// before they can be persisted or decoded by a worker.
+const MAX_COMMAND_ASSET_COUNT: usize = 16;
+const MAX_COMMAND_ASSET_BASE64_BYTES: usize = 1_400_000;
+const MAX_COMMAND_ASSETS_BASE64_BYTES: usize = 4_200_000;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct JobArtifactMetadata {
     pub id: String,
@@ -233,6 +239,58 @@ impl RemoteRunnerJobRequest {
         public
     }
 
+    fn validate_command_assets(&self) -> Result<()> {
+        let Some(assets) = self
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("command_assets"))
+            .and_then(|assets| assets.get("assets"))
+            .and_then(Value::as_array)
+        else {
+            return Ok(());
+        };
+        if assets.len() > MAX_COMMAND_ASSET_COUNT {
+            return Err(Error::validation_invalid_argument(
+                "metadata.command_assets",
+                "remote runner job has too many command assets",
+                None,
+                None,
+            ));
+        }
+        let mut total = 0usize;
+        for asset in assets {
+            let encoded = asset
+                .get("content_base64")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "metadata.command_assets",
+                        "remote runner command asset is missing base64 content",
+                        None,
+                        None,
+                    )
+                })?;
+            if encoded.len() > MAX_COMMAND_ASSET_BASE64_BYTES {
+                return Err(Error::validation_invalid_argument(
+                    "metadata.command_assets",
+                    "remote runner command asset exceeds the size limit",
+                    None,
+                    None,
+                ));
+            }
+            total = total.saturating_add(encoded.len());
+        }
+        if total > MAX_COMMAND_ASSETS_BASE64_BYTES {
+            return Err(Error::validation_invalid_argument(
+                "metadata.command_assets",
+                "remote runner command assets exceed the aggregate size limit",
+                None,
+                None,
+            ));
+        }
+        Ok(())
+    }
+
     fn dispatch_request(&self) -> Self {
         let mut request = self.clone();
         let secret_names = request.secret_env_plan.secret_env_names();
@@ -370,6 +428,7 @@ impl JobStore {
                 None,
             ));
         }
+        request.validate_command_assets()?;
         let secret_env_plan = request.normalize();
         super::with_runner_job_preparation(|p| {
             p.validate_lab_runner_workload_dispatch(
@@ -393,6 +452,7 @@ impl JobStore {
                     .as_ref()
                     .and_then(|remote| remote.request.submission_key())
                     == Some(submission_key)
+                    && stored.job.target_runner_id.as_deref() == Some(request.runner_id.as_str())
             }) {
                 return Ok(existing.job.clone());
             }

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -93,6 +93,18 @@ pub struct RemoteRunnerJobRequest {
 }
 
 impl RemoteRunnerJobRequest {
+    /// A caller-owned identity makes a retried POST safe across a lost response.
+    /// It deliberately lives in metadata so older clients can continue submitting
+    /// anonymous jobs while durable handoffs opt into replayable ownership.
+    pub(crate) fn submission_key(&self) -> Option<&str> {
+        self.metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("submission_key"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|key| !key.is_empty())
+    }
+
     pub(crate) fn normalize(&mut self) -> SecretEnvPlan {
         let mut base_plan = self
             .lab_runner_workload
@@ -219,6 +231,21 @@ impl RemoteRunnerJobRequest {
             }
         }
         public
+    }
+
+    fn dispatch_request(&self) -> Self {
+        let mut request = self.clone();
+        let secret_names = request.secret_env_plan.secret_env_names();
+        for name in secret_names {
+            if request
+                .env
+                .get(&name)
+                .is_some_and(|value| value == "<redacted>")
+            {
+                request.env.remove(&name);
+            }
+        }
+        request
     }
 
     pub(crate) fn run_ref_metadata(&self) -> Option<Value> {
@@ -356,6 +383,20 @@ impl JobStore {
         })?;
 
         let now = timestamp_ms();
+        let public_request = request.public_metadata();
+        let submission_key = request.submission_key().map(str::to_string);
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        if let Some(submission_key) = submission_key.as_deref() {
+            if let Some(existing) = inner.jobs.values().find(|stored| {
+                stored
+                    .remote_runner
+                    .as_ref()
+                    .and_then(|remote| remote.request.submission_key())
+                    == Some(submission_key)
+            }) {
+                return Ok(existing.job.clone());
+            }
+        }
         let job = Job {
             id: Uuid::new_v4(),
             operation: request.operation.clone(),
@@ -379,16 +420,17 @@ impl JobStore {
             runner_job_projection: None,
         };
 
-        let public_request = request.public_metadata();
         let run_ref_metadata = public_request.run_ref_metadata();
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
         inner.jobs.insert(
             job.id,
             StoredJob {
                 job: job.clone(),
                 events: Vec::new(),
                 remote_runner: Some(StoredRemoteRunnerJob {
-                    execution_request: Some(request),
+                    // Durable broker state intentionally contains only the
+                    // redacted request. The runner hydrates named references
+                    // immediately before dispatch.
+                    execution_request: None,
                     request: public_request,
                 }),
                 local_runner: None,
@@ -486,7 +528,7 @@ impl JobStore {
                     .execution_request
                     .as_ref()
                     .unwrap_or(&remote_runner.request)
-                    .clone();
+                    .dispatch_request();
                 claimed = Some((stored.job.id, request));
             }
         }

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -823,15 +823,7 @@ fn remote_runner_job_secret_env_is_execution_only_not_public_or_persisted() {
             remote_runner.request.env.get("RUNNER_SECRET_TOKEN"),
             Some(&"<redacted>".to_string())
         );
-        assert_eq!(
-            remote_runner
-                .execution_request
-                .as_ref()
-                .expect("execution request")
-                .env
-                .get("RUNNER_SECRET_TOKEN"),
-            Some(&sentinel.to_string())
-        );
+        assert!(remote_runner.execution_request.is_none());
     }
 
     let persisted = fs::read_to_string(&path).expect("read durable store");
@@ -844,21 +836,58 @@ fn remote_runner_job_secret_env_is_execution_only_not_public_or_persisted() {
     let reopened = JobStore::open(&path).expect("durable store reopens");
     assert_eq!(
         reopened.get(job.id).expect("reopened job").status,
-        JobStatus::Failed
+        JobStatus::Queued
     );
-    assert!(reopened
-        .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
-        .expect("claim request succeeds")
-        .is_none());
-
-    let claim = store
+    let claim = reopened
         .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
         .expect("claim succeeds")
         .expect("job is claimed");
-    assert_eq!(
-        claim.request.env.get("RUNNER_SECRET_TOKEN"),
-        Some(&sentinel.to_string())
+    assert!(claim.request.env.get("RUNNER_SECRET_TOKEN").is_none());
+    assert!(claim
+        .request
+        .secret_env_plan
+        .secret_env_names()
+        .contains(&"RUNNER_SECRET_TOKEN".to_string()));
+}
+
+#[test]
+fn remote_runner_submission_key_replays_one_redacted_durable_job() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open(&path).expect("durable store");
+    let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
+    request.env.insert(
+        "RUNNER_SECRET_TOKEN".to_string(),
+        "never-persist".to_string(),
     );
+    request.secret_env_names = vec!["RUNNER_SECRET_TOKEN".to_string()];
+    request.metadata = Some(json!({ "submission_key": "agent-task:crash-window" }));
+
+    // Models POST-before-ack-persist: the recovery POST carries the same key.
+    let first = store
+        .submit_remote_runner_job(request.clone())
+        .expect("first submit");
+    let replay = store
+        .submit_remote_runner_job(request)
+        .expect("replayed submit");
+    assert_eq!(first.id, replay.id);
+    assert_eq!(
+        store
+            .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, Some(1))
+            .expect("claim")
+            .expect("one claim")
+            .job
+            .id,
+        first.id
+    );
+    assert!(store
+        .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, Some(1))
+        .expect("duplicate wake")
+        .is_none());
+
+    let persisted = fs::read_to_string(path).expect("read durable store");
+    assert!(!persisted.contains("never-persist"));
+    assert!(persisted.contains("RUNNER_SECRET_TOKEN"));
 }
 
 #[test]

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -797,57 +797,48 @@ fn remote_runner_job_submit_targets_runner_and_project() {
 }
 
 #[test]
-fn remote_runner_job_secret_env_is_execution_only_not_public_or_persisted() {
+fn remote_runner_job_rejects_inline_secret_env_before_durable_persistence() {
     let temp = tempfile::tempdir().expect("temp dir");
     let path = temp.path().join("jobs.json");
     let store = JobStore::open(&path).expect("durable store opens");
-    let sentinel = "homeboy-secret-sentinel-do-not-persist";
     let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
-    request
-        .env
-        .insert("RUNNER_SECRET_TOKEN".to_string(), sentinel.to_string());
+    request.env.insert(
+        "RUNNER_SECRET_TOKEN".to_string(),
+        "inline-secret".to_string(),
+    );
     request
         .env
         .insert("PUBLIC_FLAG".to_string(), "1".to_string());
     request.secret_env_names = vec!["RUNNER_SECRET_TOKEN".to_string()];
 
-    let job = store
+    let error = store
         .submit_remote_runner_job(request)
-        .expect("remote runner job queues");
+        .expect_err("inline secret must be rejected before durable persistence");
 
-    {
-        let inner = store.inner.lock().expect("job store mutex poisoned");
-        let stored = inner.jobs.get(&job.id).expect("job stored");
-        let remote_runner = stored.remote_runner.as_ref().expect("remote runner job");
-        assert_eq!(
-            remote_runner.request.env.get("RUNNER_SECRET_TOKEN"),
-            Some(&"<redacted>".to_string())
-        );
-        assert!(remote_runner.execution_request.is_none());
-    }
-
-    let persisted = fs::read_to_string(&path).expect("read durable store");
-    assert!(
-        !persisted.contains(sentinel),
-        "persisted store leaked secret"
-    );
-    assert!(persisted.contains("<redacted>"));
-
-    let reopened = JobStore::open(&path).expect("durable store reopens");
+    assert_eq!(error.code, crate::ErrorCode::ValidationInvalidArgument);
     assert_eq!(
-        reopened.get(job.id).expect("reopened job").status,
-        JobStatus::Queued
+        error.details["id"],
+        serde_json::json!("durable_reverse_runner_inline_secret_env")
     );
-    let claim = reopened
-        .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
-        .expect("claim succeeds")
-        .expect("job is claimed");
-    assert!(claim.request.env.get("RUNNER_SECRET_TOKEN").is_none());
-    assert!(claim
-        .request
-        .secret_env_plan
-        .secret_env_names()
-        .contains(&"RUNNER_SECRET_TOKEN".to_string()));
+    assert!(error
+        .message
+        .contains("cannot accept inline secret env values"));
+    assert!(error.details["tried"]
+        .as_array()
+        .expect("actionable alternatives")
+        .iter()
+        .any(|value| value
+            .as_str()
+            .is_some_and(|value| value.contains("runner secret_env"))));
+    assert!(
+        store
+            .inner
+            .lock()
+            .expect("job store mutex poisoned")
+            .jobs
+            .is_empty(),
+        "rejected inline secret must not create a durable job"
+    );
 }
 
 #[test]
@@ -856,10 +847,6 @@ fn remote_runner_submission_key_replays_one_redacted_durable_job() {
     let path = temp.path().join("jobs.json");
     let store = JobStore::open(&path).expect("durable store");
     let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
-    request.env.insert(
-        "RUNNER_SECRET_TOKEN".to_string(),
-        "never-persist".to_string(),
-    );
     request.secret_env_names = vec!["RUNNER_SECRET_TOKEN".to_string()];
     request.metadata = Some(json!({ "submission_key": "agent-task:crash-window" }));
 

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -1,9 +1,13 @@
 use std::fs;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
 use tempfile::TempDir;
+
+use crate::api_jobs::{Job, JobEventKind, JobStore, RemoteRunnerJobRequest, RemoteRunnerJobResult};
 
 static SHARED_EMPTY_GIT_REPO_TEMPLATE: OnceLock<TempDir> = OnceLock::new();
 static SHARED_COMMITTED_GIT_REPO_TEMPLATE: OnceLock<TempDir> = OnceLock::new();
@@ -712,4 +716,202 @@ pub fn serve_public_artifact_base_once(status: u16) -> String {
         .expect("write public artifact response");
     });
     format!("http://{addr}/homeboy")
+}
+
+/// A minimal in-process implementation of Homeboy's public reverse-broker HTTP
+/// contract. It is intentionally owned by core test support so binary tests and
+/// runner tests exercise the same persisted broker behavior.
+pub struct ReverseBrokerFixture {
+    pub store: JobStore,
+    runner_id: String,
+    broker_url: String,
+    shutdown: Arc<std::sync::atomic::AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl ReverseBrokerFixture {
+    pub fn start(runner_id: impl Into<String>) -> Self {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let runner_id = runner_id.into();
+        let store = JobStore::default();
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind reverse broker fixture");
+        listener
+            .set_nonblocking(true)
+            .expect("make reverse broker fixture nonblocking");
+        let broker_url = format!("http://{}", listener.local_addr().expect("broker address"));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let thread_shutdown = Arc::clone(&shutdown);
+        let thread_store = store.clone();
+        let thread_runner_id = runner_id.clone();
+        let handle = std::thread::spawn(move || {
+            while !thread_shutdown.load(Ordering::SeqCst) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        stream
+                            .set_nonblocking(false)
+                            .expect("make reverse broker fixture stream blocking");
+                        let request = read_broker_request(&mut stream);
+                        let response = handle_reverse_broker_request(
+                            &thread_store,
+                            &thread_runner_id,
+                            request,
+                        );
+                        write_broker_response(&mut stream, response);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(1));
+                    }
+                    Err(error) => panic!("accept reverse broker fixture request: {error}"),
+                }
+            }
+        });
+        Self {
+            store,
+            runner_id,
+            broker_url,
+            shutdown,
+            handle: Some(handle),
+        }
+    }
+
+    pub fn url(&self) -> &str {
+        &self.broker_url
+    }
+
+    pub fn runner_id(&self) -> &str {
+        &self.runner_id
+    }
+
+    pub fn enqueue(&self, request: RemoteRunnerJobRequest) -> Job {
+        self.store
+            .submit_remote_runner_job(request)
+            .expect("enqueue reverse broker fixture job")
+    }
+
+    pub fn jobs(&self) -> Vec<Job> {
+        self.store.list()
+    }
+}
+
+impl Drop for ReverseBrokerFixture {
+    fn drop(&mut self) {
+        use std::sync::atomic::Ordering;
+
+        self.shutdown.store(true, Ordering::SeqCst);
+        // Wake the nonblocking accept loop before joining it.
+        let _ = TcpStream::connect(self.broker_url.trim_start_matches("http://"));
+        if let Some(handle) = self.handle.take() {
+            handle.join().expect("reverse broker fixture joins");
+        }
+    }
+}
+
+struct ReverseBrokerRequest {
+    method: String,
+    path: String,
+    body: serde_json::Value,
+}
+
+fn read_broker_request(stream: &mut TcpStream) -> ReverseBrokerRequest {
+    let mut buffer = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    let header_end = loop {
+        let read = stream.read(&mut chunk).expect("read broker request");
+        assert_ne!(read, 0, "broker request closed before headers");
+        buffer.extend_from_slice(&chunk[..read]);
+        if let Some(index) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
+            break index;
+        }
+    };
+    let headers = String::from_utf8_lossy(&buffer[..header_end]);
+    let mut request_line = headers.lines().next().expect("broker request line").split_whitespace();
+    let method = request_line.next().expect("broker request method").to_string();
+    let path = request_line.next().expect("broker request path").to_string();
+    let content_length = headers
+        .lines()
+        .find_map(|line| line.split_once(':').filter(|(name, _)| name.eq_ignore_ascii_case("content-length")).and_then(|(_, value)| value.trim().parse::<usize>().ok()))
+        .unwrap_or(0);
+    let body_start = header_end + 4;
+    while buffer.len() < body_start + content_length {
+        let read = stream.read(&mut chunk).expect("read broker request body");
+        assert_ne!(read, 0, "broker request closed before body");
+        buffer.extend_from_slice(&chunk[..read]);
+    }
+    let body = if content_length == 0 {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&buffer[body_start..body_start + content_length])
+            .expect("parse broker request JSON")
+    };
+    ReverseBrokerRequest { method, path, body }
+}
+
+fn handle_reverse_broker_request(
+    store: &JobStore,
+    runner_id: &str,
+    request: ReverseBrokerRequest,
+) -> serde_json::Value {
+    use serde_json::json;
+
+    let ok = |body| json!({ "success": true, "data": { "body": body } });
+    if request.method == "POST" && request.path == "/runner/sessions" {
+        return ok(json!({ "registered": true }));
+    }
+    if request.method == "POST" && request.path == "/runner/jobs" {
+        let submitted: RemoteRunnerJobRequest = serde_json::from_value(request.body)
+            .expect("parse reverse broker job submission");
+        let job = store.submit_remote_runner_job(submitted).expect("submit broker job");
+        return ok(json!({ "job": job }));
+    }
+    if request.method == "POST" && request.path == "/runner/jobs/claim" {
+        let claim = store
+            .claim_remote_runner_job(runner_id, None, 30_000, None)
+            .expect("claim broker job");
+        return ok(json!({ "claim": claim }));
+    }
+    if request.method == "GET" {
+        if let Some(job_id) = request.path.strip_prefix("/jobs/") {
+            let job = store.get(uuid::Uuid::parse_str(job_id).expect("broker job id")).expect("broker job");
+            return ok(json!({ "job": job }));
+        }
+    }
+    if let Some(job_id) = request.path.strip_prefix("/runner/jobs/") {
+        let (job_id, action) = job_id.split_once('/').unwrap_or((job_id, ""));
+        let job_id = uuid::Uuid::parse_str(job_id).expect("broker job id");
+        if request.method == "GET" && action.is_empty() {
+            return ok(json!({ "job": store.get(job_id).expect("broker job") }));
+        }
+        let claim_id = request.body["claim_id"].as_str().expect("broker claim id");
+        let result = match action {
+            "events" => store.append_remote_runner_event(
+                job_id, runner_id, claim_id, JobEventKind::Progress,
+                request.body["message"].as_str().map(ToString::to_string),
+                request.body.get("data").cloned(),
+            ).map(|event| json!({ "event": event })),
+            "heartbeat" => store.renew_remote_runner_claim(job_id, runner_id, claim_id, 30_000)
+                .map(|job| json!({ "job": job })),
+            "finish" => store.finish_remote_runner_job(
+                job_id, runner_id, claim_id,
+                serde_json::from_value::<RemoteRunnerJobResult>(request.body["result"].clone())
+                    .expect("parse broker finish result"),
+            ).map(|job| json!({ "job": job })),
+            _ => Err(crate::error::Error::internal_unexpected("unknown reverse broker fixture path")),
+        };
+        return match result {
+            Ok(body) => ok(body),
+            Err(error) => json!({ "success": false, "error": { "message": error.message } }),
+        };
+    }
+    json!({ "success": false, "error": { "message": "unknown reverse broker fixture path" } })
+}
+
+fn write_broker_response(stream: &mut TcpStream, body: serde_json::Value) {
+    let body = body.to_string();
+    write!(
+        stream,
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(), body
+    )
+    .expect("write broker response");
 }

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -825,12 +825,26 @@ fn read_broker_request(stream: &mut TcpStream) -> ReverseBrokerRequest {
         }
     };
     let headers = String::from_utf8_lossy(&buffer[..header_end]);
-    let mut request_line = headers.lines().next().expect("broker request line").split_whitespace();
-    let method = request_line.next().expect("broker request method").to_string();
-    let path = request_line.next().expect("broker request path").to_string();
+    let mut request_line = headers
+        .lines()
+        .next()
+        .expect("broker request line")
+        .split_whitespace();
+    let method = request_line
+        .next()
+        .expect("broker request method")
+        .to_string();
+    let path = request_line
+        .next()
+        .expect("broker request path")
+        .to_string();
     let content_length = headers
         .lines()
-        .find_map(|line| line.split_once(':').filter(|(name, _)| name.eq_ignore_ascii_case("content-length")).and_then(|(_, value)| value.trim().parse::<usize>().ok()))
+        .find_map(|line| {
+            line.split_once(':')
+                .filter(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+                .and_then(|(_, value)| value.trim().parse::<usize>().ok())
+        })
         .unwrap_or(0);
     let body_start = header_end + 4;
     while buffer.len() < body_start + content_length {
@@ -859,9 +873,11 @@ fn handle_reverse_broker_request(
         return ok(json!({ "registered": true }));
     }
     if request.method == "POST" && request.path == "/runner/jobs" {
-        let submitted: RemoteRunnerJobRequest = serde_json::from_value(request.body)
-            .expect("parse reverse broker job submission");
-        let job = store.submit_remote_runner_job(submitted).expect("submit broker job");
+        let submitted: RemoteRunnerJobRequest =
+            serde_json::from_value(request.body).expect("parse reverse broker job submission");
+        let job = store
+            .submit_remote_runner_job(submitted)
+            .expect("submit broker job");
         return ok(json!({ "job": job }));
     }
     if request.method == "POST" && request.path == "/runner/jobs/claim" {
@@ -872,7 +888,9 @@ fn handle_reverse_broker_request(
     }
     if request.method == "GET" {
         if let Some(job_id) = request.path.strip_prefix("/jobs/") {
-            let job = store.get(uuid::Uuid::parse_str(job_id).expect("broker job id")).expect("broker job");
+            let job = store
+                .get(uuid::Uuid::parse_str(job_id).expect("broker job id"))
+                .expect("broker job");
             return ok(json!({ "job": job }));
         }
     }
@@ -884,19 +902,31 @@ fn handle_reverse_broker_request(
         }
         let claim_id = request.body["claim_id"].as_str().expect("broker claim id");
         let result = match action {
-            "events" => store.append_remote_runner_event(
-                job_id, runner_id, claim_id, JobEventKind::Progress,
-                request.body["message"].as_str().map(ToString::to_string),
-                request.body.get("data").cloned(),
-            ).map(|event| json!({ "event": event })),
-            "heartbeat" => store.renew_remote_runner_claim(job_id, runner_id, claim_id, 30_000)
+            "events" => store
+                .append_remote_runner_event(
+                    job_id,
+                    runner_id,
+                    claim_id,
+                    JobEventKind::Progress,
+                    request.body["message"].as_str().map(ToString::to_string),
+                    request.body.get("data").cloned(),
+                )
+                .map(|event| json!({ "event": event })),
+            "heartbeat" => store
+                .renew_remote_runner_claim(job_id, runner_id, claim_id, 30_000)
                 .map(|job| json!({ "job": job })),
-            "finish" => store.finish_remote_runner_job(
-                job_id, runner_id, claim_id,
-                serde_json::from_value::<RemoteRunnerJobResult>(request.body["result"].clone())
-                    .expect("parse broker finish result"),
-            ).map(|job| json!({ "job": job })),
-            _ => Err(crate::error::Error::internal_unexpected("unknown reverse broker fixture path")),
+            "finish" => store
+                .finish_remote_runner_job(
+                    job_id,
+                    runner_id,
+                    claim_id,
+                    serde_json::from_value::<RemoteRunnerJobResult>(request.body["result"].clone())
+                        .expect("parse broker finish result"),
+                )
+                .map(|job| json!({ "job": job })),
+            _ => Err(crate::error::Error::internal_unexpected(
+                "unknown reverse broker fixture path",
+            )),
         };
         return match result {
             Ok(body) => ok(body),

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -10,8 +10,8 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use homeboy_core::api_jobs::{
-    ActiveRunnerJobSummary, JobClaimMetadata, JobEventKind, JobStatus, RemoteRunnerJobResult,
-    RunnerJobSource,
+    ActiveRunnerJobSummary, Job, JobClaimMetadata, JobEventKind, JobStatus, RemoteRunnerJobRequest,
+    RemoteRunnerJobResult, RunnerJobSource,
 };
 use homeboy_core::daemon::{
     DaemonFreshnessReport, DaemonLeaselessRecoveryResult, DaemonStaleReasonCode,
@@ -1228,6 +1228,47 @@ pub fn reverse_broker_reconcile(runner_id: &str) -> Result<Value> {
         "reconcile reverse runner broker jobs",
         broker_auth::broker_submit_token_for_runner(runner_id)?.as_deref(),
     )
+}
+
+/// Submit a redacted, replayable request to a connected reverse broker. Secret
+/// values are intentionally absent: the worker resolves named references when
+/// it prepares the claimed process.
+pub fn submit_reverse_broker_job(runner_id: &str, request: RemoteRunnerJobRequest) -> Result<Job> {
+    if request.runner_id != runner_id {
+        return Err(Error::validation_invalid_argument(
+            "runner_id",
+            "reverse broker submission runner does not match request runner",
+            Some(runner_id.to_string()),
+            None,
+        ));
+    }
+    let broker_url = reverse_broker_url(runner_id)?;
+    let client = broker_client("build reverse broker submission client")?;
+    let body = serde_json::to_value(&request).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize replayable reverse runner job".to_string()),
+        )
+    })?;
+    let response = broker_http::post_json(
+        &client,
+        &broker_url,
+        "/runner/jobs",
+        body,
+        "replay reverse runner job submission",
+        broker_auth::broker_submit_token_for_runner(runner_id)?.as_deref(),
+    )?;
+    serde_json::from_value(
+        response.get("job").cloned().ok_or_else(|| {
+            Error::internal_unexpected("reverse broker submission returned no job")
+        })?,
+    )
+    .map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("parse replayed reverse runner job".to_string()),
+        )
+    })
 }
 
 pub fn reverse_broker_artifact(runner_id: &str, job_id: &str, artifact_id: &str) -> Result<Value> {

--- a/crates/homeboy-lab-runner/src/continuation_provider.rs
+++ b/crates/homeboy-lab-runner/src/continuation_provider.rs
@@ -6,7 +6,7 @@
 //! execution, and evidence functions.
 
 use homeboy_core::agent_task_lifecycle::RunnerContinuationProvider;
-use homeboy_core::api_jobs::RunnerJobLogSnapshot;
+use homeboy_core::api_jobs::{Job, RemoteRunnerJobRequest, RunnerJobLogSnapshot};
 use homeboy_core::error::Result;
 
 /// The runner layer's `RunnerContinuationProvider`. Registered with core at startup.
@@ -52,6 +52,14 @@ impl RunnerContinuationProvider for RunnerContinuation {
             },
         )?;
         Ok(exit_code)
+    }
+
+    fn submit_reverse_broker_job(
+        &self,
+        runner_id: &str,
+        request: RemoteRunnerJobRequest,
+    ) -> Result<Job> {
+        super::connection::submit_reverse_broker_job(runner_id, request)
     }
 }
 

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -1,12 +1,15 @@
 use std::collections::HashMap;
+use std::path::Path;
 use std::time::{Duration, Instant};
 
+use base64::Engine;
 use homeboy_core::api_jobs::{Job, JobStatus, RemoteRunnerJobRequest, RunnerJobLifecycleMetadata};
 use homeboy_core::error::{Error, Result};
 use homeboy_core::lab_contract::LabRunnerWorkload;
 use homeboy_core::redaction::redact_argv;
 use homeboy_core::source_snapshot::SourceSnapshot;
 use reqwest::blocking::Client;
+use sha2::{Digest, Sha256};
 
 use super::super::broker_http;
 use super::super::evidence::mirror_reverse_broker_evidence;
@@ -59,7 +62,7 @@ pub(super) fn exec_via_reverse_broker(
     )?;
     let redaction_env = env.clone();
     let redaction_secret_env_names = secret_env_names.clone();
-    let request = RemoteRunnerJobRequest {
+    let mut request = RemoteRunnerJobRequest {
         runner_id: runner.id.clone(),
         project_id,
         operation: "runner.exec".to_string(),
@@ -89,6 +92,16 @@ pub(super) fn exec_via_reverse_broker(
         }),
         require_paths: require_paths.clone(),
     };
+    let command_assets = durable_command_assets(&command, path_materialization_plan.as_ref())?;
+    if !command_assets.is_empty() {
+        request
+            .metadata
+            .as_mut()
+            .expect("reverse broker request metadata")["command_assets"] = serde_json::json!({
+            "schema": "homeboy/reverse-runner-command-assets/v1",
+            "assets": command_assets,
+        });
+    }
     let broker_token = homeboy_core::broker_auth::broker_submit_token_for_runner(&runner.id)?;
     let data = broker_http::post_json(
         &client,
@@ -329,4 +342,50 @@ pub(super) fn exec_via_reverse_broker(
         },
         exit_code,
     ))
+}
+
+/// Preserve file-backed argv values past controller cleanup. Values are content
+/// addressed and stored only in the broker request, never in controller tempdirs.
+fn durable_command_assets(
+    command: &[String],
+    plan: Option<&PathMaterializationPlan>,
+) -> Result<Vec<serde_json::Value>> {
+    let Some(plan) = plan else {
+        return Ok(Vec::new());
+    };
+    command
+        .iter()
+        .filter_map(|argument| argument.strip_prefix('@').map(|path| (argument, path)))
+        .filter_map(|(argument, remote_path)| {
+            let entry = plan
+                .entries
+                .iter()
+                .find(|entry| remote_path.starts_with(&entry.remote_path))?;
+            let local = Path::new(entry.local_path.as_deref()?);
+            let source = if local.is_file() {
+                local.to_path_buf()
+            } else {
+                local.join(
+                    remote_path
+                        .strip_prefix(&entry.remote_path)?
+                        .trim_start_matches('/'),
+                )
+            };
+            source.is_file().then_some((argument, remote_path, source))
+        })
+        .map(|(argument, remote_path, source)| {
+            let content = std::fs::read(&source).map_err(|err| {
+                Error::internal_io(
+                    err.to_string(),
+                    Some(format!("read command asset {}", source.display())),
+                )
+            })?;
+            Ok(serde_json::json!({
+                "argument": argument,
+                "remote_path": remote_path,
+                "sha256": format!("{:x}", Sha256::digest(&content)),
+                "content_base64": base64::engine::general_purpose::STANDARD.encode(content),
+            }))
+        })
+        .collect()
 }

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -73,10 +73,13 @@ pub(super) fn exec_via_reverse_broker(
         source_snapshot: Some(source_snapshot.clone()),
         path_materialization_plan: path_materialization_plan.clone(),
         lab_runner_workload: lab_runner_workload.clone(),
-        metadata: Some(runner_exec_request_metadata(
-            run_id.as_deref(),
-            "reverse_broker",
-        )),
+        metadata: Some({
+            let mut metadata = runner_exec_request_metadata(run_id.as_deref(), "reverse_broker");
+            if let Some(run_id) = run_id.as_deref() {
+                metadata["submission_key"] = serde_json::json!(format!("agent-task:{run_id}"));
+            }
+            metadata
+        }),
         lifecycle: Some(RunnerJobLifecycleMetadata {
             source: Some("reverse-broker".to_string()),
             kind: Some("runner.exec".to_string()),

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -79,7 +79,8 @@ pub(super) fn exec_via_reverse_broker(
         metadata: Some({
             let mut metadata = runner_exec_request_metadata(run_id.as_deref(), "reverse_broker");
             if let Some(run_id) = run_id.as_deref() {
-                metadata["submission_key"] = serde_json::json!(format!("agent-task:{run_id}"));
+                metadata["submission_key"] =
+                    serde_json::json!(format!("agent-task:{}:{run_id}", runner.id));
             }
             metadata
         }),
@@ -350,29 +351,127 @@ fn durable_command_assets(
     command: &[String],
     plan: Option<&PathMaterializationPlan>,
 ) -> Result<Vec<serde_json::Value>> {
+    const MAX_COMMAND_ASSET_BYTES: u64 = 1_048_576;
+    const MAX_COMMAND_ASSETS_BYTES: u64 = 3_145_728;
     let Some(plan) = plan else {
         return Ok(Vec::new());
     };
     command
         .iter()
         .filter_map(|argument| argument.strip_prefix('@').map(|path| (argument, path)))
-        .filter_map(|(argument, remote_path)| {
+        .map(|(argument, remote_path)| {
             let entry = plan
                 .entries
                 .iter()
-                .find(|entry| remote_path.starts_with(&entry.remote_path))?;
-            let local = Path::new(entry.local_path.as_deref()?);
+                .find(|entry| {
+                    remote_path == entry.remote_path
+                        || remote_path
+                            .strip_prefix(&entry.remote_path)
+                            .is_some_and(|suffix| suffix.starts_with('/'))
+                })
+                .ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "command",
+                        "file-backed command argument is outside the materialization plan",
+                        Some(argument.to_string()),
+                        None,
+                    )
+                })?;
+            let local = Path::new(entry.local_path.as_deref().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "path_materialization_plan",
+                    "command asset materialization entry has no local path",
+                    Some(entry.remote_path.clone()),
+                    None,
+                )
+            })?);
             let source = if local.is_file() {
+                if remote_path != entry.remote_path {
+                    return Err(Error::validation_invalid_argument(
+                        "command",
+                        "file-backed command argument does not match its materialized file",
+                        Some(argument.to_string()),
+                        None,
+                    ));
+                }
                 local.to_path_buf()
             } else {
-                local.join(
-                    remote_path
-                        .strip_prefix(&entry.remote_path)?
-                        .trim_start_matches('/'),
-                )
+                let relative = remote_path
+                    .strip_prefix(&entry.remote_path)
+                    .unwrap_or_default()
+                    .trim_start_matches('/');
+                let relative = Path::new(relative);
+                if relative
+                    .components()
+                    .any(|component| !matches!(component, std::path::Component::Normal(_)))
+                {
+                    return Err(Error::validation_invalid_argument(
+                        "command",
+                        "file-backed command argument has an unsafe materialized path",
+                        Some(argument.to_string()),
+                        None,
+                    ));
+                }
+                local.join(relative)
             };
-            source.is_file().then_some((argument, remote_path, source))
+            if !source.is_file() {
+                return Ok(None);
+            }
+            let source = source.canonicalize().map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("canonicalize command asset {}", source.display())),
+                )
+            })?;
+            let local = local.canonicalize().map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!(
+                        "canonicalize materialization root {}",
+                        local.display()
+                    )),
+                )
+            })?;
+            if !source.starts_with(&local) {
+                return Err(Error::validation_invalid_argument(
+                    "command",
+                    "file-backed command argument resolves outside the materialization root",
+                    Some(argument.to_string()),
+                    None,
+                ));
+            }
+            Ok(Some((argument, remote_path, source)))
         })
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .map({
+            let mut total = 0u64;
+            move |(argument, remote_path, source)| {
+                let size = std::fs::metadata(&source)
+                    .map_err(|err| {
+                        Error::internal_io(
+                            err.to_string(),
+                            Some(format!("stat command asset {}", source.display())),
+                        )
+                    })?
+                    .len();
+                if size > MAX_COMMAND_ASSET_BYTES
+                    || total.saturating_add(size) > MAX_COMMAND_ASSETS_BYTES
+                {
+                    return Err(Error::validation_invalid_argument(
+                        "command",
+                        "file-backed command assets exceed the size limit",
+                        Some(argument.to_string()),
+                        None,
+                    ));
+                }
+                total += size;
+                Ok((argument, remote_path, source))
+            }
+        })
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
         .map(|(argument, remote_path, source)| {
             let content = std::fs::read(&source).map_err(|err| {
                 Error::internal_io(

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -130,13 +130,26 @@ pub(super) fn exec_via_reverse_broker(
         &command,
     )?;
     if let Some(run_id) = run_id.as_deref() {
-        // Match daemon handoff behavior: the accepted remote job must be bound
-        // to its controller lifecycle before a detached response is returned.
-        homeboy_core::agent_task_lifecycle::record_runner_job_identity(
-            run_id,
-            &runner.id,
-            &job.id.to_string(),
-        )?;
+        // A detached handoff must durably transition its controller projection
+        // before the response can be lost. Reconciliation reuses this same
+        // operation after an intent-only crash.
+        if detach_after_handoff {
+            homeboy_core::agent_task_lifecycle::record_detached_lab_run(
+                homeboy_core::agent_task_lifecycle::DetachedLabRunRecord {
+                    run_id,
+                    runner_id: &runner.id,
+                    runner_job_id: &job.id.to_string(),
+                    remote_workspace: &cwd,
+                    remote_command: &command,
+                },
+            )?;
+        } else {
+            homeboy_core::agent_task_lifecycle::record_runner_job_identity(
+                run_id,
+                &runner.id,
+                &job.id.to_string(),
+            )?;
+        }
     }
     let persisted_run_id = mirror_evidence
         .then(|| persist_lab_offload_handoff_run(runner, &cwd, &command, &job, run_id.as_deref()))

--- a/crates/homeboy-lab-runner/src/lab/offload/execute.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/execute.rs
@@ -1,7 +1,6 @@
 //! Top-level `execute_lab_offload` orchestration and runner-support hints.
 
 use super::*;
-use crate::runner::RunnerTunnelMode;
 
 /// Record a freshly synced, remapped agent-task workspace entry: append it to
 /// the workspace mapping and emit the matching Lab plan step. Shared by the
@@ -217,12 +216,12 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             // Only a detached, controller-owned agent-task plan has a durable
             // continuation and canonical workload suitable for broker queueing.
             // A full runner is otherwise still a readiness failure.
-            let allow_capacity_queue = request.detach_after_handoff
-                && request.durable_agent_task_plan.is_some()
-                && selection.mode == RunnerTunnelMode::Reverse;
-            if let Err(error) =
-                preflight_lab_runner_availability(&contract, &selection, allow_capacity_queue)
-            {
+            if let Err(error) = preflight_lab_runner_availability(
+                &contract,
+                &selection,
+                request.detach_after_handoff,
+                request.durable_agent_task_plan.is_some(),
+            ) {
                 if contract.routing_policy.release_gate
                     && matches!(selection.source, LabRunnerSelectionSource::Default)
                     && !release_gate_local_hot_allowed

--- a/crates/homeboy-lab-runner/src/lab/offload/execute.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/execute.rs
@@ -1,6 +1,7 @@
 //! Top-level `execute_lab_offload` orchestration and runner-support hints.
 
 use super::*;
+use crate::runner::RunnerTunnelMode;
 
 /// Record a freshly synced, remapped agent-task workspace entry: append it to
 /// the workspace mapping and emit the matching Lab plan step. Shared by the
@@ -213,7 +214,15 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     prepare_timer.finish();
     match preparation {
         LabRunnerPreparation::Ready => {
-            if let Err(error) = preflight_lab_runner_availability(&contract, &selection) {
+            // Only a detached, controller-owned agent-task plan has a durable
+            // continuation and canonical workload suitable for broker queueing.
+            // A full runner is otherwise still a readiness failure.
+            let allow_capacity_queue = request.detach_after_handoff
+                && request.durable_agent_task_plan.is_some()
+                && selection.mode == RunnerTunnelMode::Reverse;
+            if let Err(error) =
+                preflight_lab_runner_availability(&contract, &selection, allow_capacity_queue)
+            {
                 if contract.routing_policy.release_gate
                     && matches!(selection.source, LabRunnerSelectionSource::Default)
                     && !release_gate_local_hot_allowed

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -329,6 +329,15 @@ pub(crate) fn exec_lab_context(
             None,
             request.durable_agent_task_plan,
         )?;
+        if context.detach_after_handoff {
+            agent_task_lifecycle::record_lab_offload_submission_intent(
+                run_id,
+                runner_id,
+                &remote_cwd,
+                &context.remote_command,
+                &secret_env_names,
+            )?;
+        }
     }
     preflight_lab_secret_env_handoff(runner_id, context.runner, &env, &context.secret_env_handoff)?;
     if let Some(runner) = context.runner {

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/selection.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/selection.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::runner::lab_selection::allows_detached_reverse_capacity_queue;
+use crate::lab_selection::allows_detached_reverse_capacity_queue;
 
 fn select(
     command: &LabOffloadCommand,

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/selection.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/selection.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::runner::lab_selection::allows_reverse_capacity_queue;
+use crate::runner::lab_selection::allows_detached_reverse_capacity_queue;
 
 fn select(
     command: &LabOffloadCommand,
@@ -213,7 +213,7 @@ fn explicit_lab_never_allows_missing_or_busy_default_runner_to_run_local() {
 }
 
 #[test]
-fn capacity_queue_admission_requires_detached_reverse_capacity_only() {
+fn capacity_queue_admission_requires_detached_durable_reverse_capacity_only() {
     let reverse = LabRunnerSelection {
         runner_id: "homeboy-lab".to_string(),
         source: LabRunnerSelectionSource::Explicit,
@@ -256,14 +256,28 @@ fn capacity_queue_admission_requires_detached_reverse_capacity_only() {
         None,
     );
 
-    assert!(allows_reverse_capacity_queue(true, &reverse, &capacity));
-    assert!(!allows_reverse_capacity_queue(false, &reverse, &capacity));
-    assert!(!allows_reverse_capacity_queue(true, &direct, &capacity));
-    assert!(!allows_reverse_capacity_queue(
+    assert!(allows_detached_reverse_capacity_queue(
+        true, true, &reverse, &capacity
+    ));
+    assert!(!allows_detached_reverse_capacity_queue(
+        false, true, &reverse, &capacity
+    ));
+    assert!(!allows_detached_reverse_capacity_queue(
+        true, false, &reverse, &capacity
+    ));
+    assert!(!allows_detached_reverse_capacity_queue(
+        true, true, &direct, &capacity
+    ));
+    assert!(!allows_detached_reverse_capacity_queue(
+        true,
         true,
         &reverse,
         &disconnected
     ));
-    assert!(!allows_reverse_capacity_queue(true, &reverse, &stale));
-    assert!(!allows_reverse_capacity_queue(true, &reverse, &unknown));
+    assert!(!allows_detached_reverse_capacity_queue(
+        true, true, &reverse, &stale
+    ));
+    assert!(!allows_detached_reverse_capacity_queue(
+        true, true, &reverse, &unknown
+    ));
 }

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/selection.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/selection.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::runner::lab_selection::allows_reverse_capacity_queue;
 
 fn select(
     command: &LabOffloadCommand,
@@ -209,4 +210,60 @@ fn explicit_lab_never_allows_missing_or_busy_default_runner_to_run_local() {
     .expect_err("explicit Lab placement fails closed");
 
     assert!(error.message.contains("--placement lab requires"));
+}
+
+#[test]
+fn capacity_queue_admission_requires_detached_reverse_capacity_only() {
+    let reverse = LabRunnerSelection {
+        runner_id: "homeboy-lab".to_string(),
+        source: LabRunnerSelectionSource::Explicit,
+        mode: RunnerTunnelMode::Reverse,
+    };
+    let direct = LabRunnerSelection {
+        mode: RunnerTunnelMode::DirectSsh,
+        ..reverse.clone()
+    };
+    let capacity = RunnerAvailability::from_status_parts(
+        "homeboy-lab",
+        true,
+        false,
+        1,
+        &RunnerActiveJobState::Available,
+        Some(1),
+    );
+    let disconnected = RunnerAvailability::from_status_parts(
+        "homeboy-lab",
+        false,
+        false,
+        1,
+        &RunnerActiveJobState::Available,
+        Some(1),
+    );
+    let stale = RunnerAvailability::from_status_parts(
+        "homeboy-lab",
+        true,
+        true,
+        1,
+        &RunnerActiveJobState::Available,
+        Some(1),
+    );
+    let unknown = RunnerAvailability::from_status_parts(
+        "homeboy-lab",
+        true,
+        false,
+        1,
+        &RunnerActiveJobState::Unavailable,
+        None,
+    );
+
+    assert!(allows_reverse_capacity_queue(true, &reverse, &capacity));
+    assert!(!allows_reverse_capacity_queue(false, &reverse, &capacity));
+    assert!(!allows_reverse_capacity_queue(true, &direct, &capacity));
+    assert!(!allows_reverse_capacity_queue(
+        true,
+        &reverse,
+        &disconnected
+    ));
+    assert!(!allows_reverse_capacity_queue(true, &reverse, &stale));
+    assert!(!allows_reverse_capacity_queue(true, &reverse, &unknown));
 }

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -91,13 +91,19 @@ pub fn prepare_explicit_lab_runner_for_offload(runner_id: &str) -> Result<()> {
 pub(super) fn preflight_lab_runner_availability(
     command: &LabOffloadCommand,
     selection: &LabRunnerSelection,
-    allow_capacity_queue: bool,
+    detach_after_handoff: bool,
+    has_durable_agent_task_plan: bool,
 ) -> Result<()> {
     let availability = preflight_lab_runner_availability_with(selection, status)?;
     if availability.accepts_jobs {
         return Ok(());
     }
-    if allows_reverse_capacity_queue(allow_capacity_queue, selection, &availability) {
+    if allows_detached_reverse_capacity_queue(
+        detach_after_handoff,
+        has_durable_agent_task_plan,
+        selection,
+        &availability,
+    ) {
         return Ok(());
     }
 
@@ -113,14 +119,16 @@ pub(super) fn preflight_lab_runner_availability(
     ))
 }
 
-/// Capacity admission is only valid for the durable reverse-broker handoff.
-/// Every other availability failure remains a preflight failure.
-pub(super) fn allows_reverse_capacity_queue(
-    allow_capacity_queue: bool,
+/// Capacity admission is only valid for a detached, durable reverse-broker
+/// handoff. Every other availability failure remains a preflight failure.
+pub(super) fn allows_detached_reverse_capacity_queue(
+    detach_after_handoff: bool,
+    has_durable_agent_task_plan: bool,
     selection: &LabRunnerSelection,
     availability: &RunnerAvailability,
 ) -> bool {
-    allow_capacity_queue
+    detach_after_handoff
+        && has_durable_agent_task_plan
         && selection.mode == RunnerTunnelMode::Reverse
         && availability.is_capacity_exhausted()
 }

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -97,10 +97,7 @@ pub(super) fn preflight_lab_runner_availability(
     if availability.accepts_jobs {
         return Ok(());
     }
-    if allow_capacity_queue
-        && selection.mode == RunnerTunnelMode::Reverse
-        && availability.is_capacity_exhausted()
-    {
+    if allows_reverse_capacity_queue(allow_capacity_queue, selection, &availability) {
         return Ok(());
     }
 
@@ -114,6 +111,18 @@ pub(super) fn preflight_lab_runner_availability(
         Some(&availability),
         eligible,
     ))
+}
+
+/// Capacity admission is only valid for the durable reverse-broker handoff.
+/// Every other availability failure remains a preflight failure.
+pub(super) fn allows_reverse_capacity_queue(
+    allow_capacity_queue: bool,
+    selection: &LabRunnerSelection,
+    availability: &RunnerAvailability,
+) -> bool {
+    allow_capacity_queue
+        && selection.mode == RunnerTunnelMode::Reverse
+        && availability.is_capacity_exhausted()
 }
 
 fn preflight_lab_runner_availability_with(

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -91,9 +91,16 @@ pub fn prepare_explicit_lab_runner_for_offload(runner_id: &str) -> Result<()> {
 pub(super) fn preflight_lab_runner_availability(
     command: &LabOffloadCommand,
     selection: &LabRunnerSelection,
+    allow_capacity_queue: bool,
 ) -> Result<()> {
     let availability = preflight_lab_runner_availability_with(selection, status)?;
     if availability.accepts_jobs {
+        return Ok(());
+    }
+    if allow_capacity_queue
+        && selection.mode == RunnerTunnelMode::Reverse
+        && availability.is_capacity_exhausted()
+    {
         return Ok(());
     }
 

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -109,7 +109,7 @@ pub use connection::{
     connect, connect_reverse, connect_with_leaseless_orphan_reconciliation,
     connect_with_orphan_adoption, connect_with_recovery, disconnect, reverse_broker_artifact,
     reverse_broker_artifact_content, reverse_broker_reconcile, runner_artifact_content, status,
-    statuses,
+    statuses, submit_reverse_broker_job,
 };
 mod upgrade_runners;
 pub use availability_provider::register as register_runner_availability_provider;

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -1738,6 +1738,29 @@ mod tests {
                 reasons: vec!["capacity_reached".to_string()],
             }
         );
+        assert!(busy.availability().is_capacity_exhausted());
+    }
+
+    #[test]
+    fn runner_availability_does_not_treat_substrate_failures_as_queueable_capacity() {
+        let availability = RunnerAvailability::from_status_parts(
+            "lab-a",
+            false,
+            false,
+            1,
+            &RunnerActiveJobState::Unavailable,
+            Some(1),
+        );
+
+        assert!(!availability.is_capacity_exhausted());
+        assert_eq!(
+            availability.reasons,
+            vec![
+                "not_connected".to_string(),
+                "capacity_reached".to_string(),
+                "active_jobs_unavailable".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -66,6 +66,12 @@ pub enum RunnerRecoveryState {
 }
 
 impl RunnerAvailability {
+    /// A connected runner with an authoritative capacity limit may accept work
+    /// into its durable broker queue even though it cannot start it yet.
+    pub fn is_capacity_exhausted(&self) -> bool {
+        self.reasons == ["capacity_reached"]
+    }
+
     pub fn from_status_parts(
         runner_id: impl Into<String>,
         connected: bool,

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -265,7 +265,9 @@ fn run_once_output(
     // of mid-run (#5093). The local worker execution path runs this preflight
     // before handing the claimed job directly to the local runtime.
     let capability_preflight = reverse_worker_capability_preflight(&claim.request);
-    let execution_envelope = claim.request.execution_envelope();
+    let mut execution_envelope = claim.request.execution_envelope();
+    materialize_command_assets(&claim.job.id.to_string(), &mut execution_envelope)?;
+    materialize_snapshot_git_baseline(&execution_envelope)?;
     // Shared finisher so the exec-error and exec-success paths submit their
     // terminal job result through identical broker plumbing (#5091).
     let finish = |result: RemoteRunnerJobResult| {
@@ -384,6 +386,127 @@ fn run_once_output(
         ),
         exit_code,
     ))
+}
+
+/// Snapshot transport intentionally excludes `.git`. Reconstruct the verified,
+/// deterministic baseline before the nested agent-task command starts so its
+/// provider and harvest share the exact accepted workspace provenance.
+fn materialize_snapshot_git_baseline(envelope: &RunnerExecutionEnvelope) -> Result<()> {
+    let Some(dispatch) = envelope.dispatch.as_ref() else {
+        return Ok(());
+    };
+    let Some(snapshot) = dispatch.source_snapshot.clone() else {
+        return Ok(());
+    };
+    let Some(lab) = dispatch
+        .env
+        .get(homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV)
+    else {
+        return Ok(());
+    };
+    let lab: serde_json::Value = serde_json::from_str(lab).map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("parse reverse worker Lab offload metadata".to_string()),
+        )
+    })?;
+    if lab.get("sync_mode").and_then(serde_json::Value::as_str) != Some("snapshot") {
+        return Ok(());
+    }
+    let cwd = dispatch.cwd.as_deref().ok_or_else(|| {
+        Error::internal_unexpected(
+            "reverse worker snapshot materialization requires a managed workspace cwd",
+        )
+    })?;
+    crate::workspace::materialize_verified_lab_snapshot_git_baseline(
+        cwd,
+        std::path::Path::new(cwd),
+        snapshot,
+        lab,
+    )
+    .map(|_| ())
+    .map_err(Error::internal_unexpected)
+}
+
+/// Materialize broker-owned command files in the worker's durable data root and
+/// rewrite their argv entries before execution. The request body survives broker
+/// restart; controller temporary files are never consulted after claim.
+fn materialize_command_assets(
+    job_id: &str,
+    envelope: &mut homeboy_core::runner_execution_envelope::RunnerExecutionEnvelope,
+) -> homeboy_core::error::Result<()> {
+    use base64::Engine;
+    use sha2::{Digest, Sha256};
+
+    let Some(assets) = envelope
+        .metadata
+        .get("command_assets")
+        .and_then(|value| value.get("assets"))
+        .and_then(serde_json::Value::as_array)
+    else {
+        return Ok(());
+    };
+    let root = std::env::var_os("XDG_DATA_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME").map(|home| std::path::PathBuf::from(home).join(".local/share"))
+        })
+        .unwrap_or_else(std::env::temp_dir)
+        .join("homeboy/reverse-runner-jobs")
+        .join(job_id);
+    std::fs::create_dir_all(&root).map_err(|err| {
+        homeboy_core::error::Error::internal_io(
+            err.to_string(),
+            Some(format!("create command asset root {}", root.display())),
+        )
+    })?;
+    let command = envelope
+        .dispatch
+        .as_mut()
+        .map(|dispatch| &mut dispatch.command);
+    let Some(command) = command else {
+        return Ok(());
+    };
+    for (index, asset) in assets.iter().enumerate() {
+        let argument = asset
+            .get("argument")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                homeboy_core::error::Error::internal_json("command asset missing argument", None)
+            })?;
+        let encoded = asset
+            .get("content_base64")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                homeboy_core::error::Error::internal_json("command asset missing content", None)
+            })?;
+        let content = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .map_err(|err| {
+                homeboy_core::error::Error::internal_json(
+                    err.to_string(),
+                    Some("decode command asset".to_string()),
+                )
+            })?;
+        let digest = format!("{:x}", Sha256::digest(&content));
+        if asset.get("sha256").and_then(serde_json::Value::as_str) != Some(digest.as_str()) {
+            return Err(homeboy_core::error::Error::internal_json(
+                "command asset content identity mismatch",
+                None,
+            ));
+        }
+        let path = root.join(format!("asset-{index}"));
+        std::fs::write(&path, content).map_err(|err| {
+            homeboy_core::error::Error::internal_io(
+                err.to_string(),
+                Some(format!("write command asset {}", path.display())),
+            )
+        })?;
+        for value in command.iter_mut().filter(|value| *value == argument) {
+            *value = format!("@{}", path.display());
+        }
+    }
+    Ok(())
 }
 
 fn runner_exec_options_from_envelope(

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -266,7 +266,8 @@ fn run_once_output(
     // before handing the claimed job directly to the local runtime.
     let capability_preflight = reverse_worker_capability_preflight(&claim.request);
     let mut execution_envelope = claim.request.execution_envelope();
-    materialize_command_assets(&claim.job.id.to_string(), &mut execution_envelope)?;
+    let _command_assets =
+        materialize_command_assets(&claim.job.id.to_string(), &mut execution_envelope)?;
     materialize_snapshot_git_baseline(&execution_envelope)?;
     // Shared finisher so the exec-error and exec-success paths submit their
     // terminal job result through identical broker plumbing (#5091).
@@ -431,10 +432,18 @@ fn materialize_snapshot_git_baseline(envelope: &RunnerExecutionEnvelope) -> Resu
 /// Materialize broker-owned command files in the worker's durable data root and
 /// rewrite their argv entries before execution. The request body survives broker
 /// restart; controller temporary files are never consulted after claim.
+struct CommandAssetDirectory(std::path::PathBuf);
+
+impl Drop for CommandAssetDirectory {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
 fn materialize_command_assets(
     job_id: &str,
     envelope: &mut homeboy_core::runner_execution_envelope::RunnerExecutionEnvelope,
-) -> homeboy_core::error::Result<()> {
+) -> homeboy_core::error::Result<Option<CommandAssetDirectory>> {
     use base64::Engine;
     use sha2::{Digest, Sha256};
 
@@ -444,7 +453,7 @@ fn materialize_command_assets(
         .and_then(|value| value.get("assets"))
         .and_then(serde_json::Value::as_array)
     else {
-        return Ok(());
+        return Ok(None);
     };
     let root = std::env::var_os("XDG_DATA_HOME")
         .map(std::path::PathBuf::from)
@@ -454,19 +463,34 @@ fn materialize_command_assets(
         .unwrap_or_else(std::env::temp_dir)
         .join("homeboy/reverse-runner-jobs")
         .join(job_id);
+    // A claim id is broker-issued, but reject a pre-existing directory rather
+    // than following any local symlink or reusing a prior worker's plaintext.
+    if root.exists() {
+        std::fs::remove_dir_all(&root).map_err(|err| {
+            homeboy_core::error::Error::internal_io(
+                err.to_string(),
+                Some(format!(
+                    "remove stale command asset root {}",
+                    root.display()
+                )),
+            )
+        })?;
+    }
     std::fs::create_dir_all(&root).map_err(|err| {
         homeboy_core::error::Error::internal_io(
             err.to_string(),
             Some(format!("create command asset root {}", root.display())),
         )
     })?;
+    restrict_command_asset_permissions(&root, 0o700)?;
     let command = envelope
         .dispatch
         .as_mut()
         .map(|dispatch| &mut dispatch.command);
     let Some(command) = command else {
-        return Ok(());
+        return Ok(Some(CommandAssetDirectory(root)));
     };
+    let mut total_bytes = 0usize;
     for (index, asset) in assets.iter().enumerate() {
         let argument = asset
             .get("argument")
@@ -480,6 +504,14 @@ fn materialize_command_assets(
             .ok_or_else(|| {
                 homeboy_core::error::Error::internal_json("command asset missing content", None)
             })?;
+        if encoded.len() > 1_400_000 {
+            return Err(homeboy_core::error::Error::validation_invalid_argument(
+                "metadata.command_assets",
+                "remote runner command asset exceeds the size limit",
+                None,
+                None,
+            ));
+        }
         let content = base64::engine::general_purpose::STANDARD
             .decode(encoded)
             .map_err(|err| {
@@ -488,6 +520,15 @@ fn materialize_command_assets(
                     Some("decode command asset".to_string()),
                 )
             })?;
+        total_bytes = total_bytes.saturating_add(content.len());
+        if content.len() > 1_048_576 || total_bytes > 3_145_728 {
+            return Err(homeboy_core::error::Error::validation_invalid_argument(
+                "metadata.command_assets",
+                "remote runner command assets exceed the size limit",
+                None,
+                None,
+            ));
+        }
         let digest = format!("{:x}", Sha256::digest(&content));
         if asset.get("sha256").and_then(serde_json::Value::as_str) != Some(digest.as_str()) {
             return Err(homeboy_core::error::Error::internal_json(
@@ -496,16 +537,47 @@ fn materialize_command_assets(
             ));
         }
         let path = root.join(format!("asset-{index}"));
-        std::fs::write(&path, content).map_err(|err| {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .map_err(|err| {
+                homeboy_core::error::Error::internal_io(
+                    err.to_string(),
+                    Some(format!("write command asset {}", path.display())),
+                )
+            })?;
+        use std::io::Write;
+        file.write_all(&content).map_err(|err| {
             homeboy_core::error::Error::internal_io(
                 err.to_string(),
                 Some(format!("write command asset {}", path.display())),
             )
         })?;
+        restrict_command_asset_permissions(&path, 0o600)?;
         for value in command.iter_mut().filter(|value| *value == argument) {
             *value = format!("@{}", path.display());
         }
     }
+    Ok(Some(CommandAssetDirectory(root)))
+}
+
+#[cfg(unix)]
+fn restrict_command_asset_permissions(path: &std::path::Path, mode: u32) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!(
+                "restrict command asset permissions {}",
+                path.display()
+            )),
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn restrict_command_asset_permissions(_: &std::path::Path, _: u32) -> Result<()> {
     Ok(())
 }
 

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -117,6 +117,75 @@ fn reverse_worker_executes_claimed_job_and_finishes_it() {
 }
 
 #[test]
+fn reverse_worker_drains_fifo_jobs_after_completion_and_reconnect() {
+    test_support::with_isolated_home(|_| {
+        create_shell_runner();
+        let store = JobStore::default();
+        let mut first = run_id_echo_request();
+        first.command[2] = "printf first".to_string();
+        first.lifecycle = Some(RunnerJobLifecycleMetadata {
+            source: Some("lab-handoff".to_string()),
+            kind: Some("agent-task".to_string()),
+            durable_run_id: Some("lab-run-first".to_string()),
+            active_child_count: None,
+            active_cell_count: None,
+        });
+        let mut second = first.clone();
+        second.command[2] = "printf second".to_string();
+        second.lifecycle.as_mut().expect("lifecycle").durable_run_id =
+            Some("lab-run-second".to_string());
+
+        let first_job = store.submit_remote_runner_job(first).expect("queue first");
+        let second_job = store
+            .submit_remote_runner_job(second)
+            .expect("queue second");
+
+        let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
+        let (first_output, first_exit) =
+            run_reverse_worker(worker_options(broker_url)).expect("first worker");
+        assert_eq!(first_exit, 0);
+        assert_eq!(first_output.job.expect("first job").id, first_job.id);
+        handle.join().expect("first broker joins");
+        assert_eq!(
+            store.get(second_job.id).expect("queued second").status,
+            JobStatus::Queued
+        );
+
+        // A reconnect is only another worker claim: the broker retains the
+        // queue and its FIFO order instead of involving controller execution.
+        let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
+        let (second_output, second_exit) =
+            run_reverse_worker(worker_options(broker_url)).expect("reconnected worker");
+        assert_eq!(second_exit, 0);
+        assert_eq!(second_output.job.expect("second job").id, second_job.id);
+        handle.join().expect("second broker joins");
+
+        let (broker_url, handle) = spawn_mock_broker(store.clone(), 1);
+        let (idle_output, idle_exit) =
+            run_reverse_worker(worker_options(broker_url)).expect("duplicate wake");
+        assert_eq!(idle_exit, 0);
+        assert!(!idle_output.claimed);
+        handle.join().expect("idle broker joins");
+
+        assert_eq!(
+            result_event_data(&store, first_job.id)["stdout"],
+            serde_json::json!("first")
+        );
+        assert_eq!(
+            result_event_data(&store, second_job.id)["stdout"],
+            serde_json::json!("second")
+        );
+        assert_eq!(
+            store
+                .get(second_job.id)
+                .expect("finished second")
+                .claimed_by_runner_id,
+            Some("lab".to_string())
+        );
+    });
+}
+
+#[test]
 fn reverse_worker_streams_redacted_child_progress_without_trusting_stdout_lifecycle_fields() {
     test_support::with_isolated_home(|_| {
         create_shell_runner();

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -8,7 +8,7 @@ use homeboy_core::api_jobs::{
     JobEventKind, JobStatus, JobStore, RemoteRunnerJobRequest, RunnerJobLifecycleMetadata,
 };
 use homeboy_core::secret_env_plan::SecretEnvPlan;
-use homeboy_core::server::RunnerPolicy;
+use homeboy_core::server::{RunnerPolicy, RunnerSecretEnvRef};
 use homeboy_core::test_support;
 
 use super::super::run::{run_loop, run_reverse_worker};
@@ -189,12 +189,27 @@ fn reverse_worker_drains_fifo_jobs_after_completion_and_reconnect() {
 fn reverse_worker_streams_redacted_child_progress_without_trusting_stdout_lifecycle_fields() {
     test_support::with_isolated_home(|_| {
         create_shell_runner();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let token_path = temp.path().join("token");
+        std::fs::write(&token_path, "child-secret\n").expect("token file");
+        crate::merge(
+            Some("lab"),
+            &serde_json::json!({
+                "secret_env": {
+                    "TOKEN": RunnerSecretEnvRef {
+                        env: None,
+                        file: Some(token_path.display().to_string()),
+                        secret: None,
+                    }
+                }
+            })
+            .to_string(),
+            &[],
+        )
+        .expect("configure named runner secret");
         let store = JobStore::default();
         let mut request = run_id_echo_request();
         request.command[2] = "printf 'HOMEBOY_RUNNER_PROGRESS {\"schema\":\"homeboy/runner-progress/v1\",\"phase\":\"import\",\"current_item\":\"%s\",\"completed\":1,\"total\":2,\"metadata\":{\"api_key\":\"%s\"}}\\n' \"$TOKEN\" \"$TOKEN\"; printf 'HOMEBOY_RUNNER_PROGRESS {not-json}\\n'; printf 'HOMEBOY_RUNNER_PROGRESS {\"schema\":\"homeboy/runner-progress/v1\",\"phase\":\"done\",\"status\":\"succeeded\"}\\n'; sleep 0.1; dd if=/dev/zero bs=1024 count=4097 2>/dev/null; printf tail".to_string();
-        request
-            .env
-            .insert("TOKEN".to_string(), "child-secret".to_string());
         request.secret_env_names = vec!["TOKEN".to_string()];
         store.submit_remote_runner_job(request).expect("submit job");
         let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
@@ -208,7 +223,15 @@ fn reverse_worker_streams_redacted_child_progress_without_trusting_stdout_lifecy
         let events = store.events(job.id).expect("persisted events");
         let progress_index = events
             .iter()
-            .position(|event| event.kind == JobEventKind::Progress && event.data.is_some())
+            .position(|event| {
+                event.kind == JobEventKind::Progress
+                    && event
+                        .data
+                        .as_ref()
+                        .and_then(|data| data.get("phase"))
+                        .and_then(serde_json::Value::as_str)
+                        == Some("import")
+            })
             .expect("child progress event persisted before finish");
         let result_index = events
             .iter()
@@ -314,23 +337,35 @@ fn reverse_worker_uses_metadata_run_id_for_claimed_job_env() {
 fn reverse_worker_executes_from_envelope_dispatch_fields() {
     test_support::with_isolated_home(|_| {
         create_shell_runner();
-        let store = JobStore::default();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let token_b_path = temp.path().join("token-b");
+        std::fs::write(&token_b_path, "secret-b\n").expect("token B file");
+        crate::merge(
+            Some("lab"),
+            &serde_json::json!({
+                "secret_env": {
+                    "TOKEN_B": RunnerSecretEnvRef {
+                        env: None,
+                        file: Some(token_b_path.display().to_string()),
+                        secret: None,
+                    },
+                }
+            })
+            .to_string(),
+            &[],
+        )
+        .expect("configure named runner secrets");
+        let path = temp.path().join("jobs.json");
+        let store = JobStore::open_without_reconciliation(&path).expect("open durable store");
         let mut request = run_id_echo_request();
         request.command = vec![
             "sh".to_string(),
             "-c".to_string(),
-            "printf '%s|%s|%s' \"$PUBLIC_VALUE\" \"$TOKEN_A\" \"$TOKEN_B\"".to_string(),
+            "printf '%s|%s' \"$PUBLIC_VALUE\" \"$TOKEN_B\"".to_string(),
         ];
         request
             .env
             .insert("PUBLIC_VALUE".to_string(), "visible".to_string());
-        request
-            .env
-            .insert("TOKEN_A".to_string(), "secret-a".to_string());
-        request
-            .env
-            .insert("TOKEN_B".to_string(), "secret-b".to_string());
-        request.secret_env_names = vec!["TOKEN_A".to_string()];
         request.secret_env_plan = SecretEnvPlan::from_secret_env_names(["TOKEN_B".to_string()]);
         request.require_paths = vec!["/tmp".to_string()];
         request.lifecycle = Some(RunnerJobLifecycleMetadata {
@@ -341,6 +376,11 @@ fn reverse_worker_executes_from_envelope_dispatch_fields() {
             active_cell_count: Some(2),
         });
         store.submit_remote_runner_job(request).expect("submit job");
+        assert!(!std::fs::read_to_string(&path)
+            .expect("read durable job")
+            .contains("secret-b"));
+        drop(store);
+        let store = JobStore::open_without_reconciliation(&path).expect("reopen durable store");
         let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
 
         let (output, exit_code) =
@@ -351,10 +391,7 @@ fn reverse_worker_executes_from_envelope_dispatch_fields() {
         assert_eq!(job.status, JobStatus::Succeeded);
         handle.join().expect("mock broker joins");
         let result = result_event_data(&store, job.id);
-        assert_eq!(
-            result["stdout"],
-            serde_json::json!("visible|[REDACTED]|[REDACTED]")
-        );
+        assert_eq!(result["stdout"], serde_json::json!("visible|[REDACTED]"));
         assert_eq!(
             result["data"]["execution_record"]["path_materialization_plan"]["entries"][0]
                 ["remote_path"],
@@ -609,7 +646,7 @@ fn reverse_worker_skips_finish_when_cancelled_after_execution() {
             .expect("submit job");
         let seen_paths = Arc::new(std::sync::Mutex::new(Vec::new()));
         let (broker_url, handle) =
-            spawn_cancelling_on_second_snapshot_broker(store.clone(), 5, Some(seen_paths.clone()));
+            spawn_cancelling_on_second_snapshot_broker(store.clone(), 8, Some(seen_paths.clone()));
         write_reverse_controller_session(&broker_url);
 
         let (output, exit_code) =
@@ -683,7 +720,7 @@ fn reverse_worker_interrupts_running_job_when_broker_cancel_is_observed() {
             .expect("submit job");
         let seen_paths = Arc::new(std::sync::Mutex::new(Vec::new()));
         let (broker_url, handle) =
-            spawn_cancelling_on_second_snapshot_broker(store.clone(), 5, Some(seen_paths.clone()));
+            spawn_cancelling_on_second_snapshot_broker(store.clone(), 8, Some(seen_paths.clone()));
         write_reverse_controller_session(&broker_url);
 
         let (output, exit_code) =

--- a/crates/homeboy-lab-runner/src/workspace/provenance.rs
+++ b/crates/homeboy-lab-runner/src/workspace/provenance.rs
@@ -53,7 +53,11 @@ pub(crate) fn materialize_verified_lab_snapshot_git_baseline(
         );
     }
     if materialized_workspace_path.join(".git").exists() {
-        return Err("snapshot workspace unexpectedly contains root .git metadata".to_string());
+        // A replay reaches the same accepted snapshot after a prior worker has
+        // already materialized its deterministic baseline. Reuse it only after
+        // validating every provenance and Git-root invariant.
+        verify_lab_workspace_git_root(materialized_workspace_path, &provenance)?;
+        return git(materialized_workspace_path, &["rev-parse", "HEAD"]);
     }
     if let Some(path) = nested_git_metadata(materialized_workspace_path)? {
         return Err(format!(
@@ -1119,6 +1123,43 @@ mod tests {
             .expect("candidate patch");
         assert!(uncommitted_patch.contains("-candidate"));
         assert!(uncommitted_patch.contains("+uncommitted candidate"));
+    }
+
+    #[test]
+    fn verified_snapshot_baseline_replay_reuses_only_the_matching_baseline() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");
+        let snapshot = snapshot(workspace.path());
+        let lab = lab(workspace.path(), &snapshot);
+        let baseline = materialize_verified_lab_snapshot_git_baseline(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot.clone(),
+            lab.clone(),
+        )
+        .expect("initial snapshot baseline");
+
+        assert_eq!(
+            materialize_verified_lab_snapshot_git_baseline(
+                &workspace.path().display().to_string(),
+                workspace.path(),
+                snapshot.clone(),
+                lab.clone(),
+            )
+            .expect("replayed snapshot baseline"),
+            baseline,
+        );
+
+        let mut mismatched_snapshot = snapshot;
+        mismatched_snapshot.git_sha = Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string());
+        let error = materialize_verified_lab_snapshot_git_baseline(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            mismatched_snapshot,
+            lab,
+        )
+        .expect_err("mismatched accepted source provenance must fail");
+        assert!(!error.is_empty());
     }
 
     #[test]

--- a/tests/reverse_cook_queue_acceptance.rs
+++ b/tests/reverse_cook_queue_acceptance.rs
@@ -1,0 +1,157 @@
+use std::process::Command;
+
+use homeboy::core::api_jobs::{JobEventKind, JobStatus};
+use homeboy_core::test_support::{HermeticTestContext, ReverseBrokerFixture, TestBinary};
+
+fn output(command: &mut Command) -> std::process::Output {
+    let output = command.output().expect("run homeboy fixture command");
+    assert!(
+        output.status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    output
+}
+
+#[cfg(unix)]
+#[test]
+fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let context = HermeticTestContext::new();
+    let broker = ReverseBrokerFixture::start("lab");
+    let (_checkout_guard, checkout) =
+        homeboy_core::test_support::shared_committed_git_repo_fixture("cook-source");
+    let provider = context.root().join("provider.sh");
+    std::fs::write(
+        &provider,
+        "#!/bin/sh\nset -eu\ncat >/dev/null\nprintf '%s\\n' '{\"schema\":\"homeboy/agent-task-outcome/v1\",\"status\":\"succeeded\",\"summary\":\"fixture provider completed\"}'\n",
+    )
+    .expect("write provider");
+    std::fs::set_permissions(&provider, std::fs::Permissions::from_mode(0o755))
+        .expect("make provider executable");
+
+    output(context.command(TestBinary::HomeboyFixture).args([
+        "server",
+        "create",
+        "lab",
+        "--host",
+        "reverse-fixture.invalid",
+        "--user",
+        "fixture",
+    ]));
+    output(context.command(TestBinary::HomeboyFixture).args([
+        "runner",
+        "enable",
+        "lab",
+        "--workspace-root",
+        checkout.to_str().expect("checkout path"),
+        "--concurrency-limit",
+        "1",
+        "--homeboy-path",
+        context
+            .binary_path(TestBinary::HomeboyFixture)
+            .to_str()
+            .expect("homeboy path"),
+    ]));
+
+    let session_path = context
+        .config_dir()
+        .join("runner-sessions/lab/fixture-controller.json");
+    std::fs::create_dir_all(session_path.parent().expect("session parent"))
+        .expect("create session directory");
+    std::fs::write(
+        session_path,
+        serde_json::json!({
+            "runner_id": "lab",
+            "mode": "reverse",
+            "role": "controller",
+            "controller_id": "fixture-controller",
+            "broker_url": broker.url(),
+            "homeboy_version": env!("CARGO_PKG_VERSION"),
+            "homeboy_build_identity": null,
+            "connected_at": "2026-01-01T00:00:00Z",
+            "worker_identity": "fixture-worker",
+            "worker_pid": 1,
+            "last_seen_at": chrono::Utc::now().to_rfc3339()
+        })
+        .to_string(),
+    )
+    .expect("write reverse controller session");
+
+    let mut cook_command = context.command(TestBinary::HomeboyFixture);
+    cook_command.env("HOMEBOY_CONTROLLER_ID", "fixture-controller").args([
+        "--runner",
+        "lab",
+        "--placement",
+        "lab",
+        "--detach-after-handoff",
+        "agent-task",
+        "cook",
+        "--prompt",
+        "Run the deterministic fixture provider.",
+        "--backend",
+        "fixture",
+        "--cwd",
+        checkout.to_str().expect("checkout path"),
+        "--to-worktree",
+        checkout.to_str().expect("checkout path"),
+        "--provider-command",
+        provider.to_str().expect("provider path"),
+        "--verify",
+        "true",
+        "--max-attempts",
+        "1",
+        "--no-finalize",
+    ]);
+    let cook = output(&mut cook_command);
+    let accepted: serde_json::Value = serde_json::from_slice(&cook.stdout).expect("cook JSON");
+    assert_eq!(accepted["success"], true);
+    assert!(accepted.to_string().contains("queued") || accepted.to_string().contains("running"));
+
+    let queued = broker.jobs();
+    assert_eq!(queued.len(), 1, "detached Cook submits one durable job");
+    assert_eq!(queued[0].status, JobStatus::Queued);
+
+    // The worker uses the same broker URL and store as the CLI subprocess.
+    let (worker, code) = homeboy::runner::run_reverse_worker(
+        homeboy::runner::ReverseRunnerWorkerOptions {
+            runner_id: "lab".to_string(),
+            broker_url: broker.url().to_string(),
+            broker_token: None,
+            project_id: None,
+            lease_ms: 30_000,
+            concurrency_limit: Some(1),
+            loop_mode: false,
+            idle_backoff_ms: 1,
+            max_idle_backoff_ms: 10,
+            broker_failure_backoff_ms: 1,
+            broker_retry_limit: 1,
+        },
+    )
+    .expect("run reverse worker");
+    assert_eq!(code, 0);
+    assert!(worker.claimed);
+    let completed = broker.store.get(queued[0].id).expect("completed broker job");
+    assert_eq!(completed.status, JobStatus::Succeeded);
+    assert_eq!(
+        broker
+            .store
+            .events(completed.id)
+            .expect("broker events")
+            .iter()
+            .filter(|event| event.kind == JobEventKind::Result)
+            .count(),
+        1,
+    );
+
+    let (_, duplicate_code) = homeboy::runner::run_reverse_worker(
+        homeboy::runner::ReverseRunnerWorkerOptions {
+            runner_id: "lab".to_string(), broker_url: broker.url().to_string(), broker_token: None,
+            project_id: None, lease_ms: 30_000, concurrency_limit: Some(1), loop_mode: false,
+            idle_backoff_ms: 1, max_idle_backoff_ms: 10, broker_failure_backoff_ms: 1, broker_retry_limit: 1,
+        },
+    ).expect("duplicate worker wake");
+    assert_eq!(duplicate_code, 0);
+}

--- a/tests/reverse_cook_queue_acceptance.rs
+++ b/tests/reverse_cook_queue_acceptance.rs
@@ -19,10 +19,24 @@ fn output(command: &mut Command) -> std::process::Output {
 fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
     use std::os::unix::fs::PermissionsExt;
 
+    let _env_guard = homeboy_core::test_support::home_env_guard();
     let context = HermeticTestContext::new();
+    std::env::set_var("HOME", context.home());
+    std::env::set_var("XDG_CONFIG_HOME", context.root().join(".config"));
+    std::env::set_var("XDG_DATA_HOME", context.root().join("data"));
+    std::env::set_var("HOMEBOY_ARTIFACT_ROOT", context.artifact_dir());
+    std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", context.runtime_dir());
+    std::env::set_var("TMPDIR", context.temp_dir());
     let broker = ReverseBrokerFixture::start("lab");
     let (_checkout_guard, checkout) =
         homeboy_core::test_support::shared_committed_git_repo_fixture("cook-source");
+    std::fs::write(checkout.join(".gitignore"), "_lab_workspaces/\n")
+        .expect("ignore runner workspace materialization");
+    homeboy_core::test_support::run_git_fixture_command(&checkout, &["add", ".gitignore"]);
+    homeboy_core::test_support::run_git_fixture_command(
+        &checkout,
+        &["commit", "-m", "ignore runner workspace"],
+    );
     let provider = context.root().join("provider.sh");
     std::fs::write(
         &provider,
@@ -31,6 +45,19 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
     .expect("write provider");
     std::fs::set_permissions(&provider, std::fs::Permissions::from_mode(0o755))
         .expect("make provider executable");
+    let ssh = context.root().join("ssh");
+    std::fs::write(
+        &ssh,
+        "#!/bin/sh\nfor argument do command=$argument; done\ncase \"$command\" in\n  p=*'df -Pk'*) printf '%s\\n' '10485760 5242880' ;;\n  *) exec /bin/sh -c \"$command\" ;;\nesac\n",
+    )
+    .expect("write capability probe SSH shim");
+    std::fs::set_permissions(&ssh, std::fs::Permissions::from_mode(0o755))
+        .expect("make capability probe SSH shim executable");
+    let path = format!(
+        "{}:{}",
+        context.root().display(),
+        std::env::var("PATH").expect("PATH")
+    );
 
     output(context.command(TestBinary::HomeboyFixture).args([
         "server",
@@ -41,20 +68,22 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
         "--user",
         "fixture",
     ]));
-    output(context.command(TestBinary::HomeboyFixture).args([
-        "runner",
-        "enable",
-        "lab",
-        "--workspace-root",
-        checkout.to_str().expect("checkout path"),
-        "--concurrency-limit",
-        "1",
-        "--homeboy-path",
-        context
-            .binary_path(TestBinary::HomeboyFixture)
-            .to_str()
-            .expect("homeboy path"),
-    ]));
+    output(
+        context.command(TestBinary::HomeboyFixture).args([
+            "runner",
+            "enable",
+            "lab",
+            "--workspace-root",
+            checkout.to_str().expect("checkout path"),
+            "--concurrency-limit",
+            "1",
+            "--homeboy-path",
+            context
+                .binary_path(TestBinary::HomeboyFixture)
+                .to_str()
+                .expect("homeboy path"),
+        ]),
+    );
 
     let session_path = context
         .config_dir()
@@ -74,49 +103,54 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
             "connected_at": "2026-01-01T00:00:00Z",
             "worker_identity": "fixture-worker",
             "worker_pid": 1,
-            "last_seen_at": chrono::Utc::now().to_rfc3339()
+            "last_seen_at": (chrono::Utc::now() + chrono::Duration::minutes(5)).to_rfc3339()
         })
         .to_string(),
     )
     .expect("write reverse controller session");
 
     let mut cook_command = context.command(TestBinary::HomeboyFixture);
-    cook_command.env("HOMEBOY_CONTROLLER_ID", "fixture-controller").args([
-        "--runner",
-        "lab",
-        "--placement",
-        "lab",
-        "--detach-after-handoff",
-        "agent-task",
-        "cook",
-        "--prompt",
-        "Run the deterministic fixture provider.",
-        "--backend",
-        "fixture",
-        "--cwd",
-        checkout.to_str().expect("checkout path"),
-        "--to-worktree",
-        checkout.to_str().expect("checkout path"),
-        "--provider-command",
-        provider.to_str().expect("provider path"),
-        "--verify",
-        "true",
-        "--max-attempts",
-        "1",
-        "--no-finalize",
-    ]);
+    cook_command
+        .env("PATH", path)
+        .env("HOMEBOY_CONTROLLER_ID", "fixture-controller")
+        .args([
+            "--runner",
+            "lab",
+            "--placement",
+            "lab",
+            "--detach-after-handoff",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "Run the deterministic fixture provider.",
+            "--backend",
+            "fixture",
+            "--cwd",
+            checkout.to_str().expect("checkout path"),
+            "--to-worktree",
+            checkout.to_str().expect("checkout path"),
+            "--provider-command",
+            provider.to_str().expect("provider path"),
+            "--verify",
+            "true",
+            "--max-attempts",
+            "1",
+            "--no-finalize",
+        ]);
     let cook = output(&mut cook_command);
     let accepted: serde_json::Value = serde_json::from_slice(&cook.stdout).expect("cook JSON");
-    assert_eq!(accepted["success"], true);
-    assert!(accepted.to_string().contains("queued") || accepted.to_string().contains("running"));
+    assert_eq!(
+        accepted["status"], "in_flight",
+        "expected accepted queue lifecycle: {accepted}"
+    );
 
     let queued = broker.jobs();
     assert_eq!(queued.len(), 1, "detached Cook submits one durable job");
     assert_eq!(queued[0].status, JobStatus::Queued);
 
     // The worker uses the same broker URL and store as the CLI subprocess.
-    let (worker, code) = homeboy::runner::run_reverse_worker(
-        homeboy::runner::ReverseRunnerWorkerOptions {
+    let (worker, code) =
+        homeboy::runner::run_reverse_worker(homeboy::runner::ReverseRunnerWorkerOptions {
             runner_id: "lab".to_string(),
             broker_url: broker.url().to_string(),
             broker_token: None,
@@ -128,12 +162,19 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
             max_idle_backoff_ms: 10,
             broker_failure_backoff_ms: 1,
             broker_retry_limit: 1,
-        },
-    )
-    .expect("run reverse worker");
-    assert_eq!(code, 0);
+        })
+        .expect("run reverse worker");
+    assert_eq!(
+        code,
+        0,
+        "worker={worker:#?} events={:#?}",
+        broker.store.events(queued[0].id).expect("events")
+    );
     assert!(worker.claimed);
-    let completed = broker.store.get(queued[0].id).expect("completed broker job");
+    let completed = broker
+        .store
+        .get(queued[0].id)
+        .expect("completed broker job");
     assert_eq!(completed.status, JobStatus::Succeeded);
     assert_eq!(
         broker
@@ -146,12 +187,20 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
         1,
     );
 
-    let (_, duplicate_code) = homeboy::runner::run_reverse_worker(
-        homeboy::runner::ReverseRunnerWorkerOptions {
-            runner_id: "lab".to_string(), broker_url: broker.url().to_string(), broker_token: None,
-            project_id: None, lease_ms: 30_000, concurrency_limit: Some(1), loop_mode: false,
-            idle_backoff_ms: 1, max_idle_backoff_ms: 10, broker_failure_backoff_ms: 1, broker_retry_limit: 1,
-        },
-    ).expect("duplicate worker wake");
+    let (_, duplicate_code) =
+        homeboy::runner::run_reverse_worker(homeboy::runner::ReverseRunnerWorkerOptions {
+            runner_id: "lab".to_string(),
+            broker_url: broker.url().to_string(),
+            broker_token: None,
+            project_id: None,
+            lease_ms: 30_000,
+            concurrency_limit: Some(1),
+            loop_mode: false,
+            idle_backoff_ms: 1,
+            max_idle_backoff_ms: 10,
+            broker_failure_backoff_ms: 1,
+            broker_retry_limit: 1,
+        })
+        .expect("duplicate worker wake");
     assert_eq!(duplicate_code, 0);
 }


### PR DESCRIPTION
Closes #8623
Closes #8701

## Summary

- Admit eligible detached durable reverse-runner cooks into the broker queue when capacity is temporarily exhausted.
- Persist runner-owned FIFO lifecycle state and report waiting-for-capacity accurately.
- Make broker submission replay-safe with runner-scoped idempotency keys, redacted pre-submit intents, and post-ack lifecycle binding.
- Reconcile both controller crash windows to one broker job and one execution.
- Persist delayed command assets with content identity, containment and size limits, restrictive permissions, and cleanup.
- Reconstruct the verified synthetic Git baseline before delayed provider execution and harvest.
- Rehydrate named runner secrets after durable replay without persisting plaintext values.

## Compatibility

This intentionally tightens durable reverse-runner secret handling. A durable handoff declaring a secret variable with only an inline value is now rejected before broker acceptance with reason code `durable_reverse_runner_inline_secret_env`. Callers must provide an existing named runner `secret_env` or `SecretEnvPlan` reference so replay can safely re-resolve the value. Public non-secret inline environment values remain supported.

No extension paths or product-specific behavior are introduced.

## How to test

1. Run `cargo test --test reverse_cook_queue_acceptance`.
2. Run `cargo test -p homeboy-lab-runner worker --lib -- --test-threads=1`.
3. Run `cargo test -p homeboy-core detached_cook_intent_reconciliation_converges_both_crash_windows_without_secret_leakage --lib`.
4. Run `cargo test -p homeboy-core remote_runner_submission_key_replays_one_redacted_durable_job --lib`.
5. Run `cargo check`.
6. Run `cargo fmt --check`.

The root acceptance test drives the actual CLI cook path through busy reverse-runner admission, durable broker acceptance, delayed claim, deleted temporary plan recovery, verified Git-baseline reconstruction, worker execution, and lifecycle completion.

## Verification

- All numbered commands passed against current `main`.
- `git diff --check` passed.
- `git merge-tree --write-tree origin/main HEAD` succeeded.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol with OpenCode general coding subagents
- **Used for:** Root-cause analysis, implementation, fault-injection tests, adversarial security and distributed-systems review, rebase conflict resolution, and deterministic verification. Chris reviewed and owns the change.