### PR TITLE
refactor: move workspace-content identity spec into the source-snapshot contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,6 +1125,7 @@ dependencies = [
  "homeboy-lab-runner-contract",
  "homeboy-product-identity",
  "homeboy-rig",
+ "homeboy-source-snapshot-contract",
  "homeboy-upgrade",
  "libc",
  "regex",

--- a/crates/contracts/homeboy-source-snapshot-contract/src/lib.rs
+++ b/crates/contracts/homeboy-source-snapshot-contract/src/lib.rs
@@ -6,5 +6,11 @@
 //! behavior lives in `homeboy-core`.
 
 pub mod source_snapshot;
+pub mod workspace_content_identity;
 
 pub use source_snapshot::{default_sync_excludes, SourceSnapshot, SourceSnapshotPolicy};
+pub use workspace_content_identity::{
+    workspace_content_hash_algorithm, WorkspaceContentManifest, WorkspaceContentManifestEntry,
+    WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY, WORKSPACE_CONTENT_PERMISSION_PORTABLE,
+    WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE, WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
+};

--- a/crates/contracts/homeboy-source-snapshot-contract/src/workspace_content_identity.rs
+++ b/crates/contracts/homeboy-source-snapshot-contract/src/workspace_content_identity.rs
@@ -1,0 +1,125 @@
+//! Canonical specification of a materialized workspace's *content identity*.
+//!
+//! When the controller declares a Lab workspace and the runner verifies the
+//! materialized result, both sides must agree on exactly one thing: does the
+//! runner's tree contain the same content the controller described? That
+//! agreement hinges on computing an identical **content hash** on both sides,
+//! which in turn requires an identical **algorithm identity** — the marker
+//! string that names the hashing rules (traversal version + permission policy).
+//!
+//! This module is the single source of truth for that algorithm identity: the
+//! permission-policy names, the default policy, and the policy → algorithm
+//! marker mapping. It is pure data + a pure `match`, so it lives in the leaf
+//! contract crate rather than in the runner's filesystem-walking code — the
+//! controller-declare path and the runner-verify path both derive the marker
+//! from here, so they cannot disagree on what a given policy *means*.
+//!
+//! ## Algorithm lineage (why the markers are versioned)
+//!
+//! The hashing rules have evolved; each change is a new marker so a digest can
+//! never be reinterpreted under different rules:
+//! - `homeboy-workspace-content-v1` — legacy: sorted entries, content + mode.
+//! - `homeboy-workspace-content-v2+<policy>` — streaming traversal; the
+//!   permission policy decides whether/which execute bit is bound.
+//! - `homeboy-workspace-content-v3+unix-owner-executable` — binds only the
+//!   owner-execute bit, ignoring umask'd group/other bits.
+//!
+//! The *filesystem traversal* that consumes these markers (reading modes,
+//! hashing bytes, applying excludes) stays in `homeboy-lab-runner`; only the
+//! identity spec lives here.
+
+use serde::{Deserialize, Serialize};
+
+/// Content-only identity: bytes and structure, no execute bit. Portable across
+/// platforms.
+pub const WORKSPACE_CONTENT_PERMISSION_PORTABLE: &str = "portable-content-only";
+
+/// Binds whether *any* execute bit is set (Unix).
+pub const WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE: &str = "unix-executable";
+
+/// Binds only the *owner* execute bit, ignoring umask'd group/other bits (Unix).
+pub const WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE: &str = "unix-owner-executable";
+
+/// The default permission policy for new workspace-content identities.
+#[cfg(unix)]
+pub const WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY: &str =
+    WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE;
+/// The default permission policy for new workspace-content identities.
+#[cfg(not(unix))]
+pub const WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY: &str = WORKSPACE_CONTENT_PERMISSION_PORTABLE;
+
+/// The algorithm-identity marker string for a permission policy, or `None` if
+/// the policy is unsupported on this platform.
+///
+/// This marker is embedded in the hash and recorded in the workspace
+/// verification metadata; controller and runner both derive it from here so a
+/// digest is always interpreted under the same rules that produced it.
+pub fn workspace_content_hash_algorithm(policy: &str) -> Option<String> {
+    match policy {
+        WORKSPACE_CONTENT_PERMISSION_PORTABLE => {
+            Some("homeboy-workspace-content-v2+portable-content-only".to_string())
+        }
+        WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE if cfg!(unix) => {
+            Some("homeboy-workspace-content-v2+unix-executable".to_string())
+        }
+        WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE if cfg!(unix) => {
+            Some("homeboy-workspace-content-v3+unix-owner-executable".to_string())
+        }
+        _ => None,
+    }
+}
+
+/// A deterministic, content-free inventory of every path a snapshot
+/// materializes, persisted with the immutable snapshot and used to derive
+/// explicit incremental transport and deletion sets and to diagnose content-hash
+/// mismatches.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceContentManifest {
+    pub entry_count: usize,
+    pub entries: Vec<WorkspaceContentManifestEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceContentManifestEntry {
+    pub path: String,
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner_executable: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn portable_policy_marker_is_stable_and_platform_independent() {
+        assert_eq!(
+            workspace_content_hash_algorithm(WORKSPACE_CONTENT_PERMISSION_PORTABLE).as_deref(),
+            Some("homeboy-workspace-content-v2+portable-content-only")
+        );
+    }
+
+    #[test]
+    fn unknown_policy_has_no_algorithm() {
+        assert_eq!(workspace_content_hash_algorithm("nonsense-policy"), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_policies_map_to_their_versioned_markers() {
+        assert_eq!(
+            workspace_content_hash_algorithm(WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE)
+                .as_deref(),
+            Some("homeboy-workspace-content-v2+unix-executable")
+        );
+        assert_eq!(
+            workspace_content_hash_algorithm(WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE)
+                .as_deref(),
+            Some("homeboy-workspace-content-v3+unix-owner-executable")
+        );
+    }
+}

--- a/crates/homeboy-lab-runner/Cargo.toml
+++ b/crates/homeboy-lab-runner/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
+homeboy-source-snapshot-contract = { version = "0.1.0", path = "../contracts/homeboy-source-snapshot-contract" }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }
 homeboy-upgrade = { version = "0.1.0", path = "../homeboy-upgrade" }
 homeboy-rig = { version = "0.1.0", path = "../homeboy-rig" }

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -19,7 +19,6 @@ use super::util::{
 
 const RUNNER_WORKSPACE_METADATA_FILE: &str = ".homeboy/runner-workspace.json";
 const LAB_AT_FILES_DIRECTORY: &str = ".homeboy/lab-at-files";
-
 /// Runner-owned paths that Homeboy materializes *onto* a workspace after
 /// transport. They exist only on the runner side, never in the controller's
 /// source tree, so they must be excluded from every workspace content-identity
@@ -41,9 +40,19 @@ fn is_reserved_runner_workspace_path(relative: &str) -> bool {
         .iter()
         .any(|reserved| relative == *reserved)
 }
-pub(crate) const WORKSPACE_CONTENT_PERMISSION_PORTABLE: &str = "portable-content-only";
-pub(crate) const WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE: &str = "unix-executable";
-pub(crate) const WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE: &str = "unix-owner-executable";
+
+// The workspace-content *identity spec* (permission-policy names, the default
+// policy, the policy -> algorithm-marker mapping, and the content manifest
+// types) lives in the leaf `homeboy-source-snapshot-contract` crate so the
+// controller-declare and runner-verify paths derive it from one place. The
+// filesystem traversal that *applies* the spec stays here. Re-exported so
+// existing `crate::workspace::snapshot::*` / `crate::*` paths keep resolving.
+pub use homeboy_source_snapshot_contract::workspace_content_identity::{
+    workspace_content_hash_algorithm, WorkspaceContentManifest, WorkspaceContentManifestEntry,
+    WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY, WORKSPACE_CONTENT_PERMISSION_PORTABLE,
+    WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE, WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
+};
+
 pub(crate) const WORKSPACE_CONTENT_DIAGNOSTIC_PATH_LIMIT: usize = 192;
 
 // The SSH path passes this script through `sh -c` after shell-quoting it. A
@@ -56,31 +65,6 @@ const INCREMENTAL_PREPARE_COMMAND_MAX_BYTES: usize = 16 * 1024;
 // preflight deliberately overestimates so it can reject before allocating a
 // command proportional to the manifest.
 const INCREMENTAL_PREPARE_COMMAND_FIXED_OVERHEAD_BYTES: usize = 4 * 1024;
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-pub struct WorkspaceContentManifest {
-    pub entry_count: usize,
-    pub entries: Vec<WorkspaceContentManifestEntry>,
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-pub struct WorkspaceContentManifestEntry {
-    pub path: String,
-    pub kind: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sha256: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub bytes: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub owner_executable: Option<bool>,
-}
-
-#[cfg(unix)]
-pub(crate) const WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY: &str =
-    WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE;
-#[cfg(not(unix))]
-pub(crate) const WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY: &str =
-    WORKSPACE_CONTENT_PERMISSION_PORTABLE;
 
 pub(crate) fn snapshot_identity(
     local_path: &Path,
@@ -110,21 +94,6 @@ pub(crate) fn snapshot_identity(
 /// cannot be interpreted under a different platform capability contract.
 pub(crate) fn workspace_content_hash(path: &Path, excludes: &[String]) -> Result<String> {
     workspace_content_hash_for_policy(path, excludes, WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY)
-}
-
-pub(crate) fn workspace_content_hash_algorithm(policy: &str) -> Option<String> {
-    match policy {
-        WORKSPACE_CONTENT_PERMISSION_PORTABLE => {
-            Some("homeboy-workspace-content-v2+portable-content-only".to_string())
-        }
-        WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE if cfg!(unix) => {
-            Some("homeboy-workspace-content-v2+unix-executable".to_string())
-        }
-        WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE if cfg!(unix) => {
-            Some("homeboy-workspace-content-v3+unix-owner-executable".to_string())
-        }
-        _ => None,
-    }
 }
 
 pub(crate) fn workspace_content_hash_for_policy(


### PR DESCRIPTION
## Summary
Advances Lab stabilization (surface #2: canonical snapshot identity) by giving the **workspace content-hash identity** one authoritative home.

Lab materialization verification hinges on the controller and runner computing an *identical* workspace content hash. That requires an identical **algorithm identity** — the marker string naming the hashing rules (traversal version + permission policy). That spec lived inside `homeboy-lab-runner`'s filesystem-walking module, buried next to the traversal behavior, even though both the controller-declare path (`lab/offload/metadata.rs`) and the runner-verify path (`workspace/provenance.rs`) derive the marker from it. It's a shared contract, not runner behavior.

## What moved
Into the leaf `homeboy-source-snapshot-contract` crate as a new `workspace_content_identity` module:
- `WORKSPACE_CONTENT_PERMISSION_*` policy constants + `WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY`
- `workspace_content_hash_algorithm(policy) -> Option<String>` — the pure policy → algorithm-marker mapping
- `WorkspaceContentManifest` / `WorkspaceContentManifestEntry` data types
- The **v1/v2/v3 algorithm lineage documented in one place** (previously implicit across scattered match arms)

The filesystem traversal that *applies* the spec (mode reading, byte hashing, exclude matching) stays in the runner. `homeboy-lab-runner` re-exports the spec so existing `crate::*` paths resolve unchanged.

## Why this helps stabilization
The recurring Lab snapshot-identity churn (#9003, #9007, #8985, #8862…) comes from identity being defined implicitly and redundantly. This makes "what a content identity *means*" a single documented spec in a leaf crate that any side — controller, runner, future tooling, tests — can depend on without pulling in the runner. It's the foundational step toward the controller and runner computing identity from provably-shared code.

## Verification (local, VPS-safe)
- `cargo test -p homeboy-source-snapshot-contract` — 3 new spec tests pass (marker stability, unknown-policy, unix markers)
- `cargo check -p homeboy-lab-runner --lib` — clean (0 errors)
- All `workspace::tests::snapshot::` content-hash / policy / algorithm tests — pass
- `cargo fmt` — clean

> `git_backed_snapshot_uses_runner_exact_sha_without_controller_bundle_hydration` fails **identically on clean `origin/main`** (git/SSH-dependent env test) — pre-existing, unrelated.