### PR TITLE
Isolate Lab rig registries per job

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -16,6 +16,22 @@ pub(crate) fn remote_lab_artifact_dir(checkout_root: &str) -> String {
     RunnerWorkspaceOutputPaths::artifact_dir_for_workspace(checkout_root)
 }
 
+/// Job-scoped rig registry rooted in the run-owned artifact sibling.
+pub(crate) fn remote_lab_rig_registry_root(checkout_root: &str) -> String {
+    format!("{}/rig-registry", remote_lab_artifact_dir(checkout_root))
+}
+
+pub(crate) fn lab_rig_registry_env(
+    registry_root: Option<&str>,
+) -> std::collections::HashMap<String, String> {
+    registry_root.map_or_else(std::collections::HashMap::new, |root| {
+        std::collections::HashMap::from([(
+            homeboy_core::paths::RIG_REGISTRY_ROOT_ENV.to_string(),
+            root.to_string(),
+        )])
+    })
+}
+
 /// Remote path for the Lab structured-output JSON file.
 ///
 /// `checkout_root` is the runner-side synced checkout (or the resident
@@ -209,6 +225,8 @@ pub(crate) struct LabDispatchExecutionContext<'a> {
     pub(crate) agent_task_run_id: Option<String>,
     pub(crate) lab_runner_workload: Option<LabRunnerWorkload>,
     pub(crate) lab_metadata: serde_json::Value,
+    /// Admitted during standard workspace staging and authoritative at dispatch.
+    pub(crate) rig_registry_root: Option<String>,
     pub(crate) env_resolution_layers: Vec<LabEnvResolutionLayer>,
     pub(crate) secret_env_handoff: super::super::secrets::LabSecretEnvHandoffPlan,
     pub(crate) source_snapshot: Option<SourceSnapshot>,
@@ -242,6 +260,7 @@ fn lab_runner_exec_options(
         homeboy_core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV.to_string(),
         context.runner_id.to_string(),
     );
+    env.extend(lab_rig_registry_env(context.rig_registry_root.as_deref()));
     RunnerExecOptions {
         cwd: Some(context.remote_cwd.clone()),
         project_id: None,
@@ -299,6 +318,16 @@ pub(crate) fn exec_lab_context(
             env: request.job_overrides.env.clone(),
             secret_names: request.job_overrides.secret_env_names.clone(),
         }))
+        .chain(
+            context
+                .rig_registry_root
+                .as_deref()
+                .map(|root| LabEnvResolutionLayer {
+                    source: "admitted_rig_registry",
+                    env: lab_rig_registry_env(Some(root)),
+                    secret_names: Vec::new(),
+                }),
+        )
         .collect(),
     );
     let mut env = build_lab_offload_env_with_passthroughs(&context.lab_metadata);
