### PR TITLE
refactor: sink URI codec primitives into engine-primitives to break execution_contract cycle

### DIFF
--- a/crates/homeboy-core/src/artifact_ref.rs
+++ b/crates/homeboy-core/src/artifact_ref.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::execution_contract::{decode_uri_component, encode_uri_component};
 use crate::observation::ArtifactRecord;
+use homeboy_engine_primitives::artifact_ref_scheme::{decode_uri_component, encode_uri_component};
 
 pub const ARTIFACT_REF_SCHEMA: &str = "homeboy/artifact-ref/v1";
 pub const EVIDENCE_REF_SCHEMA: &str = "homeboy/evidence-ref/v1";

--- a/crates/homeboy-core/src/execution_contract.rs
+++ b/crates/homeboy-core/src/execution_contract.rs
@@ -2,6 +2,16 @@ use crate::artifact_ref::{
     ArtifactReference, METADATA_ONLY_REF_SCHEME, RUNNER_ARTIFACT_REF_SCHEME,
 };
 
+// The URI codec primitives live in `homeboy-engine-primitives` (the slim shared
+// base) alongside the artifact-ref schemes, so `core::artifact_ref` and this
+// module can both use them without a mutual `execution_contract <-> artifact_ref`
+// cycle. Re-exported here to preserve existing
+// `execution_contract::{encode_uri_component, decode_uri_component, ...}` call
+// sites, including cross-crate consumers.
+pub use homeboy_engine_primitives::artifact_ref_scheme::{
+    decode_uri_component, decode_uri_component_strict, encode_uri_component,
+};
+
 /// Typed runtime-facing execution surface shared by runner, Lab, daemon, and
 /// extension code paths.
 ///
@@ -84,61 +94,6 @@ pub const EXECUTION_CONTRACT: ExecutionContract = ExecutionContract {
         digest_algorithm_sha256: "sha256",
     },
 };
-
-pub fn encode_uri_component(value: &str) -> String {
-    let mut encoded = String::new();
-    for byte in value.bytes() {
-        match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
-                encoded.push(byte as char);
-            }
-            _ => encoded.push_str(&format!("%{byte:02X}")),
-        }
-    }
-    encoded
-}
-
-pub fn decode_uri_component(value: &str) -> String {
-    let bytes = value.as_bytes();
-    let mut decoded = Vec::new();
-    let mut index = 0;
-    while index < bytes.len() {
-        if bytes[index] == b'%' && index + 2 < bytes.len() {
-            if let Ok(hex) = std::str::from_utf8(&bytes[index + 1..index + 3]) {
-                if let Ok(byte) = u8::from_str_radix(hex, 16) {
-                    decoded.push(byte);
-                    index += 3;
-                    continue;
-                }
-            }
-        }
-        decoded.push(bytes[index]);
-        index += 1;
-    }
-    String::from_utf8_lossy(&decoded).to_string()
-}
-
-/// Strict counterpart for externally supplied selectors. Unlike the legacy
-/// display decoder, malformed percent escapes and invalid UTF-8 are rejected.
-pub fn decode_uri_component_strict(value: &str) -> Option<String> {
-    let bytes = value.as_bytes();
-    let mut decoded = Vec::with_capacity(bytes.len());
-    let mut index = 0;
-    while index < bytes.len() {
-        if bytes[index] != b'%' {
-            decoded.push(bytes[index]);
-            index += 1;
-            continue;
-        }
-        if index + 2 >= bytes.len() {
-            return None;
-        }
-        let hex = std::str::from_utf8(&bytes[index + 1..index + 3]).ok()?;
-        decoded.push(u8::from_str_radix(hex, 16).ok()?);
-        index += 3;
-    }
-    String::from_utf8(decoded).ok()
-}
 
 /// Whether an artifact path is a remote-runner artifact reference, per the
 /// execution contract's artifact rules. Lives here (not in the runner module)

--- a/crates/homeboy-engine-primitives/src/artifact_ref_scheme.rs
+++ b/crates/homeboy-engine-primitives/src/artifact_ref_scheme.rs
@@ -33,6 +33,70 @@ pub fn is_metadata_only_ref(path: &str) -> bool {
     path.starts_with(METADATA_ONLY_REF_SCHEME)
 }
 
