### PR TITLE
Record external candidate model during adoption

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -529,12 +529,14 @@ fn validate_durable_publication_eligibility(
         .provenance
         .pointer("/candidate/fingerprint/head")
         .and_then(serde_json::Value::as_str);
+    let adoption_model = promotion.provenance["adoption"]["ai_model"].as_str();
     let authenticated_adoption = lifecycle.execution.state == RunExecutionState::Cancelled
         && lifecycle.provider_runtime.is_empty()
         && promotion.provenance["adoption"]["source_run_id"]
             == promotion.source.run_id.clone().unwrap_or_default()
         && candidate_ref.is_some_and(is_git_commit_identity)
         && candidate_ref == candidate_head
+        && adoption_model.is_some_and(is_concrete_model)
         && recovery.is_some_and(|recovery| {
             recovery["schema"] == "homeboy/agent-task-candidate-adoption-recovery/v1"
                 && recovery["reason"] == "pre_provider_transport_failure"
@@ -550,6 +552,20 @@ fn validate_durable_publication_eligibility(
     }
 
     Err(Error::validation_invalid_argument("run_id", "durable run must have succeeded execution and succeeded provider runtime before publication; the only exception is an applied, green, fingerprinted candidate-adoption recovery with durable zero-execution pre-provider transport provenance", None, None))
+}
+
+fn is_concrete_model(value: &str) -> bool {
+    !value.trim().is_empty()
+        && value == value.trim()
+        && !value.chars().any(char::is_control)
+        && !matches!(
+            value.to_ascii_lowercase().as_str(),
+            "not recorded"
+                | "unknown"
+                | "ai-assisted"
+                | "ai assisted"
+                | "legacy caller did not record a model"
+        )
 }
 
 fn is_git_commit_identity(value: &str) -> bool {

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -891,6 +891,10 @@ fn durable_finalization_accepts_only_authenticated_pre_provider_candidate_adopti
     missing_head.promotion.provenance["candidate"]["fingerprint"]["head"] = json!("");
     rejected(recovery_lifecycle.clone(), missing_head);
 
+    let mut missing_model = pre_provider_adoption_gate_proof();
+    missing_model.promotion.provenance["adoption"]["ai_model"] = serde_json::Value::Null;
+    rejected(recovery_lifecycle.clone(), missing_model);
+
     let mut non_green = pre_provider_adoption_gate_proof();
     non_green.promotion.gate_results[0].status = HomeboyGateStatus::Failed;
     rejected(recovery_lifecycle, non_green);
@@ -1460,6 +1464,7 @@ fn pre_provider_adoption_gate_proof() -> AgentTaskPrDurableGateProof {
         "adoption": {
             "source_run_id": "cook-3678",
             "candidate_ref": "7f76933ef002d195ee1cc5bf21069e0f40b1c972",
+            "ai_model": "openai/gpt-5.6-sol",
             "recovery": {
                 "schema": "homeboy/agent-task-candidate-adoption-recovery/v1",
                 "reason": "pre_provider_transport_failure",

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -99,6 +99,13 @@ pub struct AgentTaskCookServiceOptions {
     pub harvest_context: crate::agent_task_scheduler::HarvestExecutionContext,
 }
 
+/// Provenance supplied when Homeboy adopts a candidate prepared outside its
+/// provider lifecycle.
+#[derive(Debug, Clone, Default)]
+pub struct AgentTaskCandidateAdoptionOptions {
+    pub ai_model: Option<String>,
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct AgentTaskCookReport {
     pub schema: &'static str,
@@ -122,7 +129,12 @@ pub fn adopt_cook_candidate(
     cook_or_run_id: &str,
     candidate_ref: &str,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
-    adopt_cook_candidate_with_dispatcher(cook_or_run_id, candidate_ref, |_| Ok(None))
+    adopt_cook_candidate_with_options_and_dispatcher(
+        cook_or_run_id,
+        candidate_ref,
+        AgentTaskCandidateAdoptionOptions::default(),
+        |_| Ok(None),
+    )
 }
 
 /// Compatibility entry point for callers that previously supplied attempt
@@ -135,9 +147,27 @@ pub fn adopt_cook_candidate_with_dispatcher(
         &Value,
     ) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
+    adopt_cook_candidate_with_options_and_dispatcher(
+        cook_or_run_id,
+        candidate_ref,
+        AgentTaskCandidateAdoptionOptions::default(),
+        reconstruct_dispatcher,
+    )
+}
+
+/// Adopt a candidate with provenance supplied by the external preparer.
+pub fn adopt_cook_candidate_with_options_and_dispatcher(
+    cook_or_run_id: &str,
+    candidate_ref: &str,
+    adoption: AgentTaskCandidateAdoptionOptions,
+    reconstruct_dispatcher: impl FnOnce(
+        &Value,
+    ) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
+) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
     adopt_cook_candidate_with_dispatcher_and_backend(
         cook_or_run_id,
         candidate_ref,
+        adoption,
         reconstruct_dispatcher,
         &mut RealAgentTaskPrFinalizationBackend,
     )
@@ -146,6 +176,7 @@ pub fn adopt_cook_candidate_with_dispatcher(
 fn adopt_cook_candidate_with_dispatcher_and_backend<B: AgentTaskPrFinalizationBackend>(
     cook_or_run_id: &str,
     candidate_ref: &str,
+    adoption: AgentTaskCandidateAdoptionOptions,
     _reconstruct_dispatcher: impl FnOnce(
         &Value,
     ) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
@@ -153,7 +184,7 @@ fn adopt_cook_candidate_with_dispatcher_and_backend<B: AgentTaskPrFinalizationBa
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
     let (record, recipe) = resolve_adoption_target(cook_or_run_id)?;
     let cook_id = &recipe.cook_id;
-    let options = super::reconstruct_adoption_options(&recipe)?;
+    let mut options = super::reconstruct_adoption_options(&recipe)?;
     let run_id = record.run_id.clone();
     let plan = agent_task_lifecycle::load_plan(&run_id)?;
     let source_request = plan.tasks.first().cloned().ok_or_else(|| {
@@ -220,12 +251,25 @@ fn adopt_cook_candidate_with_dispatcher_and_backend<B: AgentTaskPrFinalizationBa
             agent_task_lifecycle::record_promotion(&record.run_id, checkpoint).map(|_| ())
         },
     )?;
+    let (adoption_ai_model, ai_model_source) = match adoption.ai_model {
+        Some(model) => (concrete_adoption_ai_model(&model)?, "candidate_input"),
+        None => (
+            concrete_adoption_ai_model(options.ai_model.as_deref().unwrap_or_default())?,
+            "recipe_finalization",
+        ),
+    };
+    // The adopted candidate did not run through this cook's provider lifecycle.
+    // Bind its declared model to the authenticated promotion instead of inferring
+    // one from the immutable execution plan.
+    options.ai_model = Some(adoption_ai_model.clone());
     promotion.provenance["adoption"] = serde_json::json!({
         "source_run_id": record.run_id,
         "candidate_ref": candidate_ref,
         "source_worktree_path": options.source_worktree_path,
         "recorded_task_base": options.task_base_sha,
         "recovery": recovery,
+        "ai_model": adoption_ai_model,
+        "ai_model_source": ai_model_source,
     });
     let promotion_value = serde_json::to_value(&promotion)
         .map_err(|error| Error::internal_json(error.to_string(), None))?;
@@ -285,6 +329,30 @@ fn adopt_cook_candidate_with_dispatcher_and_backend<B: AgentTaskPrFinalizationBa
         None,
         exit_code,
     ))
+}
+
+fn concrete_adoption_ai_model(value: &str) -> Result<String> {
+    let normalized = value.trim();
+    if normalized.is_empty()
+        || value != normalized
+        || value.chars().any(char::is_control)
+        || matches!(
+            normalized.to_ascii_lowercase().as_str(),
+            "not recorded"
+                | "unknown"
+                | "ai-assisted"
+                | "ai assisted"
+                | "legacy caller did not record a model"
+        )
+    {
+        return Err(Error::validation_invalid_argument(
+            "ai_model",
+            "candidate adoption requires a concrete model identifier",
+            None,
+            None,
+        ));
+    }
+    Ok(normalized.to_string())
 }
 
 /// Resolve an existing run first, then recover the exact persisted attempt when
@@ -2729,6 +2797,9 @@ mod tests {
             let result = adopt_cook_candidate_with_dispatcher_and_backend(
                 cook_id,
                 &candidate,
+                AgentTaskCandidateAdoptionOptions {
+                    ai_model: Some("openai/gpt-5.6-sol".to_string()),
+                },
                 |_| Ok(None),
                 &mut backend,
             )
@@ -2760,8 +2831,27 @@ mod tests {
                     ["provider_executions_consumed"],
                 0
             );
+            assert_eq!(
+                promoted.metadata["latest_promotion"]["provenance"]["adoption"]["ai_model"],
+                "openai/gpt-5.6-sol"
+            );
+            assert_eq!(
+                promoted.metadata["latest_promotion"]["provenance"]["adoption"]["ai_model_source"],
+                "candidate_input"
+            );
+            assert!(backend.body.contains("- **Tool(s):** test"));
+            assert!(backend.body.contains("- **Model:** openai/gpt-5.6-sol"));
             assert!(backend.committed && backend.pushed && backend.created);
         });
+    }
+
+    #[test]
+    fn adoption_rejects_missing_or_placeholder_candidate_model() {
+        for model in ["", "not recorded", " unknown "] {
+            let error = concrete_adoption_ai_model(model)
+                .expect_err("adoption model must be a concrete identifier");
+            assert_eq!(error.details["field"], "ai_model");
+        }
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -373,18 +373,19 @@ pub mod secrets {
 /// High-level service entry points combining lifecycle and scheduling.
 pub mod service {
     pub use super::super::agent_task_service::{
-        adopt_cook_candidate, adopt_cook_candidate_with_dispatcher, aggregate_exit_code,
-        ai_model_from_tool, artifacts, cancel, compile_cook_attempt, discover_runs,
-        evidence_ref_task_id, hydrate_evidence_ref, hydrate_evidence_summary, logs,
-        normalize_plan_workspaces, offloaded_status_remediation,
-        persist_provider_boundary_replay_evidence, promotion_source, read_plan,
-        reconcile_terminal_artifact_projection, resume, retry, run_cook, run_cook_batch,
+        adopt_cook_candidate, adopt_cook_candidate_with_dispatcher,
+        adopt_cook_candidate_with_options_and_dispatcher, aggregate_exit_code, ai_model_from_tool,
+        artifacts, cancel, compile_cook_attempt, discover_runs, evidence_ref_task_id,
+        hydrate_evidence_ref, hydrate_evidence_summary, logs, normalize_plan_workspaces,
+        offloaded_status_remediation, persist_provider_boundary_replay_evidence, promotion_source,
+        read_plan, reconcile_terminal_artifact_projection, resume, retry, run_cook, run_cook_batch,
         run_loaded_plan, run_next, run_next_with_cook_dispatcher, run_status, run_submitted,
         run_submitted_with_timeout, source_worktree_path, status, submit_plan_spec,
-        AgentTaskCookAttemptReport, AgentTaskCookBatchCellReport, AgentTaskCookBatchOptions,
-        AgentTaskCookBatchReport, AgentTaskCookReport, AgentTaskCookServiceOptions,
-        AgentTaskDiscoveryCommands, AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter,
-        AgentTaskDiscoveryReport, AgentTaskDiscoveryRun, AgentTaskHydratedEvidence,
-        AgentTaskRetryServiceResult, AgentTaskRunResult,
+        AgentTaskCandidateAdoptionOptions, AgentTaskCookAttemptReport,
+        AgentTaskCookBatchCellReport, AgentTaskCookBatchOptions, AgentTaskCookBatchReport,
+        AgentTaskCookReport, AgentTaskCookServiceOptions, AgentTaskDiscoveryCommands,
+        AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter, AgentTaskDiscoveryReport,
+        AgentTaskDiscoveryRun, AgentTaskHydratedEvidence, AgentTaskRetryServiceResult,
+        AgentTaskRunResult,
     };
 }

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -121,6 +121,28 @@ mod tests {
         assert_eq!(args.artifact.as_deref(), Some("/trusted/homeboy"));
         assert!(args.source.is_none());
     }
+
+    #[test]
+    fn adoption_parses_external_candidate_model() {
+        let cli = Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "adopt",
+            "cook-a",
+            "--candidate-ref",
+            "0123456789abcdef0123456789abcdef01234567",
+            "--ai-model",
+            "openai/gpt-5.6-sol",
+        ])
+        .expect("adoption model parses");
+        let Commands::AgentTask(agent_task) = cli.command else {
+            panic!("expected agent-task command");
+        };
+        let AgentTaskCommand::Adopt(args) = agent_task.command else {
+            panic!("expected adoption command");
+        };
+        assert_eq!(args.ai_model.as_deref(), Some("openai/gpt-5.6-sol"));
+    }
 }
 #[derive(Args, Debug)]
 pub struct ReplayProviderBoundaryArgs {
@@ -188,6 +210,9 @@ pub struct AdoptArgs {
     /// Immutable commit revision in the recorded source worktree.
     #[arg(long, value_name = "SHA")]
     pub candidate_ref: String,
+    /// Concrete model that prepared the externally supplied candidate.
+    #[arg(long, value_name = "MODEL")]
+    pub ai_model: Option<String>,
 }
 #[derive(Args, Debug)]
 pub struct FinalizePrArgs {

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -332,9 +332,12 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
 }
 
 pub(crate) fn adopt_candidate(args: AdoptArgs) -> CmdResult<Value> {
-    let result = agent_task_service::adopt_cook_candidate_with_dispatcher(
+    let result = agent_task_service::adopt_cook_candidate_with_options_and_dispatcher(
         &args.run_or_cook_id,
         &args.candidate_ref,
+        agent_task_service::AgentTaskCandidateAdoptionOptions {
+            ai_model: args.ai_model.clone(),
+        },
         crate::commands::infra::route::reconstruct_cook_attempt_dispatcher,
     )?;
     let exit_code = result.exit_code;
@@ -343,6 +346,7 @@ pub(crate) fn adopt_candidate(args: AdoptArgs) -> CmdResult<Value> {
         "schema": "homeboy/agent-task-candidate-adoption/v1",
         "source": args.run_or_cook_id,
         "candidate_ref": args.candidate_ref,
+        "ai_model": args.ai_model,
         "controller_owned": true,
     });
     Ok((value, exit_code))


### PR DESCRIPTION
## Summary
- add `agent-task adopt --ai-model <model>` for explicit external candidate provenance
- persist the concrete candidate model in authenticated adoption evidence and use it in PR disclosure
- preserve existing service entry points while adding an options-aware adoption API
- keep absent and placeholder model identifiers fail-closed

Fixes #8983.

## How to test
1. Run `cargo test -p homeboy-agents historical_orphan_recipe_adoption_uses_recorded_policy_without_provider_replay --lib`.
2. Run `cargo test -p homeboy-agents durable_finalization_accepts_only_authenticated_pre_provider_candidate_adoption_recovery --lib`.
3. Run the CLI parsing test for `adoption_parses_external_candidate_model`.
4. Adopt an external candidate with `homeboy agent-task adopt <cook-id> --candidate-ref <sha> --ai-model openai/gpt-5.6-sol`.
5. Confirm promotion provenance records `adoption.ai_model` and `ai_model_source=candidate_input`.
6. Confirm the PR disclosure uses that exact model and the recipe's recorded tool.
7. Omit the flag when the recipe has no concrete finalization model and confirm publication fails closed.

## Verification
- Full recovered historical adoption through durable hydration and mock publication: passed.
- Publication model-presence rejection coverage: passed.
- CLI parsing coverage: passed.
- `cargo check -p homeboy-cli`: passed.
- Formatting and `git diff --check`: passed.

## Compatibility
The CLI flag and service options API are additive. Existing adoption entry points remain available; recipes with a concrete trusted finalization model retain their existing path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode
- **Used for:** Runtime diagnosis, API design, implementation, deterministic coverage, and verification. Chris reviewed and owns the change.