### PR TITLE
refactor: relocate artifact-ref types into homeboy-artifact-ref-contract (off observation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "homeboy-artifact-ref-contract"
+version = "0.1.0"
+dependencies = [
+ "homeboy-engine-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "homeboy-audit-contract"
 version = "0.1.0"
 dependencies = [
@@ -900,6 +909,7 @@ dependencies = [
  "glob-match",
  "heck",
  "homeboy-agents-contract",
+ "homeboy-artifact-ref-contract",
  "homeboy-audit-contract",
  "homeboy-cli-contract",
  "homeboy-code-audit",

--- a/crates/contracts/homeboy-artifact-ref-contract/Cargo.toml
+++ b/crates/contracts/homeboy-artifact-ref-contract/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "homeboy-artifact-ref-contract"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Chris Huber <chubes@extrachill.com>"]
+description = "Pure serializable artifact-reference contract types for homeboy"
+repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
+
+[lib]
+name = "homeboy_artifact_ref_contract"
+path = "src/lib.rs"
+
+[dependencies]
+homeboy-engine-primitives = { version = "0.1.0", path = "../../homeboy-engine-primitives" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/crates/contracts/homeboy-artifact-ref-contract/src/artifact_ref.rs
+++ b/crates/contracts/homeboy-artifact-ref-contract/src/artifact_ref.rs
@@ -1,0 +1,390 @@
+use std::fmt;
+use std::path::Path;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use homeboy_engine_primitives::artifact_ref_scheme::{decode_uri_component, encode_uri_component};
+
+pub const ARTIFACT_REF_SCHEMA: &str = "homeboy/artifact-ref/v1";
+pub const EVIDENCE_REF_SCHEMA: &str = "homeboy/evidence-ref/v1";
+// The artifact-ref URI schemes live in homeboy-engine-primitives (the slim
+// shared base) so the audit engine and CLI command contract can check them
+// without depending on this module. Re-exported here to preserve existing
+// crate::artifact_ref::{HOMEBOY_REF_SCHEME, ...} call sites.
+pub use homeboy_engine_primitives::artifact_ref_scheme::{
+    HOMEBOY_REF_SCHEME, METADATA_ONLY_REF_SCHEME, RUNNER_ARTIFACT_REF_SCHEME,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReviewerFacingArtifactRefError {
+    Empty,
+    LocalhostUrl,
+    FileUrl,
+    LocalAbsolutePath,
+    UnsupportedScheme,
+}
+
+impl fmt::Display for ReviewerFacingArtifactRefError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::Empty => "reviewer-facing artifact ref cannot be empty",
+            Self::LocalhostUrl => {
+                "reviewer-facing artifact ref cannot use localhost or loopback URLs"
+            }
+            Self::FileUrl => "reviewer-facing artifact ref cannot use file URLs",
+            Self::LocalAbsolutePath => {
+                "reviewer-facing artifact ref cannot use local absolute paths"
+            }
+            Self::UnsupportedScheme => {
+                "reviewer-facing artifact ref must be http(s), homeboy://, or runner-artifact://"
+            }
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for ReviewerFacingArtifactRefError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArtifactReference {
+    LocalPath(String),
+    RunnerArtifact {
+        value: String,
+        runner_id: String,
+        run_id: String,
+        artifact_id: String,
+    },
+    MetadataOnly(String),
+    PublishedUrl(String),
+}
+
+impl ArtifactReference {
+    pub fn parse(value: impl Into<String>) -> Self {
+        let value = value.into();
+        if let Some(rest) = value.strip_prefix(RUNNER_ARTIFACT_REF_SCHEME) {
+            let parts = rest.split('/').collect::<Vec<_>>();
+            if parts.len() == 3 {
+                let runner_id = decode_uri_component(parts[0]);
+                let run_id = decode_uri_component(parts[1]);
+                let artifact_id = decode_uri_component(parts[2]);
+                return Self::RunnerArtifact {
+                    value,
+                    runner_id,
+                    run_id,
+                    artifact_id,
+                };
+            }
+        }
+
+        if value.starts_with(METADATA_ONLY_REF_SCHEME) {
+            return Self::MetadataOnly(value);
+        }
+
+        if is_published_url(&value) {
+            return Self::PublishedUrl(value);
+        }
+
+        Self::LocalPath(value)
+    }
+
+    pub fn metadata_only(label: &str) -> Self {
+        Self::MetadataOnly(format!("{}{label}", METADATA_ONLY_REF_SCHEME))
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::LocalPath(value)
+            | Self::MetadataOnly(value)
+            | Self::PublishedUrl(value)
+            | Self::RunnerArtifact { value, .. } => value,
+        }
+    }
+}
+
+impl fmt::Display for ArtifactReference {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl Serialize for ArtifactReference {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ArtifactReference {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(Self::parse(value))
+    }
+}
+
+fn is_published_url(value: &str) -> bool {
+    value.starts_with("https://") || value.starts_with("http://")
+}
+
+pub fn validate_reviewer_facing_artifact_ref(
+    value: &str,
+) -> Result<(), ReviewerFacingArtifactRefError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(ReviewerFacingArtifactRefError::Empty);
+    }
+
+    let lower = value.to_ascii_lowercase();
+    if lower.starts_with("file://") {
+        return Err(ReviewerFacingArtifactRefError::FileUrl);
+    }
+
+    if Path::new(value).is_absolute() || is_windows_absolute_path(value) {
+        return Err(ReviewerFacingArtifactRefError::LocalAbsolutePath);
+    }
+
+    if lower.starts_with("http://") || lower.starts_with("https://") {
+        if is_localhost_http_url(value) {
+            return Err(ReviewerFacingArtifactRefError::LocalhostUrl);
+        }
+        return Ok(());
+    }
+
+    if value.starts_with(HOMEBOY_REF_SCHEME) || value.starts_with(RUNNER_ARTIFACT_REF_SCHEME) {
+        return Ok(());
+    }
+
+    Err(ReviewerFacingArtifactRefError::UnsupportedScheme)
+}
+
+fn is_localhost_http_url(value: &str) -> bool {
+    let Some(authority_and_path) = value.split_once("://").map(|(_, rest)| rest) else {
+        return false;
+    };
+    let authority = authority_and_path
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or_default();
+    let host = authority
+        .rsplit_once('@')
+        .map(|(_, host)| host)
+        .unwrap_or(authority)
+        .trim_matches(['[', ']'])
+        .split(':')
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    host == "localhost" || host == "::1" || host.starts_with("127.")
+}
+
+fn is_windows_absolute_path(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    value.starts_with("\\\\")
+        || matches!(
+            bytes,
+            [drive, b':', slash, ..]
+                if drive.is_ascii_alphabetic() && (*slash == b'\\' || *slash == b'/')
+        )
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactRef {
+    pub schema: String,
+    pub id: String,
+    pub run_id: String,
+    pub kind: String,
+    #[serde(rename = "type")]
+    pub artifact_type: String,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_key: Option<String>,
+}
+
+impl ArtifactRef {
+    pub fn canonical_uri(&self) -> String {
+        artifact_uri(&self.run_id, &self.id)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EvidenceRef {
+    pub schema: String,
+    pub kind: String,
+    pub target: String,
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact: Option<ArtifactRef>,
+}
+
+impl EvidenceRef {
+    pub fn new(
+        kind: impl Into<String>,
+        target: impl Into<String>,
+        label: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema: EVIDENCE_REF_SCHEMA.to_string(),
+            kind: kind.into(),
+            target: target.into(),
+            label: label.into(),
+            role: None,
+            semantic_key: None,
+            artifact: None,
+        }
+    }
+
+    pub fn canonical_uri(&self) -> &str {
+        &self.target
+    }
+}
+
+pub fn artifact_uri(run_id: &str, artifact_id: &str) -> String {
+    format!(
+        "{}run/{}/artifact/{}",
+        HOMEBOY_REF_SCHEME,
+        encode_uri_component(run_id),
+        encode_uri_component(artifact_id)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn artifact_reference_parses_and_serializes_existing_string_refs() {
+        let runner = ArtifactReference::parse("runner-artifact://runner%2Fa/run%20b/artifact%3Ac");
+        assert_eq!(
+            runner.to_string(),
+            "runner-artifact://runner%2Fa/run%20b/artifact%3Ac"
+        );
+        assert_eq!(
+            serde_json::to_value(&runner).expect("json"),
+            json!("runner-artifact://runner%2Fa/run%20b/artifact%3Ac")
+        );
+        match runner {
+            ArtifactReference::RunnerArtifact {
+                runner_id,
+                run_id,
+                artifact_id,
+                ..
+            } => {
+                assert_eq!(runner_id, "runner/a");
+                assert_eq!(run_id, "run b");
+                assert_eq!(artifact_id, "artifact:c");
+            }
+            other => panic!("unexpected artifact reference: {other:?}"),
+        }
+
+        assert_eq!(
+            ArtifactReference::metadata_only("trace.zip").to_string(),
+            "metadata-only:trace.zip"
+        );
+        assert_eq!(
+            ArtifactReference::parse("https://example.test/trace.zip"),
+            ArtifactReference::PublishedUrl("https://example.test/trace.zip".to_string())
+        );
+        assert_eq!(
+            ArtifactReference::parse("/tmp/trace.zip"),
+            ArtifactReference::LocalPath("/tmp/trace.zip".to_string())
+        );
+    }
+
+    #[test]
+    fn artifact_ref_serializes_stable_schema_and_type_field() {
+        let artifact = ArtifactRef {
+            schema: ARTIFACT_REF_SCHEMA.to_string(),
+            id: "artifact-1".to_string(),
+            run_id: "run-1".to_string(),
+            kind: "summary".to_string(),
+            artifact_type: "file".to_string(),
+            path: "summary.json".to_string(),
+            url: None,
+            public_url: Some("https://example.test/summary.json".to_string()),
+            role: Some("summary".to_string()),
+            semantic_key: Some("run.summary".to_string()),
+        };
+
+        assert_eq!(
+            serde_json::to_value(&artifact).expect("artifact ref json"),
+            json!({
+                "schema": "homeboy/artifact-ref/v1",
+                "id": "artifact-1",
+                "run_id": "run-1",
+                "kind": "summary",
+                "type": "file",
+                "path": "summary.json",
+                "public_url": "https://example.test/summary.json",
+                "role": "summary",
+                "semantic_key": "run.summary"
+            })
+        );
+    }
+
+    #[test]
+    fn reviewer_facing_artifact_ref_accepts_public_urls_and_declared_artifact_refs() {
+        for value in [
+            "https://artifacts.example.test/run/1/summary.json",
+            "http://artifacts.example.test/run/1/summary.json",
+            "homeboy://run/run%201/artifact/artifact%201",
+            "runner-artifact://runner-1/run-1/artifact-1",
+        ] {
+            validate_reviewer_facing_artifact_ref(value).expect(value);
+        }
+    }
+
+    #[test]
+    fn reviewer_facing_artifact_ref_rejects_local_refs() {
+        for (value, expected) in [
+            ("", ReviewerFacingArtifactRefError::Empty),
+            (
+                "http://localhost:8080/artifact.json",
+                ReviewerFacingArtifactRefError::LocalhostUrl,
+            ),
+            (
+                "https://127.0.0.1/artifact.json",
+                ReviewerFacingArtifactRefError::LocalhostUrl,
+            ),
+            (
+                "file:///tmp/artifact.json",
+                ReviewerFacingArtifactRefError::FileUrl,
+            ),
+            (
+                "/tmp/artifact.json",
+                ReviewerFacingArtifactRefError::LocalAbsolutePath,
+            ),
+            (
+                "C:\\tmp\\artifact.json",
+                ReviewerFacingArtifactRefError::LocalAbsolutePath,
+            ),
+            (
+                "artifact.json",
+                ReviewerFacingArtifactRefError::UnsupportedScheme,
+            ),
+        ] {
+            assert_eq!(
+                validate_reviewer_facing_artifact_ref(value),
+                Err(expected),
+                "{value}"
+            );
+        }
+    }
+
+}

--- a/crates/contracts/homeboy-artifact-ref-contract/src/lib.rs
+++ b/crates/contracts/homeboy-artifact-ref-contract/src/lib.rs
@@ -1,0 +1,19 @@
+//! Pure serializable artifact-reference contract types.
+//!
+//! `ArtifactReference`, `ArtifactRef`, `EvidenceRef`, and the reviewer-facing
+//! validation describe how artifacts and evidence are addressed and serialized
+//! across process boundaries. They depend only on serde and the
+//! `homeboy-engine-primitives` URI codec / scheme constants, which keeps this a
+//! leaf crate other crates can depend on without pulling in core.
+//!
+//! Conversions that couple these types to core's observation records
+//! (`ArtifactRecord` -> `ArtifactRef` / `EvidenceRef`) live in `homeboy-core` as
+//! free functions, so this crate stays observation-free.
+
+pub mod artifact_ref;
+
+pub use artifact_ref::{
+    artifact_uri, validate_reviewer_facing_artifact_ref, ArtifactRef, ArtifactReference,
+    EvidenceRef, ReviewerFacingArtifactRefError, ARTIFACT_REF_SCHEMA, EVIDENCE_REF_SCHEMA,
+    HOMEBOY_REF_SCHEME, METADATA_ONLY_REF_SCHEME, RUNNER_ARTIFACT_REF_SCHEME,
+};

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -20,6 +20,7 @@ test-support = []
 slow-tests = []
 
 [dependencies]
+homeboy-artifact-ref-contract = { version = "0.1.0", path = "../contracts/homeboy-artifact-ref-contract" }
 homeboy-cli-contract = { version = "0.1.0", path = "../contracts/homeboy-cli-contract" }
 homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
 homeboy-finding = { version = "0.1.0", path = "../homeboy-finding" }

--- a/crates/homeboy-core/src/artifact_ref.rs
+++ b/crates/homeboy-core/src/artifact_ref.rs
@@ -1,427 +1,63 @@
-use std::fmt;
-use std::path::Path;
-
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+//! Re-exports the pure artifact-reference contract types from
+//! `homeboy-artifact-ref-contract` and provides the conversions that couple them
+//! to core's observation records (`ArtifactRecord`), which cannot live in the
+//! leaf contract crate.
 
 use crate::observation::ArtifactRecord;
-use homeboy_engine_primitives::artifact_ref_scheme::{decode_uri_component, encode_uri_component};
 
-pub const ARTIFACT_REF_SCHEMA: &str = "homeboy/artifact-ref/v1";
-pub const EVIDENCE_REF_SCHEMA: &str = "homeboy/evidence-ref/v1";
-// The artifact-ref URI schemes live in homeboy-engine-primitives (the slim
-// shared base) so the audit engine and CLI command contract can check them
-// without depending on this module. Re-exported here to preserve existing
-// crate::artifact_ref::{HOMEBOY_REF_SCHEME, ...} call sites.
-pub use homeboy_engine_primitives::artifact_ref_scheme::{
+pub use homeboy_artifact_ref_contract::artifact_ref::{
+    artifact_uri, validate_reviewer_facing_artifact_ref, ArtifactRef, ArtifactReference,
+    EvidenceRef, ReviewerFacingArtifactRefError, ARTIFACT_REF_SCHEMA, EVIDENCE_REF_SCHEMA,
     HOMEBOY_REF_SCHEME, METADATA_ONLY_REF_SCHEME, RUNNER_ARTIFACT_REF_SCHEME,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ReviewerFacingArtifactRefError {
-    Empty,
-    LocalhostUrl,
-    FileUrl,
-    LocalAbsolutePath,
-    UnsupportedScheme,
-}
-
-impl fmt::Display for ReviewerFacingArtifactRefError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let message = match self {
-            Self::Empty => "reviewer-facing artifact ref cannot be empty",
-            Self::LocalhostUrl => {
-                "reviewer-facing artifact ref cannot use localhost or loopback URLs"
-            }
-            Self::FileUrl => "reviewer-facing artifact ref cannot use file URLs",
-            Self::LocalAbsolutePath => {
-                "reviewer-facing artifact ref cannot use local absolute paths"
-            }
-            Self::UnsupportedScheme => {
-                "reviewer-facing artifact ref must be http(s), homeboy://, or runner-artifact://"
-            }
-        };
-        formatter.write_str(message)
+/// Build an [`ArtifactRef`] from an observation [`ArtifactRecord`].
+///
+/// Lives in core (not the contract crate) because it couples the pure ref shape
+/// to core's observation record type.
+pub fn artifact_ref_from_record(artifact: &ArtifactRecord) -> ArtifactRef {
+    ArtifactRef {
+        schema: ARTIFACT_REF_SCHEMA.to_string(),
+        id: artifact.id.clone(),
+        run_id: artifact.run_id.clone(),
+        kind: artifact.kind.clone(),
+        artifact_type: artifact.artifact_type.clone(),
+        path: artifact.path.clone(),
+        url: artifact.url.clone(),
+        public_url: artifact.public_url.clone(),
+        role: None,
+        semantic_key: None,
     }
 }
 
-impl std::error::Error for ReviewerFacingArtifactRefError {}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ArtifactReference {
-    LocalPath(String),
-    RunnerArtifact {
-        value: String,
-        runner_id: String,
-        run_id: String,
-        artifact_id: String,
-    },
-    MetadataOnly(String),
-    PublishedUrl(String),
-}
-
-impl ArtifactReference {
-    pub fn parse(value: impl Into<String>) -> Self {
-        let value = value.into();
-        if let Some(rest) = value.strip_prefix(RUNNER_ARTIFACT_REF_SCHEME) {
-            let parts = rest.split('/').collect::<Vec<_>>();
-            if parts.len() == 3 {
-                let runner_id = decode_uri_component(parts[0]);
-                let run_id = decode_uri_component(parts[1]);
-                let artifact_id = decode_uri_component(parts[2]);
-                return Self::RunnerArtifact {
-                    value,
-                    runner_id,
-                    run_id,
-                    artifact_id,
-                };
-            }
-        }
-
-        if value.starts_with(METADATA_ONLY_REF_SCHEME) {
-            return Self::MetadataOnly(value);
-        }
-
-        if is_published_url(&value) {
-            return Self::PublishedUrl(value);
-        }
-
-        Self::LocalPath(value)
+/// Build an [`EvidenceRef`] pointing at an observation [`ArtifactRecord`].
+///
+/// Lives in core (not the contract crate) because it couples the pure evidence
+/// shape to core's observation record type.
+pub fn evidence_ref_for_artifact(
+    artifact: &ArtifactRecord,
+    label: impl Into<String>,
+    role: Option<String>,
+    semantic_key: Option<String>,
+) -> EvidenceRef {
+    let mut artifact_ref = artifact_ref_from_record(artifact);
+    artifact_ref.role = role.clone();
+    artifact_ref.semantic_key = semantic_key.clone();
+    EvidenceRef {
+        schema: EVIDENCE_REF_SCHEMA.to_string(),
+        kind: "artifact".to_string(),
+        target: artifact_ref.canonical_uri(),
+        label: label.into(),
+        role,
+        semantic_key,
+        artifact: Some(artifact_ref),
     }
-
-    pub fn metadata_only(label: &str) -> Self {
-        Self::MetadataOnly(format!("{}{label}", METADATA_ONLY_REF_SCHEME))
-    }
-
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::LocalPath(value)
-            | Self::MetadataOnly(value)
-            | Self::PublishedUrl(value)
-            | Self::RunnerArtifact { value, .. } => value,
-        }
-    }
-}
-
-impl fmt::Display for ArtifactReference {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(self.as_str())
-    }
-}
-
-impl Serialize for ArtifactReference {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(self.as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for ArtifactReference {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = String::deserialize(deserializer)?;
-        Ok(Self::parse(value))
-    }
-}
-
-fn is_published_url(value: &str) -> bool {
-    value.starts_with("https://") || value.starts_with("http://")
-}
-
-pub fn validate_reviewer_facing_artifact_ref(
-    value: &str,
-) -> Result<(), ReviewerFacingArtifactRefError> {
-    let value = value.trim();
-    if value.is_empty() {
-        return Err(ReviewerFacingArtifactRefError::Empty);
-    }
-
-    let lower = value.to_ascii_lowercase();
-    if lower.starts_with("file://") {
-        return Err(ReviewerFacingArtifactRefError::FileUrl);
-    }
-
-    if Path::new(value).is_absolute() || is_windows_absolute_path(value) {
-        return Err(ReviewerFacingArtifactRefError::LocalAbsolutePath);
-    }
-
-    if lower.starts_with("http://") || lower.starts_with("https://") {
-        if is_localhost_http_url(value) {
-            return Err(ReviewerFacingArtifactRefError::LocalhostUrl);
-        }
-        return Ok(());
-    }
-
-    if value.starts_with(HOMEBOY_REF_SCHEME) || value.starts_with(RUNNER_ARTIFACT_REF_SCHEME) {
-        return Ok(());
-    }
-
-    Err(ReviewerFacingArtifactRefError::UnsupportedScheme)
-}
-
-fn is_localhost_http_url(value: &str) -> bool {
-    let Some(authority_and_path) = value.split_once("://").map(|(_, rest)| rest) else {
-        return false;
-    };
-    let authority = authority_and_path
-        .split(['/', '?', '#'])
-        .next()
-        .unwrap_or_default();
-    let host = authority
-        .rsplit_once('@')
-        .map(|(_, host)| host)
-        .unwrap_or(authority)
-        .trim_matches(['[', ']'])
-        .split(':')
-        .next()
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-
-    host == "localhost" || host == "::1" || host.starts_with("127.")
-}
-
-fn is_windows_absolute_path(value: &str) -> bool {
-    let bytes = value.as_bytes();
-    value.starts_with("\\\\")
-        || matches!(
-            bytes,
-            [drive, b':', slash, ..]
-                if drive.is_ascii_alphabetic() && (*slash == b'\\' || *slash == b'/')
-        )
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ArtifactRef {
-    pub schema: String,
-    pub id: String,
-    pub run_id: String,
-    pub kind: String,
-    #[serde(rename = "type")]
-    pub artifact_type: String,
-    pub path: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub public_url: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub role: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub semantic_key: Option<String>,
-}
-
-impl ArtifactRef {
-    pub fn from_record(artifact: &ArtifactRecord) -> Self {
-        Self {
-            schema: ARTIFACT_REF_SCHEMA.to_string(),
-            id: artifact.id.clone(),
-            run_id: artifact.run_id.clone(),
-            kind: artifact.kind.clone(),
-            artifact_type: artifact.artifact_type.clone(),
-            path: artifact.path.clone(),
-            url: artifact.url.clone(),
-            public_url: artifact.public_url.clone(),
-            role: None,
-            semantic_key: None,
-        }
-    }
-
-    pub fn canonical_uri(&self) -> String {
-        artifact_uri(&self.run_id, &self.id)
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct EvidenceRef {
-    pub schema: String,
-    pub kind: String,
-    pub target: String,
-    pub label: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub role: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub semantic_key: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub artifact: Option<ArtifactRef>,
-}
-
-impl EvidenceRef {
-    pub fn new(
-        kind: impl Into<String>,
-        target: impl Into<String>,
-        label: impl Into<String>,
-    ) -> Self {
-        Self {
-            schema: EVIDENCE_REF_SCHEMA.to_string(),
-            kind: kind.into(),
-            target: target.into(),
-            label: label.into(),
-            role: None,
-            semantic_key: None,
-            artifact: None,
-        }
-    }
-
-    pub fn for_artifact(
-        artifact: &ArtifactRecord,
-        label: impl Into<String>,
-        role: Option<String>,
-        semantic_key: Option<String>,
-    ) -> Self {
-        let mut artifact_ref = ArtifactRef::from_record(artifact);
-        artifact_ref.role = role.clone();
-        artifact_ref.semantic_key = semantic_key.clone();
-        Self {
-            schema: EVIDENCE_REF_SCHEMA.to_string(),
-            kind: "artifact".to_string(),
-            target: artifact_ref.canonical_uri(),
-            label: label.into(),
-            role,
-            semantic_key,
-            artifact: Some(artifact_ref),
-        }
-    }
-
-    pub fn canonical_uri(&self) -> &str {
-        &self.target
-    }
-}
-
-pub fn artifact_uri(run_id: &str, artifact_id: &str) -> String {
-    format!(
-        "{}run/{}/artifact/{}",
-        HOMEBOY_REF_SCHEME,
-        encode_uri_component(run_id),
-        encode_uri_component(artifact_id)
-    )
 }
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
-
     use super::*;
-
-    #[test]
-    fn artifact_reference_parses_and_serializes_existing_string_refs() {
-        let runner = ArtifactReference::parse("runner-artifact://runner%2Fa/run%20b/artifact%3Ac");
-        assert_eq!(
-            runner.to_string(),
-            "runner-artifact://runner%2Fa/run%20b/artifact%3Ac"
-        );
-        assert_eq!(
-            serde_json::to_value(&runner).expect("json"),
-            json!("runner-artifact://runner%2Fa/run%20b/artifact%3Ac")
-        );
-        match runner {
-            ArtifactReference::RunnerArtifact {
-                runner_id,
-                run_id,
-                artifact_id,
-                ..
-            } => {
-                assert_eq!(runner_id, "runner/a");
-                assert_eq!(run_id, "run b");
-                assert_eq!(artifact_id, "artifact:c");
-            }
-            other => panic!("unexpected artifact reference: {other:?}"),
-        }
-
-        assert_eq!(
-            ArtifactReference::metadata_only("trace.zip").to_string(),
-            "metadata-only:trace.zip"
-        );
-        assert_eq!(
-            ArtifactReference::parse("https://example.test/trace.zip"),
-            ArtifactReference::PublishedUrl("https://example.test/trace.zip".to_string())
-        );
-        assert_eq!(
-            ArtifactReference::parse("/tmp/trace.zip"),
-            ArtifactReference::LocalPath("/tmp/trace.zip".to_string())
-        );
-    }
-
-    #[test]
-    fn artifact_ref_serializes_stable_schema_and_type_field() {
-        let artifact = ArtifactRef {
-            schema: ARTIFACT_REF_SCHEMA.to_string(),
-            id: "artifact-1".to_string(),
-            run_id: "run-1".to_string(),
-            kind: "summary".to_string(),
-            artifact_type: "file".to_string(),
-            path: "summary.json".to_string(),
-            url: None,
-            public_url: Some("https://example.test/summary.json".to_string()),
-            role: Some("summary".to_string()),
-            semantic_key: Some("run.summary".to_string()),
-        };
-
-        assert_eq!(
-            serde_json::to_value(&artifact).expect("artifact ref json"),
-            json!({
-                "schema": "homeboy/artifact-ref/v1",
-                "id": "artifact-1",
-                "run_id": "run-1",
-                "kind": "summary",
-                "type": "file",
-                "path": "summary.json",
-                "public_url": "https://example.test/summary.json",
-                "role": "summary",
-                "semantic_key": "run.summary"
-            })
-        );
-    }
-
-    #[test]
-    fn reviewer_facing_artifact_ref_accepts_public_urls_and_declared_artifact_refs() {
-        for value in [
-            "https://artifacts.example.test/run/1/summary.json",
-            "http://artifacts.example.test/run/1/summary.json",
-            "homeboy://run/run%201/artifact/artifact%201",
-            "runner-artifact://runner-1/run-1/artifact-1",
-        ] {
-            validate_reviewer_facing_artifact_ref(value).expect(value);
-        }
-    }
-
-    #[test]
-    fn reviewer_facing_artifact_ref_rejects_local_refs() {
-        for (value, expected) in [
-            ("", ReviewerFacingArtifactRefError::Empty),
-            (
-                "http://localhost:8080/artifact.json",
-                ReviewerFacingArtifactRefError::LocalhostUrl,
-            ),
-            (
-                "https://127.0.0.1/artifact.json",
-                ReviewerFacingArtifactRefError::LocalhostUrl,
-            ),
-            (
-                "file:///tmp/artifact.json",
-                ReviewerFacingArtifactRefError::FileUrl,
-            ),
-            (
-                "/tmp/artifact.json",
-                ReviewerFacingArtifactRefError::LocalAbsolutePath,
-            ),
-            (
-                "C:\\tmp\\artifact.json",
-                ReviewerFacingArtifactRefError::LocalAbsolutePath,
-            ),
-            (
-                "artifact.json",
-                ReviewerFacingArtifactRefError::UnsupportedScheme,
-            ),
-        ] {
-            assert_eq!(
-                validate_reviewer_facing_artifact_ref(value),
-                Err(expected),
-                "{value}"
-            );
-        }
-    }
+    use serde_json::json;
 
     #[test]
     fn evidence_ref_builds_generic_homeboy_artifact_uri() {
@@ -442,7 +78,7 @@ mod tests {
             created_at: "2026-06-27T00:00:00Z".to_string(),
         };
 
-        let reference = EvidenceRef::for_artifact(
+        let reference = evidence_ref_for_artifact(
             &artifact,
             "Fuzz result envelope",
             Some("result".to_string()),

--- a/crates/homeboy-core/src/observation/evidence_report.rs
+++ b/crates/homeboy-core/src/observation/evidence_report.rs
@@ -24,7 +24,7 @@ use serde_json::Value;
 use super::{run_owner_pid, running_status_note, ArtifactRecord, RunRecord};
 use crate::artifact_address::{ArtifactAddress, ArtifactAddressKind};
 use crate::artifact_preview::{html_preview_entrypoints, ArtifactPreviewEntrypoint};
-use crate::artifact_ref::{ArtifactRef, EvidenceRef};
+use crate::artifact_ref::{artifact_ref_from_record, ArtifactRef, EvidenceRef};
 use crate::artifacts::{generic_matrix_summary_from_artifacts, GenericMatrixSummary};
 use crate::evidence_manifest::{EvidenceManifest, TrackerRef, EVIDENCE_MANIFEST_SCHEMA};
 use crate::observation::disk_budget::DiskBudget;
@@ -544,7 +544,7 @@ fn public_base_configured() -> bool {
 }
 
 fn artifact_ref(artifact: &ArtifactRecord, address: &ArtifactAddress) -> ArtifactRef {
-    let mut reference = ArtifactRef::from_record(artifact);
+    let mut reference = artifact_ref_from_record(artifact);
     reference.path = address.value.clone();
     reference.url = public_url_from_address(address);
     reference.public_url = reference.url.clone();

--- a/crates/homeboy-fuzz/src/result_envelope_persistence.rs
+++ b/crates/homeboy-fuzz/src/result_envelope_persistence.rs
@@ -10,7 +10,7 @@
 use std::path::Path;
 
 use crate::FuzzResultEnvelope;
-use homeboy_core::artifact_ref::EvidenceRef;
+use homeboy_core::artifact_ref::{evidence_ref_for_artifact, EvidenceRef};
 use homeboy_core::observation::{ArtifactRecord, ObservationStore};
 
 /// Observation-store artifact kind for a persisted fuzz result envelope.
@@ -119,7 +119,7 @@ fn record_fuzz_result_envelope_artifact(
 
 /// Build the evidence reference for a persisted fuzz result-envelope artifact.
 pub fn fuzz_result_envelope_evidence_ref(artifact: &ArtifactRecord) -> EvidenceRef {
-    EvidenceRef::for_artifact(
+    evidence_ref_for_artifact(
         artifact,
         "Fuzz result envelope",
         Some("result".to_string()),


### PR DESCRIPTION
## Summary
- Splits `core::artifact_ref` into a **pure leaf contract crate** + core-side conversions.
- The pure serde types — `ArtifactReference` (enum), `ArtifactRef`, `EvidenceRef`, `ReviewerFacingArtifactRefError`, `validate_reviewer_facing_artifact_ref`, `artifact_uri`, and the schema/`*_SCHEME` re-exports — move down into new crate **`homeboy-artifact-ref-contract`** (deps: `serde` + `homeboy-engine-primitives` codecs only).
- The **only** thing that coupled `artifact_ref` to core was two conversion methods taking `&observation::ArtifactRecord`. Those become free functions in core: `artifact_ref_from_record` and `evidence_ref_for_artifact` — mirroring the existing `artifact_contract` pattern (observation-coupled conversions stay in core).
- `homeboy-core` re-exports the contract as `artifact_ref`, so every existing path (`core::artifact_ref::*`, CLI, fuzz) resolves unchanged. The 2 conversion call sites (core `evidence_report`, `homeboy-fuzz`) repoint to the free functions.

## Why
This is the real-engineering prerequisite the campaign was blocked on: `ArtifactReference` had to come **off its `observation` dependency** before `execution_contract` (which builds on `ArtifactReference::parse`) can be fully extracted. `artifact_ref` was otherwise entirely pure — the observation edge was isolated to 2 conversion methods with exactly 2 callers.

## Verification (local, VPS-safe)
- `cargo test -p homeboy-artifact-ref-contract` — 4 pass (parse/serialize, schema, reviewer-facing accept/reject)
- `cargo check -p homeboy-core --lib` — clean (0 errors)
- `cargo test -p homeboy-core --lib artifact_ref` — 4 pass (incl. the moved `evidence_ref_for_artifact` conversion test)
- `cargo check -p homeboy-cli --lib` — clean (verifies the re-export path + registry `rust_type` string still resolve)
- `cargo test -p homeboy-fuzz --lib` — pass (the other conversion caller)
- `cargo fmt` — clean

Independent of PRs #8980 / #8994 / #8995. Note: the pure module was written fresh rather than `git mv`'d because the file was **split** (pure types down, conversions up), so it shows as add+shrink rather than a rename.

## Follow-up (unblocked by this)
Full `execution_contract` extraction — `ArtifactReference` is now leaf, so `execution_contract`'s `ArtifactReference::parse` normalization no longer forces an observation dependency. That's the next PR.