### PR TITLE
feat: close the exec enqueue-time race with an atomic durable-run-id dedup guard

### DIFF
--- a/crates/homeboy-core/src/api_jobs/store.rs
+++ b/crates/homeboy-core/src/api_jobs/store.rs
@@ -424,12 +424,44 @@ impl JobStore {
         path_materialization_plan: Option<PathMaterializationPlan>,
         local_runner: Option<LocalRunnerJob>,
     ) -> Job {
+        self.create_or_reuse_active_local_runner_job(
+            operation,
+            source_snapshot,
+            metadata,
+            path_materialization_plan,
+            local_runner,
+        )
+        .0
+    }
+
+    /// Insert a new queued local-runner job, or reuse the existing non-terminal
+    /// job for the same controller-minted `durable_run_id`.
+    ///
+    /// The dedup lookup and the insert happen under one lock, so two
+    /// near-simultaneous first submissions of the same durable run id cannot
+    /// both create a job — the enqueue-time race the daemon's transport-layer
+    /// idempotency check cannot close. Returns `(job, created)`; `created` is
+    /// `false` when an existing active job was reused, letting the caller skip
+    /// spawning a duplicate worker for it.
+    fn create_or_reuse_active_local_runner_job(
+        &self,
+        operation: impl Into<String>,
+        source_snapshot: Option<SourceSnapshot>,
+        metadata: Option<Value>,
+        path_materialization_plan: Option<PathMaterializationPlan>,
+        local_runner: Option<LocalRunnerJob>,
+    ) -> (Job, bool) {
         let now = timestamp_ms();
         let runner_job_projection = metadata
             .as_ref()
             .and_then(|metadata| metadata.get("runner_job_projection"))
             .cloned()
             .and_then(|projection| serde_json::from_value::<RunnerJobProjection>(projection).ok());
+        let durable_run_id = local_runner
+            .as_ref()
+            .and_then(|local| local.lifecycle.as_ref())
+            .and_then(|lifecycle| lifecycle.durable_run_id.clone())
+            .filter(|run_id| !run_id.trim().is_empty());
         let job = Job {
             id: Uuid::new_v4(),
             operation: operation.into(),
@@ -454,6 +486,22 @@ impl JobStore {
         };
 
         let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        if let Some(durable_run_id) = durable_run_id.as_deref() {
+            if let Some(existing) = inner
+                .jobs
+                .values()
+                .filter(|stored| {
+                    matches!(stored.job.status, JobStatus::Queued | JobStatus::Running)
+                })
+                .filter(|stored| {
+                    stored_job_durable_run_id(stored).as_deref() == Some(durable_run_id)
+                })
+                .min_by_key(|stored| (stored.job.created_at_ms, stored.job.id))
+                .map(|stored| stored.job.clone())
+            {
+                return (existing, false);
+            }
+        }
         inner.jobs.insert(
             job.id,
             StoredJob {
@@ -472,8 +520,11 @@ impl JobStore {
             self.append_status_event(job.id, JobStatus::Queued, "job queued")
         }
         .expect("newly-created job must accept queued status event");
-        self.get(job.id)
-            .expect("newly-created job must be readable after insert")
+        (
+            self.get(job.id)
+                .expect("newly-created job must be readable after insert"),
+            true,
+        )
     }
 
     pub fn get(&self, job_id: Uuid) -> Result<Job> {
@@ -1747,7 +1798,7 @@ impl JobStore {
         T: Serialize + Send + 'static,
         F: FnOnce(JobHandle) -> Result<T> + Send + 'static,
     {
-        let job = self.create_with_source_snapshot_metadata_path_materialization_and_local_runner(
+        let (job, created) = self.create_or_reuse_active_local_runner_job(
             operation,
             source_snapshot,
             metadata,
@@ -1755,6 +1806,14 @@ impl JobStore {
             Some(local_runner.clone()),
         );
         let job_id = job.id;
+        // An idempotent resubmission reused an already-enqueued job that already
+        // has its own worker. Do not spawn a second worker for it — return a
+        // handle to a thread that completes immediately so the caller's
+        // `JobRunner` contract is preserved.
+        if !created {
+            let handle = thread::spawn(|| {});
+            return JobRunner { job_id, handle };
+        }
         let handle_store = self.clone();
         let worker_store = self.clone();
         let handle = thread::spawn(move || {

--- a/crates/homeboy-core/src/api_jobs/tests/part_a.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_a.rs
@@ -641,6 +641,91 @@ fn active_runner_job_for_durable_run_id_finds_the_enqueued_job_for_idempotent_re
 }
 
 #[test]
+fn capacity_queued_local_runner_enqueue_dedupes_on_durable_run_id() {
+    // Two enqueues carrying the same controller-minted durable_run_id must
+    // resolve to a single job — the atomic (in-lock) idempotency guard closes
+    // the enqueue-time race two near-simultaneous first submissions would
+    // otherwise create. The second enqueue reuses the first job and does not
+    // spawn a second worker.
+    let store = JobStore::default();
+    let (release, wait) = std::sync::mpsc::channel::<()>();
+    let local_runner = |run_id: &str| super::store::LocalRunnerJob {
+        runner_id: "homeboy-lab".to_string(),
+        command: vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+        ],
+        cwd: Some("/runner/worktree".to_string()),
+        lifecycle: Some(RunnerJobLifecycleMetadata {
+            source: Some("runner-daemon".to_string()),
+            kind: Some("agent-task-run-plan".to_string()),
+            durable_run_id: Some(run_id.to_string()),
+            active_child_count: None,
+            active_cell_count: None,
+        }),
+    };
+
+    let first = store
+        .run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
+            "runner.exec",
+            None,
+            None,
+            None,
+            local_runner("dup-run"),
+            usize::MAX,
+            {
+                let wait = wait;
+                move |_job| {
+                    let _ = wait.recv();
+                    Ok(serde_json::json!({}))
+                }
+            },
+        );
+
+    // Resubmit the same durable run id while the first job is still active.
+    let second = store
+        .run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
+            "runner.exec",
+            None,
+            None,
+            None,
+            local_runner("dup-run"),
+            usize::MAX,
+            move |_job| Ok(serde_json::json!({})),
+        );
+
+    assert_eq!(
+        second.job_id, first.job_id,
+        "resubmission with the same durable run id must reuse the first job"
+    );
+    assert_eq!(
+        store.list().len(),
+        1,
+        "only one job may exist for a durable run id"
+    );
+    // The reused-enqueue handle completes immediately (no second worker).
+    second.handle.join().expect("reused enqueue handle joins");
+
+    release.send(()).expect("release first runner job");
+    first.handle.join().expect("first runner job exits");
+
+    // A different durable run id enqueues a distinct job.
+    let other = store
+        .run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
+            "runner.exec",
+            None,
+            None,
+            None,
+            local_runner("other-run"),
+            usize::MAX,
+            move |_job| Ok(serde_json::json!({})),
+        );
+    assert_ne!(other.job_id, first.job_id);
+    other.handle.join().expect("other runner job exits");
+}
+
+#[test]
 fn active_runner_job_for_durable_run_id_excludes_terminal_jobs() {
     // A terminal job for a durable_run_id must NOT be returned as an idempotent
     // match: the finished run is done, so a resubmission is a genuinely new


### PR DESCRIPTION
## Summary
The next slice of the idempotency work (#9036 / issue #8966). #9036 made a daemon `/exec` resubmission dedupe **when a job already exists** — but it couldn't close the **enqueue-time race**: two near-simultaneous *first* submissions of the same `durable_run_id` both find nothing and both create a job, because the check and the create were separate lock acquisitions.

## The fix
Move the dedup into the job store's create path so it is **atomic with the insert**:

- **`create_or_reuse_active_local_runner_job`** — under one lock, returns the existing non-terminal job for the `durable_run_id` if present, else inserts a new one. Returns `(job, created)`.
- **`run_capacity_queued...local_runner`** spawns a worker **only when it actually created the job**. A reused job already has its own worker, so the deduped enqueue returns a handle to an immediately-completing thread instead of racing a **second worker** onto the same job. (This double-worker hazard is exactly why the guard belongs at the create/spawn layer, not in the low-level insert.)

The daemon's `#9036` pre-create check stays as a cheap **fast-path** (it also avoids redundant exec preparation); the store guard is now the **correctness backstop** guaranteeing at most one active job per durable run id even under concurrent first submissions.

Terminal jobs remain excluded, so a resubmission after a run finishes is still a genuinely new attempt.

## Verification (local, VPS-safe)
- `cargo check -p homeboy-core --lib` — clean (0 errors)
- New test `capacity_queued_local_runner_enqueue_dedupes_on_durable_run_id`: two enqueues of the same `durable_run_id` → **one** job (second reuses the first `job_id`, no second worker); a different run id → a distinct job.
- `cargo test -p homeboy-core --lib api_jobs::` — **all 101 pass**
- `cargo fmt` — clean

Builds on #9036 (merged). Together they make controller→Lab exec submission idempotent both on resubmission-after-transport-drop and under a concurrent first-submission race.