### PR TITLE
Fix agent task child capacity admission

### DIFF
--- a/crates/homeboy-core/src/api_jobs/store.rs
+++ b/crates/homeboy-core/src/api_jobs/store.rs
@@ -1558,6 +1558,64 @@ impl JobStore {
         JobRunner { job_id, handle }
     }
 
+    pub(crate) fn run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner<
+        T,
+        F,
+    >(
+        &self,
+        operation: impl Into<String>,
+        source_snapshot: Option<SourceSnapshot>,
+        metadata: Option<Value>,
+        path_materialization_plan: Option<PathMaterializationPlan>,
+        local_runner: LocalRunnerJob,
+        capacity: usize,
+        run: F,
+    ) -> JobRunner
+    where
+        T: Serialize + Send + 'static,
+        F: FnOnce(JobHandle) -> Result<T> + Send + 'static,
+    {
+        let job = self.create_with_source_snapshot_metadata_path_materialization_and_local_runner(
+            operation,
+            source_snapshot,
+            metadata,
+            path_materialization_plan,
+            Some(local_runner.clone()),
+        );
+        let job_id = job.id;
+        let handle_store = self.clone();
+        let worker_store = self.clone();
+        let handle = thread::spawn(move || {
+            let job_handle = JobHandle {
+                store: handle_store,
+                job_id,
+            };
+            loop {
+                if job_handle.is_cancelled() {
+                    return;
+                }
+                match worker_store.reserve_local_child_with_runner_capacity(
+                    job_id,
+                    &local_runner.runner_id,
+                    capacity,
+                ) {
+                    Ok(true) => break,
+                    Ok(false) => thread::sleep(std::time::Duration::from_millis(10)),
+                    Err(_) => return,
+                }
+            }
+            match run(job_handle) {
+                Ok(output) => {
+                    let _ = worker_store.complete(job_id, serde_json::to_value(output).ok());
+                }
+                Err(error) => {
+                    let _ = worker_store.fail(job_id, error.to_string());
+                }
+            }
+        });
+        JobRunner { job_id, handle }
+    }
+
     fn run_background_with_start_policy<T, F>(
         &self,
         operation: impl Into<String>,
@@ -1641,6 +1699,29 @@ impl JobStore {
     }
 
     pub(crate) fn reserve_local_child_at(&self, job_id: Uuid, now: u64) -> Result<()> {
+        self.reserve_local_child_at_with_runner_capacity(job_id, now, None)
+            .map(|_| ())
+    }
+
+    pub(crate) fn reserve_local_child_with_runner_capacity(
+        &self,
+        job_id: Uuid,
+        runner_id: &str,
+        capacity: usize,
+    ) -> Result<bool> {
+        self.reserve_local_child_at_with_runner_capacity(
+            job_id,
+            timestamp_ms(),
+            Some((runner_id, capacity)),
+        )
+    }
+
+    fn reserve_local_child_at_with_runner_capacity(
+        &self,
+        job_id: Uuid,
+        now: u64,
+        runner_capacity: Option<(&str, usize)>,
+    ) -> Result<bool> {
         let reservation_id = Uuid::new_v4().to_string();
         let reservation_expires_at_ms = now.saturating_add(LOCAL_CHILD_RESERVATION_LEASE_MS);
         let mut inner = self.inner.lock().expect("job store mutex poisoned");
@@ -1649,6 +1730,20 @@ impl JobStore {
             .get(&job_id)
             .cloned()
             .ok_or_else(|| job_not_found(job_id))?;
+        if let Some((runner_id, capacity)) = runner_capacity {
+            let active = inner.jobs.values().filter(|candidate| {
+                candidate.job.id != job_id
+                    && matches!(candidate.job.status, JobStatus::Queued | JobStatus::Running)
+                    && candidate.local_child.is_some()
+                    && candidate
+                        .local_runner
+                        .as_ref()
+                        .is_some_and(|runner| runner.runner_id == runner_id)
+            });
+            if active.count() >= capacity {
+                return Ok(false);
+            }
+        }
         let stored = inner.jobs.get_mut(&job_id).expect("job exists");
         if stored.job.status != JobStatus::Queued {
             return Err(Error::validation_invalid_argument(
@@ -1700,7 +1795,7 @@ impl JobStore {
                 .collect();
             inner.compaction = durable.compaction;
         }
-        Ok(())
+        Ok(true)
     }
 
     /// Terminalize expired pre-spawn reservations. A PID-bound child has

--- a/crates/homeboy-core/src/api_jobs/tests/part_a.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_a.rs
@@ -187,6 +187,160 @@ fn explicit_dead_lease_pidless_recovery_refuses_ambiguous_unexpired_or_identifie
 }
 
 #[test]
+fn runner_capacity_is_claimed_before_reserving_an_agent_task_child() {
+    let store = JobStore::default();
+    let local_runner = || super::store::LocalRunnerJob {
+        runner_id: "homeboy-lab".to_string(),
+        command: vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+        ],
+        cwd: Some("/runner/worktree".to_string()),
+        lifecycle: Some(RunnerJobLifecycleMetadata {
+            source: Some("runner-daemon".to_string()),
+            kind: Some("agent-task-run-plan".to_string()),
+            durable_run_id: None,
+            active_child_count: None,
+            active_cell_count: None,
+        }),
+    };
+    let first = store.create_test_local_runner_job(Some(local_runner()));
+    let second = store.create_test_local_runner_job(Some(local_runner()));
+
+    assert!(store
+        .reserve_local_child_with_runner_capacity(first.id, "homeboy-lab", 1)
+        .expect("idle runner admits the first child"));
+    assert!(!store
+        .reserve_local_child_with_runner_capacity(second.id, "homeboy-lab", 1)
+        .expect("second child waits behind the reservation owner"));
+    assert!(store.get(second.id).expect("queued second job").status == JobStatus::Queued);
+    assert!(!store
+        .events(second.id)
+        .expect("second job events")
+        .iter()
+        .any(|event| event
+            .data
+            .as_ref()
+            .is_some_and(|data| data["phase"] == "child_reserved")));
+
+    store
+        .start_with_reserved_child_identity(
+            first.id,
+            std::process::id(),
+            None,
+            super::store::LocalChildStartDiscriminator::Unsupported {
+                evidence: "test process owns the first capacity slot".to_string(),
+            },
+        )
+        .expect("first child starts once its reservation is admitted");
+    store
+        .complete(first.id, None)
+        .expect("release first capacity owner");
+    assert!(store
+        .reserve_local_child_with_runner_capacity(second.id, "homeboy-lab", 1)
+        .expect("next queued child claims released capacity"));
+    assert_eq!(
+        store
+            .events(second.id)
+            .expect("second child reservation")
+            .iter()
+            .filter(|event| event
+                .data
+                .as_ref()
+                .is_some_and(|data| data["phase"] == "child_reserved"))
+            .count(),
+        1,
+        "the provider path receives exactly one pre-spawn reservation"
+    );
+}
+
+#[test]
+fn capacity_queued_agent_task_spawns_once_after_claiming_an_idle_slot() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{mpsc, Arc};
+    use std::time::Duration;
+
+    let store = JobStore::default();
+    let local_runner = || super::store::LocalRunnerJob {
+        runner_id: "homeboy-lab".to_string(),
+        command: vec!["homeboy".to_string(), "agent-task".to_string()],
+        cwd: Some("/runner/worktree".to_string()),
+        lifecycle: None,
+    };
+    let starts = Arc::new(AtomicUsize::new(0));
+    let (first_started_tx, first_started_rx) = mpsc::channel();
+    let (release_first_tx, release_first_rx) = mpsc::channel();
+    let first_starts = Arc::clone(&starts);
+    let first = store.run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
+        "runner.exec",
+        None,
+        None,
+        None,
+        local_runner(),
+        1,
+        move |job| {
+            job.start_with_reserved_child_identity(
+                std::process::id(),
+                None,
+                super::store::LocalChildStartDiscriminator::Unsupported {
+                    evidence: "test provider child".to_string(),
+                },
+            )?;
+            first_starts.fetch_add(1, Ordering::SeqCst);
+            first_started_tx.send(()).expect("report first spawn");
+            release_first_rx.recv().expect("release first provider");
+            Ok(json!({}))
+        },
+    );
+    first_started_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("idle agent-task child spawns");
+
+    let (second_started_tx, second_started_rx) = mpsc::channel();
+    let second_starts = Arc::clone(&starts);
+    let second = store.run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
+        "runner.exec",
+        None,
+        None,
+        None,
+        local_runner(),
+        1,
+        move |job| {
+            job.start_with_reserved_child_identity(
+                std::process::id(),
+                None,
+                super::store::LocalChildStartDiscriminator::Unsupported {
+                    evidence: "test provider child".to_string(),
+                },
+            )?;
+            second_starts.fetch_add(1, Ordering::SeqCst);
+            second_started_tx.send(()).expect("report second spawn");
+            Ok(json!({}))
+        },
+    );
+    assert!(second_started_rx
+        .recv_timeout(Duration::from_millis(50))
+        .is_err());
+    assert!(!store
+        .events(second.job_id)
+        .expect("queued second events")
+        .iter()
+        .any(|event| event
+            .data
+            .as_ref()
+            .is_some_and(|data| data["phase"] == "child_reserved")));
+
+    release_first_tx.send(()).expect("release first provider");
+    first.handle.join().expect("first worker exits");
+    second_started_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("second child starts after capacity release");
+    second.handle.join().expect("second worker exits");
+    assert_eq!(starts.load(Ordering::SeqCst), 2);
+}
+
+#[test]
 fn pid_bound_local_child_is_not_expired_by_its_former_reservation_deadline() {
     let store = JobStore::default();
     let job = store.create("runner.exec");

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -1835,18 +1835,30 @@ fn enqueue_exec_job(
     } else {
         None
     };
+    let local_runner = LocalRunnerJob {
+        runner_id: plan.runner_id.clone(),
+        command: plan.command.clone(),
+        cwd: Some(plan.cwd.clone()),
+        lifecycle: lifecycle.clone(),
+    };
+    // Direct-daemon offload deliberately projects its transport lifecycle as
+    // `runner.exec`; the typed workload is the canonical agent-task identity.
+    let is_agent_task = request
+        .lab_runner_workload
+        .as_ref()
+        .and_then(|workload| workload.agent_task.as_ref())
+        .is_some();
+    let capacity = is_agent_task
+        .then_some(plan.concurrency_limit.unwrap_or(usize::MAX).max(1))
+        .unwrap_or(usize::MAX);
     let runner = job_store
-        .run_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
+        .run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
             operation,
             source_snapshot.clone(),
             Some(run_ref_metadata),
             path_materialization_plan.clone(),
-            Some(LocalRunnerJob {
-                runner_id: plan.runner_id.clone(),
-                command: plan.command.clone(),
-                cwd: Some(plan.cwd.clone()),
-                lifecycle: lifecycle.clone(),
-            }),
+            local_runner,
+            capacity,
             move |job| {
                 let mut plan = plan;
                 plan.env.insert(
@@ -2017,7 +2029,67 @@ fn daemon_job_store() -> &'static JobStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::daemon::runner_exec_driver::{
+        self, DaemonExecOutput, PreparedDaemonExec, RunnerExecDriver, RunnerExecPrepareRequest,
+    };
     use crate::test_support::with_isolated_home;
+    #[cfg(unix)]
+    use std::os::unix::process::CommandExt;
+    #[cfg(unix)]
+    use std::process::Command;
+    use std::sync::Arc;
+
+    struct EnqueueTestDriver;
+
+    impl RunnerExecDriver for EnqueueTestDriver {
+        fn prepare(&self, request: RunnerExecPrepareRequest) -> Result<PreparedDaemonExec> {
+            let cwd = request.cwd.unwrap_or_else(|| "/tmp".to_string());
+            Ok(PreparedDaemonExec::new(
+                request.runner_id.clone(),
+                cwd.clone(),
+                request.command,
+                request.env,
+                request.secret_env_names,
+                SourceSnapshot::existing_remote(&request.runner_id, &cwd, None),
+                request.require_paths,
+                Some(1),
+                Arc::new(()),
+            ))
+        }
+
+        fn execute(
+            &self,
+            _prepared: &PreparedDaemonExec,
+            _is_cancelled: runner_exec_driver::ExecCancellationProbe,
+            _progress_sink: Option<runner_exec_driver::ExecProgressSink>,
+            _require_child_identity_acknowledgement: bool,
+            child_started: Option<runner_exec_driver::ExecChildStarted>,
+        ) -> Result<DaemonExecOutput> {
+            #[cfg(unix)]
+            {
+                let mut command = Command::new("sh");
+                command.args(["-c", "sleep 0.1"]);
+                unsafe {
+                    command.pre_exec(|| {
+                        if libc::setpgid(0, 0) != 0 {
+                            return Err(std::io::Error::last_os_error());
+                        }
+                        Ok(())
+                    });
+                }
+                let mut child = command.spawn().map_err(|error| {
+                    Error::internal_io(error.to_string(), Some("spawn test child".to_string()))
+                })?;
+                child_started.expect("daemon supplies child acknowledgement")(child.id())?;
+                child.wait().map_err(|error| {
+                    Error::internal_io(error.to_string(), Some("reap test child".to_string()))
+                })?;
+            }
+            #[cfg(not(unix))]
+            child_started.expect("daemon supplies child acknowledgement")(std::process::id())?;
+            Ok(DaemonExecOutput::default())
+        }
+    }
 
     #[test]
     fn owner_lock_blocks_a_second_owner_without_lease_or_listener_evidence() {
@@ -2054,6 +2126,60 @@ mod tests {
 
         assert_eq!(metadata["durable_run_id"], "agent-task-run-123");
         assert_eq!(metadata["agent_task_run_id"], "agent-task-run-123");
+    }
+
+    #[test]
+    fn direct_daemon_agent_task_request_uses_workload_identity_for_capacity_admission() {
+        runner_exec_driver::register_runner_exec_driver(Arc::new(EnqueueTestDriver));
+        let store = JobStore::default();
+        let response = enqueue_exec_job(
+            Some(json!({
+                "runner_id": "homeboy-lab",
+                "cwd": "/tmp",
+                "command": ["homeboy", "agent-task", "run-plan", "--plan", "{}", "--record-run-id", "run-8926"],
+                "runner_workload": {
+                    "schema": "homeboy/runner-workload/v1",
+                    "workload_id": "plan-8926.runner_workload",
+                    "kind": { "command_label": "agent-task run-plan", "command_family": "agent_task" },
+                    "agent_task": {
+                        "run_id": "run-8926",
+                        "dispatch_kind": "run_plan",
+                        "lifecycle_mirror_policy": "run_plan_aggregate"
+                    },
+                    "workspace_mappings": { "source_path_mode": "existing_remote", "workspace_mode_policy": "existing", "mapping_ref": null },
+                    "required_capabilities": [],
+                    "required_secrets": { "categories": [], "secret_env_plan": {} },
+                    "required_extensions": [],
+                    "mutation_policy": { "capture_patch": false, "mutation_flag": null, "allow_dirty_lab_workspace": false },
+                    "assignment": { "runner_id": "homeboy-lab", "runner_mode": "direct_ssh", "source": "explicit" },
+                    "state": { "status": "offloaded", "remote_workspace": "/tmp", "fallback_reason": null },
+                    "result_refs": { "plan_id": "plan-8926", "proof_id": null, "workspace_mapping_ref": null }
+                },
+                "lifecycle": {
+                    "source": "runner-daemon",
+                    "kind": "runner.exec",
+                    "durable_run_id": "run-8926"
+                }
+            })),
+            &store,
+        )
+        .expect("direct daemon accepts the canonical agent-task workload");
+        let job_id = response["job"]["id"]
+            .as_str()
+            .expect("accepted job id")
+            .parse()
+            .expect("valid job id");
+        wait_for_daemon_job_status(&store, job_id, JobStatus::Succeeded);
+        assert!(store
+            .events(job_id)
+            .expect("job events")
+            .iter()
+            .any(|event| {
+                event
+                    .data
+                    .as_ref()
+                    .is_some_and(|data| data["phase"] == "child_reserved")
+            }));
     }
 
     // NOTE: daemon `/exec` projection is exercised end-to-end in the

--- a/crates/homeboy-core/src/daemon/runner_exec_driver.rs
+++ b/crates/homeboy-core/src/daemon/runner_exec_driver.rs
@@ -56,6 +56,9 @@ pub struct PreparedDaemonExec {
     pub secret_env_names: Vec<String>,
     pub source_snapshot: SourceSnapshot,
     pub require_paths: Vec<String>,
+    /// The runner's declared process capacity. The daemon uses this to admit a
+    /// local child before creating its bounded pre-spawn reservation.
+    pub concurrency_limit: Option<usize>,
     /// Opaque driver-owned plan handle carried back into `execute`. The daemon
     /// never inspects it; it exists so the driver can reconstruct the full
     /// runner process without re-preparing.
@@ -73,6 +76,7 @@ impl PreparedDaemonExec {
         secret_env_names: Vec<String>,
         source_snapshot: SourceSnapshot,
         require_paths: Vec<String>,
+        concurrency_limit: Option<usize>,
         plan_token: Arc<dyn std::any::Any + Send + Sync>,
     ) -> Self {
         Self {
@@ -83,6 +87,7 @@ impl PreparedDaemonExec {
             secret_env_names,
             source_snapshot,
             require_paths,
+            concurrency_limit,
             plan_token,
         }
     }

--- a/crates/homeboy-lab-runner/src/daemon_exec_driver.rs
+++ b/crates/homeboy-lab-runner/src/daemon_exec_driver.rs
@@ -74,6 +74,7 @@ impl RunnerExecDriver for RunnerDaemonExecDriver {
             plan.secret_env_names.clone(),
             plan.source_snapshot.clone(),
             plan.require_paths.clone(),
+            plan.runner.settings.concurrency_limit,
             Arc::new(plan),
         ))
     }


### PR DESCRIPTION
## Summary

- claim direct-daemon runner capacity before creating the bounded pre-spawn child reservation
- use the canonical typed agent-task workload identity rather than the transport lifecycle label
- keep queued agent tasks unreserved until capacity is available
- preserve bounded reservation expiry, PID-bound child safety, and ordinary runner-exec behavior

Fixes #8926.

## How to test

1. Check out this branch from a fresh clone.
2. Run `cargo test -p homeboy-core direct_daemon_agent_task_request_uses_workload_identity_for_capacity_admission --lib`.
3. Run `cargo test -p homeboy-core capacity_queued_agent_task_spawns_once_after_claiming_an_idle_slot --lib`.
4. Run `cargo test -p homeboy-core runner_capacity_is_claimed_before_reserving_an_agent_task_child --lib`.
5. Run `cargo check -p homeboy-core -p homeboy-lab-runner`.
6. Run `cargo fmt --check` and `git diff --check`.

## Compatibility

This changes internal daemon scheduling order for typed agent-task workloads. Public CLI contracts and extension paths are unchanged. Non-agent `runner exec` jobs retain their existing admission behavior. Agent tasks that exceed runner capacity now remain queued without holding an expiring child reservation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with `gpt-5.6-sol`
- **Used for:** Diagnosed the capacity/reservation ordering defect, implemented the generic scheduling fix and deterministic regressions, and verified the candidate with Chris; Chris reviews and owns the change.
