### PR TITLE
refactor: move TestCounts + TestScopeOutput to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/test/baseline.rs
+++ b/crates/homeboy-core/src/extension/test/baseline.rs
@@ -11,27 +11,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
 use homeboy_engine_primitives::baseline::{self as generic, BaselineConfig};
+pub use homeboy_extension_contract::test_result::TestCounts;
 
 const BASELINE_KEY: &str = "test";
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct TestCounts {
-    pub total: u64,
-    pub passed: u64,
-    pub failed: u64,
-    pub skipped: u64,
-}
-
-impl TestCounts {
-    pub fn new(total: u64, passed: u64, failed: u64, skipped: u64) -> Self {
-        Self {
-            total,
-            passed,
-            failed,
-            skipped,
-        }
-    }
-}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct TestBaselineComparison {

--- a/crates/homeboy-core/src/extension/test/mod.rs
+++ b/crates/homeboy-core/src/extension/test/mod.rs
@@ -1,3 +1,5 @@
+pub use homeboy_extension_contract::test_result::TestScopeOutput;
+
 pub mod analyze;
 pub mod baseline;
 pub mod drift;
@@ -17,24 +19,6 @@ use crate::git;
 use serde::Serialize;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
-
-#[derive(Debug, Clone, Serialize)]
-pub struct TestScopeOutput {
-    pub mode: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub changed_since: Option<String>,
-    pub selected_count: usize,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub selected_files: Vec<String>,
-    /// Changed files that are production or test source (per the component's
-    /// drift source/test patterns) yet selected zero tests. A non-empty list
-    /// with `selected_count == 0` is a false-green: source changed but the
-    /// changed-scope gate would otherwise pass without running any test.
-    /// Documentation/config-only changes leave this empty so a genuine no-test
-    /// scope can still pass. (#8340)
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub source_changes_without_tests: Vec<String>,
-}
 
 pub use analyze::{FailureCategory, FailureCluster, TestAnalysis, TestAnalysisInput, TestFailure};
 pub use baseline::{

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -21,6 +21,7 @@ pub mod bench_result;
 pub mod bench_results;
 pub mod capability;
 pub mod test_analysis;
+pub mod test_result;
 pub mod trace_parsing;
 pub use bench_artifact::{BenchArtifact, BenchArtifactViewer, BenchPreviewLifecycleMetadata};
 pub use bench_diagnostics::{
@@ -42,6 +43,7 @@ pub use capability::ExtensionCapability;
 pub use test_analysis::{
     FailureCategory, FailureCluster, TestAnalysis, TestAnalysisInput, TestFailure,
 };
+pub use test_result::{TestCounts, TestScopeOutput};
 pub use trace_parsing::{
     TraceArtifact, TraceAssertion, TraceAssertionStatus, TraceCanonicalCheck,
     TraceComponentsProvenance, TraceDependencyProvenance, TraceEvent, TraceEvidenceMetadata,

--- a/crates/homeboy-extension-contract/src/test_result.rs
+++ b/crates/homeboy-extension-contract/src/test_result.rs
@@ -1,0 +1,40 @@
+//! Pure test result contract types (counts, changed-scope selection).
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TestCounts {
+    pub total: u64,
+    pub passed: u64,
+    pub failed: u64,
+    pub skipped: u64,
+}
+
+impl TestCounts {
+    pub fn new(total: u64, passed: u64, failed: u64, skipped: u64) -> Self {
+        Self {
+            total,
+            passed,
+            failed,
+            skipped,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TestScopeOutput {
+    pub mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub changed_since: Option<String>,
+    pub selected_count: usize,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub selected_files: Vec<String>,
+    /// Changed files that are production or test source (per the component's
+    /// drift source/test patterns) yet selected zero tests. A non-empty list
+    /// with `selected_count == 0` is a false-green: source changed but the
+    /// changed-scope gate would otherwise pass without running any test.
+    /// Documentation/config-only changes leave this empty so a genuine no-test
+    /// scope can still pass. (#8340)
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub source_changes_without_tests: Vec<String>,
+}


### PR DESCRIPTION
## Summary
Continues the test phase-subsystem breakdown. `TestCounts` (pure 4-`u64` struct + pure `new()` constructor) and `TestScopeOutput` (pure changed-scope selection result) move to the contract crate.

## The split
- **Types → contract:** `TestCounts`, `TestScopeOutput`.
- **Behavior stays in core:** baseline-comparison fingerprinting, the changed-scope computation functions.

Core re-exports both, so all `crate::extension::test` paths stay stable.

## Why
Clears the `TestCounts` + `TestScopeOutput` core-import edges. The aggregate `TestCommandOutput`/`LintCommandOutput` remain in core — they are top-level result clusters (like `BenchResults` was) still blocked by field types in the report/run/workflow modules, which are future cuts.

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)