### PR TITLE
Add pin-aware controller runtime retention

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/controller_pin_reference_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/controller_pin_reference_provider.rs
@@ -28,7 +28,7 @@ impl ControllerPinReferenceProvider for AgentTaskControllerPinReferenceProvider 
         let (records, _) = list_records_with_health()?;
         let mut referenced = Vec::new();
         for record in records {
-            if !state_retains_pin(record.state) {
+            if !state_retains_pin(&record) {
                 continue;
             }
             if let Some(path) = record
@@ -47,9 +47,14 @@ impl ControllerPinReferenceProvider for AgentTaskControllerPinReferenceProvider 
 /// A record whose state can still operate on its pin retains it: queued,
 /// running, and recoverable-partial records may be re-run by lifecycle
 /// recovery, so their originating pinned executable must survive pruning.
-fn state_retains_pin(state: AgentTaskRunState) -> bool {
+fn state_retains_pin(record: &crate::agent_task_lifecycle::AgentTaskRunRecord) -> bool {
+    if record.lifecycle.artifact_retention.status
+        == homeboy_core::run_lifecycle_record::ArtifactRetentionStatus::Retained
+    {
+        return true;
+    }
     matches!(
-        state,
+        record.state,
         AgentTaskRunState::Queued
             | AgentTaskRunState::Running
             | AgentTaskRunState::CandidateRecoverable

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -500,12 +500,14 @@ fn migrate_record_controller_runtime(record: &mut AgentTaskRunRecord) -> Result<
     else {
         return Ok(());
     };
-    let migrated = homeboy_core::controller_runtime::migrate_legacy_pin(runtime)?;
-    if &migrated != runtime {
-        record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
-            migrated;
-        store::write_record(record)?;
-    }
+    let original = runtime.clone();
+    let migrated =
+        homeboy_core::controller_runtime::migrate_legacy_pin_and_persist(&original, |migrated| {
+            record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
+                migrated.clone();
+            store::write_record(record)
+        })?;
+    record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = migrated;
     Ok(())
 }
 
@@ -527,11 +529,17 @@ pub fn recover_controller_runtime(
                 None,
             )
         })?;
-    let recovered = homeboy_core::controller_runtime::recover_pin(runtime, artifact, source)?;
-    // The new pin is verified before this single-record durable mutation.
-    record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
-        recovered.clone();
-    store::write_record(&record)?;
+    let runtime = runtime.clone();
+    let recovered = homeboy_core::controller_runtime::recover_pin_and_persist(
+        &runtime,
+        artifact,
+        source,
+        |recovered| {
+            record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
+                recovered.clone();
+            store::write_record(&record)
+        },
+    )?;
     Ok(recovered)
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests.rs
@@ -266,7 +266,7 @@ fn legacy_v1_pin_migration_failures_leave_durable_record_unchanged() {
 
 #[cfg(unix)]
 #[test]
-fn controller_runtime_retention_keeps_mutable_runs_and_reports_terminal_pins_eligible() {
+fn controller_runtime_retention_keeps_mutable_and_retained_terminal_runs() {
     with_isolated_home(|_| {
         // Controller-runtime retention discovers referenced pins through the
         // agent-task pin-reference provider hook; register it so the report can
@@ -305,6 +305,7 @@ fn controller_runtime_retention_keeps_mutable_runs_and_reports_terminal_pins_eli
         }
         rewrite_record_for_test(&terminal.run_id, |record| {
             record.state = AgentTaskRunState::Succeeded;
+            record.lifecycle.artifact_retention.status = ArtifactRetentionStatus::Retained;
         })
         .expect("make terminal");
 
@@ -325,15 +326,15 @@ fn controller_runtime_retention_keeps_mutable_runs_and_reports_terminal_pins_eli
         let report =
             homeboy_core::controller_runtime::retention_report().expect("retention report");
         assert!(report.retained.contains(&active_pin));
-        assert!(report.eligible.contains(&terminal_pin));
+        assert!(report.retained.contains(&terminal_pin));
         let dry_run = prune_controller_runtime_pins(false).expect("plan pin pruning");
         assert!(dry_run.retained.contains(&active_pin));
-        assert!(dry_run.eligible.contains(&terminal_pin));
+        assert!(dry_run.retained.contains(&terminal_pin));
         assert!(dry_run.removed.is_empty());
-        let applied = prune_controller_runtime_pins(true).expect("prune terminal pin");
-        assert!(applied.removed.contains(&terminal_pin));
+        let applied = prune_controller_runtime_pins(true).expect("prune unreferenced pins");
+        assert!(!applied.removed.contains(&terminal_pin));
         assert!(active_pin.exists());
-        assert!(!terminal_pin.exists());
+        assert!(terminal_pin.exists());
     });
 }
 

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -502,25 +502,18 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
             .filter(|snapshot| snapshot.eligible)
             .map(|snapshot| snapshot.size_bytes)
             .sum();
-        let reclaimed_bytes = output
-            .removed
-            .iter()
-            .filter_map(|path| {
-                output
-                    .snapshots
-                    .iter()
-                    .find(|snapshot| snapshot.pins.contains(path))
-                    .map(|snapshot| snapshot.size_bytes)
-            })
-            .sum();
         categories.push(category_from_output(
             CONTROLLER_RUNTIMES_METADATA,
             apply,
-            output.eligible.len(),
-            output.removed.len(),
+            output
+                .snapshots
+                .iter()
+                .filter(|snapshot| snapshot.eligible)
+                .count(),
+            output.removed_identities.len(),
             output.retained.len(),
             estimated_bytes,
-            reclaimed_bytes,
+            output.reclaimed_bytes,
             output,
         )?);
     }

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -5,6 +5,7 @@ use clap::{Args, Subcommand, ValueEnum};
 use homeboy::core::cleanup::{
     self, ArtifactCleanupOptions, ArtifactCleanupSort, ResourceCleanupOptions,
 };
+use homeboy::core::controller_runtime::{self, ControllerRuntimeCleanupOptions};
 use homeboy::core::defaults;
 use homeboy::core::engine;
 use homeboy::core::engine::shell::quote_arg;
@@ -61,6 +62,7 @@ pub enum CleanupCategoryArg {
     RemoteLabWorkspaces,
     RuntimeTmp,
     ControllerScratch,
+    ControllerRuntimes,
 }
 
 #[derive(Subcommand)]
@@ -203,6 +205,8 @@ pub struct CleanupRetentionManifest {
     pub schema: &'static str,
     pub terminal_run_days: i64,
     pub runtime_tmp_days: u64,
+    pub controller_runtime_days: u64,
+    pub controller_runtime_max_bytes: u64,
     pub limit: i64,
     pub terminal_run_guard: bool,
 }
@@ -311,6 +315,14 @@ const CONTROLLER_SCRATCH_METADATA: CleanupInventoryCategoryMetadata =
         include_arg: "controller-scratch",
         dry_run_command: "homeboy cleanup --include controller-scratch",
         apply_command: "homeboy cleanup --include controller-scratch --apply",
+    };
+
+const CONTROLLER_RUNTIMES_METADATA: CleanupInventoryCategoryMetadata =
+    CleanupInventoryCategoryMetadata {
+        category: "controller_runtimes",
+        include_arg: "controller-runtimes",
+        dry_run_command: "homeboy cleanup --include controller-runtimes",
+        apply_command: "homeboy cleanup --include controller-runtimes --apply",
     };
 
 fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
@@ -475,6 +487,43 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
             output,
         )?);
     }
