### PR TITLE
Bound Lab subprocess provenance metadata

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
@@ -178,17 +178,25 @@ fn lab_workspace_mapping_metadata_records_local_to_remote_paths() {
 }
 
 #[test]
-fn lab_offload_env_contains_workspace_mapping_metadata() {
-    let mapping = serde_json::json!({
-        "schema": LAB_WORKSPACE_MAPPING_SCHEMA,
-        "local_to_remote": {
-            "/Users/user/Developer/app": "/srv/homeboy/_lab_workspaces/app-abc"
-        },
-        "workspaces": []
-    });
+fn lab_offload_env_projects_only_subprocess_provenance() {
     let metadata = serde_json::json!({
         "schema": "homeboy/lab-offload/v1",
-        "workspace_mapping": mapping,
+        "runner_id": "lab",
+        "status": "offloaded",
+        "remote_workspace": "/srv/homeboy/workspace",
+        "sync_mode": "snapshot",
+        "source_snapshot": { "runner_id": "lab" },
+        "workspace_verification": {
+            "schema": "homeboy/lab-workspace-verification/v2",
+            "identity": "snapshot:abc",
+            "content_hash": "sha256:abc",
+            "content_manifest": { "entries": ["x".repeat(2_000_000)] },
+            "primary_workspace": {
+                "identity": "snapshot:abc",
+                "remote_path": "/srv/homeboy/workspace",
+                "local_path": "/controller/workspace"
+            }
+        },
     });
 
     let env = build_lab_offload_env(&metadata);
@@ -198,7 +206,30 @@ fn lab_offload_env_contains_workspace_mapping_metadata() {
     )
     .expect("parse lab offload metadata");
 
-    assert_eq!(parsed["workspace_mapping"], mapping);
+    assert_eq!(parsed["schema"], "homeboy/lab-offload-subprocess/v1");
+    assert_eq!(parsed["dispatch_schema"], "homeboy/lab-offload/v1");
+    assert_eq!(parsed["runner_id"], "lab");
+    assert_eq!(parsed["source_snapshot"], metadata["source_snapshot"]);
+    assert_eq!(
+        parsed["workspace_verification"]["primary_workspace"]["remote_path"],
+        "/srv/homeboy/workspace"
+    );
+    assert!(parsed
+        .pointer("/workspace_verification/content_manifest")
+        .is_none());
+    assert_eq!(
+        metadata["workspace_verification"]["content_manifest"]["entries"][0]
+            .as_str()
+            .expect("durable metadata keeps the full audit manifest")
+            .len(),
+        2_000_000
+    );
+    assert!(
+        env.get(LAB_OFFLOAD_METADATA_ENV)
+            .expect("bounded subprocess metadata")
+            .len()
+            < 16 * 1024
+    );
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/lab_env.rs
+++ b/crates/homeboy-lab-runner/src/lab_env.rs
@@ -30,8 +30,46 @@ pub(super) fn forward_release_ci_env(env: &mut HashMap<String, String>) {
 pub(crate) fn build_lab_offload_env(lab_metadata: &serde_json::Value) -> HashMap<String, String> {
     HashMap::from([(
         LAB_OFFLOAD_METADATA_ENV.to_string(),
-        serde_json::to_string(lab_metadata).unwrap_or_default(),
+        serde_json::to_string(&subprocess_lab_offload_metadata(lab_metadata)).unwrap_or_default(),
     )])
+}
+
+/// Project durable Lab evidence into the small provenance envelope a subprocess
+/// needs. The complete dossier remains on the dispatch record; workspace content
+/// manifests and other audit artifacts are not safe to duplicate into `execve`.
+fn subprocess_lab_offload_metadata(lab_metadata: &serde_json::Value) -> serde_json::Value {
+    let workspace_verification = lab_metadata
+        .get("workspace_verification")
+        .map(|verification| {
+            serde_json::json!({
+                "schema": verification.get("schema"),
+                "identity": verification.get("identity"),
+                "content_hash_algorithm": verification.get("content_hash_algorithm"),
+                "permission_policy": verification.get("permission_policy"),
+                "content_hash": verification.get("content_hash"),
+                "sync_excludes": verification.get("sync_excludes"),
+                "source_snapshot": verification.get("source_snapshot"),
+                "primary_workspace": {
+                    "identity": verification.pointer("/primary_workspace/identity"),
+                    "remote_path": verification.pointer("/primary_workspace/remote_path"),
+                },
+            })
+        });
+
+    serde_json::json!({
+        "schema": "homeboy/lab-offload-subprocess/v1",
+        "dispatch_schema": lab_metadata.get("schema"),
+        "runner_id": lab_metadata.get("runner_id"),
+        "runner_mode": lab_metadata.get("runner_mode"),
+        "status": lab_metadata.get("status"),
+        "remote_workspace": lab_metadata.get("remote_workspace"),
+        "sync_mode": lab_metadata.get("sync_mode"),
+        "source_snapshot": lab_metadata.get("source_snapshot"),
+        "workspace_cleanliness": {
+            "allow_dirty_lab_workspace": lab_metadata.pointer("/workspace_cleanliness/allow_dirty_lab_workspace"),
+        },
+        "workspace_verification": workspace_verification,
+    })
 }
 
 /// Forward the preview metadata/public-url passthroughs plus release CI context


### PR DESCRIPTION
## Summary
- stop duplicating the full durable Lab dossier into `HOMEBOY_LAB_OFFLOAD_JSON`
- project only subprocess-required provenance and workspace verification fields
- keep full content manifests and audit metadata on the durable dispatch record
- add a 2 MB manifest regression proving subprocess metadata remains below 16 KiB

Closes #8926.

## Root cause
The Lab subprocess environment carried the complete durable offload dossier, including workspace content manifests. Large repositories pushed the environment beyond Linux `execve` limits, so `Command::spawn()` failed before child identity with `Argument list too long (os error 7)`. Minimal daemon spawning succeeded because it did not carry this envelope.

## How to test
1. Check out this branch on a fresh clone.
2. Run `cargo test -p homeboy-lab-runner lab_offload_env_ --lib`.
3. Run `cargo test -p homeboy-lab-runner lab_offload_workspace_verification_metadata_survives_process_env_hydration --lib`.
4. Run `cargo fmt --check`.
5. Confirm the tests pass and the large-manifest projection stays below 16 KiB.

## Backwards compatibility
`HOMEBOY_LAB_OFFLOAD_JSON` now has schema `homeboy/lab-offload-subprocess/v1` and intentionally excludes durable-only fields such as full content manifests and workspace mappings. Homeboy subprocess consumers retain every field used for workspace provenance verification. External consumers that parsed the undocumented full durable dossier from this process environment must migrate to the bounded subprocess schema or read durable dispatch evidence. Explicit public and secret environment handling is unchanged.

## Verification notes
The focused tests, `cargo fmt --check`, and `git diff --check` pass. A broader `cargo test -p homeboy-lab-runner --lib` run reported no failures before the local two-minute command limit interrupted unrelated long-running integration tests.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed the typed E2BIG spawn failure, implemented the bounded provenance projection, traced subprocess consumers, and added deterministic regression coverage. Chris remains responsible for every line.