### PR TITLE
Reserve direct Lab daemon admission

### DIFF
--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -1411,6 +1411,16 @@ where
             Ok(body) => daemon_endpoint_response("jobs.exec", body),
             Err(err) => error_response(400, err),
         },
+        ("POST", "/admissions") => match reserve_admission(body, job_store) {
+            Ok(body) => daemon_endpoint_response("admissions.reserve", body),
+            Err(err) => error_response(400, err),
+        },
+        ("POST", path) if path.starts_with("/admissions/") && path.ends_with("/release") => {
+            match release_admission(path, job_store) {
+                Ok(body) => daemon_endpoint_response("admissions.release", body),
+                Err(err) => error_response(400, err),
+            }
+        }
         ("POST", "/jobs/reconcile-terminal") => {
             match job_store.reconcile_terminal_linked_daemon_jobs() {
                 Ok(reconciled) => daemon_endpoint_response(
@@ -1449,11 +1459,13 @@ where
             Ok(body) => daemon_endpoint_response("files.download", body),
             Err(err) => remote_runner::auth_or_bad_request(err),
         },
-        ("GET", "/exec") | ("GET", "/jobs/reconcile-terminal") => HttpResponse {
-            status_code: 405,
-            body: json!({ "error": "method_not_allowed" }),
-            artifact: None,
-        },
+        ("GET", "/exec") | ("GET", "/admissions") | ("GET", "/jobs/reconcile-terminal") => {
+            HttpResponse {
+                status_code: 405,
+                body: json!({ "error": "method_not_allowed" }),
+                artifact: None,
+            }
+        }
         ("GET", "/lifecycle/stop") => method_not_allowed(),
         ("GET", "/files/mkdir") | ("GET", "/files/upload") | ("GET", "/files/download") => {
             method_not_allowed()
@@ -1476,6 +1488,112 @@ where
         }
         _ => route_read_only_api(method, path, body, job_store, analysis_runner),
     }
+}
+
+fn reserve_admission(
+    body: Option<serde_json::Value>,
+    job_store: &JobStore,
+) -> Result<serde_json::Value> {
+    let body = body.unwrap_or_else(|| json!({}));
+    let runner_id = body
+        .get("runner_id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "runner_id",
+                "admission reservation requires a runner ID",
+                None,
+                None,
+            )
+        })?;
+    let command = body
+        .get("command")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("runner admission");
+    let expected_daemon_lease_id = body
+        .get("expected_daemon_lease_id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "expected_daemon_lease_id",
+                "admission reservation requires the exact expected daemon lease ID",
+                None,
+                None,
+            )
+        })?;
+    let daemon_lease = heartbeat_lease()?;
+    validate_admission_lease(expected_daemon_lease_id, &daemon_lease.lease_id)?;
+    let job = job_store.create_with_source_snapshot_metadata_and_path_materialization_plan(
+        "runner.admission",
+        None,
+        Some(json!({
+            "runner_job_projection": {
+                "runner_id": runner_id,
+                "command": command,
+                "cwd": serde_json::Value::Null,
+                "source": "runner-daemon",
+                "kind": "runner.admission",
+                "lifecycle": serde_json::Value::Null,
+            },
+            "admission": {
+                "runner_id": runner_id,
+                "state": "reserved",
+                "daemon_lease_id": daemon_lease.lease_id.clone(),
+            },
+        })),
+        None,
+    );
+    Ok(json!({ "job": job, "daemon_lease_id": daemon_lease.lease_id }))
+}
+
+fn validate_admission_lease(expected_lease_id: &str, actual_lease_id: &str) -> Result<()> {
+    if expected_lease_id == actual_lease_id {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "expected_daemon_lease_id",
+        format!(
+            "admission reservation expected daemon lease `{expected_lease_id}` but the authoritative live lease is `{actual_lease_id}`"
+        ),
+        Some(expected_lease_id.to_string()),
+        None,
+    ))
+}
+
+fn release_admission(path: &str, job_store: &JobStore) -> Result<serde_json::Value> {
+    let job_id = path
+        .trim_start_matches("/admissions/")
+        .trim_end_matches("/release")
+        .trim_end_matches('/');
+    let job_id = uuid::Uuid::parse_str(job_id).map_err(|error| {
+        Error::validation_invalid_argument(
+            "job_id",
+            format!("invalid admission job ID: {error}"),
+            Some(job_id.to_string()),
+            None,
+        )
+    })?;
+    let job = job_store.get(job_id)?;
+    if job.operation != "runner.admission" {
+        return Err(Error::validation_invalid_argument(
+            "job_id",
+            "job is not an admission reservation",
+            Some(job_id.to_string()),
+            None,
+        ));
+    }
+    let job = if matches!(
+        job.status,
+        JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
+    ) {
+        job
+    } else {
+        job_store.cancel(job_id, "admission reservation released")?
+    };
+    Ok(json!({ "job": job }))
 }
 
 fn lifecycle_stop_request(body: Option<serde_json::Value>) -> Result<LifecycleStopRequest> {
@@ -2091,6 +2209,78 @@ mod tests {
     use std::sync::Arc;
 
     struct EnqueueTestDriver;
+
+    #[test]
+    fn admission_reservation_blocks_daemon_replacement_until_released() {
+        with_isolated_home(|_| {
+            let lease_id = "lease-admission";
+            write_test_lease(lease_id);
+            let store = JobStore::default();
+            let reserved = reserve_admission(
+                Some(json!({
+                    "runner_id": "lab",
+                    "command": "homeboy generic-workload",
+                    "expected_daemon_lease_id": lease_id,
+                })),
+                &store,
+            )
+            .expect("reserve admission");
+            let job_id = reserved["job"]["id"].as_str().expect("reservation job ID");
+
+            let active_jobs = store.active_runner_jobs();
+            assert_eq!(
+                daemon_freshness_report(&store)
+                    .expect("freshness")
+                    .active_jobs,
+                1
+            );
+            assert_eq!(active_jobs.len(), 1);
+            assert_eq!(active_jobs[0].job_id, job_id);
+            assert_eq!(active_jobs[0].operation, "runner.admission");
+            assert_eq!(active_jobs[0].kind, "runner.admission");
+
+            let released = release_admission(&format!("/admissions/{job_id}/release"), &store)
+                .expect("release admission");
+            assert_eq!(released["job"]["status"], "cancelled");
+            assert_eq!(
+                daemon_freshness_report(&store)
+                    .expect("freshness")
+                    .active_jobs,
+                0
+            );
+            assert!(store.active_runner_jobs().is_empty());
+        });
+    }
+
+    #[test]
+    fn admission_reservation_rejects_a_changed_daemon_lease_before_job_creation() {
+        let error = validate_admission_lease("lease-a", "lease-b")
+            .expect_err("a reservation must not cross daemon leases");
+        assert_eq!(
+            error.code,
+            crate::error::ErrorCode::ValidationInvalidArgument
+        );
+        assert!(error.message.contains("lease-a"));
+        assert!(error.message.contains("lease-b"));
+    }
+
+    fn write_test_lease(lease_id: &str) {
+        let now = chrono::Utc::now().to_rfc3339();
+        let state = DaemonState {
+            schema: DAEMON_LEASE_SCHEMA.to_string(),
+            lease_id: lease_id.to_string(),
+            startup_token: String::new(),
+            address: "127.0.0.1:0".to_string(),
+            pid: std::process::id(),
+            state_path: state_path().expect("state path").display().to_string(),
+            started_at: now.clone(),
+            last_seen_at: now,
+            build_identity: build_identity::current(),
+            binary_sha256: current_binary_sha256().expect("binary hash"),
+            runtime_paths: capture_daemon_runtime_snapshot(),
+        };
+        write_lease(&state_path().expect("state path"), &state).expect("write lease");
+    }
 
     impl RunnerExecDriver for EnqueueTestDriver {
         fn prepare(&self, request: RunnerExecPrepareRequest) -> Result<PreparedDaemonExec> {

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -354,6 +354,112 @@ pub(super) fn exec_via_daemon(
     ))
 }
 
+/// Keeps an admitted Lab offload visible in daemon active-job accounting until
+/// its staged execution reaches a terminal or detached handoff outcome.
+pub(crate) struct DaemonAdmissionReservation {
+    local_url: String,
+    job_id: String,
+    pub(crate) daemon_lease_id: String,
+}
+
+impl DaemonAdmissionReservation {
+    pub(crate) fn job_id(&self) -> &str {
+        &self.job_id
+    }
+}
+
+impl Drop for DaemonAdmissionReservation {
+    fn drop(&mut self) {
+        let Ok(client) = Client::builder()
+            .no_proxy()
+            .timeout(Duration::from_secs(10))
+            .build()
+        else {
+            return;
+        };
+        let _ = daemon_post_json_text(
+            &client,
+            &self.local_url,
+            &format!("/admissions/{}/release", self.job_id),
+            &json!({}),
+            DaemonPostOptions::default(),
+        );
+    }
+}
+
+pub(crate) fn reserve_daemon_admission(
+    runner_id: &str,
+    local_url: &str,
+    command: &str,
+    expected_daemon_lease_id: &str,
+) -> Result<DaemonAdmissionReservation> {
+    let client = Client::builder()
+        .no_proxy()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|err| {
+            Error::internal_unexpected(format!("build daemon admission client: {err}"))
+        })?;
+    let response = daemon_post_json_text(
+        &client,
+        local_url,
+        "/admissions",
+        &json!({
+            "runner_id": runner_id,
+            "command": command,
+            "expected_daemon_lease_id": expected_daemon_lease_id,
+        }),
+        DaemonPostOptions::default(),
+    )?;
+    let envelope: DaemonEnvelope = serde_json::from_str(&response.body).map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("parse daemon admission response".to_string()),
+        )
+    })?;
+    if response.status_code >= 400 || !envelope.success {
+        return Err(Error::validation_invalid_argument(
+            "runner",
+            format!(
+                "runner `{runner_id}` refused Lab admission reservation: {}",
+                envelope.error.unwrap_or(Value::Null)
+            ),
+            Some(runner_id.to_string()),
+            None,
+        ));
+    }
+    let data = envelope
+        .data
+        .ok_or_else(|| Error::internal_unexpected("daemon admission response missing data"))?;
+    let body = canonical_daemon_body(&data, "daemon admission response")?;
+    let daemon_lease_id = body
+        .get("daemon_lease_id")
+        .and_then(Value::as_str)
+        .filter(|lease| !lease.is_empty())
+        .ok_or_else(|| Error::internal_unexpected("daemon admission response missing lease ID"))?;
+    if daemon_lease_id != expected_daemon_lease_id {
+        return Err(Error::validation_invalid_argument(
+            "expected_daemon_lease_id",
+            format!(
+                "runner `{runner_id}` admitted against daemon lease `{daemon_lease_id}`, expected `{expected_daemon_lease_id}`"
+            ),
+            Some(expected_daemon_lease_id.to_string()),
+            None,
+        ));
+    }
+    let job: Job = serde_json::from_value(body["job"].clone()).map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("parse daemon admission job".to_string()),
+        )
+    })?;
+    Ok(DaemonAdmissionReservation {
+        local_url: local_url.to_string(),
+        job_id: job.id.to_string(),
+        daemon_lease_id: daemon_lease_id.to_string(),
+    })
+}
+
 /// Recover only a connection that failed before the daemon could answer. A
 /// timeout or response failure may already represent an accepted non-idempotent
 /// `/exec`, so it is deliberately not retried here.

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -90,7 +90,7 @@ use secrets::*;
 
 // Crate-internal surface consumed by sibling `runner` modules (evidence, worker,
 // lab_env, lab/offload) and re-exported by the parent `runner` module.
