### PR TITLE
Render Lab commands safely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,6 +1092,7 @@ dependencies = [
 name = "homeboy-redaction"
 version = "0.1.0"
 dependencies = [
+ "homeboy-engine-primitives",
  "regex",
  "serde_json",
 ]

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -9,7 +9,7 @@ use homeboy_core::error::{Error, Result};
 use homeboy_core::execution_contract::{encode_uri_component, EXECUTION_CONTRACT};
 use homeboy_core::notification_route::NotificationRoute;
 use homeboy_core::observation::{ArtifactRecord, ObservationStore, RunRecord, RunStatus};
-use homeboy_core::redaction::redact_argv_display;
+use homeboy_core::redaction::redact_argv_shell_display;
 
 use super::super::execution::{canonical_daemon_body, daemon_api_get, result_event_data};
 use super::super::{load, Runner};
@@ -367,7 +367,7 @@ pub(super) fn mirror_job_run(
         started_at: ms_to_rfc3339(job.started_at_ms.unwrap_or(job.created_at_ms)),
         finished_at: job.finished_at_ms.map(ms_to_rfc3339),
         status: job_status_as_run_status(job.status).to_string(),
-        command: Some(redact_argv_display(command)),
+        command: Some(redact_argv_shell_display(command)),
         cwd: Some(cwd.to_string()),
         homeboy_version: None,
         git_sha: None,

--- a/crates/homeboy-lab-runner/src/execution/failure.rs
+++ b/crates/homeboy-lab-runner/src/execution/failure.rs
@@ -1,7 +1,7 @@
 use serde_json::{json, Value};
 
 use homeboy_core::error::Error;
-use homeboy_core::redaction::{redact_argv, redact_argv_display};
+use homeboy_core::redaction::{redact_argv, redact_argv_shell_display};
 
 #[allow(unused_imports)]
 use super::*;
@@ -22,7 +22,7 @@ pub fn runner_exec_failure_error(output: &RunnerExecOutput) -> Option<Error> {
         .unwrap_or("runner command exited non-zero")
         .to_string();
     let execution = serde_json::to_value(output).unwrap_or(Value::Null);
-    let command = redact_argv_display(&output.argv);
+    let command = redact_argv_shell_display(&output.argv);
     let redacted_argv = redact_argv(&output.argv);
     let mut details = json!({
         "runner_id": output.runner_id,
@@ -176,7 +176,7 @@ pub(super) fn runner_exec_failure_context_hint(output: &RunnerExecOutput) -> Str
         .unwrap_or("unknown persisted run");
     let mut hint = format!(
         "Canonical failed command: `{}`; runner job: `{job}`; persisted run: `{run}`",
-        redact_argv_display(&context.command)
+        redact_argv_shell_display(&context.command)
     );
     append_failure_context_error_summary(&mut hint, &context);
     hint.push('.');

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -524,7 +524,7 @@ fn persist_runner_execution_transition(
     let store = ObservationStore::open_initialized()?;
     let run = store.start_run(
         NewRunRecord::builder("runner_execution")
-            .command(homeboy_core::redaction::redact_argv_display(command))
+            .command(homeboy_core::redaction::redact_argv_shell_display(command))
             .optional_cwd_path(Some(std::path::Path::new(cwd)))
             .metadata(serde_json::json!({
                 "runner_execution_record": record,

--- a/crates/homeboy-lab-runner/src/execution/tests/redaction.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/redaction.rs
@@ -148,6 +148,37 @@ fn runner_exec_failure_error_surfaces_canonical_failure_context() {
 }
 
 #[test]
+fn runner_exec_failure_hint_renders_copyable_redacted_shell_command() {
+    let mut output = failed_runner_exec_output("", "runner failed");
+    output.argv = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "run".to_string(),
+        "#8949".to_string(),
+        "path with spaces".to_string(),
+        "O'Brien".to_string(),
+        "$HOME/work".to_string(),
+        "--provider-auth-token".to_string(),
+        "secret-value".to_string(),
+    ];
+
+    let err = runner_exec_failure_error(&output).expect("runner failure error");
+    let hints = err
+        .hints
+        .iter()
+        .map(|hint| hint.message.as_str())
+        .collect::<Vec<_>>();
+    let command_hint = hints
+        .iter()
+        .find(|hint| hint.contains("Canonical failed command:"))
+        .expect("canonical command hint");
+
+    assert!(command_hint.contains("'#8949' 'path with spaces' 'O'\\''Brien' '$HOME/work'"));
+    assert!(command_hint.contains("--provider-auth-token '[REDACTED]'"));
+    assert!(!command_hint.contains("secret-value"));
+}
+
+#[test]
 fn runner_exec_failure_error_surfaces_resource_guard_message() {
     let mut output = failed_runner_exec_output("", "");
     output.metrics = Some(RunnerResourceMetrics {

--- a/crates/homeboy-lab-runner/src/lab/offload/errors.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/errors.rs
@@ -357,8 +357,8 @@ pub(crate) fn missing_mutation_patch_error(
     exec_output: &super::super::super::RunnerExecOutput,
 ) -> Error {
     let flag_label = mutation_flag.unwrap_or("write");
-    let original_command = redact_argv_display(normalized_args);
-    let remote_command = redact_argv_display(&exec_output.argv);
+    let original_command = redact_argv_shell_display(normalized_args);
+    let remote_command = redact_argv_shell_display(&exec_output.argv);
     let patch_artifact_id = exec_output
         .patch
         .as_ref()
@@ -428,7 +428,7 @@ pub(crate) fn append_runner_failure_context_summary(
         .unwrap_or("unknown persisted run");
     let mut summary = format!(
         "Lab offload failure context: command `{}` failed on runner `{}`; runner job `{job}`; persisted run `{run}`",
-        redact_argv_display(&context.command),
+        redact_argv_shell_display(&context.command),
         context.runner_id
     );
     append_failure_context_error_summary(&mut summary, &context);

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1051,7 +1051,7 @@ pub(crate) fn run_lab_offload_inner(
         "Lab offload preflight: source checkout `{}` at {}; active Homeboy command `{}` from runner `{}`.",
         source_path.display(),
         source_checkout_ref_display(&source_checkout),
-        redact_argv_display(&command_prefix.argv),
+        redact_argv_shell_display(&command_prefix.argv),
         runner_id,
     );
     let capability_contract =
@@ -1300,7 +1300,7 @@ pub(crate) fn run_lab_offload_inner(
 
     eprintln!(
         "Lab offload: running `{}` on runner `{}` in `{}`.",
-        redact_argv_display(&command),
+        redact_argv_shell_display(&command),
         runner_id,
         remote_cwd
     );
@@ -1310,10 +1310,10 @@ pub(crate) fn run_lab_offload_inner(
             .map(|path| path.display().to_string())
             .unwrap_or_else(|error| format!("<unavailable: {error}>")),
         build_identity::current().display,
-        redact_argv_display(request.normalized_args),
-        redact_argv_display(&remapped_args),
+        redact_argv_shell_display(request.normalized_args),
+        redact_argv_shell_display(&remapped_args),
         serde_json::to_string(&runner_required_extensions).unwrap_or_else(|_| "[]".to_string()),
-        redact_argv_display(&remote_command),
+        redact_argv_shell_display(&remote_command),
     );
     if let Some(run_id) = &agent_task_run_id {
         emit_durable_run_id_before_execution(

--- a/crates/homeboy-lab-runner/src/lab/offload/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/mod.rs
@@ -50,7 +50,7 @@ use homeboy_agents::agent_tasks::provider::provider_runner_source_contracts;
 use homeboy_core::engine::shell;
 use homeboy_core::lab_contract::LabRunnerWorkload;
 use homeboy_core::plan::{HomeboyPlan, PlanStep, PlanStepStatus, PlanValues};
-use homeboy_core::redaction::{redact_argv, redact_argv_display, RedactionPolicy};
+use homeboy_core::redaction::{redact_argv, redact_argv_shell_display, RedactionPolicy};
 use homeboy_core::runner_execution_envelope::PathMaterializationPlan;
 use homeboy_core::source_snapshot::SourceSnapshot;
 use homeboy_core::{Error, ErrorCode, Result};

--- a/crates/homeboy-lab-runner/src/lab/offload/resident.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/resident.rs
@@ -97,7 +97,7 @@ pub(crate) fn run_runner_resident_lab_offload(
 
     eprintln!(
         "Lab offload: running `{}` on runner `{}` in `{}`.",
-        redact_argv_display(&command),
+        redact_argv_shell_display(&command),
         runner_id,
         runner_workspace_root
     );

--- a/crates/homeboy-lab-runner/src/lab/provider_preflight.rs
+++ b/crates/homeboy-lab-runner/src/lab/provider_preflight.rs
@@ -8,7 +8,7 @@ use homeboy_agents::agent_tasks::provider::{
     default_backend_for_component, AgentTaskExecutorProvider, ExtensionProviderAgentTaskExecutor,
 };
 use homeboy_core::engine::shell;
-use homeboy_core::redaction::redact_argv_display;
+use homeboy_core::redaction::redact_argv_shell_display;
 use homeboy_core::source_snapshot::SourceSnapshot;
 use homeboy_core::{Error, ErrorCode, Result};
 
@@ -532,7 +532,7 @@ fn agent_task_provider_selection_preflight_error(
         ),
         provider_preflight_homeboy_identity_hint(runner_id, runner_homeboy),
         refresh_hint(runner_id, runner_homeboy, refresh_result),
-        format!("Preflight command: `{}`.", redact_argv_display(command)),
+        format!("Preflight command: `{}`.", redact_argv_shell_display(command)),
     ];
     hints.retain(|hint| !hint.is_empty());
 

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -5,7 +5,7 @@ use homeboy_core::daemon::{
 };
 
 use homeboy_core::engine::shell;
-use homeboy_core::redaction::redact_argv_display;
+use homeboy_core::redaction::redact_argv_shell_display;
 
 use homeboy_core::api_jobs::{ActiveRunnerJobSummary, Job, JobArtifactMetadata, JobStatus};
 
@@ -277,7 +277,7 @@ impl RunnerJob {
             job_id: job.id.to_string(),
             operation: job.operation.clone(),
             status: job.status,
-            command: redact_argv_display(command),
+            command: redact_argv_shell_display(command),
             cwd,
             source: source.to_string(),
             lifecycle_owner: if source == "broker" {
@@ -307,6 +307,56 @@ impl RunnerJob {
                 .map(crate::session::runner_artifact_ref_from_metadata)
                 .collect(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_runner_job_projection_uses_redacted_shell_display() {
+        let job = Job {
+            id: uuid::Uuid::nil(),
+            operation: "runner.exec".to_string(),
+            status: JobStatus::Running,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            started_at_ms: Some(1),
+            finished_at_ms: None,
+            event_count: 0,
+            source_snapshot: None,
+            path_materialization_plan: None,
+            stale_reason: None,
+            daemon_lease_id: None,
+            target_runner_id: None,
+            target_project_id: None,
+            claim_id: None,
+            claimed_by_runner_id: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            artifacts: Vec::new(),
+            runner_job_projection: None,
+        };
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run".to_string(),
+            "#8949".to_string(),
+            "path with spaces".to_string(),
+            "O'Brien".to_string(),
+            "$HOME/work".to_string(),
+            "--provider-auth-token".to_string(),
+            "secret-value".to_string(),
+        ];
+
+        let projection = RunnerJob::from_job("homeboy-lab", "daemon", &command, None, &job);
+
+        assert_eq!(
+            projection.command,
+            "homeboy agent-task run '#8949' 'path with spaces' 'O'\\''Brien' '$HOME/work' --provider-auth-token '[REDACTED]'"
+        );
+        assert!(!projection.command.contains("secret-value"));
     }
 }
 

--- a/crates/homeboy-redaction/Cargo.toml
+++ b/crates/homeboy-redaction/Cargo.toml
@@ -13,5 +13,6 @@ name = "homeboy_redaction"
 path = "src/lib.rs"
 
 [dependencies]
+homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 regex = "1.11"
 serde_json = "1.0"

--- a/crates/homeboy-redaction/src/lib.rs
+++ b/crates/homeboy-redaction/src/lib.rs
@@ -218,6 +218,11 @@ pub fn redact_argv_display(argv: &[String]) -> String {
     redact_argv(argv).join(" ")
 }
 
+/// Render redacted argv as a command that is safe to copy into a POSIX shell.
+pub fn redact_argv_shell_display(argv: &[String]) -> String {
+    homeboy_engine_primitives::shell::quote_args(&redact_argv(argv))
+}
+
 fn redact_argv_with_policy(argv: &[String], policy: &RedactionPolicy) -> Vec<String> {
     let mut redacted = Vec::with_capacity(argv.len());
     let mut redact_next_for: Option<String> = None;
@@ -479,5 +484,33 @@ mod tests {
                 "--url=https://example.test/?token=[REDACTED]&ok=1".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn shell_display_redacts_before_quoting_copyable_argv() {
+        let argv = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run".to_string(),
+            "#8949".to_string(),
+            "path with spaces".to_string(),
+            "O'Brien".to_string(),
+            "$HOME/work".to_string(),
+            "--provider-auth-token".to_string(),
+            "secret-value".to_string(),
+        ];
+
+        let display = redact_argv_shell_display(&argv);
+
+        assert_eq!(
+            display,
+            "homeboy agent-task run '#8949' 'path with spaces' 'O'\\''Brien' '$HOME/work' --provider-auth-token '[REDACTED]'"
+        );
+        assert!(!display.contains("secret-value"));
+        assert!(std::process::Command::new("sh")
+            .args(["-n", "-c", &display])
+            .status()
+            .expect("shell is available")
+            .success());
     }
 }


### PR DESCRIPTION
## Summary
- add a redacted shell-safe argv renderer
- quote copyable Lab command projections after redaction
- preserve structured argv and generic display behavior

## Testing
- `cargo fmt --check`
- `cargo check -p homeboy-lab-runner`
- `cargo test -p homeboy-redaction`
- targeted Lab runner projection tests

Closes #8949

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Root-cause analysis, implementation, and deterministic test coverage.