### PR TITLE
refactor: move bench gate types + evaluation to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/bench/gate.rs
+++ b/crates/homeboy-core/src/extension/bench/gate.rs
@@ -2,89 +2,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::gate::{HomeboyGateKind, HomeboyGateResult, HomeboyGateStatus};
+pub use homeboy_extension_contract::bench_gate::{BenchGate, BenchGateOp, BenchGateResult};
 
 use super::budget_findings;
 use super::parsing::{BenchMetrics, BenchResults};
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub struct BenchGate {
-    pub metric: String,
-    pub op: BenchGateOp,
-    pub value: f64,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum BenchGateOp {
-    Eq,
-    Gte,
-    Lte,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub struct BenchGateResult {
-    pub metric: String,
-    pub op: BenchGateOp,
-    pub expected: f64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub actual: Option<f64>,
-    pub passed: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,
-}
-
-impl BenchGate {
-    pub(crate) fn evaluate(&self, scenario_id: &str, metrics: &BenchMetrics) -> BenchGateResult {
-        let actual = metrics.get(&self.metric);
-        self.evaluate_actual(&format!("scenario `{}`", scenario_id), actual)
-    }
-
-    pub fn evaluate_actual(&self, scope: &str, actual: Option<f64>) -> BenchGateResult {
-        let passed = actual
-            .map(|value| match self.op {
-                BenchGateOp::Eq => value == self.value,
-                BenchGateOp::Gte => value >= self.value,
-                BenchGateOp::Lte => value <= self.value,
-            })
-            .unwrap_or(false);
-        let reason = if passed {
-            None
-        } else {
-            Some(match actual {
-                Some(value) => format!(
-                    "{} gate failed: {} {} {} (actual {})",
-                    scope,
-                    self.metric,
-                    self.op.as_str(),
-                    self.value,
-                    value
-                ),
-                None => format!("{} gate failed: metric `{}` is missing", scope, self.metric),
-            })
-        };
-
-        BenchGateResult {
-            metric: self.metric.clone(),
-            op: self.op,
-            expected: self.value,
-            actual,
-            passed,
-            reason,
-        }
-    }
-}
-
-impl BenchGateOp {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            BenchGateOp::Eq => "eq",
-            BenchGateOp::Gte => "gte",
-            BenchGateOp::Lte => "lte",
-        }
-    }
-}
 
 /// Evaluate semantic gates in place and return every failure reason.
 pub fn evaluate_gates(results: &mut BenchResults) -> Vec<String> {

--- a/crates/homeboy-extension-contract/src/bench_gate.rs
+++ b/crates/homeboy-extension-contract/src/bench_gate.rs
@@ -1,0 +1,85 @@
+//! Pure bench gate contract types + their evaluation logic.
+
+use serde::{Deserialize, Serialize};
+
+use crate::BenchMetrics;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchGate {
+    pub metric: String,
+    pub op: BenchGateOp,
+    pub value: f64,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum BenchGateOp {
+    Eq,
+    Gte,
+    Lte,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchGateResult {
+    pub metric: String,
+    pub op: BenchGateOp,
+    pub expected: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actual: Option<f64>,
+    pub passed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl BenchGate {
+    pub fn evaluate(&self, scenario_id: &str, metrics: &BenchMetrics) -> BenchGateResult {
+        let actual = metrics.get(&self.metric);
+        self.evaluate_actual(&format!("scenario `{}`", scenario_id), actual)
+    }
+
+    pub fn evaluate_actual(&self, scope: &str, actual: Option<f64>) -> BenchGateResult {
+        let passed = actual
+            .map(|value| match self.op {
+                BenchGateOp::Eq => value == self.value,
+                BenchGateOp::Gte => value >= self.value,
+                BenchGateOp::Lte => value <= self.value,
+            })
+            .unwrap_or(false);
+        let reason = if passed {
+            None
+        } else {
+            Some(match actual {
+                Some(value) => format!(
+                    "{} gate failed: {} {} {} (actual {})",
+                    scope,
+                    self.metric,
+                    self.op.as_str(),
+                    self.value,
+                    value
+                ),
+                None => format!("{} gate failed: metric `{}` is missing", scope, self.metric),
+            })
+        };
+
+        BenchGateResult {
+            metric: self.metric.clone(),
+            op: self.op,
+            expected: self.value,
+            actual,
+            passed,
+            reason,
+        }
+    }
+}
+
+impl BenchGateOp {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BenchGateOp::Eq => "eq",
+            BenchGateOp::Gte => "gte",
+            BenchGateOp::Lte => "lte",
+        }
+    }
+}

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -13,6 +13,7 @@ pub mod action_types;
 pub mod autofix_config;
 pub mod bench_artifact;
 pub mod bench_diagnostics;
+pub mod bench_gate;
 pub mod bench_result;
 pub mod capability;
 pub use bench_artifact::{BenchArtifact, BenchArtifactViewer, BenchPreviewLifecycleMetadata};
@@ -20,6 +21,7 @@ pub use bench_diagnostics::{
     BenchDiagnostic, BenchDiagnosticSource, BenchPhaseEvent, BenchPhaseFailureClassification,
     BenchPhaseSummary,
 };
+pub use bench_gate::{BenchGate, BenchGateOp, BenchGateResult};
 pub use bench_result::{
     BenchChildCommandFailure, BenchMemory, BenchMetricDirection, BenchMetricPhase,
     BenchMetricPolicy, BenchMetrics, BenchProvenance, BenchProvenanceLink, BenchRunExecution,


### PR DESCRIPTION
## Summary
Continues the bench cluster breakdown. The three bench gate types (`BenchGate`, `BenchGateOp`, `BenchGateResult`) plus their evaluation impls (`BenchGate::evaluate`/`evaluate_actual`, `BenchGateOp::as_str`) move to the contract crate.

## Key finding
Although `bench/gate.rs` imports core's `HomeboyGate*` types, those are used **only** by the `evaluate_gates`/`normalized_gate_results` *functions* (which also consume `BenchResults` + `budget_findings`) — **not** by the gate type definitions or their impls.

The impls are pure: they only read `BenchMetrics` (already in contract), match on `BenchGateOp`, and format strings. So the types + impls move cleanly; the two core-coupled functions stay in core. No `core::gate` relocation needed.

## Changes
- New contract `bench_gate` module with the 3 types + 2 impls.
- Widened `BenchGate::evaluate` from `pub(crate)` to `pub` for cross-crate access.
- Core's `bench/gate.rs` re-imports the types (`pub use`), keeping the bench module re-export surface stable.

## Why
`BenchGate`/`BenchGateResult` are field dependencies of `BenchScenario` — another blocker cleared toward moving the top-level bench result cluster (`BenchResults`, `BenchScenario`, `BenchRunSnapshot`) into the contract crate.

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-issues`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)