### PR TITLE
Allow adoption of exact unpushed candidate destinations

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/apply.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/apply.rs
@@ -20,6 +20,12 @@ use super::types::{
     AgentTaskPromotionCommandCapture, AgentTaskPromotionCommandReport, AgentTaskPromotionOptions,
 };
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct TrustedUnpushedCandidateDestination {
+    pub(crate) path: PathBuf,
+    pub(crate) head: String,
+}
+
 /// Environment variable carrying the promotion workspace provider command.
 const PROMOTION_PROVIDER_COMMAND_ENV: &str = "HOMEBOY_AGENT_TASK_PROMOTION_COMMAND";
 
@@ -167,6 +173,24 @@ pub fn apply_materialized_workspace_patch(workspace: &Path, request_json: &str) 
         .as_ref()
         .map(|file| file.path().to_string_lossy().into_owned())
         .unwrap_or_else(|| request.patch_path.clone());
+    if request
+        .trusted_unpushed_candidate_destination
+        .as_ref()
+        .is_some_and(|trusted| trusted_candidate_destination_matches(workspace, trusted))
+        && patch_is_already_applied(workspace, &patch_path)?
+    {
+        return serde_json::to_string(&AgentTaskPromotionApplyResponse {
+            schema: AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA.to_string(),
+            workspace_path: workspace.display().to_string(),
+            command_evidence: Vec::new(),
+        })
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize promotion provider response".to_string()),
+            )
+        });
+    }
     let mut command = Command::new("git");
     command
         .arg("-C")
@@ -206,6 +230,52 @@ pub fn apply_materialized_workspace_patch(workspace: &Path, request_json: &str) 
     })
 }
 
+fn trusted_candidate_destination_matches(
+    workspace: &Path,
+    trusted: &TrustedUnpushedCandidateDestination,
+) -> bool {
+    let Ok(workspace) = std::fs::canonicalize(workspace) else {
+        return false;
+    };
+    let Ok(path) = std::fs::canonicalize(&trusted.path) else {
+        return false;
+    };
+    workspace == path
+        && Command::new("git")
+            .args([
+                "-C",
+                workspace.to_str().unwrap_or_default(),
+                "rev-parse",
+                "--verify",
+                "HEAD^{commit}",
+            ])
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .is_some_and(|output| String::from_utf8_lossy(&output.stdout).trim() == trusted.head)
+}
+
+fn patch_is_already_applied(workspace: &Path, patch_path: &str) -> Result<bool> {
+    Command::new("git")
+        .arg("-C")
+        .arg(workspace)
+        .args([
+            "apply",
+            "--reverse",
+            "--check",
+            "--whitespace=nowarn",
+            patch_path,
+        ])
+        .status()
+        .map(|status| status.success())
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("verify already-applied agent-task promotion patch".to_string()),
+            )
+        })
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct AgentTaskPromotionApplyRequest {
     pub(crate) schema: String,
@@ -220,6 +290,8 @@ pub(crate) struct AgentTaskPromotionApplyRequest {
     pub(crate) gate_feedback_baseline: Option<serde_json::Value>,
     #[serde(default)]
     pub(crate) dry_run: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) trusted_unpushed_candidate_destination: Option<TrustedUnpushedCandidateDestination>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -346,10 +418,20 @@ impl ExternalPromotionWorkspaceProvider {
                 None,
             )
         })?;
-        let resolution = worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
+        let trusted_unpushed_destination = request
+            .trusted_unpushed_candidate_destination
+            .as_ref()
+            .map(
+                |trusted| homeboy_core::worktree_providers::TrustedUnpushedWorktree {
+                    path: trusted.path.clone(),
+                    head: trusted.head.clone(),
+                },
+            );
+        let resolution = worktree_providers::resolve_apply_enabled_worktree_provider_with_trusted_unpushed_destination_from_config(
             &request.to_workspace,
             &configured_fallback.config,
             request.gate_feedback_baseline.as_ref(),
+            trusted_unpushed_destination.as_ref(),
         )?;
         let executable = configured_fallback
             .executable

