### PR TITLE
Add exact recovery for PID-less dead-daemon jobs

### DIFF
--- a/crates/homeboy-cli/src/commands/daemon.rs
+++ b/crates/homeboy-cli/src/commands/daemon.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use uuid::Uuid;
 
 use homeboy::core::daemon::{
-    self, BrokerConfig, BrokerConfigOptions, DaemonLeaselessRecoveryResult, DaemonOrphanAdoptionResult, DaemonStartResult, DaemonStateLossRecoveryResult, DaemonStatus, DaemonStopResult,
+    self, BrokerConfig, BrokerConfigOptions, DaemonExactOrphanRecoveryResult, DaemonLeaselessRecoveryResult, DaemonOrphanAdoptionResult, DaemonStartResult, DaemonStateLossRecoveryResult, DaemonStatus, DaemonStopResult,
     ServiceIdentity,
 };
 use homeboy::core::Error;
@@ -45,6 +45,19 @@ enum DaemonCommand {
         /// Accepted migration alias for one legacy untracked child. It never mutates jobs.
         #[arg(long = "confirm-untracked-child-dead")]
         confirm_untracked_child_dead: Vec<Uuid>,
+        #[arg(long, default_value = daemon::DEFAULT_ADDR)]
+        addr: String,
+    },
+    /// Reconcile an exact PID-less job set after one proven unexpected daemon exit
+    ReconcileDeadLeaseOrphans {
+        #[arg(long)]
+        lease_id: String,
+        #[arg(long = "job-id", required = true)]
+        job_ids: Vec<Uuid>,
+        #[arg(long)]
+        confirm_pid_dead: bool,
+        #[arg(long)]
+        confirm_workload_processes_absent: bool,
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
     },
@@ -157,6 +170,7 @@ pub enum DaemonOutput {
     Start(DaemonStartResult),
     EnsureRunning(DaemonStartResult),
     AdoptOrphan(DaemonOrphanAdoptionResult),
+    ReconcileDeadLeaseOrphans(DaemonExactOrphanRecoveryResult),
     RecoverMissingChildIdentity(homeboy::core::api_jobs::Job),
     ReconcileLeaselessOrphans(DaemonLeaselessRecoveryResult),
     RecoverMissingLeaseState(DaemonStateLossRecoveryResult),
@@ -211,6 +225,12 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
                 0,
             ))
         }
