### PR TITLE
refactor: move the lint result cluster to homeboy-extension-contract

### DIFF
--- a/crates/homeboy-core/src/extension/lint/report.rs
+++ b/crates/homeboy-core/src/extension/lint/report.rs
@@ -11,52 +11,13 @@ use crate::extension::{
     PhaseFailureCategory, PhaseReport, VerificationPhase,
 };
 use crate::finding::{FindingProducerSummary, HomeboyFinding};
+pub use homeboy_extension_contract::LintCommandOutput;
 use homeboy_refactor_contract::AppliedRefactor;
 use homeboy_refactor_contract::LintFixInput;
 use serde::Serialize;
 use serde_json::Value;
 
 use super::run::{FormattingFindings, LintRunWorkflowResult, LintSummaryOutput};
-
-/// Unified output envelope for the lint command.
-///
-/// This is the single serialization target. The workflow populates relevant
-/// fields; unused fields are `None` and skipped in serialization.
-#[derive(Serialize)]
-pub struct LintCommandOutput {
-    pub passed: bool,
-    pub status: String,
-    pub component: String,
-    pub exit_code: i32,
-    pub phase: PhaseReport,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub failure: Option<PhaseFailure>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub autofix: Option<AppliedRefactor>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hints: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub baseline_comparison: Option<BaselineComparison>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub formatting_findings: Option<super::run::FormattingFindings>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub findings: Option<Vec<HomeboyFinding>>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub producer_summaries: Vec<FindingProducerSummary>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub summary: Option<LintSummaryOutput>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub self_check_capture: Option<SelfCheckCaptureMetadata>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ci_context: Option<CiContext>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub extension_phase_timings: Vec<crate::extension::ExtensionPhaseTiming>,
-    #[serde(
-        rename = "_homeboy_actionable",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub actionable: Option<Value>,
-}
 
 /// Build output from a main lint workflow result.
 pub fn from_main_workflow(result: LintRunWorkflowResult) -> (LintCommandOutput, i32) {

--- a/crates/homeboy-core/src/extension/lint/run/types.rs
+++ b/crates/homeboy-core/src/extension/lint/run/types.rs
@@ -5,6 +5,8 @@ use crate::extension::self_check::SelfCheckCaptureMetadata;
 use crate::extension::ExtensionPhaseTiming;
 use crate::finding::{FindingProducerSummary, HomeboyFinding};
 use homeboy_engine_primitives::baseline::BaselineFlags;
+pub use homeboy_extension_contract::FormattingFindings;
+pub use homeboy_extension_contract::LintSummaryOutput;
 use homeboy_refactor_contract::AppliedRefactor;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -72,28 +74,6 @@ pub struct LintRunWorkflowResult {
     pub self_check_capture: Option<SelfCheckCaptureMetadata>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extension_phase_timings: Vec<ExtensionPhaseTiming>,
-}
-
-/// Compact lint summary for automation consumers.
-#[derive(Debug, Clone, Serialize)]
-pub struct LintSummaryOutput {
-    pub total_findings: usize,
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    pub categories: BTreeMap<String, usize>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub top_findings: Vec<HomeboyFinding>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub producer_summaries: Vec<FindingProducerSummary>,
-    pub exit_code: i32,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct FormattingFindings {
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub files: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub summary: Option<String>,
-    pub suggested_command: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/homeboy-core/src/extension/self_check.rs
+++ b/crates/homeboy-core/src/extension/self_check.rs
@@ -5,6 +5,7 @@ use crate::extension::ExtensionCapability;
 use crate::observation::ActiveObservation;
 use crate::stream_capture::StreamCaptureMetadata;
 use crate::validation_progress::{write_command_artifact, ValidationProgressRecorder};
+pub use homeboy_extension_contract::SelfCheckCaptureMetadata;
 use serde::Serialize;
 use std::io::{Read, Write};
 use std::path::Path;
@@ -20,12 +21,6 @@ pub struct SelfCheckOutput {
     pub stdout: String,
     pub stderr: String,
     pub capture: SelfCheckCaptureMetadata,
-}
-
-#[derive(Debug, Clone, Default, Serialize)]
-pub struct SelfCheckCaptureMetadata {
-    pub stdout: StreamCaptureMetadata,
-    pub stderr: StreamCaptureMetadata,
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/stream_capture.rs
+++ b/crates/homeboy-core/src/stream_capture.rs
@@ -9,18 +9,5 @@
 //! defined once and the serialized contract stays consistent across every
 //! capture site.
 
+pub use homeboy_extension_contract::StreamCaptureMetadata;
 use serde::{Deserialize, Serialize};
-
-/// Truncation metadata describing how much of a captured stream was retained.
-///
-/// `seen_bytes` is the total observed length of the source; `retained_bytes`
-/// is how many bytes survived the `limit_bytes` cap; `truncated` records
-/// whether the source exceeded the cap (so the overflow is observable rather
-/// than silently dropped).
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub struct StreamCaptureMetadata {
-    pub limit_bytes: usize,
-    pub seen_bytes: usize,
-    pub retained_bytes: usize,
-    pub truncated: bool,
-}

--- a/crates/homeboy-extension-contract/src/lib.rs
+++ b/crates/homeboy-extension-contract/src/lib.rs
@@ -65,7 +65,13 @@ pub use trace_parsing::{
 };
 pub mod ci_config;
 pub mod ci_context;
+pub mod lint_result;
+pub mod lint_results;
 pub use ci_context::CiContext;
+pub use lint_result::{
+    FormattingFindings, LintSummaryOutput, SelfCheckCaptureMetadata, StreamCaptureMetadata,
+};
+pub use lint_results::LintCommandOutput;
 pub mod core_compat;
 pub mod exec_context;
 pub mod extension_contract_producer;

--- a/crates/homeboy-extension-contract/src/lint_result.rs
+++ b/crates/homeboy-extension-contract/src/lint_result.rs
@@ -1,0 +1,48 @@
+//! Pure lint + self-check + stream-capture result contract types.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+use homeboy_finding::{FindingProducerSummary, HomeboyFinding};
+
+/// Truncation metadata describing how much of a captured stream was retained.
+///
+/// `seen_bytes` is the total observed length of the source; `retained_bytes`
+/// is how many bytes survived the `limit_bytes` cap; `truncated` records
+/// whether the source exceeded the cap (so the overflow is observable rather
+/// than silently dropped).
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StreamCaptureMetadata {
+    pub limit_bytes: usize,
+    pub seen_bytes: usize,
+    pub retained_bytes: usize,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct SelfCheckCaptureMetadata {
+    pub stdout: StreamCaptureMetadata,
+    pub stderr: StreamCaptureMetadata,
+}
+
+/// Compact lint summary for automation consumers.
+#[derive(Debug, Clone, Serialize)]
+pub struct LintSummaryOutput {
+    pub total_findings: usize,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub categories: BTreeMap<String, usize>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub top_findings: Vec<HomeboyFinding>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub producer_summaries: Vec<FindingProducerSummary>,
+    pub exit_code: i32,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct FormattingFindings {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    pub suggested_command: String,
+}

--- a/crates/homeboy-extension-contract/src/lint_results.rs
+++ b/crates/homeboy-extension-contract/src/lint_results.rs
@@ -1,0 +1,54 @@
+//! Top-level lint result aggregate contract type.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use homeboy_finding::HomeboyFinding;
+
+use homeboy_engine_primitives::baseline::Comparison as BaselineComparison;
+use homeboy_finding::FindingProducerSummary;
+use homeboy_refactor_contract::AppliedRefactor;
+
+use crate::ci_context::CiContext;
+use crate::lint_result::{LintSummaryOutput, SelfCheckCaptureMetadata};
+use crate::runner_contract::{PhaseFailure, PhaseReport};
+
+/// Unified output envelope for the lint command.
+///
+/// This is the single serialization target. The workflow populates relevant
+/// fields; unused fields are `None` and skipped in serialization.
+#[derive(Serialize)]
+pub struct LintCommandOutput {
+    pub passed: bool,
+    pub status: String,
+    pub component: String,
+    pub exit_code: i32,
+    pub phase: PhaseReport,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure: Option<PhaseFailure>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub autofix: Option<AppliedRefactor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hints: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_comparison: Option<BaselineComparison>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub formatting_findings: Option<crate::lint_result::FormattingFindings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub findings: Option<Vec<HomeboyFinding>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub producer_summaries: Vec<FindingProducerSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<LintSummaryOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub self_check_capture: Option<SelfCheckCaptureMetadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci_context: Option<CiContext>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extension_phase_timings: Vec<crate::ExtensionPhaseTiming>,
+    #[serde(
+        rename = "_homeboy_actionable",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub actionable: Option<Value>,
+}


### PR DESCRIPTION
## Summary
**The finale of the phase-subsystem breakdown** — `lint` is the fourth and last (after bench, trace, test). Moves the lint result types + the top-level `LintCommandOutput` aggregate wholesale.

## What moved
- **Result types:** `StreamCaptureMetadata` (from core `stream_capture.rs`), `SelfCheckCaptureMetadata`, `LintSummaryOutput`, `FormattingFindings` — all pure serde.
- **`LintCommandOutput` aggregate** — its field dependencies all resolve to contract/leaf crates: `CiContext`/`PhaseReport`/`PhaseFailure` (extension-contract), `FindingProducerSummary`/`HomeboyFinding` (finding), `AppliedRefactor` (refactor-contract), and `BaselineComparison` (= the `homeboy-engine-primitives` `baseline::Comparison` alias).

## The split
The lint run/report **builder functions** stay in core; only the result types move. Core re-exports everything so all `crate::extension::lint` paths stay stable.

## Impact: all four phase subsystems conquered
Lint's reverse-edge surface collapses to **1 core file** — matching:
- bench: 58 → 4
- trace: 45 → 3
- test: → 1
- **lint: → 1**

All four extension phase subsystems (bench, trace, test, lint) are now fully backed by contract types.

## Tests
- `homeboy-extension-contract`, `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)