### PR TITLE
refactor: ReleaseProvider hook — invert core→deploy/release edges (prep 2/3)

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -105,6 +105,11 @@ impl CliRuntime {
         // manifests (detector rules, test mappings, provided extensions) without
         // depending on the extension layer's loader — the seam that lets audit
         // become its own crate.
+        // Register the in-core release provider so core's status mechanics
+        // (fleet/project/context/git change reporting/tag-gap) get deploy+release
+        // behavior through the hook. Moves out with deploy/release when they
+        // become the homeboy-release crate.
+        crate::core::release::provider_impl::register();
         crate::core::extension::audit_manifest_provider::register();
         // Register the fingerprint-script provider so code_audit can fall back to
         // extension fingerprint scripts (for files the core grammar engine can't

--- a/crates/homeboy-core/src/context/report.rs
+++ b/crates/homeboy-core/src/context/report.rs
@@ -4,15 +4,15 @@ use std::path::{Path, PathBuf};
 use serde::Serialize;
 
 use crate::component::{self, Component};
-use crate::deploy;
 use crate::extension::{
     extension_ready_status, is_extension_compatible, is_extension_linked, load_all_extensions,
 };
 use crate::project::{self, Project};
-use crate::release::{changelog, version};
+use crate::release_provider::{self, ReleaseStateEntry};
 use crate::server::{self, Server};
 use crate::{git, Result};
 use crate::{is_zero, is_zero_u32};
+use homeboy_release_contract::VersionTargetInfo;
 
 use super::{build_component_info, ComponentGap, ContextOutput};
 
@@ -133,7 +133,7 @@ pub struct ExtensionEntry {
 pub struct VersionSnapshot {
     pub component_id: String,
     pub version: String,
-    pub targets: Vec<version::VersionTargetInfo>,
+    pub targets: Vec<VersionTargetInfo>,
 }
 
 #[derive(Debug, Serialize)]
@@ -235,7 +235,7 @@ fn build_report_at(
     let components_with_state: Vec<ComponentWithState> = filtered_components
         .into_iter()
         .map(|component| {
-            let release_state = deploy::calculate_release_state(&component);
+            let release_state = release_provider::calculate_release_state(&component);
             let gaps = if let Some(ref cwd_path) = cwd {
                 if component::resolution::component_is_contained_in_path(&component, cwd_path) {
                     build_component_info(&component).gaps
@@ -253,11 +253,14 @@ fn build_report_at(
         })
         .collect();
 
-    let release_buckets = deploy::bucket_release_states(
-        components_with_state
-            .iter()
-            .map(|comp| (comp.component.id.as_str(), comp.release_state.as_ref())),
-    );
+    let bucket_entries: Vec<ReleaseStateEntry<'_>> = components_with_state
+        .iter()
+        .map(|comp| ReleaseStateEntry {
+            component_id: comp.component.id.as_str(),
+            release_state: comp.release_state.as_ref(),
+        })
+        .collect();
+    let release_buckets = release_provider::bucket_release_states(&bucket_entries);
     let status = compute_status(&components_with_state, &release_buckets);
     let summary = compute_summary(&components_with_state);
 
@@ -450,7 +453,7 @@ fn compute_summary(components: &[ComponentWithState]) -> ContextReportSummary {
             }
         }
 
-        let status = deploy::classify_release_state(comp.release_state.as_ref())
+        let status = release_provider::classify_release_state(comp.release_state.as_ref())
             .as_str()
             .to_string();
         *by_status.entry(status).or_insert(0) += 1;
@@ -491,7 +494,7 @@ fn build_component_summaries(
     components
         .iter()
         .map(|comp| {
-            let status = deploy::classify_release_state(comp.release_state.as_ref())
+            let status = release_provider::classify_release_state(comp.release_state.as_ref())
                 .as_str()
                 .to_string();
             let (commits, code, docs) = comp
@@ -670,7 +673,7 @@ fn build_actionable_next_steps(
 fn resolve_version_snapshot(components: &[ComponentWithState]) -> Option<VersionSnapshot> {
     let wrapper = components.first()?;
     let component = &wrapper.component;
-    let snapshot = version::read_component_snapshot(component).ok()?;
+    let snapshot = release_provider::read_component_version_snapshot(component)?;
     Some(VersionSnapshot {
         component_id: snapshot.component_id,
         version: snapshot.version,
@@ -704,10 +707,11 @@ fn resolve_changelog_snapshots(
     };
     let component = &wrapper.component;
 
-    let (last_release, changelog_snapshot) = match changelog::read_component_snapshots(component) {
-        Ok((last_release, changelog_snapshot)) => (last_release, changelog_snapshot),
-        Err(_) => return (None, None),
-    };
+    let (last_release, changelog_snapshot) =
+        match release_provider::read_changelog_snapshots(component) {
+            Some((last_release, changelog_snapshot)) => (last_release, changelog_snapshot),
+            None => return (None, None),
+        };
 
     (
         last_release.map(|snapshot| ReleaseSnapshot {
@@ -740,7 +744,7 @@ fn resolve_agent_context_files(git_root: Option<&String>) -> Vec<String> {
 fn validate_version_targets(components: &[ComponentWithState]) -> Vec<String> {
     components
         .iter()
-        .flat_map(|wrapper| version::build_init_warnings(&wrapper.component))
+        .flat_map(|wrapper| release_provider::build_version_init_warnings(&wrapper.component))
         .collect()
 }
 
@@ -748,15 +752,16 @@ fn validate_version_baseline_alignment(
     version: &Option<VersionSnapshot>,
     git: &Option<GitSnapshot>,
 ) -> Option<String> {
-    let version_snapshot = version
-        .as_ref()
-        .map(|snapshot| version::ComponentVersionSnapshot {
-            component_id: snapshot.component_id.clone(),
-            version: snapshot.version.clone(),
-            targets: snapshot.targets.clone(),
-        });
+    let version_snapshot =
+        version.as_ref().map(
+            |snapshot| homeboy_release_contract::ComponentVersionSnapshot {
+                component_id: snapshot.component_id.clone(),
+                version: snapshot.version.clone(),
+                targets: snapshot.targets.clone(),
+            },
+        );
 
-    version::validate_baseline_alignment(
+    release_provider::validate_baseline_alignment(
         version_snapshot.as_ref(),
         git.as_ref()
             .and_then(|snapshot| snapshot.baseline_ref.as_deref()),

--- a/crates/homeboy-core/src/fleet/check.rs
+++ b/crates/homeboy-core/src/fleet/check.rs
@@ -1,6 +1,6 @@
-use crate::deploy::{self, DeployConfig};
 use crate::project;
-use crate::release::version;
+use crate::release_provider;
+use homeboy_release_contract::ComponentStatus;
 use serde::Serialize;
 
 #[derive(Debug, Default, Clone, Serialize)]
@@ -42,35 +42,29 @@ pub fn collect_check(
     };
 
     for project_id in &fl.project_ids {
-        let config = DeployConfig::check_all_no_pull_head();
-
-        match deploy::run(project_id, &config) {
-            Ok(result) => {
+        match release_provider::deploy_component_statuses(project_id) {
+            Ok(results) => {
                 summary.projects_checked += 1;
 
                 let proj = project::load(project_id).ok();
                 let mut component_checks = Vec::new();
 
-                for comp_result in &result.results {
+                for comp_result in &results {
                     let status_str = match &comp_result.component_status {
-                        Some(deploy::ComponentStatus::UpToDate) => "up_to_date",
-                        Some(deploy::ComponentStatus::NeedsUpdate) => "needs_update",
-                        Some(deploy::ComponentStatus::BehindRemote) => "behind_remote",
-                        Some(deploy::ComponentStatus::BehindUpstream) => "behind_upstream",
-                        Some(deploy::ComponentStatus::SourceStale) => "source_stale",
-                        Some(deploy::ComponentStatus::Unknown) | None => "unknown",
+                        Some(ComponentStatus::UpToDate) => "up_to_date",
+                        Some(ComponentStatus::NeedsUpdate) => "needs_update",
+                        Some(ComponentStatus::BehindRemote) => "behind_remote",
+                        Some(ComponentStatus::BehindUpstream) => "behind_upstream",
+                        Some(ComponentStatus::SourceStale) => "source_stale",
+                        Some(ComponentStatus::Unknown) | None => "unknown",
                     };
 
                     match &comp_result.component_status {
-                        Some(deploy::ComponentStatus::UpToDate) => {
-                            summary.components_up_to_date += 1
-                        }
+                        Some(ComponentStatus::UpToDate) => summary.components_up_to_date += 1,
                         Some(status) if status.requires_deploy() => {
                             summary.components_needs_update += 1
                         }
-                        Some(deploy::ComponentStatus::Unknown) | None => {
-                            summary.components_unknown += 1
-                        }
+                        Some(ComponentStatus::Unknown) | None => summary.components_unknown += 1,
                         Some(_) => {}
                     }
 
@@ -78,7 +72,7 @@ pub fn collect_check(
                         && !comp_result
                             .component_status
                             .as_ref()
-                            .is_some_and(deploy::ComponentStatus::requires_deploy)
+                            .is_some_and(ComponentStatus::requires_deploy)
                     {
                         continue;
                     }
@@ -151,7 +145,7 @@ fn cached_project_component_checks(
         .map(|component_id| {
             let local_version = project::resolve_project_component(proj, &component_id)
                 .ok()
-                .and_then(|comp| version::get_component_version(&comp));
+                .and_then(|comp| release_provider::get_component_version(&comp));
 
             summary.components_unknown += 1;
 

--- a/crates/homeboy-core/src/fleet/status.rs
+++ b/crates/homeboy-core/src/fleet/status.rs
@@ -1,10 +1,9 @@
 use std::collections::HashMap;
 
-use crate::deploy::{self, DeployConfig};
 use crate::project;
-use crate::release::version;
+use crate::release_provider;
 use crate::server::health::{self, ServerHealth};
-use homeboy_release_contract::ReleaseStateStatus;
+use homeboy_release_contract::{ComponentStatus, ReleaseStateStatus};
 use serde::Serialize;
 
 // ============================================================================
@@ -241,7 +240,7 @@ fn collect_cached_status(
         let mut component_statuses = Vec::new();
         for component_id in project::project_component_ids(&proj) {
             let local_version = match project::resolve_project_component(&proj, &component_id) {
-                Ok(comp) => version::get_component_version(&comp),
+                Ok(comp) => release_provider::get_component_version(&comp),
                 Err(_) => None,
             };
 
@@ -278,12 +277,10 @@ fn collect_project_component_statuses(
     proj: &project::Project,
     component_summary: &mut FleetComponentSummary,
 ) -> Vec<FleetComponentStatus> {
-    let config = DeployConfig::check_all_no_pull_head();
-
-    match deploy::run(project_id, &config) {
-        Ok(result) => {
+    match release_provider::deploy_component_statuses(project_id) {
+        Ok(results) => {
             let mut statuses = Vec::new();
-            for comp_result in &result.results {
+            for comp_result in &results {
                 // Get release state for this component
                 let (drift, unreleased) =
                     resolve_component_drift(proj, &comp_result.id, &comp_result.component_status);
@@ -316,7 +313,7 @@ fn collect_project_component_statuses(
             let mut statuses = Vec::new();
             for component_id in project::project_component_ids(proj) {
                 let local_version = match project::resolve_project_component(proj, &component_id) {
-                    Ok(comp) => version::get_component_version(&comp),
+                    Ok(comp) => release_provider::get_component_version(&comp),
                     Err(_) => None,
                 };
 
@@ -341,13 +338,13 @@ fn collect_project_component_statuses(
 fn resolve_component_drift(
     proj: &project::Project,
     component_id: &str,
-    deploy_status: &Option<deploy::ComponentStatus>,
+    deploy_status: &Option<ComponentStatus>,
 ) -> (FleetComponentDrift, u32) {
     // Check release state (unreleased commits)
     let release_info = project::resolve_project_component(proj, component_id)
         .ok()
         .and_then(|comp| {
-            let state = deploy::calculate_release_state(&comp)?;
+            let state = release_provider::calculate_release_state(&comp)?;
             Some((state.status(), state.commits_since_version))
         });
 
@@ -370,12 +367,12 @@ fn resolve_component_drift(
 
     // Fall back to deploy status for drift detection
     let drift = match deploy_status {
-        Some(deploy::ComponentStatus::UpToDate) => FleetComponentDrift::Current,
-        Some(deploy::ComponentStatus::NeedsUpdate) => FleetComponentDrift::NeedsUpdate,
-        Some(deploy::ComponentStatus::BehindRemote) => FleetComponentDrift::BehindRemote,
-        Some(deploy::ComponentStatus::BehindUpstream) => FleetComponentDrift::BehindUpstream,
-        Some(deploy::ComponentStatus::SourceStale) => FleetComponentDrift::BehindUpstream,
-        Some(deploy::ComponentStatus::Unknown) | None => FleetComponentDrift::Unknown,
+        Some(ComponentStatus::UpToDate) => FleetComponentDrift::Current,
+        Some(ComponentStatus::NeedsUpdate) => FleetComponentDrift::NeedsUpdate,
+        Some(ComponentStatus::BehindRemote) => FleetComponentDrift::BehindRemote,
+        Some(ComponentStatus::BehindUpstream) => FleetComponentDrift::BehindUpstream,
+        Some(ComponentStatus::SourceStale) => FleetComponentDrift::BehindUpstream,
+        Some(ComponentStatus::Unknown) | None => FleetComponentDrift::Unknown,
     };
 
     let unreleased = release_info.map(|(_, u)| u).unwrap_or(0);

--- a/crates/homeboy-core/src/git/operations_changes.rs
+++ b/crates/homeboy-core/src/git/operations_changes.rs
@@ -4,7 +4,6 @@ use crate::config::read_json_spec_to_string;
 use crate::error::{Error, Result};
 use crate::output::{BulkResult, BulkResultBuilder};
 use crate::project;
-use crate::release::changelog;
 
 use super::changes::*;
 use super::commits::*;
@@ -252,19 +251,15 @@ fn resolve_changelog_info(
     component: &crate::component::Component,
     _commits: &[CommitInfo],
 ) -> Option<ChangelogInfo> {
-    let changelog_path = changelog::resolve_changelog_path(component).ok()?;
-    let content = std::fs::read_to_string(&changelog_path).ok()?;
-    let settings = changelog::resolve_effective_settings(Some(component));
-    let unreleased_entries =
-        changelog::count_unreleased_entries(&content, &settings.next_section_aliases);
+    let info = crate::release_provider::changelog_info(component)?;
 
     // No hint: homeboy auto-generates changelog entries from commits at
     // release time, so an empty `## Unreleased` section no longer implies
     // the user needs to do anything. The count itself is still useful
     // context for `homeboy release changes` output.
     Some(ChangelogInfo {
-        unreleased_entries,
-        path: Some(changelog_path.to_string_lossy().to_string()),
+        unreleased_entries: info.unreleased_entries,
+        path: Some(info.path),
         hint: None,
     })
 }
@@ -305,11 +300,10 @@ pub fn changes_at(
             // Use component version for alignment checking
             let current_version = component
                 .as_ref()
-                .and_then(crate::release::version::get_component_version);
+                .and_then(crate::release_provider::get_component_version);
             let tag_prefix = component
                 .as_ref()
-                .and_then(|component| crate::release::component_tag_prefix(component).ok())
-                .flatten();
+                .and_then(crate::release_provider::component_tag_prefix);
             detect_baseline_with_version_and_tag_prefix(
                 &path,
                 current_version.as_deref(),

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -154,6 +154,7 @@ pub mod quality;
 pub use homeboy_redaction as redaction;
 pub mod refactor_transform_provider;
 pub mod release;
+pub mod release_provider;
 pub mod release_set;
 pub mod report_compare;
 pub(crate) mod report_compare_render;

--- a/crates/homeboy-core/src/project/status.rs
+++ b/crates/homeboy-core/src/project/status.rs
@@ -1,4 +1,4 @@
-use crate::deploy::{self, DeployConfig};
+use crate::release_provider;
 use crate::server::health::{self, ServerHealth};
 
 #[derive(Debug, Clone)]
@@ -39,17 +39,16 @@ pub fn collect_status(project_id: &str, health_only: bool) -> ProjectStatusSnaps
 }
 
 fn collect_component_versions(project_id: &str) -> Option<Vec<ProjectComponentStatus>> {
-    let config = DeployConfig::check_all_no_pull_head();
-
-    deploy::run(project_id, &config).ok().map(|result| {
-        result
-            .results
-            .iter()
-            .map(|r| ProjectComponentStatus {
-                component_id: r.id.clone(),
-                version: r.remote_version.clone(),
-                version_source: Some("live".to_string()),
-            })
-            .collect()
-    })
+    release_provider::deploy_component_statuses(project_id)
+        .ok()
+        .map(|statuses| {
+            statuses
+                .iter()
+                .map(|s| ProjectComponentStatus {
+                    component_id: s.id.clone(),
+                    version: s.remote_version.clone(),
+                    version_source: Some("live".to_string()),
+                })
+                .collect()
+        })
 }

--- a/crates/homeboy-core/src/release/changelog/io.rs
+++ b/crates/homeboy-core/src/release/changelog/io.rs
@@ -88,19 +88,11 @@ pub fn resolve_changelog_path(component: &Component) -> Result<PathBuf> {
     Ok(configured_path)
 }
 
-#[derive(Debug, Clone)]
-pub struct ChangelogSnapshotData {
-    pub path: String,
-    pub label: String,
-    pub items: Vec<String>,
-}
-
-#[derive(Debug, Clone)]
-pub struct FinalizedReleaseSnapshot {
-    pub tag: String,
-    pub date: Option<String>,
-    pub summary: Option<String>,
-}
+// ChangelogSnapshotData and FinalizedReleaseSnapshot moved DOWN to
+// homeboy-release-contract so core's context status mechanic can receive them
+// through the release provider hook. Re-exported here so release code paths are
+// unchanged.
+pub use homeboy_release_contract::{ChangelogSnapshotData, FinalizedReleaseSnapshot};
 
 pub fn read_component_snapshots(
     component: &Component,

--- a/crates/homeboy-core/src/release/mod.rs
+++ b/crates/homeboy-core/src/release/mod.rs
@@ -21,6 +21,7 @@ mod planning_policy;
 mod planning_quality;
 mod planning_semver;
 mod planning_worktree;
+pub mod provider_impl;
 mod scope;
 mod types;
 mod utils;

--- a/crates/homeboy-core/src/release/provider_impl.rs
+++ b/crates/homeboy-core/src/release/provider_impl.rs
@@ -1,0 +1,114 @@
+//! In-core implementation of the `ReleaseProvider` hook.
+//!
+//! Deploy + release still live inside `homeboy-core` during the extraction prep
+//! phase, so this impl delegates straight to the in-core deploy/release fns and
+//! registers itself at startup. When deploy/release move out into the
+//! `homeboy-release` crate, this impl moves with them and registers from the
+//! CLI runtime instead — the hook seam (and all of core's status mechanics)
+//! stays unchanged.
+
+use homeboy_release_contract::{
+    ChangelogSnapshotData, ComponentDeployStatus, ComponentVersionSnapshot,
+    FinalizedReleaseSnapshot, ReleaseState, ReleaseStateBuckets, ReleaseStateStatus,
+};
+
+use crate::component::Component;
+use crate::deploy::{self, DeployConfig};
+use crate::release::{changelog, version};
+use crate::release_provider::{
+    register_release_provider, ChangelogInfoData, ReleaseProvider, ReleaseStateEntry,
+};
+use crate::Result;
+
+struct CoreReleaseProvider;
+
+impl ReleaseProvider for CoreReleaseProvider {
+    fn deploy_component_statuses(&self, project_id: &str) -> Result<Vec<ComponentDeployStatus>> {
+        let config = DeployConfig::check_all_no_pull_head();
+        let result = deploy::run(project_id, &config)?;
+        Ok(result
+            .results
+            .into_iter()
+            .map(|r| ComponentDeployStatus {
+                id: r.id,
+                component_status: r.component_status,
+                local_version: r.local_version,
+                remote_version: r.remote_version,
+            })
+            .collect())
+    }
+
+    fn calculate_release_state(&self, component: &Component) -> Option<ReleaseState> {
+        deploy::calculate_release_state(component)
+    }
+
+    fn classify_release_state(&self, state: Option<&ReleaseState>) -> ReleaseStateStatus {
+        deploy::classify_release_state(state)
+    }
+
+    fn bucket_release_states(&self, entries: &[ReleaseStateEntry<'_>]) -> ReleaseStateBuckets {
+        deploy::bucket_release_states(entries.iter().map(|e| (e.component_id, e.release_state)))
+    }
+
+    fn get_component_version(&self, component: &Component) -> Option<String> {
+        version::get_component_version(component)
+    }
+
+    fn component_tag_prefix(&self, component: &Component) -> Option<String> {
+        crate::release::component_tag_prefix(component)
+            .ok()
+            .flatten()
+    }
+
+    fn latest_component_tag(&self, component: &Component) -> Option<String> {
+        crate::release::latest_component_tag(component)
+            .ok()
+            .flatten()
+    }
+
+    fn read_component_version_snapshot(
+        &self,
+        component: &Component,
+    ) -> Option<ComponentVersionSnapshot> {
+        version::read_component_snapshot(component).ok()
+    }
+
+    fn build_version_init_warnings(&self, component: &Component) -> Vec<String> {
+        version::build_init_warnings(component)
+    }
+
+    fn validate_baseline_alignment(
+        &self,
+        version: Option<&ComponentVersionSnapshot>,
+        baseline_ref: Option<&str>,
+    ) -> Option<String> {
+        crate::release::version::validate_baseline_alignment(version, baseline_ref)
+    }
+
+    fn read_changelog_snapshots(
+        &self,
+        component: &Component,
+    ) -> Option<(
+        Option<FinalizedReleaseSnapshot>,
+        Option<ChangelogSnapshotData>,
+    )> {
+        changelog::read_component_snapshots(component).ok()
+    }
+
+    fn changelog_info(&self, component: &Component) -> Option<ChangelogInfoData> {
+        let changelog_path = changelog::resolve_changelog_path(component).ok()?;
+        let content = std::fs::read_to_string(&changelog_path).ok()?;
+        let settings = changelog::resolve_effective_settings(Some(component));
+        let unreleased_entries =
+            changelog::count_unreleased_entries(&content, &settings.next_section_aliases);
+        Some(ChangelogInfoData {
+            unreleased_entries,
+            path: changelog_path.to_string_lossy().to_string(),
+        })
+    }
+}
+
+/// Register the in-core release provider. Called once at core startup.
+pub fn register() {
+    register_release_provider(Box::new(CoreReleaseProvider));
+}

--- a/crates/homeboy-core/src/release/version/types.rs
+++ b/crates/homeboy-core/src/release/version/types.rs
@@ -3,29 +3,16 @@
 use crate::is_zero;
 use serde::Serialize;
 
-/// Information about a version target after reading
-#[derive(Debug, Clone, Serialize)]
-pub struct VersionTargetInfo {
-    pub file: String,
-    pub pattern: String,
-    pub full_path: String,
-    pub match_count: usize,
-    /// Warning message when target exists but didn't match or had issues
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub warning: Option<String>,
-}
+// VersionTargetInfo and ComponentVersionSnapshot moved DOWN to
+// homeboy-release-contract so core's context status mechanics can hold them in
+// public struct fields without a cycle. Re-exported here so release code paths
+// are unchanged.
+pub use homeboy_release_contract::{ComponentVersionSnapshot, VersionTargetInfo};
 
 /// Result of reading a component's version
 #[derive(Debug, Clone, Serialize)]
 
 pub struct ComponentVersionInfo {
-    pub version: String,
-    pub targets: Vec<VersionTargetInfo>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct ComponentVersionSnapshot {
-    pub component_id: String,
     pub version: String,
     pub targets: Vec<VersionTargetInfo>,
 }

--- a/crates/homeboy-core/src/release_provider.rs
+++ b/crates/homeboy-core/src/release_provider.rs
@@ -1,0 +1,221 @@
+//! Release/deploy provider hook.
+//!
+//! Core's status-reporting mechanics (fleet / project / context / git change
+//! reporting / tag-gap detection) read release + deploy behavior: they compute
+//! per-component deploy status, resolve component versions and tag prefixes,
+//! calculate/bucket/classify release state, and read changelog snapshots.
+//!
+//! Computing all of that is release/deploy behavior, so it is inverted behind
+//! this provider: core owns the status models and reporting, the release layer
+//! supplies the computed data. With no provider registered (no release
+//! subsystem present) the no-op reports empty/None so status reporting degrades
+//! gracefully rather than failing.
+
+use std::sync::Mutex;
+
+use homeboy_release_contract::{
+    ChangelogSnapshotData, ComponentDeployStatus, ComponentVersionSnapshot,
+    FinalizedReleaseSnapshot, ReleaseState, ReleaseStateBuckets, ReleaseStateStatus,
+};
+
+use crate::component::Component;
+use crate::Result;
+
+/// A component paired with its (optional) already-computed release state, for
+/// bucketing. Mirrors what `context` passes into `bucket_release_states`.
+pub struct ReleaseStateEntry<'a> {
+    pub component_id: &'a str,
+    pub release_state: Option<&'a ReleaseState>,
+}
+
+/// Assembled changelog info for a component: unreleased entry count + path.
+#[derive(Debug, Clone)]
+pub struct ChangelogInfoData {
+    pub unreleased_entries: usize,
+    pub path: String,
+}
+
+/// Supplies release/deploy behavior to core's status mechanics.
+pub trait ReleaseProvider: Send + Sync {
+    /// Per-component deploy status for a project (wraps a no-pull deploy check).
+    fn deploy_component_statuses(&self, project_id: &str) -> Result<Vec<ComponentDeployStatus>>;
+
+    /// Compute a component's release state (commits since last version tag).
+    fn calculate_release_state(&self, component: &Component) -> Option<ReleaseState>;
+
+    /// Classify a release state into a high-level status.
+    fn classify_release_state(&self, state: Option<&ReleaseState>) -> ReleaseStateStatus;
+
+    /// Bucket components by release state.
+    fn bucket_release_states(&self, entries: &[ReleaseStateEntry<'_>]) -> ReleaseStateBuckets;
+
+    /// A component's configured version.
+    fn get_component_version(&self, component: &Component) -> Option<String>;
+
+    /// A component's tag prefix (e.g. `homeboy-v`).
+    fn component_tag_prefix(&self, component: &Component) -> Option<String>;
+
+    /// A component's latest release tag, if any.
+    fn latest_component_tag(&self, component: &Component) -> Option<String>;
+
+    /// Read a component's version snapshot (id + version + targets).
+    fn read_component_version_snapshot(
+        &self,
+        component: &Component,
+    ) -> Option<ComponentVersionSnapshot>;
+
+    /// Version-init warnings for a component (misconfigured version targets etc).
+    fn build_version_init_warnings(&self, component: &Component) -> Vec<String>;
+
+    /// Validate that a component's source version aligns with its git baseline.
+    fn validate_baseline_alignment(
+        &self,
+        version: Option<&ComponentVersionSnapshot>,
+        baseline_ref: Option<&str>,
+    ) -> Option<String>;
+
+    /// Read a component's finalized-release + unreleased changelog snapshots.
+    #[allow(clippy::type_complexity)]
+    fn read_changelog_snapshots(
+        &self,
+        component: &Component,
+    ) -> Option<(
+        Option<FinalizedReleaseSnapshot>,
+        Option<ChangelogSnapshotData>,
+    )>;
+
+    /// Assemble a component's changelog info (unreleased count + path).
+    fn changelog_info(&self, component: &Component) -> Option<ChangelogInfoData>;
+}
+
+struct NoopProvider;
+
+impl ReleaseProvider for NoopProvider {
+    fn deploy_component_statuses(&self, _project_id: &str) -> Result<Vec<ComponentDeployStatus>> {
+        Ok(Vec::new())
+    }
+    fn calculate_release_state(&self, _component: &Component) -> Option<ReleaseState> {
+        None
+    }
+    fn classify_release_state(&self, _state: Option<&ReleaseState>) -> ReleaseStateStatus {
+        ReleaseStateStatus::Unknown
+    }
+    fn bucket_release_states(&self, _entries: &[ReleaseStateEntry<'_>]) -> ReleaseStateBuckets {
+        ReleaseStateBuckets::default()
+    }
+    fn get_component_version(&self, _component: &Component) -> Option<String> {
+        None
+    }
+    fn component_tag_prefix(&self, _component: &Component) -> Option<String> {
+        None
+    }
+    fn latest_component_tag(&self, _component: &Component) -> Option<String> {
+        None
+    }
+    fn read_component_version_snapshot(
+        &self,
+        _component: &Component,
+    ) -> Option<ComponentVersionSnapshot> {
+        None
+    }
+    fn build_version_init_warnings(&self, _component: &Component) -> Vec<String> {
+        Vec::new()
+    }
+    fn validate_baseline_alignment(
+        &self,
+        _version: Option<&ComponentVersionSnapshot>,
+        _baseline_ref: Option<&str>,
+    ) -> Option<String> {
+        None
+    }
+    fn read_changelog_snapshots(
+        &self,
+        _component: &Component,
+    ) -> Option<(
+        Option<FinalizedReleaseSnapshot>,
+        Option<ChangelogSnapshotData>,
+    )> {
+        None
+    }
+    fn changelog_info(&self, _component: &Component) -> Option<ChangelogInfoData> {
+        None
+    }
+}
+
+fn provider_slot() -> &'static Mutex<Option<Box<dyn ReleaseProvider>>> {
+    static PROVIDER: Mutex<Option<Box<dyn ReleaseProvider>>> = Mutex::new(None);
+    &PROVIDER
+}
+
+/// Register the release provider. Called once at startup by the release layer.
+pub fn register_release_provider(provider: Box<dyn ReleaseProvider>) {
+    let mut slot = provider_slot().lock().expect("release provider lock");
+    *slot = Some(provider);
+}
+
+fn with_provider<T>(f: impl FnOnce(&dyn ReleaseProvider) -> T) -> T {
+    let slot = provider_slot().lock().expect("release provider lock");
+    match slot.as_deref() {
+        Some(provider) => f(provider),
+        None => f(&NoopProvider),
+    }
+}
+
+pub(crate) fn deploy_component_statuses(project_id: &str) -> Result<Vec<ComponentDeployStatus>> {
+    with_provider(|p| p.deploy_component_statuses(project_id))
+}
+
+pub(crate) fn calculate_release_state(component: &Component) -> Option<ReleaseState> {
+    with_provider(|p| p.calculate_release_state(component))
+}
+
+pub(crate) fn classify_release_state(state: Option<&ReleaseState>) -> ReleaseStateStatus {
+    with_provider(|p| p.classify_release_state(state))
+}
+
+pub(crate) fn bucket_release_states(entries: &[ReleaseStateEntry<'_>]) -> ReleaseStateBuckets {
+    with_provider(|p| p.bucket_release_states(entries))
+}
+
+pub(crate) fn get_component_version(component: &Component) -> Option<String> {
+    with_provider(|p| p.get_component_version(component))
+}
+
+pub(crate) fn component_tag_prefix(component: &Component) -> Option<String> {
+    with_provider(|p| p.component_tag_prefix(component))
+}
+
+pub(crate) fn latest_component_tag(component: &Component) -> Option<String> {
+    with_provider(|p| p.latest_component_tag(component))
+}
+
+pub(crate) fn read_component_version_snapshot(
+    component: &Component,
+) -> Option<ComponentVersionSnapshot> {
+    with_provider(|p| p.read_component_version_snapshot(component))
+}
+
+pub(crate) fn build_version_init_warnings(component: &Component) -> Vec<String> {
+    with_provider(|p| p.build_version_init_warnings(component))
+}
+
+pub(crate) fn validate_baseline_alignment(
+    version: Option<&ComponentVersionSnapshot>,
+    baseline_ref: Option<&str>,
+) -> Option<String> {
+    with_provider(|p| p.validate_baseline_alignment(version, baseline_ref))
+}
+
+#[allow(clippy::type_complexity)]
+pub(crate) fn read_changelog_snapshots(
+    component: &Component,
+) -> Option<(
+    Option<FinalizedReleaseSnapshot>,
+    Option<ChangelogSnapshotData>,
+)> {
+    with_provider(|p| p.read_changelog_snapshots(component))
+}
+
+pub(crate) fn changelog_info(component: &Component) -> Option<ChangelogInfoData> {
+    with_provider(|p| p.changelog_info(component))
+}

--- a/crates/homeboy-core/src/tag_gap.rs
+++ b/crates/homeboy-core/src/tag_gap.rs
@@ -7,7 +7,7 @@
 
 use crate::component::Component;
 use crate::engine::command;
-use crate::release;
+use crate::release_provider;
 
 /// Information about the HEAD-vs-tag gap for a component.
 #[derive(Debug, Clone)]
@@ -24,7 +24,7 @@ pub struct TagGap {
 /// Returns None if HEAD is at or behind the tag, or if no tags exist.
 pub fn detect_tag_gap(component: &Component) -> Option<TagGap> {
     let path = &component.local_path;
-    let tag = release::latest_component_tag(component).ok().flatten()?;
+    let tag = release_provider::latest_component_tag(component)?;
 
     let ahead_str = command::run_in_optional(
         path,

--- a/crates/homeboy-release-contract/src/lib.rs
+++ b/crates/homeboy-release-contract/src/lib.rs
@@ -119,3 +119,56 @@ pub struct ReleaseStateBuckets {
     pub has_uncommitted: Vec<String>,
     pub unknown: Vec<String>,
 }
+
+/// Information about a version target after reading a component's version files.
+#[derive(Debug, Clone, Serialize)]
+pub struct VersionTargetInfo {
+    pub file: String,
+    pub pattern: String,
+    pub full_path: String,
+    pub match_count: usize,
+    /// Warning message when target exists but didn't match or had issues
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warning: Option<String>,
+}
+
+/// A component's resolved version plus the targets it was read from.
+#[derive(Debug, Clone, Serialize)]
+pub struct ComponentVersionSnapshot {
+    pub component_id: String,
+    pub version: String,
+    pub targets: Vec<VersionTargetInfo>,
+}
+
+/// Compact per-component deploy status, surfaced to core's fleet/project status
+/// mechanics by the release provider (so they don't depend on the full deploy
+/// result type). Mirrors the fields those mechanics actually read.
+#[derive(Debug, Clone)]
+pub struct ComponentDeployStatus {
+    pub id: String,
+    pub component_status: Option<ComponentStatus>,
+    pub local_version: Option<String>,
+    pub remote_version: Option<String>,
+}
+
+/// A component's most recent finalized release, as read from its changelog.
+#[derive(Debug, Clone)]
+pub struct FinalizedReleaseSnapshot {
+    pub tag: String,
+    pub date: Option<String>,
+    pub summary: Option<String>,
+}
+
+/// A component's unreleased changelog section (path + label + entries).
+#[derive(Debug, Clone)]
+pub struct ChangelogSnapshotData {
+    pub path: String,
+    pub label: String,
+    pub items: Vec<String>,
+}
+
+/// Baseline-alignment validation warning for a component's version target.
+#[derive(Debug, Clone)]
+pub struct BaselineAlignmentWarning {
+    pub message: String,
+}


### PR DESCRIPTION
## Summary
**Prep 2/3 for the deploy + release extraction.** Routes every core status mechanic that called deploy/release *behavior* through a new `crate::release_provider` hook (trait + `NoopProvider` + register), mirroring `rig_provider`/`stack_provider`.

**After this, core's status mechanics have ZERO `crate::deploy`/`crate::release` edges** — except one test-only import in `execution.rs`, repointed in prep 3/3. That's the whole point: prep 3/3 can then `git mv` deploy+release out with no core edges to untangle.

> Includes the prep-A commit (`homeboy-release-contract`, PR #8880) as its base since this builds directly on those types. If #8880 merges first, this rebases cleanly to just the hook commit.

## Inverted 6 call sites
- `project/status.rs`, `fleet/check.rs`, `fleet/status.rs`: `deploy::run` + `DeployConfig::check_all_no_pull_head` → `deploy_component_statuses` (returns a compact `ComponentDeployStatus` summary, **not** the fat deploy result type — keeps the big deploy types out of the contract).
- `fleet/status.rs`, `context/report.rs`: `calculate`/`bucket`/`classify` release state, `get_component_version`.
- `context/report.rs` (**the fat hook** — the deeply-woven one): `read_component_version_snapshot`, `build_version_init_warnings`, `validate_baseline_alignment`, `read_changelog_snapshots`.
- `git/operations_changes.rs`: `changelog_info`, `get_component_version`, `component_tag_prefix`.
- `tag_gap.rs`: `latest_component_tag`.

## Contract additions
`homeboy-release-contract` gains: `VersionTargetInfo`, `ComponentVersionSnapshot`, `ComponentDeployStatus`, `FinalizedReleaseSnapshot`, `ChangelogSnapshotData`. deploy/release re-export them so their code paths are unchanged.

## Provider impl (temporary, in-core)
`release/provider_impl.rs` delegates to the still-in-core deploy/release fns and registers from `cli_runtime`. It moves **out** with deploy/release in prep 3/3 (the git-mv), where it'll register from the release crate instead. The hook seam and all of core's status mechanics stay identical across that move.

## Verification
`cargo check --workspace --tests`: green. `cargo fmt`: clean. No functional change (behavior preserved via the registered in-core provider).

## Next
**Prep 3/3:** `git mv deploy/ release/ → crates/homeboy-release/src`, move `provider_impl` out, register from the release layer, repoint cli consumers + the `execution.rs` test import. Core drops ~205k → ~163k.