### PR TITLE
refactor: move TransformRule/TransformSet to homeboy-refactor-contract

### DIFF
--- a/crates/homeboy-core/src/agent_task_promotion/tests.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/tests.rs
@@ -1251,7 +1251,6 @@ fn empty_patch_runs_public_and_private_gates_against_pinned_candidate() {
             candidate_ref: None,
             to_worktree: "repo@candidate".to_string(),
             task_id: None,
-            candidate_ref: None,
             artifact_id: None,
             dry_run: false,
             gates: VerifyGateOptions {
@@ -1308,7 +1307,6 @@ fn empty_patch_failing_gate_is_reported_against_pinned_candidate() {
             candidate_ref: None,
             to_worktree: "repo@candidate".to_string(),
             task_id: None,
-            candidate_ref: None,
             artifact_id: None,
             dry_run: false,
             gates: VerifyGateOptions {

--- a/crates/homeboy-core/src/extension/test/drift.rs
+++ b/crates/homeboy-core/src/extension/test/drift.rs
@@ -671,7 +671,9 @@ fn is_auto_fixable(change: &ProductionChange) -> bool {
 ///
 /// For each auto-fixable change, creates a TransformRule that replaces
 /// the old symbol with the new one in test files.
-pub fn generate_transform_rules(report: &DriftReport) -> Vec<crate::refactor::TransformRule> {
+pub fn generate_transform_rules(
+    report: &DriftReport,
+) -> Vec<homeboy_refactor_contract::TransformRule> {
     let mut rules = Vec::new();
 
     for change in &report.production_changes {
@@ -743,7 +745,7 @@ pub fn generate_transform_rules(report: &DriftReport) -> Vec<crate::refactor::Tr
             _ => continue,
         };
 
-        rules.push(crate::refactor::TransformRule {
+        rules.push(homeboy_refactor_contract::TransformRule {
             id,
             description,
             find,

--- a/crates/homeboy-core/src/extension/test/workflow.rs
+++ b/crates/homeboy-core/src/extension/test/workflow.rs
@@ -7,9 +7,8 @@ use crate::extension::test::{TestBaselineComparison, TestCounts};
 use crate::refactor::{
     self,
     auto::{self, AutofixMode},
-    TransformSet,
 };
-use homeboy_refactor_contract::AppliedRefactor;
+use homeboy_refactor_contract::{AppliedRefactor, TransformSet};
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/homeboy-core/src/refactor/transform.rs
+++ b/crates/homeboy-core/src/refactor/transform.rs
@@ -19,52 +19,7 @@ use crate::error::{Error, Result};
 // Rule model
 // ============================================================================
 
-/// A collection of transform rules.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TransformSet {
-    /// Human-readable description of this transform set.
-    #[serde(default)]
-    pub description: String,
-    /// Ordered list of rules to apply.
-    pub rules: Vec<TransformRule>,
-}
-
-/// A single find/replace rule with a file glob filter.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TransformRule {
-    /// Unique identifier within the set.
-    pub id: String,
-    /// Human-readable description.
-    #[serde(default)]
-    pub description: String,
-    /// Regex pattern to find (supports capture groups).
-    pub find: String,
-    /// Replacement template. Supports `$1`, `$2`, `${name}` capture group refs,
-    /// `$1:lower`/`:upper`/`:kebab`/`:snake`/`:pascal`/`:camel` case transforms,
-    /// and `$$` for a literal dollar sign.
-    ///
-    /// Backslash escapes are collapsed before the template is handed to the
-    /// regex engine: `\\` → one literal backslash, `\n` → newline, `\t` → tab,
-    /// `\r` → CR, `\0` → nul, `\"` → `"`, `\'` → `'`. Unknown escapes pass
-    /// through verbatim. This means that to emit a fully-qualified name like
-    /// `\Example_Name` on disk, write `\\Example_Name` in JSON (which decodes
-    /// to `\Example_Name` in memory — the literal `\` you want). See #1277.
-    pub replace: String,
-    /// Glob pattern for files to apply to (e.g., `tests/**/*.txt`).
-    #[serde(default = "default_files_glob")]
-    pub files: String,
-    /// Match context: "line" (default) or "file" (whole-file regex, for multi-line).
-    #[serde(default = "default_context")]
-    pub context: String,
-}
-
-fn default_files_glob() -> String {
-    "**/*".to_string()
-}
-
-fn default_context() -> String {
-    "line".to_string()
-}
+pub use homeboy_refactor_contract::{TransformRule, TransformSet};
 
 // ============================================================================
 // Output model

--- a/crates/homeboy-refactor-contract/src/lib.rs
+++ b/crates/homeboy-refactor-contract/src/lib.rs
@@ -1,10 +1,11 @@
-//! Shared refactor/autofix result types for homeboy.
+//! Shared refactor contract types for homeboy.
 //!
-//! Behavior-free data describing the outcome of applying refactor fixes
-//! (`refactor --from lint/test/audit --write`). These live below core so
-//! consumers — the refactor engine that produces them and report layers like the
-//! extension lint/test commands that carry them — can share the vocabulary
-//! without depending on the refactor engine's behavior.
+//! Behavior-free data for the refactor subsystem: the autofix-**result** types
+//! (`refactor --from lint/test/audit --write` output) and the transform-**rule**
+//! input types (find/replace rules an extension declares). These live below core
+//! so consumers — the refactor engine that produces/applies them and report
+//! layers like the extension lint/test commands that carry and declare them — can
+//! share the vocabulary without depending on the refactor engine's behavior.
 
 use serde::{Deserialize, Serialize};
 
@@ -43,4 +44,51 @@ pub struct RuleFixCount {
 pub struct PrimitiveFixCount {
     pub primitive: String,
     pub count: usize,
+}
+
+/// A collection of transform rules.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransformSet {
+    /// Human-readable description of this transform set.
+    #[serde(default)]
+    pub description: String,
+    /// Ordered list of rules to apply.
+    pub rules: Vec<TransformRule>,
+}
+
+/// A single find/replace rule with a file glob filter.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransformRule {
+    /// Unique identifier within the set.
+    pub id: String,
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: String,
+    /// Regex pattern to find (supports capture groups).
+    pub find: String,
+    /// Replacement template. Supports `$1`, `$2`, `${name}` capture group refs,
+    /// `$1:lower`/`:upper`/`:kebab`/`:snake`/`:pascal`/`:camel` case transforms,
+    /// and `$$` for a literal dollar sign.
+    ///
+    /// Backslash escapes are collapsed before the template is handed to the
+    /// regex engine: `\\` → one literal backslash, `\n` → newline, `\t` → tab,
+    /// `\r` → CR, `\0` → nul, `\"` → `"`, `\'` → `'`. Unknown escapes pass
+    /// through verbatim. This means that to emit a fully-qualified name like
+    /// `\Example_Name` on disk, write `\\Example_Name` in JSON (which decodes
+    /// to `\Example_Name` in memory — the literal `\` you want). See #1277.
+    pub replace: String,
+    /// Glob pattern for files to apply to (e.g., `tests/**/*.txt`).
+    #[serde(default = "default_files_glob")]
+    pub files: String,
+    /// Match context: "line" (default) or "file" (whole-file regex, for multi-line).
+    #[serde(default = "default_context")]
+    pub context: String,
+}
+
+fn default_files_glob() -> String {
+    "**/*".to_string()
+}
+
+fn default_context() -> String {
+    "line".to_string()
 }


### PR DESCRIPTION
## Summary
`TransformRule` (a find/replace rule) and `TransformSet` (a collection of them) are **pure serde config types** — the input an extension declares for test-drift transforms — that lived inside the 43k-LOC `refactor::transform` **engine** module. Move the two types (+ their serde default fns `default_files_glob` / `default_context`) into `homeboy-refactor-contract` alongside the autofix-result types (#8774). The 52-fn transform engine stays in core.

## Effect
- `refactor::transform` re-exports `TransformRule`/`TransformSet`, so the engine and `crate::refactor::{TransformRule, TransformSet}` call sites are unchanged.
- Extension `test/drift.rs` (which **constructs** `TransformRule`) now imports it from `homeboy_refactor_contract` directly and is **fully severed** from `crate::refactor` — it was the only thing it used.
- `test/workflow.rs` takes `TransformSet` from the contract too, keeping only its genuine autofix-engine dep.
- Extension's `refactor` edge drops from **3 files → 2**.

This grows the refactor-contract keystone: a pure config type no longer forces consumers to depend on the transform engine.

## Pre-existing test fix (unrelated)
Removes a **duplicate** `candidate_ref` field in two `agent_task_promotion` test constructors — two separate fixes collided on `main`, producing an `E0062` duplicate-field error that made `cargo check --workspace --tests` red on clean `main`. Verified the dup is on `origin/main` and not introduced here.

## Verification
- `cargo check -p homeboy-refactor-contract --lib`, `-p homeboy-core --lib` — 0 errors.
- `cargo check --workspace --tests --locked` (topology guard) — **passes**.
- `cargo test -p homeboy-core --lib refactor::transform` — **29 passed**.
- `git grep 'crate::refactor'` in `extension/test/drift.rs` — **0 results**.

Refs #8425