### PR TITLE
Preserve root-anchored snapshot excludes

### DIFF
--- a/crates/homeboy-core/src/source_snapshot.rs
+++ b/crates/homeboy-core/src/source_snapshot.rs
@@ -281,7 +281,12 @@ pub(crate) fn gitignore_sync_excludes(path: &Path) -> Vec<String> {
 }
 
 fn append_gitignore_exclude(excludes: &mut Vec<String>, raw: &str) {
-    let pattern = raw.trim_start_matches("./").trim_start_matches('/');
+    let pattern = raw.trim_start_matches("./");
+    let pattern = if let Some(pattern) = pattern.strip_prefix('/') {
+        format!("./{pattern}")
+    } else {
+        pattern.to_string()
+    };
     if pattern.is_empty() {
         return;
     }
@@ -289,7 +294,7 @@ fn append_gitignore_exclude(excludes: &mut Vec<String>, raw: &str) {
         let base = pattern.trim_end_matches('/');
         append_unique(excludes, [base.to_string(), format!("{base}/**")]);
     } else {
-        append_unique(excludes, [pattern.to_string()]);
+        append_unique(excludes, [pattern]);
     }
 }
 
@@ -401,6 +406,17 @@ mod tests {
         assert!(snapshot
             .sync_excludes
             .contains(&".sampleplugin/".to_string()));
+    }
+
+    #[test]
+    fn gitignore_root_anchored_directory_excludes_remain_root_anchored() {
+        let tempdir = tempfile::tempdir().expect("creates source fixture");
+        fs::write(tempdir.path().join(".gitignore"), "/dist\ndist\n").expect("writes gitignore");
+
+        assert_eq!(
+            gitignore_sync_excludes(tempdir.path()),
+            vec!["./dist".to_string(), "dist".to_string()]
+        );
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -591,12 +591,13 @@ pub(super) fn is_excluded(
         return false;
     }
     excludes.iter().any(|pattern| {
+        let root_anchored = pattern.starts_with("./");
+        let pattern = pattern.trim_start_matches("./");
         let directory_pattern = pattern.trim_end_matches('/');
         pattern == rel
-            || pattern == name
             || directory_pattern == rel
             || glob_match(pattern, rel)
-            || glob_match(pattern, name)
+            || (!root_anchored && (pattern == name || glob_match(pattern, name)))
     })
 }
 
@@ -1182,11 +1183,33 @@ pub(super) fn snapshot_archive_command(
     // paths that traverse a symlinked dependency resolve to missing files on the
     // runner. Dereferencing materializes the real dependency contents into the
     // snapshot so offloaded plans find them at the remapped path (#3913).
-    format!(
-        "COPYFILE_DISABLE=1 tar --no-xattrs -h -C {src} {exclude} -cf - . | {target_command}",
+    let root_anchored = excludes
+        .iter()
+        .filter(|pattern| pattern.starts_with("./"))
+        .collect::<Vec<_>>();
+    let excludes = excludes
+        .iter()
+        .filter(|pattern| !pattern.starts_with("./"))
+        .cloned()
+        .collect::<Vec<_>>();
+    let archive = format!(
+        "COPYFILE_DISABLE=1 tar --no-xattrs -h -C {src} {exclude} -cf -",
         src = shell::quote_arg(&local_path.display().to_string()),
-        exclude = tar_exclude_args(excludes),
-        target_command = target_command,
+        exclude = tar_exclude_args(&excludes),
+    );
+
+    if root_anchored.is_empty() {
+        return format!("{archive} . | {target_command}");
+    }
+
+    let root_filter = root_anchored
+        .iter()
+        .map(|pattern| format!("! -path {}", shell::quote_arg(pattern)))
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!(
+        "(cd {src} && find . -mindepth 1 -maxdepth 1 {root_filter} -print0) | {archive} --null -T - | {target_command}",
+        src = shell::quote_arg(&local_path.display().to_string()),
     )
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -792,6 +792,43 @@ fn snapshot_archive_command_dereferences_symlinked_dependencies() {
 }
 
 #[test]
+fn root_anchored_dist_exclusion_matches_tar_and_preserves_nested_dist() {
+    let controller = tempfile::tempdir().expect("controller");
+    let source = controller.path().join("source");
+    let destination = controller.path().join("materialized");
+    let excludes = vec!["./dist".to_string()];
+    fs::create_dir_all(source.join("dist")).expect("root dist directory");
+    fs::create_dir_all(source.join("packages/example/dist")).expect("nested dist directory");
+    fs::write(source.join("dist/output.a"), "root output").expect("root dist output");
+    fs::write(source.join("packages/example/dist/input.a"), "nested input")
+        .expect("nested dist input");
+
+    let command = snapshot_archive_command(&source, "tar -xf -", &excludes);
+    assert!(
+        command.contains("find . -mindepth 1 -maxdepth 1 ! -path ./dist -print0"),
+        "root-anchored tar input must omit the matching root path: {command}"
+    );
+
+    let expected = workspace_content_hash(&source, &excludes).expect("source hash");
+    copy_snapshot_to_directory(&source, &destination, &excludes).expect("materialize snapshot");
+
+    assert!(
+        !destination.join("dist").exists(),
+        "root dist directory must be excluded"
+    );
+    assert_eq!(
+        fs::read_to_string(destination.join("packages/example/dist/input.a"))
+            .expect("nested dist input survives"),
+        "nested input"
+    );
+    assert_eq!(
+        workspace_content_hash(&destination, &excludes).expect("materialized hash"),
+        expected,
+        "content hashing must use the same root-anchored exclusion semantics as tar"
+    );
+}
+
+#[test]
 fn snapshot_content_hash_matches_materialized_workspace_after_runner_metadata_injection() {
     // This mirrors a Lab snapshot of a repository such as homeboy-extensions:
     // the runner creates its metadata directory after extracting a source that


### PR DESCRIPTION
## Summary

- preserve root-anchored `.gitignore` entries when deriving runner snapshot exclusions
- align snapshot hashing with root-only tar materialization
- prove root `/dist` is omitted while tracked nested `packages/example/dist` inputs survive

Closes #8862.

## Why

Homeboy previously normalized `/dist` to `dist`. GNU tar then excluded every directory with that basename, including tracked build inputs nested under package directories. This made Lab snapshots incomplete even though the controller checkout contained the files.

## How to test

1. Run `cargo test -p homeboy-core gitignore_root_anchored_directory_excludes_remain_root_anchored`.
2. Run `cargo test -p homeboy-lab-runner root_anchored_dist_exclusion_matches_tar_and_preserves_nested_dist`.
3. Run `cargo fmt --check`.
4. Run `cargo clippy -p homeboy-core -p homeboy-lab-runner --tests`.

## Compatibility

Unanchored ignore patterns retain their existing basename-matching behavior. Root-anchored patterns now follow their declared root-only semantics instead of over-excluding nested paths.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause analysis, implementation, deterministic tests, and verification under Chris Huber's direction.