### PR TITLE
Resume exact checkpointed promotion candidates

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -92,6 +92,7 @@ pub fn resume_promoted_patch(
         )
     })?;
     validate_artifact_content(&artifact, &patch)?;
+    validate_resume_candidate(&options, target_path, previous, &outcome, &artifact)?;
     let normalized_patch = normalize_promotion_patch(&patch, &options.to_worktree)?;
     let command_evidence = vec![verify_patch_is_present(
         target_path,
@@ -183,18 +184,113 @@ fn validate_resume_provenance(
             None,
         ));
     }
+    Ok(())
+}
+
+fn validate_resume_candidate(
+    options: &AgentTaskPromotionOptions,
+    target_path: &Path,
+    previous: &Value,
+    outcome: &AgentTaskOutcome,
+    artifact: &AgentTaskArtifact,
+) -> Result<()> {
+    if previous.pointer("/source/task_id").and_then(Value::as_str) != Some(&outcome.task_id)
+        || previous
+            .pointer("/patch_artifact/id")
+            .and_then(Value::as_str)
+            != Some(&artifact.id)
+        || previous
+            .pointer("/patch_artifact/kind")
+            .and_then(Value::as_str)
+            != Some(&artifact.kind)
+        || previous
+            .pointer("/patch_artifact/sha256")
+            .and_then(Value::as_str)
+            != artifact.sha256.as_deref()
+    {
+        return Err(Error::validation_invalid_argument(
+            "promotion",
+            "promotion resume source task or patch artifact does not match the durable post-apply promotion",
+            None,
+            None,
+        ));
+    }
+    let expected_inputs = json!({
+        "base_ref": options.base_ref,
+        "task_base_sha": options.task_base_sha,
+        "candidate_ref": options.candidate_ref,
+    });
+    if previous
+        .pointer("/provenance/resume_inputs")
+        .is_some_and(|recorded| recorded != &expected_inputs)
+    {
+        return Err(Error::validation_invalid_argument(
+            "promotion",
+            "promotion resume base or candidate input does not match the durable post-apply promotion",
+            None,
+            None,
+        ));
+    }
     let status = std::process::Command::new("git")
         .args(["status", "--porcelain"])
         .current_dir(target_path)
         .output()
         .map_err(|error| Error::git_command_failed(error.to_string()))?;
-    if !status.status.success() || !status.stdout.is_empty() {
+    if !status.status.success() {
         return Err(Error::validation_invalid_argument(
             "path",
-            "promotion resume requires a clean Git worktree",
+            "promotion resume target is not an accessible Git worktree",
             Some(target_path.display().to_string()),
             None,
         ));
+    }
+    let expected = previous
+        .pointer("/provenance/candidate")
+        .filter(|candidate| !candidate.is_null())
+        .cloned();
+    if !status.stdout.is_empty() && expected.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "promotion",
+            "promotion resume found a dirty target without an exact post-apply candidate fingerprint; rerun from a clean target",
+            None,
+            None,
+        ));
+    }
+    if let Some(expected) = expected {
+        let expected = serde_json::from_value(expected).map_err(|_| {
+            Error::validation_invalid_argument(
+                "promotion",
+                "promotion resume durable candidate fingerprint is invalid",
+                None,
+                None,
+            )
+        })?;
+        let actual = crate::agent_task_promotion::candidate_fingerprint(
+            target_path.to_string_lossy().as_ref(),
+        )?;
+        if actual != expected {
+            return Err(Error::validation_invalid_argument(
+                "promotion",
+                "promotion resume target differs from the exact checkpointed applied candidate",
+                Some(target_path.display().to_string()),
+                None,
+            ));
+        }
+    }
+    if let Some(recorded_base) = previous.get("verified_base") {
+        let current_base = serde_json::to_value(capture_declared_base(
+            target_path,
+            options.base_ref.as_deref(),
+        )?)
+        .map_err(|error| Error::internal_json(error.to_string(), None))?;
+        if &current_base != recorded_base {
+            return Err(Error::validation_invalid_argument(
+                "base_ref",
+                "promotion resume declared base no longer matches the durable post-apply promotion",
+                None,
+                None,
+            ));
+        }
     }
     Ok(())
 }
@@ -507,7 +603,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
             worktree_path,
             &outcome.schema,
             artifact.metadata.clone(),
