### PR TITLE
Keep runner-resident Lab run plans local

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -31,7 +31,10 @@ pub fn route_after_parse(
     // recursively route back through a runner-side controller daemon.
     let managed_runner_placement =
         crate::commands::utils::resource_policy::is_managed_runner_placement_context();
-    if lab_routing::is_lab_offload_subprocess() || managed_runner_placement {
+    if lab_routing::is_lab_offload_subprocess()
+        || managed_runner_placement
+        || runner_resident_agent_task_run_plan(cli)
+    {
         return Ok(None);
     }
 
@@ -260,6 +263,18 @@ pub fn route_after_parse(
             Ok(Some(output.exit_code))
         }
     }
+}
+
+/// A run plan handed to Lab already has a materialized local workspace. Its
+/// execution provenance must not cause a second controller daemon selection.
+fn runner_resident_agent_task_run_plan(cli: &Cli) -> bool {
+    homeboy::core::resource_policy_context::has_lab_execution_provenance()
+        && matches!(
+            &cli.command,
+            Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+                command: crate::commands::agent_task::AgentTaskCommand::RunPlan(_),
+            })
+        )
 }
 
 /// Fanout keeps durable batch state, worktree ownership, artifact ingestion,

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -505,12 +505,16 @@ fn managed_runner_context_bypasses_auto_routing_once() {
 }
 
 #[test]
-fn managed_run_plan_handoff_does_not_require_a_second_controller_session() {
+fn runner_resident_run_plan_does_not_require_a_second_controller_session() {
     let _env = EnvGuard::set_many(&[
         (homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV, None),
-        (homeboy::runner::RUNNER_HOSTED_EXEC_ENV, Some("1")),
-        (homeboy::runner::RUNNER_PLACEMENT_RESOLVED_ENV, Some("1")),
-        (homeboy::runner::RUNNER_ID_ENV, Some("homeboy-lab")),
+        (homeboy::runner::RUNNER_HOSTED_EXEC_ENV, None),
+        (homeboy::runner::RUNNER_PLACEMENT_RESOLVED_ENV, None),
+        (homeboy::runner::RUNNER_ID_ENV, None),
+        (
+            homeboy::core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV,
+            Some("homeboy-lab"),
+        ),
     ]);
     let normalized = vec![
         "homeboy".to_string(),
@@ -526,7 +530,7 @@ fn managed_run_plan_handoff_does_not_require_a_second_controller_session() {
     let cli = Cli::parse_from(&normalized);
 
     assert_eq!(
-        route_after_parse(&cli, &normalized, None).expect("managed handoff stays local"),
+        route_after_parse(&cli, &normalized, None).expect("runner-resident handoff stays local"),
         None
     );
 }

--- a/crates/homeboy-core/src/resource_policy_context.rs
+++ b/crates/homeboy-core/src/resource_policy_context.rs
@@ -123,6 +123,14 @@ pub fn is_runner_hosted_exec() -> bool {
         .is_some_and(|value| value == "1")
 }
 
+/// True when this process is already executing on a Lab runner. This is
+/// lifecycle provenance, not controller transport selection.
+pub fn has_lab_execution_provenance() -> bool {
+    std::env::var(crate::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV)
+        .ok()
+        .is_some_and(|runner_id| !runner_id.trim().is_empty())
+}
+
 /// True when Homeboy is executing inside a GitHub Actions CI job.
 ///
 /// CI runners are ephemeral, single-purpose, and non-interactive by design.


### PR DESCRIPTION
## Summary
- Treat Lab execution-runner identity as provenance rather than transport selection.
- Keep runner-resident `agent-task run-plan` execution local after an accepted outer handoff.
- Add exact regression coverage proving provider preflight does not request a second controller daemon session.

Closes #8748.

## Why #8773 was insufficient
#8773 consumed the controller transport marker and retained a separate execution-runner identity. Normal CLI routing still observed runner-resident execution and could auto-select Lab again, recursively requiring another daemon connection before provider execution.

## Verification
1. `cargo test -p homeboy-cli runner_resident_run_plan_does_not_require_a_second_controller_session`
2. `cargo test -p homeboy-cli managed_runner_context_bypasses_auto_routing_once`
3. `cargo check -p homeboy-core -p homeboy-cli`
4. `cargo fmt --check`
5. `git diff --check`

## Compatibility
Runner provenance remains available for lifecycle, artifacts, diagnostics, retries, and promotion. Only recursive transport selection inside an already accepted Lab execution is changed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Diagnosing the post-#8773 routing recursion, implementing the bounded fix and regression tests, and running focused verification. Chris remains responsible for review and submission.