### PR TITLE
refactor: move test-analysis types to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/test/analyze.rs
+++ b/crates/homeboy-core/src/extension/test/analyze.rs
@@ -4,6 +4,10 @@
 //! failures by similarity. Helps developers prioritize fixes by showing
 //! which root causes affect the most tests.
 
+pub use homeboy_extension_contract::test_analysis::{
+    FailureCategory, FailureCluster, TestAnalysis, TestAnalysisInput, TestFailure,
+};
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -11,110 +15,9 @@ use std::collections::HashMap;
 // Input: parsed test failures from extension
 // ============================================================================
 
-/// A single test failure parsed from test runner output.
-///
-/// This is domain input for failure clustering and analysis. Persisted and
-/// command-output finding records should project through `HomeboyFinding`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TestFailure {
-    /// Fully qualified test name (e.g., "Namespace\\ClassTest::testMethod").
-    pub test_name: String,
-    /// Test file path relative to component root.
-    pub test_file: String,
-    /// Error/failure type (e.g., "Error", "PHPUnit\\Framework\\AssertionFailedError").
-    pub error_type: String,
-    /// Error message.
-    pub message: String,
-    /// Optional: the source file in the stack trace (deepest non-test frame).
-    #[serde(default)]
-    pub source_file: String,
-    /// Optional: source line number.
-    #[serde(default)]
-    pub source_line: u32,
-}
-
-/// Full test analysis input from extension.
-///
-/// This preserves structured test-runner facts so analysis can cluster related
-/// failures before the findings layer emits canonical `HomeboyFinding` values.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TestAnalysisInput {
-    /// All test failures.
-    pub failures: Vec<TestFailure>,
-    /// Total tests run.
-    #[serde(default)]
-    pub total: u64,
-    /// Total passed.
-    #[serde(default)]
-    pub passed: u64,
-}
-
 // ============================================================================
 // Output: clustered analysis
 // ============================================================================
-
-/// A cluster of test failures sharing a common root cause.
-#[derive(Debug, Clone, Serialize)]
-pub struct FailureCluster {
-    /// Cluster identifier (derived from the pattern).
-    pub id: String,
-    /// Human-readable pattern description.
-    pub pattern: String,
-    /// Category of the failure pattern.
-    pub category: FailureCategory,
-    /// Number of failures in this cluster.
-    pub count: usize,
-    /// Test files affected.
-    pub affected_files: Vec<String>,
-    /// Representative test names (first few).
-    pub example_tests: Vec<String>,
-    /// Suggested fix if pattern is recognized.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub suggested_fix: Option<String>,
-}
-
-/// Category of a failure cluster.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(rename_all = "snake_case")]
-pub enum FailureCategory {
-    /// Method/function doesn't exist.
-    MissingMethod,
-    /// Class not found.
-    MissingClass,
-    /// Wrong return type (expected X, got Y).
-    ReturnTypeChange,
-    /// Wrong error code or message.
-    ErrorCodeChange,
-    /// Assertion mismatch (expected vs actual).
-    AssertionMismatch,
-    /// Mock/stub configuration error.
-    MockError,
-    /// Fatal error (crash, redeclare, etc.).
-    FatalError,
-    /// Argument count or type mismatch.
-    SignatureChange,
-    /// Database or environment issue.
-    EnvironmentError,
-    /// Uncategorized failure.
-    Other,
-}
-
-/// Full analysis output.
-#[derive(Debug, Clone, Serialize)]
-pub struct TestAnalysis {
-    /// Component that was analyzed.
-    pub component: String,
-    /// Total test failures.
-    pub total_failures: usize,
-    /// Total tests run.
-    pub total_tests: u64,
-    /// Total passing.
-    pub total_passed: u64,
-    /// Failure clusters, sorted by count (largest first).
-    pub clusters: Vec<FailureCluster>,
-    /// Human-readable hints.
-    pub hints: Vec<String>,
-}
 
 // ============================================================================
 // Clustering engine

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -20,6 +20,7 @@ pub mod bench_responsiveness;
 pub mod bench_result;
 pub mod bench_results;
 pub mod capability;
