### PR TITLE
refactor: add homeboy-release-contract (deploy+release prep 1/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,6 +909,7 @@ dependencies = [
  "homeboy-product-identity",
  "homeboy-redaction",
  "homeboy-refactor-contract",
+ "homeboy-release-contract",
  "homeboy-rig-contract",
  "keyring",
  "libc",
@@ -1113,6 +1114,14 @@ dependencies = [
 
 [[package]]
 name = "homeboy-refactor-contract"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "homeboy-release-contract"
 version = "0.1.0"
 dependencies = [
  "serde",

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -27,6 +27,7 @@ homeboy-output = { version = "0.1.0", path = "../homeboy-output" }
 homeboy-paths = { version = "0.1.0", path = "../homeboy-paths" }
 homeboy-process = { version = "0.1.0", path = "../homeboy-process" }
 homeboy-product-identity = { version = "0.1.0", path = "../homeboy-product-identity" }
+homeboy-release-contract = { version = "0.1.0", path = "../homeboy-release-contract" }
 homeboy-audit-contract = { version = "0.1.0", path = "../homeboy-audit-contract" }
 homeboy-refactor-contract = { version = "0.1.0", path = "../homeboy-refactor-contract" }
 homeboy-code-audit = { version = "0.1.0", path = "../homeboy-code-audit" }

--- a/crates/homeboy-core/src/context/report.rs
+++ b/crates/homeboy-core/src/context/report.rs
@@ -169,7 +169,7 @@ pub struct ChangelogSnapshot {
     pub items: Option<Vec<String>>,
 }
 
-pub type ComponentReleaseState = crate::deploy::ReleaseState;
+pub type ComponentReleaseState = homeboy_release_contract::ReleaseState;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ComponentWithState {
@@ -410,7 +410,7 @@ fn collect_focused_components(
 
 fn compute_status(
     components: &[ComponentWithState],
-    release_buckets: &crate::deploy::ReleaseStateBuckets,
+    release_buckets: &homeboy_release_contract::ReleaseStateBuckets,
 ) -> ContextReportStatus {
     let mut config_gaps = 0;
     let mut gap_details = Vec::new();

--- a/crates/homeboy-core/src/deploy/types.rs
+++ b/crates/homeboy-core/src/deploy/types.rs
@@ -334,46 +334,10 @@ pub struct BuildProvenance {
     pub artifact_identity: Option<ArtifactIdentity>,
 }
 
-/// Reason why a component was selected for deployment.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum DeployReason {
-    /// Component was explicitly specified by ID
-    ExplicitlySelected,
-    /// --all flag was used
-    AllSelected,
-    /// Local and remote versions differ
-    VersionMismatch,
-    /// Could not determine local version
-    UnknownLocalVersion,
-    /// Could not determine remote version (not deployed or no version file)
-    UnknownRemoteVersion,
-}
-
-/// Status indicator for component version comparison.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ComponentStatus {
-    /// Local and remote versions match
-    UpToDate,
-    /// Local version ahead of remote (needs deploy)
-    NeedsUpdate,
-    /// Remote version ahead of local (local behind)
-    BehindRemote,
-    /// Local checkout is behind its upstream branch
-    BehindUpstream,
-    /// Remote matches a configured source checkout that is stale or detached
-    SourceStale,
-    /// Cannot determine status
-    Unknown,
-}
-
-impl ComponentStatus {
-    /// Whether deploying the configured source would advance the target.
-    pub fn requires_deploy(&self) -> bool {
-        matches!(self, Self::NeedsUpdate)
-    }
-}
+// DeployReason and ComponentStatus moved DOWN to homeboy-release-contract so
+// core's fleet/project/context status mechanics can reference them without a
+// cycle. Re-exported here so the deploy/release code keeps its paths.
+pub use homeboy_release_contract::{ComponentStatus, DeployReason};
 
 /// Compare the configured source version with the version observed on the target.
 ///
@@ -398,73 +362,9 @@ pub fn compare_deployed_versions(
     }
 }
 
-/// Release state tracking for deployment decisions.
-/// Captures git state relative to the last version tag.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ReleaseState {
-    /// Number of commits since the last version tag
-    pub commits_since_version: u32,
-    /// Number of code commits (non-docs)
-    #[serde(skip_serializing_if = "is_zero_u32")]
-    pub code_commits: u32,
-    /// Number of docs-only commits
-    #[serde(skip_serializing_if = "is_zero_u32")]
-    pub docs_only_commits: u32,
-    /// Whether there are uncommitted changes in the working directory
-    pub has_uncommitted_changes: bool,
-    /// The baseline reference (tag or commit hash) used for comparison
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub baseline_ref: Option<String>,
-    /// Warning emitted when the detected baseline may not align with the current version
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub baseline_warning: Option<String>,
-}
-
-/// High-level status derived from a component release state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ReleaseStateStatus {
-    Uncommitted,
-    NeedsRelease,
-    DocsOnly,
-    Clean,
-    Unknown,
-}
-
-impl ReleaseState {
-    pub fn status(&self) -> ReleaseStateStatus {
-        if self.has_uncommitted_changes {
-            ReleaseStateStatus::Uncommitted
-        } else if self.code_commits > 0 {
-            ReleaseStateStatus::NeedsRelease
-        } else if self.docs_only_commits > 0 {
-            ReleaseStateStatus::DocsOnly
-        } else {
-            ReleaseStateStatus::Clean
-        }
-    }
-}
-
-impl ReleaseStateStatus {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            ReleaseStateStatus::Uncommitted => "uncommitted",
-            ReleaseStateStatus::NeedsRelease => "needs_release",
-            ReleaseStateStatus::DocsOnly => "docs_only",
-            ReleaseStateStatus::Clean => "clean",
-            ReleaseStateStatus::Unknown => "unknown",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct ReleaseStateBuckets {
-    pub ready_to_deploy: Vec<String>,
-    pub needs_release: Vec<String>,
-    pub docs_only: Vec<String>,
-    pub has_uncommitted: Vec<String>,
-    pub unknown: Vec<String>,
-}
+// ReleaseState, ReleaseStateStatus, ReleaseStateBuckets moved DOWN to
+// homeboy-release-contract (see the DeployReason/ComponentStatus note above).
+pub use homeboy_release_contract::{ReleaseState, ReleaseStateBuckets, ReleaseStateStatus};
 
 /// Result for a single component deployment.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/homeboy-core/src/fleet/status.rs
+++ b/crates/homeboy-core/src/fleet/status.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 
-use crate::deploy::{self, DeployConfig, ReleaseStateStatus};
+use crate::deploy::{self, DeployConfig};
 use crate::project;
 use crate::release::version;
 use crate::server::health::{self, ServerHealth};
+use homeboy_release_contract::ReleaseStateStatus;
 use serde::Serialize;
 
 // ============================================================================

--- a/crates/homeboy-release-contract/Cargo.toml
+++ b/crates/homeboy-release-contract/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "homeboy-release-contract"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Shared release/deploy state data types (component release state, deploy status enums, release-state buckets). Sits below homeboy-core so both core (fleet/project/context status) and homeboy-release reference them without a cycle."
+publish = false
+
+[lib]
+name = "homeboy_release_contract"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/crates/homeboy-release-contract/src/lib.rs
+++ b/crates/homeboy-release-contract/src/lib.rs
@@ -1,0 +1,121 @@
+//! Shared release/deploy state data types.
+//!
+//! These sit below `homeboy-core` so that core's status-reporting mechanics
+//! (fleet / project / context) and the `homeboy-release` feature crate can both
+//! reference them without a dependency cycle. They are pure data (plus trivial
+//! derived accessors) — all release/deploy *behavior* lives in `homeboy-release`.
+
+use serde::{Deserialize, Serialize};
+
+fn is_zero_u32(v: &u32) -> bool {
+    *v == 0
+}
+
+/// Reason a component was selected for (or flagged during) a deploy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeployReason {
+    /// Component was explicitly specified by ID
+    ExplicitlySelected,
+    /// --all flag was used
+    AllSelected,
+    /// Local and remote versions differ
+    VersionMismatch,
+    /// Could not determine local version
+    UnknownLocalVersion,
+    /// Could not determine remote version (not deployed or no version file)
+    UnknownRemoteVersion,
+}
+
+/// Status indicator for component version comparison.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentStatus {
+    /// Local and remote versions match
+    UpToDate,
+    /// Local version ahead of remote (needs deploy)
+    NeedsUpdate,
+    /// Remote version ahead of local (local behind)
+    BehindRemote,
+    /// Local checkout is behind its upstream branch
+    BehindUpstream,
+    /// Remote matches a configured source checkout that is stale or detached
+    SourceStale,
+    /// Cannot determine status
+    Unknown,
+}
+
+impl ComponentStatus {
+    /// Whether deploying the configured source would advance the target.
+    pub fn requires_deploy(&self) -> bool {
+        matches!(self, Self::NeedsUpdate)
+    }
+}
+
+/// Release state tracking for deployment decisions.
+/// Captures git state relative to the last version tag.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReleaseState {
+    /// Number of commits since the last version tag
+    pub commits_since_version: u32,
+    /// Number of code commits (non-docs)
+    #[serde(skip_serializing_if = "is_zero_u32")]
+    pub code_commits: u32,
+    /// Number of docs-only commits
+    #[serde(skip_serializing_if = "is_zero_u32")]
+    pub docs_only_commits: u32,
+    /// Whether there are uncommitted changes in the working directory
+    pub has_uncommitted_changes: bool,
+    /// The baseline reference (tag or commit hash) used for comparison
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_ref: Option<String>,
+    /// Warning emitted when the detected baseline may not align with the current version
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_warning: Option<String>,
+}
+
+/// High-level status derived from a component release state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReleaseStateStatus {
+    Uncommitted,
+    NeedsRelease,
+    DocsOnly,
+    Clean,
+    Unknown,
+}
+
+impl ReleaseState {
+    pub fn status(&self) -> ReleaseStateStatus {
+        if self.has_uncommitted_changes {
+            ReleaseStateStatus::Uncommitted
+        } else if self.code_commits > 0 {
+            ReleaseStateStatus::NeedsRelease
+        } else if self.docs_only_commits > 0 {
+            ReleaseStateStatus::DocsOnly
+        } else {
+            ReleaseStateStatus::Clean
+        }
+    }
+}
+
+impl ReleaseStateStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ReleaseStateStatus::Uncommitted => "uncommitted",
+            ReleaseStateStatus::NeedsRelease => "needs_release",
+            ReleaseStateStatus::DocsOnly => "docs_only",
+            ReleaseStateStatus::Clean => "clean",
+            ReleaseStateStatus::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ReleaseStateBuckets {
+    pub ready_to_deploy: Vec<String>,
+    pub needs_release: Vec<String>,
+    pub docs_only: Vec<String>,
+    pub has_uncommitted: Vec<String>,
+    pub unknown: Vec<String>,
+}