+    if selected.includes(CleanupCategoryArg::ControllerRuntimes) {
+        let output = controller_runtime::cleanup(ControllerRuntimeCleanupOptions {
+            apply,
+            min_age: std::time::Duration::from_secs(
+                configured.controller_runtime_days.saturating_mul(86_400),
+            ),
+            max_total_bytes: configured.controller_runtime_max_bytes,
+            limit: usize::try_from(limit).unwrap_or(usize::MAX),
+        })?;
+        let estimated_bytes = output
+            .snapshots
+            .iter()
+            .filter(|snapshot| snapshot.eligible)
+            .map(|snapshot| snapshot.size_bytes)
+            .sum();
+        let reclaimed_bytes = output
+            .removed
+            .iter()
+            .filter_map(|path| {
+                output
+                    .snapshots
+                    .iter()
+                    .find(|snapshot| snapshot.pins.contains(path))
+                    .map(|snapshot| snapshot.size_bytes)
+            })
+            .sum();
+        categories.push(category_from_output(
+            CONTROLLER_RUNTIMES_METADATA,
+            apply,
+            output.eligible.len(),
+            output.removed.len(),
+            output.retained.len(),
+            estimated_bytes,
+            reclaimed_bytes,
+            output,
+        )?);
+    }
 
     let candidate_count = categories
         .iter()
