### PR TITLE
Fix v3 snapshot executable preservation

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/materializer.rs
+++ b/crates/homeboy-lab-runner/src/workspace/materializer.rs
@@ -137,7 +137,10 @@ impl WorkspaceMaterializationOperation {
                     .join(" ")
             ),
             Self::RecreateTempDir => "rm -rf \"$tmp\" && mkdir -p \"$tmp\"".to_string(),
-            Self::ExtractTarStdinToTemp => "tar -C \"$tmp\" -xf -".to_string(),
+            // v3 snapshot provenance binds the owner execute capability. Tar's
+            // default extraction applies the runner umask, which can erase that
+            // bit before the verifier sees the materialized tree.
+            Self::ExtractTarStdinToTemp => "tar -p -C \"$tmp\" -xf -".to_string(),
             Self::WriteStdinToBundle => {
                 "rm -rf \"$tmp\" \"$bundle\" && cat > \"$bundle\"".to_string()
             }

--- a/crates/homeboy-lab-runner/src/workspace/provenance.rs
+++ b/crates/homeboy-lab-runner/src/workspace/provenance.rs
@@ -633,9 +633,9 @@ fn content_manifest_difference(
         }
     }
     format!(
-        " entry diagnostics: {} differing logical entries in a bounded {}-entry sample (controller total {}, runner total {}): {};",
+        " entry diagnostics: {} differing logical entries in a bounded {}-entry difference sample (controller total {}, runner total {}): {};",
         differing.len(),
-        expected.entries.len().max(actual.entries.len()),
+        CONTENT_MANIFEST_DIFFERENCE_LIMIT,
         expected.entry_count,
         actual.entry_count,
         if differing.is_empty() { "sample metadata matched; content differs outside bounded metadata".to_string() } else { differing.join(", ") },
@@ -645,14 +645,24 @@ fn content_manifest_difference(
 fn content_manifest_entry_difference(
     expected: &WorkspaceContentManifestEntry,
     actual: &WorkspaceContentManifestEntry,
-) -> &'static str {
+) -> String {
+    let mut differences = Vec::new();
     if expected.kind != actual.kind {
-        "kind changed"
-    } else if expected.owner_executable != actual.owner_executable {
-        "owner-executable capability changed"
-    } else {
-        "metadata changed"
+        differences.push("kind changed");
     }
+    if expected.sha256 != actual.sha256 {
+        differences.push("content digest changed");
+    }
+    if expected.bytes != actual.bytes {
+        differences.push("byte count changed");
+    }
+    if expected.owner_executable != actual.owner_executable {
+        differences.push("owner-executable capability changed");
+    }
+    if differences.is_empty() {
+        differences.push("metadata changed");
+    }
+    differences.join(", ")
 }
 
 fn validate_content_manifest(
@@ -1055,9 +1065,9 @@ mod tests {
         )
         .expect_err("changed materialization must fail");
 
-        assert!(error.contains("entry diagnostics: 0 differing logical entries"));
-        assert!(error.contains("sample metadata matched; content differs outside bounded metadata"));
-        assert!(error.contains("bounded 16-entry sample"));
+        assert!(error.contains("entry diagnostics: 1 differing logical entries"));
+        assert!(error.contains("content digest changed"));
+        assert!(error.contains("bounded 8-entry difference sample"));
         assert!(!error.contains("controller secret"));
         assert!(!error.contains("runner mutation"));
     }

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -1239,6 +1239,92 @@ fn workspace_content_hash_owner_executable_policy_normalizes_non_owner_execute_b
 
 #[test]
 #[cfg(unix)]
+fn snapshot_materialization_preserves_v3_owner_executable_capability_across_runner_umask() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let controller = tempfile::tempdir().expect("macOS controller workspace");
+    let runner = tempfile::tempdir().expect("Linux runner workspace");
+    let controller_tool = controller.path().join("tool");
+    let runner_tool = runner.path().join("tool");
+    fs::write(&controller_tool, "#!/bin/sh\nexit 0\n").expect("controller tool");
+    fs::set_permissions(&controller_tool, fs::Permissions::from_mode(0o755))
+        .expect("controller executable permissions");
+
+    let install = snapshot_install_command(&runner.path().display().to_string())
+        .replacen("tar -p -C", "(umask 0111; tar -p -C", 1)
+        .replacen("-xf - &&", "-xf -) &&", 1);
+    let target = format!("sh -c {}", homeboy_core::engine::shell::quote_arg(&install));
+    super::super::util::run_shell_command(
+        &snapshot_archive_command(controller.path(), &target, &[]),
+        "materialize restrictive-umask snapshot",
+    )
+    .expect("snapshot materialization");
+
+    assert_eq!(
+        fs::metadata(&runner_tool)
+            .expect("runner tool metadata")
+            .permissions()
+            .mode()
+            & 0o100,
+        0o100,
+        "the runner umask must not erase the v3-bound owner execute capability"
+    );
+    assert_eq!(
+        workspace_content_hash_for_policy(
+            controller.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
+        )
+        .expect("controller hash"),
+        workspace_content_hash_for_policy(
+            runner.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
+        )
+        .expect("runner hash"),
+        "controller and runner must verify the same v3 canonical snapshot"
+    );
+
+    fs::set_permissions(&runner_tool, fs::Permissions::from_mode(0o644))
+        .expect("remove runner executable capability");
+    assert_ne!(
+        workspace_content_hash_for_policy(
+            controller.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
+        )
+        .expect("controller hash"),
+        workspace_content_hash_for_policy(
+            runner.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
+        )
+        .expect("runner executable-drift hash"),
+        "meaningful owner-executable drift must remain fail-closed"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn workspace_content_hash_rejects_dereferenced_symlink_target_drift() {
+    let controller = tempfile::tempdir().expect("controller workspace");
+    let dependency = tempfile::tempdir().expect("dependency workspace");
+    let target = dependency.path().join("tool");
+    fs::write(&target, "first target\n").expect("first target contents");
+    std::os::unix::fs::symlink(&target, controller.path().join("tool"))
+        .expect("controller symlink");
+
+    let expected = workspace_content_hash(controller.path(), &[]).expect("initial hash");
+    fs::write(&target, "changed target\n").expect("changed target contents");
+    assert_ne!(
+        workspace_content_hash(controller.path(), &[]).expect("changed hash"),
+        expected,
+        "the dereferenced symlink target content remains provenance-bound"
+    );
+}
+
+#[test]
+#[cfg(unix)]
 fn workspace_content_hash_versions_legacy_any_execute_separately_from_owner_execute() {
     use std::os::unix::fs::PermissionsExt;
 


### PR DESCRIPTION
## Summary

- preserve archived permission bits while extracting Lab workspace snapshots so the runner umask cannot erase v3 owner-executable provenance
- retain fail-closed content, symlink-target, and executable-capability verification
- report bounded per-entry digest, byte-count, kind, and executable differences when hashes diverge

Closes #8411.

## Root cause

The controller hashed the source tree before transport, but the Linux runner extracted the archive using its ambient umask. A restrictive umask could clear owner-executable bits before committed-harvest verification, producing a false cross-platform mismatch under `homeboy-workspace-content-v3+unix-owner-executable`.

## How to test

1. Run `cargo test -p homeboy-lab-runner snapshot_materialization_preserves_v3_owner_executable_capability_across_runner_umask`.
2. Run `cargo test -p homeboy-lab-runner workspace::tests::snapshot::`.
3. Run `cargo check -p homeboy-lab-runner`.
4. Run `cargo fmt --check`.

The focused regression, formatting, and cargo check pass. The broader snapshot filter passes 34/35 tests; `snapshot_sync_uses_unique_clean_workspace_for_same_snapshot` also fails unchanged on current `main`, so it is unrelated baseline evidence.

## Compatibility

No public API or extension contract changes. Snapshot extraction now preserves the archive permission bits that the existing v3 provenance contract already declares authoritative.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.6-sol via OpenCode
- **Used for:** Root-cause analysis, implementation, deterministic tests, and verification.