### PR TITLE
fix: promote Lab artifacts via artifact runner provenance after reconnect (#8762)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/artifact_materialization.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/artifact_materialization.rs
@@ -98,15 +98,31 @@ fn materialize_artifact(
         return Ok(true);
     }
 
-    let (runner_id, runner_job_id) = runner_binding.ok_or_else(|| {
-        unavailable(
-            artifact,
-            "no authenticated runner/job binding exists and no verified controller-retained bytes are available",
-        )
-    })?;
+    // The record-level runner binding is the primary provenance, but it can be
+    // dropped when the controller session is lost and re-established across a
+    // reconnect. The persisted artifact still carries its own runner provenance
+    // (`metadata.source_provenance.runner_id`), which is all the download ref
+    // needs, so fall back to it to let a reconnected authenticated runner supply
+    // the bytes. `validate_file` then re-verifies size + SHA-256 against the
+    // aggregate, so a mismatched or substituted artifact still fails closed
+    // (#8762).
+    let (runner_id, runner_job_id) = match runner_binding {
+        Some((runner_id, runner_job_id)) => {
+            (runner_id.to_string(), Some(runner_job_id.to_string()))
+        }
+        None => {
+            let runner_id = artifact_provenance_runner_id(artifact).ok_or_else(|| {
+                unavailable(
+                    artifact,
+                    "no authenticated runner/job binding exists, no artifact runner provenance is recorded, and no verified controller-retained bytes are available",
+                )
+            })?;
+            (runner_id, None)
+        }
+    };
     let remote_ref = homeboy_core::execution_contract::EXECUTION_CONTRACT
         .artifacts
-        .runner_artifact_ref(runner_id, run_id, &artifact.id);
+        .runner_artifact_ref(&runner_id, run_id, &artifact.id);
     let path = materialized_path(run_id, task_id, &artifact.id)?;
     let download = homeboy_core::observation::runs_service::with_runner_evidence(|provider| {
         provider.download_remote_artifact(&remote_ref, Some(path.clone()))
@@ -115,10 +131,28 @@ fn materialize_artifact(
     artifact.path = Some(download.output_path.display().to_string());
     set_materialization_metadata(
         artifact,
-        "authenticated_runner_artifact",
-        Some((runner_id, runner_job_id)),
+        if runner_job_id.is_some() {
+            "authenticated_runner_artifact"
+        } else {
+            "reconnected_runner_artifact_provenance"
+        },
+        Some((runner_id.as_str(), runner_job_id.as_deref())),
     );
     Ok(true)
+}
+
+/// The runner that produced this artifact, recorded on the artifact itself
+/// (`metadata.source_provenance.runner_id`) so it survives the loss of the
+/// record-level runner/job binding across a controller reconnect. Empty or
+/// missing provenance yields `None` so the caller fails closed.
+fn artifact_provenance_runner_id(artifact: &AgentTaskArtifact) -> Option<String> {
+    artifact
+        .metadata
+        .pointer("/source_provenance/runner_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|runner_id| !runner_id.is_empty())
+        .map(str::to_string)
 }
 
 fn materialized_path(run_id: &str, task_id: &str, artifact_id: &str) -> Result<PathBuf> {
@@ -151,7 +185,7 @@ fn validate_file(artifact: &AgentTaskArtifact, path: &PathBuf) -> Result<()> {
 fn set_materialization_metadata(
     artifact: &mut AgentTaskArtifact,
     source: &str,
-    runner_binding: Option<(&str, &str)>,
+    runner_binding: Option<(&str, Option<&str>)>,
 ) {
     if !artifact.metadata.is_object() {
         artifact.metadata = json!({});
@@ -159,7 +193,7 @@ fn set_materialization_metadata(
     artifact.metadata["controller_artifact_materialization"] = json!({
         "source": source,
         "runner_id": runner_binding.map(|binding| binding.0),
-        "runner_job_id": runner_binding.map(|binding| binding.1),
+        "runner_job_id": runner_binding.and_then(|binding| binding.1),
     });
 }
 
@@ -263,6 +297,51 @@ mod tests {
             assert!(error
                 .message
                 .contains("no authenticated runner/job binding exists"));
+        });
+    }
+
+    #[test]
+    fn artifact_runner_provenance_authorizes_download_without_a_record_binding() {
+        // #8762: after a reconnect the record-level runner/job binding can be
+        // lost, but the artifact still carries its own runner provenance. That
+        // provenance must authorize a reconnected authenticated runner to supply
+        // the bytes rather than failing closed at the binding gate.
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut artifact = artifact(b"patch bytes");
+            artifact.metadata = json!({ "source_provenance": { "runner_id": "homeboy-lab" } });
+
+            let error = materialize_artifact(&mut artifact, "run", "task", None)
+                .expect_err("no runner evidence provider is registered in this unit test");
+
+            // The fallback got PAST the fail-closed binding gate and reached the
+            // download; without a registered provider it fails at download, not
+            // at "no authenticated runner/job binding".
+            assert!(
+                !error
+                    .message
+                    .contains("no authenticated runner/job binding exists"),
+                "provenance fallback must not fail at the binding gate: {}",
+                error.message
+            );
+            assert!(
+                error.message.contains("runner evidence provider"),
+                "must reach the runner download path: {}",
+                error.message
+            );
+        });
+    }
+
+    #[test]
+    fn empty_or_missing_artifact_provenance_still_fails_closed() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut artifact = artifact(b"patch bytes");
+            artifact.metadata = json!({ "source_provenance": { "runner_id": "   " } });
+
+            let error = materialize_artifact(&mut artifact, "run", "task", None)
+                .expect_err("blank provenance must fail closed");
+            assert!(error
+                .message
+                .contains("no artifact runner provenance is recorded"));
         });
     }
 }


