### PR TITLE
refactor: move bench responsiveness types to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/bench/responsiveness.rs
+++ b/crates/homeboy-core/src/extension/bench/responsiveness.rs
@@ -4,28 +4,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::engine::resource::ExtensionChildResourceSummary;
 use crate::error::{Error, Result};
+pub use homeboy_extension_contract::bench_responsiveness::{
+    BenchFailureMemorySample, BenchResponsivenessSummary,
+};
 
 const DEFAULT_MISSED_PING_WINDOW_MS: u64 = 10_000;
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub struct BenchResponsivenessSummary {
-    pub missed_ping_count: u64,
-    pub max_ping_gap_ms: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_ping_at: Option<String>,
-    pub ping_count: u64,
-    pub missed_ping_window_ms: u64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub struct BenchFailureMemorySample {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sampled_peak_rss_bytes: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sampled_peak_cpu_percent: Option<f64>,
-}
 
 #[derive(Debug, Clone, Deserialize)]
 struct BenchResponsivenessPing {
@@ -33,12 +16,6 @@ struct BenchResponsivenessPing {
     at: Option<String>,
     #[serde(default)]
     t_ms: Option<u64>,
-}
-
-impl BenchResponsivenessSummary {
-    pub fn responsiveness_lost(&self) -> bool {
-        self.missed_ping_count > 0
-    }
 }
 
 pub fn missed_ping_window_ms() -> u64 {

--- a/crates/homeboy-extension-contract/src/bench_responsiveness.rs
+++ b/crates/homeboy-extension-contract/src/bench_responsiveness.rs
@@ -1,0 +1,29 @@
+//! Pure bench responsiveness/memory-sample contract types.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchResponsivenessSummary {
+    pub missed_ping_count: u64,
+    pub max_ping_gap_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_ping_at: Option<String>,
+    pub ping_count: u64,
+    pub missed_ping_window_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchFailureMemorySample {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sampled_peak_rss_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sampled_peak_cpu_percent: Option<f64>,
+}
+
+impl BenchResponsivenessSummary {
+    pub fn responsiveness_lost(&self) -> bool {
+        self.missed_ping_count > 0
+    }
+}

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -14,6 +14,7 @@ pub mod autofix_config;
 pub mod bench_artifact;
 pub mod bench_diagnostics;
 pub mod bench_gate;
+pub mod bench_responsiveness;
 pub mod bench_result;
 pub mod capability;
 pub use bench_artifact::{BenchArtifact, BenchArtifactViewer, BenchPreviewLifecycleMetadata};
@@ -22,6 +23,7 @@ pub use bench_diagnostics::{
     BenchPhaseSummary,
 };
 pub use bench_gate::{BenchGate, BenchGateOp, BenchGateResult};
+pub use bench_responsiveness::{BenchFailureMemorySample, BenchResponsivenessSummary};
 pub use bench_result::{
     BenchChildCommandFailure, BenchMemory, BenchMetricDirection, BenchMetricPhase,
     BenchMetricPolicy, BenchMetrics, BenchProvenance, BenchProvenanceLink, BenchRunExecution,


### PR DESCRIPTION
## Summary
Same data/behavior split as the gate cut (#8821). `BenchResponsivenessSummary` and `BenchFailureMemorySample` are pure serde types (all primitive fields) with a pure impl (`responsiveness_lost`).

The module's core dependencies (`ExtensionChildResourceSummary`, `Error`, `Path`, env-var reads) live **only** in the functions — `read_responsiveness_summary`, `summarize_responsiveness_pings`, `memory_sample`, `missed_ping_window_ms` — which stay in core. Core re-exports the types (`pub use`).

## Why
This clears the **last sibling field dependency of `BenchScenario`**. All of `BenchScenario`/`BenchRunSnapshot`'s field types (`BenchArtifact`, `BenchDiagnostic`, `BenchGate`/`BenchGateResult`, `BenchMetrics`, `BenchProvenance`, `BenchMemory`, `ObservationEvent`/`Span*`, and now the responsiveness types) are now in contract crates — setting up the move of the top-level bench result cluster.

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)