### PR TITLE
Recover expired handoff candidate adoption

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1045,6 +1045,37 @@ pub(crate) fn is_accepted_runner_handoff(record: &AgentTaskRunRecord) -> bool {
     record.has_accepted_lab_handoff()
 }
 
+/// Reconstruct the only aggregate-free failure that can safely admit an
+/// externally prepared immutable candidate: an expired handoff before the
+/// runner recorded a job or consumed a provider execution.
+pub fn candidate_adoption_recovery_outcome(
+    record: &AgentTaskRunRecord,
+    task: &AgentTaskRequest,
+) -> Option<AgentTaskOutcome> {
+    let handoff = record.lab_handoff.as_ref()?;
+    let eligible = record.state == AgentTaskRunState::Cancelled
+        && record.aggregate_path.is_none()
+        && record.totals.is_none()
+        && record.artifact_refs.is_empty()
+        && record.provider_handles.is_empty()
+        && record.latest_executor_evidence.is_none()
+        && record.lab_handoff_validation_error().is_none()
+        && handoff.state == AgentTaskLabHandoffState::Expired
+        && handoff.runner_job_id.is_none()
+        && record.metadata["phase"] == "handoff_rejected"
+        && record.metadata["provider_executions_consumed"] == 0
+        && record.metadata["handoff_acceptance"]["state"] == "expired"
+        && record.metadata["handoff_acceptance"]["reason"] == EXPIRED_LAB_HANDOFF_REASON;
+    eligible.then(|| {
+        build_pre_execution_failure_outcome(
+            &record.run_id,
+            task,
+            "lab_handoff_preacceptance",
+            &Error::internal_unexpected(EXPIRED_LAB_HANDOFF_REASON.to_string()),
+        )
+    })
+}
+
 fn expire_unaccepted_lab_handoff(run_id: &str) -> Result<bool> {
     let _lock = LabHandoffLock::lock(run_id)?;
     // Re-read while holding the handoff lock: an accepted job is runner-owned
@@ -1071,6 +1102,7 @@ fn expire_unaccepted_lab_handoff(run_id: &str) -> Result<bool> {
         }),
     );
     metadata.insert("phase".to_string(), json!("handoff_rejected"));
+    metadata.insert("provider_executions_consumed".to_string(), json!(0));
     metadata.insert(
         "phase_activity".to_string(),
         json!("runner handoff acceptance deadline expired before runner acceptance"),

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -156,7 +156,24 @@ pub fn adopt_cook_candidate_with_dispatcher(
             None,
         ));
     }