@@ -510,6 +559,8 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
             schema: "homeboy/retention-manifest/v1",
             terminal_run_days,
             runtime_tmp_days: configured.runtime_tmp_days,
+            controller_runtime_days: configured.controller_runtime_days,
+            controller_runtime_max_bytes: configured.controller_runtime_max_bytes,
             limit,
             terminal_run_guard: true,
         },
@@ -1215,6 +1266,13 @@ mod tests {
                 "runtime-tmp",
                 "homeboy self cleanup-runtime-tmp",
                 "homeboy self cleanup-runtime-tmp --apply",
+            ),
+            (
+                CONTROLLER_RUNTIMES_METADATA,
+                "controller_runtimes",
+                "controller-runtimes",
+                "homeboy cleanup --include controller-runtimes",
+                "homeboy cleanup --include controller-runtimes --apply",
             ),
         ];
 

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -10,7 +10,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Mutex, MutexGuard, OnceLock};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 use uuid::Uuid;
 
 use crate::{build_identity, paths, Error, Result};
@@ -34,13 +34,34 @@ static ADMISSION_LOCK_PROCESS_GUARDS: OnceLock<Mutex<BTreeMap<PathBuf, &'static 
 pub struct ControllerRuntimeRetentionReport {
     pub retained: Vec<PathBuf>,
     pub eligible: Vec<PathBuf>,
+    pub snapshots: Vec<ControllerRuntimeSnapshot>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ControllerRuntimeSnapshot {
+    pub identity: String,
+    pub path: PathBuf,
+    pub size_bytes: u64,
+    pub age_seconds: u64,
+    pub pins: Vec<PathBuf>,
+    pub retention_reasons: Vec<String>,
+    pub eligible: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ControllerRuntimeCleanupOptions {
+    pub apply: bool,
+    pub min_age: Duration,
+    pub max_total_bytes: u64,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct ControllerRuntimePruneResult {
     pub retained: Vec<PathBuf>,
     pub eligible: Vec<PathBuf>,
     pub removed: Vec<PathBuf>,
+    pub snapshots: Vec<ControllerRuntimeSnapshot>,
 }
 
 /// Discover pin references through the durable lifecycle store and classify the
@@ -48,6 +69,10 @@ pub struct ControllerRuntimePruneResult {
 /// recoverable partial records retain their pins because lifecycle recovery can
 /// still operate on them. The active admission generation is retained as well.
 pub fn retention_report() -> Result<ControllerRuntimeRetentionReport> {
+    retention_report_at(SystemTime::now())
+}
+
+fn retention_report_at(now: SystemTime) -> Result<ControllerRuntimeRetentionReport> {
     let root = runtime_root()?;
     let referenced = crate::controller_pin_reference::referenced_controller_pins()?;
     let mut retained = BTreeSet::new();
@@ -85,33 +110,193 @@ pub fn retention_report() -> Result<ControllerRuntimeRetentionReport> {
 
     let pins = discover_pin_paths(&root)?;
     let eligible = pins.difference(&retained).cloned().collect();
+    let mut snapshots = Vec::new();
+    for entry in fs::read_dir(&root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("list controller runtime identities".to_string()),
+        )
+    })? {
+        let entry = entry.map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("read controller runtime identity".to_string()),
+            )
+        })?;
+        let path = entry.path();
+        if !path.is_dir()
+            || path
+                .file_name()
+                .is_some_and(|name| name == ADMISSION_LOCK_DIR)
+        {
+            continue;
+        }
+        let identity_pins = pins
+            .iter()
+            .filter(|pin| pin.starts_with(&path))
+            .cloned()
+            .collect::<Vec<_>>();
+        if identity_pins.is_empty() {
+            continue;
+        }
+        let mut reasons = Vec::new();
+        if identity_pins.iter().any(|pin| retained.contains(pin)) {
+            reasons.push("pinned_by_active_or_resumable_run_or_current_generation".to_string());
+        }
+        let modified = fs::metadata(&path)
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(now);
+        let age_seconds = now.duration_since(modified).unwrap_or_default().as_secs();
+        snapshots.push(ControllerRuntimeSnapshot {
+            identity: path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string(),
+            size_bytes: path_size(&path),
+            age_seconds,
+            pins: identity_pins,
+            eligible: reasons.is_empty(),
+            retention_reasons: reasons,
+            path,
+        });
+    }
+    snapshots.sort_by(|left, right| left.path.cmp(&right.path));
     Ok(ControllerRuntimeRetentionReport {
         retained: retained.into_iter().collect(),
         eligible,
+        snapshots,
     })
 }
 
 /// Remove only content-addressed pins not referenced by a nonterminal durable
 /// record or the active generation. The caller chooses mutation explicitly.
 pub fn prune_pins(apply: bool) -> Result<ControllerRuntimePruneResult> {
-    let report = retention_report()?;
-    let mut removed = Vec::new();
-    if apply {
-        for path in &report.eligible {
-            fs::remove_file(path).map_err(|error| {
+    let result = cleanup(ControllerRuntimeCleanupOptions {
+        apply,
+        min_age: Duration::ZERO,
+        max_total_bytes: 0,
+        limit: usize::MAX,
+    })?;
+    Ok(ControllerRuntimePruneResult {
+        retained: result.retained,
+        eligible: result.eligible,
+        removed: result.removed,
+        snapshots: result.snapshots,
+    })
+}
+
+/// Inventory and reclaim immutable runtime identities. The admission lock makes
+/// the final reachability check atomic with activation and materialization.
+pub fn cleanup(options: ControllerRuntimeCleanupOptions) -> Result<ControllerRuntimePruneResult> {
+    let root = runtime_root()?;
+    let _lock = acquire_admission_lock(&root.join(ADMISSION_LOCK_DIR))?;
+    // A prior process may have stopped after the atomic rename. Tombstones are
+    // never runtime identities and can be completed safely under this lock.
+    for entry in fs::read_dir(&root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("list interrupted controller runtime cleanup".to_string()),
+        )
+    })? {
+        let path = entry
+            .map_err(|error| {
                 Error::internal_io(
                     error.to_string(),
-                    Some("prune unreferenced controller runtime pin".to_string()),
+                    Some("read interrupted controller runtime cleanup".to_string()),
+                )
+            })?
+            .path();
+        if path.is_dir()
+            && path
+                .file_name()
+                .is_some_and(|name| name.to_string_lossy().starts_with(".cleanup-"))
+        {
+            fs::remove_dir_all(path).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("complete interrupted controller runtime cleanup".to_string()),
                 )
             })?;
-            removed.push(path.clone());
         }
     }
