### PR TITLE
refactor: sever stay-in-core rig edges (homeboy-rig extraction prep)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,6 +890,7 @@ dependencies = [
  "homeboy-product-identity",
  "homeboy-redaction",
  "homeboy-refactor-contract",
+ "homeboy-rig-contract",
  "keyring",
  "libc",
  "regex",
@@ -1091,6 +1092,14 @@ dependencies = [
 
 [[package]]
 name = "homeboy-refactor-contract"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "homeboy-rig-contract"
 version = "0.1.0"
 dependencies = [
  "serde",

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -118,6 +118,9 @@ impl CliRuntime {
         // Register the audit fixability provider so code_audit can report how
         // fixable its findings are without calling up into the refactor engine's
         // fix planner — the seam that removes the last code_audit->refactor edge.
+        // Register the rig toolchain provider so core's extension exec-env
+        // builder can prepend the rig toolchain PATH.
+        crate::core::rig::toolchain::register();
         crate::refactor::audit_fixability_provider::register();
         // Register the refactor transform provider so core's extension
         // test-drift auto-fixer can apply generated transform rules.

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -32,6 +32,7 @@ homeboy-refactor-contract = { version = "0.1.0", path = "../homeboy-refactor-con
 homeboy-code-audit = { version = "0.1.0", path = "../homeboy-code-audit" }
 homeboy-extension-contract = { version = "0.1.0", path = "../homeboy-extension-contract" }
 homeboy-lifecycle-contract = { version = "0.1.0", path = "../homeboy-lifecycle-contract" }
+homeboy-rig-contract = { version = "0.1.0", path = "../homeboy-rig-contract" }
 homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 homeboy-lab-contract = { version = "0.1.0", path = "../homeboy-lab-contract" }
 homeboy-lab-runner-contract = { version = "0.1.0", path = "../homeboy-lab-runner-contract" }

--- a/crates/homeboy-core/src/extension/bench/report.rs
+++ b/crates/homeboy-core/src/extension/bench/report.rs
@@ -12,7 +12,7 @@ use crate::ci_profile::CiContext;
 use crate::execution_contract::reportable_artifact_evidence_path;
 use crate::finding::HomeboyFinding;
 use crate::gate::HomeboyGateResult;
-use crate::rig::RigStateSnapshot;
+use homeboy_lifecycle_contract::RigStateSnapshot;
 
 pub use super::side_by_side::{
     BenchSideBySideArtifact, BenchSideBySideMetric, BenchSideBySidePreviewLink,

--- a/crates/homeboy-core/src/extension/bench/report/comparison/types.rs
+++ b/crates/homeboy-core/src/extension/bench/report/comparison/types.rs
@@ -9,7 +9,7 @@ use crate::extension::bench::diagnostic::BenchDiagnostic;
 use crate::extension::bench::parsing::{BenchMetricPhase, BenchMetricPolicy, BenchResults};
 use crate::extension::bench::run::BenchRunFailure;
 use crate::extension::bench::side_by_side::BenchSideBySideReport;
-use crate::rig::RigStateSnapshot;
+use homeboy_lifecycle_contract::RigStateSnapshot;
 
 /// Cross-rig comparison envelope.
 ///

--- a/crates/homeboy-core/src/extension/execution.rs
+++ b/crates/homeboy-core/src/extension/execution.rs
@@ -2,7 +2,7 @@ use crate::component::{self, Component};
 use crate::engine::{template, validation};
 use crate::error::{Error, Result};
 use crate::project::Project;
-use crate::rig::toolchain;
+
 use crate::server::{
     execute_local_command_in_dir, execute_local_command_in_dir_with_timeout,
     execute_local_command_interactive, execute_local_command_passthrough,
@@ -800,7 +800,7 @@ fn build_exec_env(
         env.extend(helper_pairs);
     }
 
-    if let Some(path) = toolchain::command_step_path() {
+    if let Some(path) = crate::rig_toolchain_provider::command_step_path() {
         env.push(("PATH".to_string(), path.to_string_lossy().to_string()));
     }
 

--- a/crates/homeboy-core/src/extension/trace/parsing.rs
+++ b/crates/homeboy-core/src/extension/trace/parsing.rs
@@ -9,8 +9,8 @@ use crate::error::{Error, Result};
 use crate::observation::timeline::{
     ObservationEvent, ObservationSpanDefinition, ObservationSpanResult, ObservationSpanStatus,
 };
-use crate::rig::RigStateSnapshot;
 use crate::structured_sidecar;
+use homeboy_lifecycle_contract::RigStateSnapshot;
 
 use super::preview::TracePreviewMetadata;
 pub use homeboy_extension_contract::trace_parsing::{

--- a/crates/homeboy-core/src/extension/trace/preflight.rs
+++ b/crates/homeboy-core/src/extension/trace/preflight.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use crate::error::{Error, Result};
 use crate::extension::ExtensionExecutionContext;
-use crate::rig::TraceDependencySpec;
+use homeboy_rig_contract::TraceDependencySpec;
 
 use super::parsing::TraceDependencyProvenance;
 

--- a/crates/homeboy-core/src/extension/trace/preview.rs
+++ b/crates/homeboy-core/src/extension/trace/preview.rs
@@ -7,10 +7,12 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::time::Duration;
 
 use crate::error::{Error, Result};
-use crate::rig::{TraceNativePublicPreviewSpec, TracePublicPreviewMode, TracePublicPreviewSpec};
 pub use homeboy_extension_contract::trace_preview::{
     TracePreviewAssetCheck, TracePreviewAssetFanoutReport, TracePreviewAssetFanoutRequest,
     TracePreviewLogPaths, TracePreviewMetadata,
+};
+use homeboy_rig_contract::{
+    TraceNativePublicPreviewSpec, TracePublicPreviewMode, TracePublicPreviewSpec,
 };
 
 const DEFAULT_STARTUP_TIMEOUT_SECONDS: u64 = 20;
@@ -854,7 +856,7 @@ fn asset_fanout_report(
 }
 
 fn empty_asset_fanout_report(
-    fanout: &crate::rig::TracePreviewAssetFanoutSpec,
+    fanout: &homeboy_rig_contract::TracePreviewAssetFanoutSpec,
 ) -> TracePreviewAssetFanoutReport {
     TracePreviewAssetFanoutReport {
         schema: "homeboy/preview-asset-fanout/v1".to_string(),
@@ -925,7 +927,7 @@ fn stop_child(child: &mut Option<Child>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{first_https_origin, TracePublicPreviewSession};
-    use crate::rig::{
+    use homeboy_rig_contract::{
         TraceNativePublicPreviewSpec, TracePreviewAssetFanoutSpec, TracePublicPreviewMode,
         TracePublicPreviewSpec,
     };

--- a/crates/homeboy-core/src/extension/trace/report.rs
+++ b/crates/homeboy-core/src/extension/trace/report.rs
@@ -16,8 +16,8 @@ use super::span_summary::{
     TraceSpanSummaryOutput,
 };
 use crate::execution_contract::is_reportable_artifact_evidence_path;
-use crate::rig::RigStateSnapshot;
 use homeboy_engine_primitives::detail_output::{bounded_items, DEFAULT_DETAIL_ITEM_LIMIT};
+use homeboy_lifecycle_contract::RigStateSnapshot;
 
 pub use aggregate_types::*;
 pub use builders::*;

--- a/crates/homeboy-core/src/extension/trace/run/types.rs
+++ b/crates/homeboy-core/src/extension/trace/run/types.rs
@@ -5,8 +5,8 @@ use std::path::PathBuf;
 
 use crate::engine::invocation::InvocationRequirements;
 use crate::extension::trace::baseline::TraceBaselineComparison;
-use crate::rig::TraceDependencySpec;
 use homeboy_engine_primitives::baseline::BaselineFlags;
+use homeboy_rig_contract::TraceDependencySpec;
 
 use super::super::attach::TraceAttachment;
 use super::super::canonicality::TraceCanonicalPolicy;
@@ -65,7 +65,7 @@ pub struct TraceRunnerInputs {
     pub dependencies: Vec<TraceDependencySpec>,
     pub runner_capabilities: Vec<String>,
     pub invocation_requirements: InvocationRequirements,
-    pub public_preview: Option<crate::rig::TracePublicPreviewSpec>,
+    pub public_preview: Option<homeboy_rig_contract::TracePublicPreviewSpec>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/homeboy-core/src/extension/trace/run/workflow.rs
+++ b/crates/homeboy-core/src/extension/trace/run/workflow.rs
@@ -9,7 +9,7 @@ use crate::error::{Error, Result};
 use crate::extension::{
     resolve_execution_context, stderr_tail, ExtensionCapability, ExtensionExecutionContext,
 };
-use crate::rig::RigStateSnapshot;
+use homeboy_lifecycle_contract::RigStateSnapshot;
 
 use super::super::attach::{append_attach_observations, observe_trace_attachments};
 use super::super::canonicality::{

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -159,6 +159,7 @@ pub mod resource_policy_context;
 pub mod resources;
 pub mod review;
 pub mod rig;
+pub mod rig_toolchain_provider;
 pub mod run_lifecycle_record;
 pub mod run_lifecycle_status;
 pub mod run_outcome_envelope;

--- a/crates/homeboy-core/src/rig/spec/trace.rs
+++ b/crates/homeboy-core/src/rig/spec/trace.rs
@@ -1,42 +1,15 @@
 //! Trace-workload schema for rig specs — variant/profile/guardrail/experiment
 //! and public-preview tunnel declarations consumed by `homeboy trace`.
 
+pub use homeboy_rig_contract::{
+    TraceDependencySpec, TraceNativePublicPreviewSpec, TracePreviewAssetFanoutSpec,
+    TracePublicPreviewMode, TracePublicPreviewSpec,
+};
+
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 use super::CheckSpec;
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct TraceDependencySpec {
-    pub id: String,
-    pub kind: String,
-    pub source: String,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub path: Option<String>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub plugin_file: Option<String>,
-
-    #[serde(default)]
-    pub requires_built_assets: bool,
-
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub required_paths: Vec<String>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source_url: Option<String>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub r#ref: Option<String>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub package_marker: Option<String>,
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TraceVariantSpec {
@@ -99,108 +72,6 @@ pub struct TraceCompareBundleProfileSpec {
 
     #[serde(default)]
     pub canonical: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct TracePublicPreviewSpec {
-    /// Preview provider lifecycle mode. Defaults to the existing external
-    /// command/public-origin behavior.
-    #[serde(default)]
-    pub mode: TracePublicPreviewMode,
-
-    /// Local HTTP origin to expose, for example `http://127.0.0.1:8888`.
-    pub local_origin: String,
-
-    /// Optional already-known public origin. When omitted, Homeboy starts
-    /// `command` and reads the first HTTPS URL printed to stdout.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub public_origin: Option<String>,
-
-    /// Long-running shell command that starts the tunnel provider.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub command: Option<String>,
-
-    /// Fail before the trace runner starts unless the effective origin is HTTPS.
-    #[serde(default)]
-    pub require_https: bool,
-
-    /// Human-readable provider label for artifacts.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub provider: Option<String>,
-
-    /// Seconds to wait for the provider command to print a public HTTPS URL.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub startup_timeout_seconds: Option<u64>,
-
-    /// Public-origin-relative asset URLs that must load before trace collection starts.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub required_asset_paths: Vec<String>,
-
-    /// Optional concurrent static-asset fanout check for public preview tunnels.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub asset_fanout: Option<TracePreviewAssetFanoutSpec>,
-
-    /// Homeboy-native preview tunnel settings used when `mode` is `homeboy_native`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub native: Option<TraceNativePublicPreviewSpec>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct TracePreviewAssetFanoutSpec {
-    /// Public-origin-relative asset URLs to fetch concurrently through the preview origin.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub asset_paths: Vec<String>,
-
-    /// Maximum number of concurrent fetch workers.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub concurrency: Option<usize>,
-
-    /// Number of times to request each asset path.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub repeat_count: Option<usize>,
-
-    /// Optional body substring that every successful response must contain.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub expected_body_contains: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-#[derive(Default)]
-pub enum TracePublicPreviewMode {
-    #[default]
-    External,
-    HomeboyNative,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(deny_unknown_fields)]
-pub struct TraceNativePublicPreviewSpec {
-    /// Deterministic public host reserved by the native preview ingress.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub public_host: Option<String>,
-
-    /// Operator-owned wildcard domain used to derive `{session}-tunnel.<domain>`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub operator_domain: Option<String>,
-
-    /// Stable session ID used for host generation and native client metadata.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub session_id: Option<String>,
-
-    /// Native preview ingress/broker URL consumed by `homeboy tunnel preview-client start`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ingress_url: Option<String>,
-
-    /// Environment variable name that supplies the native preview tunnel token.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub token_env: Option<String>,
-
-    /// Optional path to a Homeboy binary that implements the preview-client command.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub client_binary: Option<String>,
 }
 
 impl TraceProfileSpec {

--- a/crates/homeboy-core/src/rig/toolchain.rs
+++ b/crates/homeboy-core/src/rig/toolchain.rs
@@ -181,3 +181,20 @@ mod tests {
         assert!(!parts.contains(&missing));
     }
 }
+
+/// Rig-toolchain implementation of core's command-step PATH hook.
+struct RigToolchainProviderImpl;
+
+impl crate::rig_toolchain_provider::RigToolchainProvider for RigToolchainProviderImpl {
+    fn command_step_path(&self) -> Option<std::ffi::OsString> {
+        command_step_path()
+    }
+}
+
+/// Register the rig toolchain provider so core's extension exec-env builder can
+/// prepend the rig toolchain PATH without depending on the rig subsystem.
+pub fn register() {
+    crate::rig_toolchain_provider::register_rig_toolchain_provider(Box::new(
+        RigToolchainProviderImpl,
+    ));
+}

--- a/crates/homeboy-core/src/rig_toolchain_provider.rs
+++ b/crates/homeboy-core/src/rig_toolchain_provider.rs
@@ -1,0 +1,49 @@
+//! Rig toolchain command-step PATH hook.
+//!
+//! Building the exec environment for an extension command step can prepend the
+//! rig toolchain's discovered bin directories (home bin dirs, nvm node bins,
+//! absolute toolchain dirs) to `PATH`. That path assembly is rig-toolchain
+//! behavior, so it is inverted behind this provider: core owns exec-env
+//! construction, the rig layer supplies the command-step PATH.
+//!
+//! With no provider registered (no rig layer present) the no-op contributes no
+//! path, so the exec env's `PATH` is left unchanged.
+
+use std::ffi::OsString;
+use std::sync::Mutex;
+
+/// Supplies the rig toolchain command-step PATH.
+pub trait RigToolchainProvider: Send + Sync {
+    /// The `PATH` value (rig toolchain bin dirs prepended to the current PATH)
+    /// for an extension command step, or `None` when no toolchain path applies.
+    fn command_step_path(&self) -> Option<OsString>;
+}
+
+struct NoopProvider;
+
+impl RigToolchainProvider for NoopProvider {
+    fn command_step_path(&self) -> Option<OsString> {
+        None
+    }
+}
+
+fn provider_slot() -> &'static Mutex<Option<Box<dyn RigToolchainProvider>>> {
+    static PROVIDER: Mutex<Option<Box<dyn RigToolchainProvider>>> = Mutex::new(None);
+    &PROVIDER
+}
+
+/// Register the rig toolchain provider. Called once at startup by the rig layer.
+pub fn register_rig_toolchain_provider(provider: Box<dyn RigToolchainProvider>) {
+    let mut slot = provider_slot().lock().expect("rig toolchain provider lock");
+    *slot = Some(provider);
+}
+
+/// The rig toolchain command-step PATH via the registered provider (or none when
+/// the rig layer is absent).
+pub(crate) fn command_step_path() -> Option<OsString> {
+    let slot = provider_slot().lock().expect("rig toolchain provider lock");
+    match slot.as_deref() {
+        Some(provider) => provider.command_step_path(),
+        None => NoopProvider.command_step_path(),
+    }
+}

--- a/crates/homeboy-rig-contract/Cargo.toml
+++ b/crates/homeboy-rig-contract/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "homeboy-rig-contract"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Shared rig trace-spec data types (trace-dependency and public-preview specs). Sits below homeboy-core so both core (extension trace) and homeboy-rig reference them without a cycle."
+publish = false
+
+[lib]
+name = "homeboy_rig_contract"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/crates/homeboy-rig-contract/src/lib.rs
+++ b/crates/homeboy-rig-contract/src/lib.rs
@@ -1,0 +1,142 @@
+//! Shared rig trace-spec data types.
+//!
+//! Pure-data trace-dependency and public-preview spec types, read by both
+//! homeboy-core (the extension trace subsystem) and homeboy-rig. They sit below
+//! core so neither crate needs the other for these types.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TraceDependencySpec {
+    pub id: String,
+    pub kind: String,
+    pub source: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plugin_file: Option<String>,
+
+    #[serde(default)]
+    pub requires_built_assets: bool,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_paths: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub r#ref: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package_marker: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TracePublicPreviewSpec {
+    /// Preview provider lifecycle mode. Defaults to the existing external
+    /// command/public-origin behavior.
+    #[serde(default)]
+    pub mode: TracePublicPreviewMode,
+
+    /// Local HTTP origin to expose, for example `http://127.0.0.1:8888`.
+    pub local_origin: String,
+
+    /// Optional already-known public origin. When omitted, Homeboy starts
+    /// `command` and reads the first HTTPS URL printed to stdout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_origin: Option<String>,
+
+    /// Long-running shell command that starts the tunnel provider.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+
+    /// Fail before the trace runner starts unless the effective origin is HTTPS.
+    #[serde(default)]
+    pub require_https: bool,
+
+    /// Human-readable provider label for artifacts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+
+    /// Seconds to wait for the provider command to print a public HTTPS URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub startup_timeout_seconds: Option<u64>,
+
+    /// Public-origin-relative asset URLs that must load before trace collection starts.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_asset_paths: Vec<String>,
+
+    /// Optional concurrent static-asset fanout check for public preview tunnels.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub asset_fanout: Option<TracePreviewAssetFanoutSpec>,
+
+    /// Homeboy-native preview tunnel settings used when `mode` is `homeboy_native`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub native: Option<TraceNativePublicPreviewSpec>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TracePreviewAssetFanoutSpec {
+    /// Public-origin-relative asset URLs to fetch concurrently through the preview origin.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub asset_paths: Vec<String>,
+
+    /// Maximum number of concurrent fetch workers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub concurrency: Option<usize>,
+
+    /// Number of times to request each asset path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repeat_count: Option<usize>,
+
+    /// Optional body substring that every successful response must contain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_body_contains: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(Default)]
+pub enum TracePublicPreviewMode {
+    #[default]
+    External,
+    HomeboyNative,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct TraceNativePublicPreviewSpec {
+    /// Deterministic public host reserved by the native preview ingress.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_host: Option<String>,
+
+    /// Operator-owned wildcard domain used to derive `{session}-tunnel.<domain>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operator_domain: Option<String>,
+
+    /// Stable session ID used for host generation and native client metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+
+    /// Native preview ingress/broker URL consumed by `homeboy tunnel preview-client start`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ingress_url: Option<String>,
+
+    /// Environment variable name that supplies the native preview tunnel token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_env: Option<String>,
+
+    /// Optional path to a Homeboy binary that implements the preview-client command.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_binary: Option<String>,
+}


### PR DESCRIPTION
## Summary
First prep-PR for extracting the **rig subsystem** (~15.3k LOC) into its own `homeboy-rig` crate — the next boundary after agents/runner/code-audit/refactor.

I censused both `deploy` and `rig` for the next pick. **`deploy` turned out to be a trap** — it's bidirectionally entangled with `release`, and core status/reporting modules (`fleet`, `git`, `context`) call ~14 distinct deploy/release *behavior* functions. **`rig` is dramatically cleaner**: its edges are almost all type-imports, and its biggest one (`RigStateSnapshot`) was already sitting in a contract below core.

## What changed
1. **`RigStateSnapshot`** (5 refs in extension/trace + bench) was already re-exported from `homeboy-lifecycle-contract` — repointed those uses directly to the contract. **Zero new infra.**
2. **`Trace*Spec` types** — moved the 5 self-contained trace-spec data types (`TraceDependencySpec`, `TracePublicPreviewSpec`, `TracePreviewAssetFanoutSpec`, `TracePublicPreviewMode`, `TraceNativePublicPreviewSpec`) to a new **`homeboy-rig-contract`** crate below core. `extension/trace` reads them from the contract; rig re-exports them from `trace.rs` so its internals are unchanged.
3. **`extension/execution.rs`** called `rig::toolchain::command_step_path()` to build the exec-env `PATH`. Inverted behind a **`RigToolchainProvider`** hook.

## Effect
- `extension/trace/*`, `extension/bench/*`, `extension/execution.rs`: `crate::rig` refs → **0**.
- Only remaining core→rig ref is `trace_experiment.rs` (rig-experiment logic misfiled at core top-level), which moves *with* rig at the git-mv.
- rig has no other feature-crate deps (only `homeboy-lab-runner-contract`, below core).

## Verification
- `cargo check --workspace --tests`: **green**.
- `cargo fmt`: clean.