### PR TITLE
refactor: establish homeboy-refactor-contract crate keystone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,6 +852,7 @@ dependencies = [
  "homeboy-process",
  "homeboy-product-identity",
  "homeboy-redaction",
+ "homeboy-refactor-contract",
  "keyring",
  "libc",
  "regex",
@@ -1026,6 +1027,14 @@ name = "homeboy-redaction"
 version = "0.1.0"
 dependencies = [
  "regex",
+ "serde_json",
+]
+
+[[package]]
+name = "homeboy-refactor-contract"
+version = "0.1.0"
+dependencies = [
+ "serde",
  "serde_json",
 ]
 

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -321,19 +321,22 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
     with_temp_home(|| {
         let mut config = homeboy::core::defaults::load_config();
         config.agent_task.rotation = Some(
-            homeboy::core::agent_task_scheduler::AgentTaskProviderRotationPolicy {
-                entries: vec![
-                    homeboy::core::agent_task_scheduler::AgentTaskProviderRotationEntry {
-                        model: Some("openai/gpt-5.6-terra".to_string()),
-                        ..Default::default()
-                    },
-                    homeboy::core::agent_task_scheduler::AgentTaskProviderRotationEntry {
-                        model: Some("fallback-model".to_string()),
-                        ..Default::default()
-                    },
-                ],
-                ..Default::default()
-            },
+            serde_json::to_value(
+                homeboy::core::agent_task_scheduler::AgentTaskProviderRotationPolicy {
+                    entries: vec![
+                        homeboy::core::agent_task_scheduler::AgentTaskProviderRotationEntry {
+                            model: Some("openai/gpt-5.6-terra".to_string()),
+                            ..Default::default()
+                        },
+                        homeboy::core::agent_task_scheduler::AgentTaskProviderRotationEntry {
+                            model: Some("fallback-model".to_string()),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                },
+            )
+            .expect("serialize provider rotation policy"),
         );
         homeboy::core::defaults::save_config(&config).expect("save provider rotation");
         let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -28,6 +28,7 @@ homeboy-paths = { version = "0.1.0", path = "../homeboy-paths" }
 homeboy-process = { version = "0.1.0", path = "../homeboy-process" }
 homeboy-product-identity = { version = "0.1.0", path = "../homeboy-product-identity" }
 homeboy-audit-contract = { version = "0.1.0", path = "../homeboy-audit-contract" }
+homeboy-refactor-contract = { version = "0.1.0", path = "../homeboy-refactor-contract" }
 homeboy-code-audit = { version = "0.1.0", path = "../homeboy-code-audit" }
 homeboy-extension-contract = { version = "0.1.0", path = "../homeboy-extension-contract" }
 homeboy-lifecycle-contract = { version = "0.1.0", path = "../homeboy-lifecycle-contract" }

--- a/crates/homeboy-core/src/refactor/auto/outcome.rs
+++ b/crates/homeboy-core/src/refactor/auto/outcome.rs
@@ -38,26 +38,7 @@ pub struct FixApplied {
 }
 
 /// Aggregate summary of extension fix results.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FixResultsSummary {
-    pub fixes_applied: usize,
-    pub files_modified: usize,
-    pub rules: Vec<RuleFixCount>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub primitives: Vec<PrimitiveFixCount>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RuleFixCount {
-    pub rule: String,
-    pub count: usize,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PrimitiveFixCount {
-    pub primitive: String,
-    pub count: usize,
-}
+pub use homeboy_refactor_contract::{FixResultsSummary, PrimitiveFixCount, RuleFixCount};
 
 pub fn standard_outcome(
     mode: AutofixMode,

--- a/crates/homeboy-core/src/refactor/mod.rs
+++ b/crates/homeboy-core/src/refactor/mod.rs
@@ -37,31 +37,26 @@ pub fn resolve_root(component_id: Option<&str>, path: Option<&str>) -> crate::Re
 
 /// Shared output for refactors/fixes.
 ///
-/// `refactor --from lint/test/audit --write` are the entrypoints for fixes.
-/// Keep the applied-change reporting in refactor so commands don't invent
-/// parallel output models.
-#[derive(Debug, Clone, Serialize)]
-pub struct AppliedRefactor {
-    pub files_modified: usize,
-    pub rerun_recommended: bool,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub changed_files: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub fix_summary: Option<FixResultsSummary>,
-}
+// AppliedRefactor and its FixResultsSummary/RuleFixCount/PrimitiveFixCount
+// result-type cluster live in homeboy-refactor-contract so consumers (e.g. the
+// extension lint/test report layer) can carry refactor results without depending
+// on this engine. Re-exported here to preserve crate::refactor::AppliedRefactor
+// call sites.
+pub use homeboy_refactor_contract::AppliedRefactor;
 
-impl AppliedRefactor {
-    pub fn from_capture(
-        capture: AppliedAutofixCapture,
-        rerun_recommended: bool,
-        changed_files: Vec<String>,
-    ) -> Self {
-        Self {
-            files_modified: capture.files_modified,
-            rerun_recommended,
-            changed_files,
-            fix_summary: capture.fix_summary,
-        }
+/// Build an [`AppliedRefactor`] from an autofix capture. Lives in the refactor
+/// engine (not on the contract type) because it consumes the engine-internal
+/// `AppliedAutofixCapture`.
+pub fn applied_refactor_from_capture(
+    capture: AppliedAutofixCapture,
+    rerun_recommended: bool,
+    changed_files: Vec<String>,
+) -> AppliedRefactor {
+    AppliedRefactor {
+        files_modified: capture.files_modified,
+        rerun_recommended,
+        changed_files,
+        fix_summary: capture.fix_summary,
     }
 }
 

--- a/crates/homeboy-refactor-contract/Cargo.toml
+++ b/crates/homeboy-refactor-contract/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "homeboy-refactor-contract"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Chris Huber <chubes@extrachill.com>"]
+description = "Shared refactor/autofix result types for homeboy. Behavior-free data (applied-fix reporting) that both homeboy-core's refactor engine and consumers like the extension lint/test report layer depend on, so they can carry refactor results without depending on the refactor engine's behavior."
+repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
+
+[lib]
+name = "homeboy_refactor_contract"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/crates/homeboy-refactor-contract/src/lib.rs
+++ b/crates/homeboy-refactor-contract/src/lib.rs
@@ -1,0 +1,46 @@
+//! Shared refactor/autofix result types for homeboy.
+//!
+//! Behavior-free data describing the outcome of applying refactor fixes
+//! (`refactor --from lint/test/audit --write`). These live below core so
+//! consumers — the refactor engine that produces them and report layers like the
+//! extension lint/test commands that carry them — can share the vocabulary
+//! without depending on the refactor engine's behavior.
+
+use serde::{Deserialize, Serialize};
+
+/// Applied-change reporting for a refactor run. `refactor --from lint/test/audit
+/// --write` are the entrypoints for fixes; this keeps applied-change reporting in
+/// one place so commands don't invent parallel output models.
+#[derive(Debug, Clone, Serialize)]
+pub struct AppliedRefactor {
+    pub files_modified: usize,
+    pub rerun_recommended: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub changed_files: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fix_summary: Option<FixResultsSummary>,
+}
+
+/// Aggregated summary of the fixes applied in a refactor run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FixResultsSummary {
+    pub fixes_applied: usize,
+    pub files_modified: usize,
+    pub rules: Vec<RuleFixCount>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub primitives: Vec<PrimitiveFixCount>,
+}
+
+/// Count of fixes applied for a single rule.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuleFixCount {
+    pub rule: String,
+    pub count: usize,
+}
+
+/// Count of fixes applied for a single refactor primitive.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrimitiveFixCount {
+    pub primitive: String,
+    pub count: usize,
+}


### PR DESCRIPTION
## Summary
Creates a new `homeboy-refactor-contract` keystone crate and seeds it with the pure autofix-**result** type cluster: `AppliedRefactor`, `FixResultsSummary`, `RuleFixCount`, `PrimitiveFixCount`.

These are behavior-free serde types describing the outcome of applying refactor fixes (`refactor --from lint/test/audit --write`). They're carried — and constructed — by consumers like the **extension lint/test report layer**, which shouldn't have to depend on the whole refactor engine just for the result vocabulary.

## Why (keystone-first decoupling)
The extension subsystem reaches up into `refactor` in 5 lint/test files (`use crate::refactor::AppliedRefactor`). This crate is the **seam** that lets those consumers carry refactor results without depending on the refactor engine — the same discipline as `audit-contract` before `code_audit` and `extension-contract` before a future `homeboy-extension`: build the leaf contract below core first, then repoint consumers over time. It's a maintainability win on its own (the refactor result vocabulary is now shareable) and unblocks future extension→refactor edge draining.

## Design
- New crate deps only `serde`/`serde_json` — a pure leaf below core, no cycle.
- `homeboy-core` re-exports the types (`crate::refactor::AppliedRefactor`, `refactor::auto::outcome::{FixResultsSummary, ...}`) so all existing call sites are unchanged.
- `AppliedRefactor::from_capture` (an inherent method with **no external callers**) becomes a free fn `refactor::applied_refactor_from_capture` — the contract type can't carry an engine-internal impl since `from_capture` consumes the refactor-internal `AppliedAutofixCapture`.

## Pre-existing test fix (unrelated)
`config.agent_task.rotation` became `Option<serde_json::Value>` on main, but `promotion_review.rs` still assigned a typed `AgentTaskProviderRotationPolicy` (type mismatch — `cargo check --workspace --tests` was already red on clean `main`). Wrapped it in `serde_json::to_value(...)`. Verified broken identically on clean `origin/main`.

## Verification
- `cargo check -p homeboy-refactor-contract --lib`, `-p homeboy-core --lib`, `-p homeboy-cli --lib` — 0 errors.
- `cargo check --workspace --tests --locked` (topology guard) — **passes**.

Refs #8425