### PR TITLE
Scope runs show mirror refresh

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/handlers.rs
+++ b/crates/homeboy-cli/src/commands/runs/handlers.rs
@@ -114,9 +114,10 @@ fn active_runner_job_run_summary_if_durable(
 
 pub fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
-    runs_service::refresh_running_mirrored_daemon_evidence_best_effort(&store);
-    reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
     let run = runs_service::require_run(&store, run_id)?;
+    runs_service::refresh_selected_mirrored_daemon_evidence_best_effort(&store, &run);
+    let run = runs_service::require_run(&store, &run.id)?;
+    reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
     let run = runs_service::require_run(&store, &run.id)?;
     let run = run_detail(&store, run)?;
     let actionable = actionable_for_run_detail(&run);

--- a/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
+++ b/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
@@ -189,6 +189,63 @@ pub fn refresh_mirrored_daemon_evidence_best_effort(run_id: &str) {
     }
 }
 
+/// Refresh one selected mirrored run. A daemon 404 means the persisted mirror
+/// can no longer be observed, so preserve that terminal diagnostic locally
+/// instead of emitting a generic refresh warning.
+pub fn refresh_selected_mirrored_daemon_evidence_best_effort(
+    store: &ObservationStore,
+    run: &RunRecord,
+) {
+    if let Some(err) = refresh_selected_mirrored_daemon_evidence(store, run) {
+        eprintln!(
+            "Warning: could not refresh mirrored Lab runner evidence for `{}`: {}",
+            run.id, err.message
+        );
+    }
+}
+
+pub(crate) fn refresh_selected_mirrored_daemon_evidence(
+    store: &ObservationStore,
+    run: &RunRecord,
+) -> Option<Error> {
+    let Some((runner_id, job_id)) =
+        runner_evidence::with_runner_evidence(|p| p.mirrored_runner_job_identity(run))
+    else {
+        return None;
+    };
+
+    match runner_evidence::with_runner_evidence(|p| p.refresh_mirrored_daemon_evidence(&run.id)) {
+        Ok(_) => None,
+        Err(err) if err.details.get("http_status").and_then(Value::as_u64) == Some(404) => {
+            let mut metadata = run.metadata_json.clone();
+            if !metadata.is_object() {
+                metadata = serde_json::json!({ "homeboy_original_metadata": metadata });
+            }
+            if let Some(object) = metadata.as_object_mut() {
+                object.insert(
+                    "runner_terminal_evidence".to_string(),
+                    serde_json::json!({
+                        "runner_id": runner_id,
+                        "job_id": job_id,
+                        "status": "not_found",
+                        "lifecycle_state": "stale",
+                        "stale_reason": "daemon_job_not_found",
+                        "retryable": false,
+                        "diagnostic": {
+                            "code": err.code.as_str(),
+                            "message": err.message,
+                            "details": err.details,
+                        },
+                    }),
+                );
+            }
+            let _ = store.finish_run(&run.id, RunStatus::Stale, Some(metadata));
+            None
+        }
+        Err(err) => Some(err),
+    }
+}
+
 /// Best-effort refresh of all locally-running Lab runner mirror records.
 ///
 /// A controller can exit, disconnect, or time out while the runner daemon keeps

