### PR TITLE
refactor: invert component-script execution behind a provider hook (the last cycle edge)

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -111,6 +111,7 @@ impl CliRuntime {
         // become the homeboy-release crate.
         crate::core::release::provider_impl::register();
         crate::core::extension::audit_manifest_provider::register();
+        crate::core::extension::component_script::register_component_script_runner();
         // Register the fingerprint-script provider so code_audit can fall back to
         // extension fingerprint scripts (for files the core grammar engine can't
         // handle) without depending on the extension script runner.

--- a/crates/homeboy-core/src/component_script_provider.rs
+++ b/crates/homeboy-core/src/component_script_provider.rs
@@ -1,0 +1,90 @@
+//! Component-script runner provider hook.
+//!
+//! Core's dependency resolution (`deps_provider`) needs to run a component's
+//! declared dependency scripts. Running component scripts is extension
+//! execution behavior (it drives the extension runner), so it is inverted
+//! behind this provider: core owns the dependency-resolution flow and the
+//! result envelope, the extension layer supplies the script execution.
+//!
+//! With no provider registered (no extension subsystem present) the no-op
+//! returns a not-supported error, so callers degrade gracefully.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use homeboy_extension_contract::{ExtensionCapability, ExtensionPhaseTiming};
+
+use crate::component::Component;
+use crate::engine::resource::ExtensionChildResourceSummary;
+use crate::{Error, Result};
+
+/// Result of running a component's scripts for a capability.
+///
+/// A behavior-free envelope owned by core so the provider trait (and its core
+/// callers) can name the return type without depending on the extension layer.
+#[derive(Debug, Clone)]
+pub struct ComponentScriptOutput {
+    pub exit_code: i32,
+    pub success: bool,
+    pub stdout: String,
+    pub stderr: String,
+    pub timed_out: bool,
+    pub child_resource: Option<ExtensionChildResourceSummary>,
+    pub extension_phase_timings: Vec<ExtensionPhaseTiming>,
+}
+
+/// Runs a component's declared scripts for a capability. Supplied by the
+/// extension layer; consumed by core dependency resolution.
+pub trait ComponentScriptRunner: Send + Sync {
+    fn run_component_scripts_with_env(
+        &self,
+        component: &Component,
+        capability: ExtensionCapability,
+        source_path: &Path,
+        passthrough: bool,
+        extra_env: &[(String, String)],
+        script_args: &[String],
+    ) -> Result<ComponentScriptOutput>;
+}
+
+fn provider_slot() -> &'static Mutex<Option<Box<dyn ComponentScriptRunner>>> {
+    static PROVIDER: Mutex<Option<Box<dyn ComponentScriptRunner>>> = Mutex::new(None);
+    &PROVIDER
+}
+
+/// Register the component-script runner. Called once at startup by the
+/// extension layer.
+pub fn register_component_script_runner(provider: Box<dyn ComponentScriptRunner>) {
+    let mut slot = provider_slot()
+        .lock()
+        .expect("component script runner lock");
+    *slot = Some(provider);
+}
+
+/// Run a component's scripts for a capability through the registered provider.
+pub fn run_component_scripts_with_env(
+    component: &Component,
+    capability: ExtensionCapability,
+    source_path: &Path,
+    passthrough: bool,
+    extra_env: &[(String, String)],
+    script_args: &[String],
+) -> Result<ComponentScriptOutput> {
+    let slot = provider_slot()
+        .lock()
+        .expect("component script runner lock");
+    match slot.as_deref() {
+        Some(provider) => provider.run_component_scripts_with_env(
+            component,
+            capability,
+            source_path,
+            passthrough,
+            extra_env,
+            script_args,
+        ),
+        None => Err(Error::internal_io(
+            "no component-script runner registered; the extension subsystem is not available",
+            None,
+        )),
+    }
+}

