### PR TITLE
refactor: extract api-jobs data types into homeboy-api-jobs-contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "homeboy-api-jobs-contract"
+version = "0.1.0"
+dependencies = [
+ "homeboy-lab-contract",
+ "homeboy-source-snapshot-contract",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "homeboy-artifact-ref-contract"
 version = "0.1.0"
 dependencies = [
@@ -928,6 +939,7 @@ dependencies = [
  "glob-match",
  "heck",
  "homeboy-agents-contract",
+ "homeboy-api-jobs-contract",
  "homeboy-artifact-ref-contract",
  "homeboy-audit-contract",
  "homeboy-cli-contract",

--- a/crates/contracts/homeboy-api-jobs-contract/Cargo.toml
+++ b/crates/contracts/homeboy-api-jobs-contract/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "homeboy-api-jobs-contract"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Chris Huber <chubes@extrachill.com>"]
+description = "Pure serializable job model contract types for homeboy (Job/JobStatus/JobEvent)"
+repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
+
+[lib]
+name = "homeboy_api_jobs_contract"
+path = "src/lib.rs"
+
+[dependencies]
+homeboy-lab-contract = { version = "0.1.0", path = "../homeboy-lab-contract" }
+homeboy-source-snapshot-contract = { version = "0.1.0", path = "../homeboy-source-snapshot-contract" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+uuid = { version = "1.11", features = ["v4", "v5", "serde"] }

--- a/crates/contracts/homeboy-api-jobs-contract/src/lib.rs
+++ b/crates/contracts/homeboy-api-jobs-contract/src/lib.rs
@@ -1,0 +1,22 @@
+//! Pure serializable job-model contract types.
+//!
+//! `Job`, `JobStatus`, `JobEvent`, and their runner/daemon companions describe
+//! the shape of a homeboy API job as it crosses process boundaries between the
+//! controller, daemon, and runner. These are behavior-free serde data types
+//! (plus the pure `JobArtifactMetadata` / `RunnerJobLifecycleMetadata`), so this
+//! is a leaf crate other crates can depend on without pulling in core.
+//!
+//! The job *store* (`api_jobs::store`, persistence, remote-runner dispatch,
+//! provider hooks) stays in `homeboy-core`.
+
+pub mod metadata;
+pub mod types;
+
+pub use metadata::{JobArtifactMetadata, RunnerJobLifecycleMetadata};
+pub use types::{
+    ActiveRunnerJobRunSummary, ActiveRunnerJobSummary, DaemonActiveJobRecoveryDisposition,
+    DaemonActiveJobRecoveryEvidence, DaemonLeaseJobDiagnostics, DaemonLinkedDurableRunState, Job,
+    JobClaimMetadata, JobEvent, JobEventKind, JobStatus, LeaselessOrphanAffectedJob,
+    LeaselessOrphanJobDiagnostics, RunnerJobLifecycleOwner, RunnerJobLogSnapshot,
+    RunnerJobProjection, RunnerJobSource,
+};

--- a/crates/contracts/homeboy-api-jobs-contract/src/metadata.rs
+++ b/crates/contracts/homeboy-api-jobs-contract/src/metadata.rs
@@ -1,0 +1,40 @@
+//! Pure job artifact / lifecycle metadata structs shared by the job model and
+//! the runner-facing execution surface.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JobArtifactMetadata {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_base64: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerJobLifecycleMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub durable_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_child_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_cell_count: Option<u64>,
+}

--- a/crates/contracts/homeboy-api-jobs-contract/src/types.rs
+++ b/crates/contracts/homeboy-api-jobs-contract/src/types.rs
@@ -4,10 +4,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use super::remote_runner::JobArtifactMetadata;
-use super::remote_runner::RunnerJobLifecycleMetadata;
-use crate::runner_execution_envelope::PathMaterializationPlan;
-use crate::source_snapshot::SourceSnapshot;
+use crate::metadata::JobArtifactMetadata;
+use crate::metadata::RunnerJobLifecycleMetadata;
+use homeboy_lab_contract::path_materialization::PathMaterializationPlan;
+use homeboy_source_snapshot_contract::SourceSnapshot;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -20,7 +20,7 @@ pub enum JobStatus {
 }
 
 impl JobStatus {
-    pub(super) fn is_terminal(self) -> bool {
+    pub fn is_terminal(self) -> bool {
         matches!(self, Self::Succeeded | Self::Failed | Self::Cancelled)
     }
 

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -22,6 +22,7 @@ slow-tests = []
 [dependencies]
 homeboy-artifact-ref-contract = { version = "0.1.0", path = "../contracts/homeboy-artifact-ref-contract" }
 homeboy-command-contract = { version = "0.1.0", path = "../contracts/homeboy-command-contract" }
+homeboy-api-jobs-contract = { version = "0.1.0", path = "../contracts/homeboy-api-jobs-contract" }
 homeboy-source-snapshot-contract = { version = "0.1.0", path = "../contracts/homeboy-source-snapshot-contract" }
 homeboy-component-contract = { version = "0.1.0", path = "../contracts/homeboy-component-contract" }
 homeboy-cli-contract = { version = "0.1.0", path = "../contracts/homeboy-cli-contract" }

--- a/crates/homeboy-core/src/api_jobs/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/mod.rs
@@ -4,7 +4,11 @@ mod remote_runner;
 mod runner_job_preparation;
 mod store;
 mod summary;
-mod types;
+// The pure job-model data types (Job/JobStatus/JobEvent + companions) were
+// extracted to the homeboy-api-jobs-contract leaf crate. Re-exported as
+// `api_jobs::types` so existing `crate::api_jobs::types::*` paths keep
+// resolving. The job store / persistence / remote-runner behavior stays here.
+use homeboy_api_jobs_contract::types;
 
 pub use remote_runner::{
     JobArtifactMetadata, RemoteRunnerJobClaim, RemoteRunnerJobRequest, RemoteRunnerJobResult,

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -26,40 +26,7 @@ const MAX_COMMAND_ASSET_COUNT: usize = 16;
 const MAX_COMMAND_ASSET_BASE64_BYTES: usize = 1_400_000;
 const MAX_COMMAND_ASSETS_BASE64_BYTES: usize = 4_200_000;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct JobArtifactMetadata {
-    pub id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub path: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub mime: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub size_bytes: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sha256: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub content_base64: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<Value>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunnerJobLifecycleMetadata {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub kind: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub durable_run_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub active_child_count: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub active_cell_count: Option<u64>,
-}
+pub use homeboy_api_jobs_contract::metadata::{JobArtifactMetadata, RunnerJobLifecycleMetadata};
 
 /// Caller-owned identity required to cancel one daemon-local runner projection.
 /// This is deliberately distinct from the operator-facing job cancellation API.


### PR DESCRIPTION
## Summary
Extracts the api_jobs **job model** — `Job`, `JobStatus`, `JobEvent`, `JobEventKind`, `RunnerJobLogSnapshot`, `JobClaimMetadata`, and the daemon/lease diagnostics (17 pure serde types) — out of `homeboy-core` into a new leaf crate **`homeboy-api-jobs-contract`**.

These are among the most widely-consumed types in the workspace (`JobStatus` 42×, `JobEvent` 15×, `Job` 15× cross-crate) but they lived in core right next to the **104k-LOC** job store.

### The split
- **Down to the contract**: `api_jobs/types.rs` (all 17 types). Its dependencies are all leaves now — `SourceSnapshot` (`homeboy-source-snapshot-contract`, #9019), `PathMaterializationPlan` (`homeboy-lab-contract`), `uuid`, `serde`.
- The 2 pure metadata structs it embeds (`JobArtifactMetadata`, `RunnerJobLifecycleMetadata`) lived in the behavior-heavy `remote_runner.rs`; moved them into the contract's `metadata` module. Core's `remote_runner` re-exports them, so its `From<RunnerJobLifecycleMetadata>` impl and other refs are unchanged.
- Widened `JobStatus::is_terminal` `pub(super)`→`pub` (core `store`/`persistence`/`remote_runner` call it cross-crate now).

**Stays in core**: `store.rs`, `persistence.rs`, `remote_runner` dispatch behavior, the `RunnerJobPreparationProvider` hook, `agent_task_terminal_recovery`, `summary`. Core re-exports the contract as `api_jobs::types`, so all consumer paths (`agents`, `lab-runner`, `cli`) resolve unchanged.

## Verification (local, VPS-safe)
- `cargo check -p homeboy-api-jobs-contract` — clean
- `cargo check -p homeboy-core --lib` — clean (0 errors)
- `cargo test -p homeboy-core --lib api_jobs::` — **98 pass** (store, persistence, remote-runner, recovery)
- `cargo check -p homeboy-agents --lib` / `-p homeboy-lab-runner --lib` / `-p homeboy-cli --lib` — all clean
- `cargo fmt` — clean

Builds on #9019 (source-snapshot), which made `SourceSnapshot` a leaf — the prerequisite since `Job` embeds it. History preserved via `git mv` for `types.rs`.