### PR TITLE
Publish authenticated recovered candidate adoptions

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -42,7 +42,6 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     let mut durable_changed_files = Vec::new();
     if !options.manual_finalization {
         let lifecycle = backend.hydrate_run(&options.run_id)?;
-        validate_durable_publication_eligibility(&lifecycle)?;
         let gate_proof = backend.hydrate_gate_proof(&options.run_id)?;
         if gate_proof.run_id != options.run_id {
             return Err(Error::validation_invalid_argument(
@@ -53,6 +52,8 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
             ));
         }
         validate_gate_proof_binding(&gate_proof, &options)?;
+        let eligibility =
+            validate_durable_publication_eligibility(&lifecycle, &gate_proof.promotion)?;
         durable_changed_files = gate_proof.promotion.changed_files.clone();
         options.normalized_gate_results = gate_proof.promotion.gate_results;
         if options.normalized_gate_results.is_empty() {
@@ -63,7 +64,9 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
                 None,
             ));
         }
-        options.review_dossier.ai_assistance.model = durable_model(&lifecycle)?;
+        if eligibility == DurablePublicationEligibility::ProviderRun {
+            options.review_dossier.ai_assistance.model = durable_model(&lifecycle)?;
+        }
         options.evidence.lifecycle = Some(lifecycle);
     }
     validate_green_gates(&options.normalized_gate_results)?;
@@ -499,18 +502,58 @@ fn report(
     }
 }
 
