### PR TITLE
Fix unified task-worktree cleanup commands

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -989,7 +989,7 @@ fn cleanup_actionable(
         }
         actionable.next_actions.push(CommandNextAction::new(
             format!("{} cleanup", category.category.replace('_', " ")),
-            if apply {
+            if apply || category.category == TASK_WORKTREES_METADATA.category {
                 category.specialist_command.clone()
             } else {
                 apply_command(&category.specialist_command)
@@ -1510,6 +1510,39 @@ mod tests {
                 metadata.canonical_cleanup_command(true),
                 format!("homeboy cleanup --include {include_arg} --apply")
             );
+        }
+    }
+
+    #[test]
+    fn task_worktree_cleanup_next_actions_preserve_mode_specific_commands() {
+        let cases = [
+            (
+                false,
+                "homeboy worktree cleanup --dry-run --cleanup-branches",
+            ),
+            (true, "homeboy worktree cleanup --cleanup-branches"),
+        ];
+
+        for (apply, command) in cases {
+            let category = CleanupInventoryCategory {
+                category: TASK_WORKTREES_METADATA.category,
+                canonical_cleanup_command: TASK_WORKTREES_METADATA.canonical_cleanup_command(apply),
+                specialist_command: TASK_WORKTREES_METADATA
+                    .specialist_command(apply)
+                    .to_string(),
+                included: true,
+                skipped: false,
+                skip_reason: None,
+                candidate_count: 1,
+                applied_count: 0,
+                skipped_count: 0,
+                estimated_bytes: 0,
+                reclaimed_bytes: 0,
+                output: Value::Null,
+            };
+
+            let actionable = cleanup_actionable(&[category], apply);
+            assert_eq!(actionable.next_actions[0].command, command);
         }
     }
 


### PR DESCRIPTION
## Summary
Emit executable task-worktree cleanup commands from unified cleanup in both preview and apply modes.

## What changed
- Preserve the task-worktree specialist command because its apply mode is represented by omitting --dry-run rather than adding --apply.
- Add deterministic next-action coverage for preview and apply command strings.

## How to test
1. Run `cargo test -p homeboy-cli commands::cleanup::tests --lib`; expect All focused cleanup CLI tests pass (16 passed, 0 failed)..

## Compatibility
No backwards-compatibility impact: cleanup selection, safety classification, and application behavior are unchanged; only generated remediation commands are corrected.

## Evidence
- Base unchanged since verification: main remains at 2edea5c57733ca56855a58806c06cf97bb9664c4.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8893
- Verified finalization base: main at 2edea5c57733ca56855a58806c06cf97bb9664c4
- focused-tests: Passed
- format: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the generated-command mismatch, drafted the focused fix and regression coverage, and verified cleanup CLI behavior.

## Source relationships
- Closes #8893
