### PR TITLE
Fix leaked Lab runner process trees

### DIFF
--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -11,6 +11,12 @@ use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_CAPTURE_LIMIT_BYTES: usize = 4 * 1024 * 1024;
 const MAX_OBSERVED_LINE_BYTES: usize = 64 * 1024;
+#[cfg(unix)]
+const PROCESS_TREE_TERM_GRACE: Duration = Duration::from_secs(2);
+#[cfg(unix)]
+const PROCESS_TREE_KILL_GRACE: Duration = Duration::from_secs(2);
+#[cfg(unix)]
+const PROCESS_TREE_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
 pub type StdoutLineObserver = Arc<dyn Fn(&str) + Send + Sync + 'static>;
 
@@ -182,8 +188,7 @@ pub fn wait_with_bounded_output_until_cancelled_with_stdout_observer(
             break status;
         }
         if is_cancelled() {
-            terminate_process_tree(child.id())?;
-            break child.wait()?;
+            break terminate_process_tree_and_reap(child)?;
         }
         thread::sleep(Duration::from_millis(100));
     };
@@ -220,30 +225,51 @@ pub fn isolate_process_tree(command: &mut Command) {
     }
 }
 
-fn terminate_process_tree(root_pid: u32) -> io::Result<()> {
+fn signal_process_group(root_pid: u32, signal: libc::c_int) -> io::Result<()> {
     #[cfg(unix)]
     unsafe {
         let pgid = -(root_pid as libc::pid_t);
-        if libc::kill(pgid, libc::SIGTERM) != 0 {
+        if libc::kill(pgid, signal) != 0 {
             let error = io::Error::last_os_error();
             if error.raw_os_error() != Some(libc::ESRCH) {
                 return Err(error);
             }
-        }
-        thread::sleep(Duration::from_millis(500));
-        if libc::kill(pgid, 0) == 0 {
-            let _ = libc::kill(pgid, libc::SIGKILL);
         }
         Ok(())
     }
 
     #[cfg(not(unix))]
     {
-        let _ = root_pid;
+        let _ = (root_pid, signal);
         Err(io::Error::other(
             "process tree cancellation is not implemented on this platform",
         ))
     }
+}
+
+#[cfg(unix)]
+fn process_group_is_running(root_pid: u32) -> bool {
+    unsafe { libc::kill(-(root_pid as libc::pid_t), 0) == 0 }
+}
+
+#[cfg(unix)]
+fn wait_for_process_group_exit(
+    child: &mut Child,
+    root_pid: u32,
+    grace: Duration,
+    status: &mut Option<ExitStatus>,
+) -> io::Result<bool> {
+    let deadline = std::time::Instant::now() + grace;
+    while process_group_is_running(root_pid) {
+        if status.is_none() {
+            *status = child.try_wait()?;
+        }
+        if std::time::Instant::now() >= deadline {
+            return Ok(false);
+        }
+        thread::sleep(PROCESS_TREE_POLL_INTERVAL);
+    }
+    Ok(true)
 }
 
 /// Terminate an isolated child process tree and reap its direct child process.
@@ -251,11 +277,24 @@ fn terminate_process_tree(root_pid: u32) -> io::Result<()> {
 /// termination and reaping of the spawned process.
 pub fn terminate_process_tree_and_reap(child: &mut Child) -> io::Result<ExitStatus> {
     #[cfg(unix)]
-    if let Err(error) = terminate_process_tree(child.id()) {
-        // Reap the direct child even if its process-group cleanup failed.
-        let _ = child.kill();
-        let _ = child.wait();
-        return Err(error);
+    {
+        let root_pid = child.id();
+        signal_process_group(root_pid, libc::SIGTERM)?;
+        let mut status = child.try_wait()?;
+        if !wait_for_process_group_exit(child, root_pid, PROCESS_TREE_TERM_GRACE, &mut status)? {
+            signal_process_group(root_pid, libc::SIGKILL)?;
+            if !wait_for_process_group_exit(child, root_pid, PROCESS_TREE_KILL_GRACE, &mut status)?
+            {
+                if status.is_none() {
+                    let _ = child.wait()?;
+                }
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("process group {root_pid} remained alive after SIGKILL"),
+                ));
+            }
+        }
+        return status.map(Ok).unwrap_or_else(|| child.wait());
     }
 
     #[cfg(not(unix))]
@@ -265,9 +304,8 @@ pub fn terminate_process_tree_and_reap(child: &mut Child) -> io::Result<ExitStat
                 return Err(error);
             }
         }
+        child.wait()
     }
