### PR TITLE
Wait for contended Lab reconnect handoffs

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
+++ b/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
@@ -1,6 +1,6 @@
 use super::super::lab_selection::{
-    prepare_lab_runner_for_offload_with, wait_for_contended_runner, LabRunnerPreparation,
-    LabRunnerSelection,
+    contended_runner_unavailable_error, prepare_lab_runner_for_offload_with,
+    wait_for_contended_runner, LabRunnerPreparation, LabRunnerSelection,
 };
 use super::*;
 use crate::{RunnerActiveJobState, RunnerConnectReport, RunnerStatusReport, RunnerTunnelMode};
@@ -384,31 +384,45 @@ fn concurrent_unreachable_health_handoffs_connect_once() {
 fn lease_contender_waits_for_owner_session_without_a_second_connect() {
     use std::sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
-        Arc,
+        Arc, Barrier,
     };
 
     let connected = Arc::new(AtomicBool::new(false));
     let connects = Arc::new(AtomicUsize::new(0));
+    let handoff_start = Arc::new(Barrier::new(2));
     let owner_connected = Arc::clone(&connected);
     let owner_connects = Arc::clone(&connects);
+    let owner_start = Arc::clone(&handoff_start);
     let owner = std::thread::spawn(move || {
+        owner_start.wait();
         owner_connects.fetch_add(1, Ordering::SeqCst);
         std::thread::sleep(std::time::Duration::from_millis(75));
         owner_connected.store(true, Ordering::SeqCst);
     });
 
-    // This is the contender branch after RuntimePromotionLease::acquire reports
-    // another process owns the reconnect transaction.
-    let lease_error = contention_error();
-    let session = wait_for_contended_runner(lease_error, std::time::Duration::from_secs(1), |_| {
-        Ok(connected.load(Ordering::SeqCst).then(|| {
-            connected_direct_session("lab-lease-contention", Some("http://127.0.0.1:63378"))
-        }))
-    })
-    .expect("wait succeeds")
-    .expect("owner publishes a healthy session");
+    let contender_connected = Arc::clone(&connected);
+    let contender_start = Arc::clone(&handoff_start);
+    let contender = std::thread::spawn(move || {
+        contender_start.wait();
+        // This is the contender handoff after RuntimePromotionLease::acquire
+        // reports that the owner is reconnecting the shared runner.
+        let session = wait_for_contended_runner(
+            contention_error(),
+            std::time::Duration::from_secs(1),
+            |_| {
+                Ok(contender_connected.load(Ordering::SeqCst).then(|| {
+                    connected_direct_session("lab-lease-contention", Some("http://127.0.0.1:63378"))
+                }))
+            },
+        )
+        .expect("wait succeeds")
+        .expect("owner publishes a healthy session");
+
+        session
+    });
 
     owner.join().expect("owner");
+    let session = contender.join().expect("contender handoff");
     assert_eq!(session.runner_id, "lab-lease-contention");
     assert_eq!(connects.load(Ordering::SeqCst), 1);
 }
