### PR TITLE
fix: centralize reserved runner-workspace paths so content-hash algorithms cannot drift

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -19,6 +19,28 @@ use super::util::{
 
 const RUNNER_WORKSPACE_METADATA_FILE: &str = ".homeboy/runner-workspace.json";
 const LAB_AT_FILES_DIRECTORY: &str = ".homeboy/lab-at-files";
+
+/// Runner-owned paths that Homeboy materializes *onto* a workspace after
+/// transport. They exist only on the runner side, never in the controller's
+/// source tree, so they must be excluded from every workspace content-identity
+/// computation — otherwise the runner and controller hash different trees and
+/// materialization verification fails spuriously.
+///
+/// This is the single source of truth: the content-hash traversals and the
+/// pre-sync collision check all derive from it, so a new reserved path cannot
+/// leak into one hash algorithm while being excluded from another (the drift
+/// that produced #9003 and left the v1 traversal missing `lab-at-files`).
+const RESERVED_RUNNER_WORKSPACE_PATHS: &[&str] =
+    &[RUNNER_WORKSPACE_METADATA_FILE, LAB_AT_FILES_DIRECTORY];
+
+/// Whether `relative` (a `/`-normalized workspace-relative path) is a
+/// runner-owned materialization artifact that must never contribute to a
+/// workspace content identity.
+fn is_reserved_runner_workspace_path(relative: &str) -> bool {
+    RESERVED_RUNNER_WORKSPACE_PATHS
+        .iter()
+        .any(|reserved| relative == *reserved)
+}
 pub(crate) const WORKSPACE_CONTENT_PERMISSION_PORTABLE: &str = "portable-content-only";
 pub(crate) const WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE: &str = "unix-executable";
 pub(crate) const WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE: &str = "unix-owner-executable";
@@ -237,8 +259,7 @@ fn collect_content_hash_entries_v2(
         let is_runner_metadata_directory = relative == ".homeboy";
         if relative == ".git"
             || is_excluded(root, &root.join(&relative_path), excludes, &[])
-            || relative == RUNNER_WORKSPACE_METADATA_FILE
-            || relative == LAB_AT_FILES_DIRECTORY
+            || is_reserved_runner_workspace_path(&relative)
         {
             continue;
         }
@@ -438,7 +459,7 @@ fn collect_content_hash_entries_v1(
         let is_runner_metadata_directory = relative == ".homeboy";
         if relative == ".git"
             || is_excluded(root, &root.join(&relative_path), excludes, &[])
-            || relative == RUNNER_WORKSPACE_METADATA_FILE
+            || is_reserved_runner_workspace_path(&relative)
         {
             continue;
         }
@@ -1307,7 +1328,7 @@ pub(crate) fn copy_snapshot_to_directory(
 }
 
 pub(crate) fn ensure_no_runner_workspace_metadata_collision(local_path: &Path) -> Result<()> {
-    for reserved in [RUNNER_WORKSPACE_METADATA_FILE, LAB_AT_FILES_DIRECTORY] {
+    for reserved in RESERVED_RUNNER_WORKSPACE_PATHS.iter().copied() {
         let reserved_path = local_path.join(reserved);
         match fs::symlink_metadata(&reserved_path) {
             Ok(_) => {

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -8,8 +8,8 @@ use crate::workspace::snapshot::{
     copy_snapshot_to_directory, ensure_no_runner_workspace_metadata_collision,
     snapshot_archive_command, snapshot_install_command, synthetic_checkout_value,
     workspace_content_hash, workspace_content_hash_algorithm, workspace_content_hash_for_policy,
-    workspace_content_manifest_for_policy, WORKSPACE_CONTENT_PERMISSION_PORTABLE,
-    WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
+    workspace_content_hash_v1, workspace_content_manifest_for_policy,
+    WORKSPACE_CONTENT_PERMISSION_PORTABLE, WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
     WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
 };
 
@@ -1194,6 +1194,50 @@ fn snapshot_content_hash_matches_materialized_workspace_after_runner_metadata_in
         workspace_content_hash(&destination, &excludes).expect("materialized hash"),
         expected,
         "the controller hash must describe the bytes and structure that the runner verifies"
+    );
+}
+
+#[test]
+fn every_content_hash_algorithm_ignores_all_reserved_runner_workspace_paths() {
+    // Both the v1 and v2 content-hash traversals must exclude every
+    // runner-owned materialization artifact from `RESERVED_RUNNER_WORKSPACE_PATHS`
+    // identically. Regression guard for the drift where the v2 traversal was
+    // taught to skip `.homeboy/lab-at-files` (#9003) but the v1 traversal was
+    // not, so a v1 workspace carrying that runner path would hash differently on
+    // the runner than on the controller.
+    let controller = tempfile::tempdir().expect("controller");
+    let source = controller.path().join("source");
+    fs::create_dir_all(source.join("packages")).expect("source package directory");
+    fs::write(source.join("packages/app.rs"), "fn main() {}\n").expect("source file");
+    let excludes: Vec<String> = Vec::new();
+
+    let expected_v1 = workspace_content_hash_v1(&source, &excludes).expect("v1 source hash");
+    let expected_v2 = workspace_content_hash(&source, &excludes).expect("v2 source hash");
+
+    // Inject every reserved runner-owned path, exactly as the runner would after
+    // transport, then re-hash. The identity must be unchanged for both
+    // algorithms.
+    fs::create_dir_all(source.join(".homeboy/lab-at-files")).expect("lab-at-files directory");
+    fs::write(
+        source.join(".homeboy/lab-at-files/at-input.txt"),
+        "runner-owned transport artifact\n",
+    )
+    .expect("lab-at-files entry");
+    fs::write(
+        source.join(".homeboy/runner-workspace.json"),
+        r#"{"schema":"homeboy/runner-workspace/v1"}"#,
+    )
+    .expect("runner metadata");
+
+    assert_eq!(
+        workspace_content_hash_v1(&source, &excludes).expect("v1 injected hash"),
+        expected_v1,
+        "v1 content hash must ignore every reserved runner-owned workspace path"
+    );
+    assert_eq!(
+        workspace_content_hash(&source, &excludes).expect("v2 injected hash"),
+        expected_v2,
+        "v2 content hash must ignore every reserved runner-owned workspace path"
     );
 }
 


### PR DESCRIPTION
## Summary
Fixes a **latent workspace-content-hash mismatch** and removes the structural drift that keeps producing this class of bug.

The runner materializes its own paths onto a workspace *after* transport — `.homeboy/runner-workspace.json` and `.homeboy/lab-at-files`. These exist only on the runner side, never in the controller's source tree, so they must be excluded from every workspace content-identity computation. Otherwise the runner and controller hash different trees and materialization verification fails with "workspace content hash does not match the controller materialization."

## The latent bug
That exclusion was encoded as inline `relative == X` checks scattered across **three** sites that had drifted:
- the **v2** content-hash traversal — excludes `runner-workspace.json` **and** `lab-at-files` (taught by #9003)
- the pre-sync collision check — excludes both (also #9003)
- the **v1** content-hash traversal — excludes **only** `runner-workspace.json`  ← **missing `lab-at-files`**

So a v1-algorithm workspace carrying `.homeboy/lab-at-files` hashes differently on the runner than on the controller — a still-live instance of the exact failure #9003 thought it fixed.

## The fix
Replace the scattered inline checks with **one declarative source of truth** (`RESERVED_RUNNER_WORKSPACE_PATHS`) and **one predicate** (`is_reserved_runner_workspace_path`), used by both traversals and the collision check. A newly-reserved runner path now cannot leak into one algorithm while being excluded from another — the drift becomes structurally impossible.

This is deliberately a small, surgical fix targeting the *root pattern* behind the recurring Lab snapshot-identity churn (#9003, #8862, #9007, #8985 …): identity inclusion rules encoded implicitly and redundantly, so two derivations of "the same content" keep disagreeing.

## Verification (local, VPS-safe)
- `cargo check -p homeboy-lab-runner --lib` — clean
- New regression test `every_content_hash_algorithm_ignores_all_reserved_runner_workspace_paths` — passes (asserts v1 **and** v2 ignore every reserved path identically; would fail on the pre-fix v1 traversal)
- All other `workspace::tests::snapshot::` content-hash tests — pass

> Note: `git_backed_snapshot_uses_runner_exact_sha_without_controller_bundle_hydration` fails **identically on clean `origin/main`** (a git/SSH-dependent test on this environment) — pre-existing, unrelated to this change.