### PR TITLE
Incrementally materialize workspace snapshots

### DIFF
--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -200,6 +200,7 @@ pub use workspace::{
     RunnerWorkspacePullOutput, RunnerWorkspacePullPlan, RunnerWorkspaceSnapshotAppliedFilters,
     RunnerWorkspaceSnapshotEntry, RunnerWorkspaceSnapshotFilters, RunnerWorkspaceSnapshotsOutput,
     RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+    WorkspaceContentManifest, WorkspaceContentManifestEntry,
 };
 pub(crate) use workspace::{
     verify_lab_workspace_from_env, workspace_content_hash, workspace_content_hash_algorithm,

--- a/crates/homeboy-lab-runner/src/workspace/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/mod.rs
@@ -51,6 +51,7 @@ pub(crate) use snapshot::{
     workspace_content_hash_algorithm, workspace_content_manifest_for_policy,
     WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
 };
+pub use snapshot::{WorkspaceContentManifest, WorkspaceContentManifestEntry};
 pub use snapshot_provider::register as register_workspace_snapshot_provider;
 pub(crate) use types::{canonical_workspace_path, DEFAULT_EXCLUDES};
 pub(crate) use util::{

--- a/crates/homeboy-lab-runner/src/workspace/provenance.rs
+++ b/crates/homeboy-lab-runner/src/workspace/provenance.rs
@@ -657,19 +657,28 @@ fn validate_content_manifest(
     manifest: &WorkspaceContentManifest,
     permission_policy: Option<&str>,
 ) -> std::result::Result<(), String> {
-    if manifest.entries.len() > 16 || manifest.entry_count < manifest.entries.len() {
-        return Err("has invalid bounded workspace content manifest".to_string());
+    if manifest.entry_count != manifest.entries.len() {
+        return Err("has incomplete workspace content manifest".to_string());
     }
     for entry in &manifest.entries {
         if entry.path.is_empty()
-            || entry.path.len() > super::snapshot::WORKSPACE_CONTENT_DIAGNOSTIC_PATH_LIMIT
             || entry.path.contains('\0')
             || !matches!(entry.kind.as_str(), "file" | "directory")
         {
-            return Err("has invalid bounded workspace content manifest entry".to_string());
+            return Err("has invalid workspace content manifest entry".to_string());
         }
         if entry.kind == "directory" && entry.owner_executable.is_some() {
             return Err("has invalid directory workspace content manifest entry".to_string());
+        }
+        if entry.kind == "file"
+            && (entry
+                .sha256
+                .as_deref()
+                .filter(|hash| hash.starts_with("sha256:"))
+                .is_none()
+                || entry.bytes.is_none())
+        {
+            return Err("has incomplete file workspace content manifest entry".to_string());
         }
         if entry.kind == "file"
             && permission_policy
@@ -1056,13 +1065,15 @@ mod tests {
         let entry = WorkspaceContentManifestEntry {
             path: "file.txt".to_string(),
             kind: "file".to_string(),
+            sha256: Some("sha256:fixture".to_string()),
+            bytes: Some(1),
             owner_executable: Some(false),
         };
         let oversized = WorkspaceContentManifest {
             entry_count: 17,
             entries: vec![entry.clone(); 17],
         };
-        assert!(validate_content_manifest(&oversized, None).is_err());
+        assert!(validate_content_manifest(&oversized, None).is_ok());
 
         let long_path = WorkspaceContentManifest {
             entry_count: 1,
@@ -1072,7 +1083,7 @@ mod tests {
                 ..entry
             }],
         };
-        assert!(validate_content_manifest(&long_path, None).is_err());
+        assert!(validate_content_manifest(&long_path, None).is_ok());
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -1,4 +1,6 @@
+use std::collections::BTreeMap;
 use std::fs;
+use std::io::Write;
 use std::path::Path;
 
 use glob_match::glob_match;
@@ -9,31 +11,34 @@ use homeboy_core::error::{Error, Result};
 
 use super::super::{Runner, RunnerKind};
 use super::materializer::{WorkspaceMaterializationOperation, WorkspaceMaterializer};
-use super::types::SnapshotStats;
+use super::types::{ByteFileCounts, SnapshotStats, SnapshotTransferStats};
 use super::util::{
-    git_output, hex_prefix, run_shell_capture, run_shell_command, ssh_args, ssh_client_for_runner,
-    tar_exclude_args,
+    git_output, hex_prefix, owner_capture_shell, owner_restore_shell, parent_remote_path,
+    run_shell_capture, run_shell_command, ssh_args, ssh_client_for_runner, tar_exclude_args,
 };
 
 const RUNNER_WORKSPACE_METADATA_FILE: &str = ".homeboy/runner-workspace.json";
 pub(crate) const WORKSPACE_CONTENT_PERMISSION_PORTABLE: &str = "portable-content-only";
 pub(crate) const WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE: &str = "unix-executable";
 pub(crate) const WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE: &str = "unix-owner-executable";
-const WORKSPACE_CONTENT_DIAGNOSTIC_ENTRY_LIMIT: usize = 16;
 pub(crate) const WORKSPACE_CONTENT_DIAGNOSTIC_PATH_LIMIT: usize = 192;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-pub(crate) struct WorkspaceContentManifest {
-    pub(crate) entry_count: usize,
-    pub(crate) entries: Vec<WorkspaceContentManifestEntry>,
+pub struct WorkspaceContentManifest {
+    pub entry_count: usize,
+    pub entries: Vec<WorkspaceContentManifestEntry>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-pub(crate) struct WorkspaceContentManifestEntry {
-    pub(crate) path: String,
-    pub(crate) kind: String,
+pub struct WorkspaceContentManifestEntry {
+    pub path: String,
+    pub kind: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) owner_executable: Option<bool>,
+    pub sha256: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner_executable: Option<bool>,
 }
 
 #[cfg(unix)]
@@ -119,8 +124,9 @@ pub(crate) fn workspace_content_hash_for_policy(
     Ok(format!("sha256:{:x}", hasher.finalize()))
 }
 
-/// A bounded, content-free sample used only to explain a verification mismatch.
-/// The complete hash remains the authority; this manifest never contains bytes.
+/// A deterministic, content-free inventory of every path a snapshot materializes.
+/// It is persisted with the immutable snapshot and used to derive explicit
+/// incremental transport and deletion sets.
 pub(crate) fn workspace_content_manifest_for_policy(
     path: &Path,
     excludes: &[String],
@@ -140,7 +146,7 @@ pub(crate) fn workspace_content_manifest_for_policy(
     let root = content_hash_root(path)?;
     let mut manifest = WorkspaceContentManifest {
         entry_count: 0,
-        entries: Vec::with_capacity(WORKSPACE_CONTENT_DIAGNOSTIC_ENTRY_LIMIT),
+        entries: Vec::new(),
     };
     // Use the authoritative v2 traversal so diagnostics and the content hash
     // have identical symlink, exclusion, and metadata behavior.
@@ -264,6 +270,8 @@ fn collect_content_hash_entries_v2(
                     relative.clone(),
                     "directory",
                     None,
+                    None,
+                    None,
                 );
             }
             ancestors.push(canonical);
@@ -293,6 +301,8 @@ fn collect_content_hash_entries_v2(
                 &mut manifest,
                 relative,
                 "file",
+                Some(format!("sha256:{:x}", Sha256::digest(&contents))),
+                Some(contents.len() as u64),
                 executable_capability.owner_value(&metadata),
             );
         }
@@ -304,21 +314,21 @@ fn record_workspace_content_manifest_entry(
     manifest: &mut Option<&mut WorkspaceContentManifest>,
     path: String,
     kind: &str,
+    sha256: Option<String>,
+    bytes: Option<u64>,
     owner_executable: Option<bool>,
 ) {
     let Some(manifest) = manifest.as_deref_mut() else {
         return;
     };
     manifest.entry_count += 1;
-    if path.len() <= WORKSPACE_CONTENT_DIAGNOSTIC_PATH_LIMIT
-        && manifest.entries.len() < WORKSPACE_CONTENT_DIAGNOSTIC_ENTRY_LIMIT
-    {
-        manifest.entries.push(WorkspaceContentManifestEntry {
-            path,
-            kind: kind.to_string(),
-            owner_executable,
-        });
-    }
+    manifest.entries.push(WorkspaceContentManifestEntry {
+        path,
+        kind: kind.to_string(),
+        sha256,
+        bytes,
+        owner_executable,
+    });
 }
 
 #[cfg(unix)]
@@ -636,6 +646,334 @@ pub(crate) fn materialize_snapshot(
             }
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SnapshotManifestDelta {
+    pub(crate) changed_paths: Vec<String>,
+    pub(crate) deleted_paths: Vec<String>,
+    pub(crate) replaced_paths: Vec<String>,
+    pub(crate) changed_file_paths: Vec<String>,
+    pub(crate) transfer: SnapshotTransferStats,
+}
+
+pub(crate) fn snapshot_manifest_delta(
+    controller: &WorkspaceContentManifest,
+    seed: &WorkspaceContentManifest,
+) -> Result<SnapshotManifestDelta> {
+    validate_workspace_content_manifest(controller)?;
+    validate_workspace_content_manifest(seed)?;
+    let index = |manifest: &WorkspaceContentManifest| -> Result<BTreeMap<String, WorkspaceContentManifestEntry>> {
+        let mut entries = BTreeMap::new();
+        for entry in &manifest.entries {
+            if entries.insert(entry.path.clone(), entry.clone()).is_some() {
+                return Err(Error::internal_unexpected(
+                    "workspace snapshot content manifest contains duplicate or invalid paths",
+                ));
+            }
+        }
+        Ok(entries)
+    };
+    let controller_entries = index(controller)?;
+    let seed_entries = index(seed)?;
+    let changed_paths = controller_entries
+        .iter()
+        .filter_map(|(path, entry)| (seed_entries.get(path) != Some(entry)).then(|| path.clone()))
+        .collect::<Vec<_>>();
+    let replaced_paths = changed_paths
+        .iter()
+        .filter(|path| {
+            seed_entries
+                .get(*path)
+                .is_some_and(|seed_entry| seed_entry.kind != controller_entries[*path].kind)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let changed_file_paths = changed_paths
+        .iter()
+        .filter(|path| controller_entries[*path].kind == "file")
+        .cloned()
+        .collect::<Vec<_>>();
+    let deleted_paths = seed_entries
+        .keys()
+        .filter(|path| !controller_entries.contains_key(*path))
+        .cloned()
+        .collect::<Vec<_>>();
+    let count_files = |entries: Vec<&WorkspaceContentManifestEntry>| {
+        entries
+            .into_iter()
+            .fold(ByteFileCounts::default(), |mut counts, entry| {
+                if entry.kind == "file" {
+                    counts.files += 1;
+                    counts.bytes = counts.bytes.saturating_add(entry.bytes.unwrap_or_default());
+                }
+                counts
+            })
+    };
+    let transferred = count_files(
+        changed_paths
+            .iter()
+            .filter_map(|path| controller_entries.get(path))
+            .collect(),
+    );
+    let final_size = count_files(controller_entries.values().collect());
+    Ok(SnapshotManifestDelta {
+        changed_paths,
+        deleted_paths,
+        replaced_paths,
+        changed_file_paths,
+        transfer: SnapshotTransferStats {
+            reused: ByteFileCounts {
+                files: final_size.files.saturating_sub(transferred.files),
+                bytes: final_size.bytes.saturating_sub(transferred.bytes),
+            },
+            transferred,
+            final_size,
+        },
+    })
+}
+
+fn validate_workspace_content_manifest(manifest: &WorkspaceContentManifest) -> Result<()> {
+    if manifest.entry_count != manifest.entries.len() {
+        return Err(Error::internal_unexpected(
+            "workspace snapshot content manifest is incomplete or corrupt",
+        ));
+    }
+    for entry in &manifest.entries {
+        let path = Path::new(&entry.path);
+        let valid_path = !entry.path.is_empty()
+            && !entry.path.contains('\0')
+            && !path.is_absolute()
+            && path
+                .components()
+                .all(|component| matches!(component, std::path::Component::Normal(_)));
+        let valid_file = entry.kind == "file"
+            && entry.bytes.is_some()
+            && entry.sha256.as_deref().is_some_and(|hash| {
+                hash.len() == 71
+                    && hash.starts_with("sha256:")
+                    && hash[7..].bytes().all(|byte| byte.is_ascii_hexdigit())
+            });
+        if !valid_path
+            || !(entry.kind == "directory" || valid_file)
+            || (entry.kind == "directory"
+                && (entry.sha256.is_some()
+                    || entry.bytes.is_some()
+                    || entry.owner_executable.is_some()))
+        {
+            return Err(Error::internal_unexpected(
+                "workspace snapshot content manifest contains invalid entries",
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Materialize an immutable snapshot by linking unchanged content from a
+/// compatible runner-local seed, deleting paths absent from the controller
+/// manifest, and transporting only the manifest's explicit changed paths.
+pub(crate) fn materialize_snapshot_incremental(
+    runner: &Runner,
+    local_path: &Path,
+    remote_path: &str,
+    seed_path: &str,
+    delta: &SnapshotManifestDelta,
+) -> Result<SnapshotTransferStats> {
+    let temporary = format!("{}.tmp-{}", remote_path, uuid::Uuid::new_v4());
+    let prepare = incremental_prepare_command(remote_path, &temporary, seed_path, delta);
+    let finalize = incremental_finalize_command(remote_path, &temporary);
+    let result = match runner.kind {
+        RunnerKind::Local => {
+            run_shell_command(&prepare, "prepare incremental local workspace snapshot")
+                .and_then(|_| {
+                    materialize_changed_paths(
+                        local_path,
+                        &local_extract_command(&temporary),
+                        &delta.changed_paths,
+                        "materialize incremental local workspace delta",
+                    )
+                })
+                .and_then(|_| {
+                    run_shell_command(&finalize, "finalize incremental local workspace snapshot")
+                })
+        }
+        RunnerKind::Ssh => {
+            let (_server, client) = ssh_client_for_runner(runner)?;
+            if client.is_local {
+                run_shell_command(&prepare, "prepare incremental local workspace snapshot")
+                    .and_then(|_| {
+                        materialize_changed_paths(
+                            local_path,
+                            &local_extract_command(&temporary),
+                            &delta.changed_paths,
+                            "materialize incremental local workspace delta",
+                        )
+                    })
+                    .and_then(|_| {
+                        run_shell_command(
+                            &finalize,
+                            "finalize incremental local workspace snapshot",
+                        )
+                    })
+            } else {
+                let remote = format!("{}@{}", client.user, client.host);
+                let remote_shell = |script: &str| {
+                    format!(
+                        "ssh {} {} {}",
+                        ssh_args(&client),
+                        shell::quote_arg(&remote),
+                        shell::quote_arg(script),
+                    )
+                };
+                run_shell_command(
+                    &remote_shell(&prepare),
+                    "prepare incremental SSH workspace snapshot",
+                )
+                .and_then(|_| {
+                    materialize_changed_paths(
+                        local_path,
+                        &remote_extract_command(&client, &remote, &temporary),
+                        &delta.changed_paths,
+                        "materialize incremental SSH workspace delta",
+                    )
+                })
+                .and_then(|_| {
+                    run_shell_command(
+                        &remote_shell(&finalize),
+                        "finalize incremental SSH workspace snapshot",
+                    )
+                })
+            }
+        }
+    };
+    if result.is_err() {
+        cleanup_incremental_temporary(runner, &temporary);
+    }
+    result.map(|_| delta.transfer.clone())
+}
+
+fn cleanup_incremental_temporary(runner: &Runner, temporary: &str) {
+    let command = format!("rm -rf -- {}", shell::quote_arg(temporary));
+    match runner.kind {
+        RunnerKind::Local => {
+            let _ = run_shell_command(&command, "clean incremental workspace temporary");
+        }
+        RunnerKind::Ssh => {
+            if let Ok((_server, client)) = ssh_client_for_runner(runner) {
+                if client.is_local {
+                    let _ = run_shell_command(&command, "clean incremental workspace temporary");
+                } else {
+                    let remote = format!("{}@{}", client.user, client.host);
+                    let command = format!(
+                        "ssh {} {} {}",
+                        ssh_args(&client),
+                        shell::quote_arg(&remote),
+                        shell::quote_arg(&command),
+                    );
+                    let _ =
+                        run_shell_command(&command, "clean incremental SSH workspace temporary");
+                }
+            }
+        }
+    }
+}
+
+fn incremental_prepare_command(
+    remote_path: &str,
+    temporary: &str,
+    seed_path: &str,
+    delta: &SnapshotManifestDelta,
+) -> String {
+    let parent = parent_remote_path(remote_path);
+    let removals = delta
+        .deleted_paths
+        .iter()
+        .chain(delta.replaced_paths.iter())
+        // The seed is hard-link cloned. Unlink changed files before tar writes
+        // them so a new snapshot can never mutate its immutable seed inode.
+        .chain(delta.changed_file_paths.iter())
+        .map(|path| {
+            format!(
+                "rm -rf -- {}/{}",
+                shell::quote_arg(temporary),
+                shell::quote_arg(path)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" && ");
+    format!(
+        "{owner_capture} ; mkdir -p {parent} && rm -rf {temporary} && mkdir -p {temporary} && {seed} {removals}",
+        owner_capture = owner_capture_shell(&parent),
+        parent = shell::quote_arg(&parent),
+        temporary = shell::quote_arg(&temporary),
+        seed = seed_snapshot_command(seed_path, temporary),
+        removals = if removals.is_empty() { String::new() } else { format!(" && {removals}") },
+    )
+}
+
+fn incremental_finalize_command(remote_path: &str, temporary: &str) -> String {
+    let parent = parent_remote_path(remote_path);
+    format!(
+        "mv {} {} && {}",
+        shell::quote_arg(temporary),
+        shell::quote_arg(remote_path),
+        owner_restore_shell(&parent, remote_path),
+    )
+}
+
+fn seed_snapshot_command(seed_path: &str, destination: &str) -> String {
+    // A hard-link clone gives the new immutable snapshot its own directory
+    // without copying unchanged bytes. If the runner filesystem cannot link
+    // across its storage boundary, retain correctness with a local copy while
+    // transfer metrics continue to report controller-to-runner content only.
+    format!(
+        "(cp -al {seed}/. {destination}/ 2>/dev/null || cp -a {seed}/. {destination}/) && rm -f {destination}/{metadata}",
+        seed = shell::quote_arg(seed_path),
+        destination = destination,
+        metadata = shell::quote_arg(RUNNER_WORKSPACE_METADATA_FILE),
+    )
+}
+
+fn materialize_changed_paths(
+    local_path: &Path,
+    target_command: &str,
+    changed_paths: &[String],
+    action: &str,
+) -> Result<()> {
+    if changed_paths.is_empty() {
+        return Ok(());
+    }
+    let mut list = tempfile::NamedTempFile::new()
+        .map_err(|err| Error::internal_io(err.to_string(), Some(action.to_string())))?;
+    for path in changed_paths {
+        list.write_all(path.as_bytes())
+            .and_then(|_| list.write_all(&[0]))
+            .map_err(|err| Error::internal_io(err.to_string(), Some(action.to_string())))?;
+    }
+    let command = format!(
+        "COPYFILE_DISABLE=1 tar --no-xattrs -h -C {} --null -T {} -cf - | {}",
+        shell::quote_arg(&local_path.display().to_string()),
+        shell::quote_arg(&list.path().display().to_string()),
+        target_command,
+    );
+    run_shell_command(&command, action)
+}
+
+fn local_extract_command(destination: &str) -> String {
+    format!("tar --no-xattrs -xf - -C {}", shell::quote_arg(destination))
+}
+
+fn remote_extract_command(
+    client: &homeboy_core::server::SshClient,
+    remote: &str,
+    destination: &str,
+) -> String {
+    format!(
+        "ssh {} {} {}",
+        ssh_args(client),
+        shell::quote_arg(remote),
+        shell::quote_arg(&local_extract_command(destination)),
+    )
 }
 
 pub(crate) fn materialize_snapshot_git(

--- a/crates/homeboy-lab-runner/src/workspace/sync.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync.rs
@@ -20,7 +20,10 @@ use super::super::{
 use super::git::{git_snapshot, materialize_git, materialize_git_from_controller_bundle};
 use super::snapshot::{
     effective_snapshot_excludes, ensure_no_runner_workspace_metadata_collision,
-    local_snapshot_stats, materialize_snapshot, materialize_snapshot_git, snapshot_identity,
+    local_snapshot_stats, materialize_snapshot, materialize_snapshot_git,
+    materialize_snapshot_incremental, snapshot_identity, snapshot_manifest_delta,
+    workspace_content_manifest_for_policy, SnapshotManifestDelta,
+    WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
 };
 use super::types::{
     canonical_workspace_path, ByteFileCounts, LocalGitState, RunnerWorkspaceCurrentSummary,
@@ -101,7 +104,7 @@ pub fn sync_workspace(
             } else {
                 "snapshot_unique_workspace"
             };
-            let materialization_plan = workspace_materialization_plan(
+            let mut materialization_plan = workspace_materialization_plan(
                 workspace_root,
                 &local_path,
                 &remote_path,
@@ -111,6 +114,11 @@ pub fn sync_workspace(
                 workspace_cleanliness,
             );
             let stats = local_snapshot_stats(&local_path, &excludes, &includes)?;
+            let content_manifest = workspace_content_manifest_for_policy(
+                &local_path,
+                &excludes,
+                WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+            )?;
             let synthetic_checkout = if options.mode == RunnerWorkspaceSyncMode::SnapshotGit {
                 match materialize_snapshot_git(
                     &runner,
@@ -126,7 +134,40 @@ pub fn sync_workspace(
                     }
                 }
             } else {
-                materialize_snapshot(&runner, &local_path, &remote_path, &excludes)?;
+                let seed = compatible_incremental_snapshot(
+                    &runner,
+                    &local_path,
+                    &excludes,
+                    &content_manifest,
+                )?;
+                materialization_plan.snapshot_transfer = Some(match seed {
+                    Some((seed, delta)) => match materialize_snapshot_incremental(
+                        &runner,
+                        &local_path,
+                        &remote_path,
+                        &seed.remote_path,
+                        &delta,
+                    ) {
+                        Ok(transfer) => transfer,
+                        Err(error) => {
+                            rollback_materialized_workspace(&runner, workspace_root, &remote_path);
+                            return Err(error);
+                        }
+                    },
+                    None => {
+                        if let Err(error) =
+                            materialize_snapshot(&runner, &local_path, &remote_path, &excludes)
+                        {
+                            rollback_materialized_workspace(&runner, workspace_root, &remote_path);
+                            return Err(error);
+                        }
+                        super::types::SnapshotTransferStats {
+                            reused: ByteFileCounts::default(),
+                            transferred: stats.clone(),
+                            final_size: stats.clone(),
+                        }
+                    }
+                });
                 None
             };
             let metadata = workspace_metadata(
@@ -135,6 +176,8 @@ pub fn sync_workspace(
                 &remote_path,
                 options.mode,
                 &snapshot,
+                &excludes,
+                Some(content_manifest),
                 options.run_isolation_token.as_deref(),
                 ResourceCleanupPolicy::DeleteOnSuccess,
             );
@@ -274,6 +317,8 @@ pub fn sync_workspace(
                 &remote_path,
                 RunnerWorkspaceSyncMode::Git,
                 &git.head,
+                &excludes,
+                None,
                 options.run_isolation_token.as_deref(),
                 ResourceCleanupPolicy::DeleteOnSuccess,
             );
@@ -455,6 +500,37 @@ pub fn reuse_compatible_snapshot_workspace(
         includes,
         workspace_cleanliness: workspace_cleanliness.to_string(),
         validation_dependencies: Vec::new(),
+    }))
+}
+
+/// A seed may differ in source revision, but must have been materialized from
+/// the same controller path under the exact effective security/exclude policy.
+/// Older metadata lacks that policy and is deliberately ineligible.
+fn compatible_incremental_snapshot(
+    runner: &super::super::Runner,
+    local_path: &Path,
+    excludes: &[String],
+    controller_manifest: &super::snapshot::WorkspaceContentManifest,
+) -> Result<Option<(RunnerWorkspaceSnapshotEntry, SnapshotManifestDelta)>> {
+    let (snapshots, _) = workspace_snapshots(
+        &runner.id,
+        RunnerWorkspaceSnapshotFilters {
+            limit: usize::MAX,
+            ..Default::default()
+        },
+    )?;
+    let local_path = local_path.display().to_string();
+    Ok(snapshots.snapshots.into_iter().find_map(|snapshot| {
+        (snapshot.sync_mode == RunnerWorkspaceSyncMode::Snapshot.label()
+            && snapshot.local_path == local_path
+            && snapshot.snapshot_excludes == excludes)
+            .then(|| {
+                let manifest = snapshot.content_manifest.clone()?;
+                snapshot_manifest_delta(controller_manifest, &manifest)
+                    .ok()
+                    .map(|delta| (snapshot, delta))
+            })
+            .flatten()
     }))
 }
 
@@ -925,6 +1001,8 @@ fn workspace_snapshot_entry(
         remote_path: metadata.remote_path,
         sync_mode: metadata.sync_mode,
         snapshot_identity: metadata.snapshot_identity,
+        snapshot_excludes: metadata.snapshot_excludes,
+        content_manifest: metadata.content_manifest,
         created_at: metadata.synced_at,
         source_ref: metadata.source_ref,
         source_commit: metadata.source_commit,
@@ -968,6 +1046,8 @@ fn workspace_metadata(
     remote_path: &str,
     sync_mode: RunnerWorkspaceSyncMode,
     snapshot_identity: &str,
+    snapshot_excludes: &[String],
+    content_manifest: Option<super::snapshot::WorkspaceContentManifest>,
     run_id: Option<&str>,
     cleanup_policy: ResourceCleanupPolicy,
 ) -> RunnerWorkspaceMetadata {
@@ -982,6 +1062,8 @@ fn workspace_metadata(
         remote_path: remote_path.to_string(),
         sync_mode: sync_mode.label().to_string(),
         snapshot_identity: snapshot_identity.to_string(),
+        snapshot_excludes: snapshot_excludes.to_vec(),
+        content_manifest,
         synced_at: chrono::Utc::now().to_rfc3339(),
         source_ref: git_state.ref_name,
         source_commit: git_state.commit,

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -1082,7 +1082,7 @@ fn workspace_content_hash_versions_legacy_any_execute_separately_from_owner_exec
 }
 
 #[test]
-fn workspace_content_manifest_omits_long_paths_but_counts_them() {
+fn workspace_content_manifest_contains_every_materialized_path() {
     let workspace = tempfile::tempdir().expect("workspace");
     fs::write(workspace.path().join("a".repeat(193)), "contents\n").expect("long path file");
 
@@ -1093,7 +1093,9 @@ fn workspace_content_manifest_omits_long_paths_but_counts_them() {
     )
     .expect("content manifest");
     assert_eq!(manifest.entry_count, 1);
-    assert!(manifest.entries.is_empty());
+    assert_eq!(manifest.entries.len(), 1);
+    assert_eq!(manifest.entries[0].bytes, Some(9));
+    assert!(manifest.entries[0].sha256.is_some());
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
@@ -181,6 +181,222 @@ fn clean_snapshot_reuse_preserves_exact_source_provenance_without_git_materializ
     });
 }
 
+#[test]
+fn incremental_snapshots_reuse_unchanged_content_and_reconcile_deltas() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root");
+        create_local_runner("lab-local-incremental", runner_root.path());
+        let source = tempfile::tempdir().expect("source");
+        fs::create_dir_all(source.path().join("src")).expect("source directory");
+        fs::write(source.path().join("src/unchanged.txt"), "unchanged\n").expect("unchanged");
+        fs::write(source.path().join("src/changed.txt"), "first\n").expect("changed");
+        fs::write(source.path().join("removed.txt"), "remove\n").expect("removed");
+
+        let (first, _) = sync_workspace(
+            "lab-local-incremental",
+            sync_options(
+                source.path().display().to_string(),
+                Some("first".to_string()),
+            ),
+        )
+        .expect("first snapshot");
+        fs::write(source.path().join("src/changed.txt"), "second\n").expect("small delta");
+        fs::remove_file(source.path().join("removed.txt")).expect("delete source file");
+        let (second, _) = sync_workspace(
+            "lab-local-incremental",
+            sync_options(
+                source.path().display().to_string(),
+                Some("second".to_string()),
+            ),
+        )
+        .expect("incremental snapshot");
+
+        let transfer = second
+            .materialization_plan
+            .snapshot_transfer
+            .expect("transfer accounting");
+        assert_eq!(transfer.transferred.files, 1);
+        assert_eq!(transfer.reused.files, 1);
+        assert_eq!(
+            fs::read_to_string(format!("{}/src/changed.txt", second.remote_path)).unwrap(),
+            "second\n"
+        );
+        assert!(!std::path::Path::new(&second.remote_path)
+            .join("removed.txt")
+            .exists());
+        assert_eq!(
+            fs::read_to_string(format!("{}/src/changed.txt", first.remote_path)).unwrap(),
+            "first\n"
+        );
+    });
+}
+
+#[test]
+fn incremental_snapshots_materialize_unchanged_content_without_transfer() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root");
+        create_local_runner("lab-local-unchanged", runner_root.path());
+        let source = tempfile::tempdir().expect("source");
+        fs::write(source.path().join("unchanged.txt"), "unchanged\n").expect("source file");
+        sync_workspace(
+            "lab-local-unchanged",
+            sync_options(
+                source.path().display().to_string(),
+                Some("first".to_string()),
+            ),
+        )
+        .expect("first snapshot");
+
+        let (second, _) = sync_workspace(
+            "lab-local-unchanged",
+            sync_options(
+                source.path().display().to_string(),
+                Some("second".to_string()),
+            ),
+        )
+        .expect("unchanged incremental snapshot");
+
+        let transfer = second
+            .materialization_plan
+            .snapshot_transfer
+            .expect("transfer accounting");
+        assert_eq!(transfer.transferred.files, 0);
+        assert_eq!(transfer.reused.files, 1);
+        assert_eq!(transfer.final_size.files, 1);
+        assert_eq!(
+            fs::read_to_string(std::path::Path::new(&second.remote_path).join("unchanged.txt"))
+                .expect("reused file"),
+            "unchanged\n"
+        );
+    });
+}
+
+#[test]
+fn incremental_snapshot_refuses_seed_when_effective_excludes_change() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root");
+        create_local_runner("lab-local-exclude-change", runner_root.path());
+        let source = tempfile::tempdir().expect("source");
+        fs::write(source.path().join("kept.txt"), "kept\n").expect("kept");
+        fs::write(source.path().join("secret.txt"), "secret\n").expect("secret");
+        sync_workspace(
+            "lab-local-exclude-change",
+            sync_options(
+                source.path().display().to_string(),
+                Some("first".to_string()),
+            ),
+        )
+        .expect("first snapshot");
+        // A runner policy change changes effective snapshot filtering, so the
+        // prior tree is not a compatible source for hard-link reuse.
+        crate::merge(
+            Some("lab-local-exclude-change"),
+            r#"{"policy":{"snapshot_excludes":["secret.txt"]}}"#,
+            &["policy".to_string()],
+        )
+        .expect("update runner");
+        let (second, _) = sync_workspace(
+            "lab-local-exclude-change",
+            sync_options(
+                source.path().display().to_string(),
+                Some("second".to_string()),
+            ),
+        )
+        .expect("filtered snapshot");
+        let transfer = second
+            .materialization_plan
+            .snapshot_transfer
+            .expect("transfer");
+        assert_eq!(transfer.reused.files, 0);
+        assert_eq!(transfer.transferred.files, 1);
+        assert!(!std::path::Path::new(&second.remote_path)
+            .join("secret.txt")
+            .exists());
+    });
+}
+
+#[test]
+fn incremental_snapshot_falls_back_when_seed_manifest_is_corrupt() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root");
+        create_local_runner("lab-local-corrupt-manifest", runner_root.path());
+        let source = tempfile::tempdir().expect("source");
+        fs::write(source.path().join("file.txt"), "contents\n").expect("source file");
+        let (first, _) = sync_workspace(
+            "lab-local-corrupt-manifest",
+            sync_options(
+                source.path().display().to_string(),
+                Some("first".to_string()),
+            ),
+        )
+        .expect("first snapshot");
+        let metadata_path =
+            std::path::Path::new(&first.remote_path).join(".homeboy/runner-workspace.json");
+        let mut metadata: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&metadata_path).expect("metadata"))
+                .expect("metadata JSON");
+        metadata["content_manifest"]["entry_count"] = serde_json::json!(999);
+        fs::write(&metadata_path, metadata.to_string()).expect("corrupt manifest");
+
+        let (second, _) = sync_workspace(
+            "lab-local-corrupt-manifest",
+            sync_options(
+                source.path().display().to_string(),
+                Some("second".to_string()),
+            ),
+        )
+        .expect("safe full fallback");
+        let transfer = second
+            .materialization_plan
+            .snapshot_transfer
+            .expect("transfer accounting");
+        assert_eq!(transfer.reused.files, 0);
+        assert_eq!(transfer.transferred.files, 1);
+        assert_eq!(
+            fs::read_to_string(std::path::Path::new(&second.remote_path).join("file.txt"))
+                .expect("fallback file"),
+            "contents\n"
+        );
+    });
+}
+
+#[test]
+fn incremental_snapshot_refuses_seed_from_another_source_path() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root");
+        create_local_runner("lab-local-incompatible", runner_root.path());
+        let first = tempfile::tempdir().expect("first source");
+        let second = tempfile::tempdir().expect("second source");
+        fs::write(first.path().join("file.txt"), "first\n").expect("first file");
+        fs::write(second.path().join("file.txt"), "second\n").expect("second file");
+        sync_workspace(
+            "lab-local-incompatible",
+            sync_options(
+                first.path().display().to_string(),
+                Some("first".to_string()),
+            ),
+        )
+        .expect("first snapshot");
+        let (synced, _) = sync_workspace(
+            "lab-local-incompatible",
+            sync_options(
+                second.path().display().to_string(),
+                Some("second".to_string()),
+            ),
+        )
+        .expect("second snapshot");
+        assert_eq!(
+            synced
+                .materialization_plan
+                .snapshot_transfer
+                .expect("transfer")
+                .reused
+                .files,
+            0
+        );
+    });
+}
+
 fn create_local_runner(id: &str, workspace_root: &std::path::Path) {
     crate::create(
         &format!(

--- a/crates/homeboy-lab-runner/src/workspace/types.rs
+++ b/crates/homeboy-lab-runner/src/workspace/types.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::super::validation_dependencies::RunnerValidationDependencySyncOutput;
 use super::super::RunnerWorkspaceLease;
+use super::snapshot::WorkspaceContentManifest;
 use homeboy_core::resource_lifecycle_index::ResourceLifecycleRecord;
 
 pub(crate) const DEFAULT_EXCLUDES: &[&str] = &[
@@ -71,6 +72,17 @@ pub struct RunnerWorkspaceMaterializationContract {
     pub output_paths: RunnerWorkspaceOutputPaths,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub controller_git_bundle: Option<ControllerGitBundleProvenance>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snapshot_transfer: Option<SnapshotTransferStats>,
+}
+
+/// Content accounting for a snapshot transport. `reused` is linked from the
+/// compatible immutable seed; `transferred` is copied from the controller.
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+pub struct SnapshotTransferStats {
+    pub reused: ByteFileCounts,
+    pub transferred: ByteFileCounts,
+    pub final_size: ByteFileCounts,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -182,6 +194,7 @@ impl RunnerWorkspaceMaterializationContract {
             },
             output_paths: RunnerWorkspaceOutputPaths::for_remote_path(&workspace_root, remote_path),
             controller_git_bundle: None,
+            snapshot_transfer: None,
         }
     }
 
@@ -362,6 +375,10 @@ pub struct RunnerWorkspaceSnapshotEntry {
     pub remote_path: String,
     pub sync_mode: String,
     pub snapshot_identity: String,
+    #[serde(default)]
+    pub snapshot_excludes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_manifest: Option<WorkspaceContentManifest>,
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_ref: Option<String>,
@@ -388,6 +405,10 @@ pub(super) struct RunnerWorkspaceMetadata {
     pub remote_path: String,
     pub sync_mode: String,
     pub snapshot_identity: String,
+    #[serde(default)]
+    pub snapshot_excludes: Vec<String>,
+    #[serde(default)]
+    pub content_manifest: Option<WorkspaceContentManifest>,
     pub synced_at: String,
     #[serde(default)]
     pub source_ref: Option<String>,


### PR DESCRIPTION
## Summary
- persist deterministic immutable content manifests for workspace snapshots
- select only source- and exclude-compatible seeds
- derive explicit changed, deleted, replacement, and unchanged path sets
- hard-link unchanged seed content and transport only changed paths
- report reused, transferred, and final file/byte metrics
- reject malformed/corrupt manifests and safely fall back to full materialization

Closes #8785.

## How to test
1. Run `cargo test -p homeboy-lab-runner workspace::tests::snapshots`.
2. Confirm all eight cases pass, including unchanged, one-file delta, deletion, exclude change, incompatible source, and corrupt-manifest fallback.
3. Run `cargo check -p homeboy-lab-runner`.
4. Run `cargo fmt --check`.
5. Run `git diff --check`.

## Compatibility
Snapshot metadata is extended additively. Incompatible or invalid prior manifests fall back to the existing full-snapshot path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode general coding subagents
- **Used for:** Investigated transport identity, designed the manifest-driven delta, implemented immutable seed reuse and metrics, and added deterministic coverage with Chris.