-
-    child.wait()
 }
 
 #[derive(Debug)]
@@ -441,5 +479,40 @@ mod tests {
         assert_eq!(captured.metadata.bytes_seen, 2);
         assert_eq!(captured.metadata.bytes_retained, 2);
         assert!(!captured.metadata.truncated);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cancellation_reaps_the_entire_isolated_process_group() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let pid_file = temp.path().join("descendant.pid");
+        let script = format!(
+            "trap '' TERM; sh -c 'trap \"\" TERM; while :; do :; done' & echo $! > {}; wait",
+            shell_quote_path(&pid_file)
+        );
+        let mut command = Command::new("sh");
+        command.args(["-c", &script]);
+        isolate_process_tree(&mut command);
+        let mut child = command.spawn().expect("spawn process tree");
+
+        let status =
+            wait_with_bounded_output_until_cancelled(&mut child, 1024, || pid_file.exists())
+                .expect("cancel and reap process tree");
+        assert!(!status.status.success());
+
+        let descendant_pid = std::fs::read_to_string(&pid_file)
+            .expect("descendant pid")
+            .trim()
+            .parse::<libc::pid_t>()
+            .expect("numeric descendant pid");
+        assert_ne!(unsafe { libc::kill(descendant_pid, 0) }, 0);
+    }
+
+    #[cfg(unix)]
+    fn shell_quote_path(path: &std::path::Path) -> String {
+        format!(
+            "'{}'",
+            path.display().to_string().replace('\'', "'\\\"'\\\"'")
+        )
     }
 }

--- a/crates/homeboy-lab-runner/src/resource_metrics.rs
+++ b/crates/homeboy-lab-runner/src/resource_metrics.rs
@@ -7,9 +7,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use homeboy_core::engine::command::{
-    isolate_process_tree, supports_process_tree_isolation, wait_with_bounded_output,
-    wait_with_bounded_output_until_cancelled_with_stdout_observer, CommandCaptureMetadata,
-    StdoutLineObserver, DEFAULT_CAPTURE_LIMIT_BYTES,
+    isolate_process_tree, supports_process_tree_isolation, terminate_process_tree_and_reap,
+    wait_with_bounded_output, wait_with_bounded_output_until_cancelled_with_stdout_observer,
+    CommandCaptureMetadata, StdoutLineObserver, DEFAULT_CAPTURE_LIMIT_BYTES,
 };
 use homeboy_core::error::{Error, Result};
 
@@ -191,20 +191,14 @@ pub(crate) fn measured_command_output_until_cancelled_with_progress(
     })
 }
 
