### PR TITLE
Recover expired PID-less daemon reservations

### DIFF
--- a/crates/homeboy-cli/src/commands/daemon.rs
+++ b/crates/homeboy-cli/src/commands/daemon.rs
@@ -42,7 +42,7 @@ enum DaemonCommand {
         /// Accepted migration alias for legacy child recovery. It never mutates jobs.
         #[arg(long)]
         recover_missing_child_identity: bool,
-        /// Accepted migration alias for one legacy untracked child. It never mutates jobs.
+        /// Confirm the one expired PID-less reservation to terminalize before replacement.
         #[arg(long = "confirm-untracked-child-dead")]
         confirm_untracked_child_dead: Vec<Uuid>,
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
@@ -196,16 +196,15 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
             confirm_untracked_child_dead,
             addr,
         } => {
-            if recover_missing_child_identity || !confirm_untracked_child_dead.is_empty() {
+            if recover_missing_child_identity {
                 return Err(legacy_child_recovery_migration_error(
-                    recover_missing_child_identity,
-                    &confirm_untracked_child_dead,
                 ));
             }
             Ok((
                 DaemonOutput::AdoptOrphan(daemon::adopt_orphaned_lease(
                     &lease_id,
                     confirm_pid_dead,
+                    &confirm_untracked_child_dead,
                     &addr,
                 )?),
                 0,
@@ -260,19 +259,11 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
     }
 }
 
-fn legacy_child_recovery_migration_error(
-    recover_missing_child_identity: bool,
-    confirm_untracked_child_dead: &[Uuid],
-) -> Error {
-    let pairing = if recover_missing_child_identity && !confirm_untracked_child_dead.is_empty() {
-        "The released legacy flags were supplied together."
-    } else {
-        "The released legacy flags must be supplied together, but either form is now migration-only."
-    };
+fn legacy_child_recovery_migration_error() -> Error {
     Error::validation_invalid_argument(
         "recover_missing_child_identity",
         format!(
-            "{pairing} Homeboy will not bulk-terminalize legacy jobs; recover each job with exact persisted evidence instead"
+            "--recover-missing-child-identity is migration-only. Recover each job with exact persisted evidence instead"
         ),
         None,
         Some(vec![
@@ -402,14 +393,8 @@ mod tests {
     }
 
     #[test]
-    fn legacy_adoption_flags_parse_but_return_exact_non_mutating_migration() {
+    fn legacy_child_recovery_alias_remains_migration_only() {
         with_isolated_home(|_| {
-            let jobs_path = homeboy::core::paths::daemon_jobs_file().expect("jobs path");
-            let store = homeboy::core::api_jobs::JobStore::open_without_reconciliation(&jobs_path)
-                .expect("store");
-            let job = store.create("runner.exec");
-            store.start(job.id).expect("start job");
-            let before = std::fs::read(&jobs_path).expect("store bytes");
             let cli = Cli::try_parse_from([
                 "homeboy",
                 "daemon",
@@ -418,42 +403,34 @@ mod tests {
                 "lease-dead",
                 "--confirm-pid-dead",
                 "--recover-missing-child-identity",
-                "--confirm-untracked-child-dead",
-                &job.id.to_string(),
             ])
-            .expect("released aliases still parse");
+            .expect("legacy alias still parses");
             let Commands::Daemon(args) = cli.command else {
                 panic!("expected daemon command");
             };
 
             let error = run(args, &crate::commands::GlobalArgs {})
-                .expect_err("legacy aliases must not mutate");
-            assert!(error.message.contains("will not bulk-terminalize"));
+                .expect_err("legacy alias must not mutate");
+            assert!(error.message.contains("migration-only"));
             let rendered = format!("{error:?}");
             for field in [
-                "recover-missing-child-identity",
-                "expected-lease",
-                "recorded-daemon-pid",
-                "recorded-daemon-endpoint",
-                "job-id",
-                "child-pid",
-                "child-starttime-ticks",
+                "recover-missing-child-identity", "expected-lease", "recorded-daemon-pid",
             ] {
                 assert!(rendered.contains(field), "missing remediation field {field}");
             }
-            assert_eq!(std::fs::read(&jobs_path).expect("store bytes"), before);
         });
     }
 
     #[test]
-    fn unpaired_legacy_adoption_alias_returns_the_same_migration_contract() {
+    fn pidless_confirmation_is_not_a_migration_alias() {
         let cli = Cli::try_parse_from([
             "homeboy",
             "daemon",
             "adopt-orphan",
             "--lease-id",
             "lease-dead",
-            "--recover-missing-child-identity",
+                "--confirm-untracked-child-dead",
+                "00000000-0000-0000-0000-000000000001",
         ])
         .expect("one released alias still parses");
         let Commands::Daemon(args) = cli.command else {
@@ -461,9 +438,8 @@ mod tests {
         };
 
         let error = run(args, &crate::commands::GlobalArgs {})
-            .expect_err("unpaired legacy alias is migration-only");
-        assert!(error.message.contains("must be supplied together"));
-        assert!(format!("{error:?}").contains("recover-missing-child-identity"));
+            .expect_err("absent daemon lease fails before recovery");
+        assert!(!error.message.contains("migration-only"));
     }
 
     #[test]

--- a/crates/homeboy-core/src/api_jobs/store.rs
+++ b/crates/homeboy-core/src/api_jobs/store.rs
@@ -641,6 +641,118 @@ impl JobStore {
         )
     }
 
+    /// Terminalize one explicitly confirmed pre-spawn reservation after its
+    /// daemon owner is proven dead. This intentionally refuses every other
+    /// active job so orphan adoption cannot infer ownership or bulk-recover.
+    pub fn recover_expired_pidless_reservation_for_dead_daemon_lease(
+        &self,
+        expected_lease_id: &str,
+        confirmed_job_ids: &[Uuid],
+    ) -> Result<DaemonLeaseJobDiagnostics> {
+        let [job_id] = confirmed_job_ids else {
+            return Err(Error::validation_invalid_argument(
+                "confirm_untracked_child_dead",
+                "exactly one job ID must be confirmed for expired PID-less reservation recovery",
+                Some(expected_lease_id.to_string()),
+                None,
+            ));
+        };
+        let now = timestamp_ms();
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let active_job_ids = inner
+            .jobs
+            .values()
+            .filter(|stored| {
+                matches!(stored.job.status, JobStatus::Queued | JobStatus::Running)
+                    && stored.job.daemon_lease_id.as_deref() == Some(expected_lease_id)
+            })
+            .map(|stored| stored.job.id)
+            .collect::<Vec<_>>();
+        if active_job_ids.as_slice() != [*job_id] {
+            return Err(Error::validation_invalid_argument(
+                "confirm_untracked_child_dead",
+                format!(
+                    "expired PID-less reservation recovery requires the only active job for lease `{expected_lease_id}`; active jobs: {}",
+                    active_job_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ")
+                ),
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        let stored = inner
+            .jobs
+            .get_mut(job_id)
+            .expect("confirmed active job exists");
+        let reservation = stored.local_child.as_ref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "confirm_untracked_child_dead",
+                "confirmed job has no local child reservation",
+                Some(job_id.to_string()),
+                None,
+            )
+        })?;
+        if stored.job.status != JobStatus::Queued
+            || reservation.process.is_some()
+            || reservation
+                .reservation_expires_at_ms
+                .is_none_or(|expires_at| expires_at > now)
+        {
+            return Err(Error::validation_invalid_argument(
+                "confirm_untracked_child_dead",
+                "confirmed job is not an expired PID-less pre-spawn reservation",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        let terminal_result = serde_json::json!({
+            "status": JobStatus::Failed,
+            "reason": "operator_confirmed_expired_pidless_reservation_after_dead_daemon_lease",
+            "retryable": true,
+            "expected_lease_id": expected_lease_id,
+            "reservation_id": reservation.reservation_id,
+            "reservation_expires_at_ms": reservation.reservation_expires_at_ms,
+            "operator_confirmation": true,
+        });
+        stored.job.status = JobStatus::Failed;
+        stored.job.updated_at_ms = now;
+        stored.job.finished_at_ms = Some(now);
+        stored.job.stale_reason =
+            Some("local child reservation lease expired before spawn".to_string());
+        for (kind, message) in [
+            (
+                JobEventKind::Error,
+                "expired PID-less reservation recovered after dead daemon lease",
+            ),
+            (
+                JobEventKind::Result,
+                "retryable terminal reservation recovery",
+            ),
+            (
+                JobEventKind::Status,
+                "job marked failed after explicit expired reservation recovery",
+            ),
+        ] {
+            let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+            stored.events.push(JobEvent {
+                sequence,
+                job_id: *job_id,
+                kind,
+                timestamp_ms: now,
+                message: Some(message.to_string()),
+                data: Some(terminal_result.clone()),
+            });
+        }
+        apply_event_retention(&mut stored.events, self.event_retention_limit());
+        stored.job.event_count = stored.events.len();
+        drop(inner);
+        self.persist()?;
+        Ok(DaemonLeaseJobDiagnostics {
+            expected_lease_id: expected_lease_id.to_string(),
+            matching_job_ids: vec![*job_id],
+            ..DaemonLeaseJobDiagnostics::default()
+        })
+    }
+
     /// Reconcile only jobs whose linked durable run has already reached a
     /// terminal state. This deliberately does not inspect, stop, or alter live
     /// children, so it is safe when a daemon's aggregate count includes both

--- a/crates/homeboy-core/src/api_jobs/tests/part_a.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_a.rs
@@ -89,6 +89,104 @@ fn expired_local_child_reservation_releases_capacity_and_persists_retryable_fail
 }
 
 #[test]
+fn explicit_dead_lease_recovery_terminalizes_only_one_expired_pidless_reservation() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open_without_reconciliation(&path)
+        .expect("store")
+        .with_daemon_lease("lease-dead".to_string());
+    let job = store.create("runner.exec");
+    store
+        .reserve_local_child_at(job.id, 0)
+        .expect("persist expired reservation");
+
+    let recovered = store
+        .recover_expired_pidless_reservation_for_dead_daemon_lease("lease-dead", &[job.id])
+        .expect("exact expired reservation recovers");
+
+    assert_eq!(recovered.matching_job_ids, vec![job.id]);
+    assert_eq!(
+        store.get(job.id).expect("terminal job").status,
+        JobStatus::Failed
+    );
+    let events = JobStore::open_without_reconciliation(&path)
+        .expect("reopen durable store")
+        .events(job.id)
+        .expect("durable evidence");
+    assert!(events.iter().any(|event| {
+        event.kind == JobEventKind::Result
+            && event.data.as_ref().is_some_and(|data| {
+                data["reason"]
+                    == "operator_confirmed_expired_pidless_reservation_after_dead_daemon_lease"
+                    && data["retryable"] == true
+                    && data["expected_lease_id"] == "lease-dead"
+            })
+    }));
+}
+
+#[test]
+fn explicit_dead_lease_pidless_recovery_refuses_ambiguous_unexpired_or_identified_jobs() {
+    let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
+    let selected = store.create("runner.exec");
+    store
+        .reserve_local_child_at(selected.id, 0)
+        .expect("reserve selected");
+    let additional = store.create("runner.exec");
+    store
+        .reserve_local_child_at(additional.id, 0)
+        .expect("reserve additional");
+    let before = store.events(selected.id).expect("events").len();
+
+    let ambiguity = store
+        .recover_expired_pidless_reservation_for_dead_daemon_lease("lease-dead", &[selected.id])
+        .expect_err("additional active reservation is ambiguous");
+    assert!(ambiguity.message.contains("only active job"));
+    assert_eq!(store.events(selected.id).expect("events").len(), before);
+
+    let single = JobStore::default().with_daemon_lease("lease-dead".to_string());
+    let unexpired = single.create("runner.exec");
+    single
+        .reserve_local_child(unexpired.id)
+        .expect("reserve job");
+    let error = single
+        .recover_expired_pidless_reservation_for_dead_daemon_lease("lease-dead", &[unexpired.id])
+        .expect_err("unexpired reservation fails closed");
+    assert!(error.message.contains("not an expired PID-less"));
+    assert_eq!(
+        single.get(unexpired.id).expect("job").status,
+        JobStatus::Queued
+    );
+    let wrong_lease = single
+        .recover_expired_pidless_reservation_for_dead_daemon_lease("wrong-lease", &[unexpired.id])
+        .expect_err("wrong lease fails closed");
+    assert!(wrong_lease.message.contains("only active job"));
+    let wrong_job = single
+        .recover_expired_pidless_reservation_for_dead_daemon_lease("lease-dead", &[Uuid::new_v4()])
+        .expect_err("wrong job fails closed");
+    assert!(wrong_job.message.contains("only active job"));
+
+    let identified = JobStore::default().with_daemon_lease("lease-dead".to_string());
+    let job = identified.create("runner.exec");
+    identified
+        .reserve_local_child_at(job.id, 0)
+        .expect("reserve job");
+    identified
+        .start_with_reserved_child_identity(
+            job.id,
+            u32::MAX,
+            None,
+            super::store::LocalChildStartDiscriminator::Unsupported {
+                evidence: "test identity".to_string(),
+            },
+        )
+        .expect("persist identity");
+    let error = identified
+        .recover_expired_pidless_reservation_for_dead_daemon_lease("lease-dead", &[job.id])
+        .expect_err("persisted child identity fails closed");
+    assert!(error.message.contains("not an expired PID-less"));
+}
+
+#[test]
 fn pid_bound_local_child_is_not_expired_by_its_former_reservation_deadline() {
     let store = JobStore::default();
     let job = store.create("runner.exec");

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -946,6 +946,7 @@ pub fn ensure_running(addr: &str) -> Result<DaemonStartResult> {
 pub fn adopt_orphaned_lease(
     lease_id: &str,
     confirm_pid_dead: bool,
+    confirmed_no_pid_job_ids: &[uuid::Uuid],
     addr: &str,
 ) -> Result<DaemonOrphanAdoptionResult> {
     if !confirm_pid_dead {
@@ -966,7 +967,14 @@ pub fn adopt_orphaned_lease(
         || {
             let store =
                 super::JobStore::open_without_reconciliation(crate::paths::daemon_jobs_file()?)?;
-            store.reconcile_dead_daemon_lease_jobs(lease_id)
+            if confirmed_no_pid_job_ids.is_empty() {
+                store.reconcile_dead_daemon_lease_jobs(lease_id)
+            } else {
+                store.recover_expired_pidless_reservation_for_dead_daemon_lease(
+                    lease_id,
+                    confirmed_no_pid_job_ids,
+                )
+            }
         },
         || start_or_return_live_unlocked(addr),
     )

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -610,7 +610,7 @@ fn exact_lease_adoption_refuses_owner_lock_and_preserves_store() {
             .expect("owner lock")
             .expect("owner acquired");
 
-        let error = super::adopt_orphaned_lease("lease-dead", true, "127.0.0.1:0")
+        let error = super::adopt_orphaned_lease("lease-dead", true, &[], "127.0.0.1:0")
             .expect_err("owner lock blocks adoption");
         assert!(error.message.contains("owner lock is held"));
         assert_eq!(std::fs::read(&jobs_path).expect("store bytes"), before);


### PR DESCRIPTION
## Summary

- add an explicit exact-job confirmation path to dead-lease adoption
- terminalize one expired PID-less pre-spawn reservation as retryable before replacement startup
- refuse wrong leases/jobs, unexpired or identified children, and ambiguous additional active jobs
- preserve fail-closed default adoption behavior

Fixes #8931.

## How to test

1. Check out this branch from a fresh clone.
2. Run `cargo test -p homeboy-core explicit_dead_lease`.
3. Run `cargo test -p homeboy-cli commands::daemon::tests`.
4. Run `cargo check -p homeboy-cli -p homeboy-lab-runner`.
5. Run `cargo fmt --check`.
6. Run `git diff origin/main...HEAD --check`.

## Verification

- core recovery tests: 2 passed
- daemon CLI tests: 7 passed
- CLI/Lab compilation: passed with pre-existing warnings
- formatting and diff hygiene: passed

## Backwards compatibility

Default orphan adoption remains fail-closed. The existing `--confirm-untracked-child-dead` flag now performs narrowly scoped recovery only when one exact expired PID-less reservation is the sole active job for the proven-dead lease.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6-sol via OpenCode
- **Used for:** Diagnosed the recovery deadlock, drafted the strict recovery primitive and tests, and ran verification with Chris reviewing and owning the change.