### PR TITLE
refactor: invert activity report's agent-task source behind a hook

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -181,6 +181,10 @@ impl CliRuntime {
         // agent-task gate-feedback candidate without depending on the agent-task
         // subsystem.
         crate::core::agent_task_candidate_baseline::register();
+        // Register the agent-task activity provider so core's activity report
+        // includes durable agent-task records and their health summary without
+        // depending on the agent-task subsystem.
+        crate::core::agent_task_lifecycle::activity_provider::register();
         // Register the command-label resolver so core::runner can map dispatched
         // argv to a hot-command label without depending on the full CLI parser.
         crate::runner::set_command_label_resolver(|argv| {

--- a/crates/homeboy-core/src/activity.rs
+++ b/crates/homeboy-core/src/activity.rs
@@ -4,12 +4,13 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::agent_task_lifecycle::{self, AgentTaskRunRecord};
 use crate::api_jobs::{self, ActiveRunnerJobSummary, Job, JobEvent};
 use crate::observation::{ObservationStore, RunListFilter, RunRecord, RunStatus};
 use crate::run_lifecycle_record::RunExecutionState;
 use crate::run_lifecycle_status::RunLifecycleStatus;
 use crate::{paths, Error, Result};
+
+pub mod agent_task_provider;
 
 pub const ACTIVITY_REPORT_SCHEMA: &str = "homeboy/activity-report/v1";
 
@@ -125,8 +126,11 @@ pub struct ActivityReport {
     pub command: &'static str,
     pub counts: ActivityCounts,
     pub items: Vec<ActivityItem>,
+    /// Agent-task record-health summary, carried as JSON so core does not depend
+    /// on the agent-task health type. Supplied by the agent-task activity
+    /// provider (null when the agent-task subsystem is absent).
     #[serde(default)]
-    pub agent_task_record_health: agent_task_lifecycle::AgentTaskRecordHealthSummary,
+    pub agent_task_record_health: Value,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub next_actions: Vec<String>,
 }
@@ -134,11 +138,13 @@ pub struct ActivityReport {
 pub fn activity_report(scope: ActivityScope, limit: usize) -> Result<ActivityReport> {
     let mut collector = ActivityCollector::default();
     observation::collect(&mut collector, limit)?;
-    agent_tasks::collect(&mut collector)?;
+    for item in agent_task_provider::agent_task_activity_items()? {
+        collector.insert(item);
+    }
     daemon_jobs::collect(&mut collector)?;
     runner_sessions::collect(&mut collector);
     let mut report = report_from_items(collector.items(scope, limit), "activity");
-    report.agent_task_record_health = agent_task_lifecycle::record_health_summary()?;
+    report.agent_task_record_health = agent_task_provider::agent_task_record_health()?;
     Ok(report)
 }
 
@@ -199,7 +205,7 @@ fn report_from_items(items: Vec<ActivityItem>, command: &'static str) -> Activit
         command,
         counts,
         items,
-        agent_task_record_health: agent_task_lifecycle::AgentTaskRecordHealthSummary::healthy(),
+        agent_task_record_health: Value::Null,
         next_actions,
     }
 }
@@ -514,96 +520,6 @@ mod observation {
         ));
         if matches!(state, ActivityState::Stale) {
             actions.push(action("reconcile stale runs", "homeboy runs reconcile"));
-        }
-        actions
-    }
-}
-
-mod agent_tasks {
-    use super::*;
-
-    pub(super) fn collect(collector: &mut ActivityCollector) -> Result<()> {
-        for record in agent_task_lifecycle::list_records()? {
-            collector.insert(item_from_agent_task(record));
-        }
-        Ok(())
-    }
-
-    fn item_from_agent_task(record: AgentTaskRunRecord) -> ActivityItem {
-        let runner_id = metadata_string(&record.metadata, &["runner_id"]);
-        let job_id = metadata_string(&record.metadata, &["runner_job_id", "job_id"]);
-        let remote_run_id = metadata_string(&record.metadata, &["remote_run_id"]);
-        let state = ActivityState::from(RunExecutionState::from(record.state));
-        ActivityItem {
-            id: record.run_id.clone(),
-            kind: "agent-task".to_string(),
-            source_store: "agent-task.lifecycle".to_string(),
-            state,
-            created_at: record.submitted_at.clone(),
-            updated_at: record.updated_at.clone(),
-            finished_at: if is_active(state) {
-                None
-            } else {
-                record.updated_at.clone()
-            },
-            command: None,
-            cwd: None,
-            runner: ActivityRunnerRefs {
-                runner_id,
-                job_id: job_id.clone(),
-                transport: remote_run_id,
-            },
-            refs: ActivityCrossRefs {
-                run_id: None,
-                agent_task_run_id: Some(record.run_id.clone()),
-                runner_job_id: job_id,
-            },
-            artifacts: record
-                .artifact_refs
-                .into_iter()
-                .map(|artifact| ActivityEvidenceRef {
-                    id: artifact.task_id,
-                    kind: artifact.kind,
-                    uri: artifact.uri,
-                })
-                .collect(),
-            evidence: record
-                .latest_executor_evidence
-                .into_iter()
-                .flat_map(|evidence| evidence.refs())
-                .enumerate()
-                .map(|(index, evidence)| ActivityEvidenceRef {
-                    id: evidence
-                        .label
-                        .unwrap_or_else(|| format!("evidence-{}", index + 1)),
-                    kind: evidence.kind,
-                    uri: evidence.uri,
-                })
-                .collect(),
-            source_projections: Vec::new(),
-            next_actions: actions_for_agent_task(&record.run_id, state),
-        }
-    }
-
-    fn actions_for_agent_task(run_id: &str, state: ActivityState) -> Vec<ActivityNextAction> {
-        let mut actions = vec![
-            action("status", format!("homeboy agent-task status {run_id}")),
-            action("logs", format!("homeboy agent-task logs {run_id}")),
-            action(
-                "artifacts",
-                format!("homeboy agent-task artifacts {run_id}"),
-            ),
-        ];
-        if is_active(state) {
-            actions.push(action("watch", format!("homeboy activity watch {run_id}")));
-        } else if is_failure(state) {
-            actions.push(action(
-                "retry",
-                format!("homeboy agent-task retry --run {run_id}"),
-            ));
-        }
-        if matches!(state, ActivityState::Stale) {
-            actions.push(action("reconcile", "homeboy agent-task active --reconcile"));
         }
         actions
     }

--- a/crates/homeboy-core/src/activity/agent_task_provider.rs
+++ b/crates/homeboy-core/src/activity/agent_task_provider.rs
@@ -1,0 +1,78 @@
+//! Agent-task activity hook.
+//!
+//! The activity report aggregates work from several sources; the agent-task
+//! source lists durable agent-task records and projects each into an
+//! [`ActivityItem`], plus a record-health summary. That projection reads
+//! agent-task lifecycle records and is therefore agent-task behavior, so it is
+//! inverted behind this provider: core owns the activity report and the
+//! `ActivityItem` shape, the agent-task layer supplies the items and health.
+//!
+//! With no provider registered (no agent-task subsystem present) the no-op
+//! provider contributes no items and an empty health summary.
+
+use std::sync::Mutex;
+
+use serde_json::Value;
+
+use super::ActivityItem;
+use crate::Result;
+
+/// Supplies the agent-task contribution to the activity report.
+pub trait ActivityAgentTaskProvider: Send + Sync {
+    /// Project every durable agent-task record into an activity item.
+    fn agent_task_activity_items(&self) -> Result<Vec<ActivityItem>>;
+
+    /// The agent-task record-health summary, serialized as JSON so core does not
+    /// depend on the agent-task health type.
+    fn agent_task_record_health(&self) -> Result<Value>;
+}
+
+struct NoopProvider;
+
+impl ActivityAgentTaskProvider for NoopProvider {
+    fn agent_task_activity_items(&self) -> Result<Vec<ActivityItem>> {
+        Ok(Vec::new())
+    }
+
+    fn agent_task_record_health(&self) -> Result<Value> {
+        Ok(Value::Null)
+    }
+}
+
+fn provider_slot() -> &'static Mutex<Option<Box<dyn ActivityAgentTaskProvider>>> {
+    static PROVIDER: Mutex<Option<Box<dyn ActivityAgentTaskProvider>>> = Mutex::new(None);
+    &PROVIDER
+}
+
+/// Register the agent-task activity provider. Called once at startup by the
+/// agent-task layer.
+pub fn register_activity_agent_task_provider(provider: Box<dyn ActivityAgentTaskProvider>) {
+    let mut slot = provider_slot()
+        .lock()
+        .expect("activity agent-task provider lock");
+    *slot = Some(provider);
+}
+
+/// The agent-task activity items via the registered provider (or none when the
+/// agent-task subsystem is absent).
+pub(crate) fn agent_task_activity_items() -> Result<Vec<ActivityItem>> {
+    let slot = provider_slot()
+        .lock()
+        .expect("activity agent-task provider lock");
+    match slot.as_deref() {
+        Some(provider) => provider.agent_task_activity_items(),
+        None => NoopProvider.agent_task_activity_items(),
+    }
+}
+
+/// The agent-task record-health summary (as JSON) via the registered provider
+/// (or an empty summary when the agent-task subsystem is absent).
+pub(crate) fn agent_task_record_health() -> Result<Value> {
+    let slot = provider_slot()
+        .lock()
+        .expect("activity agent-task provider lock");
+    match slot.as_deref() {
+        Some(provider) => provider.agent_task_record_health(),
+        None => NoopProvider.agent_task_record_health(),
+    }
+}

