### PR TITLE
refactor: extract homeboy-review crate (~1.9k LOC out of core)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,6 +825,7 @@ dependencies = [
  "homeboy-redaction",
  "homeboy-refactor",
  "homeboy-refactor-contract",
+ "homeboy-review",
  "homeboy-rig",
  "homeboy-stack",
  "homeboy-triage",
@@ -1114,6 +1115,19 @@ dependencies = [
 name = "homeboy-refactor-contract"
 version = "0.1.0"
 dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "homeboy-review"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "homeboy-code-audit",
+ "homeboy-core",
+ "homeboy-error",
+ "homeboy-finding",
  "serde",
  "serde_json",
 ]

--- a/crates/homeboy-cli/Cargo.toml
+++ b/crates/homeboy-cli/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 [dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
 homeboy-stack = { version = "0.1.0", path = "../homeboy-stack" }
+homeboy-review = { version = "0.1.0", path = "../homeboy-review" }
 homeboy-upgrade = { version = "0.1.0", path = "../homeboy-upgrade" }
 homeboy-agents = { version = "0.1.0", path = "../homeboy-agents" }
 homeboy-refactor = { version = "0.1.0", path = "../homeboy-refactor" }

--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -22,7 +22,7 @@ use homeboy::core::git;
 use homeboy::core::plan::PlanStep;
 use homeboy::core::quality::{build_quality_plan, QualityPlanOptions};
 use homeboy::core::release::changelog;
-use homeboy::core::review::{
+use homeboy_review::review::{
     self, ReviewArtifactFindings, ReviewCommandOutput, ReviewOutputInput, ReviewService,
     ReviewStage, ReviewStages,
 };

--- a/crates/homeboy-cli/src/commands/review/observation.rs
+++ b/crates/homeboy-cli/src/commands/review/observation.rs
@@ -2,10 +2,10 @@ use std::path::Path;
 
 use homeboy::core::git::short_head_revision_at;
 use homeboy::core::observation::{merge_metadata, ActiveObservation, NewRunRecord, RunStatus};
-use homeboy::core::review::{
+use homeboy::core::ObservationOutputMetadata;
+use homeboy_review::review::{
     artifact_command, ReviewArtifactFindings, ReviewCommandOutput, ReviewStage,
 };
-use homeboy::core::ObservationOutputMetadata;
 
 use super::ReviewArgs;
 
@@ -183,7 +183,7 @@ mod tests {
     use crate::commands::utils::args::{
         BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs,
     };
-    use homeboy::core::review::{build_artifact, ReviewSummary};
+    use homeboy_review::review::{build_artifact, ReviewSummary};
 
     fn review_args() -> ReviewArgs {
         ReviewArgs {

--- a/crates/homeboy-cli/src/commands/review/raw_output.rs
+++ b/crates/homeboy-cli/src/commands/review/raw_output.rs
@@ -1,6 +1,6 @@
 use crate::commands::output_runtime::CommandRun;
 use crate::commands::GlobalArgs;
-use homeboy::core::review::render;
+use homeboy_review::review::render;
 
 use super::{run_umbrella, ReviewArgs};
 

--- a/crates/homeboy-cli/src/lib.rs
+++ b/crates/homeboy-cli/src/lib.rs
@@ -12,6 +12,7 @@ extern crate self as homeboy;
 pub use homeboy_agents as agents;
 pub use homeboy_core as core;
 pub use homeboy_refactor as refactor;
+pub use homeboy_review as review;
 pub use homeboy_rig as rig;
 pub use homeboy_stack as stack;
 

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -161,7 +161,6 @@ pub mod resource_cleanup_intent;
 pub mod resource_lifecycle_index;
 pub mod resource_policy_context;
 pub mod resources;
-pub mod review;
 pub mod rig_provider;
 pub mod rig_toolchain_provider;
 pub mod run_lifecycle_record;

--- a/crates/homeboy-review/Cargo.toml
+++ b/crates/homeboy-review/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "homeboy-review"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Review subsystem for homeboy: renders the scoped audit + lint + test umbrella (the review command) into human- and machine-readable output. Depends on homeboy-core; core does not depend on it."
+publish = false
+
+[lib]
+name = "homeboy_review"
+path = "src/lib.rs"
+
+[dependencies]
+homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
+homeboy-code-audit = { version = "0.1.0", path = "../homeboy-code-audit" }
+homeboy-finding = { version = "0.1.0", path = "../homeboy-finding" }
+homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = "0.4"
+
+[dev-dependencies]
+homeboy-core = { version = "0.1.0", path = "../homeboy-core", features = ["test-support"] }
+homeboy-code-audit = { version = "0.1.0", path = "../homeboy-code-audit", features = ["test-support"] }

--- a/crates/homeboy-review/src/lib.rs
+++ b/crates/homeboy-review/src/lib.rs
@@ -1,0 +1,9 @@
+//! Review subsystem for homeboy: renders the scoped audit + lint + test
+//! umbrella (the `review` command) into human- and machine-readable output,
+//! including audit findings and artifact-derived finding summaries.
+//!
+//! Depends on homeboy-core; core does not depend on it.
+
+pub mod review;
+
+pub use review::*;

--- a/crates/homeboy-review/src/review/artifact_findings.rs
+++ b/crates/homeboy-review/src/review/artifact_findings.rs
@@ -1,10 +1,10 @@
 use serde_json::Value;
 
-use crate::ci_profile::CiRunOutput;
-use crate::code_audit::{homeboy_finding_from_audit, AuditCommandOutput};
-use crate::extension::lint::LintCommandOutput;
-use crate::extension::test::TestCommandOutput;
-use crate::finding::HomeboyFinding;
+use homeboy_code_audit::{homeboy_finding_from_audit, AuditCommandOutput};
+use homeboy_core::ci_profile::CiRunOutput;
+use homeboy_core::extension::lint::LintCommandOutput;
+use homeboy_core::extension::test::TestCommandOutput;
+use homeboy_finding::HomeboyFinding;
 
 pub trait ReviewArtifactFindings {
     fn review_artifact_findings(&self) -> Vec<HomeboyFinding> {
@@ -67,9 +67,9 @@ impl ReviewArtifactFindings for Value {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::baseline::BaselineComparison;
-    use crate::code_audit::report::AuditSummaryOutput;
-    use crate::code_audit::{AuditFinding, AuditSummary, CodeAuditResult, Finding, Severity};
+    use homeboy_code_audit::baseline::BaselineComparison;
+    use homeboy_code_audit::report::AuditSummaryOutput;
+    use homeboy_code_audit::{AuditFinding, AuditSummary, CodeAuditResult, Finding, Severity};
 
     #[test]
     fn audit_full_maps_result_findings_to_review_artifact_findings() {

--- a/crates/homeboy-review/src/review/mod.rs
+++ b/crates/homeboy-review/src/review/mod.rs
@@ -4,14 +4,14 @@ use chrono::Utc;
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::ci_profile::CiRunOutput;
-use crate::code_audit::AuditCommandOutput;
-use crate::execution::{self, PlanExecutionRun};
-use crate::extension::lint::LintCommandOutput;
-use crate::extension::test::TestCommandOutput;
-use crate::finding::HomeboyFinding;
-use crate::plan::{HomeboyPlan, PlanStep};
-use crate::ObservationOutputMetadata;
+use homeboy_code_audit::AuditCommandOutput;
+use homeboy_core::ci_profile::CiRunOutput;
+use homeboy_core::execution::{self, PlanExecutionRun};
+use homeboy_core::extension::lint::LintCommandOutput;
+use homeboy_core::extension::test::TestCommandOutput;
+use homeboy_core::plan::{HomeboyPlan, PlanStep};
+use homeboy_core::ObservationOutputMetadata;
+use homeboy_finding::HomeboyFinding;
 
 mod artifact_findings;
 pub mod render;
@@ -238,9 +238,9 @@ fn artifact_commands(stages: &ReviewStages) -> Vec<ReviewArtifactCommand> {
 pub fn execute_review_plan_steps<R, Dispatch>(
     steps: &[PlanStep],
     dispatch: Dispatch,
-) -> crate::Result<PlanExecutionRun<R>>
+) -> homeboy_core::Result<PlanExecutionRun<R>>
 where
-    Dispatch: FnMut(&PlanStep) -> crate::Result<Option<R>>,
+    Dispatch: FnMut(&PlanStep) -> homeboy_core::Result<Option<R>>,
 {
     execution::execute_plan_steps(steps, dispatch, |_| false)
 }
@@ -330,7 +330,7 @@ pub fn artifact_status(commands: &[ReviewArtifactCommand]) -> &'static str {
 }
 
 pub fn git_ref(path: &str, git_ref: &str) -> Option<String> {
-    crate::git::rev_parse(std::path::Path::new(path), git_ref)
+    homeboy_core::git::rev_parse(std::path::Path::new(path), git_ref)
 }
 
 fn generated_at_now() -> String {
@@ -439,7 +439,7 @@ mod tests {
             PlanStep::builder(
                 "review.test",
                 "review.test",
-                crate::plan::PlanStepStatus::Skipped,
+                homeboy_core::plan::PlanStepStatus::Skipped,
             )
             .build(),
         ];

--- a/crates/homeboy-review/src/review/render.rs
+++ b/crates/homeboy-review/src/review/render.rs
@@ -17,13 +17,13 @@
 
 use std::fmt::Write as _;
 
-use crate::ci_profile::CiRunOutput;
-use crate::code_audit::AuditCommandOutput;
-use crate::extension::lint::LintCommandOutput;
-use crate::extension::test::TestCommandOutput;
-use crate::extension::ExtensionPhaseTiming;
-use crate::finding::HomeboyFinding;
-use crate::top_n::top_n_by;
+use homeboy_code_audit::AuditCommandOutput;
+use homeboy_core::ci_profile::CiRunOutput;
+use homeboy_core::extension::lint::LintCommandOutput;
+use homeboy_core::extension::test::TestCommandOutput;
+use homeboy_core::extension::ExtensionPhaseTiming;
+use homeboy_core::top_n::top_n_by;
+use homeboy_finding::HomeboyFinding;
 
 use super::{ReviewCommandOutput, ReviewStage};
 
@@ -376,14 +376,16 @@ fn render_ci_body(out: &mut String, output: &CiRunOutput) {
 mod tests {
     use super::*;
 
-    use crate::ci_profile::{CiContext, CiJobRunOutput, CiRunOutput, CiRunSelection};
-    use crate::code_audit::{AuditCommandOutput, AuditFinding, CodeAuditResult, Finding, Severity};
-    use crate::extension::lint::LintCommandOutput;
-    use crate::extension::test::{TestCommandOutput, TestCounts};
-    use crate::extension::CiJobMapping;
-    use crate::extension::{PhaseReport, PhaseStatus, VerificationPhase};
-    use crate::finding::HomeboyFinding;
-    use crate::quality::{build_quality_plan, QualityPlanOptions};
+    use homeboy_code_audit::{
+        AuditCommandOutput, AuditFinding, CodeAuditResult, Finding, Severity,
+    };
+    use homeboy_core::ci_profile::{CiContext, CiJobRunOutput, CiRunOutput, CiRunSelection};
+    use homeboy_core::extension::lint::LintCommandOutput;
+    use homeboy_core::extension::test::{TestCommandOutput, TestCounts};
+    use homeboy_core::extension::CiJobMapping;
+    use homeboy_core::extension::{PhaseReport, PhaseStatus, VerificationPhase};
+    use homeboy_core::quality::{build_quality_plan, QualityPlanOptions};
+    use homeboy_finding::HomeboyFinding;
 
     // ── Builders for fixture envelopes ──────────────────────────────────
 
@@ -517,7 +519,7 @@ mod tests {
         let result = CodeAuditResult {
             component_id: "my-comp".to_string(),
             source_path: "/tmp/my-comp".to_string(),
-            summary: crate::code_audit::AuditSummary {
+            summary: homeboy_code_audit::AuditSummary {
                 files_scanned: 0,
                 conventions_detected: 0,
                 outliers_found: 0,

--- a/crates/homeboy-review/src/review/render_audit.rs
+++ b/crates/homeboy-review/src/review/render_audit.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write as _;
 
-use crate::code_audit::{AuditCommandOutput, AuditFinding, Finding, Severity};
-use crate::finding::HomeboyFinding;
+use homeboy_code_audit::{AuditCommandOutput, AuditFinding, Finding, Severity};
+use homeboy_finding::HomeboyFinding;
 
 use super::TOP_N;
 


### PR DESCRIPTION
## Summary
Extracts the **review subsystem** (~1.9k LOC) out of `homeboy-core` into its own `homeboy-review` crate — the last of the clean single-module cuts (after agents/runner/code-audit/refactor/rig/upgrade/stack).

`homeboy-review` renders the scoped audit + lint + test umbrella (the `review` command) into human- and machine-readable output, including audit findings and artifact-derived finding summaries. **core does not depend on it.**

**`cargo check --workspace --tests`: GREEN.**

## The cleanest cut of the campaign
**Zero** core reverse-edges — verified by both the word-boundary grep *and* the brace-import check that caught hidden edges in rig/stack. So: **no provider hook, no contract crate, no behavior inversion.** Just move it and repoint the one consumer surface (cli).

## What changed
- **git-mv** `review.rs` + `review/` → `crates/homeboy-review/src` (`review.rs` became `review/mod.rs`; `render.rs` keeps its local `#[path = "render_audit.rs"]` include).
- Rewrote paths. Notably, review depended on **already-extracted feature crates**: `code_audit` → `homeboy_code_audit` and `finding` → `homeboy_finding` (both their own crates, re-exported in core as `crate::code_audit`/`crate::finding`). Core modules (`extension`, `ci_profile`, `plan`, `top_n`, `quality`, `git`, `execution`) + root types (`ObservationOutputMetadata`, `Result`) → `homeboy_core::`.
- Repointed cli (3 files) `homeboy_core::review` → `homeboy_review`; added the dep; cli re-exports `homeboy_review as review`.

## Verification
`cargo check --workspace --tests`: green. `cargo fmt`: clean.

## Campaign context
This clears the clean single-module targets. Merged so far: agents #8809 (~89k), refactor #8844 (~22.7k), rig #8863 (~15.3k), upgrade #8874 (~4.9k), stack #8876 (~2.5k), + code-audit/runner. **Remaining: the big `deploy` + `release` pair (~42k, bidirectionally entangled — its own dedicated campaign.)**