-fn validate_durable_publication_eligibility(lifecycle: &RunLifecycleRecord) -> Result<()> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DurablePublicationEligibility {
+    ProviderRun,
+    PreProviderCandidateAdoptionRecovery,
+}
+
+fn validate_durable_publication_eligibility(
+    lifecycle: &RunLifecycleRecord,
+    promotion: &AgentTaskPromotionReport,
+) -> Result<DurablePublicationEligibility> {
     use homeboy_core::run_lifecycle_record::{ProviderRuntimeState, RunExecutionState};
-    if lifecycle.execution.state != RunExecutionState::Succeeded
-        || lifecycle.provider_runtime.is_empty()
-        || lifecycle
+    if lifecycle.execution.state == RunExecutionState::Succeeded
+        && !lifecycle.provider_runtime.is_empty()
+        && lifecycle
             .provider_runtime
             .iter()
-            .any(|runtime| runtime.state != ProviderRuntimeState::Succeeded)
+            .all(|runtime| runtime.state == ProviderRuntimeState::Succeeded)
     {
-        return Err(Error::validation_invalid_argument("run_id", "durable run must have succeeded execution and succeeded provider runtime before publication", None, None));
+        return Ok(DurablePublicationEligibility::ProviderRun);
     }
-    Ok(())
+
+    let recovery = promotion.provenance.pointer("/adoption/recovery");
+    let candidate_ref = promotion.provenance["adoption"]["candidate_ref"].as_str();
+    let candidate_head = promotion
+        .provenance
+        .pointer("/candidate/fingerprint/head")
+        .and_then(serde_json::Value::as_str);
+    let authenticated_adoption = lifecycle.execution.state == RunExecutionState::Cancelled
+        && lifecycle.provider_runtime.is_empty()
+        && promotion.provenance["adoption"]["source_run_id"]
+            == promotion.source.run_id.clone().unwrap_or_default()
+        && candidate_ref.is_some_and(is_git_commit_identity)
+        && candidate_ref == candidate_head
+        && recovery.is_some_and(|recovery| {
+            recovery["schema"] == "homeboy/agent-task-candidate-adoption-recovery/v1"
+                && recovery["reason"] == "pre_provider_transport_failure"
+                && recovery["provider_executions_consumed"] == 0
+        })
+        && !promotion.gate_results.is_empty()
+        && promotion
+            .gate_results
+            .iter()
+            .all(|gate| gate.status == HomeboyGateStatus::Passed);
+    if authenticated_adoption {
+        return Ok(DurablePublicationEligibility::PreProviderCandidateAdoptionRecovery);
+    }
+
+    Err(Error::validation_invalid_argument("run_id", "durable run must have succeeded execution and succeeded provider runtime before publication; the only exception is an applied, green, fingerprinted candidate-adoption recovery with durable zero-execution pre-provider transport provenance", None, None))
+}
+
+fn is_git_commit_identity(value: &str) -> bool {
+    matches!(value.len(), 40 | 64) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn durable_model(lifecycle: &RunLifecycleRecord) -> Result<String> {

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -816,6 +816,87 @@ fn durable_finalization_requires_successful_provider_run_and_hydrates_model() {
 }
 
 #[test]
+fn durable_finalization_accepts_only_authenticated_pre_provider_candidate_adoption_recovery() {
+    let recovery_lifecycle = RunLifecycleRecord {
+        execution: RunExecutionLifecycle {
+            state: RunExecutionState::Cancelled,
+            started_at: None,
+            finished_at: Some("2026-01-01T00:00:00Z".to_string()),
+            updated_at: None,
+        },
+        ..RunLifecycleRecord::default()
+    };
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        lifecycle: Some(recovery_lifecycle.clone()),
+        gate_proof: Some(pre_provider_adoption_gate_proof()),
+        ..Default::default()
+    };
+    let mut finalization_options = options();
+    finalization_options.manual_finalization = false;
+    let report = finalize_pr_with_backend(finalization_options, &mut backend)
+        .expect("authenticated recovery publishes");
+    assert_eq!(report.status, "review_ready");
+    assert_eq!(report.review_dossier.ai_assistance.model, "GPT-5.5");
+    assert!(backend.committed && backend.pushed && backend.created);
+
+    let rejected = |lifecycle: RunLifecycleRecord, gate_proof: AgentTaskPrDurableGateProof| {
+        let mut backend = MockBackend {
+            changed_files: vec!["src/lib.rs".to_string()],
+            lifecycle: Some(lifecycle),
+            gate_proof: Some(gate_proof),
+            ..Default::default()
+        };
+        let mut finalization_options = options();
+        finalization_options.manual_finalization = false;
+        let error = finalize_pr_with_backend(finalization_options, &mut backend)
+            .expect_err("unsafe recovery is blocked");
+        assert!(error.message.contains("durable run must have succeeded"));
+        assert!(!backend.committed && !backend.pushed && !backend.created);
+    };
+
+    rejected(recovery_lifecycle.clone(), successful_gate_proof());
+
+    let mut provider_executed = recovery_lifecycle.clone();
+    provider_executed
+        .provider_runtime
+        .push(ProviderRuntimeLifecycle {
+            task_id: "task".to_string(),
+            backend: "provider".to_string(),
+            state: ProviderRuntimeState::Cancelled,
+            stream_uri: None,
+            external_runtime_ids: Vec::new(),
+            metadata: serde_json::Value::Null,
+        });
+    rejected(provider_executed, pre_provider_adoption_gate_proof());
+
+    let mut legacy = pre_provider_adoption_gate_proof();
+    legacy.promotion.provenance["adoption"]["recovery"] = serde_json::Value::Null;
+    rejected(recovery_lifecycle.clone(), legacy);
+
+    let mut mismatched = pre_provider_adoption_gate_proof();
+    mismatched.promotion.provenance["adoption"]["source_run_id"] = json!("other-run");
+    rejected(recovery_lifecycle.clone(), mismatched);
+
+    let mut unbound_candidate = pre_provider_adoption_gate_proof();
+    unbound_candidate.promotion.provenance["candidate"] = serde_json::Value::Null;
+    rejected(recovery_lifecycle.clone(), unbound_candidate);
+
+    let mut mismatched_head = pre_provider_adoption_gate_proof();
+    mismatched_head.promotion.provenance["candidate"]["fingerprint"]["head"] =
+        json!("0000000000000000000000000000000000000000");
+    rejected(recovery_lifecycle.clone(), mismatched_head);
+
+    let mut missing_head = pre_provider_adoption_gate_proof();
+    missing_head.promotion.provenance["candidate"]["fingerprint"]["head"] = json!("");
+    rejected(recovery_lifecycle.clone(), missing_head);
+
+    let mut non_green = pre_provider_adoption_gate_proof();
+    non_green.promotion.gate_results[0].status = HomeboyGateStatus::Failed;
+    rejected(recovery_lifecycle, non_green);
+}
+
+#[test]
 fn durable_finalization_publishes_clean_synced_recovered_candidate() {
     let mut gate_proof = successful_gate_proof();
     gate_proof.promotion.changed_files = vec!["src/lib.rs".to_string()];
@@ -1365,6 +1446,28 @@ fn successful_gate_proof() -> AgentTaskPrDurableGateProof {
             "gate_results": [{ "id": "gate", "name": "cargo test", "kind": "command", "status": "passed" }]
         })).expect("promotion proof"),
     }
