### PR TITLE
Keep runner-only upgrades pinned to controller identity

### DIFF
--- a/crates/homeboy-core/src/extension/lifecycle/source_metadata.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/source_metadata.rs
@@ -1,5 +1,7 @@
 use super::{load_extension, read_source_revision, read_source_url, write_source_metadata};
 use crate::error::{Error, Result};
+use crate::extension::is_extension_linked;
+use crate::git;
 use crate::paths;
 
 pub use homeboy_extension_contract::source_metadata_repair::SourceMetadataRepair;
@@ -10,19 +12,31 @@ pub struct SourceMetadataResolution {
     pub(crate) repair: Option<SourceMetadataRepair>,
 }
 
+/// Resolve extension source provenance without repairing metadata on disk.
+///
+/// This is suitable for reporting and remote materialization paths where merely
+/// inspecting installed extensions must not modify local state.
+pub fn resolve_source_url_read_only(extension_id: &str) -> Result<String> {
+    let extension = load_extension(extension_id)?;
+    let extension_dir = paths::extension(extension_id)?;
+
+    manifest_source_url(&extension)
+        .or_else(|| read_source_url(&extension_dir).and_then(normalize_source_url))
+        .or_else(|| {
+            is_extension_linked(extension_id)
+                .then(|| git::remote_origin_url(&extension_dir))
+                .flatten()
+                .and_then(|url| normalize_source_url(url))
+        })
+        .ok_or_else(|| missing_source_url_error(extension_id, extension.extension_path.as_deref()))
+}
+
 pub fn resolve_source_url(extension_id: &str) -> Result<SourceMetadataResolution> {
     let extension = load_extension(extension_id)?;
     let extension_dir = paths::extension(extension_id)?;
     let metadata_url = read_source_url(&extension_dir);
 
-    let manifest_source_url = extension.source_url.clone().or_else(|| {
-        extension
-            .extra
-            .get("sourceUrl")
-            .and_then(|value| value.as_str())
-            .map(str::to_string)
-            .filter(|value| !value.trim().is_empty())
-    });
+    let manifest_source_url = manifest_source_url(&extension);
 
     if let Some(source_url) = manifest_source_url {
         let repair = if metadata_url.as_deref() != Some(source_url.as_str()) {
@@ -53,6 +67,32 @@ pub fn resolve_source_url(extension_id: &str) -> Result<SourceMetadataResolution
         });
     }
 
+    Err(missing_source_url_error(
+        extension_id,
+        extension.extension_path.as_deref(),
+    ))
+}
+
+fn manifest_source_url(extension: &crate::extension::ExtensionManifest) -> Option<String> {
+    extension
+        .source_url
+        .clone()
+        .and_then(normalize_source_url)
+        .or_else(|| {
+            extension
+                .extra
+                .get("sourceUrl")
+                .and_then(|value| value.as_str())
+                .and_then(normalize_source_url)
+        })
+}
+
+fn normalize_source_url(value: impl AsRef<str>) -> Option<String> {
+    let value = value.as_ref().trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+fn missing_source_url_error(extension_id: &str, extension_path: Option<&str>) -> Error {
     let mut err = Error::validation_invalid_argument(
         "extension_id",
         format!(
@@ -67,11 +107,11 @@ pub fn resolve_source_url(extension_id: &str) -> Result<SourceMetadataResolution
         extension_id
     ));
 
-    if let Some(path) = extension.extension_path {
+    if let Some(path) = extension_path {
         err = err.with_hint(format!("Installed extension path: {}", path));
     }
 
-    Err(err)
+    err
 }
 
 fn repair_command(extension_id: &str, source_url: &str) -> String {

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -87,8 +87,8 @@ pub use homeboy_extension_contract::update_output::{
 };
 pub use homeboy_extension_contract::version::{parse_extension_version, VersionConstraint};
 pub use homeboy_extension_contract::{DeployArchiveInstallPolicy, DeployRequiredHeader};
-pub use lifecycle::source_metadata::resolve_source_url;
 pub use lifecycle::source_metadata::SourceMetadataRepair;
+pub use lifecycle::source_metadata::{resolve_source_url, resolve_source_url_read_only};
 pub use lifecycle::{
     derive_id_from_url, install, install_for_component, install_with_revision,
     read_source_revision, read_source_url, refresh, slugify_id, uninstall, update,

--- a/crates/homeboy-lab-runner/src/upgrade_runners/extensions.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/extensions.rs
@@ -30,10 +30,10 @@ pub fn sync_runner_extensions(
                 extension_id: extension.extension_id.clone(),
                 source_revision: extension.source_revision.clone().unwrap_or_default(),
                 synced: false,
-                detail: Some(
+                detail: Some(extension.source_update.update_note.clone().unwrap_or_else(|| {
                     "unrefreshable: installed extension lacks reproducible source URL or revision"
-                        .to_string(),
-                ),
+                        .to_string()
+                })),
                 recovery_commands: Vec::new(),
             });
             continue;

--- a/crates/homeboy-lab-runner/src/upgrade_runners/extensions.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/extensions.rs
@@ -122,6 +122,28 @@ pub fn defer_extension_failures_for_path_drift(
     }));
 }
 
