### PR TITLE
refactor: point extension lint/test at homeboy-refactor-contract for AppliedRefactor

### DIFF
--- a/crates/homeboy-core/src/extension/lint/report.rs
+++ b/crates/homeboy-core/src/extension/lint/report.rs
@@ -12,7 +12,7 @@ use crate::extension::{
 };
 use crate::finding::{FindingProducerSummary, HomeboyFinding};
 use crate::refactor::plan::RefactorSourceRun;
-use crate::refactor::AppliedRefactor;
+use homeboy_refactor_contract::AppliedRefactor;
 use serde::Serialize;
 use serde_json::Value;
 

--- a/crates/homeboy-core/src/extension/lint/run/types.rs
+++ b/crates/homeboy-core/src/extension/lint/run/types.rs
@@ -4,8 +4,8 @@ use crate::extension::lint::baseline as lint_baseline;
 use crate::extension::self_check::SelfCheckCaptureMetadata;
 use crate::extension::ExtensionPhaseTiming;
 use crate::finding::{FindingProducerSummary, HomeboyFinding};
-use crate::refactor::AppliedRefactor;
 use homeboy_engine_primitives::baseline::BaselineFlags;
+use homeboy_refactor_contract::AppliedRefactor;
 use serde::Serialize;
 use std::collections::BTreeMap;
 

--- a/crates/homeboy-core/src/extension/test/report.rs
+++ b/crates/homeboy-core/src/extension/test/report.rs
@@ -14,7 +14,7 @@ use crate::extension::{
     PhaseFailureCategory, PhaseReport, PhaseStatus, VerificationPhase,
 };
 use crate::finding::HomeboyFinding;
-use crate::refactor::AppliedRefactor;
+use homeboy_refactor_contract::AppliedRefactor;
 use serde::Serialize;
 use serde_json::Value;
 

--- a/crates/homeboy-core/src/extension/test/run.rs
+++ b/crates/homeboy-core/src/extension/test/run.rs
@@ -13,11 +13,11 @@ use crate::extension::test::{
 use crate::extension::{self, ExtensionCapability, ExtensionPhaseTiming};
 use crate::finding::HomeboyFinding;
 use crate::observation::homeboy_findings_from_test_analysis_input;
-use crate::refactor::AppliedRefactor;
 use crate::validation_progress::{write_command_artifact, ValidationProgressRecorder};
 use homeboy_engine_primitives::baseline::BaselineFlags;
 use homeboy_engine_primitives::local_files;
 use homeboy_engine_primitives::output_parse::ParseSpec;
+use homeboy_refactor_contract::AppliedRefactor;
 use serde::Serialize;
 use std::path::Path;
 

--- a/crates/homeboy-core/src/extension/test/workflow.rs
+++ b/crates/homeboy-core/src/extension/test/workflow.rs
@@ -4,12 +4,12 @@ use crate::extension::test::resolve_drift_options;
 use crate::extension::test::TestScopeOutput;
 use crate::extension::test::{ChangeType, TestAnalysis};
 use crate::extension::test::{TestBaselineComparison, TestCounts};
-use crate::refactor::AppliedRefactor;
 use crate::refactor::{
     self,
     auto::{self, AutofixMode},
     TransformSet,
 };
+use homeboy_refactor_contract::AppliedRefactor;
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## Summary
Follow-up to #8774 (which established `homeboy-refactor-contract` and moved `AppliedRefactor` there). Repoints the 5 extension lint/test imports from `crate::refactor::AppliedRefactor` → `homeboy_refactor_contract::AppliedRefactor` directly.

## Effect
- **Fully severs** the `extension -> refactor` edge for 3 files — `lint/run/types`, `test/report`, `test/run` now have **zero** `crate::refactor` references.
- **Reduces** it for `lint/report` and `test/workflow`, which retain genuine *behavioral* refactor deps (`RefactorSourceRun` / the autofix engine `auto::{AutofixMode}`, `TransformSet`) that need hook inversion in a later cut.

Instead of reaching up into the refactor engine for a pure result type, the extension report layer now depends on the slim contract seam — the whole point of the keystone.

## Verification
- `cargo check -p homeboy-core --lib`, `-p homeboy-cli --lib` — 0 errors.
- `cargo check --workspace --tests --locked` (topology guard) — **passes**.
- Pure import repoint: 5 files, 5 lines changed.

Refs #8425