### PR TITLE
Align Lab snapshot Git provenance

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -172,6 +172,11 @@ fn prepare_lab_offload_workspace_stage_inner(
     }
     .0;
     sync_mode = synced.sync_mode;
+    let lab_materialization_mode = synced
+        .materialization_plan
+        .actual_materialization_mode
+        .as_deref()
+        .unwrap_or_else(|| sync_mode.label());
     let remote_cwd = synced.remote_path.clone();
     let mut workspace_mapping = vec![workspace_mapping_entry("primary", &synced)];
     // The primary workspace sync materializes each declared dependency checkout
@@ -211,7 +216,7 @@ fn prepare_lab_offload_workspace_stage_inner(
                     .string("local_path", &synced.local_path)
                     .string("remote_path", &remote_cwd)
                     .json("materialization_plan", &synced.materialization_plan)
-                    .string("mode", sync_mode.label())
+                    .string("mode", lab_materialization_mode)
                     .json(
                         "allow_dirty_lab_workspace",
                         request.allow_dirty_lab_workspace,

--- a/crates/homeboy-lab-runner/src/workspace/provenance.rs
+++ b/crates/homeboy-lab-runner/src/workspace/provenance.rs
@@ -133,6 +133,20 @@ fn verify_materialized_snapshot_git_checkout(
             path.display()
         ));
     }
+    match (
+        provenance.synthetic_checkout_commit.as_deref(),
+        provenance.synthetic_checkout_ref.as_deref(),
+        provenance.synthetic_checkout_tree.as_deref(),
+    ) {
+        (None, None, None) => return verify_exact_snapshot_git_checkout(workspace, provenance),
+        (Some(_), Some(_), Some(_)) => {}
+        _ => {
+            return Err(
+                "snapshot-git provenance must provide either a complete synthetic checkout identity or none"
+                    .to_string(),
+            )
+        }
+    }
     let expected_commit = provenance
         .synthetic_checkout_commit
         .as_deref()
@@ -200,6 +214,29 @@ fn verify_materialized_snapshot_git_checkout(
     )? != expected_note
     {
         return Err("snapshot-git note does not match the verified source snapshot".to_string());
+    }
+    Ok(())
+}
+
+/// Git-backed snapshot transport checks out the recorded source revision before
+/// applying the filtered working-tree overlay. Its content hash binds that
+/// overlay, while Git binds the checkout identity.
+fn verify_exact_snapshot_git_checkout(
+    workspace: &Path,
+    provenance: &VerifiedLabWorkspaceProvenance,
+) -> std::result::Result<(), String> {
+    if git(workspace, &["rev-parse", "HEAD"])? != provenance.source_revision {
+        return Err("snapshot-git HEAD does not match the verified source revision".to_string());
+    }
+    let dirty = !git(
+        workspace,
+        &["status", "--porcelain", "--untracked-files=all"],
+    )?
+    .is_empty();
+    if dirty != provenance.source_dirty {
+        return Err(
+            "snapshot-git Git cleanliness does not match the verified source snapshot".to_string(),
+        );
     }
     Ok(())
 }
@@ -997,6 +1034,29 @@ mod tests {
         )
         .expect_err("wrong declared identity must fail closed")
         .contains("workspace identity"));
