### PR TITLE
Persist declared release artifacts before packaging

### DIFF
--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -807,12 +807,12 @@ mod tests {
     }
 
     #[test]
-    fn run_package_collects_declared_component_artifact_alongside_provider_artifacts() {
+    fn run_package_persists_declared_component_artifact_before_provider_can_delete_it() {
         homeboy_core::test_support::with_isolated_home(|_| {
             let component_dir = tempfile::tempdir().expect("component tempdir");
             let package = release_package_extension(
                 "nodejs",
-                "mkdir -p target; printf npm > target/plugin-1.2.3.tgz; \
+                "rm -f packages/plugin/dist/plugin.zip; mkdir -p target; printf npm > target/plugin-1.2.3.tgz; \
                  printf '[{\"path\":\"target/plugin-1.2.3.tgz\",\"type\":\"npm\"}]'",
             );
             homeboy_core::extension::save_manifest(&package).expect("save package extension");
@@ -846,12 +846,20 @@ mod tests {
             .expect("package step should collect declared artifact");
 
             assert_eq!(state.artifacts.len(), 2);
-            assert_eq!(state.artifacts[0].path, "target/plugin-1.2.3.tgz");
-            assert_eq!(state.artifacts[1].path, "packages/plugin/dist/plugin.zip");
-            assert!(state.artifacts[1]
+            assert_eq!(state.artifacts[0].path, "packages/plugin/dist/plugin.zip");
+            assert_eq!(state.artifacts[1].path, "target/plugin-1.2.3.tgz");
+            assert!(!component_dir
+                .path()
+                .join("packages/plugin/dist/plugin.zip")
+                .exists());
+            let durable_path = state.artifacts[0]
                 .durable_path
                 .as_deref()
-                .is_some_and(|path| std::path::Path::new(path).is_file()));
+                .expect("declared durable artifact path");
+            assert_eq!(
+                std::fs::read_to_string(durable_path).expect("declared durable artifact bytes"),
+                "plugin"
+            );
             assert_eq!(
                 std::fs::read_to_string(component_dir.path().join(".homeboy-build-count"))
                     .expect("component build marker"),

--- a/crates/homeboy-release/src/release/executor/package.rs
+++ b/crates/homeboy-release/src/release/executor/package.rs
@@ -50,7 +50,16 @@ pub(crate) fn run_package(
         ));
     }
 
-    build_declared_component_artifact(component, declared_build_artifact)?;
+    let declared_artifact_built =
+        build_declared_component_artifact(component, declared_build_artifact)?;
+    if declared_artifact_built {
+        collect_declared_build_artifact(
+            state,
+            declared_build_artifact,
+            component_id,
+            component_local_path,
+        )?;
+    }
 
     let extra_config = package_build_config(skip_build_validation);
     let mut responses = Vec::new();
@@ -76,12 +85,14 @@ pub(crate) fn run_package(
         }));
     }
 
-    collect_declared_build_artifact(
-        state,
-        declared_build_artifact,
-        component_id,
-        component_local_path,
-    )?;
+    if !declared_artifact_built {
+        collect_declared_build_artifact(
+            state,
+            declared_build_artifact,
+            component_id,
+            component_local_path,
+        )?;
+    }
 
     let data = if responses.len() == 1 {
         let response = responses.pop().expect("single package response");
@@ -107,11 +118,11 @@ pub(crate) fn run_package(
 fn build_declared_component_artifact(
     component: &Component,
     declared_build_artifact: Option<&str>,
-) -> Result<()> {
+) -> Result<bool> {
     if declared_build_artifact.is_none_or(|path| path.trim().is_empty())
         || !component.has_script(ExtensionCapability::Build)
     {
-        return Ok(());
+        return Ok(false);
     }
 
     let (exit_code, build_error) = homeboy_core::build::build_component(component);
@@ -127,7 +138,7 @@ fn build_declared_component_artifact(
         ));
     }
 
-    Ok(())
+    Ok(true)
 }
 
 /// Add a component-owned deploy artifact even when its packaging provider also


### PR DESCRIPTION
## Summary
- persist component-built declared artifacts before package providers run
- retain post-provider collection for artifacts produced without a component build script
- cover providers deleting the original declared artifact while preserving its durable bytes

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-release release::executor::tests::run_package_`.
3. Confirm all eight release package tests pass, including `run_package_persists_declared_component_artifact_before_provider_can_delete_it`.

## Compatibility
No extension-path or backwards-compatibility impact. This preserves configured release artifacts across provider cleanup.

Closes #8906

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol and openai/gpt-5.6-terra
- **Used for:** Root-cause analysis, implementation, regression coverage, and deterministic verification; Chris reviewed and owns the change.