### PR TITLE
Support force-added ignored promotion candidates

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -121,7 +121,7 @@ pub fn resume_promoted_patch(
             path: patch_path.display().to_string(),
             sha256: artifact.sha256,
         },
-        changed_files: normalized_patch.changed_files,
+        changed_files: persisted_changed_files(normalized_patch.changed_files, candidate.as_ref()),
         command_evidence,
         deterministic_gates: gates.deterministic_gates,
         gate_results: gates.gate_results,
@@ -534,7 +534,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
             path: patch_path.display().to_string(),
             sha256: artifact.sha256,
         },
-        changed_files,
+        changed_files: persisted_changed_files(changed_files, candidate.as_ref()),
         command_evidence,
         deterministic_gates: gates.deterministic_gates,
         gate_results: gates.gate_results,
@@ -840,7 +840,7 @@ fn promote_committed_changes(
             path: committed_patch.patch_path.display().to_string(),
             sha256: Some(committed_patch.sha256),
         },
-        changed_files: normalized_patch.changed_files,
+        changed_files: persisted_changed_files(normalized_patch.changed_files, candidate.as_ref()),
         command_evidence,
         deterministic_gates: gates.deterministic_gates,
         gate_results: gates.gate_results,
@@ -1170,6 +1170,20 @@ fn post_apply_report(
             "post_apply": true,
         }),
         operator_notification,
+    }
+}
+
+fn persisted_changed_files(
+    patch_changed_files: Vec<String>,
+    candidate: Option<&crate::agent_task_promotion::AgentTaskPromotionCandidate>,
+) -> Vec<String> {
+    match candidate {
+        Some(crate::agent_task_promotion::AgentTaskPromotionCandidate::Git { fingerprint })
+            if !fingerprint.changed_files.is_empty() =>
+        {
+            fingerprint.changed_files.clone()
+        }
+        _ => patch_changed_files,
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
@@ -55,6 +55,7 @@ pub(super) struct FakePromotionWorkspaceProvider {
     )>,
     verify_exit_code: i32,
     verify_transport_error: bool,
+    force_add_ignored_file: bool,
 }
 
 impl AgentTaskPromotionWorkspaceProvider for FakePromotionWorkspaceProvider {
@@ -73,6 +74,17 @@ impl AgentTaskPromotionWorkspaceProvider for FakePromotionWorkspaceProvider {
                 None,
             )
         })?;
+        if self.force_add_ignored_file {
+            git(&path, &["apply", &request.patch_path]);
+            std::fs::write(path.join(".git/info/exclude"), "ignored/\n")
+                .expect("ignore nested candidate file");
+            let ignored = path.join("ignored/nested/force-added.rs");
+            std::fs::create_dir_all(ignored.parent().expect("ignored parent"))
+                .expect("create ignored nested directory");
+            std::fs::write(&ignored, "pub const FORCED: bool = true;\n")
+                .expect("write ignored nested candidate file");
+            git(&path, &["add", "-f", "ignored/nested/force-added.rs"]);
+        }
         Ok(AgentTaskPromotionWorkspace {
             path,
             command_evidence: vec![command_report(vec![

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
@@ -531,6 +531,59 @@ fn promote_applies_patch_with_fake_workspace_provider() {
 }
 
 #[test]
+fn promote_persists_force_added_ignored_git_candidate_paths() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let worktree_path = temp.path().join("controlled-worktree");
+    std::fs::create_dir(&worktree_path).expect("worktree");
+    git(&worktree_path, &["init"]);
+    git(
+        &worktree_path,
+        &["config", "user.email", "test@example.com"],
+    );
+    git(&worktree_path, &["config", "user.name", "Test"]);
+    std::fs::create_dir_all(worktree_path.join("src")).expect("src");
+    std::fs::write(worktree_path.join("src/lib.rs"), "old\n").expect("base source");
+    git(&worktree_path, &["add", "."]);
+    git(&worktree_path, &["commit", "-m", "base"]);
+    let (source_path, source) = write_patch_source(&temp);
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(worktree_path),
+        force_add_ignored_file: true,
+        ..Default::default()
+    };
+
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("run-8935".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            candidate_ref: None,
+            to_worktree: "repo@controlled-worktree".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions::default(),
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+    )
+    .expect("promotion accepts the force-added ignored candidate file");
+
+    assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
+    assert_eq!(
+        report.changed_files,
+        vec![
+            "ignored/nested/force-added.rs".to_string(),
+            "src/lib.rs".to_string(),
+        ]
+    );
+}
+
+#[test]
 fn promote_materializes_worktree_dependencies_before_verify_gate() {
     // #3771: a freshly created worktree has no installed dependencies, so a
     // verify gate that touches autoloaded deps fatals on missing deps


### PR DESCRIPTION
## Summary
Support force-added ignored promotion candidates

## What changed
- Applies the verified agent-task candidate.

## How to test
1. Run `cargo test -p homeboy-agents promotion_uses_force_added_ignored_git_candidate_files --lib --locked && cargo test -p homeboy-agents production_validator_normalizes_changed_file_order_and_duplicates --lib --locked && cargo fmt --check`; expect passes.

## Compatibility
No compatibility impact was recorded by the cook workflow.

## Evidence
- Base advanced after verification: verified main at b0848c2a4689e50f60645fb983d60a5a809abc9b; publication observed c3e16a03257d802819e87489ce25a13b6423a137. Candidate ancestry was validated against the verified snapshot.
- CI expected: Homeboy CI after push
- Durable run execution: Succeeded
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8935
- Verified finalization base: main at b0848c2a4689e50f60645fb983d60a5a809abc9b
- gate-1: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** AI-assisted
- **Model:** openai/gpt-5.6-terra
- **Used for:** Drafted implementation and tests; Chris reviews and owns the change.