+    let mut report = retention_report()?;
+    let mut total = report
+        .snapshots
+        .iter()
+        .map(|snapshot| snapshot.size_bytes)
+        .sum::<u64>();
+    let mut candidates = report
+        .snapshots
+        .iter_mut()
+        .filter(|snapshot| snapshot.eligible)
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| {
+        right
+            .age_seconds
+            .cmp(&left.age_seconds)
+            .then_with(|| right.size_bytes.cmp(&left.size_bytes))
+    });
+    let mut removed = Vec::new();
+    for snapshot in candidates {
+        let expired = snapshot.age_seconds >= options.min_age.as_secs();
+        let pressured = total > options.max_total_bytes;
+        if !(expired || pressured) {
+            snapshot
+                .retention_reasons
+                .push("within_age_and_size_budget".to_string());
+            continue;
+        }
+        if removed.len() >= options.limit {
+            snapshot
+                .retention_reasons
+                .push("cleanup_limit_reached".to_string());
+            continue;
+        }
+        if options.apply {
+            // Rename first: an interrupted cleanup leaves a non-discoverable
+            // tombstone rather than a partially materialized identity.
+            let tombstone = root.join(format!(".cleanup-{}", Uuid::new_v4()));
+            fs::rename(&snapshot.path, &tombstone).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("stage controller runtime identity cleanup".to_string()),
+                )
+            })?;
+            fs::remove_dir_all(&tombstone).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("remove controller runtime identity".to_string()),
+                )
+            })?;
+            removed.extend(snapshot.pins.clone());
+            total = total.saturating_sub(snapshot.size_bytes);
+        }
+    }
+    let removed_set = removed.iter().collect::<BTreeSet<_>>();
+    report.eligible.retain(|path| !removed_set.contains(path));
     Ok(ControllerRuntimePruneResult {
         retained: report.retained,
         eligible: report.eligible,
         removed,
+        snapshots: report.snapshots,
     })