+pub mod test_analysis;
 pub mod trace_parsing;
 pub use bench_artifact::{BenchArtifact, BenchArtifactViewer, BenchPreviewLifecycleMetadata};
 pub use bench_diagnostics::{
@@ -38,6 +39,9 @@ pub use bench_result::{
 };
 pub use bench_results::{BenchResults, BenchRunMetadata, BenchRunSnapshot, BenchScenario};
 pub use capability::ExtensionCapability;
+pub use test_analysis::{
+    FailureCategory, FailureCluster, TestAnalysis, TestAnalysisInput, TestFailure,
+};
 pub use trace_parsing::{
     TraceArtifact, TraceAssertion, TraceAssertionStatus, TraceCanonicalCheck,
     TraceComponentsProvenance, TraceDependencyProvenance, TraceEvent, TraceEvidenceMetadata,

--- a/crates/homeboy-extension-contract/src/test_analysis.rs
+++ b/crates/homeboy-extension-contract/src/test_analysis.rs
@@ -1,0 +1,104 @@
+//! Pure test-analysis contract types (failure clustering + categorization).
+
+use serde::{Deserialize, Serialize};
+
+/// A single test failure parsed from test runner output.
+///
+/// This is domain input for failure clustering and analysis. Persisted and
+/// command-output finding records should project through `HomeboyFinding`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestFailure {
+    /// Fully qualified test name (e.g., "Namespace\\ClassTest::testMethod").
+    pub test_name: String,
+    /// Test file path relative to component root.
+    pub test_file: String,
+    /// Error/failure type (e.g., "Error", "PHPUnit\\Framework\\AssertionFailedError").
+    pub error_type: String,
+    /// Error message.
+    pub message: String,
+    /// Optional: the source file in the stack trace (deepest non-test frame).
+    #[serde(default)]
+    pub source_file: String,
+    /// Optional: source line number.
+    #[serde(default)]
+    pub source_line: u32,
+}
+
+/// Full test analysis input from extension.
+///
+/// This preserves structured test-runner facts so analysis can cluster related
+/// failures before the findings layer emits canonical `HomeboyFinding` values.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestAnalysisInput {
+    /// All test failures.
+    pub failures: Vec<TestFailure>,
+    /// Total tests run.
+    #[serde(default)]
+    pub total: u64,
+    /// Total passed.
+    #[serde(default)]
+    pub passed: u64,
+}
+
+/// A cluster of test failures sharing a common root cause.
+#[derive(Debug, Clone, Serialize)]
+pub struct FailureCluster {
+    /// Cluster identifier (derived from the pattern).
+    pub id: String,
+    /// Human-readable pattern description.
+    pub pattern: String,
+    /// Category of the failure pattern.
+    pub category: FailureCategory,
+    /// Number of failures in this cluster.
+    pub count: usize,
+    /// Test files affected.
+    pub affected_files: Vec<String>,
+    /// Representative test names (first few).
+    pub example_tests: Vec<String>,
+    /// Suggested fix if pattern is recognized.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggested_fix: Option<String>,
+}
+
+/// Category of a failure cluster.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureCategory {
+    /// Method/function doesn't exist.
+    MissingMethod,
+    /// Class not found.
+    MissingClass,
+    /// Wrong return type (expected X, got Y).
+    ReturnTypeChange,
+    /// Wrong error code or message.
+    ErrorCodeChange,
+    /// Assertion mismatch (expected vs actual).
+    AssertionMismatch,
+    /// Mock/stub configuration error.
+    MockError,
+    /// Fatal error (crash, redeclare, etc.).
+    FatalError,
+    /// Argument count or type mismatch.
+    SignatureChange,
+    /// Database or environment issue.
+    EnvironmentError,
+    /// Uncategorized failure.
+    Other,
+}
+
+/// Full analysis output.
+#[derive(Debug, Clone, Serialize)]
+pub struct TestAnalysis {
+    /// Component that was analyzed.
+    pub component: String,
+    /// Total test failures.
+    pub total_failures: usize,
+    /// Total tests run.
+    pub total_tests: u64,
+    /// Total passing.
+    pub total_passed: u64,
+    /// Failure clusters, sorted by count (largest first).
+    pub clusters: Vec<FailureCluster>,
+    /// Human-readable hints.
+    pub hints: Vec<String>,
+}


### PR DESCRIPTION
## Summary
Opens the **test phase-subsystem breakdown** with the same data/behavior split proven on bench/trace. The five test-analysis types (`TestFailure`, `TestAnalysisInput`, `FailureCluster`, `FailureCategory`, `TestAnalysis`) are a pure self-contained closure — zero dependencies, only referencing each other.

## The split
- **Types → contract:** the 5 analysis result types.
- **Behavior stays in core:** the 11 analysis functions in `test/analyze.rs` (failure clustering/categorization logic).

Core re-exports the types so all `crate::extension::test` paths stay stable.

## Why
Clears the `TestFailure` core-import edge and sets up further test/lint cuts (`TestCounts`, `TestCommandOutput`, `LintCommandOutput`) toward severing the test/lint phase behavior surface — the last phase subsystems before a wholesale `homeboy-extension` crate.

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)