### PR TITLE
fix: remove duplicate candidate_ref in AgentTaskPromotionOptions test initializers

### DIFF
--- a/crates/homeboy-core/src/agent_task_promotion/tests.rs
+++ b/crates/homeboy-core/src/agent_task_promotion/tests.rs
@@ -1251,7 +1251,6 @@ fn empty_patch_runs_public_and_private_gates_against_pinned_candidate() {
             candidate_ref: None,
             to_worktree: "repo@candidate".to_string(),
             task_id: None,
-            candidate_ref: None,
             artifact_id: None,
             dry_run: false,
             gates: VerifyGateOptions {
@@ -1308,7 +1307,6 @@ fn empty_patch_failing_gate_is_reported_against_pinned_candidate() {
             candidate_ref: None,
             to_worktree: "repo@candidate".to_string(),
             task_id: None,
-            candidate_ref: None,
             artifact_id: None,
             dry_run: false,
             gates: VerifyGateOptions {


### PR DESCRIPTION
## Summary
Two separate fixes for the same missing-`candidate_ref` break landed independently (#8807 and another), each adding `candidate_ref: None` to the same two `AgentTaskPromotionOptions` initializers in `agent_task_promotion/tests.rs`. The result is a **duplicate field** — `E0062: field candidate_ref specified more than once` — breaking `homeboy-core --tests` on `main`.

Removes the redundant occurrence (the one after `task_id`, keeping the one placed in struct-declaration order after `task_base_sha`).

## Verification
- `homeboy-core --tests` now compiles clean (was 2 errors on `main`).
- Pure test-fixture fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)