+pub fn defer_runner_extensions_for_binary_drift(
+    extension_updates: &[ExtensionUpgradeEntry],
+    path_drift: &str,
+) -> Vec<RunnerExtensionSyncEntry> {
+    extension_updates
+        .iter()
+        .filter_map(|extension| {
+            let source_revision = extension.source_revision.as_ref()?;
+            extension.source_url.as_ref()?;
+            Some(RunnerExtensionSyncEntry {
+                extension_id: extension.extension_id.clone(),
+                source_revision: source_revision.clone(),
+                synced: false,
+                detail: Some(format!(
+                    "deferred because runner executable did not converge: {path_drift}"
+                )),
+                recovery_commands: Vec::new(),
+            })
+        })
+        .collect()
+}
+
 fn runner_extension_install_recovery_command(
     homeboy_path: &str,
     source_url: &str,

--- a/crates/homeboy-lab-runner/src/upgrade_runners/extensions.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/extensions.rs
@@ -22,10 +22,20 @@ pub fn sync_runner_extensions(
     let mut skipped = Vec::new();
     let mut failed = Vec::new();
     for extension in extension_updates {
-        let Some(source_url) = extension.source_url.as_deref() else {
-            continue;
-        };
-        let Some(source_revision) = extension.source_revision.as_deref() else {
+        let (Some(source_url), Some(source_revision)) = (
+            extension.source_url.as_deref(),
+            extension.source_revision.as_deref(),
+        ) else {
+            skipped.push(RunnerExtensionSyncEntry {
+                extension_id: extension.extension_id.clone(),
+                source_revision: extension.source_revision.clone().unwrap_or_default(),
+                synced: false,
+                detail: Some(
+                    "unrefreshable: installed extension lacks reproducible source URL or revision"
+                        .to_string(),
+                ),
+                recovery_commands: Vec::new(),
+            });
             continue;
         };
         if !runner_supports_extension_sync(runner, &extension.extension_id) {
@@ -128,10 +138,26 @@ pub fn defer_runner_extensions_for_binary_drift(
 ) -> Vec<RunnerExtensionSyncEntry> {
     extension_updates
         .iter()
-        .filter_map(|extension| {
-            let source_revision = extension.source_revision.as_ref()?;
-            extension.source_url.as_ref()?;
-            Some(RunnerExtensionSyncEntry {
+        .map(|extension| {
+            let Some(source_revision) = extension.source_revision.as_ref() else {
+                return RunnerExtensionSyncEntry {
+                    extension_id: extension.extension_id.clone(),
+                    source_revision: String::new(),
+                    synced: false,
+                    detail: Some("unrefreshable: installed extension lacks reproducible source URL or revision".to_string()),
+                    recovery_commands: Vec::new(),
+                };
+            };
+            if extension.source_url.is_none() {
+                return RunnerExtensionSyncEntry {
+                    extension_id: extension.extension_id.clone(),
+                    source_revision: source_revision.clone(),
+                    synced: false,
+                    detail: Some("unrefreshable: installed extension lacks reproducible source URL or revision".to_string()),
+                    recovery_commands: Vec::new(),
+                };
+            }
+            RunnerExtensionSyncEntry {
                 extension_id: extension.extension_id.clone(),
                 source_revision: source_revision.clone(),
                 synced: false,
@@ -139,7 +165,7 @@ pub fn defer_runner_extensions_for_binary_drift(
                     "deferred because runner executable did not converge: {path_drift}"
                 )),
                 recovery_commands: Vec::new(),
-            })
+            }
         })
         .collect()
 }

--- a/crates/homeboy-lab-runner/src/upgrade_runners/mod.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/mod.rs
@@ -45,6 +45,7 @@ impl RunnerUpgradeProvider for RunnerUpgrade {
         method_override: Option<InstallMethod>,
         source_path: Option<&Path>,
         explicit_source_path: bool,
+        expected_controller_identity: Option<&str>,
         runner_targets: &[String],
         extension_updates: &[ExtensionUpgradeEntry],
     ) -> Result<(Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>)> {
@@ -53,6 +54,7 @@ impl RunnerUpgradeProvider for RunnerUpgrade {
             method_override,
             source_path,
             explicit_source_path,
+            expected_controller_identity,
             runner_targets,
             extension_updates,
         )

--- a/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
@@ -408,8 +408,25 @@ pub fn upgrade_runner_with_executor(
         }
     }
 
+    if path_drift.is_none() {
+        path_drift = source_runner_identity_drift(
+            runner,
+            &homeboy_path,
+            method_override,
+            expected_source_identity.as_deref(),
+            exec,
+        );
+    }
     let (extensions_synced, mut extensions_skipped, mut extensions_failed) =
-        sync_runner_extensions(runner, &homeboy_path, extension_updates, exec);
+        if let Some(drift) = path_drift.as_deref() {
+            (
+                Vec::new(),
+                defer_runner_extensions_for_binary_drift(extension_updates, drift),
+                Vec::new(),
+            )
+        } else {
+            sync_runner_extensions(runner, &homeboy_path, extension_updates, exec)
+        };
     if path_drift.is_some() && is_auto_realignable_homeboy_path(&homeboy_path) {
         let refreshed_bare_homeboy_version =
             runner_bare_homeboy_version(runner, &homeboy_path, exec);

--- a/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
@@ -408,14 +408,19 @@ pub fn upgrade_runner_with_executor(
         }
     }
 
-    if path_drift.is_none() {
-        path_drift = source_runner_identity_drift(
+    let mut source_identity_drift = if path_drift.is_none() {
+        source_runner_identity_drift(
             runner,
             &homeboy_path,
             method_override,
             expected_source_identity.as_deref(),
             exec,
-        );
+        )
+    } else {
+        None
+    };
+    if path_drift.is_none() {
+        path_drift = source_identity_drift.clone();
     }
     let (extensions_synced, mut extensions_skipped, mut extensions_failed) =
         if let Some(drift) = path_drift.as_deref() {
@@ -490,6 +495,18 @@ pub fn upgrade_runner_with_executor(
     );
     if path_drift.is_none() {
         path_drift = local_version_drift;
+    }
+    // PATH alignment is semver-only. Re-check the final configured executable
+    // so an equal-version bare binary cannot erase source identity divergence.
+    source_identity_drift = source_runner_identity_drift(
+        runner,
+        &homeboy_path,
+        method_override,
+        expected_source_identity.as_deref(),
+        exec,
+    );
+    if path_drift.is_none() {
+        path_drift = source_identity_drift.clone();
     }
 
     defer_extension_failures_for_path_drift(

--- a/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
@@ -44,6 +44,7 @@ pub fn upgrade_configured_runners_with_explicit_source_path(
     method_override: Option<InstallMethod>,
     source_path: Option<&Path>,
     explicit_source_path: bool,
+    expected_controller_identity: Option<&str>,
     runner_targets: &[String],
     extension_updates: &[ExtensionUpgradeEntry],
 ) -> Result<(Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>)> {
@@ -67,16 +68,19 @@ pub fn upgrade_configured_runners_with_explicit_source_path(
         "Updating {} configured runner(s)...",
         runners.len()
     );
-    Ok(upgrade_runners_with_executor_and_source_materializer(
-        &runners,
-        force,
-        method_override,
-        source_path,
-        extension_updates,
-        runner::exec,
-        runner::status,
-        materialize_explicit_runner_source_path,
-    ))
+    Ok(
+        upgrade_runners_with_executor_and_source_materializer_with_expected_controller_identity(
+            &runners,
+            force,
+            method_override,
+            source_path,
+            extension_updates,
+            runner::exec,
+            runner::status,
+            materialize_explicit_runner_source_path,
+            expected_controller_identity,
+        ),
+    )
 }
 
 pub fn runner_upgrade_targets(runner_targets: &[String]) -> Result<Vec<Runner>> {
@@ -120,11 +124,35 @@ pub fn upgrade_runners_with_executor_and_source_materializer(
     method_override: Option<InstallMethod>,
     source_path: Option<&Path>,
     extension_updates: &[ExtensionUpgradeEntry],
+    exec: impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
+    status: impl Fn(&str) -> Result<RunnerStatusReport>,
+    materialize_source_path: impl FnMut(&Runner, &Path) -> Result<String>,
+) -> (Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>) {
+    upgrade_runners_with_executor_and_source_materializer_with_expected_controller_identity(
+        runners,
+        force,
+        method_override,
+        source_path,
+        extension_updates,
+        exec,
+        status,
+        materialize_source_path,
+        None,
+    )
+}
+
+fn upgrade_runners_with_executor_and_source_materializer_with_expected_controller_identity(
+    runners: &[Runner],
+    force: bool,
+    method_override: Option<InstallMethod>,
+    source_path: Option<&Path>,
+    extension_updates: &[ExtensionUpgradeEntry],
     mut exec: impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
     status: impl Fn(&str) -> Result<RunnerStatusReport>,
     mut materialize_source_path: impl FnMut(&Runner, &Path) -> Result<String>,
+    expected_controller_identity: Option<&str>,
 ) -> (Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>) {
-    upgrade_runners_with_executor_source_materializer_and_path_updater(
+    upgrade_runners_with_executor_source_materializer_and_path_updater_with_expected_controller_identity(
         runners,
         force,
         method_override,
@@ -134,6 +162,7 @@ pub fn upgrade_runners_with_executor_and_source_materializer(
         status,
         &mut materialize_source_path,
         update_runner_homeboy_path,
+        expected_controller_identity,
     )
 }
 
@@ -143,12 +172,38 @@ pub fn upgrade_runners_with_executor_source_materializer_and_path_updater(
     method_override: Option<InstallMethod>,
     source_path: Option<&Path>,
     extension_updates: &[ExtensionUpgradeEntry],
+    exec: impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
+    status: impl Fn(&str) -> Result<RunnerStatusReport>,
+    materialize_source_path: impl FnMut(&Runner, &Path) -> Result<String>,
+    update_homeboy_path: impl FnMut(&str, &str) -> Result<()>,
+) -> (Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>) {
+    upgrade_runners_with_executor_source_materializer_and_path_updater_with_expected_controller_identity(
+        runners,
+        force,
+        method_override,
+        source_path,
+        extension_updates,
+        exec,
+        status,
+        materialize_source_path,
+        update_homeboy_path,
+        None,
+    )
+}
+
+fn upgrade_runners_with_executor_source_materializer_and_path_updater_with_expected_controller_identity(
+    runners: &[Runner],
+    force: bool,
+    method_override: Option<InstallMethod>,
+    source_path: Option<&Path>,
+    extension_updates: &[ExtensionUpgradeEntry],
     mut exec: impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
     status: impl Fn(&str) -> Result<RunnerStatusReport>,
     mut materialize_source_path: impl FnMut(&Runner, &Path) -> Result<String>,
     mut update_homeboy_path: impl FnMut(&str, &str) -> Result<()>,
+    expected_controller_identity: Option<&str>,
 ) -> (Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>) {
-    upgrade_runners_with_executor_source_materializer_path_updater_and_reconnector(
+    upgrade_runners_with_executor_source_materializer_path_updater_and_reconnector_with_expected_controller_identity(
         runners,
         force,
         method_override,
@@ -159,10 +214,39 @@ pub fn upgrade_runners_with_executor_source_materializer_and_path_updater(
         reconnect_runner_daemon,
         &mut materialize_source_path,
         &mut update_homeboy_path,
+        expected_controller_identity,
     )
 }
 
 pub fn upgrade_runners_with_executor_source_materializer_path_updater_and_reconnector(
+    runners: &[Runner],
+    force: bool,
+    method_override: Option<InstallMethod>,
+    source_path: Option<&Path>,
+    extension_updates: &[ExtensionUpgradeEntry],
+    exec: impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
+    status: impl Fn(&str) -> Result<RunnerStatusReport>,
+    reconnect_stale_daemon: impl FnMut(&str) -> Result<String>,
+    materialize_source_path: impl FnMut(&Runner, &Path) -> Result<String>,
+    update_homeboy_path: impl FnMut(&str, &str) -> Result<()>,
+) -> (Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>) {
+    upgrade_runners_with_executor_source_materializer_path_updater_and_reconnector_with_expected_controller_identity(
+        runners,
+        force,
+        method_override,
+        source_path,
+        extension_updates,
+        exec,
+        status,
+        reconnect_stale_daemon,
+        materialize_source_path,
+        update_homeboy_path,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn upgrade_runners_with_executor_source_materializer_path_updater_and_reconnector_with_expected_controller_identity(
     runners: &[Runner],
     force: bool,
     method_override: Option<InstallMethod>,
@@ -173,6 +257,7 @@ pub fn upgrade_runners_with_executor_source_materializer_path_updater_and_reconn
     mut reconnect_stale_daemon: impl FnMut(&str) -> Result<String>,
     mut materialize_source_path: impl FnMut(&Runner, &Path) -> Result<String>,
     mut update_homeboy_path: impl FnMut(&str, &str) -> Result<()>,
+    expected_controller_identity: Option<&str>,
 ) -> (Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>) {
     let mut updated = Vec::new();
     let mut skipped = Vec::new();
@@ -189,6 +274,7 @@ pub fn upgrade_runners_with_executor_source_materializer_path_updater_and_reconn
             &mut reconnect_stale_daemon,
             &mut materialize_source_path,
             &mut update_homeboy_path,
+            expected_controller_identity,
         );
         if entry.success {
             homeboy_core::log_status!(
@@ -218,6 +304,7 @@ pub fn upgrade_runner_with_executor(
     reconnect_stale_daemon: &mut impl FnMut(&str) -> Result<String>,
     materialize_source_path: &mut impl FnMut(&Runner, &Path) -> Result<String>,
     update_homeboy_path: &mut impl FnMut(&str, &str) -> Result<()>,
+    expected_controller_identity: Option<&str>,
 ) -> RunnerUpgradeEntry {
     let original_homeboy_path = runner
         .settings
@@ -227,11 +314,13 @@ pub fn upgrade_runner_with_executor(
     let previous_version = runner_homeboy_version(runner, &original_homeboy_path, exec)
         .ok()
         .flatten();
-    let expected_source_identity = if method_override == Some(InstallMethod::Source) {
-        source_path.and_then(source_checkout_build_identity)
-    } else {
-        None
-    };
+    let expected_build_identity = expected_controller_identity
+        .map(str::to_string)
+        .or_else(|| {
+            (method_override == Some(InstallMethod::Source))
+                .then(|| source_path.and_then(source_checkout_build_identity))
+                .flatten()
+        });
     let command_source_path = match runner_upgrade_source_path(
         runner,
         method_override,
@@ -340,7 +429,7 @@ pub fn upgrade_runner_with_executor(
         command_source_path.as_deref(),
         &upgrade_homeboy_path,
         new_version.as_deref(),
-        expected_source_identity.as_deref(),
+        expected_build_identity.as_deref(),
         exec,
     ) {
         match update_homeboy_path(&runner.id, &realignment.homeboy_path) {
@@ -409,11 +498,10 @@ pub fn upgrade_runner_with_executor(
     }
 
     let mut source_identity_drift = if path_drift.is_none() {
-        source_runner_identity_drift(
+        runner_build_identity_drift(
             runner,
             &homeboy_path,
-            method_override,
-            expected_source_identity.as_deref(),
+            expected_build_identity.as_deref(),
             exec,
         )
     } else {
@@ -498,11 +586,10 @@ pub fn upgrade_runner_with_executor(
     }
     // PATH alignment is semver-only. Re-check the final configured executable
     // so an equal-version bare binary cannot erase source identity divergence.
-    source_identity_drift = source_runner_identity_drift(
+    source_identity_drift = runner_build_identity_drift(
         runner,
         &homeboy_path,
-        method_override,
-        expected_source_identity.as_deref(),
+        expected_build_identity.as_deref(),
         exec,
     );
     if path_drift.is_none() {

--- a/crates/homeboy-lab-runner/src/upgrade_runners/path_alignment.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/path_alignment.rs
@@ -121,17 +121,13 @@ pub fn source_upgrade_homeboy_path_realignment(
     None
 }
 
-pub fn source_runner_identity_drift(
+pub fn runner_build_identity_drift(
     runner: &Runner,
     homeboy_path: &str,
-    method_override: Option<InstallMethod>,
-    expected_source_identity: Option<&str>,
+    expected_build_identity: Option<&str>,
     exec: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
 ) -> Option<String> {
-    if method_override != Some(InstallMethod::Source) {
-        return None;
-    }
-    let expected_identity = expected_source_identity?;
+    let expected_identity = expected_build_identity?;
     let actual_identity = runner_homeboy_identity(runner, homeboy_path, exec)
         .ok()
         .flatten();
@@ -139,7 +135,7 @@ pub fn source_runner_identity_drift(
         return None;
     }
     Some(format!(
-        "configured runner executable `{homeboy_path}` did not converge to initiating source identity `{expected_identity}`; observed `{}`",
+        "configured runner executable `{homeboy_path}` did not converge to initiating controller identity `{expected_identity}`; observed `{}`",
         actual_identity.as_deref().unwrap_or("unverifiable build identity")
     ))
 }

--- a/crates/homeboy-lab-runner/src/upgrade_runners/path_alignment.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/path_alignment.rs
@@ -121,6 +121,29 @@ pub fn source_upgrade_homeboy_path_realignment(
     None
 }
 
+pub fn source_runner_identity_drift(
+    runner: &Runner,
+    homeboy_path: &str,
+    method_override: Option<InstallMethod>,
+    expected_source_identity: Option<&str>,
+    exec: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
+) -> Option<String> {
+    if method_override != Some(InstallMethod::Source) {
+        return None;
+    }
+    let expected_identity = expected_source_identity?;
+    let actual_identity = runner_homeboy_identity(runner, homeboy_path, exec)
+        .ok()
+        .flatten();
+    if actual_identity.as_deref() == Some(expected_identity) {
+        return None;
+    }
+    Some(format!(
+        "configured runner executable `{homeboy_path}` did not converge to initiating source identity `{expected_identity}`; observed `{}`",
+        actual_identity.as_deref().unwrap_or("unverifiable build identity")
+    ))
+}
+
 pub struct RunnerHomeboyPathAlignment {
     pub drift: Option<String>,
     pub update_to: Option<String>,

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
@@ -388,6 +388,9 @@ fn source_runner_upgrade_realigns_to_same_version_source_checkout_identity() {
                 8 if options.command[0] == source_binary => {
                     (format!("{expected_identity}\n"), String::new(), 0)
                 }
+                9 if options.command[0] == source_binary => {
+                    (format!("{expected_identity}\n"), String::new(), 0)
+                }
                 other => (
                     String::new(),
                     format!("unexpected command {other}: {:?}", options.command),
@@ -427,7 +430,10 @@ fn rejects_stale_source_runner_identity_before_extension_sync() {
     let expected_identity = source_checkout_build_identity(source_dir.path()).unwrap();
     let remote_source = "/home/user/Developer/_lab_workspaces/homeboy-current-main";
     let source_binary = format!("{remote_source}/target/release/homeboy");
-    let runner = ssh_runner("lab", Some("/home/user/.cargo/bin/homeboy"));
+    let runner = ssh_runner(
+        "lab",
+        Some("/home/user/Developer/homeboy@stale/target/release/homeboy"),
+    );
     let extension_updates = vec![extension_update("required-extension", "48517ac3")];
     let mut commands = Vec::new();
 
@@ -455,6 +461,8 @@ fn rejects_stale_source_runner_identity_before_extension_sync() {
                 9 => format!("homeboy {}+stale\n", current_version()),
                 10 => format!("homeboy {}+stale\n", current_version()),
                 11 => format!("homeboy {}\n", current_version()),
+                12 => format!("homeboy {}+stale\n", current_version()),
+                13 => format!("homeboy {}+stale\n", current_version()),
                 other => panic!("unexpected runner command {other}: {:?}", options.command),
             };
             Ok((exec_output(runner_id, options.command, &stdout, "", 0), 0))

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
@@ -492,6 +492,69 @@ fn rejects_stale_source_runner_identity_before_extension_sync() {
 }
 
 #[test]
+fn reports_unrefreshable_extensions_when_runner_binary_drift_defers_sync() {
+    let extensions = vec![ExtensionUpgradeEntry {
+        extension_id: "local-extension".to_string(),
+        old_version: "1.0.0".to_string(),
+        new_version: "1.0.0".to_string(),
+        linked: false,
+        source_path: None,
+        git_root: None,
+        source_url: None,
+        source_revision: None,
+        source_update: Default::default(),
+    }];
+
+    let skipped = defer_runner_extensions_for_binary_drift(&extensions, "identity mismatch");
+
+    assert_eq!(skipped.len(), 1);
+    assert_eq!(skipped[0].extension_id, "local-extension");
+    assert!(skipped[0]
+        .detail
+        .as_deref()
+        .unwrap()
+        .contains("unrefreshable"));
+}
+
+#[test]
+fn rejects_packaged_runner_with_same_version_but_different_controller_identity() {
+    let runner = ssh_runner("lab", Some("/opt/homeboy/homeboy"));
+    let extensions = vec![extension_update("required-extension", "48517ac3")];
+    let mut calls = 0;
+
+    let entry = upgrade_runner_with_executor(
+        &runner,
+        true,
+        Some(InstallMethod::Binary),
+        None,
+        &extensions,
+        &mut |runner_id, options| {
+            calls += 1;
+            let stdout = match calls {
+                1 | 3 => format!("homeboy {}\n", current_version()),
+                2 => "{\"success\":true}\n".to_string(),
+                _ => format!("homeboy {}+other-build\n", current_version()),
+            };
+            Ok((exec_output(runner_id, options.command, &stdout, "", 0), 0))
+        },
+        &runner_status,
+        &mut |_| Ok("reconnected".to_string()),
+        &mut |_, _| Ok("unused".to_string()),
+        &mut |_, _| Ok(()),
+        Some("controller-build"),
+    );
+
+    assert!(!entry.success);
+    assert!(entry
+        .path_drift
+        .as_deref()
+        .unwrap()
+        .contains("controller-build"));
+    assert_eq!(entry.extensions_synced.len(), 0);
+    assert_eq!(entry.extensions_skipped.len(), 1);
+}
+
+#[test]
 fn runner_source_prepare_detached_checkout_ignores_default_branch_checked_out_elsewhere() {
     let fixture = remote_source_fixture();
     let primary = fixture.root.path().join("primary");

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
@@ -385,6 +385,9 @@ fn source_runner_upgrade_realigns_to_same_version_source_checkout_identity() {
                 7 if options.command[0] == source_binary => {
                     (format!("{expected_identity}\n"), String::new(), 0)
                 }
+                8 if options.command[0] == source_binary => {
+                    (format!("{expected_identity}\n"), String::new(), 0)
+                }
                 other => (
                     String::new(),
                     format!("unexpected command {other}: {:?}", options.command),
@@ -416,6 +419,68 @@ fn source_runner_upgrade_realigns_to_same_version_source_checkout_identity() {
     assert_eq!(updated[0].new_version.as_deref(), Some(current_version()));
     assert_eq!(updated[0].path_drift, None);
     assert_eq!(path_updates, vec![("lab".to_string(), source_binary)]);
+}
+
+#[test]
+fn rejects_stale_source_runner_identity_before_extension_sync() {
+    let source_dir = git_source_checkout();
+    let expected_identity = source_checkout_build_identity(source_dir.path()).unwrap();
+    let remote_source = "/home/user/Developer/_lab_workspaces/homeboy-current-main";
+    let source_binary = format!("{remote_source}/target/release/homeboy");
+    let runner = ssh_runner("lab", Some("/home/user/.cargo/bin/homeboy"));
+    let extension_updates = vec![extension_update("required-extension", "48517ac3")];
+    let mut commands = Vec::new();
+
+    let (updated, skipped) = upgrade_runners_with_executor_and_source_materializer(
+        &[runner],
+        true,
+        Some(InstallMethod::Source),
+        Some(source_dir.path()),
+        &extension_updates,
+        |runner_id, options| {
+            commands.push(options.command.clone());
+            let stdout = match commands.len() {
+                1 => format!("homeboy {}+oldbuild\n", current_version()),
+                2 => "prepared source checkout\n".to_string(),
+                3 => "{\"success\":true}\n".to_string(),
+                4 => format!("homeboy {}\n", current_version()),
+                5 => format!("homeboy {}+stale\n", current_version()),
+                6 if options.command[0] == source_binary => {
+                    format!("homeboy {}\n", current_version())
+                }
+                7 if options.command[0] == source_binary => {
+                    format!("homeboy {}+stale\n", current_version())
+                }
+                8 => format!("homeboy {}\n", current_version()),
+                9 => format!("homeboy {}+stale\n", current_version()),
+                10 => format!("homeboy {}+stale\n", current_version()),
+                11 => format!("homeboy {}\n", current_version()),
+                other => panic!("unexpected runner command {other}: {:?}", options.command),
+            };
+            Ok((exec_output(runner_id, options.command, &stdout, "", 0), 0))
+        },
+        runner_status,
+        |_runner, _path| Ok(remote_source.to_string()),
+    );
+
+    assert!(updated.is_empty());
+    assert_eq!(skipped.len(), 1);
+    assert!(!skipped[0].success);
+    assert!(skipped[0]
+        .path_drift
+        .as_deref()
+        .unwrap()
+        .contains(&expected_identity));
+    assert_eq!(skipped[0].extensions_synced.len(), 0);
+    assert_eq!(skipped[0].extensions_skipped.len(), 1);
+    assert!(skipped[0].extensions_skipped[0]
+        .detail
+        .as_deref()
+        .unwrap()
+        .contains("did not converge"));
+    assert!(!commands
+        .iter()
+        .any(|command| command.contains(&"extension".to_string())));
 }
 
 #[test]

--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -789,12 +789,10 @@ fn workspace_from_exe_path(exe_path: &Path) -> Option<PathBuf> {
     if build_dir != "release" && build_dir != "debug" {
         return None;
     }
-
     let target_dir = parent.parent()?;
     if target_dir.file_name()?.to_string_lossy() != "target" {
         return None;
     }
-
     target_dir.parent().map(Path::to_path_buf)
 }
 

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -193,6 +193,7 @@ pub fn run_upgrade_with_method(
                         runner_method_override,
                         source_upgrade_path.as_deref(),
                         source_path.is_some(),
+                        None,
                         runner_targets,
                         &extensions_updated,
                     )
@@ -273,6 +274,7 @@ pub fn run_upgrade_with_method(
                 runner_method_override,
                 source_upgrade_path.as_deref(),
                 source_path.is_some(),
+                None,
                 runner_targets,
                 &extensions_updated,
             )
@@ -365,8 +367,9 @@ fn run_targeted_runner_upgrade(
             runner_method_override,
             source_checkout.as_deref(),
             source_checkout.is_some(),
+            Some(&previous_build_identity),
             runner_targets,
-            &[],
+            &installed_extension_catalog(),
         )
     })?;
 
@@ -393,6 +396,32 @@ fn run_targeted_runner_upgrade(
         services_restarted: Vec::new(),
         services_pending_restart: Vec::new(),
     })
+}
+
+/// Read extension provenance without refreshing local extension sources. Entries
+/// lacking a reproducible URL or revision are forwarded as unrefreshable so the
+/// runner can report that condition explicitly.
+fn installed_extension_catalog() -> Vec<ExtensionUpgradeEntry> {
+    extension::available_extension_ids()
+        .into_iter()
+        .filter_map(|extension_id| {
+            let manifest = extension::load_extension(&extension_id).ok()?;
+            Some(ExtensionUpgradeEntry {
+                extension_id: extension_id.clone(),
+                old_version: manifest.version.clone(),
+                new_version: manifest.version,
+                linked: false,
+                source_path: None,
+                git_root: None,
+                source_url: manifest
+                    .extension_path
+                    .as_deref()
+                    .and_then(|path| extension::read_source_url(Path::new(path))),
+                source_revision: extension::read_source_revision(&extension_id),
+                source_update: Default::default(),
+            })
+        })
+        .collect()
 }
 
 fn initiating_controller_source_checkout(

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -404,23 +404,46 @@ fn run_targeted_runner_upgrade(
 fn installed_extension_catalog() -> Vec<ExtensionUpgradeEntry> {
     extension::available_extension_ids()
         .into_iter()
-        .filter_map(|extension_id| {
-            let manifest = extension::load_extension(&extension_id).ok()?;
-            Some(ExtensionUpgradeEntry {
-                extension_id: extension_id.clone(),
-                old_version: manifest.version.clone(),
-                new_version: manifest.version,
-                linked: false,
-                source_path: None,
-                git_root: None,
-                source_url: manifest
-                    .extension_path
-                    .as_deref()
-                    .and_then(|path| extension::read_source_url(Path::new(path))),
-                source_revision: extension::read_source_revision(&extension_id),
-                source_update: Default::default(),
-            })
-        })
+        .map(
+            |extension_id| match extension::load_extension(&extension_id) {
+                Ok(manifest) => {
+                    let source_url = extension::resolve_source_url_read_only(&extension_id);
+                    ExtensionUpgradeEntry {
+                        extension_id: extension_id.clone(),
+                        old_version: manifest.version.clone(),
+                        new_version: manifest.version,
+                        linked: extension::is_extension_linked(&extension_id),
+                        source_path: manifest.extension_path,
+                        git_root: None,
+                        source_url: source_url.as_ref().ok().cloned(),
+                        source_revision: extension::read_source_revision(&extension_id),
+                        source_update: homeboy_core::extension::ExtensionSourceUpdate {
+                            update_note: source_url.err().map(|err| {
+                                format!("unrefreshable extension provenance: {}", err.message)
+                            }),
+                            ..Default::default()
+                        },
+                    }
+                }
+                Err(err) => ExtensionUpgradeEntry {
+                    extension_id,
+                    old_version: String::new(),
+                    new_version: String::new(),
+                    linked: false,
+                    source_path: None,
+                    git_root: None,
+                    source_url: None,
+                    source_revision: None,
+                    source_update: homeboy_core::extension::ExtensionSourceUpdate {
+                        update_note: Some(format!(
+                            "unrefreshable extension manifest: {}",
+                            err.message
+                        )),
+                        ..Default::default()
+                    },
+                },
+            },
+        )
         .collect()
 }
 

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -144,7 +144,7 @@ pub fn run_upgrade_with_method(
     source_path: Option<&Path>,
 ) -> Result<UpgradeResult> {
     if !runner_targets.is_empty() {
-        return run_targeted_runner_upgrade(force, runner_targets, source_path);
+        return run_targeted_runner_upgrade(force, method_override, runner_targets, source_path);
     }
 
     let promotion_lease = homeboy_core::runtime_promotion::acquire(
@@ -329,24 +329,42 @@ pub fn run_upgrade_with_method(
     })
 }
 
-/// Upgrade only explicitly selected runners from the exact source revision that
-/// built this controller. This must stay ahead of controller install-method
-/// detection and promotion: a runner-only recovery must not replace its caller.
+/// Upgrade only explicitly selected runners without promoting the controller.
+/// Source controllers pin their checkout identity; packaged controllers retain
+/// the runner's existing install-method contract.
 fn run_targeted_runner_upgrade(
     force: bool,
+    method_override: Option<InstallMethod>,
     runner_targets: &[String],
     source_path: Option<&Path>,
 ) -> Result<UpgradeResult> {
     let previous_version = current_version().to_string();
     let previous_build_identity = build_identity::current().display;
-    let source_checkout =
-        initiating_controller_source_checkout(source_path, &previous_build_identity)?;
+    let install_method = method_override.unwrap_or_else(detect_install_method);
+    if install_method == InstallMethod::Unknown {
+        return Err(Error::validation_invalid_argument(
+            "install_method",
+            "Could not detect installation method",
+            None,
+            None,
+        )
+        .with_hint("Pass --method to select the runner upgrade policy."));
+    }
+    let runner_method_override = runner_method_override_for_method(method_override, install_method);
+    let source_checkout = if runner_method_override == Some(InstallMethod::Source) {
+        Some(initiating_controller_source_checkout(
+            source_path,
+            &previous_build_identity,
+        )?)
+    } else {
+        None
+    };
     let (runners_updated, runners_skipped) = super::with_runner_upgrade(|provider| {
         provider.upgrade_configured_runners_with_explicit_source_path(
             force,
-            Some(InstallMethod::Source),
-            Some(&source_checkout),
-            true,
+            runner_method_override,
+            source_checkout.as_deref(),
+            source_checkout.is_some(),
             runner_targets,
             &[],
         )
@@ -354,15 +372,18 @@ fn run_targeted_runner_upgrade(
 
     Ok(UpgradeResult {
         command: "upgrade".to_string(),
-        install_method: InstallMethod::Source,
+        install_method,
         previous_version: previous_version.clone(),
         new_version: Some(previous_version),
         previous_build_identity: Some(previous_build_identity.clone()),
         new_build_identity: Some(previous_build_identity),
         source_revision: None,
         upgraded: false,
-        message: "Selected runners refreshed from the initiating controller source identity"
-            .to_string(),
+        message: if source_checkout.is_some() {
+            "Selected runners refreshed from the initiating controller source identity".to_string()
+        } else {
+            "Selected runners refreshed without promoting the initiating controller".to_string()
+        },
         restart_required: false,
         extensions_updated: Vec::new(),
         extensions_skipped: Vec::new(),
@@ -899,6 +920,17 @@ mod runner_source_upgrade_tests {
             runner_method_override_for_method(Some(InstallMethod::Binary), InstallMethod::Source),
             Some(InstallMethod::Binary)
         );
+        for method in [
+            InstallMethod::Homebrew,
+            InstallMethod::Secondary,
+            InstallMethod::Binary,
+        ] {
+            assert_eq!(runner_method_override_for_method(None, method), None);
+            assert_eq!(
+                runner_method_override_for_method(Some(method), method),
+                Some(method)
+            );
+        }
     }
 
     #[test]

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -143,6 +143,10 @@ pub fn run_upgrade_with_method(
     runner_targets: &[String],
     source_path: Option<&Path>,
 ) -> Result<UpgradeResult> {
+    if !runner_targets.is_empty() {
+        return run_targeted_runner_upgrade(force, runner_targets, source_path);
+    }
+
     let promotion_lease = homeboy_core::runtime_promotion::acquire(
         "controller upgrade",
         source_path
@@ -323,6 +327,110 @@ pub fn run_upgrade_with_method(
         services_restarted,
         services_pending_restart,
     })
+}
+
+/// Upgrade only explicitly selected runners from the exact source revision that
+/// built this controller. This must stay ahead of controller install-method
+/// detection and promotion: a runner-only recovery must not replace its caller.
+fn run_targeted_runner_upgrade(
+    force: bool,
+    runner_targets: &[String],
+    source_path: Option<&Path>,
+) -> Result<UpgradeResult> {
+    let previous_version = current_version().to_string();
+    let previous_build_identity = build_identity::current().display;
+    let source_checkout =
+        initiating_controller_source_checkout(source_path, &previous_build_identity)?;
+    let (runners_updated, runners_skipped) = super::with_runner_upgrade(|provider| {
+        provider.upgrade_configured_runners_with_explicit_source_path(
+            force,
+            Some(InstallMethod::Source),
+            Some(&source_checkout),
+            true,
+            runner_targets,
+            &[],
+        )
+    })?;
+
+    Ok(UpgradeResult {
+        command: "upgrade".to_string(),
+        install_method: InstallMethod::Source,
+        previous_version: previous_version.clone(),
+        new_version: Some(previous_version),
+        previous_build_identity: Some(previous_build_identity.clone()),
+        new_build_identity: Some(previous_build_identity),
+        source_revision: None,
+        upgraded: false,
+        message: "Selected runners refreshed from the initiating controller source identity"
+            .to_string(),
+        restart_required: false,
+        extensions_updated: Vec::new(),
+        extensions_skipped: Vec::new(),
+        runners_updated,
+        runners_skipped,
+        extensions_unrefreshed: Vec::new(),
+        services_restarted: Vec::new(),
+        services_pending_restart: Vec::new(),
+    })
+}
+
+fn initiating_controller_source_checkout(
+    source_path: Option<&Path>,
+    expected_identity: &str,
+) -> Result<PathBuf> {
+    let checkout = if let Some(path) = source_path {
+        resolve_source_workspace(Some(path))?
+    } else {
+        let executable_checkout = std::env::current_exe()
+            .ok()
+            .and_then(|path| workspace_from_executable_path(&path));
+        executable_checkout
+            .or_else(|| resolve_source_workspace(None).ok())
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "upgrade-runner",
+                    "Runner-only upgrade requires the source checkout that built the initiating controller",
+                    None,
+                    None,
+                )
+                .with_hint("Run from the controller source checkout or pass --source-path <PATH>.")
+            })?
+    };
+    let identity =
+        super::with_runner_upgrade(|provider| provider.source_checkout_build_identity(&checkout))
+            .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "source_path",
+                "Runner-only upgrade source checkout has no verifiable build identity",
+                Some(checkout.display().to_string()),
+                None,
+            )
+        })?;
+    if identity != expected_identity {
+        return Err(Error::validation_invalid_argument(
+            "source_path",
+            format!(
+                "Runner-only upgrade source identity `{identity}` does not match initiating controller `{expected_identity}`"
+            ),
+            Some(checkout.display().to_string()),
+            None,
+        )
+        .with_hint("Pass the exact source checkout that built the initiating controller."));
+    }
+    Ok(checkout)
+}
+
+fn workspace_from_executable_path(exe_path: &Path) -> Option<PathBuf> {
+    let parent = exe_path.parent()?;
+    let build_dir = parent.file_name()?.to_string_lossy();
+    if build_dir != "release" && build_dir != "debug" {
+        return None;
+    }
+    let target_dir = parent.parent()?;
+    if target_dir.file_name()?.to_string_lossy() != "target" {
+        return None;
+    }
+    target_dir.parent().map(Path::to_path_buf)
 }
 
 // Upgrade output must remain visible when a controller captures stdout/stderr.

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -402,8 +402,13 @@ fn run_targeted_runner_upgrade(
 /// lacking a reproducible URL or revision are forwarded as unrefreshable so the
 /// runner can report that condition explicitly.
 fn installed_extension_catalog() -> Vec<ExtensionUpgradeEntry> {
-    extension::available_extension_ids()
-        .into_iter()
+    installed_extension_catalog_for(&extension::available_extension_ids())
+}
+
+fn installed_extension_catalog_for(extension_ids: &[String]) -> Vec<ExtensionUpgradeEntry> {
+    extension_ids
+        .iter()
+        .cloned()
         .map(
             |extension_id| match extension::load_extension(&extension_id) {
                 Ok(manifest) => {
@@ -956,6 +961,117 @@ mod runner_source_upgrade_tests {
         ] {
             assert_eq!(latest_version_endpoint(method), GITHUB_RELEASES_API);
         }
+    }
+
+    fn write_extension(dir: &Path, id: &str, manifest: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join(format!("{id}.json")), manifest).unwrap();
+    }
+
+    #[test]
+    fn installed_extension_catalog_reads_provenance_without_mutating_metadata() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let extensions = home.path().join(".config/homeboy/extensions");
+            write_extension(
+                &extensions.join("manifest"),
+                "manifest",
+                r#"{"name":"manifest","version":"1.0.0","source_url":" https://example.test/manifest.git "}"#,
+            );
+            write_extension(
+                &extensions.join("alias"),
+                "alias",
+                r#"{"name":"alias","version":"1.0.0","sourceUrl":"https://example.test/alias.git"}"#,
+            );
+            write_extension(
+                &extensions.join("sidecar"),
+                "sidecar",
+                r#"{"name":"sidecar","version":"1.0.0"}"#,
+            );
+            std::fs::write(
+                extensions.join("sidecar/.source-url"),
+                "https://example.test/sidecar.git\n",
+            )
+            .unwrap();
+
+            let catalog = installed_extension_catalog();
+            assert_eq!(catalog.len(), 3);
+            assert_eq!(
+                catalog
+                    .iter()
+                    .find(|entry| entry.extension_id == "manifest")
+                    .unwrap()
+                    .source_url
+                    .as_deref(),
+                Some("https://example.test/manifest.git")
+            );
+            assert_eq!(
+                catalog
+                    .iter()
+                    .find(|entry| entry.extension_id == "alias")
+                    .unwrap()
+                    .source_url
+                    .as_deref(),
+                Some("https://example.test/alias.git")
+            );
+            assert_eq!(
+                catalog
+                    .iter()
+                    .find(|entry| entry.extension_id == "sidecar")
+                    .unwrap()
+                    .source_url
+                    .as_deref(),
+                Some("https://example.test/sidecar.git")
+            );
+            assert!(catalog.iter().all(|entry| entry.source_revision.is_none()));
+            assert!(!extensions.join("manifest/.source-url").exists());
+            assert!(!extensions.join("alias/.source-url").exists());
+            assert_eq!(
+                std::fs::read_to_string(extensions.join("sidecar/.source-url")).unwrap(),
+                "https://example.test/sidecar.git\n"
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn installed_extension_catalog_keeps_linked_and_broken_extensions_unrefreshable() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let extensions = home.path().join(".config/homeboy/extensions");
+            let linked = home.path().join("linked");
+            write_extension(&linked, "linked", r#"{"name":"linked","version":"1.0.0"}"#);
+            git(&linked, &["init"]);
+            git(
+                &linked,
+                &["remote", "add", "origin", "https://example.test/linked.git"],
+            );
+            std::fs::create_dir_all(&extensions).unwrap();
+            std::os::unix::fs::symlink(&linked, extensions.join("linked")).unwrap();
+            std::os::unix::fs::symlink(home.path().join("missing"), extensions.join("broken"))
+                .unwrap();
+
+            let catalog =
+                installed_extension_catalog_for(&["linked".to_string(), "broken".to_string()]);
+            let linked = catalog
+                .iter()
+                .find(|entry| entry.extension_id == "linked")
+                .unwrap();
+            assert_eq!(
+                linked.source_url.as_deref(),
+                Some("https://example.test/linked.git")
+            );
+            assert!(linked.source_revision.is_none());
+            let broken = catalog
+                .iter()
+                .find(|entry| entry.extension_id == "broken")
+                .unwrap();
+            assert!(broken.source_url.is_none());
+            assert!(broken
+                .source_update
+                .update_note
+                .as_deref()
+                .unwrap()
+                .contains("unrefreshable extension manifest"));
+        });
     }
 
     #[test]

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -412,7 +412,25 @@ fn installed_extension_catalog_for(extension_ids: &[String]) -> Vec<ExtensionUpg
         .map(
             |extension_id| match extension::load_extension(&extension_id) {
                 Ok(manifest) => {
-                    let source_url = extension::resolve_source_url_read_only(&extension_id);
+                    let (source_url, update_note) =
+                        match extension::resolve_source_url_read_only(&extension_id) {
+                            Ok(source_url) if extension::is_git_url(&source_url) => {
+                                (Some(source_url), None)
+                            }
+                            Ok(source_url) => (
+                                None,
+                                Some(format!(
+                                    "unrefreshable extension provenance: local source `{source_url}` cannot be materialized on a runner"
+                                )),
+                            ),
+                            Err(err) => (
+                                None,
+                                Some(format!(
+                                    "unrefreshable extension provenance: {}",
+                                    err.message
+                                )),
+                            ),
+                        };
                     ExtensionUpgradeEntry {
                         extension_id: extension_id.clone(),
                         old_version: manifest.version.clone(),
@@ -420,12 +438,10 @@ fn installed_extension_catalog_for(extension_ids: &[String]) -> Vec<ExtensionUpg
                         linked: extension::is_extension_linked(&extension_id),
                         source_path: manifest.extension_path,
                         git_root: None,
-                        source_url: source_url.as_ref().ok().cloned(),
+                        source_url,
                         source_revision: extension::read_source_revision(&extension_id),
                         source_update: homeboy_core::extension::ExtensionSourceUpdate {
-                            update_note: source_url.err().map(|err| {
-                                format!("unrefreshable extension provenance: {}", err.message)
-                            }),
+                            update_note,
                             ..Default::default()
                         },
                     }
@@ -992,9 +1008,14 @@ mod runner_source_upgrade_tests {
                 "https://example.test/sidecar.git\n",
             )
             .unwrap();
+            write_extension(
+                &extensions.join("local"),
+                "local",
+                r#"{"name":"local","version":"1.0.0","source_url":"/Users/chris/Developer/local-extension"}"#,
+            );
 
             let catalog = installed_extension_catalog();
-            assert_eq!(catalog.len(), 3);
+            assert_eq!(catalog.len(), 4);
             assert_eq!(
                 catalog
                     .iter()
@@ -1022,9 +1043,21 @@ mod runner_source_upgrade_tests {
                     .as_deref(),
                 Some("https://example.test/sidecar.git")
             );
+            let local = catalog
+                .iter()
+                .find(|entry| entry.extension_id == "local")
+                .unwrap();
+            assert!(local.source_url.is_none());
+            assert!(local
+                .source_update
+                .update_note
+                .as_deref()
+                .unwrap()
+                .contains("cannot be materialized on a runner"));
             assert!(catalog.iter().all(|entry| entry.source_revision.is_none()));
             assert!(!extensions.join("manifest/.source-url").exists());
             assert!(!extensions.join("alias/.source-url").exists());
+            assert!(!extensions.join("local/.source-url").exists());
             assert_eq!(
                 std::fs::read_to_string(extensions.join("sidecar/.source-url")).unwrap(),
                 "https://example.test/sidecar.git\n"

--- a/crates/homeboy-upgrade/src/upgrade/runner_upgrade_provider.rs
+++ b/crates/homeboy-upgrade/src/upgrade/runner_upgrade_provider.rs
@@ -26,6 +26,7 @@ pub trait RunnerUpgradeProvider: Send + Sync {
         method_override: Option<InstallMethod>,
         source_path: Option<&Path>,
         explicit_source_path: bool,
+        expected_controller_identity: Option<&str>,
         runner_targets: &[String],
         extension_updates: &[ExtensionUpgradeEntry],
     ) -> Result<(Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>)>;
@@ -46,6 +47,7 @@ impl RunnerUpgradeProvider for NoopRunnerUpgradeProvider {
         _method_override: Option<InstallMethod>,
         _source_path: Option<&Path>,
         _explicit_source_path: bool,
+        _expected_controller_identity: Option<&str>,
         _runner_targets: &[String],
         _extension_updates: &[ExtensionUpgradeEntry],
     ) -> Result<(Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>)> {

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -27,7 +27,7 @@ Runner sync uses this contract:
 - `--no-restart`: Skip automatic restart after upgrade. Useful for scripted environments.
 - `--skip-extensions`: Skip automatic extension updates.
 - `--skip-runners`: Skip automatic configured runner upgrades.
-- `--upgrade-runner`: Upgrade only the named configured runner. Repeat to target multiple runners.
+- `--upgrade-runner`: Upgrade only the named configured runner. Repeat to target multiple runners. Runner-only mode leaves the controller unchanged and requires the configured runner binary to converge to the initiating controller's source identity.
 - `--method`: Override install method detection (`homebrew|cargo|source|binary`).
 
 ## Installation Method Detection

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -27,7 +27,7 @@ Runner sync uses this contract:
 - `--no-restart`: Skip automatic restart after upgrade. Useful for scripted environments.
 - `--skip-extensions`: Skip automatic extension updates.
 - `--skip-runners`: Skip automatic configured runner upgrades.
-- `--upgrade-runner`: Upgrade only the named configured runner. Repeat to target multiple runners. Runner-only mode leaves the controller unchanged and requires the configured runner binary to converge to the initiating controller's source identity.
+- `--upgrade-runner`: Upgrade only the named configured runner. Repeat to target multiple runners. Runner-only mode leaves the controller unchanged; source-built controllers pin the initiating source identity, while packaged controllers retain their configured runner upgrade method.
 - `--method`: Override install method detection (`homebrew|cargo|source|binary`).
 
 ## Installation Method Detection


### PR DESCRIPTION
## Summary

- make `--upgrade-runner` bypass controller promotion and installation entirely
- carry the initiating controller build identity through runner materialization and require the final configured executable to match exactly
- preserve source checkout identity for source builds while retaining supported remote install-method behavior for packaged builds
- prevent semver-only PATH alignment from erasing stronger build-identity drift
- synchronize runner extensions from a read-only local provenance catalog after binary convergence
- report broken, incomplete, or non-portable extension provenance as unrefreshable instead of silently omitting it or attempting invalid remote Git materialization

Closes #8965.
Contributes to #8012.

## Root cause

Targeted runner upgrades still entered the normal controller upgrade path before refreshing the selected runner. In the reproduced case, that downgraded the initiating controller, rebuilt the runner from a stale source worktree, left configured and bare remote executables divergent, deferred extension synchronization, and returned exit 0 despite selected-runner failure.

Runner convergence also relied on semver in later PATH-alignment stages, allowing equal-version/different-revision executables to overwrite an earlier exact-identity failure.

## Behavioral contract

A runner-only upgrade treats the initiating controller as immutable input. It succeeds only when every selected configured runner converges to that build identity. Source controllers additionally pin the exact source checkout identity. Extension synchronization is read-only on the controller and begins only after binary convergence.

## How to test

1. Run `cargo fmt --check`.
2. Run `git diff --check origin/main...HEAD`.
3. Run `cargo test -p homeboy-upgrade --lib`.
4. Run `cargo test -p homeboy-lab-runner upgrade_runners --lib`.
5. Run `cargo test -p homeboy-cli commands::upgrade::tests --lib`.
6. From a source-built controller, run `homeboy upgrade --force --upgrade-runner <runner> --method source --source-path <exact-controller-checkout>` and confirm the local `homeboy self identity` is unchanged.
7. Confirm success reports the selected configured runner at the same build identity as the initiating controller; introduce a same-semver/different-revision runner and confirm the command fails non-zero with exact drift evidence.

## Verification

- `homeboy-upgrade`: 97 passed
- focused runner-upgrade tests: 29 passed
- CLI upgrade status tests: 4 passed
- formatting and diff checks passed

## Compatibility

This intentionally changes targeted runner-upgrade behavior: `--upgrade-runner` no longer upgrades or replaces the local controller as a side effect, and selected runners that match only by semver now fail until their exact configured executable identity converges. Non-targeted upgrade behavior is unchanged. The runner provider API gains optional expected-controller identity input; all in-repository implementations and call sites are updated.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Reproduction analysis, implementation, deterministic tests, iterative adversarial review, and remediation. Chris reviewed and owns the change.