### PR TITLE
refactor: relocate tag-gap provenance out of deploy (extension build stops depending on deploy)

### DIFF
--- a/crates/homeboy-core/src/deploy/provenance.rs
+++ b/crates/homeboy-core/src/deploy/provenance.rs
@@ -12,7 +12,6 @@ use sha2::{Digest, Sha256};
 
 use crate::component::Component;
 use crate::engine::command;
-use crate::release;
 
 use super::generated_artifacts::uncommitted_file_report_excluding_known_generated;
 use super::types::{ArtifactIdentity, BuildProvenance, BuildSource};
@@ -98,86 +97,7 @@ fn sha256_file(path: &Path) -> Option<String> {
     Some(format!("{:x}", hasher.finalize()))
 }
 
-/// Information about the HEAD-vs-tag gap for a component.
-#[derive(Debug, Clone)]
-pub struct TagGap {
-    /// The latest tag
-    pub tag: String,
-    /// Number of commits HEAD is ahead
-    pub ahead: u32,
-    /// Short commit subjects (newest first)
-    pub commits: Vec<String>,
-}
-
-/// Check if HEAD is ahead of the latest tag for a component.
-/// Returns None if HEAD is at or behind the tag, or if no tags exist.
-pub fn detect_tag_gap(component: &Component) -> Option<TagGap> {
-    let path = &component.local_path;
-    let tag = release::latest_component_tag(component).ok().flatten()?;
-
-    let ahead_str = command::run_in_optional(
-        path,
-        "git",
-        &["rev-list", "--count", &format!("{}..HEAD", tag)],
-    )?;
-    let ahead = ahead_str.trim().parse::<u32>().ok()?;
-
-    if ahead == 0 {
-        return None;
-    }
-
-    // Get commit subjects for the unreleased commits (max 10)
-    let log_output = command::run_in_optional(
-        path,
-        "git",
-        &[
-            "log",
-            "--oneline",
-            "--format=%h %s",
-            "-10",
-            &format!("{}..HEAD", tag),
-        ],
-    )
-    .unwrap_or_default();
-
-    let commits: Vec<String> = log_output
-        .lines()
-        .filter(|l| !l.is_empty())
-        .map(|l| l.to_string())
-        .collect();
-
-    Some(TagGap {
-        tag,
-        ahead,
-        commits,
-    })
-}
-
-/// Format a tag gap as a human-readable warning string.
-///
-/// Used by both `build` and `deploy` commands.
-fn format_tag_gap(component_id: &str, gap: &TagGap, context: &str) -> String {
-    let mut lines = vec![format!(
-        "[{}] '{}': HEAD is {} commit(s) ahead of latest tag {}",
-        context, component_id, gap.ahead, gap.tag
-    )];
-    for commit in &gap.commits {
-        lines.push(format!("[{}]      {}", context, commit));
-    }
-    if gap.ahead > 10 {
-        lines.push(format!(
-            "[{}]      ... and {} more",
-            context,
-            gap.ahead - gap.commits.len() as u32
-        ));
-    }
-    lines.join("\n")
-}
-
-/// Print a tag gap warning to stderr. Always prints regardless of TTY.
-pub fn warn_tag_gap(component_id: &str, gap: &TagGap, context: &str) {
-    eprintln!("{}", format_tag_gap(component_id, gap, context));
-}
+pub use crate::tag_gap::{detect_tag_gap, warn_tag_gap};
 
 #[cfg(test)]
 mod provenance_tests {

--- a/crates/homeboy-core/src/extension/build/mod.rs
+++ b/crates/homeboy-core/src/extension/build/mod.rs
@@ -432,8 +432,8 @@ fn execute_build_component(
 
     // Warn when HEAD is ahead of the latest tag — the build will include
     // unreleased commits that won't be deployed unless using `deploy --head`.
-    if let Some(gap) = crate::deploy::provenance::detect_tag_gap(comp) {
-        crate::deploy::provenance::warn_tag_gap(&comp.id, &gap, "build");
+    if let Some(gap) = crate::tag_gap::detect_tag_gap(comp) {
+        crate::tag_gap::warn_tag_gap(&comp.id, &gap, "build");
         log_status!(
             "build",
             "Build uses current working tree. To deploy these commits: use `deploy --head` or run `homeboy release`."

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -217,6 +217,7 @@ pub mod source_snapshot;
 pub mod stack;
 pub mod stream_capture;
 pub mod structured_sidecar;
+pub mod tag_gap;
 pub mod top_n;
 pub mod trace_compare;
 pub mod trace_experiment;

--- a/crates/homeboy-core/src/tag_gap.rs
+++ b/crates/homeboy-core/src/tag_gap.rs
@@ -1,0 +1,91 @@
+//! Component tag-gap detection: HEAD-vs-latest-tag provenance advisory.
+//!
+//! Warns when a component's HEAD is ahead of its latest release tag — used by
+//! both `build` and `deploy` to flag that unreleased commits are involved.
+//! Lives at core level (not under `deploy`) so the extension build path can
+//! reach it without depending on the deploy subsystem.
+
+use crate::component::Component;
+use crate::engine::command;
+use crate::release;
+
+/// Information about the HEAD-vs-tag gap for a component.
+#[derive(Debug, Clone)]
+pub struct TagGap {
+    /// The latest tag
+    pub tag: String,
+    /// Number of commits HEAD is ahead
+    pub ahead: u32,
+    /// Short commit subjects (newest first)
+    pub commits: Vec<String>,
+}
+
+/// Check if HEAD is ahead of the latest tag for a component.
+/// Returns None if HEAD is at or behind the tag, or if no tags exist.
+pub fn detect_tag_gap(component: &Component) -> Option<TagGap> {
+    let path = &component.local_path;
+    let tag = release::latest_component_tag(component).ok().flatten()?;
+
+    let ahead_str = command::run_in_optional(
+        path,
+        "git",
+        &["rev-list", "--count", &format!("{}..HEAD", tag)],
+    )?;
+    let ahead = ahead_str.trim().parse::<u32>().ok()?;
+
+    if ahead == 0 {
+        return None;
+    }
+
+    // Get commit subjects for the unreleased commits (max 10)
+    let log_output = command::run_in_optional(
+        path,
+        "git",
+        &[
+            "log",
+            "--oneline",
+            "--format=%h %s",
+            "-10",
+            &format!("{}..HEAD", tag),
+        ],
+    )
+    .unwrap_or_default();
+
+    let commits: Vec<String> = log_output
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect();
+
+    Some(TagGap {
+        tag,
+        ahead,
+        commits,
+    })
+}
+
+/// Format a tag gap as a human-readable warning string.
+///
+/// Used by both `build` and `deploy` commands.
+fn format_tag_gap(component_id: &str, gap: &TagGap, context: &str) -> String {
+    let mut lines = vec![format!(
+        "[{}] '{}': HEAD is {} commit(s) ahead of latest tag {}",
+        context, component_id, gap.ahead, gap.tag
+    )];
+    for commit in &gap.commits {
+        lines.push(format!("[{}]      {}", context, commit));
+    }
+    if gap.ahead > 10 {
+        lines.push(format!(
+            "[{}]      ... and {} more",
+            context,
+            gap.ahead - gap.commits.len() as u32
+        ));
+    }
+    lines.join("\n")
+}
+
+/// Print a tag gap warning to stderr. Always prints regardless of TTY.
+pub fn warn_tag_gap(component_id: &str, gap: &TagGap, context: &str) {
+    eprintln!("{}", format_tag_gap(component_id, gap, context));
+}


### PR DESCRIPTION
## Summary
`detect_tag_gap` / `warn_tag_gap` / `TagGap` warn when a component's HEAD is ahead of its latest release tag. Their own doc says they're *"used by both `build` and `deploy` commands"* — a shared build-provenance advisory that only happened to live under `deploy::provenance`, which forced the **extension build path to import `crate::deploy`**.

Relocate the tag-gap trio (+ private `format_tag_gap` helper) to a core-level `crate::tag_gap` module (deps only `component` / `engine::command` / `release`).

## Effect
- **Severs one of the extension build path's two `deploy` edges** — `extension/build/mod.rs` now imports `crate::tag_gap` instead of `crate::deploy::provenance`.
- `deploy::provenance` re-exports `detect_tag_gap`/`warn_tag_gap` so deploy's own consumer (`orchestration::preflight`) is unchanged.
- The remaining deploy edge (`deploy::permissions::fix_local_permissions`) is a separate concern for a later cut.
- Also fixes the misfiling: a shared build/deploy provenance utility no longer lives inside the deploy subsystem.

## Verification
- `cargo check -p homeboy-core --lib --tests` — 0 errors, no new warnings (dropped the now-unused `crate::release` import in `provenance.rs`).
- `cargo check --workspace --tests --locked` (topology guard) — **passes**.
- `git mv`-style relocation; deploy's re-export keeps internal call sites intact.

Refs #8425