### PR TITLE
refactor: move ArtifactRecord to homeboy-lifecycle-contract (joins ArtifactViewerLink)

### DIFF
--- a/crates/homeboy-core/src/extension/bench/artifact_persistence.rs
+++ b/crates/homeboy-core/src/extension/bench/artifact_persistence.rs
@@ -16,7 +16,8 @@ use crate::engine::run_dir::{self, RunDir};
 use crate::extension::bench::{
     BenchArtifact, BenchDiagnostic, BenchDiagnosticSource, BenchResults, BenchRunWorkflowResult,
 };
-use crate::observation::{finding_records_from_budget, ActiveObservation, ArtifactRecord};
+use crate::observation::{finding_records_from_budget, ActiveObservation};
+use homeboy_lifecycle_contract::ArtifactRecord;
 
 /// Persist every bench artifact referenced by `workflow`'s results into the
 /// observation store, rewrite the results file with the recorded links, record

--- a/crates/homeboy-core/src/observation/records.rs
+++ b/crates/homeboy-core/src/observation/records.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::context::RunContext;
-pub use homeboy_lifecycle_contract::ArtifactViewerLink;
+pub use homeboy_lifecycle_contract::{ArtifactRecord, ArtifactViewerLink};
 
 #[path = "finding_records.rs"]
 mod finding_records;
@@ -90,30 +90,6 @@ pub struct RunListFilter {
     pub limit: Option<i64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ArtifactRecord {
-    pub id: String,
-    pub run_id: String,
-    pub kind: String,
-    #[serde(rename = "type", default = "default_artifact_type")]
-    pub artifact_type: String,
-    pub path: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub public_url: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub viewer_url: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub viewer_links: Vec<ArtifactViewerLink>,
-    pub sha256: Option<String>,
-    pub size_bytes: Option<i64>,
-    pub mime: Option<String>,
-    #[serde(default)]
-    pub metadata_json: serde_json::Value,
-    pub created_at: String,
-}
-
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ArtifactCleanupFilter {
     pub created_before: Option<String>,
@@ -132,10 +108,6 @@ pub struct ArtifactCleanupCandidateRecord {
     pub component_id: Option<String>,
     pub run_started_at: String,
     pub run_status: String,
-}
-
-fn default_artifact_type() -> String {
-    "file".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/crates/homeboy-lifecycle-contract/src/artifact_contract.rs
+++ b/crates/homeboy-lifecycle-contract/src/artifact_contract.rs
@@ -18,6 +18,37 @@ pub struct ArtifactViewerLink {
     pub replay: Option<serde_json::Value>,
 }
 
+/// A recorded artifact produced by a run: its identity, on-disk path, optional
+/// URLs/viewer links, and metadata. A behavior-free record type shared by the
+/// observation store that persists it and report layers that carry it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactRecord {
+    pub id: String,
+    pub run_id: String,
+    pub kind: String,
+    #[serde(rename = "type", default = "default_artifact_type")]
+    pub artifact_type: String,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub viewer_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub viewer_links: Vec<ArtifactViewerLink>,
+    pub sha256: Option<String>,
+    pub size_bytes: Option<i64>,
+    pub mime: Option<String>,
+    #[serde(default)]
+    pub metadata_json: serde_json::Value,
+    pub created_at: String,
+}
+
+fn default_artifact_type() -> String {
+    "file".to_string()
+}
+
 pub const ARTIFACT_CONTRACT_SCHEMA: &str = "homeboy/artifact-contract/v1";
 pub const EVIDENCE_CONTRACT_SCHEMA: &str = "homeboy/evidence-contract/v1";
 
@@ -162,10 +193,6 @@ fn artifact_contract_schema() -> String {
 
 fn evidence_contract_schema() -> String {
     EVIDENCE_CONTRACT_SCHEMA.to_string()
-}
-
-fn default_artifact_type() -> String {
-    "file".to_string()
 }
 
 fn normalize_optional_string(value: Option<String>) -> Option<String> {

--- a/crates/homeboy-lifecycle-contract/src/lib.rs
+++ b/crates/homeboy-lifecycle-contract/src/lib.rs
@@ -13,8 +13,8 @@ pub mod lifecycle;
 pub mod timeline;
 
 pub use artifact_contract::{
-    ArtifactContract, ArtifactViewerLink, EvidenceContract, ARTIFACT_CONTRACT_SCHEMA,
-    EVIDENCE_CONTRACT_SCHEMA,
+    ArtifactContract, ArtifactRecord, ArtifactViewerLink, EvidenceContract,
+    ARTIFACT_CONTRACT_SCHEMA, EVIDENCE_CONTRACT_SCHEMA,
 };
 pub use lifecycle::{
     LifecycleContract, LifecyclePhaseContract, LifecyclePhaseKind, LifecyclePhaseResult,


### PR DESCRIPTION
## Summary
`ArtifactRecord` is a pure serde record type describing a recorded run artifact. Its only nested type, `ArtifactViewerLink`, **already lives in `homeboy-lifecycle-contract::artifact_contract`** (moved there in a recent cut). Move `ArtifactRecord` alongside it rather than leaving the pair split across the crate boundary.

## Context
This replaces my closed #8820 (which created a redundant `homeboy-observation-contract`). While that was in flight, a parallel cut moved `ArtifactViewerLink` into `lifecycle-contract`, so the right move is to reunite `ArtifactRecord` with it there — not spin up a separate crate.

## Effect
- `lifecycle-contract`'s `artifact_contract` gains `ArtifactRecord` (reusing the `default_artifact_type` fn already present there); `lib.rs` re-exports it.
- `homeboy-core` re-exports `crate::observation::{ArtifactRecord, ArtifactViewerLink}` from the contract, so the ~58 `ArtifactRecord` call sites are unchanged.
- Extension `bench/artifact_persistence.rs` takes `ArtifactRecord` from the contract directly, **reducing its `crate::observation` edge** (keeps only its genuine `ActiveObservation` / finding-records behavior deps).

Reunites the artifact-record vocabulary in one contract crate.

## Verification
- `cargo check -p homeboy-lifecycle-contract --lib`, `-p homeboy-core --lib`, `-p homeboy-cli --lib` — 0 errors.
- `cargo check --workspace --tests --locked` (topology guard) — **passes**.
- `cargo test -p homeboy-lifecycle-contract --lib` — 13 passed; `homeboy-core observation::records` — 33 passed.

Refs #8425