### PR TITLE
fix: add candidate_ref to AgentTaskPromotionOptions test initializers

### DIFF
--- a/crates/homeboy-core/src/agent_task_promotion/tests.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/tests.rs
@@ -1250,6 +1250,7 @@ fn empty_patch_runs_public_and_private_gates_against_pinned_candidate() {
             task_base_sha: None,
             to_worktree: "repo@candidate".to_string(),
             task_id: None,
+            candidate_ref: None,
             artifact_id: None,
             dry_run: false,
             gates: VerifyGateOptions {
@@ -1305,6 +1306,7 @@ fn empty_patch_failing_gate_is_reported_against_pinned_candidate() {
             task_base_sha: None,
             to_worktree: "repo@candidate".to_string(),
             task_id: None,
+            candidate_ref: None,
             artifact_id: None,
             dry_run: false,
             gates: VerifyGateOptions {


### PR DESCRIPTION
## Summary
A recent change added the `candidate_ref: Option<String>` field to `AgentTaskPromotionOptions`, but two test initializers in `agent_task_promotion/tests.rs` were not updated — breaking `homeboy-core --tests` on `main` with `E0063: missing field candidate_ref`.

Adds `candidate_ref: None` to both.

## Verification
- `homeboy-core --tests` now compiles clean (was 2 errors on `main`).
- Pure test-fixture fix; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)