### PR TITLE
refactor: establish homeboy-observation-contract crate keystone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,6 +847,7 @@ dependencies = [
  "homeboy-lab-contract",
  "homeboy-lab-runner-contract",
  "homeboy-lifecycle-contract",
+ "homeboy-observation-contract",
  "homeboy-output",
  "homeboy-paths",
  "homeboy-process",
@@ -983,6 +984,14 @@ dependencies = [
 
 [[package]]
 name = "homeboy-lifecycle-contract"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "homeboy-observation-contract"
 version = "0.1.0"
 dependencies = [
  "serde",

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -28,6 +28,7 @@ homeboy-paths = { version = "0.1.0", path = "../homeboy-paths" }
 homeboy-process = { version = "0.1.0", path = "../homeboy-process" }
 homeboy-product-identity = { version = "0.1.0", path = "../homeboy-product-identity" }
 homeboy-audit-contract = { version = "0.1.0", path = "../homeboy-audit-contract" }
+homeboy-observation-contract = { version = "0.1.0", path = "../homeboy-observation-contract" }
 homeboy-refactor-contract = { version = "0.1.0", path = "../homeboy-refactor-contract" }
 homeboy-code-audit = { version = "0.1.0", path = "../homeboy-code-audit" }
 homeboy-extension-contract = { version = "0.1.0", path = "../homeboy-extension-contract" }

--- a/crates/homeboy-core/src/extension/bench/artifact.rs
+++ b/crates/homeboy-core/src/extension/bench/artifact.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::observation::ArtifactViewerLink;
+use homeboy_observation_contract::ArtifactViewerLink;
 
 /// Viewer pointers shared by bench artifact records and the compact
 /// artifact index. Embedded via `#[serde(flatten)]` so the on-wire JSON

--- a/crates/homeboy-core/src/extension/bench/artifact_persistence.rs
+++ b/crates/homeboy-core/src/extension/bench/artifact_persistence.rs
@@ -16,7 +16,8 @@ use crate::engine::run_dir::{self, RunDir};
 use crate::extension::bench::{
     BenchArtifact, BenchDiagnostic, BenchDiagnosticSource, BenchResults, BenchRunWorkflowResult,
 };
-use crate::observation::{finding_records_from_budget, ActiveObservation, ArtifactRecord};
+use crate::observation::{finding_records_from_budget, ActiveObservation};
+use homeboy_observation_contract::ArtifactRecord;
 
 /// Persist every bench artifact referenced by `workflow`'s results into the
 /// observation store, rewrite the results file with the recorded links, record

--- a/crates/homeboy-core/src/observation/records.rs
+++ b/crates/homeboy-core/src/observation/records.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::context::RunContext;
+pub use homeboy_observation_contract::{ArtifactRecord, ArtifactViewerLink};
 
 #[path = "finding_records.rs"]
 mod finding_records;
@@ -89,38 +90,6 @@ pub struct RunListFilter {
     pub limit: Option<i64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ArtifactRecord {
-    pub id: String,
-    pub run_id: String,
-    pub kind: String,
-    #[serde(rename = "type", default = "default_artifact_type")]
-    pub artifact_type: String,
-    pub path: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub public_url: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub viewer_url: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub viewer_links: Vec<ArtifactViewerLink>,
-    pub sha256: Option<String>,
-    pub size_bytes: Option<i64>,
-    pub mime: Option<String>,
-    #[serde(default)]
-    pub metadata_json: serde_json::Value,
-    pub created_at: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ArtifactViewerLink {
-    pub kind: String,
-    pub url: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub replay: Option<serde_json::Value>,
-}
-
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ArtifactCleanupFilter {
     pub created_before: Option<String>,
@@ -139,10 +108,6 @@ pub struct ArtifactCleanupCandidateRecord {
     pub component_id: Option<String>,
     pub run_started_at: String,
     pub run_status: String,
-}
-
-fn default_artifact_type() -> String {
-    "file".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/crates/homeboy-observation-contract/Cargo.toml
+++ b/crates/homeboy-observation-contract/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "homeboy-observation-contract"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Chris Huber <chubes@extrachill.com>"]
+description = "Shared observation record types for homeboy. Behavior-free data (artifact records + viewer links) that both homeboy-core's observation store and consumers like the extension bench report layer depend on, so they can carry observation records without depending on the observation store."
+repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
+
+[lib]
+name = "homeboy_observation_contract"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/crates/homeboy-observation-contract/src/lib.rs
+++ b/crates/homeboy-observation-contract/src/lib.rs
@@ -1,0 +1,47 @@
+//! Shared observation record types for homeboy.
+//!
+//! Behavior-free data describing recorded run artifacts. These live below core so
+//! consumers — the observation store that persists them and report layers like
+//! the extension bench commands that carry them — can share the vocabulary
+//! without depending on the observation store.
+
+use serde::{Deserialize, Serialize};
+
+/// A recorded artifact produced by a run: its identity, on-disk path, optional
+/// URLs/viewer links, and metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactRecord {
+    pub id: String,
+    pub run_id: String,
+    pub kind: String,
+    #[serde(rename = "type", default = "default_artifact_type")]
+    pub artifact_type: String,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub viewer_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub viewer_links: Vec<ArtifactViewerLink>,
+    pub sha256: Option<String>,
+    pub size_bytes: Option<i64>,
+    pub mime: Option<String>,
+    #[serde(default)]
+    pub metadata_json: serde_json::Value,
+    pub created_at: String,
+}
+
+/// A viewer link for a recorded artifact (e.g. a trace viewer or replay URL).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactViewerLink {
+    pub kind: String,
+    pub url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replay: Option<serde_json::Value>,
+}
+
+fn default_artifact_type() -> String {
+    "file".to_string()
+}


### PR DESCRIPTION
## Summary
Creates a new `homeboy-observation-contract` keystone crate and seeds it with the pure artifact-record type cluster: `ArtifactRecord` + `ArtifactViewerLink` (+ the `default_artifact_type` serde fn).

These are behavior-free serde types describing a recorded run artifact. They're carried by consumers like the **extension bench report layer**, which shouldn't have to depend on the observation store just for the record vocabulary.

## Why (keystone-first decoupling)
Same discipline as `homeboy-refactor-contract` (#8774): build the leaf contract below core, then drain type edges over time toward a future `homeboy-extension` extraction. `ArtifactRecord`'s only nested type is `ArtifactViewerLink` (moves with it); everything else is primitives — a clean, self-contained cluster.

## Effect
- New crate deps only `serde`/`serde_json` — pure leaf below core, no cycle.
- `homeboy-core` re-exports `crate::observation::{ArtifactRecord, ArtifactViewerLink}` so existing call sites are unchanged.
- Extension `bench/artifact.rs` (carries `Vec<ArtifactViewerLink>`) is **fully severed** from `crate::observation`.
- `bench/artifact_persistence.rs` takes `ArtifactRecord` from the contract too, keeping only its genuine `ActiveObservation` / finding-records behavior deps.
- Extension's `observation` edge drops from **13 files → 12**.

## Verification
- `cargo check -p homeboy-observation-contract --lib`, `-p homeboy-core --lib`, `-p homeboy-cli --lib` — 0 errors.
- `cargo check --workspace --tests --locked` (topology guard) — **passes**.
- `cargo test -p homeboy-core --lib observation::records` — **33 passed**.
- `git grep 'crate::observation'` in `extension/bench/artifact.rs` — **0 results**.

Refs #8425