### PR TITLE
refactor: carry agent-task config types opaquely in core config + component

### DIFF
--- a/crates/homeboy-core/src/agent_task_dispatch_plan.rs
+++ b/crates/homeboy-core/src/agent_task_dispatch_plan.rs
@@ -288,7 +288,10 @@ pub fn build_dispatch_plan_with_provider_requirements(
     // absent rotation. Per-task `metadata.provider_rotation` still overrides it.
     plan.options.rotation = match &request.core.resolved_provider_policy {
         Some(_) => resolved_rotation,
-        None => defaults::load_config().agent_task.rotation,
+        None => defaults::load_config()
+            .agent_task
+            .rotation
+            .and_then(|rotation| serde_json::from_value(rotation).ok()),
     };
     if let Some(policy) = &request.core.resolved_provider_policy {
         for task in &mut plan.tasks {
@@ -1041,7 +1044,7 @@ mod tests {
     fn dispatch_plan_applies_global_agent_task_rotation_policy() {
         with_isolated_home(|_| {
             let mut config = defaults::load_config();
-            config.agent_task.rotation = Some(
+            config.agent_task.rotation = serde_json::to_value(
                 crate::agent_task_scheduler::AgentTaskProviderRotationPolicy {
                     entries: vec![
                         crate::agent_task_scheduler::AgentTaskProviderRotationEntry {
@@ -1052,7 +1055,8 @@ mod tests {
                     max_attempts: Some(2),
                     ..Default::default()
                 },
-            );
+            )
+            .ok();
             defaults::save_config(&config).expect("save config");
 
             let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
@@ -1090,7 +1094,7 @@ mod tests {
     fn submitted_provider_policy_preserves_controller_execution_policy() {
         with_isolated_home(|_| {
             let mut runner_config = defaults::load_config();
-            runner_config.agent_task.rotation = Some(
+            runner_config.agent_task.rotation = serde_json::to_value(
                 crate::agent_task_scheduler::AgentTaskProviderRotationPolicy {
                     entries: vec![
                         crate::agent_task_scheduler::AgentTaskProviderRotationEntry {
@@ -1100,7 +1104,8 @@ mod tests {
                     ],
                     ..Default::default()
                 },
-            );
+            )
+            .ok();
             defaults::save_config(&runner_config).expect("save runner config");
 
             let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
@@ -1192,7 +1197,7 @@ mod tests {
     fn submitted_provider_policy_without_rotation_ignores_runner_rotation() {
         with_isolated_home(|_| {
             let mut runner_config = defaults::load_config();
-            runner_config.agent_task.rotation = Some(
+            runner_config.agent_task.rotation = serde_json::to_value(
                 crate::agent_task_scheduler::AgentTaskProviderRotationPolicy {
                     entries: vec![
                         crate::agent_task_scheduler::AgentTaskProviderRotationEntry {
@@ -1202,7 +1207,8 @@ mod tests {
                     ],
                     ..Default::default()
                 },
-            );
+            )
+            .ok();
             defaults::save_config(&runner_config).expect("save runner config");
 
             let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
@@ -1290,7 +1296,7 @@ mod tests {
     fn controller_plan_compilation_uses_initial_global_rotation_model() {
         with_isolated_home(|_| {
             let mut config = defaults::load_config();
-            config.agent_task.rotation = Some(
+            config.agent_task.rotation = serde_json::to_value(
                 crate::agent_task_scheduler::AgentTaskProviderRotationPolicy {
                     entries: vec![
                         crate::agent_task_scheduler::AgentTaskProviderRotationEntry {
@@ -1300,7 +1306,8 @@ mod tests {
                     ],
                     ..Default::default()
                 },
-            );
+            )
+            .ok();
             defaults::save_config(&config).expect("save config");
             let mut request = dispatch_request(DispatchRequestOverrides {
                 prompt: Some("Cook with the selected global model.".to_string()),
@@ -1331,7 +1338,7 @@ mod tests {
     fn controller_plan_compilation_preserves_submitted_provider_policy() {
         with_isolated_home(|_| {
             let mut config = defaults::load_config();
-            config.agent_task.rotation = Some(
+            config.agent_task.rotation = serde_json::to_value(
                 crate::agent_task_scheduler::AgentTaskProviderRotationPolicy {
                     entries: vec![
                         crate::agent_task_scheduler::AgentTaskProviderRotationEntry {
@@ -1341,7 +1348,8 @@ mod tests {
                     ],
                     ..Default::default()
                 },
-            );
+            )
+            .ok();
             defaults::save_config(&config).expect("save config");
             let submitted_policy =
                 crate::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy {

--- a/crates/homeboy-core/src/agent_task_dispatch_service.rs
+++ b/crates/homeboy-core/src/agent_task_dispatch_service.rs
@@ -322,6 +322,9 @@ pub fn controller_resolved_execution_policy(
     let rotation = crate::defaults::load_config()
         .agent_task
         .rotation
+        .and_then(|rotation| {
+            serde_json::from_value::<AgentTaskProviderRotationPolicy>(rotation).ok()
+        })
         .map(|mut rotation| {
             if explicit_backend {
                 // A controller pin describes one immutable runtime. Global fallback
@@ -660,7 +663,7 @@ mod tests {
 
             let mut config = crate::defaults::load_config();
             config.agent_task.default_backend = Some("opencode".to_string());
-            config.agent_task.rotation = Some(AgentTaskProviderRotationPolicy {
+            config.agent_task.rotation = serde_json::to_value(AgentTaskProviderRotationPolicy {
                 entries: vec![
                     crate::agent_task_scheduler::AgentTaskProviderRotationEntry {
                         backend: Some("opencode".to_string()),
@@ -668,7 +671,8 @@ mod tests {
                     },
                 ],
                 ..Default::default()
-            });
+            })
+            .ok();
             crate::defaults::save_config(&config).expect("save config");
 
             let request = resolve_dispatch_request_with_default_and_config(

--- a/crates/homeboy-core/src/agent_task_review_dossier.rs
+++ b/crates/homeboy-core/src/agent_task_review_dossier.rs
@@ -120,7 +120,19 @@ pub fn default_profile() -> AgentTaskReviewProfile {
 /// config therefore fails finalization instead of being mistaken for profile absence.
 pub fn resolve_review_profile(path: &str) -> Result<AgentTaskReviewProfile> {
     let component = crate::component::resolve_effective(None, Some(path), None)?;
-    let profile = component.review_profile.unwrap_or_else(default_profile);
+    // The component model carries the profile opaquely as JSON; deserialize it
+    // here (the agent-task layer owns the profile schema). A present-but-invalid
+    // profile fails finalization instead of being mistaken for profile absence.
+    let profile = match component.review_profile {
+        Some(value) => serde_json::from_value(value).map_err(|error| {
+            crate::Error::validation_invalid_json(
+                error,
+                Some("parse component review profile".to_string()),
+                None,
+            )
+        })?,
+        None => default_profile(),
+    };
     validate_profile(&profile)?;
     Ok(profile)
 }

--- a/crates/homeboy-core/src/component/model.rs
+++ b/crates/homeboy-core/src/component/model.rs
@@ -7,7 +7,6 @@ use super::config::{
     ComponentReleaseConfig, ComponentScriptsConfig, DependencyStackEdge, GitDeployConfig,
     GithubConfig, ScopeConfig, ScopedExtensionConfig, VersionTarget,
 };
-use crate::agent_task_review_dossier::AgentTaskReviewProfile;
 
 /// Lifecycle state of a component.
 ///
@@ -156,8 +155,12 @@ pub struct Component {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audit_rules: Option<serde_json::Value>,
     /// Declarative reviewer-body policy for agent-task PR finalization.
+    ///
+    /// Carried opaquely as JSON so the core component model does not depend on
+    /// the agent-task subsystem; the agent-task review-dossier layer
+    /// deserializes it into its `AgentTaskReviewProfile`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub review_profile: Option<AgentTaskReviewProfile>,
+    pub review_profile: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -245,7 +248,7 @@ struct RawComponent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     audit_rules: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    review_profile: Option<AgentTaskReviewProfile>,
+    review_profile: Option<serde_json::Value>,
 }
 
 impl From<RawComponent> for Component {

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -2,8 +2,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::agent_task_schedule::AgentTaskProviderRotationPolicy;
-
 #[path = "defaults/builtins.rs"]
 mod builtins;
 mod io;
@@ -285,8 +283,12 @@ pub struct AgentTaskConfig {
     /// `homeboy config set /agent_task/rotation <json> --json`. A per-plan
     /// `options.rotation` or per-task `metadata.provider_rotation` override
     /// takes precedence (#6978).
+    ///
+    /// Carried opaquely as JSON so core config does not depend on the agent-task
+    /// subsystem; the agent-task dispatch layer deserializes it into its
+    /// `AgentTaskProviderRotationPolicy` when building a plan.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub rotation: Option<AgentTaskProviderRotationPolicy>,
+    pub rotation: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -454,6 +456,7 @@ pub fn builtin_defaults() -> Defaults {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent_task_schedule::AgentTaskProviderRotationPolicy;
     use crate::test_support::with_isolated_home;
 
     #[test]
@@ -530,7 +533,9 @@ mod tests {
         )
         .unwrap();
 
-        let rotation = config.agent_task.rotation.expect("rotation policy");
+        let rotation: AgentTaskProviderRotationPolicy =
+            serde_json::from_value(config.agent_task.rotation.expect("rotation policy"))
+                .expect("rotation policy deserializes");
         assert_eq!(rotation.entries.len(), 2);
         assert_eq!(rotation.max_attempts, Some(3));
         assert_eq!(


### PR DESCRIPTION
## Summary
Stage 2 prep-PR of the homeboy-agents crate extraction campaign (wiki: `homeboy-agents-crate-extraction-plan`). Independent PR off `main`.

Two core structs embedded agent-task types they only ever **pass through**, while every typed read lives in agent-task code — a `core -> agent_task` cycle at extraction (agent depends on these host modules AND they import agent types):
- `HomeboyConfig.agent_task.rotation: Option<AgentTaskProviderRotationPolicy>` (`defaults.rs`)
- `ComponentModel.review_profile: Option<AgentTaskReviewProfile>` (`component/model.rs`)

## What changed
Both fields become `Option<serde_json::Value>` — carried **opaquely** as JSON, byte-identical wire format. This mirrors the `audit_rules` field already opaque in the same component model. The agent-task layer deserializes at the read boundary:
- rotation: `agent_task_dispatch_service` (the one prod reader that filters entries / reads `liveness_timeout_ms`) + `agent_task_dispatch_plan` (config fallback). Test writers wrap with `serde_json::to_value`.
- review profile: `agent_task_review_dossier::resolve_review_profile`. A present-but-invalid profile still **fails finalization** (explicit deser error) rather than being mistaken for profile absence — preserving the original serde-at-load-time behavior.

## Effect
- `defaults.rs` + `component/model.rs`: prod agent-task refs -> **0** (`defaults.rs` retains only a test-module import).
- Severs the **last cycle-risk type-import edges**. Remaining core→agent edges are now all clean type-imports (flip to `homeboy_agents::` at git-mv) or agent-owned modules that move with agent — no more pre-work cycles.

## Verification
- `cargo check -p homeboy-core --lib` / `--tests`, `-p homeboy-cli --lib`: clean.
- `cargo test`: rotation policy parse test + 13 provider-rotation tests + 7 review-dossier tests pass.
- One unrelated test (`rotation_preserves_uncommitted_candidate_..._clean_baseline`) fails **identically on clean origin/main** (v0.289.0) — a pre-existing flaky threading assertion (`attempt checkouts are retired after their executor threads stop`), not caused by this PR.
- `cargo fmt`: clean.