### PR TITLE
refactor: extract component model + config into homeboy-component-contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,6 +904,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "homeboy-component-contract"
+version = "0.1.0"
+dependencies = [
+ "homeboy-audit-contract",
+ "homeboy-error",
+ "homeboy-extension-contract",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "homeboy-core"
 version = "0.1.0"
 dependencies = [
@@ -922,6 +933,7 @@ dependencies = [
  "homeboy-cli-contract",
  "homeboy-code-audit",
  "homeboy-command-contract",
+ "homeboy-component-contract",
  "homeboy-engine-primitives",
  "homeboy-error",
  "homeboy-execution-contract",

--- a/crates/contracts/homeboy-component-contract/Cargo.toml
+++ b/crates/contracts/homeboy-component-contract/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "homeboy-component-contract"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Chris Huber <chubes@extrachill.com>"]
+description = "Pure serializable component model + config contract types for homeboy"
+repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
+
+[lib]
+name = "homeboy_component_contract"
+path = "src/lib.rs"
+
+[dependencies]
+homeboy-error = { version = "0.1.0", path = "../../homeboy-error" }
+homeboy-audit-contract = { version = "0.1.0", path = "../homeboy-audit-contract" }
+homeboy-extension-contract = { version = "0.1.0", path = "../homeboy-extension-contract" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/crates/contracts/homeboy-component-contract/src/config.rs
+++ b/crates/contracts/homeboy-component-contract/src/config.rs
@@ -1,7 +1,7 @@
 use serde::{ser::SerializeMap, Deserialize, Serialize, Serializer};
 use std::collections::HashMap;
 
-use crate::error::{Error, Result as HomeboyResult};
+use homeboy_error::{Error, Result as HomeboyResult};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 
@@ -157,7 +157,7 @@ impl ComponentOverrideConfig {
     ///
     /// `None` and empty collection fields mean "no override" so existing
     /// on-disk config keeps the same sparse-layer behavior.
-    pub fn apply_to_component(&self, component: &mut crate::component::Component) {
+    pub fn apply_to_component(&self, component: &mut crate::model::Component) {
         if let Some(remote_path) = &self.remote_path {
             component.remote_path = remote_path.clone();
         }

--- a/crates/contracts/homeboy-component-contract/src/lib.rs
+++ b/crates/contracts/homeboy-component-contract/src/lib.rs
@@ -1,0 +1,25 @@
+//! Pure serializable component model + config contract types.
+//!
+//! The `Component` struct and its `config`-module companions (`VersionTarget`,
+//! `GithubConfig`, `ComponentScriptsConfig`, `ScopeConfig`, …) describe the
+//! shape of a homeboy component as declared in `homeboy.json`. They are
+//! behavior-free data (serde + `homeboy-error` for validation + the
+//! `homeboy-audit-contract` / `homeboy-extension-contract` leaf types), so this
+//! is a leaf crate other crates can depend on without pulling in core.
+//!
+//! The extension-driven, filesystem-touching behavior on `Component`
+//! (auto-resolving `remote_path` from extension deploy rules) lives in
+//! `homeboy-core` as free functions, because it reaches into core's
+//! `extension_store` and the filesystem.
+
+pub mod config;
+pub mod model;
+
+pub use config::{
+    ArtifactInput, CleanupArtifactDeclaration, CommandScopeConfig, ComponentDeployConfig,
+    ComponentGithubReleaseConfig, ComponentOverrideConfig, ComponentReleaseConfig,
+    ComponentScriptsConfig, DependencyStackEdge, GitDeployConfig, GithubConfig, GithubHostConfig,
+    GithubReleaseOwner, PackageCoverageArtifactMatch, PackageCoverageConfig, ScopeConfig,
+    ScopedExtensionConfig, VersionTarget,
+};
+pub use model::{render_remote_path_template, Component, ComponentLifecycle};

--- a/crates/contracts/homeboy-component-contract/src/model.rs
+++ b/crates/contracts/homeboy-component-contract/src/model.rs
@@ -1,12 +1,12 @@
 use serde::{Deserialize, Deserializer, Serialize};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 
-use super::audit::AuditConfig;
-use super::config::{
+use crate::config::{
     is_default_github_config, ArtifactInput, CleanupArtifactDeclaration, ComponentDeployConfig,
     ComponentReleaseConfig, ComponentScriptsConfig, DependencyStackEdge, GitDeployConfig,
     GithubConfig, ScopeConfig, ScopedExtensionConfig, VersionTarget,
 };
+use homeboy_audit_contract::AuditConfig;
 
 /// Lifecycle state of a component.
 ///
@@ -396,77 +396,6 @@ impl Component {
         }
     }
 
-    /// Auto-resolve `remote_path` from linked extension deploy rules when not explicitly set.
-    ///
-    /// Extensions can declare generic file-content checks and target-path templates.
-    /// Core does not know framework-specific deploy paths; it only evaluates the
-    /// extension-provided contract.
-    ///
-    /// Extension templates can use the **local directory name** (basename of
-    /// `local_path`) separately from the component ID. This keeps deploy paths
-    /// correct when a component ID differs from the on-disk package directory.
-    ///
-    /// Returns `Some(path)` if auto-resolved, `None` if not applicable or not detectable.
-    pub fn auto_resolve_remote_path(&self) -> Option<String> {
-        // File components cannot auto-resolve — they must have explicit remote_path.
-        if std::path::Path::new(&self.local_path).is_file() {
-            return None;
-        }
-
-        let local = std::path::Path::new(&self.local_path);
-
-        // Use the directory basename as the remote directory name.
-        let dir_name = local.file_name()?.to_str()?;
-
-        let mut matches = HashSet::new();
-        for extension_id in self.extensions.as_ref()?.keys() {
-            let Ok(extension) = crate::extension_store::load_extension(extension_id) else {
-                continue;
-            };
-
-            for rule in extension.remote_path_inference_rules() {
-                if self.remote_path_inference_rule_matches(rule, local, dir_name) {
-                    matches.insert(render_remote_path_template(
-                        &rule.remote_path,
-                        &self.id,
-                        dir_name,
-                    ));
-                }
-            }
-        }
-
-        if matches.len() == 1 {
-            matches.into_iter().next()
-        } else {
-            None
-        }
-    }
-
-    fn remote_path_inference_rule_matches(
-        &self,
-        rule: &homeboy_extension_contract::RemotePathInferenceRule,
-        local: &std::path::Path,
-        dir_name: &str,
-    ) -> bool {
-        let relative_file =
-            render_remote_path_template(&rule.when_file_contains.file, &self.id, dir_name);
-        let relative_path = std::path::Path::new(&relative_file);
-        if relative_path.is_absolute()
-            || relative_path
-                .components()
-                .any(|component| matches!(component, std::path::Component::ParentDir))
-        {
-            return false;
-        }
-
-        let file = local.join(relative_path);
-        let Ok(content) = std::fs::read_to_string(file) else {
-            return false;
-        };
-
-        content.contains(&rule.when_file_contains.text)
-    }
-
     /// Whether this component is independently deployable per its lifecycle.
     ///
     /// `Bundled` and `Retired` components are not independently deployable —
@@ -554,7 +483,7 @@ impl Component {
         !self.script_commands(capability).is_empty()
     }
 
-    pub fn validate_supported_build_config(&self) -> crate::Result<()> {
+    pub fn validate_supported_build_config(&self) -> homeboy_error::Result<()> {
         let Some(command) = self
             .build_command
             .as_deref()
@@ -564,7 +493,7 @@ impl Component {
             return Ok(());
         };
 
-        Err(crate::Error::validation_invalid_argument(
+        Err(homeboy_error::Error::validation_invalid_argument(
             "build_command",
             format!(
                 "Component '{}' uses unsupported legacy build_command. Use scripts.build instead.",
@@ -577,21 +506,12 @@ impl Component {
             ]),
         ))
     }
-
-    /// Ensure `remote_path` is populated. If empty, attempt auto-resolution.
-    ///
-    /// This should be called after all config layers (repo portable, project overrides)
-    /// have been applied. It fills in `remote_path` only if still empty.
-    pub fn resolve_remote_path(&mut self) {
-        if self.remote_path.trim().is_empty() {
-            if let Some(resolved) = self.auto_resolve_remote_path() {
-                self.remote_path = resolved;
-            }
-        }
-    }
 }
 
-fn render_remote_path_template(template: &str, component_id: &str, dir_name: &str) -> String {
+/// Render an extension remote-path template against a component id + on-disk
+/// directory name. Pure string substitution; the extension-driven auto-resolve
+/// behavior that consumes it lives in `homeboy-core`.
+pub fn render_remote_path_template(template: &str, component_id: &str, dir_name: &str) -> String {
     template
         .replace("{{component_id}}", component_id)
         .replace("{{id}}", component_id)

--- a/crates/homeboy-cli/src/commands/bench/matrix.rs
+++ b/crates/homeboy-cli/src/commands/bench/matrix.rs
@@ -246,7 +246,7 @@ pub(super) fn rig_component_for_bench(spec: &RigSpec, component_id: &str) -> Opt
     let mut component = rig::resolve_component(spec, component_id).ok()?;
     component.remote_url = rig_component.remote_url.clone().or(component.remote_url);
     component.extensions = Some(extensions);
-    component.resolve_remote_path();
+    homeboy::core::component::resolve_remote_path(&mut component);
     Some(component)
 }
 

--- a/crates/homeboy-cli/src/commands/fuzz/workloads.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/workloads.rs
@@ -220,7 +220,7 @@ pub(super) fn rig_component_for_fuzz(spec: &RigSpec, component_id: &str) -> Opti
     let mut component = rig::resolve_component(spec, component_id).ok()?;
     component.remote_url = rig_component.remote_url.clone().or(component.remote_url);
     component.extensions = Some(extensions);
-    component.resolve_remote_path();
+    homeboy::core::component::resolve_remote_path(&mut component);
     Some(component)
 }
 
@@ -245,7 +245,7 @@ fn rig_component_for_fuzz_with_path(
         extensions: Some(extensions),
         ..Component::default()
     };
-    component.resolve_remote_path();
+    homeboy::core::component::resolve_remote_path(&mut component);
     Some(component)
 }
 

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -22,6 +22,7 @@ slow-tests = []
 [dependencies]
 homeboy-artifact-ref-contract = { version = "0.1.0", path = "../contracts/homeboy-artifact-ref-contract" }
 homeboy-command-contract = { version = "0.1.0", path = "../contracts/homeboy-command-contract" }
+homeboy-component-contract = { version = "0.1.0", path = "../contracts/homeboy-component-contract" }
 homeboy-cli-contract = { version = "0.1.0", path = "../contracts/homeboy-cli-contract" }
 homeboy-execution-contract = { version = "0.1.0", path = "../contracts/homeboy-execution-contract" }
 homeboy-gate-contract = { version = "0.1.0", path = "../contracts/homeboy-gate-contract" }

--- a/crates/homeboy-core/src/component/mod.rs
+++ b/crates/homeboy-core/src/component/mod.rs
@@ -5,13 +5,20 @@ pub mod audit_provider;
 // module tree. Re-exported as `component::audit` so existing
 // `crate::component::audit::*` paths keep resolving.
 pub use homeboy_audit_contract as audit;
-pub mod config;
+// The pure component model + config data types were extracted to the
+// homeboy-component-contract leaf crate. Re-exported as `component::config` and
+// `component::model` so existing `crate::component::{config,model}::*` paths
+// keep resolving. The extension-driven, fs-touching remote-path resolution that
+// used to live on `Component` stays in core as free functions in
+// `remote_path`.
+pub use homeboy_component_contract::config;
+pub use homeboy_component_contract::model;
 pub mod drift;
 pub mod inventory;
-pub mod model;
 pub mod mutations;
 pub mod portable;
 pub mod relationships;
+pub mod remote_path;
 pub mod resolution;
 pub mod scope;
 pub mod versioning;
@@ -46,6 +53,7 @@ pub use portable::{
     try_discover_from_portable, write_portable_config,
 };
 pub use relationships::{associated_projects, projects_using, rename_component, shared_components};
+pub use remote_path::{auto_resolve_remote_path, resolve_remote_path};
 pub use resolution::{
     local_path_is_relative, normalize_component_local_path, normalize_component_local_path_against,
     resolve, resolve_artifact, resolve_effective, resolve_target, resolve_target_from_component,

--- a/crates/homeboy-core/src/component/remote_path.rs
+++ b/crates/homeboy-core/src/component/remote_path.rs
@@ -1,0 +1,97 @@
+//! Extension-driven `remote_path` auto-resolution for components.
+//!
+//! These functions used to be `Component` methods, but they reach into core's
+//! `extension_store` (to load extension deploy rules) and the filesystem (to
+//! test rule file-content conditions), so they cannot live in the leaf
+//! `homeboy-component-contract` crate. They stay in core as free functions over
+//! `&Component` / `&mut Component`.
+
+use std::collections::HashSet;
+
+use homeboy_component_contract::model::render_remote_path_template;
+use homeboy_component_contract::Component;
+
+/// Auto-resolve `remote_path` from linked extension deploy rules when not
+/// explicitly set.
+///
+/// Extensions can declare generic file-content checks and target-path
+/// templates. Core does not know framework-specific deploy paths; it only
+/// evaluates the extension-provided contract.
+///
+/// Extension templates can use the **local directory name** (basename of
+/// `local_path`) separately from the component ID. This keeps deploy paths
+/// correct when a component ID differs from the on-disk package directory.
+///
+/// Returns `Some(path)` if auto-resolved, `None` if not applicable or not
+/// detectable.
+pub fn auto_resolve_remote_path(component: &Component) -> Option<String> {
+    // File components cannot auto-resolve — they must have explicit remote_path.
+    if std::path::Path::new(&component.local_path).is_file() {
+        return None;
+    }
+
+    let local = std::path::Path::new(&component.local_path);
+
+    // Use the directory basename as the remote directory name.
+    let dir_name = local.file_name()?.to_str()?;
+
+    let mut matches = HashSet::new();
+    for extension_id in component.extensions.as_ref()?.keys() {
+        let Ok(extension) = crate::extension_store::load_extension(extension_id) else {
+            continue;
+        };
+
+        for rule in extension.remote_path_inference_rules() {
+            if remote_path_inference_rule_matches(component, rule, local, dir_name) {
+                matches.insert(render_remote_path_template(
+                    &rule.remote_path,
+                    &component.id,
+                    dir_name,
+                ));
+            }
+        }
+    }
+
+    if matches.len() == 1 {
+        matches.into_iter().next()
+    } else {
+        None
+    }
+}
+
+fn remote_path_inference_rule_matches(
+    component: &Component,
+    rule: &homeboy_extension_contract::RemotePathInferenceRule,
+    local: &std::path::Path,
+    dir_name: &str,
+) -> bool {
+    let relative_file =
+        render_remote_path_template(&rule.when_file_contains.file, &component.id, dir_name);
+    let relative_path = std::path::Path::new(&relative_file);
+    if relative_path.is_absolute()
+        || relative_path
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return false;
+    }
+
+    let file = local.join(relative_path);
+    let Ok(content) = std::fs::read_to_string(file) else {
+        return false;
+    };
+
+    content.contains(&rule.when_file_contains.text)
+}
+
+/// Ensure `remote_path` is populated. If empty, attempt auto-resolution.
+///
+/// This should be called after all config layers (repo portable, project
+/// overrides) have been applied. It fills in `remote_path` only if still empty.
+pub fn resolve_remote_path(component: &mut Component) {
+    if component.remote_path.trim().is_empty() {
+        if let Some(resolved) = auto_resolve_remote_path(component) {
+            component.remote_path = resolved;
+        }
+    }
+}

--- a/crates/homeboy-core/src/component/resolution.rs
+++ b/crates/homeboy-core/src/component/resolution.rs
@@ -83,7 +83,7 @@ pub struct ResolvedTarget {
 fn resolved_target_from_component(mut component: Component, synthetic: bool) -> ResolvedTarget {
     let source_path = PathBuf::from(shellexpand::tilde(&component.local_path).into_owned());
     let git_root = detect_git_root(&source_path);
-    component.resolve_remote_path();
+    crate::component::resolve_remote_path(&mut component);
 
     ResolvedTarget {
         component_id: component.id.clone(),
@@ -273,13 +273,13 @@ fn prefer_cwd_for_component(component_id: &str) -> Option<Component> {
         registered.local_path = rebase_registered_path_to_checkout(&registered_path, &cwd_git_root)
             .to_string_lossy()
             .to_string();
-        registered.resolve_remote_path();
+        crate::component::resolve_remote_path(&mut registered);
         return Some(registered);
     }
 
     if is_named_component_worktree(component_id, &registered_path, &cwd_git_root) {
         registered.local_path = cwd_git_root.to_string_lossy().to_string();
-        registered.resolve_remote_path();
+        crate::component::resolve_remote_path(&mut registered);
         return Some(registered);
     }
 
@@ -380,7 +380,7 @@ fn resolve_path_override(path: &str) -> Result<Component> {
             Some(Path::new(path)),
         )?;
         discovered.local_path = path.to_string();
-        discovered.resolve_remote_path();
+        crate::component::resolve_remote_path(&mut discovered);
         return Ok(discovered);
     }
 
@@ -390,7 +390,7 @@ fn resolve_path_override(path: &str) -> Result<Component> {
             if let Some(mut discovered) = try_discover_from_portable(&git_root)? {
                 validate_duplicate_portable_component_ids(&discovered.id, &git_root, None)?;
                 discovered.local_path = path.to_string();
-                discovered.resolve_remote_path();
+                crate::component::resolve_remote_path(&mut discovered);
                 return Ok(discovered);
             }
         }
@@ -618,7 +618,7 @@ fn resolve_effective_inner(
                     Some(Path::new(path)),
                 )?;
                 discovered.local_path = path.to_string();
-                discovered.resolve_remote_path();
+                crate::component::resolve_remote_path(&mut discovered);
                 Ok(discovered)
             } else {
                 // Fallback: create a synthetic component when --path is
@@ -651,7 +651,7 @@ fn resolve_effective_inner(
                         Some(id_path),
                     )?;
                     discovered.local_path = local_path;
-                    discovered.resolve_remote_path();
+                    crate::component::resolve_remote_path(&mut discovered);
                     return Ok(discovered);
                 }
 

--- a/crates/homeboy-core/src/component/tests.rs
+++ b/crates/homeboy-core/src/component/tests.rs
@@ -437,7 +437,7 @@ fn auto_resolve_remote_path_uses_extension_rule() {
         };
 
         assert_eq!(
-            component.auto_resolve_remote_path(),
+            crate::component::auto_resolve_remote_path(&component),
             Some("remote/my-component".to_string()),
         );
     });
@@ -474,7 +474,7 @@ fn auto_resolve_remote_path_uses_dirname_not_component_id() {
         };
 
         assert_eq!(
-            component.auto_resolve_remote_path(),
+            crate::component::auto_resolve_remote_path(&component),
             Some("remote/source-dir".to_string()),
         );
     });
@@ -492,7 +492,7 @@ fn auto_resolve_remote_path_returns_none_without_matching_extension_rule() {
         ..Component::default()
     };
 
-    assert_eq!(component.auto_resolve_remote_path(), None);
+    assert_eq!(crate::component::auto_resolve_remote_path(&component), None);
 }
 
 #[test]
@@ -528,7 +528,7 @@ fn auto_resolve_remote_path_returns_none_on_conflicting_extension_rules() {
             ..Component::default()
         };
 
-        assert_eq!(component.auto_resolve_remote_path(), None);
+        assert_eq!(crate::component::auto_resolve_remote_path(&component), None);
     });
 }
 
@@ -563,7 +563,7 @@ fn resolve_remote_path_fills_empty() {
             ..Component::default()
         };
 
-        component.resolve_remote_path();
+        crate::component::resolve_remote_path(&mut component);
         assert_eq!(component.remote_path, "remote/my-component");
     });
 }
