### PR TITLE
fix: preserve accepted Lab handoffs across controller session loss (#8824)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -10,6 +10,19 @@ pub fn record_pre_execution_failure(
 ) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
     let mut record = store::read_record(&run_id)?;
+
+    // Once a Lab handoff is accepted, the runner daemon owns the durable job
+    // and remains the authority until it reports a terminal result. A transient
+    // controller-session loss (e.g. a concurrent runner refresh) must not be
+    // recorded as a pre-execution failure, which would discard authoritative
+    // in-flight remote work as `provider_executions_consumed: 0` and no
+    // candidate (#8824). Preserve the accepted handoff as a retryable in-flight
+    // state so later reconciliation can project the real runner result exactly
+    // once.
+    if record.has_accepted_lab_handoff() {
+        return retain_accepted_handoff_after_pre_execution_disruption(record, phase, error);
+    }
+
     let task_count = plan.tasks.len();
     let failed = task_count;
     let retryable = error.retryable == Some(true);
@@ -81,6 +94,37 @@ pub fn record_pre_execution_failure(
     );
     store::write_record(&failed_record)?;
     Ok(failed_record)
+}
+
+/// Preserve an accepted-handoff run when a would-be pre-execution failure is
+/// raised after acceptance. The accepted handoff and its runner job identity
+/// remain untouched (the runner daemon is still the authority); the record is
+/// annotated as a retryable, disconnected in-flight state and left non-terminal
+/// so `reconcile_active_lab_runner_handoffs` / `status` can project the real
+/// runner result later.
+fn retain_accepted_handoff_after_pre_execution_disruption(
+    mut record: AgentTaskRunRecord,
+    phase: &str,
+    error: &Error,
+) -> Result<AgentTaskRunRecord> {
+    record.annotate_runner_disconnected();
+    let metadata = record.ensure_metadata_object();
+    // Always mark retryable: acceptance means the durable runner job exists and
+    // the disruption is controller-side, independent of `annotate_runner_disconnected`'s
+    // state/runner-backed preconditions.
+    metadata.insert("retryable".to_string(), json!(true));
+    metadata.insert(
+        "accepted_handoff_pre_execution_disruption".to_string(),
+        json!({
+            "phase": phase,
+            "error_code": error.code.as_str(),
+            "message": error.message,
+            "controller_identity": homeboy_core::build_identity::current().display,
+            "at": now_timestamp(),
+        }),
+    );
+    store::write_record(&record)?;
+    Ok(record)
 }
 
 pub(crate) fn build_pre_execution_failure_outcome(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -226,6 +226,74 @@ fn detached_cook_preacceptance_failure_terminalizes_attempt_proxy() {
 }
 
 #[test]
+fn accepted_handoff_survives_a_pre_execution_disruption_without_terminalizing() {
+    // #8824: once a Lab handoff is accepted the runner daemon owns the durable
+    // job. A transient controller-session loss (e.g. a concurrent runner
+    // refresh) must not be recorded as a pre-execution failure that discards
+    // the authoritative in-flight remote work. The run stays non-terminal and
+    // retryable so reconciliation can project the real runner result later.
+    with_isolated_home(|_| {
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+        let plan = test_plan();
+        record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "accepted-handoff-disrupted",
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+            durable_plan: Some(&plan),
+        })
+        .expect("controller proxy recorded before handoff");
+        let accepted = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "accepted-handoff-disrupted",
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-accepted-in-flight",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("runner accepts the handoff");
+        assert!(accepted.has_accepted_lab_handoff());
+        assert_eq!(accepted.state, AgentTaskRunState::Running);
+
+        // A pre-execution failure raised after acceptance (controller lost its
+        // session) must NOT terminalize the accepted handoff.
+        let after = record_pre_execution_failure(
+            "accepted-handoff-disrupted",
+            &plan,
+            "lab_handoff_preacceptance",
+            &Error::validation_invalid_argument(
+                "runner",
+                "runner is not connected to a daemon",
+                None,
+                None,
+            ),
+        )
+        .expect("accepted handoff is preserved, not failed");
+
+        assert_ne!(
+            after.state,
+            AgentTaskRunState::Failed,
+            "an accepted handoff must not be reclassified as a pre-execution failure"
+        );
+        assert!(
+            after.has_accepted_lab_handoff(),
+            "the accepted handoff and its runner job must be preserved"
+        );
+        assert_eq!(after.runner_job_id(), Some("job-accepted-in-flight"));
+        assert_eq!(after.metadata["retryable"], true);
+        assert_eq!(
+            after.metadata["accepted_handoff_pre_execution_disruption"]["phase"],
+            "lab_handoff_preacceptance"
+        );
+        // No terminal pre-execution failure aggregate was written.
+        assert!(after.metadata.get("pre_execution_failure").is_none());
+    });
+}
+
+#[test]
 fn failed_lab_handoff_retry_recovers_the_materialized_user_plan() {
     with_isolated_home(|_| {
         let mut plan = test_plan();


### PR DESCRIPTION
## Summary

An accepted detached Lab handoff — one the runner daemon owns and is executing remotely with sustained heartbeats — was terminalized as a `lab_handoff_preacceptance` failure when the originating controller temporarily lost its runner session (e.g. a concurrent runner refresh). The run was marked failed with `provider_executions_consumed: 0` and no candidate, discarding authoritative in-flight remote work (#8824).

Observed sequence: handoff `accepted` → runner child heartbeats ~12 min → concurrent runner refresh changes controller/session connectivity → final reconciliation marks the task failed, phase `lab_handoff_preacceptance`, zero provider executions, no candidate.

## Root cause

`record_pre_execution_failure` (`agent_task_lifecycle/failure_recording.rs`) wrote a terminal `Failed` aggregate **unconditionally**, never consulting the typed handoff authority added in #8960 (`record.has_accepted_lab_handoff()`). So any controller-side disruption raised after acceptance stomped the runner-owned in-flight job as a *pre*-execution failure.

## Change

Guard `record_pre_execution_failure`: when the record already has an accepted Lab handoff, the runner daemon remains the authority until it reports a terminal job result. A controller-side disruption must not rewrite it as a pre-execution failure.

Instead the run:
- keeps its accepted handoff and runner job identity untouched,
- is annotated as a **retryable, disconnected in-flight** state (via `annotate_runner_disconnected` + explicit `retryable`),
- records an `accepted_handoff_pre_execution_disruption` breadcrumb (phase/error/controller identity/time),
- stays **non-terminal**, so `reconcile_active_lab_runner_handoffs` / `status` can project the real runner result exactly once.

Genuine pre-acceptance failures (no accepted handoff) still terminalize exactly as before.

This satisfies the issue's acceptance criteria: accepted handoffs survive session loss/refresh without pre-execution reclassification; an unavailable connection retains a retryable in-flight state when no authoritative terminal result exists; existing pre-acceptance behavior is unchanged.

## Testing

- `cargo check -p homeboy-agents --lib --tests` — clean (EXIT 0).
- `cargo fmt`.
- New `accepted_handoff_survives_a_pre_execution_disruption_without_terminalizing` — an accepted handoff hit by a `lab_handoff_preacceptance` disruption stays non-terminal, retryable, keeps its runner job, and writes no terminal pre-execution-failure aggregate. **Passes.**
- Existing `detached_cook_preacceptance_failure_terminalizes_attempt_proxy` (genuine pre-acceptance still fails) and `failed_lab_handoff_retry_recovers_the_materialized_user_plan` — both still **pass**.

Heavy workspace build/test intentionally left to CI per repo policy.

Fixes #8824

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Traced the post-acceptance terminalization to `record_pre_execution_failure` ignoring the typed handoff authority (#8960), implemented the accepted-handoff guard + retryable in-flight preservation, and added coverage. Chris reviews and owns the change.