### PR TITLE
fix: gate Lab dispatch on authoritative availability, not a bare connected flag

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -857,7 +857,12 @@ pub(crate) fn run_lab_offload_inner(
         ));
     }
 
-    require_connected_lab_runner(runner_id, &runner_status)?;
+    require_available_lab_runner(
+        runner_id,
+        &runner_status,
+        runner.settings.concurrency_limit,
+        contract.hot_label,
+    )?;
 
     let runner_workspace_root = request
         .job_overrides
@@ -1509,21 +1514,46 @@ pub(crate) fn run_lab_offload_inner(
     })
 }
 
-fn require_connected_lab_runner(runner_id: &str, runner_status: &RunnerStatusReport) -> Result<()> {
-    if runner_status.connected {
+/// Gate Lab dispatch on the same authoritative availability verdict the
+/// selection preflight uses, rather than a bare `connected` boolean.
+///
+/// A raw `connected` check is lossy in two directions and was the shared root
+/// cause of several Lab reliability reports:
+///
+/// - A runner can be `connected: true` while `accepts_jobs: false` because its
+///   daemon is version-stale (`stale_daemon`). The old boolean gate *passed*
+///   such a runner, so dispatch proceeded and then failed opaquely downstream
+///   (#8811), while the exact `runner refresh-homeboy ... --reconnect` recovery
+///   command that status already computed was discarded.
+/// - A disconnected runner was rejected with a generic "requires a connected
+///   daemon" message that omitted the structured reason and recovery evidence.
+///
+/// Routing through `RunnerAvailability` + `lab_runner_availability_error` keeps
+/// this deeper gate consistent with the preflight gate and preserves the
+/// stale-daemon reason and its exact recovery command in the returned error.
+fn require_available_lab_runner(
+    runner_id: &str,
+    runner_status: &RunnerStatusReport,
+    concurrency_limit: Option<usize>,
+    command_label: &str,
+) -> Result<()> {
+    let availability = RunnerAvailability::from_status_parts(
+        runner_id.to_string(),
+        runner_status.connected,
+        runner_status.stale_daemon.is_some(),
+        runner_status.active_jobs.len(),
+        &runner_status.active_job_state,
+        concurrency_limit,
+    );
+    if availability.accepts_jobs {
         return Ok(());
     }
 
-    Err(Error::validation_invalid_argument(
-        "runner",
-        format!(
-            "Lab offload requires a connected {} runner daemon",
-            status_tunnel_mode(runner_status).label()
-        ),
-        Some(runner_id.to_string()),
-        Some(vec![format!(
-            "Connect runner `{runner_id}` before using --runner."
-        )]),
+    Err(lab_runner_availability_error(
+        command_label,
+        Some(&availability),
+        Some(runner_status),
+        vec![availability.clone()],
     ))
 }
 
@@ -1707,16 +1737,70 @@ fn artifact_name_or_kind_is_fuzz_result(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{RunnerActiveJobState, RunnerSessionState};
+    use crate::{RunnerActiveJobState, RunnerSessionState, RunnerStaleDaemonWarning};
 
     #[test]
     fn inner_uses_authoritative_preflight_status_not_conflicting_cwd_projection() {
         let preflight_status = runner_status(true);
         let conflicting_cwd_projection = runner_status(false);
 
-        require_connected_lab_runner("homeboy-lab", &preflight_status)
+        require_available_lab_runner("homeboy-lab", &preflight_status, None, "cook")
             .expect("inner accepts the connected status selected during preflight");
-        assert!(require_connected_lab_runner("homeboy-lab", &conflicting_cwd_projection).is_err());
+        assert!(require_available_lab_runner(
+            "homeboy-lab",
+            &conflicting_cwd_projection,
+            None,
+            "cook"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn inner_rejects_connected_but_stale_daemon_with_recovery_command() {
+        // #8811: a runner can be `connected: true` while its daemon is
+        // version-stale. The old bare-boolean gate passed such a runner and
+        // dispatch then failed opaquely downstream. The unified availability
+        // gate must reject it up front with the structured `stale_daemon`
+        // reason and the exact `refresh-homeboy` recovery command that status
+        // already computed, instead of the generic "not connected" message.
+        let mut status = runner_status(true);
+        status.stale_daemon = Some(RunnerStaleDaemonWarning {
+            severity: "warning",
+            session_homeboy_version: "0.289.1".to_string(),
+            current_homeboy_version: "0.289.3".to_string(),
+            session_homeboy_build_identity: None,
+            current_homeboy_build_identity: None,
+            active_daemon_control_plane_version: "0.289.1".to_string(),
+            job_command_binary_version: "0.289.3".to_string(),
+            active_daemon_control_plane_build_identity: None,
+            job_command_binary_build_identity: None,
+            refresh_command:
+                "homeboy runner refresh-homeboy homeboy-lab --ref v0.289.3 --reconnect".to_string(),
+            stale_runtime_paths: Vec::new(),
+            changed_runtime_paths: Vec::new(),
+            message: "daemon is stale".to_string(),
+            recovery_commands: Vec::new(),
+        });
+
+        let error = require_available_lab_runner("homeboy-lab", &status, None, "cook")
+            .expect_err("connected-but-stale runner must not pass the Lab dispatch gate");
+
+        // The rejection is the structured availability diagnosis, not the
+        // generic "requires a connected daemon" boolean error.
+        assert!(
+            !error.message.contains("requires a connected"),
+            "stale-daemon rejection must not use the generic connectivity message: {}",
+            error.message
+        );
+        let details = serde_json::to_string(&error.details).expect("serialize error details");
+        assert!(
+            details.contains("stale_daemon"),
+            "error must preserve the stale_daemon reason: {details}"
+        );
+        assert!(
+            details.contains("refresh-homeboy"),
+            "error must surface the exact refresh-homeboy recovery command: {details}"
+        );
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab/offload/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/mod.rs
@@ -84,10 +84,10 @@ use super::super::lab_env::{
 };
 use super::super::lab_plan::{base_lab_plan, disabled_select_runner_plan, with_step};
 use super::super::lab_selection::{
-    fail_if_no_default_runner_accepts_jobs, preflight_lab_runner_availability,
-    prepare_lab_runner_for_offload, release_gate_local_hot_denied_error,
-    resolve_lab_runner_selection, status_tunnel_mode, LabRunnerPreparation, LabRunnerSelection,
-    LabRunnerSelectionSource,
+    fail_if_no_default_runner_accepts_jobs, lab_runner_availability_error,
+    preflight_lab_runner_availability, prepare_lab_runner_for_offload,
+    release_gate_local_hot_denied_error, resolve_lab_runner_selection, status_tunnel_mode,
+    LabRunnerPreparation, LabRunnerSelection, LabRunnerSelectionSource,
 };
 use super::super::lab_workspaces::{
     agent_task_fanout_extra_workspaces, agent_task_plan_extra_workspaces,
@@ -110,10 +110,11 @@ use super::super::{
     preflight_lab_offload_changed_since, prepare_git_lab_offload_changed_since,
     prepare_lab_runner_capability, remote_runner_homeboy_path, reuse_compatible_snapshot_workspace,
     rig_materialization, status, status_for_admission, sync_workspace, LabRunnerGateDecision,
-    MaterializedWorkspace, Runner, RunnerCapabilityPreflight, RunnerDependencyCacheSaveOutput,
-    RunnerDependencyCacheSaveRequest, RunnerExecOptions, RunnerFileTransfer, RunnerStatusReport,
-    RunnerWorkspaceApplyOutput, RunnerWorkspaceOutputPaths, RunnerWorkspaceSyncMode,
-    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput, WorkspaceCleanupPolicy,
+    MaterializedWorkspace, Runner, RunnerAvailability, RunnerCapabilityPreflight,
+    RunnerDependencyCacheSaveOutput, RunnerDependencyCacheSaveRequest, RunnerExecOptions,
+    RunnerFileTransfer, RunnerStatusReport, RunnerWorkspaceApplyOutput, RunnerWorkspaceOutputPaths,
+    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+    WorkspaceCleanupPolicy,
 };
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

The deep Lab dispatch gate in `crates/homeboy-lab-runner/src/lab/offload/inner.rs` checked only `runner_status.connected`. That bare boolean was the shared root cause behind a cluster of Lab reliability reports — it is lossy in **both** directions:

- **Connected-but-stale passes silently (#8811):** a runner can be `connected: true` while `accepts_jobs: false` because its daemon is version-stale (`stale_daemon`). The boolean gate let it through, so dispatch proceeded and then failed opaquely during workspace materialization. The exact `runner refresh-homeboy … --reconnect` recovery command that `runner status` had already computed was discarded.
- **Disconnected fails generically:** a disconnected runner was rejected with `Lab offload requires a connected … runner daemon`, omitting the structured reason and recovery evidence.

Notably, the correct verdict already exists: `preflight_lab_runner_availability` (in `lab_selection.rs`, called from `execute.rs`) builds a full `RunnerAvailability` with `accepts_jobs`, structured `reasons` (incl. `stale_daemon`), and `lab_runner_availability_error` even surfaces the exact refresh command. The inner gate was a **second, redundant, lossy** check that bypassed all of it.

## Change

- Replace `require_connected_lab_runner` with `require_available_lab_runner`, which builds the same `RunnerAvailability::from_status_parts` verdict and, on failure, returns `lab_runner_availability_error(...)` — preserving the `stale_daemon` reason and its recovery command.
- Wire the crate-root re-exports (`RunnerAvailability`, `lab_runner_availability_error`) into the offload module.
- Add coverage for the connected-but-stale case: asserts the rejection is the structured availability diagnosis (contains `stale_daemon` + the `refresh-homeboy` recovery command) and is **not** the generic "requires a connected" message.

This unifies the deeper dispatch gate with the preflight gate so the two can no longer disagree about the same runner.

## Why this issue

Part of a triage of the daemon/Lab reliability cluster (~11 open issues). The bare `connected` boolean was identified as the single highest-leverage root cause: it sits on the front door of every cook, and routing it through the already-computed diagnosis converts "opaque failure + manual lease surgery" into "here is the exact recovery command." Follow-up issues in the same cluster (#8803 opaque materialization failures, #8694 fresh-but-disconnected recovery) benefit from the same availability-first framing but are tracked separately.

## Testing

- `cargo check -p homeboy-lab-runner --lib --tests` — clean (EXIT 0).
- `cargo fmt -p homeboy-lab-runner`.
- Targeted `cargo test -p homeboy-lab-runner --lib inner::` — 7 passed, including the new `inner_rejects_connected_but_stale_daemon_with_recovery_command` and the updated `inner_uses_authoritative_preflight_status_not_conflicting_cwd_projection`.

Heavy workspace build/test intentionally left to CI per repo policy.

Fixes #8811

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Root-cause triage of the Lab reliability cluster, mapping the two divergent availability gates, and implementing the unification + coverage. Chris reviews and owns the change.