### PR TITLE
refactor: carry durable agent-task plan opaquely through core lab routing

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -143,6 +143,8 @@ pub fn route_after_parse(
         None
     };
     let normalized_args = inject_agent_task_cook_attempt_plan(normalized_args, cook_plan.as_ref())?;
+    // Lab routing carries the durable plan opaquely as JSON (core does not
+    // depend on the agent-task subsystem); serialize the selected typed plan.
     let durable_agent_task_plan = run_handoff
         .as_ref()
         .map(|handoff| &handoff.plan)
@@ -151,7 +153,16 @@ pub fn route_after_parse(
                 .as_ref()
                 .map(|handoff| &handoff.plan)
                 .or(cook_plan.as_ref())
-        });
+        })
+        .map(|plan| {
+            serde_json::to_value(plan).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("serialize durable agent-task plan".to_string()),
+                )
+            })
+        })
+        .transpose()?;
     let observer = lab_dispatch_observer(cli, &normalized_args, inferred_runner_id.as_deref());
     let active_run_id = observer
         .run_id()
@@ -197,7 +208,7 @@ pub fn route_after_parse(
                 .lab_route_contract()?
                 .is_some_and(|contract| contract.command.routing_policy.read_only_polling),
             local_output_file: output_file,
-            durable_agent_task_plan,
+            durable_agent_task_plan: durable_agent_task_plan.as_ref(),
             // A serialized run-plan has no workspace CLI argument. Carry its
             // canonical plan root through the portable source channel so Lab
             // snapshots it before remapping nested plan/config paths.
@@ -567,6 +578,14 @@ impl crate::core::agent_task_service::AgentTaskCookAttemptDispatcher for LabCook
                 Some("serialize Lab cook attempt plan".to_string()),
             )
         })?;
+        // Lab routing carries the durable plan opaquely as JSON (only its
+        // presence is consulted); serialize the typed plan for the request.
+        let durable_agent_task_plan = serde_json::to_value(&plan).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize durable agent-task plan".to_string()),
+            )
+        })?;
         let provider_args = lab_cook_attempt_args(serialized_plan, run_id);
         let provider_cli = Cli::try_parse_from(&provider_args).map_err(|error| {
             Error::validation_invalid_argument(
@@ -598,7 +617,7 @@ impl crate::core::agent_task_service::AgentTaskCookAttemptDispatcher for LabCook
                 require_controller_git_bundle: false,
                 reuse_compatible_snapshot: false,
                 local_output_file: None,
-                durable_agent_task_plan: Some(&plan),
+                durable_agent_task_plan: Some(&durable_agent_task_plan),
                 // A retry's baseline is controller-owned capability, not plan
                 // data. Stage that exact clean checkout; never substitute the
                 // controller's original workspace during nested Lab dispatch.

--- a/crates/homeboy-core/src/lab_routing.rs
+++ b/crates/homeboy-core/src/lab_routing.rs
@@ -42,7 +42,11 @@ pub struct LabRoutingRequest<'a> {
     /// Controller-local `--output` path forwarded to the offload executor so the
     /// durable agent-task run id can be persisted before long execution (#5684).
     pub local_output_file: Option<&'a str>,
-    pub durable_agent_task_plan: Option<&'a crate::agent_task_scheduler::AgentTaskPlan>,
+    /// The durable agent-task plan authorizing a controller retry, carried
+    /// opaquely as JSON so core lab routing does not depend on the agent-task
+    /// subsystem. Only its presence is consulted along the routing path; the
+    /// agent-task layer owns the typed plan.
+    pub durable_agent_task_plan: Option<&'a serde_json::Value>,
     /// Controller checkout selected independently of CLI argv, such as the
     /// logical primary workspace of a materialized retry plan.
     pub source_path: Option<&'a std::path::Path>,

--- a/crates/homeboy-lab-runner/src/lab_offload_provider.rs
+++ b/crates/homeboy-lab-runner/src/lab_offload_provider.rs
@@ -16,6 +16,23 @@ pub struct RunnerLabOffload;
 
 impl LabOffloadProvider for RunnerLabOffload {
     fn execute_lab_offload(&self, request: LabRoutingRequest<'_>) -> Result<LabOffloadOutcome> {
+        // Core carries the durable agent-task plan opaquely as JSON so it does
+        // not depend on the agent-task subsystem. The runner layer owns the
+        // typed plan, so deserialize it here and borrow it for the offload.
+        let durable_agent_task_plan = request
+            .durable_agent_task_plan
+            .map(|plan| {
+                serde_json::from_value::<homeboy_core::agent_task_scheduler::AgentTaskPlan>(
+                    plan.clone(),
+                )
+            })
+            .transpose()
+            .map_err(|error| {
+                homeboy_core::error::Error::internal_json(
+                    error.to_string(),
+                    Some("deserialize durable agent-task plan".to_string()),
+                )
+            })?;
         crate::execute_lab_offload(LabOffloadRequest {
             command: request.command,
             normalized_args: request.normalized_args,
@@ -30,7 +47,7 @@ impl LabOffloadProvider for RunnerLabOffload {
             output_file_requested: request.output_file_requested,
             read_only_polling: request.read_only_polling,
             local_output_file: request.local_output_file,
-            durable_agent_task_plan: request.durable_agent_task_plan,
+            durable_agent_task_plan: durable_agent_task_plan.as_ref(),
             source_path: request.source_path,
             verified_cook_baseline: request.verified_cook_baseline,
             require_controller_git_bundle: request.require_controller_git_bundle,


### PR DESCRIPTION
## Summary
Stage 3 prep-PR of the homeboy-agents crate extraction campaign (wiki: `homeboy-agents-crate-extraction-plan`). Independent PR off `main`.

`core::lab_routing::LabRoutingRequest` held `durable_agent_task_plan: Option<&AgentTaskPlan>` — a `core -> agent_task` type edge in a core file that stays in core (a cycle once agent-task is its own crate).

## What changed
The plan is only ever **presence-checked** (`.is_some()`) along the core+runner routing path; its typed contents are read only in the runner layer's agent-task lifecycle recorders.

- Core field -> `Option<&serde_json::Value>` (carried opaquely, byte-identical wire format).
- cli serializes the selected typed plan (`run_handoff`/`retry_handoff`/`cook_plan`) when building the request.
- The runner's `lab_offload_provider` deserializes it back into a typed `AgentTaskPlan` at its boundary and borrows it — the runner owns the typed plan and passes it to `agent_task_lifecycle::record_lab_offload_*`.

## Effect
- `lab_routing.rs`: `crate::agent_task` refs -> **0** (edge severed). Presence semantics unchanged.

## Verification
- `cargo check -p homeboy-core --lib`, `-p homeboy-cli --lib`, `-p homeboy-lab-runner --lib`: clean.
- `cargo check --workspace --tests`: clean (full workspace test-compile gate).
- `cargo fmt`: clean.