### PR TITLE
Allow adoption after transport failures

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -14,6 +14,7 @@ pub fn record_pre_execution_failure(
     let failed = task_count;
     let retryable = error.retryable == Some(true);
     let failure_classification = pre_execution_failure_classification(error);
+    let candidate_adoption_recovery = candidate_adoption_recovery(phase);
     let outcomes = plan
         .tasks
         .iter()
@@ -68,6 +69,7 @@ pub fn record_pre_execution_failure(
             "details": error.details.clone(),
             "hints": error.hints.iter().map(|hint| hint.message.as_str()).collect::<Vec<_>>(),
             "provider_executions_consumed": 0,
+            "candidate_adoption_recovery": candidate_adoption_recovery,
             "controller_identity": homeboy_core::build_identity::current().display,
             "runner_id": runner_id,
             "task_linkage": plan.tasks.iter().map(|task| json!({
@@ -89,6 +91,7 @@ pub(crate) fn build_pre_execution_failure_outcome(
 ) -> AgentTaskOutcome {
     let retryable = error.retryable == Some(true);
     let failure_classification = pre_execution_failure_classification(error);
+    let candidate_adoption_recovery = candidate_adoption_recovery(phase);
     let diagnostic = AgentTaskDiagnostic {
         class: "pre_execution_failure".to_string(),
         message: error.message.clone(),
@@ -134,8 +137,23 @@ pub(crate) fn build_pre_execution_failure_outcome(
             "error_code": error.code.as_str(),
             "retryable": retryable,
             "provider_executions_consumed": 0,
+            "candidate_adoption_recovery": candidate_adoption_recovery,
         }),
     }
+}
+
+fn candidate_adoption_recovery(phase: &str) -> Option<serde_json::Value> {
+    matches!(
+        phase,
+        "lab_handoff_preacceptance" | "transport_dispatcher_prepare"
+    )
+    .then(|| {
+        json!({
+            "schema": "homeboy/agent-task-candidate-adoption-recovery/v1",
+            "reason": "pre_provider_transport_failure",
+            "provider_executions_consumed": 0,
+        })
+    })
 }
 
 fn pre_execution_failure_classification(error: &Error) -> AgentTaskFailureClassification {

--- a/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
@@ -37,6 +37,17 @@ pub(crate) fn committed_changes_patch(
         ensure_clean_source(worktree_path)?;
     }
     let candidate = resolve_candidate(worktree_path, options.candidate_ref.as_deref())?;
+    if options.candidate_ref.is_some() {
+        let head = git_stdout(worktree_path, &["rev-parse", "--verify", "HEAD^{commit}"])?;
+        if candidate != head.trim() {
+            return Err(Error::validation_invalid_argument(
+                "candidate_ref",
+                "candidate revision must equal the recorded source worktree HEAD",
+                Some(candidate),
+                None,
+            ));
+        }
+    }
     let is_ancestor = Command::new("git")
         .args(["merge-base", "--is-ancestor", &base_ref, &candidate])
         .current_dir(worktree_path)

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -269,20 +269,29 @@ pub(super) fn promote_with_provider_and_checkpoint(
     let source_for_provenance = source_value.clone();
     let (source_kind, outcome) = select_outcome(source_value, options.task_id.as_deref())?;
 
+    let failed_candidate_adoption = options.candidate_ref.is_some()
+        && outcome.status == AgentTaskOutcomeStatus::Failed
+        && has_pre_provider_transport_recovery_eligibility(&outcome);
     if !matches!(
         outcome.status,
         AgentTaskOutcomeStatus::Succeeded
             | AgentTaskOutcomeStatus::CandidateRecoverable
             | AgentTaskOutcomeStatus::NoOp
-    ) {
-        return Err(Error::validation_invalid_argument(
-            "source",
+    ) && !failed_candidate_adoption
+    {
+        let problem = if options.candidate_ref.is_some()
+            && outcome.status == AgentTaskOutcomeStatus::Failed
+        {
+            "immutable candidate adoption requires explicit durable pre-provider transport recovery eligibility; legacy or provider/test failures remain ineligible. Retry the cook or record a new transport failure through Homeboy."
+                .to_string()
+        } else {
             format!(
                 "promotion requires a succeeded, recoverable-candidate, or no-op outcome; task {} has status {:?}",
                 outcome.task_id, outcome.status
-            ),
-            None,
-            None,
+            )
+        };
+        return Err(Error::validation_invalid_argument(
+            "source", problem, None, None,
         ));
     }
 
@@ -548,6 +557,20 @@ pub(super) fn promote_with_provider_and_checkpoint(
         }),
         operator_notification,
     })
+}
+
+fn has_pre_provider_transport_recovery_eligibility(outcome: &AgentTaskOutcome) -> bool {
+    let eligibility = outcome
+        .metadata
+        .get("candidate_adoption_recovery")
+        .or_else(|| outcome.outputs.get("candidate_adoption_recovery"));
+    eligibility
+        .filter(|value| {
+            value["schema"] == "homeboy/agent-task-candidate-adoption-recovery/v1"
+                && value["reason"] == "pre_provider_transport_failure"
+                && value["provider_executions_consumed"] == 0
+        })
+        .is_some()
 }
 
 fn gate_feedback_baseline_for_artifact(

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
@@ -642,6 +642,62 @@ fn explicit_candidate_commit_adoption_promotes_and_records_green_gate_handoff() 
 }
 
 #[test]
+fn explicit_candidate_adopts_only_durable_pre_provider_transport_failures() {
+    let (temp, repo, base, candidate) = adopted_commit_repo();
+    let failed_source = |recovery: Value| {
+        serde_json::json!({
+            "schema": AGENT_TASK_OUTCOME_SCHEMA,
+            "task_id": "adoption-task",
+            "status": "failed",
+            "artifacts": [],
+            "metadata": { "candidate_adoption_recovery": recovery }
+        })
+        .to_string()
+    };
+    let eligible = serde_json::json!({
+        "schema": "homeboy/agent-task-candidate-adoption-recovery/v1",
+        "reason": "pre_provider_transport_failure",
+        "provider_executions_consumed": 0
+    });
+    let mut options = adopted_commit_options(
+        &temp,
+        &repo,
+        base.clone(),
+        candidate.clone(),
+        VerifyGateOptions {
+            verify: vec!["cargo test --lib".to_string()],
+            ..Default::default()
+        },
+    );
+    options.source = failed_source(eligible);
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(repo.clone()),
+        ..Default::default()
+    };
+    let report = promote_with_provider(options.clone(), &mut provider)
+        .expect("eligible transport failure adopts immutable candidate through gates");
+    assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
+    assert_eq!(provider.apply_calls.len(), 1);
+    assert_eq!(provider.verify_calls.len(), 1);
+
+    for recovery in [
+        Value::Null,
+        serde_json::json!({ "reason": "provider_failure" }),
+    ] {
+        options.source = failed_source(recovery);
+        let error = promote_with_provider(options.clone(), &mut provider)
+            .expect_err("legacy and provider failures fail closed");
+        assert!(
+            error
+                .message
+                .contains("explicit durable pre-provider transport recovery eligibility"),
+            "{}",
+            error.message
+        );
+    }
+}
+
+#[test]
 fn promotion_options_deserialize_legacy_flat_gate_payload() {
     // Payloads authored before the refactor used flat keys; they must still
     // deserialize into the flattened `gates` field unchanged.

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -52,6 +52,12 @@ pub trait AgentTaskCookAttemptDispatcher: Send + Sync + std::fmt::Debug {
         Ok(())
     }
 
+    /// External transports identify dispatch failures before a provider can
+    /// execute so candidate recovery remains distinct from provider failures.
+    fn pre_execution_failure_phase(&self) -> &'static str {
+        "cook_pre_execution"
+    }
+
     /// `derived_cook_baseline` is process-local authority for a gate-fix retry.
     /// Implementations must not serialize it into the provider request.
     fn dispatch_attempt(
@@ -116,6 +122,19 @@ pub fn adopt_cook_candidate(
     cook_or_run_id: &str,
     candidate_ref: &str,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
+    adopt_cook_candidate_with_dispatcher(cook_or_run_id, candidate_ref, |_| Ok(None))
+}
+
+/// Adopt an immutable candidate using the caller's durable transport
+/// reconstruction boundary. This keeps a persisted cook's placement policy in
+/// force even when its original provider attempt failed before transport setup.
+pub fn adopt_cook_candidate_with_dispatcher(
+    cook_or_run_id: &str,
+    candidate_ref: &str,
+    reconstruct_dispatcher: impl FnOnce(
+        &Value,
+    ) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
+) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
     let record = agent_task_lifecycle::status(cook_or_run_id)?;
     let cook_id = record
         .metadata
@@ -123,7 +142,12 @@ pub fn adopt_cook_candidate(
         .and_then(Value::as_str)
         .unwrap_or(cook_or_run_id);
     let recipe = super::load_recipe(cook_id)?;
-    let options = super::reconstruct_options(&recipe)?;
+    let attempt_dispatcher =
+        reconstruct_dispatcher(&recipe.promotion_transport["attempt_dispatch"])?;
+    let options = super::reconstruct_options_with_dispatcher(&recipe, attempt_dispatcher)?;
+    if let Some(dispatcher) = &options.attempt_dispatcher {
+        dispatcher.prepare_for_cook()?;
+    }
     let run_id = record.run_id.clone();
     let plan = agent_task_lifecycle::load_plan(&run_id)?;
     let source_request = plan.tasks.first().cloned().ok_or_else(|| {
@@ -465,7 +489,12 @@ where
                 let record = match agent_task_lifecycle::status(&run_id) {
                     Ok(record) => Some(record),
                     Err(_) => {
-                        record_pre_execution_failure(&plan, &run_id, &error)?;
+                        let phase = options
+                            .attempt_dispatcher
+                            .as_ref()
+                            .map(|dispatcher| dispatcher.pre_execution_failure_phase())
+                            .unwrap_or("cook_pre_execution");
+                        record_pre_execution_failure(&plan, &run_id, &error, phase)?;
                         agent_task_lifecycle::status(&run_id).ok()
                     }
                 };
@@ -826,14 +855,14 @@ where
 
 /// Pre-execution failures happen before a provider can receive work. Persist a
 /// normal terminal run so the Cook alias can expose its complete retry history.
-fn record_pre_execution_failure(plan: &AgentTaskPlan, run_id: &str, error: &Error) -> Result<()> {
+fn record_pre_execution_failure(
+    plan: &AgentTaskPlan,
+    run_id: &str,
+    error: &Error,
+    phase: &str,
+) -> Result<()> {
     if agent_task_lifecycle::submit_plan(plan, Some(run_id)).is_ok() {
-        agent_task_lifecycle::record_pre_execution_failure(
-            run_id,
-            plan,
-            "cook_pre_execution",
-            error,
-        )?;
+        agent_task_lifecycle::record_pre_execution_failure(run_id, plan, phase, error)?;
     }
     Ok(())
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -754,6 +754,26 @@ mod tests {
     };
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    #[derive(Debug)]
+    struct ReconstructedDispatcher;
+
+    impl AgentTaskCookAttemptDispatcher for ReconstructedDispatcher {
+        fn durable_recipe(&self) -> Result<Value> {
+            Ok(serde_json::json!({ "kind": "test" }))
+        }
+
+        fn dispatch_attempt(
+            &self,
+            _plan: AgentTaskPlan,
+            _run_id: &str,
+            _derived_cook_baseline: Option<
+                &crate::agent_task_service::cook::DerivedCookBaselineCapability,
+            >,
+        ) -> Result<()> {
+            Ok(())
+        }
+    }
+
     fn recipe() -> AgentTaskCookRecipe {
         let request = AgentTaskRequest {
             schema: crate::agent_task::AGENT_TASK_REQUEST_SCHEMA.to_string(),
@@ -861,6 +881,51 @@ mod tests {
             .unwrap_err()
             .message
             .contains("sensitive mappings"));
+    }
+
+    #[test]
+    fn external_dispatcher_recipe_requires_and_accepts_durable_reconstruction() {
+        let mut remote_recipe = recipe();
+        remote_recipe.promotion_transport["attempt_dispatch"] = serde_json::json!({
+            "kind": "remote"
+        });
+
+        let error = reconstruct_options(&remote_recipe).expect_err("missing dispatcher blocks");
+        assert_eq!(
+            error.details["field"],
+            "cook_recipe.promotion_transport.attempt_dispatch"
+        );
+        assert_eq!(
+            error.details["problem"],
+            "cook recipe requires `remote` attempt dispatcher reconstruction"
+        );
+
+        let options = reconstruct_options_with_dispatcher(
+            &remote_recipe,
+            Some(Arc::new(ReconstructedDispatcher)),
+        )
+        .expect("durable dispatcher reconstruction permits normal cook gates");
+        assert!(options.attempt_dispatcher.is_some());
+        assert_eq!(options.gates.verify, Vec::<String>::new());
+        assert_eq!(options.to_worktree, "target");
+        assert_eq!(options.base, "main");
+    }
+
+    #[test]
+    fn recipe_reconstruction_reports_missing_finalization_field() {
+        let mut incomplete = recipe();
+        incomplete
+            .finalization
+            .as_object_mut()
+            .expect("finalization object")
+            .remove("to_worktree");
+
+        let error = reconstruct_options(&incomplete).expect_err("missing target blocks adoption");
+        assert_eq!(error.details["field"], "cook_recipe.finalization");
+        assert_eq!(
+            error.details["problem"],
+            "missing finalization field `to_worktree`"
+        );
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -372,9 +372,10 @@ pub mod secrets {
 /// High-level service entry points combining lifecycle and scheduling.
 pub mod service {
     pub use super::super::agent_task_service::{
-        adopt_cook_candidate, aggregate_exit_code, ai_model_from_tool, artifacts, cancel,
-        compile_cook_attempt, discover_runs, evidence_ref_task_id, hydrate_evidence_ref,
-        hydrate_evidence_summary, logs, normalize_plan_workspaces, offloaded_status_remediation,
+        adopt_cook_candidate, adopt_cook_candidate_with_dispatcher, aggregate_exit_code,
+        ai_model_from_tool, artifacts, cancel, compile_cook_attempt, discover_runs,
+        evidence_ref_task_id, hydrate_evidence_ref, hydrate_evidence_summary, logs,
+        normalize_plan_workspaces, offloaded_status_remediation,
         persist_provider_boundary_replay_evidence, promotion_source, read_plan,
         reconcile_terminal_artifact_projection, resume, retry, run_cook, run_cook_batch,
         run_loaded_plan, run_next, run_next_with_cook_dispatcher, run_status, run_submitted,

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -318,8 +318,11 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
 }
 
 pub(crate) fn adopt_candidate(args: AdoptArgs) -> CmdResult<Value> {
-    let result =
-        agent_task_service::adopt_cook_candidate(&args.run_or_cook_id, &args.candidate_ref)?;
+    let result = agent_task_service::adopt_cook_candidate_with_dispatcher(
+        &args.run_or_cook_id,
+        &args.candidate_ref,
+        crate::commands::infra::route::reconstruct_cook_attempt_dispatcher,
+    )?;
     let exit_code = result.exit_code;
     let mut value = serde_json::to_value(result.value).unwrap_or(Value::Null);
     value["adoption"] = serde_json::json!({

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -582,6 +582,10 @@ impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
         runners::prepare_explicit_lab_runner_for_offload(&self.runner_id)
     }
 
+    fn pre_execution_failure_phase(&self) -> &'static str {
+        "transport_dispatcher_prepare"
+    }
+
     fn dispatch_attempt(
         &self,
         plan: homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,


### PR DESCRIPTION
## Summary
- persist durable pre-provider transport failures with enough task context to support later recovery
- allow `agent-task adopt` only for those explicitly classified transport failures
- require the candidate commit to equal the clean recorded worktree HEAD and descend from the task base before normal verification, promotion, protected-branch, finalization, and evidence gates run
- keep legacy ambiguous failures and provider, test, or code failures ineligible

Closes #8938

## How to test
1. Check out this branch in a fresh clone.
2. Run `cargo test -p homeboy-agents agent_task_promotion::tests::part_c`.
3. Run `cargo check -p homeboy-agents -p homeboy-cli`.
4. Record a task outcome classified as `pre_provider_transport_failure`, leave its managed worktree clean at the candidate commit, and confirm `homeboy agent-task adopt` proceeds through the normal promotion gates.
5. Confirm adoption rejects a candidate that differs from the recorded worktree HEAD or does not descend from the task base.
6. Confirm legacy ambiguous failures and provider, test, and code failures remain ineligible for adoption.

## Verification
- focused failed-transport adoption tests pass
- `cargo check -p homeboy-agents -p homeboy-cli` passes

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed the failed-cook recovery gap, implemented durable failure classification and guarded adoption, added deterministic coverage, and prepared the PR.