+}
+
+fn path_size(path: &Path) -> u64 {
+    let Ok(metadata) = fs::symlink_metadata(path) else {
+        return 0;
+    };
+    if metadata.is_file() {
+        return metadata.len();
+    }
+    fs::read_dir(path)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.ok())
+        .map(|entry| path_size(&entry.path()))
+        .sum()
 }
 
 fn content_addressed_pin_path(root: &Path, path: &Path) -> bool {
@@ -1680,6 +1865,54 @@ mod tests {
                 runtime_a_bytes
             );
             validate_pin(&recovered).expect("recovered runtime A validates");
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_preserves_active_generation_and_reclaims_unpinned_identity_under_size_pressure() {
+        crate::test_support::with_isolated_home(|_| {
+            let temporary = tempfile::tempdir().expect("temporary controller directory");
+            let current = temporary.path().join("current");
+            let stale = temporary.path().join("stale");
+            let current_digest = fake_controller(&current, "homeboy test+current", "current");
+            let stale_digest = fake_controller(&stale, "homeboy test+stale", "stale");
+            let current_pin =
+                pinned_path("homeboy test+current", &current_digest).expect("current path");
+            let stale_pin = pinned_path("homeboy test+stale", &stale_digest).expect("stale path");
+            publish_pin(&current, &current_pin, &current_digest).expect("publish current");
+            publish_pin(&stale, &stale_pin, &stale_digest).expect("publish stale");
+            write_active_generation(
+                &runtime_root().expect("root").join(ACTIVE_GENERATION_FILE),
+                &json!({ "originating": { "pinned_executable": current_pin } }),
+            )
+            .expect("activate current");
+
+            let inventory = cleanup(ControllerRuntimeCleanupOptions {
+                apply: false,
+                min_age: Duration::from_secs(u64::MAX),
+                max_total_bytes: 0,
+                limit: 10,
+            })
+            .expect("inventory");
+            assert!(inventory
+                .snapshots
+                .iter()
+                .any(|snapshot| snapshot.pins.contains(&current_pin) && !snapshot.eligible));
+            assert!(inventory
+                .snapshots
+                .iter()
+                .any(|snapshot| snapshot.pins.contains(&stale_pin) && snapshot.eligible));
+            let applied = cleanup(ControllerRuntimeCleanupOptions {
+                apply: true,
+                min_age: Duration::from_secs(u64::MAX),
+                max_total_bytes: 0,
+                limit: 10,
+            })
+            .expect("apply");
+            assert!(applied.removed.contains(&stale_pin));
+            assert!(current_pin.exists());
+            assert!(!stale_pin.exists());
         });
     }
 }

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -61,6 +61,8 @@ pub struct ControllerRuntimePruneResult {
     pub retained: Vec<PathBuf>,
     pub eligible: Vec<PathBuf>,
     pub removed: Vec<PathBuf>,
+    pub removed_identities: Vec<PathBuf>,
+    pub reclaimed_bytes: u64,
     pub snapshots: Vec<ControllerRuntimeSnapshot>,
 }
 
@@ -182,6 +184,8 @@ pub fn prune_pins(apply: bool) -> Result<ControllerRuntimePruneResult> {
         retained: result.retained,
         eligible: result.eligible,
         removed: result.removed,
+        removed_identities: result.removed_identities,
+        reclaimed_bytes: result.reclaimed_bytes,
         snapshots: result.snapshots,
     })
 }
