### PR TITLE
Retain executed test failure results

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/output_runtime.rs
+++ b/crates/homeboy-cli/src/commands/infra/output_runtime.rs
@@ -425,6 +425,32 @@ mod tests {
     }
 
     #[test]
+    fn generic_output_file_keeps_failed_test_result_available() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("test.json");
+        let run = CommandRun::from_stdout_result(
+            Ok(json!({
+                "passed": false,
+                "status": "failed",
+                "test_counts": { "total": 36, "passed": 21, "failed": 15, "skipped": 0 }
+            })),
+            1,
+        );
+
+        write_output_file(
+            &run,
+            CommandOutputFileMode::GenericEnvelope,
+            Some(path.to_str().expect("utf8 path")),
+        );
+
+        let written = std::fs::read_to_string(path).expect("failed result written");
+        let json: Value = serde_json::from_str(&written).expect("valid json");
+        assert_eq!(json["success"], false);
+        assert_eq!(json["exit_code"], 1);
+        assert_eq!(json["data"]["test_counts"]["failed"], 15);
+    }
+
+    #[test]
     fn review_output_file_writes_stable_artifact_without_envelope() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("review.json");

--- a/crates/homeboy-core/src/extension/test/parsing.rs
+++ b/crates/homeboy-core/src/extension/test/parsing.rs
@@ -307,16 +307,41 @@ pub fn parse_test_results_text_with_spec(text: &str, spec: &ParseSpec) -> Option
 
     let parsed = spec.parse(text);
     let total = parsed.get("total").copied().unwrap_or(0.0).max(0.0) as u64;
-    if total == 0 {
-        return None;
-    }
     let passed = parsed.get("passed").copied().unwrap_or(0.0).max(0.0) as u64;
     let failed = parsed.get("failed").copied().unwrap_or(0.0).max(0.0) as u64;
     let errors = parsed.get("errors").copied().unwrap_or(0.0).max(0.0) as u64;
     let skipped = parsed.get("skipped").copied().unwrap_or(0.0).max(0.0) as u64;
     // `TestCounts` has no separate errors field; fold runner errors into
     // `failed` so status/baseline decisions do not treat errors as passing.
-    Some(TestCounts::new(total, passed, failed + errors, skipped))
+    if total > 0 {
+        return Some(TestCounts::new(total, passed, failed + errors, skipped));
+    }
+
+    parse_key_value_test_summary(text)
+}
+
+/// Parse terminal summaries emitted by runners that report aggregate counts as
+/// `passed=<n> failed=<n>` rather than a framework-specific result line.
+fn parse_key_value_test_summary(text: &str) -> Option<TestCounts> {
+    let summary =
+        regex::Regex::new(r"(?m)^\S.*?\bpassed=(\d+)\s+failed=(\d+)(?:\s+skipped=(\d+))?\s*$")
+            .expect("key-value test summary regex is valid");
+    let captures = summary.captures_iter(text).last()?;
+    let passed = captures.get(1)?.as_str().parse().ok()?;
+    let failed = captures.get(2)?.as_str().parse().ok()?;
+    let skipped = captures
+        .get(3)
+        .map(|capture| capture.as_str().parse())
+        .transpose()
+        .ok()?
+        .unwrap_or(0);
+
+    Some(TestCounts::new(
+        passed + failed + skipped,
+        passed,
+        failed,
+        skipped,
+    ))
 }
 
 fn parse_test_results_text_with_adapter(text: &str, adapter: &str) -> Option<TestCounts> {
@@ -554,6 +579,21 @@ mod tests {
         assert_eq!(counts.passed, 4);
         assert_eq!(counts.failed, 3);
         assert_eq!(counts.skipped, 13);
+    }
+
+    #[test]
+    fn default_parse_spec_reads_terminal_key_value_summary() {
+        let counts = parse_test_results_text(
+            "HOST_SMOKE_SUMMARY:passed=21 failed=15\n\
+             Real-WordPress smoke tests failed (15 of 36):\n\
+               - tests/wiki/upsert-delegation-smoke.php (exit 1)",
+        )
+        .expect("key-value terminal summary should parse");
+
+        assert_eq!(counts.total, 36);
+        assert_eq!(counts.passed, 21);
+        assert_eq!(counts.failed, 15);
+        assert_eq!(counts.skipped, 0);
     }
 
     #[test]

--- a/crates/homeboy-core/src/extension/test/run.rs
+++ b/crates/homeboy-core/src/extension/test/run.rs
@@ -551,12 +551,12 @@ fn run_main_test_workflow_inner(
 
     // When tests failed with no parseable counts, surface a dedicated hint so
     // the user understands `raw_output` is the only signal about what went
-    // wrong (typically a bootstrap error). (#1143)
+    // wrong. A missing sidecar does not prove that no tests executed.
     let mut hints_vec = hints.unwrap_or_default();
     if status == "failed" && test_counts.is_none() && raw_output.is_some() {
         hints_vec.insert(
             0,
-            "No tests ran — the runner failed before producing results. \
+            "The test runner failed before producing structured results. \
              See raw_output.stderr_tail / raw_output.stdout_tail for the underlying error \
              (bootstrap failure, missing deps, DB connection, etc.)."
                 .to_string(),


### PR DESCRIPTION
## Summary
- parse generic terminal `passed=<n> failed=<n> [skipped=<n>]` summaries emitted by extension workloads
- retain executed test counts in failed immediate output envelopes
- reserve zero-test guidance for genuine pre-result failures
- add regression coverage matching the observed WordPress host-smoke summary

Closes #8860

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-core extension::test::parsing::tests::default_parse_spec_reads_terminal_key_value_summary`.
3. Run `cargo test -p homeboy-cli commands::infra::output_runtime::tests::generic_output_file_keeps_failed_test_result_available`.
4. Confirm a failed `HOST_SMOKE_SUMMARY:passed=21 failed=15` result reports 36 executed tests and remains present in the immediate output JSON.

## Verification
- parser regression passed
- immediate output regression passed
- `cargo fmt --check` passed
- `git diff --check` passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Traced the misleading result classification, implemented generic summary parsing and output retention, and added deterministic tests; Chris reviews and owns the change.