-    let (source, source_path) = promotion_source(&record.run_id)?;
+    let (source, source_path) =
+        if let Ok((source, path)) = agent_task_lifecycle::aggregate_source(&record.run_id) {
+            (source, Some(path))
+        } else if let Some(outcome) =
+            agent_task_lifecycle::candidate_adoption_recovery_outcome(&record, &source_request)
+        {
+            (
+                serde_json::to_string(&outcome).map_err(|error| {
+                    Error::internal_json(
+                        error.to_string(),
+                        Some("serialize candidate adoption recovery outcome".to_string()),
+                    )
+                })?,
+                None,
+            )
+        } else {
+            promotion_source(&record.run_id)?
+        };
     let promotion = promote_with_checkpoint(
         AgentTaskPromotionOptions {
             source,
@@ -2642,6 +2659,41 @@ mod tests {
             std::fs::write(&recipe_path, serde_json::to_vec(&recipe).unwrap())
                 .expect("persist historical runtime");
 
+            let command = vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+            ];
+            agent_task_lifecycle::record_lab_offload_planned(
+                agent_task_lifecycle::LabOffloadProxyPlan {
+                    run_id,
+                    runner_id: "fixture-lab",
+                    remote_workspace: "/runner/workspace",
+                    remote_command: &command,
+                    durable_plan: Some(&options.initial_plan),
+                },
+            )
+            .expect("persist preacceptance handoff");
+            agent_task_lifecycle::record_cook_attempt(cook_id, 1, run_id)
+                .expect("link recipe attempt");
+            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                record
+                    .lab_handoff
+                    .as_mut()
+                    .expect("typed handoff")
+                    .acceptance_deadline_at = Some("2000-01-01T00:00:00+00:00".to_string());
+            })
+            .expect("expire handoff deadline");
+            let expired =
+                agent_task_lifecycle::status(run_id).expect("expire preacceptance handoff");
+            assert_eq!(
+                expired.state,
+                agent_task_lifecycle::AgentTaskRunState::Cancelled
+            );
+            assert!(expired.aggregate_path.is_none());
+            assert!(expired.artifact_refs.is_empty());
+            assert_eq!(expired.metadata["provider_executions_consumed"], 0);
+
             let invalid = adopt_cook_candidate(cook_id, &base)
                 .expect_err("candidate validation remains active");
             assert!(invalid
@@ -2667,6 +2719,34 @@ mod tests {
                 std::fs::read_to_string(target.join("lib.rs")).unwrap(),
                 "candidate\n"
             );
+            let promoted = agent_task_lifecycle::status(run_id).expect("adopted lifecycle record");
+            assert_eq!(
+                promoted.metadata["latest_promotion"]["provenance"]["adoption"]["candidate_ref"],
+                candidate
+            );
+        });
+    }
+
+    #[test]
+    fn adoption_rejects_aggregate_free_cancelled_runs_without_pre_provider_evidence() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let cook_id = "cook-adopt-cancelled-without-evidence";
+            let run_id = "cook-adopt-cancelled-without-evidence-attempt-1";
+            let mut options =
+                batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+            options.initial_run_id = run_id.to_string();
+            super::super::persist_initial_recipe(&options).expect("persist recipe");
+            agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id))
+                .expect("persist lifecycle record");
+            agent_task_lifecycle::record_cook_attempt(cook_id, 1, run_id)
+                .expect("link recipe attempt");
+            let cancelled = agent_task_lifecycle::cancel_run(run_id, Some("fixture cancellation"))
+                .expect("cancel attempt");
+            assert!(cancelled.aggregate_path.is_none());
+
+            let error = adopt_cook_candidate(cook_id, "candidate")
+                .expect_err("cancelled run without recovery evidence is rejected");
+            assert_eq!(error.code, homeboy_core::ErrorCode::ValidationInvalidJson);
         });
     }
 


### PR DESCRIPTION
## Summary
- reconstruct a typed failed promotion outcome for expired, unaccepted Lab handoffs with zero provider executions and no aggregate
- preserve the existing explicit candidate-adoption recovery marker and immutable candidate promotion path
- reject aggregate-free cancellations without the complete durable pre-provider evidence

Follow-up to #8987 and #8989. Closes #8983.

## Runtime evidence
With exact #8989 merge commit `739655de07ee`, the original cook ID correctly resolved its sole cancelled attempt, then failed because `promotion_source()` parsed the run ID as JSON when the pre-provider attempt had no aggregate. The exact diagnostic and attempt identity are recorded on #8983.

## How to test
1. Run `cargo test -p homeboy-agents adoption -- --test-threads=1`.
2. Run `cargo test -p homeboy-agents provider_replay_keeps_runtime_pin_while_adoption_accepts_historical_policy -- --test-threads=1`.
3. Run `cargo fmt --all --check`.
4. Run `cargo check -p homeboy-agents`.

Expected: all commands pass. The check may report pre-existing unused-code warnings.

## Compatibility
The new recovery is limited to cancelled handoffs that expired before runner acceptance, have no runner job, aggregate, artifacts, provider handles, or executor evidence, and durably record zero provider executions. Normal provider promotion and other cancellation behavior remain unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Reproduced the aggregate-free promotion failure against the original runtime cook, designed the fail-closed lifecycle evidence boundary, implemented end-to-end regression coverage, and prepared verification and PR documentation in collaboration with Chris.