### PR TITLE
refactor: move bench diagnostic + phase-event types to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/bench/diagnostic.rs
+++ b/crates/homeboy-core/src/extension/bench/diagnostic.rs
@@ -5,35 +5,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use super::parsing::BenchResults;
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub struct BenchDiagnostic {
-    /// Workload-defined diagnostic class used for grouping related failures.
-    #[serde(alias = "kind", alias = "code")]
-    pub class: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub message: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub severity: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source: Option<BenchDiagnosticSource>,
-    #[serde(default, alias = "details", skip_serializing_if = "BTreeMap::is_empty")]
-    pub metadata: BTreeMap<String, serde_json::Value>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case", tag = "kind")]
-pub enum BenchDiagnosticSource {
-    Run,
-    Scenario {
-        scenario_id: String,
-    },
-    ScenarioRun {
-        scenario_id: String,
-        run_index: usize,
-    },
-}
+pub use homeboy_extension_contract::bench_diagnostics::{BenchDiagnostic, BenchDiagnosticSource};
 
 pub fn collect_diagnostics(results: Option<&BenchResults>) -> Vec<BenchDiagnostic> {
     let Some(results) = results else {

--- a/crates/homeboy-core/src/extension/bench/phase_events.rs
+++ b/crates/homeboy-core/src/extension/bench/phase_events.rs
@@ -3,65 +3,9 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use super::parsing::BenchResults;
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[serde(deny_unknown_fields)]
-pub struct BenchPhaseEvent {
-    /// Generic phase identifier. Core treats this as a label, not a closed
-    /// enum, so extensions can model their own lifecycle.
-    pub phase: String,
-    /// Event status, for example `started`, `heartbeat`, `completed`,
-    /// `failed`, or `timeout`.
-    pub status: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub t_ms: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub started_at: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ended_at: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub duration_ms: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub message: Option<String>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub diagnostics: BTreeMap<String, serde_json::Value>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub payload: BTreeMap<String, serde_json::Value>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[serde(deny_unknown_fields)]
-pub struct BenchPhaseSummary {
-    pub phase: String,
-    pub status: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub first_t_ms: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub last_t_ms: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub started_at: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ended_at: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub duration_ms: Option<u64>,
-    #[serde(default, skip_serializing_if = "is_zero_usize")]
-    pub heartbeat_count: usize,
-    #[serde(default, skip_serializing_if = "is_zero_usize")]
-    pub diagnostic_count: usize,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub message: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[serde(deny_unknown_fields)]
-pub struct BenchPhaseFailureClassification {
-    /// `timeout` or `failure` for classified terminal events.
-    pub kind: String,
-    pub phase: String,
-    pub status: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub message: Option<String>,
-}
+pub use homeboy_extension_contract::bench_diagnostics::{
+    BenchPhaseEvent, BenchPhaseFailureClassification, BenchPhaseSummary,
+};
 
 pub fn evaluate_phase_events(results: &mut BenchResults) {
     results.phase_summaries = summarize_phase_events(&results.phase_events);

--- a/crates/homeboy-extension-contract/src/bench_diagnostics.rs
+++ b/crates/homeboy-extension-contract/src/bench_diagnostics.rs
@@ -1,0 +1,96 @@
+//! Pure bench diagnostic + phase-event contract types.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+fn is_zero_usize(value: &usize) -> bool {
+    *value == 0
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchDiagnostic {
+    /// Workload-defined diagnostic class used for grouping related failures.
+    #[serde(alias = "kind", alias = "code")]
+    pub class: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub severity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<BenchDiagnosticSource>,
+    #[serde(default, alias = "details", skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum BenchDiagnosticSource {
+    Run,
+    Scenario {
+        scenario_id: String,
+    },
+    ScenarioRun {
+        scenario_id: String,
+        run_index: usize,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct BenchPhaseEvent {
+    /// Generic phase identifier. Core treats this as a label, not a closed
+    /// enum, so extensions can model their own lifecycle.
+    pub phase: String,
+    /// Event status, for example `started`, `heartbeat`, `completed`,
+    /// `failed`, or `timeout`.
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub t_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub diagnostics: BTreeMap<String, serde_json::Value>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub payload: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct BenchPhaseSummary {
+    pub phase: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_t_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_t_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub heartbeat_count: usize,
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub diagnostic_count: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct BenchPhaseFailureClassification {
+    /// `timeout` or `failure` for classified terminal events.
+    pub kind: String,
+    pub phase: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -11,8 +11,13 @@
 
 pub mod action_types;
 pub mod autofix_config;
+pub mod bench_diagnostics;
 pub mod bench_result;
 pub mod capability;
+pub use bench_diagnostics::{
+    BenchDiagnostic, BenchDiagnosticSource, BenchPhaseEvent, BenchPhaseFailureClassification,
+    BenchPhaseSummary,
+};
 pub use bench_result::{
     BenchChildCommandFailure, BenchMemory, BenchMetricDirection, BenchMetricPhase,
     BenchMetricPolicy, BenchMetrics, BenchProvenance, BenchProvenanceLink, BenchRunExecution,


### PR DESCRIPTION
## Summary
Stage-2 cut continuing the bench subsystem breakdown (following the pure bench types #8790 and the `observation::timeline` relocation #8806). Splits the pure diagnostic and phase-event types out of their behavior.

## What moved
- **`diagnostic.rs`** → `BenchDiagnostic`, `BenchDiagnosticSource` (the `collect_diagnostics` function, which consumes `BenchResults`, stays in core)
- **`phase_events.rs`** → `BenchPhaseEvent`, `BenchPhaseSummary`, `BenchPhaseFailureClassification` (`evaluate_phase_events` stays in core)

All five are pure serde types referencing only each other + `BTreeMap`. Moved their `is_zero_usize` serde helper too.

## Zero downstream churn
Core re-exports them (`pub use`) so the bench module paths stay stable for the ~18 consumers.

## Why
These types are field dependencies of the still-entangled `BenchResults`/`BenchScenario`/`BenchRunSnapshot` cluster. Moving them — combined with the `observation::timeline` relocation and the already-moved pure bench types — continues clearing the field-dependency graph so those larger result models can eventually follow into the contract crate.

## Tests
- `homeboy-extension-contract`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-core` clean on `--lib`; `homeboy-lab-runner`, `homeboy-issues`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.
- Note: `homeboy-core --tests` had a **pre-existing duplicate-field break on `main`** (two independent fixes both added `candidate_ref`) — unrelated to this PR, fixed separately in the dedup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)