@@ -581,7 +581,7 @@ fn resolve_remote_path_preserves_explicit_value() {
         ..Component::default()
     };
 
-    component.resolve_remote_path();
+    crate::component::resolve_remote_path(&mut component);
     assert_eq!(component.remote_path, "custom/deploy/path");
 }
 

--- a/crates/homeboy-core/src/project/component/resolution.rs
+++ b/crates/homeboy-core/src/project/component/resolution.rs
@@ -95,7 +95,7 @@ pub fn resolve_project_component_with_standalone_snapshot(
     // Auto-resolve remote_path if still empty after all config layers.
     // Repo homeboy.json intentionally omits remote_path (it's deploy config),
     // so auto-detect it from source files when possible (#812).
-    resolved.resolve_remote_path();
+    crate::component::resolve_remote_path(&mut resolved);
 
     Ok(resolved)
 }

--- a/crates/homeboy-release/src/deploy/path_roots.rs
+++ b/crates/homeboy-release/src/deploy/path_roots.rs
@@ -10,8 +10,7 @@ use std::collections::HashSet;
 
 pub(super) fn component_remote_path(component: &Component) -> String {
     if component.remote_path.trim().is_empty() {
-        component
-            .auto_resolve_remote_path()
+        homeboy_core::component::auto_resolve_remote_path(component)
             .unwrap_or_else(|| component.remote_path.clone())
     } else {
         component.remote_path.clone()

--- a/crates/homeboy-rig/src/component_resolution.rs
+++ b/crates/homeboy-rig/src/component_resolution.rs
@@ -95,7 +95,7 @@ fn component_from_spec(
         extensions: spec.extensions.clone(),
         ..Component::default()
     };
-    component.resolve_remote_path();
+    component::resolve_remote_path(&mut component);
     component
 }
 
@@ -116,7 +116,7 @@ fn apply_rig_component_overrides(
     if let Some(extensions) = spec.extensions.clone() {
         component.extensions = Some(extensions);
     }
-    component.resolve_remote_path();
+    component::resolve_remote_path(component);
 }
 
 fn path_from_path_setting(spec: &ComponentSpec) -> Option<String> {


### PR DESCRIPTION
## Summary
`component::Component` was the **biggest remaining data cluster in core** — ~7.4k LOC across 14 files, referenced cross-crate **118×**. Its `model` and `config` modules are almost entirely pure serde data; only a few `Component` methods reach into core.

This extracts the pure surface into a new leaf crate **`homeboy-component-contract`** and keeps the fs/extension-touching behavior in core.

### What moved down (leaf crate)
- **`model.rs`** — `Component`, `ComponentLifecycle`, `RawComponent` + `From` conversions, and the pure `Component` methods (`deploy_config`, `script_commands`, `has_script`, `is_active_lifecycle`, …). `validate_supported_build_config` moved too — it only used `homeboy_error` (a leaf).
- **`config.rs`** — all 18 pure config types (`VersionTarget`, `GithubConfig`, `ComponentScriptsConfig`, `ScopeConfig`, `ScopedExtensionConfig`, `ComponentDeployConfig`, …).
- Deps: `serde` + `homeboy-error` + `homeboy-audit-contract` + `homeboy-extension-contract` — all leaves, no core.

### What stayed in core
- The extension-driven, **filesystem-touching** remote-path resolution (`auto_resolve_remote_path` / `resolve_remote_path`) reaches `crate::extension_store` + `std::fs`. Converted from `Component` methods to **free functions** in `component::remote_path`, re-exported from `component`.
- All the component behavior modules (`inventory`, `portable`, `resolution`, `mutations`, `drift`, `relationships`, `scope`, `versioning`, `artifacts`).

Core re-exports the contract as `component::{model, config}`, so the whole behavior surface and every consumer resolve unchanged. The only caller edits were the ~20 sites that used `x.resolve_remote_path()` as a method → `component::resolve_remote_path(&mut x)` (core resolution/project/tests, rig, release, cli).

## Verification (local, VPS-safe)
- `cargo check -p homeboy-component-contract` — clean
- `cargo check -p homeboy-core --lib` — clean (0 errors)
- `cargo test -p homeboy-core --lib component::tests::` — **36 pass**, including `auto_resolve_remote_path` / `resolve_remote_path` (the moved free functions)
- `cargo check --lib` on all 6 consumer crates (`agents`, `lab-runner`, `refactor`, `release`, `rig`, `cli`) — all clean
- `cargo fmt` — clean

History preserved via `git mv` for `model.rs`/`config.rs`.

## Note
This is the first of the "big" data/behavior splits from the campaign backlog (`component`, `api_jobs`, `source_snapshot`). Behavior stays in core; only the data shape moved.