### PR TITLE
Consume Lab runner intent at the handoff boundary

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1559,11 +1559,18 @@ mod tests {
             crate::runner::RUNNER_HOSTED_EXEC_ENV,
             crate::runner::RUNNER_PLACEMENT_RESOLVED_ENV,
             crate::runner::RUNNER_ID_ENV,
+            "HOMEBOY_LAB_RUNNER_ID",
+            homeboy::core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV,
         ]
         .map(|name| (name, std::env::var(name).ok()));
         std::env::set_var(crate::runner::RUNNER_HOSTED_EXEC_ENV, "1");
         std::env::set_var(crate::runner::RUNNER_PLACEMENT_RESOLVED_ENV, "1");
         std::env::set_var(crate::runner::RUNNER_ID_ENV, "homeboy-lab");
+        std::env::set_var("HOMEBOY_LAB_RUNNER_ID", "homeboy-lab");
+        std::env::set_var(
+            homeboy::core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV,
+            "homeboy-lab",
+        );
 
         *marker_context_before_run_command()
             .lock()
@@ -1580,6 +1587,12 @@ mod tests {
             "run_command must not inherit managed placement markers"
         );
         assert!(!resource_policy::is_managed_runner_placement_context());
+        assert!(std::env::var_os("HOMEBOY_LAB_RUNNER_ID").is_none());
+        assert_eq!(
+            std::env::var_os(homeboy::core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV),
+            Some("homeboy-lab".into()),
+            "runner execution provenance survives without exposing controller transport intent"
+        );
 
         for (name, value) in previous {
             match value {

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -276,7 +276,7 @@ pub(super) fn run_plan(args: RunPlanArgs) -> CmdResult<Value> {
 }
 
 fn emit_runner_lifecycle_progress(plan: &AgentTaskPlan, run_id: Option<&str>) {
-    if std::env::var_os("HOMEBOY_LAB_RUNNER_ID").is_none() {
+    if std::env::var_os(homeboy::core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV).is_none() {
         return;
     }
     for task in &plan.tasks {

--- a/crates/homeboy-core/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/promote.rs
@@ -47,7 +47,7 @@ pub fn promote_with_checkpoint(
     if let Some(provenance) = provider.provenance() {
         report.provenance["worktree_provider"] = provenance.clone();
     }
-    if let Ok(runner_id) = std::env::var("HOMEBOY_LAB_RUNNER_ID") {
+    if let Ok(runner_id) = std::env::var(crate::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV) {
         if !runner_id.trim().is_empty() {
             report.provenance["lab_offload"] = json!({
                 "runner_id": runner_id,

--- a/crates/homeboy-core/src/resource_policy_context.rs
+++ b/crates/homeboy-core/src/resource_policy_context.rs
@@ -165,4 +165,7 @@ pub fn clear_managed_runner_placement_context() {
     std::env::remove_var(homeboy_lab_runner_contract::RUNNER_HOSTED_EXEC_ENV);
     std::env::remove_var(homeboy_lab_runner_contract::RUNNER_PLACEMENT_RESOLVED_ENV);
     std::env::remove_var(homeboy_lab_runner_contract::RUNNER_ID_ENV);
+    // This legacy value selected a controller daemon. A runner-local child must
+    // not pass it into provider preflight after the Lab handoff is accepted.
+    std::env::remove_var("HOMEBOY_LAB_RUNNER_ID");
 }

--- a/crates/homeboy-lab-contract/src/lab/types.rs
+++ b/crates/homeboy-lab-contract/src/lab/types.rs
@@ -5,6 +5,9 @@ use super::workload::LabRunnerWorkloadCapability;
 pub const LAB_CAPABILITY_PLAYWRIGHT: &str = "playwright";
 pub const LAB_TRACE_EXTRA_CAPABILITIES: &[&str] = &[LAB_CAPABILITY_PLAYWRIGHT];
 pub const LAB_NO_SECRET_ENV_SOURCES: &[LabSecretEnvSource] = &[];
+/// Runner identity retained by a child already executing on Lab. Unlike the
+/// controller transport marker, consumers must treat this as provenance only.
+pub const LAB_EXECUTION_RUNNER_ID_ENV: &str = "HOMEBOY_LAB_EXECUTION_RUNNER_ID";
 pub const LAB_NO_EXTRA_CAPABILITIES: &[&str] = &[];
 pub const LAB_AGENT_TASK_SECRET_ENV_SOURCES: &[LabSecretEnvSource] =
     &[LabSecretEnvSource::AgentTask];

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -239,7 +239,7 @@ fn lab_runner_exec_options(
         "1".to_string(),
     );
     env.insert(
-        "HOMEBOY_LAB_RUNNER_ID".to_string(),
+        homeboy_core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV.to_string(),
         context.runner_id.to_string(),
     );
     RunnerExecOptions {


### PR DESCRIPTION
## Summary
- Consume controller-selected runner intent after the outer Lab handoff is accepted.
- Preserve execution runner identity separately for lifecycle, artifact, diagnostic, promotion, and retry provenance.
- Prevent runner-resident agent-task provider preflight from requiring a second controller daemon session.

Closes #8748.

## Verification
1. `cargo fmt --check`
2. `cargo test -p homeboy-cli managed_runner_context_clears_before_production_run_command --lib`
3. `cargo check -p homeboy-lab-contract -p homeboy-core -p homeboy-lab-runner -p homeboy-cli`
4. `git diff --check`
5. Lab handoff reached the remote candidate checkout after the daemon was refreshed, proving controller-to-runner materialization and execution. The full `homeboy review` then stopped on the pre-existing stale audit source root `crates/homeboy-core/src/code_audit/detectors/`, which matches zero files and is unrelated to this change.

## Compatibility
This preserves runner provenance while changing only how inherited Lab transport intent is represented after an accepted handoff. No product-specific behavior or public extension contract is added.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Diagnosing the nested Lab preflight failure, implementing the handoff-boundary repair and regression coverage, and running targeted verification. Chris remains responsible for review and submission.