### PR DESCRIPTION
## Summary

A successful direct-SSH Lab `agent-task cook` persists complete artifact metadata (runner provenance, SHA-256, size, runner-side path), but `agent-task promote` failed after a controller reconnect with:

```text
recovered runner artifact `patch` cannot be materialized: no authenticated runner/job binding exists and no verified controller-retained bytes are available
```

…stranding a successful provider result and blocking Homeboy's own promotion/finalization contract (#8762).

## Root cause

`materialize_artifact` (`agent_task_lifecycle/artifact_materialization.rs`) tries three byte sources in order: local file → controller-retained projection → **remote runner download**. The remote download was gated on the *record-level* runner binding, `record.runner_id().zip(record.runner_job_id())`. That binding can be dropped when the controller session is lost and re-established across a reconnect, so the download was refused even though the same runner was reconnected and the bytes existed at the recorded remote path with a known hash.

Two facts make the fix safe and small:
- `runner_artifact_ref(runner_id, run_id, artifact_id)` only needs the **runner id**, not the job id.
- The artifact already carries its own runner provenance at `metadata.source_provenance.runner_id` (the same field `runner_id_from_artifact_provenance` reads elsewhere), which survives the loss of the record-level binding.

## Change

When the record-level runner binding is absent, fall back to the artifact's own `source_provenance.runner_id` to authorize a reconnected authenticated runner to supply the bytes. `validate_file` still re-verifies **size + SHA-256** against the aggregate, so a mismatched or substituted artifact fails closed. Blank/missing provenance also fails closed. The materialization metadata records `reconnected_runner_artifact_provenance` so the recovery path is auditable.

This implements the issue's second suggested shape — *"allow a reconnected authenticated runner to supply bytes whose size/hash match the persisted artifact metadata"* — without changing the durable-binding-before-handoff path.

## Testing

- `cargo check -p homeboy-agents --lib --tests` — clean (EXIT 0).
- `cargo fmt`.
- `cargo test -p homeboy-agents --lib agent_task_lifecycle::artifact_materialization::tests` — **4 passed**:
  - `artifact_runner_provenance_authorizes_download_without_a_record_binding` (new) — a provenance-only artifact reaches the download path instead of failing at the binding gate.
  - `empty_or_missing_artifact_provenance_still_fails_closed` (new) — blank provenance fails closed.
  - existing `controller_retained_bytes_materialize_without_a_runner_binding` and `runner_artifact_without_a_job_binding_fails_closed` unchanged.

Heavy workspace build/test intentionally left to CI per repo policy.

Fixes #8762

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Traced the three-source materialization path to the record-binding gate, found the artifact carries its own runner provenance, implemented the reconnect-safe fallback with hash re-verification, and added coverage. Chris reviews and owns the change.