### PR TITLE
refactor: move rig state snapshot types to homeboy-lifecycle-contract

### DIFF
--- a/crates/homeboy-core/src/rig/state.rs
+++ b/crates/homeboy-core/src/rig/state.rs
@@ -10,6 +10,8 @@ use std::fs;
 use crate::error::{Error, Result};
 use crate::paths;
 
+pub use homeboy_lifecycle_contract::{ComponentSnapshot, RigStateSnapshot};
+
 use super::spec::RigResourcesSpec;
 
 /// Snapshot of a rig's running state.
@@ -56,73 +58,6 @@ pub struct MaterializedRigState {
     /// Component state captured at materialization time.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub components: BTreeMap<String, ComponentSnapshot>,
-}
-
-/// Captured component state for one entry in a rig's components map.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ComponentSnapshot {
-    /// Effective filesystem path used for the invocation.
-    ///
-    /// When a `--path` override (or any caller-supplied effective path) is in
-    /// effect, this is the override path — not the rig-declared one — so the
-    /// snapshot accurately reflects what the workload actually exercised. See
-    /// [`RigStateSnapshot::set_effective_component_path`].
-    pub path: String,
-
-    /// Rig-declared path that `path` was overridden away from, if any.
-    ///
-    /// Absent when `path` matches the rig spec. Present when the invocation
-    /// pinned a different checkout via `--path` or another override, so
-    /// callers can still see what the rig itself configured.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub declared_path: Option<String>,
-
-    /// `git rev-parse HEAD` for the path's repo.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sha: Option<String>,
-
-    /// `git rev-parse --abbrev-ref HEAD`, or `HEAD` when detached.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub branch: Option<String>,
-}
-
-/// Snapshot of every component in a rig at a moment in time.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct RigStateSnapshot {
-    pub rig_id: String,
-    pub captured_at: String,
-    pub components: BTreeMap<String, ComponentSnapshot>,
-}
-
-impl RigStateSnapshot {
-    /// Record the effective filesystem path used for `component_id`.
-    ///
-    /// If the snapshot already lists the component and the rig-declared `path`
-    /// differs from `effective_path`, the rig-declared path is preserved in
-    /// `declared_path` and `path` is updated to the effective one. Git SHA and
-    /// branch are re-queried against the effective path so the snapshot
-    /// reflects what was actually exercised.
-    ///
-    /// No-op when the component isn't tracked by the snapshot or the effective
-    /// path already matches `path`.
-    pub fn set_effective_component_path(
-        &mut self,
-        component_id: &str,
-        effective_path: &str,
-        git_lookup: impl FnOnce(&str) -> (Option<String>, Option<String>),
-    ) {
-        let Some(snapshot) = self.components.get_mut(component_id) else {
-            return;
-        };
-        if snapshot.path == effective_path {
-            return;
-        }
-        let declared = std::mem::replace(&mut snapshot.path, effective_path.to_string());
-        snapshot.declared_path = Some(declared);
-        let (sha, branch) = git_lookup(effective_path);
-        snapshot.sha = sha;
-        snapshot.branch = branch;
-    }
 }
 
 /// Per-service state: PID, start time, health.

--- a/crates/homeboy-lifecycle-contract/src/lib.rs
+++ b/crates/homeboy-lifecycle-contract/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod artifact_contract;
 pub mod lifecycle;
