### PR TITLE
refactor: relocate extension update-check + is_git_url utils to core (extraction prep)

### DIFF
--- a/crates/homeboy-core/src/context/report.rs
+++ b/crates/homeboy-core/src/context/report.rs
@@ -641,7 +641,7 @@ fn build_actionable_next_steps(
 
     let mut outdated_extensions = Vec::new();
     for extension in all_extensions {
-        if let Some(update) = crate::extension::check_update_available(&extension.id) {
+        if let Some(update) = crate::extension_update_check::check_update_available(&extension.id) {
             outdated_extensions.push(update);
         }
     }

--- a/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
@@ -64,7 +64,7 @@ pub(super) fn install_configured_extension(
     source: &str,
     extension_id: &str,
 ) -> Result<InstallResult> {
-    if super::is_git_url(source) {
+    if crate::extension_update_check::is_git_url(source) {
         return super::install(source, Some(extension_id));
     }
 

--- a/crates/homeboy-core/src/extension/lifecycle/mod.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/mod.rs
@@ -53,15 +53,6 @@ pub fn derive_id_from_url(url: &str) -> Result<String> {
     slugify_id(segment)
 }
 
-/// Check if a string looks like a git URL (vs a local path).
-pub fn is_git_url(source: &str) -> bool {
-    source.starts_with("http://")
-        || source.starts_with("https://")
-        || source.starts_with("git@")
-        || source.starts_with("ssh://")
-        || source.ends_with(".git")
-}
-
 /// Returns the path to a extension's manifest file: {extension_dir}/{id}.json
 fn manifest_path_for_extension(extension_dir: &Path, id: &str) -> PathBuf {
     extension_dir.join(format!("{}.json", id))
@@ -80,7 +71,7 @@ pub fn install_with_revision(
     id_override: Option<&str>,
     revision: Option<&str>,
 ) -> Result<InstallResult> {
-    if is_git_url(source) {
+    if crate::extension_update_check::is_git_url(source) {
         install_from_url(source, id_override, revision)
     } else {
         install_from_path(source, id_override, None, revision)
@@ -163,7 +154,7 @@ pub fn refresh(
         None => derive_id_from_url(source)?,
     };
 
-    let local_source_revision = if is_git_url(source) {
+    let local_source_revision = if crate::extension_update_check::is_git_url(source) {
         None
     } else {
         git::short_head_revision(&absolute_source_path(source)?)
@@ -193,7 +184,7 @@ pub fn refresh(
 }
 
 fn durable_refresh_source(source: &str, extension_id: &str) -> Result<String> {
-    if is_git_url(source) {
+    if crate::extension_update_check::is_git_url(source) {
         return Ok(source.to_string());
     }
 
@@ -325,9 +316,7 @@ mod update;
 use update::is_extension_update_workdir_clean;
 pub(crate) use update::write_requested_source_ref;
 pub(crate) use update::write_source_metadata;
-pub use update::{
-    check_update_available, read_source_revision, read_source_url, update, UpdateAvailable,
-};
+pub use update::{read_source_revision, read_source_url, update};
 
 /// Uninstall a extension. Automatically detects symlinks vs cloned directories.
 /// - Symlinked extensions: removes symlink only (source preserved)

--- a/crates/homeboy-core/src/extension/lifecycle/update.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/update.rs
@@ -399,63 +399,6 @@ fn linked_extension_git_root(extension_id: &str, source_dir: &Path) -> Result<Pa
     )))
 }
 
-/// Check if a git-cloned extension has updates available.
-/// Runs `git fetch` then checks if HEAD is behind the remote tracking branch.
-/// Returns None for linked extensions or if check fails.
-pub fn check_update_available(extension_id: &str) -> Option<UpdateAvailable> {
-    let extension_dir = paths::extension(extension_id).ok()?;
-    if !extension_dir.exists() || is_extension_linked(extension_id) {
-        return None;
-    }
-
-    // Check it's a git repo
-    if !extension_dir.join(".git").exists() {
-        return None;
-    }
-
-    // Fetch latest (best-effort, short timeout)
-    Command::new("git")
-        .args(["fetch", "--quiet"])
-        .current_dir(&extension_dir)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .ok()?;
-
-    // Check how many commits we're behind
-    let output = Command::new("git")
-        .args(["rev-list", "HEAD..@{u}", "--count"])
-        .current_dir(&extension_dir)
-        .stdin(std::process::Stdio::null())
-        .output()
-        .ok()?;
-
-    let count_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let behind_count: usize = count_str.parse().ok()?;
-
-    if behind_count == 0 {
-        return None;
-    }
-
-    // Get installed version
-    let extension = load_extension(extension_id).ok()?;
-    let installed_version = extension.version.clone();
-
-    Some(UpdateAvailable {
-        extension_id: extension_id.to_string(),
-        installed_version,
-        behind_count,
-    })
-}
-
-#[derive(Debug, Clone)]
-pub struct UpdateAvailable {
-    pub extension_id: String,
-    pub installed_version: String,
-    pub behind_count: usize,
-}
-
 /// Read the source revision for an installed extension.
 /// Checks (in order): .git directory (git rev-parse), then .source-revision file.
 pub fn read_source_revision(extension_id: &str) -> Option<String> {

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -1,3 +1,4 @@
+pub use crate::extension_update_check::{check_update_available, is_git_url, UpdateAvailable};
 pub mod audit_compiler_warning_provider;
 pub mod audit_fingerprint_script_provider;
 pub mod audit_grammar_source_provider;
@@ -89,10 +90,9 @@ pub use homeboy_extension_contract::{DeployArchiveInstallPolicy, DeployRequiredH
 pub use lifecycle::source_metadata::resolve_source_url;
 pub use lifecycle::source_metadata::SourceMetadataRepair;
 pub use lifecycle::{
-    check_update_available, derive_id_from_url, install, install_for_component,
-    install_with_revision, is_git_url, read_source_revision, read_source_url, refresh, slugify_id,
-    uninstall, update, InstallForComponentResult, InstallResult, RefreshResult, UpdateAvailable,
-    UpdateResult,
+    derive_id_from_url, install, install_for_component, install_with_revision,
+    read_source_revision, read_source_url, refresh, slugify_id, uninstall, update,
+    InstallForComponentResult, InstallResult, RefreshResult, UpdateResult,
 };
 pub use maintenance::{exec_tool, update_all};
 pub use manifest::{

--- a/crates/homeboy-core/src/extension/repair.rs
+++ b/crates/homeboy-core/src/extension/repair.rs
@@ -1,6 +1,7 @@
 use crate::config::{self, from_str};
 use crate::error::{Error, Result};
 use crate::extension_provider_discovery::validate_installed_extension_provider_discovery;
+use crate::extension_update_check::is_git_url;
 use crate::git;
 use crate::paths;
 use homeboy_engine_primitives::local_files;
@@ -8,8 +9,8 @@ use std::path::{Path, PathBuf};
 
 use super::execution::run_setup;
 use super::lifecycle::{
-    derive_id_from_url, install_linked_shared_assets, is_git_url, rename_dir,
-    resolve_cloned_extension, slugify_id, write_requested_source_ref, write_source_metadata,
+    derive_id_from_url, install_linked_shared_assets, rename_dir, resolve_cloned_extension,
+    slugify_id, write_requested_source_ref, write_source_metadata,
 };
 use super::manifest::ExtensionManifest;
 

--- a/crates/homeboy-core/src/extension/update_check.rs
+++ b/crates/homeboy-core/src/extension/update_check.rs
@@ -98,7 +98,7 @@ pub fn run_startup_check() {
     let mut extensions_behind: HashMap<String, usize> = HashMap::new();
 
     for id in &extension_ids {
-        if let Some(update) = extension::check_update_available(id) {
+        if let Some(update) = crate::extension_update_check::check_update_available(id) {
             extensions_behind.insert(update.extension_id, update.behind_count);
         }
     }

--- a/crates/homeboy-core/src/extension_update_check.rs
+++ b/crates/homeboy-core/src/extension_update_check.rs
@@ -1,0 +1,75 @@
+//! Extension update-check + source-URL utilities (core glue over an extension's
+//! git checkout). Relocated from the extension lifecycle module - depends only on
+//! core paths/git/error + the core extension store, no extension behavior.
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::error::Result;
+use crate::extension_store::{is_extension_linked, load_extension};
+use crate::paths;
+
+/// Check if a string looks like a git URL (vs a local path).
+pub fn is_git_url(source: &str) -> bool {
+    source.starts_with("http://")
+        || source.starts_with("https://")
+        || source.starts_with("git@")
+        || source.starts_with("ssh://")
+        || source.ends_with(".git")
+}
+
+/// Check if a git-cloned extension has updates available.
+/// Runs `git fetch` then checks if HEAD is behind the remote tracking branch.
+/// Returns None for linked extensions or if check fails.
+pub fn check_update_available(extension_id: &str) -> Option<UpdateAvailable> {
+    let extension_dir = paths::extension(extension_id).ok()?;
+    if !extension_dir.exists() || is_extension_linked(extension_id) {
+        return None;
+    }
+
+    // Check it's a git repo
+    if !extension_dir.join(".git").exists() {
+        return None;
+    }
+
+    // Fetch latest (best-effort, short timeout)
+    Command::new("git")
+        .args(["fetch", "--quiet"])
+        .current_dir(&extension_dir)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .ok()?;
+
+    // Check how many commits we're behind
+    let output = Command::new("git")
+        .args(["rev-list", "HEAD..@{u}", "--count"])
+        .current_dir(&extension_dir)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .ok()?;
+
+    let count_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let behind_count: usize = count_str.parse().ok()?;
+
+    if behind_count == 0 {
+        return None;
+    }
+
+    // Get installed version
+    let extension = load_extension(extension_id).ok()?;
+    let installed_version = extension.version.clone();
+
+    Some(UpdateAvailable {
+        extension_id: extension_id.to_string(),
+        installed_version,
+        behind_count,
+    })
+}
+#[derive(Debug, Clone)]
+pub struct UpdateAvailable {
+    pub extension_id: String,
+    pub installed_version: String,
+    pub behind_count: usize,
+}

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -101,6 +101,7 @@ pub mod extension_invocation_context;
 pub mod extension_provider_discovery;
 pub mod extension_scope;
 pub mod extension_store;
+pub mod extension_update_check;
 // finding moved to the internal `homeboy-finding` crate. Re-exported so existing
 // `crate::finding::*` call sites keep working unchanged.
 pub use homeboy_finding as finding;

--- a/crates/homeboy-core/src/runtime_package.rs
+++ b/crates/homeboy-core/src/runtime_package.rs
@@ -35,7 +35,7 @@ pub fn refresh(
     let temp_dir = runtime_root.join(format!(".refresh-tmp-{runtime_id}"));
     remove_path_if_exists(&temp_dir, "clean stale runtime package refresh temp")?;
 
-    let (source_root, source_revision) = if crate::extension::is_git_url(source) {
+    let (source_root, source_revision) = if crate::extension_update_check::is_git_url(source) {
         git::clone_repo_at_ref(source, &temp_dir, revision)?;
         let source_revision = git::short_head_revision(&temp_dir);
         (temp_dir.as_path(), source_revision)


### PR DESCRIPTION
## Summary
Extension-crate extraction prep (1 of ~4 remaining edges surfaced when attempting the wholesale `homeboy-extension` git-mv).

`check_update_available` (+ `UpdateAvailable`) and `is_git_url` are **core glue misfiled in the extension lifecycle module**:
- `check_update_available` inspects an extension's git checkout via `paths`/`git`/`is_extension_linked` — no extension behavior.
- `is_git_url` is a pure URL-prefix string check.

## The move
Relocates both to `crate::extension_update_check`. The extension module re-exports them for path stability (`crate::extension::{is_git_url, check_update_available, UpdateAvailable}` still resolve), so consumers — `context/report.rs` (core), `homeboy-upgrade`, `homeboy-rig` — stay stable.

## Why
When I attempted the wholesale `homeboy-extension` git-mv, compiling revealed a handful of genuine core→extension edges the earlier function-name scans missed (they build/call extension items directly). This clears two of them. The remaining edges (a `deps_provider` `ExtensionRunner` execution path, `deps.rs`'s `build` usage) are follow-up prep before the clean git-mv can land.

## Tests
- `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)