### PR TITLE
Fix changed Rust test scoping in workspaces

### DIFF
--- a/crates/homeboy-core/src/extension/test/mod.rs
+++ b/crates/homeboy-core/src/extension/test/mod.rs
@@ -211,24 +211,32 @@ fn rust_cargo_changed_test_env(component: &Component, files: &[String]) -> Vec<(
     let mut fallback_message = None;
 
     for test_file in files {
-        if test_file.starts_with("tests/") && test_file.ends_with(".rs") {
-            let rest = test_file.trim_start_matches("tests/");
+        let Some(routing_file) = cargo_relative_test_path(component, test_file) else {
+            fallback_message = Some(
+                "Changed Rust test path has no owning Cargo package; running the full test command."
+                    .to_string(),
+            );
+            continue;
+        };
+
+        if routing_file.starts_with("tests/") && routing_file.ends_with(".rs") {
+            let rest = routing_file.trim_start_matches("tests/");
             if !rest.contains('/') {
                 integration_args.push(rest.trim_end_matches(".rs").to_string());
                 continue;
             }
         }
 
-        let mut module_path = test_file
+        let mut module_path = routing_file
             .strip_prefix("src/")
-            .unwrap_or(test_file)
+            .unwrap_or(&routing_file)
             .strip_prefix("tests/")
-            .unwrap_or_else(|| test_file.strip_prefix("src/").unwrap_or(test_file))
+            .unwrap_or_else(|| routing_file.strip_prefix("src/").unwrap_or(&routing_file))
             .trim_end_matches(".rs")
             .trim_end_matches("/mod")
             .to_string();
 
-        if test_file.starts_with("tests/") && test_file.ends_with("_test.rs") {
+        if routing_file.starts_with("tests/") && routing_file.ends_with("_test.rs") {
             let test_module = module_path
                 .rsplit('/')
                 .next()
@@ -242,14 +250,17 @@ fn rust_cargo_changed_test_env(component: &Component, files: &[String]) -> Vec<(
 
             if source_file.is_file() || source_mod.is_file() {
                 module_path = format!("{source_module}::{test_module}");
-            } else if test_file.starts_with("tests/") && test_file["tests/".len()..].contains('/') {
+            } else if routing_file.starts_with("tests/")
+                && routing_file["tests/".len()..].contains('/')
+            {
                 fallback_message = Some(
                     "Changed files include nested tests without a direct target; running the full test command."
                         .to_string(),
                 );
                 continue;
             }
-        } else if test_file.starts_with("tests/") && test_file["tests/".len()..].contains('/') {
+        } else if routing_file.starts_with("tests/") && routing_file["tests/".len()..].contains('/')
+        {
             fallback_message = Some(
                 "Changed files include nested tests without a direct target; running the full test command."
                     .to_string(),
@@ -262,7 +273,7 @@ fn rust_cargo_changed_test_env(component: &Component, files: &[String]) -> Vec<(
         // cargo filter that matches zero tests. The runner treats "ran 0 tests"
         // as a failure, producing a spurious test-phase failure with no counts.
         // Fall back to the full suite instead of emitting an empty filter.
-        if is_inline_test_support_file(component, test_file) {
+        if is_inline_test_support_file(component, test_file, &routing_file) {
             fallback_message = Some(
                 "Changed files include an inline test support module without test functions; running the full test command."
                     .to_string(),
@@ -346,6 +357,36 @@ fn rust_cargo_changed_test_env(component: &Component, files: &[String]) -> Vec<(
     Vec::new()
 }
 
+/// Return a changed file path relative to its Cargo package.
+///
+/// Changed-file selection is repository-relative for workspace components, but
+/// Cargo test filters are module-relative to the owning package. Component
+/// relative `src/` and `tests/` paths already satisfy that contract. For other
+/// paths, locate the nearest package manifest rather than treating directory
+/// names above `src/` as Rust modules.
+fn cargo_relative_test_path(component: &Component, test_file: &str) -> Option<String> {
+    if test_file.starts_with("src/") || test_file.starts_with("tests/") {
+        return Some(test_file.to_string());
+    }
+
+    let component_root = component_source_path(component);
+    let file_path = component_root.join(test_file);
+    let mut directory = file_path.parent()?;
+
+    loop {
+        if directory.join("Cargo.toml").is_file() {
+            return file_path
+                .strip_prefix(directory)
+                .ok()
+                .map(|path| path.to_string_lossy().replace('\\', "/"));
+        }
+        directory = directory.parent()?;
+        if !directory.starts_with(&component_root) {
+            return None;
+        }
+    }
+}
+
 /// Returns `true` when `test_file` is an inline test module (lives under a
 /// `tests/` directory inside `src/`) that defines no test functions and would
 /// therefore produce a cargo filter matching zero tests.
@@ -353,10 +394,10 @@ fn rust_cargo_changed_test_env(component: &Component, files: &[String]) -> Vec<(
 /// Only files that exist on disk and contain no `#[test]`/`#[*::test]` attribute
 /// are treated as support modules; if the file is missing or cannot be read we
 /// conservatively return `false` so normal filter routing is preserved.
-fn is_inline_test_support_file(component: &Component, test_file: &str) -> bool {
+fn is_inline_test_support_file(component: &Component, test_file: &str, routing_file: &str) -> bool {
     // Restrict to inline test modules: `src/.../tests/....rs`. Integration
     // tests under the top-level `tests/` dir are handled separately above.
-    let Some(relative) = test_file.strip_prefix("src/") else {
+    let Some(relative) = routing_file.strip_prefix("src/") else {
         return false;
     };
     if !relative.ends_with(".rs") {
@@ -725,6 +766,59 @@ mod tests {
             "HOMEBOY_TEST_RUNNER_ARGS".to_string(),
             "--\ncore::daemon".to_string()
         )));
+    }
+
+    #[test]
+    fn rust_cargo_changed_routing_maps_repository_relative_inline_test_to_owning_package() {
+        let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("homeboy-core should live in the workspace crates directory");
+        let component = Component::new(
+            "fixture-component".to_string(),
+            workspace_root.to_string_lossy().to_string(),
+            "/tmp/remote".to_string(),
+            None,
+        );
+
+        let env = rust_cargo_changed_test_env(
+            &component,
+            &["crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs".to_string()],
+        );
+
+        assert!(env.contains(&(
+            "HOMEBOY_TEST_SCOPE_KIND".to_string(),
+            "rust_filter".to_string()
+        )));
+        assert!(
+            env.contains(&(
+                "HOMEBOY_TEST_RUNNER_ARGS".to_string(),
+                "--\nworkspace::tests::snapshot".to_string()
+            )),
+            "env: {env:?}"
+        );
+    }
+
+    #[test]
+    fn rust_cargo_changed_routing_falls_back_without_an_owning_package() {
+        let dir = TempDir::new().expect("temp dir should be created");
+        let component = Component::new(
+            "fixture-component".to_string(),
+            dir.path().to_string_lossy().to_string(),
+            "/tmp/remote".to_string(),
+            None,
+        );
+
+        let env = rust_cargo_changed_test_env(
+            &component,
+            &["packages/example/src/tests/scope.rs".to_string()],
+        );
+
+        assert!(
+            env.contains(&("HOMEBOY_TEST_SCOPE_KIND".to_string(), "full".to_string())),
+            "env: {env:?}"
+        );
+        assert!(!env.iter().any(|(key, _)| key == "HOMEBOY_TEST_RUNNER_ARGS"));
     }
 
     #[test]

--- a/crates/homeboy-core/src/extension/test/report.rs
+++ b/crates/homeboy-core/src/extension/test/report.rs
@@ -219,7 +219,7 @@ fn test_phase_report(status: &str, exit_code: i32, counts: Option<&TestCounts>) 
                 "test phase passed".to_string()
             }
         } else if counts.map(|counts| counts.total == 0).unwrap_or(false) {
-            "PHPUnit discovery found zero tests; no PHPUnit assertions ran".to_string()
+            "test runner reported zero executed tests".to_string()
         } else if exit_code >= 2 {
             format!("test harness infrastructure failure (exit {})", exit_code)
         } else if counts.map(|counts| counts.failed == 0).unwrap_or(false) {
@@ -254,7 +254,7 @@ fn test_phase_failure(exit_code: i32, counts: Option<&TestCounts>) -> PhaseFailu
         summary: match category {
             PhaseFailureCategory::Infrastructure => {
                 if counts.map(|counts| counts.total == 0).unwrap_or(false) {
-                    "PHPUnit discovery found zero tests; no PHPUnit assertions ran".to_string()
+                    "test runner reported zero executed tests".to_string()
                 } else if counts.map(|counts| counts.failed == 0).unwrap_or(false) {
                     format!(
                         "test runner failed after reporting zero test failures (exit {})",
@@ -266,7 +266,11 @@ fn test_phase_failure(exit_code: i32, counts: Option<&TestCounts>) -> PhaseFailu
             }
             PhaseFailureCategory::Findings => {
                 if let Some(counts) = counts {
-                    format!("{} test failure(s) detected", counts.failed)
+                    if counts.total == 0 {
+                        "test runner reported zero executed tests".to_string()
+                    } else {
+                        format!("{} test failure(s) detected", counts.failed)
+                    }
                 } else {
                     format!("test phase reported failures (exit {})", exit_code)
                 }
@@ -437,6 +441,23 @@ mod tests {
         assert_eq!(json["status"], "passed");
         assert_eq!(json["exit_code"], 0);
         assert!(json.get("failure").is_none());
+    }
+
+    #[test]
+    fn zero_executed_tests_use_runner_neutral_failure_summary() {
+        let (output, exit_code) =
+            from_main_workflow(workflow_result_with_counts(1, TestCounts::new(0, 0, 0, 0)));
+
+        let json = serde_json::to_value(output).expect("serialize test command output");
+        assert_eq!(exit_code, 1);
+        assert_eq!(
+            json["phase"]["summary"],
+            "test runner reported zero executed tests"
+        );
+        assert_eq!(
+            json["failure"]["summary"],
+            "test runner reported zero executed tests"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Normalize repository-relative Rust test paths to their owning Cargo package before deriving scoped filters.

## What changed
- Resolve workspace-relative changed files against the nearest owning Cargo.toml, preserve component-relative routing, fall back to full scope when ownership is unsafe, and use runner-neutral zero-test reporting.

## How to test
1. Run `cargo test -p homeboy-core rust_cargo_changed --locked`; expect routing regressions pass.
2. Run `cargo test -p homeboy-core reports_no_tests --locked`; expect runner-neutral report regression passes.
3. Run `cargo test -p homeboy-lab-runner --lib --locked -- workspace::tests::snapshot`; expect 32 snapshot module tests execute.
4. Run `cargo check --workspace --tests --locked`; expect workspace check passes.

## Compatibility
No public extension contract changes. Existing component-relative Rust paths keep their current behavior; unresolvable workspace paths safely expand test scope instead of emitting zero-match filters.

## Evidence
- Base advanced after verification: verified main at 5fb617a3aeee4c5c958b7c83789493e56def126c; publication observed 592c0af2a467540a11a14b53253b4d4aff1b0946. Candidate ancestry was validated against the verified snapshot.
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8758
- Verified finalization base: main at 5fb617a3aeee4c5c958b7c83789493e56def126c
- candidate\_patch\_equivalence: Passed
- format: Passed
- targeted\_tests: Passed
- workspace\_check: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the release failure, drafted the implementation and regression coverage, and orchestrated verification and recovery; Chris reviews and owns the change.

## Source relationships
- Closes #8758