+        DaemonCommand::ReconcileDeadLeaseOrphans { lease_id, job_ids, confirm_pid_dead, confirm_workload_processes_absent, addr } => Ok((
+            DaemonOutput::ReconcileDeadLeaseOrphans(daemon::reconcile_dead_lease_orphans(
+                &lease_id, &job_ids, confirm_pid_dead, confirm_workload_processes_absent, &addr,
+            )?),
+            0,
+        )),
         DaemonCommand::RecoverMissingChildIdentity { lease_id, recorded_daemon_pid, recorded_daemon_endpoint, job_id, child_pid, child_starttime_ticks } => Ok((
             DaemonOutput::RecoverMissingChildIdentity(daemon::recover_missing_child_identity(&lease_id, recorded_daemon_pid, &recorded_daemon_endpoint, job_id, child_pid, child_starttime_ticks)?),
             0,
@@ -373,6 +393,42 @@ mod tests {
         assert!(Cli::try_parse_from([
             "homeboy", "daemon", "recover-missing-child-identity", "--lease-id", "lease", "--recorded-daemon-pid", "42", "--recorded-daemon-endpoint", "127.0.0.1:1", "--job-id", "00000000-0000-0000-0000-000000000001", "--child-pid", "43", "--child-starttime-ticks", "1",
         ]).is_ok());
+    }
+
+    #[test]
+    fn exact_dead_lease_recovery_requires_both_operator_confirmations() {
+        for args in [
+            vec![
+                "homeboy",
+                "daemon",
+                "reconcile-dead-lease-orphans",
+                "--lease-id",
+                "lease-dead",
+                "--job-id",
+                "00000000-0000-0000-0000-000000000001",
+            ],
+            vec![
+                "homeboy",
+                "daemon",
+                "reconcile-dead-lease-orphans",
+                "--lease-id",
+                "lease-dead",
+                "--job-id",
+                "00000000-0000-0000-0000-000000000001",
+                "--confirm-pid-dead",
+            ],
+        ] {
+            let cli = Cli::try_parse_from(args).expect("recovery command parses");
+            let Commands::Daemon(args) = cli.command else {
+                panic!("expected daemon command");
+            };
+            let error = run(args, &crate::commands::GlobalArgs {})
+                .expect_err("missing operator confirmation is rejected before state access");
+            assert!(
+                error.message.contains("confirm-pid-dead")
+                    || error.message.contains("confirm-workload-processes-absent")
+            );
+        }
     }
 
     #[test]

--- a/crates/homeboy-core/src/api_jobs/persistence.rs
+++ b/crates/homeboy-core/src/api_jobs/persistence.rs
@@ -25,6 +25,7 @@ pub(super) struct JobStoreCompactionEvidence {
     pub(super) timestamp_ms: u64,
     pub(super) removed_terminal_jobs: usize,
     pub(super) retained_terminal_jobs: usize,
+    #[serde(default)]
     pub(super) retained_terminal_bytes: usize,
     pub(super) active_jobs: usize,
 }

--- a/crates/homeboy-core/src/api_jobs/store.rs
+++ b/crates/homeboy-core/src/api_jobs/store.rs
@@ -641,6 +641,121 @@ impl JobStore {
         )
     }
 
+    /// Terminalize an operator-supplied, complete set of PID-less jobs after a
+    /// daemon's unexpected death has been proven by the lifecycle controller.
+    /// This is deliberately separate from automatic reconciliation: every
+    /// active job must be named, owned by the exact lease, and have no child
+    /// identity that could contradict the operator's absence confirmation.
+    pub fn reconcile_exact_daemon_loss_jobs(
+        &self,
+        expected_lease_id: &str,
+        expected_job_ids: &[Uuid],
+        daemon_pid: u32,
+    ) -> Result<DaemonLeaseJobDiagnostics> {
+        let expected = expected_job_ids
+            .iter()
+            .copied()
+            .collect::<std::collections::BTreeSet<_>>();
+        if expected.is_empty() || expected.len() != expected_job_ids.len() {
+            return Err(Error::validation_invalid_argument(
+                "job_id",
+                "dead-daemon recovery requires a non-empty, unique exact active job set",
+                None,
+                None,
+            ));
+        }
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let active = inner
+            .jobs
+            .values()
+            .filter(|stored| matches!(stored.job.status, JobStatus::Queued | JobStatus::Running))
+            .map(|stored| stored.job.id)
+            .collect::<std::collections::BTreeSet<_>>();
+        if active != expected {
+            return Err(Error::validation_invalid_argument(
+                "job_id",
+                format!(
+                    "dead-daemon recovery job IDs must name the exact active durable-job set; expected {:?}, found {:?}",
+                    expected, active
+                ),
+                Some(expected_lease_id.to_string()),
+                None,
+            ));
+        }
+        for job_id in &expected {
+            let stored = inner.jobs.get(job_id).expect("active job exists");
+            if stored.job.daemon_lease_id.as_deref() != Some(expected_lease_id) {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    format!("job `{job_id}` is not owned by daemon lease `{expected_lease_id}`"),
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            if stored
+                .local_child
+                .as_ref()
+                .and_then(|child| child.process.as_ref())
+                .is_some()
+            {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    format!("job `{job_id}` has persisted child-process evidence; refusing operator no-PID recovery"),
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+        }
+        let now = timestamp_ms();
+        for job_id in &expected {
+            let stored = inner.jobs.get_mut(job_id).expect("active job exists");
+            stored.job.status = JobStatus::Failed;
+            stored.job.updated_at_ms = now;
+            stored.job.finished_at_ms = Some(now);
+            stored.job.stale_reason = Some(
+                "daemon lost after unexpected termination; operator confirmed workloads absent"
+                    .to_string(),
+            );
+            let data = serde_json::json!({
+                "status": JobStatus::Failed,
+                "reason": "operator_confirmed_daemon_loss_after_unexpected_termination",
+                "daemon_lease_id": expected_lease_id,
+                "daemon_pid": daemon_pid,
+                "operator_confirmed_workload_processes_absent": true,
+                "exact_active_job_set": expected,
+            });
+            for (kind, message) in [
+                (
+                    JobEventKind::Error,
+                    "daemon lost after unexpected termination",
+                ),
+                (
+                    JobEventKind::Status,
+                    "job marked failed after exact operator daemon-loss reconciliation",
+                ),
+            ] {
+                let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+                stored.events.push(JobEvent {
+                    sequence,
+                    job_id: *job_id,
+                    kind,
+                    timestamp_ms: now,
+                    message: Some(message.to_string()),
+                    data: Some(data.clone()),
+                });
+            }
+            apply_event_retention(&mut stored.events, self.event_retention_limit());
+            stored.job.event_count = stored.events.len();
+        }
+        drop(inner);
+        self.persist()?;
+        Ok(DaemonLeaseJobDiagnostics {
+            expected_lease_id: expected_lease_id.to_string(),
+            matching_job_ids: expected.into_iter().collect(),
+            ..DaemonLeaseJobDiagnostics::default()
+        })
+    }
+
     /// Reconcile only jobs whose linked durable run has already reached a
     /// terminal state. This deliberately does not inspect, stop, or alter live
     /// children, so it is safe when a daemon's aggregate count includes both

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -281,6 +281,96 @@ fn dead_lease_reconciliation_requires_exact_confirmation_for_untracked_children(
 }
 
 #[test]
+fn exact_daemon_loss_recovery_requires_the_complete_pidless_active_set_and_persists_evidence() {
+    let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
+    let first = store.create("runner.exec");
+    store.start(first.id).expect("first starts");
+    let second = store.create("runner.exec");
+    store.start(second.id).expect("second starts");
+
+    for ids in [&[first.id][..], &[first.id, Uuid::new_v4()][..]] {
+        let error = store
+            .reconcile_exact_daemon_loss_jobs("lease-dead", ids, 4242)
+            .expect_err("omitted or unknown active jobs are refused");
+        assert!(error.message.contains("exact active durable-job set"));
+    }
+    assert_eq!(
+        store.get(first.id).expect("first").status,
+        JobStatus::Running
+    );
+
+    let diagnostics = store
+        .reconcile_exact_daemon_loss_jobs("lease-dead", &[first.id, second.id], 4242)
+        .expect("the exact complete set reconciles");
+    assert_eq!(
+        diagnostics.matching_job_ids,
+        [first.id, second.id]
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+    );
+    for id in [first.id, second.id] {
+        assert_eq!(
+            store.get(id).expect("terminal job").status,
+            JobStatus::Failed
+        );
+        assert!(store
+            .events(id)
+            .expect("durable events")
+            .iter()
+            .any(|event| {
+                event.data.as_ref().is_some_and(|data| {
+                    data["reason"] == "operator_confirmed_daemon_loss_after_unexpected_termination"
+                        && data["daemon_lease_id"] == "lease-dead"
+                        && data["daemon_pid"] == 4242
+                        && data["operator_confirmed_workload_processes_absent"] == true
+                })
+            }));
+    }
+    assert!(store
+        .reconcile_exact_daemon_loss_jobs("lease-dead", &[first.id, second.id], 4242)
+        .expect_err("replay refuses because the named jobs are no longer active")
+        .message
+        .contains("exact active durable-job set"));
+}
+
+#[test]
+fn exact_daemon_loss_recovery_refuses_persisted_child_process_evidence() {
+    let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
+    let job = store.create("runner.exec");
+    record_test_local_child(&store, job.id, u32::MAX);
+
+    let error = store
+        .reconcile_exact_daemon_loss_jobs("lease-dead", &[job.id], 4242)
+        .expect_err("live-process evidence contradicts no-PID recovery");
+
+    assert!(error.message.contains("child-process evidence"));
+    assert_eq!(
+        store.get(job.id).expect("protected job").status,
+        JobStatus::Running
+    );
+}
+
+#[test]
+fn exact_daemon_loss_recovery_accepts_a_reservation_without_process_identity() {
+    let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
+    let job = store.create("runner.exec");
+    store
+        .reserve_local_child_at(job.id, 100)
+        .expect("pre-spawn reservation persists");
+
+    store
+        .reconcile_exact_daemon_loss_jobs("lease-dead", &[job.id], 4242)
+        .expect("a reservation without process identity remains a PID-less job");
+
+    assert_eq!(
+        store.get(job.id).expect("terminal job").status,
+        JobStatus::Failed
+    );
+}
+
+#[test]
 fn dead_lease_reconciliation_is_idempotent_after_terminalizing_a_dead_child() {
     let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
     let job = store.create("runner.exec");
@@ -840,6 +930,51 @@ fn terminal_job_retention_compacts_existing_store_without_losing_active_recovery
     assert_eq!(
         restarted.get(running.id).expect("running job").status,
         JobStatus::Running
+    );
+}
+
+#[test]
+fn legacy_compaction_evidence_without_retained_bytes_reopens() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store opens");
+    let job = store.create("terminal");
+    store.start(job.id).expect("terminal job starts");
+    store
+        .complete(job.id, None)
+        .expect("terminal job completes");
+
+    let mut durable: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).expect("durable store is readable"))
+            .expect("durable store is valid JSON");
+    durable["compaction"] = json!({
+        "timestamp_ms": 100,
+        "removed_terminal_jobs": 1,
+        "retained_terminal_jobs": 1,
+        "active_jobs": 0
+    });
+    fs::write(
+        &path,
+        serde_json::to_string_pretty(&durable).expect("legacy store serializes"),
+    )
+    .expect("legacy store persists");
+
+    let reopened = JobStore::open_without_reconciliation(&path)
+        .expect("legacy compaction evidence remains readable");
+    assert_eq!(
+        reopened.get(job.id).expect("job survives").status,
+        JobStatus::Succeeded
+    );
+    assert_eq!(
+        reopened
+            .inner
+            .lock()
+            .expect("job store mutex")
+            .compaction
+            .as_ref()
+            .expect("compaction evidence survives")
+            .retained_terminal_bytes,
+        0
     );
 }
 

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -41,8 +41,8 @@ pub use artifact_download::ArtifactDownload;
 pub use broker_config::{render_broker_config, BrokerConfig, BrokerConfigOptions, ServiceIdentity};
 pub use control::{
     adopt_orphaned_lease, artifact_content_url, ensure_running, fetch_artifact_to_path,
-    reconcile_leaseless_orphans, recover_missing_child_identity, recover_missing_lease_state,
-    start_background, supervise, ArtifactFetchOutcome,
+    reconcile_dead_lease_orphans, reconcile_leaseless_orphans, recover_missing_child_identity,
+    recover_missing_lease_state, start_background, supervise, ArtifactFetchOutcome,
 };
 use patch_capture::{capture_baseline, capture_patch_report};
 