--- a/crates/homeboy-core/src/deps_provider.rs
+++ b/crates/homeboy-core/src/deps_provider.rs
@@ -1132,8 +1132,8 @@ fn run_component_deps_script(
     component: &Component,
     path: &Path,
     args: &[String],
-) -> Result<crate::extension::component_script::ComponentScriptOutput> {
-    let output = crate::extension::component_script::run_component_scripts_with_env(
+) -> Result<crate::component_script_provider::ComponentScriptOutput> {
+    let output = crate::component_script_provider::run_component_scripts_with_env(
         component,
         ExtensionCapability::Deps,
         path,

--- a/crates/homeboy-core/src/extension/component_script.rs
+++ b/crates/homeboy-core/src/extension/component_script.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::component::Component;
+pub use crate::component_script_provider::ComponentScriptOutput;
 use crate::engine::invocation::{InvocationGuard, InvocationRequirements};
 use crate::engine::resource::ExtensionChildResourceSummary;
 use crate::engine::run_dir::RunDir;
@@ -10,17 +11,6 @@ use crate::extension::{
     env_provider, exec_context, load_extension, ExtensionCapability, ExtensionPhaseTiming,
     RunnerOutput,
 };
-
-#[derive(Debug, Clone)]
-pub struct ComponentScriptOutput {
-    pub exit_code: i32,
-    pub success: bool,
-    pub stdout: String,
-    pub stderr: String,
-    pub timed_out: bool,
-    pub child_resource: Option<ExtensionChildResourceSummary>,
-    pub extension_phase_timings: Vec<ExtensionPhaseTiming>,
-}
 
 impl From<RunnerOutput> for ComponentScriptOutput {
     fn from(output: RunnerOutput) -> Self {
@@ -292,3 +282,36 @@ pub fn source_path(component: &Component, path_override: Option<&str>) -> PathBu
 // component scripts end-to-end through commands::test), so they live in the
 // homeboy-cli crate's test scope rather than here — core cannot depend on the CLI
 // command layer. See crates/homeboy-cli tests for component-script coverage.
+
+/// Provider that wires the extension component-script runner into core's
+/// `component_script_provider` hook.
+pub struct ExtensionComponentScriptRunner;
+
+impl crate::component_script_provider::ComponentScriptRunner for ExtensionComponentScriptRunner {
+    fn run_component_scripts_with_env(
+        &self,
+        component: &crate::component::Component,
+        capability: homeboy_extension_contract::ExtensionCapability,
+        source_path: &std::path::Path,
+        passthrough: bool,
+        extra_env: &[(String, String)],
+        script_args: &[String],
+    ) -> crate::Result<ComponentScriptOutput> {
+        run_component_scripts_with_env(
+            component,
+            capability,
+            source_path,
+            passthrough,
+            extra_env,
+            script_args,
+        )
+    }
+}
+
+/// Register the extension component-script runner with core. Call once at
+/// startup.
+pub fn register_component_script_runner() {
+    crate::component_script_provider::register_component_script_runner(Box::new(
+        ExtensionComponentScriptRunner,
+    ));
+}

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -90,6 +90,7 @@ pub use homeboy_lab_contract::env_materialization_plan;
 // error moved to the internal `homeboy-error` crate. Re-exported here so existing
 // `crate::error::*` call sites keep working unchanged.
 pub use homeboy_error as error;
+pub mod component_script_provider;
 pub mod evidence_manifest;
 pub mod execution;
 pub mod execution_contract;


### PR DESCRIPTION
## Summary
**Breaks the last genuine core→extension behavior cycle.** After the full type-model extraction and the manifest/scope/execution-context relocations, `deps_provider.rs` (core dependency resolution) was the **only** core caller still reaching into extension behavior living in the extension module — it called `extension::component_script::run_component_scripts_with_env` to run a component's dependency scripts.

## The inversion
Mirrors the runner-era provider hooks (rig/release/stack/etc.):
- Core defines a `ComponentScriptRunner` trait + a behavior-free `ComponentScriptOutput` result envelope (its fields — `ExtensionChildResourceSummary`, `ExtensionPhaseTiming` — are core/contract types) in `crate::component_script_provider`.
- `deps_provider` calls through the hook instead of into the extension module.
- The extension layer registers `ExtensionComponentScriptRunner` at CLI startup.
- With no provider registered, callers get a clean not-supported error (graceful degradation, as with the other providers).

## The milestone
`deps_provider` now has **zero extension-behavior references**. This was the final edge. With:
- the entire type-model in contract crates,
- the manifest store / scope / invocation-context / execution-context glue relocated to core,
- and now component-script execution inverted behind a hook,

**core no longer calls into the extension module's behavior.** `homeboy-extension` is now *severable* — the wholesale `git mv` of the extension module into its own crate (depending on `homeboy-core`, one-directional) is unblocked.

## Tests
- `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)