### PR TITLE
Instrument capacity-queued child spawn failures

### DIFF
--- a/crates/homeboy-core/src/api_jobs/store.rs
+++ b/crates/homeboy-core/src/api_jobs/store.rs
@@ -1624,12 +1624,32 @@ impl JobStore {
                     Err(_) => return,
                 }
             }
+            let _ = job_handle.progress(serde_json::json!({
+                "phase": "local_child_worker_started",
+            }));
             match run(job_handle) {
                 Ok(output) => {
                     let _ = worker_store.complete(job_id, serde_json::to_value(output).ok());
                 }
                 Err(error) => {
-                    let _ = worker_store.fail(job_id, error.to_string());
+                    let error_message = error.to_string();
+                    if worker_store
+                        .get(job_id)
+                        .is_ok_and(|job| job.status == JobStatus::Queued)
+                    {
+                        let _ = worker_store.append_event(
+                            job_id,
+                            JobEventKind::Progress,
+                            Some("local child worker failed before child identity".to_string()),
+                            Some(serde_json::json!({
+                                "phase": "local_child_worker_failed_before_child_identity",
+                                "error": error_message,
+                                "error_code": error.code.as_str(),
+                                "error_details": error.details,
+                            })),
+                        );
+                    }
+                    let _ = worker_store.fail(job_id, error_message);
                 }
             }
         });

--- a/crates/homeboy-core/src/api_jobs/tests/part_a.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_a.rs
@@ -342,6 +342,52 @@ fn capacity_queued_agent_task_spawns_once_after_claiming_an_idle_slot() {
 }
 
 #[test]
+fn capacity_queued_agent_task_persists_typed_failure_before_child_identity() {
+    let store = JobStore::default();
+    let runner = store.run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
+        "runner.exec",
+        None,
+        None,
+        None,
+        super::store::LocalRunnerJob {
+            runner_id: "homeboy-lab".to_string(),
+            command: vec!["homeboy".to_string(), "agent-task".to_string()],
+            cwd: Some("/runner/worktree".to_string()),
+            lifecycle: None,
+        },
+        1,
+        move |_job| {
+            Err::<serde_json::Value, _>(Error::internal_io(
+                "spawn failed",
+                Some("execute runner command".to_string()),
+            ))
+        },
+    );
+    runner.handle.join().expect("worker exits");
+
+    let events = store.events(runner.job_id).expect("events");
+    assert!(events.iter().any(|event| {
+        event
+            .data
+            .as_ref()
+            .is_some_and(|data| data["phase"] == "local_child_worker_started")
+    }));
+    assert!(events.iter().any(|event| {
+        event.data.as_ref().is_some_and(|data| {
+            data["phase"] == "local_child_worker_failed_before_child_identity"
+                && data["error"] == "IO error"
+                && data["error_code"] == "internal.io_error"
+                && data["error_details"]["error"] == "spawn failed"
+                && data["error_details"]["context"] == "execute runner command"
+        })
+    }));
+    assert_eq!(
+        store.get(runner.job_id).expect("job").status,
+        JobStatus::Failed
+    );
+}
+
+#[test]
 fn pid_bound_local_child_is_not_expired_by_its_former_reservation_deadline() {
     let store = JobStore::default();
     let job = store.create("runner.exec");


### PR DESCRIPTION
## Summary
- instrument the capacity-queued local-child worker used by current agent-task dispatch
- persist `local_child_worker_started` after capacity reservation succeeds
- preserve typed error code and structured details when the active worker fails before child identity
- add deterministic coverage against the production-path helper introduced by #8936

Closes #8926.

## Root cause
PR #8940 instrumented the older local-child helper. Current agent tasks route through `run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner`, which still collapsed structured spawn errors to the generic `IO error` display message. Three controlled attempts on merged runtime `e26b2e76f2c6` proved the live path bypassed the prior instrumentation.

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-core capacity_queued_agent_task_persists_typed_failure_before_child_identity`.
3. Run `cargo test -p homeboy-core capacity_queued_agent_task_spawns_once_after_claiming_an_idle_slot`.
4. Run `git diff --check origin/main...HEAD`.

## Compatibility
No public contract or execution policy changes. Existing events remain unchanged; failures gain structured diagnostic fields.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Traced the merged diagnostic gap to the active capacity-queued helper, implemented durable typed evidence, and added production-path tests with Chris.