### PR TITLE
fix: stamp agent-task retry replacement runs with the current controller runtime (#8550)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -135,6 +135,100 @@ fn active_pinned_run_does_not_block_controller_promotion() {
     });
 }
 
+// Stamp a durable run's controller-runtime metadata with an obsolete build
+// identity, simulating a run created before a controller/runner upgrade.
+fn stamp_stale_controller_runtime(run_id: &str, stale_identity: &str) {
+    rewrite_record_for_test(run_id, |record| {
+        record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = json!({
+            "schema": "homeboy/controller-runtime-pin/v2",
+            "requested": stale_identity,
+            "originating": {
+                "build_identity": stale_identity,
+                "executable": "/legacy/homeboy",
+                "pinned_executable": "/legacy/homeboy",
+                "sha256": "0".repeat(64),
+            },
+            "current": stale_identity,
+            "executed": stale_identity,
+        });
+    })
+    .expect("stamp stale controller runtime");
+}
+
+fn stamped_runtime_identity(run_id: &str) -> String {
+    status(run_id).expect("record loaded").metadata
+        [homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]["originating"]
+        ["build_identity"]
+        .as_str()
+        .expect("stamped build identity")
+        .to_string()
+}
+
+#[test]
+fn retry_stamps_replacement_run_with_current_runtime_not_stale_source() {
+    // #8550: a Lab cook created under an older controller runtime left the durable
+    // run pinned to that obsolete build. After controller and runner were upgraded
+    // to the same current build, a clean lifecycle retry produced a fresh run ID
+    // but retained the obsolete runtime provenance, so the runner refused it with
+    // `Invalid argument controller_runtime`. A replacement run must be owned by the
+    // runtime that creates it.
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        let current_identity = homeboy_core::build_identity::current().display;
+        let stale_identity = format!("{current_identity}-obsolete-predecessor");
+        assert_ne!(stale_identity, current_identity);
+
+        let source = submit_plan(&plan, Some("cook-8550-source")).expect("source submitted");
+        stamp_stale_controller_runtime(&source.run_id, &stale_identity);
+        assert_eq!(stamped_runtime_identity(&source.run_id), stale_identity);
+
+        // (1) A failed run created by runtime A can be retried with a new run ID
+        //     under runtime B, and the replacement run records runtime B.
+        let replacement = retry(&source.run_id, Some("cook-8550-retry")).expect("retry succeeds");
+        assert_ne!(replacement.run_id, source.run_id);
+        assert_eq!(
+            stamped_runtime_identity(&replacement.run_id),
+            current_identity,
+            "replacement run must be stamped with the current runtime that created it"
+        );
+        assert_eq!(
+            replacement.metadata["retry_of"].as_str(),
+            Some(source.run_id.as_str())
+        );
+
+        // (2) Mutating the original runtime-A run under runtime B remains rejected.
+        let source_record = status(&source.run_id).expect("source record");
+        let mutation = homeboy_core::controller_runtime::validate_for_mutation(
+            &source_record.metadata,
+            &current_identity,
+        );
+        assert!(
+            mutation.is_err(),
+            "mutating the stale source run under the current runtime must stay fail-closed"
+        );
+
+        // (3) A same-runtime retry retains current behavior: the replacement is
+        //     owned by the current runtime and the source is untouched.
+        let same_runtime_source =
+            submit_plan(&plan, Some("cook-8550-fresh")).expect("fresh source submitted");
+        assert_eq!(
+            stamped_runtime_identity(&same_runtime_source.run_id),
+            current_identity
+        );
+        let same_runtime_replacement =
+            retry(&same_runtime_source.run_id, None).expect("same-runtime retry succeeds");
+        assert_eq!(
+            stamped_runtime_identity(&same_runtime_replacement.run_id),
+            current_identity
+        );
+        assert_eq!(
+            stamped_runtime_identity(&same_runtime_source.run_id),
+            current_identity,
+            "retry must not rewrite the source run's runtime provenance"
+        );
+    });
+}
+
 #[test]
 fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
     with_isolated_home(|_| {

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -503,11 +503,16 @@ fn delegate_agent_task_lifecycle_to_pinned_runtime(
     cli: &Cli,
     normalized_args: &[String],
 ) -> homeboy::core::Result<Option<i32>> {
+    // Run and Resume mutate the SAME durable record, so they must re-exec under
+    // the runtime that admitted it. Retry is intentionally excluded: it reads the
+    // source record but creates a NEW replacement run, which must be owned by the
+    // runtime that creates it rather than inheriting the source's (possibly stale)
+    // pinned runtime. Delegating Retry here stamped the replacement with the
+    // obsolete runtime after an upgrade (Extra-Chill/homeboy#8550).
     let run_id = match &cli.command {
         Commands::AgentTask(agent_task) => match &agent_task.command {
             crate::commands::agent_task::AgentTaskCommand::Run(args) => Some(&args.run_id),
             crate::commands::agent_task::AgentTaskCommand::Resume(args) => Some(&args.run_id),
-            crate::commands::agent_task::AgentTaskCommand::Retry(args) => Some(&args.run_id),
             _ => None,
         },
         _ => None,


### PR DESCRIPTION
## Summary

A Lab `agent-task cook` and a clean lifecycle retry both failed **before provider execution** after the controller and runner had already been upgraded to the same current build:

```text
Invalid argument controller_runtime: durable run was created by controller runtime `homeboy 0.288.4+b15cdd7c7987`, but this command is `homeboy 0.288.6+05f528c22487`
```

The retry received a fresh durable run ID from a clean git worktree but retained the **obsolete runtime provenance** from the failed source run, so the runner refused it and no repository code ran (#8550).

## Root cause

The CLI delegates certain agent-task lifecycle commands to the durable run's *pinned* controller runtime (`delegate_agent_task_lifecycle_to_pinned_runtime` in `cli_runtime.rs`), re-execing under the runtime that admitted the record. `run` and `resume` **mutate the same durable record**, so re-execing under its owning runtime is correct and keeps fail-closed ownership.

`retry` was in that same list — but `retry` only *reads* the source record and creates a **new replacement run** (`retry()` reads `source`, writes a fresh `retry` record, never mutates `source`). Re-execing retry under the source's pinned runtime meant the replacement's admission (`submit_plan` → `admit_current`) ran under the **stale** runtime and stamped the new run with the obsolete build identity.

## Change

- Exclude `retry` from the pinned-runtime delegation. It now runs under the current runtime, and `submit_plan`'s admission stamps the replacement with the runtime that created it.
- `run` and `resume` are unchanged — they still re-exec under the record's owning runtime.
- Fail-closed behavior for actual mutations is preserved: `retry` never mutates the source record, and mutating the original stale run under a newer runtime still fails via `validate_for_mutation`.

## Testing

- `cargo check -p homeboy-agents -p homeboy-cli --lib --tests` — clean (EXIT 0).
- `cargo fmt`.
- New `retry_stamps_replacement_run_with_current_runtime_not_stale_source` (passes), covering the acceptance criteria:
  1. A run stamped with runtime A is retried into a replacement stamped with the current runtime B.
  2. Mutating the original runtime-A run under runtime B remains rejected.
  3. A same-runtime retry retains current behavior and leaves the source provenance untouched.

Heavy workspace build/test intentionally left to CI per repo policy.

Fixes #8550

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Traced the runner-side `controller_runtime` refusal to the CLI re-execing retry under the source run's stale pinned runtime, scoped the fix to excluding retry (which creates a new run) from that delegation, and added coverage. Chris reviews and owns the change.