### PR TITLE
Bound durable daemon terminal-job retention

### DIFF
--- a/crates/homeboy-core/src/api_jobs/persistence.rs
+++ b/crates/homeboy-core/src/api_jobs/persistence.rs
@@ -1,7 +1,9 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
@@ -11,6 +13,17 @@ use super::types::{JobEvent, JobEventKind, JobStatus};
 use crate::error::{Error, Result};
 
 pub(super) const DEFAULT_EVENT_RETENTION_LIMIT: usize = 1000;
+/// Keep enough completed jobs for status and log reconciliation without letting
+/// the daemon's append-only store grow with every historical execution.
+pub(super) const DEFAULT_TERMINAL_JOB_RETENTION_LIMIT: usize = 1000;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct JobStoreCompactionEvidence {
+    pub(super) timestamp_ms: u64,
+    pub(super) removed_terminal_jobs: usize,
+    pub(super) retained_terminal_jobs: usize,
+    pub(super) active_jobs: usize,
+}
 
 pub(super) fn request_metadata_string(
     request: &RemoteRunnerJobRequest,
@@ -102,6 +115,53 @@ pub(super) fn write_durable_store(path: &Path, durable: &DurableJobStore) -> Res
             )),
         )
     })
+}
+
+pub(super) fn compact_terminal_jobs(
+    durable: &mut DurableJobStore,
+    terminal_job_retention_limit: usize,
+) -> Option<JobStoreCompactionEvidence> {
+    let mut terminal = durable
+        .jobs
+        .iter()
+        .filter(|stored| stored.job.status.is_terminal())
+        .collect::<Vec<_>>();
+    if terminal.len() <= terminal_job_retention_limit {
+        return None;
+    }
+
+    terminal.sort_unstable_by_key(|stored| {
+        (
+            stored
+                .job
+                .finished_at_ms
+                .unwrap_or(stored.job.updated_at_ms),
+            stored.job.updated_at_ms,
+            stored.job.created_at_ms,
+            stored.job.id,
+        )
+    });
+    let removed_job_ids = terminal
+        .iter()
+        .take(terminal.len() - terminal_job_retention_limit)
+        .map(|stored| stored.job.id)
+        .collect::<HashSet<_>>();
+    let removed_terminal_jobs = removed_job_ids.len();
+    durable
+        .jobs
+        .retain(|stored| !removed_job_ids.contains(&stored.job.id));
+    let evidence = JobStoreCompactionEvidence {
+        timestamp_ms: timestamp_ms(),
+        removed_terminal_jobs,
+        retained_terminal_jobs: terminal_job_retention_limit,
+        active_jobs: durable.jobs.len() - terminal_job_retention_limit,
+    };
+    durable.compaction = Some(evidence.clone());
+    eprintln!(
+        "Homeboy compacted daemon job store: removed {} terminal jobs; retained {} terminal and {} active jobs",
+        evidence.removed_terminal_jobs, evidence.retained_terminal_jobs, evidence.active_jobs,
+    );
+    Some(evidence)
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/api_jobs/store.rs
+++ b/crates/homeboy-core/src/api_jobs/store.rs
@@ -10,9 +10,10 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use super::persistence::{
-    apply_event_retention, job_not_found, recovered_terminal_from_result,
+    apply_event_retention, compact_terminal_jobs, job_not_found, recovered_terminal_from_result,
     stale_after_restart_classification, timestamp_ms, validate_transition, write_durable_store,
-    DEFAULT_EVENT_RETENTION_LIMIT,
+    JobStoreCompactionEvidence, DEFAULT_EVENT_RETENTION_LIMIT,
+    DEFAULT_TERMINAL_JOB_RETENTION_LIMIT,
 };
 #[cfg(test)]
 use super::persistence::{read_durable_store, reconcile_stale_jobs};
@@ -44,11 +45,13 @@ pub struct JobStore {
 pub(super) struct JobStorePersistence {
     pub(super) path: PathBuf,
     pub(super) event_retention_limit: usize,
+    pub(super) terminal_job_retention_limit: usize,
 }
 
 #[derive(Debug, Default)]
 pub(super) struct JobStoreInner {
     pub(super) jobs: HashMap<Uuid, StoredJob>,
+    pub(super) compaction: Option<JobStoreCompactionEvidence>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -103,6 +106,8 @@ pub(crate) enum LocalChildStartDiscriminator {
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub(super) struct DurableJobStore {
     pub(super) jobs: Vec<StoredJob>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) compaction: Option<JobStoreCompactionEvidence>,
 }
 
 #[derive(Debug)]
@@ -141,7 +146,11 @@ impl JobStore {
 
     #[cfg(test)]
     pub(crate) fn open(path: impl Into<PathBuf>) -> Result<Self> {
-        Self::open_with_event_retention(path, DEFAULT_EVENT_RETENTION_LIMIT)
+        Self::open_with_retention(
+            path,
+            DEFAULT_EVENT_RETENTION_LIMIT,
+            DEFAULT_TERMINAL_JOB_RETENTION_LIMIT,
+        )
     }
 
     #[cfg(test)]
@@ -149,10 +158,25 @@ impl JobStore {
         path: impl Into<PathBuf>,
         event_retention_limit: usize,
     ) -> Result<Self> {
+        Self::open_with_retention(
+            path,
+            event_retention_limit,
+            DEFAULT_TERMINAL_JOB_RETENTION_LIMIT,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn open_with_retention(
+        path: impl Into<PathBuf>,
+        event_retention_limit: usize,
+        terminal_job_retention_limit: usize,
+    ) -> Result<Self> {
         let path = path.into();
         let mut durable = read_durable_store(&path)?;
         let event_retention_limit = event_retention_limit.max(1);
+        let terminal_job_retention_limit = terminal_job_retention_limit.max(1);
         let next_sequence = reconcile_stale_jobs(&mut durable, event_retention_limit);
+        compact_terminal_jobs(&mut durable, terminal_job_retention_limit);
         let store = Self {
             inner: Arc::new(Mutex::new(JobStoreInner {
                 jobs: durable
@@ -160,11 +184,13 @@ impl JobStore {
                     .into_iter()
                     .map(|stored| (stored.job.id, stored))
                     .collect(),
+                compaction: durable.compaction,
             })),
             next_event_sequence: Arc::new(AtomicU64::new(next_sequence)),
             persistence: Some(Arc::new(JobStorePersistence {
                 path,
                 event_retention_limit,
+                terminal_job_retention_limit,
             })),
             daemon_lease_id: None,
         };
@@ -197,30 +223,81 @@ impl JobStore {
         path: impl Into<PathBuf>,
         raw: &[u8],
     ) -> Result<Self> {
+        Self::open_without_reconciliation_from_bytes_with_retention(
+            path,
+            raw,
+            DEFAULT_EVENT_RETENTION_LIMIT,
+            DEFAULT_TERMINAL_JOB_RETENTION_LIMIT,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn open_without_reconciliation_with_retention(
+        path: impl Into<PathBuf>,
+        event_retention_limit: usize,
+        terminal_job_retention_limit: usize,
+    ) -> Result<Self> {
         let path = path.into();
-        let durable: DurableJobStore = serde_json::from_slice(raw)
+        let raw = fs::read(&path).unwrap_or_else(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                b"{\"jobs\":[]}".to_vec()
+            } else {
+                Vec::new()
+            }
+        });
+        if raw.is_empty() && path.exists() {
+            return Err(Error::internal_io(
+                "read durable job store",
+                Some(path.display().to_string()),
+            ));
+        }
+        Self::open_without_reconciliation_from_bytes_with_retention(
+            path,
+            &raw,
+            event_retention_limit,
+            terminal_job_retention_limit,
+        )
+    }
+
+    fn open_without_reconciliation_from_bytes_with_retention(
+        path: impl Into<PathBuf>,
+        raw: &[u8],
+        event_retention_limit: usize,
+        terminal_job_retention_limit: usize,
+    ) -> Result<Self> {
+        let path = path.into();
+        let mut durable: DurableJobStore = serde_json::from_slice(raw)
             .map_err(|err| Error::config_invalid_json(path.display().to_string(), err))?;
+        let event_retention_limit = event_retention_limit.max(1);
+        let terminal_job_retention_limit = terminal_job_retention_limit.max(1);
+        let compacted = compact_terminal_jobs(&mut durable, terminal_job_retention_limit);
         let next_sequence = durable
             .jobs
             .iter()
             .flat_map(|stored| stored.events.iter().map(|event| event.sequence))
             .max()
             .unwrap_or(0);
-        Ok(Self {
+        let store = Self {
             inner: Arc::new(Mutex::new(JobStoreInner {
                 jobs: durable
                     .jobs
                     .into_iter()
                     .map(|stored| (stored.job.id, stored))
                     .collect(),
+                compaction: durable.compaction,
             })),
             next_event_sequence: Arc::new(AtomicU64::new(next_sequence)),
             persistence: Some(Arc::new(JobStorePersistence {
                 path,
-                event_retention_limit: DEFAULT_EVENT_RETENTION_LIMIT,
+                event_retention_limit,
+                terminal_job_retention_limit,
             })),
             daemon_lease_id: None,
-        })
+        };
+        if compacted.is_some() {
+            store.persist()?;
+        }
+        Ok(store)
     }
 
     pub(crate) fn with_daemon_lease(mut self, daemon_lease_id: String) -> Self {
@@ -1432,12 +1509,24 @@ impl JobStore {
         });
         stored.job.event_count = stored.events.len();
         if let Some(persistence) = &self.persistence {
-            let durable = DurableJobStore {
+            let mut durable = DurableJobStore {
                 jobs: inner.jobs.values().cloned().collect(),
+                compaction: inner.compaction.clone(),
             };
+            let compacted =
+                compact_terminal_jobs(&mut durable, persistence.terminal_job_retention_limit);
             if let Err(error) = write_durable_store(&persistence.path, &durable) {
                 inner.jobs.insert(job_id, prior);
                 return Err(error);
+            }
+            if compacted.is_some() {
+                inner.jobs = durable
+                    .jobs
+                    .iter()
+                    .cloned()
+                    .map(|stored| (stored.job.id, stored))
+                    .collect();
+                inner.compaction = durable.compaction;
             }
         }
         Ok(())
@@ -1693,12 +1782,24 @@ impl JobStore {
         };
 
         if let Some(persistence) = &self.persistence {
-            let durable = DurableJobStore {
+            let mut durable = DurableJobStore {
                 jobs: inner.jobs.values().cloned().collect(),
+                compaction: inner.compaction.clone(),
             };
+            let compacted =
+                compact_terminal_jobs(&mut durable, persistence.terminal_job_retention_limit);
             if let Err(error) = write_durable_store(&persistence.path, &durable) {
                 *inner.jobs.get_mut(&job_id).expect("job exists") = prior;
                 return Err(error);
+            }
+            if compacted.is_some() {
+                inner.jobs = durable
+                    .jobs
+                    .iter()
+                    .cloned()
+                    .map(|stored| (stored.job.id, stored))
+                    .collect();
+                inner.compaction = durable.compaction;
             }
         }
         Ok(started)
@@ -1755,19 +1856,35 @@ impl JobStore {
             .unwrap_or(usize::MAX)
     }
 
+    fn terminal_job_retention_limit(&self) -> usize {
+        self.persistence
+            .as_ref()
+            .map(|persistence| persistence.terminal_job_retention_limit)
+            .unwrap_or(usize::MAX)
+    }
+
     pub(super) fn persist(&self) -> Result<()> {
         let Some(persistence) = &self.persistence else {
             return Ok(());
         };
 
-        let durable = {
-            let inner = self.inner.lock().expect("job store mutex poisoned");
-            DurableJobStore {
-                jobs: inner.jobs.values().cloned().collect(),
-            }
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let mut durable = DurableJobStore {
+            jobs: inner.jobs.values().cloned().collect(),
+            compaction: inner.compaction.clone(),
         };
-
-        write_durable_store(&persistence.path, &durable)
+        let compacted = compact_terminal_jobs(&mut durable, self.terminal_job_retention_limit());
+        write_durable_store(&persistence.path, &durable)?;
+        if compacted.is_some() {
+            inner.jobs = durable
+                .jobs
+                .iter()
+                .cloned()
+                .map(|stored| (stored.job.id, stored))
+                .collect();
+            inner.compaction = durable.compaction;
+        }
+        Ok(())
     }
 }
 

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -779,6 +779,71 @@ fn test_open_with_event_retention() {
 }
 
 #[test]
+fn terminal_job_retention_compacts_existing_store_without_losing_active_recovery_evidence() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store opens");
+    let queued = store.create("queued");
+    let running = store.create("running");
+    store.start(running.id).expect("running job starts");
+    let terminal = (0..4)
+        .map(|_| {
+            let job = store.create("terminal");
+            store.start(job.id).expect("terminal job starts");
+            store
+                .complete(job.id, None)
+                .expect("terminal job completes");
+            job.id
+        })
+        .collect::<Vec<_>>();
+    {
+        let mut inner = store.inner.lock().expect("job store mutex poisoned");
+        for (index, job_id) in terminal.iter().enumerate() {
+            let stored = inner.jobs.get_mut(job_id).expect("terminal job exists");
+            let timestamp = (index as u64 + 1) * 100;
+            stored.job.created_at_ms = timestamp;
+            stored.job.updated_at_ms = timestamp;
+            stored.job.finished_at_ms = Some(timestamp);
+        }
+    }
+    store.persist().expect("seed store persists");
+
+    let compacted = JobStore::open_without_reconciliation_with_retention(&path, 3, 2)
+        .expect("existing store compacts on open");
+    assert!(compacted.get(queued.id).is_ok());
+    assert_eq!(
+        compacted.get(running.id).expect("running job").status,
+        JobStatus::Running
+    );
+    assert!(compacted.get(terminal[0]).is_err());
+    assert!(compacted.get(terminal[1]).is_err());
+    assert!(compacted.get(terminal[2]).is_ok());
+    assert!(compacted.get(terminal[3]).is_ok());
+
+    let persisted = fs::read_to_string(&path).expect("compacted store persists");
+    assert_eq!(persisted.matches("\"operation\": \"terminal\"").count(), 2);
+    assert!(persisted.contains("\"removed_terminal_jobs\": 2"));
+    assert!(persisted.contains("\"active_jobs\": 2"));
+
+    let restarted = JobStore::open_without_reconciliation_with_retention(&path, 3, 2)
+        .expect("compacted store restarts");
+    assert_eq!(restarted.list().len(), 4);
+    for _ in 0..5 {
+        let job = restarted.create("terminal");
+        restarted.start(job.id).expect("new terminal job starts");
+        restarted
+            .complete(job.id, None)
+            .expect("new terminal job completes");
+    }
+    assert_eq!(restarted.list().len(), 4, "terminal history stays bounded");
+    assert!(restarted.get(queued.id).is_ok());
+    assert_eq!(
+        restarted.get(running.id).expect("running job").status,
+        JobStatus::Running
+    );
+}
+
+#[test]
 fn remote_runner_job_submit_targets_runner_and_project() {
     let store = JobStore::default();
     let job = store


### PR DESCRIPTION
## Summary
Keep daemon job persistence bounded on long-lived runners without dropping active recovery state.

## What changed
- Retain all active jobs plus the newest 1,000 terminal jobs, compact before durable writes and on startup, and persist one bounded operator-visible compaction receipt.

## How to test
1. Run `cargo test -p homeboy-core api_jobs::tests --lib --quiet`; expect All 78 API-job tests pass, including active preservation, deterministic pruning, restart durability, and bounded subsequent growth..
2. Run `cargo check -p homeboy`; expect The full Homeboy binary and affected crates compile successfully..

## Compatibility
Recent terminal job logs remain available; older terminal daemon-job records are intentionally pruned, while run artifacts and every active recovery record are preserved.

## Evidence
- Base advanced after verification: verified main at decedfa52fd55a55c8372549ee5bf8b71e01f809; publication observed 30ed1920e2db1dab84cf2e361fe1c1b30fdeaf95. Candidate ancestry was validated against the verified snapshot.
- CI expected: Homeboy pull request CI
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8911
- Verified finalization base: main at decedfa52fd55a55c8372549ee5bf8b71e01f809
- affected-crate-checks: Passed
- api-job-tests: Passed
- diff-check: Passed
- formatting: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed unbounded daemon-store growth and drafted the bounded retention implementation and durability tests; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8911
