### PR TITLE
Resolve canonical Lab run labels

### DIFF
--- a/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
+++ b/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
@@ -40,11 +40,60 @@ fn resolve_run_label(store: &ObservationStore, label: &str) -> Result<Option<Run
 }
 
 fn resolve_run_label_matches(label: &str, matches: Vec<RunRecord>) -> Result<Option<RunRecord>> {
+    let matches = canonicalize_lab_run_label_matches(matches);
     match matches.len() {
         0 => Ok(None),
         1 => Ok(matches.into_iter().next()),
         _ => Err(ambiguous_run_label_error(label, &matches)),
     }
+}
+
+/// Collapse a caller and its Lab mirrors only when their durable job lineage
+/// identifies one execution and exactly one caller record remains.
+fn canonicalize_lab_run_label_matches(matches: Vec<RunRecord>) -> Vec<RunRecord> {
+    let mut canonical = Vec::new();
+    for (index, run) in matches.iter().enumerate() {
+        let Some(lineage) = lab_run_lineage(run) else {
+            canonical.push(run.clone());
+            continue;
+        };
+        if matches[..index]
+            .iter()
+            .any(|candidate| lab_run_lineage(candidate).as_ref() == Some(&lineage))
+        {
+            continue;
+        }
+        let related = matches
+            .iter()
+            .filter(|candidate| lab_run_lineage(candidate).as_ref() == Some(&lineage))
+            .collect::<Vec<_>>();
+        let callers = related
+            .iter()
+            .filter(|candidate| candidate.kind != "runner-exec")
+            .collect::<Vec<_>>();
+        if callers.len() == 1 {
+            canonical.push((*callers[0]).clone());
+        } else {
+            canonical.extend(related.into_iter().cloned());
+        }
+    }
+    canonical
+}
+
+fn lab_run_lineage(run: &RunRecord) -> Option<(String, String)> {
+    runner_evidence::with_runner_evidence(|provider| provider.mirrored_runner_job_identity(run))
+        .or_else(|| {
+            let lab = run.metadata_json.get("lab")?;
+            let runner_id = lab
+                .pointer("/runner/id")
+                .or_else(|| lab.get("runner_id"))
+                .and_then(Value::as_str)?;
+            let job_id = lab
+                .pointer("/remote_job/id")
+                .or_else(|| lab.get("remote_job_id"))
+                .and_then(Value::as_str)?;
+            Some((runner_id.to_string(), job_id.to_string()))
+        })
 }
 
 fn ambiguous_run_label_error(label: &str, matches: &[RunRecord]) -> Error {

--- a/crates/homeboy-core/src/observation/runs_service/tests.rs
+++ b/crates/homeboy-core/src/observation/runs_service/tests.rs
@@ -607,3 +607,76 @@ fn require_run_rejects_ambiguous_requested_run_id_alias() {
         assert!(joined.contains("rig=studio-b"));
     });
 }
+
+fn lab_labeled_run(id: &str, kind: &str, label: &str, job_id: &str) -> RunRecord {
+    RunRecord {
+        id: id.to_string(),
+        kind: kind.to_string(),
+        component_id: Some("homeboy".to_string()),
+        started_at: "2026-07-18T00:00:00Z".to_string(),
+        finished_at: None,
+        status: "running".to_string(),
+        command: Some(format!("homeboy {kind} --run-id {label}")),
+        cwd: Some("/tmp/homeboy-fixture".to_string()),
+        homeboy_version: None,
+        git_sha: None,
+        rig_id: Some("studio".to_string()),
+        metadata_json: serde_json::json!({
+            "requested_run_id": label,
+            "lab": {
+                "runner": { "id": "homeboy-lab" },
+                "remote_job": { "id": job_id }
+            }
+        }),
+    }
+}
+
+#[test]
+fn require_run_resolves_lab_label_to_caller_across_mirrors() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let caller = lab_labeled_run("caller", "fuzz", "shared-label", "job-1");
+        store.upsert_imported_run(&caller).expect("caller");
+        for id in ["mirror-a", "mirror-b", "mirror-c"] {
+            store
+                .upsert_imported_run(&lab_labeled_run(id, "runner-exec", "shared-label", "job-1"))
+                .expect("mirror");
+        }
+
+        let resolved = require_run(&store, "shared-label").expect("canonical caller");
+        assert_eq!(resolved.id, caller.id);
+    });
+}
+
+#[test]
+fn require_run_keeps_unrelated_lab_label_collision_ambiguous() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let caller = lab_labeled_run("caller", "fuzz", "shared-label", "job-1");
+        let collision = lab_labeled_run("collision", "fuzz", "shared-label", "job-2");
+        store.upsert_imported_run(&caller).expect("caller");
+        for id in ["mirror-a", "mirror-b", "mirror-c"] {
+            store
+                .upsert_imported_run(&lab_labeled_run(id, "runner-exec", "shared-label", "job-1"))
+                .expect("mirror");
+        }
+        store.upsert_imported_run(&collision).expect("collision");
+
+        let err = require_run(&store, "shared-label").expect_err("ambiguous label");
+        assert!(err.message.contains("2 persisted runs match"));
+        let joined = err.details["tried"]
+            .as_array()
+            .expect("disambiguation entries")
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(joined.contains(&caller.id));
+        assert!(joined.contains(&collision.id));
+        assert!(!joined.contains("mirror-a"));
+        assert!(!joined.contains("mirror-b"));
+        assert!(!joined.contains("mirror-c"));
+    });
+}


### PR DESCRIPTION
## Summary
- collapse caller and mirror records sharing durable Lab job lineage
- resolve one logical execution to its canonical caller record
- preserve ambiguity for unrelated same-label runs

## Testing
- `cargo fmt --check`
- `cargo test -p homeboy-core observation::runs_service::tests::require_run_ --locked`
- `cargo check --workspace --tests --locked`

Closes #8948

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Root-cause analysis, implementation, and deterministic test coverage.