@@ -1228,6 +1257,7 @@ pub(crate) fn run_lab_offload_inner(
         dependency_cache_saves,
         runtime_overlay_env,
         runtime_overlay_metadata,
+        rig_registry_root,
     } = workspace_stage;
     plan = next_plan;
     if agent_task_run_id != pre_acceptance_run_id {
@@ -1260,14 +1290,16 @@ pub(crate) fn run_lab_offload_inner(
     let materialized_workspace = MaterializedWorkspace::new(
         runner_id.to_string(),
         remote_cwd.clone(),
-        remote_output_file
-            .as_deref()
-            .map(|_| remote_lab_artifact_dir(&remote_cwd)),
+        (remote_output_file.is_some() || rig_registry_root.is_some())
+            .then(|| remote_lab_artifact_dir(&remote_cwd)),
         cleanup_policy,
     );
 
-    if let Some(output_file) = remote_output_file.as_deref() {
-        ensure_remote_lab_artifact_dir(runner_id, output_file)?;
+    if let Some(artifact_path) = remote_output_file
+        .as_deref()
+        .or(rig_registry_root.as_deref())
+    {
+        ensure_remote_lab_artifact_dir(runner_id, artifact_path)?;
     }
 
     let dependency_hydration = hydrate_for_lab_workspace_exec(
@@ -1374,6 +1406,7 @@ pub(crate) fn run_lab_offload_inner(
         &remapped_args,
     );
     let mut env_delta = std::collections::HashMap::new();
+    env_delta.extend(lab_rig_registry_env(rig_registry_root.as_deref()));
     let rig_component_path_env =
         forward_rig_component_path_env(&mut env_delta, &workspace_mapping)?;
     let declared_dependency_paths_env =
@@ -1435,6 +1468,7 @@ pub(crate) fn run_lab_offload_inner(
         "step": "lab.sync_rigs",
         "synced_count": synced_rigs.len(),
         "source_snapshot_remote_path": remote_cwd,
+        "registry_root": rig_registry_root,
         "rigs": synced_rigs,
         "selected_before_remote_settings_resolution": true,
     });
@@ -1474,6 +1508,7 @@ pub(crate) fn run_lab_offload_inner(
         agent_task_run_id,
         lab_runner_workload: Some(lab_runner_workload),
         lab_metadata,
+        rig_registry_root,
         env_resolution_layers: vec![
             LabEnvResolutionLayer {
                 source: "env_delta",
@@ -1737,7 +1772,105 @@ fn artifact_name_or_kind_is_fuzz_result(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{RunnerActiveJobState, RunnerSessionState, RunnerStaleDaemonWarning};
+    use crate::{
+        RunnerActiveJobState, RunnerSessionState, RunnerStaleDaemonWarning, RunnerTunnelMode,
+    };
+
+    #[test]
+    fn final_dispatch_reasserts_the_admitted_rig_registry_root() {
+        let root = "/runner/app-homeboy-artifacts/rig-registry".to_string();
+        let args = Vec::new();
+        let request = LabOffloadRequest {
+            command: None,
+            normalized_args: &args,
+            explicit_runner: None,
+            placement: homeboy_cli_contract::Placement::Auto,
+            allow_local_fallback: true,
+            allow_dirty_lab_workspace: false,
+            skip_deps_hydration: false,
+            capture_patch: false,
+            mutation_flag: None,
+            detach_after_handoff: false,
+            output_file_requested: false,
+            read_only_polling: false,
+            local_output_file: None,
+            durable_agent_task_plan: None,
+            source_path: None,
+            verified_cook_baseline: None,
+            require_controller_git_bundle: false,
+            reuse_compatible_snapshot: false,
+            job_overrides: LabJobOverrides {
+                env: std::collections::HashMap::from([(
+                    homeboy_core::paths::RIG_REGISTRY_ROOT_ENV.to_string(),
+                    "/caller/conflict".to_string(),
+                )]),
+                ..Default::default()
+            },
+        };
+        let selection = LabRunnerSelection {
+            runner_id: "homeboy-lab".to_string(),
+            source: LabRunnerSelectionSource::Explicit,
+            mode: RunnerTunnelMode::Reverse,
+        };
+        let contract = LabOffloadCommand {
+            command: homeboy_core::lab_contract::LabCommandContract::portable(
+                "test",
+                None,
+                true,
+                &[],
+            ),
+            required_extensions: Vec::new(),
+            required_capabilities: Vec::new(),
+            workload: None,
+        };
+        let secret_env_handoff = build_lab_secret_env_handoff_plan(&[], &args, Default::default())
+            .expect("empty secret handoff");
+        let runner_status = runner_status(true);
+        let context = LabDispatchExecutionContext {
+            request: &request,
+            selection: &selection,
+            contract: &contract,
+            runner: None,
+            runner_id: "homeboy-lab",
+            runner_status: &runner_status,
+            source_path: std::path::PathBuf::from("/controller/app"),
+            remote_cwd: "/runner/app".to_string(),
+            command: vec!["homeboy".to_string(), "bench".to_string()],
+            remote_command: Vec::new(),
+            remapped_args: Vec::new(),
+            accepted_extension_settings: Vec::new(),
+            secret_preflight_args: Vec::new(),
+            agent_task_run_id: None,
+            lab_runner_workload: None,
+            lab_metadata: serde_json::json!({}),
+            rig_registry_root: Some(root.clone()),
+            env_resolution_layers: Vec::new(),
+            secret_env_handoff,
+            source_snapshot: None,
+            path_materialization_plan: None,
+            capability_preflight: None,
+            provider_preflight: None,
+            path_remaps: Vec::new(),
+            workspace_mapping_metadata: serde_json::json!({}),
+            materialized_workspace: None,
+            dependency_cache_saves: Vec::new(),
+            remote_output_file: None,
+            host_telemetry: None,
+            plan: base_lab_plan(None),
+            messages: Vec::new(),
+            overhead: LabOffloadOverhead::start(),
+            mirror_evidence: false,
+            print_handoff: false,
+            detach_after_handoff: false,
+        };
+        let options =
+            lab_runner_exec_options(&context, request.job_overrides.env.clone(), Vec::new());
+
+        assert_eq!(
+            options.env.get(homeboy_core::paths::RIG_REGISTRY_ROOT_ENV),
+            Some(&root)
+        );
+    }
 
     #[test]
     fn inner_uses_authoritative_preflight_status_not_conflicting_cwd_projection() {

--- a/crates/homeboy-lab-runner/src/lab/offload/resident.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/resident.rs
@@ -174,6 +174,7 @@ pub(crate) fn run_runner_resident_lab_offload(
         agent_task_run_id,
         lab_runner_workload: Some(lab_runner_workload),
         lab_metadata,
+        rig_registry_root: None,
         env_resolution_layers: vec![LabEnvResolutionLayer {
             source: SECRET_ENV_PLAN_ENV_DELTA_SOURCE,
             env: secret_env_handoff.env_delta.clone(),

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -32,6 +32,8 @@ pub(crate) struct LabOffloadWorkspaceStage {
     pub(crate) runtime_overlay_env: Vec<(String, String)>,
     /// Offload-evidence metadata for the synced runtime overlays.
     pub(crate) runtime_overlay_metadata: serde_json::Value,
+    /// Per-job runner root for mutable rig registry state.
+    pub(crate) rig_registry_root: Option<String>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -330,10 +332,12 @@ fn prepare_lab_offload_workspace_stage_inner(
         );
     }
 
+    let candidate_rig_registry_root = remote_lab_rig_registry_root(&remote_cwd);
     let synced_rigs = rig_materialization::sync_lab_offload_rigs(
         runner_id,
         homeboy_path,
         &remote_cwd,
+        &candidate_rig_registry_root,
         &changed_since_preflight.args,
         rig_materialization::LabOffloadPrimaryRigSource {
             local_path: &synced.local_path,
@@ -350,11 +354,13 @@ fn prepare_lab_offload_workspace_stage_inner(
                     PlanValues::new()
                         .json("count", synced_rigs.len())
                         .string("source_snapshot_remote_path", &remote_cwd)
+                        .string("registry_root", &candidate_rig_registry_root)
                         .json("rigs", &synced_rigs),
                 )
                 .build(),
         );
     }
+    let rig_registry_root = (!synced_rigs.is_empty()).then_some(candidate_rig_registry_root);
 
     let rig_component_sync = rig_materialization::sync_lab_offload_rig_component_dependencies(
         runner_id,
@@ -500,6 +506,7 @@ fn prepare_lab_offload_workspace_stage_inner(
         dependency_cache_saves,
         runtime_overlay_env,
         runtime_overlay_metadata,
+        rig_registry_root,
     })
 }
 
@@ -888,6 +895,22 @@ mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
+
+    #[test]
+    fn same_rig_jobs_derive_distinct_registry_roots_from_unique_workspaces() {
+        let first = remote_lab_rig_registry_root("/runner/_lab_workspaces/app-job-one");
+        let second = remote_lab_rig_registry_root("/runner/_lab_workspaces/app-job-two");
+
+        assert_ne!(first, second);
+        assert_eq!(
+            first,
+            "/runner/_lab_workspaces/app-job-one-homeboy-artifacts/rig-registry"
+        );
+        assert_eq!(
+            second,
+            "/runner/_lab_workspaces/app-job-two-homeboy-artifacts/rig-registry"
+        );
+    }
 
     fn rig_workload(
         kind: homeboy_core::lab_contract::LabRigWorkloadKind,

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -16,7 +16,7 @@ use super::{
 mod rig_source_install;
 use rig_source_install::{
     remote_package_path, remove_runner_installed_rig_source, rig_install_capability_preflight,
-    validate_installed_rig_source,
+    rig_registry_env, runner_rig_install_command, validate_installed_rig_source,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -99,6 +99,7 @@ pub(super) fn sync_lab_offload_rigs(
     runner_id: &str,
     command_path: &str,
     remote_cwd: &str,
+    registry_root: &str,
     args: &[String],
     primary: LabOffloadPrimaryRigSource<'_>,
 ) -> Result<Vec<LabOffloadRigSync>> {
@@ -229,17 +230,15 @@ pub(super) fn sync_lab_offload_rigs(
                 )
             };
 
-        let removed_source =
-            remove_runner_installed_rig_source(runner_id, command_path, remote_cwd, rig_id)?;
+        let removed_source = remove_runner_installed_rig_source(
+            runner_id,
+            command_path,
+            remote_cwd,
+            registry_root,
+            rig_id,
+        )?;
 
-        let install_command = vec![
-            command_path.to_string(),
-            "rig".to_string(),
-            "install".to_string(),
-            source.clone(),
-            "--id".to_string(),
-            rig_id.clone(),
-        ];
+        let install_command = runner_rig_install_command(command_path, &source, rig_id);
 
         // Path-translation preflight: the rig install source has already been
         // resolved to a runner-side remote path (primary snapshot remote path or
@@ -264,6 +263,7 @@ pub(super) fn sync_lab_offload_rigs(
             // runner and fails early otherwise (#5285).
             RunnerExecOptions::command(install_command)
                 .with_cwd(remote_cwd)
+                .with_env(rig_registry_env(registry_root))
                 .with_capability_preflight(rig_install_capability_preflight()),
         )?;
 

--- a/crates/homeboy-lab-runner/src/rig_materialization/rig_source_install.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/rig_source_install.rs
@@ -5,6 +5,7 @@
 //! metadata, and validating installed source paths. Kept in a sibling module so
 //! the root stays under the structural item-count threshold (#5241).
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use homeboy_core::{Error, Result};
@@ -56,28 +57,63 @@ fn exec_runner_rig_sources_command(
     runner_id: &str,
     command_path: &str,
     remote_cwd: &str,
+    registry_root: &str,
     args: &[&str],
 ) -> Result<(RunnerExecOutput, i32)> {
+    exec(
+        runner_id,
+        RunnerExecOptions::command(runner_rig_sources_command(command_path, args))
+            .with_cwd(remote_cwd)
+            .with_env(rig_registry_env(registry_root)),
+    )
+}
+
+pub(super) fn runner_rig_sources_command(command_path: &str, args: &[&str]) -> Vec<String> {
     let mut command = vec![
         command_path.to_string(),
         "rig".to_string(),
         "sources".to_string(),
     ];
     command.extend(args.iter().map(|arg| arg.to_string()));
-    exec(
-        runner_id,
-        RunnerExecOptions::command(command).with_cwd(remote_cwd),
-    )
+    command
+}
+
+pub(super) fn runner_rig_install_command(
+    command_path: &str,
+    source: &str,
+    rig_id: &str,
+) -> Vec<String> {
+    vec![
+        command_path.to_string(),
+        "rig".to_string(),
+        "install".to_string(),
+        source.to_string(),
+        "--id".to_string(),
+        rig_id.to_string(),
+    ]
+}
+
+pub(super) fn rig_registry_env(registry_root: &str) -> HashMap<String, String> {
+    HashMap::from([(
+        homeboy_core::paths::RIG_REGISTRY_ROOT_ENV.to_string(),
+        registry_root.to_string(),
+    )])
 }
 
 pub(super) fn remove_runner_installed_rig_source(
     runner_id: &str,
     command_path: &str,
     remote_cwd: &str,
+    registry_root: &str,
     rig_id: &str,
 ) -> Result<Option<String>> {
-    let (list_output, list_exit_code) =
-        exec_runner_rig_sources_command(runner_id, command_path, remote_cwd, &["list"])?;
+    let (list_output, list_exit_code) = exec_runner_rig_sources_command(
+        runner_id,
+        command_path,
+        remote_cwd,
+        registry_root,
+        &["list"],
+    )?;
     if list_exit_code != 0 {
         return Err(Error::validation_invalid_argument(
             "rig",
@@ -97,6 +133,7 @@ pub(super) fn remove_runner_installed_rig_source(
         runner_id,
         command_path,
         remote_cwd,
+        registry_root,
         &["remove", selector.as_str()],
     )?;
     if remove_exit_code != 0 {
@@ -206,6 +243,34 @@ mod tests {
             vec![RunnerRequiredTool::homeboy()]
         );
         assert!(!preflight.is_empty());
+    }
+
+    #[test]
+    fn runner_rig_commands_and_env_share_the_admitted_registry_root() {
+        let root = "/runner/app-homeboy-artifacts/rig-registry";
+        assert_eq!(
+            runner_rig_sources_command("homeboy", &["list"]),
+            vec!["homeboy", "rig", "sources", "list"]
+        );
+        assert_eq!(
+            runner_rig_sources_command("homeboy", &["remove", "old-source"]),
+            vec!["homeboy", "rig", "sources", "remove", "old-source"]
+        );
+        assert_eq!(
+            runner_rig_install_command("homeboy", "/runner/source", "fixture"),
+            vec![
+                "homeboy",
+                "rig",
+                "install",
+                "/runner/source",
+                "--id",
+                "fixture"
+            ]
+        );
+        assert_eq!(
+            rig_registry_env(root).get(homeboy_core::paths::RIG_REGISTRY_ROOT_ENV),
+            Some(&root.to_string())
+        );
     }
 
     #[test]

--- a/crates/homeboy-paths/src/rigs.rs
+++ b/crates/homeboy-paths/src/rigs.rs
@@ -1,9 +1,37 @@
-use super::{homeboy, Result};
+use super::{expand_tilde_path, homeboy, Result};
+use std::env;
 use std::path::PathBuf;
+
+/// Environment variable selecting the root for rig-specific mutable state.
+pub const RIG_REGISTRY_ROOT_ENV: &str = "HOMEBOY_RIG_REGISTRY_ROOT";
+
+/// Root for rig-specific mutable state.
+///
+/// An unset or blank override retains the historical `homeboy()` root. This
+/// intentionally scopes only rig registries; general Homeboy configuration is
+/// unaffected.
+pub fn rig_registry_root() -> Result<PathBuf> {
+    let default_root = homeboy()?;
+    Ok(rig_registry_root_from_env(
+        env::var(RIG_REGISTRY_ROOT_ENV).ok(),
+        &default_root,
+    ))
+}
+
+/// Resolve a rig registry root from an explicit environment value.
+///
+/// Kept pure so callers can verify the environment contract without mutating
+/// process-global environment state.
+pub fn rig_registry_root_from_env(value: Option<String>, default_root: &PathBuf) -> PathBuf {
+    value
+        .filter(|path| !path.trim().is_empty())
+        .map(expand_tilde_path)
+        .unwrap_or_else(|| default_root.clone())
+}
 
 /// Rigs directory (~/.config/homeboy/rigs/)
 pub fn rigs() -> Result<PathBuf> {
-    Ok(homeboy()?.join("rigs"))
+    Ok(rig_registry_root()?.join("rigs"))
 }
 
 /// Rig config file path (~/.config/homeboy/rigs/{id}.json)
@@ -13,7 +41,7 @@ pub fn rig_config(id: &str) -> Result<PathBuf> {
 
 /// Installed rig package directory (~/.config/homeboy/rig-packages/)
 pub fn rig_packages() -> Result<PathBuf> {
-    Ok(homeboy()?.join("rig-packages"))
+    Ok(rig_registry_root()?.join("rig-packages"))
 }
 
 /// Cloned rig package path (~/.config/homeboy/rig-packages/{id}/)
@@ -23,7 +51,7 @@ pub fn rig_package(id: &str) -> Result<PathBuf> {
 
 /// Rig source metadata directory (~/.config/homeboy/rig-sources/)
 pub fn rig_sources() -> Result<PathBuf> {
-    Ok(homeboy()?.join("rig-sources"))
+    Ok(rig_registry_root()?.join("rig-sources"))
 }
 
 /// Rig source metadata file (~/.config/homeboy/rig-sources/{id}.json)
@@ -33,7 +61,7 @@ pub fn rig_source_metadata(id: &str) -> Result<PathBuf> {
 
 /// Stack source metadata directory (~/.config/homeboy/stack-sources/)
 pub fn stack_sources() -> Result<PathBuf> {
-    Ok(homeboy()?.join("stack-sources"))
+    Ok(rig_registry_root()?.join("stack-sources"))
 }
 
 /// Stack source metadata file (~/.config/homeboy/stack-sources/{id}.json)
@@ -68,12 +96,12 @@ pub fn rig_baseline_root(id: &str) -> Result<PathBuf> {
 
 /// Active rig run leases (~/.config/homeboy/rig-leases/).
 pub fn rig_leases_dir() -> Result<PathBuf> {
-    Ok(homeboy()?.join("rig-leases"))
+    Ok(rig_registry_root()?.join("rig-leases"))
 }
 
 /// Stacks directory (~/.config/homeboy/stacks/)
 pub fn stacks() -> Result<PathBuf> {
-    Ok(homeboy()?.join("stacks"))
+    Ok(rig_registry_root()?.join("stacks"))
 }
 
 /// Stack config file path (~/.config/homeboy/stacks/{id}.json)
@@ -90,6 +118,48 @@ mod tests {
         let path = rigs().expect("rigs path resolves");
         assert!(path.ends_with("rigs"), "got {}", path.display());
         assert!(path.parent().expect("parent").ends_with("homeboy"));
+    }
+
+    #[test]
+    fn rig_registry_root_override_scopes_all_rig_state() {
+        let default_root = PathBuf::from("/default/homeboy");
+        assert_eq!(
+            rig_registry_root_from_env(None, &default_root),
+            default_root
+        );
+        assert_eq!(
+            rig_registry_root_from_env(Some("   ".into()), &PathBuf::from("/default/homeboy")),
+            PathBuf::from("/default/homeboy")
+        );
+        let root = rig_registry_root_from_env(
+            Some("/runner/job-artifacts/rig-registry".into()),
+            &PathBuf::from("/default/homeboy"),
+        );
+        assert_eq!(root, PathBuf::from("/runner/job-artifacts/rig-registry"));
+        assert_eq!(
+            root.join("rigs"),
+            PathBuf::from("/runner/job-artifacts/rig-registry/rigs")
+        );
+        assert_eq!(
+            root.join("rig-packages"),
+            PathBuf::from("/runner/job-artifacts/rig-registry/rig-packages")
+        );
+        assert_eq!(
+            root.join("rig-sources"),
+            PathBuf::from("/runner/job-artifacts/rig-registry/rig-sources")
+        );
+        assert_eq!(
+            root.join("stack-sources"),
+            PathBuf::from("/runner/job-artifacts/rig-registry/stack-sources")
+        );
+        assert_eq!(
+            root.join("rig-leases"),
+            PathBuf::from("/runner/job-artifacts/rig-registry/rig-leases")
+        );
+        assert_eq!(
+            root.join("stacks"),
+            PathBuf::from("/runner/job-artifacts/rig-registry/stacks")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `HOMEBOY_RIG_REGISTRY_ROOT` as a generic override for rig-owned mutable paths
- derive a unique registry root from each standard Lab offload workspace and use it for rig list, remove, install, and final dispatch
- record the admitted registry in evidence and bind its artifact directory to existing workspace cleanup

## Why
Concurrent Lab jobs could replace the same runner-global rig ID between synchronization and final dispatch. A job could therefore execute another job’s workload catalog even though its target workspace was isolated.

This change keeps general Homeboy configuration untouched while moving rig configs, source metadata, packages, stacks, leases, and state into the admitted job’s registry root. Final dispatch reasserts that root after generic job environment overrides so the admitted value remains authoritative.

## Scope
This advances #8974 by fixing the rig-registry collision. Binary admission and extension snapshot isolation remain tracked by that issue.

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-paths`.
3. Run `cargo test -p homeboy-lab-runner --lib registry`.
4. Confirm the tests prove same-rig-ID jobs derive different roots and that a conflicting job env override cannot replace the admitted root at final dispatch.

## Verification
- `cargo fmt --check` passed.
- `cargo test -p homeboy-paths` passed: 7 tests.
- `cargo test -p homeboy-lab-runner --lib registry` passed: 8 tests.
- `git diff --check origin/main...HEAD` passed.
- The broader `homeboy-lab-runner` suite was attempted. The untouched timing test `connection::session_store::tests::session_health_accepts_a_healthy_endpoint_after_one_hundred_milliseconds` failed reproducibly; focused tests for this change pass.

## Compatibility
Unset or blank `HOMEBOY_RIG_REGISTRY_ROOT` preserves the existing `~/.config/homeboy` rig paths. Runner-resident offloads and non-rig Homeboy configuration are unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Investigated the Lab concurrency failure, implemented the scoped registry contract and tests, and drafted the PR description. Chris remains responsible for every line.