### PR TITLE
feat: make daemon /exec idempotent on the controller durable run id (#8966)

### DIFF
--- a/crates/homeboy-core/src/api_jobs/store.rs
+++ b/crates/homeboy-core/src/api_jobs/store.rs
@@ -1457,6 +1457,33 @@ impl JobStore {
         jobs
     }
 
+    /// The already-enqueued, non-terminal job for a controller `durable_run_id`,
+    /// if one exists.
+    ///
+    /// A daemon `/exec` submission is not idempotent at the transport layer: a
+    /// dropped connection or timeout can hide that the daemon already accepted
+    /// the request. The controller-minted `durable_run_id` is a stable key for
+    /// the unit of work, so the daemon can treat a resubmission carrying the same
+    /// key as a no-op that returns the existing job instead of enqueuing a
+    /// duplicate. Only `Queued`/`Running` jobs are considered — a terminal job
+    /// for the same run id is finished, so a resubmission is a genuinely new
+    /// attempt and must enqueue a fresh job.
+    pub(crate) fn active_runner_job_for_durable_run_id(&self, durable_run_id: &str) -> Option<Job> {
+        if durable_run_id.trim().is_empty() {
+            return None;
+        }
+        let inner = self.inner.lock().expect("job store mutex poisoned");
+        inner
+            .jobs
+            .values()
+            .filter(|stored| matches!(stored.job.status, JobStatus::Queued | JobStatus::Running))
+            .filter(|stored| stored_job_durable_run_id(stored).as_deref() == Some(durable_run_id))
+            // Deterministic across a resubmission race: the oldest active job for
+            // the run id is the canonical one to return.
+            .min_by_key(|stored| (stored.job.created_at_ms, stored.job.id))
+            .map(|stored| stored.job.clone())
+    }
+
     pub(crate) fn stale_runner_jobs(&self) -> Vec<super::types::ActiveRunnerJobSummary> {
         let now = timestamp_ms();
         let inner = self.inner.lock().expect("job store mutex poisoned");
@@ -2435,6 +2462,24 @@ impl RecoveredTerminalJob {
             artifacts,
         }
     }
+}
+
+/// The controller-minted `durable_run_id` a stored job was enqueued for, from
+/// whichever runner-lifecycle carries it (remote-runner request or local-runner
+/// direct-daemon offload).
+fn stored_job_durable_run_id(stored: &StoredJob) -> Option<String> {
+    stored
+        .remote_runner
+        .as_ref()
+        .and_then(|remote| remote.request.lifecycle.as_ref())
+        .or_else(|| {
+            stored
+                .local_runner
+                .as_ref()
+                .and_then(|local| local.lifecycle.as_ref())
+        })
+        .and_then(|lifecycle| lifecycle.durable_run_id.clone())
+        .filter(|run_id| !run_id.trim().is_empty())
 }
 
 /// A remote runner workload records its agent-task run ID in a typed execution

--- a/crates/homeboy-core/src/api_jobs/tests/part_a.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_a.rs
@@ -595,6 +595,86 @@ fn local_runner_jobs_retain_durable_identity_in_active_projection() {
 }
 
 #[test]
+fn active_runner_job_for_durable_run_id_finds_the_enqueued_job_for_idempotent_resubmission() {
+    let store = JobStore::default();
+    let (release, wait) = std::sync::mpsc::channel::<()>();
+    let runner = store
+        .run_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
+            "runner.exec",
+            None,
+            None,
+            None,
+            Some(super::store::LocalRunnerJob {
+                runner_id: "homeboy-lab".to_string(),
+                command: vec!["homeboy".to_string(), "agent-task".to_string(), "run-plan".to_string()],
+                cwd: Some("/runner/worktree".to_string()),
+                lifecycle: Some(RunnerJobLifecycleMetadata {
+                    source: Some("runner-daemon".to_string()),
+                    kind: Some("agent-task-run-plan".to_string()),
+                    durable_run_id: Some("agent-task-durable-run".to_string()),
+                    active_child_count: None,
+                    active_cell_count: None,
+                }),
+            }),
+            move |_job| {
+                let _ = wait.recv();
+                Ok(serde_json::json!({}))
+            },
+        );
+
+    // A resubmission carrying the same controller-minted durable_run_id resolves
+    // to the already-enqueued job, so the daemon can return it instead of
+    // spawning a duplicate.
+    let existing = store
+        .active_runner_job_for_durable_run_id("agent-task-durable-run")
+        .expect("active job for the durable run id");
+    assert_eq!(existing.id.to_string(), runner.job_id.to_string());
+
+    // A different (or empty) run id must not collide with this job.
+    assert!(store
+        .active_runner_job_for_durable_run_id("some-other-run")
+        .is_none());
+    assert!(store.active_runner_job_for_durable_run_id("").is_none());
+
+    release.send(()).expect("release runner job");
+    runner.handle.join().expect("runner job exits");
+}
+
+#[test]
+fn active_runner_job_for_durable_run_id_excludes_terminal_jobs() {
+    // A terminal job for a durable_run_id must NOT be returned as an idempotent
+    // match: the finished run is done, so a resubmission is a genuinely new
+    // attempt that must enqueue a fresh job.
+    let store = JobStore::default();
+    let mut request = super::remote_runner_request("homeboy-lab", Some("extrachill"));
+    request.lifecycle = Some(RunnerJobLifecycleMetadata {
+        source: Some("runner-daemon".to_string()),
+        kind: Some("agent-task-run-plan".to_string()),
+        durable_run_id: Some("terminal-durable-run".to_string()),
+        active_child_count: None,
+        active_cell_count: None,
+    });
+    let job = store
+        .submit_remote_runner_job(request)
+        .expect("submit remote runner job");
+
+    // While queued, the resubmission dedupes to this job.
+    assert_eq!(
+        store
+            .active_runner_job_for_durable_run_id("terminal-durable-run")
+            .expect("queued job matches")
+            .id,
+        job.id
+    );
+
+    // Once terminal, the same run id no longer matches.
+    store.fail(job.id, "runner exec failed").expect("job fails");
+    assert!(store
+        .active_runner_job_for_durable_run_id("terminal-durable-run")
+        .is_none());
+}
+
+#[test]
 fn test_start() {
     let store = JobStore::default();
     let job = store.create("audit");

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -1970,6 +1970,33 @@ fn enqueue_exec_job(
         "path_materialization_plan": path_materialization_plan,
         "lifecycle": lifecycle.clone(),
     });
