### PR TITLE
Preserve explicit runner admission

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1633,6 +1633,32 @@ mod tests {
     }
 
     #[test]
+    fn scoped_cook_runner_is_preserved_for_pinned_reexecution() {
+        let matches = Cli::command_with_scoped_lab_args()
+            .try_get_matches_from([
+                "homeboy",
+                "agent-task",
+                "cook",
+                "--to-worktree",
+                "homeboy@fix-explicit-runner",
+                "--prompt",
+                "fix the issue",
+                "--verify",
+                "true",
+                "--runner",
+                "selected-lab",
+            ])
+            .expect("scoped cook accepts an explicit runner");
+        let (cli, _) = Cli::from_registered_arg_matches(&matches).expect("typed cli");
+
+        assert_eq!(cli.runner.as_deref(), Some("selected-lab"));
+        assert_eq!(
+            resource_policy_runner_hint(&cli, Some("default-lab")),
+            Some("selected-lab")
+        );
+    }
+
+    #[test]
     fn managed_runner_context_clears_before_production_run_command() {
         let _lock = env_lock().lock().unwrap_or_else(|err| err.into_inner());
         let previous = [

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -338,6 +338,7 @@ impl CliRuntime {
         };
         commands::set_skip_deps_hydration(cli.skip_deps_hydration);
         normalize_runs_runner_options(&mut cli, &normalized);
+        normalize_cook_runner_option(&mut cli, &normalized);
 
         if matches!(&cli.command, Commands::Runs(args) if args.is_bundle_export()) {
             output_file = None;
@@ -948,6 +949,39 @@ fn normalize_runs_runner_options(cli: &mut Cli, normalized_args: &[String]) {
             cli.runner = args.absorb_global_runner_for_command_option(cli.runner.take());
         }
     }
+}
+
+/// Cook is re-executed by a pinned controller binary. Retain an explicit runner
+/// from that exact argv even when a command-scoped Clap argument did not hydrate
+/// the root global field used by admission and placement routing.
+fn normalize_cook_runner_option(cli: &mut Cli, normalized_args: &[String]) {
+    if cli.runner.is_some()
+        || !matches!(
+            &cli.command,
+            Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+                command: crate::commands::agent_task::AgentTaskCommand::Cook(_),
+            })
+        )
+    {
+        return;
+    }
+    cli.runner = explicit_runner_from_args(normalized_args);
+}
+
+fn explicit_runner_from_args(args: &[String]) -> Option<String> {
+    let mut args = args.iter();
+    while let Some(arg) = args.next() {
+        if arg == "--" {
+            return None;
+        }
+        if arg == "--runner" {
+            return args.next().cloned();
+        }
+        if let Some(runner_id) = arg.strip_prefix("--runner=") {
+            return Some(runner_id.to_string());
+        }
+    }
+    None
 }
 
 fn is_runs_list_runner_option(args: &[String]) -> bool {
@@ -1655,6 +1689,43 @@ mod tests {
         assert_eq!(
             resource_policy_runner_hint(&cli, Some("default-lab")),
             Some("selected-lab")
+        );
+    }
+
+    #[test]
+    fn pinned_cook_argv_restores_explicit_runner_before_admission() {
+        let mut cli = Cli::parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--to-worktree",
+            "homeboy@fix-explicit-runner",
+            "--prompt",
+            "fix the issue",
+            "--verify",
+            "true",
+        ]);
+        let pinned_argv = vec![
+            "/tmp/homeboy/controller-runtimes/homeboy_0_290_0/homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--to-worktree".to_string(),
+            "homeboy@fix-explicit-runner".to_string(),
+            "--prompt".to_string(),
+            "fix the issue".to_string(),
+            "--verify".to_string(),
+            "true".to_string(),
+            "--runner".to_string(),
+            "homeboy-lab".to_string(),
+        ];
+
+        normalize_cook_runner_option(&mut cli, &pinned_argv);
+
+        assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+        assert_eq!(
+            resource_policy_runner_hint(&cli, None),
+            Some("homeboy-lab"),
+            "hot-machine admission must receive the runner selected in pinned argv"
         );
     }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/execute.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/execute.rs
@@ -24,9 +24,11 @@ pub(crate) fn record_synced_remapped_workspace_entry(
 }
 
 pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadOutcome> {
-    if request.placement == homeboy_cli_contract::Placement::Auto
-        && homeboy_core::resource_policy_context::is_managed_runner_placement_context()
-    {
+    if should_skip_managed_runner_placement(
+        request.placement,
+        request.explicit_runner,
+        homeboy_core::resource_policy_context::is_managed_runner_placement_context(),
+    ) {
         return Ok(LabOffloadOutcome::RunLocal {
             plan: disabled_select_runner_plan(
                 base_lab_plan(request.command.as_ref()),
@@ -349,6 +351,37 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         overhead,
         runner_status,
     )
+}
+
+fn should_skip_managed_runner_placement(
+    placement: homeboy_cli_contract::Placement,
+    explicit_runner: Option<&str>,
+    managed_runner_placement: bool,
+) -> bool {
+    placement == homeboy_cli_contract::Placement::Auto
+        && explicit_runner.is_none()
+        && managed_runner_placement
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_runner_is_not_suppressed_by_resolved_automatic_placement() {
+        // A controller re-entering from a managed runner must still honor a new
+        // explicit selection so selection can report that runner's own status.
+        assert!(should_skip_managed_runner_placement(
+            homeboy_cli_contract::Placement::Auto,
+            None,
+            true,
+        ));
+        assert!(!should_skip_managed_runner_placement(
+            homeboy_cli_contract::Placement::Auto,
+            Some("homeboy-lab"),
+            true,
+        ));
+    }
 }
 
 pub(crate) fn unsupported_runner_hints(


### PR DESCRIPTION
## Summary
Preserve explicit runner intent through pinned cook admission and managed placement so hot controllers route eligible work instead of recommending an already-present flag.

## What changed
- Recover scoped cook runner intent before admission and keep explicit runner selection eligible after managed automatic-placement resolution.

## How to test
1. Run `cargo fmt --check`; expect Formatting exits successfully..
2. Run `cargo test -p homeboy-lab-runner explicit_runner_is_not_suppressed_by_resolved_automatic_placement -- --nocapture`; expect The explicit runner remains eligible after managed automatic placement..
3. Run `cargo test -p homeboy-cli pinned_cook_argv_restores_explicit_runner_before_admission -- --nocapture`; expect Pinned cook argv restores runner intent before admission..
4. Run `cargo test -p homeboy-cli scoped_cook_runner_is_preserved_for_pinned_reexecution -- --nocapture`; expect Scoped cook runner intent survives pinned re-execution..
5. Run `cargo check -p homeboy-cli -p homeboy-lab-runner`; expect Both changed packages compile..

## Compatibility
No backwards compatibility break: explicit runner requests now follow their declared routing semantics; automatic placement remains unchanged.

## Evidence
- Base advanced after verification: verified main at 4387f1084bd0a47c47567c36dbde4f54a56f1287; publication observed b99f16dce711a922a967be124d04dba07c86dd64. Candidate ancestry was validated against the verified snapshot.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8153
- Verified finalization base: main at 4387f1084bd0a47c47567c36dbde4f54a56f1287
- cargo-check: Passed
- focused-tests: Passed
- format: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the runner-admission regression, drafted implementation and tests, and reconciled rebases; Chris reviews and owns the change.

## Source relationships
- Closes #8153
