### PR TITLE
refactor: move ExtensionCapability enum + descriptor to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/capability.rs
+++ b/crates/homeboy-core/src/extension/capability.rs
@@ -7,95 +7,13 @@ use super::manifest::ExtensionManifest;
 use super::registry::{extension_path, load_extension};
 use super::runner::ExtensionRunner;
 use super::ResolvedExtensionInvocationContext;
+use homeboy_extension_contract::ExtensionCapability;
 
 pub(crate) fn stderr_tail(stderr: &str) -> String {
     const MAX_LINES: usize = 20;
     let lines: Vec<&str> = stderr.lines().collect();
     let start = lines.len().saturating_sub(MAX_LINES);
     lines[start..].join("\n")
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ExtensionCapability {
-    Lint,
-    Test,
-    Build,
-    Bench,
-    Fuzz,
-    Trace,
-    Deps,
-}
-
-/// Static metadata for an [`ExtensionCapability`] variant.
-///
-/// Centralizing label, manifest-support probe, and script accessor in one
-/// descriptor keeps variant additions localized: a new capability only
-/// needs one new arm in [`ExtensionCapability::descriptor`] instead of
-/// parallel arms scattered across each getter / policy method.
-struct ExtensionCapabilityDescriptor {
-    label: &'static str,
-    has_manifest_support: fn(&ExtensionManifest) -> bool,
-    script_path: fn(&ExtensionManifest) -> Option<&str>,
-}
-
-impl ExtensionCapability {
-    fn descriptor(self) -> ExtensionCapabilityDescriptor {
-        match self {
-            ExtensionCapability::Lint => ExtensionCapabilityDescriptor {
-                label: "lint",
-                has_manifest_support: ExtensionManifest::has_lint,
-                script_path: ExtensionManifest::lint_script,
-            },
-            ExtensionCapability::Test => ExtensionCapabilityDescriptor {
-                label: "test",
-                has_manifest_support: ExtensionManifest::has_test,
-                script_path: ExtensionManifest::test_script,
-            },
-            ExtensionCapability::Build => ExtensionCapabilityDescriptor {
-                label: "build",
-                has_manifest_support: ExtensionManifest::has_build,
-                script_path: ExtensionManifest::build_script,
-            },
-            ExtensionCapability::Bench => ExtensionCapabilityDescriptor {
-                label: "bench",
-                has_manifest_support: ExtensionManifest::has_bench,
-                script_path: ExtensionManifest::bench_script,
-            },
-            ExtensionCapability::Fuzz => ExtensionCapabilityDescriptor {
-                label: "fuzz",
-                has_manifest_support: ExtensionManifest::has_fuzz,
-                script_path: ExtensionManifest::fuzz_script,
-            },
-            ExtensionCapability::Trace => ExtensionCapabilityDescriptor {
-                label: "trace",
-                has_manifest_support: ExtensionManifest::has_trace,
-                script_path: ExtensionManifest::trace_script,
-            },
-            ExtensionCapability::Deps => ExtensionCapabilityDescriptor {
-                label: "deps",
-                has_manifest_support: ExtensionManifest::has_deps,
-                script_path: ExtensionManifest::deps_script,
-            },
-        }
-    }
-
-    pub fn label(self) -> &'static str {
-        self.descriptor().label
-    }
-
-    pub(crate) fn has_manifest_support(self, manifest: &ExtensionManifest) -> bool {
-        (self.descriptor().has_manifest_support)(manifest)
-    }
-
-    pub(crate) fn script_path(self, manifest: &ExtensionManifest) -> Option<&str> {
-        (self.descriptor().script_path)(manifest)
-    }
-
-    pub(crate) fn requires_script(self) -> bool {
-        // Fuzz supports manifest-only workload discovery; `fuzz run` validates
-        // its runner script before execution.
-        !matches!(self, ExtensionCapability::Build | ExtensionCapability::Fuzz)
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -39,8 +39,8 @@ mod validation;
 
 pub use capability::{
     build_scenario_runner, extract_component_extension_settings, path_list_env_value,
-    resolve_execution_context, resolve_extension_for_capability, ExtensionCapability,
-    ExtensionExecutionContext, ScenarioRunnerOptions,
+    resolve_execution_context, resolve_extension_for_capability, ExtensionExecutionContext,
+    ScenarioRunnerOptions,
 };
 pub(crate) use capability::{
     extension_guidance_hints, has_linked_extension_for_capability,
@@ -55,6 +55,7 @@ pub use homeboy_extension_contract::core_compat::{
     validate_core_compatibility, CoreCompatibilityReport, CORE_COMPAT_REMEDIATION_COMMAND,
     CORE_INCOMPATIBLE_DIAGNOSTIC,
 };
+pub use homeboy_extension_contract::ExtensionCapability;
 
 pub(crate) use execution::{build_settings_json_from_manifest, execute_action};
 pub use execution::{

--- a/crates/homeboy-extension-contract/src/capability.rs
+++ b/crates/homeboy-extension-contract/src/capability.rs
@@ -1,0 +1,90 @@
+//! Extension capability enum + manifest-support descriptor.
+//!
+//! Pure data + manifest-driven metadata (all dependencies resolve to
+//! `ExtensionManifest` in this crate). Execution behavior lives in
+//! `homeboy-core`.
+
+use crate::ExtensionManifest;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtensionCapability {
+    Lint,
+    Test,
+    Build,
+    Bench,
+    Fuzz,
+    Trace,
+    Deps,
+}
+
+/// Static metadata for an [`ExtensionCapability`] variant.
+///
+/// Centralizing label, manifest-support probe, and script accessor in one
+/// descriptor keeps variant additions localized: a new capability only
+/// needs one new arm in [`ExtensionCapability::descriptor`] instead of
+/// parallel arms scattered across each getter / policy method.
+struct ExtensionCapabilityDescriptor {
+    label: &'static str,
+    has_manifest_support: fn(&ExtensionManifest) -> bool,
+    script_path: fn(&ExtensionManifest) -> Option<&str>,
+}
+
+impl ExtensionCapability {
+    fn descriptor(self) -> ExtensionCapabilityDescriptor {
+        match self {
+            ExtensionCapability::Lint => ExtensionCapabilityDescriptor {
+                label: "lint",
+                has_manifest_support: ExtensionManifest::has_lint,
+                script_path: ExtensionManifest::lint_script,
+            },
+            ExtensionCapability::Test => ExtensionCapabilityDescriptor {
+                label: "test",
+                has_manifest_support: ExtensionManifest::has_test,
+                script_path: ExtensionManifest::test_script,
+            },
+            ExtensionCapability::Build => ExtensionCapabilityDescriptor {
+                label: "build",
+                has_manifest_support: ExtensionManifest::has_build,
+                script_path: ExtensionManifest::build_script,
+            },
+            ExtensionCapability::Bench => ExtensionCapabilityDescriptor {
+                label: "bench",
+                has_manifest_support: ExtensionManifest::has_bench,
+                script_path: ExtensionManifest::bench_script,
+            },
+            ExtensionCapability::Fuzz => ExtensionCapabilityDescriptor {
+                label: "fuzz",
+                has_manifest_support: ExtensionManifest::has_fuzz,
+                script_path: ExtensionManifest::fuzz_script,
+            },
+            ExtensionCapability::Trace => ExtensionCapabilityDescriptor {
+                label: "trace",
+                has_manifest_support: ExtensionManifest::has_trace,
+                script_path: ExtensionManifest::trace_script,
+            },
+            ExtensionCapability::Deps => ExtensionCapabilityDescriptor {
+                label: "deps",
+                has_manifest_support: ExtensionManifest::has_deps,
+                script_path: ExtensionManifest::deps_script,
+            },
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        self.descriptor().label
+    }
+
+    pub fn has_manifest_support(self, manifest: &ExtensionManifest) -> bool {
+        (self.descriptor().has_manifest_support)(manifest)
+    }
+
+    pub fn script_path(self, manifest: &ExtensionManifest) -> Option<&str> {
+        (self.descriptor().script_path)(manifest)
+    }
+
+    pub fn requires_script(self) -> bool {
+        // Fuzz supports manifest-only workload discovery; `fuzz run` validates
+        // its runner script before execution.
+        !matches!(self, ExtensionCapability::Build | ExtensionCapability::Fuzz)
+    }
+}

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -11,6 +11,8 @@
 
 pub mod action_types;
 pub mod autofix_config;
+pub mod capability;
+pub use capability::ExtensionCapability;
 pub mod ci_config;
 pub mod core_compat;
 pub mod exec_context;


### PR DESCRIPTION
## Summary
Stage-2 cut following the `ExtensionManifest` move (#8779). The `ExtensionCapability` enum (`Lint`/`Test`/`Build`/`Bench`/`Fuzz`/`Trace`/`Deps`), its `ExtensionCapabilityDescriptor`, and the **full `impl ExtensionCapability` block** all move into the contract crate.

## Why the behavior travels with the data
Every method on the impl — `descriptor`, `label`, `has_manifest_support`, `script_path`, `requires_script` — only touches `ExtensionManifest`. Now that `ExtensionManifest` lives in the contract crate, the manifest-support function pointers (`ExtensionManifest::has_lint`, `ExtensionManifest::lint_script`, etc.) resolve inside the leaf crate. So this isn't a data/behavior split — the whole thing moves cleanly.

## Changes
- New contract `capability` module holds the enum, descriptor, and impl.
- Widened the three `pub(crate)` methods (`has_manifest_support`, `script_path`, `requires_script`) to `pub` for cross-crate access.
- Core's `capability.rs` re-imports the enum (its `ExtensionExecutionContext` still uses it as a field); extension `mod.rs` re-exports it from the contract crate.

## Zero downstream churn
`crate::extension::ExtensionCapability` stays valid across all ~17 core consumers via the re-export.

## Impact
`ExtensionCapability` was one of the **most-referenced extension symbols** (17 core prod refs, 2nd only to the phase submodules). Moving it — a *type* the whole codebase pattern-matches on — meaningfully shrinks the reverse-edge surface for the eventual `homeboy-extension` behavior crate.

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-issues`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)