### PR TITLE
Compare runner doctor build identities consistently

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/doctor/checks.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/checks.rs
@@ -127,34 +127,49 @@ pub fn path_writable_check(
 
 pub fn homeboy_version_skew_check(
     local_version: &str,
-    remote_version: &str,
+    local_build_identity: &str,
+    remote_build_identity: &str,
     runner_id: &str,
     server_id: &str,
 ) -> Option<RunnerCheck> {
     let local_version = local_version.trim();
-    let remote_version = remote_version.trim();
+    let local_build_identity = normalize_homeboy_build_identity(local_build_identity);
+    let remote_build_identity = normalize_homeboy_build_identity(remote_build_identity);
     if local_version.is_empty()
-        || remote_version.is_empty()
-        || remote_version == "unknown"
-        || local_version == remote_version
+        || local_build_identity.is_empty()
+        || remote_build_identity.is_empty()
+        || remote_build_identity == "unknown"
+        || local_build_identity == remote_build_identity
     {
         return None;
     }
 
     let mut details = BTreeMap::new();
     details.insert("local_version".to_string(), local_version.to_string());
-    details.insert("remote_version".to_string(), remote_version.to_string());
+    details.insert(
+        "local_build_identity".to_string(),
+        local_build_identity.to_string(),
+    );
+    details.insert(
+        "remote_version".to_string(),
+        remote_build_identity.to_string(),
+    );
     let quoted_runner_id = shell::quote_arg(runner_id);
     Some(warning_with_details(
         "homeboy.version_skew",
         format!(
-            "Local Homeboy {local_version} differs from remote runner Homeboy {remote_version}"
+            "Local Homeboy {local_build_identity} differs from remote runner Homeboy {remote_build_identity}"
         ),
         Some(format!(
             "Align runner `{runner_id}` to this controller with `homeboy runner refresh-homeboy {quoted_runner_id} --ref v{local_version} --reconnect`; if that fails, inspect the remote runner with `homeboy ssh {server_id} -- homeboy --version`"
         )),
         details,
     ))
+}
+
+fn normalize_homeboy_build_identity(identity: &str) -> &str {
+    let identity = identity.trim();
+    identity.strip_prefix("homeboy ").unwrap_or(identity)
 }
 
 pub fn ok(id: impl Into<String>, message: String, remediation: Option<String>) -> RunnerCheck {

--- a/crates/homeboy-cli/src/commands/runner/doctor/remote.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/remote.rs
@@ -49,7 +49,8 @@ pub fn report(
     });
 
     let homeboy_command = runner.settings.homeboy_path.as_deref().unwrap_or("homeboy");
-    let local_homeboy_version = homeboy_product_identity::product_version();
+    let local_homeboy_identity = homeboy_product_identity::build_identity();
+    let local_homeboy_version = local_homeboy_identity.version.as_str();
     let homeboy = HomeboyProbe {
         version: common::remote_line(
             client,
@@ -67,6 +68,7 @@ pub fn report(
     };
     if let Some(check) = checks::homeboy_version_skew_check(
         local_homeboy_version,
+        &local_homeboy_identity.display,
         &homeboy.version,
         runner_id,
         &server.id,

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/homeboy_path.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/homeboy_path.rs
@@ -127,28 +127,60 @@ fn lab_homeboy_path_shadow_accepts_matching_bare_homeboy() {
 }
 
 #[test]
-fn homeboy_version_skew_check_is_absent_for_equal_versions() {
-    assert!(checks::homeboy_version_skew_check("0.198.7", "0.198.7", "lab", "lab").is_none());
+fn homeboy_version_skew_check_is_absent_for_matching_build_identities() {
+    assert!(checks::homeboy_version_skew_check(
+        "0.290.0",
+        "homeboy 0.290.0+00d2756ef115",
+        "0.290.0+00d2756ef115",
+        "lab",
+        "lab",
+    )
+    .is_none());
 }
 
 #[test]
-fn homeboy_version_skew_check_warns_for_different_versions() {
-    let check = checks::homeboy_version_skew_check("0.198.7", "0.197.7", "lab", "lab")
-        .expect("version skew warning");
+fn homeboy_version_skew_check_warns_for_different_build_identities() {
+    let check = checks::homeboy_version_skew_check(
+        "0.290.0",
+        "homeboy 0.290.0+00d2756ef115",
+        "0.290.0+differentbuild",
+        "lab",
+        "lab",
+    )
+    .expect("version skew warning");
 
     assert_eq!(check.id, "homeboy.version_skew");
     assert_eq!(check.status, RunnerDoctorStatus::Warning);
-    assert!(check.message.contains("0.198.7"));
-    assert!(check.message.contains("0.197.7"));
+    assert!(check.message.contains("0.290.0+00d2756ef115"));
+    assert!(check.message.contains("0.290.0+differentbuild"));
     assert_eq!(
         check.details.get("local_version").map(String::as_str),
-        Some("0.198.7")
+        Some("0.290.0")
+    );
+    assert_eq!(
+        check
+            .details
+            .get("local_build_identity")
+            .map(String::as_str),
+        Some("0.290.0+00d2756ef115")
     );
     assert_eq!(
         check.details.get("remote_version").map(String::as_str),
-        Some("0.197.7")
+        Some("0.290.0+differentbuild")
     );
     assert!(check.remediation.as_deref().is_some_and(
-        |value| value.contains("homeboy runner refresh-homeboy lab --ref v0.198.7 --reconnect")
+        |value| value.contains("homeboy runner refresh-homeboy lab --ref v0.290.0 --reconnect")
     ));
+}
+
+#[test]
+fn homeboy_version_skew_check_warns_for_different_semantic_versions() {
+    assert!(checks::homeboy_version_skew_check(
+        "0.290.0",
+        "homeboy 0.290.0+00d2756ef115",
+        "0.289.0+00d2756ef115",
+        "lab",
+        "lab",
+    )
+    .is_some());
 }


### PR DESCRIPTION
## Summary
- compare normalized full controller and runner build identities in doctor checks
- retain semantic versions for release refresh references
- avoid false skew warnings for exact build parity
- preserve actionable warnings for both build-only and semantic-version drift

Closes #8849

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-cli homeboy_version_skew_check --lib`.
3. Confirm matching full build identities produce no skew check.
4. Confirm different build revisions and different semantic versions each produce warnings.

## Verification
- focused doctor identity suite: 3 passed, 0 failed
- `cargo fmt --check` passed
- `git diff --check` passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed the semantic/full-identity mismatch, implemented normalized comparisons, and added parity and drift tests; Chris reviews and owns the change.
