### PR TITLE
Preserve oversized terminal daemon jobs

### DIFF
--- a/crates/homeboy-core/src/api_jobs/persistence.rs
+++ b/crates/homeboy-core/src/api_jobs/persistence.rs
@@ -169,8 +169,9 @@ pub(super) fn compact_terminal_jobs(
     let mut retained_terminal_bytes = original_terminal_bytes;
     let mut removed_job_ids = HashSet::new();
     for (stored, serialized_len) in terminal {
-        if retained_terminal_jobs <= terminal_job_retention_limit
-            && retained_terminal_bytes <= terminal_job_retention_bytes
+        if retained_terminal_jobs <= 1
+            || (retained_terminal_jobs <= terminal_job_retention_limit
+                && retained_terminal_bytes <= terminal_job_retention_bytes)
         {
             break;
         }

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -1056,6 +1056,60 @@ fn terminal_payload_budget_bounds_high_event_history_before_child_reservation_pe
 }
 
 #[test]
+fn oversized_terminal_result_remains_observable_when_it_exceeds_the_byte_budget() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let path = temp.path().join("jobs.json");
+    let terminal_job_retention_bytes = 64;
+    let store = JobStore::open_without_reconciliation_with_retention_and_terminal_byte_limit(
+        &path,
+        10,
+        10,
+        terminal_job_retention_bytes,
+    )
+    .expect("durable store opens");
+    let job = store.create("oversized-result");
+    store.start(job.id).expect("job starts");
+
+    let completed = store
+        .complete(job.id, Some(json!({ "output": "x".repeat(10_000) })))
+        .expect("terminal transition remains observable");
+
+    assert_eq!(completed.status, JobStatus::Succeeded);
+    assert_eq!(
+        store
+            .get(job.id)
+            .expect("terminal job remains readable")
+            .status,
+        JobStatus::Succeeded
+    );
+    let events = store
+        .events(job.id)
+        .expect("terminal events remain readable");
+    assert!(events
+        .iter()
+        .any(|event| event.kind == JobEventKind::Result));
+    assert!(events.iter().any(|event| event.kind == JobEventKind::Status
+        && event
+            .data
+            .as_ref()
+            .is_some_and(|data| data["status"] == "succeeded")));
+
+    let evidence = store
+        .inner
+        .lock()
+        .expect("job store mutex")
+        .compaction
+        .clone()
+        .expect("compaction evidence records the oversized terminal job");
+    assert_eq!(evidence.removed_terminal_jobs, 0);
+    assert_eq!(evidence.retained_terminal_jobs, 1);
+    assert!(
+        evidence.retained_terminal_bytes > terminal_job_retention_bytes,
+        "the single retained terminal record may exceed the byte budget"
+    );
+}
+
+#[test]
 fn remote_runner_job_submit_targets_runner_and_project() {
     let store = JobStore::default();
     let job = store


### PR DESCRIPTION
## Summary
- retain at least the newest terminal daemon job when its serialized payload alone exceeds the terminal-history byte budget
- keep normal count, byte, event, and active-job retention behavior unchanged
- cover the full oversized result transition so terminal status, result events, and job lookup remain observable

## Root cause
A direct Lab daemon job reached a terminal failure under an unchanged daemon lease, PID, and binary, then `/jobs/:id` returned 404. The daemon store compaction evidence at that failure reported 16 terminal jobs removed and zero retained.

`JobStore::transition()` marks the job terminal and persists before appending the terminal status event. Byte-budget compaction could remove every terminal record when one record exceeded the 4 MiB history budget, including the job currently transitioning. The subsequent status append then failed with `job not found`, removing the authoritative result from polling and logs.

This change treats the byte budget as soft only for the final newest terminal record. Older history is still evicted first and active jobs remain protected.

Closes part of #8974.

## How to test
1. Run `cargo test -p homeboy-core api_jobs::tests --no-fail-fast`.
2. Confirm all 91 API-jobs tests pass, including `oversized_terminal_result_remains_observable_when_it_exceeds_the_byte_budget`.
3. Run `cargo fmt --all -- --check` and `git diff --check`.

## Verification
- `cargo test -p homeboy-core api_jobs::tests --no-fail-fast`: 91 passed.
- Homeboy review audit: passed with no introduced findings.
- Homeboy review lint: passed with no findings.
- Full `homeboy-core` package test run: 1,479 passed and 20 unrelated existing environment/baseline tests failed across daemon fixtures, extension registration, symbol-graph assumptions, fleet, and Lab routing.
- Changed-scope Homeboy review test selection incorrectly translated `part_b.rs` into a Cargo filter matching zero tests; the direct package-scoped command above executed the affected suite.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Root-cause analysis, implementation, deterministic regression coverage, and verification.