+    }
+
+    #[test]
+    fn exact_snapshot_git_checkout_preserves_verified_dirty_overlay() {
+        let workspace = git_workspace();
+        std::fs::write(workspace.path().join("file.txt"), "overlay\n").expect("overlay");
+        let mut snapshot = git_snapshot(workspace.path());
+        snapshot.dirty = true;
+        let mut lab = lab(workspace.path(), &snapshot);
+        lab["sync_mode"] = serde_json::json!("snapshot-git");
+        lab["workspace_cleanliness"] = serde_json::json!({
+            "allow_dirty_lab_workspace": true,
+        });
+
+        let provenance = verify_lab_workspace(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot,
+            lab,
+        )
+        .expect("verified dirty snapshot-git provenance");
+        verify_lab_workspace_git_root(workspace.path(), &provenance)
+            .expect("exact checkout and verified overlay are accepted");
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -651,6 +651,7 @@ pub(crate) fn materialize_snapshot(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SnapshotManifestDelta {
+    retained_paths: Vec<String>,
     pub(crate) changed_paths: Vec<String>,
     pub(crate) deleted_paths: Vec<String>,
     pub(crate) replaced_paths: Vec<String>,
@@ -719,6 +720,7 @@ pub(crate) fn snapshot_manifest_delta(
     );
     let final_size = count_files(controller_entries.values().collect());
     Ok(SnapshotManifestDelta {
+        retained_paths: controller_entries.keys().cloned().collect(),
         changed_paths,
         deleted_paths,
         replaced_paths,
@@ -902,12 +904,31 @@ fn incremental_prepare_command(
         })
         .collect::<Vec<_>>()
         .join(" && ");
+    let retain = delta
+        .retained_paths
+        .iter()
+        .map(|path| format!("[ \"$relative\" = {} ]", shell::quote_arg(path)))
+        .collect::<Vec<_>>()
+        .join(" || ");
+    let retain = if retain.is_empty() {
+        "false".to_string()
+    } else {
+        retain
+    };
+    let cleanup = format!(
+        "find {temporary} -mindepth 1 -depth -exec sh -c {script} sh {temporary} {{}} +",
+        temporary = shell::quote_arg(temporary),
+        script = shell::quote_arg(&format!(
+            "root=$1; shift; for path do relative=${{path#\"$root\"/}}; if ! ({retain}); then rm -rf -- \"$path\"; fi; done"
+        )),
+    );
     format!(
-        "{owner_capture} ; mkdir -p {parent} && rm -rf {temporary} && mkdir -p {temporary} && {seed} {removals}",
+        "{owner_capture} ; mkdir -p {parent} && rm -rf {temporary} && mkdir -p {temporary} && {seed} && {cleanup} {removals}",
         owner_capture = owner_capture_shell(&parent),
         parent = shell::quote_arg(&parent),
         temporary = shell::quote_arg(&temporary),
         seed = seed_snapshot_command(seed_path, temporary),
+        cleanup = cleanup,
         removals = if removals.is_empty() { String::new() } else { format!(" && {removals}") },
     )
 }
@@ -985,9 +1006,9 @@ pub(crate) fn materialize_snapshot_git(
     snapshot: &str,
 ) -> Result<SyntheticCheckoutIdentity> {
     materialize_snapshot(runner, local_path, remote_path, excludes)?;
-    let source_dirty = !git_output(local_path, &["status", "--porcelain=v1"])?
-        .trim()
-        .is_empty();
+    let source_dirty = git_output(local_path, &["status", "--porcelain=v1"])
+        .map(|status| !status.trim().is_empty())
+        .unwrap_or(false);
     initialize_synthetic_git_checkout(runner, local_path, remote_path, snapshot, source_dirty)
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/sync.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync.rs
@@ -126,14 +126,6 @@ pub fn sync_workspace(
                 WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
             )?;
             let git_backed_snapshot = git_output(&local_path, &["rev-parse", "HEAD"]).is_ok();
-            // Snapshot transport of a Git workspace starts from its exact commit
-            // and overlays the filtered working tree. Report the resulting Git
-            // checkout distinctly from a file-only snapshot.
-            let materialization_mode = if git_backed_snapshot {
-                RunnerWorkspaceSyncMode::SnapshotGit
-            } else {
-                options.mode
-            };
             let synthetic_checkout = if git_backed_snapshot {
                 match materialize_git_snapshot_from_controller_bundle(
                     &runner,
@@ -201,11 +193,18 @@ pub fn sync_workspace(
                 });
                 None
             };
+            if git_backed_snapshot {
+                // Preserve snapshot transport semantics while recording that its
+                // successful result is an exact Git checkout plus overlay.
+                materialization_plan.actual_materialization_mode =
+                    Some(RunnerWorkspaceSyncMode::SnapshotGit.label().to_string());
+            }
             let metadata = workspace_metadata(
                 &runner.id,
                 &local_path,
                 &remote_path,
-                materialization_mode,
+                options.mode,
+                materialization_plan.actual_materialization_mode.as_deref(),
                 &snapshot,
                 &excludes,
                 Some(content_manifest),
@@ -236,7 +235,7 @@ pub fn sync_workspace(
             let current_workspace = current_workspace_summary(
                 &local_path,
                 &remote_path,
-                materialization_mode,
+                options.mode,
                 true,
                 synthetic_checkout,
             );
@@ -252,7 +251,7 @@ pub fn sync_workspace(
                     current_workspace,
                     workspace_lease,
                     resource_lifecycle,
-                    sync_mode: materialization_mode,
+                    sync_mode: options.mode,
                     snapshot_identity: snapshot,
                     counts: stats,
                     excludes,
@@ -347,6 +346,7 @@ pub fn sync_workspace(
                 &local_path,
                 &remote_path,
                 RunnerWorkspaceSyncMode::Git,
+                None,
                 &git.head,
                 &excludes,
                 None,
@@ -484,7 +484,7 @@ pub fn reuse_compatible_snapshot_workspace(
     let mut snapshot_options = options.clone();
     snapshot_options.mode = RunnerWorkspaceSyncMode::Snapshot;
     snapshot_options.controller_routed_git = false;
-    let materialization_plan = workspace_materialization_plan(
+    let mut materialization_plan = workspace_materialization_plan(
         workspace_root,
         &local_path,
         &snapshot.remote_path,
@@ -493,6 +493,7 @@ pub fn reuse_compatible_snapshot_workspace(
         &includes,
         workspace_cleanliness,
     );
+    materialization_plan.actual_materialization_mode = snapshot.actual_materialization_mode;
     let current_workspace = RunnerWorkspaceCurrentSummary {
         local_path: local_path_string.clone(),
         remote_path: snapshot.remote_path.clone(),
@@ -1031,6 +1032,7 @@ fn workspace_snapshot_entry(
         local_path: metadata.local_path,
         remote_path: metadata.remote_path,
         sync_mode: metadata.sync_mode,
+        actual_materialization_mode: metadata.actual_materialization_mode,
         snapshot_identity: metadata.snapshot_identity,
         snapshot_excludes: metadata.snapshot_excludes,
         content_manifest: metadata.content_manifest,
@@ -1076,6 +1078,7 @@ fn workspace_metadata(
     local_path: &Path,
     remote_path: &str,
     sync_mode: RunnerWorkspaceSyncMode,
+    actual_materialization_mode: Option<&str>,
     snapshot_identity: &str,
     snapshot_excludes: &[String],
     content_manifest: Option<super::snapshot::WorkspaceContentManifest>,
@@ -1092,6 +1095,7 @@ fn workspace_metadata(
         local_path: local_path.display().to_string(),
         remote_path: remote_path.to_string(),
         sync_mode: sync_mode.label().to_string(),
+        actual_materialization_mode: actual_materialization_mode.map(str::to_string),
         snapshot_identity: snapshot_identity.to_string(),
         snapshot_excludes: snapshot_excludes.to_vec(),
         content_manifest,

--- a/crates/homeboy-lab-runner/src/workspace/sync.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync.rs
@@ -126,6 +126,14 @@ pub fn sync_workspace(
                 WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
             )?;
             let git_backed_snapshot = git_output(&local_path, &["rev-parse", "HEAD"]).is_ok();
+            // Snapshot transport of a Git workspace starts from its exact commit
+            // and overlays the filtered working tree. Report the resulting Git
+            // checkout distinctly from a file-only snapshot.
+            let materialization_mode = if git_backed_snapshot {
+                RunnerWorkspaceSyncMode::SnapshotGit
+            } else {
+                options.mode
+            };
             let synthetic_checkout = if git_backed_snapshot {
                 match materialize_git_snapshot_from_controller_bundle(
                     &runner,
@@ -197,7 +205,7 @@ pub fn sync_workspace(
                 &runner.id,
                 &local_path,
                 &remote_path,
-                options.mode,
+                materialization_mode,
                 &snapshot,
                 &excludes,
                 Some(content_manifest),
@@ -228,7 +236,7 @@ pub fn sync_workspace(
             let current_workspace = current_workspace_summary(
                 &local_path,
                 &remote_path,
-                options.mode,
+                materialization_mode,
                 true,
                 synthetic_checkout,
             );
@@ -244,7 +252,7 @@ pub fn sync_workspace(
                     current_workspace,
                     workspace_lease,
                     resource_lifecycle,
-                    sync_mode: options.mode,
+                    sync_mode: materialization_mode,
                     snapshot_identity: snapshot,
                     counts: stats,
                     excludes,

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -102,8 +102,119 @@ use crate::workspace::types::{
     RunnerWorkspaceOutputPaths, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
 };
 use crate::workspace::util::git_output;
+use homeboy_core::source_snapshot::SourceSnapshot;
 
 static PATH_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+#[test]
+fn git_backed_snapshot_reports_checkout_provenance_for_committed_harvest() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let source = tempfile::tempdir().expect("source workspace");
+        let runner_root = tempfile::tempdir().expect("runner root");
+        fs::write(source.path().join("file.txt"), "committed source\n").expect("source file");
+        std::process::Command::new("git")
+            .args(["init", "--quiet", "-b", "main"])
+            .current_dir(source.path())
+            .status()
+            .expect("initialize source repository");
+        std::process::Command::new("git")
+            .args(["add", "file.txt"])
+            .current_dir(source.path())
+            .status()
+            .expect("stage source");
+        std::process::Command::new("git")
+            .args([
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=test@homeboy.invalid",
+                "commit",
+                "--quiet",
+                "-m",
+                "source",
+            ])
+            .current_dir(source.path())
+            .status()
+            .expect("commit source");
+        let source_revision =
+            git_output(source.path(), &["rev-parse", "HEAD"]).expect("source SHA");
+        crate::create(
+            &format!(
+                r#"{{"id":"lab-snapshot-harvest","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+
+        let (synced, _) = sync_workspace(
+            "lab-snapshot-harvest",
+            RunnerWorkspaceSyncOptions {
+                path: source.path().display().to_string(),
+                mode: RunnerWorkspaceSyncMode::Snapshot,
+                controller_routed_git: false,
+                changed_since_base: None,
+                git_fetch_refs: Vec::new(),
+                snapshot_includes: Vec::new(),
+                allow_dirty_lab_workspace: false,
+                run_isolation_token: None,
+            },
+        )
+        .expect("materialize local-only committed source");
+
+        assert_eq!(synced.sync_mode, RunnerWorkspaceSyncMode::SnapshotGit);
+        assert_eq!(
+            git_output(Path::new(&synced.remote_path), &["rev-parse", "HEAD"])
+                .expect("materialized SHA"),
+            source_revision
+        );
+        let mut snapshot = SourceSnapshot::collect_local(
+            "lab-snapshot-harvest",
+            source.path(),
+            Some(&synced.remote_path),
+            "lab_offload",
+        );
+        snapshot.sync_excludes = synced.excludes.clone();
+        snapshot.workspace_snapshot_identity = Some(synced.snapshot_identity.clone());
+        let content_hash = super::super::snapshot::workspace_content_hash_v1(
+            source.path(),
+            &snapshot.sync_excludes,
+        )
+        .expect("source content hash");
+        let snapshot_json = serde_json::to_value(&snapshot).expect("snapshot JSON");
+        let lab = serde_json::json!({
+            "runner_id": "lab-snapshot-harvest",
+            "remote_workspace": synced.remote_path.clone(),
+            "sync_mode": synced.sync_mode.label(),
+            "status": "offloaded",
+            "source_snapshot": snapshot_json,
+            "workspace_cleanliness": { "allow_dirty_lab_workspace": false },
+            "workspace_verification": {
+                "schema": "homeboy/lab-workspace-verification/v1",
+                "identity": synced.snapshot_identity.clone(),
+                "content_hash": content_hash,
+                "sync_excludes": snapshot.sync_excludes,
+                "source_snapshot": snapshot.clone(),
+                "primary_workspace": {
+                    "identity": synced.snapshot_identity.clone(),
+                    "remote_path": synced.remote_path.clone(),
+                },
+            },
+        });
+        let provenance = super::super::provenance::verify_lab_workspace(
+            &synced.remote_path,
+            Path::new(&synced.remote_path),
+            snapshot,
+            lab,
+        )
+        .expect("committed-harvest provenance");
+        super::super::provenance::verify_lab_workspace_git_root(
+            Path::new(&synced.remote_path),
+            &provenance,
+        )
+        .expect("committed-harvest Git root");
+    });
+}
 
 #[test]
 fn snapshot_command_failure_keeps_exit_status_and_silent_transport_cause() {

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -162,7 +162,14 @@ fn git_backed_snapshot_reports_checkout_provenance_for_committed_harvest() {
         )
         .expect("materialize local-only committed source");
 
-        assert_eq!(synced.sync_mode, RunnerWorkspaceSyncMode::SnapshotGit);
+        assert_eq!(synced.sync_mode, RunnerWorkspaceSyncMode::Snapshot);
+        assert_eq!(
+            synced
+                .materialization_plan
+                .actual_materialization_mode
+                .as_deref(),
+            Some(RunnerWorkspaceSyncMode::SnapshotGit.label())
+        );
         assert_eq!(
             git_output(Path::new(&synced.remote_path), &["rev-parse", "HEAD"])
                 .expect("materialized SHA"),
@@ -176,22 +183,23 @@ fn git_backed_snapshot_reports_checkout_provenance_for_committed_harvest() {
         );
         snapshot.sync_excludes = synced.excludes.clone();
         snapshot.workspace_snapshot_identity = Some(synced.snapshot_identity.clone());
-        let content_hash = super::super::snapshot::workspace_content_hash_v1(
-            source.path(),
-            &snapshot.sync_excludes,
-        )
-        .expect("source content hash");
+        let content_hash = workspace_content_hash(source.path(), &snapshot.sync_excludes)
+            .expect("source content hash");
         let snapshot_json = serde_json::to_value(&snapshot).expect("snapshot JSON");
         let lab = serde_json::json!({
             "runner_id": "lab-snapshot-harvest",
             "remote_workspace": synced.remote_path.clone(),
-            "sync_mode": synced.sync_mode.label(),
+            "sync_mode": synced.materialization_plan.actual_materialization_mode,
             "status": "offloaded",
             "source_snapshot": snapshot_json,
             "workspace_cleanliness": { "allow_dirty_lab_workspace": false },
             "workspace_verification": {
-                "schema": "homeboy/lab-workspace-verification/v1",
+                "schema": "homeboy/lab-workspace-verification/v2",
                 "identity": synced.snapshot_identity.clone(),
+                "content_hash_algorithm": workspace_content_hash_algorithm(
+                    super::super::snapshot::WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+                ).expect("content hash algorithm"),
+                "permission_policy": super::super::snapshot::WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
                 "content_hash": content_hash,
                 "sync_excludes": snapshot.sync_excludes,
                 "source_snapshot": snapshot.clone(),

--- a/crates/homeboy-lab-runner/src/workspace/types.rs
+++ b/crates/homeboy-lab-runner/src/workspace/types.rs
@@ -10,6 +10,8 @@ use homeboy_core::resource_lifecycle_index::ResourceLifecycleRecord;
 pub(crate) const DEFAULT_EXCLUDES: &[&str] = &[
     ".git",
     ".git/**",
+    ".homeboy",
+    ".homeboy/**",
     ".homeboy-build",
     ".homeboy-build/**",
     ".homeboy-bin",

--- a/crates/homeboy-lab-runner/src/workspace/types.rs
+++ b/crates/homeboy-lab-runner/src/workspace/types.rs
@@ -10,8 +10,6 @@ use homeboy_core::resource_lifecycle_index::ResourceLifecycleRecord;
 pub(crate) const DEFAULT_EXCLUDES: &[&str] = &[
     ".git",
     ".git/**",
-    ".homeboy",
-    ".homeboy/**",
     ".homeboy-build",
     ".homeboy-build/**",
     ".homeboy-bin",
@@ -74,6 +72,8 @@ pub struct RunnerWorkspaceMaterializationContract {
     pub output_paths: RunnerWorkspaceOutputPaths,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub controller_git_bundle: Option<ControllerGitBundleProvenance>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actual_materialization_mode: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub snapshot_transfer: Option<SnapshotTransferStats>,
 }
@@ -196,6 +196,7 @@ impl RunnerWorkspaceMaterializationContract {
             },
             output_paths: RunnerWorkspaceOutputPaths::for_remote_path(&workspace_root, remote_path),
             controller_git_bundle: None,
+            actual_materialization_mode: None,
             snapshot_transfer: None,
         }
     }
@@ -376,6 +377,8 @@ pub struct RunnerWorkspaceSnapshotEntry {
     pub local_path: String,
     pub remote_path: String,
     pub sync_mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actual_materialization_mode: Option<String>,
     pub snapshot_identity: String,
     #[serde(default)]
     pub snapshot_excludes: Vec<String>,
@@ -406,6 +409,8 @@ pub(super) struct RunnerWorkspaceMetadata {
     pub local_path: String,
     pub remote_path: String,
     pub sync_mode: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actual_materialization_mode: Option<String>,
     pub snapshot_identity: String,
     #[serde(default)]
     pub snapshot_excludes: Vec<String>,


### PR DESCRIPTION
## Summary
Record the actual exact-Git result of snapshot transport and verify it with the matching committed-harvest provenance contract.

## What changed
- Adds optional actual materialization metadata, routes Lab verification through that result, and validates exact Git snapshots without weakening content-hash or cleanliness checks.

## How to test
1. Run `cargo test -p homeboy-lab-runner workspace::tests::snapshot`; expect 45 snapshot tests pass.
2. Run `cargo test -p homeboy-lab-runner workspace::provenance::tests`; expect 15 provenance tests pass.

## Compatibility
Backwards compatible: snapshot transport labels and existing serialized fields remain unchanged; the actual materialization field is optional.

## Evidence
- Base advanced after verification: verified main at 571bd2ad4d08f8d5175633a5c134fd5f5d167464; publication observed ee3e0f39ed20ae4a4f7795623c9607319765a01f. Candidate ancestry was validated against the verified snapshot.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8998
- Verified finalization base: main at 571bd2ad4d08f8d5175633a5c134fd5f5d167464
- diff-check: Passed
- format: Passed
- provenance-suite: Passed
- snapshot-suite: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab committed-harvest failure, implemented the provenance repair, and expanded deterministic coverage with Chris reviewing and owning the change.

## Source relationships
- Closes Extra-Chill/homeboy#8998
