### PR TITLE
Use realistic runner session health budgets

### DIFF
--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 pub(super) fn session_is_live(session: &RunnerSession) -> bool {
-    session_is_live_with_timeout(session, Duration::from_millis(200))
+    session_is_live_with_timeout(session, Duration::from_secs(2))
 }
 
 pub(super) fn session_is_live_with_timeout(session: &RunnerSession, timeout: Duration) -> bool {
@@ -16,14 +16,13 @@ pub(super) fn session_is_live_with_timeout(session: &RunnerSession, timeout: Dur
     let Some(local_url) = session.local_url.as_deref() else {
         return false;
     };
-    let probe_timeout = timeout / 2;
     session.local_port.is_some_and(|port| {
-        wait_for_tcp(port, probe_timeout)
+        wait_for_tcp(port, timeout)
             && super::connection_daemon::daemon_http_health_matches_with_timeout(
                 local_url,
                 session.remote_daemon_lease_id.as_deref(),
                 session.remote_daemon_pid,
-                probe_timeout,
+                timeout,
             )
     })
 }
@@ -303,6 +302,8 @@ fn live_peer_session_in(
 mod tests {
     use super::*;
     use crate::{RunnerSessionRole, RunnerTunnelMode};
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
     use tempfile::TempDir;
 
     fn session(controller_id: &str, lease_id: &str) -> RunnerSession {
@@ -327,6 +328,117 @@ mod tests {
             last_seen_at: None,
             leaseless_recovery_evidence: None,
         }
+    }
+
+    fn serve_health(
+        lease_id: &str,
+        pid: u32,
+        delay: Duration,
+    ) -> (u16, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let port = listener.local_addr().expect("address").port();
+        let freshness = DaemonFreshnessReport {
+            fresh: true,
+            stale_reason_code: None,
+            restartable: false,
+            lease_id: Some(lease_id.to_string()),
+            pid: Some(pid),
+            recovery_evidence: None,
+            ownership_evidence: None,
+            adoption_command: None,
+            binary_hash: None,
+            daemon_version: Some("test".to_string()),
+            daemon_build_identity: Some("homeboy test".to_string()),
+            runtime_paths: None,
+            active_jobs: 0,
+            termination_evidence: None,
+            repair_plan: Vec::new(),
+        };
+        let body = serde_json::json!({ "freshness": freshness, "pid": pid }).to_string();
+        let server = std::thread::spawn(move || {
+            // wait_for_tcp opens and immediately closes the first connection.
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept().expect("health connection");
+                let mut request = [0; 1024];
+                let read = stream.read(&mut request).expect("read request");
+                if read == 0 {
+                    continue;
+                }
+                assert!(std::str::from_utf8(&request[..read])
+                    .expect("request text")
+                    .starts_with("GET /health HTTP/1.1"));
+                std::thread::sleep(delay);
+                stream
+                    .write_all(
+                        format!(
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                            body.len(), body
+                        )
+                        .as_bytes(),
+                    )
+                    .expect("health response");
+                return;
+            }
+            panic!("health request was not received");
+        });
+        (port, server)
+    }
+
+    fn session_for_health_endpoint(port: u16, lease_id: &str, pid: u32) -> RunnerSession {
+        let mut session = session("controller", lease_id);
+        session.local_port = Some(port);
+        session.local_url = Some(format!("http://127.0.0.1:{port}"));
+        session.remote_daemon_pid = Some(pid);
+        session
+    }
+
+    #[test]
+    fn session_health_accepts_a_healthy_endpoint_after_one_hundred_milliseconds() {
+        let (port, server) = serve_health("lease-live", 42, Duration::from_millis(125));
+        let session = session_for_health_endpoint(port, "lease-live", 42);
+
+        assert!(session_is_live_with_timeout(
+            &session,
+            Duration::from_millis(200)
+        ));
+        server.join().expect("server");
+    }
+
+    #[test]
+    fn session_health_rejects_a_mismatched_lease() {
+        let (port, server) = serve_health("lease-other", 42, Duration::ZERO);
+        let session = session_for_health_endpoint(port, "lease-live", 42);
+
+        assert!(!session_is_live_with_timeout(
+            &session,
+            Duration::from_millis(200)
+        ));
+        server.join().expect("server");
+    }
+
+    #[test]
+    fn session_health_rejects_a_mismatched_pid() {
+        let (port, server) = serve_health("lease-live", 43, Duration::ZERO);
+        let session = session_for_health_endpoint(port, "lease-live", 42);
+
+        assert!(!session_is_live_with_timeout(
+            &session,
+            Duration::from_millis(200)
+        ));
+        server.join().expect("server");
+    }
+
+    #[test]
+    fn session_health_rejects_a_closed_tunnel() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let port = listener.local_addr().expect("address").port();
+        drop(listener);
+        let session = session_for_health_endpoint(port, "lease-live", 42);
+
+        assert!(!session_is_live_with_timeout(
+            &session,
+            Duration::from_millis(100)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Prevent healthy direct-SSH runner sessions from being marked disconnected under normal forwarded latency.

## What changed
- Use the established 2-second default session health bound and apply explicit TCP and authenticated health timeouts independently instead of halving one budget.

## How to test
1. Run `cargo test -p homeboy-lab-runner session_health`; expect Four focused tests pass for delayed healthy responses, lease mismatch, PID mismatch, and closed tunnels..
2. Run `cargo check -p homeboy-lab-runner`; expect The homeboy-lab-runner crate compiles successfully..

## Compatibility
Lease and PID identity validation is unchanged; only the bounded wait available to healthy direct-SSH session probes increases.

## Evidence
- Base unchanged since verification: main remains at b3a0683645b0ae1f2f1e89ac494b923dd90776d2.
- CI expected: Homeboy pull request CI
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8903
- Verified finalization base: main at b3a0683645b0ae1f2f1e89ac494b923dd90776d2
- crate-check: Passed
- diff-check: Passed
- focused-session-health-tests: Passed
- formatting: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the runner tunnel timing mismatch and drafted the bounded implementation and deterministic tests; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8903
