### PR TITLE
Honor explicit runners during resource preflight

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -883,7 +883,7 @@ fn preflight_hot_command(cli: &Cli, output_file: Option<&str>) -> Option<i32> {
                         &std::env::args().collect::<Vec<_>>(),
                         selected_lab_runner,
                     ),
-                    default_lab_runner.as_deref(),
+                    selected_lab_runner,
                 ) {
                     output_runtime::emit_json_result(Err(err), output_file, 2);
                     return Some(2);
@@ -1573,6 +1573,62 @@ mod tests {
             resource_policy_runner_hint(&cli, Some("default-lab")),
             Some("selected-lab")
         );
+    }
+
+    #[test]
+    fn explicit_runner_preserves_lab_routing_for_hot_cook_and_review_commands() {
+        let cases: &[(&[&str], &str)] = &[
+            (
+                &[
+                    "homeboy",
+                    "--runner",
+                    "homeboy-lab",
+                    "agent-task",
+                    "cook",
+                    "--to-worktree",
+                    "homeboy@fix-explicit-runner",
+                    "--prompt",
+                    "fix the issue",
+                ],
+                "agent-task cook/run-plan/retry --run",
+            ),
+            (
+                &["homeboy", "--runner", "homeboy-lab", "review", "audit"],
+                "review audit",
+            ),
+            (
+                &[
+                    "homeboy",
+                    "--runner",
+                    "homeboy-lab",
+                    "review",
+                    "lint",
+                    "homeboy",
+                ],
+                "review lint",
+            ),
+            (
+                &[
+                    "homeboy",
+                    "--runner",
+                    "homeboy-lab",
+                    "review",
+                    "test",
+                    "homeboy",
+                ],
+                "review test",
+            ),
+        ];
+
+        for (args, label) in cases {
+            let cli = Cli::try_parse_from(*args).expect("parse explicit Lab runner command");
+            let hot_command = resource_policy::hot_command(&cli.command)
+                .expect("command has a resource policy contract");
+
+            assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+            assert!(hot_command.lab_offload_supported);
+            assert_eq!(hot_command.label, *label);
+        }
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/utils/resource_policy.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy.rs
@@ -245,7 +245,7 @@ pub fn non_interactive_preflight_error(
     local_override: bool,
     interactive: bool,
     local_hot_rerun_command: Option<String>,
-    default_runner: Option<&str>,
+    selected_lab_runner: Option<&str>,
 ) -> Option<crate::core::Error> {
     // GitHub Actions runners are ephemeral, single-purpose, and always
     // non-interactive: the warm-machine refusal would fail otherwise-good PR
@@ -254,7 +254,7 @@ pub fn non_interactive_preflight_error(
     if local_override || interactive || is_runner_hosted_exec() || is_ci_execution() {
         return None;
     }
-    if default_runner.is_some() && warning.message.contains("--runner") {
+    if selected_lab_runner.is_some() && warning.message.contains("--runner") {
         return None;
     }
 
@@ -264,7 +264,7 @@ pub fn non_interactive_preflight_error(
             "Refusing to start `{}` on a {} machine from a non-interactive shell. {} Use a safe Lab/offload path once this command supports it, or rerun later when `homeboy self doctor` reports ok.",
             warning.command,
             severity_str(warning.recommendation),
-            primary_action(warning, default_runner),
+            primary_action(warning, selected_lab_runner),
         ),
         None,
         None,
@@ -668,6 +668,23 @@ mod tests {
     }
 
     #[test]
+    fn non_interactive_hot_warning_allows_explicit_lab_runner_without_default() {
+        let _lock = env_lock();
+        let _guard = EnvVarGuard::remove(crate::runner::RUNNER_HOSTED_EXEC_ENV);
+        let warning = evaluate_with_runner_hint(
+            lab_supported_hot("agent-task cook/run-plan/retry --run"),
+            &resources(ResourceRecommendation::Hot),
+            Some("homeboy-lab"),
+        )
+        .expect("hot machines warn");
+
+        assert!(
+            non_interactive_preflight_error(&warning, false, false, None, Some("homeboy-lab"))
+                .is_none()
+        );
+    }
+
+    #[test]
     fn non_interactive_local_only_refusal_includes_local_hot_rerun_command() {
         let _lock = env_lock();
         let _guard = EnvVarGuard::remove(crate::runner::RUNNER_HOSTED_EXEC_ENV);
@@ -715,6 +732,27 @@ mod tests {
         assert_eq!(
             rerun.as_deref(),
             Some("homeboy --runner homeboy-lab audit --changed-since origin/main")
+        );
+    }
+
+    #[test]
+    fn portable_rerun_preserves_explicit_runner_without_placement() {
+        let rerun = rerun_command(
+            lab_supported_hot("review test"),
+            &[
+                "homeboy".to_string(),
+                "--runner".to_string(),
+                "homeboy-lab".to_string(),
+                "review".to_string(),
+                "test".to_string(),
+                "homeboy".to_string(),
+            ],
+            Some("homeboy-lab"),
+        );
+
+        assert_eq!(
+            rerun.as_deref(),
+            Some("homeboy --runner homeboy-lab review test homeboy")
         );
     }
 


### PR DESCRIPTION
## Summary
- feed the explicitly selected runner into resource-policy admission instead of consulting only the default runner
- preserve `--runner` as pinned Lab intent for Cook and full review commands
- keep generated recovery commands free of redundant placement flags
- add parser and resource-policy regression coverage across Cook and review audit/lint/test

Closes #8850

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-cli resource_policy --lib`.
3. Confirm `--runner homeboy-lab` admits a portable hot-machine command even when no default runner exists.
4. Confirm generated rerun commands preserve the explicit runner without adding `--placement`.

## Verification
- resource-policy suite: 30 passed, 0 failed
- focused explicit-runner parser/routing coverage passed
- `cargo fmt --check` passed
- `git diff --check` passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Reproduced the explicit-runner admission failure, implemented the routing fix, and added Cook/review regression coverage; Chris reviews and owns the change.
