### PR TITLE
refactor: move extension capability structs to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/manifest.rs
+++ b/crates/homeboy-core/src/extension/manifest.rs
@@ -35,6 +35,10 @@ pub use homeboy_extension_contract::fuzz_config::{FuzzConfig, FuzzWorkloadConfig
 pub use homeboy_extension_contract::manifest_action_config::{
     ActionConfig, InputConfig, RuntimeConfig, SelectOption, SettingConfig,
 };
+pub use homeboy_extension_contract::manifest_capabilities::{
+    AgentTaskPolicyConfig, AuditCapability, DeployCapability, ExecutableCapability,
+    PlatformCapability,
+};
 pub use homeboy_extension_contract::manifest_toolchain_config::{
     BenchConfig, BuildConfig, CliAutoFlag, CliAutoFlagCondition, CliConfig, CliHelpConfig,
     DatabaseCliConfig, DatabaseConfig, DeployOverride, DeployOwnerHint, DeployVerification,
@@ -52,101 +56,8 @@ pub use homeboy_extension_contract::action_types::{ActionType, BuiltinAction, Ht
 // Capability Groups
 // ============================================================================
 
-/// Deploy lifecycle: verification rules, install overrides, version patterns, @since tags.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct DeployCapability {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub verifications: Vec<DeployVerification>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub overrides: Vec<DeployOverride>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub protected_path_suffixes: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub owner_hints: Vec<DeployOwnerHint>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub archive_install: Vec<DeployArchiveInstallPolicy>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub remote_path_inference: Vec<RemotePathInferenceRule>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub path_roots: Vec<RemotePathRootRule>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub version_patterns: Vec<VersionPatternConfig>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub since_tag: Option<SinceTagConfig>,
-}
-
 /// Test mapping convention: how source files map to test files.
 pub use homeboy_extension_contract::test_drift::TestDriftConfig;
-
-/// Docs audit: ignore patterns and feature detection patterns.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AuditCapability {
-    /// Shell script that resolves reference dependencies and exports
-    /// `HOMEBOY_AUDIT_REFERENCE_PATHS` (newline-separated directory paths).
-    /// Reference dependencies are fingerprinted for cross-reference analysis
-    /// (dead code detection) but excluded from convention and duplication detection.
-    /// Example: framework or package dependencies declared by an extension.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub setup_references: Option<String>,
-    /// Detector rules supplied by this extension for its language/framework.
-    #[serde(default, skip_serializing_if = "AuditConfig::is_empty")]
-    pub detector_rules: AuditConfig,
-    /// Glob patterns for paths to ignore during docs audit.
-    /// Uses `*` for single segment and `**` for multiple segments (e.g., `/wp-json/**`).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub ignore_claim_patterns: Vec<String>,
-    /// Regex patterns to detect feature registrations in source code.
-    /// Each pattern should have a capture group for the feature name.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub feature_patterns: Vec<String>,
-    /// Human-readable labels for feature patterns, keyed by a substring of the pattern.
-    /// Used by `docs generate --from-audit` to group and label features in generated docs.
-    /// Example: `{"register_post_type": "Post Types", "register_rest_route": "REST API Routes"}`
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub feature_labels: HashMap<String, String>,
-    /// Doc generation targets: maps a feature label to a file path and optional heading.
-    /// Used by `docs generate --from-audit` to place features in the right doc files.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub doc_targets: HashMap<String, DocTarget>,
-    /// Context extraction rules for feature patterns, keyed by a substring of the pattern.
-    /// Tells the audit system what additional context to extract around each detected feature.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub feature_context: HashMap<String, FeatureContextRule>,
-    /// Test mapping convention for structural test coverage gap detection.
-    /// Defines how source files map to test files and how methods map to test methods.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub test_mapping: Option<TestMappingConfig>,
-}
-
-/// Executable tool: runtime, inputs, and output schema.
-/// Represents a extension that can be run as a standalone tool.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExecutableCapability {
-    pub runtime: RuntimeConfig,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub inputs: Vec<InputConfig>,
-
-    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
-    pub extra: HashMap<String, serde_json::Value>,
-}
-
-/// Desktop/platform UI config: pinned files, database, discovery, commands.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PlatformCapability {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub config_schema: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub default_pinned_files: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub default_pinned_logs: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub database: Option<DatabaseConfig>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub discovery: Option<DiscoveryConfig>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub commands: Vec<String>,
-}
 
 // ============================================================================
 // ExtensionManifest
