### PR TITLE
Fix ignored Git candidate paths during promotion

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -121,7 +121,7 @@ pub fn resume_promoted_patch(
             path: patch_path.display().to_string(),
             sha256: artifact.sha256,
         },
-        changed_files: normalized_patch.changed_files,
+        changed_files: persisted_changed_files(normalized_patch.changed_files, candidate.as_ref()),
         command_evidence,
         deterministic_gates: gates.deterministic_gates,
         gate_results: gates.gate_results,
@@ -534,7 +534,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
             path: patch_path.display().to_string(),
             sha256: artifact.sha256,
         },
-        changed_files,
+        changed_files: persisted_changed_files(changed_files, candidate.as_ref()),
         command_evidence,
         deterministic_gates: gates.deterministic_gates,
         gate_results: gates.gate_results,
@@ -840,7 +840,7 @@ fn promote_committed_changes(
             path: committed_patch.patch_path.display().to_string(),
             sha256: Some(committed_patch.sha256),
         },
-        changed_files: normalized_patch.changed_files,
+        changed_files: persisted_changed_files(normalized_patch.changed_files, candidate.as_ref()),
         command_evidence,
         deterministic_gates: gates.deterministic_gates,
         gate_results: gates.gate_results,
@@ -1170,6 +1170,20 @@ fn post_apply_report(
             "post_apply": true,
         }),
         operator_notification,
+    }
+}
+
+fn persisted_changed_files(
+    patch_changed_files: Vec<String>,
+    candidate: Option<&crate::agent_task_promotion::AgentTaskPromotionCandidate>,
+) -> Vec<String> {
+    match candidate {
+        Some(crate::agent_task_promotion::AgentTaskPromotionCandidate::Git { fingerprint })
+            if !fingerprint.changed_files.is_empty() =>
+        {
+            fingerprint.changed_files.clone()
+        }
+        _ => patch_changed_files,
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
@@ -55,6 +55,7 @@ pub(super) struct FakePromotionWorkspaceProvider {
     )>,
     verify_exit_code: i32,
     verify_transport_error: bool,
+    force_add_ignored_file: bool,
 }
 
 impl AgentTaskPromotionWorkspaceProvider for FakePromotionWorkspaceProvider {
@@ -73,6 +74,17 @@ impl AgentTaskPromotionWorkspaceProvider for FakePromotionWorkspaceProvider {
                 None,
             )
         })?;
+        if self.force_add_ignored_file {
+            git(&path, &["apply", &request.patch_path]);
+            std::fs::write(path.join(".git/info/exclude"), "ignored/\n")
+                .expect("ignore nested candidate file");
+            let ignored = path.join("ignored/nested/force-added.rs");
+            std::fs::create_dir_all(ignored.parent().expect("ignored parent"))
+                .expect("create ignored nested directory");
+            std::fs::write(&ignored, "pub const FORCED: bool = true;\n")
+                .expect("write ignored nested candidate file");
+            git(&path, &["add", "-f", "ignored/nested/force-added.rs"]);
+        }
         Ok(AgentTaskPromotionWorkspace {
             path,
             command_evidence: vec![command_report(vec![

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
@@ -531,6 +531,59 @@ fn promote_applies_patch_with_fake_workspace_provider() {
 }
 
 #[test]
+fn promote_persists_force_added_ignored_git_candidate_paths() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let worktree_path = temp.path().join("controlled-worktree");
+    std::fs::create_dir(&worktree_path).expect("worktree");
+    git(&worktree_path, &["init"]);
+    git(
+        &worktree_path,
+        &["config", "user.email", "test@example.com"],
+    );
+    git(&worktree_path, &["config", "user.name", "Test"]);
+    std::fs::create_dir_all(worktree_path.join("src")).expect("src");
+    std::fs::write(worktree_path.join("src/lib.rs"), "old\n").expect("base source");
+    git(&worktree_path, &["add", "."]);
+    git(&worktree_path, &["commit", "-m", "base"]);
+    let (source_path, source) = write_patch_source(&temp);
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(worktree_path),
+        force_add_ignored_file: true,
+        ..Default::default()
+    };
+
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("run-8935".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            candidate_ref: None,
+            to_worktree: "repo@controlled-worktree".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions::default(),
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+    )
+    .expect("promotion accepts the force-added ignored candidate file");
+
+    assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
+    assert_eq!(
+        report.changed_files,
+        vec![
+            "ignored/nested/force-added.rs".to_string(),
+            "src/lib.rs".to_string(),
+        ]
+    );
+}
+
+#[test]
 fn promote_materializes_worktree_dependencies_before_verify_gate() {
     // #3771: a freshly created worktree has no installed dependencies, so a
     // verify gate that touches autoloaded deps fatals on missing deps


### PR DESCRIPTION
Fixes #8935.

## Summary
- Persist nonempty authoritative Git candidate fingerprint paths in applied and resumed promotion reports.
- Retain patch-derived paths when the Git candidate is clean or the target is non-Git.
- Cover a fake provider that creates an ignored nested file and stages it with `git add -f`.

## Evidence
- Source relationship: finalization validates caller paths against `candidate_fingerprint(...).changed_files`; promotion previously persisted only normalized patch-header paths.
- Change kind: minimal runtime persistence alignment plus deterministic regression coverage.
- Verification capability: the regression materializes a Git worktree, ignores a nested file through `.git/info/exclude`, force-adds it, and confirms the successful report persists both authoritative paths.
- Scope: the runtime change only substitutes a nonempty Git fingerprint path list. Clean committed candidates and non-Git targets retain patch-derived paths, so it does not broaden target or finalization behavior.

## Verification
1. `cargo fmt --check`
2. `cargo test -p homeboy-agents agent_task_promotion::tests::part_c::promote_persists_force_added_ignored_git_candidate_paths`
3. `cargo test -p homeboy-agents agent_task_finalization::tests`
4. `cargo test -p homeboy-agents agent_task_promotion::tests` (46 passed; 6 existing fixture/environment failures: missing test `origin`, unavailable component-script runner, and shared-state-sensitive assertions.)

## Compatibility Impact
No schema or API changes. Applied Git promotions with a nonempty authoritative fingerprint now persist the same changed-path set used by finalization. Clean committed Git candidates and non-Git targets keep their existing patch-derived paths.

## AI Assistance
Implemented with assistance from OpenAI `gpt-5.6-terra`.