### PR TITLE
fix: validate durable declared release artifacts

### DIFF
--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -865,7 +865,33 @@ mod tests {
                     .expect("component build marker"),
                 "built"
             );
+            github_release::validate_declared_build_artifact(&component, &state, false)
+                .expect("durably persisted declared artifact should satisfy GitHub Release");
         });
+    }
+
+    #[test]
+    fn github_release_rejects_declared_artifact_when_source_and_durable_bytes_are_missing() {
+        let component = Component {
+            build_artifact: Some("build/plugin.zip".to_string()),
+            ..Component::default()
+        };
+        let state = ReleaseState {
+            artifacts: vec![ReleaseArtifact {
+                path: "build/plugin.zip".to_string(),
+                durable_path: Some(".homeboy/artifacts/missing-plugin.zip".to_string()),
+                artifact_type: None,
+                platform: None,
+            }],
+            ..ReleaseState::default()
+        };
+
+        let error = github_release::validate_declared_build_artifact(&component, &state, false)
+            .expect_err("declared artifact with no source or durable bytes must fail");
+
+        assert!(error
+            .message
+            .contains("Configured build_artifact 'build/plugin.zip' is absent"));
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/executor/github_release/mod.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/mod.rs
@@ -18,6 +18,9 @@ mod tests;
 
 pub(crate) use run::run_github_release;
 
+#[cfg(test)]
+pub(crate) use run::validate_declared_build_artifact;
+
 // `gh` availability/auth/existence probes are reused by the sibling `tagging`
 // step to gate tag-availability preflight, so they are part of the module's
 // non-test surface.

--- a/crates/homeboy-release/src/release/executor/github_release/run.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/run.rs
@@ -6,8 +6,7 @@ use homeboy_core::error::{Error, Result};
 
 use super::super::step_success;
 use super::gh_cli::{
-    gh_command, gh_is_authenticated, gh_is_available, gh_release_exists,
-    github_release_artifact_paths, github_release_asset_paths,
+    gh_command, gh_is_authenticated, gh_is_available, gh_release_exists, github_release_asset_paths,
 };
 use super::notes::{
     build_github_release_body, github_changelog_url, github_release_notes_start_tag,
@@ -448,11 +447,17 @@ pub(crate) fn validate_declared_build_artifact(
                 None,
             )
         })?;
-    let is_collected = github_release_artifact_paths(state).iter().any(|path| {
-        std::path::Path::new(path)
+    let is_collected = state.artifacts.iter().any(|artifact| {
+        let has_declared_identity = std::path::Path::new(&artifact.path)
             .file_name()
             .and_then(|name| name.to_str())
-            == Some(expected_name)
+            == Some(expected_name);
+        let has_bytes = std::path::Path::new(&artifact.path).is_file()
+            || artifact
+                .durable_path
+                .as_deref()
+                .is_some_and(|path| std::path::Path::new(path).is_file());
+        has_declared_identity && has_bytes
     });
     if is_collected {
         return Ok(());


### PR DESCRIPTION
## Summary
Closes #8919.

GitHub Release validation now matches the configured declared artifact against its persisted `ReleaseArtifact.path` identity, while accepting it only when either the original source file or its durable copy still exists. This keeps the durable upload path independent from the declared filename.

## Evidence
- Source relationship: #8919 reproduces the post-#8914 contract, where `release.package` removes a component-declared source after #8914 has persisted its bytes.
- Change kind: narrow generic validation correction in `homeboy-release`; no provider, WordPress, or component-specific behavior.
- Scope: preserves provider-only artifact handling and continues to fail a declared artifact when neither its source nor durable bytes exist.
- Why runtime change is bounded: only validation identity changes from the selected upload path to existing artifact metadata; upload selection, package ordering, and provider output remain unchanged.

## Compatibility
No configuration or API changes. Existing releases still validate declared artifacts by filename; releases whose durable copy has a different stored filename now validate correctly after source cleanup.

## Verification
1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-release release::executor::tests::` (35 passed).
3. Run `cargo test -p homeboy-release release::executor::github_release::` (33 passed).

The regression performs the package build, lets the provider delete the declared source, verifies the durable bytes, then invokes GitHub Release declared-artifact validation. A complementary test verifies that validation fails when both source and durable bytes are absent.

## AI Disclosure
Implemented with OpenAI GPT-5.6-terra assistance; changes and verification results were reviewed in the managed worktree.