### PR TITLE
refactor: relocate the extension manifest store to core (extension_store)

### DIFF
--- a/crates/homeboy-core/src/extension/audit_manifest_provider.rs
+++ b/crates/homeboy-core/src/extension/audit_manifest_provider.rs
@@ -7,11 +7,11 @@
 //! by the CLI, mirroring the runner-evidence / tunnel provider hooks.
 
 use super::manifest::ExtensionManifest;
-use super::registry::{load_all_extensions, load_extension};
 use crate::code_audit::extension_manifests::{
     register_audit_extension_manifest_provider, AuditExtensionManifest,
     AuditExtensionManifestProvider,
 };
+use crate::extension_store::{load_all_extensions, load_extension};
 
 /// Project a loaded `ExtensionManifest` into the audit-relevant view.
 fn project(manifest: &ExtensionManifest) -> AuditExtensionManifest {

--- a/crates/homeboy-core/src/extension/capability.rs
+++ b/crates/homeboy-core/src/extension/capability.rs
@@ -4,9 +4,9 @@ use crate::error::{Error, ErrorCode, Result};
 use std::path::{Path, PathBuf};
 
 use super::manifest::ExtensionManifest;
-use super::registry::{extension_path, load_extension};
 use super::runner::ExtensionRunner;
 use super::ResolvedExtensionInvocationContext;
+use crate::extension_store::{extension_path, load_extension};
 use homeboy_extension_contract::ExtensionCapability;
 
 pub(crate) fn stderr_tail(stderr: &str) -> String {

--- a/crates/homeboy-core/src/extension/maintenance.rs
+++ b/crates/homeboy-core/src/extension/maintenance.rs
@@ -2,10 +2,10 @@ use crate::error::{Error, Result};
 
 use super::exec_context;
 use super::lifecycle::update;
-use super::registry::{available_extension_ids, load_extension};
 use super::update_output::{
     SourceMetadataRepairEntry, UpdateAllResult, UpdateEntry, UpdateSkippedEntry,
 };
+use crate::extension_store::{available_extension_ids, load_extension};
 
 /// Update all installed extensions through the same path used by single-extension updates.
 pub fn update_all(force: bool) -> UpdateAllResult {

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -24,7 +24,8 @@ mod manifest;
 mod manifest_config;
 mod manifest_sidecar;
 mod refactor_protocol;
-mod registry;
+// Manifest store relocated to crate::extension_store (core-level; operates on
+// the contract ExtensionManifest type). Re-exported here for path stability.
 mod repair;
 mod runner;
 mod runtime_helper;
@@ -57,6 +58,10 @@ pub use homeboy_extension_contract::core_compat::{
 };
 pub use homeboy_extension_contract::ExtensionCapability;
 
+pub use crate::extension_store::{
+    available_extension_ids, extension_path, find_extension_by_tool, find_extension_for_file_ext,
+    is_extension_linked, load_all_extensions, load_extension, merge, save_manifest,
+};
 pub(crate) use execution::{build_settings_json_from_manifest, execute_action};
 pub use execution::{
     extension_ready_status, is_extension_compatible, run_action, run_extension, run_setup,
@@ -117,10 +122,6 @@ pub use refactor_protocol::{
     run_refactor_script, run_refactor_script_result, AdjustedItem, ParsedItem,
     RefactorScriptFailure, RefactorScriptFailureKind, RelatedTests, ResolvedImports,
     RewrittenImport,
-};
-pub use registry::{
-    available_extension_ids, extension_path, find_extension_by_tool, find_extension_for_file_ext,
-    is_extension_linked, load_all_extensions, load_extension, merge, save_manifest,
 };
 pub use repair::{relink, replace, replace_with_revision, ReplaceResult};
 pub use runner::{ExtensionRunner, RunnerOutput};

--- a/crates/homeboy-core/src/extension/runner.rs
+++ b/crates/homeboy-core/src/extension/runner.rs
@@ -342,7 +342,7 @@ impl ExtensionRunner {
             .map(|extension_id| {
                 Ok((
                     extension_id.clone(),
-                    super::registry::extension_path(extension_id),
+                    crate::extension_store::extension_path(extension_id),
                 ))
             })
             .collect()

--- a/crates/homeboy-core/src/extension/summary.rs
+++ b/crates/homeboy-core/src/extension/summary.rs
@@ -3,8 +3,8 @@ use serde::Serialize;
 use super::execution::{extension_ready_status, is_extension_compatible};
 use super::lifecycle::read_source_revision;
 use super::manifest::ActionType;
-use super::registry::{broken_extension_links, is_extension_linked, load_all_extensions};
 use super::{evaluate_core_compatibility, CoreCompatibilityReport};
+use crate::extension_store::{broken_extension_links, is_extension_linked, load_all_extensions};
 
 /// Summary of an extension for list views.
 #[derive(Debug, Clone, Serialize)]

--- a/crates/homeboy-core/src/extension/validation.rs
+++ b/crates/homeboy-core/src/extension/validation.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 
-use super::registry::{is_extension_linked, load_extension};
 use super::version;
+use crate::extension_store::{is_extension_linked, load_extension};
 
 /// Validate that all extensions declared in a component's `extensions` field are installed.
 ///

--- a/crates/homeboy-core/src/extension_store.rs
+++ b/crates/homeboy-core/src/extension_store.rs
@@ -4,7 +4,7 @@ use crate::output::MergeOutput;
 use crate::paths;
 use std::path::PathBuf;
 
-use super::manifest::ExtensionManifest;
+use homeboy_extension_contract::ExtensionManifest;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BrokenExtensionLink {

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -96,6 +96,7 @@ pub mod execution_contract;
 pub(crate) mod expand;
 pub mod extension;
 pub mod extension_provider_discovery;
+pub mod extension_store;
 // finding moved to the internal `homeboy-finding` crate. Re-exported so existing
 // `crate::finding::*` call sites keep working unchanged.
 pub use homeboy_finding as finding;


### PR DESCRIPTION
## Summary
Breaks the **single biggest blocker (~42 refs) to a severable `homeboy-extension` crate**: the core→extension manifest-CRUD dependency cycle.

## The insight
The manifest CRUD functions (`load_extension`, `save_manifest`, `load_all_extensions`, `find_extension_for_file_ext`, `extension_path`, `merge`, `available_extension_ids`, `is_extension_linked`) lived in `extension/registry.rs` — but they are **not extension behavior**. They are thin operations over core's generic config store (`config::load`/`save`/`list`) on the `ExtensionManifest` type — which is now a **contract type**.

Their *only* extension coupling was `use super::manifest::ExtensionManifest`.

## The move
- Relocate `registry.rs` → `crate::extension_store` (a top-level core module).
- Repoint its one extension import to `homeboy_extension_contract::ExtensionManifest`.
- The extension module re-exports these functions from `crate::extension_store`, so **all ~16 core callers** (release, deploy, component, ci_profile, upgrade, notify, engine, context, deps) and every `crate::extension::*` path stay stable — **zero churn**.

## Why this matters
`extension_store` is now **fully independent of the extension module** (verified: zero `crate::extension::`/`super::` refs). Core's release/deploy/component subsystems no longer reach into extension *behavior* for manifest loading — they operate on a core-level store over a contract type.

This is the keystone that flips the extension crate from "not severable" toward "severable": the largest core→extension behavior edge (manifest CRUD, ~42 refs across load/save/load_all) is dissolved, not hooked — because it was core logic misfiled in the extension module all along.

## Tests
- `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)