### PR TITLE
refactor: invert component-build execution behind a provider hook (extraction prep)

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -112,6 +112,7 @@ impl CliRuntime {
         crate::release::provider_impl::register();
         crate::core::extension::audit_manifest_provider::register();
         crate::core::extension::component_script::register_component_script_runner();
+        crate::core::extension::build::register_component_build_runner();
         // Register the fingerprint-script provider so code_audit can fall back to
         // extension fingerprint scripts (for files the core grammar engine can't
         // handle) without depending on the extension script runner.

--- a/crates/homeboy-core/src/component_build_provider.rs
+++ b/crates/homeboy-core/src/component_build_provider.rs
@@ -1,0 +1,53 @@
+//! Component-build runner provider hook.
+//!
+//! Core's dependency resolution (`deps`) rebuilds a component after applying a
+//! dependency update. Running a component's build is extension execution
+//! behavior (it drives the extension runner through the Build capability), so it
+//! is inverted behind this provider: core owns the dependency-update flow, the
+//! extension layer supplies the build execution.
+//!
+//! The build result is returned pre-serialized as JSON plus the exit code, since
+//! that is all core's rebuild flow needs (it forwards the JSON to its command
+//! result and gates on the exit code).
+//!
+//! With no provider registered (no extension subsystem present) the no-op
+//! returns a not-supported error, so callers degrade gracefully.
+
+use std::sync::Mutex;
+
+use serde_json::Value;
+
+use crate::component::Component;
+use crate::{Error, Result};
+
+/// Runs a component's build for the dependency-rebuild flow. Supplied by the
+/// extension layer; consumed by core dependency resolution.
+pub trait ComponentBuildRunner: Send + Sync {
+    /// Build the component. Returns `(json_result, exit_code)`.
+    fn run_component_build(&self, component: &Component) -> Result<(Value, i32)>;
+}
+
+fn provider_slot() -> &'static Mutex<Option<Box<dyn ComponentBuildRunner>>> {
+    static PROVIDER: Mutex<Option<Box<dyn ComponentBuildRunner>>> = Mutex::new(None);
+    &PROVIDER
+}
+
+/// Register the component-build runner. Called once at startup by the extension
+/// layer.
+pub fn register_component_build_runner(provider: Box<dyn ComponentBuildRunner>) {
+    let mut slot = provider_slot().lock().expect("component build runner lock");
+    *slot = Some(provider);
+}
+
+/// Build a component through the registered provider. Returns
+/// `(json_result, exit_code)`.
+pub fn run_component_build(component: &Component) -> Result<(Value, i32)> {
+    let slot = provider_slot().lock().expect("component build runner lock");
+    match slot.as_deref() {
+        Some(provider) => provider.run_component_build(component),
+        None => Err(Error::internal_io(
+            "no component-build runner registered; the extension subsystem is not available",
+            None,
+        )),
+    }
+}

--- a/crates/homeboy-core/src/deps.rs
+++ b/crates/homeboy-core/src/deps.rs
@@ -1,6 +1,5 @@
 use crate::component::{self, Component};
 use crate::extension;
-use crate::extension::build;
 use crate::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -442,7 +441,8 @@ fn extension_install_invocation(
 fn rebuild_component(component: &Component, path: &Path) -> Result<DependencyCommandResult> {
     let mut build_component = component.clone();
     build_component.local_path = path.display().to_string();
-    let (result, exit_code) = build::run_component(&build_component)?;
+    let (result, exit_code) =
+        crate::component_build_provider::run_component_build(&build_component)?;
     let stdout = serde_json::to_string(&result).map_err(|e| {
         Error::internal_json(e.to_string(), Some("serialize deps rebuild".to_string()))
     })?;

--- a/crates/homeboy-core/src/extension/build/mod.rs
+++ b/crates/homeboy-core/src/extension/build/mod.rs
@@ -952,3 +952,28 @@ mod tests {
         )));
     }
 }
+
+/// Provider that wires the extension component-build runner into core's
+/// `component_build_provider` hook.
+pub struct ExtensionComponentBuildRunner;
+
+impl crate::component_build_provider::ComponentBuildRunner for ExtensionComponentBuildRunner {
+    fn run_component_build(
+        &self,
+        component: &crate::component::Component,
+    ) -> crate::Result<(serde_json::Value, i32)> {
+        let (result, exit_code) = run_component(component)?;
+        let value = serde_json::to_value(&result).map_err(|e| {
+            crate::Error::internal_json(e.to_string(), Some("serialize build result".to_string()))
+        })?;
+        Ok((value, exit_code))
+    }
+}
+
+/// Register the extension component-build runner with core. Call once at
+/// startup.
+pub fn register_component_build_runner() {
+    crate::component_build_provider::register_component_build_runner(Box::new(
+        ExtensionComponentBuildRunner,
+    ));
+}

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -90,6 +90,7 @@ pub use homeboy_lab_contract::env_materialization_plan;
 // `crate::error::*` call sites keep working unchanged.
 pub use homeboy_error as error;
 pub mod build_artifact_path;
+pub mod component_build_provider;
 pub mod component_script_provider;
 pub mod evidence_manifest;
 pub mod execution;


### PR DESCRIPTION
## Summary
Extension-crate extraction prep (edge 3 of 4). `deps.rs::rebuild_component` (core dependency resolution) called `extension::build::run_component` to rebuild a component after a dependency update — genuine extension execution (`build::run_component` drives the `ExtensionRunner` through the Build capability).

## The inversion
Mirrors the component-script hook (#8899): core defines a `ComponentBuildRunner` trait in `crate::component_build_provider` returning `(serde_json::Value, i32)`.

Key simplification: `deps.rs` never inspects `BuildResult`'s internals — it just serializes the result to stdout and gates on the exit code. So the hook returns the **pre-serialized JSON + exit code**, and no `BuildResult` result-type move is needed.

The extension layer registers `ExtensionComponentBuildRunner` at CLI startup. With no provider registered, callers get a clean not-supported error.

## Impact
`deps.rs` now has **zero extension-behavior references**. This clears the third of the four edges that block the wholesale `homeboy-extension` git-mv (after `is_git_url`/`check_update_available` in #8904). The last one is the `deps_provider` `ExtensionRunner` execution path.

## Tests
- `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-fuzz`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)