@@ -233,6 +233,16 @@ pub struct DaemonOrphanAdoptionResult {
     pub dead_pid: u32,
     pub active_jobs_terminalized: usize,
     pub retry_guidance: String,
+    pub replacement: DaemonStartResult,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DaemonExactOrphanRecoveryResult {
+    pub recovered_lease_id: String,
+    pub dead_pid: u32,
+    pub reconciled_job_ids: Vec<Uuid>,
+    pub termination_evidence: DaemonTerminationEvidence,
+    pub ownership_proof: Vec<String>,
     pub replacement: DaemonStartResult,
 }
 

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -20,10 +20,10 @@ use crate::process::pid_is_running;
 use super::{
     acquire_daemon_operation_lock, acquire_daemon_operation_lock_for_ensure, parse_bind_addr,
     read_status, repair_legacy_lease_for_start, stop_unlocked, try_acquire_daemon_owner_lock,
-    DaemonLeaselessOrphanReconciliationResult, DaemonLeaselessRecoveryResult,
-    DaemonOrphanAdoptionResult, DaemonProcessCandidate, DaemonProcessOwnership,
-    DaemonStaleReasonCode, DaemonStartResult, DaemonTerminationClassification,
-    DaemonTerminationEvidence, DAEMON_STARTUP_TOKEN_ENV,
+    DaemonExactOrphanRecoveryResult, DaemonLeaselessOrphanReconciliationResult,
+    DaemonLeaselessRecoveryResult, DaemonOrphanAdoptionResult, DaemonProcessCandidate,
+    DaemonProcessOwnership, DaemonStaleReasonCode, DaemonStartResult,
+    DaemonTerminationClassification, DaemonTerminationEvidence, DAEMON_STARTUP_TOKEN_ENV,
 };
 
 /// Enumerate foreground daemon processes without inferring ownership from a
@@ -970,6 +970,149 @@ pub fn adopt_orphaned_lease(
         },
         || start_or_return_live_unlocked(addr),
     )
