### PR TITLE
refactor: move the top-level test result cluster to homeboy-extension-contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,7 @@ dependencies = [
  "homeboy-finding",
  "homeboy-lifecycle-contract",
  "homeboy-product-identity",
+ "homeboy-refactor-contract",
  "semver",
  "serde",
  "serde_json",

--- a/crates/homeboy-core/src/extension/test/report.rs
+++ b/crates/homeboy-core/src/extension/test/report.rs
@@ -14,63 +14,13 @@ use crate::extension::{
     PhaseFailureCategory, PhaseReport, PhaseStatus, VerificationPhase,
 };
 use crate::finding::HomeboyFinding;
+pub use homeboy_extension_contract::test_results::TestCommandOutput;
 use homeboy_refactor_contract::AppliedRefactor;
 use serde::Serialize;
 use serde_json::Value;
 
 use super::run::{RawTestOutput, TestRunWorkflowResult};
 use super::workflow::{AutoFixDriftOutput, AutoFixDriftWorkflowResult, DriftWorkflowResult};
-
-/// Unified output envelope for all test command modes.
-///
-/// This is the single serialization target for the test command. Each sub-workflow
-/// populates its relevant fields; unused fields are `None` and skipped in serialization.
-#[derive(Serialize)]
-pub struct TestCommandOutput {
-    pub passed: bool,
-    pub status: String,
-    pub component: String,
-    pub exit_code: i32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub phase: Option<PhaseReport>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub failure: Option<PhaseFailure>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub test_counts: Option<TestCounts>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub findings: Option<Vec<HomeboyFinding>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub coverage: Option<CoverageOutput>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub baseline_comparison: Option<TestBaselineComparison>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub analysis: Option<TestAnalysis>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub autofix: Option<AppliedRefactor>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hints: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub drift: Option<DriftReport>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub auto_fix_drift: Option<AutoFixDriftOutput>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub test_scope: Option<TestScopeOutput>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub summary: Option<TestSummaryOutput>,
-    /// Tail of runner stdout/stderr when tests fail — lets CI wrappers and
-    /// users see the actual PHPUnit/cargo output. (#1143)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub raw_output: Option<RawTestOutput>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ci_context: Option<CiContext>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub extension_phase_timings: Vec<crate::extension::ExtensionPhaseTiming>,
-    #[serde(
-        rename = "_homeboy_actionable",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub actionable: Option<Value>,
-}
 
 /// Build output from a main test workflow result.
 pub fn from_main_workflow(result: TestRunWorkflowResult) -> (TestCommandOutput, i32) {

--- a/crates/homeboy-core/src/extension/test/run.rs
+++ b/crates/homeboy-core/src/extension/test/run.rs
@@ -17,6 +17,7 @@ use crate::validation_progress::{write_command_artifact, ValidationProgressRecor
 use homeboy_engine_primitives::baseline::BaselineFlags;
 use homeboy_engine_primitives::local_files;
 use homeboy_engine_primitives::output_parse::ParseSpec;
+pub use homeboy_extension_contract::test_results::TestRunWorkflowResult;
 pub use homeboy_extension_contract::test_workflow::RawTestOutput;
 use homeboy_refactor_contract::AppliedRefactor;
 use serde::Serialize;
@@ -40,30 +41,6 @@ pub struct TestRunWorkflowArgs {
     pub restore_checkout: bool,
     pub ci_env: Vec<(String, String)>,
     pub passthrough_args: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct TestRunWorkflowResult {
-    pub status: String,
-    pub component: String,
-    pub exit_code: i32,
-    pub test_counts: Option<TestCounts>,
-    pub findings: Option<Vec<HomeboyFinding>>,
-    #[serde(skip)]
-    pub failure_analysis_input: Option<TestAnalysisInput>,
-    pub coverage: Option<CoverageOutput>,
-    pub baseline_comparison: Option<TestBaselineComparison>,
-    pub analysis: Option<TestAnalysis>,
-    pub autofix: Option<AppliedRefactor>,
-    pub hints: Option<Vec<String>>,
-    pub test_scope: Option<TestScopeOutput>,
-    pub summary: Option<TestSummaryOutput>,
-    /// Tail of the runner's stdout/stderr, surfaced when tests fail so users
-    /// can see runner output (bootstrap errors, stack traces) without
-    /// having to re-run with a different flag. (#1143)
-    pub raw_output: Option<RawTestOutput>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub extension_phase_timings: Vec<ExtensionPhaseTiming>,
 }
 
 const RAW_OUTPUT_TAIL_LINES: usize = 80;

--- a/crates/homeboy-core/src/extension/test/workflow.rs
+++ b/crates/homeboy-core/src/extension/test/workflow.rs
@@ -4,39 +4,12 @@ use crate::extension::test::resolve_drift_options;
 use crate::extension::test::TestScopeOutput;
 use crate::extension::test::{ChangeType, TestAnalysis};
 use crate::extension::test::{TestBaselineComparison, TestCounts};
+pub use homeboy_extension_contract::test_results::{
+    AutoFixDriftWorkflowResult, DriftWorkflowResult, MainTestWorkflowResult,
+};
 pub use homeboy_extension_contract::test_workflow::AutoFixDriftOutput;
 use homeboy_refactor_contract::{AppliedRefactor, TransformSet};
 use serde::Serialize;
-
-#[derive(Debug, Clone, Serialize)]
-pub struct DriftWorkflowResult {
-    pub component: String,
-    pub report: DriftReport,
-    pub exit_code: i32,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct AutoFixDriftWorkflowResult {
-    pub component: String,
-    pub output: AutoFixDriftOutput,
-    pub hints: Vec<String>,
-    pub report: Option<DriftReport>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct MainTestWorkflowResult {
-    pub status: String,
-    pub component: String,
-    pub exit_code: i32,
-    pub test_counts: Option<TestCounts>,
-    pub coverage: Option<serde_json::Value>,
-    pub baseline_comparison: Option<TestBaselineComparison>,
-    pub analysis: Option<TestAnalysis>,
-    pub autofix: Option<AppliedRefactor>,
-    pub hints: Option<Vec<String>>,
-    pub test_scope: Option<TestScopeOutput>,
-    pub summary: Option<serde_json::Value>,
-}
 
 pub fn detect_test_drift(
     component_id: &str,

--- a/crates/homeboy-extension-contract/Cargo.toml
+++ b/crates/homeboy-extension-contract/Cargo.toml
@@ -19,6 +19,7 @@ homeboy-product-identity = { version = "0.1.0", path = "../homeboy-product-ident
 homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 homeboy-lifecycle-contract = { version = "0.1.0", path = "../homeboy-lifecycle-contract" }
 homeboy-finding = { version = "0.1.0", path = "../homeboy-finding" }
+homeboy-refactor-contract = { version = "0.1.0", path = "../homeboy-refactor-contract" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 semver = "1.0"

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -23,6 +23,7 @@ pub mod capability;
 pub mod test_analysis;
 pub mod test_parsing;
 pub mod test_result;
+pub mod test_results;
 pub mod test_workflow;
 pub mod trace_parsing;
 pub use bench_artifact::{BenchArtifact, BenchArtifactViewer, BenchPreviewLifecycleMetadata};
@@ -47,6 +48,10 @@ pub use test_analysis::{
 };
 pub use test_parsing::{CoverageOutput, TestFailureSummaryItem, TestSummaryOutput, UncoveredFile};
 pub use test_result::{TestCounts, TestScopeOutput};
+pub use test_results::{
+    AutoFixDriftWorkflowResult, DriftWorkflowResult, MainTestWorkflowResult, TestCommandOutput,
+    TestRunWorkflowResult,
+};
 pub use test_workflow::{
     AutoFixDriftOutput, ChangeType, DriftReport, DriftedTest, ProductionChange, RawTestOutput,
     TestBaselineComparison,

--- a/crates/homeboy-extension-contract/src/test_results.rs
+++ b/crates/homeboy-extension-contract/src/test_results.rs
@@ -1,0 +1,123 @@
+//! Top-level test result aggregate contract types.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use homeboy_finding::HomeboyFinding;
+
+use homeboy_refactor_contract::AppliedRefactor;
+
+use crate::ci_context::CiContext;
+use crate::runner_contract::{PhaseFailure, PhaseReport};
+use crate::test_analysis::{TestAnalysis, TestAnalysisInput};
+use crate::test_parsing::{CoverageOutput, TestSummaryOutput};
+use crate::test_result::{TestCounts, TestScopeOutput};
+use crate::test_workflow::{
+    AutoFixDriftOutput, DriftReport, RawTestOutput, TestBaselineComparison,
+};
+use crate::ExtensionPhaseTiming;
+
+/// Unified output envelope for all test command modes.
+///
+/// This is the single serialization target for the test command. Each sub-workflow
+/// populates its relevant fields; unused fields are `None` and skipped in serialization.
+#[derive(Serialize)]
+pub struct TestCommandOutput {
+    pub passed: bool,
+    pub status: String,
+    pub component: String,
+    pub exit_code: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase: Option<PhaseReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure: Option<PhaseFailure>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_counts: Option<TestCounts>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub findings: Option<Vec<HomeboyFinding>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub coverage: Option<CoverageOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_comparison: Option<TestBaselineComparison>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub analysis: Option<TestAnalysis>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub autofix: Option<AppliedRefactor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hints: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub drift: Option<DriftReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_fix_drift: Option<AutoFixDriftOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_scope: Option<TestScopeOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<TestSummaryOutput>,
+    /// Tail of runner stdout/stderr when tests fail — lets CI wrappers and
+    /// users see the actual PHPUnit/cargo output. (#1143)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_output: Option<RawTestOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci_context: Option<CiContext>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extension_phase_timings: Vec<ExtensionPhaseTiming>,
+    #[serde(
+        rename = "_homeboy_actionable",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub actionable: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TestRunWorkflowResult {
+    pub status: String,
+    pub component: String,
+    pub exit_code: i32,
+    pub test_counts: Option<TestCounts>,
+    pub findings: Option<Vec<HomeboyFinding>>,
+    #[serde(skip)]
+    pub failure_analysis_input: Option<TestAnalysisInput>,
+    pub coverage: Option<CoverageOutput>,
+    pub baseline_comparison: Option<TestBaselineComparison>,
+    pub analysis: Option<TestAnalysis>,
+    pub autofix: Option<AppliedRefactor>,
+    pub hints: Option<Vec<String>>,
+    pub test_scope: Option<TestScopeOutput>,
+    pub summary: Option<TestSummaryOutput>,
+    /// Tail of the runner's stdout/stderr, surfaced when tests fail so users
+    /// can see runner output (bootstrap errors, stack traces) without
+    /// having to re-run with a different flag. (#1143)
+    pub raw_output: Option<RawTestOutput>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extension_phase_timings: Vec<ExtensionPhaseTiming>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DriftWorkflowResult {
+    pub component: String,
+    pub report: DriftReport,
+    pub exit_code: i32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AutoFixDriftWorkflowResult {
+    pub component: String,
+    pub output: AutoFixDriftOutput,
+    pub hints: Vec<String>,
+    pub report: Option<DriftReport>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MainTestWorkflowResult {
+    pub status: String,
+    pub component: String,
+    pub exit_code: i32,
+    pub test_counts: Option<TestCounts>,
+    pub coverage: Option<serde_json::Value>,
+    pub baseline_comparison: Option<TestBaselineComparison>,
+    pub analysis: Option<TestAnalysis>,
+    pub autofix: Option<AppliedRefactor>,
+    pub hints: Option<Vec<String>>,
+    pub test_scope: Option<TestScopeOutput>,
+    pub summary: Option<serde_json::Value>,
+}


### PR DESCRIPTION
## Summary
**The finale of the test subsystem breakdown.** With every field dependency now in a contract/leaf crate (via the preceding test cuts + `CiContext` #8885, and `AppliedRefactor` already in `homeboy-refactor-contract`), the five top-level test result aggregates move wholesale:
`TestCommandOutput`, `TestRunWorkflowResult`, `MainTestWorkflowResult`, `DriftWorkflowResult`, `AutoFixDriftWorkflowResult`.

## Impact: the test cluster collapse
This takes the extension `test` reverse-edge surface **down to 1 core file** — mirroring the bench (58 → 4) and trace (45 → 3) cluster collapses. The test phase subsystem is now fully backed by contract types.

## Details
- Added `homeboy-refactor-contract` as a direct `homeboy-extension-contract` dependency — a pure serde-only leaf — for `AppliedRefactor`.
- The test command/run/workflow **builder functions** stay in core; only the result aggregate types move.
- Core re-exports the aggregates so all `crate::extension::test` paths stay stable.

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

## Next
The `lint` subsystem is the last phase subsystem — same playbook (its aggregate `LintCommandOutput` is blocked by `BaselineComparison`, `LintSummaryOutput`, `SelfCheckCaptureMetadata`, all pure result types awaiting the same treatment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)