--- a/crates/homeboy-core/src/agent_task_lifecycle/activity_provider.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/activity_provider.rs
@@ -1,0 +1,140 @@
+//! Agent-task implementation of the activity hook.
+//!
+//! Projects durable agent-task lifecycle records into core `ActivityItem`s and
+//! supplies the record-health summary, provided to core's activity report
+//! through the `ActivityAgentTaskProvider` hook so the activity report does not
+//! depend on the agent-task subsystem directly.
+
+use serde_json::Value;
+
+use crate::activity::agent_task_provider::{
+    register_activity_agent_task_provider, ActivityAgentTaskProvider,
+};
+use crate::activity::{
+    is_active, is_failure, ActivityCrossRefs, ActivityEvidenceRef, ActivityItem,
+    ActivityNextAction, ActivityRunnerRefs, ActivityState,
+};
+use crate::agent_task_lifecycle::{self, AgentTaskRunRecord};
+use crate::run_lifecycle_record::RunExecutionState;
+use crate::Result;
+
+struct AgentTaskActivityProvider;
+
+impl ActivityAgentTaskProvider for AgentTaskActivityProvider {
+    fn agent_task_activity_items(&self) -> Result<Vec<ActivityItem>> {
+        Ok(agent_task_lifecycle::list_records()?
+            .into_iter()
+            .map(item_from_agent_task)
+            .collect())
+    }
+
+    fn agent_task_record_health(&self) -> Result<Value> {
+        let summary = agent_task_lifecycle::record_health_summary()?;
+        serde_json::to_value(summary).map_err(|error| {
+            crate::Error::internal_json(
+                error.to_string(),
+                Some("serialize agent-task record health".to_string()),
+            )
+        })
+    }
+}
+
+fn metadata_string(value: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_str))
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+}
+
+fn action(label: impl Into<String>, command: impl Into<String>) -> ActivityNextAction {
+    ActivityNextAction {
+        label: label.into(),
+        command: command.into(),
+    }
+}
+
+fn item_from_agent_task(record: AgentTaskRunRecord) -> ActivityItem {
+    let runner_id = metadata_string(&record.metadata, &["runner_id"]);
+    let job_id = metadata_string(&record.metadata, &["runner_job_id", "job_id"]);
+    let remote_run_id = metadata_string(&record.metadata, &["remote_run_id"]);
+    let state = ActivityState::from(RunExecutionState::from(record.state));
+    ActivityItem {
+        id: record.run_id.clone(),
+        kind: "agent-task".to_string(),
+        source_store: "agent-task.lifecycle".to_string(),
+        state,
+        created_at: record.submitted_at.clone(),
+        updated_at: record.updated_at.clone(),
+        finished_at: if is_active(state) {
+            None
+        } else {
+            record.updated_at.clone()
+        },
+        command: None,
+        cwd: None,
+        runner: ActivityRunnerRefs {
+            runner_id,
+            job_id: job_id.clone(),
+            transport: remote_run_id,
+        },
+        refs: ActivityCrossRefs {
+            run_id: None,
+            agent_task_run_id: Some(record.run_id.clone()),
+            runner_job_id: job_id,
+        },
+        artifacts: record
+            .artifact_refs
+            .into_iter()
+            .map(|artifact| ActivityEvidenceRef {
+                id: artifact.task_id,
+                kind: artifact.kind,
+                uri: artifact.uri,
+            })
+            .collect(),
+        evidence: record
+            .latest_executor_evidence
+            .into_iter()
+            .flat_map(|evidence| evidence.refs())
+            .enumerate()
+            .map(|(index, evidence)| ActivityEvidenceRef {
+                id: evidence
+                    .label
+                    .unwrap_or_else(|| format!("evidence-{}", index + 1)),
+                kind: evidence.kind,
+                uri: evidence.uri,
+            })
+            .collect(),
+        source_projections: Vec::new(),
+        next_actions: actions_for_agent_task(&record.run_id, state),
+    }
+}
+
+fn actions_for_agent_task(run_id: &str, state: ActivityState) -> Vec<ActivityNextAction> {
+    let mut actions = vec![
+        action("status", format!("homeboy agent-task status {run_id}")),
+        action("logs", format!("homeboy agent-task logs {run_id}")),
+        action(
+            "artifacts",
+            format!("homeboy agent-task artifacts {run_id}"),
+        ),
+    ];
+    if is_active(state) {
+        actions.push(action("watch", format!("homeboy activity watch {run_id}")));
+    } else if is_failure(state) {
+        actions.push(action(
+            "retry",
+            format!("homeboy agent-task retry --run {run_id}"),
+        ));
+    }
+    if matches!(state, ActivityState::Stale) {
+        actions.push(action("reconcile", "homeboy agent-task active --reconcile"));
+    }
+    actions
+}
+
+/// Register the agent-task activity provider. Called once at startup so core's
+/// activity report includes agent-task records without depending on the
+/// agent-task subsystem.
+pub fn register() {
+    register_activity_agent_task_provider(Box::new(AgentTaskActivityProvider));
+}

