### PR TITLE
Verify no-op Cook candidates

### DIFF
--- a/crates/homeboy-core/src/agent_task_cook_loop.rs
+++ b/crates/homeboy-core/src/agent_task_cook_loop.rs
@@ -56,6 +56,7 @@ pub struct AgentTaskCookLoopReport {
 pub enum AgentTaskCookLoopStatus {
     GreenCompleted,
     NoChanges,
+    NoOpGateFailed,
     RetryRequested,
     RetriesExhausted,
 }
@@ -75,6 +76,7 @@ pub enum AgentTaskCookLoopQualityClassification {
     PatchProduced,
     LargeOrRiskyPatch,
     VerifiedPatch,
+    VerifiedNoOp,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -115,6 +117,8 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
     let follow_up_request = should_retry.then(|| build_follow_up_request(&options, &failed_gates));
     let status = if follow_up_request.is_some() {
         AgentTaskCookLoopStatus::RetryRequested
+    } else if options.promotion_report.status == AgentTaskPromotionStatus::NoChangesGateFailed {
+        AgentTaskCookLoopStatus::NoOpGateFailed
     } else if quality.classification == AgentTaskCookLoopQualityClassification::NoChanges {
         AgentTaskCookLoopStatus::NoChanges
     } else if failed_gates.is_empty() {
@@ -143,6 +147,18 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
 fn classify_cook_loop_quality(report: &AgentTaskPromotionReport) -> AgentTaskCookLoopQualityReport {
     let changed_file_count = report.changed_files.len();
     if changed_file_count == 0 {
+        if report.status == AgentTaskPromotionStatus::VerifiedNoChanges {
+            return AgentTaskCookLoopQualityReport {
+                classification: AgentTaskCookLoopQualityClassification::VerifiedNoOp,
+                summary:
+                    "provider produced no patch and the pinned candidate passed deterministic gates"
+                        .to_string(),
+                signals: vec![
+                    "changed_files=0".to_string(),
+                    "verification=passed".to_string(),
+                ],
+            };
+        }
         return AgentTaskCookLoopQualityReport {
             classification: AgentTaskCookLoopQualityClassification::NoChanges,
             summary: "cook produced no changed files; task likely still requires review or retry"
@@ -556,6 +572,44 @@ mod tests {
         );
         assert!(report.quality.summary.contains("no changed files"));
         assert!(report.follow_up_request.is_none());
+    }
+
+    #[test]
+    fn verified_no_op_completes_and_failed_no_op_is_terminal_failure() {
+        let verified = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report_with_changed_files(
+                AgentTaskPromotionStatus::VerifiedNoChanges,
+                vec![green_gate()],
+                Vec::new(),
+            ),
+            attempt: 1,
+            max_attempts: 3,
+            source_run_id: Some("run-verified-no-op".to_string()),
+            current_diff: String::new(),
+            metadata: Value::Null,
+        });
+        assert_eq!(verified.status, AgentTaskCookLoopStatus::GreenCompleted);
+        assert_eq!(
+            verified.quality.classification,
+            AgentTaskCookLoopQualityClassification::VerifiedNoOp
+        );
+
+        let failed = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report_with_changed_files(
+                AgentTaskPromotionStatus::NoChangesGateFailed,
+                vec![failed_gate()],
+                Vec::new(),
+            ),
+            attempt: 1,
+            max_attempts: 3,
+            source_run_id: Some("run-failed-no-op".to_string()),
+            current_diff: String::new(),
+            metadata: Value::Null,
+        });
+        assert_eq!(failed.status, AgentTaskCookLoopStatus::NoOpGateFailed);
+        assert!(failed.follow_up_request.is_none());
     }
 
     #[test]

--- a/crates/homeboy-core/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/promote.rs
@@ -377,9 +377,26 @@ pub(super) fn promote_with_provider_and_checkpoint(
                 committed_patch,
             );
         }
-        let status = AgentTaskPromotionStatus::NoChanges;
-        let target = AgentTaskPromotionTarget::from_worktree(options.to_worktree.clone(), None);
+        let worktree_path = options.source_worktree_path.as_deref();
+        let target =
+            AgentTaskPromotionTarget::from_worktree(options.to_worktree.clone(), worktree_path);
+        let gates = if let Some(worktree_path) = worktree_path {
+            run_promotion_gates(&options, provider, worktree_path)?
+        } else {
+            PromotionGateRun::without_gates(options.dry_run)
+        };
+        let status = match gates.status {
+            AgentTaskPromotionStatus::Applied => AgentTaskPromotionStatus::VerifiedNoChanges,
+            AgentTaskPromotionStatus::GateFailed => AgentTaskPromotionStatus::NoChangesGateFailed,
+            _ => AgentTaskPromotionStatus::NoChanges,
+        };
         let operator_notification = promotion_notification(status, &target);