--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -248,7 +248,10 @@ pub fn with_runner_evidence<T>(f: impl FnOnce(&dyn RunnerEvidenceProvider) -> T)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::OnceLock;
+    use std::sync::{Arc, OnceLock};
+
+    use crate::observation::{ObservationStore, RunStatus};
+    use crate::test_support::with_isolated_home;
 
     fn provider_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -430,5 +433,159 @@ mod tests {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .take();
+    }
+
+    struct SelectedRefreshProvider {
+        calls: Arc<Mutex<Vec<String>>>,
+        error: Option<Error>,
+    }
+
+    impl RunnerEvidenceProvider for SelectedRefreshProvider {
+        fn mirror_connected_runner_run(&self, _: &str) -> Result<Option<RunRecord>> {
+            Ok(None)
+        }
+
+        fn statuses(&self) -> Vec<RunnerConnectionInfo> {
+            Vec::new()
+        }
+
+        fn daemon_api_get(&self, _: &str, _: &str) -> Result<Value> {
+            Ok(Value::Null)
+        }
+
+        fn runner_artifact_content(&self, _: &str, _: &str, _: &str) -> Result<Value> {
+            Ok(Value::Null)
+        }
+
+        fn runner_job_cancel(
+            &self,
+            _: &str,
+            _: &str,
+        ) -> Result<(crate::api_jobs::Job, Vec<crate::api_jobs::JobEvent>)> {
+            unreachable!()
+        }
+
+        fn refresh_mirrored_daemon_evidence(&self, run_id: &str) -> Result<Option<Vec<RunRecord>>> {
+            self.calls.lock().expect("calls").push(run_id.to_string());
+            self.error.clone().map_or(Ok(None), Err)
+        }
+
+        fn mirrored_runner_job_identity(&self, run: &RunRecord) -> Option<(String, String)> {
+            run.metadata_json
+                .pointer("/lab/runner/id")
+                .and_then(Value::as_str)
+                .zip(
+                    run.metadata_json
+                        .pointer("/lab/remote_job/id")
+                        .and_then(Value::as_str),
+                )
+                .map(|(runner, job)| (runner.to_string(), job.to_string()))
+        }
+
+        fn download_remote_artifact(
+            &self,
+            _: &str,
+            _: Option<PathBuf>,
+        ) -> Result<RemoteArtifactDownloadInfo> {
+            unreachable!()
+        }
+    }
+
+    fn mirrored_run(id: &str) -> RunRecord {
+        let mut run = run(id);
+        run.metadata_json = serde_json::json!({
+            "lab": { "runner": { "id": "lab" }, "remote_job": { "id": "job-1" } }
+        });
+        run
+    }
+
+    #[test]
+    fn selected_refresh_skips_unrelated_mirrors_and_non_mirrors() {
+        let _lock = provider_lock().lock().expect("provider lock");
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let selected = run("selected");
+            let unrelated = mirrored_run("unrelated");
+            store.import_run(&selected).expect("selected");
+            store.import_run(&unrelated).expect("unrelated");
+            let calls = Arc::new(Mutex::new(Vec::new()));
+            register_runner_evidence_provider(Box::new(SelectedRefreshProvider {
+                calls: calls.clone(),
+                error: Some(Error::internal_unexpected("unrelated refresh must not run")),
+            }));
+
+            assert!(
+                super::super::refresh_selected_mirrored_daemon_evidence(&store, &selected)
+                    .is_none()
+            );
+            assert!(calls.lock().expect("calls").is_empty());
+        });
+        PROVIDER.lock().expect("provider").take();
+    }
+
+    #[test]
+    fn selected_daemon_job_not_found_becomes_stale_diagnostics() {
+        let _lock = provider_lock().lock().expect("provider lock");
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let selected = mirrored_run("selected");
+            store.import_run(&selected).expect("selected");
+            let calls = Arc::new(Mutex::new(Vec::new()));
+            register_runner_evidence_provider(Box::new(SelectedRefreshProvider {
+                calls: calls.clone(),
+                error: Some(Error::new(
+                    crate::error::ErrorCode::InternalUnexpected,
+                    "daemon request failed: job not found",
+                    serde_json::json!({ "http_status": 404, "path": "/jobs/job-1" }),
+                )),
+            }));
+
+            assert!(
+                super::super::refresh_selected_mirrored_daemon_evidence(&store, &selected)
+                    .is_none()
+            );
+            assert_eq!(*calls.lock().expect("calls"), vec!["selected"]);
+            let refreshed = store.get_run("selected").expect("read").expect("run");
+            assert_eq!(refreshed.status, RunStatus::Stale.as_str());
+            assert_eq!(
+                refreshed.metadata_json["runner_terminal_evidence"]["stale_reason"],
+                "daemon_job_not_found"
+            );
+            assert_eq!(
+                refreshed.metadata_json["runner_terminal_evidence"]["diagnostic"]["details"]
+                    ["http_status"],
+                404
+            );
+        });
+        PROVIDER.lock().expect("provider").take();
+    }
+
+    #[test]
+    fn selected_transport_refresh_failure_remains_actionable() {
+        let _lock = provider_lock().lock().expect("provider lock");
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let selected = mirrored_run("selected");
+            store.import_run(&selected).expect("selected");
+            let calls = Arc::new(Mutex::new(Vec::new()));
+            register_runner_evidence_provider(Box::new(SelectedRefreshProvider {
+                calls: calls.clone(),
+                error: Some(Error::internal_unexpected("runner transport unavailable")),
+            }));
+
+            let err = super::super::refresh_selected_mirrored_daemon_evidence(&store, &selected)
+                .expect("actionable refresh error");
+            assert_eq!(err.message, "runner transport unavailable");
+            assert_eq!(*calls.lock().expect("calls"), vec!["selected"]);
+            assert_eq!(
+                store
+                    .get_run("selected")
+                    .expect("read")
+                    .expect("run")
+                    .status,
+                RunStatus::Running.as_str()
+            );
+        });
+        PROVIDER.lock().expect("provider").take();
     }
 }

--- a/crates/homeboy-lab-runner/src/daemon_http_get.rs
+++ b/crates/homeboy-lab-runner/src/daemon_http_get.rs
@@ -31,10 +31,14 @@ pub(super) fn daemon_get(client: &Client, local_url: &str, path: &str) -> Result
     let envelope: DaemonGetEnvelope =
         parse_daemon_response_json(&body, status_code, path, "parse daemon response")?;
     if !envelope.success {
-        return Err(Error::internal_unexpected(format!(
-            "daemon request failed: {}",
-            envelope.error.unwrap_or(Value::Null)
-        )));
+        return Err(Error::new(
+            ErrorCode::InternalUnexpected,
+            format!(
+                "daemon request failed: {}",
+                envelope.error.unwrap_or(Value::Null)
+            ),
+            json!({ "http_status": status_code, "path": path }),
+        ));
     }
     envelope
         .data


### PR DESCRIPTION
## Summary
- resolve the requested run before refreshing mirrored evidence
- refresh only the selected mirror
- classify selected missing daemon jobs as stale diagnostics while retaining actionable transport warnings

## Testing
- `cargo fmt --check`
- `cargo test -p homeboy-core observation::runs_service::runner_evidence::tests --lib`
- `cargo test -p homeboy-cli commands::runs::tests::run_show --lib`
- `cargo check --workspace`

Closes #8947

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Root-cause analysis, implementation, and deterministic test coverage.