--- a/crates/homeboy-core/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/mod.rs
@@ -29,6 +29,7 @@ mod lifecycle_store;
 
 use lifecycle_store as store;
 
+pub mod activity_provider;
 pub mod agent_task_lifecycle_event;
 mod artifact_materialization;
 mod cancellation;


### PR DESCRIPTION
## Summary
Stage 3 prep-PR of the homeboy-agents crate extraction campaign. Independent PR off `main`.

`core::activity` listed durable agent-task records (`agent_task_lifecycle::list_records` / `record_health_summary`), projected each into an `ActivityItem`, and stored the `AgentTaskRecordHealthSummary` on the report — a `core -> agent_task` edge in a core file that stays in core (a cycle once agent-task is its own crate).

## What changed
Inverted behind an `ActivityAgentTaskProvider` hook (`core/src/activity/agent_task_provider.rs`):
- Core owns the activity report + the `ActivityItem` shape; the agent-task layer supplies the items (`agent_task_activity_items`) and the health summary (`agent_task_record_health`, as JSON).
- The item-projection logic (`item_from_agent_task` / `actions_for_agent_task`) moves to the agent-side provider impl (`agent_task_lifecycle/activity_provider.rs`), which builds core's pub `ActivityItem` using the pub `is_active`/`is_failure` helpers + trivial local `action`/`metadata_string` copies.
- The report's `agent_task_record_health` field becomes an opaque `serde_json::Value`.
- Registered at startup in `cli_runtime.rs`. No-op contributes no items + null health.

## Effect
- `activity.rs`: prod `crate::agent_task` refs -> **0** (edge severed; remaining refs are agent-behavior tests that move with agent at the git-mv).

## Verification
- `cargo check --workspace --tests`: clean.
- `cargo test -p homeboy-core --lib activity::tests`: 13 passed.
- `cargo fmt`: clean.