### PR TITLE
refactor: extract execution-contract types into homeboy-execution-contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,7 @@ dependencies = [
  "homeboy-code-audit",
  "homeboy-engine-primitives",
  "homeboy-error",
+ "homeboy-execution-contract",
  "homeboy-extension",
  "homeboy-extension-contract",
  "homeboy-finding",
@@ -972,6 +973,15 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "homeboy-execution-contract"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "homeboy-artifact-ref-contract",
+ "homeboy-engine-primitives",
 ]
 
 [[package]]

--- a/crates/contracts/homeboy-execution-contract/Cargo.toml
+++ b/crates/contracts/homeboy-execution-contract/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "homeboy-execution-contract"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Chris Huber <chubes@extrachill.com>"]
+description = "Typed runtime-facing execution surface contract for homeboy (artifact URI / apply / lab-offload)"
+repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
+
+[lib]
+name = "homeboy_execution_contract"
+path = "src/lib.rs"
+
+[dependencies]
+homeboy-artifact-ref-contract = { version = "0.1.0", path = "../homeboy-artifact-ref-contract" }
+homeboy-engine-primitives = { version = "0.1.0", path = "../../homeboy-engine-primitives" }
+base64 = "0.22"

--- a/crates/contracts/homeboy-execution-contract/src/execution_contract.rs
+++ b/crates/contracts/homeboy-execution-contract/src/execution_contract.rs
@@ -1,0 +1,161 @@
+use homeboy_artifact_ref_contract::artifact_ref::{
+    ArtifactReference, METADATA_ONLY_REF_SCHEME, RUNNER_ARTIFACT_REF_SCHEME,
+};
+
+// The URI codec primitives live in `homeboy-engine-primitives` (the slim shared
+// base) alongside the artifact-ref schemes. Re-exported here to preserve
+// existing `execution_contract::{encode_uri_component, decode_uri_component,
+// ...}` call sites, including cross-crate consumers.
+pub use homeboy_engine_primitives::artifact_ref_scheme::{
+    decode_uri_component, decode_uri_component_strict, encode_uri_component,
+};
+
+/// Typed runtime-facing execution surface shared by runner, Lab, daemon, and
+/// extension code paths.
+///
+/// `HomeboyPlan` describes workflow steps. `ExecutionContract` describes the
+/// concrete runtime values those steps exchange across process boundaries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExecutionContract {
+    pub artifacts: ArtifactUriContract,
+    pub lab_offload: LabOffloadExecutionContract,
+    pub apply: ApplyChangeContract,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArtifactUriContract {
+    pub runner_artifact_scheme: &'static str,
+    pub metadata_only_scheme: &'static str,
+}
+
+impl ArtifactUriContract {
+    pub fn is_runner_artifact_ref(self, path: &str) -> bool {
+        path.starts_with(self.runner_artifact_scheme)
+    }
+
+    pub fn is_metadata_only_ref(self, path: &str) -> bool {
+        path.starts_with(self.metadata_only_scheme)
+    }
+
+    pub fn strip_runner_artifact_scheme(self, path: &str) -> Option<&str> {
+        path.strip_prefix(self.runner_artifact_scheme)
+    }
+
+    pub fn runner_artifact_ref(self, runner_id: &str, run_id: &str, artifact_id: &str) -> String {
+        ArtifactReference::parse(format!(
+            "{}{}/{}/{}",
+            self.runner_artifact_scheme,
+            encode_uri_component(runner_id),
+            encode_uri_component(run_id),
+            encode_uri_component(artifact_id)
+        ))
+        .to_string()
+    }
+
+    pub fn metadata_only_ref(self, label: &str) -> String {
+        ArtifactReference::parse(format!("{}{label}", self.metadata_only_scheme)).to_string()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LabOffloadExecutionContract {
+    pub metadata_schema: &'static str,
+}
+
+/// Canonical apply/change wire contract shared by Lab, runners, and adapters.
+///
+/// `core::change_artifact` owns this schema's serializable payload structs.
+/// `core::execution` owns higher-level lifecycle envelopes that may reference
+/// these artifacts when describing execute/artifact/approve/apply/publish flows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ApplyChangeContract {
+    pub change_artifact_schema: &'static str,
+    pub change_apply_result_schema: &'static str,
+    pub runner_workspace_apply_adapter: &'static str,
+    pub unified_diff_patch_format: &'static str,
+    pub digest_algorithm_sha256: &'static str,
+}
+
+pub const EXECUTION_CONTRACT: ExecutionContract = ExecutionContract {
+    artifacts: ArtifactUriContract {
+        runner_artifact_scheme: RUNNER_ARTIFACT_REF_SCHEME,
+        metadata_only_scheme: METADATA_ONLY_REF_SCHEME,
+    },
+    lab_offload: LabOffloadExecutionContract {
+        metadata_schema: "homeboy/lab-offload/v1",
+    },
+    apply: ApplyChangeContract {
+        change_artifact_schema: "homeboy/change-artifact/v1",
+        change_apply_result_schema: "homeboy/change-apply-result/v1",
+        runner_workspace_apply_adapter: "homeboy/runner-workspace-apply/v1",
+        unified_diff_patch_format: "unified_diff",
+        digest_algorithm_sha256: "sha256",
+    },
+};
+
+/// Whether an artifact path is a remote-runner artifact reference, per the
+/// execution contract's artifact rules. Lives here (not in the runner module)
+/// so core code can classify artifact paths without a core -> runner edge — the
+/// classification is a contract concern, not runner behavior.
+pub fn is_remote_runner_artifact_path(path: &str) -> bool {
+    EXECUTION_CONTRACT.artifacts.is_runner_artifact_ref(path)
+}
+
+/// A runner-artifact token addressing an artifact-store locator. Contract-driven
+/// token construction (base64 URL-safe locator), not runner behavior, so it
+/// lives alongside the artifact URI contract.
+pub fn runner_artifact_store_token(runner_id: &str, run_id: &str, locator: &str) -> String {
+    use base64::Engine;
+    let encoded_locator = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(locator);
+    EXECUTION_CONTRACT.artifacts.runner_artifact_ref(
+        runner_id,
+        run_id,
+        &format!("artifact-store:{encoded_locator}"),
+    )
+}
+
+/// The artifact-store locator encoded in a runner artifact id, if present.
+pub fn artifact_store_locator_from_runner_artifact_id(artifact_id: &str) -> Option<String> {
+    use base64::Engine;
+    let encoded_locator = artifact_id.strip_prefix("artifact-store:")?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(encoded_locator)
+        .ok()?;
+    String::from_utf8(bytes).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn artifact_contract_builds_and_classifies_runtime_refs() {
+        let artifacts = EXECUTION_CONTRACT.artifacts;
+        let token = artifacts.runner_artifact_ref("runner/a", "run b", "artifact:c");
+        assert_eq!(token, "runner-artifact://runner%2Fa/run%20b/artifact%3Ac");
+        assert!(artifacts.is_runner_artifact_ref(&token));
+        assert!(artifacts.is_metadata_only_ref("metadata-only:trace.zip"));
+        assert_eq!(
+            artifacts.metadata_only_ref("trace.zip"),
+            "metadata-only:trace.zip"
+        );
+        assert_eq!(decode_uri_component("runner%2Fa"), "runner/a");
+    }
+
+    #[test]
+    fn apply_contract_names_canonical_wire_schemas() {
+        let apply = EXECUTION_CONTRACT.apply;
+
+        assert_eq!(apply.change_artifact_schema, "homeboy/change-artifact/v1");
+        assert_eq!(
+            apply.change_apply_result_schema,
+            "homeboy/change-apply-result/v1"
+        );
+        assert_eq!(
+            apply.runner_workspace_apply_adapter,
+            "homeboy/runner-workspace-apply/v1"
+        );
+        assert_eq!(apply.unified_diff_patch_format, "unified_diff");
+        assert_eq!(apply.digest_algorithm_sha256, "sha256");
+    }
+}

--- a/crates/contracts/homeboy-execution-contract/src/lib.rs
+++ b/crates/contracts/homeboy-execution-contract/src/lib.rs
@@ -1,0 +1,22 @@
+//! Typed runtime-facing execution surface contract.
+//!
+//! `ExecutionContract` and its component contracts (`ArtifactUriContract`,
+//! `LabOffloadExecutionContract`, `ApplyChangeContract`) describe the concrete
+//! runtime values that workflow steps exchange across process boundaries —
+//! artifact URI schemes, apply/change wire schemas, and lab-offload metadata.
+//! Plus the pure classification/token helpers built on those schemes.
+//!
+//! These depend only on the artifact-ref contract, the engine-primitives URI
+//! codecs, and base64 — no core engine — so this is a leaf crate consumers can
+//! depend on directly. The one path-touching classifier
+//! (`is_reportable_artifact_evidence_path`, which does `std::fs::metadata`)
+//! stays in `homeboy-core` as a free function.
+
+pub mod execution_contract;
+
+pub use execution_contract::{
+    artifact_store_locator_from_runner_artifact_id, decode_uri_component,
+    decode_uri_component_strict, encode_uri_component, is_remote_runner_artifact_path,
+    runner_artifact_store_token, ApplyChangeContract, ArtifactUriContract, ExecutionContract,
+    LabOffloadExecutionContract, EXECUTION_CONTRACT,
+};

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -22,6 +22,7 @@ slow-tests = []
 [dependencies]
 homeboy-artifact-ref-contract = { version = "0.1.0", path = "../contracts/homeboy-artifact-ref-contract" }
 homeboy-cli-contract = { version = "0.1.0", path = "../contracts/homeboy-cli-contract" }
+homeboy-execution-contract = { version = "0.1.0", path = "../contracts/homeboy-execution-contract" }
 homeboy-run-lifecycle-contract = { version = "0.1.0", path = "../contracts/homeboy-run-lifecycle-contract" }
 homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
 homeboy-finding = { version = "0.1.0", path = "../homeboy-finding" }

--- a/crates/homeboy-core/src/execution_contract.rs
+++ b/crates/homeboy-core/src/execution_contract.rs
@@ -1,112 +1,19 @@
-use crate::artifact_ref::{
-    ArtifactReference, METADATA_ONLY_REF_SCHEME, RUNNER_ARTIFACT_REF_SCHEME,
+//! Re-exports the typed execution-surface contract from
+//! `homeboy-execution-contract` and provides the one path-touching classifier
+//! that must reach the filesystem (`std::fs::metadata`), which cannot live in
+//! the leaf contract crate.
+
+pub use homeboy_execution_contract::execution_contract::{
+    artifact_store_locator_from_runner_artifact_id, decode_uri_component,
+    decode_uri_component_strict, encode_uri_component, is_remote_runner_artifact_path,
+    runner_artifact_store_token, ApplyChangeContract, ArtifactUriContract, ExecutionContract,
+    LabOffloadExecutionContract, EXECUTION_CONTRACT,
 };
-
-// The URI codec primitives live in `homeboy-engine-primitives` (the slim shared
-// base) alongside the artifact-ref schemes, so `core::artifact_ref` and this
-// module can both use them without a mutual `execution_contract <-> artifact_ref`
-// cycle. Re-exported here to preserve existing
-// `execution_contract::{encode_uri_component, decode_uri_component, ...}` call
-// sites, including cross-crate consumers.
-pub use homeboy_engine_primitives::artifact_ref_scheme::{
-    decode_uri_component, decode_uri_component_strict, encode_uri_component,
-};
-
-/// Typed runtime-facing execution surface shared by runner, Lab, daemon, and
-/// extension code paths.
-///
-/// `HomeboyPlan` describes workflow steps. `ExecutionContract` describes the
-/// concrete runtime values those steps exchange across process boundaries.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ExecutionContract {
-    pub artifacts: ArtifactUriContract,
-    pub lab_offload: LabOffloadExecutionContract,
-    pub apply: ApplyChangeContract,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ArtifactUriContract {
-    pub runner_artifact_scheme: &'static str,
-    pub metadata_only_scheme: &'static str,
-}
-
-impl ArtifactUriContract {
-    pub fn is_runner_artifact_ref(self, path: &str) -> bool {
-        path.starts_with(self.runner_artifact_scheme)
-    }
-
-    pub fn is_metadata_only_ref(self, path: &str) -> bool {
-        path.starts_with(self.metadata_only_scheme)
-    }
-
-    pub fn strip_runner_artifact_scheme(self, path: &str) -> Option<&str> {
-        path.strip_prefix(self.runner_artifact_scheme)
-    }
-
-    pub fn runner_artifact_ref(self, runner_id: &str, run_id: &str, artifact_id: &str) -> String {
-        ArtifactReference::parse(format!(
-            "{}{}/{}/{}",
-            self.runner_artifact_scheme,
-            encode_uri_component(runner_id),
-            encode_uri_component(run_id),
-            encode_uri_component(artifact_id)
-        ))
-        .to_string()
-    }
-
-    pub fn metadata_only_ref(self, label: &str) -> String {
-        ArtifactReference::parse(format!("{}{label}", self.metadata_only_scheme)).to_string()
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct LabOffloadExecutionContract {
-    pub metadata_schema: &'static str,
-}
-
-/// Canonical apply/change wire contract shared by Lab, runners, and adapters.
-///
-/// `core::change_artifact` owns this schema's serializable payload structs.
-/// `core::execution` owns higher-level lifecycle envelopes that may reference
-/// these artifacts when describing execute/artifact/approve/apply/publish flows.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ApplyChangeContract {
-    pub change_artifact_schema: &'static str,
-    pub change_apply_result_schema: &'static str,
-    pub runner_workspace_apply_adapter: &'static str,
-    pub unified_diff_patch_format: &'static str,
-    pub digest_algorithm_sha256: &'static str,
-}
-
-pub const EXECUTION_CONTRACT: ExecutionContract = ExecutionContract {
-    artifacts: ArtifactUriContract {
-        runner_artifact_scheme: RUNNER_ARTIFACT_REF_SCHEME,
-        metadata_only_scheme: METADATA_ONLY_REF_SCHEME,
-    },
-    lab_offload: LabOffloadExecutionContract {
-        metadata_schema: "homeboy/lab-offload/v1",
-    },
-    apply: ApplyChangeContract {
-        change_artifact_schema: "homeboy/change-artifact/v1",
-        change_apply_result_schema: "homeboy/change-apply-result/v1",
-        runner_workspace_apply_adapter: "homeboy/runner-workspace-apply/v1",
-        unified_diff_patch_format: "unified_diff",
-        digest_algorithm_sha256: "sha256",
-    },
-};
-
-/// Whether an artifact path is a remote-runner artifact reference, per the
-/// execution contract's artifact rules. Lives here (not in the runner module)
-/// so core code can classify artifact paths without a core -> runner edge — the
-/// classification is a contract concern, not runner behavior.
-pub fn is_remote_runner_artifact_path(path: &str) -> bool {
-    EXECUTION_CONTRACT.artifacts.is_runner_artifact_ref(path)
-}
 
 /// Whether an artifact path is worth reporting as retrievable evidence: a
 /// retrievable runner-artifact token, a metadata-only ref, a relative path, or
-/// a real local file/dir. Contract-driven classification (not runner behavior),
-/// so it lives in core.
+/// a real local file/dir. Lives in core (not the leaf contract crate) because
+/// the final branch probes the filesystem with `std::fs::metadata`.
 pub fn is_reportable_artifact_evidence_path(path: &str) -> bool {
     EXECUTION_CONTRACT
         .artifacts
@@ -123,63 +30,4 @@ pub fn is_reportable_artifact_evidence_path(path: &str) -> bool {
 pub fn reportable_artifact_evidence_path(path: Option<&String>) -> Option<String> {
     path.filter(|path| is_reportable_artifact_evidence_path(path))
         .cloned()
-}
-
-/// A runner-artifact token addressing an artifact-store locator. Contract-driven
-/// token construction (base64 URL-safe locator), not runner behavior, so it
-/// lives in core alongside the artifact URI contract.
-pub fn runner_artifact_store_token(runner_id: &str, run_id: &str, locator: &str) -> String {
-    use base64::Engine;
-    let encoded_locator = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(locator);
-    EXECUTION_CONTRACT.artifacts.runner_artifact_ref(
-        runner_id,
-        run_id,
-        &format!("artifact-store:{encoded_locator}"),
-    )
-}
-
-/// The artifact-store locator encoded in a runner artifact id, if present.
-pub fn artifact_store_locator_from_runner_artifact_id(artifact_id: &str) -> Option<String> {
-    use base64::Engine;
-    let encoded_locator = artifact_id.strip_prefix("artifact-store:")?;
-    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .decode(encoded_locator)
-        .ok()?;
-    String::from_utf8(bytes).ok()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn artifact_contract_builds_and_classifies_runtime_refs() {
-        let artifacts = EXECUTION_CONTRACT.artifacts;
-        let token = artifacts.runner_artifact_ref("runner/a", "run b", "artifact:c");
-        assert_eq!(token, "runner-artifact://runner%2Fa/run%20b/artifact%3Ac");
-        assert!(artifacts.is_runner_artifact_ref(&token));
-        assert!(artifacts.is_metadata_only_ref("metadata-only:trace.zip"));
-        assert_eq!(
-            artifacts.metadata_only_ref("trace.zip"),
-            "metadata-only:trace.zip"
-        );
-        assert_eq!(decode_uri_component("runner%2Fa"), "runner/a");
-    }
-
-    #[test]
-    fn apply_contract_names_canonical_wire_schemas() {
-        let apply = EXECUTION_CONTRACT.apply;
-
-        assert_eq!(apply.change_artifact_schema, "homeboy/change-artifact/v1");
-        assert_eq!(
-            apply.change_apply_result_schema,
-            "homeboy/change-apply-result/v1"
-        );
-        assert_eq!(
-            apply.runner_workspace_apply_adapter,
-            "homeboy/runner-workspace-apply/v1"
-        );
-        assert_eq!(apply.unified_diff_patch_format, "unified_diff");
-        assert_eq!(apply.digest_algorithm_sha256, "sha256");
-    }
 }


### PR DESCRIPTION
## Summary
- Extracts the typed runtime execution surface out of `homeboy-core` into a new leaf crate **`homeboy-execution-contract`**: `ExecutionContract`, `ArtifactUriContract`, `LabOffloadExecutionContract`, `ApplyChangeContract`, the `EXECUTION_CONTRACT` const, the pure `is_remote_runner_artifact_path` classifier, and the base64 token helpers (`runner_artifact_store_token`, `artifact_store_locator_from_runner_artifact_id`).
- The **only** thing that forced this to stay in core was `is_reportable_artifact_evidence_path`, whose final branch probes the filesystem (`std::fs::metadata`). That function and its wrapper `reportable_artifact_evidence_path` **stay in core** as free functions.
- `homeboy-core` re-exports the contract as `execution_contract`, so every existing path (core-internal, agents, lab-runner, cli) resolves unchanged. Core's `execution_contract.rs` shrinks from 185 → 33 LOC.

## Why
This completes the extraction the campaign was building toward. `execution_contract` was blocked because its `ArtifactUriContract::runner_artifact_ref` / `metadata_only_ref` methods call `ArtifactReference::parse`, and `ArtifactReference` used to live in `core::artifact_ref` (which depended on `observation`). PR #8997 relocated `ArtifactReference` into the leaf `homeboy-artifact-ref-contract`, severing that edge — so the pure execution-surface types can now move down cleanly.

New crate deps: `homeboy-artifact-ref-contract` + `homeboy-engine-primitives` + `base64` — no core engine.

## Verification (local, VPS-safe)
- `cargo test -p homeboy-execution-contract` — 2 pass (runtime-ref build/classify, apply-schema names)
- `cargo check -p homeboy-core --lib` — clean (0 errors)
- `cargo test -p homeboy-core --lib change_artifact::tests::constants_are_sourced_from_canonical_execution_contract` — pass (verifies the re-exported const still sources core's change-artifact schema constants)
- `cargo check -p homeboy-agents --lib` / `-p homeboy-lab-runner --lib` / `-p homeboy-cli --lib` — all clean
- `cargo fmt` — clean

Note: the pure module was written fresh rather than `git mv`'d because the file was **split** (pure surface down, fs-touching classifier up). Depends conceptually on #8997 (already merged to main).