### PR TITLE
Preserve runner context for nested Lab workloads

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -33,7 +33,7 @@ pub fn route_after_parse(
         crate::commands::utils::resource_policy::is_managed_runner_placement_context();
     if lab_routing::is_lab_offload_subprocess()
         || managed_runner_placement
-        || runner_resident_agent_task_run_plan(cli)
+        || runner_resident_execution(cli)
     {
         return Ok(None);
     }
@@ -265,16 +265,19 @@ pub fn route_after_parse(
     }
 }
 
-/// A run plan handed to Lab already has a materialized local workspace. Its
-/// execution provenance must not cause a second controller daemon selection.
-fn runner_resident_agent_task_run_plan(cli: &Cli) -> bool {
-    homeboy::core::resource_policy_context::has_lab_execution_provenance()
-        && matches!(
+/// A runner-resident plan, or a nested command targeting the runner that
+/// selected this process, executes in place. The execution-provenance marker
+/// survives the parent handoff, while controller transport markers are
+/// intentionally consumed before provider code runs.
+fn runner_resident_execution(cli: &Cli) -> bool {
+    homeboy::core::resource_policy_context::lab_execution_runner_id().is_some_and(|runner_id| {
+        matches!(
             &cli.command,
             Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
                 command: crate::commands::agent_task::AgentTaskCommand::RunPlan(_),
             })
-        )
+        ) || cli.runner.as_deref() == Some(runner_id.as_str())
+    })
 }
 
 /// Fanout keeps durable batch state, worktree ownership, artifact ingestion,

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -518,10 +518,6 @@ fn runner_resident_run_plan_does_not_require_a_second_controller_session() {
     ]);
     let normalized = vec![
         "homeboy".to_string(),
-        "--runner".to_string(),
-        "homeboy-lab".to_string(),
-        "--placement".to_string(),
-        "lab".to_string(),
         "agent-task".to_string(),
         "run-plan".to_string(),
         "--plan".to_string(),
@@ -531,6 +527,37 @@ fn runner_resident_run_plan_does_not_require_a_second_controller_session() {
 
     assert_eq!(
         route_after_parse(&cli, &normalized, None).expect("runner-resident handoff stays local"),
+        None
+    );
+}
+
+#[test]
+fn nested_command_targeting_parent_runner_does_not_require_a_second_controller_session() {
+    let _env = EnvGuard::set_many(&[
+        (homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV, None),
+        (homeboy::runner::RUNNER_HOSTED_EXEC_ENV, None),
+        (homeboy::runner::RUNNER_PLACEMENT_RESOLVED_ENV, None),
+        (homeboy::runner::RUNNER_ID_ENV, None),
+        (
+            homeboy::core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV,
+            Some("homeboy-lab"),
+        ),
+    ]);
+    let normalized = vec![
+        "homeboy".to_string(),
+        "--runner".to_string(),
+        "homeboy-lab".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+        "--to-worktree".to_string(),
+        "homeboy@nested-runner-context".to_string(),
+        "--prompt".to_string(),
+        "run a nested workload".to_string(),
+    ];
+    let cli = Cli::parse_from(&normalized);
+
+    assert_eq!(
+        route_after_parse(&cli, &normalized, None).expect("runner-resident cook stays local"),
         None
     );
 }

--- a/crates/homeboy-core/src/resource_policy_context.rs
+++ b/crates/homeboy-core/src/resource_policy_context.rs
@@ -126,9 +126,17 @@ pub fn is_runner_hosted_exec() -> bool {
 /// True when this process is already executing on a Lab runner. This is
 /// lifecycle provenance, not controller transport selection.
 pub fn has_lab_execution_provenance() -> bool {
+    lab_execution_runner_id().is_some()
+}
+
+/// The runner that selected this process for execution, when running inside a
+/// Lab handoff. This is durable execution provenance, not controller transport
+/// intent, so nested commands may resolve the current host without reconnecting
+/// to the controller-side runner registry.
+pub fn lab_execution_runner_id() -> Option<String> {
     std::env::var(crate::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV)
         .ok()
-        .is_some_and(|runner_id| !runner_id.trim().is_empty())
+        .filter(|runner_id| !runner_id.trim().is_empty())
 }
 
 /// True when Homeboy is executing inside a GitHub Actions CI job.

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -406,6 +406,10 @@ pub fn load(id: &str) -> Result<Runner> {
         return load_server_runner(&runner_id);
     }
 
+    if let Some(runner) = execution_context_runner(id) {
+        return Ok(runner);
+    }
+
     Err(Error::runner_not_found(
         id.to_string(),
         runner_suggestions(id),
@@ -491,6 +495,18 @@ fn builtin_local_runner() -> Runner {
     }
 }
 
+/// Materialize the current Lab execution host as a local runner only when a
+/// nested command asks for the runner that selected this process. The configured
+/// registry always wins, so controller-side and ordinary local lookup retain
+/// their existing behavior.
+fn execution_context_runner(id: &str) -> Option<Runner> {
+    let runner_id = homeboy_core::resource_policy_context::lab_execution_runner_id()?;
+    (runner_id == id).then(|| Runner {
+        id: runner_id,
+        ..builtin_local_runner()
+    })
+}
+
 pub fn effective_env(id: &str) -> Result<HashMap<String, String>> {
     let runner = load(id)?;
     Ok(RunnerSpec::from_runner(&runner).effective_env())
@@ -510,6 +526,12 @@ pub fn list() -> Result<Vec<Runner>> {
             .filter(|server| server.runner.is_some())
             .map(|server| runner_from_server(&server.id, server.runner.expect("checked above"))),
     );
+    if let Some(runner) = homeboy_core::resource_policy_context::lab_execution_runner_id()
+        .and_then(|runner_id| execution_context_runner(&runner_id))
+        .filter(|runner| !runners.iter().any(|configured| configured.id == runner.id))
+    {
+        runners.push(runner);
+    }
     runners.sort_by(|a, b| a.id.cmp(&b.id));
     Ok(runners)
 }
@@ -1080,6 +1102,27 @@ mod tests {
             assert_eq!(runner.kind, RunnerKind::Local);
             assert_eq!(runner.server_id, None);
             assert!(runner.workspace_root.is_some());
+        });
+    }
+
+    #[test]
+    fn runner_lookup_and_list_resolve_current_lab_execution_context() {
+        test_support::with_isolated_home(|_| {
+            let execution_runner = homeboy_core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV;
+            let previous = std::env::var_os(execution_runner);
+            std::env::set_var(execution_runner, "homeboy-lab");
+
+            let runner = load("homeboy-lab").expect("nested lookup resolves current runner");
+            let listed = list().expect("nested runner list resolves current runner");
+
+            match previous {
+                Some(value) => std::env::set_var(execution_runner, value),
+                None => std::env::remove_var(execution_runner),
+            }
+
+            assert_eq!(runner.id, "homeboy-lab");
+            assert_eq!(runner.kind, RunnerKind::Local);
+            assert!(listed.iter().any(|runner| runner.id == "homeboy-lab"));
         });
     }
 


### PR DESCRIPTION
## Summary
- resolve the runner selected by a parent Lab handoff as the current local execution host for nested Homeboy commands
- keep configured runner definitions authoritative and limit contextual fallback to the exact provenance runner ID
- execute nested commands targeting that runner in place instead of attempting an unavailable second controller dispatch
- retain the existing runner-resident `agent-task run-plan` behavior and add focused lookup/routing regressions

Closes #8856.

## Root cause

Lab handoff preserves `HOMEBOY_LAB_EXECUTION_RUNNER_ID` as durable execution provenance while correctly consuming controller transport markers. Nested Homeboy commands then looked only in the runner-local registry, where the controller-defined runner ID does not exist, and failed with `runner.not_found` even though the process was already executing on that runner.

## Compatibility impact

No public CLI or persisted-data format changes. Configured runners retain precedence. Ordinary local execution, unknown non-contextual runner IDs, and non-nested routing keep their existing behavior. The new fallback applies only when Lab execution provenance exactly matches the requested runner ID.

## How to test

1. Run `cargo test -p homeboy-lab-runner runner_lookup_and_list_resolve_current_lab_execution_context`.
2. Run `cargo test -p homeboy-cli runner_resident_run_plan_does_not_require_a_second_controller_session`.
3. Run `cargo test -p homeboy-cli nested_command_targeting_parent_runner_does_not_require_a_second_controller_session`.
4. Run `cargo check -p homeboy-core -p homeboy-lab-runner -p homeboy-cli`.
5. Run `cargo fmt --check`.
6. Run `git diff --check origin/main...HEAD`.

All commands pass locally. Existing workspace warnings remain unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode
- **Used for:** We diagnosed the Lab context loss, implemented the generic runner-resolution and routing fix, reviewed the candidate, preserved existing regression coverage, and ran deterministic verification.