### PR TITLE
Bound incremental Lab snapshot preparation

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -24,6 +24,10 @@ pub(crate) const WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE: &str = "unix-exec
 pub(crate) const WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE: &str = "unix-owner-executable";
 pub(crate) const WORKSPACE_CONTENT_DIAGNOSTIC_PATH_LIMIT: usize = 192;
 
+// Commands are passed through a shell and, for remote runners, SSH. Keep well
+// below platform argv limits after their quoting and environment overhead.
+const INCREMENTAL_PREPARE_COMMAND_MAX_BYTES: usize = 32 * 1024;
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct WorkspaceContentManifest {
     pub entry_count: usize,
@@ -782,10 +786,19 @@ pub(crate) fn materialize_snapshot_incremental(
     local_path: &Path,
     remote_path: &str,
     seed_path: &str,
+    excludes: &[String],
     delta: &SnapshotManifestDelta,
 ) -> Result<SnapshotTransferStats> {
     let temporary = format!("{}.tmp-{}", remote_path, uuid::Uuid::new_v4());
     let prepare = incremental_prepare_command(remote_path, &temporary, seed_path, delta);
+    if prepare.len() > INCREMENTAL_PREPARE_COMMAND_MAX_BYTES {
+        materialize_snapshot(runner, local_path, remote_path, excludes)?;
+        return Ok(SnapshotTransferStats {
+            reused: ByteFileCounts::default(),
+            transferred: delta.transfer.final_size.clone(),
+            final_size: delta.transfer.final_size.clone(),
+        });
+    }
     let finalize = incremental_finalize_command(remote_path, &temporary);
     let result = match runner.kind {
         RunnerKind::Local => {

--- a/crates/homeboy-lab-runner/src/workspace/sync.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync.rs
@@ -169,6 +169,7 @@ pub fn sync_workspace(
                         &local_path,
                         &remote_path,
                         &seed.remote_path,
+                        &excludes,
                         &delta,
                     ) {
                         Ok(transfer) => transfer,

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
@@ -272,6 +272,63 @@ fn incremental_snapshots_materialize_unchanged_content_without_transfer() {
 }
 
 #[test]
+fn incremental_snapshot_falls_back_to_full_transport_for_large_compatible_seed() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root");
+        create_local_runner("lab-local-large-incremental", runner_root.path());
+        let source = tempfile::tempdir().expect("source");
+        fs::create_dir_all(source.path().join("files")).expect("source directory");
+        for index in 0..2_254 {
+            fs::write(
+                source.path().join(format!("files/retained-{index:04}.txt")),
+                format!("seed-{index}\n"),
+            )
+            .expect("seed file");
+        }
+        sync_workspace(
+            "lab-local-large-incremental",
+            sync_options(
+                source.path().display().to_string(),
+                Some("first".to_string()),
+            ),
+        )
+        .expect("large seed snapshot");
+
+        fs::write(source.path().join("files/retained-0000.txt"), "updated\n").expect("small delta");
+        let (second, _) = sync_workspace(
+            "lab-local-large-incremental",
+            sync_options(
+                source.path().display().to_string(),
+                Some("second".to_string()),
+            ),
+        )
+        .expect("large compatible snapshot");
+
+        let transfer = second
+            .materialization_plan
+            .snapshot_transfer
+            .expect("transfer accounting");
+        assert_eq!(transfer.reused.files, 0);
+        assert_eq!(transfer.transferred.files, 2_254);
+        assert_eq!(transfer.final_size.files, 2_254);
+        assert_eq!(
+            fs::read_to_string(
+                std::path::Path::new(&second.remote_path).join("files/retained-0000.txt")
+            )
+            .expect("updated file"),
+            "updated\n"
+        );
+        assert_eq!(
+            fs::read_to_string(
+                std::path::Path::new(&second.remote_path).join("files/retained-2253.txt")
+            )
+            .expect("retained file"),
+            "seed-2253\n"
+        );
+    });
+}
+
+#[test]
 fn incremental_snapshot_refuses_seed_when_effective_excludes_change() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let runner_root = tempfile::tempdir().expect("runner root");


### PR DESCRIPTION
## Summary
- cap generated incremental snapshot preparation commands at 32 KiB
- fall back to existing full snapshot transport before invoking shell/SSH when a manifest would exceed that bound
- report full-transfer metrics accurately while preserving incremental reuse for bounded deltas

Fixes #9009.

## Root cause
`incremental_prepare_command()` embedded every retained and removed manifest path into one command and passed it as a single SSH argv element. The 2,254-entry Homeboy workspace exceeded controller `ARG_MAX` before provider execution.

## How to test
1. Run `cargo test -p homeboy-lab-runner incremental_snapshot -- --nocapture`.
2. Run `cargo check -p homeboy-lab-runner`.
3. Confirm the six focused tests pass, including the 2,254-entry compatible-seed regression.
4. Confirm the large regression reports zero reused files and all 2,254 files transferred while preserving both changed and retained content.
5. Confirm existing small-delta tests still report unchanged-content reuse and exact deletion/replacement reconciliation.

## Compatibility
No caller contract changes. Large compatible snapshots may use full transport instead of incremental reuse when generated preparation syntax exceeds the conservative bound; this trades optimization for deterministic correctness. Small compatible snapshots retain existing incremental behavior.

## Verification
- Focused incremental snapshot tests: 6 passed
- `cargo check -p homeboy-lab-runner`: passed
- `git diff --check`: passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol and OpenAI GPT-5.6 Terra via OpenCode
- **Used for:** Control-plane diagnosis, implementation, behavioral regression tests, and verification