@@ -191,34 +195,8 @@ pub fn prune_pins(apply: bool) -> Result<ControllerRuntimePruneResult> {
 pub fn cleanup(options: ControllerRuntimeCleanupOptions) -> Result<ControllerRuntimePruneResult> {
     let root = runtime_root()?;
     let _lock = acquire_admission_lock(&root.join(ADMISSION_LOCK_DIR))?;
-    // A prior process may have stopped after the atomic rename. Tombstones are
-    // never runtime identities and can be completed safely under this lock.
-    for entry in fs::read_dir(&root).map_err(|error| {
-        Error::internal_io(
-            error.to_string(),
-            Some("list interrupted controller runtime cleanup".to_string()),
-        )
-    })? {
-        let path = entry
-            .map_err(|error| {
-                Error::internal_io(
-                    error.to_string(),
-                    Some("read interrupted controller runtime cleanup".to_string()),
-                )
-            })?
-            .path();
-        if path.is_dir()
-            && path
-                .file_name()
-                .is_some_and(|name| name.to_string_lossy().starts_with(".cleanup-"))
-        {
-            fs::remove_dir_all(path).map_err(|error| {
-                Error::internal_io(
-                    error.to_string(),
-                    Some("complete interrupted controller runtime cleanup".to_string()),
-                )
-            })?;
-        }
+    if options.apply {
+        recover_cleanup_tombstones(&root)?;
     }
     let mut report = retention_report()?;
     let mut total = report
@@ -238,6 +216,8 @@ pub fn cleanup(options: ControllerRuntimeCleanupOptions) -> Result<ControllerRun
             .then_with(|| right.size_bytes.cmp(&left.size_bytes))
     });
     let mut removed = Vec::new();
+    let mut removed_identities = Vec::new();
+    let mut reclaimed_bytes: u64 = 0;
     for snapshot in candidates {
         let expired = snapshot.age_seconds >= options.min_age.as_secs();
         let pressured = total > options.max_total_bytes;
@@ -270,6 +250,8 @@ pub fn cleanup(options: ControllerRuntimeCleanupOptions) -> Result<ControllerRun
                 )
             })?;
             removed.extend(snapshot.pins.clone());
+            removed_identities.push(snapshot.path.clone());
+            reclaimed_bytes = reclaimed_bytes.saturating_add(snapshot.size_bytes);
             total = total.saturating_sub(snapshot.size_bytes);
         }
     }
@@ -279,8 +261,41 @@ pub fn cleanup(options: ControllerRuntimeCleanupOptions) -> Result<ControllerRun
         retained: report.retained,
         eligible: report.eligible,
         removed,
+        removed_identities,
+        reclaimed_bytes,
         snapshots: report.snapshots,
     })
+}
+
+fn recover_cleanup_tombstones(root: &Path) -> Result<()> {
+    for entry in fs::read_dir(root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("list interrupted controller runtime cleanup".to_string()),
+        )
+    })? {
+        let path = entry
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("read interrupted controller runtime cleanup".to_string()),
+                )
+            })?
+            .path();
+        if path.is_dir()
+            && path
+                .file_name()
+                .is_some_and(|name| name.to_string_lossy().starts_with(".cleanup-"))
+        {
+            fs::remove_dir_all(path).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("complete interrupted controller runtime cleanup".to_string()),
+                )
+            })?;
+        }
+    }
+    Ok(())
 }
 
 fn path_size(path: &Path) -> u64 {
@@ -334,6 +349,12 @@ fn discover_pin_paths(root: &Path) -> Result<BTreeSet<PathBuf>> {
             )
         })?;
         let path = entry.path();
