### PR TITLE
Use product identity for runner readiness

### DIFF
--- a/crates/homeboy-core/src/build_identity.rs
+++ b/crates/homeboy-core/src/build_identity.rs
@@ -3,3 +3,18 @@ pub use homeboy_product_identity::BuildIdentity;
 pub fn current() -> BuildIdentity {
     homeboy_product_identity::build_identity()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn core_package_version_does_not_override_product_build_version() {
+        assert_eq!(env!("CARGO_PKG_VERSION"), "0.1.0");
+        assert_eq!(
+            current().version,
+            homeboy_product_identity::product_version()
+        );
+        assert_ne!(current().version, env!("CARGO_PKG_VERSION"));
+    }
+}

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -631,7 +631,7 @@ pub fn connect_reverse(options: ReverseRunnerConnectOptions) -> Result<(RunnerCo
 
     let runner = load(&options.runner_id)?;
     let session_path = session_path(&runner.id)?;
-    let homeboy_identity = homeboy_core::build_identity::current();
+    let homeboy_identity = homeboy_product_identity::build_identity();
     let homeboy_version = homeboy_identity.version.clone();
     let now = Utc::now().to_rfc3339();
     let session = RunnerSession {

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -371,7 +371,7 @@ pub(super) fn remote_daemon_connect_action(
     remote_daemon_connect_action_with_controller_identity(
         previous_session,
         status,
-        &homeboy_core::build_identity::current().display,
+        &homeboy_product_identity::build_identity().display,
     )
 }
 

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -205,6 +205,10 @@ fn stale_daemon_warning_includes_explicit_refresh_recovery_command() {
             homeboy_product_identity::product_version()
         )]
     );
+    assert_ne!(
+        warning.refresh_command,
+        "homeboy runner refresh-homeboy homeboy-lab --ref v0.1.0 --reconnect"
+    );
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -1028,7 +1028,7 @@ fn runner_exec_homeboy_binaries(
     runner: &Runner,
     session: Option<&RunnerSession>,
 ) -> RunnerExecHomeboyBinaries {
-    let controller_identity = homeboy_core::build_identity::current();
+    let controller_identity = homeboy_product_identity::build_identity();
     let configured_executable = match runner.kind {
         RunnerKind::Local => Some(
             runner

--- a/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
@@ -200,7 +200,7 @@ pub(crate) fn lab_runner_homeboy_metadata(
     status: &RunnerStatusReport,
 ) -> serde_json::Value {
     let controller_version = homeboy_product_identity::product_version();
-    let controller_build_identity = homeboy_core::build_identity::current().display;
+    let controller_build_identity = homeboy_product_identity::build_identity().display;
     let refresh_commands = vec![
         runner_homeboy_align_to_controller_command(runner_id),
         format!("homeboy runner disconnect {}", shell::quote_arg(runner_id)),

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -1828,6 +1828,25 @@ mod tests {
     }
 
     #[test]
+    fn matching_product_build_runner_accepts_jobs() {
+        let availability = RunnerAvailability::from_status_parts(
+            "homeboy-lab",
+            true,
+            false,
+            0,
+            &RunnerActiveJobState::Available,
+            Some(8),
+        );
+
+        assert!(availability.accepts_jobs);
+        assert_ne!(
+            env!("CARGO_PKG_VERSION"),
+            homeboy_product_identity::product_version(),
+            "internal runner crate versions must not make matching product builds stale"
+        );
+    }
+
+    #[test]
     fn at_capacity_runner_still_rejects_even_with_failed_active_job_poll() {
         // A genuinely busy runner stays blocked; the soft active-job signal must
         // not let a saturated runner through.

--- a/crates/homeboy-lab-runner/src/runtime_materialization_status.rs
+++ b/crates/homeboy-lab-runner/src/runtime_materialization_status.rs
@@ -1,7 +1,5 @@
 use serde::Serialize;
 
-use homeboy_core::build_identity;
-
 use super::session::{RunnerSession, RunnerStatusReport};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -48,7 +46,7 @@ impl RuntimeMaterializationStatus {
         configured_executable: &str,
         status: &RunnerStatusReport,
     ) -> Self {
-        let controller = build_identity::current();
+        let controller = homeboy_product_identity::build_identity();
         let active_daemon_version = status
             .session
             .as_ref()
@@ -201,6 +199,12 @@ mod tests {
             Some(homeboy_product_identity::product_version())
         );
         assert_eq!(status.stale_daemon_hint(), None);
+        assert!(!status.has_drift());
+        assert_ne!(
+            env!("CARGO_PKG_VERSION"),
+            homeboy_product_identity::product_version(),
+            "the runner crate's internal package version must not become a compatibility version"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- source runner compatibility from authoritative Homeboy product build identity
- remove internal crate-version leakage from readiness and recovery guidance
- cover matching job acceptance and product release remediation

Closes #8439.

## How to test
1. Run the focused core product identity test.
2. Run the focused runner readiness, job acceptance, and recovery-command tests.
3. Run `cargo check -p homeboy -p homeboy-lab-runner`.
4. Run `cargo fmt --check`.

## Compatibility
No public or extension-path break. Runner metadata now reports the intended product identity.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode general coding subagent
- **Used for:** Traced product identity leakage, implemented the repair and deterministic coverage, and verified the candidate with Chris.