### PR TITLE
refactor: move NotificationTransportConfig to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/manifest.rs
+++ b/crates/homeboy-core/src/extension/manifest.rs
@@ -158,64 +158,9 @@ pub struct ExtensionDiagnosticsConfig {
     pub tools: Vec<ExtensionToolDiagnosticDeclaration>,
 }
 
-pub const NOTIFICATION_TRANSPORT_SCHEMA: &str = "homeboy/notification-transport/v1";
-
-/// An installed extension-owned notification command. `command` is a literal
-/// argv prefix, never a shell command or template. Homeboy appends the typed
-/// completion event arguments defined by the schema.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct NotificationTransportConfig {
-    #[serde(default = "default_notification_transport_schema")]
-    pub schema: String,
-    pub id: String,
-    pub command: Vec<String>,
-}
-
-fn default_notification_transport_schema() -> String {
-    NOTIFICATION_TRANSPORT_SCHEMA.to_string()
-}
-
-impl NotificationTransportConfig {
-    pub fn validate(&self) -> Result<()> {
-        if self.schema != NOTIFICATION_TRANSPORT_SCHEMA {
-            return Err(Error::validation_invalid_argument(
-                "notification_transports.schema",
-                format!("must be {NOTIFICATION_TRANSPORT_SCHEMA}"),
-                Some(self.schema.clone()),
-                None,
-            ));
-        }
-        let valid_id = !self.id.is_empty()
-            && self.id.len() <= 128
-            && self
-                .id
-                .bytes()
-                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'));
-        if !valid_id {
-            return Err(Error::validation_invalid_argument(
-                "notification_transports.id",
-                "must contain 1-128 ASCII letters, digits, '.', '_' or '-'",
-                Some(self.id.clone()),
-                None,
-            ));
-        }
-        if self.command.is_empty()
-            || self
-                .command
-                .iter()
-                .any(|arg| arg.is_empty() || arg.contains('\0'))
-        {
-            return Err(Error::validation_invalid_argument(
-                "notification_transports.command",
-                "must be a non-empty literal argv array without empty or NUL values",
-                Some(self.id.clone()),
-                None,
-            ));
-        }
-        Ok(())
-    }
-}
+pub use homeboy_extension_contract::notification_transport_config::{
+    NotificationTransportConfig, NOTIFICATION_TRANSPORT_SCHEMA,
+};
 
 impl ExtensionDiagnosticsConfig {
     pub fn is_empty(&self) -> bool {

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -21,6 +21,7 @@ pub mod manifest_capability_config;
 pub mod manifest_deploy_config;
 pub mod manifest_test_config;
 pub mod manifest_toolchain_config;
+pub mod notification_transport_config;
 pub mod runner_contract;
 pub mod source_metadata_repair;
 pub mod test_drift;

--- a/crates/homeboy-extension-contract/src/notification_transport_config.rs
+++ b/crates/homeboy-extension-contract/src/notification_transport_config.rs
@@ -1,0 +1,68 @@
+//! Extension-owned notification transport config.
+//!
+//! An installed extension declares a notification command (a literal argv
+//! prefix) that homeboy invokes with typed completion-event arguments. A pure
+//! serde config type + its validation contract, shared below core so the
+//! extension subsystem and its future crate depend on the slim seam.
+
+use homeboy_error::{Error, Result};
+use serde::{Deserialize, Serialize};
+
+pub const NOTIFICATION_TRANSPORT_SCHEMA: &str = "homeboy/notification-transport/v1";
+
+/// An installed extension-owned notification command. `command` is a literal
+/// argv prefix, never a shell command or template. Homeboy appends the typed
+/// completion event arguments defined by the schema.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct NotificationTransportConfig {
+    #[serde(default = "default_notification_transport_schema")]
+    pub schema: String,
+    pub id: String,
+    pub command: Vec<String>,
+}
+
+fn default_notification_transport_schema() -> String {
+    NOTIFICATION_TRANSPORT_SCHEMA.to_string()
+}
+
+impl NotificationTransportConfig {
+    pub fn validate(&self) -> Result<()> {
+        if self.schema != NOTIFICATION_TRANSPORT_SCHEMA {
+            return Err(Error::validation_invalid_argument(
+                "notification_transports.schema",
+                format!("must be {NOTIFICATION_TRANSPORT_SCHEMA}"),
+                Some(self.schema.clone()),
+                None,
+            ));
+        }
+        let valid_id = !self.id.is_empty()
+            && self.id.len() <= 128
+            && self
+                .id
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'));
+        if !valid_id {
+            return Err(Error::validation_invalid_argument(
+                "notification_transports.id",
+                "must contain 1-128 ASCII letters, digits, '.', '_' or '-'",
+                Some(self.id.clone()),
+                None,
+            ));
+        }
+        if self.command.is_empty()
+            || self
+                .command
+                .iter()
+                .any(|arg| arg.is_empty() || arg.contains('\0'))
+        {
+            return Err(Error::validation_invalid_argument(
+                "notification_transports.command",
+                "must be a non-empty literal argv array without empty or NUL values",
+                Some(self.id.clone()),
+                None,
+            ));
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
Moves `NotificationTransportConfig` (plus its `NOTIFICATION_TRANSPORT_SCHEMA` const, default fn, and `validate()` impl) from `homeboy-core`'s `extension::manifest` into `homeboy-extension-contract`.

It's a pure serde config type declaring an extension-owned notification command (a literal argv prefix homeboy invokes with typed completion-event args). Depends only on `serde` + `homeboy_error` — both already contract deps. Re-exported from `extension::manifest` so `crate::extension::{NotificationTransportConfig, NOTIFICATION_TRANSPORT_SCHEMA}` call sites are unchanged.

## Why (gradual untangling)
Continues the `extension-contract` keystone campaign (#8757 / #8760 / ...): steadily draining pure config types out of the extension subsystem into the contract, so a future `homeboy-extension` extraction depends on a slim seam rather than all of core. Each move makes core more modular and the extension boundary clearer — worth doing on its own.

## Verification
- `cargo check -p homeboy-extension-contract --lib`, `-p homeboy-core --lib`, `-p homeboy-cli --lib` — 0 errors.
- `cargo check --workspace --tests --locked` (topology guard) — **passes**.
- `cargo test -p homeboy-extension-contract --lib` — **38 passed**.
- Wire-format preserved: `NOTIFICATION_TRANSPORT_SCHEMA` value unchanged (`"homeboy/notification-transport/v1"`); only the definition moved.

Refs #8425