+}
+
+/// Explicit recovery for the otherwise irreconcilable case where a proven-dead
+/// daemon lost jobs before it could persist a child identity. This never widens
+/// automatic adoption: the operator must name every active job and attest that
+/// workload processes were inspected and are absent.
+pub fn reconcile_dead_lease_orphans(
+    lease_id: &str,
+    job_ids: &[uuid::Uuid],
+    confirm_pid_dead: bool,
+    confirm_workload_processes_absent: bool,
+    addr: &str,
+) -> Result<DaemonExactOrphanRecoveryResult> {
+    if !confirm_pid_dead {
+        return Err(Error::validation_invalid_argument(
+            "confirm_pid_dead",
+            "exact dead-lease recovery requires --confirm-pid-dead",
+            None,
+            None,
+        ));
+    }
+    if !confirm_workload_processes_absent {
+        return Err(Error::validation_invalid_argument("confirm_workload_processes_absent", "exact dead-lease recovery requires --confirm-workload-processes-absent after inspecting workload processes", None, None));
+    }
+    parse_bind_addr(addr)?;
+    let _lock = acquire_daemon_operation_lock()?;
+    reconcile_dead_lease_orphans_with_operations(
+        lease_id,
+        job_ids,
+        read_status,
+        pid_is_running,
+        try_acquire_daemon_owner_lock,
+        || prove_no_daemon_owner(addr),
+        |pid| {
+            let store =
+                super::JobStore::open_without_reconciliation(crate::paths::daemon_jobs_file()?)?;
+            store.reconcile_exact_daemon_loss_jobs(lease_id, job_ids, pid)
+        },
+        || start_or_return_live_unlocked(addr),
+    )
+}
+
+fn reconcile_dead_lease_orphans_with_operations<
+    Status,
+    PidIsRunning,
+    AcquireOwner,
+    OwnerLock,
+    ProveNoOwner,
+    Reconcile,
+    Start,
+>(
+    lease_id: &str,
+    _job_ids: &[uuid::Uuid],
+    status: Status,
+    pid_is_running: PidIsRunning,
+    acquire_owner: AcquireOwner,
+    prove_no_owner: ProveNoOwner,
+    reconcile: Reconcile,
+    start: Start,
+) -> Result<DaemonExactOrphanRecoveryResult>
+where
+    Status: FnOnce() -> Result<super::DaemonStatus>,
+    PidIsRunning: Fn(u32) -> bool,
+    AcquireOwner: FnOnce() -> Result<Option<OwnerLock>>,
+    ProveNoOwner: FnOnce() -> Result<Vec<String>>,
+    Reconcile: FnOnce(u32) -> Result<crate::api_jobs::DaemonLeaseJobDiagnostics>,
+    Start: FnOnce() -> Result<super::DaemonStartResult>,
+{
+    let status = status()?;
+    let state = status.state.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "lease_id",
+            "exact dead-lease recovery requires a persisted daemon lease",
+            Some(lease_id.to_string()),
+            None,
+        )
+    })?;
+    if state.lease_id != lease_id {
+        return Err(Error::validation_invalid_argument(
+            "lease_id",
+            "recorded daemon lease does not match requested dead lease",
+            Some(lease_id.to_string()),
+            None,
+        ));
+    }
+    if status.freshness.stale_reason_code != Some(DaemonStaleReasonCode::PidDead)
+        || pid_is_running(state.pid)
+    {
+        return Err(Error::validation_invalid_argument(
+            "lease_id",
+            "recorded daemon PID is live or not proven dead",
+            Some(lease_id.to_string()),
+            None,
+        ));
+    }
+    let termination = status.termination_evidence.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "termination_evidence",
+            "exact dead-lease recovery requires persisted unexpected-termination evidence",
+            Some(lease_id.to_string()),
+            None,
+        )
+    })?;
+    if termination.classification != DaemonTerminationClassification::UnexpectedExit
+        || termination.stop_requested
+        || termination.lease_id.as_deref() != Some(lease_id)
+        || termination.pid != Some(state.pid)
+    {
+        return Err(Error::validation_invalid_argument(
+            "termination_evidence",
+            "persisted termination evidence does not prove this lease's unexpected daemon exit",
+            Some(lease_id.to_string()),
+            None,
+        ));
+    }
+    let owner_lock = acquire_owner()?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "lease_id",
+            "daemon owner lock is held; refusing exact dead-lease recovery",
+            Some(lease_id.to_string()),
+            None,
+        )
+    })?;
+    if pid_is_running(state.pid) {
+        return Err(Error::validation_invalid_argument(
+            "lease_id",
+            "recorded daemon PID became live or was reused during recovery",
+            Some(lease_id.to_string()),
+            None,
+        ));
+    }
+    let ownership_proof = prove_no_owner()?;
+    let reconciled = reconcile(state.pid)?;
+    drop(owner_lock);
+    let replacement = start()?;
+    Ok(DaemonExactOrphanRecoveryResult {
+        recovered_lease_id: lease_id.to_string(),
+        dead_pid: state.pid,
+        reconciled_job_ids: reconciled.matching_job_ids,
+        termination_evidence: termination,
+        ownership_proof,
+        replacement,
+    })
 }
 
 /// Recover one legacy durable job only after an operator supplies the exact

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -65,6 +65,23 @@ The released `adopt-orphan --recover-missing-child-identity` and
 aliases. They must be supplied together when used, return the exact command and
 all required evidence fields above, and never mutate jobs.
 
