### PR TITLE
fix: make a fresh, idle remote daemon recoverable by reconnect (#8694)

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -6,7 +6,7 @@ use homeboy::core::agent_runtime_manifest::{
     AgentRuntimeRuntimeDiagnosticDeclaration, AgentRuntimeSourceConsistencyDiagnostic,
     AgentRuntimeToolDiagnosticDeclaration,
 };
-use homeboy::core::daemon::DaemonStaleReasonCode;
+use homeboy::core::daemon::{DaemonRecoveryEvidence, DaemonStaleReasonCode};
 use homeboy::runner::runners::{
     self as runner, RunnerActiveJobState, RunnerAvailability, RunnerBinarySource, RunnerSession,
     RunnerStatusReport, RunnerTunnelMode, RuntimeMaterializationStatus,
@@ -1100,6 +1100,24 @@ pub(super) fn runner_status_operator_commands(
                 job_id: None,
                 command: command.clone(),
                 description: "Reconcile the stale daemon split view only after the remote owner-lock, process, and listener probes prove no daemon-owned process remains alive.".to_string(),
+            });
+        }
+    }
+
+    // A fresh, authoritatively idle remote daemon whose controller session was
+    // lost is recoverable by a plain reconnect (#8694). Surface the reconnect
+    // command so operators are not left with a disconnected, non-restartable
+    // runner and no actionable path.
+    if let Some(freshness) = report.daemon_freshness.as_ref().filter(|freshness| {
+        freshness.recovery_evidence == Some(DaemonRecoveryEvidence::Recoverable)
+    }) {
+        if let Some(command) = freshness.adoption_command.as_ref() {
+            commands.push(RunnerOperatorCommand {
+                scope: "daemon_reconnect_fresh_idle",
+                runner_id: report.runner_id.clone(),
+                job_id: None,
+                command: command.clone(),
+                description: "Reconnect the controller session to the fresh, idle remote daemon; it reports zero authoritatively idle jobs and needs no replacement.".to_string(),
             });
         }
     }

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -176,6 +176,11 @@ pub enum DaemonStaleReasonCode {
 #[serde(rename_all = "snake_case")]
 pub enum DaemonRecoveryEvidence {
     ProvenDead,
+    /// The remote daemon is fresh and authoritatively idle (zero active jobs);
+    /// the controller merely lost its session and can safely reconnect. This is
+    /// a benign recovery, distinct from `Unavailable`, which withholds an action
+    /// because ownership/liveness could not be established.
+    Recoverable,
     Unavailable,
 }
 

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1142,13 +1142,19 @@ pub(super) fn active_jobs_before_daemon_replacement(
     Ok(report.active_jobs)
 }
 
-/// A daemon freshness report is the daemon's own job count. Only a restartable
-/// daemon which reports zero jobs can replace an unavailable typed `/jobs` view.
+/// A daemon freshness report is the daemon's own job count. A daemon can
+/// authoritatively prove zero active jobs either by being restartable (a stale
+/// daemon safe to stop/start) or by being freshly `Recoverable` — a healthy
+/// remote daemon with zero authoritatively idle jobs whose controller session
+/// was merely lost and can be reconnected (#8694). Both cases can safely
+/// replace an unavailable typed `/jobs` view.
 pub(crate) fn authoritative_zero_active_jobs(report: &RunnerStatusReport) -> bool {
-    report
-        .daemon_freshness
-        .as_ref()
-        .is_some_and(|freshness| freshness.restartable && freshness.active_jobs == 0)
+    report.daemon_freshness.as_ref().is_some_and(|freshness| {
+        freshness.active_jobs == 0
+            && (freshness.restartable
+                || freshness.recovery_evidence
+                    == Some(homeboy_core::daemon::DaemonRecoveryEvidence::Recoverable))
+    })
 }
 
 fn runner_daemon_freshness(

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -213,6 +213,11 @@ impl RemoteDaemonWorkEvidence {
     fn is_authoritatively_idle(self) -> bool {
         self == Self::AuthoritativelyIdle
     }
+
+    #[cfg(test)]
+    pub(in crate::connection) fn idle() -> Self {
+        Self::AuthoritativelyIdle
+    }
 }
 
 pub(super) fn remote_daemon_recovery_freshness_from_status(
@@ -234,6 +239,19 @@ pub(super) fn remote_daemon_recovery_freshness_from_status(
                     | DaemonStaleReasonCode::VersionMismatch
             )
         );
+    // A remote daemon that self-reports fresh and authoritatively idle (zero
+    // active jobs proven via its typed `/jobs` view) is not a recovery hazard:
+    // the controller simply lost its session to a healthy daemon. Reconnecting
+    // is the safe, deterministic recovery. Without this case such a daemon fell
+    // into the generic "lease evidence unavailable; active jobs are protected"
+    // branch below, which produced no adoption command and left Lab placement
+    // waiting for controller generation admission (#8694). "Protected active
+    // jobs" is also nonsensical when there are provably zero.
+    let recoverable_fresh_idle = !proven_dead
+        && !leaseless_reconciliation_available
+        && status.fresh
+        && status.active_jobs == 0
+        && status.work_evidence.is_authoritatively_idle();
     let mut ownership_evidence = if proven_dead {
         Some(format!(
             "remote daemon status over SSH proved PID {} is dead for lease `{}`",
@@ -242,6 +260,8 @@ pub(super) fn remote_daemon_recovery_freshness_from_status(
         ))
     } else if leaseless_reconciliation_available {
         Some("active durable jobs require explicit reconciliation; it will verify the owner lock, process list, and configured listener before terminalizing them".to_string())
+    } else if recoverable_fresh_idle {
+        Some("remote daemon is fresh with zero authoritatively idle jobs; the controller session can be safely reconnected".to_string())
     } else {
         Some("remote daemon lease evidence is unavailable; active jobs are protected from implicit replacement".to_string())
     };
@@ -268,6 +288,11 @@ pub(super) fn remote_daemon_recovery_freshness_from_status(
             "homeboy runner connect {} --reconcile-leaseless-orphans --confirm-no-daemon-owner",
             shell::quote_arg(runner_id),
         ))
+    } else if recoverable_fresh_idle {
+        Some(format!(
+            "homeboy runner connect {}",
+            shell::quote_arg(runner_id),
+        ))
     } else {
         None
     };
@@ -279,6 +304,8 @@ pub(super) fn remote_daemon_recovery_freshness_from_status(
         pid,
         recovery_evidence: Some(if proven_dead {
             DaemonRecoveryEvidence::ProvenDead
+        } else if recoverable_fresh_idle {
+            DaemonRecoveryEvidence::Recoverable
         } else {
             DaemonRecoveryEvidence::Unavailable
         }),

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -266,6 +266,41 @@ fn remote_status_without_reason_is_evidence_unavailable_and_non_adoptable() {
 }
 
 #[test]
+fn fresh_idle_remote_daemon_is_recoverable_by_reconnect() {
+    // #8694: a remote daemon that self-reports fresh with zero authoritatively
+    // idle jobs, while the controller session is lost, must be recoverable via
+    // a plain reconnect — not reported as a non-restartable dead end with the
+    // nonsensical "active jobs are protected" message.
+    let mut status = remote_daemon_status_for_test(true, true, 0, "lease-live", 4545);
+    status.work_evidence = crate::connection::remote_daemon::RemoteDaemonWorkEvidence::idle();
+
+    let recovery = remote_daemon_recovery_freshness_from_status("homeboy-lab", &status);
+
+    assert_eq!(recovery.active_jobs, 0);
+    assert!(recovery.fresh);
+    assert_eq!(
+        recovery.recovery_evidence,
+        Some(homeboy_core::daemon::DaemonRecoveryEvidence::Recoverable)
+    );
+    assert_eq!(
+        recovery.adoption_command.as_deref(),
+        Some("homeboy runner connect homeboy-lab")
+    );
+    let ownership = recovery
+        .ownership_evidence
+        .as_deref()
+        .expect("recovery guidance");
+    assert!(
+        ownership.contains("safely reconnected"),
+        "ownership evidence must describe the reconnect recovery: {ownership}"
+    );
+    assert!(
+        !ownership.contains("active jobs are protected"),
+        "must not claim protected jobs when there are provably zero: {ownership}"
+    );
+}
+
+#[test]
 fn remote_missing_or_corrupt_lease_with_active_jobs_exposes_bounded_reconciliation() {
     for reason in [
         DaemonStaleReasonCode::LeaseMissing,


### PR DESCRIPTION
## Summary

A configured Lab runner could self-report a **fresh remote daemon with zero active jobs** while the controller session was lost (`connected: false`). `remote_daemon_recovery_freshness_from_status` (`connection/remote_daemon.rs`) had no case for this benign state, so it fell through to the generic branch:

```json
{ "connected": false, "daemon_freshness": {
  "fresh": true, "active_jobs": 0, "restartable": false,
  "ownership_evidence": "remote daemon lease evidence is unavailable; active jobs are protected from implicit replacement",
  "recovery_evidence": "unavailable" } }
```

With `restartable: false`, no adoption command, and a "protected active jobs" message that is nonsensical when there are provably zero, the runner was a dead end — and Lab placement waited for controller generation admission until it timed out (#8694).

## Change

Add a `recoverable_fresh_idle` case: when the remote daemon self-reports **fresh with zero authoritatively idle jobs** (proven via its typed `/jobs` view, `RemoteDaemonWorkEvidence::AuthoritativelyIdle`) and is neither proven-dead nor leaseless-reconcilable, it is recovered by a plain `homeboy runner connect <runner>` reconnect.

- New **`DaemonRecoveryEvidence::Recoverable`** variant distinguishes this benign reconnect from `Unavailable` (where ownership/liveness genuinely could not be established).
- `remote_daemon_recovery_freshness_from_status` emits honest ownership evidence (*"fresh with zero authoritatively idle jobs; the controller session can be safely reconnected"*) and the reconnect adoption command for this case.
- `authoritative_zero_active_jobs` treats `Recoverable` + zero jobs as an authoritative idle verdict alongside `restartable`.
- Runner status (`runner/status.rs`) renders the reconnect command as an operator action so a fresh-idle runner is no longer disconnected-and-non-restartable with no path.

Active-job protection, proven-dead adoption, and leaseless reconciliation are all unchanged — the new case is strictly additive and only triggers when the remote daemon **authoritatively** proves zero jobs.

## Testing

- `cargo check` clean for `homeboy-lab-runner`, `homeboy-core`, and `homeboy-cli` (`--lib --tests`, EXIT 0).
- `cargo fmt`.
- `cargo test -p homeboy-lab-runner --lib connection::tests::recovery::` — **43 passed**, including the new `fresh_idle_remote_daemon_is_recoverable_by_reconnect` (asserts `Recoverable`, the `homeboy runner connect homeboy-lab` command, reconnect-oriented ownership evidence, and absence of the "active jobs are protected" message). Existing proven-dead / leaseless / unavailable tests remain green.

Heavy workspace build/test intentionally left to CI per repo policy.

Fixes #8694

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Traced the disconnected-recovery freshness decision tree, identified the missing fresh-idle case, implemented the `Recoverable` verdict + reconnect path + operator rendering, and added coverage. Chris reviews and owns the change.