-pub(crate) use daemon::result_event_data;
+pub(crate) use daemon::{reserve_daemon_admission, result_event_data, DaemonAdmissionReservation};
 pub use daemon_api::{canonical_daemon_body, daemon_api_get};
 pub(crate) use failure::{
     append_failure_context_error_summary, runner_exec_failure_context_from_output,

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -401,11 +401,8 @@ pub fn refresh_homeboy_binary(
     if options.reconnect {
         promotion_lease.assert_generation()?;
         let active_jobs = active_jobs_before_daemon_replacement(&plan.runner_id)?;
-        interrupted_job_ids = protect_active_jobs_before_reconnect(
-            &plan.runner_id,
-            active_jobs.iter().map(|job| job.job_id.as_str()),
-            options.force,
-        )?;
+        interrupted_job_ids =
+            protect_active_jobs_before_reconnect(&plan.runner_id, &active_jobs, options.force)?;
         if let Err(error) =
             disconnect_with_session(&plan.runner_id, refresh_session.as_ref(), options.force)
         {
@@ -1535,14 +1532,14 @@ fn active_job_reconnect_error(runner_id: &str, job_ids: &[String]) -> Error {
     error
 }
 
-fn protect_active_jobs_before_reconnect<'a>(
+fn protect_active_jobs_before_reconnect(
     runner_id: &str,
-    active_job_ids: impl IntoIterator<Item = &'a str>,
+    active_jobs: &[homeboy_core::api_jobs::ActiveRunnerJobSummary],
     force: bool,
 ) -> Result<Vec<String>> {
-    let job_ids = active_job_ids
+    let job_ids = active_jobs
         .into_iter()
-        .map(str::to_string)
+        .map(|job| job.job_id.clone())
         .collect::<Vec<_>>();
     if !job_ids.is_empty() && !force {
         return Err(active_job_reconnect_error(runner_id, &job_ids));

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -6,13 +6,10 @@ use crate::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};
 use homeboy_core::test_support;
 
 #[test]
-fn routine_reconnect_refuses_to_interrupt_a_detached_lab_cook() {
-    let error = protect_active_jobs_before_reconnect(
-        "homeboy-lab",
-        ["0b77251a-b6a7-42a6-91a3-e49ff5f57c16"],
-        false,
-    )
-    .expect_err("routine reconnect must preserve the active cook");
+fn routine_reconnect_refuses_to_interrupt_an_admitted_lab_offload() {
+    let admission = active_admission("0b77251a-b6a7-42a6-91a3-e49ff5f57c16");
+    let error = protect_active_jobs_before_reconnect("homeboy-lab", &[admission], false)
+        .expect_err("routine reconnect must preserve the active cook");
 
     assert_eq!(
         error.details["active_job_ids"],
@@ -27,17 +24,40 @@ fn routine_reconnect_refuses_to_interrupt_a_detached_lab_cook() {
 
 #[test]
 fn forced_reconnect_reports_the_jobs_it_will_interrupt() {
-    let interrupted = protect_active_jobs_before_reconnect(
-        "homeboy-lab",
-        ["0b77251a-b6a7-42a6-91a3-e49ff5f57c16"],
-        true,
-    )
-    .expect("explicit force permits interruption");
+    let admission = active_admission("0b77251a-b6a7-42a6-91a3-e49ff5f57c16");
+    let interrupted = protect_active_jobs_before_reconnect("homeboy-lab", &[admission], true)
+        .expect("explicit force permits interruption");
 
     assert_eq!(
         interrupted,
         vec!["0b77251a-b6a7-42a6-91a3-e49ff5f57c16".to_string()]
     );
+}
+
+fn active_admission(job_id: &str) -> homeboy_core::api_jobs::ActiveRunnerJobSummary {
+    homeboy_core::api_jobs::ActiveRunnerJobSummary {
+        runner_id: "homeboy-lab".to_string(),
+        job_id: job_id.to_string(),
+        operation: "runner.admission".to_string(),
+        source: "runner-daemon".to_string(),
+        kind: "runner.admission".to_string(),
+        status: homeboy_core::api_jobs::JobStatus::Queued,
+        command: "homeboy generic-workload".to_string(),
+        cwd: None,
+        started_at_ms: 1,
+        updated_at_ms: 1,
+        elapsed_ms: 0,
+        heartbeat_age_ms: 0,
+        claim: Default::default(),
+        claim_expires_in_ms: None,
+        lifecycle: None,
+        durable_run_id: None,
+        stale_reason: None,
+        lifecycle_state: Some("active".to_string()),
+        retryable: Some(false),
+        active_child_count: None,
+        active_cell_count: None,
+    }
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -239,6 +239,7 @@ pub(crate) struct LabDispatchExecutionContext<'a> {
     pub(crate) dependency_cache_saves: Vec<RunnerDependencyCacheSaveRequest>,
     pub(crate) remote_output_file: Option<String>,
     pub(crate) host_telemetry: Option<LabHostTelemetryCapture>,
+    pub(crate) admission: Option<DaemonAdmissionReservation>,
     pub(crate) plan: HomeboyPlan,
     pub(crate) messages: Vec<String>,
     pub(crate) overhead: LabOffloadOverhead,
@@ -290,6 +291,8 @@ fn lab_runner_exec_options(
 pub(crate) fn exec_lab_context(
     mut context: LabDispatchExecutionContext<'_>,
 ) -> Result<LabOffloadOutcome> {
+    // Keep the daemon-visible admission active until this function returns.
+    let _admission = context.admission.take();
     let request = context.request;
     let selection = context.selection;
     let contract = context.contract;
@@ -1196,6 +1199,20 @@ pub(crate) fn run_lab_offload_inner(
     }
 
     let capability_preflight: Option<RunnerCapabilityPreflight> = capability_plan.map(Into::into);
+    let admission = direct_daemon_admission_coordinates(
+        runner_id,
+        &selection.mode,
+        runner_status.session.as_ref(),
+    )?
+    .map(|(local_url, expected_daemon_lease_id)| {
+        reserve_daemon_admission(
+            runner_id,
+            local_url,
+            &redact_argv_shell_display(&command_prefix.argv),
+            expected_daemon_lease_id,
+        )
+    })
+    .transpose()?;
     let workspace_sync_timer = overhead.phase(LabOffloadPhase::WorkspaceSync);
     let workspace_stage = match prepare_lab_offload_workspace_stage(
         &request,
@@ -1462,6 +1479,14 @@ pub(crate) fn run_lab_offload_inner(
     lab_metadata["settings_env"] =
         settings_env_diagnostics(&remapped_args, &secret_env_handoff.env_delta);
     lab_metadata["runner_homeboy"] = runner_homeboy.clone();
+    if let Some(admission) = admission.as_ref() {
+        lab_metadata["admission_reservation"] = serde_json::json!({
+            "job_id": admission.job_id(),
+            "daemon_lease_id": admission.daemon_lease_id,
+            "status": "reserved",
+            "release_policy": "best_effort_on_context_exit_after_terminal_or_detached_handoff",
+        });
+    }
     lab_metadata["source_checkout"] = source_checkout.clone();
     lab_metadata["job_scoped_overrides"] = job_scoped_overrides_metadata(&request.job_overrides);
     lab_metadata["rig_sync"] = serde_json::json!({
@@ -1540,6 +1565,7 @@ pub(crate) fn run_lab_offload_inner(
         dependency_cache_saves,
         remote_output_file,
         host_telemetry: Some(host_telemetry),
+        admission,
         plan,
         messages,
         overhead,
@@ -1547,6 +1573,49 @@ pub(crate) fn run_lab_offload_inner(
         print_handoff: true,
         detach_after_handoff: request.detach_after_handoff,
     })
+}
+
+fn direct_daemon_admission_coordinates<'a>(
+    runner_id: &str,
+    mode: &super::super::super::RunnerTunnelMode,
+    session: Option<&'a super::super::super::RunnerSession>,
+) -> Result<Option<(&'a str, &'a str)>> {
+    if *mode == super::super::super::RunnerTunnelMode::Reverse {
+        return Ok(None);
+    }
+    let session = session.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "runner",
+            format!("runner `{runner_id}` has no direct session for Lab admission"),
+            Some(runner_id.to_string()),
+            None,
+        )
+    })?;
+    if session.mode != super::super::super::RunnerTunnelMode::DirectSsh {
+        return Err(Error::validation_invalid_argument(
+            "runner",
+            format!("runner `{runner_id}` direct Lab admission found a non-direct session"),
+            Some(runner_id.to_string()),
+            None,
+        ));
+    }
+    let local_url = session.local_url.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "runner",
+            format!("runner `{runner_id}` has no direct daemon endpoint for Lab admission"),
+            Some(runner_id.to_string()),
+            None,
+        )
+    })?;
+    let lease_id = session.remote_daemon_lease_id.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "runner",
+            format!("runner `{runner_id}` has no proven daemon lease for Lab admission"),
+            Some(runner_id.to_string()),
+            None,
+        )
+    })?;
+    Ok(Some((local_url, lease_id)))
 }
 
 /// Gate Lab dispatch on the same authoritative availability verdict the
@@ -1856,6 +1925,7 @@ mod tests {
             dependency_cache_saves: Vec::new(),
             remote_output_file: None,
             host_telemetry: None,
+            admission: None,
             plan: base_lab_plan(None),
             messages: Vec::new(),
             overhead: LabOffloadOverhead::start(),
@@ -1999,6 +2069,71 @@ mod tests {
             reconcile_lab_mutation_output(output, &["src/lib.rs".to_string()]),
             output
         );
+    }
+
+    #[test]
+    fn direct_lab_admission_requires_and_preserves_daemon_coordinates() {
+        let session = admission_session(
+            RunnerTunnelMode::DirectSsh,
+            Some("http://127.0.0.1:7421"),
+            Some("lease-a"),
+        );
+        assert_eq!(
+            direct_daemon_admission_coordinates(
+                "homeboy-lab",
+                &RunnerTunnelMode::DirectSsh,
+                Some(&session),
+            )
+            .expect("direct admission coordinates"),
+            Some(("http://127.0.0.1:7421", "lease-a")),
+        );
+
+        let missing_endpoint =
+            admission_session(RunnerTunnelMode::DirectSsh, None, Some("lease-a"));
+        let error = direct_daemon_admission_coordinates(
+            "homeboy-lab",
+            &RunnerTunnelMode::DirectSsh,
+            Some(&missing_endpoint),
+        )
+        .expect_err("direct admission requires an endpoint");
+        assert!(error.message.contains("direct daemon endpoint"));
+    }
+
+    #[test]
+    fn reverse_lab_admission_keeps_broker_path_without_direct_reservation() {
+        assert_eq!(
+            direct_daemon_admission_coordinates("homeboy-lab", &RunnerTunnelMode::Reverse, None)
+                .expect("reverse sessions use broker admission"),
+            None,
+        );
+    }
+
+    fn admission_session(
+        mode: RunnerTunnelMode,
+        local_url: Option<&str>,
+        lease_id: Option<&str>,
+    ) -> crate::RunnerSession {
+        crate::RunnerSession {
+            runner_id: "homeboy-lab".to_string(),
+            mode,
+            role: crate::RunnerSessionRole::Controller,
+            server_id: None,
+            controller_id: None,
+            broker_url: None,
+            remote_daemon_address: None,
+            local_port: None,
+            local_url: local_url.map(str::to_string),
+            tunnel_pid: None,
+            remote_daemon_pid: None,
+            remote_daemon_lease_id: lease_id.map(str::to_string),
+            homeboy_version: "test".to_string(),
+            homeboy_build_identity: None,
+            connected_at: "2026-01-01T00:00:00Z".to_string(),
+            worker_identity: None,
+            worker_pid: None,
+            last_seen_at: None,
+            leaseless_recovery_evidence: None,
+        }
     }
 
     fn runner_status(connected: bool) -> RunnerStatusReport {

--- a/crates/homeboy-lab-runner/src/lab/offload/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/mod.rs
@@ -60,9 +60,9 @@ use super::super::command_path::{
 };
 use super::super::daemon_health::runner_daemon_health_failure;
 use super::super::execution::{
-    append_failure_context_error_summary, lab_offload_handoff_hints,
+    append_failure_context_error_summary, lab_offload_handoff_hints, reserve_daemon_admission,
     runner_exec_failure_context_from_output, runner_exec_failure_context_remediation_hint,
-    DaemonJobHandoffState,
+    DaemonAdmissionReservation, DaemonJobHandoffState,
 };
 use super::super::lab_apply::{
     apply_lab_offload_patch, apply_lab_promotion_patch, PromotionPatchIntent,

--- a/crates/homeboy-lab-runner/src/lab/offload/resident.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/resident.rs
@@ -195,6 +195,7 @@ pub(crate) fn run_runner_resident_lab_offload(
         dependency_cache_saves: Vec::new(),
         remote_output_file,
         host_telemetry: None,
+        admission: None,
         plan,
         messages,
         overhead,


### PR DESCRIPTION
## Summary
- reserve daemon-visible active work before direct Lab workspace, rig, and extension staging begins
- bind the reservation to the exact admitted daemon lease and fail closed if the lease changes
- reuse typed active-job refresh protection so ordinary Homeboy refresh/reconnect cannot replace an admitted daemon
- release the reservation when the execution context exits while preserving the existing reverse-broker path

## Why
A direct Lab offload could observe an idle daemon, spend time staging its execution bundle, and then lose its proven daemon lease or configured command binary to a concurrent refresh before final submission. In the live Gutenberg fuzz campaign this first caused a lease-mismatch refusal, then caused an accepted runner job to disappear before polling could observe it. No fuzz child or artifacts survived.

The runner now creates a typed `runner.admission` job against the exact heartbeat lease before mutable staging. Existing active-job protections see that reservation and refuse routine daemon replacement. Once `/exec` is accepted, the real daemon job is already persisted before the reservation is released, so protection transfers without an idle gap.

## Scope
This advances the binary/daemon admission portion of #8974. Job-scoped extension snapshots remain separately tracked there.

The reservation currently applies to direct-SSH daemon sessions. Reverse-broker runners retain their existing broker/capacity admission contract.

## How to test
1. Run `cargo check -p homeboy-core -p homeboy-lab-runner`.
2. Run `cargo test -p homeboy-core daemon::tests::admission_reservation --lib`.
3. Run `cargo test -p homeboy-lab-runner admitted_lab_offload --lib`.
4. Run `cargo test -p homeboy-lab-runner routine_reconnect_refuses_to_interrupt_an_admitted_lab_offload --lib`.
5. Verify lease mismatch creates no reservation, an admitted direct job appears in typed active-job accounting, routine reconnect is refused while active, release clears protection, and reverse admission remains unchanged.

## Verification
- Both touched crates compile successfully.
- Core daemon reservation tests pass.
- Direct/reverse Lab admission tests pass.
- Refresh protection test passes.
- Changed-file formatting and `git diff --check` pass.
- Repository-wide `cargo fmt --check` still reports an unrelated existing difference in `crates/homeboy-agents/src/agent_tasks.rs`.

## Compatibility
- Existing direct Lab commands gain an internal lease-bound admission request before staging.
- Reverse-broker execution is unchanged.
- Explicit forced reconnect retains its existing operator override behavior.
- If best-effort release loses daemon transport, the reservation remains conservatively active instead of allowing unsafe replacement.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed the live Lab lease race, implemented the daemon admission protocol and deterministic tests, and drafted the PR description. Chris remains responsible for every line.