-        ))?;
+        )?)?;
     }
     let verified_base = if let Some(worktree_path) = applied_worktree_path.as_deref() {
         let verified_base = capture_declared_base(worktree_path, options.base_ref.as_deref())?;
@@ -830,7 +926,7 @@ fn promote_committed_changes(
             artifact
                 .map(|artifact| artifact.metadata.clone())
                 .unwrap_or(Value::Null),
-        ))?;
+        )?)?;
     }
     let verified_base = if let Some(path) = applied_worktree_path.as_deref() {
         let verified_base = capture_declared_base(path, options.base_ref.as_deref())?;
@@ -1170,10 +1266,19 @@ fn post_apply_report(
     worktree_path: &Path,
     source_schema: &str,
     artifact_metadata: Value,
-) -> AgentTaskPromotionReport {
+) -> Result<AgentTaskPromotionReport> {
     let status = AgentTaskPromotionStatus::VerificationPending;
     let operator_notification = promotion_notification(status, &target);
-    AgentTaskPromotionReport {
+    let candidate =
+        crate::agent_task_promotion::candidate_fingerprint(&worktree_path.display().to_string())
+            .ok();
+    // A base observation is recorded when the target can reach its remote. The
+    // post-apply checkpoint must still survive a transient remote failure so it
+    // can protect the already-applied candidate for recovery.
+    let verified_base = capture_declared_base(worktree_path, options.base_ref.as_deref())
+        .ok()
+        .flatten();
+    Ok(AgentTaskPromotionReport {
         schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
         status,
         source: promotion_source(source_kind, outcome, options),
@@ -1184,16 +1289,22 @@ fn post_apply_report(
         command_evidence,
         deterministic_gates: Vec::new(),
         gate_results: Vec::new(),
-        verified_base: None,
+        verified_base,
         provenance: json!({
             "source_schema": source_schema,
             "artifact_metadata": artifact_metadata,
             "worktree_path": worktree_path,
             "dependencies_materialized": false,
             "post_apply": true,
+            "candidate": candidate,
+            "resume_inputs": {
+                "base_ref": options.base_ref,
+                "task_base_sha": options.task_base_sha,
+                "candidate_ref": options.candidate_ref,
+            },
         }),
         operator_notification,
-    }
+    })
 }
 
 fn persisted_changed_files(

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
@@ -56,6 +56,7 @@ pub(super) struct FakePromotionWorkspaceProvider {
     verify_exit_code: i32,
     verify_transport_error: bool,
     force_add_ignored_file: bool,
+    apply_to_git: bool,
 }
 
 impl AgentTaskPromotionWorkspaceProvider for FakePromotionWorkspaceProvider {
@@ -74,6 +75,9 @@ impl AgentTaskPromotionWorkspaceProvider for FakePromotionWorkspaceProvider {
                 None,
             )
         })?;
+        if self.apply_to_git {
+            git(&path, &["apply", &request.patch_path]);
+        }
         if self.force_add_ignored_file {
             git(&path, &["apply", &request.patch_path]);
             std::fs::write(path.join(".git/info/exclude"), "ignored/\n")

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -381,21 +381,48 @@ fn promotion_checkpoints_applied_target_before_gate_transport_failure() {
     let worktree_path = temp.path().join("managed-target");
     std::fs::create_dir(&worktree_path).expect("create target");
     git(&worktree_path, &["init"]);
+    git(
+        &worktree_path,
+        &["config", "user.email", "test@example.com"],
+    );
+    git(&worktree_path, &["config", "user.name", "Test"]);
+    std::fs::create_dir_all(worktree_path.join("src")).expect("source dir");
+    std::fs::write(worktree_path.join("src/lib.rs"), "old\n").expect("base source");
+    git(&worktree_path, &["add", "."]);
+    git(&worktree_path, &["commit", "-m", "base"]);
+    git(&worktree_path, &["branch", "-M", "main"]);
+    let remote = temp.path().join("origin.git");
+    assert!(Command::new("git")
+        .args(["init", "--bare", remote.to_str().expect("remote path")])
+        .status()
+        .expect("create remote")
+        .success());
+    git(
+        &worktree_path,
+        &[
+            "remote",
+            "add",
+            "origin",
+            remote.to_str().expect("remote path"),
+        ],
+    );
+    git(&worktree_path, &["push", "-u", "origin", "main"]);
     let (source_path, source) = write_patch_source(&temp);
     let mut provider = FakePromotionWorkspaceProvider {
         workspace_path: Some(worktree_path.clone()),
         verify_transport_error: true,
+        apply_to_git: true,
         ..Default::default()
     };
     let mut checkpoints = Vec::new();
 
     let error = promote_with_provider_and_checkpoint(
         AgentTaskPromotionOptions {
-            source,
+            source: source.clone(),
             source_run_id: Some("restartable-run".to_string()),
-            source_path: Some(source_path),
+            source_path: Some(source_path.clone()),
             source_worktree_path: None,
-            base_ref: None,
+            base_ref: Some("main".to_string()),
             task_base_sha: None,
             candidate_ref: None,
             to_worktree: "homeboy@restartable".to_string(),
@@ -432,6 +459,63 @@ fn promotion_checkpoints_applied_target_before_gate_transport_failure() {
         worktree_path.to_str()
     );
     assert_eq!(checkpoints[0].provenance["post_apply"], true);
+    assert!(checkpoints[0].provenance["candidate"].is_object());
+    assert_eq!(
+        checkpoints[0]
+            .verified_base
+            .as_ref()
+            .map(|base| base.base.as_str()),
+        Some("main")
+    );
+    assert_eq!(
+        Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(&worktree_path)
+            .output()
+            .expect("git status")
+            .stdout,
+        b" M src/lib.rs\n"
+    );
+
+    let resume_options = || AgentTaskPromotionOptions {
+        source: source.clone(),
+        source_run_id: Some("restartable-run".to_string()),
+        source_path: Some(source_path.clone()),
+        source_worktree_path: None,
+        base_ref: Some("main".to_string()),
+        task_base_sha: None,
+        candidate_ref: None,
+        to_worktree: "homeboy@restartable".to_string(),
+        task_id: None,
+        artifact_id: None,
+        dry_run: false,
+        gates: VerifyGateOptions {
+            verify: vec!["true".to_string()],
+            private_verify: Vec::new(),
+            private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+        },
+        provider_command: None,
+        provider_invocation: None,
+    };
+    let checkpoint = serde_json::to_value(&checkpoints[0]).expect("checkpoint value");
+    let resumed = resume_promoted_patch(resume_options(), &worktree_path, &checkpoint)
+        .expect("resume exact applied candidate");
+    assert_eq!(resumed.status, AgentTaskPromotionStatus::Applied);
+    assert_eq!(provider.apply_calls.len(), 1, "resume must not reapply");
+
+    std::fs::write(worktree_path.join("src/lib.rs"), "tampered\n").expect("tamper candidate");
+    let mismatch = resume_promoted_patch(resume_options(), &worktree_path, &checkpoint)
+        .expect_err("modified candidate rejected");
+    assert!(mismatch
+        .message
+        .contains("differs from the exact checkpointed"));
+
+    std::fs::write(worktree_path.join("extra.rs"), "extra\n").expect("add extra candidate file");
+    let extra = resume_promoted_patch(resume_options(), &worktree_path, &checkpoint)
+        .expect_err("extra candidate change rejected");
+    assert!(extra
+        .message
+        .contains("differs from the exact checkpointed"));
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -567,8 +567,10 @@ fn resume_promoted_patch_rebuilds_green_proof_from_pending_post_apply_checkpoint
         "schema": "homeboy/agent-task-promotion-report/v1",
         "status": "verification_pending",
         "source_run_id": "run-8307",
+        "source": { "task_id": "task-1" },
         "to_worktree": "repo@fix-8307",
         "target": { "worktree": "repo@fix-8307", "path": target },
+        "patch_artifact": { "id": "patch", "kind": "patch", "sha256": sha256_hex(VALID_PATCH) },
     });
 
     let report = resume_promoted_patch(options, &target, &previous).expect("resume proof");


### PR DESCRIPTION
## Summary
- persist exact applied-candidate, source-artifact, resume-input, and observed-base identity in post-apply checkpoints
- authenticate the checkpointed dirty candidate before resuming deterministic gates
- reject extra, missing, modified, or mismatched candidate state without reapplying patches

Fixes #8861.

## How to test
1. Run `cargo fmt --all -- --check`.
2. Run `cargo check -p homeboy-cli`.
3. Run `cargo test -p homeboy-agents promotion_checkpoints_applied_target_before_gate_transport_failure`.
4. Run `cargo test -p homeboy-agents resume_promoted_patch_rebuilds_green_proof_from_pending_post_apply_checkpoint`.
5. Interrupt a promotion after the patch is applied but before gates complete.
6. Rerun promotion with the same run, target, base, task, and artifact and confirm gates resume without a second apply.
7. Modify or add a candidate file and confirm resume fails closed.

## Verification
- Formatting passed.
- CLI compilation passed with existing warnings.
- Exact checkpoint interruption/resume test passed.
- Existing pending-checkpoint green-proof test passed.
- Promotion module subset: 46 passed; seven existing current-main/environment fixture failures remained.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode
- **Used for:** Root-cause analysis, current-main implementation, integrity tests, and verification.