### PR TITLE
Preserve runner identity through Lab cook handoff

### DIFF
--- a/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/failure_recording.rs
@@ -827,10 +827,7 @@ pub(crate) fn project_terminal_artifacts(
                 continue;
             }
             if let Some(runner_id) = record.runner_id().filter(|runner_id| {
-                std::env::var(homeboy_lab_runner_contract::RUNNER_ID_ENV)
-                    .ok()
-                    .as_deref()
-                    != Some(*runner_id)
+                super::lifecycle_ops::execution_runner_id().as_deref() != Some(*runner_id)
             }) {
                 if runner_id.trim().is_empty() {
                     return Err(Error::validation_invalid_argument(

--- a/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-core/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -352,10 +352,8 @@ where
         "lifecycle_schema": RUN_LIFECYCLE_RECORD_SCHEMA,
         "note": "submitted tasks are durable; provider run ids are recorded after an executor returns them as generic artifacts or evidence refs"
     });
-    if let Ok(runner_id) = std::env::var(homeboy_lab_runner_contract::RUNNER_ID_ENV) {
-        if !runner_id.trim().is_empty() {
-            metadata["runner_id"] = json!(runner_id);
-        }
+    if let Some(runner_id) = execution_runner_id() {
+        metadata["runner_id"] = json!(runner_id);
     }
     if let Some(route) = crate::notification_route::current() {
         route.insert_into_metadata(&mut metadata);
@@ -392,6 +390,12 @@ where
         }
     }
     Ok(record)
+}
+
+pub(crate) fn execution_runner_id() -> Option<String> {
+    std::env::var(crate::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV)
+        .ok()
+        .filter(|runner_id| !runner_id.trim().is_empty())
 }
 
 /// Bind an inherited route when a detached workload recreates an agent-task run.

--- a/crates/homeboy-core/src/agent_task_service/tests.rs
+++ b/crates/homeboy-core/src/agent_task_service/tests.rs
@@ -92,6 +92,41 @@ fn service_run_loaded_plan_persists_durable_lifecycle() {
 }
 
 #[test]
+fn lab_handoff_run_plan_executes_with_runner_provenance_after_transport_is_consumed() {
+    with_isolated_home(|_| {
+        let execution_runner = crate::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV;
+        let transport_runner = homeboy_lab_runner_contract::RUNNER_ID_ENV;
+        let previous_execution_runner = std::env::var_os(execution_runner);
+        let previous_transport_runner = std::env::var_os(transport_runner);
+        std::env::set_var(execution_runner, "homeboy-lab");
+        std::env::remove_var(transport_runner);
+
+        let result = run_loaded_plan(
+            test_plan(),
+            Some("lab-handoff-run-plan"),
+            SucceedingExecutor,
+        )
+        .expect("runner-local provider execution starts without a nested daemon connection");
+        assert_eq!(
+            agent_task_lifecycle::execution_runner_id().as_deref(),
+            Some("homeboy-lab")
+        );
+
+        match previous_execution_runner {
+            Some(value) => std::env::set_var(execution_runner, value),
+            None => std::env::remove_var(execution_runner),
+        }
+        match previous_transport_runner {
+            Some(value) => std::env::set_var(transport_runner, value),
+            None => std::env::remove_var(transport_runner),
+        }
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.value.totals.succeeded, 1);
+    });
+}
+
+#[test]
 fn lab_runner_handoff_materializes_the_run_before_preparation_failure() {
     with_isolated_home(|_| {
         let mut plan = test_plan();


### PR DESCRIPTION
## Summary
Uses the durable Lab execution runner identity after handoff consumes the controller transport marker, preventing runner-local cook execution from recursively requiring a daemon connection.

## What changed
- Reads HOMEBOY\_LAB\_EXECUTION\_RUNNER\_ID for lifecycle provenance and terminal artifact projection, and adds regression coverage for runner-local run-plan execution after transport intent is consumed.

## How to test
1. Run `cargo fmt --check`; expect Formatting passes..
2. Run `cargo test -p homeboy-core lab_handoff_run_plan_executes_with_runner_provenance_after_transport_is_consumed`; expect The runner-local provider executes successfully with durable runner provenance and no nested daemon lookup..
3. Run `git diff --check`; expect The patch has no whitespace errors..

## Compatibility
Internal control-plane correction only. Existing local and automatic placement contracts are unchanged; durable runner provenance is preserved after Lab transport intent is consumed.

## Evidence
- Base unchanged since verification: main remains at 592c0af2a467540a11a14b53253b4d4aff1b0946.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8780
- Verified finalization base: main at 592c0af2a467540a11a14b53253b4d4aff1b0946
- lab-cook-handoff: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via direct recovery and Homeboy promotion
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed and implemented the control-plane recovery candidate; Homeboy promoted it and ran deterministic verification.

## Source relationships
- Closes Extra-Chill/homeboy#8780
