### PR TITLE
fix: declare windows-sys dep for homeboy-agents crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,7 @@ dependencies = [
  "shellexpand",
  "tempfile",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/homeboy-agents/Cargo.toml
+++ b/crates/homeboy-agents/Cargo.toml
@@ -31,6 +31,9 @@ shellexpand = "3.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls", "socks", "http2", "charset", "system-proxy"] }
 tempfile = "3.14"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_IO"] }
+
 [dev-dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core", features = ["test-support"] }
 


### PR DESCRIPTION
## Summary
- Fixes the **Windows Build** compile failure (`error[E0433]: cannot find module or crate windows_sys`) that has blocked **every Release since v0.290.0**.
- The agents extraction (#8809) moved `agent_task_provider/artifact_finalization.rs` into `homeboy-agents`, but its `#[cfg(windows)]` file-identity code still references `windows_sys` while the dependency stayed declared only in `homeboy-core`.
- Adds the identical `[target.'cfg(windows)'.dependencies]` `windows-sys` declaration (version + features mirrored from `homeboy-core`) so the Windows target links.

## Why it slipped past CI
Linux/local CI and `cargo check --lib` don't compile `#[cfg(windows)]` code, so the break only surfaced on the Release workflow's dedicated **Windows Build** job — which gates GitHub Release creation. Result: releases silently stalled at v0.290.0 while main kept accumulating commits.

## Scope check
Audited all workspace crates: only `homeboy-core` and `homeboy-agents` reference `windows_sys`, and both now declare it. No other extracted crate has the same latent gap.

## Changes
- `crates/homeboy-agents/Cargo.toml` — add `windows-sys` under `[target.'cfg(windows)'.dependencies]`
- `Cargo.lock` — record `windows-sys` as a `homeboy-agents` dependency (lockfile-only refresh, no version bumps)