### PR TITLE
fix: align cook placement/runner rejection with clap exclusivity

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -382,15 +382,10 @@ fn run_split_placement_cook(
             ]),
         ));
     }
+    // `--runner` implies Lab placement and is mutually exclusive with an
+    // explicit `--placement` at argument parsing, so `--placement local` here
+    // always means a fully local cook with no pinned runner.
     if cli.placement == homeboy::cli_surface::Placement::Local {
-        if cli.runner.is_some() {
-            return Err(Error::validation_invalid_argument(
-                "runner",
-                "--placement local cannot be combined with --runner for agent-task cook; omit --runner for a fully local cook or select Lab placement for its provider attempt",
-                cli.runner.clone(),
-                None,
-            ));
-        }
         return Ok(None);
     }
     let Some(runner_id) = runner_id else {

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -1060,33 +1060,6 @@ fn explicit_local_cook_does_not_enter_lab_attempt_dispatch() {
 }
 
 #[test]
-fn explicit_local_cook_runner_is_rejected_before_worktree_resolution() {
-    let cli = Cli::parse_from([
-        "homeboy",
-        "--placement",
-        "local",
-        "--runner",
-        "homeboy-lab",
-        "agent-task",
-        "cook",
-        "--to-worktree",
-        "missing@worktree",
-        "--verify",
-        "true",
-        "--prompt",
-        "stay local",
-    ]);
-
-    let error = run_split_placement_cook(&cli, &[], None, Some("homeboy-lab"))
-        .expect_err("mixed local placement and runner must fail before plan materialization");
-
-    assert_eq!(error.details["field"], "runner");
-    assert!(error
-        .message
-        .contains("--placement local cannot be combined with --runner"));
-}
-
-#[test]
 fn cook_to_worktree_provider_workspace_survives_failed_attempt_and_lab_retry() {
     crate::test_support::with_isolated_home(|_| {
         let workspace = tempfile::tempdir().expect("workspace");

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -6,6 +6,10 @@ fn homeboy() -> Command {
 
 #[test]
 fn cook_rejects_invalid_controller_transport_before_worktree_resolution() {
+    // `--runner` implies Lab placement, so combining it with an explicit
+    // `--placement` is contradictory and rejected at argument parsing (see
+    // `runner_and_placement_are_mutually_exclusive`). That rejection happens
+    // before any worktree provider resolution.
     let output = homeboy()
         .args([
             "--placement",
@@ -26,8 +30,10 @@ fn cook_rejects_invalid_controller_transport_before_worktree_resolution() {
 
     assert!(!output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("--placement local cannot be combined with --runner"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("'--placement <PLACEMENT>' cannot be used with '--runner <RUNNER_ID>'"));
     assert!(!stdout.contains("worktree provider"));
+    assert!(!stderr.contains("worktree provider"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Fixes the `Test`-gate failure that has been blocking the release pipeline on `main` (`cook_rejects_invalid_controller_transport_before_worktree_resolution`).

## Root cause
Two designs collided:
- **#8842** (`fix: make runner and placement exclusive`) added a clap-level `conflicts_with` between `--placement` and `--runner`, since `--runner` already implies Lab placement. Any `--placement X --runner Y` combo is now rejected at argument parsing with an `ArgumentConflict` (exit 2, message on **stderr**).
- The older `agent-task cook` path (and its integration test from #8477) still had a **semantic** `local + runner` rejection in `route.rs` that printed a domain message to **stdout**. clap now intercepts the combination first, so that branch was **unreachable** and the integration test failed on `main`.

## Fix
Adopt #8842's exclusivity as the source of truth and remove the now-dead semantic path:
- Drop the unreachable `local + runner` branch in `run_split_placement_cook` (keep the `--placement local` → local-bypass return for the valid no-runner case).
- Remove the now-dead `explicit_local_cook_runner_is_rejected_before_worktree_resolution` unit test (it parsed an impossible arg combination).
- Update `cook_lab_handoff_test` to assert clap's stderr `ArgumentConflict`, still verifying the rejection happens **before** any worktree provider resolution (the test's actual intent).

## Verification
- `cargo test --test cook_lab_handoff_test` — 3/3 pass.
- `cli_surface::tests::runner_and_placement_are_mutually_exclusive` and `explicit_local_cook_does_not_enter_lab_attempt_dispatch` — pass.
- `cargo check -p homeboy-cli --tests` clean; touched files fmt-clean.
- No remaining references to the removed semantic message.

Note: `crates/homeboy-agents/src/agent_tasks.rs` has pre-existing fmt drift on `main` (unrelated to this change) and is left untouched.