### PR TITLE
refactor: move test drift + run/baseline result types to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/test/baseline.rs
+++ b/crates/homeboy-core/src/extension/test/baseline.rs
@@ -12,19 +12,9 @@ use serde::{Deserialize, Serialize};
 use crate::error::Result;
 use homeboy_engine_primitives::baseline::{self as generic, BaselineConfig};
 pub use homeboy_extension_contract::test_result::TestCounts;
+pub use homeboy_extension_contract::test_workflow::TestBaselineComparison;
 
 const BASELINE_KEY: &str = "test";
-
-#[derive(Debug, Clone, Serialize)]
-pub struct TestBaselineComparison {
-    pub baseline: TestCounts,
-    pub current: TestCounts,
-    pub passed_delta: i64,
-    pub failed_delta: i64,
-    pub regression: bool,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub reasons: Vec<String>,
-}
 
 pub type TestBaseline = generic::Baseline<TestCounts>;
 

--- a/crates/homeboy-core/src/extension/test/drift.rs
+++ b/crates/homeboy-core/src/extension/test/drift.rs
@@ -17,83 +17,13 @@ use crate::error::{Error, Result};
 use crate::extension::TestDriftConfig;
 use crate::git;
 use homeboy_engine_primitives::test_path::is_test_path;
+pub use homeboy_extension_contract::test_workflow::{
+    ChangeType, DriftReport, DriftedTest, ProductionChange,
+};
 
 // ============================================================================
 // Models
 // ============================================================================
-
-/// A production change that may cause test drift.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ProductionChange {
-    /// Type of change detected.
-    pub change_type: ChangeType,
-    /// Production file where the change occurred.
-    pub file: String,
-    /// The old symbol/value (removed/changed from).
-    pub old_symbol: String,
-    /// The new symbol/value (added/changed to), if applicable.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub new_symbol: Option<String>,
-    /// Line number in the diff (approximate).
-    #[serde(default)]
-    pub line: usize,
-}
-
-/// Type of production change detected from git diff.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum ChangeType {
-    /// Method/function was renamed.
-    MethodRename,
-    /// Method/function was removed entirely.
-    MethodRemoved,
-    /// Class/trait was renamed.
-    ClassRename,
-    /// Class/trait was removed entirely.
-    ClassRemoved,
-    /// Error code string changed.
-    ErrorCodeChange,
-    /// Return type annotation changed.
-    ReturnTypeChange,
-    /// Method signature changed (different parameters).
-    SignatureChange,
-    /// File was moved/renamed.
-    FileMove,
-    /// String constant changed.
-    StringChange,
-}
-
-/// A test file that references a changed symbol.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DriftedTest {
-    /// Test file path.
-    pub test_file: String,
-    /// Line number where the old symbol is referenced.
-    pub line: usize,
-    /// The line content.
-    pub content: String,
-    /// Reference to the production change that caused the drift.
-    pub change_index: usize,
-}
-
-/// Full drift report.
-#[derive(Debug, Clone, Serialize)]
-pub struct DriftReport {
-    /// Component name.
-    pub component: String,
-    /// Git ref used as baseline (tag, commit, branch).
-    pub since: String,
-    /// Production changes detected.
-    pub production_changes: Vec<ProductionChange>,
-    /// Tests that reference changed symbols.
-    pub drifted_tests: Vec<DriftedTest>,
-    /// Total unique test files affected.
-    pub total_drifted_files: usize,
-    /// Total drift references found.
-    pub total_drift_references: usize,
-    /// Changes that could be auto-fixed with refactor transform.
-    pub auto_fixable: usize,
-}
 
 // ============================================================================
 // Git diff parsing

