### PR TITLE
refactor: relocate extension scope + invocation-context glue to core

### DIFF
--- a/crates/homeboy-core/src/extension/capability.rs
+++ b/crates/homeboy-core/src/extension/capability.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use super::manifest::ExtensionManifest;
 use super::runner::ExtensionRunner;
-use super::ResolvedExtensionInvocationContext;
+use crate::extension_invocation_context::ResolvedExtensionInvocationContext;
 use crate::extension_store::{extension_path, load_extension};
 use homeboy_extension_contract::ExtensionCapability;
 

--- a/crates/homeboy-core/src/extension/execution.rs
+++ b/crates/homeboy-core/src/extension/execution.rs
@@ -26,7 +26,7 @@ use super::manifest::{ExtensionManifest, RuntimeConfig};
 use super::read_source_revision;
 use super::runner_contract::RunnerStepFilter;
 use super::runtime_helper;
-use super::ResolvedExtensionInvocationContext;
+use crate::extension_invocation_context::ResolvedExtensionInvocationContext;
 
 pub(crate) use action::execute_action;
 pub use readiness::{extension_ready_status, is_extension_compatible, ExtensionReadyStatus};

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -10,7 +10,7 @@ pub mod component_script;
 mod env_provider;
 mod execution;
 mod fingerprint;
-mod invocation_context;
+// invocation_context relocated to crate::extension_invocation_context
 // The grammar parsing engine is a language-agnostic primitive; it now lives in
 // homeboy-engine-primitives. Re-exported here so existing
 // `crate::extension::grammar` / `crate::extension::grammar_items` paths keep
@@ -29,7 +29,7 @@ mod refactor_protocol;
 mod repair;
 mod runner;
 mod runtime_helper;
-mod scope;
+// scope relocated to crate::extension_scope (core glue over the contract manifest)
 pub mod self_check;
 mod setup_env;
 mod summary;
@@ -58,6 +58,8 @@ pub use homeboy_extension_contract::core_compat::{
 };
 pub use homeboy_extension_contract::ExtensionCapability;
 
+pub use crate::extension_invocation_context::ResolvedExtensionInvocationContext;
+pub use crate::extension_scope::ExtensionScope;
 pub use crate::extension_store::{
     available_extension_ids, extension_path, find_extension_by_tool, find_extension_for_file_ext,
     is_extension_linked, load_all_extensions, load_extension, merge, save_manifest,
@@ -83,7 +85,6 @@ pub use homeboy_extension_contract::update_output::{
 };
 pub use homeboy_extension_contract::version::{parse_extension_version, VersionConstraint};
 pub use homeboy_extension_contract::{DeployArchiveInstallPolicy, DeployRequiredHeader};
-pub use invocation_context::ResolvedExtensionInvocationContext;
 pub use lifecycle::source_metadata::resolve_source_url;
 pub use lifecycle::source_metadata::SourceMetadataRepair;
 pub use lifecycle::{
@@ -128,7 +129,6 @@ pub use runner::{ExtensionRunner, RunnerOutput};
 pub use runtime_helper::{
     helper_path, BASH_PREFLIGHT_ENV, COMMAND_CAPTURE_ENV, RUNNER_PRELUDE_ENV, RUNNER_STEPS_ENV,
 };
-pub use scope::ExtensionScope;
 pub use summary::{list_summaries, ActionSummary, ExtensionSummary};
 pub use validation::{
     extension_provides_build, validate_extension_requirements, validate_required_extensions,

--- a/crates/homeboy-core/src/extension_invocation_context.rs
+++ b/crates/homeboy-core/src/extension_invocation_context.rs
@@ -5,7 +5,8 @@ use crate::engine::template;
 use crate::error::{Error, Result};
 use crate::project::{self, Project};
 
-use super::{ExtensionManifest, ExtensionScope};
+use crate::extension_scope::ExtensionScope;
+use homeboy_extension_contract::ExtensionManifest;
 
 /// The resolved project/component/settings identity for one extension invocation.
 ///

--- a/crates/homeboy-core/src/extension_scope.rs
+++ b/crates/homeboy-core/src/extension_scope.rs
@@ -3,8 +3,8 @@ use crate::error::{Error, Result};
 use crate::project::Project;
 use std::collections::HashMap;
 
-use super::load_extension;
-use super::manifest::ExtensionManifest;
+use crate::extension_store::load_extension;
+use homeboy_extension_contract::ExtensionManifest;
 
 /// Settings resolution for extensions with project/component context.
 pub struct ExtensionScope;

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -95,7 +95,9 @@ pub mod execution;
 pub mod execution_contract;
 pub(crate) mod expand;
 pub mod extension;
+pub mod extension_invocation_context;
 pub mod extension_provider_discovery;
+pub mod extension_scope;
 pub mod extension_store;
 // finding moved to the internal `homeboy-finding` crate. Re-exported so existing
 // `crate::finding::*` call sites keep working unchanged.


### PR DESCRIPTION
## Summary
Continues dissolving the core↔extension coupling that blocks a severable `homeboy-extension` crate. Like the manifest store (#8852), `ExtensionScope` and `ResolvedExtensionInvocationContext` are **core glue, not extension behavior** — they bridge `Component`/`Project` (core) with the contract `ExtensionManifest`, using the now-core manifest store to load extensions.

## The move
- `extension/scope.rs` → `crate::extension_scope`
- `extension/invocation_context.rs` → `crate::extension_invocation_context`

Repointed their only extension couplings:
- `super::manifest::ExtensionManifest` → `homeboy_extension_contract::ExtensionManifest`
- `super::load_extension` → `crate::extension_store::load_extension`
- `super::ExtensionScope` → `crate::extension_scope`

The extension module re-exports both types, so all `crate::extension::*` paths stay stable — **zero churn**.

## Impact
Both new modules are **fully independent of the extension module** — continuing to shrink the behavior surface that blocks a severable `homeboy-extension` crate. This is part of the same realization the manifest-store cut surfaced: a lot of "extension behavior" is actually core glue over a now-contract manifest type, misfiled inside the extension module.

Next in this thread: the `ExtensionExecutionContext` + `resolve_execution_context` family in `capability.rs` (the remaining execution-glue), which the 3 core callers (component/resolution, engine/execution_context, deps_provider) reach for.

## Tests
- `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)