+For a proven unexpected daemon exit where exact active jobs have no persisted
+child identity, use the explicit all-active-job-set recovery command. It requires
+the dead lease, every active job ID, PID-death confirmation, and an operator
+attestation that workload processes were inspected and absent. It refuses a live
+or reused daemon PID, missing or mismatched unexpected-exit evidence, a held
+daemon owner lock, conflicting daemon-process evidence, child identities, or an
+omitted/extra/non-active job ID. Each named job receives durable typed
+daemon-loss failure evidence before the replacement daemon starts:
+
+```sh
+homeboy daemon reconcile-dead-lease-orphans \
+  --lease-id <exact-dead-lease> \
+  --job-id <active-job-id> \
+  --confirm-pid-dead \
+  --confirm-workload-processes-absent
+```
+
 ## VPS Reverse Runner Broker
 
 `homeboy daemon broker-config` renders the code-backed deployment shape for a

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -14,6 +14,7 @@ use crate::api_jobs::{JobEventKind, JobStatus, JobStore};
 use crate::build_identity::BuildIdentity;
 use crate::daemon::{
     DaemonFreshnessReport, DaemonRuntimeSnapshot, DaemonStaleReasonCode, DaemonState, DaemonStatus,
+    DaemonTerminationClassification, DaemonTerminationEvidence,
 };
 use crate::test_support::with_isolated_home;
 
