### PR TITLE
refactor: split structured-sidecar types from behavior into homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/manifest.rs
+++ b/crates/homeboy-core/src/extension/manifest.rs
@@ -396,7 +396,9 @@ impl ExtensionManifest {
     pub fn structured_sidecars(&self) -> Vec<StructuredSidecarDeclaration> {
         self.structured_sidecars
             .iter()
-            .filter_map(|(name, contract)| contract.declaration(name))
+            .filter_map(|(name, contract)| {
+                super::manifest_sidecar::structured_sidecar_declaration(contract, name)
+            })
             .collect()
     }
 

--- a/crates/homeboy-core/src/extension/manifest_sidecar.rs
+++ b/crates/homeboy-core/src/extension/manifest_sidecar.rs
@@ -1,61 +1,48 @@
+//! Structured-sidecar declaration resolution.
+//!
+//! The pure contract types live in `homeboy-extension-contract`; this module
+//! re-exports them and provides the resolution logic that depends on core's
+//! run-dir file constants and `structured_sidecar` defaults.
+
 use crate::{engine::run_dir, structured_sidecar};
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum StructuredSidecarContract {
-    Enabled(bool),
-    Detail(StructuredSidecarDetail),
-}
+pub use homeboy_extension_contract::sidecar_config::{
+    StructuredSidecarContract, StructuredSidecarDeclaration, StructuredSidecarDetail,
+};
 
-impl StructuredSidecarContract {
-    pub(super) fn declaration(&self, name: &str) -> Option<StructuredSidecarDeclaration> {
-        match self {
-            StructuredSidecarContract::Enabled(true) => Some(StructuredSidecarDeclaration {
-                name: name.to_string(),
-                path: default_structured_sidecar_path(name),
-                schema_version: structured_sidecar::default_schema_version(name)
-                    .map(str::to_string),
-                producer: default_structured_sidecar_producer(name),
-            }),
-            StructuredSidecarContract::Enabled(false) => None,
-            StructuredSidecarContract::Detail(detail) => {
-                if !detail.enabled {
-                    return None;
-                }
-
-                Some(StructuredSidecarDeclaration {
-                    name: name.to_string(),
-                    path: detail
-                        .path
-                        .clone()
-                        .unwrap_or_else(|| default_structured_sidecar_path(name)),
-                    schema_version: detail.schema_version.clone(),
-                    producer: detail
-                        .producer
-                        .clone()
-                        .or_else(|| default_structured_sidecar_producer(name)),
-                })
+/// Resolve a structured-sidecar contract into a concrete declaration for the
+/// given sidecar name, applying core's default paths and producers.
+pub(super) fn structured_sidecar_declaration(
+    contract: &StructuredSidecarContract,
+    name: &str,
+) -> Option<StructuredSidecarDeclaration> {
+    match contract {
+        StructuredSidecarContract::Enabled(true) => Some(StructuredSidecarDeclaration {
+            name: name.to_string(),
+            path: default_structured_sidecar_path(name),
+            schema_version: structured_sidecar::default_schema_version(name).map(str::to_string),
+            producer: default_structured_sidecar_producer(name),
+        }),
+        StructuredSidecarContract::Enabled(false) => None,
+        StructuredSidecarContract::Detail(detail) => {
+            if !detail.enabled {
+                return None;
             }
+
+            Some(StructuredSidecarDeclaration {
+                name: name.to_string(),
+                path: detail
+                    .path
+                    .clone()
+                    .unwrap_or_else(|| default_structured_sidecar_path(name)),
+                schema_version: detail.schema_version.clone(),
+                producer: detail
+                    .producer
+                    .clone()
+                    .or_else(|| default_structured_sidecar_producer(name)),
+            })
         }
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct StructuredSidecarDetail {
-    #[serde(default = "default_true")]
-    pub enabled: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub path: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub schema_version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub producer: Option<String>,
-}
-
-fn default_true() -> bool {
-    true
 }
 
 fn default_structured_sidecar_path(name: &str) -> String {
@@ -96,15 +83,4 @@ fn default_structured_sidecar_producer(name: &str) -> Option<String> {
         _ => None,
     }
     .map(str::to_string)
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct StructuredSidecarDeclaration {
-    pub name: String,
-    pub path: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub schema_version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub producer: Option<String>,
 }

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -24,6 +24,7 @@ pub mod manifest_test_config;
 pub mod manifest_toolchain_config;
 pub mod notification_transport_config;
 pub mod runner_contract;
+pub mod sidecar_config;
 pub mod source_metadata_repair;
 pub mod test_drift;
 pub mod trace_config;

--- a/crates/homeboy-extension-contract/src/sidecar_config.rs
+++ b/crates/homeboy-extension-contract/src/sidecar_config.rs
@@ -1,0 +1,43 @@
+//! Structured-sidecar manifest contract types.
+//!
+//! Pure serde data describing an extension's structured-sidecar declarations.
+//! The logic that resolves a contract into a concrete declaration (default
+//! paths/producers, which depend on core's run-dir file constants) lives in
+//! `homeboy-core` as a free function, so these types stay behavior-free.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum StructuredSidecarContract {
+    Enabled(bool),
+    Detail(StructuredSidecarDetail),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct StructuredSidecarDetail {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub producer: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct StructuredSidecarDeclaration {
+    pub name: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub producer: Option<String>,
+}


### PR DESCRIPTION
## Summary
**First Stage-2 cut** of the extension campaign (wiki id 12840). Applies the data/behavior split pattern (proven on `ArtifactContract` in #8752) to `manifest_sidecar` — and clears the last core-typed field blocking `ExtensionManifest` itself.

## The split
The three structured-sidecar types (`StructuredSidecarContract`, `StructuredSidecarDetail`, `StructuredSidecarDeclaration`) are pure serde data, but the module carried **behavior**: the `declaration()` method resolves default sidecar paths and producers via `run_dir::files` constants and the `structured_sidecar` module — both core-only.

- **Pure types → new contract `sidecar_config` module.**
- **Resolution logic → core free function** `structured_sidecar_declaration(contract, name)`, which keeps the `run_dir`/`structured_sidecar` dependencies where they belong.
- `manifest.rs`'s `structured_sidecars()` now calls the free function instead of the former `pub(super)` inherent method (its only caller).

## Why this matters
`ExtensionManifest`'s struct fields are now **entirely** backed by contract-crate types — every capability/config type moved in cuts 1–11, and this clears the final holdout (`StructuredSidecarContract`). The manifest struct is now a pure-data candidate; only its `ConfigEntity` trait impl (core behavior) remains to be handled.

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-issues`, `homeboy-fuzz`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)