### PR TITLE
refactor: move trace preview metadata types to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/trace/preview.rs
+++ b/crates/homeboy-core/src/extension/trace/preview.rs
@@ -8,96 +8,15 @@ use std::time::Duration;
 
 use crate::error::{Error, Result};
 use crate::rig::{TraceNativePublicPreviewSpec, TracePublicPreviewMode, TracePublicPreviewSpec};
+pub use homeboy_extension_contract::trace_preview::{
+    TracePreviewAssetCheck, TracePreviewAssetFanoutReport, TracePreviewAssetFanoutRequest,
+    TracePreviewLogPaths, TracePreviewMetadata,
+};
 
 const DEFAULT_STARTUP_TIMEOUT_SECONDS: u64 = 20;
 const DEFAULT_ASSET_CHECK_TIMEOUT_SECONDS: u64 = 10;
 const DEFAULT_ASSET_FANOUT_CONCURRENCY: usize = 16;
 const DEFAULT_ASSET_FANOUT_REPEAT_COUNT: usize = 1;
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct TracePreviewAssetCheck {
-    pub path: String,
-    pub url: String,
-    pub status: Option<u16>,
-    pub ok: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct TracePreviewAssetFanoutRequest {
-    pub path: String,
-    pub url: String,
-    pub status: Option<u16>,
-    pub ok: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub failure_bucket: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct TracePreviewAssetFanoutReport {
-    pub schema: String,
-    pub concurrency: usize,
-    pub repeat_count: usize,
-    pub asset_path_count: usize,
-    pub expected_request_count: usize,
-    pub client_request_count: usize,
-    pub success_count: usize,
-    pub failure_count: usize,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ingress_request_count: Option<usize>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub local_origin_request_count: Option<usize>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub status_counts: BTreeMap<String, usize>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub failure_buckets: BTreeMap<String, usize>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub requests: Vec<TracePreviewAssetFanoutRequest>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct TracePreviewMetadata {
-    pub schema: String,
-    pub requested_mode: String,
-    pub provider: String,
-    pub local_origin: String,
-    pub local_url: String,
-    pub public_origin: String,
-    pub public_url: String,
-    pub browser_effective_origin: String,
-    pub window_location_origin: String,
-    pub window_is_secure_context: bool,
-    pub require_https: bool,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub required_assets: Vec<TracePreviewAssetCheck>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub asset_fanout: Option<TracePreviewAssetFanoutReport>,
-    pub status: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub process_id: Option<String>,
-    pub cleanup_status: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub session_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub public_host: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ingress_url: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub client_command: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub log_paths: Option<TracePreviewLogPaths>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct TracePreviewLogPaths {
-    pub client_stdout_path: String,
-    pub client_stderr_path: String,
-}
 
 pub struct TracePublicPreviewSession {
     child: Option<Child>,

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -64,6 +64,7 @@ pub use manifest::ExtensionManifest;
 pub mod source_metadata_repair;
 pub mod test_drift;
 pub mod trace_config;
+pub mod trace_preview;
 pub mod update_output;
 pub mod version;
 

--- a/crates/homeboy-extension-contract/src/trace_preview.rs
+++ b/crates/homeboy-extension-contract/src/trace_preview.rs
@@ -1,0 +1,89 @@
+//! Pure trace preview metadata contract types.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TracePreviewAssetCheck {
+    pub path: String,
+    pub url: String,
+    pub status: Option<u16>,
+    pub ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TracePreviewAssetFanoutRequest {
+    pub path: String,
+    pub url: String,
+    pub status: Option<u16>,
+    pub ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_bucket: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TracePreviewAssetFanoutReport {
+    pub schema: String,
+    pub concurrency: usize,
+    pub repeat_count: usize,
+    pub asset_path_count: usize,
+    pub expected_request_count: usize,
+    pub client_request_count: usize,
+    pub success_count: usize,
+    pub failure_count: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ingress_request_count: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_origin_request_count: Option<usize>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub status_counts: BTreeMap<String, usize>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub failure_buckets: BTreeMap<String, usize>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requests: Vec<TracePreviewAssetFanoutRequest>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct TracePreviewMetadata {
+    pub schema: String,
+    pub requested_mode: String,
+    pub provider: String,
+    pub local_origin: String,
+    pub local_url: String,
+    pub public_origin: String,
+    pub public_url: String,
+    pub browser_effective_origin: String,
+    pub window_location_origin: String,
+    pub window_is_secure_context: bool,
+    pub require_https: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_assets: Vec<TracePreviewAssetCheck>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub asset_fanout: Option<TracePreviewAssetFanoutReport>,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process_id: Option<String>,
+    pub cleanup_status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_host: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ingress_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log_paths: Option<TracePreviewLogPaths>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct TracePreviewLogPaths {
+    pub client_stdout_path: String,
+    pub client_stderr_path: String,
+}


### PR DESCRIPTION
## Summary
Clears **one of the two `TraceResults` blockers**. The `TracePreviewMetadata` type closure (`TracePreviewMetadata`, `TracePreviewAssetCheck`, `TracePreviewAssetFanoutReport`, `TracePreviewAssetFanoutRequest`, `TracePreviewLogPaths`) is fully self-contained — **0 impls, no custom serde helpers**, external refs are only `BTreeMap`/`Option`/`String`.

## The data/behavior split
`trace/preview.rs` *looked* entangled because it imports `crate::rig::{TracePublicPreviewSpec, ...}`. But those rig types are used **only in the preview-launch functions** (`start`, `start_external`, `start_homeboy_native`), not in the metadata type definitions. So the types move to the contract crate; the launch functions stay in core.

## Zero downstream churn
Core re-exports the moved types, so all trace preview paths stay stable.

## Progress
This clears `TracePreviewMetadata` — one of `TraceResults`' two remaining core dependencies. The other is `RigStateSnapshot` (`crate::rig`). Once both clear, `TraceResults` and the `baseline` cluster can move wholesale, collapsing the ~45-ref trace reverse-edge surface (the same way the bench cluster went 58 → 4).

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)