### PR TITLE
refactor: use a local dispatch identity in daemon patch-capture

### DIFF
--- a/crates/homeboy-core/src/daemon/patch_capture.rs
+++ b/crates/homeboy-core/src/daemon/patch_capture.rs
@@ -6,11 +6,18 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::agent_task_lifecycle::RunDispatchIdentity;
 use crate::error::{Error, Result};
 use crate::observation::{ArtifactRecord, ObservationStore, RunRecord};
 use crate::paths;
 use crate::source_snapshot::SourceSnapshot;
+
+/// Local `(run_id, runner_id)` identity for a captured patch run. Kept local to
+/// the daemon patch-capture path so core does not depend on the agent-task
+/// subsystem for this trivial borrow pair.
+struct RunDispatchIdentity<'a> {
+    run_id: &'a str,
+    runner_id: &'a str,
+}
 
 const PATCH_CAPTURE_EXCLUDES: &[&str] = &[
     ".git",


### PR DESCRIPTION
## Summary
Stage 3 prep-PR of the homeboy-agents crate extraction campaign (wiki: `homeboy-agents-crate-extraction-plan`). Independent PR off `main`.

Stage 1 & 2 inverted behavior edges and made pass-through config/envelope fields opaque. Stage 3 is the wholesale git-mv, but a handful of core files that **stay in core** still import agent-task types — which would be a dependency cycle once agent-task is its own crate (core cannot depend on `homeboy-agents`). This PR severs the first one.

`daemon/patch_capture` imported `agent_task_lifecycle::RunDispatchIdentity` but only used it **locally** as a `(run_id, runner_id)` borrow pair — it never passed the value to any agent-task function. It's replaced with a local struct of the same shape.

## Effect
- `daemon/patch_capture.rs`: agent-task refs -> **0** (edge severed, zero behavior change — same fields, same values).

## Verification
- `cargo check -p homeboy-core --lib` / `--tests`: clean.
- `cargo fmt`: clean.