### PR TITLE
refactor: move ExtensionDiagnosticsConfig to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/manifest.rs
+++ b/crates/homeboy-core/src/extension/manifest.rs
@@ -63,21 +63,10 @@ pub use homeboy_extension_contract::test_drift::TestDriftConfig;
 // ExtensionManifest
 // ============================================================================
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
-pub struct ExtensionDiagnosticsConfig {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub tools: Vec<ExtensionToolDiagnosticDeclaration>,
-}
-
+pub use homeboy_extension_contract::manifest_capability_config::ExtensionDiagnosticsConfig;
 pub use homeboy_extension_contract::notification_transport_config::{
     NotificationTransportConfig, NOTIFICATION_TRANSPORT_SCHEMA,
 };
-
-impl ExtensionDiagnosticsConfig {
-    pub fn is_empty(&self) -> bool {
-        self.tools.is_empty()
-    }
-}
 
 /// Unified extension manifest decomposed into capability groups.
 ///

--- a/crates/homeboy-extension-contract/src/manifest_capability_config.rs
+++ b/crates/homeboy-extension-contract/src/manifest_capability_config.rs
@@ -161,6 +161,18 @@ pub struct ExtensionToolDiagnosticDeclaration {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct ExtensionDiagnosticsConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<ExtensionToolDiagnosticDeclaration>,
+}
+
+impl ExtensionDiagnosticsConfig {
+    pub fn is_empty(&self) -> bool {
+        self.tools.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct RuntimeRequirementsConfig {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]


### PR DESCRIPTION
## Summary
Moves `ExtensionDiagnosticsConfig` (+ its trivial `is_empty()` impl) from `homeboy-core`'s `extension::manifest` into `homeboy-extension-contract`'s `manifest_capability_config` — **alongside its element type** `ExtensionToolDiagnosticDeclaration`, which #8765 already moved there. It's a pure serde config type (just `Vec<ExtensionToolDiagnosticDeclaration>`).

Re-exported from `extension::manifest` so `crate::extension::ExtensionDiagnosticsConfig` call sites (the `ExtensionManifest.diagnostics` field, `mod.rs` re-export) are unchanged.

## Why (gradual untangling)
Continues the `extension-contract` keystone campaign (#8757 / #8760 / #8764 / #8765): steadily draining pure config types out of the extension subsystem into the contract, so a future `homeboy-extension` extraction depends on a slim seam. This one also **reunites the config with its element type** that already lives in the contract — cleaner than having them split across the crate boundary.

## Verification
- `cargo check -p homeboy-extension-contract --lib`, `-p homeboy-core --lib`, `-p homeboy-cli --lib` — 0 errors.
- `cargo check --workspace --tests --locked` (topology guard) — **passes**.
- `cargo test -p homeboy-extension-contract --lib` — **38 passed**.

Refs #8425