-/// Terminate an unrecorded child with every available ownership boundary before
-/// reaping it. The root fallback keeps cleanup safe where group/tree control is
-/// unavailable, while the caller preserves the original persistence failure.
+/// Terminate and reap an unrecorded child through the same bounded, verified
+/// process-tree lifecycle used by cancellation.
 fn terminate_unpersisted_child_and_reap(child: &mut std::process::Child) -> Result<()> {
-    let pid = child.id();
-    let group = homeboy_core::process::terminate_isolated_process_group(pid);
-    let tree = homeboy_core::process::terminate_process_tree_best_effort(pid);
-    if group.is_err() || tree.is_err() {
-        let _ = child.kill();
-    }
-    child.wait().map_err(|error| {
-        Error::internal_io(error.to_string(), Some("reap runner child".to_string()))
-    })?;
-    tree.or(group)
+    terminate_process_tree_and_reap(child)
+        .map(|_| ())
+        .map_err(|error| {
+            Error::internal_io(error.to_string(), Some("reap runner child".to_string()))
+        })
 }
 
 struct ResourceMetricsCollector {
@@ -818,12 +812,14 @@ mod tests {
     #[test]
     fn failed_initial_child_identity_persistence_terminates_and_reaps_the_process_tree() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let marker = temp.path().join("should-not-exist");
+        let descendant_pid_file = temp.path().join("descendant.pid");
+        let callback_pid_file = descendant_pid_file.clone();
         let spawned_pid = Arc::new(Mutex::new(None));
         let progress_sink = {
             let spawned_pid = Arc::clone(&spawned_pid);
             Arc::new(move |data: Value| {
                 *spawned_pid.lock().expect("pid lock") = data["process"]["root_pid"].as_u64();
+                wait_for_path(&callback_pid_file);
                 Err(Error::internal_io(
                     "durable progress unavailable",
                     Some("test progress persistence".to_string()),
@@ -831,7 +827,13 @@ mod tests {
             })
         };
         let mut command = Command::new("sh");
-        command.args(["-c", &format!("sleep 1; touch {}", marker.display())]);
+        command.args([
+            "-c",
+            &format!(
+                "sh -c 'trap \"\" TERM; while :; do :; done' & echo $! > {}; wait",
+                shell_quote_path(&descendant_pid_file)
+            ),
+        ]);
 
         let error = measured_command_output_until_cancelled_with_progress(
             &mut command,
@@ -850,11 +852,29 @@ mod tests {
             .expect("pid lock")
             .expect("initial callback received PID") as u32;
         assert!(!homeboy_core::process::pid_is_running(pid));
-        std::thread::sleep(Duration::from_millis(1200));
-        assert!(
-            !marker.exists(),
-            "child process tree must not continue running"
-        );
+        let descendant_pid = std::fs::read_to_string(&descendant_pid_file)
+            .expect("descendant pid")
+            .trim()
+            .parse::<libc::pid_t>()
+            .expect("numeric descendant pid");
+        assert_ne!(unsafe { libc::kill(descendant_pid, 0) }, 0);
+    }
+
+    #[cfg(unix)]
+    fn shell_quote_path(path: &std::path::Path) -> String {
+        format!(
+            "'{}'",
+            path.display().to_string().replace('\'', "'\\\"'\\\"'")
+        )
+    }
+
+    #[cfg(unix)]
+    fn wait_for_path(path: &std::path::Path) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !path.exists() {
+            assert!(Instant::now() < deadline, "timed out waiting for {path:?}");
+            std::thread::sleep(Duration::from_millis(10));
+        }
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- terminate cancelled Unix process groups with `SIGTERM`, bounded polling/reaping, and `SIGKILL` escalation
- route Lab pre-persistence cleanup through the same shared process-tree primitive
- add deterministic regressions with PID-file synchronization and a SIGTERM-resistant descendant

Closes #8925.

## Root cause

Cancellation signalled an isolated process group but returned after reaping only the direct child. Lab pre-persistence cleanup used a separate weaker path. Descendants could therefore survive the leader, retain temporary fixtures, and recursively launch additional identity probes.

## How to test

1. Check out this branch on macOS or Linux.
2. Run `cargo test -p homeboy-engine-primitives --lib`.
3. Run `cargo test -p homeboy-lab-runner failed_initial_child_identity_persistence_terminates_and_reaps_the_process_tree -- --nocapture`.
4. Run `cargo fmt --check`.
5. Run `git diff --check origin/main...HEAD`.
6. Confirm both process-tree regressions pass and no `homeboy self identity` descendant remains after each test exits.

## Verification

- `cargo test -p homeboy-engine-primitives --lib`: 165 passed
- focused engine process-group regression: passed
- focused Lab pre-persistence regression: passed
- `cargo fmt --check`: passed
- `git diff --check origin/main...HEAD`: passed

The complete `homeboy-lab-runner` library suite exceeded 120 seconds and 600 seconds in separate runs and reported two unrelated existing failures: `direct_daemon_detached_handoff_returns_while_the_workload_remains_running` and `materialize_script_records_the_peeled_commit_for_tags_and_direct_commits`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.6-sol)
- **Used for:** Investigated the leaked process tree and drafted the shared cleanup primitive and regression tests; Chris reviews and owns the change.