+
+    // Idempotent resubmission: a daemon `/exec` is not idempotent at the
+    // transport layer — a dropped connection or timeout can hide that the daemon
+    // already accepted this work. When the controller resubmits the same
+    // controller-minted `durable_run_id`, return the job already enqueued for it
+    // instead of spawning a duplicate. Only non-terminal (Queued/Running) jobs
+    // dedupe; a terminal job for the same run id is finished, so a resubmission
+    // is a genuinely new attempt and falls through to a fresh enqueue.
+    if let Some(durable_run_id) = lifecycle
+        .as_ref()
+        .and_then(|lifecycle| lifecycle.durable_run_id.as_deref())
+    {
+        if let Some(existing) = job_store.active_runner_job_for_durable_run_id(durable_run_id) {
+            let existing_job_id = existing.id;
+            return Ok(json!({
+                "command": "api.runner.exec.enqueue",
+                "job": existing,
+                "poll": {
+                    "job": format!("/jobs/{existing_job_id}"),
+                    "events": format!("/jobs/{existing_job_id}/events"),
+                },
+                "request": summary,
+                "idempotent_resubmission": true,
+            }));
+        }
+    }
+
     let operation = "runner.exec".to_string();
     let mut run_ref_metadata = exec_request_run_ref_metadata(
         lifecycle.as_ref(),


### PR DESCRIPTION
## Summary
Closes the root cause behind the **agent-task adoption / recovery / handoff churn**: the controller→Lab daemon `/exec` submission is **not idempotent**.

A dropped connection or a timeout can hide that the daemon already accepted an `/exec` — the code even documents this (`submit_daemon_exec_with_session_recovery` deliberately only retries a *connect-phase* failure, because a later failure "may already represent an accepted non-idempotent `/exec`"). So every resubmission risks enqueuing a **duplicate job** for the same unit of work, and the controller then has to reconcile "did this already run?" after the fact — which is a primary source of the recover-orphan / adopt-candidate / resume-handoff PR churn.

## The fix
The controller already mints a stable `durable_run_id` and ships it in the exec lifecycle metadata. Use it as the idempotency key:

- **`JobStore::active_runner_job_for_durable_run_id(run_id)`** returns the already-enqueued **non-terminal** (`Queued`/`Running`) job for a durable run id, checking both the remote-runner request lifecycle and the local-runner (direct-daemon offload) lifecycle. **Terminal jobs are excluded** — a finished run means a resubmission is a genuinely new attempt.
- **`enqueue_exec_job`**, right after resolving the canonical `durable_run_id`, returns the existing job's enqueue envelope (marked `idempotent_resubmission`) instead of spawning a duplicate.

This makes controller→Lab exec resubmission a safe no-op — the property issue #8966 asks for.

## Why this is the high-leverage fix
Per the stabilization root-cause analysis, the whole area is fragile because *work has no stable identity carried across boundaries*, so every failure timing needs its own reconciliation path. Giving `/exec` a stable idempotency key means retry is trivially safe, which retires a whole class of "recover/adopt after interruption" work rather than patching one more timing.

## Verification (local, VPS-safe)
- `cargo check -p homeboy-core --lib` — clean (0 errors)
- 2 new tests:
  - `active_runner_job_for_durable_run_id_finds_the_enqueued_job_for_idempotent_resubmission` — dedupe on matching run id; no collision on different/empty ids
  - `active_runner_job_for_durable_run_id_excludes_terminal_jobs` — a failed/terminal job for the same run id is **not** returned (resubmission = fresh attempt)
- `cargo test -p homeboy-core --lib api_jobs::` — **all 100 pass**
- `cargo fmt` — clean

## Scope note
This is the **first, self-contained slice** of the idempotency work: it deduplicates at the enqueue boundary using the identity that already exists. It does not yet change the wire protocol to have the controller *assert* a key the daemon must honor on the first attempt — that's a natural follow-up, but this alone makes the common resubmission-after-transport-drop case safe.