### PR TITLE
Fix expired local child reservations

### DIFF
--- a/crates/homeboy-core/src/api_jobs/store.rs
+++ b/crates/homeboy-core/src/api_jobs/store.rs
@@ -27,6 +27,11 @@ use crate::error::{Error, Result};
 use crate::runner_execution_envelope::PathMaterializationPlan;
 use crate::source_snapshot::SourceSnapshot;
 
+/// A reservation bounds the interval between durable admission and persisting a
+/// child identity. The child is normally spawned immediately after admission;
+/// a longer-lived record means no child was durably confirmed.
+const LOCAL_CHILD_RESERVATION_LEASE_MS: u64 = 60_000;
+
 #[derive(Debug, Clone, Default)]
 pub struct JobStore {
     pub(super) inner: Arc<Mutex<JobStoreInner>>,
@@ -72,6 +77,10 @@ pub(crate) struct LocalRunnerJob {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct LocalChildExecution {
     reservation_id: String,
+    /// Missing only on records written before reservation leases existed. Those
+    /// records remain fail-closed because Homeboy cannot prove their spawn state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    reservation_expires_at_ms: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     process: Option<LocalChildProcessIdentity>,
 }
@@ -1382,7 +1391,12 @@ impl JobStore {
     }
 
     pub(crate) fn reserve_local_child(&self, job_id: Uuid) -> Result<()> {
+        self.reserve_local_child_at(job_id, timestamp_ms())
+    }
+
+    pub(crate) fn reserve_local_child_at(&self, job_id: Uuid, now: u64) -> Result<()> {
         let reservation_id = Uuid::new_v4().to_string();
+        let reservation_expires_at_ms = now.saturating_add(LOCAL_CHILD_RESERVATION_LEASE_MS);
         let mut inner = self.inner.lock().expect("job store mutex poisoned");
         let prior = inner
             .jobs
@@ -1400,6 +1414,7 @@ impl JobStore {
         }
         stored.local_child = Some(LocalChildExecution {
             reservation_id: reservation_id.clone(),
+            reservation_expires_at_ms: Some(reservation_expires_at_ms),
             process: None,
         });
         let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
@@ -1407,11 +1422,13 @@ impl JobStore {
             sequence,
             job_id,
             kind: JobEventKind::Progress,
-            timestamp_ms: timestamp_ms(),
+            timestamp_ms: now,
             message: Some("local runner child reserved before spawn".to_string()),
-            data: Some(
-                serde_json::json!({ "phase": "child_reserved", "reservation_id": reservation_id }),
-            ),
+            data: Some(serde_json::json!({
+                "phase": "child_reserved",
+                "reservation_id": reservation_id,
+                "reservation_expires_at_ms": reservation_expires_at_ms,
+            })),
         });
         stored.job.event_count = stored.events.len();
         if let Some(persistence) = &self.persistence {
@@ -1424,6 +1441,89 @@ impl JobStore {
             }
         }
         Ok(())
+    }
+
+    /// Terminalize expired pre-spawn reservations. A PID-bound child has
+    /// atomically claimed the reservation and is intentionally left to normal
+    /// child liveness recovery, even when the original admission deadline has
+    /// passed.
+    pub(crate) fn reconcile_expired_local_child_reservations(&self) -> Result<Vec<Uuid>> {
+        self.reconcile_expired_local_child_reservations_at(timestamp_ms())
+    }
+
+    pub(crate) fn reconcile_expired_local_child_reservations_at(
+        &self,
+        now: u64,
+    ) -> Result<Vec<Uuid>> {
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let expired = inner
+            .jobs
+            .values()
+            .filter(|stored| {
+                stored.job.status == JobStatus::Queued
+                    && stored.local_child.as_ref().is_some_and(|child| {
+                        child.process.is_none()
+                            && child
+                                .reservation_expires_at_ms
+                                .is_some_and(|expires_at| expires_at <= now)
+                    })
+            })
+            .map(|stored| stored.job.id)
+            .collect::<Vec<_>>();
+
+        for job_id in &expired {
+            let stored = inner.jobs.get_mut(job_id).expect("expired job exists");
+            let child = stored
+                .local_child
+                .as_ref()
+                .expect("expired reservation exists");
+            let reason = "local child reservation lease expired before spawn";
+            stored.job.status = JobStatus::Failed;
+            stored.job.updated_at_ms = now;
+            stored.job.finished_at_ms = Some(now);
+            stored.job.stale_reason = Some(reason.to_string());
+            let terminal_result = serde_json::json!({
+                "status": JobStatus::Failed,
+                "reason": "local_child_reservation_expired",
+                "retryable": true,
+                "reservation_id": child.reservation_id,
+                "reservation_expires_at_ms": child.reservation_expires_at_ms,
+            });
+            for (kind, message, data) in [
+                (
+                    JobEventKind::Error,
+                    reason.to_string(),
+                    terminal_result.clone(),
+                ),
+                (
+                    JobEventKind::Result,
+                    "retryable terminal reservation failure".to_string(),
+                    terminal_result.clone(),
+                ),
+                (
+                    JobEventKind::Status,
+                    "job marked failed after local child reservation lease expiry".to_string(),
+                    terminal_result,
+                ),
+            ] {
+                let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+                stored.events.push(JobEvent {
+                    sequence,
+                    job_id: *job_id,
+                    kind,
+                    timestamp_ms: now,
+                    message: Some(message),
+                    data: Some(data),
+                });
+            }
+            apply_event_retention(&mut stored.events, self.event_retention_limit());
+            stored.job.event_count = stored.events.len();
+        }
+        drop(inner);
+        if !expired.is_empty() {
+            self.persist()?;
+        }
+        Ok(expired)
     }
 
     /// Explicit, per-job legacy recovery. The supplied PID/start ticks must
@@ -1505,6 +1605,7 @@ impl JobStore {
         let now = timestamp_ms();
         stored.local_child = Some(LocalChildExecution {
             reservation_id: format!("operator-recovery-{job_id}"),
+            reservation_expires_at_ms: None,
             process: Some(LocalChildProcessIdentity {
                 pid,
                 process_group_id: None,
@@ -1553,6 +1654,9 @@ impl JobStore {
                 .jobs
                 .get_mut(&job_id)
                 .ok_or_else(|| job_not_found(job_id))?;
+            // Retain the unclaimed reservation so a failed durable write never
+            // leaves queued visibility paired with an uncommitted child PID.
+            let prior = stored.clone();
             validate_transition(stored.job.status, JobStatus::Running)?;
             let local_child = stored.local_child.as_mut().ok_or_else(|| {
                 Error::internal_unexpected("local child spawned without a durable reservation")
@@ -1562,7 +1666,6 @@ impl JobStore {
                 process_group_id,
                 discriminator: discriminator.clone(),
             });
-            let prior = stored.clone();
             let now = timestamp_ms();
             stored.job.status = JobStatus::Running;
             stored.job.started_at_ms = Some(now);

--- a/crates/homeboy-core/src/api_jobs/tests/part_a.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_a.rs
@@ -43,6 +43,80 @@ fn active_count_reads_durable_jobs_without_reconciling_them() {
 }
 
 #[test]
+fn expired_local_child_reservation_releases_capacity_and_persists_retryable_failure() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open_without_reconciliation(&path).expect("open store");
+    let job = store.create("runner.exec");
+    let reserved_at = 10_000;
+    store
+        .reserve_local_child_at(job.id, reserved_at)
+        .expect("persist reservation");
+
+    assert!(store
+        .reconcile_expired_local_child_reservations_at(reserved_at + 59_999)
+        .expect("reservation remains leased")
+        .is_empty());
+    assert_eq!(
+        JobStore::active_count_at_path(&path).expect("active capacity before expiry"),
+        1
+    );
+
+    assert_eq!(
+        store
+            .reconcile_expired_local_child_reservations_at(reserved_at + 60_000)
+            .expect("expire reservation"),
+        vec![job.id]
+    );
+    assert_eq!(
+        store.get(job.id).expect("terminal job").status,
+        JobStatus::Failed
+    );
+    assert_eq!(
+        JobStore::active_count_at_path(&path).expect("expired capacity released"),
+        0
+    );
+    let events = JobStore::open_without_reconciliation(&path)
+        .expect("reopen durable terminal result")
+        .events(job.id)
+        .expect("events");
+    assert!(events.iter().any(|event| {
+        event.kind == JobEventKind::Result
+            && event.data.as_ref().is_some_and(|data| {
+                data["reason"] == "local_child_reservation_expired" && data["retryable"] == true
+            })
+    }));
+}
+
+#[test]
+fn pid_bound_local_child_is_not_expired_by_its_former_reservation_deadline() {
+    let store = JobStore::default();
+    let job = store.create("runner.exec");
+    store
+        .reserve_local_child_at(job.id, 10_000)
+        .expect("reserve child");
+    store
+        .start_with_reserved_child_identity(
+            job.id,
+            std::process::id(),
+            None,
+            super::store::LocalChildStartDiscriminator::Unsupported {
+                evidence: "test owns a live current-process identity".to_string(),
+            },
+        )
+        .expect("atomically bind live child identity");
+
+    assert!(store
+        .reconcile_expired_local_child_reservations_at(1_000_000)
+        .expect("do not expire spawned child")
+        .is_empty());
+    assert_eq!(
+        store.get(job.id).expect("live job").status,
+        JobStatus::Running
+    );
+}
+
+#[test]
 fn test_create_with_source_snapshot() {
     let store = JobStore::default();
     let snapshot =

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -1159,9 +1159,13 @@ where
     let state = write_state(local_addr)?;
     let job_store = JobStore::open_without_reconciliation(paths::daemon_jobs_file()?)
         .map(|store| store.with_daemon_lease(state.lease_id.clone()))?;
+    // A restart cannot resume the thread that owned a pre-spawn reservation.
+    // Expire only reservations that never recorded a child identity.
+    job_store.reconcile_expired_local_child_reservations()?;
     let _ = daemon_runtime_snapshot();
     let loopback_bind = local_addr.ip().is_loopback();
 
+    spawn_local_child_reservation_reconciler(job_store.clone());
     spawn_completion_notifier();
 
     for stream in listener.incoming() {
@@ -1186,6 +1190,18 @@ where
 /// seconds. Defaults to [`COMPLETION_NOTIFY_DEFAULT_INTERVAL_SECS`].
 const COMPLETION_NOTIFY_INTERVAL_ENV: &str = "HOMEBOY_DAEMON_NOTIFY_INTERVAL_SECS";
 const COMPLETION_NOTIFY_DEFAULT_INTERVAL_SECS: u64 = 5;
+const LOCAL_CHILD_RESERVATION_RECONCILE_INTERVAL_SECS: u64 = 5;
+
+/// Reclaim capacity even when no controller polls the daemon after a failed
+/// handoff. The store owns the fail-closed child-identity check.
+fn spawn_local_child_reservation_reconciler(job_store: JobStore) {
+    std::thread::spawn(move || loop {
+        let _ = job_store.reconcile_expired_local_child_reservations();
+        std::thread::sleep(std::time::Duration::from_secs(
+            LOCAL_CHILD_RESERVATION_RECONCILE_INTERVAL_SECS,
+        ));
+    });
+}
 
 /// Spawn the background thread that watches in-flight runs and fires a local
 /// notification when one completes, so a detached/offloaded run never becomes a
@@ -1311,6 +1327,9 @@ fn route_with_job_store_and_body_and_runner_and_auth<R>(
 where
     R: AnalysisJobRunner,
 {
+    if let Err(error) = job_store.reconcile_expired_local_child_reservations() {
+        return error_response(500, error);
+    }
     match (method, path) {
         ("GET", "/health") => HttpResponse {
             status_code: 200,
@@ -1808,6 +1827,14 @@ fn enqueue_exec_job(
         "kind": lifecycle.as_ref().and_then(|lifecycle| lifecycle.kind.clone()).unwrap_or_else(|| "runner.exec".to_string()),
         "lifecycle": lifecycle.clone(),
     });
+    // Capture any potentially slow baseline before reserving child capacity.
+    // Once the reservation is durable, the worker performs only the bounded
+    // process-spawn handoff before persisting child ownership.
+    let baseline = if request.capture_patch {
+        Some(capture_baseline(&plan.cwd, source_snapshot.as_ref())?)
+    } else {
+        None
+    };
     let runner = job_store
         .run_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
             operation,
@@ -1826,11 +1853,6 @@ fn enqueue_exec_job(
                     "HOMEBOY_RUNNER_CHILD_RESERVATION".to_string(),
                     job.local_child_reservation_id()?,
                 );
-                let baseline = if request.capture_patch {
-                    Some(capture_baseline(&plan.cwd, source_snapshot.as_ref())?)
-                } else {
-                    None
-                };
                 let progress_job = job.clone();
                 let progress_sink = Arc::new(move |data| progress_job.progress(data).map(|_| ()));
                 let started_job = job.clone();


### PR DESCRIPTION
## Summary
Release daemon capacity held by abandoned pre-spawn local child reservations.

## What changed
- Persist a bounded reservation deadline, reconcile expired PID-less reservations at startup, on requests, and periodically, and emit retryable terminal evidence.

## How to test
1. Run `cargo test -p homeboy-core expired_local_child_reservation_releases_capacity_and_persists_retryable_failure`; expect The expired queued PID-less reservation becomes retryable failed state and active capacity returns to zero..
2. Run `cargo test -p homeboy-core pid_bound_local_child_is_not_expired_by_its_former_reservation_deadline`; expect The PID-bound running child remains running after the former reservation deadline..
3. Run `cargo check -p homeboy-core`; expect The homeboy-core crate compiles successfully..

## Compatibility
Existing persisted reservations without a deadline remain fail-closed; spawned child and child-liveness behavior is unchanged.

## Evidence
- Base unchanged since verification: main remains at 2edea5c57733ca56855a58806c06cf97bb9664c4.
- CI expected: Homeboy pull request CI
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8892
- Verified finalization base: main at 2edea5c57733ca56855a58806c06cf97bb9664c4
- crate-check: Passed
- diff-check: Passed
- focused-reservation-tests: Passed
- formatting: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Investigated the daemon queue failure and drafted the implementation and deterministic tests; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8892