--- a/crates/homeboy-core/src/extension/test/run.rs
+++ b/crates/homeboy-core/src/extension/test/run.rs
@@ -17,6 +17,7 @@ use crate::validation_progress::{write_command_artifact, ValidationProgressRecor
 use homeboy_engine_primitives::baseline::BaselineFlags;
 use homeboy_engine_primitives::local_files;
 use homeboy_engine_primitives::output_parse::ParseSpec;
+pub use homeboy_extension_contract::test_workflow::RawTestOutput;
 use homeboy_refactor_contract::AppliedRefactor;
 use serde::Serialize;
 use std::path::Path;
@@ -63,47 +64,6 @@ pub struct TestRunWorkflowResult {
     pub raw_output: Option<RawTestOutput>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extension_phase_timings: Vec<ExtensionPhaseTiming>,
-}
-
-/// Captured tail of a test runner's stdout/stderr.
-///
-/// Surfaced on failure so the actual tool output
-/// is visible in the structured JSON response. The tail is bounded by
-/// `RAW_OUTPUT_TAIL_LINES` to keep JSON payloads small while still showing
-/// the last error / stack frame, which is almost always the relevant part
-/// for bootstrap failures. (#1143)
-#[derive(Debug, Clone, Serialize)]
-pub struct RawTestOutput {
-    /// Last N lines of stdout. Empty string if the runner emitted no stdout.
-    pub stdout_tail: String,
-    /// Last N lines of stderr. Empty string if the runner emitted no stderr.
-    pub stderr_tail: String,
-    /// Whether either tail was truncated from the original output.
-    pub truncated: bool,
-    /// Whether stdout capture itself was bounded before the line tail was built.
-    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
-    pub stdout_truncated: bool,
-    /// Whether stderr capture itself was bounded before the line tail was built.
-    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
-    pub stderr_truncated: bool,
-    /// Total stdout bytes observed before bounded capture retained its tail.
-    #[serde(skip_serializing_if = "crate::is_zero", default)]
-    pub stdout_seen_bytes: usize,
-    /// Stdout bytes retained in this structured raw-output excerpt.
-    #[serde(skip_serializing_if = "crate::is_zero", default)]
-    pub stdout_retained_bytes: usize,
-    /// Total stderr bytes observed before bounded capture retained its tail.
-    #[serde(skip_serializing_if = "crate::is_zero", default)]
-    pub stderr_seen_bytes: usize,
-    /// Stderr bytes retained in this structured raw-output excerpt.
-    #[serde(skip_serializing_if = "crate::is_zero", default)]
-    pub stderr_retained_bytes: usize,
-    /// Maximum stdout bytes retained by the self-check capture buffer.
-    #[serde(skip_serializing_if = "crate::is_zero", default)]
-    pub stdout_limit_bytes: usize,
-    /// Maximum stderr bytes retained by the self-check capture buffer.
-    #[serde(skip_serializing_if = "crate::is_zero", default)]
-    pub stderr_limit_bytes: usize,
 }
 
 const RAW_OUTPUT_TAIL_LINES: usize = 80;

--- a/crates/homeboy-core/src/extension/test/workflow.rs
+++ b/crates/homeboy-core/src/extension/test/workflow.rs
@@ -4,19 +4,9 @@ use crate::extension::test::resolve_drift_options;
 use crate::extension::test::TestScopeOutput;
 use crate::extension::test::{ChangeType, TestAnalysis};
 use crate::extension::test::{TestBaselineComparison, TestCounts};
+pub use homeboy_extension_contract::test_workflow::AutoFixDriftOutput;
 use homeboy_refactor_contract::{AppliedRefactor, TransformSet};
 use serde::Serialize;
-
-#[derive(Debug, Clone, Serialize)]
-pub struct AutoFixDriftOutput {
-    pub since: String,
-    pub auto_fixable_changes: usize,
-    pub generated_rules: usize,
-    pub replacements: usize,
-    pub files_modified: usize,
-    pub written: bool,
-    pub rerun_recommended: bool,
-}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct DriftWorkflowResult {

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -23,6 +23,7 @@ pub mod capability;
 pub mod test_analysis;
 pub mod test_parsing;
 pub mod test_result;
+pub mod test_workflow;
 pub mod trace_parsing;
 pub use bench_artifact::{BenchArtifact, BenchArtifactViewer, BenchPreviewLifecycleMetadata};
 pub use bench_diagnostics::{
@@ -46,6 +47,10 @@ pub use test_analysis::{
 };
 pub use test_parsing::{CoverageOutput, TestFailureSummaryItem, TestSummaryOutput, UncoveredFile};
 pub use test_result::{TestCounts, TestScopeOutput};
+pub use test_workflow::{
+    AutoFixDriftOutput, ChangeType, DriftReport, DriftedTest, ProductionChange, RawTestOutput,
+    TestBaselineComparison,
+};
 pub use trace_parsing::{
     TraceArtifact, TraceAssertion, TraceAssertionStatus, TraceCanonicalCheck,
     TraceComponentsProvenance, TraceDependencyProvenance, TraceEvent, TraceEvidenceMetadata,

--- a/crates/homeboy-extension-contract/src/test_workflow.rs
+++ b/crates/homeboy-extension-contract/src/test_workflow.rs
@@ -1,0 +1,145 @@
+//! Pure test drift + run/baseline result contract types.
+
+use serde::{Deserialize, Serialize};
+
+use crate::TestCounts;
+
+fn is_zero(v: &usize) -> bool {
+    *v == 0
+}
+
+/// A production change that may cause test drift.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProductionChange {
+    /// Type of change detected.
+    pub change_type: ChangeType,
+    /// Production file where the change occurred.
+    pub file: String,
+    /// The old symbol/value (removed/changed from).
+    pub old_symbol: String,
+    /// The new symbol/value (added/changed to), if applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_symbol: Option<String>,
+    /// Line number in the diff (approximate).
+    #[serde(default)]
+    pub line: usize,
+}
+
+/// Type of production change detected from git diff.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeType {
+    /// Method/function was renamed.
+    MethodRename,
+    /// Method/function was removed entirely.
+    MethodRemoved,
+    /// Class/trait was renamed.
+    ClassRename,
+    /// Class/trait was removed entirely.
+    ClassRemoved,
+    /// Error code string changed.
+    ErrorCodeChange,
+    /// Return type annotation changed.
+    ReturnTypeChange,
+    /// Method signature changed (different parameters).
+    SignatureChange,
+    /// File was moved/renamed.
+    FileMove,
+    /// String constant changed.
+    StringChange,
+}
+
+/// A test file that references a changed symbol.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DriftedTest {
+    /// Test file path.
+    pub test_file: String,
+    /// Line number where the old symbol is referenced.
+    pub line: usize,
+    /// The line content.
+    pub content: String,
+    /// Reference to the production change that caused the drift.
+    pub change_index: usize,
+}
+
+/// Full drift report.
+#[derive(Debug, Clone, Serialize)]
+pub struct DriftReport {
+    /// Component name.
+    pub component: String,
+    /// Git ref used as baseline (tag, commit, branch).
+    pub since: String,
+    /// Production changes detected.
+    pub production_changes: Vec<ProductionChange>,
+    /// Tests that reference changed symbols.
+    pub drifted_tests: Vec<DriftedTest>,
+    /// Total unique test files affected.
+    pub total_drifted_files: usize,
+    /// Total drift references found.
+    pub total_drift_references: usize,
+    /// Changes that could be auto-fixed with refactor transform.
+    pub auto_fixable: usize,
+}
+
+/// Captured tail of a test runner's stdout/stderr.
+///
+/// Surfaced on failure so the actual tool output
+/// is visible in the structured JSON response. The tail is bounded by
+/// `RAW_OUTPUT_TAIL_LINES` to keep JSON payloads small while still showing
+/// the last error / stack frame, which is almost always the relevant part
+/// for bootstrap failures. (#1143)
+#[derive(Debug, Clone, Serialize)]
+pub struct RawTestOutput {
+    /// Last N lines of stdout. Empty string if the runner emitted no stdout.
+    pub stdout_tail: String,
+    /// Last N lines of stderr. Empty string if the runner emitted no stderr.
+    pub stderr_tail: String,
+    /// Whether either tail was truncated from the original output.
+    pub truncated: bool,
+    /// Whether stdout capture itself was bounded before the line tail was built.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub stdout_truncated: bool,
+    /// Whether stderr capture itself was bounded before the line tail was built.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub stderr_truncated: bool,
+    /// Total stdout bytes observed before bounded capture retained its tail.
+    #[serde(skip_serializing_if = "is_zero", default)]
+    pub stdout_seen_bytes: usize,
+    /// Stdout bytes retained in this structured raw-output excerpt.
+    #[serde(skip_serializing_if = "is_zero", default)]
+    pub stdout_retained_bytes: usize,
+    /// Total stderr bytes observed before bounded capture retained its tail.
+    #[serde(skip_serializing_if = "is_zero", default)]
+    pub stderr_seen_bytes: usize,
+    /// Stderr bytes retained in this structured raw-output excerpt.
+    #[serde(skip_serializing_if = "is_zero", default)]
+    pub stderr_retained_bytes: usize,
+    /// Maximum stdout bytes retained by the self-check capture buffer.
+    #[serde(skip_serializing_if = "is_zero", default)]
+    pub stdout_limit_bytes: usize,
+    /// Maximum stderr bytes retained by the self-check capture buffer.
+    #[serde(skip_serializing_if = "is_zero", default)]
+    pub stderr_limit_bytes: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AutoFixDriftOutput {
+    pub since: String,
+    pub auto_fixable_changes: usize,
+    pub generated_rules: usize,
+    pub replacements: usize,
+    pub files_modified: usize,
+    pub written: bool,
+    pub rerun_recommended: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TestBaselineComparison {
+    pub baseline: TestCounts,
+    pub current: TestCounts,
+    pub passed_delta: i64,
+    pub failed_delta: i64,
+    pub regression: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub reasons: Vec<String>,
+}


### PR DESCRIPTION
## Summary
Continues the test subsystem breakdown with a batch of pure result types.

## What moved
- **Drift closure:** `ProductionChange`, `ChangeType`, `DriftedTest`, `DriftReport`
- **`RawTestOutput`** (test/run.rs)
- **`AutoFixDriftOutput`** (test/workflow.rs)
- **`TestBaselineComparison`** (test/baseline.rs) — unblocked now that its only field dependency `TestCounts` is already in the contract crate (#8875)

## The split
The drift-detection functions, baseline fingerprinting, and run/workflow behavior stay in core. Moved the `is_zero` serde helper the baseline type needs. Core re-exports all types, so `crate::extension::test` paths stay stable.

## Why
These clear more of the `TestRunWorkflowResult` / `MainTestWorkflowResult` / `TestCommandOutput` field graph — the same leaf-first approach that let the bench/trace aggregate clusters fall once their fields were out.

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)