### PR TITLE
Make runner reconnect failure converge

### DIFF
--- a/crates/homeboy-cli/src/commands/daemon.rs
+++ b/crates/homeboy-cli/src/commands/daemon.rs
@@ -247,15 +247,24 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
             daemon::supervise(&addr, &startup_token)?;
             Ok((DaemonOutput::Serve(DaemonStartResult { pid: std::process::id(), address: addr, state_path: String::new(), lease_id: String::new() }), 0))
         }
-        DaemonCommand::Stop { lease_id, force } => Ok((
-            DaemonOutput::Stop(match (force, lease_id) {
+        DaemonCommand::Stop { lease_id, force } => {
+            let lease_bound = lease_id.is_some();
+            let result = match (force, lease_id) {
                 (true, Some(lease_id)) => daemon::force_stop_for_lease(&lease_id)?,
                 (true, None) => unreachable!("clap requires --lease-id with --force"),
                 (false, Some(lease_id)) => daemon::stop_for_lease(&lease_id)?,
                 (false, None) => daemon::stop()?,
-            }),
-            0,
-        )),
+            };
+            if lease_bound && !result.stopped && !result.already_absent {
+                return Err(Error::validation_invalid_argument(
+                    "daemon_stop",
+                    "lease-bound daemon stop did not stop the exact owner or prove it already absent",
+                    None,
+                    None,
+                ));
+            }
+            Ok((DaemonOutput::Stop(result), 0))
+        }
         DaemonCommand::Status => Ok((DaemonOutput::Status(daemon::read_status()?), 0)),
         DaemonCommand::BrokerConfig {
             listen_addr,

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -296,11 +296,19 @@ pub struct DaemonLeaselessOrphanReconciliationResult {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct DaemonStopResult {
     pub stopped: bool,
+    /// The exact requested lease was already absent after an idle-work check.
+    /// This is a successful idempotent lease-bound stop, not a failed stop.
+    #[serde(skip_serializing_if = "is_false")]
+    pub already_absent: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pid: Option<u32>,
     pub state_path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub termination_evidence: Option<DaemonTerminationEvidence>,
+}
+
+fn is_false(value: &bool) -> bool {
+    !value
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -893,6 +901,7 @@ pub fn force_stop_for_lease(expected_lease_id: &str) -> Result<DaemonStopResult>
         remove_lease_if_identity_matches(&path, &identity)?;
         return Ok(DaemonStopResult {
             stopped: false,
+            already_absent: true,
             pid: Some(state.pid),
             state_path: state_path_display,
             termination_evidence: None,
@@ -935,6 +944,7 @@ pub fn force_stop_for_lease(expected_lease_id: &str) -> Result<DaemonStopResult>
     remove_lease_if_identity_matches(&path, &identity)?;
     Ok(DaemonStopResult {
         stopped: true,
+        already_absent: false,
         pid: Some(state.pid),
         state_path: state_path_display,
         termination_evidence: Some(evidence),
@@ -964,7 +974,18 @@ fn stop_with_force_for_lease(expected_lease_id: &str, force: bool) -> Result<Dae
             None,
         ));
     }
-    stop_unlocked_with_force(force)
+    let mut result = stop_unlocked_with_force(force)?;
+    if !result.stopped {
+        // A stale-but-live lease is not a successful completion. Re-probe so
+        // only disappearance or replacement of the exact requested owner is
+        // reported as idempotent absence.
+        let status = read_status()?;
+        result.already_absent = status
+            .state
+            .as_ref()
+            .is_none_or(|state| state.lease_id != expected_lease_id);
+    }
+    Ok(result)
 }
 
 /// A lease-bound stop can be replayed after a previous stop removed a dead
@@ -997,6 +1018,7 @@ fn reconcile_absent_lease_stop(
     }
     Ok(DaemonStopResult {
         stopped: false,
+        already_absent: true,
         pid: None,
         state_path,
         termination_evidence: None,
@@ -1020,6 +1042,7 @@ fn stop_unlocked_with_force(force: bool) -> Result<DaemonStopResult> {
     let Some(state) = validation.state.as_ref() else {
         return Ok(DaemonStopResult {
             stopped: false,
+            already_absent: false,
             pid: None,
             state_path: state_path_display,
             termination_evidence: None,
@@ -1032,6 +1055,7 @@ fn stop_unlocked_with_force(force: bool) -> Result<DaemonStopResult> {
         }
         return Ok(DaemonStopResult {
             stopped: false,
+            already_absent: false,
             pid: Some(state.pid),
             state_path: state_path_display,
             termination_evidence: None,
@@ -1103,6 +1127,7 @@ fn stop_unlocked_with_force(force: bool) -> Result<DaemonStopResult> {
 
     Ok(DaemonStopResult {
         stopped,
+        already_absent: false,
         pid: Some(pid),
         state_path: state_path_display,
         termination_evidence: None,

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -402,6 +402,16 @@ fn validate_remote_lease_bound_daemon_stop_output(
     {
         return Err("remote lease-bound daemon stop returned an unexpected response".to_string());
     }
+    let completed = envelope.data.as_ref().is_some_and(|data| {
+        data.get("stopped").and_then(Value::as_bool) == Some(true)
+            || data.get("already_absent").and_then(Value::as_bool) == Some(true)
+    });
+    if !completed {
+        return Err(
+            "remote lease-bound daemon stop returned `stopped:false` without proving the exact lease already absent"
+                .to_string(),
+        );
+    }
     Ok(())
 }
 
@@ -844,5 +854,39 @@ mod tests {
         let malformed_error = validate_remote_lease_bound_daemon_stop_output(&malformed)
             .expect_err("malformed SSH stop output must fail closed");
         assert!(malformed_error.contains("invalid JSON"));
+    }
+
+    #[test]
+    fn lease_bound_ssh_stop_rejects_successful_stopped_false_response() {
+        let output = homeboy_core::server::CommandOutput {
+            stdout: r#"{"success":true,"data":{"action":"stop","stopped":false}}"#.to_string(),
+            stderr: String::new(),
+            success: true,
+            exit_code: 0,
+            timed_out: false,
+            child_resource: None,
+        };
+
+        let error = validate_remote_lease_bound_daemon_stop_output(&output)
+            .expect_err("a lease-bound stop must prove completion");
+
+        assert!(error.contains("stopped:false"));
+    }
+
+    #[test]
+    fn lease_bound_ssh_stop_accepts_proven_already_absent_response() {
+        let output = homeboy_core::server::CommandOutput {
+            stdout:
+                r#"{"success":true,"data":{"action":"stop","stopped":false,"already_absent":true}}"#
+                    .to_string(),
+            stderr: String::new(),
+            success: true,
+            exit_code: 0,
+            timed_out: false,
+            child_resource: None,
+        };
+
+        validate_remote_lease_bound_daemon_stop_output(&output)
+            .expect("an exact already-absent lease is an idempotent completion");
     }
 }

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -426,7 +426,7 @@ pub fn refresh_homeboy_binary(
         ) {
             Ok(result) => result,
             Err(error) => {
-                return rollback_refresh_error(
+                return rollback_refresh_connect_error(
                     &plan.runner_id,
                     previous_homeboy_path.as_deref(),
                     error,
@@ -1187,6 +1187,50 @@ fn rollback_refresh_error<T>(
 ) -> Result<T> {
     rollback_refresh_error_with(primary_error, || {
         restore_runner_homeboy_path(runner_id, previous_homeboy_path)
+    })
+}
+
+/// Once the old daemon has been stopped, restoring only the configured binary
+/// leaves no valid controller session. Restore and reconnect as one
+/// compensation step so a later request cannot carry stale lease proof.
+fn rollback_refresh_connect_error<T>(
+    runner_id: &str,
+    previous_homeboy_path: Option<&str>,
+    primary_error: Error,
+) -> Result<T> {
+    rollback_refresh_connect_error_with(
+        primary_error,
+        || restore_runner_homeboy_path(runner_id, previous_homeboy_path),
+        || {
+            let (report, exit_code) =
+                connect_with_orphan_adoption(runner_id, None, &[], false, None, None, None)?;
+            if exit_code != 0 || !report.connected {
+                return Err(Error::validation_invalid_argument(
+                    "reconnect",
+                    report.failure_message.unwrap_or_else(|| {
+                        "rollback reconnect did not persist an active daemon session".to_string()
+                    }),
+                    Some(runner_id.to_string()),
+                    None,
+                ));
+            }
+            Ok(())
+        },
+    )
+}
+
+fn rollback_refresh_connect_error_with<T, Restore, Reconnect>(
+    primary_error: Error,
+    restore: Restore,
+    reconnect: Reconnect,
+) -> Result<T>
+where
+    Restore: FnOnce() -> Result<()>,
+    Reconnect: FnOnce() -> Result<()>,
+{
+    rollback_refresh_error_with(primary_error, || {
+        restore()?;
+        reconnect()
     })
 }
 

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -578,6 +578,38 @@ fn reconnect_error_after_disconnect_restores_the_pre_refresh_binary() {
 }
 
 #[test]
+fn reconnect_failure_after_stop_restores_and_reconnects_before_returning() {
+    let operations = std::cell::RefCell::new(Vec::new());
+
+    let error = rollback_refresh_connect_error_with::<(), _, _>(
+        Error::internal_io("selected daemon reconnect failed".to_string(), None),
+        || {
+            operations
+                .borrow_mut()
+                .push("restore old binary".to_string());
+            Ok(())
+        },
+        || {
+            operations
+                .borrow_mut()
+                .push("persist old-or-new authoritative lease".to_string());
+            Ok(())
+        },
+    )
+    .expect_err("the original reconnect failure remains visible after convergence");
+
+    assert_eq!(error.details["error"], "selected daemon reconnect failed");
+    assert_eq!(
+        operations.into_inner(),
+        [
+            "restore old binary",
+            "persist old-or-new authoritative lease"
+        ],
+        "a failed reconnect after the old session is removed must compensate before returning"
+    );
+}
+
+#[test]
 fn nonzero_reconnect_report_rollback_restores_the_pre_refresh_binary() {
     test_support::with_isolated_home(|_| {
         crate::create(

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -858,6 +858,20 @@ fn force_stop_default_non_force_behavior_remains_unchanged() {
 }
 
 #[test]
+fn lease_bound_stop_does_not_report_live_stale_owner_as_already_absent() {
+    let _home = HomeGuard::new();
+    let mut state = daemon_state_for_test(std::process::id(), "127.0.0.1:49152");
+    state.binary_sha256 = Some("stale-binary-hash".to_string());
+    write_daemon_state_for_test(&state);
+
+    let result = stop_for_lease(&state.lease_id).expect("lease-bound stale stop");
+
+    assert!(!result.stopped);
+    assert!(!result.already_absent);
+    assert!(state_path().expect("state path").exists());
+}
+
+#[test]
 fn lease_bound_stop_reconciles_an_absent_lease_idempotently_without_jobs() {
     let _home = HomeGuard::new();
 
@@ -866,6 +880,8 @@ fn lease_bound_stop_reconciles_an_absent_lease_idempotently_without_jobs() {
 
     assert!(!normal.stopped);
     assert!(!forced.stopped);
+    assert!(normal.already_absent);
+    assert!(forced.already_absent);
     assert_eq!(normal.pid, None);
     assert_eq!(forced.pid, None);
 }


### PR DESCRIPTION
## Summary
- require lease-bound daemon stops to prove the exact owner stopped or was already absent
- reject successful remote stop envelopes carrying only `stopped:false`
- restore the previous binary and reconnect an authoritative persisted session when refresh reconnect fails
- preserve fail-closed behavior for active jobs, lease mismatch, PID reuse, ambiguous ownership, and unreachable evidence

Closes #8968.

## Root cause
Runner refresh treated a successful daemon-stop command invocation as completed even when its payload said `stopped:false`. Remote validation checked the response action but not stop completion. If reconnect then failed after session removal, rollback restored only the configured binary path, leaving stale lease proof while daemon ownership could independently change.

## How to test
1. Check out this branch on a fresh clone.
2. Run `cargo test -p homeboy-core lease_bound_stop_ --lib`.
3. Run `cargo test -p homeboy-lab-runner lease_bound_ssh_stop --lib`.
4. Run `cargo test -p homeboy-lab-runner reconnect_failure_after_stop_restores_and_reconnects_before_returning --lib`.
5. Run `cargo check -p homeboy-cli`.
6. Run `cargo fmt --check`.
7. Confirm all commands pass.

## Backwards compatibility
Lease-bound `homeboy daemon stop --lease-id ...` now exits nonzero when it neither stops the exact owner nor proves that owner already absent. Successful idempotent absence is explicitly represented by `already_absent:true`. Callers that treated any exit-zero stop envelope as completion should inspect `stopped || already_absent`. Unbound stop behavior and public paths are unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed live runner lease divergence, implemented transactional reconnect compensation and stop completion evidence, and added deterministic regression coverage. Chris remains responsible for every line.