### PR TITLE
Reuse clean snapshots for agent-task retries

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -93,7 +93,7 @@ pub fn route_after_parse(
         }
     }
 
-    let mut lab_command = lab_offload_command(&cli.command)?;
+    let lab_command = lab_offload_command(&cli.command)?;
 
     let inferred_runner_id = if lab_command.is_some() {
         cli.runner
@@ -128,14 +128,6 @@ pub fn route_after_parse(
     } else {
         None
     };
-    if retry_handoff.is_some() {
-        if let Some(command) = lab_command.as_mut() {
-            // A retry's task primary must be a real checkout so the provider can
-            // capture a bounded git diff instead of receiving a source snapshot.
-            command.command.workspace_mode_policy =
-                homeboy::command_contract::LabWorkspaceModePolicy::GitCheckoutRequired;
-        }
-    }
     let normalized_args = run_handoff
         .as_ref()
         .map(|handoff| handoff.args.as_slice())
@@ -218,7 +210,8 @@ pub fn route_after_parse(
                         .map(|handoff| handoff.primary_workspace.as_path())
                 }),
             verified_cook_baseline: None,
-            require_controller_git_bundle: retry_handoff.is_some(),
+            require_controller_git_bundle: false,
+            reuse_compatible_snapshot: retry_handoff.is_some(),
             job_overrides,
         },
         inferred_runner_id.as_deref(),
@@ -603,6 +596,7 @@ impl crate::core::agent_task_service::AgentTaskCookAttemptDispatcher for LabCook
                 output_file_requested: false,
                 read_only_polling: false,
                 require_controller_git_bundle: false,
+                reuse_compatible_snapshot: false,
                 local_output_file: None,
                 durable_agent_task_plan: Some(&plan),
                 // A retry's baseline is controller-owned capability, not plan

--- a/crates/homeboy-core/src/lab_routing.rs
+++ b/crates/homeboy-core/src/lab_routing.rs
@@ -52,6 +52,8 @@ pub struct LabRoutingRequest<'a> {
     /// Require controller bundle materialization for the selected source
     /// checkout before any runner-side Git transport is attempted.
     pub require_controller_git_bundle: bool,
+    /// Reuse an exact clean snapshot already materialized on the selected runner.
+    pub reuse_compatible_snapshot: bool,
     pub job_overrides: crate::lab_offload::LabJobOverrides,
 }
 
@@ -516,6 +518,7 @@ fn execute_lab_offload_with_timeout(
     let source_path = request.source_path.map(std::path::Path::to_path_buf);
     let verified_cook_baseline = request.verified_cook_baseline.cloned();
     let require_controller_git_bundle = request.require_controller_git_bundle;
+    let reuse_compatible_snapshot = request.reuse_compatible_snapshot;
     let job_overrides = request.job_overrides;
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
@@ -539,6 +542,7 @@ fn execute_lab_offload_with_timeout(
             source_path: source_path.as_deref(),
             verified_cook_baseline: verified_cook_baseline.as_ref(),
             require_controller_git_bundle,
+            reuse_compatible_snapshot,
             job_overrides,
         });
         let _ = tx.send(result);
@@ -729,6 +733,7 @@ mod tests {
             source_path: None,
             verified_cook_baseline: None,
             require_controller_git_bundle: false,
+            reuse_compatible_snapshot: false,
             job_overrides: crate::lab_offload::LabJobOverrides::default(),
         })
         .unwrap();
@@ -1033,6 +1038,7 @@ mod tests {
                 source_path: None,
                 verified_cook_baseline: None,
                 require_controller_git_bundle: false,
+                reuse_compatible_snapshot: false,
                 job_overrides: crate::lab_offload::LabJobOverrides::default(),
             },
             None,