@@ -443,6 +457,24 @@ fn contended_session_wait_obeys_the_deadline() {
 
     assert!(result.is_none());
     assert!(started.elapsed() < std::time::Duration::from_millis(750));
+}
+
+#[test]
+fn contended_handoff_failure_preserves_reconnect_lease_evidence() {
+    let error = contended_runner_unavailable_error("lab", contention_error());
+
+    assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+    assert_eq!(error.details["reconnect_lease"]["holder_pid"], 42);
+    assert!(error
+        .message
+        .contains("another controller owned its reconnect lease"));
+    assert!(error.details["tried"]
+        .as_array()
+        .expect("remediation list")
+        .iter()
+        .any(|hint| hint
+            .as_str()
+            .is_some_and(|hint| hint.contains("Waited 30s"))));
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -50,6 +50,9 @@ pub(super) enum LabRunnerPreparation {
 static HANDOFF_CONNECT_LOCKS: OnceLock<Mutex<std::collections::BTreeMap<String, Arc<Mutex<()>>>>> =
     OnceLock::new();
 const HANDOFF_CONNECT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+// A reconnect owner and its contending handoff share this bounded window. The
+// owner's short automatic-connect timeout remains separate from admission.
+const HANDOFF_ADMISSION_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub(super) fn prepare_lab_runner_for_offload(
     selection: &LabRunnerSelection,
@@ -251,43 +254,27 @@ fn connect_runner_for_offload(
     // Serialize with other controller processes before replacing a direct-SSH
     // session. The child `runner connect` receives this lease capability.
     let timeout = lab_connect_timeout(source);
-    let lease = match homeboy_core::runtime_promotion::acquire(
-        "Lab runner handoff",
-        runner_id.to_string(),
-    ) {
-        Ok(lease) => lease,
-        Err(lease_error) => {
-            if let Some(session) =
-                wait_for_contended_runner(lease_error.clone(), timeout, |remaining| {
-                    crate::local_live_session(runner_id, remaining)
-                })?
-            {
-                return connected_runner_connect_report_from_session(
-                    runner_id,
-                    session,
-                    homeboy_core::paths::runner_session_file(runner_id)?
-                        .display()
-                        .to_string(),
-                );
+    let lease =
+        match homeboy_core::runtime_promotion::acquire("Lab runner handoff", runner_id.to_string())
+        {
+            Ok(lease) => lease,
+            Err(lease_error) => {
+                if let Some(session) = wait_for_contended_runner(
+                    lease_error.clone(),
+                    HANDOFF_ADMISSION_TIMEOUT,
+                    |remaining| crate::local_live_session(runner_id, remaining),
+                )? {
+                    return connected_runner_connect_report_from_session(
+                        runner_id,
+                        session,
+                        homeboy_core::paths::runner_session_file(runner_id)?
+                            .display()
+                            .to_string(),
+                    );
+                }
+                return Err(contended_runner_unavailable_error(runner_id, lease_error));
             }
-            return Err(Error::validation_invalid_argument(
-                "runner",
-                format!(
-                    "Lab runner `{runner_id}` remained unavailable while another controller owned its reconnect lease: {}",
-                    lease_error.message
-                ),
-                Some(runner_id.to_string()),
-                Some(vec![
-                    format!(
-                        "Waited {}s for the reconnect owner to publish a healthy session; it did not complete.",
-                        timeout.as_secs()
-                    ),
-                    format!("Inspect `homeboy runner status {runner_id} --json` before retrying."),
-                    format!("Inspect `homeboy runner doctor {runner_id}` if the daemon remains unreachable."),
-                ]),
-            ));
-        }
-    };
+        };
     if let Ok(report) = status(runner_id) {
         if report.connected {
             return connected_runner_connect_report(runner_id, report);
@@ -341,6 +328,30 @@ fn connect_runner_for_offload(
         },
         exit_code,
     ))
+}
+
+pub(super) fn contended_runner_unavailable_error(runner_id: &str, lease_error: Error) -> Error {
+    Error::new(
+        ErrorCode::ValidationInvalidArgument,
+        format!(
+            "Lab runner `{runner_id}` remained unavailable while another controller owned its reconnect lease: {}",
+            lease_error.message
+        ),
+        serde_json::json!({
+            "field": "runner",
+            "problem": "a contended reconnect did not publish a healthy runner session before the admission deadline",
+            "id": runner_id,
+            "reconnect_lease": lease_error.details,
+            "tried": [
+                format!(
+                    "Waited {}s for the reconnect owner to publish a healthy session; it did not complete.",
+                    HANDOFF_ADMISSION_TIMEOUT.as_secs()
+                ),
+                format!("Inspect `homeboy runner status {runner_id} --json` before retrying."),
+                format!("Inspect `homeboy runner doctor {runner_id}` if the daemon remains unreachable."),
+            ],
+        }),
+    )
 }
 
 pub(super) fn wait_for_contended_runner<Session>(


### PR DESCRIPTION
## Summary
- give contended Lab reconnect admission a bounded 30-second shared window instead of reusing the three-second automatic-connect timeout
- adopt the healthy session published by the reconnect owner without starting a second daemon
- preserve structured reconnect lease evidence when the owner never publishes a usable session

Fixes #8822.

## How to test
1. Run `cargo test -p homeboy-lab-runner lab::preparation_tests:: --lib` and confirm all 15 preparation tests pass.
2. Run `cargo check -p homeboy-lab-runner` and confirm the package checks successfully.
3. Run `cargo fmt --check` and confirm formatting passes.
4. Run `git diff --check origin/main...HEAD` and confirm the patch has no whitespace errors.

## Compatibility
No CLI argument or output schema is removed. A contending Lab handoff may now wait up to 30 seconds for the reconnect owner instead of failing after the short automatic-connect window. Non-contention failures and deadline expiry remain fail-closed.

## Evidence bounds
- Change kind: runtime fix
- Evidence discriminator: `RuntimePromotionContended` for the same Lab runner handoff target
- Preserved contract: non-contention lease failures are not retried
- Preserved contract: deadline expiry retains lease details and actionable runner diagnostics

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the blocked Homeboy control plane, prepared and reviewed the reconnect contention repair, and added deterministic tests. Chris reviewed and owns the change.