+        let verified_revision = target.head.clone();
+        let candidate = target
+            .path
+            .as_deref()
+            .map(crate::agent_task_promotion::candidate_fingerprint)
+            .transpose()?;
 
         return Ok(AgentTaskPromotionReport {
             schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
@@ -395,14 +412,16 @@ pub(super) fn promote_with_provider_and_checkpoint(
             },
             changed_files: Vec::new(),
             command_evidence: Vec::new(),
-            deterministic_gates: Vec::new(),
-            gate_results: Vec::new(),
+            deterministic_gates: gates.deterministic_gates,
+            gate_results: gates.gate_results,
             verified_base: None,
             provenance: json!({
                 "source_schema": outcome.schema,
                 "artifact_metadata": artifact.metadata,
-                "worktree_path": null,
-                "dependencies_materialized": false,
+                "worktree_path": worktree_path,
+                "verified_revision": verified_revision,
+                "dependencies_materialized": gates.dependencies_materialized,
+                "candidate": candidate,
             }),
             operator_notification,
         });
@@ -1062,6 +1081,18 @@ fn promotion_notification(
             resumable_blocker: Some(
                 "run `homeboy agent-task gate-feedback` with the promotion report, then retry the follow-up request".to_string(),
             ),
+            next_command: None,
+        },
+        AgentTaskPromotionStatus::VerifiedNoChanges => AgentTaskPromotionNotification {
+            status: "completed".to_string(),
+            message: "provider produced no patch; the pinned candidate workspace passed deterministic verification".to_string(),
+            resumable_blocker: None,
+            next_command: None,
+        },
+        AgentTaskPromotionStatus::NoChangesGateFailed => AgentTaskPromotionNotification {
+            status: "blocked".to_string(),
+            message: "provider produced no patch, but deterministic verification failed in the pinned candidate workspace".to_string(),
+            resumable_blocker: Some("repair the candidate and rerun Cook so the declared verification gates pass".to_string()),
             next_command: None,
         },
         AgentTaskPromotionStatus::DryRun => AgentTaskPromotionNotification {

--- a/crates/homeboy-core/src/agent_task_promotion/tests.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/tests.rs
@@ -1215,6 +1215,116 @@ fn promote_reports_no_changes_for_empty_patch_metadata() {
 }
 
 #[test]
+fn empty_patch_runs_public_and_private_gates_against_pinned_candidate() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir(&repo).expect("create repo");
+    git(&repo, &["init"]);
+    git(&repo, &["config", "user.email", "homeboy@example.test"]);
+    git(&repo, &["config", "user.name", "Homeboy Test"]);
+    std::fs::write(repo.join("lib.rs"), "candidate\n").expect("write candidate");
+    git(&repo, &["add", "lib.rs"]);
+    git(&repo, &["commit", "-m", "candidate"]);
+    let revision = git_head(&repo, "HEAD");
+    let (source_path, source) = write_empty_patch_source(&temp);
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(repo.clone()),
+        ..Default::default()
+    };
+
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("run-empty".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: Some(repo.clone()),
+            base_ref: None,
+            task_base_sha: None,
+            to_worktree: "repo@candidate".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["public-check".to_string()],
+                private_verify: vec!["private-check".to_string()],
+                private_gate_reveal: AgentTaskGateRevealPolicy::SummaryOnly,
+            },
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+    )
+    .expect("empty candidate verifies");
+
+    assert_eq!(report.status, AgentTaskPromotionStatus::VerifiedNoChanges);
+    assert_eq!(report.target.head.as_deref(), Some(revision.as_str()));
+    assert_eq!(report.provenance["verified_revision"], revision);
+    assert_eq!(provider.apply_calls.len(), 0);
+    assert_eq!(provider.verify_calls.len(), 2);
+    assert_eq!(provider.verify_calls[0].0, repo);
+    assert_eq!(provider.verify_calls[1].2, AgentTaskGateVisibility::Private);
+    assert_eq!(
+        provider.verify_calls[1].3,
+        AgentTaskGateRevealPolicy::SummaryOnly
+    );
+}
+
+#[test]
+fn empty_patch_failing_gate_is_reported_against_pinned_candidate() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir(&repo).expect("create repo");
+    git(&repo, &["init"]);
+    git(&repo, &["config", "user.email", "homeboy@example.test"]);
+    git(&repo, &["config", "user.name", "Homeboy Test"]);
+    std::fs::write(repo.join("lib.rs"), "candidate\n").expect("write candidate");
+    git(&repo, &["add", "lib.rs"]);
+    git(&repo, &["commit", "-m", "candidate"]);
+    let (source_path, source) = write_empty_patch_source(&temp);
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(repo.clone()),
+        verify_exit_code: 7,
+        ..Default::default()
+    };
+
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("run-empty-fail".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: Some(repo.clone()),
+            base_ref: None,
+            task_base_sha: None,
+            to_worktree: "repo@candidate".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["failing-check".to_string()],
+                private_verify: Vec::new(),
+                private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+            },
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+    )
+    .expect("failed no-op gate is recorded");
+
+    assert_eq!(report.status, AgentTaskPromotionStatus::NoChangesGateFailed);
+    assert_eq!(
+        report.deterministic_gates[0].status,
+        crate::agent_task_gate::AgentTaskGateStatus::Failed
+    );
+    assert_eq!(
+        report.gate_results[0].status,
+        crate::gate::HomeboyGateStatus::Failed
+    );
+    assert_eq!(provider.apply_calls.len(), 0);
+    assert_eq!(provider.verify_calls[0].0, repo);
+}
+
+#[test]
 fn promote_no_op_outcome_uses_audited_committed_candidate() {
     let temp = tempfile::tempdir().expect("tempdir");
     let repo = temp.path().join("repo");

--- a/crates/homeboy-core/src/agent_task_promotion/types.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/types.rs
@@ -84,6 +84,12 @@ pub enum AgentTaskPromotionStatus {
     VerificationPending,
     Applied,
     GateFailed,
+    /// A provider produced no patch, but the pinned candidate workspace passed
+    /// every declared deterministic verification gate.
+    VerifiedNoChanges,
+    /// A provider produced no patch and the pinned candidate workspace failed
+    /// deterministic verification. The candidate remains available for repair.
+    NoChangesGateFailed,
     NoChanges,
 }
 
@@ -108,6 +114,8 @@ impl AgentTaskPromotionStatus {
             Self::VerificationPending => "patch_promoted_verification_pending",
             Self::Applied => "patch_promoted_no_pr",
             Self::GateFailed => "patch_promoted_gates_failed",
+            Self::VerifiedNoChanges => "no_patch_verified",
+            Self::NoChangesGateFailed => "no_patch_gates_failed",
             Self::DryRun => "patch_not_promoted_dry_run",
             Self::NoChanges => "patch_not_promoted_no_changes",
         }

--- a/crates/homeboy-core/src/agent_task_service/cook.rs
+++ b/crates/homeboy-core/src/agent_task_service/cook.rs
@@ -528,6 +528,19 @@ where
                     1,
                 ));
             }