+/// Percent-encode a single URI path component (RFC 3986 unreserved set kept
+/// verbatim, everything else `%XX`-escaped).
+///
+/// Lives here alongside the artifact-ref schemes because the runner/Lab/daemon
+/// execution surface and `core::artifact_ref` both build and parse these
+/// references and must agree on the encoding — pushing it to the primitives
+/// layer lets both depend on it without a `core` cycle.
+pub fn encode_uri_component(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    encoded
+}
+
+/// Lenient percent-decode for display: malformed escapes are passed through
+/// and invalid UTF-8 is replaced (`from_utf8_lossy`).
+pub fn decode_uri_component(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' && index + 2 < bytes.len() {
+            if let Ok(hex) = std::str::from_utf8(&bytes[index + 1..index + 3]) {
+                if let Ok(byte) = u8::from_str_radix(hex, 16) {
+                    decoded.push(byte);
+                    index += 3;
+                    continue;
+                }
+            }
+        }
+        decoded.push(bytes[index]);
+        index += 1;
+    }
+    String::from_utf8_lossy(&decoded).to_string()
+}
+
+/// Strict counterpart for externally supplied selectors. Unlike the lenient
+/// display decoder, malformed percent escapes and invalid UTF-8 are rejected.
+pub fn decode_uri_component_strict(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'%' {
+            decoded.push(bytes[index]);
+            index += 1;
+            continue;
+        }
+        if index + 2 >= bytes.len() {
+            return None;
+        }
+        let hex = std::str::from_utf8(&bytes[index + 1..index + 3]).ok()?;
+        decoded.push(u8::from_str_radix(hex, 16).ok()?);
+        index += 3;
+    }
+    String::from_utf8(decoded).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -49,5 +113,25 @@ mod tests {
         assert!(is_metadata_only_ref("metadata-only:label"));
         assert!(!is_metadata_only_ref("runner-artifact://r/run/a"));
         assert!(!is_metadata_only_ref("/abs/path"));
+    }
+
+    #[test]
+    fn uri_component_round_trips_reserved_bytes() {
+        assert_eq!(encode_uri_component("runner/a"), "runner%2Fa");
+        assert_eq!(encode_uri_component("run b"), "run%20b");
+        assert_eq!(encode_uri_component("keep-._~"), "keep-._~");
+        assert_eq!(decode_uri_component("runner%2Fa"), "runner/a");
+        assert_eq!(decode_uri_component("run%20b"), "run b");
+    }
+
+    #[test]
+    fn strict_decode_rejects_malformed_escapes() {
+        assert_eq!(
+            decode_uri_component_strict("runner%2Fa").as_deref(),
+            Some("runner/a")
+        );
+        assert_eq!(decode_uri_component_strict("bad%"), None);
+        assert_eq!(decode_uri_component_strict("bad%2"), None);
+        assert_eq!(decode_uri_component_strict("bad%ZZ"), None);
     }
 }


### PR DESCRIPTION
## Summary
- Moves the three pure-`std` URI codec functions (`encode_uri_component`, `decode_uri_component`, `decode_uri_component_strict`) out of `core::execution_contract` and down into `homeboy-engine-primitives::artifact_ref_scheme`, right next to the `RUNNER_ARTIFACT_REF_SCHEME` / `METADATA_ONLY_REF_SCHEME` constants they operate on.
- Repoints `core::artifact_ref` to import the codecs from the primitives layer instead of from `execution_contract`.
- `execution_contract` re-exports the codecs so every existing call site — including cross-crate consumers `homeboy-agents` and `homeboy-lab-runner` (`execution_contract::encode_uri_component`, `execution_contract::decode_uri_component_strict`) — resolves unchanged.

## Why
There was a **mutual cycle inside `homeboy-core`**: `artifact_ref` imported the codecs *from* `execution_contract`, while `execution_contract` imported `ArtifactReference` + the schemes back *from* `artifact_ref`. These codecs are protocol-level primitives (the runner/Lab/daemon surface and `artifact_ref` must agree on the encoding), so the correct home is the slim shared base both can see — not either module reaching sideways into the other.

This is the foundational cycle-break that unblocks a later full `execution-contract` extraction (which additionally requires relocating `ArtifactReference` off its `observation` dependency). Part of the ongoing homeboy contracts/decomposition campaign.

## Verification (local, VPS-safe)
- `cargo test -p homeboy-engine-primitives artifact_ref_scheme` — 4 pass (added round-trip + strict-reject tests for the moved codecs)
- `cargo check -p homeboy-core --lib` — clean (0 errors; only pre-existing dead-code warnings)
- `cargo test -p homeboy-core --lib execution_contract` — 3 pass (incl. the round-trip classification test)
- `cargo check -p homeboy-agents --lib` / `-p homeboy-lab-runner --lib` — both clean
- `cargo fmt` — clean

Independent of PR #8980 (command-invocation contract) — no shared commits.