### PR TITLE
refactor: move CiContext to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/ci_profile.rs
+++ b/crates/homeboy-core/src/ci_profile.rs
@@ -8,6 +8,7 @@ use crate::error::{Error, Result};
 use crate::extension::{
     self, CiJobFidelity, CiJobMapping, CiJobSpec, CiLocalContext, CiProfileSpec, ExtensionManifest,
 };
+pub use homeboy_extension_contract::CiContext;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct CiInventory {
@@ -86,17 +87,6 @@ pub struct CiResolvedJob {
     pub extension_id: String,
     pub id: String,
     pub spec: CiJobSpec,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct CiContext {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub profile: Option<String>,
-    pub job_id: String,
-    #[serde(flatten)]
-    pub mapping: CiJobMapping,
-    #[serde(flatten)]
-    pub local_context: CiLocalContext,
 }
 
 pub fn list_for_extension(source_path: &Path, extension_id: &str) -> Result<CiInventory> {

--- a/crates/homeboy-extension-contract/src/ci_context.rs
+++ b/crates/homeboy-extension-contract/src/ci_context.rs
@@ -1,0 +1,16 @@
+//! CI execution-context contract type.
+
+use serde::{Deserialize, Serialize};
+
+use crate::ci_config::{CiJobMapping, CiLocalContext};
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CiContext {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    pub job_id: String,
+    #[serde(flatten)]
+    pub mapping: CiJobMapping,
+    #[serde(flatten)]
+    pub local_context: CiLocalContext,
+}

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -59,6 +59,8 @@ pub use trace_parsing::{
     TraceToolchainProvenance,
 };
 pub mod ci_config;
+pub mod ci_context;
+pub use ci_context::CiContext;
 pub mod core_compat;
 pub mod exec_context;
 pub mod extension_contract_producer;


### PR DESCRIPTION
## Summary
`CiContext` is a pure serde struct (0 impls, no custom serde helpers) whose field types `CiJobMapping` and `CiLocalContext` already live in the contract crate (from the manifest-config cuts). It's a field dependency of the aggregate `TestCommandOutput`/`LintCommandOutput` result clusters.

## The move
Moves `CiContext` out of `ci_profile.rs` into the contract crate; the CI-profile resolution functions stay in core. Core re-exports it so all `crate::extension` paths stay stable.

## Why
This clears one of the **non-test-specific** field dependencies of the top-level test/lint result clusters (`TestCommandOutput`/`LintCommandOutput`). Combined with `AppliedRefactor` (already in `homeboy-refactor-contract`) and the test result-type cuts (#8871/#8875/#8878/#8881), the aggregate clusters' field graphs are nearly clear — setting up their wholesale move, the same way the bench/trace aggregates fell.

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)