+}
+
+fn pre_provider_adoption_gate_proof() -> AgentTaskPrDurableGateProof {
+    let mut proof = successful_gate_proof();
+    proof.promotion.provenance = json!({
+        "candidate": {
+            "kind": "git",
+            "fingerprint": {
+                "head": "7f76933ef002d195ee1cc5bf21069e0f40b1c972"
+            }
+        },
+        "adoption": {
+            "source_run_id": "cook-3678",
+            "candidate_ref": "7f76933ef002d195ee1cc5bf21069e0f40b1c972",
+            "recovery": {
+                "schema": "homeboy/agent-task-candidate-adoption-recovery/v1",
+                "reason": "pre_provider_transport_failure",
+                "provider_executions_consumed": 0
+            }
+        }
+    });
+    proof
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -156,12 +156,13 @@ pub fn adopt_cook_candidate_with_dispatcher(
             None,
         ));
     }
-    let (source, source_path) =
+    let (source, source_path, recovery) =
         if let Ok((source, path)) = agent_task_lifecycle::aggregate_source(&record.run_id) {
-            (source, Some(path))
+            (source, Some(path), None)
         } else if let Some(outcome) =
             agent_task_lifecycle::candidate_adoption_recovery_outcome(&record, &source_request)
         {
+            let recovery = outcome.metadata["candidate_adoption_recovery"].clone();
             (
                 serde_json::to_string(&outcome).map_err(|error| {
                     Error::internal_json(
@@ -170,9 +171,11 @@ pub fn adopt_cook_candidate_with_dispatcher(
                     )
                 })?,
                 None,
+                Some(recovery),
             )
         } else {
-            promotion_source(&record.run_id)?
+            let (source, path) = promotion_source(&record.run_id)?;
+            (source, path, None)
         };
     let promotion = promote_with_checkpoint(
         AgentTaskPromotionOptions {
@@ -208,6 +211,7 @@ pub fn adopt_cook_candidate_with_dispatcher(
         "candidate_ref": candidate_ref,
         "source_worktree_path": options.source_worktree_path,
         "recorded_task_base": options.task_base_sha,
+        "recovery": recovery,
     });
     agent_task_lifecycle::record_promotion(&record.run_id, promotion_value)?;
     let feedback = evaluate_cook_loop(AgentTaskCookLoopOptions {
@@ -2723,6 +2727,11 @@ mod tests {
             assert_eq!(
                 promoted.metadata["latest_promotion"]["provenance"]["adoption"]["candidate_ref"],
                 candidate
+            );
+            assert_eq!(
+                promoted.metadata["latest_promotion"]["provenance"]["adoption"]["recovery"]
+                    ["provider_executions_consumed"],
+                0
             );
         });
     }


### PR DESCRIPTION
## Summary
- allow durable publication for the existing authenticated zero-provider pre-handoff candidate-adoption recovery path
- bind publication to an applied green promotion, exact source run, exact candidate ref/fingerprint HEAD, and durable recovery envelope
- keep ordinary cancelled, failed, provider-executed, legacy, non-adoption, mismatched-candidate, and non-green runs blocked

Fixes #8983.

## How to test
1. Run `cargo test -p homeboy-agents durable_finalization_accepts_only_authenticated_pre_provider_candidate_adoption_recovery`.
2. Create a durable cook whose Lab handoff expires before provider execution and adopt an exact committed candidate.
3. Confirm promotion records an applied report, all-passed deterministic gates, exact candidate fingerprint HEAD, and zero-provider recovery provenance.
4. Confirm finalization pushes and creates the PR.
5. Change the candidate fingerprint HEAD, recovery envelope, provider execution state, source run, or gate result and confirm publication fails before commit, push, or PR creation.

## Verification
- Focused finalization acceptance/rejection test passes on current `origin/main`.
- Existing expired-handoff adoption persistence coverage passes.
- Changed files are rustfmt-clean and `git diff --check` passes.
- Broader `cargo test -p homeboy-agents agent_task_finalization` compiled and began successfully but exceeded the local 120-second limit in unrelated existing tests.

## Compatibility
Provider-backed publication is unchanged. The exception is restricted to the already-supported candidate-adoption recovery contract and requires exact durable identity plus green promotion proof.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode
- **Used for:** Runtime diagnosis, finalizer safety design, implementation, deterministic rejection coverage, and verification. Chris reviewed and owns the change.