### PR TITLE
refactor: sever extension->refactor prod edges (homeboy-refactor extraction prep)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,7 @@ dependencies = [
  "homeboy-process",
  "homeboy-product-identity",
  "homeboy-redaction",
+ "homeboy-refactor-contract",
  "homeboy-triage",
  "homeboy-tunnel",
  "libc",

--- a/crates/homeboy-cli/Cargo.toml
+++ b/crates/homeboy-cli/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 [dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
 homeboy-agents = { version = "0.1.0", path = "../homeboy-agents" }
+homeboy-refactor-contract = { version = "0.1.0", path = "../homeboy-refactor-contract" }
 homeboy-lab-runner = { version = "0.1.0", path = "../homeboy-lab-runner" }
 homeboy-fuzz = { version = "0.1.0", path = "../homeboy-fuzz" }
 homeboy-issues = { version = "0.1.0", path = "../homeboy-issues" }

--- a/crates/homeboy-cli/src/commands/lint.rs
+++ b/crates/homeboy-cli/src/commands/lint.rs
@@ -7,6 +7,22 @@ use homeboy::core::extension::lint::{
 };
 use homeboy::core::extension::ExtensionCapability;
 use homeboy::core::git;
+
+/// Build the slim `LintFixInput` the core lint report consumes from a full
+/// refactor source-run, so core does not depend on the refactor engine's
+/// `RefactorSourceRun` type.
+fn lint_fix_input(
+    run: &homeboy::core::refactor::plan::RefactorSourceRun,
+) -> homeboy_refactor_contract::LintFixInput {
+    homeboy_refactor_contract::LintFixInput {
+        applied: run.applied,
+        files_modified: run.files_modified,
+        changed_files: run.changed_files.clone(),
+        hints: run.hints.clone(),
+        warnings: run.warnings.clone(),
+        fix_summary: run.fix_summary.clone(),
+    }
+}
 use homeboy::core::observation::{
     finding_records_from_lint, merge_metadata, ActiveObservation, NewFindingRecord, NewRunRecord,
     RunStatus,
@@ -493,7 +509,7 @@ fn run_fix(
 
     let run = collect_refactor_sources(request)?;
 
-    Ok(report::from_lint_fix(component_label, run))
+    Ok(report::from_lint_fix(component_label, lint_fix_input(&run)))
 }
 
 #[cfg(test)]
@@ -650,7 +666,8 @@ mod tests {
         // The contract under #1507: autofixable findings never fail the run.
         // Even when --fix actually modifies files, the lint command exits 0.
         let run = fixture_refactor_run(true, 3);
-        let (output, exit_code) = report::from_lint_fix("demo".to_string(), run);
+        let (output, exit_code) =
+            report::from_lint_fix("demo".to_string(), super::lint_fix_input(&run));
 
         assert_eq!(exit_code, 0);
         assert!(output.passed);
@@ -675,7 +692,8 @@ mod tests {
         // When no autofixable findings exist, --fix is a clean no-op:
         // exit 0, no autofix changes reported, friendly hint.
         let run = fixture_refactor_run(false, 0);
-        let (output, exit_code) = report::from_lint_fix("demo".to_string(), run);
+        let (output, exit_code) =
+            report::from_lint_fix("demo".to_string(), super::lint_fix_input(&run));
 
         assert_eq!(exit_code, 0);
         assert!(output.passed);

--- a/crates/homeboy-core/src/extension/lint/report.rs
+++ b/crates/homeboy-core/src/extension/lint/report.rs
@@ -11,8 +11,8 @@ use crate::extension::{
     PhaseFailureCategory, PhaseReport, VerificationPhase,
 };
 use crate::finding::{FindingProducerSummary, HomeboyFinding};
-use crate::refactor::plan::RefactorSourceRun;
 use homeboy_refactor_contract::AppliedRefactor;
+use homeboy_refactor_contract::LintFixInput;
 use serde::Serialize;
 use serde_json::Value;
 
@@ -165,7 +165,7 @@ fn producer_summary_label(producer_summaries: &[FindingProducerSummary]) -> Stri
 /// Build a [`LintCommandOutput`] from a `homeboy review lint --fix` dispatch.
 ///
 /// `--fix` is a thin alias for `homeboy refactor <component> --from lint
-/// --write`, so the fix path receives a `RefactorSourceRun` rather than the
+/// --write`, so the fix path receives a `LintFixInput` (slim view) rather than the
 /// usual lint workflow result. We surface the applied autofix via the existing
 /// `autofix` field on `LintCommandOutput` so consumers see a consistent shape
 /// regardless of which mode was requested.
@@ -173,7 +173,7 @@ fn producer_summary_label(producer_summaries: &[FindingProducerSummary]) -> Stri
 /// Exit code semantics: autofixable findings should never fail the run, so
 /// the fix dispatch returns exit 0 even when fixes were applied. Real fixer
 /// errors propagate through `Result` and never reach this builder.
-pub fn from_lint_fix(component_label: String, run: RefactorSourceRun) -> (LintCommandOutput, i32) {
+pub fn from_lint_fix(component_label: String, run: LintFixInput) -> (LintCommandOutput, i32) {
     let exit_code = 0;
     let phase = PhaseReport {
         phase: VerificationPhase::Lint,

--- a/crates/homeboy-core/src/extension/test/workflow.rs
+++ b/crates/homeboy-core/src/extension/test/workflow.rs
@@ -4,10 +4,6 @@ use crate::extension::test::resolve_drift_options;
 use crate::extension::test::TestScopeOutput;
 use crate::extension::test::{ChangeType, TestAnalysis};
 use crate::extension::test::{TestBaselineComparison, TestCounts};
-use crate::refactor::{
-    self,
-    auto::{self, AutofixMode},
-};
 use homeboy_refactor_contract::{AppliedRefactor, TransformSet};
 use serde::Serialize;
 
@@ -205,15 +201,18 @@ pub fn auto_fix_test_drift(
     let output = if rules.is_empty() {
         crate::log_status!("test", "No auto-fixable drift detected. Nothing to apply.");
 
-        AutoFixDriftOutput {
-            since: since.to_string(),
-            auto_fixable_changes: drift_report.auto_fixable,
-            generated_rules: 0,
-            replacements: 0,
-            files_modified: 0,
-            written: write,
-            rerun_recommended: false,
-        }
+        (
+            AutoFixDriftOutput {
+                since: since.to_string(),
+                auto_fixable_changes: drift_report.auto_fixable,
+                generated_rules: 0,
+                replacements: 0,
+                files_modified: 0,
+                written: write,
+                rerun_recommended: false,
+            },
+            Vec::new(),
+        )
     } else {
         let set = TransformSet {
             description: format!(
@@ -222,27 +221,34 @@ pub fn auto_fix_test_drift(
             ),
             rules,
         };
+        let generated_rules = set.rules.len();
 
-        let result = refactor::apply_transforms(
+        // Applying transforms + formatting the autofix outcome is refactor-engine
+        // behavior, inverted behind the refactor transform provider hook so the
+        // extension does not depend on the refactor feature layer.
+        let summary = crate::refactor_transform_provider::apply_transform_set(
             &source_path,
             "test_auto_fix_drift",
             &set,
             write,
-            None,
-            Some(refactor::DEFAULT_MATCH_DETAIL_LIMIT),
+            Some(format!("homeboy review test {} --analyze", component_id)),
+            vec![format!(
+                "Use --since <ref> to target a drift window (current: {})",
+                since
+            )],
         )?;
 
         crate::log_status!(
             "test",
             "Applied {} replacement{} across {} file{}",
-            result.total_replacements,
-            if result.total_replacements == 1 {
+            summary.total_replacements,
+            if summary.total_replacements == 1 {
                 ""
             } else {
                 "s"
             },
-            result.total_files,
-            if result.total_files == 1 { "" } else { "s" },
+            summary.total_files,
+            if summary.total_files == 1 { "" } else { "s" },
         );
 
         if !write {
@@ -250,7 +256,7 @@ pub fn auto_fix_test_drift(
                 "hint",
                 "Dry-run only. Re-run with --write to apply generated fixes."
             );
-        } else if result.total_replacements > 0 {
+        } else if summary.total_replacements > 0 {
             crate::log_status!(
                 "hint",
                 "Re-run tests: homeboy review test {} --analyze",
@@ -258,38 +264,25 @@ pub fn auto_fix_test_drift(
             );
         }
 
-        AutoFixDriftOutput {
-            since: since.to_string(),
-            auto_fixable_changes: drift_report.auto_fixable,
-            generated_rules: set.rules.len(),
-            replacements: result.total_replacements,
-            files_modified: result.total_files,
-            written: write,
-            rerun_recommended: write && result.total_replacements > 0,
-        }
+        (
+            AutoFixDriftOutput {
+                since: since.to_string(),
+                auto_fixable_changes: drift_report.auto_fixable,
+                generated_rules,
+                replacements: summary.total_replacements,
+                files_modified: summary.total_files,
+                written: write,
+                rerun_recommended: summary.rerun_recommended,
+            },
+            summary.hints,
+        )
     };
-
-    let outcome = auto::standard_outcome(
-        if write {
-            AutofixMode::Write
-        } else {
-            AutofixMode::DryRun
-        },
-        output.replacements,
-        Some(format!("homeboy review test {} --analyze", component_id)),
-        vec![format!(
-            "Use --since <ref> to target a drift window (current: {})",
-            since
-        )],
-    );
+    let (output, outcome_hints) = output;
 
     Ok(AutoFixDriftWorkflowResult {
         component: component_id.to_string(),
-        output: AutoFixDriftOutput {
-            rerun_recommended: outcome.rerun_recommended,
-            ..output
-        },
-        hints: outcome.hints,
+        output,
+        hints: outcome_hints,
         report: if include_report {
             Some(drift_report)
         } else {

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -149,6 +149,7 @@ pub mod quality;
 // existing `crate::redaction::*` call sites keep working unchanged.
 pub use homeboy_redaction as redaction;
 pub mod refactor;
+pub mod refactor_transform_provider;
 pub mod release;
 pub mod release_set;
 pub mod report_compare;

--- a/crates/homeboy-core/src/refactor_transform_provider.rs
+++ b/crates/homeboy-core/src/refactor_transform_provider.rs
@@ -1,0 +1,94 @@
+//! Refactor transform-application hook.
+//!
+//! The extension test-drift auto-fixer generates a set of transform rules and
+//! applies them to a component's sources. Applying transforms (regex-based
+//! source edits) and formatting the autofix outcome is the refactor engine's
+//! job, so it is inverted behind this provider: the extension layer owns drift
+//! detection and rule generation, the refactor layer applies the transforms.
+//!
+//! With no provider registered (no refactor layer present) the no-op applies
+//! nothing.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use homeboy_refactor_contract::TransformSet;
+
+use crate::Result;
+
+/// The slim result of applying a transform set, as the extension test-drift
+/// workflow consumes it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AppliedTransformSummary {
+    pub total_replacements: usize,
+    pub total_files: usize,
+    pub rerun_recommended: bool,
+    pub hints: Vec<String>,
+}
+
+/// Applies a transform set to a component's sources.
+pub trait RefactorTransformProvider: Send + Sync {
+    /// Apply `set` under `root`, writing changes when `write` is true, and
+    /// return a slim summary. `rerun_hint` / `extra_hints` shape the outcome
+    /// hints the caller surfaces.
+    fn apply_transform_set(
+        &self,
+        root: &Path,
+        name: &str,
+        set: &TransformSet,
+        write: bool,
+        rerun_hint: Option<String>,
+        extra_hints: Vec<String>,
+    ) -> Result<AppliedTransformSummary>;
+}
+
+struct NoopProvider;
+
+impl RefactorTransformProvider for NoopProvider {
+    fn apply_transform_set(
+        &self,
+        _root: &Path,
+        _name: &str,
+        _set: &TransformSet,
+        _write: bool,
+        _rerun_hint: Option<String>,
+        _extra_hints: Vec<String>,
+    ) -> Result<AppliedTransformSummary> {
+        Ok(AppliedTransformSummary::default())
+    }
+}
+
+fn provider_slot() -> &'static Mutex<Option<Box<dyn RefactorTransformProvider>>> {
+    static PROVIDER: Mutex<Option<Box<dyn RefactorTransformProvider>>> = Mutex::new(None);
+    &PROVIDER
+}
+
+/// Register the refactor transform provider. Called once at startup by the
+/// refactor layer.
+pub fn register_refactor_transform_provider(provider: Box<dyn RefactorTransformProvider>) {
+    let mut slot = provider_slot()
+        .lock()
+        .expect("refactor transform provider lock");
+    *slot = Some(provider);
+}
+
+/// Apply a transform set via the registered provider (or the no-op when the
+/// refactor layer is absent).
+pub(crate) fn apply_transform_set(
+    root: &Path,
+    name: &str,
+    set: &TransformSet,
+    write: bool,
+    rerun_hint: Option<String>,
+    extra_hints: Vec<String>,
+) -> Result<AppliedTransformSummary> {
+    let slot = provider_slot()
+        .lock()
+        .expect("refactor transform provider lock");
+    match slot.as_deref() {
+        Some(provider) => {
+            provider.apply_transform_set(root, name, set, write, rerun_hint, extra_hints)
+        }
+        None => NoopProvider.apply_transform_set(root, name, set, write, rerun_hint, extra_hints),
+    }
+}

--- a/crates/homeboy-refactor-contract/src/lib.rs
+++ b/crates/homeboy-refactor-contract/src/lib.rs
@@ -92,3 +92,23 @@ fn default_files_glob() -> String {
 fn default_context() -> String {
     "line".to_string()
 }
+
+/// Slim view of a refactor source-run, as the extension lint-command report
+/// layer consumes it when formatting `refactor --from lint --write` output.
+///
+/// Carries only the fields the lint report reads, so `homeboy-core` can format
+/// the report without depending on the refactor engine's full `RefactorSourceRun`
+/// type. The refactor layer (via the CLI) builds this from its run result.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LintFixInput {
+    pub applied: bool,
+    pub files_modified: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed_files: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hints: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fix_summary: Option<FixResultsSummary>,
+}


### PR DESCRIPTION
## Summary
First prep-PR for extracting the **refactor engine** (~22.7k LOC) into its own `homeboy-refactor` crate — the next core-subsystem boundary after agents/runner/code-audit.

The refactor engine (`homeboy refactor` command: rename/decompose/move-items/autofix) is a clean feature-up candidate: **only 2 prod upward edges**, no other feature-crate deps, and the one potential cycle (`refactor ↔ code_audit`) was already inverted via the fixability hook when code_audit extracted.

Both prod edges are in the extension subsystem (which stays in core), so they'd cycle once refactor moves above core. This PR severs them.

## What changed
1. **`extension/test/workflow.rs`** (`auto_fix_test_drift`) called `refactor::apply_transforms` + `auto::standard_outcome`. Inverted behind a **`RefactorTransformProvider`** hook: the extension owns drift detection + rule generation and passes the (already-contract) `TransformSet` to the hook; the refactor layer applies the transforms and returns a slim `AppliedTransformSummary` (replacements/files/rerun/hints).
2. **`extension/lint/report.rs`** (`from_lint_fix`) took a refactor `RefactorSourceRun`. Added a slim **`LintFixInput`** to `homeboy-refactor-contract` (the 6 fields the lint report reads); cli builds it from its `RefactorSourceRun` via a helper.

## Effect
- `extension/lint/report.rs` + `extension/test/workflow.rs`: `crate::refactor` refs → **0**.
- Only remaining core→refactor edge is test-only (`engine/symbol_graph.rs`), which resolves at the wholesale git-mv.

## Verification
- `cargo check --workspace --tests`: **green**.
- `cargo fmt`: clean.