### PR TITLE
Type durable Lab handoff authority

### DIFF
--- a/crates/homeboy-agents/src/agent_task_controller_service/actions.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/actions.rs
@@ -309,7 +309,14 @@ pub(super) fn accepted_lab_runner_handoff_identity(execution: &Value) -> Result<
     }
 
     let persisted = lifecycle::status(run_id)?;
-    if persisted.runner_id() != Some(runner_id) || persisted.runner_job_id() != Some(runner_job_id)
+    if !persisted.has_accepted_lab_handoff()
+        || persisted
+            .lab_handoff
+            .as_ref()
+            .is_none_or(|persisted_identity| {
+                persisted_identity.runner_id != runner_id
+                    || persisted_identity.runner_job_id.as_deref() != Some(runner_job_id)
+            })
     {
         return Err(Error::validation_invalid_argument(
             "controller runner handoff identity",

--- a/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
@@ -23,7 +23,9 @@ pub(crate) fn diagnose_run(
         quarantined,
         remediation: remediation.to_string(),
     })?;
-    let reason = if record.schema != schemas::RUN
+    let reason = if record.lab_handoff_validation_error().is_some() {
+        Some(AgentTaskRecordHealthReason::MalformedMetadata)
+    } else if record.schema != schemas::RUN
         || record.lifecycle.schema != RUN_LIFECYCLE_RECORD_SCHEMA
     {
         Some(AgentTaskRecordHealthReason::LegacySchema)
@@ -84,11 +86,16 @@ pub fn reconcile_record_health(dry_run: bool) -> Result<AgentTaskRecordReconcili
             continue;
         }
         report.considered += 1;
-        let reconstructable = matches!(
-            item.reason,
-            AgentTaskRecordHealthReason::MissingMetadata
-                | AgentTaskRecordHealthReason::MalformedMetadata
-        ) && store::read_controller_plan(&run.id).is_ok();
+        let reconstructable = !run
+            .metadata_json
+            .pointer("/agent_task_run/lab_handoff")
+            .is_some()
+            && matches!(
+                item.reason,
+                AgentTaskRecordHealthReason::MissingMetadata
+                    | AgentTaskRecordHealthReason::MalformedMetadata
+            )
+            && store::read_controller_plan(&run.id).is_ok();
         let action = if reconstructable || item.reason == AgentTaskRecordHealthReason::LegacySchema
         {
             "migrate"
@@ -169,6 +176,7 @@ fn reconstruct_record(run: &RunRecord) -> Result<AgentTaskRunRecord> {
         provider_handles: Vec::new(),
         latest_executor_evidence: None,
         lifecycle,
+        lab_handoff: None,
         metadata: json!({
             "lifecycle_reconstruction": {
                 "source": "observation_status_and_durable_plan",

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -374,6 +374,7 @@ where
         provider_handles: Vec::new(),
         latest_executor_evidence: None,
         lifecycle: lifecycle_for_submitted_plan(plan),
+        lab_handoff: None,
         metadata,
     };
     store::write_record(&record)?;
@@ -718,7 +719,7 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     if reconcile_pending_runner_submission_intent(&resolved_run_id)? {
         record = store::read_record(&resolved_run_id)?;
     }
-    if is_expired_unaccepted_lab_handoff(&record, chrono::Utc::now()) {
+    if record.has_expired_pending_lab_handoff(chrono::Utc::now()) {
         let _ = expire_unaccepted_lab_handoff(&resolved_run_id)?;
         record = store::read_record(&resolved_run_id)?;
     }
@@ -867,14 +868,11 @@ pub fn reconcile_active_lab_runner_handoffs() -> Result<usize> {
     // mutations. `list_records` refreshes through `status`, which also expires
     // pending handoffs as a user-visible read-side convergence guarantee.
     for record in store::read_records()? {
-        if record.state == AgentTaskRunState::Running
-            && record.runner_id().is_some()
-            && record.runner_job_id().is_some()
-        {
+        if record.state == AgentTaskRunState::Running && record.has_accepted_lab_handoff() {
             accepted_run_ids.push(record.run_id);
         } else if has_pending_runner_submission_intent(&record) {
             pending_intent_run_ids.push(record.run_id);
-        } else if is_expired_unaccepted_lab_handoff(&record, now) {
+        } else if record.has_expired_pending_lab_handoff(now) {
             expired_run_ids.push(record.run_id);
         }
     }
@@ -1032,27 +1030,6 @@ pub fn reconcile_pending_runner_submission_intent(run_id: &str) -> Result<bool> 
     }
 }
 
-fn is_expired_unaccepted_lab_handoff(
-    record: &AgentTaskRunRecord,
-    now: chrono::DateTime<chrono::Utc>,
-) -> bool {
-    record.state == AgentTaskRunState::Queued
-        && record.runner_id().is_some()
-        && record.runner_job_id().is_none()
-        && record
-            .metadata
-            .get("lifecycle_store_owner")
-            .and_then(Value::as_str)
-            == Some("controller")
-        && record
-            .metadata
-            .get("handoff_acceptance")
-            .filter(|acceptance| acceptance.get("state").and_then(Value::as_str) == Some("pending"))
-            .and_then(|acceptance| acceptance.get("deadline_at").and_then(Value::as_str))
-            .and_then(|deadline| chrono::DateTime::parse_from_rfc3339(deadline).ok())
-            .is_some_and(|deadline| deadline.with_timezone(&chrono::Utc) <= now)
-}
-
 /// Whether the controller has durably transferred this run to a specific
 /// runner daemon job. Once this is true, controller transport errors are not
 /// pre-acceptance failures: the stored runner identity is the reconciliation
@@ -1065,31 +1042,7 @@ pub fn has_accepted_runner_handoff(run_id: &str) -> Result<bool> {
 /// Pure durable-handoff predicate for callers that already hold the lifecycle
 /// record and must not re-enter the store.
 pub(crate) fn is_accepted_runner_handoff(record: &AgentTaskRunRecord) -> bool {
-    let Some(runner_id) = record.runner_id() else {
-        return false;
-    };
-    let Some(runner_job_id) = record.runner_job_id() else {
-        return false;
-    };
-    let handoff = record.metadata.get("runner_handoff");
-    record
-        .metadata
-        .get("handoff_acceptance")
-        .and_then(|acceptance| acceptance.get("state"))
-        .and_then(Value::as_str)
-        == Some("accepted")
-        && handoff
-            .and_then(|value| value.get("authority"))
-            .and_then(Value::as_str)
-            == Some("runner_daemon")
-        && handoff
-            .and_then(|value| value.pointer("/identity/runner_id"))
-            .and_then(Value::as_str)
-            == Some(runner_id)
-        && handoff
-            .and_then(|value| value.pointer("/identity/runner_job_id"))
-            .and_then(Value::as_str)
-            == Some(runner_job_id)
+    record.has_accepted_lab_handoff()
 }
 
 fn expire_unaccepted_lab_handoff(run_id: &str) -> Result<bool> {
@@ -1097,7 +1050,7 @@ fn expire_unaccepted_lab_handoff(run_id: &str) -> Result<bool> {
     // Re-read while holding the handoff lock: an accepted job is runner-owned
     // and must never be terminalized by controller deadline recovery.
     let record = store::read_record(run_id)?;
-    if !is_expired_unaccepted_lab_handoff(&record, chrono::Utc::now()) {
+    if !record.has_expired_pending_lab_handoff(chrono::Utc::now()) {
         return Ok(false);
     }
 
@@ -1105,6 +1058,9 @@ fn expire_unaccepted_lab_handoff(run_id: &str) -> Result<bool> {
     let expired_at = now_timestamp();
     let record_run_id = record.run_id.clone();
     let runner_id = record.runner_id().unwrap_or_default().to_string();
+    if let Some(handoff) = record.lab_handoff.as_ref() {
+        record.lab_handoff = Some(handoff.expired(expired_at.clone()));
+    }
     let metadata = record.ensure_metadata_object();
     metadata.insert(
         "handoff_acceptance".to_string(),
@@ -2084,14 +2040,57 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
         }
         Err(error) => return Err(error),
     };
+    if let Some(problem) = record.lab_handoff_validation_error() {
+        return Err(Error::validation_invalid_argument(
+            "lab_handoff",
+            problem,
+            Some(record.run_id.clone()),
+            None,
+        ));
+    }
+    if let Some(accepted) = record.lab_handoff.as_ref().filter(|handoff| {
+        handoff.state == AgentTaskLabHandoffState::Accepted
+            && handoff.authority == AgentTaskLabHandoffAuthority::RunnerDaemon
+    }) {
+        if accepted.runner_id == input.runner_id
+            && accepted.runner_job_id.as_deref() == Some(input.runner_job_id)
+        {
+            return Ok(record);
+        }
+        return Err(Error::validation_invalid_argument(
+            "lab_handoff",
+            format!(
+                "Lab handoff for run '{}' is already accepted by runner '{}' job '{}'; refusing a different acceptance",
+                record.run_id,
+                accepted.runner_id,
+                accepted.runner_job_id.as_deref().unwrap_or_default(),
+            ),
+            Some(record.run_id.clone()),
+            None,
+        ));
+    }
+    if let Some(pending) = record.lab_handoff.as_ref().filter(|handoff| {
+        handoff.state == AgentTaskLabHandoffState::Pending
+            && handoff.authority == AgentTaskLabHandoffAuthority::Controller
+    }) {
+        if pending.runner_id != input.runner_id {
+            return Err(Error::validation_invalid_argument(
+                "runner_id",
+                format!(
+                    "Lab handoff for run '{}' is pending acceptance by runner '{}'; refusing acceptance from '{}'",
+                    record.run_id, pending.runner_id, input.runner_id,
+                ),
+                Some(record.run_id.clone()),
+                None,
+            ));
+        }
+    }
     let expired_unaccepted_handoff = record.state == AgentTaskRunState::Cancelled
-        && record.runner_id() == Some(input.runner_id)
-        && record
-            .metadata
-            .get("handoff_acceptance")
-            .and_then(|acceptance| acceptance.get("state"))
-            .and_then(Value::as_str)
-            == Some("expired");
+        && record.lab_handoff.as_ref().is_some_and(|handoff| {
+            handoff.state == AgentTaskLabHandoffState::Expired
+                && handoff.authority == AgentTaskLabHandoffAuthority::Controller
+                && handoff.runner_id == input.runner_id
+        });
     if !expired_unaccepted_handoff
         && matches!(
             record.state,
@@ -2133,6 +2132,15 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
         }
     }
     let accepted_at = record.updated_at.clone();
+    let accepted_at = accepted_at.unwrap_or_else(now_timestamp);
+    let pending_handoff = record.lab_handoff.clone().unwrap_or_else(|| {
+        AgentTaskLabHandoff::pending(
+            input.runner_id,
+            record.submitted_at.clone(),
+            accepted_at.clone(),
+        )
+    });
+    record.lab_handoff = Some(pending_handoff.accepted(input.runner_job_id, accepted_at.clone()));
     let metadata = record.ensure_metadata_object();
     metadata.insert("kind".to_string(), json!("lab_offload_detached_handoff"));
     if let Some(intent) = metadata.get_mut("runner_submission_intent") {
@@ -2248,6 +2256,31 @@ fn record_lab_offload_proxy(
         }
         Err(error) => return Err(error),
     };
+    if let Some(problem) = record.lab_handoff_validation_error() {
+        return Err(Error::validation_invalid_argument(
+            "lab_handoff",
+            problem,
+            Some(record.run_id.clone()),
+            None,
+        ));
+    }
+    if let Some(accepted) = record.lab_handoff.as_ref().filter(|handoff| {
+        handoff.state == AgentTaskLabHandoffState::Accepted
+            && handoff.authority == AgentTaskLabHandoffAuthority::RunnerDaemon
+    }) {
+        if accepted.runner_id == runner_id {
+            return Ok(record);
+        }
+        return Err(Error::validation_invalid_argument(
+            "runner_id",
+            format!(
+                "Lab handoff for run '{}' is already accepted by runner '{}'; refusing resume on '{}'",
+                record.run_id, accepted.runner_id, runner_id,
+            ),
+            Some(record.run_id.clone()),
+            None,
+        ));
+    }
     // A previous interruption may have committed the record but not its plan.
     // Repair from the controller-compiled plan before exposing another handoff
     // phase; without it the runner would later create a fake running attempt.
@@ -2265,25 +2298,31 @@ fn record_lab_offload_proxy(
         }
     }
     record.plan_path = store::controller_plan_path(&run_id)?.display().to_string();
+    let pending_handoff = (!record.has_accepted_lab_handoff()).then(|| {
+        let now = chrono::Utc::now();
+        AgentTaskLabHandoff::pending(
+            runner_id,
+            now.to_rfc3339(),
+            (now + chrono::Duration::seconds(lab_handoff_acceptance_timeout_seconds()))
+                .to_rfc3339(),
+        )
+    });
+    if let Some(handoff) = pending_handoff.as_ref() {
+        record.lab_handoff = Some(handoff.clone());
+    }
     let metadata = record.ensure_metadata_object();
     metadata.insert("kind".to_string(), json!("lab_offload_controller_proxy"));
     // This record is the controller's durable projection of a runner handoff.
     // It remains controller-owned until a runner-local record is independently
     // discovered, so controller-generated commands must keep resolving here.
     metadata.insert("lifecycle_store_owner".to_string(), json!("controller"));
-    if metadata
-        .get("handoff_acceptance")
-        .and_then(|acceptance| acceptance.get("state"))
-        .and_then(Value::as_str)
-        != Some("accepted")
-    {
-        let now = chrono::Utc::now();
+    if let Some(handoff) = pending_handoff {
         metadata.insert(
             "handoff_acceptance".to_string(),
             json!({
                 "state": "pending",
-                "started_at": now.to_rfc3339(),
-                "deadline_at": (now + chrono::Duration::seconds(lab_handoff_acceptance_timeout_seconds())).to_rfc3339(),
+                "started_at": handoff.submitted_at,
+                "deadline_at": handoff.acceptance_deadline_at,
             }),
         );
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -93,8 +93,44 @@ pub struct AgentTaskRunRecord {
     pub latest_executor_evidence: Option<AgentTaskLatestExecutorEvidence>,
     #[serde(default)]
     pub lifecycle: RunLifecycleRecord,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lab_handoff: Option<AgentTaskLabHandoff>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
+}
+
+/// Durable authority for a controller-to-Lab runner handoff. This lives on the
+/// controller record because it remains authoritative across transport loss.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskLabHandoff {
+    pub state: AgentTaskLabHandoffState,
+    pub authority: AgentTaskLabHandoffAuthority,
+    pub runner_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_job_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub submitted_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acceptance_deadline_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub accepted_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expired_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskLabHandoffState {
+    Pending,
+    Accepted,
+    Expired,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskLabHandoffAuthority {
+    Controller,
+    RunnerDaemon,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -152,6 +188,42 @@ impl AgentTaskLatestExecutorEvidence {
 }
 
 impl AgentTaskRunRecord {
+    /// Hydrate only the established v1 Lab metadata shape. Invalid or
+    /// inconsistent legacy projections deliberately remain untrusted.
+    pub(crate) fn hydrate_legacy_lab_handoff(&mut self) {
+        if self.lab_handoff.is_none() {
+            self.lab_handoff = AgentTaskLabHandoff::from_legacy_metadata(&self.metadata);
+        }
+    }
+
+    pub(crate) fn has_accepted_lab_handoff(&self) -> bool {
+        self.lab_handoff.as_ref().is_some_and(|handoff| {
+            handoff.is_valid() && handoff.state == AgentTaskLabHandoffState::Accepted
+        })
+    }
+
+    pub(crate) fn lab_handoff_validation_error(&self) -> Option<&'static str> {
+        self.lab_handoff
+            .as_ref()
+            .and_then(AgentTaskLabHandoff::validation_error)
+    }
+
+    pub(crate) fn has_expired_pending_lab_handoff(
+        &self,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> bool {
+        self.state == AgentTaskRunState::Queued
+            && self.lab_handoff.as_ref().is_some_and(|handoff| {
+                handoff.is_valid()
+                    && handoff.state == AgentTaskLabHandoffState::Pending
+                    && handoff
+                        .acceptance_deadline_at
+                        .as_deref()
+                        .and_then(parse_rfc3339)
+                        .is_some_and(|deadline| deadline <= now)
+            })
+    }
+
     pub(crate) fn record_runner_metadata(&mut self, reclaimed_stale: bool) {
         let metadata = self.ensure_metadata_object();
         metadata.insert("runner_pid".to_string(), json!(std::process::id()));
@@ -235,6 +307,13 @@ impl AgentTaskRunRecord {
     }
 
     pub fn runner_job_id(&self) -> Option<&str> {
+        if let Some(handoff) = self.lab_handoff.as_ref() {
+            return handoff
+                .is_valid()
+                .then_some(handoff)
+                .filter(|handoff| handoff.state == AgentTaskLabHandoffState::Accepted)
+                .and_then(|handoff| handoff.runner_job_id.as_deref());
+        }
         self.metadata
             .get("runner_job_id")
             .or_else(|| self.metadata.get("job_id"))
@@ -243,6 +322,9 @@ impl AgentTaskRunRecord {
     }
 
     pub fn runner_id(&self) -> Option<&str> {
+        if let Some(handoff) = self.lab_handoff.as_ref() {
+            return handoff.is_valid().then_some(handoff.runner_id.as_str());
+        }
         self.metadata
             .get("runner_id")
             .and_then(Value::as_str)
@@ -274,6 +356,306 @@ impl AgentTaskRunRecord {
             self.metadata = json!({});
         }
         self.metadata.as_object_mut().expect("metadata object")
+    }
+}
+
+impl AgentTaskLabHandoff {
+    pub(crate) fn pending(
+        runner_id: &str,
+        submitted_at: String,
+        acceptance_deadline_at: String,
+    ) -> Self {
+        Self {
+            state: AgentTaskLabHandoffState::Pending,
+            authority: AgentTaskLabHandoffAuthority::Controller,
+            runner_id: runner_id.to_string(),
+            runner_job_id: None,
+            submitted_at: Some(submitted_at),
+            acceptance_deadline_at: Some(acceptance_deadline_at),
+            accepted_at: None,
+            expired_at: None,
+        }
+    }
+
+    pub(crate) fn accepted(&self, runner_job_id: &str, accepted_at: String) -> Self {
+        Self {
+            state: AgentTaskLabHandoffState::Accepted,
+            authority: AgentTaskLabHandoffAuthority::RunnerDaemon,
+            runner_id: self.runner_id.clone(),
+            runner_job_id: Some(runner_job_id.to_string()),
+            submitted_at: self.submitted_at.clone(),
+            acceptance_deadline_at: self.acceptance_deadline_at.clone(),
+            accepted_at: Some(accepted_at),
+            expired_at: None,
+        }
+    }
+
+    pub(crate) fn expired(&self, expired_at: String) -> Self {
+        Self {
+            state: AgentTaskLabHandoffState::Expired,
+            authority: AgentTaskLabHandoffAuthority::Controller,
+            runner_id: self.runner_id.clone(),
+            runner_job_id: None,
+            submitted_at: self.submitted_at.clone(),
+            acceptance_deadline_at: self.acceptance_deadline_at.clone(),
+            accepted_at: None,
+            expired_at: Some(expired_at),
+        }
+    }
+
+    fn is_valid(&self) -> bool {
+        self.validation_error().is_none()
+    }
+
+    fn validation_error(&self) -> Option<&'static str> {
+        if self.runner_id.trim().is_empty() {
+            return Some("Lab handoff runner_id is blank");
+        }
+        let valid_optional_timestamp = |timestamp: &Option<String>| {
+            timestamp
+                .as_deref()
+                .is_none_or(|timestamp| parse_rfc3339(timestamp).is_some())
+        };
+        if !valid_optional_timestamp(&self.submitted_at)
+            || !valid_optional_timestamp(&self.acceptance_deadline_at)
+            || !valid_optional_timestamp(&self.accepted_at)
+            || !valid_optional_timestamp(&self.expired_at)
+        {
+            return Some("Lab handoff contains an invalid timestamp");
+        }
+        match self.state {
+            AgentTaskLabHandoffState::Pending
+                if self.authority != AgentTaskLabHandoffAuthority::Controller
+                    || self.runner_job_id.is_some()
+                    || self.submitted_at.is_none()
+                    || self.acceptance_deadline_at.is_none()
+                    || self.accepted_at.is_some()
+                    || self.expired_at.is_some() =>
+            {
+                Some("pending Lab handoff has invalid authority or timestamps")
+            }
+            AgentTaskLabHandoffState::Accepted
+                if self.authority != AgentTaskLabHandoffAuthority::RunnerDaemon
+                    || self
+                        .runner_job_id
+                        .as_deref()
+                        .is_none_or(|job_id| job_id.trim().is_empty())
+                    || self.accepted_at.is_none()
+                    || self.expired_at.is_some() =>
+            {
+                Some("accepted Lab handoff has invalid authority, job identity, or timestamp")
+            }
+            AgentTaskLabHandoffState::Expired
+                if self.authority != AgentTaskLabHandoffAuthority::Controller
+                    || self.runner_job_id.is_some()
+                    || self.expired_at.is_none()
+                    || self.accepted_at.is_some() =>
+            {
+                Some("expired Lab handoff has invalid authority, job identity, or timestamp")
+            }
+            _ => None,
+        }
+    }
+
+    fn from_legacy_metadata(metadata: &Value) -> Option<Self> {
+        let object = metadata.as_object()?;
+        let runner_id = required_string(object.get("runner_id"))?;
+        let acceptance = object.get("handoff_acceptance")?.as_object()?;
+        match acceptance.get("state")?.as_str()? {
+            "pending"
+                if object.get("lifecycle_store_owner").and_then(Value::as_str)
+                    == Some("controller") =>
+            {
+                Some(Self::pending(
+                    &runner_id,
+                    required_timestamp(acceptance.get("started_at"))?,
+                    required_timestamp(acceptance.get("deadline_at"))?,
+                ))
+            }
+            "accepted" => {
+                let accepted_at = required_timestamp(acceptance.get("accepted_at"))?;
+                let runner_job_id = required_string(acceptance.get("runner_job_id"))?;
+                let handoff = object.get("runner_handoff")?.as_object()?;
+                let identity = handoff.get("identity")?.as_object()?;
+                if handoff.get("authority").and_then(Value::as_str) != Some("runner_daemon")
+                    || identity.get("runner_id").and_then(Value::as_str) != Some(runner_id.as_str())
+                    || identity.get("runner_job_id").and_then(Value::as_str)
+                        != Some(runner_job_id.as_str())
+                    || required_string(object.get("runner_job_id")).as_deref()
+                        != Some(runner_job_id.as_str())
+                {
+                    return None;
+                }
+                Some(Self {
+                    state: AgentTaskLabHandoffState::Accepted,
+                    authority: AgentTaskLabHandoffAuthority::RunnerDaemon,
+                    runner_id,
+                    runner_job_id: Some(runner_job_id),
+                    submitted_at: acceptance.get("started_at").and_then(optional_timestamp),
+                    acceptance_deadline_at: acceptance
+                        .get("deadline_at")
+                        .and_then(optional_timestamp),
+                    accepted_at: Some(accepted_at),
+                    expired_at: None,
+                })
+            }
+            "expired"
+                if object.get("lifecycle_store_owner").and_then(Value::as_str)
+                    == Some("controller") =>
+            {
+                Some(Self {
+                    state: AgentTaskLabHandoffState::Expired,
+                    authority: AgentTaskLabHandoffAuthority::Controller,
+                    runner_id,
+                    runner_job_id: None,
+                    submitted_at: None,
+                    acceptance_deadline_at: None,
+                    accepted_at: None,
+                    expired_at: required_timestamp(acceptance.get("expired_at")),
+                })
+            }
+            _ => None,
+        }
+    }
+}
+
+fn required_string(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+}
+
+fn parse_rfc3339(value: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|timestamp| timestamp.with_timezone(&chrono::Utc))
+}
+
+fn required_timestamp(value: Option<&Value>) -> Option<String> {
+    let timestamp = required_string(value)?;
+    parse_rfc3339(&timestamp)?;
+    Some(timestamp)
+}
+
+fn optional_timestamp(value: &Value) -> Option<String> {
+    required_timestamp(Some(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn legacy_record(metadata: Value) -> AgentTaskRunRecord {
+        serde_json::from_value(json!({
+            "schema": schemas::RUN,
+            "run_id": "legacy-handoff",
+            "plan_id": "plan",
+            "state": "queued",
+            "submitted_at": "2026-01-01T00:00:00+00:00",
+            "plan_path": "plan.json",
+            "metadata": metadata,
+        }))
+        .expect("backward-compatible record parses")
+    }
+
+    #[test]
+    fn legacy_pending_handoff_hydrates_and_round_trips() {
+        let mut record = legacy_record(json!({
+            "lifecycle_store_owner": "controller",
+            "runner_id": "homeboy-lab",
+            "handoff_acceptance": {
+                "state": "pending",
+                "started_at": "2026-01-01T00:00:00+00:00",
+                "deadline_at": "2026-01-01T00:02:00+00:00"
+            }
+        }));
+        assert!(record.lab_handoff.is_none());
+        record.hydrate_legacy_lab_handoff();
+        assert_eq!(
+            record.lab_handoff.as_ref().map(|handoff| handoff.state),
+            Some(AgentTaskLabHandoffState::Pending)
+        );
+        assert!(record.has_expired_pending_lab_handoff(
+            chrono::DateTime::parse_from_rfc3339("2026-01-01T00:02:00+00:00")
+                .expect("timestamp")
+                .with_timezone(&chrono::Utc)
+        ));
+        let round_trip: AgentTaskRunRecord =
+            serde_json::from_value(serde_json::to_value(&record).expect("serialize"))
+                .expect("deserialize");
+        assert_eq!(round_trip.lab_handoff, record.lab_handoff);
+    }
+
+    #[test]
+    fn legacy_accepted_handoff_hydrates_but_inconsistent_metadata_fails_closed() {
+        let metadata = json!({
+            "runner_id": "homeboy-lab",
+            "runner_job_id": "job-1",
+            "handoff_acceptance": {
+                "state": "accepted",
+                "accepted_at": "2026-01-01T00:01:00+00:00",
+                "runner_job_id": "job-1"
+            },
+            "runner_handoff": {
+                "authority": "runner_daemon",
+                "identity": { "runner_id": "homeboy-lab", "runner_job_id": "job-1" }
+            }
+        });
+        let mut accepted = legacy_record(metadata.clone());
+        accepted.hydrate_legacy_lab_handoff();
+        assert!(accepted.has_accepted_lab_handoff());
+
+        let mut inconsistent = legacy_record(metadata);
+        inconsistent.metadata["runner_handoff"]["identity"]["runner_job_id"] = json!("other-job");
+        inconsistent.hydrate_legacy_lab_handoff();
+        assert!(inconsistent.lab_handoff.is_none());
+        assert!(!inconsistent.has_accepted_lab_handoff());
+    }
+
+    #[test]
+    fn malformed_typed_handoff_variants_fail_closed() {
+        let pending = AgentTaskLabHandoff::pending(
+            "homeboy-lab",
+            "2026-01-01T00:00:00+00:00".to_string(),
+            "2026-01-01T00:02:00+00:00".to_string(),
+        );
+        let accepted = pending.accepted("job-1", "2026-01-01T00:01:00+00:00".to_string());
+        let expired = pending.expired("2026-01-01T00:03:00+00:00".to_string());
+        let malformed = vec![
+            AgentTaskLabHandoff {
+                runner_id: " ".to_string(),
+                ..pending.clone()
+            },
+            AgentTaskLabHandoff {
+                authority: AgentTaskLabHandoffAuthority::RunnerDaemon,
+                submitted_at: Some("invalid".to_string()),
+                ..pending
+            },
+            AgentTaskLabHandoff {
+                runner_job_id: Some(" ".to_string()),
+                ..accepted.clone()
+            },
+            AgentTaskLabHandoff {
+                accepted_at: None,
+                ..accepted
+            },
+            AgentTaskLabHandoff {
+                authority: AgentTaskLabHandoffAuthority::RunnerDaemon,
+                ..expired.clone()
+            },
+            AgentTaskLabHandoff {
+                expired_at: Some("invalid".to_string()),
+                ..expired
+            },
+        ];
+        for handoff in malformed {
+            let mut record = legacy_record(Value::Null);
+            record.lab_handoff = Some(handoff);
+            assert!(record.lab_handoff_validation_error().is_some());
+            assert!(!record.has_accepted_lab_handoff());
+        }
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -194,6 +194,111 @@ fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
 }
 
 #[test]
+fn accepted_handoff_replays_idempotently_and_rejects_a_different_identity() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "immutable-handoff",
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+            durable_plan: None,
+        })
+        .expect("planned handoff");
+        let input = DetachedLabRunRecord {
+            run_id: "immutable-handoff",
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-immutable",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        };
+        let accepted = record_detached_lab_run(input.clone()).expect("accepted handoff");
+        let replay = record_detached_lab_run(input).expect("idempotent replay");
+        assert_eq!(replay, accepted);
+
+        let error = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "immutable-handoff",
+            runner_id: "other-runner",
+            runner_job_id: "other-job",
+            remote_workspace: "/other/workspace",
+            remote_command: &command,
+        })
+        .expect_err("different accepted identity is rejected");
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        let stored = status("immutable-handoff").expect("accepted record retained");
+        assert_eq!(stored.runner_id(), Some("homeboy-lab"));
+        assert_eq!(stored.runner_job_id(), Some("job-immutable"));
+    });
+}
+
+#[test]
+fn pending_handoff_rejects_acceptance_from_a_different_runner_without_mutation() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let planned = record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "pending-runner-identity",
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+            durable_plan: None,
+        })
+        .expect("planned handoff");
+
+        let error = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "pending-runner-identity",
+            runner_id: "other-runner",
+            runner_job_id: "job-other",
+            remote_workspace: "/other/workspace",
+            remote_command: &command,
+        })
+        .expect_err("different runner cannot accept pending handoff");
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        let stored = status("pending-runner-identity").expect("pending handoff retained");
+        assert_eq!(stored, planned);
+    });
+}
+
+#[test]
+fn accepted_proxy_resume_rejects_a_different_runner_without_rewriting_legacy_projection() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "immutable-proxy",
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+            durable_plan: None,
+        })
+        .expect("planned handoff");
+        record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "immutable-proxy",
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-proxy",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("accepted handoff");
+
+        let error = record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "immutable-proxy",
+            runner_id: "other-runner",
+            remote_workspace: "/other/workspace",
+            remote_command: &command,
+            durable_plan: None,
+        })
+        .expect_err("different runner resume is rejected");
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        let stored = status("immutable-proxy").expect("accepted record retained");
+        assert_eq!(stored.metadata["runner_id"], "homeboy-lab");
+        assert_eq!(stored.metadata["runner_job_id"], "job-proxy");
+        assert_eq!(
+            stored.metadata["runner_execution_record"]["status"],
+            "running"
+        );
+    });
+}
+
+#[test]
 fn detached_cook_attempt_proxy_advances_after_daemon_acceptance() {
     with_isolated_home(|_| {
         let command = vec![
@@ -562,6 +667,7 @@ fn detached_runner_failure_transitions_parent_and_task_terminal() {
         provider_handles: Vec::new(),
         latest_executor_evidence: None,
         lifecycle: lifecycle_for_submitted_plan(&plan),
+        lab_handoff: None,
         metadata: json!({ "runner_id": "homeboy-lab", "runner_job_id": "job-123" }),
     };
     record.tasks[0].state = AgentTaskState::Running;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -985,6 +985,35 @@ fn record_health_migrates_legacy_and_quarantines_conflicting_projections() {
 }
 
 #[test]
+fn malformed_typed_pending_handoff_is_health_malformed_and_unreconciled() {
+    with_isolated_home(|_| {
+        submit_plan(&test_plan(), Some("malformed-typed-pending")).expect("submitted");
+        rewrite_record_for_test("malformed-typed-pending", |record| {
+            record.lab_handoff = Some(AgentTaskLabHandoff {
+                state: AgentTaskLabHandoffState::Pending,
+                authority: AgentTaskLabHandoffAuthority::Controller,
+                runner_id: "homeboy-lab".to_string(),
+                runner_job_id: None,
+                submitted_at: Some("invalid".to_string()),
+                acceptance_deadline_at: None,
+                accepted_at: None,
+                expired_at: None,
+            });
+        })
+        .expect("malformed typed state stored");
+
+        let health = record_health_summary().expect("health report");
+        assert_eq!(health.malformed, 1);
+        let report = reconcile_record_health(false).expect("quarantine malformed state");
+        assert_eq!(report.quarantined, 1);
+        assert_eq!(
+            report.records[0].reason,
+            AgentTaskRecordHealthReason::MalformedMetadata
+        );
+    });
+}
+
+#[test]
 fn artifact_refs_treat_empty_url_as_missing_and_fall_back_to_path() {
     let outcomes = vec![outcome_with_refs(
         "task-a",

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -294,8 +294,11 @@ fn status_expires_an_unaccepted_handoff_but_late_runner_acceptance_wins() {
         })
         .expect("controller proxy recorded before handoff");
         rewrite_record_for_test("expired-handoff-late-acceptance", |record| {
-            record.metadata["handoff_acceptance"]["deadline_at"] =
-                json!("2000-01-01T00:00:00+00:00");
+            record
+                .lab_handoff
+                .as_mut()
+                .expect("typed handoff")
+                .acceptance_deadline_at = Some("2000-01-01T00:00:00+00:00".to_string());
         })
         .expect("expire acceptance deadline");
 
@@ -314,6 +317,7 @@ fn status_expires_an_unaccepted_handoff_but_late_runner_acceptance_wins() {
         })
         .expect("late acceptance supersedes only the synthetic expiry cancellation");
         assert_eq!(accepted.state, AgentTaskRunState::Running);
+        assert!(accepted.has_accepted_lab_handoff());
         assert_eq!(accepted.metadata["handoff_acceptance"]["state"], "accepted");
         assert_eq!(
             accepted.metadata["runner_job_id"],
@@ -323,6 +327,16 @@ fn status_expires_an_unaccepted_handoff_but_late_runner_acceptance_wins() {
             accepted.metadata["runner_execution_record"]["status"],
             "running"
         );
+        let accepted_with_stale_deadline =
+            rewrite_record_for_test("expired-handoff-late-acceptance", |record| {
+                record
+                    .lab_handoff
+                    .as_mut()
+                    .expect("typed accepted handoff")
+                    .acceptance_deadline_at = Some("2000-01-01T00:00:00+00:00".to_string());
+            })
+            .expect("make the historical acceptance deadline stale");
+        assert!(!accepted_with_stale_deadline.has_expired_pending_lab_handoff(chrono::Utc::now()));
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -294,10 +294,11 @@ fn classify_liveness(
     last_update_age_minutes: Option<i64>,
     now: chrono::DateTime<chrono::Utc>,
 ) -> AgentTaskLiveness {
+    if record.lab_handoff_validation_error().is_some() {
+        return AgentTaskLiveness::Unreconciled;
+    }
     if record.state != agent_task_lifecycle::AgentTaskRunState::Running {
-        if record.state == agent_task_lifecycle::AgentTaskRunState::Queued
-            && handoff_acceptance_expired(record, now)
-        {
+        if record.has_expired_pending_lab_handoff(now) {
             return AgentTaskLiveness::Unreconciled;
         }
         // Queued runs are genuinely pending work unless their controller-owned
@@ -313,7 +314,7 @@ fn classify_liveness(
         last_update_age_minutes.is_some_and(|age| age >= STALE_UPDATE_THRESHOLD_MINUTES);
 
     let has_owner_signal =
-        record.metadata.get("runner_pid").is_some() || record.metadata.get("runner_id").is_some();
+        record.metadata.get("runner_pid").is_some() || record.runner_id().is_some();
 
     match (stale_by_age, has_owner_signal) {
         (true, _) => AgentTaskLiveness::Suspect,
@@ -324,30 +325,12 @@ fn classify_liveness(
     }
 }
 
-fn handoff_acceptance_expired(
-    record: &AgentTaskRunRecord,
-    now: chrono::DateTime<chrono::Utc>,
-) -> bool {
-    record
-        .metadata
-        .get("handoff_acceptance")
-        .filter(|acceptance| acceptance.get("state").and_then(Value::as_str) == Some("pending"))
-        .and_then(|acceptance| acceptance.get("deadline_at").and_then(Value::as_str))
-        .and_then(|deadline| chrono::DateTime::parse_from_rfc3339(deadline).ok())
-        .is_some_and(|deadline| deadline.with_timezone(&chrono::Utc) <= now)
-}
-
 /// Label where a run executes so an operator can trace the runner process.
 fn run_source(record: &AgentTaskRunRecord) -> String {
-    if let Some(runner_id) =
-        metadata_string(&record.metadata, "runner_id").filter(|id| !id.trim().is_empty())
-    {
+    if let Some(runner_id) = record.runner_id() {
         return format!("runner:{runner_id}");
     }
-    if record.metadata.get("remote_run_id").is_some()
-        || record.metadata.get("runner_job_id").is_some()
-        || record.metadata.get("job_id").is_some()
-    {
+    if record.metadata.get("remote_run_id").is_some() || record.runner_job_id().is_some() {
         return "remote".to_string();
     }
     "local".to_string()
@@ -395,8 +378,8 @@ fn discovery_run(
     // record ownership. Controller handoff projections retain their durable
     // record locally across runner reconnects, so their commands must remain
     // controller-scoped until a runner-local record is independently discovered.
-    let runner_id = metadata_string(&record.metadata, "runner_id")
-        .filter(|runner_id| !runner_id.trim().is_empty());
+    let runner_id = record.runner_id().map(str::to_string);
+    let runner_job_id = record.runner_job_id().map(str::to_string);
     let command_prefix = if metadata_string(&record.metadata, "lifecycle_store_owner").as_deref()
         == Some("controller")
     {
@@ -417,9 +400,8 @@ fn discovery_run(
         counts: discovery_counts(&record.tasks),
         submitted_at: record.submitted_at,
         updated_at: record.updated_at,
-        runner_id: metadata_string(&record.metadata, "runner_id"),
-        runner_job_id: metadata_string(&record.metadata, "runner_job_id")
-            .or_else(|| metadata_string(&record.metadata, "job_id")),
+        runner_id,
+        runner_job_id,
         remote_run_id: metadata_string(&record.metadata, "remote_run_id"),
         stale: metadata_bool(&record.metadata, "stale_running"),
         stale_reason: metadata_string(&record.metadata, "stale_running_reason"),

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -799,8 +799,11 @@ fn reconcile_terminalizes_an_unaccepted_controller_handoff_after_its_deadline() 
         )
         .expect("controller handoff persisted before runner acceptance");
         agent_task_lifecycle::rewrite_record_for_test("controller-handoff-unaccepted", |record| {
-            record.metadata["handoff_acceptance"]["deadline_at"] =
-                serde_json::json!("2000-01-01T00:00:00+00:00");
+            record
+                .lab_handoff
+                .as_mut()
+                .expect("typed handoff")
+                .acceptance_deadline_at = Some("2000-01-01T00:00:00+00:00".to_string());
         })
         .expect("expire acceptance deadline");
 

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -326,12 +326,21 @@ pub(super) fn record_from_run(run: &RunRecord) -> Result<AgentTaskRunRecord> {
             json!({ "context": run.id }),
         )
     })?;
-    serde_json::from_value(value.clone()).map_err(|error| {
-        Error::internal_json(
-            error.to_string(),
-            Some(format!("parse agent-task run {}", run.id)),
-        )
-    })
+    let mut record: AgentTaskRunRecord =
+        serde_json::from_value(value.clone()).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some(format!("parse agent-task run {}", run.id)),
+            )
+        })?;
+    record.hydrate_legacy_lab_handoff();
+    if let Some(problem) = record.lab_handoff_validation_error() {
+        return Err(Error::internal_json(
+            problem,
+            Some(format!("validate agent-task Lab handoff {}", run.id)),
+        ));
+    }
+    Ok(record)
 }
 
 fn read_mirrored_aggregate(run_id: &str) -> Result<Option<AgentTaskAggregate>> {

--- a/docs/architecture/lifecycle-contracts.md
+++ b/docs/architecture/lifecycle-contracts.md
@@ -81,3 +81,12 @@ it under `results.lifecycle` in the `homeboy/fuzz-campaign/v1` campaign object.
 Snapshot refs are metadata pointers, not implicit filesystem paths. Use
 `artifact_id` or the nested `artifact` contract when snapshot bytes are persisted
 as Homeboy artifacts; use `locator` only for runner-owned opaque references.
+
+## Agent-Task Lab Handoffs
+
+Controller-owned agent-task records persist a typed Lab handoff with pending,
+accepted, or expired state, runner identity, deadline, and the accepted daemon
+job identity. Existing v1 metadata is hydrated only when its redundant identity
+fields agree; malformed legacy metadata fails closed. The compatibility slice
+preserves v1 metadata while new records write the typed projection. Idempotent
+daemon submission remains a follow-up.


### PR DESCRIPTION
## Summary

- add a typed `AgentTaskLabHandoff` state for pending, accepted, and expired controller-to-Lab authority transfer
- hydrate existing v1 metadata through one compatibility adapter while validating typed state at the lifecycle-store boundary
- make accepted runner/job identity immutable and reject mismatched pending acceptance or accepted proxy resume before mutation
- route expiry, reconciliation, controller validation, discovery, and runner identity through typed authority
- quarantine malformed typed handoff records instead of treating them as accepted or indefinitely active

Closes #8932.

## Why

Recent Lab fixes repeatedly reconstructed daemon acceptance and lifecycle authority from several metadata projections. This change establishes one typed in-memory authority model while preserving existing persisted records and legacy metadata writes during the compatibility window.

## How to test

1. Run `cargo fmt --check`.
2. Run `git diff --check origin/main...HEAD`.
3. Run `cargo test -p homeboy-agents agent_task_lifecycle::records::tests --lib -- --test-threads=1`.
4. Run `cargo test -p homeboy-agents accepted_handoff --lib -- --test-threads=1`.
5. Run `cargo test -p homeboy-agents pending_handoff --lib -- --test-threads=1`.
6. Run `cargo test -p homeboy-agents accepted_proxy_resume --lib -- --test-threads=1`.
7. Run `cargo test -p homeboy-agents malformed_typed --lib -- --test-threads=1`.

## Verification notes

The focused handoff and lifecycle tests above pass. The broad `cargo test -p homeboy-agents --lib` suite is not currently green on `main` or this branch. The same baseline failures reproduce on an unchanged fresh `main` checkout:

- `agent_task_executor_evidence::tests::persisted_input_redacts_secrets_but_retains_contracts_paths_and_artifacts`
- `agent_task_lifecycle::tests::handoff_and_proxy::controller_runtime_retention_keeps_mutable_and_retained_terminal_runs`
- `agent_task_lifecycle::tests::status_and_recovery::detached_lab_handoff_persists_inspectable_running_record`

## Compatibility

Persisted v1 records remain readable. Recognized legacy metadata hydrates into typed state; malformed or conflicting projections fail closed. New writes temporarily maintain legacy metadata for concrete persisted compatibility. Idempotent daemon submission remains a follow-up boundary.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Architecture analysis, implementation, tests, iterative code review, and remediation. Chris reviewed and owns the change.