### PR TITLE
style: fix pre-existing rustfmt drift in agent_tasks.rs

### DIFF
--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -258,14 +258,14 @@ pub mod lifecycle {
         record_promotion, record_remote_dispatch_failure, record_run_aggregate,
         record_runner_job_identity, resolve_promotion_patch_artifact_id, retry,
         run_id_for_aggregate_path, run_record_exists, run_record_exists_resolved, run_status,
-        status, submit_plan,
-        verified_controller_artifact_projection_path, AgentTaskArtifactRef, AgentTaskCookIndex,
-        AgentTaskCookIndexAttempt, AgentTaskEventEnvelope, AgentTaskPreDispatchFailure,
-        AgentTaskRecordHealthItem, AgentTaskRecordHealthReason, AgentTaskRecordHealthSummary,
-        AgentTaskRecordReconciliationItem, AgentTaskRecordReconciliationReport,
-        AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts, AgentTaskRunLog,
-        AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState, AgentTaskRunStatus,
-        AgentTaskRunTask, ControllerRuntimePruneResult, DetachedLabRunRecord, LabOffloadProxyPlan,
+        status, submit_plan, verified_controller_artifact_projection_path, AgentTaskArtifactRef,
+        AgentTaskCookIndex, AgentTaskCookIndexAttempt, AgentTaskEventEnvelope,
+        AgentTaskPreDispatchFailure, AgentTaskRecordHealthItem, AgentTaskRecordHealthReason,
+        AgentTaskRecordHealthSummary, AgentTaskRecordReconciliationItem,
+        AgentTaskRecordReconciliationReport, AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts,
+        AgentTaskRunLog, AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState,
+        AgentTaskRunStatus, AgentTaskRunTask, ControllerRuntimePruneResult, DetachedLabRunRecord,
+        LabOffloadProxyPlan,
     };
 }
 


### PR DESCRIPTION
## Summary
A stale `use`-import block in `crates/homeboy-agents/src/agent_tasks.rs` was never rustfmt-normalized. It trips `cargo fmt --check` on `main`, so every PR that runs `cargo fmt` picks up incidental churn in this unrelated file (I hit it repeatedly across today's extraction/fix PRs and had to keep reverting it).

## Change
Pure formatting — rustfmt re-wrapping the import list. **No semantic change.**

## Verification
- `cargo fmt --check` — now clean (0 diffs across the workspace).
- `cargo check -p homeboy-agents --lib` — clean.