### PR TITLE
Gate stale daemon replacement on typed work evidence

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1555,7 +1555,7 @@ fn stale_reattach_warning_for_report(
     report: &DaemonFreshnessReport,
 ) -> Option<String> {
     (!report.fresh).then(|| format!(
-        "Reattached the live remote daemon lease after drift ({:?}; {}); active jobs were preserved. Refresh it explicitly with `homeboy runner refresh-homeboy {runner_id} --reconnect` when its work is complete.",
+        "Reattached the live remote daemon lease after drift ({:?}; {}); active jobs were preserved. Continue with `homeboy runner refresh-homeboy {runner_id} --reconnect` when its work is complete.",
         report.stale_reason_code,
         report.ownership_evidence.as_deref().unwrap_or("remote status freshness drift")
     ))

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -188,11 +188,31 @@ pub(super) struct RemoteDaemonStatus {
     pub(super) reachable: bool,
     pub(super) active_jobs: usize,
     /// The typed `/jobs` view is independently required before replacing a
-    /// reachable stale daemon. `None` means the endpoint was unavailable or
-    /// malformed, which must fail closed for replacement.
-    pub(super) typed_unresolved_jobs: Option<usize>,
+    /// reachable stale daemon. Missing or malformed evidence fails closed.
+    pub(super) work_evidence: RemoteDaemonWorkEvidence,
     pub(super) endpoint_probe_error: Option<String>,
     pub(super) termination_evidence: Option<homeboy_core::daemon::DaemonTerminationEvidence>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RemoteDaemonWorkEvidence {
+    Unknown,
+    ActiveOrUnresolved(usize),
+    AuthoritativelyIdle,
+}
+
+impl RemoteDaemonWorkEvidence {
+    fn from_unresolved_count(count: usize) -> Self {
+        if count == 0 {
+            Self::AuthoritativelyIdle
+        } else {
+            Self::ActiveOrUnresolved(count)
+        }
+    }
+
+    fn is_authoritatively_idle(self) -> bool {
+        self == Self::AuthoritativelyIdle
+    }
 }
 
 pub(super) fn remote_daemon_recovery_freshness_from_status(
@@ -439,7 +459,7 @@ pub(super) fn remote_daemon_connect_action_with_controller_identity(
     // through Homeboy's daemon lifecycle command.
     if !status.fresh {
         if status.active_jobs == 0
-            && status.typed_unresolved_jobs == Some(0)
+            && status.work_evidence.is_authoritatively_idle()
             && status.endpoint_probe_error.is_none()
             && daemon
                 .build_identity
@@ -559,7 +579,7 @@ pub(super) fn remote_daemon_status(
                 .and_then(Value::as_bool)
                 .unwrap_or(false),
             active_jobs: remote_daemon_active_jobs(&data),
-            typed_unresolved_jobs: None,
+            work_evidence: RemoteDaemonWorkEvidence::Unknown,
             endpoint_probe_error: None,
             termination_evidence,
         });
@@ -578,7 +598,7 @@ pub(super) fn remote_daemon_status(
                 .and_then(Value::as_bool)
                 .unwrap_or(false),
             active_jobs: remote_daemon_active_jobs(&data),
-            typed_unresolved_jobs: None,
+            work_evidence: RemoteDaemonWorkEvidence::Unknown,
             endpoint_probe_error: None,
             termination_evidence,
         });
@@ -593,7 +613,7 @@ pub(super) fn remote_daemon_status(
             .and_then(Value::as_bool)
             .unwrap_or(false),
         active_jobs: remote_daemon_active_jobs(&data),
-        typed_unresolved_jobs: None,
+        work_evidence: RemoteDaemonWorkEvidence::Unknown,
         endpoint_probe_error: None,
         termination_evidence,
     })
@@ -688,7 +708,8 @@ pub(super) fn probe_remote_daemon_endpoint(client: &SshClient, status: &mut Remo
             Some("remote daemon typed job probe did not return stale_runner_jobs".to_string());
         return;
     };
-    status.typed_unresolved_jobs = Some(active.len().saturating_add(stale.len()));
+    status.work_evidence =
+        RemoteDaemonWorkEvidence::from_unresolved_count(active.len().saturating_add(stale.len()));
 }
 
 fn remote_daemon_from_state(state: &Value) -> RemoteDaemon {

--- a/crates/homeboy-lab-runner/src/connection/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/mod.rs
@@ -213,7 +213,7 @@ pub(super) fn remote_daemon_status_for_test_with_reason(
         fresh,
         reachable,
         active_jobs,
-        typed_unresolved_jobs: None,
+        work_evidence: RemoteDaemonWorkEvidence::Unknown,
         endpoint_probe_error: None,
         termination_evidence: None,
     }

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -81,7 +81,7 @@ fn stale_daemon_without_jobs_reattaches_without_replacement() {
     );
 }
 
-fn idle_stale_status(typed_unresolved_jobs: Option<usize>) -> RemoteDaemonStatus {
+fn idle_stale_status(work_evidence: RemoteDaemonWorkEvidence) -> RemoteDaemonStatus {
     let mut status = remote_daemon_status_for_test_with_reason(
         false,
         true,
@@ -93,13 +93,13 @@ fn idle_stale_status(typed_unresolved_jobs: Option<usize>) -> RemoteDaemonStatus
     let daemon = status.daemon.as_mut().expect("daemon");
     daemon.version = Some("0.288.13".to_string());
     daemon.build_identity = Some("homeboy 0.288.13+stale".to_string());
-    status.typed_unresolved_jobs = typed_unresolved_jobs;
+    status.work_evidence = work_evidence;
     status
 }
 
 #[test]
 fn replaces_idle_stale_daemon_when_typed_jobs_are_zero_without_lease_recovery_evidence() {
-    let status = idle_stale_status(Some(0));
+    let status = idle_stale_status(RemoteDaemonWorkEvidence::AuthoritativelyIdle);
 
     assert_eq!(
         remote_daemon_connect_action_with_controller_identity(
@@ -118,12 +118,12 @@ fn replaces_idle_stale_daemon_when_typed_jobs_are_zero_without_lease_recovery_ev
 #[test]
 fn idle_stale_replacement_fails_closed_for_active_or_inconsistent_typed_jobs() {
     let configured = "homeboy 0.289.0+configured";
-    let mut freshness_active = idle_stale_status(Some(0));
+    let mut freshness_active = idle_stale_status(RemoteDaemonWorkEvidence::AuthoritativelyIdle);
     freshness_active.active_jobs = 1;
-    let typed_active = idle_stale_status(Some(1));
-    let typed_unreachable = idle_stale_status(None);
+    let typed_active = idle_stale_status(RemoteDaemonWorkEvidence::ActiveOrUnresolved(1));
+    let typed_unknown = idle_stale_status(RemoteDaemonWorkEvidence::Unknown);
 
-    for status in [freshness_active, typed_active, typed_unreachable] {
+    for status in [freshness_active, typed_active, typed_unknown] {
         assert_eq!(
             remote_daemon_connect_action_with_controller_identity(None, &status, configured)
                 .expect("unsafe evidence retains the daemon"),
@@ -134,7 +134,7 @@ fn idle_stale_replacement_fails_closed_for_active_or_inconsistent_typed_jobs() {
 
 #[test]
 fn idle_stale_replacement_refuses_unreachable_daemon_evidence() {
-    let mut status = idle_stale_status(Some(0));
+    let mut status = idle_stale_status(RemoteDaemonWorkEvidence::AuthoritativelyIdle);
     status.reachable = false;
 
     assert!(remote_daemon_connect_action_with_controller_identity(
@@ -148,7 +148,7 @@ fn idle_stale_replacement_refuses_unreachable_daemon_evidence() {
 
 #[test]
 fn reconnect_converges_to_configured_identity_and_repeated_recovery_reattaches() {
-    let mut status = idle_stale_status(Some(0));
+    let mut status = idle_stale_status(RemoteDaemonWorkEvidence::AuthoritativelyIdle);
     let daemon = status.daemon.as_mut().expect("daemon");
     daemon.version = Some("0.289.0".to_string());
     daemon.build_identity = Some("homeboy 0.289.0+configured".to_string());
@@ -192,7 +192,9 @@ fn reattaches_live_stale_daemon_with_active_jobs_without_replacing_it() {
         .expect("stale reattach warning");
     assert!(warning.contains("VersionMismatch"));
     assert!(warning.contains("active jobs were preserved"));
-    assert!(warning.contains("refresh-homeboy homeboy-lab --reconnect"));
+    assert!(warning.contains(
+        "Continue with `homeboy runner refresh-homeboy homeboy-lab --reconnect` when its work is complete."
+    ));
     assert_eq!(
         recovery.adoption_command.as_deref(),
         Some("homeboy runner connect homeboy-lab --reconcile-leaseless-orphans --confirm-no-daemon-owner")

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -15,7 +15,7 @@ fn first_connect_routes_to_idempotent_ensure_start_when_no_daemon_exists() {
         fresh: false,
         reachable: false,
         active_jobs: 0,
-        typed_unresolved_jobs: None,
+        work_evidence: RemoteDaemonWorkEvidence::Unknown,
         endpoint_probe_error: None,
         termination_evidence: None,
     };
@@ -35,7 +35,7 @@ fn missing_daemon_state_with_active_jobs_refuses_ensure_running() {
         fresh: false,
         reachable: false,
         active_jobs: 1,
-        typed_unresolved_jobs: None,
+        work_evidence: RemoteDaemonWorkEvidence::Unknown,
         endpoint_probe_error: None,
         termination_evidence: None,
     };

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -473,7 +473,7 @@ mod tests {
             fresh: reachable,
             reachable,
             active_jobs,
-            typed_unresolved_jobs: None,
+            work_evidence: RemoteDaemonWorkEvidence::Unknown,
             endpoint_probe_error: None,
             termination_evidence: None,
         }
@@ -648,7 +648,7 @@ mod tests {
             fresh: false,
             reachable: false,
             active_jobs: 0,
-            typed_unresolved_jobs: None,
+            work_evidence: RemoteDaemonWorkEvidence::Unknown,
             endpoint_probe_error: None,
             termination_evidence: Some(homeboy_core::daemon::DaemonTerminationEvidence {
                 classification: homeboy_core::daemon::DaemonTerminationClassification::CleanStop,
@@ -696,7 +696,7 @@ mod tests {
             fresh: false,
             reachable: false,
             active_jobs: 0,
-            typed_unresolved_jobs: None,
+            work_evidence: RemoteDaemonWorkEvidence::Unknown,
             endpoint_probe_error: None,
             termination_evidence: None,
         };


### PR DESCRIPTION
## Summary
- model remote daemon work evidence as unknown, active/unresolved, or authoritatively idle
- replace stale daemons only from authoritative zero-job evidence
- preserve fail-closed behavior for unknown or active work
- emit one explicit recovery continuation

Closes #8782.

## How to test
1. Run `cargo test -p homeboy-lab-runner connection::tests::recovery -- --test-threads=1`.
2. Run `cargo check -p homeboy-lab-runner`.
3. Run `cargo fmt --check`.

## Compatibility
Recovery remains fail-closed unless zero active work is authoritative.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode general coding subagent
- **Used for:** Modeled typed daemon work evidence, implemented convergent recovery, and added deterministic tests with Chris.