### PR DESCRIPTION
## Summary
**Prep 1/3 for the deploy + release extraction** — the last big feature subsystem (~42k LOC) still in `homeboy-core`.

Deploy and release are mutually dependent, so they'll extract together as one `homeboy-release` crate. But core's status-reporting *mechanics* (`fleet` / `project` / `context` — all core-internal, zero external consumers, so they must stay) reference release/deploy state types and behavior. This PR handles the **types** half: moves the pure state data types DOWN into a new below-core contract crate so those mechanics can keep referencing them without a dependency cycle.

## What moved to `homeboy-release-contract`
Pure data (plus trivial derived accessors), no behavior:
- `DeployReason`, `ComponentStatus` (+ `requires_deploy()`)
- `ReleaseState` (+ `status()`), `ReleaseStateStatus` (+ `as_str()`), `ReleaseStateBuckets`

`deploy/types.rs` re-exports them so the deploy/release code paths are untouched; `context/report.rs` + `fleet/status.rs` now reference the contract directly.

## What did NOT move
All behavior — `deploy::run`, `release::version::*`, `release::changelog`, `DeployConfig` — stays in core for now. That's **prep 2/3** (a `ReleaseProvider` hook mirroring `rig_provider`/`stack_provider`), after which core will have zero `crate::deploy`/`crate::release` edges and **prep 3/3** git-mv's the ~42k LOC out.

## Verification
`cargo check --workspace --tests`: green. `cargo fmt`: clean. No functional change.

## Campaign
Follows the pattern of `homeboy-rig-contract` / `homeboy-agents-contract`. After the full deploy+release extraction, core drops ~205k → ~163k and becomes purely the mechanical engine.