### PR TITLE
Replace idle stale Lab daemons safely

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -295,6 +295,7 @@ pub fn connect_with_orphan_adoption(
         &client,
         homeboy,
         previous_session.as_ref(),
+        &identity.display,
         orphan_lease_id,
         confirmed_no_pid_job_ids,
     );

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -187,6 +187,10 @@ pub(super) struct RemoteDaemonStatus {
     pub(super) fresh: bool,
     pub(super) reachable: bool,
     pub(super) active_jobs: usize,
+    /// The typed `/jobs` view is independently required before replacing a
+    /// reachable stale daemon. `None` means the endpoint was unavailable or
+    /// malformed, which must fail closed for replacement.
+    pub(super) typed_unresolved_jobs: Option<usize>,
     pub(super) endpoint_probe_error: Option<String>,
     pub(super) termination_evidence: Option<homeboy_core::daemon::DaemonTerminationEvidence>,
 }
@@ -297,12 +301,14 @@ pub(super) fn unavailable_recovery_freshness(error: impl Into<String>) -> Daemon
 pub(super) enum RemoteDaemonConnectAction {
     Reattach,
     Start,
+    ReplaceIdleStale,
 }
 
 pub(super) fn ensure_remote_daemon(
     client: &SshClient,
     homeboy: &str,
     previous_session: Option<&RunnerSession>,
+    configured_identity: &str,
     orphan_lease_id: Option<&str>,
     confirmed_no_pid_job_ids: &[uuid::Uuid],
 ) -> std::result::Result<RemoteDaemon, String> {
@@ -329,7 +335,7 @@ pub(super) fn ensure_remote_daemon(
     match remote_daemon_connect_action_with_controller_identity(
         previous_session,
         &status,
-        &homeboy_core::build_identity::current().display,
+        configured_identity,
     )? {
         RemoteDaemonConnectAction::Reattach => {
             let mut daemon = status.daemon.ok_or_else(|| {
@@ -339,6 +345,21 @@ pub(super) fn ensure_remote_daemon(
             return Ok(daemon);
         }
         RemoteDaemonConnectAction::Start => return remote_daemon_ensure_running(client, homeboy),
+        RemoteDaemonConnectAction::ReplaceIdleStale => {
+            let daemon = status.daemon.as_ref().expect("replacement requires daemon");
+            let lease_id = daemon
+                .lease_id
+                .as_deref()
+                .expect("replacement requires lease");
+            remote_daemon_force_stop(client, homeboy, lease_id)?;
+            let replacement = remote_daemon_ensure_running(client, homeboy)?;
+            return verify_remote_daemon_replacement(
+                client,
+                homeboy,
+                &replacement,
+                configured_identity,
+            );
+        }
     }
 }
 
@@ -357,7 +378,7 @@ pub(super) fn remote_daemon_connect_action(
 pub(super) fn remote_daemon_connect_action_with_controller_identity(
     previous_session: Option<&RunnerSession>,
     status: &RemoteDaemonStatus,
-    controller_identity: &str,
+    expected_identity: &str,
 ) -> std::result::Result<RemoteDaemonConnectAction, String> {
     let Some(daemon) = status.daemon.as_ref() else {
         if status.active_jobs > 0 {
@@ -411,10 +432,22 @@ pub(super) fn remote_daemon_connect_action_with_controller_identity(
         }
     }
 
-    // Retain a live daemon across version/build/runtime drift. The tunnel's
-    // health endpoint must still prove this exact lease and PID before a
-    // session is persisted.
+    // A lease-less freshness report ordinarily prevents replacement. The one
+    // bounded exception is an idle daemon whose identity differs from the
+    // configured executable and whose typed `/jobs` endpoint independently
+    // proves no active or unresolved work. The stop itself remains lease-bound
+    // through Homeboy's daemon lifecycle command.
     if !status.fresh {
+        if status.active_jobs == 0
+            && status.typed_unresolved_jobs == Some(0)
+            && status.endpoint_probe_error.is_none()
+            && daemon
+                .build_identity
+                .as_deref()
+                .is_some_and(|identity| identity.trim() != expected_identity.trim())
+        {
+            return Ok(RemoteDaemonConnectAction::ReplaceIdleStale);
+        }
         return Ok(RemoteDaemonConnectAction::Reattach);
     }
 
@@ -431,9 +464,9 @@ pub(super) fn remote_daemon_connect_action_with_controller_identity(
                 "remote daemon has {} active job(s) but its reachable endpoint did not provide a version; refusing reattachment or replacement",
                 status.active_jobs
             ))?;
-            if daemon_identity.trim() != controller_identity.trim() {
+            if daemon_identity.trim() != expected_identity.trim() {
                 return Err(format!(
-                    "remote daemon has {} active job(s) under reachable lease `{}` (PID {}) but build identity `{daemon_identity}` / version `{daemon_version}` does not match this controller `{controller_identity}`; refusing replacement. Run a controller pinned to `{daemon_identity}` and retry `homeboy runner connect <runner-id>` to reattach this exact lease.",
+                    "remote daemon has {} active job(s) under reachable lease `{}` (PID {}) but build identity `{daemon_identity}` / version `{daemon_version}` does not match this configured runner binary `{expected_identity}`; refusing replacement. Run a controller pinned to `{daemon_identity}` and retry `homeboy runner connect <runner-id>` to reattach this exact lease.",
                     status.active_jobs,
                     daemon.lease_id.as_deref().unwrap_or("unavailable"),
                     daemon.pid.map(|pid| pid.to_string()).as_deref().unwrap_or("unavailable"),
@@ -526,6 +559,7 @@ pub(super) fn remote_daemon_status(
                 .and_then(Value::as_bool)
                 .unwrap_or(false),
             active_jobs: remote_daemon_active_jobs(&data),
+            typed_unresolved_jobs: None,
             endpoint_probe_error: None,
             termination_evidence,
         });
@@ -544,6 +578,7 @@ pub(super) fn remote_daemon_status(
                 .and_then(Value::as_bool)
                 .unwrap_or(false),
             active_jobs: remote_daemon_active_jobs(&data),
+            typed_unresolved_jobs: None,
             endpoint_probe_error: None,
             termination_evidence,
         });
@@ -558,6 +593,7 @@ pub(super) fn remote_daemon_status(
             .and_then(Value::as_bool)
             .unwrap_or(false),
         active_jobs: remote_daemon_active_jobs(&data),
+        typed_unresolved_jobs: None,
         endpoint_probe_error: None,
         termination_evidence,
     })
@@ -617,6 +653,42 @@ pub(super) fn probe_remote_daemon_endpoint(client: &SshClient, status: &mut Remo
                 .to_string(),
         );
     }
+    let command = format!(
+        "curl --fail --silent --show-error --max-time 2 {}/jobs",
+        shell::quote_arg(&format!("http://{}", daemon.address))
+    );
+    let output = client.execute_with_timeout(&command, REMOTE_DAEMON_STATUS_TIMEOUT);
+    if !output.success {
+        status.endpoint_probe_error = Some(command_failure_message(
+            "remote daemon typed job probe failed",
+            &output,
+        ));
+        return;
+    }
+    let body: Value = match parse_json_from_mixed_stdout(&output.stdout) {
+        Ok(body) => body,
+        Err(error) => {
+            status.endpoint_probe_error = Some(format!(
+                "remote daemon typed job probe returned invalid JSON: {error}"
+            ));
+            return;
+        }
+    };
+    let jobs = body
+        .pointer("/data/body")
+        .or_else(|| body.get("body"))
+        .unwrap_or(&body);
+    let Some(active) = jobs.get("active_runner_jobs").and_then(Value::as_array) else {
+        status.endpoint_probe_error =
+            Some("remote daemon typed job probe did not return active_runner_jobs".to_string());
+        return;
+    };
+    let Some(stale) = jobs.get("stale_runner_jobs").and_then(Value::as_array) else {
+        status.endpoint_probe_error =
+            Some("remote daemon typed job probe did not return stale_runner_jobs".to_string());
+        return;
+    };
+    status.typed_unresolved_jobs = Some(active.len().saturating_add(stale.len()));
 }
 
 fn remote_daemon_from_state(state: &Value) -> RemoteDaemon {
@@ -695,6 +767,88 @@ pub(super) fn remote_daemon_ensure_running(
         build_identity: None,
         inspected_freshness: None,
     })
+}
+
+pub(super) fn remote_daemon_force_stop(
+    client: &SshClient,
+    homeboy: &str,
+    lease_id: &str,
+) -> std::result::Result<(), String> {
+    let command = format!(
+        "{} daemon stop --force --lease-id {}",
+        shell::quote_arg(homeboy),
+        shell::quote_arg(lease_id),
+    );
+    let output = client.execute_with_timeout(&command, REMOTE_DAEMON_STATUS_TIMEOUT);
+    if !output.success {
+        return Err(command_failure_message(
+            "remote bounded stale-daemon replacement stop failed",
+            &output,
+        ));
+    }
+    let envelope = parse_envelope(&output.stdout).map_err(|error| {
+        format!("remote bounded stale-daemon replacement stop returned invalid JSON: {error}")
+    })?;
+    if !envelope.success {
+        return Err(
+            "remote bounded stale-daemon replacement stop returned an error envelope".to_string(),
+        );
+    }
+    if envelope
+        .data
+        .as_ref()
+        .and_then(|data| data.get("action"))
+        .and_then(Value::as_str)
+        != Some("stop")
+    {
+        return Err(
+            "remote bounded stale-daemon replacement stop returned an unexpected response"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn verify_remote_daemon_replacement(
+    client: &SshClient,
+    homeboy: &str,
+    replacement: &RemoteDaemon,
+    configured_identity: &str,
+) -> std::result::Result<RemoteDaemon, String> {
+    let mut status = remote_daemon_status(client, homeboy)?;
+    probe_remote_daemon_endpoint(client, &mut status);
+    let daemon = status.daemon.ok_or_else(|| {
+        "remote stale-daemon replacement re-probe returned no daemon state".to_string()
+    })?;
+    if !status.fresh || !status.reachable {
+        return Err(
+            "remote stale-daemon replacement re-probe did not prove a fresh reachable daemon"
+                .to_string(),
+        );
+    }
+    if status.endpoint_probe_error.is_some() {
+        return Err(format!(
+            "remote stale-daemon replacement endpoint re-probe failed: {}",
+            status.endpoint_probe_error.unwrap_or_default()
+        ));
+    }
+    if daemon.lease_id != replacement.lease_id
+        || daemon.pid != replacement.pid
+        || daemon.address != replacement.address
+    {
+        return Err(
+            "remote stale-daemon replacement ownership changed before re-probe; refusing to persist a different daemon"
+                .to_string(),
+        );
+    }
+    if daemon.build_identity.as_deref().map(str::trim) != Some(configured_identity.trim()) {
+        return Err(format!(
+            "remote stale-daemon replacement identity `{}` does not match configured runner binary `{}`",
+            daemon.build_identity.as_deref().unwrap_or("unavailable"),
+            configured_identity,
+        ));
+    }
+    Ok(daemon)
 }
 
 fn remote_daemon_adopt_orphan(

--- a/crates/homeboy-lab-runner/src/connection/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/mod.rs
@@ -213,6 +213,7 @@ pub(super) fn remote_daemon_status_for_test_with_reason(
         fresh,
         reachable,
         active_jobs,
+        typed_unresolved_jobs: None,
         endpoint_probe_error: None,
         termination_evidence: None,
     }

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -81,6 +81,92 @@ fn stale_daemon_without_jobs_reattaches_without_replacement() {
     );
 }
 
+fn idle_stale_status(typed_unresolved_jobs: Option<usize>) -> RemoteDaemonStatus {
+    let mut status = remote_daemon_status_for_test_with_reason(
+        false,
+        true,
+        0,
+        "lease-stale",
+        4444,
+        Some(DaemonStaleReasonCode::VersionMismatch),
+    );
+    let daemon = status.daemon.as_mut().expect("daemon");
+    daemon.version = Some("0.288.13".to_string());
+    daemon.build_identity = Some("homeboy 0.288.13+stale".to_string());
+    status.typed_unresolved_jobs = typed_unresolved_jobs;
+    status
+}
+
+#[test]
+fn replaces_idle_stale_daemon_when_typed_jobs_are_zero_without_lease_recovery_evidence() {
+    let status = idle_stale_status(Some(0));
+
+    assert_eq!(
+        remote_daemon_connect_action_with_controller_identity(
+            Some(&direct_ssh_session("lease-stale")),
+            &status,
+            "homeboy 0.289.0+configured",
+        )
+        .expect("bounded stale replacement"),
+        RemoteDaemonConnectAction::ReplaceIdleStale,
+    );
+    let freshness = remote_daemon_recovery_freshness_from_status("homeboy-lab", &status);
+    assert!(!freshness.restartable, "lease evidence remains unavailable");
+    assert_eq!(freshness.active_jobs, 0);
+}
+
+#[test]
+fn idle_stale_replacement_fails_closed_for_active_or_inconsistent_typed_jobs() {
+    let configured = "homeboy 0.289.0+configured";
+    let mut freshness_active = idle_stale_status(Some(0));
+    freshness_active.active_jobs = 1;
+    let typed_active = idle_stale_status(Some(1));
+    let typed_unreachable = idle_stale_status(None);
+
+    for status in [freshness_active, typed_active, typed_unreachable] {
+        assert_eq!(
+            remote_daemon_connect_action_with_controller_identity(None, &status, configured)
+                .expect("unsafe evidence retains the daemon"),
+            RemoteDaemonConnectAction::Reattach,
+        );
+    }
+}
+
+#[test]
+fn idle_stale_replacement_refuses_unreachable_daemon_evidence() {
+    let mut status = idle_stale_status(Some(0));
+    status.reachable = false;
+
+    assert!(remote_daemon_connect_action_with_controller_identity(
+        None,
+        &status,
+        "homeboy 0.289.0+configured",
+    )
+    .expect_err("unreachable evidence must fail closed")
+    .contains("unreachable"));
+}
+
+#[test]
+fn reconnect_converges_to_configured_identity_and_repeated_recovery_reattaches() {
+    let mut status = idle_stale_status(Some(0));
+    let daemon = status.daemon.as_mut().expect("daemon");
+    daemon.version = Some("0.289.0".to_string());
+    daemon.build_identity = Some("homeboy 0.289.0+configured".to_string());
+    status.fresh = true;
+    status.stale_reason = None;
+    status.stale_reason_code = None;
+
+    assert_eq!(
+        remote_daemon_connect_action_with_controller_identity(
+            Some(&direct_ssh_session("lease-stale")),
+            &status,
+            "homeboy 0.289.0+configured",
+        )
+        .expect("converged daemon reattaches"),
+        RemoteDaemonConnectAction::Reattach,
+    );
+}
+
 #[test]
 fn reattaches_live_stale_daemon_with_active_jobs_without_replacing_it() {
     let status = remote_daemon_status_for_test_with_reason(
@@ -727,4 +813,196 @@ fn dead_recorded_daemon_without_active_jobs_routes_to_idempotent_ensure_start() 
             .expect("ensure start"),
         RemoteDaemonConnectAction::Start
     );
+}
+
+#[cfg(unix)]
+fn with_idle_stale_replacement_shim(
+    post_lease_id: &str,
+    post_identity: &str,
+    run: impl FnOnce(&SshClient, &str, &str, PathBuf),
+) {
+    test_support::with_isolated_home(|home| {
+        let daemon = home.path().join("remote-homeboy");
+        let marker = home.path().join("replacement-complete");
+        let argv_path = home.path().join("replacement-argv");
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("address");
+        let marker_for_server = marker.clone();
+        let post_lease_id = post_lease_id.to_string();
+        let post_identity = post_identity.to_string();
+        let post_lease_id_for_server = post_lease_id.clone();
+        let server = std::thread::spawn(move || {
+            for _ in 0..4 {
+                let (mut stream, _) = listener.accept().expect("request");
+                let mut request = [0; 4096];
+                let length = stream.read(&mut request).expect("read request");
+                let request = String::from_utf8(request[..length].to_vec()).expect("request text");
+                let replacement_complete = marker_for_server.exists();
+                let identity = if replacement_complete {
+                    post_identity.as_str()
+                } else {
+                    "homeboy 0.288.13+stale"
+                };
+                let body = if request.starts_with("GET /version ") {
+                    serde_json::json!({
+                        "version": "0.289.0",
+                        "build_identity": { "display": identity },
+                    })
+                } else {
+                    assert!(request.starts_with("GET /jobs "), "{request}");
+                    serde_json::json!({
+                        "success": true,
+                        "data": { "body": {
+                            "active_runner_jobs": [],
+                            "stale_runner_jobs": [],
+                        }},
+                    })
+                }
+                .to_string();
+                stream
+                    .write_all(
+                        format!(
+                            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .as_bytes(),
+                    )
+                    .expect("response");
+            }
+        });
+        std::fs::write(
+            &daemon,
+            format!(
+                r#"#!/bin/sh
+printf '%s\n' "$@" >> "$HOMEBOY_TEST_REPLACEMENT_ARGV"
+case "$1 $2" in
+  "daemon status")
+    if [ -f "{marker}" ]; then
+      printf '%s\n' '{{"success":true,"data":{{"running":true,"fresh":true,"reachable":true,"freshness":{{"active_jobs":0}},"state":{{"address":"{address}","pid":222,"lease_id":"{post_lease_id}"}}}}}}'
+    else
+      printf '%s\n' '{{"success":true,"data":{{"running":true,"fresh":false,"reachable":true,"freshness":{{"active_jobs":0,"stale_reason_code":"version_mismatch"}},"state":{{"address":"{address}","pid":111,"lease_id":"lease-old"}}}}}}'
+    fi
+    ;;
+  "daemon stop")
+    touch "{marker}"
+    printf '%s\n' '{{"success":true,"data":{{"action":"stop"}}}}'
+    ;;
+  "daemon ensure-running")
+    printf '%s\n' '{{"success":true,"data":{{"address":"{address}","pid":222,"lease_id":"lease-new"}}}}'
+    ;;
+esac
+"#,
+                marker = marker.display(),
+                address = address,
+                post_lease_id = post_lease_id_for_server,
+            ),
+        )
+        .expect("write remote Homeboy shim");
+        let mut permissions = std::fs::metadata(&daemon)
+            .expect("read remote Homeboy shim metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&daemon, permissions)
+            .expect("make remote Homeboy shim executable");
+        server::create(
+            &serde_json::json!({ "id": "local-runner", "host": "localhost", "user": "test" })
+                .to_string(),
+            false,
+        )
+        .expect("create local server");
+        let server_config = server::load("local-runner").expect("load local server");
+        let mut client =
+            SshClient::from_server(&server_config, "local-runner").expect("SSH client");
+        client.env.insert(
+            "HOMEBOY_TEST_REPLACEMENT_ARGV".to_string(),
+            argv_path.display().to_string(),
+        );
+        run(
+            &client,
+            daemon.to_str().expect("daemon path"),
+            "homeboy 0.289.0+configured",
+            argv_path,
+        );
+        server.join().expect("server");
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn idle_stale_replacement_uses_actual_endpoint_envelopes_and_reprobes_the_new_owner() {
+    with_idle_stale_replacement_shim(
+        "lease-new",
+        "homeboy 0.289.0+configured",
+        |client, homeboy, configured_identity, argv_path| {
+            let daemon =
+                ensure_remote_daemon(client, homeboy, None, configured_identity, None, &[])
+                    .expect("replacement succeeds");
+            assert_eq!(daemon.lease_id.as_deref(), Some("lease-new"));
+            assert_eq!(daemon.pid, Some(222));
+            assert_eq!(daemon.build_identity.as_deref(), Some(configured_identity));
+            assert_eq!(
+                std::fs::read_to_string(argv_path).expect("read command argv"),
+                "daemon\nstatus\ndaemon\nstop\n--force\n--lease-id\nlease-old\ndaemon\nensure-running\n--addr\n127.0.0.1:0\ndaemon\nstatus\n"
+            );
+        },
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn idle_stale_replacement_refuses_a_post_stop_owner_or_identity_change() {
+    with_idle_stale_replacement_shim(
+        "lease-raced",
+        "homeboy 0.288.13+stale",
+        |client, homeboy, configured_identity, _| {
+            let error = ensure_remote_daemon(client, homeboy, None, configured_identity, None, &[])
+                .expect_err("concurrent stale daemon is refused");
+            assert!(error.contains("ownership changed"));
+        },
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn idle_stale_replacement_refuses_a_post_stop_identity_change() {
+    with_idle_stale_replacement_shim(
+        "lease-new",
+        "homeboy 0.288.13+stale",
+        |client, homeboy, configured_identity, _| {
+            let error = ensure_remote_daemon(client, homeboy, None, configured_identity, None, &[])
+                .expect_err("stale replacement identity is refused");
+            assert!(error.contains("does not match configured runner binary"));
+        },
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn stale_replacement_force_stop_rejects_a_success_envelope_without_stop_action() {
+    test_support::with_isolated_home(|home| {
+        let daemon = home.path().join("remote-homeboy");
+        std::fs::write(
+            &daemon,
+            "#!/bin/sh\nprintf '%s\\n' '{\"success\":true,\"data\":{\"action\":\"status\"}}'\n",
+        )
+        .expect("write remote Homeboy shim");
+        let mut permissions = std::fs::metadata(&daemon).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&daemon, permissions).expect("make shim executable");
+        server::create(
+            &serde_json::json!({ "id": "local-runner", "host": "localhost", "user": "test" })
+                .to_string(),
+            false,
+        )
+        .expect("create local server");
+        let server_config = server::load("local-runner").expect("load local server");
+        let client = SshClient::from_server(&server_config, "local-runner").expect("SSH client");
+        let error = remote_daemon::remote_daemon_force_stop(
+            &client,
+            daemon.to_str().expect("daemon path"),
+            "lease-old",
+        )
+        .expect_err("malformed success response");
+        assert!(error.contains("unexpected response"));
+    });
 }

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -15,6 +15,7 @@ fn first_connect_routes_to_idempotent_ensure_start_when_no_daemon_exists() {
         fresh: false,
         reachable: false,
         active_jobs: 0,
+        typed_unresolved_jobs: None,
         endpoint_probe_error: None,
         termination_evidence: None,
     };
@@ -34,6 +35,7 @@ fn missing_daemon_state_with_active_jobs_refuses_ensure_running() {
         fresh: false,
         reachable: false,
         active_jobs: 1,
+        typed_unresolved_jobs: None,
         endpoint_probe_error: None,
         termination_evidence: None,
     };

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -473,6 +473,7 @@ mod tests {
             fresh: reachable,
             reachable,
             active_jobs,
+            typed_unresolved_jobs: None,
             endpoint_probe_error: None,
             termination_evidence: None,
         }
@@ -647,6 +648,7 @@ mod tests {
             fresh: false,
             reachable: false,
             active_jobs: 0,
+            typed_unresolved_jobs: None,
             endpoint_probe_error: None,
             termination_evidence: Some(homeboy_core::daemon::DaemonTerminationEvidence {
                 classification: homeboy_core::daemon::DaemonTerminationClassification::CleanStop,
@@ -694,6 +696,7 @@ mod tests {
             fresh: false,
             reachable: false,
             active_jobs: 0,
+            typed_unresolved_jobs: None,
             endpoint_probe_error: None,
             termination_evidence: None,
         };


### PR DESCRIPTION
## Summary
- replace an idle stale direct-SSH daemon only when freshness and typed job views both prove zero unresolved work
- keep replacement lease-bound and fail closed on malformed, unreachable, active, or inconsistent evidence
- re-probe the replacement and require exact lease, PID, address, and configured build identity before persisting the session
- cover the real `/version` and `/jobs` envelopes plus stop/start races with transport-level tests

Closes #8770.

## How to test
1. Run `cargo test -p homeboy-lab-runner connection::tests --lib`.
2. Run `cargo test -p homeboy-lab-runner idle_stale_ --lib -- --test-threads=1`.
3. Run `cargo test -p homeboy-lab-runner stale_replacement_force_stop_rejects_a_success_envelope_without_stop_action --lib`.
4. Run `cargo fmt --check`.
5. Run `cargo check -p homeboy-lab-runner`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode
- **Used for:** We reviewed the stale-daemon recovery design, implemented the bounded replacement path and transport regressions, and ran deterministic verification.