### PR TITLE
fix(lab): stop force-offloading cheap commands on a merely warm machine

### DIFF
--- a/crates/homeboy-cli/src/commands/contract_lab_routing.rs
+++ b/crates/homeboy-cli/src/commands/contract_lab_routing.rs
@@ -90,7 +90,11 @@ impl Commands {
                 Some("--to-worktree"),
                 false,
                 LAB_NO_EXTRA_CAPABILITIES,
-            ),
+            )
+            // Promotion is a fast local-state git worktree projection, not a
+            // workload run: a merely `warm` controller should not pay the Lab
+            // round-trip for it. Only offload when the machine is genuinely hot.
+            .cheap(),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command: agent_task::AgentTaskCommand::Providers(_),
             }) => LabCommandContract::explicit_runner_simple(AGENT_TASK_PROVIDERS_LAB_LABEL),
@@ -222,6 +226,9 @@ impl Commands {
                     false,
                     LAB_NO_EXTRA_CAPABILITIES,
                 )
+                // Mechanical rename/refactor is cheap relative to a Lab
+                // round-trip; only offload it on a genuinely hot machine.
+                .cheap()
             }
             Commands::Rig(args) => return args.portability_contract(),
             Commands::Trace(args) => return args.portability_contract(),

--- a/crates/homeboy-core/src/lab_routing.rs
+++ b/crates/homeboy-core/src/lab_routing.rs
@@ -625,6 +625,7 @@ mod tests {
                 release_gate: false,
                 requires_extension_parity: true,
                 read_only_polling: false,
+                offload_only_when_hot: false,
             },
         }
     }

--- a/crates/homeboy-lab-contract/src/lab/types.rs
+++ b/crates/homeboy-lab-contract/src/lab/types.rs
@@ -34,6 +34,31 @@ pub struct LabRoutingPolicy {
     /// Whether runner-resident reads should avoid durable mirror runs and
     /// handoff boilerplate unless the command itself emits them.
     pub read_only_polling: bool,
+    /// Whether automatic pressure-driven Lab offload requires a genuinely `hot`
+    /// machine rather than merely `warm`. Cheap portable commands set this so a
+    /// slightly-loaded (`warm`) controller does not pay the full Lab
+    /// round-trip for work that finishes faster locally. Expensive portable
+    /// commands (bench/audit/test/agent-task) leave it `false` and offload as
+    /// soon as the machine leaves `ok`.
+    pub offload_only_when_hot: bool,
+}
+
+impl LabRoutingPolicy {
+    /// Whether a machine at the given resource severity (`"ok"` / `"warm"` /
+    /// `"hot"`) should trigger automatic pressure-driven Lab offload for this
+    /// command. `ok` never offloads; cheap commands
+    /// (`offload_only_when_hot`) require `hot`; everything else offloads once
+    /// the machine leaves `ok`. Single source of truth for the offload
+    /// decision so the runner-side execute path and tests agree.
+    pub fn should_pressure_offload(&self, severity: &str) -> bool {
+        if severity == "ok" {
+            return false;
+        }
+        if self.offload_only_when_hot {
+            return severity == "hot";
+        }
+        true
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
@@ -169,6 +194,7 @@ impl LabCommandContract {
                 release_gate: false,
                 requires_extension_parity,
                 read_only_polling: false,
+                offload_only_when_hot: false,
             },
         }
     }
@@ -254,12 +280,21 @@ impl LabCommandContract {
                 release_gate: false,
                 requires_extension_parity: false,
                 read_only_polling: false,
+                offload_only_when_hot: false,
             },
         }
     }
 
     pub const fn release_gate(mut self) -> Self {
         self.routing_policy.release_gate = true;
+        self
+    }
+
+    /// Mark a portable command as cheap: automatic pressure-driven Lab offload
+    /// then requires a genuinely `hot` machine, not merely `warm`. Prevents
+    /// paying the Lab round-trip for fast work on a slightly-loaded controller.
+    pub const fn cheap(mut self) -> Self {
+        self.routing_policy.offload_only_when_hot = true;
         self
     }
 