@@ -221,12 +132,6 @@ impl ExtensionDiagnosticsConfig {
     pub fn is_empty(&self) -> bool {
         self.tools.is_empty()
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
-pub struct AgentTaskPolicyConfig {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub default_backend: Option<String>,
 }
 
 /// Unified extension manifest decomposed into capability groups.

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -17,6 +17,7 @@ pub mod exec_context;
 pub mod extension_contract_producer;
 pub mod fuzz_config;
 pub mod manifest_action_config;
+pub mod manifest_capabilities;
 pub mod manifest_capability_config;
 pub mod manifest_deploy_config;
 pub mod manifest_test_config;

--- a/crates/homeboy-extension-contract/src/manifest_capabilities.rs
+++ b/crates/homeboy-extension-contract/src/manifest_capabilities.rs
@@ -1,0 +1,113 @@
+//! Extension capability contract types (deploy, audit, executable, platform,
+//! agent-task policy).
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::manifest_action_config::{InputConfig, RuntimeConfig};
+use crate::manifest_capability_config::{DocTarget, FeatureContextRule};
+use crate::manifest_deploy_config::DeployArchiveInstallPolicy;
+use crate::manifest_toolchain_config::{
+    DatabaseConfig, DeployOverride, DeployOwnerHint, DeployVerification, DiscoveryConfig,
+    RemotePathInferenceRule, RemotePathRootRule, SinceTagConfig, VersionPatternConfig,
+};
+use homeboy_audit_contract::{AuditConfig, TestMappingConfig};
+
+/// Deploy lifecycle: verification rules, install overrides, version patterns, @since tags.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeployCapability {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub verifications: Vec<DeployVerification>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub overrides: Vec<DeployOverride>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub protected_path_suffixes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub owner_hints: Vec<DeployOwnerHint>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub archive_install: Vec<DeployArchiveInstallPolicy>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub remote_path_inference: Vec<RemotePathInferenceRule>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub path_roots: Vec<RemotePathRootRule>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub version_patterns: Vec<VersionPatternConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub since_tag: Option<SinceTagConfig>,
+}
+
+/// Docs audit: ignore patterns and feature detection patterns.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditCapability {
+    /// Shell script that resolves reference dependencies and exports
+    /// `HOMEBOY_AUDIT_REFERENCE_PATHS` (newline-separated directory paths).
+    /// Reference dependencies are fingerprinted for cross-reference analysis
+    /// (dead code detection) but excluded from convention and duplication detection.
+    /// Example: framework or package dependencies declared by an extension.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub setup_references: Option<String>,
+    /// Detector rules supplied by this extension for its language/framework.
+    #[serde(default, skip_serializing_if = "AuditConfig::is_empty")]
+    pub detector_rules: AuditConfig,
+    /// Glob patterns for paths to ignore during docs audit.
+    /// Uses `*` for single segment and `**` for multiple segments (e.g., `/wp-json/**`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ignore_claim_patterns: Vec<String>,
+    /// Regex patterns to detect feature registrations in source code.
+    /// Each pattern should have a capture group for the feature name.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub feature_patterns: Vec<String>,
+    /// Human-readable labels for feature patterns, keyed by a substring of the pattern.
+    /// Used by `docs generate --from-audit` to group and label features in generated docs.
+    /// Example: `{"register_post_type": "Post Types", "register_rest_route": "REST API Routes"}`
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub feature_labels: HashMap<String, String>,
+    /// Doc generation targets: maps a feature label to a file path and optional heading.
+    /// Used by `docs generate --from-audit` to place features in the right doc files.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub doc_targets: HashMap<String, DocTarget>,
+    /// Context extraction rules for feature patterns, keyed by a substring of the pattern.
+    /// Tells the audit system what additional context to extract around each detected feature.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub feature_context: HashMap<String, FeatureContextRule>,
+    /// Test mapping convention for structural test coverage gap detection.
+    /// Defines how source files map to test files and how methods map to test methods.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_mapping: Option<TestMappingConfig>,
+}
+
+/// Executable tool: runtime, inputs, and output schema.
+/// Represents a extension that can be run as a standalone tool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutableCapability {
+    pub runtime: RuntimeConfig,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inputs: Vec<InputConfig>,
+
+    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Desktop/platform UI config: pinned files, database, discovery, commands.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlatformCapability {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_schema: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub default_pinned_files: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub default_pinned_logs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub database: Option<DatabaseConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discovery: Option<DiscoveryConfig>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub commands: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct AgentTaskPolicyConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_backend: Option<String>,
+}


### PR DESCRIPTION
## Summary
Eleventh sub-cut of the **extension crate extraction campaign** (Stage 1, wiki id 12840). Moves the **five capability structs** out of `manifest.rs` — now possible because all their field sub-trees landed in contract crates over the previous cuts.

## What moved
Into a new `manifest_capabilities` contract module:
`DeployCapability`, `AuditCapability`, `ExecutableCapability`, `PlatformCapability`, `AgentTaskPolicyConfig`.

All five are **impl-free, no custom serde helpers**. Their field types now resolve entirely from contract crates:
- extension-contract submodules (`manifest_toolchain_config`, `manifest_action_config`, `manifest_capability_config`, `manifest_deploy_config`) — the deploy/build/test/cli sub-trees moved in cuts 6/8
- `homeboy-audit-contract` (`AuditConfig`, `TestMappingConfig`)

This is the payoff of the earlier sub-tree cuts: `DeployCapability` (blocked in cut 7, its `DeployVerification`/`DeployOverride`/etc. sub-tree unblocked in cut 8) now moves cleanly.

## Zero downstream churn
`manifest.rs` re-exports the five with `pub use`, keeping the `crate::extension::*` surface stable.

## What's left in manifest.rs
Only the **behavior-bearing types** remain: `ExtensionManifest` (the `ConfigEntity`, 2 impls), `ExtensionDiagnosticsConfig` and `NotificationTransportConfig` (1 impl each). That's the **Stage 1 → Stage 2 boundary** — moving those requires hook-inverting their behavior, not just relocating data.

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-issues`, `homeboy-fuzz`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)