+pub mod rig_snapshot;
 pub mod timeline;
 
 pub use artifact_contract::{
@@ -20,6 +21,7 @@ pub use lifecycle::{
     LifecycleContract, LifecyclePhaseContract, LifecyclePhaseKind, LifecyclePhaseResult,
     LifecyclePhaseStatus, LifecycleResultMetadata, LifecycleSnapshotRef,
 };
+pub use rig_snapshot::{ComponentSnapshot, RigStateSnapshot};
 pub use timeline::{
     event_matches_key, merge_span_definitions, parse_phase_milestone, parse_span_definition,
     phase_span_definitions, reporting_timeline, summarize_spans, ObservationEvent,

--- a/crates/homeboy-lifecycle-contract/src/rig_snapshot.rs
+++ b/crates/homeboy-lifecycle-contract/src/rig_snapshot.rs
@@ -1,0 +1,71 @@
+//! Rig state snapshot contract types (component filesystem/git snapshot).
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Captured component state for one entry in a rig's components map.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ComponentSnapshot {
+    /// Effective filesystem path used for the invocation.
+    ///
+    /// When a `--path` override (or any caller-supplied effective path) is in
+    /// effect, this is the override path — not the rig-declared one — so the
+    /// snapshot accurately reflects what the workload actually exercised. See
+    /// [`RigStateSnapshot::set_effective_component_path`].
+    pub path: String,
+
+    /// Rig-declared path that `path` was overridden away from, if any.
+    ///
+    /// Absent when `path` matches the rig spec. Present when the invocation
+    /// pinned a different checkout via `--path` or another override, so
+    /// callers can still see what the rig itself configured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub declared_path: Option<String>,
+
+    /// `git rev-parse HEAD` for the path's repo.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha: Option<String>,
+
+    /// `git rev-parse --abbrev-ref HEAD`, or `HEAD` when detached.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+}
+
+/// Snapshot of every component in a rig at a moment in time.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RigStateSnapshot {
+    pub rig_id: String,
+    pub captured_at: String,
+    pub components: BTreeMap<String, ComponentSnapshot>,
+}
+
+impl RigStateSnapshot {
+    /// Record the effective filesystem path used for `component_id`.
+    ///
+    /// If the snapshot already lists the component and the rig-declared `path`
+    /// differs from `effective_path`, the rig-declared path is preserved in
+    /// `declared_path` and `path` is updated to the effective one. Git SHA and
+    /// branch are re-queried against the effective path so the snapshot
+    /// reflects what was actually exercised.
+    ///
+    /// No-op when the component isn't tracked by the snapshot or the effective
+    /// path already matches `path`.
+    pub fn set_effective_component_path(
+        &mut self,
+        component_id: &str,
+        effective_path: &str,
+        git_lookup: impl FnOnce(&str) -> (Option<String>, Option<String>),
+    ) {
+        let Some(snapshot) = self.components.get_mut(component_id) else {
+            return;
+        };
+        if snapshot.path == effective_path {
+            return;
+        }
+        let declared = std::mem::replace(&mut snapshot.path, effective_path.to_string());
+        snapshot.declared_path = Some(declared);
+        let (sha, branch) = git_lookup(effective_path);
+        snapshot.sha = sha;
+        snapshot.branch = branch;
+    }
+}


### PR DESCRIPTION
## Summary
Clears the **last `TraceResults` blocker**. `RigStateSnapshot` + `ComponentSnapshot` are pure serde state-snapshot types that move to the lifecycle/evidence-contract leaf crate, alongside the artifact/timeline evidence types already there.

## Purity
- `ComponentSnapshot`: 0 impls, pure serde (path/git-sha/branch fields).
- `RigStateSnapshot`: 1 impl (`set_effective_component_path`) which is fully pure — it takes a `git_lookup` **closure** and touches no core APIs.

## What stays in core
`MaterializedRigState` (which carries a `BTreeMap<String, ComponentSnapshot>`) and the other rig state types stay in core and re-import `ComponentSnapshot`. Core's rig module re-exports both moved types, so all consumers (rig, trace, bench, cli) stay stable.

## Progress
With this, **both `TraceResults` blockers are cleared** — `TracePreviewMetadata` (#8841) and now `RigStateSnapshot`. The top-level trace result cluster can now move wholesale in a follow-up, collapsing the ~45-ref trace reverse-edge surface the same way the bench cluster went 58 → 4.

## Tests
- `homeboy-lifecycle-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)