### PR TITLE
Await detached handoff aggregate synchronization

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1596,17 +1596,41 @@ pub(crate) fn reconcile_runner_job_snapshot(
             if let Some(event) = terminal_runner_lifecycle_event(&reconciled, snapshot)? {
                 project_terminal_runner_lifecycle_event(&mut reconciled, snapshot, &event)?;
             } else {
-                apply_runner_job_terminal_state(
-                    &mut reconciled,
-                    snapshot.job.status,
-                    &snapshot.events,
-                );
+                record_pending_runner_synchronization(&mut reconciled, snapshot);
                 store::write_record(&reconciled)?;
             }
         }
     }
     *record = reconciled;
     Ok(())
+}
+
+/// A terminal daemon transport result is not an agent-task result on its own.
+/// Keep the controller record live until the daemon publishes the aggregate
+/// lifecycle event, which is the single authoritative terminal projection.
+fn record_pending_runner_synchronization(
+    record: &mut AgentTaskRunRecord,
+    snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
+) {
+    let metadata = record.ensure_metadata_object();
+    metadata.insert("runner_job_status".to_string(), json!(snapshot.job.status));
+    metadata.insert("runner_job_events".to_string(), json!(snapshot.events));
+    metadata.insert(
+        "phase".to_string(),
+        json!("awaiting_runner_synchronization"),
+    );
+    metadata.insert(
+        "phase_activity".to_string(),
+        json!("runner job is terminal; awaiting its authoritative agent-task aggregate"),
+    );
+    metadata.insert("provider_state".to_string(), json!("synchronizing"));
+    metadata.insert(
+        "runner_result_synchronization".to_string(),
+        json!({
+            "state": "pending",
+            "runner_job_status": snapshot.job.status,
+        }),
+    );
 }
 
 fn terminal_runner_lifecycle_event(
@@ -1834,6 +1858,7 @@ fn aggregate_projection_plan_from_outcomes(aggregate: &AgentTaskAggregate) -> Ag
     AgentTaskPlan::new(&aggregate.plan_id, tasks)
 }
 
+#[cfg(test)]
 pub(crate) fn apply_runner_job_terminal_state(
     record: &mut AgentTaskRunRecord,
     status: homeboy_core::api_jobs::JobStatus,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -339,19 +339,17 @@ fn terminal_lab_artifact_attachment_refuses_runner_provenance_mismatch() {
 }
 
 #[test]
-fn accepted_handoff_projects_remote_failure_and_cancellation_without_a_lifecycle_event() {
+fn accepted_handoff_waits_for_authoritative_aggregate_after_terminal_daemon_status() {
     with_isolated_home(|_| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        for (run_id, job_status, expected_state) in [
+        for (run_id, job_status) in [
             (
                 "agent-task-remote-failure",
                 homeboy_core::api_jobs::JobStatus::Failed,
-                AgentTaskRunState::Failed,
             ),
             (
                 "agent-task-remote-cancellation",
                 homeboy_core::api_jobs::JobStatus::Cancelled,
-                AgentTaskRunState::Cancelled,
             ),
         ] {
             let mut record = record_detached_lab_run(DetachedLabRunRecord {
@@ -367,10 +365,15 @@ fn accepted_handoff_projects_remote_failure_and_cancellation_without_a_lifecycle
             snapshot.events.clear();
 
             reconcile_runner_job_snapshot(&mut record, &snapshot)
-                .expect("terminal daemon result reconciles");
+                .expect("terminal daemon result records pending synchronization");
 
-            assert_eq!(record.state, expected_state);
+            assert_eq!(record.state, AgentTaskRunState::Running);
             assert_eq!(record.metadata["runner_job_status"], json!(job_status));
+            assert_eq!(
+                record.metadata["runner_result_synchronization"]["state"],
+                "pending"
+            );
+            assert_eq!(record.metadata["phase"], "awaiting_runner_synchronization");
         }
     });
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -597,6 +597,52 @@ fn disconnected_proxy_projects_terminal_child_aggregate_once_reachable() {
 }
 
 #[test]
+fn terminal_daemon_status_waits_for_delayed_aggregate_then_projects_once() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-delayed-aggregate",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("accepted handoff");
+        let mut terminal_without_aggregate =
+            terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        terminal_without_aggregate.events.clear();
+
+        reconcile_runner_job_snapshot(&mut record, &terminal_without_aggregate)
+            .expect("terminal transport awaits aggregate synchronization");
+        assert_eq!(record.state, AgentTaskRunState::Running);
+        assert!(store::read_aggregate(&record.run_id).is_err());
+
+        let aggregate = succeeded_aggregate(&test_plan());
+        let mut terminal_with_aggregate = terminal_child_snapshot(&aggregate);
+        let identity = terminal_with_aggregate.events[0]
+            .data
+            .as_mut()
+            .and_then(|event| event.get_mut("identity"))
+            .and_then(Value::as_object_mut)
+            .expect("terminal lifecycle identity");
+        identity.insert("persisted_run_id".to_string(), json!(record.run_id));
+        identity.insert("run_id".to_string(), json!(record.run_id));
+        reconcile_runner_job_snapshot(&mut record, &terminal_with_aggregate)
+            .expect("delayed aggregate terminalizes the handoff");
+        let terminal = record.clone();
+        reconcile_runner_job_snapshot(&mut record, &terminal_with_aggregate)
+            .expect("repeated aggregate reconciliation is idempotent");
+
+        assert_eq!(record, terminal);
+        assert_eq!(record.state, AgentTaskRunState::Succeeded);
+        assert_eq!(
+            store::read_aggregate(&record.run_id).expect("aggregate persisted"),
+            aggregate
+        );
+    });
+}
+
+#[test]
 fn accepted_handoff_projects_a_remote_timeout_aggregate_even_when_daemon_transport_succeeds() {
     with_isolated_home(|_| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];


### PR DESCRIPTION
Closes #9030

## Summary
- represent accepted detached handoffs as pending aggregate synchronization
- prevent missing local aggregates from cancelling live runner jobs
- reconcile delayed aggregate and runner state deterministically

## How to test
1. Run the targeted delayed-aggregate lifecycle tests serially.
2. Run the pending-synchronization status tests serially.
3. Run the live-runner reconciliation tests serially.
4. Run `cargo check -p homeboy-agents` and `cargo fmt --check`.

All targeted commands passed. The reverse-cook integration fixture has an independent mutually exclusive argument bug tracked by #9040.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol via Kimaki/OpenCode
- **Used for:** Implemented detached handoff lifecycle reconciliation and tests in collaboration with Chris.