### PR TITLE
Expose typed agent-task execution states

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -154,6 +154,12 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
     let failure_reasons = aggregate
         .map(super::status::failure_reasons_from_aggregate)
         .filter(|reasons| !reasons.is_empty());
+    let execution_states = aggregate.map(|aggregate| {
+        super::status::execution_states_from_aggregate(
+            aggregate,
+            &serde_json::to_value(&record).unwrap_or(Value::Null),
+        )
+    });
     let promotion_candidates = aggregate_review
         .as_ref()
         .map(|review| {
@@ -188,6 +194,7 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
             "aggregate_review": aggregate_review,
             "diagnostic_summary": diagnostic_summary,
             "failure_reasons": failure_reasons,
+            "execution_states": execution_states,
             "promotion_candidates": promotion_candidates,
             "next_actions": next_actions,
             "transport": {

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -914,6 +914,7 @@ fn enrich_with_diagnostic_summary(value: &mut Value, run_id: &str) -> homeboy::c
     if !failure_reasons.is_empty() {
         value["failure_reasons"] = Value::Array(failure_reasons);
     }
+    value["execution_states"] = execution_states_from_aggregate(&aggregate, value);
     Ok(())
 }
 
@@ -937,6 +938,113 @@ pub(crate) fn diagnostic_summary_from_aggregate(aggregate: &AgentTaskAggregate) 
     failure_reasons_from_aggregate(aggregate).into_iter().next()
 }
 
+/// Project terminal execution facts into stable machine-readable states. These
+/// fields deliberately derive from typed outcome and lifecycle values, never
+/// provider summary prose or diagnostic messages.
+pub(crate) fn execution_states_from_aggregate(
+    aggregate: &AgentTaskAggregate,
+    record: &Value,
+) -> Value {
+    let review =
+        homeboy::core::agent_tasks::AgentTaskAggregateReport::from(aggregate.outcomes.clone());
+    let provider = aggregate
+        .outcomes
+        .iter()
+        .map(|outcome| {
+            let state = if matches!(
+                outcome.status,
+                AgentTaskOutcomeStatus::Failed
+                    | AgentTaskOutcomeStatus::ProviderError
+                    | AgentTaskOutcomeStatus::Timeout
+                    | AgentTaskOutcomeStatus::UnableToRemediate
+                    | AgentTaskOutcomeStatus::Cancelled
+            ) {
+                "failed"
+            } else {
+                "succeeded"
+            };
+            json!({
+                "task_id": outcome.task_id,
+                "state": state,
+                "outcome_status": outcome.status,
+                "failure_classification": outcome.failure_classification,
+            })
+        })
+        .collect::<Vec<_>>();
+    let candidates = review
+        .tasks
+        .iter()
+        .map(|task| {
+            let reason_code = if task.status == AgentTaskOutcomeStatus::NoOp {
+                "no_changes_produced"
+            } else {
+                match task.decision {
+                homeboy::core::agent_tasks::AgentTaskReconciliationDecision::NoOp => {
+                    "no_changes_produced"
+                }
+                homeboy::core::agent_tasks::AgentTaskReconciliationDecision::ApplyCandidate => {
+                    "patch_available"
+                }
+                homeboy::core::agent_tasks::AgentTaskReconciliationDecision::RetryCandidate => {
+                    "provider_retry_required"
+                }
+                homeboy::core::agent_tasks::AgentTaskReconciliationDecision::IssueReportCandidate => {
+                    "issue_report_required"
+                }
+                homeboy::core::agent_tasks::AgentTaskReconciliationDecision::ReviewCandidate => {
+                    "review_required"
+                }
+                }
+            };
+            json!({
+                "task_id": task.task_id,
+                "state": task.decision,
+                "reason_code": reason_code,
+            })
+        })
+        .collect::<Vec<_>>();
+    let promotion_status = record
+        .pointer("/metadata/latest_promotion/status")
+        .and_then(Value::as_str)
+        .unwrap_or("not_attempted");
+    let finalization_status = record
+        .pointer("/metadata/cook_finalization/status")
+        .and_then(Value::as_str)
+        .unwrap_or("not_attempted");
+    let patch_promoted = matches!(
+        promotion_status,
+        "verification_pending" | "applied" | "gate_failed"
+    );
+
+    json!({
+        "schema": "homeboy/agent-task-execution-states/v1",
+        "provider": provider,
+        "candidate": {
+            "state": if review.summary.apply_candidates > 0 {
+                "patch_available"
+            } else if review.summary.no_op > 0 {
+                "no_changes_produced"
+            } else {
+                "not_available"
+            },
+            "tasks": candidates,
+        },
+        "gate": {
+            "state": match promotion_status {
+                "applied" => "passed",
+                "gate_failed" => "failed",
+                "verification_pending" => "pending",
+                _ => "not_run",
+            },
+        },
+        "promotion": {
+            "state": promotion_status,
+            "patch_promoted": patch_promoted,
+        },
+        "finalization": { "state": finalization_status },
+    })
+}
+
 /// Cap the number of surfaced failure reasons so a pathological run with
 /// hundreds of nested diagnostics cannot flood the failure summary. Overflow is
 /// still available in the full nested payload (`--full` / aggregate file).
@@ -957,8 +1065,9 @@ const FAILURE_REASON_LIMIT: usize = 8;
 pub(crate) fn failure_reasons_from_aggregate(aggregate: &AgentTaskAggregate) -> Vec<Value> {
     let mut collected: Vec<CollectedDiagnostic> = Vec::new();
 
-    // Prefer failed/errored outcomes, but fall back to scanning every outcome so
-    // a root cause attached to a non-failed cell is still surfaced.
+    // Failure reasons only describe failed outcomes. Scanning successful
+    // outcomes incorrectly promoted provider success diagnostics (including
+    // exit status zero) into failure summaries.
     let failed_first = aggregate.outcomes.iter().filter(|outcome| {
         matches!(
             outcome.status,
@@ -968,13 +1077,7 @@ pub(crate) fn failure_reasons_from_aggregate(aggregate: &AgentTaskAggregate) -> 
                 | AgentTaskOutcomeStatus::UnableToRemediate
         )
     });
-    let any_failed = failed_first.clone().next().is_some();
-
-    let scan: Vec<&homeboy::core::agent_tasks::AgentTaskOutcome> = if any_failed {
-        failed_first.collect()
-    } else {
-        aggregate.outcomes.iter().collect()
-    };
+    let scan: Vec<&homeboy::core::agent_tasks::AgentTaskOutcome> = failed_first.collect();
 
     for outcome in scan {
         for diagnostic in &outcome.diagnostics {
@@ -1169,6 +1272,9 @@ fn compact_status_summary(record: &Value, run_id: &str) -> Value {
         {
             summary["failure_reasons"] = failure_reasons.clone();
         }
+    }
+    if let Some(execution_states) = record.get("execution_states") {
+        summary["execution_states"] = execution_states.clone();
     }
     if let Some(aggregate_path) = record.get("aggregate_path") {
         if !aggregate_path.is_null() {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -665,6 +665,123 @@ fn generic_contract_fixtures_surface_runtime_import_before_missing_artifact() {
 }
 
 #[test]
+fn execution_states_distinguish_patch_noop_provider_failure_and_gate_failure() {
+    let patch = execution_states(
+        fixture_execution_outcome(
+            AgentTaskOutcomeStatus::Succeeded,
+            None,
+            vec![AgentTaskArtifact {
+                schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                id: "patch".to_string(),
+                kind: "patch".to_string(),
+                name: None,
+                label: None,
+                role: None,
+                semantic_key: None,
+                path: None,
+                url: None,
+                mime: None,
+                size_bytes: Some(1),
+                sha256: None,
+                metadata: Value::Null,
+            }],
+            Value::Null,
+        ),
+        "applied",
+    );
+    assert_eq!(patch["provider"][0]["state"], "succeeded");
+    assert_eq!(patch["candidate"]["state"], "patch_available");
+    assert_eq!(patch["gate"]["state"], "passed");
+    assert_eq!(patch["promotion"]["state"], "applied");
+
+    let no_op_aggregate = aggregate_for_execution_outcome(fixture_execution_outcome(
+        AgentTaskOutcomeStatus::NoOp,
+        None,
+        Vec::new(),
+        json!({
+            "diagnostics": [{
+                "class": "provider_process",
+                "message": "OpenCode CLI exited with status 0."
+            }]
+        }),
+    ));
+    assert!(super::super::status::failure_reasons_from_aggregate(&no_op_aggregate).is_empty());
+    let no_op = super::super::status::execution_states_from_aggregate(
+        &no_op_aggregate,
+        &json!({ "metadata": { "latest_promotion": { "status": "no_changes" } } }),
+    );
+    assert_eq!(no_op["provider"][0]["state"], "succeeded");
+    assert_eq!(no_op["candidate"]["state"], "no_changes_produced");
+    assert_eq!(
+        no_op["candidate"]["tasks"][0]["reason_code"],
+        "no_changes_produced"
+    );
+
+    let provider_failure = aggregate_for_execution_outcome(fixture_execution_outcome(
+        AgentTaskOutcomeStatus::ProviderError,
+        Some(AgentTaskFailureClassification::Provider),
+        Vec::new(),
+        json!({
+            "diagnostics": [{
+                "class": "provider_process",
+                "message": "OpenCode CLI exited with status 1."
+            }]
+        }),
+    ));
+    assert_eq!(
+        super::super::status::failure_reasons_from_aggregate(&provider_failure)[0]["message"],
+        "OpenCode CLI exited with status 1."
+    );
+    let gate_failure = super::super::status::execution_states_from_aggregate(
+        &provider_failure,
+        &json!({ "metadata": { "latest_promotion": { "status": "gate_failed" } } }),
+    );
+    assert_eq!(gate_failure["provider"][0]["state"], "failed");
+    assert_eq!(gate_failure["gate"]["state"], "failed");
+}
+
+fn execution_states(outcome: AgentTaskOutcome, promotion_status: &str) -> Value {
+    super::super::status::execution_states_from_aggregate(
+        &aggregate_for_execution_outcome(outcome),
+        &json!({ "metadata": { "latest_promotion": { "status": promotion_status } } }),
+    )
+}
+
+fn aggregate_for_execution_outcome(outcome: AgentTaskOutcome) -> AgentTaskAggregate {
+    serde_json::from_value(json!({
+        "schema": "homeboy/agent-task-aggregate/v1",
+        "plan_id": "plan",
+        "status": "succeeded",
+        "totals": { "skipped": 0 },
+        "outcomes": [outcome],
+    }))
+    .expect("aggregate fixture")
+}
+
+fn fixture_execution_outcome(
+    status: AgentTaskOutcomeStatus,
+    failure_classification: Option<AgentTaskFailureClassification>,
+    artifacts: Vec<AgentTaskArtifact>,
+    outputs: Value,
+) -> AgentTaskOutcome {
+    AgentTaskOutcome {
+        schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+        task_id: String::new(),
+        status,
+        summary: None,
+        failure_classification,
+        artifacts,
+        typed_artifacts: Vec::new(),
+        evidence_refs: Vec::new(),
+        diagnostics: Vec::new(),
+        outputs,
+        workflow: None,
+        follow_up: None,
+        metadata: Value::Null,
+    }
+}
+
+#[test]
 fn generic_contract_fixtures_hydrate_local_file_and_path_evidence() {
     with_isolated_home(|home| {
         let structured_path = home.path().join("structured-result.json");


### PR DESCRIPTION
## Summary
- stop scanning successful provider diagnostics into failure reasons
- expose typed provider, candidate, gate, promotion, and finalization states
- represent no-op with `no_changes_produced`
- preserve nonzero provider failures

Closes #8787.

## How to test
1. Run `cargo test -p homeboy-cli execution_states_distinguish_patch_noop_provider_failure_and_gate_failure --lib --jobs 1`.
2. Run `cargo check -p homeboy-cli --tests --jobs 1`.
3. Run `cargo fmt --check`.

## Compatibility
The execution-state projection is additive; consumers can migrate from prose without breaking existing fields.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode general coding subagent
- **Used for:** Traced diagnostic projection, implemented typed states, and added lifecycle regressions with Chris.