### PR TITLE
refactor: move the TraceResults type to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/trace/parsing.rs
+++ b/crates/homeboy-core/src/extension/trace/parsing.rs
@@ -20,44 +20,7 @@ pub use homeboy_extension_contract::trace_parsing::{
     TraceSpanResult, TraceSpanStatus, TraceStatus, TraceTemporalAssertionDefinition,
     TraceToolchainProvenance,
 };
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub struct TraceResults {
-    pub component_id: String,
-    pub scenario_id: String,
-    pub status: TraceStatus,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub summary: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub failure: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub rig: Option<RigStateSnapshot>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub evidence: Option<TraceEvidenceMetadata>,
-    #[serde(default)]
-    pub timeline: Vec<TraceEvent>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub span_definitions: Vec<TraceSpanDefinition>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub span_results: Vec<TraceSpanResult>,
-    #[serde(default)]
-    pub assertions: Vec<TraceAssertion>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub temporal_assertions: Vec<TraceTemporalAssertionDefinition>,
-    #[serde(default)]
-    pub artifacts: Vec<TraceArtifact>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub dependencies: Vec<TraceDependencyProvenance>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub metrics: BTreeMap<String, serde_json::Value>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub toolchain: Option<TraceToolchainProvenance>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub components: Option<TraceComponentsProvenance>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub preview: Option<TracePreviewMetadata>,
-}
+pub use homeboy_extension_contract::trace_results::TraceResults;
 
 pub fn parse_trace_results_file(path: &Path) -> Result<TraceResults> {
     let content = std::fs::read_to_string(path).map_err(|e| {

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -65,6 +65,7 @@ pub mod source_metadata_repair;
 pub mod test_drift;
 pub mod trace_config;
 pub mod trace_preview;
+pub mod trace_results;
 pub mod update_output;
 pub mod version;
 

--- a/crates/homeboy-extension-contract/src/trace_results.rs
+++ b/crates/homeboy-extension-contract/src/trace_results.rs
@@ -1,0 +1,51 @@
+//! Top-level trace result contract type.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+use crate::trace_parsing::{
+    TraceArtifact, TraceAssertion, TraceComponentsProvenance, TraceDependencyProvenance,
+    TraceEvent, TraceEvidenceMetadata, TraceScenario, TraceSpanDefinition, TraceSpanResult,
+    TraceStatus, TraceTemporalAssertionDefinition, TraceToolchainProvenance,
+};
+use crate::trace_preview::TracePreviewMetadata;
+use homeboy_lifecycle_contract::timeline::ObservationEvent;
+use homeboy_lifecycle_contract::RigStateSnapshot;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct TraceResults {
+    pub component_id: String,
+    pub scenario_id: String,
+    pub status: TraceStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rig: Option<RigStateSnapshot>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<TraceEvidenceMetadata>,
+    #[serde(default)]
+    pub timeline: Vec<TraceEvent>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub span_definitions: Vec<TraceSpanDefinition>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub span_results: Vec<TraceSpanResult>,
+    #[serde(default)]
+    pub assertions: Vec<TraceAssertion>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub temporal_assertions: Vec<TraceTemporalAssertionDefinition>,
+    #[serde(default)]
+    pub artifacts: Vec<TraceArtifact>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dependencies: Vec<TraceDependencyProvenance>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metrics: BTreeMap<String, serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub toolchain: Option<TraceToolchainProvenance>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub components: Option<TraceComponentsProvenance>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preview: Option<TracePreviewMetadata>,
+}


### PR DESCRIPTION
## Summary
**The finale of the trace subsystem breakdown.** With both blockers cleared (`TracePreviewMetadata` #8841, `RigStateSnapshot` #8843) and all 14+ parsing types already moved (#8832), `TraceResults` — the top-level trace aggregate — moves wholesale into the contract crate.

## Every field type now resolves from a contract/leaf crate
- Trace parsing types (`TraceArtifact`, `TraceAssertion`, the `*Provenance` types, `TraceEvidenceMetadata`, etc.) — contract
- Span/event aliases (`TraceEvent`/`TraceSpanResult`/`TraceSpanDefinition` → observation timeline) — leaf
- `TracePreviewMetadata` — contract
- `RigStateSnapshot` — leaf

The trace parse **functions** (using `error`/`structured_sidecar`/`Path`) stay in core.

## Impact: the trace cluster collapse
This takes the extension `trace` reverse-edge surface from **~45 references to 3 core files** — mirroring the bench cluster's 58 → 4. Core's `parsing.rs` re-exports `TraceResults` so all consumers stay stable.

## Milestone
With **both** the bench and trace subsystems — the two largest extension reverse-edge clusters — now backed by contract types, the extension behavior module's coupling to core is dramatically reduced. This is the groundwork for the eventual wholesale `homeboy-extension` behavior-crate extraction.

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)