### PR TITLE
refactor: route deps-provider extension execution through the component-script hook (last edge)

### DIFF
--- a/crates/homeboy-core/src/component_script_provider.rs
+++ b/crates/homeboy-core/src/component_script_provider.rs
@@ -45,6 +45,16 @@ pub trait ComponentScriptRunner: Send + Sync {
         extra_env: &[(String, String)],
         script_args: &[String],
     ) -> Result<ComponentScriptOutput>;
+
+    /// Run a pre-resolved extension execution context against a component.
+    /// Used by dependency-provider extensions that carry their own context.
+    fn run_with_context(
+        &self,
+        context: &crate::extension_execution::ExtensionExecutionContext,
+        component: &Component,
+        path_override: Option<String>,
+        script_args: &[String],
+    ) -> Result<ComponentScriptOutput>;
 }
 
 fn provider_slot() -> &'static Mutex<Option<Box<dyn ComponentScriptRunner>>> {
@@ -59,6 +69,25 @@ pub fn register_component_script_runner(provider: Box<dyn ComponentScriptRunner>
         .lock()
         .expect("component script runner lock");
     *slot = Some(provider);
+}
+
+/// Run a pre-resolved execution context through the registered provider.
+pub fn run_with_context(
+    context: &crate::extension_execution::ExtensionExecutionContext,
+    component: &Component,
+    path_override: Option<String>,
+    script_args: &[String],
+) -> Result<ComponentScriptOutput> {
+    let slot = provider_slot()
+        .lock()
+        .expect("component script runner lock");
+    match slot.as_deref() {
+        Some(provider) => provider.run_with_context(context, component, path_override, script_args),
+        None => Err(Error::internal_io(
+            "no component-script runner registered; the extension subsystem is not available",
+            None,
+        )),
+    }
 }
 
 /// Run a component's scripts for a capability through the registered provider.

--- a/crates/homeboy-core/src/deps_provider.rs
+++ b/crates/homeboy-core/src/deps_provider.rs
@@ -1,7 +1,8 @@
 use crate::component::Component;
 use crate::deps::{DependencyCommandResult, DependencyPackage, DependencyUpdateResult};
-use crate::extension::{self, ExtensionCapability, ExtensionExecutionContext};
+use crate::extension_execution::ExtensionExecutionContext;
 use crate::{paths, Error, Result};
+use homeboy_extension_contract::ExtensionCapability;
 use serde::Deserialize;
 use std::collections::{BTreeSet, HashSet};
 use std::fs;
@@ -227,9 +228,10 @@ pub(crate) fn resolve_dependency_providers_optional(
         .map(|extensions| !extensions.is_empty())
         .unwrap_or(false)
     {
-        if let Some(context) =
-            extension::resolve_execution_context_if_available(component, ExtensionCapability::Deps)?
-        {
+        if let Some(context) = crate::extension_execution::resolve_execution_context_if_available(
+            component,
+            ExtensionCapability::Deps,
+        )? {
             providers.push(DependencyProvider::Extension(Box::new(
                 ExtensionDependencyProvider { context },
             )));
@@ -1117,14 +1119,13 @@ impl ExtensionDependencyProvider {
         component: &Component,
         path: &Path,
         args: &[String],
-    ) -> Result<crate::extension::RunnerOutput> {
-        crate::extension::ExtensionRunner::for_context(self.context.clone())
-            .component(component.clone())
-            .path_override(Some(path.display().to_string()))
-            .working_dir(&path.display().to_string())
-            .passthrough(false)
-            .script_args(args)
-            .run()
+    ) -> Result<crate::component_script_provider::ComponentScriptOutput> {
+        crate::component_script_provider::run_with_context(
+            &self.context,
+            component,
+            Some(path.display().to_string()),
+            args,
+        )
     }
 }
 
@@ -1321,8 +1322,8 @@ fn first_non_empty_line(output: &str) -> Option<&str> {
 mod tests {
     use super::*;
     use crate::component::Component;
-    use crate::extension::ExtensionCapability;
     use crate::paths;
+    use homeboy_extension_contract::ExtensionCapability;
     use std::fs;
     use tempfile::tempdir;
 
@@ -1362,7 +1363,7 @@ esac
             None,
         );
         let provider = ExtensionDependencyProvider {
-            context: crate::extension::ExtensionExecutionContext {
+            context: crate::extension_execution::ExtensionExecutionContext {
                 component: component.clone(),
                 capability: ExtensionCapability::Deps,
                 extension_id: "fixture-deps".to_string(),

--- a/crates/homeboy-core/src/extension/component_script.rs
+++ b/crates/homeboy-core/src/extension/component_script.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use super::runner::ExtensionRunner;
 use crate::component::Component;
 pub use crate::component_script_provider::ComponentScriptOutput;
 use crate::engine::invocation::{InvocationGuard, InvocationRequirements};
@@ -305,6 +306,23 @@ impl crate::component_script_provider::ComponentScriptRunner for ExtensionCompon
             extra_env,
             script_args,
         )
+    }
+
+    fn run_with_context(
+        &self,
+        context: &crate::extension_execution::ExtensionExecutionContext,
+        component: &crate::component::Component,
+        path_override: Option<String>,
+        script_args: &[String],
+    ) -> crate::Result<ComponentScriptOutput> {
+        let mut runner = ExtensionRunner::for_context(context.clone())
+            .component(component.clone())
+            .passthrough(false)
+            .script_args(script_args);
+        if let Some(path) = path_override {
+            runner = runner.path_override(Some(path.clone())).working_dir(&path);
+        }
+        Ok(runner.run()?.into())
     }
 }
 


### PR DESCRIPTION
## Summary
Extension-crate extraction prep — the `deps_provider` `ExtensionRunner` edge, the last genuine core→extension behavior edge.

`ExtensionDependencyProvider` (core dependency resolution) held a resolved `ExtensionExecutionContext` and called `ExtensionRunner::for_context(ctx).run()` directly, returning extension's `RunnerOutput`.

## The inversion
Extends the existing `ComponentScriptRunner` hook (#8899) with a `run_with_context` method: core passes the pre-resolved `ExtensionExecutionContext` (already a core type via `extension_execution`) + component/path/args; the extension provider runs the `ExtensionRunner` and returns the core-owned `ComponentScriptOutput` — which has exactly the `stdout`/`stderr`/`success`/`exit_code` the deps callers use (`RunnerOutput` was structurally identical, so no separate type move needed).

## Impact
`deps_provider` now uses `crate::component_script_provider::run_with_context` and `ExtensionExecutionContext` from `crate::extension_execution` — **zero `crate::extension` references**.

Combined with the build hook (#8910) and the util relocations (#8904), this clears the **last of the core→extension behavior edges**. The wholesale `homeboy-extension` git-mv is now fully unblocked.

## Tests
- `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-code-audit`, bin clean on `--lib`.
- (`deps.rs`'s `build` edge is cleared by #8910, which is not yet on this base.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)