### PR TITLE
fix: keep every cook-batch fanout coordinator controller-owned (#8025)

### DIFF
--- a/crates/homeboy-cli/src/commands/utils/resource_policy.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy.rs
@@ -183,14 +183,24 @@ pub fn hot_command(command: &Commands) -> Option<HotCommand> {
     }
 }
 
+/// The `cook-batch` fanout coordinator is controller-owned in every mode: it
+/// compiles the plan (default), previews it (`--dry-run`), or runs the batch
+/// coordinator locally (`--run-plan`). In none of these modes may the
+/// coordinator command itself be offloaded to Lab as a single job — the
+/// coordinator owns worktree creation, the durable batch record, and child
+/// dispatch. Only the child cooks it generates are Lab-eligible.
+///
+/// Previously this guard only matched `run_plan: true`, so a default (neither
+/// `--dry-run` nor `--run-plan`) coordinator invocation fell through to being
+/// treated as a portable, offloadable hot command. That allowed the whole
+/// coordinator to be dispatched to Lab, where it timed out before creating its
+/// local batch record/worktrees and stranded the run (#8025).
 fn is_controller_owned_fanout_coordination(command: &Commands) -> bool {
     matches!(
         command,
         Commands::AgentTask(agent_task::AgentTaskArgs {
             command: agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
-                command: agent_task::AgentTaskFanoutCommand::CookBatch(
-                    agent_task::AgentTaskFanoutCookBatchArgs { run_plan: true, .. },
-                ),
+                command: agent_task::AgentTaskFanoutCommand::CookBatch(_),
             }),
         })
     )
@@ -581,6 +591,33 @@ mod tests {
         ]);
 
         assert!(hot_command(&cli.command).is_none());
+    }
+
+    #[test]
+    fn default_cook_batch_coordinator_is_controller_owned_and_not_offloadable() {
+        // #8025: the default cook-batch invocation (neither --dry-run nor
+        // --run-plan) compiles the plan on the controller. It owns worktree
+        // creation and the durable batch record, so the coordinator command
+        // itself must never be treated as a portable, offloadable hot command.
+        // Previously only --run-plan was guarded, so this default variant fell
+        // through and could be dispatched to Lab as a single job, timing out
+        // before creating its local batch record.
+        let cli = Cli::parse_from([
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "cook-batch",
+            "--repo",
+            "homeboy",
+            "--verify",
+            "cargo test --lib",
+            "https://github.com/Extra-Chill/homeboy/issues/8025",
+        ]);
+
+        assert!(
+            hot_command(&cli.command).is_none(),
+            "default cook-batch coordinator must be controller-owned, not offloadable"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the concrete placement seam behind #8025's repro: *"the fanout coordinator was offloaded as a Lab job, timed out before creating its local batch record/worktrees."*

`is_controller_owned_fanout_coordination` (`commands/utils/resource_policy.rs`) only matched `cook-batch --run-plan`. `cook-batch` has exactly two mode flags — `--dry-run` and `--run-plan` — giving three states:

| Invocation | Behavior | Previously guarded? |
|---|---|---|
| `--dry-run` | plan only | ✅ `is_plan_only_command` |
| `--run-plan` | coordinator runs the batch locally | ✅ `is_controller_owned_fanout_coordination` |
| **default (neither)** | compiles + returns the plan on the controller | ❌ **fell through both** |

The default variant fell through, so `hot_command` classified it as a portable, offloadable hot command — and the whole coordinator could be dispatched to Lab as a single job, where it timed out before creating its local batch record and stranded the run.

## Change

The cook-batch coordinator is controller-owned in **every** mode — it owns worktree creation, the durable batch record, and child dispatch. Only the child cooks it generates are Lab-eligible. Broaden the guard to match every `CookBatch` variant.

`hot_command` returning `None` short-circuits `preflight_hot_command` in `cli_runtime.rs` (the single chokepoint into hot/Lab-offload routing), so the coordinator command stays local regardless of mode.

## Scope note

This is `Refs #8025`, not `Fixes` — deliberately. While mapping this out I found the **bulk of #8025's acceptance criteria are already implemented**: controller runtime identity pinning (`controller_runtime.rs` — `pin_current`/`admit_current`), the pre-invocation SHA256 + build-identity integrity check the issue's comment asked for (`validate_pin`), mutation-time identity validation (`validate_for_mutation`), and generation pins that block upgrade during an active run (`runtime_promotion.rs`). The fanout-coordinator-offload guard was the one concrete, still-open seam I could verify. I'm leaving #8025 open for the runtime-identity-pinning acceptance to be confirmed/closed separately rather than claiming the whole contract.

## Testing

- `cargo check -p homeboy-cli --lib --tests` — clean (EXIT 0).
- `cargo fmt`.
- `cargo test -p homeboy-cli --lib resource_policy::` — **28 passed**, including the new `default_cook_batch_coordinator_is_controller_owned_and_not_offloadable` and the existing `--dry-run` / `--run-plan` guard tests.

Refs #8025

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Mapped the existing runtime-pinning machinery, isolated the run_plan-only guard gap against the cook-batch flag model, tightened the guard, and added coverage. Chris reviews and owns the change.