### PR TITLE
refactor: move test parsing-result types to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/test/parsing.rs
+++ b/crates/homeboy-core/src/extension/test/parsing.rs
@@ -6,43 +6,9 @@ use crate::extension::test::TestCounts;
 use crate::structured_sidecar;
 use homeboy_engine_primitives::local_files;
 use homeboy_engine_primitives::output_parse::{Aggregate, DeriveRule, ParseRule, ParseSpec};
-
-#[derive(Debug, Clone, Serialize)]
-pub struct CoverageOutput {
-    pub lines_pct: f64,
-    pub lines_total: u64,
-    pub lines_covered: u64,
-    pub methods_pct: f64,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub uncovered_files: Vec<UncoveredFile>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct UncoveredFile {
-    pub file: String,
-    pub line_pct: f64,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct TestFailureSummaryItem {
-    pub test_name: String,
-    pub message: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub file: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub line: Option<u32>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct TestSummaryOutput {
-    pub total: u64,
-    pub passed: u64,
-    pub failed: u64,
-    pub skipped: u64,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub failures: Vec<TestFailureSummaryItem>,
-    pub exit_code: i32,
-}
+pub use homeboy_extension_contract::test_parsing::{
+    CoverageOutput, TestFailureSummaryItem, TestSummaryOutput, UncoveredFile,
+};
 
 #[derive(Debug, Deserialize)]
 struct RawTestFailure {

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -21,6 +21,7 @@ pub mod bench_result;
 pub mod bench_results;
 pub mod capability;
 pub mod test_analysis;
+pub mod test_parsing;
 pub mod test_result;
 pub mod trace_parsing;
 pub use bench_artifact::{BenchArtifact, BenchArtifactViewer, BenchPreviewLifecycleMetadata};
@@ -43,6 +44,7 @@ pub use capability::ExtensionCapability;
 pub use test_analysis::{
     FailureCategory, FailureCluster, TestAnalysis, TestAnalysisInput, TestFailure,
 };
+pub use test_parsing::{CoverageOutput, TestFailureSummaryItem, TestSummaryOutput, UncoveredFile};
 pub use test_result::{TestCounts, TestScopeOutput};
 pub use trace_parsing::{
     TraceArtifact, TraceAssertion, TraceAssertionStatus, TraceCanonicalCheck,

--- a/crates/homeboy-extension-contract/src/test_parsing.rs
+++ b/crates/homeboy-extension-contract/src/test_parsing.rs
@@ -1,0 +1,40 @@
+//! Pure test parsing-result contract types (summary, coverage).
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CoverageOutput {
+    pub lines_pct: f64,
+    pub lines_total: u64,
+    pub lines_covered: u64,
+    pub methods_pct: f64,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub uncovered_files: Vec<UncoveredFile>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UncoveredFile {
+    pub file: String,
+    pub line_pct: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TestFailureSummaryItem {
+    pub test_name: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TestSummaryOutput {
+    pub total: u64,
+    pub passed: u64,
+    pub failed: u64,
+    pub skipped: u64,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub failures: Vec<TestFailureSummaryItem>,
+    pub exit_code: i32,
+}


### PR DESCRIPTION
## Summary
Continues the test subsystem breakdown. The four test parsing-result types (`CoverageOutput`, `UncoveredFile`, `TestFailureSummaryItem`, `TestSummaryOutput`) form a pure self-contained closure and move to the contract crate.

## The split
- **Types → contract:** the 4 parsing-result types.
- **Behavior stays in core:** `build_test_summary`, `parse_test_results_file`/`_text`, `parse_coverage_file`, the `From<RawTestFailure>` conversion, and the `ParseSpec` adapters.

Core re-exports the types, so all `crate::extension::test` paths stay stable.

## Why
These are field dependencies of the aggregate `TestCommandOutput` cluster. Combined with `TestCounts`/`TestScopeOutput` (#8875) and the test-analysis types (#8871), this clears more of `TestCommandOutput`'s field graph toward moving the top-level test result cluster (the same way the bench/trace clusters fell once their fields were out).

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)