--- a/crates/homeboy-lab-runner/src/lab/offload/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/mod.rs
@@ -108,12 +108,12 @@ use super::super::{
     lab_offload_changed_since_ref, lab_offload_metadata,
     lab_offload_metadata_with_workspace_mapping, load, plan_managed_runner_source_syncs,
     preflight_lab_offload_changed_since, prepare_git_lab_offload_changed_since,
-    prepare_lab_runner_capability, remote_runner_homeboy_path, rig_materialization, status,
-    sync_workspace, LabRunnerGateDecision, MaterializedWorkspace, Runner,
-    RunnerCapabilityPreflight, RunnerDependencyCacheSaveOutput, RunnerDependencyCacheSaveRequest,
-    RunnerExecOptions, RunnerFileTransfer, RunnerStatusReport, RunnerWorkspaceApplyOutput,
-    RunnerWorkspaceOutputPaths, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
-    RunnerWorkspaceSyncOutput, WorkspaceCleanupPolicy,
+    prepare_lab_runner_capability, remote_runner_homeboy_path, reuse_compatible_snapshot_workspace,
+    rig_materialization, status, sync_workspace, LabRunnerGateDecision, MaterializedWorkspace,
+    Runner, RunnerCapabilityPreflight, RunnerDependencyCacheSaveOutput,
+    RunnerDependencyCacheSaveRequest, RunnerExecOptions, RunnerFileTransfer, RunnerStatusReport,
+    RunnerWorkspaceApplyOutput, RunnerWorkspaceOutputPaths, RunnerWorkspaceSyncMode,
+    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput, WorkspaceCleanupPolicy,
 };
 
 #[cfg(test)]

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
@@ -446,6 +446,7 @@ fn plan_records_skipped_auto_offload() {
         source_path: None,
         verified_cook_baseline: None,
         require_controller_git_bundle: false,
+        reuse_compatible_snapshot: false,
         job_overrides: LabJobOverrides::default(),
     })
     .expect("outcome");
@@ -479,6 +480,7 @@ fn lab_placement_refuses_local_execution_without_lab_contract() {
         source_path: None,
         verified_cook_baseline: None,
         require_controller_git_bundle: false,
+        reuse_compatible_snapshot: false,
         job_overrides: LabJobOverrides::default(),
     });
 
@@ -515,6 +517,7 @@ fn lab_placement_refuses_local_only_rig_install_with_actionable_boundary() {
         source_path: None,
         verified_cook_baseline: None,
         require_controller_git_bundle: false,
+        reuse_compatible_snapshot: false,
         job_overrides: LabJobOverrides::default(),
     });
 
@@ -553,6 +556,7 @@ fn build_runner_error_gives_managed_runner_replacement() {
         source_path: None,
         verified_cook_baseline: None,
         require_controller_git_bundle: false,
+        reuse_compatible_snapshot: false,
         job_overrides: LabJobOverrides::default(),
     });
 
@@ -600,6 +604,7 @@ fn build_lab_placement_error_gives_managed_runner_replacement() {
         source_path: None,
         verified_cook_baseline: None,
         require_controller_git_bundle: false,
+        reuse_compatible_snapshot: false,
         job_overrides: LabJobOverrides::default(),
     });
 
@@ -649,6 +654,7 @@ fn unsupported_runner_error_guides_tunnel_service_inspection() {
         source_path: None,
         verified_cook_baseline: None,
         require_controller_git_bundle: false,
+        reuse_compatible_snapshot: false,
         job_overrides: LabJobOverrides::default(),
     });
 

--- a/crates/homeboy-lab-runner/src/lab/offload/types.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/types.rs
@@ -36,6 +36,9 @@ pub struct LabOffloadRequest<'a> {
     pub verified_cook_baseline: Option<&'a serde_json::Value>,
     /// Select controller-bundle materialization before runner-side Git transport.
     pub require_controller_git_bundle: bool,