--- a/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
@@ -10,6 +10,7 @@ use super::types::AgentTaskPromotionOptions;
 
 pub(crate) struct CommittedChangesPatch {
     pub(crate) base_ref: String,
+    pub(crate) candidate: String,
     pub(crate) patch_path: PathBuf,
     pub(crate) sha256: String,
     pub(crate) commit_range: String,
@@ -103,6 +104,7 @@ pub(crate) fn committed_changes_patch(
     })?;
     Ok(Some(CommittedChangesPatch {
         base_ref,
+        candidate,
         patch_path,
         sha256,
         commit_range,

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -16,7 +16,8 @@ use homeboy_core::{Error, Result};
 
 use super::apply::{
     AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspaceProvider,
-    ExternalPromotionWorkspaceProvider, AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA,
+    ExternalPromotionWorkspaceProvider, TrustedUnpushedCandidateDestination,
+    AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA,
 };
 use super::committed_changes::{committed_changes_patch, CommittedChangesPatch};
 use super::patch::write_normalized_patch;
@@ -575,6 +576,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
             changed_files: changed_files.clone(),
             gate_feedback_baseline,
             dry_run: options.dry_run,
+            trusted_unpushed_candidate_destination: None,
         })?;
         command_evidence.extend(target.command_evidence);
         if !options.dry_run {
@@ -900,6 +902,15 @@ fn promote_committed_changes(
             .and_then(|artifact| artifact.metadata.get("gate_feedback_baseline"))
             .cloned(),
         dry_run: options.dry_run,
+        trusted_unpushed_candidate_destination: options.candidate_ref.as_ref().map(|_| {
+            TrustedUnpushedCandidateDestination {
+                path: options
+                    .source_worktree_path
+                    .clone()
+                    .expect("candidate has source workspace"),
+                head: committed_patch.candidate.clone(),
+            }
+        }),
     })?;
     command_evidence.extend(target.command_evidence);
     let applied_worktree_path = (!options.dry_run).then_some(target.path);

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -619,6 +619,7 @@ fn provider_command_response_supplies_workspace_and_evidence() {
         changed_files: vec!["src/lib.rs".to_string()],
         gate_feedback_baseline: None,
         dry_run: false,
+        trusted_unpushed_candidate_destination: None,
     };
     let workspace = run_provider_command(
         &CommandInvocation {

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -673,6 +673,7 @@ fn provider_failure_surfaces_bounded_stdout_and_stderr_evidence() {
         changed_files: vec!["src/lib.rs".to_string()],
         gate_feedback_baseline: None,
         dry_run: false,
+        trusted_unpushed_candidate_destination: None,
     };
 
     let error = run_provider_command(

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
@@ -5,7 +5,8 @@ use super::super::apply::{
     preflight_configured_workspace_provider_with_config, run_provider_command,
     AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspace,
     AgentTaskPromotionWorkspaceProvider, ExternalPromotionWorkspaceProvider,
-    AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA, AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
+    TrustedUnpushedCandidateDestination, AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA,
+    AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
 };
 use super::super::promote::{
     normalize_promotion_patch, promote, promote_with_provider,
@@ -184,6 +185,7 @@ fn configured_command_provider_is_resolved_lazily_with_provenance() {
             changed_files: vec!["src/lib.rs".to_string()],
             gate_feedback_baseline: None,
             dry_run: false,
+            trusted_unpushed_candidate_destination: None,
         })
         .expect_err("fixture executable is not an adapter");
 
@@ -206,6 +208,91 @@ fn configured_command_provider_is_resolved_lazily_with_provenance() {
     assert_eq!(
         error.details["worktree_provider"]["path"],
         workspace.path().display().to_string()
+    );
+}
+
+#[test]
+fn configured_provider_accepts_only_the_unpushed_immutable_candidate_destination() {
+    let (_temp, repo, _base, candidate) = adopted_commit_repo();
+    let provider = tempfile::NamedTempFile::new().expect("provider command");
+    std::fs::write(
+        provider.path(),
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' '{}'\n",
+            serde_json::json!({
+                "worktrees": [{
+                    "handle": "fixture@candidate",
+                    "path": repo,
+                    "branch": "main",
+                    "safety": { "dirty": false, "unpushed": true, "primary": false }
+                }]
+            })
+        ),
+    )
+    .expect("write provider command");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(provider.path())
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(provider.path(), permissions).expect("make provider executable");
+    }
+    let mut config = HomeboyConfig::default();
+    config.worktree_providers.insert(
+        "fixture".to_string(),
+        WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: true,
+            commands: WorktreeProviderCommands {
+                resolve: Some(vec![
+                    provider.path().display().to_string(),
+                    "{handle}".to_string(),
+                ]),
+                ..Default::default()
+            },
+            list_result_mapping: Some(WorktreeProviderListResultMapping {
+                items: "$.worktrees".to_string(),
+                handle: "$.handle".to_string(),
+                path: "$.path".to_string(),
+                branch: "$.branch".to_string(),
+                dirty: "$.safety.dirty".to_string(),
+                unpushed: "$.safety.unpushed".to_string(),
+                primary: "$.safety.primary".to_string(),
+            }),
+        },
+    );
+    let mut provider = ExternalPromotionWorkspaceProvider::from_options_with_config_and_environment(
+        &promotion_options("fixture@candidate"),
+        &config,
+        Some(PathBuf::from("/fixture/homeboy")),
+        None,
+    );
+    let error = provider
+        .apply_patch(AgentTaskPromotionApplyRequest {
+            schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
+            to_workspace: "fixture@candidate".to_string(),
+            patch: Some(VALID_PATCH.to_string()),
+            patch_path: "changes.patch".to_string(),
+            changed_files: vec!["lib.rs".to_string()],
+            gate_feedback_baseline: None,
+            dry_run: false,
+            trusted_unpushed_candidate_destination: Some(TrustedUnpushedCandidateDestination {
+                path: repo.clone(),
+                head: candidate,
+            }),
+        })
+        .expect_err("fixture executable is not an adapter");
+    assert!(!error.message.contains("unpushed"), "{}", error.message);
+    assert_eq!(
+        provider
+            .invocation()
+            .expect("resolved provider")
+            .argv
+            .last(),
+        Some(&repo.display().to_string())
     );
 }
 
@@ -782,6 +869,7 @@ fn provider_response_overflow_is_terminated_with_bounded_evidence() {
         changed_files: vec!["src/lib.rs".to_string()],
         gate_feedback_baseline: None,
         dry_run: false,
+        trusted_unpushed_candidate_destination: None,
     };
 
     let error = run_provider_command(

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
@@ -185,6 +185,7 @@ fn lookup_only_configured_provider_cannot_construct_a_promotion_adapter() {
             changed_files: vec!["src/lib.rs".to_string()],
             gate_feedback_baseline: None,
             dry_run: false,
+            trusted_unpushed_candidate_destination: None,
         })
         .expect_err("lookup-only provider must not authorize promotion");
 

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -120,7 +120,7 @@ pub fn resolve_worktree_provider_from_config(
     handle: &str,
     config: &HomeboyConfig,
 ) -> Result<WorktreeProviderResolution> {
-    resolve_worktree_provider_with_policy_from_config(handle, config, false, None)
+    resolve_worktree_provider_with_policy_from_config(handle, config, false, None, None)
 }
 
 /// Resolve a workspace only from providers explicitly authorized for apply operations.
@@ -129,7 +129,36 @@ pub fn resolve_apply_enabled_worktree_provider_from_config(
     config: &HomeboyConfig,
     gate_feedback_baseline: Option<&serde_json::Value>,
 ) -> Result<WorktreeProviderResolution> {
-    resolve_worktree_provider_with_policy_from_config(handle, config, true, gate_feedback_baseline)
+    resolve_apply_enabled_worktree_provider_with_trusted_unpushed_destination_from_config(
+        handle,
+        config,
+        gate_feedback_baseline,
+        None,
+    )
+}
+
+/// A clean immutable candidate may be its own destination before Homeboy's
+/// finalizer pushes it. The exception remains bound to this exact checkout and
+/// commit; every other destination safety requirement still applies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrustedUnpushedWorktree {
+    pub path: std::path::PathBuf,
+    pub head: String,
+}
+
+pub fn resolve_apply_enabled_worktree_provider_with_trusted_unpushed_destination_from_config(
+    handle: &str,
+    config: &HomeboyConfig,
+    gate_feedback_baseline: Option<&serde_json::Value>,
+    trusted_unpushed_destination: Option<&TrustedUnpushedWorktree>,
+) -> Result<WorktreeProviderResolution> {
+    resolve_worktree_provider_with_policy_from_config(
+        handle,
+        config,
+        true,
+        gate_feedback_baseline,
+        trusted_unpushed_destination,
+    )
 }
 
 fn resolve_worktree_provider_with_policy_from_config(
@@ -137,6 +166,7 @@ fn resolve_worktree_provider_with_policy_from_config(
     config: &HomeboyConfig,
     require_apply_enabled: bool,
     gate_feedback_baseline: Option<&serde_json::Value>,
+    trusted_unpushed_destination: Option<&TrustedUnpushedWorktree>,
 ) -> Result<WorktreeProviderResolution> {
     let mut provider_ids = config
         .worktree_providers
@@ -160,7 +190,12 @@ fn resolve_worktree_provider_with_policy_from_config(
             attempted.push(provider_id.clone());
             let worktrees = run_provider_resolve_command(&provider_id, provider, command, handle)?;
             if let Some(worktree) = worktrees.into_iter().find(|item| item.handle == handle) {
-                validate_provider_handle(&provider_id, &worktree, gate_feedback_baseline)?;
+                validate_provider_handle(
+                    &provider_id,
+                    &worktree,
+                    gate_feedback_baseline,
+                    trusted_unpushed_destination,
+                )?;
                 return Ok(WorktreeProviderResolution {
                     provider_id,
                     worktree,
@@ -174,7 +209,12 @@ fn resolve_worktree_provider_with_policy_from_config(
         attempted.push(provider_id.clone());
         let worktrees = run_provider_list_command(&provider_id, provider, command)?;
         if let Some(worktree) = worktrees.into_iter().find(|item| item.handle == handle) {
-            validate_provider_handle(&provider_id, &worktree, gate_feedback_baseline)?;
+            validate_provider_handle(
+                &provider_id,
+                &worktree,
+                gate_feedback_baseline,
+                trusted_unpushed_destination,
+            )?;
             return Ok(WorktreeProviderResolution {
                 provider_id,
                 worktree,
@@ -440,6 +480,7 @@ fn validate_provider_handle(
     provider_id: &str,
     worktree: &WorktreeProviderHandle,
     gate_feedback_baseline: Option<&serde_json::Value>,
+    trusted_unpushed_destination: Option<&TrustedUnpushedWorktree>,
 ) -> Result<()> {
     let path = std::path::PathBuf::from(&worktree.path);
     if !path.is_dir() {
@@ -479,7 +520,11 @@ fn validate_provider_handle(
             worktree.safety.dirty && !verified_gate_feedback_baseline,
             "dirty",
         ),
-        (worktree.safety.unpushed, "unpushed"),
+        (
+            worktree.safety.unpushed
+                && !trusted_unpushed_destination_matches(&path, trusted_unpushed_destination),
+            "unpushed",
+        ),
         (worktree.safety.primary, "primary"),
     ]
     .into_iter()
@@ -511,6 +556,29 @@ fn validate_provider_handle(
         ));
     }
     Ok(())
+}
+
+fn trusted_unpushed_destination_matches(
+    path: &std::path::Path,
+    trusted: Option<&TrustedUnpushedWorktree>,
+) -> bool {
+    let Some(trusted) = trusted else {
+        return false;
+    };
+    let Ok(path) = std::fs::canonicalize(path) else {
+        return false;
+    };
+    let Ok(trusted_path) = std::fs::canonicalize(&trusted.path) else {
+        return false;
+    };
+    path == trusted_path
+        && crate::git::run_git(
+            &path,
+            &["rev-parse", "--verify", "HEAD^{commit}"],
+            "verify trusted unpushed worktree HEAD",
+        )
+        .ok()
+        .is_some_and(|head| head.trim() == trusted.head)
 }
 
 pub fn cleanup_worktree_providers_from_config(
@@ -1431,6 +1499,76 @@ mod tests {
             .expect_err("unsafe metadata must fail closed");
             assert!(err.message.contains(expected), "{}", err.message);
         }
+    }
+
+    #[test]
+    fn trusted_immutable_destination_is_the_only_unpushed_apply_exception() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path(), "cook-target");
+        let git = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(workspace.path())
+                .output()
+                .expect("run git");
+            assert!(output.status.success());
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        };
+        git(&["config", "user.email", "agent@example.test"]);
+        git(&["config", "user.name", "Agent"]);
+        std::fs::write(workspace.path().join("candidate"), "candidate\n").expect("write candidate");
+        git(&["add", "candidate"]);
+        git(&["commit", "-m", "candidate"]);
+        let head = git(&["rev-parse", "HEAD"]);
+        let mut config = config_with_provider(list_provider(
+            fake_list_provider_script(json!({ "worktrees": [{
+                "handle": "fixture@cook-target", "path": workspace.path(), "branch": "cook-target",
+                "safety": { "dirty": false, "unpushed": true, "primary": false }
+            }]})),
+            worktrees_mapping(),
+        ));
+        config
+            .worktree_providers
+            .get_mut("fixture")
+            .expect("fixture provider")
+            .apply_enabled = true;
+
+        let rejected = resolve_apply_enabled_worktree_provider_from_config(
+            "fixture@cook-target",
+            &config,
+            None,
+        )
+        .expect_err("ordinary unpushed destination remains blocked");
+        assert!(rejected.message.contains("unpushed"));
+
+        let resolved =
+            resolve_apply_enabled_worktree_provider_with_trusted_unpushed_destination_from_config(
+                "fixture@cook-target",
+                &config,
+                None,
+                Some(&TrustedUnpushedWorktree {
+                    path: workspace.path().to_path_buf(),
+                    head: head.clone(),
+                }),
+            )
+            .expect("exact immutable destination is allowed before finalizer push");
+        assert_eq!(
+            resolved.worktree.path,
+            workspace.path().display().to_string()
+        );
+
+        let stale =
+            resolve_apply_enabled_worktree_provider_with_trusted_unpushed_destination_from_config(
+                "fixture@cook-target",
+                &config,
+                None,
+                Some(&TrustedUnpushedWorktree {
+                    path: workspace.path().to_path_buf(),
+                    head: format!("{head}0"),
+                }),
+            )
+            .expect_err("different candidate commit remains blocked");
+        assert!(stale.message.contains("unpushed"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- admit an unpushed promotion destination only when it canonically matches the recorded source worktree and its HEAD equals the verified immutable candidate SHA
- treat that exact candidate patch as already applied before running the recorded gates and Homeboy-owned finalizer
- keep ordinary unpushed, dirty, primary, path-mismatched, and SHA-mismatched destinations blocked

Fixes #8983.

## How to test
1. Run `cargo test -p homeboy-core trusted_immutable_destination_is_the_only_unpushed_apply_exception`.
2. Run `cargo test -p homeboy-agents configured_provider_accepts_only_the_unpushed_immutable_candidate_destination`.
3. Create a cook whose pre-provider Lab handoff expires before provider execution and whose committed immutable candidate remains on the recipe source branch.
4. Run `homeboy agent-task adopt <cook-id> --candidate-ref <sha>`.
5. Confirm Homeboy accepts only the exact clean source path at that SHA, runs recorded gates, and retains push/PR finalization authority.
6. Change the destination path or HEAD and confirm adoption still fails closed as unpushed.

## Verification
- Both focused regression tests pass on current `origin/main`.
- `cargo check -p homeboy-agents` passes with existing warnings.
- `cargo test -p homeboy-agents -p homeboy-core --no-run` passes.
- Changed files are rustfmt-clean and `git diff --check` passes.
- Repository-wide `cargo fmt --all -- --check` still reports two unrelated existing differences.
- The existing historical orphan-adoption test reached provider execution but did not terminate within the five-minute local timeout; it is not claimed as passing.

## Compatibility
The exception is candidate-adoption-specific and requires canonical path plus exact commit identity. Ordinary cook destination safety and DMC dirty/primary protections are unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode
- **Used for:** Root-cause analysis, implementation, deterministic regression coverage, and verification. Chris reviewed and owns the change.