### PR TITLE
Make runner and placement selection mutually exclusive

### DIFF
--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -48,9 +48,16 @@ pub struct Cli {
     )]
     pub notification_route: Option<String>,
 
-    /// Select where eligible work executes. `auto` uses the command contract,
-    /// controller pressure, and ready Lab capacity.
-    #[arg(long, global = true, value_enum, default_value_t = Placement::Auto)]
+    /// Select where eligible work executes without pinning a runner. `auto` uses
+    /// the command contract, controller pressure, and ready Lab capacity. Use
+    /// `--runner <id>` instead to pin a connected Lab runner.
+    #[arg(
+        long,
+        global = true,
+        value_enum,
+        default_value_t = Placement::Auto,
+        conflicts_with = "runner"
+    )]
     pub placement: Placement,
 
     /// Return after a runner daemon accepts the job instead of waiting for remote completion.
@@ -62,8 +69,14 @@ pub struct Cli {
     #[arg(long, global = true, value_name = "DIR")]
     pub artifact_root: Option<PathBuf>,
 
-    /// Route commands with portable Lab offload support to a connected runner.
-    #[arg(long, global = true, value_name = "RUNNER_ID")]
+    /// Pin portable work to a connected Lab runner. This implies Lab placement;
+    /// use `--placement <policy>` instead to select placement without pinning.
+    #[arg(
+        long,
+        global = true,
+        value_name = "RUNNER_ID",
+        conflicts_with = "placement"
+    )]
     pub runner: Option<String>,
 
     /// Permit Lab git workspace materialization to overwrite a dirty runner-side checkout.
@@ -1104,6 +1117,41 @@ mod tests {
     }
 
     #[test]
+    fn runner_and_placement_are_mutually_exclusive() {
+        for placement in ["lab", "local"] {
+            let result = Cli::command_with_scoped_lab_args().try_get_matches_from([
+                "homeboy",
+                "bench",
+                "example",
+                "--runner",
+                "homeboy-lab",
+                "--placement",
+                placement,
+            ]);
+            let Err(error) = result else {
+                panic!("runner selection and placement policy must not be combined");
+            };
+
+            assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+            let message = error.to_string();
+            assert!(message.contains("--runner"));
+            assert!(message.contains("--placement"));
+        }
+    }
+
+    #[test]
+    fn runner_only_preserves_auto_placement() {
+        let matches = Cli::command_with_scoped_lab_args()
+            .try_get_matches_from(["homeboy", "bench", "example", "--runner", "homeboy-lab"])
+            .expect("runner-only selection should parse");
+        let (cli, _) = Cli::from_registered_arg_matches(&matches)
+            .expect("runner-only selection should deserialize");
+
+        assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+        assert_eq!(cli.placement, Placement::Auto);
+    }
+
+    #[test]
     fn placement_does_not_consume_passthrough_arguments() {
         let cli = Cli::try_parse_from([
             "homeboy",
@@ -1157,6 +1205,8 @@ mod tests {
         ] {
             assert!(help.contains(flag), "bench must advertise {flag}");
         }
+        assert!(help.contains("without pinning a runner"));
+        assert!(help.contains("This implies Lab placement"));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/fuzz/stable.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/stable.rs
@@ -66,8 +66,6 @@ fn run_stable_plan(args: FuzzStablePlanArgs) -> Result<FuzzStablePlanOutput> {
                 "homeboy".to_string(),
                 "fuzz".to_string(),
                 "run".to_string(),
-                "--placement".to_string(),
-                "lab".to_string(),
                 "--rig".to_string(),
                 rig_id.clone(),
                 "--workload".to_string(),
@@ -122,6 +120,9 @@ fn append_common_run_options(command: &mut Vec<String>, args: &FuzzStablePlanArg
     if let Some(runner) = &args.runner {
         command.push("--runner".to_string());
         command.push(runner.clone());
+    } else {
+        command.push("--placement".to_string());
+        command.push("lab".to_string());
     }
     if let Some(artifact_root) = &args.artifact_root {
         command.push("--artifact-root".to_string());
@@ -205,11 +206,12 @@ fn with_lab_options(parts: Vec<&str>, args: &FuzzStablePlanArgs) -> Vec<String> 
         command.push("--component".to_string());
         command.push(component.clone());
     }
-    command.push("--placement".to_string());
-    command.push("lab".to_string());
     if let Some(runner) = &args.runner {
         command.push("--runner".to_string());
         command.push(runner.clone());
+    } else {
+        command.push("--placement".to_string());
+        command.push("lab".to_string());
     }
     if let Some(artifact_root) = &args.artifact_root {
         command.push("--artifact-root".to_string());
@@ -376,8 +378,6 @@ mod tests {
                 "homeboy",
                 "fuzz",
                 "run",
-                "--placement",
-                "lab",
                 "--rig",
                 "demo-rig",
                 "--workload",
@@ -415,8 +415,6 @@ mod tests {
                 "3",
                 "--component",
                 "component-a",
-                "--placement",
-                "lab",
                 "--runner",
                 "lab",
             ]

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/selection.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/selection.rs
@@ -20,11 +20,11 @@ fn select(
 }
 
 #[test]
-fn explicit_runner_has_precedence_over_placement() {
+fn explicit_runner_selects_lab_with_auto_placement() {
     let selection = select(
         &portable_lab_command("test"),
         Some("lab-explicit"),
-        homeboy_cli_contract::Placement::Local,
+        homeboy_cli_contract::Placement::Auto,
         false,
         false,
         Some("lab-default".to_string()),


### PR DESCRIPTION
## Summary
- reject explicit `--runner` and `--placement` combinations at clap parsing across the scoped Lab-portable command surface
- preserve runner-only implicit `Placement::Auto` routing and placement-only default runner selection
- update help text and generated stable-fuzz commands to express exactly one routing intent

Fixes #8817.

Depends on #8840 for the Homeboy Lab reconnect-contention repair discovered while cooking this change.

## How to test
1. Run `cargo test -p homeboy-cli runner_and_placement_are_mutually_exclusive --lib` and confirm the parser rejects redundant and contradictory combinations.
2. Run `cargo test -p homeboy-cli runner_only_preserves_auto_placement --lib` and confirm runner-only input retains internal automatic placement.
3. Run `cargo test -p homeboy-cli commands::fuzz::stable::tests --lib` and confirm generated Lab commands emit either runner or placement, never both.
4. Run `cargo test -p homeboy-lab-runner lab::offload::tests::selection --lib` and confirm all 13 routing-selection tests pass.
5. Run `cargo check -p homeboy-cli`, `cargo fmt --check`, and `git diff --check origin/main...HEAD`.

## Compatibility
This intentionally rejects previously accepted invocations that supplied both `--runner` and `--placement`, including redundant `--placement lab`. Callers must keep one intent. Runner-only and placement-only behavior remains unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Investigated the CLI ambiguity, prepared and reviewed the parser/help/generator changes, and added deterministic coverage. Chris reviewed and owns the change.