### PR TITLE
Parse raw SnapshotGit commit messages for build identity

### DIFF
--- a/crates/homeboy-product-identity/build.rs
+++ b/crates/homeboy-product-identity/build.rs
@@ -96,7 +96,8 @@ fn synthetic_snapshot_provenance(root: &Path) -> Option<SyntheticSnapshotProvena
     {
         return None;
     }
-    let message = git_output_raw(root, &["show", "-s", "--format=%B", "HEAD"])?;
+    let commit_object = git_output_raw(root, &["cat-file", "commit", "HEAD"])?;
+    let (_, message) = commit_object.split_once("\n\n")?;
     let message = message.strip_suffix('\n')?;
     if message.ends_with('\n') {
         return None;


### PR DESCRIPTION
## Summary

- parse the stored SnapshotGit commit object instead of `git show --format=%B` presentation output
- preserve the existing exact one-terminal-newline message validation
- allow valid SnapshotGit provenance to resolve to the original source commit rather than synthetic HEAD

Closes #8965.
Follow-up to #8985.

## Root cause

Post-merge live acceptance showed all production SnapshotGit invariants were correct, but product identity still fell back to synthetic commit `b730d8f3066d`. `git show -s --format=%B` appends a presentation separator newline, so the canonical stored one-newline message was observed with two terminal newlines and rejected.

`git cat-file commit` exposes the raw commit object. Splitting its headers from its message validates the actual stored message without relaxing any provenance rule.

## How to test

1. Run `cargo fmt --all -- --check`.
2. Run `git diff --check origin/main...HEAD`.
3. Run `cargo test -p homeboy-product-identity`.
4. Create a Homeboy Snapshot root commit with canonical message and note, compile/run `crates/homeboy-product-identity/build.rs` with its `CARGO_MANIFEST_DIR`, and confirm it emits the note source commit rather than synthetic HEAD.
5. After merge, rerun `homeboy upgrade --force --upgrade-runner <runner> --method source --source-path <exact-controller-checkout>` and require exact controller/configured-runner identity equality.

## Verification

A production-shaped synthetic checkout using the exact live commit/note values emitted `HOMEBOY_PRODUCT_GIT_COMMIT=f7e7ebd7772b`; before this change it emitted synthetic `b730d8f3066d`. Product identity tests, formatting, and diff checks pass.

## Compatibility

No identity rules are relaxed. This only changes message acquisition from Git presentation output to the raw commit object.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Live failure diagnosis, raw Git-object analysis, implementation, and deterministic production-shape verification. Chris reviewed and owns the change.