@@ -1127,6 +1128,87 @@ fn exact_adoption_keeps_legacy_missing_identity_blocked() {
 }
 
 #[test]
+fn exact_no_pid_recovery_requires_unexpected_termination_and_refuses_process_contradiction() {
+    let daemon = fake_daemon(4242, "lease-dead");
+    let mismatch = super::reconcile_dead_lease_orphans_with_operations(
+        "other-lease",
+        &[uuid::Uuid::new_v4()],
+        || Ok(dead_status_with_unexpected_termination(daemon.clone())),
+        |_| false,
+        || Ok(Some(())),
+        || unreachable!("lease mismatch blocks owner probe"),
+        |_| unreachable!("lease mismatch blocks mutation"),
+        || unreachable!("lease mismatch blocks replacement"),
+    )
+    .expect_err("mismatched lease is refused");
+    assert!(mismatch.message.contains("does not match"));
+
+    let missing = super::reconcile_dead_lease_orphans_with_operations(
+        "lease-dead",
+        &[uuid::Uuid::new_v4()],
+        || Ok(fake_dead_status(daemon.clone())),
+        |_| false,
+        || Ok(Some(())),
+        || Ok(vec!["no owner".to_string()]),
+        |_| unreachable!("missing evidence blocks mutation"),
+        || unreachable!("missing evidence blocks replacement"),
+    )
+    .expect_err("missing unexpected-exit evidence is refused");
+    assert!(missing.message.contains("unexpected-termination evidence"));
+
+    let job = uuid::Uuid::new_v4();
+    let status = dead_status_with_unexpected_termination(daemon.clone());
+    let contradiction = super::reconcile_dead_lease_orphans_with_operations(
+        "lease-dead",
+        &[job],
+        || Ok(status),
+        |_| false,
+        || Ok(Some(())),
+        || {
+            Err(crate::error::Error::validation_invalid_argument(
+                "owner_probe",
+                "live workload process evidence contradicts operator confirmation",
+                None,
+                None,
+            ))
+        },
+        |_| unreachable!("contradictory process evidence blocks mutation"),
+        || unreachable!("contradictory process evidence blocks replacement"),
+    )
+    .expect_err("contradictory process evidence is refused");
+    assert!(contradiction.message.contains("contradicts"));
+}
+
+#[test]
+fn exact_no_pid_recovery_starts_only_after_reconciliation() {
+    let daemon = fake_daemon(4242, "lease-dead");
+    let job = uuid::Uuid::new_v4();
+    let result = super::reconcile_dead_lease_orphans_with_operations(
+        "lease-dead",
+        &[job],
+        || Ok(dead_status_with_unexpected_termination(daemon)),
+        |_| false,
+        || Ok(Some(())),
+        || Ok(vec!["owner lock acquired".to_string()]),
+        |_| {
+            Ok(crate::api_jobs::DaemonLeaseJobDiagnostics {
+                expected_lease_id: "lease-dead".to_string(),
+                matching_job_ids: vec![job],
+                ..Default::default()
+            })
+        },
+        || Ok(fake_daemon(4343, "replacement")),
+    )
+    .expect("exact reconciliation succeeds before replacement");
+    assert_eq!(result.reconciled_job_ids, vec![job]);
+    assert_eq!(
+        result.termination_evidence.classification,
+        DaemonTerminationClassification::UnexpectedExit
+    );
+    assert_eq!(result.replacement.lease_id, "replacement");
+}
+
+#[test]
 fn fetch_artifact_to_path_downloads_daemon_byte_alias() {
     with_isolated_home(|home| {
         let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
@@ -1892,6 +1974,26 @@ fn fake_dead_status(daemon: super::DaemonStartResult) -> DaemonStatus {
         active_job_recovery_evidence: Vec::new(),
         termination_evidence: None,
     }
+}
+
+fn dead_status_with_unexpected_termination(daemon: super::DaemonStartResult) -> DaemonStatus {
+    let mut status = fake_dead_status(daemon.clone());
+    status.termination_evidence = Some(DaemonTerminationEvidence {
+        classification: DaemonTerminationClassification::UnexpectedExit,
+        observed_at: "2026-01-01T00:00:00Z".to_string(),
+        lease_id: Some(daemon.lease_id),
+        pid: Some(daemon.pid),
+        binary_identity: None,
+        active_jobs: 1,
+        resource_evidence: "test".to_string(),
+        os_evidence: "test".to_string(),
+        exit_code: None,
+        signal: Some(libc::SIGTERM),
+        stdout: None,
+        stderr: None,
+        stop_requested: false,
+    });
+    status
 }
 
 fn fake_daemon_state(daemon: super::DaemonStartResult) -> DaemonState {


### PR DESCRIPTION
## Summary
- add an explicit `daemon reconcile-dead-lease-orphans` recovery command bound to an exact dead lease and complete active job set
- require persisted unexpected-exit evidence plus explicit PID-death and workload-absence confirmations
- persist typed daemon-loss failure evidence before starting a replacement daemon
- distinguish a PID-less pre-spawn reservation from an actual persisted child process identity
- allow durable job stores written before `retained_terminal_bytes` to migrate safely on read

Closes #8216.

## Safety contract
Automatic orphan adoption remains fail-closed. Exact recovery refuses lease mismatch, live or reused daemon PID, missing or mismatched termination evidence, held daemon ownership, incomplete or duplicate job sets, foreign/non-active jobs, and persisted child process identity.

## Runtime evidence
The command recovered a real dead-daemon incident only after direct process inspection confirmed the recorded daemon PID and workload were absent. It terminalized exactly one named PID-less reservation job with typed evidence, started a replacement daemon, and returned the durable store to zero active jobs. This operational evidence is supplementary to the deterministic repository tests below.

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-core exact_daemon_loss_recovery`.
3. Run `cargo test -p homeboy-core exact_no_pid_recovery`.
4. Run `cargo test -p homeboy-core legacy_compaction_evidence_without_retained_bytes`.
5. Run `cargo test -p homeboy-cli exact_dead_lease_recovery_requires_both_operator_confirmations`.
6. Run `git diff --check origin/main...HEAD`.

## Compatibility
No public extension contract changes. The serde default is a one-step persisted-data migration for job stores written by the preceding Homeboy schema; subsequent writes emit the current field.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Implemented and verified the exact dead-daemon orphan recovery contract, persisted schema migration, and deterministic tests with Chris.