### PR TITLE
Converge successful Lab reconnect sessions

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
+++ b/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
@@ -1,6 +1,7 @@
 use super::super::lab_selection::{
     contended_runner_unavailable_error, prepare_lab_runner_for_offload_with,
-    wait_for_contended_runner, LabRunnerPreparation, LabRunnerSelection,
+    wait_for_contended_runner, wait_for_live_session_with, LabRunnerPreparation,
+    LabRunnerSelection,
 };
 use super::*;
 use crate::{RunnerActiveJobState, RunnerConnectReport, RunnerStatusReport, RunnerTunnelMode};
@@ -75,6 +76,61 @@ fn lab_runner_preparation_falls_back_for_unreachable_default_runner() {
             reason: "SSH connectivity check failed".to_string()
         }
     );
+}
+
+#[test]
+fn successful_connect_session_converges_after_transient_disconnection() {
+    let probes = std::cell::Cell::new(0);
+    let pauses = std::cell::Cell::new(0);
+    let elapsed = std::cell::Cell::new(std::time::Duration::ZERO);
+    let started = std::time::Instant::now();
+
+    let session =
+        wait_for_live_session_with(
+            std::time::Duration::from_millis(150),
+            |_| {
+                let probe = probes.get();
+                probes.set(probe + 1);
+                Ok((probe == 2)
+                    .then(|| connected_direct_session("lab", Some("http://127.0.0.1:1234"))))
+            },
+            || started + elapsed.get(),
+            |duration| {
+                pauses.set(pauses.get() + 1);
+                elapsed.set(elapsed.get() + duration);
+            },
+        )
+        .expect("session convergence");
+
+    assert!(session.is_some());
+    assert_eq!(probes.get(), 3);
+    assert_eq!(pauses.get(), 2);
+}
+
+#[test]
+fn successful_connect_session_convergence_exhausts_its_deadline() {
+    let probes = std::cell::Cell::new(0);
+    let pauses = std::cell::Cell::new(0);
+    let elapsed = std::cell::Cell::new(std::time::Duration::ZERO);
+    let started = std::time::Instant::now();
+
+    let session = wait_for_live_session_with(
+        std::time::Duration::from_millis(150),
+        |_| {
+            probes.set(probes.get() + 1);
+            Ok(None)
+        },
+        || started + elapsed.get(),
+        |duration| {
+            pauses.set(pauses.get() + 1);
+            elapsed.set(elapsed.get() + duration);
+        },
+    )
+    .expect("session convergence");
+
+    assert!(session.is_none());
+    assert_eq!(probes.get(), 3);
+    assert_eq!(pauses.get(), 3);
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -50,6 +50,7 @@ pub(super) enum LabRunnerPreparation {
 static HANDOFF_CONNECT_LOCKS: OnceLock<Mutex<std::collections::BTreeMap<String, Arc<Mutex<()>>>>> =
     OnceLock::new();
 const HANDOFF_CONNECT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const HANDOFF_CONNECT_STATUS_CONVERGENCE_TIMEOUT: Duration = Duration::from_millis(500);
 // A reconnect owner and its contending handoff share this bounded window. The
 // owner's short automatic-connect timeout remains separate from admission.
 const HANDOFF_ADMISSION_TIMEOUT: Duration = Duration::from_secs(30);
@@ -282,6 +283,23 @@ fn connect_runner_for_offload(
     }
     let (stdout, stderr, exit_code, timed_out) =
         run_runner_connect_command(runner_id, timeout, &lease)?;
+    if !timed_out && exit_code == 0 {
+        if let Some(session) =
+            wait_for_live_session(HANDOFF_CONNECT_STATUS_CONVERGENCE_TIMEOUT, |remaining| {
+                crate::local_live_session(runner_id, remaining)
+            })?
+        {
+            return connected_runner_connect_report_from_session(
+                runner_id,
+                session,
+                homeboy_core::paths::runner_session_file(runner_id)?
+                    .display()
+                    .to_string(),
+            );
+        }
+    }
+    // The live-session wait has a deadline. Read full status once afterward so
+    // an unavailable runner retains the existing detailed diagnostic.
     let status = status(runner_id)?;
 
     if status.connected {
@@ -330,6 +348,49 @@ fn connect_runner_for_offload(
     ))
 }
 
+pub(super) fn wait_for_live_session<Session>(
+    timeout: Duration,
+    session: Session,
+) -> Result<Option<super::RunnerSession>>
+where
+    Session: Fn(Duration) -> Result<Option<super::RunnerSession>>,
+{
+    wait_for_live_session_with(
+        timeout,
+        session,
+        std::time::Instant::now,
+        std::thread::sleep,
+    )
+}
+
+pub(super) fn wait_for_live_session_with<Session, Now, Pause>(
+    timeout: Duration,
+    session: Session,
+    mut now: Now,
+    mut pause: Pause,
+) -> Result<Option<super::RunnerSession>>
+where
+    Session: Fn(Duration) -> Result<Option<super::RunnerSession>>,
+    Now: FnMut() -> std::time::Instant,
+    Pause: FnMut(Duration),
+{
+    let deadline = now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(now());
+        if remaining.is_zero() {
+            return Ok(None);
+        }
+        if let Some(session) = session(remaining.min(HANDOFF_CONNECT_POLL_INTERVAL))? {
+            return Ok(Some(session));
+        }
+        let remaining = deadline.saturating_duration_since(now());
+        if remaining.is_zero() {
+            return Ok(None);
+        }
+        pause(remaining.min(HANDOFF_CONNECT_POLL_INTERVAL));
+    }
+}
+
 pub(super) fn contended_runner_unavailable_error(runner_id: &str, lease_error: Error) -> Error {
     Error::new(
         ErrorCode::ValidationInvalidArgument,
@@ -365,21 +426,7 @@ where
     if !homeboy_core::runtime_promotion::is_contention_error(&lease_error) {
         return Err(lease_error);
     }
-    let deadline = std::time::Instant::now() + timeout;
-    loop {
-        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-        if remaining.is_zero() {
-            return Ok(None);
-        }
-        if let Some(session) = session(remaining.min(HANDOFF_CONNECT_POLL_INTERVAL))? {
-            return Ok(Some(session));
-        }
-        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-        if remaining.is_zero() {
-            return Ok(None);
-        }
-        std::thread::sleep(remaining.min(HANDOFF_CONNECT_POLL_INTERVAL));
-    }
+    wait_for_live_session(timeout, session)
 }
 
 fn connected_runner_connect_report(


### PR DESCRIPTION
## Summary
- wait under an absolute 500 ms deadline for a live session after an exit-0 direct-SSH connect child
- use the existing timeout-aware daemon liveness primitive and perform one full status read only after convergence exhausts
- share the bounded live-session wait with reconnect-lease contention and add deterministic no-sleep convergence tests

Fixes #9025.

## How to test
1. Run `cargo test -p homeboy-lab-runner preparation_tests --lib`.
2. Confirm all 17 Lab preparation tests pass, including transient convergence and deadline exhaustion.
3. Run `cargo check -p homeboy-lab-runner`.
4. Run `git diff --check origin/main...HEAD`.

## Compatibility
No public contract changes. Nonzero and timed-out connect children retain one final status probe and existing diagnostics; successful children gain a bounded authoritative daemon-session convergence window.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Diagnosed the reconnect publication race, reviewed timing semantics, drafted the bounded repair and deterministic tests, and verified the candidate.