### PR TITLE
Preflight incremental snapshot command size

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -24,9 +24,16 @@ pub(crate) const WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE: &str = "unix-exec
 pub(crate) const WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE: &str = "unix-owner-executable";
 pub(crate) const WORKSPACE_CONTENT_DIAGNOSTIC_PATH_LIMIT: usize = 192;
 
-// Commands are passed through a shell and, for remote runners, SSH. Keep well
-// below platform argv limits after their quoting and environment overhead.
-const INCREMENTAL_PREPARE_COMMAND_MAX_BYTES: usize = 32 * 1024;
+// The SSH path passes this script through `sh -c` after shell-quoting it. A
+// single quote can expand from one byte to five bytes at that layer. 16 KiB
+// therefore remains below Linux's 128 KiB single-argument limit even in that
+// worst case, while leaving room for the SSH invocation and its environment.
+const INCREMENTAL_PREPARE_COMMAND_MAX_BYTES: usize = 16 * 1024;
+
+// Fixed shell syntax, owner capture, UUID, and repeated path references. The
+// preflight deliberately overestimates so it can reject before allocating a
+// command proportional to the manifest.
+const INCREMENTAL_PREPARE_COMMAND_FIXED_OVERHEAD_BYTES: usize = 4 * 1024;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct WorkspaceContentManifest {
@@ -790,6 +797,14 @@ pub(crate) fn materialize_snapshot_incremental(
     delta: &SnapshotManifestDelta,
 ) -> Result<SnapshotTransferStats> {
     let temporary = format!("{}.tmp-{}", remote_path, uuid::Uuid::new_v4());
+    if !incremental_prepare_command_fits(remote_path, &temporary, seed_path, delta) {
+        materialize_snapshot(runner, local_path, remote_path, excludes)?;
+        return Ok(SnapshotTransferStats {
+            reused: ByteFileCounts::default(),
+            transferred: delta.transfer.final_size.clone(),
+            final_size: delta.transfer.final_size.clone(),
+        });
+    }
     let prepare = incremental_prepare_command(remote_path, &temporary, seed_path, delta);
     if prepare.len() > INCREMENTAL_PREPARE_COMMAND_MAX_BYTES {
         materialize_snapshot(runner, local_path, remote_path, excludes)?;
@@ -868,6 +883,65 @@ pub(crate) fn materialize_snapshot_incremental(
         cleanup_incremental_temporary(runner, &temporary);
     }
     result.map(|_| delta.transfer.clone())
+}
+
+fn saturating_shell_quote_upper_bound(value: &str) -> usize {
+    // `quote_arg` can render each apostrophe as `'\\''` and add delimiters.
+    const SHELL_META: &[char] = &[
+        ' ', '\t', '\n', '\'', '"', '\\', '$', '`', '!', '*', '?', '[', ']', '(', ')', '{', '}',
+        '<', '>', '|', '&', ';', '#', '~',
+    ];
+    if value.contains(SHELL_META) {
+        value.len().saturating_mul(5).saturating_add(2)
+    } else {
+        value.len()
+    }
+}
+
+pub(super) fn incremental_prepare_command_fits(
+    remote_path: &str,
+    temporary: &str,
+    seed_path: &str,
+    delta: &SnapshotManifestDelta,
+) -> bool {
+    incremental_prepare_command_preflight_bytes(remote_path, temporary, seed_path, delta)
+        <= INCREMENTAL_PREPARE_COMMAND_MAX_BYTES
+}
+
+fn incremental_prepare_command_preflight_bytes(
+    remote_path: &str,
+    temporary: &str,
+    seed_path: &str,
+    delta: &SnapshotManifestDelta,
+) -> usize {
+    let parent = parent_remote_path(remote_path);
+    let mut bytes = INCREMENTAL_PREPARE_COMMAND_FIXED_OVERHEAD_BYTES;
+
+    // Account for every path embedded in the outer command, including the
+    // nested `sh -c` cleanup predicate for retained paths.
+    for path in &delta.retained_paths {
+        bytes = bytes.saturating_add(
+            saturating_shell_quote_upper_bound(path)
+                .saturating_mul(5)
+                .saturating_add(64),
+        );
+    }
+    for path in delta
+        .deleted_paths
+        .iter()
+        .chain(delta.replaced_paths.iter())
+        .chain(delta.changed_file_paths.iter())
+    {
+        bytes = bytes.saturating_add(saturating_shell_quote_upper_bound(path).saturating_add(64));
+    }
+
+    // These values are repeated in the generated setup, clone, cleanup, and
+    // removal clauses. Multiplying their conservative quoted size keeps the
+    // check independent of controller or runner path length.
+    bytes = bytes.saturating_add(saturating_shell_quote_upper_bound(&parent).saturating_mul(4));
+    bytes = bytes.saturating_add(saturating_shell_quote_upper_bound(temporary).saturating_mul(12));
+    bytes = bytes.saturating_add(saturating_shell_quote_upper_bound(seed_path).saturating_mul(2));
+    bytes
 }
 
 fn cleanup_incremental_temporary(runner: &Runner, temporary: &str) {

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
@@ -1,12 +1,14 @@
 use std::fs;
 
 use super::git;
+use crate::workspace::snapshot::{incremental_prepare_command_fits, snapshot_manifest_delta};
 use crate::workspace::sync::{
     reuse_compatible_snapshot_workspace, sync_workspace, workspace_snapshots,
 };
 use crate::workspace::types::{
     RunnerWorkspaceSnapshotFilters, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
 };
+use crate::workspace::{WorkspaceContentManifest, WorkspaceContentManifestEntry};
 
 #[test]
 fn workspace_snapshots_render_metadata_for_synced_workspace() {
@@ -325,7 +327,48 @@ fn incremental_snapshot_falls_back_to_full_transport_for_large_compatible_seed()
             .expect("retained file"),
             "seed-2253\n"
         );
+        for index in 0..2_254 {
+            let expected = if index == 0 {
+                "updated\n".to_string()
+            } else {
+                format!("seed-{index}\n")
+            };
+            assert_eq!(
+                fs::read_to_string(
+                    std::path::Path::new(&second.remote_path)
+                        .join(format!("files/retained-{index:04}.txt"))
+                )
+                .expect("exact fallback content"),
+                expected
+            );
+        }
     });
+}
+
+#[test]
+fn incremental_prepare_preflight_rejects_quote_heavy_manifest_before_command_construction() {
+    let entry = |index| WorkspaceContentManifestEntry {
+        path: format!("files/{}-{index:04}.txt", "'".repeat(64)),
+        kind: "file".to_string(),
+        sha256: Some(format!("sha256:{}", "0".repeat(64))),
+        bytes: Some(1),
+        owner_executable: None,
+    };
+    let manifest = WorkspaceContentManifest {
+        entry_count: 256,
+        entries: (0..256).map(entry).collect(),
+    };
+    let delta = snapshot_manifest_delta(&manifest, &manifest).expect("valid manifest delta");
+
+    assert!(
+        !incremental_prepare_command_fits(
+            "/runner/workspace/with a deliberately long remote path",
+            "/runner/workspace/with a deliberately long remote path.tmp-12345678",
+            "/runner/seed/with a deliberately long path",
+            &delta,
+        ),
+        "quote-heavy paths must select full transport before building the nested shell command"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- select full snapshot transport from a saturating estimate before constructing manifest-sized shell syntax
- cap generated incremental preparation scripts at 16 KiB so worst-case SSH quote expansion stays below Linux single-argument limits
- verify quote-heavy manifests and every file in the 2,254-entry fallback snapshot

Follow-up to #9014. Relates to #9009.

## Root cause
The first repair checked the generated script only after allocating it and before SSH applied a second shell-quoting layer. Quote-heavy paths could expand a nominally bounded script beyond the process argument limit, while very large manifests still required constructing an unbounded command before fallback selection.

## How to test
1. Run `cargo test -p homeboy-lab-runner workspace::tests::snapshots -- --nocapture`.
2. Confirm all 10 snapshot tests pass, including the quote-heavy preflight and 2,254-entry exact-content fallback cases.
3. Run `cargo check -p homeboy-lab-runner`.
4. Run `git diff --check origin/main...HEAD`.

## Compatibility
No public caller contract changes. The change only makes full-transport fallback more conservative for manifests whose generated incremental command cannot be safely bounded; small compatible snapshots retain incremental reuse.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Reviewed the initial repair, identified SSH quote-expansion and pre-allocation gaps, implemented deterministic preflight coverage, and verified the follow-up.