+            AgentTaskCookLoopStatus::NoOpGateFailed => {
+                return Ok(cook_report(
+                    cook_id,
+                    "no_op_gate_failed",
+                    attempts,
+                    None,
+                    Some(
+                        "provider produced no patch and the pinned candidate failed deterministic verification"
+                            .to_string(),
+                    ),
+                    1,
+                ));
+            }
             AgentTaskCookLoopStatus::RetryRequested => {
                 let Some(mut follow_up_request) = follow_up_request else {
                     return Ok(cook_report(


### PR DESCRIPTION
## Summary
- run public and private gates against the pinned source workspace for empty patch outcomes
- record the exact verified revision
- distinguish verified no-change from failed no-op gates
- preserve private gate reveal policy

Closes #8783.

## How to test
1. Run `cargo test -p homeboy-core agent_task_promotion::tests::empty_patch --lib`.
2. Run `cargo test -p homeboy-core agent_task_cook_loop::tests::verified_no_op --lib`.
3. Run `cargo check -p homeboy-core -p homeboy-cli`.
4. Run `cargo fmt --check`.

## Compatibility
No extension-path break. No-op Cooks now honor their already-declared verification contract.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode general coding subagent
- **Used for:** Traced the no-op promotion bypass, implemented gate execution and provenance, and added pass/fail coverage with Chris.