### PR TITLE
fix: don't collapse an empty patch with real work evidence to NoOp (#7719)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/outcome_normalization.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/outcome_normalization.rs
@@ -63,9 +63,37 @@ pub(super) fn normalize_homeboy_local_artifact_sizes(
     }
 
     if outcome.status == AgentTaskOutcomeStatus::Succeeded && has_known_empty_change_set(outcome) {
-        outcome.status = AgentTaskOutcomeStatus::NoOp;
-        outcome.summary = Some("provider produced an empty change artifact".to_string());
+        if has_substantive_non_change_evidence(outcome) {
+            // An empty change artifact next to substantive work evidence
+            // (a transcript, report, log, or other content-bearing artifact)
+            // is not a clean "nothing happened" — it is a patch-capture
+            // failure that would otherwise silently discard real changes,
+            // including committed ones (#7719). Surface it for controller
+            // review/salvage instead of collapsing it to NoOp.
+            outcome.status = AgentTaskOutcomeStatus::CandidateRecoverable;
+            outcome.summary = Some(
+                "provider reported success with an empty change artifact but produced substantive work evidence; the patch may have failed to capture real changes and needs review"
+                    .to_string(),
+            );
+        } else {
+            outcome.status = AgentTaskOutcomeStatus::NoOp;
+            outcome.summary = Some("provider produced an empty change artifact".to_string());
+        }
     }
+}
+
+/// Evidence that the executor did real work even though its change artifact is
+/// empty: any content-bearing artifact that is not itself a change/patch — a
+/// transcript, report, log, or any other artifact with positive size. Used to
+/// distinguish a genuine no-op from a failed patch capture that would
+/// otherwise silently discard committed work (#7719).
+fn has_substantive_non_change_evidence(outcome: &AgentTaskOutcome) -> bool {
+    outcome.artifacts.iter().any(|artifact| {
+        !matches!(
+            artifact.kind.as_str(),
+            "patch" | "diff" | "change_artifact" | "workspace_patch" | "artifact"
+        ) && matches!(artifact.size_bytes, Some(size) if size > 0)
+    })
 }
 
 fn measure_homeboy_local_artifact(

--- a/crates/homeboy-agents/src/agent_task_provider/tests/outcome_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/outcome_tests.rs
@@ -347,6 +347,62 @@ fn homeboy_local_artifact_normalization_measures_empty_nonempty_and_unavailable_
 }
 
 #[test]
+fn empty_patch_with_substantive_evidence_is_flagged_for_review_not_noop() {
+    // #7719: a successful cook whose patch artifact is empty but which produced
+    // substantive work evidence (transcript/report) must NOT be silently
+    // collapsed to NoOp, which would discard real (possibly committed) work.
+    // It is surfaced as a recoverable candidate for controller review/salvage.
+    let root = tempfile::tempdir().expect("artifact root");
+    let empty_patch_path = root.path().join("cook.patch");
+    let transcript_path = root.path().join("transcript.md");
+    fs::write(&empty_patch_path, "").expect("empty patch");
+    fs::write(
+        &transcript_path,
+        "# transcript\nreal provider work happened\n",
+    )
+    .expect("transcript");
+
+    let provenance = AgentTaskArtifactsPathProvenance {
+        owner: "homeboy".to_string(),
+        locality: "runner".to_string(),
+        plan_id: "plan".to_string(),
+        run_id: None,
+        task_id: "opencode-empty-patch-with-evidence".to_string(),
+        attempt: 1,
+    };
+
+    let mut empty_patch =
+        fixture_artifact("patch", "patch", &empty_patch_path, Some("text/x-patch"));
+    empty_patch.size_bytes = None;
+    let mut transcript = fixture_artifact(
+        "transcript",
+        "transcript",
+        &transcript_path,
+        Some("text/markdown"),
+    );
+    transcript.size_bytes = None;
+
+    let mut outcome = failed_outcome_with_run_result(Value::Null);
+    outcome.status = AgentTaskOutcomeStatus::Succeeded;
+    outcome.failure_classification = None;
+    outcome.artifacts = vec![empty_patch, transcript];
+    normalize_homeboy_local_artifact_sizes(&mut outcome, root.path(), &provenance);
+
+    assert_eq!(
+        outcome.status,
+        AgentTaskOutcomeStatus::CandidateRecoverable,
+        "empty patch beside substantive evidence must be reviewable, not NoOp"
+    );
+    assert_eq!(outcome.artifacts[0].size_bytes, Some(0));
+    assert!(outcome.artifacts[1].size_bytes.unwrap_or_default() > 0);
+    assert!(outcome
+        .summary
+        .as_deref()
+        .unwrap_or_default()
+        .contains("needs review"));
+}
+
+#[test]
 fn declared_sandbox_result_contract_rejects_private_runtime_result_shape() {
     let (_, mut provider) = request("task-sandbox-private", "node provider.js".to_string());
     provider.backend = "runtime-provider".to_string();


### PR DESCRIPTION
## Summary

Addresses the core silent-discard in #7719: successful child cooks produced real Git commits and useful transcript/report artifacts, but their patch artifacts were empty (0 bytes). Homeboy uniformly reclassified an empty-change `Succeeded` outcome to `NoOp` ("provider produced an empty change artifact"), so the work read as *nothing happened* and had to be salvaged by hand.

## Change

In `agent_task_provider/outcome_normalization.rs`, an empty change artifact **next to substantive non-change evidence** (a transcript, report, log, or any other content-bearing artifact with positive size) is no longer collapsed to `NoOp`. That combination is a patch-capture failure, not a clean no-op — so it is reclassified to `CandidateRecoverable` with a review-oriented summary and surfaces for controller review/salvage.

An empty patch with **no** other substantive evidence still reclassifies to `NoOp` exactly as before.

## Scope

`Refs #7719`, not `Fixes`. #7719 has four asks; this lands the highest-value, self-contained one — *"treat an empty patch artifact with a non-empty Git diff/commit as an artifact failure"* — using evidence available at the normalization layer without reaching into child-worktree git state. The remaining asks (capture a fallback patch from the worktree before finalizing, `agent-task status` for generic runner children, richer fanout aggregate refs) are separate, larger changes and are left for follow-up.

## Testing

- `cargo check -p homeboy-agents --lib --tests` — clean (EXIT 0).
- `cargo fmt`.
- `cargo test -p homeboy-agents --lib outcome_tests` — **33 passed**, including the new `empty_patch_with_substantive_evidence_is_flagged_for_review_not_noop` and the preserved `homeboy_local_artifact_normalization_measures_empty_nonempty_and_unavailable_files` (empty-patch-alone still → NoOp).
- `cargo test -p homeboy-agents --lib agent_task_aggregate` — 12 passed (the `CandidateRecoverable` consumer is unaffected).

Heavy workspace build/test intentionally left to CI per repo policy.

Refs #7719

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Mapped the empty-patch reclassification path, scoped the tightest fix against #7719's four asks, implemented the evidence-aware reclassification, and added coverage. Chris reviews and owns the change.