### PR TITLE
fix: classify dropped SSH materialization transport as retryable (#8803)

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -143,6 +143,84 @@ fn snapshot_command_failure_bounds_transport_output() {
 }
 
 #[test]
+fn snapshot_signal_death_is_a_retryable_transport_failure() {
+    // #8803: an SSH transport that drops mid-pipe kills `sh` with a signal, so
+    // it exits with no code (surfaced as -1). This must be classified as a
+    // retryable transport failure carrying structured diagnostics, not an
+    // opaque internal error.
+    let error = super::super::util::run_shell_command(
+        "kill -PIPE $$",
+        "materialize SSH workspace snapshot",
+    )
+    .expect_err("signal death must be an actionable transport failure");
+
+    assert_eq!(
+        error.code,
+        homeboy_core::error::ErrorCode::RunnerLabTransportFailure
+    );
+    assert_eq!(
+        error.retryable,
+        Some(true),
+        "transport failures must be retryable"
+    );
+    let details = serde_json::to_string(&error.details).expect("serialize details");
+    assert!(
+        details.contains("\"signal_death\":true"),
+        "must record that the process was killed by a signal: {details}"
+    );
+    assert!(
+        details.contains("transport_close_reason"),
+        "must record a transport close reason: {details}"
+    );
+    // The generic non-transport message must not be used for a transport drop.
+    assert!(
+        !error.message.contains("failed during command execution"),
+        "signal death must not fall through to the generic command error: {}",
+        error.message
+    );
+}
+
+#[test]
+fn snapshot_ssh_connection_exit_is_a_retryable_transport_failure() {
+    // SSH exits 255 on a connection-level error, distinct from a remote
+    // command's own non-zero exit code.
+    let error = super::super::util::run_shell_command(
+        "echo 'ssh: connect to host lab port 22: Connection refused' >&2; exit 255",
+        "materialize SSH workspace snapshot",
+    )
+    .expect_err("ssh connection error must be an actionable transport failure");
+
+    assert_eq!(
+        error.code,
+        homeboy_core::error::ErrorCode::RunnerLabTransportFailure
+    );
+    assert_eq!(error.retryable, Some(true));
+    assert!(
+        error.message.to_lowercase().contains("connection refused"),
+        "must surface the transport close reason: {}",
+        error.message
+    );
+}
+
+#[test]
+fn snapshot_ordinary_command_failure_is_not_classified_as_transport() {
+    // A genuine remote command failure (non-signal, non-255, no transient
+    // stderr) must remain a plain command error so real bugs are not silently
+    // retried as transport flakes.
+    let error = super::super::util::run_shell_command(
+        "echo boom >&2; exit 2",
+        "materialize SSH workspace snapshot",
+    )
+    .expect_err("ordinary failure still errors");
+
+    assert_ne!(
+        error.code,
+        homeboy_core::error::ErrorCode::RunnerLabTransportFailure
+    );
+    assert!(error.message.contains("exit status 2"));
+}
+
+#[test]
 fn snapshot_command_failure_bounds_multibyte_output_at_a_character_boundary() {
     let error = super::super::util::run_shell_command(
         "head -c 4095 /dev/zero | tr '\\0' Z; printf '\\342\\202\\254'; exit 26",

--- a/crates/homeboy-lab-runner/src/workspace/util.rs
+++ b/crates/homeboy-lab-runner/src/workspace/util.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use sha2::{Digest, Sha256};
 
 use homeboy_core::engine::shell;
-use homeboy_core::error::{Error, Result};
+use homeboy_core::error::{Error, ErrorCode, Result};
 use homeboy_core::server::{self, Server, SshClient};
 
 use super::super::Runner;
@@ -121,6 +121,17 @@ pub(crate) fn run_shell_command(command: &str, action: &str) -> Result<()> {
     }
     let stdout = bounded_command_output(&output.stdout);
     let stderr = bounded_command_output(&output.stderr);
+    // The command is typically a local `tar ... | ssh <runner> <extract>`
+    // pipe, so an SSH transport that drops mid-materialization surfaces here
+    // as a signal death (`sh` returns no exit code, reported as -1) or an
+    // SSH connection error (exit 255 / transient connection stderr) rather
+    // than a genuine remote command failure. Classify that as a retryable
+    // transport failure with structured evidence so the caller can resume
+    // from a deterministic phase instead of terminalizing an opaque
+    // `invalid_input` with no diagnosable cause (#8803).
+    if let Some(error) = classify_transport_failure(action, &output.status, &stdout, &stderr) {
+        return Err(error);
+    }
     let evidence = match (stdout.is_empty(), stderr.is_empty()) {
         (true, true) => "the command exited without stdout or stderr".to_string(),
         (false, true) => format!("stdout: {stdout}"),
@@ -131,6 +142,79 @@ pub(crate) fn run_shell_command(command: &str, action: &str) -> Result<()> {
         "{action} failed during command execution (exit status {}): {evidence}",
         output.status.code().unwrap_or(-1),
     )))
+}
+
+/// SSH connection failures worth retrying, matched against the piped command's
+/// stderr. Kept in sync with `homeboy_core::server::is_transient_ssh_error`,
+/// which operates on the runner `CommandOutput` type rather than the local
+/// `sh` process output available here.
+const TRANSIENT_SSH_STDERR_PATTERNS: [&str; 10] = [
+    "connection refused",
+    "connection reset",
+    "connection timed out",
+    "no route to host",
+    "network is unreachable",
+    "temporary failure in name resolution",
+    "could not resolve hostname",
+    "broken pipe",
+    "ssh_exchange_identification",
+    "connection closed by remote host",
+];
+
+/// Return a retryable [`ErrorCode::RunnerLabTransportFailure`] when a piped
+/// materialization command failed because its SSH transport dropped, or `None`
+/// when the failure is an ordinary non-transport command error.
+fn classify_transport_failure(
+    action: &str,
+    status: &std::process::ExitStatus,
+    stdout: &str,
+    stderr: &str,
+) -> Option<Error> {
+    // `code() == None` means the process was killed by a signal (e.g. SIGPIPE
+    // when the remote SSH end closed), reported to callers as exit status -1.
+    let signal_death = status.code().is_none();
+    // SSH itself exits 255 on a connection-level error, distinct from a remote
+    // command's own non-zero exit code.
+    let ssh_connection_exit = status.code() == Some(255);
+    let lower_stderr = stderr.to_lowercase();
+    let matched_transient = TRANSIENT_SSH_STDERR_PATTERNS
+        .iter()
+        .find(|pattern| lower_stderr.contains(**pattern))
+        .copied();
+
+    if !signal_death && !ssh_connection_exit && matched_transient.is_none() {
+        return None;
+    }
+
+    let close_reason = stderr
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| matched_transient.map(str::to_string))
+        .unwrap_or_else(|| {
+            if signal_death {
+                "SSH transport closed the command without an exit code".to_string()
+            } else {
+                "SSH connection error (exit 255) without stderr".to_string()
+            }
+        });
+
+    let exit_code = status.code().unwrap_or(-1);
+    Some(
+        Error::new(
+            ErrorCode::RunnerLabTransportFailure,
+            format!("{action} failed (exit status {exit_code}): {close_reason}"),
+            serde_json::json!({
+                "action": action,
+                "exit_code": exit_code,
+                "signal_death": signal_death,
+                "transport_close_reason": close_reason,
+                "stdout": stdout,
+                "stderr": stderr,
+            }),
+        )
+        .with_retryable(true),
+    )
 }
 
 const COMMAND_FAILURE_OUTPUT_LIMIT: usize = 4 * 1024;


