### PR TITLE
Fix controller pinning in dependent tests

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -1122,17 +1122,19 @@ fn run_next_claims_oldest_queued_run_and_leaves_later_runs_queued() {
             .expect("first submitted");
         agent_task_lifecycle::submit_plan(&test_plan(), Some("run-next-b"))
             .expect("second submitted");
-        let pinned = lifecycle_status("run-next-a")
-            .expect("first submitted status")
-            .metadata["controller_runtime"]["originating"]["pinned_executable"]
+        let submitted = lifecycle_status("run-next-a").expect("first submitted status");
+        let source = submitted.metadata["controller_runtime"]["originating"]["executable"]
             .as_str()
             .map(std::path::PathBuf::from)
-            .expect("pinned controller executable");
+            .expect("controller fixture source");
+        assert_eq!(source, controller_runtime_test_executable());
         assert_ne!(
-            pinned,
+            source,
             std::env::current_exe().expect("current test executable"),
             "dependent core must not pin the libtest harness"
         );
+        homeboy::core::agent_task_lifecycle::validate_controller_runtime("run-next-a")
+            .expect("pinned controller identity validates");
         let observed_status = Arc::new(Mutex::new(None));
 
         let (_value, exit_code) = run_next_with_executor(InspectingExecutor {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -1133,7 +1133,7 @@ fn run_next_claims_oldest_queued_run_and_leaves_later_runs_queued() {
             std::env::current_exe().expect("current test executable"),
             "dependent core must not pin the libtest harness"
         );
-        homeboy::core::agent_task_lifecycle::validate_controller_runtime("run-next-a")
+        agent_task_lifecycle::validate_controller_runtime("run-next-a")
             .expect("pinned controller identity validates");
         let observed_status = Arc::new(Mutex::new(None));
 

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -1133,7 +1133,7 @@ fn run_next_claims_oldest_queued_run_and_leaves_later_runs_queued() {
             std::env::current_exe().expect("current test executable"),
             "dependent core must not pin the libtest harness"
         );
-        agent_task_lifecycle::validate_controller_runtime("run-next-a")
+        homeboy::agents::agent_task_lifecycle::validate_controller_runtime("run-next-a")
             .expect("pinned controller identity validates");
         let observed_status = Arc::new(Mutex::new(None));
 

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -1122,6 +1122,17 @@ fn run_next_claims_oldest_queued_run_and_leaves_later_runs_queued() {
             .expect("first submitted");
         agent_task_lifecycle::submit_plan(&test_plan(), Some("run-next-b"))
             .expect("second submitted");
+        let pinned = lifecycle_status("run-next-a")
+            .expect("first submitted status")
+            .metadata["controller_runtime"]["originating"]["pinned_executable"]
+            .as_str()
+            .map(std::path::PathBuf::from)
+            .expect("pinned controller executable");
+        assert_ne!(
+            pinned,
+            std::env::current_exe().expect("current test executable"),
+            "dependent core must not pin the libtest harness"
+        );
         let observed_status = Arc::new(Mutex::new(None));
 
         let (_value, exit_code) = run_next_with_executor(InspectingExecutor {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/support.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/support.rs
@@ -49,7 +49,7 @@ pub(crate) use homeboy::agents::agent_tasks::scheduler::{
     AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan,
 };
 
-pub(crate) use crate::test_support::with_isolated_home;
+pub(crate) use crate::test_support::{controller_runtime_test_executable, with_isolated_home};
 pub(crate) use homeboy::agents::agent_tasks::controller_service as agent_task_controller_service;
 pub(crate) use homeboy::agents::agent_tasks::lifecycle::{
     self as agent_task_lifecycle, status as lifecycle_status, AgentTaskRunRecord, AgentTaskRunState,

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -1137,7 +1137,7 @@ fn verify_self_status_identity(path: &Path, expected: &str) -> Result<()> {
 }
 
 fn executable_identity(path: &Path) -> Result<String> {
-    #[cfg(all(not(unix), any(test, feature = "test-support")))]
+    #[cfg(any(test, feature = "test-support"))]
     if let Some(identity) = test_controller_identity(path) {
         return identity;
     }
@@ -1174,10 +1174,10 @@ fn executable_identity(path: &Path) -> Result<String> {
     Ok(actual.expect("identity was checked above"))
 }
 
-/// Non-Unix test hosts cannot execute the Unix shell identity fixture. The
-/// test-support contract is limited to byte-identical copies of its explicit
-/// source executable, so arbitrary fake controller binaries still fail closed.
-#[cfg(all(not(unix), any(test, feature = "test-support")))]
+/// Test-support uses a copied libtest executable as its fixture. The contract
+/// is limited to byte-identical copies of its explicit source executable, so
+/// arbitrary fake controller binaries still execute and fail closed.
+#[cfg(any(test, feature = "test-support"))]
 fn test_controller_identity(path: &Path) -> Option<Result<String>> {
     let source = std::env::var_os(TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV)?;
     let identity = std::env::var(TEST_CONTROLLER_RUNTIME_IDENTITY_ENV).ok()?;

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -19,6 +19,9 @@ pub const CONTROLLER_RUNTIME_METADATA_KEY: &str = "controller_runtime";
 #[cfg(any(test, feature = "test-support"))]
 pub(crate) const TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV: &str =
     "HOMEBOY_TEST_CONTROLLER_RUNTIME_EXECUTABLE";
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) const TEST_CONTROLLER_RUNTIME_IDENTITY_ENV: &str =
+    "HOMEBOY_TEST_CONTROLLER_RUNTIME_IDENTITY";
 
 const ACTIVE_GENERATION_FILE: &str = "active.json";
 const ADMISSION_LOCK_DIR: &str = "admission.lock";
@@ -1134,17 +1137,9 @@ fn verify_self_status_identity(path: &Path, expected: &str) -> Result<()> {
 }
 
 fn executable_identity(path: &Path) -> Result<String> {
-    #[cfg(all(test, not(unix)))]
-    if std::env::current_exe().ok().is_some_and(|current| {
-        executable_digest(&current)
-            .ok()
-            .zip(executable_digest(path).ok())
-            .is_some_and(|(current, candidate)| current == candidate)
-    }) {
-        // Non-Unix tests cannot use the shell executable fixture supplied by
-        // test support. Pins are byte-identical copies, so avoid recursively
-        // launching the test harness there. Explicit fake controllers execute.
-        return Ok(build_identity::current().display);
+    #[cfg(all(not(unix), any(test, feature = "test-support")))]
+    if let Some(identity) = test_controller_identity(path) {
+        return identity;
     }
     let output = Command::new(path)
         .args(["self", "identity"])
@@ -1177,6 +1172,36 @@ fn executable_identity(path: &Path) -> Result<String> {
         ));
     }
     Ok(actual.expect("identity was checked above"))
+}
+
+/// Non-Unix test hosts cannot execute the Unix shell identity fixture. The
+/// test-support contract is limited to byte-identical copies of its explicit
+/// source executable, so arbitrary fake controller binaries still fail closed.
+#[cfg(all(not(unix), any(test, feature = "test-support")))]
+fn test_controller_identity(path: &Path) -> Option<Result<String>> {
+    let source = std::env::var_os(TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV)?;
+    let identity = std::env::var(TEST_CONTROLLER_RUNTIME_IDENTITY_ENV).ok()?;
+    let source_digest = executable_digest(Path::new(&source)).map_err(|error| {
+        Error::validation_invalid_argument(
+            "controller_runtime",
+            format!("test controller source cannot be hashed: {error}"),
+            Some(PathBuf::from(&source).display().to_string()),
+            None,
+        )
+    });
+    let candidate_digest = executable_digest(path);
+    Some(match (source_digest, candidate_digest) {
+        (Ok(source_digest), Ok(candidate_digest)) if source_digest == candidate_digest => {
+            Ok(identity)
+        }
+        (Err(error), _) | (_, Err(error)) => Err(error),
+        _ => Err(Error::validation_invalid_argument(
+            "controller_runtime",
+            "test controller identity contract does not match the pinned executable",
+            Some(path.display().to_string()),
+            None,
+        )),
+    })
 }
 
 fn activated_executable_identity(path: &Path) -> Result<String> {
@@ -1705,19 +1730,27 @@ mod tests {
         });
     }
 
-    #[cfg(unix)]
     #[test]
     fn pin_current_uses_the_explicit_test_controller_fixture() {
         crate::test_support::with_isolated_home(|_| {
             let runtime = pin_current().expect("pin explicit controller fixture");
+            let source = runtime
+                .pointer("/originating/executable")
+                .and_then(Value::as_str)
+                .map(PathBuf::from)
+                .expect("controller fixture source");
             let pinned = runtime
                 .pointer("/originating/pinned_executable")
                 .and_then(Value::as_str)
                 .map(PathBuf::from)
                 .expect("pinned executable");
 
+            assert_eq!(
+                source,
+                crate::test_support::controller_runtime_test_executable()
+            );
             assert_ne!(
-                pinned,
+                source,
                 std::env::current_exe().expect("current test executable")
             );
             assert_eq!(

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -1190,18 +1190,13 @@ fn test_controller_identity(path: &Path) -> Option<Result<String>> {
         )
     });
     let candidate_digest = executable_digest(path);
-    Some(match (source_digest, candidate_digest) {
+    match (source_digest, candidate_digest) {
         (Ok(source_digest), Ok(candidate_digest)) if source_digest == candidate_digest => {
-            Ok(identity)
+            Some(Ok(identity))
         }
-        (Err(error), _) | (_, Err(error)) => Err(error),
-        _ => Err(Error::validation_invalid_argument(
-            "controller_runtime",
-            "test controller identity contract does not match the pinned executable",
-            Some(path.display().to_string()),
-            None,
-        )),
-    })
+        (Err(error), _) | (_, Err(error)) => Some(Err(error)),
+        _ => None,
+    }
 }
 
 fn activated_executable_identity(path: &Path) -> Result<String> {

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -16,6 +16,9 @@ use uuid::Uuid;
 use crate::{build_identity, paths, Error, Result};
 
 pub const CONTROLLER_RUNTIME_METADATA_KEY: &str = "controller_runtime";
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) const TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV: &str =
+    "HOMEBOY_TEST_CONTROLLER_RUNTIME_EXECUTABLE";
 
 const ACTIVE_GENERATION_FILE: &str = "active.json";
 const ADMISSION_LOCK_DIR: &str = "admission.lock";
@@ -425,13 +428,22 @@ pub fn pin_current() -> Result<Value> {
 
 fn pin_current_unlocked() -> Result<Value> {
     let identity = build_identity::current();
-    let executable = std::env::current_exe().map_err(|error| {
+    let executable = current_executable()?;
+    pin_executable(&executable, &identity.display)
+}
+
+fn current_executable() -> Result<PathBuf> {
+    #[cfg(any(test, feature = "test-support"))]
+    if let Some(executable) = std::env::var_os(TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV) {
+        return Ok(PathBuf::from(executable));
+    }
+
+    std::env::current_exe().map_err(|error| {
         Error::internal_io(
             error.to_string(),
             Some("resolve controller executable".to_string()),
         )
-    })?;
-    pin_executable(&executable, &identity.display)
+    })
 }
 
 fn pin_executable(executable: &Path, identity: &str) -> Result<Value> {
@@ -1122,16 +1134,16 @@ fn verify_self_status_identity(path: &Path, expected: &str) -> Result<()> {
 }
 
 fn executable_identity(path: &Path) -> Result<String> {
-    #[cfg(test)]
+    #[cfg(all(test, not(unix)))]
     if std::env::current_exe().ok().is_some_and(|current| {
         executable_digest(&current)
             .ok()
             .zip(executable_digest(path).ok())
             .is_some_and(|(current, candidate)| current == candidate)
     }) {
-        // Unit tests run inside the libtest executable, not the Homeboy CLI.
-        // Pins are byte-identical copies, so accept them without recursively
-        // launching the test harness. Explicit fake controllers still execute.
+        // Non-Unix tests cannot use the shell executable fixture supplied by
+        // test support. Pins are byte-identical copies, so avoid recursively
+        // launching the test harness there. Explicit fake controllers execute.
         return Ok(build_identity::current().display);
     }
     let output = Command::new(path)
@@ -1690,6 +1702,28 @@ mod tests {
             )
             .expect("parse refreshed active generation");
             assert_eq!(active["originating"]["build_identity"], current);
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pin_current_uses_the_explicit_test_controller_fixture() {
+        crate::test_support::with_isolated_home(|_| {
+            let runtime = pin_current().expect("pin explicit controller fixture");
+            let pinned = runtime
+                .pointer("/originating/pinned_executable")
+                .and_then(Value::as_str)
+                .map(PathBuf::from)
+                .expect("pinned executable");
+
+            assert_ne!(
+                pinned,
+                std::env::current_exe().expect("current test executable")
+            );
+            assert_eq!(
+                executable_identity(&pinned).expect("fixture identity"),
+                build_identity::current().display
+            );
         });
     }
 

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -134,6 +134,7 @@ pub struct HomeGuard {
     prior_no_update_check: Option<String>,
     prior_daemon_binary_sha: Option<String>,
     prior_controller_runtime_executable: Option<String>,
+    prior_controller_runtime_identity: Option<String>,
     context: HermeticTestContext,
     _guard: MutexGuard<'static, ()>,
 }
@@ -208,6 +209,8 @@ impl HomeGuard {
             std::env::var(crate::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV).ok();
         let prior_controller_runtime_executable =
             std::env::var(crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV).ok();
+        let prior_controller_runtime_identity =
+            std::env::var(crate::controller_runtime::TEST_CONTROLLER_RUNTIME_IDENTITY_ENV).ok();
         // The isolated HOME hosts `~/.config/homeboy/extensions/**/*.sh`
         // capability scripts that tests execute. On `noexec`-`/tmp` hosts a
         // plain `TempDir::new()` lands the whole HOME on a `noexec` mount,
@@ -241,6 +244,10 @@ impl HomeGuard {
             crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV,
             test_controller_fixture(context.runtime_dir()),
         );
+        std::env::set_var(
+            crate::controller_runtime::TEST_CONTROLLER_RUNTIME_IDENTITY_ENV,
+            crate::build_identity::current().display,
+        );
         Self {
             prior,
             prior_xdg_data_home,
@@ -250,6 +257,7 @@ impl HomeGuard {
             prior_no_update_check,
             prior_daemon_binary_sha,
             prior_controller_runtime_executable,
+            prior_controller_runtime_identity,
             context,
             _guard: guard,
         }
@@ -432,6 +440,15 @@ impl Drop for HomeGuard {
                 crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV,
             ),
         }
+        match &self.prior_controller_runtime_identity {
+            Some(value) => std::env::set_var(
+                crate::controller_runtime::TEST_CONTROLLER_RUNTIME_IDENTITY_ENV,
+                value,
+            ),
+            None => std::env::remove_var(
+                crate::controller_runtime::TEST_CONTROLLER_RUNTIME_IDENTITY_ENV,
+            ),
+        }
         reset_cached_test_state();
     }
 }
@@ -456,8 +473,22 @@ fn test_controller_fixture(directory: &Path) -> PathBuf {
 }
 
 #[cfg(not(unix))]
-fn test_controller_fixture(_directory: &Path) -> PathBuf {
-    std::env::current_exe().expect("current test executable")
+fn test_controller_fixture(directory: &Path) -> PathBuf {
+    let path = directory.join("homeboy-controller-fixture");
+    fs::copy(
+        std::env::current_exe().expect("current test executable"),
+        &path,
+    )
+    .expect("copy controller fixture");
+    path
+}
+
+/// Source executable selected by the hermetic controller-runtime test contract.
+pub fn controller_runtime_test_executable() -> PathBuf {
+    PathBuf::from(
+        std::env::var_os(crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV)
+            .expect("controller runtime test executable"),
+    )
 }
 
 pub fn with_isolated_home<R>(body: impl FnOnce(&TempDir) -> R) -> R {

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -453,26 +453,6 @@ impl Drop for HomeGuard {
     }
 }
 
-#[cfg(unix)]
-fn test_controller_fixture(directory: &Path) -> PathBuf {
-    use std::os::unix::fs::PermissionsExt;
-
-    let path = directory.join("homeboy-controller-fixture");
-    let identity = serde_json::to_string(&crate::build_identity::current().display)
-        .expect("serialize controller fixture identity");
-    fs::write(
-        &path,
-        format!(
-            "#!/bin/sh\nif [ \"$1\" = self ] && [ \"$2\" = identity ]; then\n  printf '%s\\n' '{{\"data\":{{\"display\":{identity}}}}}'\n  exit 0\nfi\nexit 1\n"
-        ),
-    )
-    .expect("write controller fixture");
-    fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
-        .expect("make controller fixture executable");
-    path
-}
-
-#[cfg(not(unix))]
 fn test_controller_fixture(directory: &Path) -> PathBuf {
     let path = directory.join("homeboy-controller-fixture");
     fs::copy(

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -133,6 +133,7 @@ pub struct HomeGuard {
     prior_invocation_runtime: Option<String>,
     prior_no_update_check: Option<String>,
     prior_daemon_binary_sha: Option<String>,
+    prior_controller_runtime_executable: Option<String>,
     context: HermeticTestContext,
     _guard: MutexGuard<'static, ()>,
 }
@@ -205,6 +206,8 @@ impl HomeGuard {
         let prior_no_update_check = std::env::var("HOMEBOY_NO_UPDATE_CHECK").ok();
         let prior_daemon_binary_sha =
             std::env::var(crate::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV).ok();
+        let prior_controller_runtime_executable =
+            std::env::var(crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV).ok();
         // The isolated HOME hosts `~/.config/homeboy/extensions/**/*.sh`
         // capability scripts that tests execute. On `noexec`-`/tmp` hosts a
         // plain `TempDir::new()` lands the whole HOME on a `noexec` mount,
@@ -234,6 +237,10 @@ impl HomeGuard {
             crate::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV,
             TEST_DAEMON_BINARY_SHA,
         );
+        std::env::set_var(
+            crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV,
+            test_controller_fixture(context.runtime_dir()),
+        );
         Self {
             prior,
             prior_xdg_data_home,
@@ -242,6 +249,7 @@ impl HomeGuard {
             prior_invocation_runtime,
             prior_no_update_check,
             prior_daemon_binary_sha,
+            prior_controller_runtime_executable,
             context,
             _guard: guard,
         }
@@ -415,8 +423,41 @@ impl Drop for HomeGuard {
             Some(value) => std::env::set_var(crate::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV, value),
             None => std::env::remove_var(crate::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV),
         }
+        match &self.prior_controller_runtime_executable {
+            Some(value) => std::env::set_var(
+                crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV,
+                value,
+            ),
+            None => std::env::remove_var(
+                crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV,
+            ),
+        }
         reset_cached_test_state();
     }
+}
+
+#[cfg(unix)]
+fn test_controller_fixture(directory: &Path) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = directory.join("homeboy-controller-fixture");
+    let identity = serde_json::to_string(&crate::build_identity::current().display)
+        .expect("serialize controller fixture identity");
+    fs::write(
+        &path,
+        format!(
+            "#!/bin/sh\nif [ \"$1\" = self ] && [ \"$2\" = identity ]; then\n  printf '%s\\n' '{{\"data\":{{\"display\":{identity}}}}}'\n  exit 0\nfi\nexit 1\n"
+        ),
+    )
+    .expect("write controller fixture");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
+        .expect("make controller fixture executable");
+    path
+}
+
+#[cfg(not(unix))]
+fn test_controller_fixture(_directory: &Path) -> PathBuf {
+    std::env::current_exe().expect("current test executable")
 }
 
 pub fn with_isolated_home<R>(body: impl FnOnce(&TempDir) -> R) -> R {


### PR DESCRIPTION
Closes #8805

## Summary
- inject an explicit controller executable for hermetic dependent-crate tests instead of pinning the libtest harness
- bind test identity substitution to the declared fixture source and exact SHA-256 digest
- execute `self identity` for every non-fixture controller, including fake and invalid candidates
- assert the originating executable source in dependent lifecycle coverage rather than the copied pin destination
- carry the regression across the current `homeboy-agents` crate boundary

## Root cause

`controller_runtime::pin_current()` used `std::env::current_exe()`. In `homeboy-cli` tests, `homeboy-core` is a normal dependency and `current_exe()` is the libtest harness. The copied harness was then executed as `homeboy self identity`, producing test-runner output instead of identity JSON and cascading across lifecycle tests. The old `#[cfg(test)]` exception existed only when testing `homeboy-core` itself, not from dependent crates.

## How to test

1. Run `cargo fmt --all -- --check`.
2. Run `cargo check --workspace --tests --locked`.
3. Run `cargo test -p homeboy-core --lib --locked -- controller_runtime --test-threads=1`; expect 22 passing controller-runtime tests.
4. Run the focused dependent lifecycle regression in `homeboy-cli`; expect the lifecycle submission to pin the explicit fixture source rather than the libtest executable.
5. Run the corresponding `homeboy-agents` lifecycle regression; expect submission and status hydration to pass through the public lifecycle module.
6. Run `cargo test -p homeboy-cli --lib --locked` and `cargo test -p homeboy-agents --lib --locked` as the complete affected-crate gate.

## Compatibility

Production controller pinning is unchanged: immutable pins still execute `self identity` and fail closed on invalid output or identity mismatch. Identity substitution exists only in test/test-support builds and only when the candidate digest exactly matches the explicitly declared fixture source. Non-fixture controllers always execute normally. No public CLI or persisted production schema changes.

## Verification

- Formatting passed.
- Workspace test compilation passed.
- Controller-runtime suite: 22 passed.
- Focused dependent CLI lifecycle regression: passed.
- Focused `homeboy-agents` lifecycle regression: passed.
- The full agents suite exceeded the local 20-minute budget; CI is the authoritative complete-suite gate.

## Control-plane note

This PR was finalized directly after explicit operator authorization to bypass the shared Lab control plane. The daemon currently has unrelated jobs stuck after child reservation, tracked in #8883; no runner jobs were cancelled or replaced while preparing this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** `openai/gpt-5.6-sol`, `openai/gpt-5.6-terra`
- **Used for:** Diagnosed the release-gate regression, implemented and reviewed the test controller boundary, rebased across crate splits, and drafted deterministic coverage. Chris reviewed and owns the change.