### PR TITLE
Fix scoped review Lab fallback commands

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/fallback_commands.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/fallback_commands.rs
@@ -66,9 +66,9 @@ pub(crate) fn review_lab_fallback_commands(
     }
 
     Some(ReviewLabFallbackCommands {
-        audit: fallback_command("audit", &common),
-        lint: fallback_command("lint", &common),
-        test: fallback_command("test", &common),
+        audit: fallback_command("review audit", &common),
+        lint: fallback_command("review lint", &common),
+        test: fallback_command("review test", &common),
     })
 }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
@@ -128,7 +128,7 @@ fn scoped_review_runner_rejection_includes_full_gate_fallbacks() {
     let hints = unsupported_runner_hints("homeboy-lab", &args, "support".to_string());
 
     assert!(hints.iter().any(|hint| hint.contains(
-        "`homeboy audit --runner homeboy-lab --extension rust homeboy`; `homeboy lint --runner homeboy-lab --extension rust homeboy`; `homeboy test --runner homeboy-lab --extension rust homeboy`"
+        "`homeboy review audit --runner homeboy-lab --extension rust homeboy`; `homeboy review lint --runner homeboy-lab --extension rust homeboy`; `homeboy review test --runner homeboy-lab --extension rust homeboy`"
     )));
 }
 


### PR DESCRIPTION
## Summary
- render scoped review Lab fallbacks through the supported `homeboy review audit|lint|test` command group
- preserve runner, extension, path, and component arguments
- update deterministic coverage to reject the nonexistent top-level command shape

Closes #8831

## How to test
1. Check formatting with `cargo fmt --check`.
2. Run `cargo test -p homeboy-lab-runner scoped_review_runner_rejection_includes_full_gate_fallbacks`.
3. Verify each generated shape parses: `cargo run --quiet -- review audit --runner homeboy-lab --extension rust homeboy --help`, then repeat for `lint` and `test`.

## Verification
- `cargo fmt --check` passed
- focused Rust test passed: 1 passed, 0 failed
- all three parser-level help checks passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed the control-plane failure and implemented the focused fix and deterministic tests; Chris reviews and owns the change.
