### PR TITLE
fix: isolate three agent-task lifecycle tests from shared runtime state (#8964)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_executor_evidence.rs
+++ b/crates/homeboy-agents/src/agent_task_executor_evidence.rs
@@ -280,7 +280,20 @@ mod tests {
 
     fn executor_test_request() -> AgentTaskExecutorRequest {
         let request = test_request();
-        let artifacts_path = std::env::temp_dir();
+        // Use a deterministic isolated `.../runner/artifacts/task` directory
+        // instead of the host `std::env::temp_dir()`. The provenance assertions
+        // check the retained path ends in that stable segment; the ambient temp
+        // dir is host-dependent (and, once canonicalized, never contained the
+        // asserted path), making the test pass or fail by host configuration
+        // rather than behavior (#8964). The tempdir is intentionally leaked so the
+        // captured path stays valid for the lifetime of the test process.
+        let root = tempfile::Builder::new()
+            .prefix("hb-executor-artifacts-")
+            .tempdir()
+            .expect("executor artifacts root")
+            .keep();
+        let artifacts_path = root.join("runner").join("artifacts").join("task");
+        std::fs::create_dir_all(&artifacts_path).expect("create isolated artifacts path");
         AgentTaskExecutorRequest {
             artifacts_root_identity: crate::agent_task_provider::artifact_finalization::ExecutorArtifactRootIdentity::capture(&artifacts_path).expect("artifact root identity"),
             artifacts_path,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
@@ -50,6 +50,10 @@ pub use homeboy_core::controller_runtime::ControllerRuntimePruneResult;
 pub use lifecycle_ops::*;
 pub use lifecycle_record_ops::cook_attempt_run_id;
 pub use records::*;
+#[cfg(any(test, feature = "test-support"))]
+pub use runner_continuation::{
+    clear_runner_continuation_provider_for_test, RunnerContinuationTestGuard,
+};
 pub use runner_continuation::{register_runner_continuation_provider, RunnerContinuationProvider};
 
 pub(crate) use conversion::*;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
@@ -110,6 +110,41 @@ pub fn register_runner_continuation_provider(provider: Box<dyn RunnerContinuatio
     *slot = Some(provider);
 }
 
+/// Clear any registered runner-continuation provider so a fresh test starts from
+/// the no-op default. The provider slot is a process-global; without this reset a
+/// provider registered by one test would leak into every later test in the same
+/// process, making lifecycle results order-dependent (#8964).
+#[cfg(any(test, feature = "test-support"))]
+pub fn clear_runner_continuation_provider_for_test() {
+    let mut slot = provider_slot()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *slot = None;
+}
+
+/// RAII guard that installs a runner-continuation provider for the duration of a
+/// test and restores the no-op default on drop (including on panic), so the
+/// registration cannot leak into another test.
+#[cfg(any(test, feature = "test-support"))]
+pub struct RunnerContinuationTestGuard {
+    _private: (),
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl RunnerContinuationTestGuard {
+    pub fn install(provider: Box<dyn RunnerContinuationProvider>) -> Self {
+        register_runner_continuation_provider(provider);
+        Self { _private: () }
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl Drop for RunnerContinuationTestGuard {
+    fn drop(&mut self) {
+        clear_runner_continuation_provider_for_test();
+    }
+}
+
 /// Run `f` against the registered provider, falling back to the no-op provider
 /// when the runner subsystem is absent.
 pub(crate) fn with_runner_continuation<R>(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -49,6 +49,7 @@ fn submit_plan_persists_queued_status() {
 #[cfg(unix)]
 #[test]
 fn controller_runtime_retention_keeps_mutable_and_retained_terminal_runs() {
+    super::ensure_runner_continuation_provider_reset_hook();
     with_isolated_home(|_| {
         // Controller-runtime retention discovers referenced pins through the
         // agent-task pin-reference provider hook; register it so the report can
@@ -86,7 +87,13 @@ fn controller_runtime_retention_keeps_mutable_and_retained_terminal_runs() {
             recover_controller_runtime(&record.run_id, Some(artifact), None).expect("recover pin");
         }
         rewrite_record_for_test(&terminal.run_id, |record| {
-            record.state = AgentTaskRunState::Succeeded;
+            // Use `set_run_state` so the run state and its lifecycle execution
+            // projection stay consistent. A raw `record.state = Succeeded` write
+            // left `lifecycle.execution.state` unchanged, so `diagnose_run`
+            // flagged the record `ConflictingProjections` and dropped it from
+            // `list_records_with_health` — the source the retention report reads —
+            // making the terminal pin silently unreferenced (#8964).
+            set_run_state(record, AgentTaskRunState::Succeeded);
             record.lifecycle.artifact_retention.status = ArtifactRetentionStatus::Retained;
         })
         .expect("make terminal");

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
@@ -15,7 +15,20 @@ use crate::agent_task_scheduler::{
 use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStore, RemoteRunnerJobRequest};
 use homeboy_core::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Once};
+
+/// Register the runner-continuation provider reset as a hermetic-home cache-reset
+/// hook exactly once. Every `with_isolated_home` setup then clears any provider a
+/// previous test left registered, so the process-global slot cannot leak across
+/// tests and make results order-dependent (#8964).
+pub(super) fn ensure_runner_continuation_provider_reset_hook() {
+    static HOOK: Once = Once::new();
+    HOOK.call_once(|| {
+        homeboy_core::test_support::register_test_cache_reset_hook(
+            clear_runner_continuation_provider_for_test,
+        );
+    });
+}
 
 #[cfg(unix)]
 pub(super) fn fake_controller_artifact(
@@ -92,6 +105,56 @@ impl RunnerContinuationProvider for IntentReplayProvider {
             ));
         }
         Ok(job)
+    }
+}
+
+/// A runner-continuation provider that reports a runner as connected and present
+/// without a backing job store. Detached-handoff tests use this so a freshly
+/// recorded running record reconciles against a connected runner rather than the
+/// no-op default (which reports every runner disconnected and flags the record
+/// `stale_running`), independent of any real runner subsystem (#8964).
+#[derive(Clone)]
+pub(super) struct ConnectedRunnerProvider;
+
+impl RunnerContinuationProvider for ConnectedRunnerProvider {
+    fn runner_job_log_snapshot(
+        &self,
+        _runner_id: &str,
+        _job_id: &str,
+    ) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot> {
+        // No live snapshot; `reconcile_runner_job_state` treats an error from a
+        // connected runner as "no new progress" and leaves the record running.
+        Err(Error::internal_unexpected(
+            "no runner job log snapshot in test",
+        ))
+    }
+
+    fn is_runner_connected(&self, _runner_id: &str) -> bool {
+        true
+    }
+
+    fn runner_exists(&self, _runner_id: &str) -> bool {
+        true
+    }
+
+    fn run_continuation_exec(
+        &self,
+        _runner_id: &str,
+        _cwd: &str,
+        _command: &[String],
+        _run_id: &str,
+    ) -> Result<i32> {
+        Err(Error::internal_unexpected(
+            "no runner continuation exec in test",
+        ))
+    }
+
+    fn submit_reverse_broker_job(
+        &self,
+        _runner_id: &str,
+        _request: RemoteRunnerJobRequest,
+    ) -> Result<Job> {
+        Err(Error::internal_unexpected("no reverse broker job in test"))
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -95,7 +95,13 @@ fn execution_budget_future_version_fails_closed_without_rewrite() {
 
 #[test]
 fn detached_lab_handoff_persists_inspectable_running_record() {
+    super::ensure_runner_continuation_provider_reset_hook();
     with_isolated_home(|_| {
+        // A detached running record reconciles against runner connectivity. Install
+        // a connected runner so the record is not flagged `runner_disconnected`
+        // stale by the no-op default (#8964). The guard restores the default on drop.
+        let _runner =
+            RunnerContinuationTestGuard::install(Box::new(super::ConnectedRunnerProvider));
         for (run_id, handoff) in [
             ("agent-task-detached-cook", "cook"),
             ("agent-task-detached-batch", "cook-batch"),
@@ -142,11 +148,14 @@ fn detached_lab_handoff_persists_inspectable_running_record() {
 
 #[test]
 fn detached_cook_intent_reconciliation_converges_both_crash_windows_without_secret_leakage() {
+    super::ensure_runner_continuation_provider_reset_hook();
     with_isolated_home(|_| {
         let store = JobStore::default();
         let submitted = Arc::new(Mutex::new(Vec::new()));
         let fail_after_accept_once = Arc::new(Mutex::new(false));
-        register_runner_continuation_provider(Box::new(IntentReplayProvider {
+        // Scope the provider to this test so it cannot leak into later tests and
+        // make lifecycle results order-dependent (#8964).
+        let _runner = RunnerContinuationTestGuard::install(Box::new(IntentReplayProvider {
             store: store.clone(),
             submitted: Arc::clone(&submitted),
             fail_after_accept_once: Arc::clone(&fail_after_accept_once),


### PR DESCRIPTION
## Summary

Three `homeboy-agents` lifecycle tests failed on unchanged fresh `main` **even run alone**, so changed-since CI treated the suite as baseline red and obscured candidate-specific regressions (#8964). I reproduced each failure and traced a distinct, verified root cause rather than relaxing assertions.

## Root causes & fixes

**1. `persisted_input_redacts_secrets_but_retains_contracts_paths_and_artifacts`**
The fixture set `artifacts_path` from the host `std::env::temp_dir()`, then the test asserted the persisted (retained, un-redacted) path contained `/runner/artifacts/task` — a segment the ambient temp dir never produces, and which `ExecutorArtifactRootIdentity::capture` canonicalizes away entirely. The result depended on host tmp configuration.
→ Materialize a deterministic isolated `.../runner/artifacts/task` directory and assert against that.

**2. `detached_lab_handoff_persists_inspectable_running_record`**
A freshly recorded running record reconciles against runner connectivity. With no runner-continuation provider registered, the no-op default reports every runner disconnected, so `reconcile_runner_job_state` flagged the record `stale_running` / `runner_disconnected`.
→ Install a scoped connected runner-continuation provider for the test.

**3. `controller_runtime_retention_keeps_mutable_and_retained_terminal_runs`**
The test forced the terminal run with a raw `record.state = Succeeded` write, leaving `lifecycle.execution.state` inconsistent. `diagnose_run` then flagged the record `ConflictingProjections` and **dropped it from `list_records_with_health`** — the exact source `retention_report()` reads for referenced pins — so the terminal pin was silently unreferenced and pruned.
→ Use `set_run_state`, which keeps the run state and its lifecycle projection consistent.

## Isolation leak

The runner-continuation provider slot is a process-global that persisted across tests, making lifecycle results order-dependent. This PR adds:
- `RunnerContinuationTestGuard` — RAII, restores the no-op default on drop (even on panic).
- A hermetic-home cache-reset hook that clears the provider slot for each isolated test.
- Routes the existing bare `register_runner_continuation_provider` test call through the guard.

## Testing

- `cargo check -p homeboy-agents --lib --tests` — clean (EXIT 0), `cargo fmt`.
- Each of the three fixed tests **passes alone**; the detached-handoff test also verified passing serially in-binary.

## Scope note

A separate, **pre-existing** `HermeticTestContext` fixture race surfaces only under full-module parallelism (`copy controller fixture: NotFound` — a temp-dir teardown race in the shared test harness, unrelated to the three named tests or the provider slot). It is out of scope for this issue's acceptance list and left for a dedicated follow-up rather than papered over here.

Refs #8964

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Reproduced all three baseline failures, instrumented and traced each to a distinct root cause (host-path fixture, runner-connectivity default, run-state/lifecycle projection inconsistency), fixed each plus the process-global provider leak, and verified. Chris reviews and owns the change.