### PR TITLE
Exclude broker inputs from Lab snapshot identity

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -18,6 +18,7 @@ use super::util::{
 };
 
 const RUNNER_WORKSPACE_METADATA_FILE: &str = ".homeboy/runner-workspace.json";
+const LAB_AT_FILES_DIRECTORY: &str = ".homeboy/lab-at-files";
 pub(crate) const WORKSPACE_CONTENT_PERMISSION_PORTABLE: &str = "portable-content-only";
 pub(crate) const WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE: &str = "unix-executable";
 pub(crate) const WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE: &str = "unix-owner-executable";
@@ -226,6 +227,7 @@ fn collect_content_hash_entries_v2(
         if relative == ".git"
             || is_excluded(root, &root.join(&relative_path), excludes, &[])
             || relative == RUNNER_WORKSPACE_METADATA_FILE
+            || relative == LAB_AT_FILES_DIRECTORY
         {
             continue;
         }
@@ -1197,22 +1199,31 @@ pub(crate) fn copy_snapshot_to_directory(
 }
 
 pub(crate) fn ensure_no_runner_workspace_metadata_collision(local_path: &Path) -> Result<()> {
-    let metadata_path = local_path.join(RUNNER_WORKSPACE_METADATA_FILE);
-    match fs::symlink_metadata(&metadata_path) {
-        Ok(_) => Err(Error::validation_invalid_argument(
-            "workspace",
-            "source workspace contains the reserved runner metadata path `.homeboy/runner-workspace.json`; remove or rename it before syncing",
-            Some(metadata_path.display().to_string()),
-            Some(vec![
-                "Remove or rename the source file before syncing; Homeboy writes this path only after runner materialization.".to_string(),
-            ]),
-        )),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(Error::internal_io(
-            error.to_string(),
-            Some("inspect reserved runner metadata path".to_string()),
-        )),
+    for reserved in [RUNNER_WORKSPACE_METADATA_FILE, LAB_AT_FILES_DIRECTORY] {
+        let reserved_path = local_path.join(reserved);
+        match fs::symlink_metadata(&reserved_path) {
+            Ok(_) => {
+                return Err(Error::validation_invalid_argument(
+                    "workspace",
+                    format!(
+                        "source workspace contains the reserved runner path `{reserved}`; remove or rename it before syncing"
+                    ),
+                    Some(reserved_path.display().to_string()),
+                    Some(vec![
+                        "Remove or rename the source path before syncing; Homeboy owns this path on materialized runner workspaces.".to_string(),
+                    ]),
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(Error::internal_io(
+                    error.to_string(),
+                    Some("inspect reserved runner workspace path".to_string()),
+                ));
+            }
+        }
     }
+    Ok(())
 }
 
 fn materialize_snapshot_piped(

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -5,10 +5,11 @@ use std::path::Path;
 use std::sync::{Mutex, OnceLock};
 
 use crate::workspace::snapshot::{
-    copy_snapshot_to_directory, snapshot_archive_command, snapshot_install_command,
-    synthetic_checkout_value, workspace_content_hash, workspace_content_hash_algorithm,
-    workspace_content_hash_for_policy, workspace_content_manifest_for_policy,
-    WORKSPACE_CONTENT_PERMISSION_PORTABLE, WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
+    copy_snapshot_to_directory, ensure_no_runner_workspace_metadata_collision,
+    snapshot_archive_command, snapshot_install_command, synthetic_checkout_value,
+    workspace_content_hash, workspace_content_hash_algorithm, workspace_content_hash_for_policy,
+    workspace_content_manifest_for_policy, WORKSPACE_CONTENT_PERMISSION_PORTABLE,
+    WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
     WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
 };
 
@@ -364,7 +365,7 @@ fn runner_snapshot_rejects_source_runner_workspace_metadata_collision() {
         )
         .expect_err("reserved runner metadata must reject staging");
 
-        assert!(error.message.contains("reserved runner metadata path"));
+        assert!(error.message.contains("reserved runner path"));
         assert!(error.message.contains("remove or rename"));
         assert_eq!(
             fs::read_dir(runner_root.path())
@@ -374,6 +375,19 @@ fn runner_snapshot_rejects_source_runner_workspace_metadata_collision() {
             "collision must fail before creating a materialized workspace"
         );
     });
+}
+
+#[test]
+fn runner_snapshot_rejects_source_lab_at_file_collision() {
+    let source = tempfile::tempdir().expect("source tempdir");
+    fs::create_dir_all(source.path().join(".homeboy/lab-at-files")).expect("Lab input collision");
+
+    let error = ensure_no_runner_workspace_metadata_collision(source.path())
+        .expect_err("reserved Lab input path must reject staging");
+
+    assert!(error.message.contains("reserved runner path"));
+    assert!(error.message.contains(".homeboy/lab-at-files"));
+    assert!(error.message.contains("remove or rename"));
 }
 
 #[test]
@@ -1417,7 +1431,7 @@ fn workspace_content_hash_non_unix_rejects_unix_executable_policy() {
 }
 
 #[test]
-fn snapshot_content_hash_binds_user_owned_homeboy_files_but_ignores_runner_metadata() {
+fn snapshot_content_hash_binds_user_owned_homeboy_files_but_ignores_runner_state() {
     let controller = tempfile::tempdir().expect("controller");
     let source = controller.path().join("homeboy-extensions@fixture");
     let destination = controller.path().join("materialized");
@@ -1443,6 +1457,31 @@ fn snapshot_content_hash_binds_user_owned_homeboy_files_but_ignores_runner_metad
         workspace_content_hash(&destination, &excludes).expect("materialized hash"),
         expected,
         "runner metadata must not change the controller identity"
+    );
+
+    fs::create_dir_all(destination.join(".homeboy/lab-at-files")).expect("Lab input directory");
+    fs::write(
+        destination.join(".homeboy/lab-at-files/plan.json"),
+        "{\"task\":\"fixture\"}\n",
+    )
+    .expect("materialized Lab input");
+    assert_eq!(
+        workspace_content_hash(&destination, &excludes).expect("Lab input-insensitive hash"),
+        expected,
+        "broker-owned Lab @files must not change the controller identity"
+    );
+    let manifest = workspace_content_manifest_for_policy(
+        &destination,
+        &excludes,
+        crate::WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+    )
+    .expect("materialized manifest");
+    assert!(
+        manifest
+            .entries
+            .iter()
+            .all(|entry| !entry.path.starts_with(".homeboy/lab-at-files")),
+        "broker-owned Lab @files must not enter the source manifest"
     );
 
     fs::write(


### PR DESCRIPTION
## Summary
- reserve `.homeboy/lab-at-files` as a Homeboy-owned runner path
- exclude that exact broker input subtree from workspace content hash and manifest traversal
- keep all other user-owned `.homeboy` content bound to snapshot provenance

Fixes #8411.

## Root cause
Lab computed the source snapshot hash, then materialized the agent-task plan as an `@file` under `.homeboy/lab-at-files` before runner provenance verification. The verifier excluded `.homeboy/runner-workspace.json` but included the broker-owned plan, so a byte-identical source checkout failed its content hash before provider execution.

## How to test
1. Run `cargo test -p homeboy-lab-runner snapshot_content_hash_binds_user_owned_homeboy_files_but_ignores_runner_state`.
2. Run `cargo test -p homeboy-lab-runner runner_snapshot_rejects_source`.
3. Run `cargo check -p homeboy-lab-runner`.
4. Confirm the tests prove a source hash remains stable after Lab adds a plan under `.homeboy/lab-at-files`, the generated manifest omits that broker path, other user-owned `.homeboy` files remain hash-bound, and source collisions with reserved runner paths fail before sync.

## Compatibility
This intentionally reserves `.homeboy/lab-at-files`. A source checkout already using that internal control-plane path now fails sync with a remediation message instead of being overwritten or misclassified as broker state. Other `.homeboy` paths remain supported and provenance-bound.

## Verification
- Focused hash regression: passed
- Reserved-path collision tests: 2 passed
- `cargo check -p homeboy-lab-runner`: passed
- Repository-wide `cargo fmt --check`: pre-existing unrelated formatting differences remain in `crates/contracts/homeboy-artifact-ref-contract/src/artifact_ref.rs` and `crates/homeboy-agents/src/agent_tasks.rs`; changed files were formatted directly and `git diff --check` passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause analysis, implementation, regression tests, and verification