+        if path
+            .file_name()
+            .is_some_and(|name| name.to_string_lossy().starts_with(".cleanup-"))
+        {
+            continue;
+        }
         let direct_pin = path.join("homeboy");
         if content_addressed_pin_path(root, &direct_pin) && direct_pin.is_file() {
             pins.insert(direct_pin);
@@ -391,6 +412,12 @@ impl Drop for AdmissionLock {
 }
 
 pub fn pin_current() -> Result<Value> {
+    let root = runtime_root()?;
+    let _lock = acquire_admission_lock(&root.join(ADMISSION_LOCK_DIR))?;
+    pin_current_unlocked()
+}
+
+fn pin_current_unlocked() -> Result<Value> {
     let identity = build_identity::current();
     let executable = std::env::current_exe().map_err(|error| {
         Error::internal_io(
@@ -435,7 +462,7 @@ pub fn admit_current() -> Result<RuntimeAdmission> {
     let root = runtime_root()?;
     let lock_path = root.join(ADMISSION_LOCK_DIR);
     let lock = acquire_admission_lock(&lock_path)?;
-    let runtime = pin_current()?;
+    let runtime = pin_current_unlocked()?;
     write_active_generation(&root.join(ACTIVE_GENERATION_FILE), &runtime)?;
     validate_pin(&runtime)?;
     Ok(RuntimeAdmission {
@@ -516,6 +543,12 @@ pub fn validate_for_mutation(metadata: &Value, current_identity: &str) -> Result
 /// Upgrade a legacy pin into the immutable content-addressed v2 format.
 /// The caller persists the returned metadata only after this has completed.
 pub fn migrate_legacy_pin(runtime: &Value) -> Result<Value> {
+    let root = runtime_root()?;
+    let _lock = acquire_admission_lock(&root.join(ADMISSION_LOCK_DIR))?;
+    migrate_legacy_pin_unlocked(runtime)
+}
+
+fn migrate_legacy_pin_unlocked(runtime: &Value) -> Result<Value> {
     let identity =
         required_runtime_string(runtime, "/originating/build_identity", "build identity")?;
     let current = required_runtime_string(
@@ -572,6 +605,16 @@ pub fn validate(runtime: &Value) -> Result<()> {
 /// artifact or source checkout without changing the durable identity or digest
 /// contract.
 pub fn recover_pin(
+    runtime: &Value,
+    artifact: Option<&Path>,
+    source: Option<&Path>,
+) -> Result<Value> {
+    let root = runtime_root()?;
+    let _lock = acquire_admission_lock(&root.join(ADMISSION_LOCK_DIR))?;
+    recover_pin_unlocked(runtime, artifact, source)
+}
+
+fn recover_pin_unlocked(
     runtime: &Value,
     artifact: Option<&Path>,
     source: Option<&Path>,
@@ -1913,6 +1956,33 @@ mod tests {
             assert!(applied.removed.contains(&stale_pin));
             assert!(current_pin.exists());
             assert!(!stale_pin.exists());
+        });
+    }
+
+    #[test]
+    fn cleanup_dry_run_preserves_tombstones_and_apply_recovers_them() {
+        crate::test_support::with_isolated_home(|_| {
+            let root = runtime_root().expect("runtime root");
+            let tombstone = root.join(".cleanup-interrupted");
+            fs::create_dir_all(&tombstone).expect("create tombstone");
+            fs::write(tombstone.join("homeboy"), b"interrupted").expect("write tombstone");
+
+            cleanup(ControllerRuntimeCleanupOptions {
+                apply: false,
+                min_age: Duration::ZERO,
+                max_total_bytes: 0,
+                limit: 1,
+            })
+            .expect("dry run");
+            assert!(tombstone.exists());
+            cleanup(ControllerRuntimeCleanupOptions {
+                apply: true,
+                min_age: Duration::ZERO,
+                max_total_bytes: 0,
+                limit: 1,
+            })
+            .expect("apply");
+            assert!(!tombstone.exists());
         });
     }
 }

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -71,17 +71,20 @@ pub struct ControllerRuntimePruneResult {
 /// recoverable partial records retain their pins because lifecycle recovery can
 /// still operate on them. The active admission generation is retained as well.
 pub fn retention_report() -> Result<ControllerRuntimeRetentionReport> {
-    retention_report_at(SystemTime::now())
+    let referenced = crate::controller_pin_reference::referenced_controller_pins()?;
+    retention_report_with_references_at(&referenced, SystemTime::now())
 }
 
-fn retention_report_at(now: SystemTime) -> Result<ControllerRuntimeRetentionReport> {
+fn retention_report_with_references_at(
+    referenced: &[PathBuf],
+    now: SystemTime,
+) -> Result<ControllerRuntimeRetentionReport> {
     let root = runtime_root()?;
-    let referenced = crate::controller_pin_reference::referenced_controller_pins()?;
     let mut retained = BTreeSet::new();
 
     for path in referenced {
         if content_addressed_pin_path(&root, &path) {
-            retained.insert(path);
+            retained.insert(path.clone());
         }
     }
 
@@ -194,11 +197,14 @@ pub fn prune_pins(apply: bool) -> Result<ControllerRuntimePruneResult> {
 /// the final reachability check atomic with activation and materialization.
 pub fn cleanup(options: ControllerRuntimeCleanupOptions) -> Result<ControllerRuntimePruneResult> {
     let root = runtime_root()?;
+    // Lifecycle inventory may migrate legacy records, which itself needs the
+    // admission lock. Collect reachability before taking the runtime lock.
+    let referenced = crate::controller_pin_reference::referenced_controller_pins()?;
     let _lock = acquire_admission_lock(&root.join(ADMISSION_LOCK_DIR))?;
     if options.apply {
         recover_cleanup_tombstones(&root)?;
     }
-    let mut report = retention_report()?;
+    let mut report = retention_report_with_references_at(&referenced, SystemTime::now())?;
     let mut total = report
         .snapshots
         .iter()
@@ -548,6 +554,21 @@ pub fn migrate_legacy_pin(runtime: &Value) -> Result<Value> {
     migrate_legacy_pin_unlocked(runtime)
 }
 
+/// Publish a migrated pin and persist its durable reference while the admission
+/// lock remains held, so cleanup cannot reclaim the new identity in between.
+pub fn migrate_legacy_pin_and_persist(
+    runtime: &Value,
+    persist: impl FnOnce(&Value) -> Result<()>,
+) -> Result<Value> {
+    let root = runtime_root()?;
+    let _lock = acquire_admission_lock(&root.join(ADMISSION_LOCK_DIR))?;
+    let migrated = migrate_legacy_pin_unlocked(runtime)?;
+    if &migrated != runtime {
+        persist(&migrated)?;
+    }
+    Ok(migrated)
+}
+
 fn migrate_legacy_pin_unlocked(runtime: &Value) -> Result<Value> {
     let identity =
         required_runtime_string(runtime, "/originating/build_identity", "build identity")?;
@@ -612,6 +633,21 @@ pub fn recover_pin(
     let root = runtime_root()?;
     let _lock = acquire_admission_lock(&root.join(ADMISSION_LOCK_DIR))?;
     recover_pin_unlocked(runtime, artifact, source)
+}
+
+/// Publish a recovered pin and persist its durable reference under one
+/// admission lock, closing the publication-to-record race with cleanup.
+pub fn recover_pin_and_persist(
+    runtime: &Value,
+    artifact: Option<&Path>,
+    source: Option<&Path>,
+    persist: impl FnOnce(&Value) -> Result<()>,
+) -> Result<Value> {
+    let root = runtime_root()?;
+    let _lock = acquire_admission_lock(&root.join(ADMISSION_LOCK_DIR))?;
+    let recovered = recover_pin_unlocked(runtime, artifact, source)?;
+    persist(&recovered)?;
+    Ok(recovered)
 }
 
 fn recover_pin_unlocked(

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -160,6 +160,10 @@ pub struct RetentionConfig {
     pub terminal_run_days: i64,
     #[serde(default = "default_runtime_tmp_retention_days")]
     pub runtime_tmp_days: u64,
+    #[serde(default = "default_controller_runtime_retention_days")]
+    pub controller_runtime_days: u64,
+    #[serde(default = "default_controller_runtime_max_bytes")]
+    pub controller_runtime_max_bytes: u64,
     #[serde(default = "default_retention_limit")]
     pub limit: i64,
 }
@@ -169,6 +173,8 @@ impl Default for RetentionConfig {
         Self {
             terminal_run_days: default_terminal_run_retention_days(),
             runtime_tmp_days: default_runtime_tmp_retention_days(),
+            controller_runtime_days: default_controller_runtime_retention_days(),
+            controller_runtime_max_bytes: default_controller_runtime_max_bytes(),
             limit: default_retention_limit(),
         }
     }
@@ -180,6 +186,14 @@ fn default_terminal_run_retention_days() -> i64 {
 
 fn default_runtime_tmp_retention_days() -> u64 {
     7
+}
+
+fn default_controller_runtime_retention_days() -> u64 {
+    30
+}
+
+fn default_controller_runtime_max_bytes() -> u64 {
+    2 * 1024 * 1024 * 1024
 }
 
 fn default_retention_limit() -> i64 {


### PR DESCRIPTION
## Summary
- inventory controller runtime identities with lifecycle pin evidence
- preserve current, active, resumable, and retained runtime pins
- reclaim unpinned snapshots under age and size policy
- serialize cleanup with recovery and migration publication
- recover interrupted cleanup tombstones only during apply

Closes #8838.

## How to test
1. Run the focused controller runtime cleanup tests in `homeboy-core`.
2. Run `cargo fmt --check` and `git diff --check`.
3. Materialize current, retained, and unpinned runtime identities.
4. Confirm dry-run does not mutate tombstones and apply reclaims only unpinned out-of-budget identities.

## Known verification gap
`controller_runtime_retention_keeps_mutable_and_retained_terminal_runs` stalls after compilation in the current lifecycle harness. The candidate avoids inventory lock recursion, but the test still requires a process stack trace. Under-budget reporting and broader age/size concurrency coverage remain incomplete.

## Compatibility
Adds defaulted runtime-retention policy without changing existing command syntax.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Runtime retention design, implementation, tests, and three review/fix passes with Chris Huber.