@@ -271,5 +306,53 @@ impl LabCommandContract {
     pub const fn with_secret_env_sources(mut self, sources: &'static [LabSecretEnvSource]) -> Self {
         self.secret_env_sources = sources;
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eager_portable_offloads_on_warm_and_hot_but_not_ok() {
+        let policy = LabCommandContract::portable("bench", None, false, LAB_NO_EXTRA_CAPABILITIES)
+            .routing_policy;
+        assert!(!policy.offload_only_when_hot);
+        assert!(!policy.should_pressure_offload("ok"));
+        assert!(policy.should_pressure_offload("warm"));
+        assert!(policy.should_pressure_offload("hot"));
+    }
+
+    #[test]
+    fn cheap_portable_offloads_only_when_hot() {
+        let policy =
+            LabCommandContract::portable("promote", None, false, LAB_NO_EXTRA_CAPABILITIES)
+                .cheap()
+                .routing_policy;
+        assert!(policy.offload_only_when_hot);
+        assert!(!policy.should_pressure_offload("ok"));
+        // The bug this fixes: a merely warm machine must NOT force a cheap
+        // command onto the Lab.
+        assert!(!policy.should_pressure_offload("warm"));
+        assert!(policy.should_pressure_offload("hot"));
+    }
+
+    #[test]
+    fn cheap_is_opt_in_and_default_constructors_stay_eager() {
+        assert!(
+            !LabCommandContract::local_only("x", "r")
+                .routing_policy
+                .offload_only_when_hot
+        );
+        assert!(
+            !LabCommandContract::explicit_runner_simple("x")
+                .routing_policy
+                .offload_only_when_hot
+        );
+        assert!(
+            !LabCommandContract::portable("x", None, false, LAB_NO_EXTRA_CAPABILITIES)
+                .routing_policy
+                .offload_only_when_hot
+        );
     }
 }

--- a/crates/homeboy-lab-runner/src/lab/offload/execute.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/execute.rs
@@ -95,12 +95,19 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     // controller pressure. Other portable workspace commands use the single
     // preflight snapshot captured by CliRuntime: cold controllers stay local,
     // while warm/hot controllers may use an eligible default Lab runner.
+    //
+    // Cheap commands (`offload_only_when_hot`) require a genuinely `hot`
+    // machine before auto-offloading, so a merely `warm` controller does not
+    // pay the full Lab round-trip for work that finishes faster locally.
     if !contract.routing_policy.default_lab_offload
         && request.placement == homeboy_cli_contract::Placement::Auto
         && contract.source_path_mode
             != homeboy_core::lab_contract::LabSourcePathMode::RunnerResident
-        && homeboy_core::resource_policy_context::captured_context()
-            .is_some_and(|context| context.severity != "ok")
+        && homeboy_core::resource_policy_context::captured_context().is_some_and(|context| {
+            contract
+                .routing_policy
+                .should_pressure_offload(&context.severity)
+        })
     {
         contract.routing_policy.default_lab_offload = true;
     }


### PR DESCRIPTION
## Summary

Portable commands were auto-routed to the Lab whenever the controller's resource severity left `ok` — i.e. **warm OR hot** — with no notion of command *cost*. Cheap portable commands (agent-task `promote`, `refactor`) therefore paid the full Lab round-trip on a slightly-loaded machine for work that finishes faster locally. This is the "wastes the Lab connection for things that don't need it / blocks orchestration on a warm machine" class of misclassification bug.

## The bug

`homeboy-lab-runner/src/lab/offload/execute.rs` force-set `default_lab_offload = true` for any `Portable`, `Auto`-placement, non-runner-resident command whenever `captured_context().severity != "ok"`. `!= "ok"` catches `warm` as well as `hot`. There was no third axis for "is offloading this actually worth it?", so cheap-but-portable ≡ expensive-and-portable.

## The fix

- Add `LabRoutingPolicy::offload_only_when_hot` (opt-in via `LabCommandContract::cheap()`).
- Centralize the decision in `LabRoutingPolicy::should_pressure_offload(severity)` — single source of truth used by the runner execute path:
  - `ok` → never auto-offload
  - cheap command → only when `hot`
  - everything else → offload once the machine leaves `ok` (unchanged)
- Mark **agent-task `promote`** (fast local git worktree projection) and **`refactor`** (mechanical rename) as `.cheap()`.
- Leave **bench / audit / lint / trace / fuzz** eager — they're genuinely heavy and benefit from offload on `warm`.

**Backward compatible:** the flag defaults `false`, so every existing command keeps today's routing unless explicitly marked cheap.

## Tests

New unit tests in `homeboy-lab-contract` lock in the contract:
- eager portable offloads on warm+hot but not ok
- cheap portable offloads **only** on hot (the bug this fixes: warm must stay local)
- `.cheap()` is opt-in; default constructors stay eager

`cargo test -p homeboy-lab-contract --lib` → 31 passed. Libs for `homeboy-core`, `homeboy-lab-runner`, `homeboy-cli` compile clean; `homeboy-lab-runner --tests` compiles clean.

Note: `homeboy-cli` lib tests currently fail to compile on `origin/main` (pre-existing E0308 in error-code handling, unrelated to this change); the full CLI test suite will validate in CI.