### PR TITLE
refactor: relocate extension readiness + hook hygiene build (final extraction prep)

### DIFF
--- a/crates/homeboy-core/src/component_build_provider.rs
+++ b/crates/homeboy-core/src/component_build_provider.rs
@@ -25,6 +25,10 @@ use crate::{Error, Result};
 pub trait ComponentBuildRunner: Send + Sync {
     /// Build the component. Returns `(json_result, exit_code)`.
     fn run_component_build(&self, component: &Component) -> Result<(Value, i32)>;
+
+    /// Whether the component has a resolvable build command (used to decide
+    /// if a dependency-build lifecycle step should run at all).
+    fn can_build(&self, component: &Component) -> bool;
 }
 
 fn provider_slot() -> &'static Mutex<Option<Box<dyn ComponentBuildRunner>>> {
@@ -37,6 +41,15 @@ fn provider_slot() -> &'static Mutex<Option<Box<dyn ComponentBuildRunner>>> {
 pub fn register_component_build_runner(provider: Box<dyn ComponentBuildRunner>) {
     let mut slot = provider_slot().lock().expect("component build runner lock");
     *slot = Some(provider);
+}
+
+/// Whether the registered provider can build the component.
+pub fn can_build(component: &Component) -> bool {
+    let slot = provider_slot().lock().expect("component build runner lock");
+    match slot.as_deref() {
+        Some(provider) => provider.can_build(component),
+        None => false,
+    }
 }
 
 /// Build a component through the registered provider. Returns

--- a/crates/homeboy-core/src/extension/build/mod.rs
+++ b/crates/homeboy-core/src/extension/build/mod.rs
@@ -968,6 +968,10 @@ impl crate::component_build_provider::ComponentBuildRunner for ExtensionComponen
         })?;
         Ok((value, exit_code))
     }
+
+    fn can_build(&self, component: &crate::component::Component) -> bool {
+        resolve_build_command(component).is_ok()
+    }
 }
 
 /// Register the extension component-build runner with core. Call once at

--- a/crates/homeboy-core/src/extension/execution.rs
+++ b/crates/homeboy-core/src/extension/execution.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use std::time::Duration;
 
 mod action;
-mod readiness;
+// readiness relocated to crate::extension_readiness (core glue)
 mod settings;
 
 use super::env_provider;
@@ -28,8 +28,10 @@ use super::runner_contract::RunnerStepFilter;
 use super::runtime_helper;
 use crate::extension_invocation_context::ResolvedExtensionInvocationContext;
 
+pub use crate::extension_readiness::{
+    extension_ready_status, is_extension_compatible, ExtensionReadyStatus,
+};
 pub use action::execute_action;
-pub use readiness::{extension_ready_status, is_extension_compatible, ExtensionReadyStatus};
 use settings::serialize_settings;
 pub(crate) use settings::{build_settings_json_from_manifest, load_extension_manifest_from_dir};
 

--- a/crates/homeboy-core/src/extension_readiness.rs
+++ b/crates/homeboy-core/src/extension_readiness.rs
@@ -4,7 +4,8 @@ use crate::project::Project;
 use crate::server::execute_local_command_in_dir;
 use homeboy_engine_primitives::template;
 
-use super::{load_extension, ExtensionManifest};
+use crate::extension_store::load_extension;
+use homeboy_extension_contract::ExtensionManifest;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ExtensionReadyStatus {

--- a/crates/homeboy-core/src/hygiene.rs
+++ b/crates/homeboy-core/src/hygiene.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use crate::component::{self, Component};
 use crate::deps::provider;
 use crate::error::{Error, ErrorCode, Result, ValidationErrorItem};
-use crate::extension::{build, ExtensionCapability};
+use crate::extension::ExtensionCapability;
 
 const LAB_SOURCE_EVIDENCE_FILE: &str = ".homeboy/lab-source-evidence.json";
 const DEPENDENCY_LIFECYCLE_ARTIFACT_DIR: &str = ".homeboy/dependency-lifecycle";
@@ -650,12 +650,12 @@ fn run_dependency_install_lifecycle(component: &Component, path: &Path) -> Resul
 
 fn run_dependency_build_lifecycle(component: &Component, path: &Path) -> Result<()> {
     if !component.has_script(ExtensionCapability::Build)
-        && build::resolve_build_command(component).is_err()
+        && !crate::component_build_provider::can_build(component)
     {
         return Ok(());
     }
 
-    let (result, exit_code) = build::run_component(component)?;
+    let (result, exit_code) = crate::component_build_provider::run_component_build(component)?;
     if exit_code == 0 {
         return Ok(());
     }

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -100,6 +100,7 @@ pub mod extension;
 pub mod extension_execution;
 pub mod extension_invocation_context;
 pub mod extension_provider_discovery;
+pub mod extension_readiness;
 pub mod extension_scope;
 pub mod extension_store;
 pub mod extension_update_check;


### PR DESCRIPTION
## Summary
The last two core→extension edges surfaced by attempting the wholesale `homeboy-extension` git-mv.

## 1. `extension_readiness` relocation
`execution/readiness.rs` → `crate::extension_readiness`. `is_extension_compatible` / `extension_ready_status` / `ExtensionReadyStatus` are **core glue** (deps `project`/`server`/`template`/`load_extension` + contract `ExtensionManifest`, no extension behavior). Only `context/report.rs` (core) consumes them. The extension module re-exports for path stability.

## 2. hygiene build hook
`hygiene.rs::run_dependency_build_lifecycle` called `extension::build::run_component` + `resolve_build_command` directly. Routes both through the `component_build_provider` hook (#8910), extended with a `can_build()` method for the buildability guard.

## Impact
**Core now has zero genuine extension-behavior references.** (The remaining `extension::resolve_execution_context` refs resolve to the core `extension_execution` module via re-export — not a real edge.)

With this, every core→extension edge is a contract type, a relocated-to-core glue module, or a provider hook. The wholesale `homeboy-extension` git-mv — 128 files becoming a crate depending one-directionally on core — is **fully unblocked**.

## Tests
- `homeboy-core`, `homeboy-cli` clean on `--lib` **and** `--tests`; `homeboy-lab-runner`, `homeboy-code-audit`, bin clean on `--lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)