### PR TITLE
Materialize Git snapshots as exact runner worktrees

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/git.rs
+++ b/crates/homeboy-lab-runner/src/workspace/git.rs
@@ -9,6 +9,7 @@ use homeboy_core::error::{Error, Result};
 
 use super::super::{Runner, RunnerKind};
 use super::materializer::{WorkspaceMaterializationOperation, WorkspaceMaterializer};
+use super::snapshot::materialize_snapshot_overlay;
 use super::types::ControllerGitBundleProvenance;
 use super::types::GitSnapshot;
 use super::util::{git_output, run_shell_command, ssh_args, ssh_client_for_runner};
@@ -231,6 +232,36 @@ pub(super) fn materialize_git_from_controller_bundle(
         // The controller tempdir is removed as soon as the transfer finishes.
         cleanup_ttl: "PT0S",
     })
+}
+
+/// Materialize a controller Git workspace as its exact captured commit, then
+/// apply its filtered working-tree contents. The bundle creates runner-local
+/// Git metadata; the overlay deliberately excludes controller `.git` data.
+pub(super) fn materialize_git_snapshot_from_controller_bundle(
+    runner: &Runner,
+    local_path: &Path,
+    remote_path: &str,
+    excludes: &[String],
+) -> Result<ControllerGitBundleProvenance> {
+    let head = git_output(local_path, &["rev-parse", "HEAD"])?;
+    let branch = git_output(local_path, &["rev-parse", "--abbrev-ref", "HEAD"])
+        .ok()
+        .filter(|branch| branch != "HEAD");
+    let remote_url = git_output(local_path, &["config", "--get", "remote.origin.url"])
+        .unwrap_or_else(|_| "homeboy-controller-bundle".to_string());
+    let provenance = materialize_git_from_controller_bundle(
+        runner,
+        local_path,
+        remote_path,
+        &head,
+        branch.as_deref(),
+        &remote_url,
+        None,
+        &[],
+        false,
+    )?;
+    materialize_snapshot_overlay(runner, local_path, remote_path, excludes)?;
+    Ok(provenance)
 }
 
 fn sha256_file(path: &Path) -> Result<String> {

--- a/crates/homeboy-lab-runner/src/workspace/git.rs
+++ b/crates/homeboy-lab-runner/src/workspace/git.rs
@@ -235,33 +235,98 @@ pub(super) fn materialize_git_from_controller_bundle(
 }
 
 /// Materialize a controller Git workspace as its exact captured commit, then
-/// apply its filtered working-tree contents. The bundle creates runner-local
-/// Git metadata; the overlay deliberately excludes controller `.git` data.
+/// apply its filtered working-tree contents. Prefer the runner's configured
+/// remote so partial controller clones never need to hydrate historical
+/// promisor objects. An unpublished commit falls back to a controller bundle.
 pub(super) fn materialize_git_snapshot_from_controller_bundle(
     runner: &Runner,
     local_path: &Path,
     remote_path: &str,
     excludes: &[String],
-) -> Result<ControllerGitBundleProvenance> {
+) -> Result<Option<ControllerGitBundleProvenance>> {
     let head = git_output(local_path, &["rev-parse", "HEAD"])?;
     let branch = git_output(local_path, &["rev-parse", "--abbrev-ref", "HEAD"])
         .ok()
         .filter(|branch| branch != "HEAD");
-    let remote_url = git_output(local_path, &["config", "--get", "remote.origin.url"])
-        .unwrap_or_else(|_| "homeboy-controller-bundle".to_string());
-    let provenance = materialize_git_from_controller_bundle(
+    let remote_url = git_output(local_path, &["config", "--get", "remote.origin.url"]).ok();
+    if let Some(remote_url) = remote_url.as_deref().filter(|url| !url.trim().is_empty()) {
+        match materialize_git(
+            runner,
+            remote_path,
+            remote_url,
+            &head,
+            branch.as_deref(),
+            None,
+            &[],
+            false,
+        ) {
+            Ok(()) => {
+                materialize_snapshot_overlay(runner, local_path, remote_path, excludes)?;
+                return Ok(None);
+            }
+            Err(runner_error) => {
+                return materialize_git_snapshot_from_controller_bundle_fallback(
+                    runner,
+                    local_path,
+                    remote_path,
+                    excludes,
+                    &head,
+                    branch.as_deref(),
+                    remote_url,
+                    Some(runner_error),
+                );
+            }
+        }
+    }
+    materialize_git_snapshot_from_controller_bundle_fallback(
         runner,
         local_path,
         remote_path,
+        excludes,
         &head,
         branch.as_deref(),
-        &remote_url,
+        "homeboy-controller-bundle",
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn materialize_git_snapshot_from_controller_bundle_fallback(
+    runner: &Runner,
+    local_path: &Path,
+    remote_path: &str,
+    excludes: &[String],
+    head: &str,
+    branch: Option<&str>,
+    remote_url: &str,
+    runner_error: Option<Error>,
+) -> Result<Option<ControllerGitBundleProvenance>> {
+    let result = materialize_git_from_controller_bundle(
+        runner,
+        local_path,
+        remote_path,
+        head,
+        branch,
+        remote_url,
         None,
         &[],
         false,
-    )?;
+    );
+    let provenance = match result {
+        Ok(provenance) => provenance,
+        Err(bundle_error) => {
+            let runner_diagnostic = runner_error.map_or_else(
+                || "runner-side exact-SHA materialization was unavailable because the source has no origin remote".to_string(),
+                |error| error.message,
+            );
+            return Err(Error::internal_unexpected(format!(
+                "could not materialize exact Git commit `{head}`: runner-side checkout failed: {runner_diagnostic}; controller bundle fallback failed: {}",
+                bundle_error.message
+            )));
+        }
+    };
     materialize_snapshot_overlay(runner, local_path, remote_path, excludes)?;
-    Ok(provenance)
+    Ok(Some(provenance))
 }
 
 fn sha256_file(path: &Path) -> Result<String> {

--- a/crates/homeboy-lab-runner/src/workspace/materializer.rs
+++ b/crates/homeboy-lab-runner/src/workspace/materializer.rs
@@ -330,6 +330,10 @@ fn sync_git_checkout_command(
     fetch_refs: &[String],
     allow_dirty: bool,
 ) -> String {
+    if changed_since_base.is_none() && fetch_refs.is_empty() {
+        return fresh_exact_git_checkout_command(remote_url, head, branch, allow_dirty);
+    }
+
     let fetch_changed_since = changed_since_base
         .map(|base| {
             format!(
@@ -367,6 +371,36 @@ fn sync_git_checkout_command(
     );
     format!(
         "if [ -d \"$dest\"/.git ]; then {dirty_guard} && git -C \"$dest\" reset --hard && git -C \"$dest\" clean -ffdqx && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf \"$dest\" && git clone {remote_url} \"$dest\" && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; fi{fetch_extra_refs}{fetch_changed_since} && {checkout} && git -C \"$dest\" reset --hard {head} && git -C \"$dest\" clean -ffdqx",
+        remote_url = shell::quote_arg(remote_url),
+        head = shell::quote_arg(head),
+        checkout = checkout,
+    )
+}
+
+fn fresh_exact_git_checkout_command(
+    remote_url: &str,
+    head: &str,
+    branch: Option<&str>,
+    allow_dirty: bool,
+) -> String {
+    let checkout = branch.map_or_else(
+        || {
+            format!(
+                "git -C \"$dest\" checkout --detach {head}",
+                head = shell::quote_arg(head)
+            )
+        },
+        |branch| {
+            format!(
+                "git -C \"$dest\" checkout -B {branch} {head}",
+                branch = shell::quote_arg(branch),
+                head = shell::quote_arg(head),
+            )
+        },
+    );
+    format!(
+        "if [ -d \"$dest\"/.git ]; then {dirty_guard} && git -C \"$dest\" reset --hard && git -C \"$dest\" clean -ffdqx && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf \"$dest\" && git init \"$dest\" && git -C \"$dest\" remote add origin {remote_url} && git -C \"$dest\" fetch --filter=blob:none origin {head}; fi && {checkout} && git -C \"$dest\" reset --hard {head} && git -C \"$dest\" clean -ffdqx",
+        dirty_guard = dirty_git_workspace_guard("$dest", allow_dirty),
         remote_url = shell::quote_arg(remote_url),
         head = shell::quote_arg(head),
         checkout = checkout,

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -991,6 +991,55 @@ pub(crate) fn materialize_snapshot_git(
     initialize_synthetic_git_checkout(runner, local_path, remote_path, snapshot, source_dirty)
 }
 
+/// Apply a filtered controller snapshot over an existing runner checkout while
+/// preserving its runner-created Git directory. The overlay is staged before
+/// replacing worktree content so an interrupted transfer cannot leave a
+/// partially extracted archive behind.
+pub(crate) fn materialize_snapshot_overlay(
+    runner: &Runner,
+    local_path: &Path,
+    remote_path: &str,
+    excludes: &[String],
+) -> Result<()> {
+    let target = format!(
+        "sh -c {}",
+        shell::quote_arg(&snapshot_overlay_install_command(remote_path))
+    );
+    match runner.kind {
+        RunnerKind::Local => materialize_snapshot_piped(
+            local_path,
+            &target,
+            excludes,
+            "apply local Git workspace snapshot overlay",
+        ),
+        RunnerKind::Ssh => {
+            let (_server, client) = ssh_client_for_runner(runner)?;
+            if client.is_local {
+                materialize_snapshot_piped(
+                    local_path,
+                    &target,
+                    excludes,
+                    "apply local Git workspace snapshot overlay",
+                )
+            } else {
+                let remote = format!("{}@{}", client.user, client.host);
+                let command = snapshot_overlay_install_command(remote_path);
+                materialize_snapshot_piped(
+                    local_path,
+                    &format!(
+                        "ssh {} {} {}",
+                        ssh_args(&client),
+                        shell::quote_arg(&remote),
+                        shell::quote_arg(&command),
+                    ),
+                    excludes,
+                    "apply SSH Git workspace snapshot overlay",
+                )
+            }
+        }
+    }
+}
+
 /// Identity of the synthetic git checkout materialized for a `snapshot-git`
 /// sync. Surfaced as run evidence so write-capable agent-task dispatches can
 /// trace the dirty controller-side worktree back to the synthetic commit that
@@ -1262,4 +1311,11 @@ pub(super) fn snapshot_install_command(remote_path: &str) -> String {
         .op(WorkspaceMaterializationOperation::AtomicReplaceTemp)
         .restore_owner()
         .command()
+}
+
+fn snapshot_overlay_install_command(remote_path: &str) -> String {
+    let remote_path = shell::quote_arg(remote_path);
+    format!(
+        "dest={remote_path}; tmp=\"${{dest}}.overlay.$$\"; rm -rf \"$tmp\" && mkdir -p \"$tmp\" && trap 'rm -rf \"$tmp\"' EXIT && tar -C \"$tmp\" -xf - && find \"$dest\" -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {{}} + && cp -a \"$tmp\"/. \"$dest\"/"
+    )
 }

--- a/crates/homeboy-lab-runner/src/workspace/sync.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync.rs
@@ -17,7 +17,10 @@ use super::super::validation_dependencies::{
 use super::super::{
     load, source_materialization, RunnerKind, RunnerLifecycleOwner, RunnerWorkspaceLease,
 };
-use super::git::{git_snapshot, materialize_git, materialize_git_from_controller_bundle};
+use super::git::{
+    git_snapshot, materialize_git, materialize_git_from_controller_bundle,
+    materialize_git_snapshot_from_controller_bundle,
+};
 use super::snapshot::{
     effective_snapshot_excludes, ensure_no_runner_workspace_metadata_collision,
     local_snapshot_stats, materialize_snapshot, materialize_snapshot_git,
@@ -122,7 +125,24 @@ pub fn sync_workspace(
                 &excludes,
                 WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
             )?;
-            let synthetic_checkout = if options.mode == RunnerWorkspaceSyncMode::SnapshotGit {
+            let git_backed_snapshot = git_output(&local_path, &["rev-parse", "HEAD"]).is_ok();
+            let synthetic_checkout = if git_backed_snapshot {
+                match materialize_git_snapshot_from_controller_bundle(
+                    &runner,
+                    &local_path,
+                    &remote_path,
+                    &excludes,
+                ) {
+                    Ok(provenance) => {
+                        materialization_plan.controller_git_bundle = Some(provenance);
+                        None
+                    }
+                    Err(error) => {
+                        rollback_materialized_workspace(&runner, workspace_root, &remote_path);
+                        return Err(error);
+                    }
+                }
+            } else if options.mode == RunnerWorkspaceSyncMode::SnapshotGit {
                 match materialize_snapshot_git(
                     &runner,
                     &local_path,

--- a/crates/homeboy-lab-runner/src/workspace/sync.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync.rs
@@ -134,7 +134,7 @@ pub fn sync_workspace(
                     &excludes,
                 ) {
                     Ok(provenance) => {
-                        materialization_plan.controller_git_bundle = Some(provenance);
+                        materialization_plan.controller_git_bundle = provenance;
                         None
                     }
                     Err(error) => {

--- a/crates/homeboy-lab-runner/src/workspace/tests/materializer.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/materializer.rs
@@ -110,6 +110,32 @@ fn workspace_materializer_builds_direct_git_checkout_command() {
 }
 
 #[test]
+fn workspace_materializer_fetches_only_the_exact_sha_for_a_fresh_checkout() {
+    let command = WorkspaceMaterializer::new("/srv/homeboy/_lab_workspaces/homeboy-abc")
+        .op(WorkspaceMaterializationOperation::SyncGitCheckout {
+            remote_url: "https://github.com/Extra-Chill/homeboy.git".to_string(),
+            head: "abc123".to_string(),
+            branch: None,
+            changed_since_base: None,
+            fetch_refs: Vec::new(),
+            allow_dirty: false,
+        })
+        .command();
+
+    assert!(command.contains("git init \"$dest\""));
+    assert!(command.contains("remote add origin https://github.com/Extra-Chill/homeboy.git"));
+    assert!(command.contains("fetch --filter=blob:none origin abc123"));
+    assert!(command.contains("checkout --detach abc123"));
+    assert!(!command.contains("git clone"));
+    assert_eq!(
+        command
+            .matches("'+refs/heads/*:refs/remotes/origin/*'")
+            .count(),
+        1
+    );
+}
+
+#[test]
 fn workspace_materializer_builds_dependency_cache_restore_command() {
     let command = dependency_cache_restore_command(
         "/srv/homeboy/_lab_workspaces/homeboy-abc",

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -33,7 +33,8 @@ fn snapshot_git_readback_failure_rolls_back_remote_workspace_and_registration() 
         .lock()
         .expect("PATH lock");
     homeboy_core::test_support::with_isolated_home(|_| {
-        let source = super::dirty_git_repo();
+        let source = tempfile::tempdir().expect("source tempdir");
+        fs::write(source.path().join("file.txt"), "snapshot\n").expect("source file");
         let runner_root = tempfile::tempdir().expect("runner root");
         let shim_root = tempfile::tempdir().expect("git shim root");
         let shim = shim_root.path().join("git");
@@ -720,10 +721,12 @@ fn workspace_list_reports_recent_lab_workspaces_with_exec_commands() {
 }
 
 #[test]
-fn snapshot_git_sync_materializes_dirty_source_as_synthetic_git_checkout() {
+fn git_backed_snapshot_sync_preserves_exact_commit_and_dirty_overlay() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let source = super::dirty_git_repo();
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        let head = git_output(source.path(), &["rev-parse", "HEAD"]).expect("source head");
+        fs::write(source.path().join("untracked.txt"), "untracked\n").expect("untracked file");
         git(
             source.path(),
             &[
@@ -743,15 +746,11 @@ fn snapshot_git_sync_materializes_dirty_source_as_synthetic_git_checkout() {
         )
         .expect("create runner");
 
-        std::env::set_var("GIT_COMMITTER_NAME", "Ambient Committer");
-        std::env::set_var("GIT_COMMITTER_EMAIL", "ambient@example.test");
-        std::env::set_var("GIT_COMMITTER_DATE", "2001-01-01T00:00:00Z");
-
         let (output, exit_code) = sync_workspace(
             "lab-local-snapshot-git",
             RunnerWorkspaceSyncOptions {
                 path: source.path().display().to_string(),
-                mode: RunnerWorkspaceSyncMode::SnapshotGit,
+                mode: RunnerWorkspaceSyncMode::Snapshot,
                 controller_routed_git: false,
                 changed_since_base: None,
                 git_fetch_refs: Vec::new(),
@@ -761,22 +760,16 @@ fn snapshot_git_sync_materializes_dirty_source_as_synthetic_git_checkout() {
             },
         )
         .expect("sync workspace");
-        std::env::remove_var("GIT_COMMITTER_NAME");
-        std::env::remove_var("GIT_COMMITTER_EMAIL");
-        std::env::remove_var("GIT_COMMITTER_DATE");
 
         let remote = Path::new(&output.remote_path);
         assert_eq!(exit_code, 0);
-        assert_eq!(output.sync_mode, RunnerWorkspaceSyncMode::SnapshotGit);
+        assert_eq!(output.sync_mode, RunnerWorkspaceSyncMode::Snapshot);
         assert_eq!(
             output.current_workspace.sync_mode,
-            RunnerWorkspaceSyncMode::SnapshotGit
+            RunnerWorkspaceSyncMode::Snapshot
         );
         assert_eq!(output.current_workspace.source_dirty, Some(true));
-        assert_eq!(
-            output.workspace_cleanliness,
-            "snapshot_synthetic_git_unique_workspace"
-        );
+        assert_eq!(output.workspace_cleanliness, "snapshot_unique_workspace");
         assert_eq!(
             fs::read_to_string(remote.join("file.txt")).unwrap(),
             "dirty\n"
@@ -785,54 +778,42 @@ fn snapshot_git_sync_materializes_dirty_source_as_synthetic_git_checkout() {
             git_output(remote, &["rev-parse", "--is-inside-work-tree"]).unwrap(),
             "true"
         );
+        assert_eq!(git_output(remote, &["rev-parse", "HEAD"]).unwrap(), head);
         assert_eq!(
             git_output(remote, &["config", "--get", "remote.origin.url"]).unwrap(),
             "https://github.com/example/app.git"
         );
-        assert_eq!(
-            git_output(remote, &["status", "--porcelain=v1"]).unwrap(),
-            "",
-            "Homeboy-owned runner metadata must not dirty synthetic checkouts before patch capture"
-        );
-        assert_eq!(
-            git_output(remote, &["notes", "--ref=homeboy-snapshot", "show", "HEAD"],).unwrap(),
-            format!(
-                "snapshot_identity={}\nsource_head={}\nsource_dirty=true",
-                output.snapshot_identity,
-                output.current_workspace.source_commit.as_deref().unwrap()
-            )
-        );
+        let status = git_output(remote, &["status", "--porcelain=v1"]).unwrap();
+        assert!(status.contains("file.txt"));
+        assert!(status.contains("?? untracked.txt"));
         assert!(fs::read_to_string(remote.join(".git/info/exclude"))
             .unwrap()
             .lines()
             .any(|line| line == ".homeboy/"));
-        assert!(git_output(remote, &["log", "-1", "--pretty=%B"])
-            .unwrap()
-            .contains(&output.snapshot_identity));
         assert_eq!(
-            git_output(remote, &["show", "-s", "--format=%cn <%ce>", "HEAD"]).unwrap(),
-            "Homeboy Snapshot <homeboy-snapshot@localhost>",
-            "ambient committer overrides must not affect synthetic snapshot-git commits"
+            output.current_workspace.source_commit.as_deref(),
+            Some(head.as_str())
+        );
+        assert_eq!(
+            output
+                .materialization_plan
+                .controller_git_bundle
+                .as_ref()
+                .expect("git-backed snapshot records controller bundle provenance")
+                .source_sha,
+            head
         );
 
-        // The synthetic checkout identity must be surfaced as run evidence so a
-        // write-capable agent-task dispatch can trace the dirty controller-side
-        // worktree back to the synthetic commit carrying it into the runner
-        // workspace (#6136 acceptance criterion #2).
-        let synthetic_commit = output
-            .current_workspace
-            .synthetic_checkout_commit
-            .clone()
-            .expect("synthetic checkout commit recorded as run evidence");
+        // Lifecycle scripts can clean the checkout before dependency install.
+        git(remote, &["reset", "--hard", "HEAD"]);
+        git(remote, &["clean", "-ffdqx"]);
+        assert_eq!(git_output(remote, &["rev-parse", "HEAD"]).unwrap(), head);
         assert_eq!(
-            synthetic_commit,
-            git_output(remote, &["rev-parse", "HEAD"]).unwrap(),
-            "recorded synthetic checkout commit must match the materialized workspace HEAD"
+            fs::read_to_string(remote.join("file.txt")).unwrap(),
+            "base\n",
+            "Git cleanup must restore the captured baseline"
         );
-        assert!(
-            output.current_workspace.source_commit.is_some(),
-            "snapshot-git evidence must also record the source commit"
-        );
+        assert!(!remote.join("untracked.txt").exists());
     });
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -849,6 +849,12 @@ fn git_backed_snapshot_uses_runner_exact_sha_without_controller_bundle_hydration
             ],
         );
         git(author.path(), &["push", "origin", "main"]);
+        git(author.path(), &["checkout", "-b", "unrelated"]);
+        fs::write(author.path().join("unrelated.txt"), "unrelated\n").expect("unrelated file");
+        git(author.path(), &["add", "."]);
+        git(author.path(), &["commit", "-m", "unrelated"]);
+        git(author.path(), &["push", "origin", "unrelated"]);
+        git(author.path(), &["checkout", "main"]);
         git(
             source.path(),
             &[
@@ -892,6 +898,19 @@ fn git_backed_snapshot_uses_runner_exact_sha_without_controller_bundle_hydration
         assert_eq!(exit_code, 0);
         assert!(output.materialization_plan.controller_git_bundle.is_none());
         assert_eq!(git_output(remote, &["rev-parse", "HEAD"]).unwrap(), head);
+        assert!(
+            git_output(
+                remote,
+                &[
+                    "show-ref",
+                    "--verify",
+                    "--quiet",
+                    "refs/remotes/origin/unrelated"
+                ]
+            )
+            .is_err(),
+            "fresh exact-SHA materialization must not fetch every remote branch"
+        );
         assert_eq!(
             fs::read_to_string(remote.join("file.txt")).unwrap(),
             "dirty\n"

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -721,7 +721,7 @@ fn workspace_list_reports_recent_lab_workspaces_with_exec_commands() {
 }
 
 #[test]
-fn git_backed_snapshot_sync_preserves_exact_commit_and_dirty_overlay() {
+fn git_backed_snapshot_sync_falls_back_for_unpublished_commit_and_preserves_dirty_overlay() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let source = super::dirty_git_repo();
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
@@ -733,7 +733,7 @@ fn git_backed_snapshot_sync_preserves_exact_commit_and_dirty_overlay() {
                 "remote",
                 "set-url",
                 "origin",
-                "https://github.com/example/app.git",
+                "file:///does-not-exist/unpublished-fixture.git",
             ],
         );
 
@@ -781,7 +781,7 @@ fn git_backed_snapshot_sync_preserves_exact_commit_and_dirty_overlay() {
         assert_eq!(git_output(remote, &["rev-parse", "HEAD"]).unwrap(), head);
         assert_eq!(
             git_output(remote, &["config", "--get", "remote.origin.url"]).unwrap(),
-            "https://github.com/example/app.git"
+            "file:///does-not-exist/unpublished-fixture.git"
         );
         let status = git_output(remote, &["status", "--porcelain=v1"]).unwrap();
         assert!(status.contains("file.txt"));
@@ -814,6 +814,101 @@ fn git_backed_snapshot_sync_preserves_exact_commit_and_dirty_overlay() {
             "Git cleanup must restore the captured baseline"
         );
         assert!(!remote.join("untracked.txt").exists());
+    });
+}
+
+#[test]
+fn git_backed_snapshot_uses_runner_exact_sha_without_controller_bundle_hydration() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let origin = tempfile::tempdir().expect("origin tempdir");
+        let author = tempfile::tempdir().expect("author tempdir");
+        let source = tempfile::tempdir().expect("source tempdir");
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        git(origin.path(), &["init", "--bare"]);
+        git(origin.path(), &["config", "uploadpack.allowFilter", "true"]);
+        git(author.path(), &["init", "-b", "main"]);
+        git(author.path(), &["config", "user.email", "test@example.com"]);
+        git(author.path(), &["config", "user.name", "Test User"]);
+        fs::write(author.path().join("removed.txt"), "base-only\n").expect("base file");
+        git(author.path(), &["add", "."]);
+        git(author.path(), &["commit", "-m", "base"]);
+        let base_blob =
+            git_output(author.path(), &["rev-parse", "HEAD:removed.txt"]).expect("base blob");
+        fs::remove_file(author.path().join("removed.txt")).expect("remove base file");
+        fs::write(author.path().join("file.txt"), "head\n").expect("head file");
+        git(author.path(), &["add", "."]);
+        git(author.path(), &["commit", "-m", "head"]);
+        let head = git_output(author.path(), &["rev-parse", "HEAD"]).expect("head");
+        git(
+            author.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                &format!("file://{}", origin.path().display()),
+            ],
+        );
+        git(author.path(), &["push", "origin", "main"]);
+        git(
+            source.path(),
+            &[
+                "clone",
+                "--filter=blob:none",
+                &format!("file://{}", origin.path().display()),
+                ".",
+            ],
+        );
+        assert!(
+            git_output(
+                source.path(),
+                &["rev-list", "--objects", "--missing=print", "HEAD"]
+            )
+            .expect("inspect partial clone")
+            .contains(&format!("?{base_blob}")),
+            "fixture must retain a missing historical promisor blob"
+        );
+        fs::write(source.path().join("file.txt"), "dirty\n").expect("tracked overlay");
+        fs::write(source.path().join("untracked.txt"), "untracked\n").expect("untracked overlay");
+        crate::create(
+            &format!(
+                r#"{{"id":"lab-local-partial-snapshot","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+
+        let (output, exit_code) = sync_workspace(
+            "lab-local-partial-snapshot",
+            RunnerWorkspaceSyncOptions {
+                path: source.path().display().to_string(),
+                mode: RunnerWorkspaceSyncMode::Snapshot,
+                ..Default::default()
+            },
+        )
+        .expect("runner resolves published exact SHA");
+
+        let remote = Path::new(&output.remote_path);
+        assert_eq!(exit_code, 0);
+        assert!(output.materialization_plan.controller_git_bundle.is_none());
+        assert_eq!(git_output(remote, &["rev-parse", "HEAD"]).unwrap(), head);
+        assert_eq!(
+            fs::read_to_string(remote.join("file.txt")).unwrap(),
+            "dirty\n"
+        );
+        assert_eq!(
+            fs::read_to_string(remote.join("untracked.txt")).unwrap(),
+            "untracked\n"
+        );
+        assert!(
+            git_output(
+                source.path(),
+                &["rev-list", "--objects", "--missing=print", "HEAD"]
+            )
+            .expect("inspect controller after runner checkout")
+            .contains(&format!("?{base_blob}")),
+            "runner-side materialization must not hydrate controller promisor objects"
+        );
     });
 }
 


### PR DESCRIPTION
## Summary

- materialize Git-backed Lab snapshots as usable runner-side worktrees at the captured commit
- apply filtered tracked and untracked controller overlays without copying controller-local Git metadata
- prefer a filtered exact-SHA fetch on the runner and fall back to a controller bundle for unpublished commits
- avoid full repository and all-branch clones for fresh exact-SHA snapshots

Closes #8977.

## Root cause

Lab snapshot transport copied repository files without a usable `.git` worktree. Repository-native lifecycle commands such as Gutenberg dependency installation then failed with `fatal: not a git repository`. The first exact-commit repair also exposed two scale cases: partial controller clones could not always hydrate a bundle, and fresh runner checkouts cloned every remote branch before selecting one SHA.

## How to test

1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-lab-runner workspace_materializer --lib`.
3. Run `cargo test -p homeboy-lab-runner git_backed_snapshot_uses_runner_exact_sha_without_controller_bundle_hydration --lib`.
4. Run `cargo test -p homeboy-lab-runner git_backed_snapshot_sync_falls_back_for_unpublished_commit_and_preserves_dirty_overlay --lib`.
5. Run `git diff --check origin/main...HEAD`.
6. From a clean Git checkout with a repository-native install hook, dispatch a Lab-portable command in snapshot mode.
7. Confirm the runner checkout reports the captured SHA, Git lifecycle commands work, and fresh published snapshots fetch only the exact SHA.

## Verification

All focused tests and formatting checks pass. As supplementary end-to-end evidence, the repaired path materialized WordPress/gutenberg PR #79020 at exact SHA `a9786977d4e575e5f72534be834aa5cbf2ee4f43`, built Gutenberg on Lab, and completed an eight-case browser fuzz campaign with all strict gates passing: https://homeboy-artifacts-tunnel.dev.chubes.net/gutenberg-79020-notes-attachment-attempt-17/68f48e0a-065c-4ead-b7f1-3f69aaa5ac24-fuzz-results.json

## Compatibility

Non-Git source snapshots retain their existing behavior. Unpublished commits retain controller-bundle fallback. Existing reusable destinations, explicit fetch refs, changed-since bases, dirty guards, and transport diagnostics remain intact. This complements SnapshotGit provenance handling rather than replacing it.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Root-cause analysis, implementation, regression tests, rebase conflict resolution, and end-to-end Lab verification. Chris reviewed and owns the change.