### PR TITLE
Preserve authoritative runner status through Lab offload

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/execute.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/execute.rs
@@ -218,56 +218,60 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     let prepare_timer = overhead.phase(LabOffloadPhase::Preflight);
     let preparation = prepare_lab_runner_for_offload(&selection)?;
     prepare_timer.finish();
-    match preparation {
+    let runner_status = match preparation {
         LabRunnerPreparation::Ready => {
             // Only a detached, controller-owned agent-task plan has a durable
             // continuation and canonical workload suitable for broker queueing.
             // A full runner is otherwise still a readiness failure.
-            if let Err(error) = preflight_lab_runner_availability(
+            let runner_status = match preflight_lab_runner_availability(
                 &contract,
                 &selection,
                 request.detach_after_handoff,
                 request.durable_agent_task_plan.is_some(),
             ) {
-                if contract.routing_policy.release_gate
-                    && matches!(selection.source, LabRunnerSelectionSource::Default)
-                    && !release_gate_local_hot_allowed
-                {
-                    return Err(release_gate_local_hot_denied_error(
+                Ok(status) => status,
+                Err(error) => {
+                    if contract.routing_policy.release_gate
+                        && matches!(selection.source, LabRunnerSelectionSource::Default)
+                        && !release_gate_local_hot_allowed
+                    {
+                        return Err(release_gate_local_hot_denied_error(
                         format!(
                             "Release gate `{}` selected default Lab runner `{}` but it cannot accept jobs ({}); `/release_gate/local_hot` is `fail_closed`, so the gate will not silently fall back to local execution",
                             contract.hot_label, selection.runner_id, error.message
                         ),
                         "release_gate",
                     ));
+                    }
+                    if request.placement == homeboy_cli_contract::Placement::Auto
+                        && matches!(selection.source, LabRunnerSelectionSource::Default)
+                    {
+                        let reason = format!("runner_unavailable: {}", error.message);
+                        overhead.set_fallback_reason(&reason);
+                        let mut metadata = lab_offload_metadata(
+                            &plan,
+                            selection.source.metadata_value(),
+                            Some(&selection.runner_id),
+                            Some(selection.mode.metadata_value()),
+                            "fallback",
+                            None,
+                            Some(&reason),
+                        );
+                        attach_lab_offload_overhead(&mut metadata, &overhead);
+                        return Ok(LabOffloadOutcome::RunLocal {
+                            metadata: Some(metadata),
+                            plan,
+                            messages: vec![format!("Lab offload: {reason}; running locally.")],
+                        });
+                    }
+                    return Err(error);
                 }
-                if request.placement == homeboy_cli_contract::Placement::Auto
-                    && matches!(selection.source, LabRunnerSelectionSource::Default)
-                {
-                    let reason = format!("runner_unavailable: {}", error.message);
-                    overhead.set_fallback_reason(&reason);
-                    let mut metadata = lab_offload_metadata(
-                        &plan,
-                        selection.source.metadata_value(),
-                        Some(&selection.runner_id),
-                        Some(selection.mode.metadata_value()),
-                        "fallback",
-                        None,
-                        Some(&reason),
-                    );
-                    attach_lab_offload_overhead(&mut metadata, &overhead);
-                    return Ok(LabOffloadOutcome::RunLocal {
-                        metadata: Some(metadata),
-                        plan,
-                        messages: vec![format!("Lab offload: {reason}; running locally.")],
-                    });
-                }
-                return Err(error);
-            }
+            };
             plan = with_step(
                 plan,
                 PlanStep::ready("lab.connect_runner", "lab.connect_runner").build(),
             );
+            runner_status
         }
         LabRunnerPreparation::FallBackLocal { reason } => {
             plan = with_step(
@@ -334,9 +338,17 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
                 messages: vec![format!("Lab offload: {reason}; running locally.")],
             });
         }
-    }
+    };
 
-    run_lab_offload_inner(request, selection, contract, plan, messages, overhead)
+    run_lab_offload_inner(
+        request,
+        selection,
+        contract,
+        plan,
+        messages,
+        overhead,
+        runner_status,
+    )
 }
 
 pub(crate) fn unsupported_runner_hints(

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -417,9 +417,10 @@ pub(crate) fn exec_lab_context(
     }
 
     let remote_exec_started = std::time::Instant::now();
-    let exec_result = exec(
+    let exec_result = exec_with_status_snapshot(
         runner_id,
         lab_runner_exec_options(&context, env, secret_env_names),
+        Some(context.runner_status.clone()),
     );
     context
         .overhead
@@ -839,10 +840,10 @@ pub(crate) fn run_lab_offload_inner(
     mut plan: HomeboyPlan,
     mut messages: Vec<String>,
     mut overhead: LabOffloadOverhead,
+    runner_status: RunnerStatusReport,
 ) -> Result<LabOffloadOutcome> {
     let runner_id = &selection.runner_id;
     let runner = load(runner_id)?;
-    let runner_status = status(runner_id)?;
     if runner.kind != super::super::super::RunnerKind::Ssh {
         return Err(Error::validation_invalid_argument(
             "runner",
@@ -855,19 +856,7 @@ pub(crate) fn run_lab_offload_inner(
         ));
     }
 
-    if !runner_status.connected {
-        return Err(Error::validation_invalid_argument(
-            "runner",
-            format!(
-                "Lab offload requires a connected {} runner daemon",
-                status_tunnel_mode(&runner_status).label()
-            ),
-            Some(runner_id.to_string()),
-            Some(vec![format!(
-                "Connect runner `{runner_id}` before using --runner."
-            )]),
-        ));
-    }
+    require_connected_lab_runner(runner_id, &runner_status)?;
 
     let runner_workspace_root = request
         .job_overrides
@@ -1519,6 +1508,24 @@ pub(crate) fn run_lab_offload_inner(
     })
 }
 
+fn require_connected_lab_runner(runner_id: &str, runner_status: &RunnerStatusReport) -> Result<()> {
+    if runner_status.connected {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "runner",
+        format!(
+            "Lab offload requires a connected {} runner daemon",
+            status_tunnel_mode(runner_status).label()
+        ),
+        Some(runner_id.to_string()),
+        Some(vec![format!(
+            "Connect runner `{runner_id}` before using --runner."
+        )]),
+    ))
+}
+
 fn reconcile_lab_mutation_output(output: &str, changed_files: &[String]) -> String {
     let Ok(mut value) = serde_json::from_str::<serde_json::Value>(output) else {
         return output.to_string();
@@ -1699,6 +1706,17 @@ fn artifact_name_or_kind_is_fuzz_result(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{RunnerActiveJobState, RunnerSessionState};
+
+    #[test]
+    fn inner_uses_authoritative_preflight_status_not_conflicting_cwd_projection() {
+        let preflight_status = runner_status(true);
+        let conflicting_cwd_projection = runner_status(false);
+
+        require_connected_lab_runner("homeboy-lab", &preflight_status)
+            .expect("inner accepts the connected status selected during preflight");
+        assert!(require_connected_lab_runner("homeboy-lab", &conflicting_cwd_projection).is_err());
+    }
 
     #[test]
     fn reconciles_refactor_sources_output_after_lab_patch_apply() {
@@ -1763,6 +1781,31 @@ mod tests {
             reconcile_lab_mutation_output(output, &["src/lib.rs".to_string()]),
             output
         );
+    }
+
+    fn runner_status(connected: bool) -> RunnerStatusReport {
+        RunnerStatusReport {
+            runner_id: "homeboy-lab".to_string(),
+            connected,
+            state: if connected {
+                RunnerSessionState::Connected
+            } else {
+                RunnerSessionState::Disconnected
+            },
+            session: None,
+            stale_daemon: None,
+            daemon_freshness: None,
+            active_jobs: Vec::new(),
+            active_runner_jobs: Vec::new(),
+            active_job_count: 0,
+            stale_runner_jobs: Vec::new(),
+            stale_runner_job_count: 0,
+            active_job_state: RunnerActiveJobState::Available,
+            active_job_source: None,
+            active_job_error: None,
+            active_job_recovery_evidence: None,
+            session_path: "/tmp/homeboy-lab.json".to_string(),
+        }
     }
 }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/mod.rs
@@ -105,7 +105,7 @@ use super::super::lab_workspaces::{
 use super::super::offload_changed_since::LabOffloadChangedSincePreflight;
 use super::super::{
     dependency_cache_save, evaluate_lab_runner_capabilities_for_runner, exec,
-    lab_offload_changed_since_ref, lab_offload_metadata,
+    exec_with_status_snapshot, lab_offload_changed_since_ref, lab_offload_metadata,
     lab_offload_metadata_with_workspace_mapping, load, plan_managed_runner_source_syncs,
     preflight_lab_offload_changed_since, prepare_git_lab_offload_changed_since,
     prepare_lab_runner_capability, remote_runner_homeboy_path, reuse_compatible_snapshot_workspace,

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/mod.rs
@@ -4,7 +4,8 @@ pub(super) use super::super::super::lab_capabilities::lab_runner_capability_cont
 pub(super) use super::super::super::lab_env::build_lab_offload_env;
 pub(super) use super::super::super::lab_plan::base_lab_plan;
 pub(super) use super::super::super::lab_selection::{
-    fail_if_no_default_runner_accepts_jobs_with, resolve_lab_runner_selection_from_placement,
+    fail_if_no_default_runner_accepts_jobs_with, lab_runner_availability_error,
+    resolve_lab_runner_selection_from_placement,
 };
 pub(super) use super::super::super::lab_workspaces::{
     workspace_mapping_entry, LAB_WORKSPACE_MAPPING_SCHEMA,

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/selection.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/selection.rs
@@ -198,6 +198,82 @@ fn busy_default_runner_fails_closed_for_release_gate() {
 }
 
 #[test]
+fn explicit_connected_stale_runner_preserves_drift_diagnosis_and_recovery() {
+    let status = stale_reverse_status("homeboy-lab");
+    let availability = RunnerAvailability::from_status_parts(
+        status.runner_id.clone(),
+        status.connected,
+        status.stale_daemon.is_some(),
+        status.active_jobs.len(),
+        &status.active_job_state,
+        Some(1),
+    );
+
+    assert!(availability.connected);
+    assert!(!availability.accepts_jobs);
+    assert_eq!(availability.reasons, ["stale_daemon"]);
+
+    let error = lab_runner_availability_error(
+        "agent-task cook",
+        Some(&availability),
+        Some(&status),
+        vec![availability.clone()],
+    );
+    let refresh = status
+        .stale_daemon
+        .as_ref()
+        .expect("stale daemon warning")
+        .refresh_command
+        .clone();
+
+    assert!(error.message.contains("cannot accept jobs"));
+    assert_eq!(
+        error.details["runner_availability"]["reasons"],
+        serde_json::json!(["stale_daemon"])
+    );
+    assert_eq!(error.details["runner_status"]["connected"], true);
+    assert_eq!(
+        error.details["runner_status"]["stale_daemon"]["active_daemon_control_plane_version"],
+        "homeboy 0.228.0"
+    );
+    assert_eq!(
+        error.details["runner_status"]["stale_daemon"]["job_command_binary_version"],
+        "homeboy 0.229.11"
+    );
+    assert_eq!(error.details["stale_daemon_recovery_command"], refresh);
+    assert!(error.details["tried"][0]
+        .as_str()
+        .expect("recovery hint")
+        .contains(&refresh));
+}
+
+#[test]
+fn disconnected_runner_keeps_existing_availability_diagnosis() {
+    let availability = RunnerAvailability::from_status_parts(
+        "homeboy-lab",
+        false,
+        false,
+        0,
+        &RunnerActiveJobState::Available,
+        Some(1),
+    );
+
+    let error = lab_runner_availability_error(
+        "agent-task cook",
+        Some(&availability),
+        None,
+        vec![availability.clone()],
+    );
+
+    assert_eq!(
+        error.details["runner_availability"]["reasons"],
+        serde_json::json!(["not_connected"])
+    );
+    assert!(error.details["runner_status"].is_null());
+    assert!(error.details["stale_daemon_recovery_command"].is_null());
+}
+
+#[test]
 fn explicit_lab_never_allows_missing_or_busy_default_runner_to_run_local() {
     let error = select(
         &portable_lab_command("test"),

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -93,10 +93,10 @@ pub(super) fn preflight_lab_runner_availability(
     selection: &LabRunnerSelection,
     detach_after_handoff: bool,
     has_durable_agent_task_plan: bool,
-) -> Result<()> {
-    let availability = preflight_lab_runner_availability_with(selection, status)?;
+) -> Result<RunnerStatusReport> {
+    let (availability, status) = preflight_lab_runner_availability_with(selection, status)?;
     if availability.accepts_jobs {
-        return Ok(());
+        return Ok(status);
     }
     if allows_detached_reverse_capacity_queue(
         detach_after_handoff,
@@ -104,7 +104,7 @@ pub(super) fn preflight_lab_runner_availability(
         selection,
         &availability,
     ) {
-        return Ok(());
+        return Ok(status);
     }
 
     let eligible = if matches!(selection.source, LabRunnerSelectionSource::Default) {
@@ -115,6 +115,7 @@ pub(super) fn preflight_lab_runner_availability(
     Err(lab_runner_availability_error(
         command.hot_label,
         Some(&availability),
+        Some(&status),
         eligible,
     ))
 }
@@ -136,16 +137,17 @@ pub(super) fn allows_detached_reverse_capacity_queue(
 fn preflight_lab_runner_availability_with(
     selection: &LabRunnerSelection,
     status_fn: impl Fn(&str) -> Result<RunnerStatusReport>,
-) -> Result<RunnerAvailability> {
+) -> Result<(RunnerAvailability, RunnerStatusReport)> {
     let status = status_fn(&selection.runner_id)?;
-    Ok(RunnerAvailability::from_status_parts(
+    let availability = RunnerAvailability::from_status_parts(
         selection.runner_id.clone(),
         status.connected,
         status.stale_daemon.is_some(),
         status.active_jobs.len(),
         &status.active_job_state,
         load(&selection.runner_id)?.settings.concurrency_limit,
-    ))
+    );
+    Ok((availability, status))
 }
 
 pub(super) fn fail_if_no_default_runner_accepts_jobs(command: &LabOffloadCommand) -> Result<()> {
@@ -178,6 +180,7 @@ pub(super) fn fail_if_no_default_runner_accepts_jobs_with(
     Err(lab_runner_availability_error(
         command.hot_label,
         None,
+        None,
         eligible,
     ))
 }
@@ -185,6 +188,7 @@ pub(super) fn fail_if_no_default_runner_accepts_jobs_with(
 pub(super) fn lab_runner_availability_error(
     command_label: &str,
     selected: Option<&RunnerAvailability>,
+    selected_status: Option<&RunnerStatusReport>,
     eligible: Vec<RunnerAvailability>,
 ) -> Error {
     let selected_runner_id = selected.map(|availability| availability.runner_id.clone());
@@ -206,6 +210,21 @@ pub(super) fn lab_runner_availability_error(
         )
     };
 
+    let stale_daemon_recovery = selected_status
+        .and_then(|status| status.stale_daemon.as_ref())
+        .map(|warning| warning.refresh_command.clone());
+    let mut tried = vec![
+        "Wait for an active Lab runner job to finish, then retry.".to_string(),
+        "Choose another available runner with --runner <runner-id>.".to_string(),
+        "Inspect availability with `homeboy runner status <runner-id> --json`.".to_string(),
+    ];
+    if let Some(recovery) = stale_daemon_recovery.as_ref() {
+        tried.insert(
+            0,
+            format!("Refresh the connected stale runner: `{recovery}`."),
+        );
+    }
+
     Error::new(
         ErrorCode::ValidationInvalidArgument,
         format!("Invalid argument 'runner': {message}"),
@@ -218,11 +237,9 @@ pub(super) fn lab_runner_availability_error(
                 "eligible": eligible,
                 "reasons": reasons,
             },
-            "tried": [
-                "Wait for an active Lab runner job to finish, then retry.",
-                "Choose another available runner with --runner <runner-id>.",
-                "Inspect availability with `homeboy runner status <runner-id> --json`.",
-            ],
+            "runner_status": selected_status,
+            "stale_daemon_recovery_command": stale_daemon_recovery,
+            "tried": tried,
         }),
     )
 }

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -132,8 +132,8 @@ pub use execution::{
     RunnerExecPromotedOutput, RunnerExecStructuredSummary,
 };
 pub(crate) use execution::{
-    execute_runner_process_until_cancelled_with_progress, prepare_daemon_local_process,
-    RunnerProcessRequest,
+    exec_with_status_snapshot, execute_runner_process_until_cancelled_with_progress,
+    prepare_daemon_local_process, RunnerProcessRequest,
 };
 pub use execution::{RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV, RUNNER_PLACEMENT_RESOLVED_ENV};
 pub(crate) use extension_materialization::extension_source_content_hash;


### PR DESCRIPTION
## Summary
Carry the connected runner status selected during Lab preflight through inner execution so a second CWD-scoped lookup cannot reject the same live daemon as disconnected.

## What changed
- Return the authoritative RunnerStatusReport from Lab availability preflight and pass it into inner offload execution.
- Reuse the same status snapshot for remote exec instead of resolving another CWD-scoped runner session.
- Preserve stale-daemon reasons, build drift evidence, and the exact refresh/reconnect remediation when a connected runner is unavailable.
- Add deterministic regression coverage for conflicting CWD projections and retain disconnected-runner behavior.

## How to test
1. Run `cargo test -p homeboy-lab-runner lab::offload::tests::selection --lib`; expect all Lab selection and availability tests pass.
2. Run `cargo test -p homeboy-lab-runner inner_uses_authoritative_preflight_status_not_conflicting_cwd_projection --lib`; expect inner execution accepts the connected preflight snapshot rather than a conflicting later projection.
3. Run `cargo test -p homeboy-lab-runner refresh_execution_uses_the_connected_preflight_session_without_a_second_lookup --lib`; expect remote execution reuses the connected status snapshot.
4. Run `cargo fmt --check && git diff --check`; expect Rust formatting and patch whitespace checks pass.

## Compatibility
No CLI argument or output schema is removed. Connected runner handoffs stop re-resolving CWD-scoped session state; disconnected and stale-daemon fail-closed behavior remains, with more precise evidence.

## Evidence
- Base advanced after verification: verified main at d0a10b6984aa68dc9ec3d4a6a184b6ea4c0bc2de; publication observed 748adc813ccb8c80751d1bf600562b802dde9bb8. Candidate ancestry was validated against the verified snapshot.
- CI expected: Rust tests and checks
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8733
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8811
- Verified finalization base: main at d0a10b6984aa68dc9ec3d4a6a184b6ea4c0bc2de
- authoritative-status: Passed
- format: Passed
- selection-tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the CWD-scoped runner split view, implemented authoritative status propagation, and added deterministic regression coverage; Chris reviewed and owns the change.