### PR DESCRIPTION
## Summary

Lab workspace **snapshot materialization** runs a local `tar … | ssh <runner> <extract>` pipe through `run_shell_command` (`workspace/util.rs`). When the SSH transport dropped mid-pipe, `sh` was killed by a signal and returned no exit code — surfaced to the operator as `exit status -1` with *"the command exited without stdout or stderr"*. `run_shell_command` classified every non-zero result as a generic `internal.unexpected`, so upstream the durable run terminalized as **`invalid_input`** with no diagnosable command/phase/transport-close reason, and **not retryable** (#8803).

The sibling `workspace_metadata_write` path (`workspace/sync.rs`) already handles this correctly: `ErrorCode::RunnerLabTransportFailure` + structured phase/exit/stderr + `.with_retryable(transport_closed || timed_out)`. This PR brings snapshot materialization to the same contract.

## Change

`run_shell_command` now classifies a failure as a **retryable `RunnerLabTransportFailure`** when it looks like a transport drop:

- **signal death** — `ExitStatus::code() == None` (SIGPIPE etc. when the remote SSH end closed), i.e. the reported `-1`;
- **SSH connection exit** — 255 (distinct from a remote command's own exit code);
- **transient SSH stderr** — connection refused/reset/timed out, broken pipe, connection closed by remote host, etc. (kept in sync with `homeboy_core::server::is_transient_ssh_error`, which operates on the runner `CommandOutput` type unavailable at this local-`sh` layer).

The error carries structured `action`, `exit_code`, `signal_death`, `transport_close_reason`, and bounded `stdout`/`stderr`, so the failure is diagnosable and the caller can resume from a deterministic phase. **Ordinary non-transport command failures keep the existing generic error** so real bugs are not masked as transient flakes.

## Testing

- `cargo check -p homeboy-lab-runner --lib --tests` — clean (EXIT 0).
- `cargo fmt -p homeboy-lab-runner`.
- Targeted `cargo test -p homeboy-lab-runner --lib workspace::tests::snapshot::snapshot_` — my 3 new tests pass (`snapshot_signal_death_is_a_retryable_transport_failure`, `snapshot_ssh_connection_exit_is_a_retryable_transport_failure`, `snapshot_ordinary_command_failure_is_not_classified_as_transport`) and the 4 existing exit-23/24/25 command-failure tests remain green.

### Pre-existing unrelated failure (not from this PR)
`snapshot_sync_uses_unique_clean_workspace_for_same_snapshot` fails on **pristine `origin/main`** in this Linux environment too (verified by stashing this change) — it asserts `!join("sentinel.txt").exists()` after a real local `tar` re-materialization, an environment/platform-sensitive assertion. Out of scope here; flagging so it isn't attributed to this change.

Heavy workspace build/test intentionally left to CI per repo policy.

Fixes #8803

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Traced the materialization failure to the untyped `run_shell_command` helper, mirrored the already-correct metadata-write transport contract, and added coverage. Chris reviews and owns the change.