+    /// Reuse a clean, exact-source snapshot already materialized on the selected
+    /// runner instead of rebuilding the source through Git transport.
+    pub reuse_compatible_snapshot: bool,
     pub job_overrides: LabJobOverrides,
 }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -90,7 +90,7 @@ fn prepare_lab_offload_workspace_stage_inner(
     lifecycle_args: &[String],
     preferred_attempt_run_id: Option<&str>,
 ) -> Result<LabOffloadWorkspaceStage> {
-    let sync_mode =
+    let mut sync_mode =
         lab_workspace_sync_mode(contract.workspace_mode_policy, lifecycle_args, source_path)?;
     let changed_since_preflight = if sync_mode == RunnerWorkspaceSyncMode::Git {
         prepare_git_lab_offload_changed_since(lifecycle_args, source_path)?
@@ -144,27 +144,32 @@ fn prepare_lab_offload_workspace_stage_inner(
     // can observe its leftover untracked artifacts (#4393). Resolve the
     // agent-task run id (existing or freshly generated) up front and fold it
     // into the workspace identity so each run gets a clean, isolated directory.
-    let synced = sync_workspace(
-        runner_id,
-        RunnerWorkspaceSyncOptions {
-            path: source_path.display().to_string(),
-            mode: sync_mode,
-            // Retry handoffs must stage the controller checkout before the
-            // runner attempts Git transport: private origins are intentionally
-            // unavailable to the runner, and changed-since must resolve from
-            // the staged bundle.
-            controller_routed_git: sync_mode == RunnerWorkspaceSyncMode::Git
-                && (request.require_controller_git_bundle
-                    || contract.workspace_mode_policy
-                        != LabOffloadWorkspaceModePolicy::GitCheckoutRequired),
-            changed_since_base: changed_since_preflight.resolved_base.clone(),
-            git_fetch_refs: git_fetch_refs.clone(),
-            snapshot_includes: Vec::new(),
-            allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
-            run_isolation_token: run_isolation_token.clone(),
-        },
-    )?
+    let sync_options = RunnerWorkspaceSyncOptions {
+        path: source_path.display().to_string(),
+        mode: sync_mode,
+        // Retry handoffs must stage the controller checkout before the
+        // runner attempts Git transport: private origins are intentionally
+        // unavailable to the runner, and changed-since must resolve from
+        // the staged bundle.
+        controller_routed_git: sync_mode == RunnerWorkspaceSyncMode::Git
+            && (request.require_controller_git_bundle
+                || contract.workspace_mode_policy
+                    != LabOffloadWorkspaceModePolicy::GitCheckoutRequired),
+        changed_since_base: changed_since_preflight.resolved_base.clone(),
+        git_fetch_refs: git_fetch_refs.clone(),
+        snapshot_includes: Vec::new(),
+        allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
+        run_isolation_token: run_isolation_token.clone(),
+    };
+    let synced = if request.reuse_compatible_snapshot {
+        reuse_compatible_snapshot_workspace(runner_id, &sync_options)?
+            .map(|snapshot| (snapshot, 0))
+            .unwrap_or(sync_workspace(runner_id, sync_options)?)
+    } else {
+        sync_workspace(runner_id, sync_options)?
+    }
     .0;
+    sync_mode = synced.sync_mode;
     let remote_cwd = synced.remote_path.clone();
     let mut workspace_mapping = vec![workspace_mapping_entry("primary", &synced)];
     // The primary workspace sync materializes each declared dependency checkout
@@ -2159,6 +2164,7 @@ mod tests {
                 source_path: None,
                 verified_cook_baseline: None,
                 require_controller_git_bundle: true,
+                reuse_compatible_snapshot: false,
                 job_overrides: LabJobOverrides::default(),
             };
             let contract = LabOffloadCommand {
@@ -2312,6 +2318,7 @@ mod tests {
                 source_path: Some(source.as_path()),
                 verified_cook_baseline: None,
                 require_controller_git_bundle: false,
+                reuse_compatible_snapshot: false,
                 job_overrides: LabJobOverrides::default(),
             };
             let mut contract = LabOffloadCommand {

--- a/crates/homeboy-lab-runner/src/lab_offload_provider.rs
+++ b/crates/homeboy-lab-runner/src/lab_offload_provider.rs
@@ -34,6 +34,7 @@ impl LabOffloadProvider for RunnerLabOffload {
             source_path: request.source_path,
             verified_cook_baseline: request.verified_cook_baseline,
             require_controller_git_bundle: request.require_controller_git_bundle,
+            reuse_compatible_snapshot: request.reuse_compatible_snapshot,
             job_overrides: request.job_overrides,
         })
     }

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -191,15 +191,15 @@ pub use upgrade_runners::register as register_runner_upgrade;
 pub use worker::{run_reverse_worker, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput};
 pub use workspace::reap_run_workspace;
 pub use workspace::{
-    list_workspaces, plan_workspace_pull, prune_workspaces, pull_workspace, sync_workspace,
-    workspace_snapshots, ByteFileCounts, RunnerWorkspaceCurrentSummary, RunnerWorkspaceListEntry,
-    RunnerWorkspaceListOutput, RunnerWorkspaceMaterializationContract,
-    RunnerWorkspaceMaterializationPlan, RunnerWorkspaceOutputPaths, RunnerWorkspacePruneEntry,
-    RunnerWorkspacePruneOptions, RunnerWorkspacePruneOutput, RunnerWorkspacePruneSkippedEntry,
-    RunnerWorkspacePullOptions, RunnerWorkspacePullOutput, RunnerWorkspacePullPlan,
-    RunnerWorkspaceSnapshotAppliedFilters, RunnerWorkspaceSnapshotEntry,
-    RunnerWorkspaceSnapshotFilters, RunnerWorkspaceSnapshotsOutput, RunnerWorkspaceSyncMode,
-    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+    list_workspaces, plan_workspace_pull, prune_workspaces, pull_workspace,
+    reuse_compatible_snapshot_workspace, sync_workspace, workspace_snapshots, ByteFileCounts,
+    RunnerWorkspaceCurrentSummary, RunnerWorkspaceListEntry, RunnerWorkspaceListOutput,
+    RunnerWorkspaceMaterializationContract, RunnerWorkspaceMaterializationPlan,
+    RunnerWorkspaceOutputPaths, RunnerWorkspacePruneEntry, RunnerWorkspacePruneOptions,
+    RunnerWorkspacePruneOutput, RunnerWorkspacePruneSkippedEntry, RunnerWorkspacePullOptions,
+    RunnerWorkspacePullOutput, RunnerWorkspacePullPlan, RunnerWorkspaceSnapshotAppliedFilters,
+    RunnerWorkspaceSnapshotEntry, RunnerWorkspaceSnapshotFilters, RunnerWorkspaceSnapshotsOutput,
+    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 pub(crate) use workspace::{
     verify_lab_workspace_from_env, workspace_content_hash, workspace_content_hash_algorithm,

--- a/crates/homeboy-lab-runner/src/workspace/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/mod.rs
@@ -21,7 +21,10 @@ pub use pull::{plan_workspace_pull, pull_workspace};
 pub use sync::sync_workspace;
 #[cfg(test)]
 pub(crate) use sync::workspace_resource_lifecycle;
-pub use sync::{list_workspaces, prune_workspaces, reap_run_workspace, workspace_snapshots};
+pub use sync::{
+    list_workspaces, prune_workspaces, reap_run_workspace, reuse_compatible_snapshot_workspace,
+    workspace_snapshots,
+};
 pub use types::{
     ByteFileCounts, RunnerWorkspaceCurrentSummary, RunnerWorkspaceListEntry,
     RunnerWorkspaceListOutput, RunnerWorkspaceMaterializationContract,

--- a/crates/homeboy-lab-runner/src/workspace/sync.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync.rs
@@ -331,6 +331,133 @@ pub fn sync_workspace(
     }
 }
 
+/// Return a previously materialized source snapshot only when it is tied to the
+/// exact clean controller checkout now being dispatched. This lets callers that
+/// already hold a runner snapshot avoid reopening Git transport (and its object
+/// closure) merely to hand the same source to a provider.
+pub fn reuse_compatible_snapshot_workspace(
+    runner_id: &str,
+    options: &RunnerWorkspaceSyncOptions,
+) -> Result<Option<RunnerWorkspaceSyncOutput>> {
+    if options.changed_since_base.is_some() || !options.git_fetch_refs.is_empty() {
+        return Ok(None);
+    }
+
+    let runner = load(runner_id)?;
+    let local_path = canonical_workspace_path(&options.path)?;
+    let source_commit = git_output(&local_path, &["rev-parse", "HEAD"]).ok();
+    let source_dirty = git_output(&local_path, &["status", "--porcelain=v1"])
+        .ok()
+        .map(|status| !status.trim().is_empty());
+    let Some(source_commit) = source_commit else {
+        return Ok(None);
+    };
+    if source_dirty != Some(false) {
+        return Ok(None);
+    }
+
+    let (snapshots, _) = workspace_snapshots(
+        runner_id,
+        RunnerWorkspaceSnapshotFilters {
+            limit: usize::MAX,
+            ..Default::default()
+        },
+    )?;
+    let local_path_string = local_path.display().to_string();
+    let Some(snapshot) = snapshots.snapshots.into_iter().find(|snapshot| {
+        snapshot.sync_mode == RunnerWorkspaceSyncMode::Snapshot.label()
+            && snapshot.local_path == local_path_string
+            && snapshot.source_commit.as_deref() == Some(source_commit.as_str())
+            && snapshot.source_dirty == Some(false)
+    }) else {
+        return Ok(None);
+    };
+
+    let workspace_root = runner.workspace_root.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "workspace_root",
+            "runner workspace sync requires workspace_root",
+            Some(runner.id.clone()),
+            Some(vec![
+                "Set runner.workspace_root to the remote workspace directory.".to_string(),
+            ]),
+        )
+    })?;
+    let mut excludes = DEFAULT_EXCLUDES
+        .iter()
+        .map(|value| value.to_string())
+        .collect::<Vec<_>>();
+    for pattern in &runner.policy.snapshot_excludes {
+        if !excludes.contains(pattern) {
+            excludes.push(pattern.clone());
+        }
+    }
+    for pattern in homeboy_core::source_snapshot::declared_sync_excludes_for_path(&local_path) {
+        if !excludes.contains(&pattern) {
+            excludes.push(pattern);
+        }
+    }
+    let mut includes = runner.policy.snapshot_includes.clone();
+    for pattern in &options.snapshot_includes {
+        if !includes.contains(pattern) {
+            includes.push(pattern.clone());
+        }
+    }
+    let excludes = effective_snapshot_excludes(excludes, &includes);
+    let workspace_cleanliness = "snapshot_reused_clean_workspace";
+    let mut snapshot_options = options.clone();
+    snapshot_options.mode = RunnerWorkspaceSyncMode::Snapshot;
+    snapshot_options.controller_routed_git = false;
+    let materialization_plan = workspace_materialization_plan(
+        workspace_root,
+        &local_path,
+        &snapshot.remote_path,
+        &snapshot.snapshot_identity,
+        &snapshot_options,
+        &includes,
+        workspace_cleanliness,
+    );
+    let current_workspace = RunnerWorkspaceCurrentSummary {
+        local_path: local_path_string.clone(),
+        remote_path: snapshot.remote_path.clone(),
+        sync_mode: RunnerWorkspaceSyncMode::Snapshot,
+        materialized: true,
+        source_commit: snapshot.source_commit.clone(),
+        source_ref: snapshot.source_ref.clone(),
+        source_dirty: snapshot.source_dirty,
+        synthetic_checkout_commit: None,
+        synthetic_checkout_ref: None,
+        synthetic_checkout_tree: None,
+    };
+    let resource_lifecycle = snapshot.resource_lifecycle.unwrap_or_else(|| {
+        workspace_resource_lifecycle(
+            &runner.id,
+            &snapshot.remote_path,
+            None,
+            ResourceCleanupPolicy::DeleteOnSuccess,
+        )
+    });
+
+    Ok(Some(RunnerWorkspaceSyncOutput {
+        variant: "workspace_sync",
+        command: "runner.workspace.sync",
+        runner_id: runner.id.clone(),
+        local_path: local_path_string,
+        remote_path: snapshot.remote_path,
+        materialization_plan,
+        workspace_lease: workspace_lease(&runner.id, &current_workspace),
+        current_workspace,
+        resource_lifecycle,
+        sync_mode: RunnerWorkspaceSyncMode::Snapshot,
+        snapshot_identity: snapshot.snapshot_identity,
+        counts: ByteFileCounts::default(),
+        excludes,
+        includes,
+        workspace_cleanliness: workspace_cleanliness.to_string(),
+        validation_dependencies: Vec::new(),
+    }))
+}
+
 fn is_runner_git_auth_or_network_failure(error: &Error) -> bool {
     let message = error.message.to_ascii_lowercase();
     [

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
@@ -1,7 +1,9 @@
 use std::fs;
 
 use super::git;
-use crate::workspace::sync::{sync_workspace, workspace_snapshots};
+use crate::workspace::sync::{
+    reuse_compatible_snapshot_workspace, sync_workspace, workspace_snapshots,
+};
 use crate::workspace::types::{
     RunnerWorkspaceSnapshotFilters, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
 };
@@ -129,6 +131,53 @@ fn workspace_snapshots_filters_by_repo_ref_commit_and_run() {
         )
         .expect("mismatched filter");
         assert!(none.snapshots.is_empty());
+    });
+}
+
+#[test]
+fn clean_snapshot_reuse_preserves_exact_source_provenance_without_git_materialization() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        create_local_runner("lab-local-reuse", runner_root.path());
+        let source = git_source("homeboy@partial-clone", "fix/reuse", "source\n");
+        let commit = crate::workspace::util::git_output(source.path(), &["rev-parse", "HEAD"])
+            .expect("source commit");
+
+        // Snapshot sync is intentionally independent of Git object closure
+        // hydration, as a blob:none controller checkout may not hold it.
+        let (synced, _) = sync_workspace(
+            "lab-local-reuse",
+            sync_options(source.path().display().to_string(), None),
+        )
+        .expect("initial snapshot sync");
+        let mut retry_options = sync_options(
+            source.path().display().to_string(),
+            Some("retry-attempt".to_string()),
+        );
+        // A retry normally requests Git materialization. An exact snapshot is
+        // still the stronger transport choice when no Git-only ref is needed.
+        retry_options.mode = RunnerWorkspaceSyncMode::Git;
+        let reused = reuse_compatible_snapshot_workspace("lab-local-reuse", &retry_options)
+            .expect("look up compatible snapshot")
+            .expect("clean exact snapshot is reused");
+
+        assert_eq!(reused.remote_path, synced.remote_path);
+        assert_eq!(reused.snapshot_identity, synced.snapshot_identity);
+        assert_eq!(
+            reused.current_workspace.source_commit.as_deref(),
+            Some(commit.as_str())
+        );
+        assert_eq!(reused.current_workspace.source_dirty, Some(false));
+        assert_eq!(reused.sync_mode, RunnerWorkspaceSyncMode::Snapshot);
+        assert_eq!(
+            reused.materialization_plan.declared_inputs.mode,
+            RunnerWorkspaceSyncMode::Snapshot
+        );
+        assert_eq!(
+            reused.workspace_cleanliness,
+            "snapshot_reused_clean_workspace"
+        );
+        assert!(reused.materialization_plan.controller_git_bundle.is_none());
     });
 }
 


### PR DESCRIPTION
## Summary

- reuse an exact clean runner snapshot when source path and commit match
- stop retry from forcing Git bundle materialization when snapshot provenance is sufficient
- retain snapshot identity and remote workspace provenance through Lab offload
- keep Git materialization for workflows that require Git-only refs or bases

Fixes #8768.

## How to test

1. Check out this branch from a fresh clone.
2. Run `cargo test -p homeboy-lab-runner clean_snapshot_reuse_preserves_exact_source_provenance_without_git_materialization --lib`.
3. Run `cargo check -p homeboy-lab-runner -p homeboy-cli`.
4. Run `cargo fmt --check`.
5. Create a clean partial clone, sync it with `homeboy runner workspace sync <runner> --path <checkout> --mode snapshot`, then retry an issue-linked agent task on that runner. Confirm the handoff records the matching snapshot identity and does not enumerate the controller Git bundle closure.

## Verification

- Focused snapshot reuse test: passed (1 test; 1009 filtered)
- `cargo check -p homeboy-lab-runner -p homeboy-cli`: passed
- `cargo fmt --check`: passed
- `git diff --check origin/main...HEAD`: passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed the control-plane failure, drafted the implementation and deterministic tests, and verified the issue-linked repair with Chris.