### PR TITLE
fix: register extension providers in deps integration tests

### DIFF
--- a/tests/deps_test.rs
+++ b/tests/deps_test.rs
@@ -3,6 +3,15 @@ use homeboy::core::deps::{self, DependencyInstallInvocation, DependencyUpdateOpt
 use std::fs;
 use tempfile::tempdir;
 
+// The component-script/build runners live in the extension subsystem, which is
+// a separate crate registered at binary startup via `cli_runtime`. Integration
+// tests that exercise extension-backed dependency behavior must register those
+// providers explicitly (registration is an idempotent Mutex-backed slot).
+fn register_component_script_runner() {
+    homeboy_extension::component_script::register_component_script_runner();
+    homeboy_extension::build::register_component_build_runner();
+}
+
 fn write_file(path: &std::path::Path, contents: &str) {
     fs::write(path, contents).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
 }
@@ -251,6 +260,7 @@ fn stack_plan_compatibility_fields_are_serialized_from_homeboy_plan() {
 
 #[test]
 fn stack_plan_derives_edges_from_provider_reported_dependency_identities() {
+    register_component_script_runner();
     let dir = tempdir().unwrap();
     let upstream_path = dir.path().join("upstream");
     let downstream_path = dir.path().join("downstream");
@@ -305,6 +315,7 @@ fn stack_plan_derives_edges_from_provider_reported_dependency_identities() {
 
 #[test]
 fn stack_plan_keeps_explicit_edge_config_when_provider_edge_matches() {
+    register_component_script_runner();
     let dir = tempdir().unwrap();
     let upstream_path = dir.path().join("upstream");
     let downstream_path = dir.path().join("downstream");
@@ -443,6 +454,7 @@ fn non_composer_component_returns_clear_unsupported_error() {
 
 #[test]
 fn update_runs_component_provider_install_and_optional_rebuild() {
+    register_component_script_runner();
     let dir = tempdir().unwrap();
     let root = dir.path();
     fs::create_dir_all(root.join("scripts")).unwrap();


### PR DESCRIPTION
## Summary
Fixes the `Test`-gate regression on `main` introduced by the homeboy-extension crate extraction (#8984).

## Root cause
The component-script and component-build runners now live in the `homeboy-extension` crate and are registered at binary startup via `cli_runtime`. Three `deps_test` **integration** tests exercise extension-backed dependency behavior directly (not through `cli_runtime`), so the provider slots were empty and they panicked with:

```
no component-script runner registered; the extension subsystem is not available
no component-build runner registered; the extension subsystem is not available
```

## Fix
Register both providers (idempotent Mutex-backed slots) at the start of the three affected tests via a shared helper. `homeboy-extension` is already a dev-dependency of the root crate (added in #8984).

Affected tests:
- `stack_plan_derives_edges_from_provider_reported_dependency_identities`
- `stack_plan_keeps_explicit_edge_config_when_provider_edge_matches`
- `update_runs_component_provider_install_and_optional_rebuild`

## Verification
- `cargo test --test deps_test` — 10 passed, 0 failed, 1 ignored (the ignored one shells out to real composer).
- Only affected root integration test; `component_script_test` is `#[path]`-included into `homeboy-cli` and already has provider context.
- `tests/deps_test.rs` fmt-clean.