### PR TITLE
Match durable declared artifacts during GitHub Release validation

### DIFF
--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -865,7 +865,33 @@ mod tests {
                     .expect("component build marker"),
                 "built"
             );
+            github_release::validate_declared_build_artifact(&component, &state, false)
+                .expect("durably persisted declared artifact should satisfy GitHub Release");
         });
+    }
+
+    #[test]
+    fn github_release_rejects_declared_artifact_when_source_and_durable_bytes_are_missing() {
+        let component = Component {
+            build_artifact: Some("build/plugin.zip".to_string()),
+            ..Component::default()
+        };
+        let state = ReleaseState {
+            artifacts: vec![ReleaseArtifact {
+                path: "build/plugin.zip".to_string(),
+                durable_path: Some(".homeboy/artifacts/missing-plugin.zip".to_string()),
+                artifact_type: None,
+                platform: None,
+            }],
+            ..ReleaseState::default()
+        };
+
+        let error = github_release::validate_declared_build_artifact(&component, &state, false)
+            .expect_err("declared artifact with no source or durable bytes must fail");
+
+        assert!(error
+            .message
+            .contains("Configured build_artifact 'build/plugin.zip' is absent"));
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/executor/github_release/mod.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/mod.rs
@@ -18,6 +18,9 @@ mod tests;
 
 pub(crate) use run::run_github_release;
 
+#[cfg(test)]
+pub(crate) use run::validate_declared_build_artifact;
+
 // `gh` availability/auth/existence probes are reused by the sibling `tagging`
 // step to gate tag-availability preflight, so they are part of the module's
 // non-test surface.

--- a/crates/homeboy-release/src/release/executor/github_release/run.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/run.rs
@@ -6,8 +6,7 @@ use homeboy_core::error::{Error, Result};
 
 use super::super::step_success;
 use super::gh_cli::{
-    gh_command, gh_is_authenticated, gh_is_available, gh_release_exists,
-    github_release_artifact_paths, github_release_asset_paths,
+    gh_command, gh_is_authenticated, gh_is_available, gh_release_exists, github_release_asset_paths,
 };
 use super::notes::{
     build_github_release_body, github_changelog_url, github_release_notes_start_tag,
@@ -448,11 +447,17 @@ pub(crate) fn validate_declared_build_artifact(
                 None,
             )
         })?;
-    let is_collected = github_release_artifact_paths(state).iter().any(|path| {
-        std::path::Path::new(path)
+    let is_collected = state.artifacts.iter().any(|artifact| {
+        let has_declared_identity = std::path::Path::new(&artifact.path)
             .file_name()
             .and_then(|name| name.to_str())
-            == Some(expected_name)
+            == Some(expected_name);
+        let has_bytes = std::path::Path::new(&artifact.path).is_file()
+            || artifact
+                .durable_path
+                .as_deref()
+                .is_some_and(|path| std::path::Path::new(path).is_file());
+        has_declared_identity && has_bytes
     });
     if is_collected {
         return Ok(());


### PR DESCRIPTION
## Summary
Recognize declared release artifacts through their logical path and durable persisted bytes after provider cleanup.

## What changed
- Validate the declared artifact against release-state metadata, accepting readable source or durable bytes while preserving failure when both are absent.

## How to test
1. Run `cargo test -p homeboy-release release::executor::tests::run_package_`; expect All eight package tests pass, including provider deletion after durable persistence..
2. Run `cargo test -p homeboy-release github_release`; expect All 51 GitHub Release tests pass, including durable success and missing-byte rejection..

## Compatibility
No extension-path or backwards-compatibility impact; this corrects validation of existing ReleaseArtifact durable\_path metadata.

## Evidence
- Base advanced after verification: verified main at 07d46d7075a46555dab45f610e22a3c49615b275; publication observed 589f8af71a1ef5298f09781dfd4b30cb2a565b36. Candidate ancestry was validated against the verified snapshot.
- Durable run execution: Succeeded
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8919
- Verified finalization base: main at 07d46d7075a46555dab45f610e22a3c49615b275
- gate-1: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Investigated, implemented, and verified durable declared-artifact validation; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#8919
