### PR TITLE
Resolve recorded attempts during cook adoption

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -292,7 +292,15 @@ fn resolve_adoption_target(
         .filter_map(|(attempt, exists)| (!exists).then_some(attempt))
         .collect::<Vec<_>>();
     if orphaned_attempts.is_empty() {
-        return Ok((agent_task_lifecycle::status(cook_or_run_id)?, recipe));
+        let [attempt] = recipe.attempts.as_slice() else {
+            return Err(Error::validation_invalid_argument(
+                "cook_recipe.attempts",
+                "candidate adoption requires exactly one durable cook attempt",
+                Some(recipe.cook_id.clone()),
+                None,
+            ));
+        };
+        return Ok((agent_task_lifecycle::status(&attempt.run_id)?, recipe));
     }
     let [attempt] = orphaned_attempts.as_slice() else {
         return Err(Error::validation_invalid_argument(
@@ -2685,6 +2693,60 @@ mod tests {
                 record.state,
                 agent_task_lifecycle::AgentTaskRunState::Queued
             );
+        });
+    }
+
+    #[test]
+    fn adoption_by_cook_id_selects_the_existing_recipe_attempt_record() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let cook_id = "cook-adopt-existing-attempt";
+            let run_id = "cook-adopt-existing-attempt-1";
+            let mut options =
+                batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+            options.initial_run_id = run_id.to_string();
+            super::super::persist_initial_recipe(&options).expect("persist recipe");
+            agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id))
+                .expect("persist lifecycle record");
+            agent_task_lifecycle::record_cook_attempt(cook_id, 1, run_id)
+                .expect("link cook attempt");
+            agent_task_lifecycle::cancel(run_id).expect("cancel recorded attempt");
+
+            let (record, recipe) =
+                resolve_adoption_target(cook_id).expect("adoption resolves recorded cook attempt");
+
+            assert_eq!(recipe.cook_id, cook_id);
+            assert_eq!(record.run_id, run_id);
+            assert_eq!(
+                record.state,
+                agent_task_lifecycle::AgentTaskRunState::Cancelled
+            );
+        });
+    }
+
+    #[test]
+    fn adoption_by_cook_id_rejects_multiple_recorded_recipe_attempts() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let cook_id = "cook-adopt-ambiguous-attempts";
+            let first_run_id = "cook-adopt-ambiguous-attempts-1";
+            let second_run_id = "cook-adopt-ambiguous-attempts-2";
+            let mut options =
+                batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+            options.initial_run_id = first_run_id.to_string();
+            super::super::persist_initial_recipe(&options).expect("persist recipe");
+            super::super::record_recipe_attempt(cook_id, 2, second_run_id, &options.initial_plan)
+                .expect("persist second recipe attempt");
+            agent_task_lifecycle::submit_plan(&options.initial_plan, Some(first_run_id))
+                .expect("persist first lifecycle record");
+            agent_task_lifecycle::submit_plan(&options.initial_plan, Some(second_run_id))
+                .expect("persist second lifecycle record");
+
+            let error = resolve_adoption_target(cook_id)
+                .expect_err("ambiguous recipe adoption fails closed");
+
+            assert_eq!(error.details["field"], "cook_recipe.attempts");
+            assert!(error
+                .message
+                .contains("candidate adoption requires exactly one durable cook attempt"));
         });
     }
 


### PR DESCRIPTION
## Summary
- resolve a cook ID to its sole recipe-owned attempt when that attempt already has a durable run record
- support terminal pre-provider attempts such as cancelled Lab handoffs
- fail closed when a cook recipe contains multiple recorded attempts

Follow-up to #8987. Closes #8983.

## Runtime evidence
After installing #8987 merge commit `6533bd664cf9`, the original cook-ID command still treated the cook ID as a run ID. Its recipe contained one existing cancelled attempt record, exposing the untested resolver branch. The exact evidence is recorded on #8983.

## How to test
1. Run `cargo test -p homeboy-agents adoption_ -- --test-threads=1`.
2. Run `cargo test -p homeboy-agents provider_replay_keeps_runtime_pin_while_adoption_accepts_historical_policy -- --test-threads=1`.
3. Run `cargo fmt --all --check`.
4. Run `cargo check -p homeboy-agents`.

Expected: all commands pass. The check may report pre-existing unused-code warnings.

## Compatibility
This completes the documented `adopt <RUN_OR_COOK_ID>` behavior for cook recipes whose sole attempt already has a run record. Direct run-ID adoption and recordless orphan recovery are unchanged. Multi-attempt cook-ID adoption now fails explicitly rather than selecting an ambiguous attempt.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Reproduced the merged repair against the original runtime cook, diagnosed the uncovered resolver branch, implemented regression coverage, and prepared verification and PR documentation in collaboration with Chris.