### PR TITLE
Bound daemon job persistence by serialized size

### DIFF
--- a/crates/homeboy-core/src/api_jobs/persistence.rs
+++ b/crates/homeboy-core/src/api_jobs/persistence.rs
@@ -16,12 +16,16 @@ pub(super) const DEFAULT_EVENT_RETENTION_LIMIT: usize = 1000;
 /// Keep enough completed jobs for status and log reconciliation without letting
 /// the daemon's append-only store grow with every historical execution.
 pub(super) const DEFAULT_TERMINAL_JOB_RETENTION_LIMIT: usize = 1000;
+/// Bound terminal history independently of active jobs, whose recovery records
+/// must remain durable until they reach a terminal state.
+pub(super) const DEFAULT_TERMINAL_JOB_RETENTION_BYTES: usize = 4 * 1024 * 1024;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct JobStoreCompactionEvidence {
     pub(super) timestamp_ms: u64,
     pub(super) removed_terminal_jobs: usize,
     pub(super) retained_terminal_jobs: usize,
+    pub(super) retained_terminal_bytes: usize,
     pub(super) active_jobs: usize,
 }
 
@@ -119,18 +123,37 @@ pub(super) fn write_durable_store(path: &Path, durable: &DurableJobStore) -> Res
 
 pub(super) fn compact_terminal_jobs(
     durable: &mut DurableJobStore,
+    event_retention_limit: usize,
     terminal_job_retention_limit: usize,
+    terminal_job_retention_bytes: usize,
 ) -> Option<JobStoreCompactionEvidence> {
+    for stored in &mut durable.jobs {
+        apply_event_retention(&mut stored.events, event_retention_limit);
+        stored.job.event_count = stored.events.len();
+    }
     let mut terminal = durable
         .jobs
         .iter()
         .filter(|stored| stored.job.status.is_terminal())
+        .map(|stored| {
+            let serialized_len = serde_json::to_vec(stored)
+                .expect("stored daemon job must serialize")
+                .len();
+            (stored, serialized_len)
+        })
         .collect::<Vec<_>>();
-    if terminal.len() <= terminal_job_retention_limit {
+    let original_terminal_count = terminal.len();
+    let original_terminal_bytes = terminal
+        .iter()
+        .map(|(_, serialized_len)| serialized_len)
+        .sum::<usize>();
+    if original_terminal_count <= terminal_job_retention_limit
+        && original_terminal_bytes <= terminal_job_retention_bytes
+    {
         return None;
     }
 
-    terminal.sort_unstable_by_key(|stored| {
+    terminal.sort_unstable_by_key(|(stored, _)| {
         (
             stored
                 .job
@@ -141,11 +164,19 @@ pub(super) fn compact_terminal_jobs(
             stored.job.id,
         )
     });
-    let removed_job_ids = terminal
-        .iter()
-        .take(terminal.len() - terminal_job_retention_limit)
-        .map(|stored| stored.job.id)
-        .collect::<HashSet<_>>();
+    let mut retained_terminal_jobs = original_terminal_count;
+    let mut retained_terminal_bytes = original_terminal_bytes;
+    let mut removed_job_ids = HashSet::new();
+    for (stored, serialized_len) in terminal {
+        if retained_terminal_jobs <= terminal_job_retention_limit
+            && retained_terminal_bytes <= terminal_job_retention_bytes
+        {
+            break;
+        }
+        removed_job_ids.insert(stored.job.id);
+        retained_terminal_jobs -= 1;
+        retained_terminal_bytes -= serialized_len;
+    }
     let removed_terminal_jobs = removed_job_ids.len();
     durable
         .jobs
@@ -153,13 +184,17 @@ pub(super) fn compact_terminal_jobs(
     let evidence = JobStoreCompactionEvidence {
         timestamp_ms: timestamp_ms(),
         removed_terminal_jobs,
-        retained_terminal_jobs: terminal_job_retention_limit,
-        active_jobs: durable.jobs.len() - terminal_job_retention_limit,
+        retained_terminal_jobs,
+        retained_terminal_bytes,
+        active_jobs: durable.jobs.len() - retained_terminal_jobs,
     };
     durable.compaction = Some(evidence.clone());
     eprintln!(
-        "Homeboy compacted daemon job store: removed {} terminal jobs; retained {} terminal and {} active jobs",
-        evidence.removed_terminal_jobs, evidence.retained_terminal_jobs, evidence.active_jobs,
+        "Homeboy compacted daemon job store: removed {} terminal jobs; retained {} terminal jobs ({} bytes) and {} active jobs",
+        evidence.removed_terminal_jobs,
+        evidence.retained_terminal_jobs,
+        evidence.retained_terminal_bytes,
+        evidence.active_jobs,
     );
     Some(evidence)
 }

--- a/crates/homeboy-core/src/api_jobs/store.rs
+++ b/crates/homeboy-core/src/api_jobs/store.rs
@@ -13,7 +13,7 @@ use super::persistence::{
     apply_event_retention, compact_terminal_jobs, job_not_found, recovered_terminal_from_result,
     stale_after_restart_classification, timestamp_ms, validate_transition, write_durable_store,
     JobStoreCompactionEvidence, DEFAULT_EVENT_RETENTION_LIMIT,
-    DEFAULT_TERMINAL_JOB_RETENTION_LIMIT,
+    DEFAULT_TERMINAL_JOB_RETENTION_BYTES, DEFAULT_TERMINAL_JOB_RETENTION_LIMIT,
 };
 #[cfg(test)]
 use super::persistence::{read_durable_store, reconcile_stale_jobs};
@@ -46,6 +46,7 @@ pub(super) struct JobStorePersistence {
     pub(super) path: PathBuf,
     pub(super) event_retention_limit: usize,
     pub(super) terminal_job_retention_limit: usize,
+    pub(super) terminal_job_retention_bytes: usize,
 }
 
 #[derive(Debug, Default)]
@@ -171,12 +172,33 @@ impl JobStore {
         event_retention_limit: usize,
         terminal_job_retention_limit: usize,
     ) -> Result<Self> {
+        Self::open_with_retention_and_terminal_byte_limit(
+            path,
+            event_retention_limit,
+            terminal_job_retention_limit,
+            DEFAULT_TERMINAL_JOB_RETENTION_BYTES,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn open_with_retention_and_terminal_byte_limit(
+        path: impl Into<PathBuf>,
+        event_retention_limit: usize,
+        terminal_job_retention_limit: usize,
+        terminal_job_retention_bytes: usize,
+    ) -> Result<Self> {
         let path = path.into();
         let mut durable = read_durable_store(&path)?;
         let event_retention_limit = event_retention_limit.max(1);
         let terminal_job_retention_limit = terminal_job_retention_limit.max(1);
+        let terminal_job_retention_bytes = terminal_job_retention_bytes.max(1);
         let next_sequence = reconcile_stale_jobs(&mut durable, event_retention_limit);
-        compact_terminal_jobs(&mut durable, terminal_job_retention_limit);
+        compact_terminal_jobs(
+            &mut durable,
+            event_retention_limit,
+            terminal_job_retention_limit,
+            terminal_job_retention_bytes,
+        );
         let store = Self {
             inner: Arc::new(Mutex::new(JobStoreInner {
                 jobs: durable
@@ -191,6 +213,7 @@ impl JobStore {
                 path,
                 event_retention_limit,
                 terminal_job_retention_limit,
+                terminal_job_retention_bytes,
             })),
             daemon_lease_id: None,
         };
@@ -228,6 +251,7 @@ impl JobStore {
             raw,
             DEFAULT_EVENT_RETENTION_LIMIT,
             DEFAULT_TERMINAL_JOB_RETENTION_LIMIT,
+            DEFAULT_TERMINAL_JOB_RETENTION_BYTES,
         )
     }
 
@@ -236,6 +260,21 @@ impl JobStore {
         path: impl Into<PathBuf>,
         event_retention_limit: usize,
         terminal_job_retention_limit: usize,
+    ) -> Result<Self> {
+        Self::open_without_reconciliation_with_retention_and_terminal_byte_limit(
+            path,
+            event_retention_limit,
+            terminal_job_retention_limit,
+            DEFAULT_TERMINAL_JOB_RETENTION_BYTES,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn open_without_reconciliation_with_retention_and_terminal_byte_limit(
+        path: impl Into<PathBuf>,
+        event_retention_limit: usize,
+        terminal_job_retention_limit: usize,
+        terminal_job_retention_bytes: usize,
     ) -> Result<Self> {
         let path = path.into();
         let raw = fs::read(&path).unwrap_or_else(|error| {
@@ -256,6 +295,7 @@ impl JobStore {
             &raw,
             event_retention_limit,
             terminal_job_retention_limit,
+            terminal_job_retention_bytes,
         )
     }
 
@@ -264,13 +304,20 @@ impl JobStore {
         raw: &[u8],
         event_retention_limit: usize,
         terminal_job_retention_limit: usize,
+        terminal_job_retention_bytes: usize,
     ) -> Result<Self> {
         let path = path.into();
         let mut durable: DurableJobStore = serde_json::from_slice(raw)
             .map_err(|err| Error::config_invalid_json(path.display().to_string(), err))?;
         let event_retention_limit = event_retention_limit.max(1);
         let terminal_job_retention_limit = terminal_job_retention_limit.max(1);
-        let compacted = compact_terminal_jobs(&mut durable, terminal_job_retention_limit);
+        let terminal_job_retention_bytes = terminal_job_retention_bytes.max(1);
+        compact_terminal_jobs(
+            &mut durable,
+            event_retention_limit,
+            terminal_job_retention_limit,
+            terminal_job_retention_bytes,
+        );
         let next_sequence = durable
             .jobs
             .iter()
@@ -291,12 +338,11 @@ impl JobStore {
                 path,
                 event_retention_limit,
                 terminal_job_retention_limit,
+                terminal_job_retention_bytes,
             })),
             daemon_lease_id: None,
         };
-        if compacted.is_some() {
-            store.persist()?;
-        }
+        store.persist()?;
         Ok(store)
     }
 
@@ -1524,21 +1570,23 @@ impl JobStore {
                 jobs: inner.jobs.values().cloned().collect(),
                 compaction: inner.compaction.clone(),
             };
-            let compacted =
-                compact_terminal_jobs(&mut durable, persistence.terminal_job_retention_limit);
+            compact_terminal_jobs(
+                &mut durable,
+                persistence.event_retention_limit,
+                persistence.terminal_job_retention_limit,
+                persistence.terminal_job_retention_bytes,
+            );
             if let Err(error) = write_durable_store(&persistence.path, &durable) {
                 inner.jobs.insert(job_id, prior);
                 return Err(error);
             }
-            if compacted.is_some() {
-                inner.jobs = durable
-                    .jobs
-                    .iter()
-                    .cloned()
-                    .map(|stored| (stored.job.id, stored))
-                    .collect();
-                inner.compaction = durable.compaction;
-            }
+            inner.jobs = durable
+                .jobs
+                .iter()
+                .cloned()
+                .map(|stored| (stored.job.id, stored))
+                .collect();
+            inner.compaction = durable.compaction;
         }
         Ok(())
     }
@@ -1797,21 +1845,23 @@ impl JobStore {
                 jobs: inner.jobs.values().cloned().collect(),
                 compaction: inner.compaction.clone(),
             };
-            let compacted =
-                compact_terminal_jobs(&mut durable, persistence.terminal_job_retention_limit);
+            compact_terminal_jobs(
+                &mut durable,
+                persistence.event_retention_limit,
+                persistence.terminal_job_retention_limit,
+                persistence.terminal_job_retention_bytes,
+            );
             if let Err(error) = write_durable_store(&persistence.path, &durable) {
                 *inner.jobs.get_mut(&job_id).expect("job exists") = prior;
                 return Err(error);
             }
-            if compacted.is_some() {
-                inner.jobs = durable
-                    .jobs
-                    .iter()
-                    .cloned()
-                    .map(|stored| (stored.job.id, stored))
-                    .collect();
-                inner.compaction = durable.compaction;
-            }
+            inner.jobs = durable
+                .jobs
+                .iter()
+                .cloned()
+                .map(|stored| (stored.job.id, stored))
+                .collect();
+            inner.compaction = durable.compaction;
         }
         Ok(started)
     }
@@ -1874,6 +1924,13 @@ impl JobStore {
             .unwrap_or(usize::MAX)
     }
 
+    fn terminal_job_retention_bytes(&self) -> usize {
+        self.persistence
+            .as_ref()
+            .map(|persistence| persistence.terminal_job_retention_bytes)
+            .unwrap_or(usize::MAX)
+    }
+
     pub(super) fn persist(&self) -> Result<()> {
         let Some(persistence) = &self.persistence else {
             return Ok(());
@@ -1884,17 +1941,20 @@ impl JobStore {
             jobs: inner.jobs.values().cloned().collect(),
             compaction: inner.compaction.clone(),
         };
-        let compacted = compact_terminal_jobs(&mut durable, self.terminal_job_retention_limit());
+        compact_terminal_jobs(
+            &mut durable,
+            self.event_retention_limit(),
+            self.terminal_job_retention_limit(),
+            self.terminal_job_retention_bytes(),
+        );
         write_durable_store(&persistence.path, &durable)?;
-        if compacted.is_some() {
-            inner.jobs = durable
-                .jobs
-                .iter()
-                .cloned()
-                .map(|stored| (stored.job.id, stored))
-                .collect();
-            inner.compaction = durable.compaction;
-        }
+        inner.jobs = durable
+            .jobs
+            .iter()
+            .cloned()
+            .map(|stored| (stored.job.id, stored))
+            .collect();
+        inner.compaction = durable.compaction;
         Ok(())
     }
 }

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -844,6 +844,83 @@ fn terminal_job_retention_compacts_existing_store_without_losing_active_recovery
 }
 
 #[test]
+fn terminal_payload_budget_bounds_high_event_history_before_child_reservation_persists() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store opens");
+    let queued = store.create("queued");
+    let running = store.create("running");
+    record_test_local_child(&store, running.id, std::process::id());
+
+    let terminal = (0..8)
+        .map(|index| {
+            let job = store.create("terminal");
+            store.start(job.id).expect("terminal job starts");
+            store
+                .complete(
+                    job.id,
+                    Some(json!({ "index": index, "output": "x".repeat(20_000) })),
+                )
+                .expect("terminal job completes");
+            job.id
+        })
+        .collect::<Vec<_>>();
+
+    let compacted = JobStore::open_without_reconciliation_with_retention_and_terminal_byte_limit(
+        &path, 10, 8, 70_000,
+    )
+    .expect("high-payload history compacts on open");
+    assert!(
+        compacted.get(queued.id).is_ok(),
+        "queued work survives compaction"
+    );
+    assert_eq!(
+        compacted
+            .get(running.id)
+            .expect("running job survives")
+            .status,
+        JobStatus::Running
+    );
+    assert!(compacted
+        .events(running.id)
+        .expect("recovery events")
+        .iter()
+        .any(|event| event
+            .data
+            .as_ref()
+            .is_some_and(|data| data["phase"] == "spawned")));
+    assert!(
+        compacted.get(terminal[0]).is_err(),
+        "oldest terminal evicts first"
+    );
+    assert!(compacted
+        .get(*terminal.last().expect("terminal jobs"))
+        .is_ok());
+    assert!(
+        fs::metadata(&path).expect("compacted store metadata").len() < 80_000,
+        "the persisted store remains bounded despite high-payload terminal events"
+    );
+
+    let reserved = compacted.create("new-child");
+    record_test_local_child(&compacted, reserved.id, std::process::id());
+    assert!(compacted
+        .events(reserved.id)
+        .expect("spawn events")
+        .iter()
+        .any(|event| event
+            .data
+            .as_ref()
+            .is_some_and(|data| data["phase"] == "spawned")));
+    assert!(
+        fs::metadata(&path)
+            .expect("reserved child store metadata")
+            .len()
+            < 80_000,
+        "reservation and PID persistence do not rewrite historical payloads"
+    );
+}
+
+#[test]
 fn remote_runner_job_submit_targets_runner_and_project() {
     let store = JobStore::default();
     let job = store


### PR DESCRIPTION
## Summary

- cap retained terminal-job history at 4 MiB in addition to the existing job/event count limits
- evict the oldest terminal jobs deterministically before each durable write and during startup
- preserve every queued/running job and its recovery evidence outside the terminal-history byte budget
- record retained terminal bytes in bounded compaction evidence

Fixes #8923. Follow-up to #8911 and #8913.

## Root cause

The 1,000-terminal-job cap still allowed a 56.3 MB compacted store because each job could retain up to 1,000 events. Every lifecycle mutation synchronously serialized, rewrote, and synced that full payload. On Lab storage, queued/reserved persistence exceeded the 60-second PID-less reservation lease, so jobs expired before child identity was persisted.

## How to test

1. Check out this branch from a fresh clone.
2. Run `cargo test -p homeboy-core api_jobs::tests --lib`.
3. Confirm all 79 daemon-job tests pass, including `terminal_payload_budget_bounds_high_event_history_before_child_reservation_persists`.
4. Run `cargo fmt --check`.
5. Run `cargo check -p homeboy-core`.
6. Run `git diff origin/main...HEAD --check`.

## Verification

- `cargo test -p homeboy-core api_jobs::tests --lib`: 79 passed
- `cargo fmt --check`: passed
- `cargo check -p homeboy-core`: passed with pre-existing workspace warnings
- `git diff origin/main...HEAD --check`: passed
- `homeboy review --changed-since origin/main --summary`: audit and lint passed; its Rust changed-file test selector executed zero tests and failed closed. That independent regression is tracked in #8758.

## Backwards compatibility

No command, configuration, or serialized-schema compatibility break. Older stores remain readable. The intentional behavior change is shorter terminal daemon-job history when its compact serialized payload exceeds 4 MiB; active jobs and recovery records are never removed by this budget.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6-sol via OpenCode
- **Used for:** Diagnosed the persistence-latency failure, drafted the implementation and regression coverage, and ran verification with Chris reviewing and owning the change.