### PR TITLE
Converge rebuildable artifact cleanup

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -86,6 +86,11 @@ impl AttemptWorkspace {
     }
 
     pub(super) fn cleanup(&self) -> Result<(), String> {
+        // The provider has returned and this exact detached checkout is no
+        // longer leased. Remove only declared rebuildable output before the
+        // source-state guard decides whether the worktree itself is removable.
+        homeboy_core::cleanup::cleanup_worktree_artifacts(&self.root)
+            .map_err(|error| format!("cannot cleanup rebuildable artifacts: {}", error.message))?;
         let status = git_output(&self.root, &["status", "--porcelain=v1"])
             .map_err(|error| format!("cannot inspect attempt workspace state: {error:?}"))?;
         if !status.trim().is_empty() {
@@ -500,4 +505,71 @@ pub(crate) fn fingerprint(contents: &[u8]) -> String {
 
 fn sha256_hex(contents: &[u8]) -> String {
     format!("{:x}", Sha256::digest(contents))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+
+    #[test]
+    fn terminal_cleanup_reclaims_build_output_before_preserving_changed_source() {
+        let source = tempfile::tempdir().expect("source repository");
+        git(source.path(), &["init", "-b", "main"]);
+        fs::create_dir_all(source.path().join("src")).expect("source directory");
+        fs::write(source.path().join("src/lib.rs"), "base").expect("source file");
+        git(source.path(), &["add", "src/lib.rs"]);
+        git(
+            source.path(),
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=homeboy@example.test",
+                "commit",
+                "-m",
+                "initial",
+            ],
+        );
+        let attempt_root = source.path().join("attempt");
+        git(
+            source.path(),
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                attempt_root.to_str().expect("attempt path"),
+                "HEAD",
+            ],
+        );
+        fs::create_dir_all(attempt_root.join("target/debug")).expect("target directory");
+        fs::write(attempt_root.join("target/debug/app"), "artifact").expect("target artifact");
+        fs::write(attempt_root.join("src/lib.rs"), "changed source").expect("changed source");
+
+        let workspace = AttemptWorkspace {
+            source_root: source.path().to_path_buf(),
+            root: attempt_root.clone(),
+            base_sha: git_output(&attempt_root, &["rev-parse", "HEAD"]).expect("attempt head"),
+        };
+        let error = workspace
+            .cleanup()
+            .expect_err("changed source retains worktree");
+
+        assert!(error.contains("uncommitted changes"));
+        assert!(!attempt_root.join("target").exists());
+        assert_eq!(
+            fs::read_to_string(attempt_root.join("src/lib.rs")).expect("source remains"),
+            "changed source"
+        );
+    }
+
+    fn git(cwd: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git {:?} failed with {status}", args);
+    }
 }

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -159,6 +159,31 @@ struct GitSafety {
 pub fn cleanup_artifacts(options: ArtifactCleanupOptions) -> Result<ArtifactCleanupOutput> {
     let root = resolve_root(&options)?;
     let worktrees = discover_worktrees(&root)?;
+    cleanup_artifacts_in_worktrees(root, worktrees, &options, true)
+}
+
+/// Remove declared rebuildable artifacts from one completed worktree without
+/// inspecting sibling worktrees that may still be owned by active tasks.
+pub fn cleanup_worktree_artifacts(worktree: &Path) -> Result<ArtifactCleanupOutput> {
+    let root = git_root(worktree)?;
+    let worktree = root.clone();
+    cleanup_artifacts_in_worktrees(
+        root,
+        vec![WorktreeInfo { path: worktree }],
+        &ArtifactCleanupOptions {
+            apply: true,
+            ..Default::default()
+        },
+        false,
+    )
+}
+
+fn cleanup_artifacts_in_worktrees(
+    root: PathBuf,
+    worktrees: Vec<WorktreeInfo>,
+    options: &ArtifactCleanupOptions,
+    include_self_temp_artifacts: bool,
+) -> Result<ArtifactCleanupOutput> {
     let mut candidates = Vec::new();
     let mut skipped = Vec::new();
     let mut applied = Vec::new();
@@ -221,8 +246,10 @@ pub fn cleanup_artifacts(options: ArtifactCleanupOptions) -> Result<ArtifactClea
         }
     }
 
-    for candidate in self_temp_artifact_candidates(&options)? {
-        candidates.push(candidate);
+    if include_self_temp_artifacts {
+        for candidate in self_temp_artifact_candidates(options)? {
+            candidates.push(candidate);
+        }
     }
 
     order_and_limit_candidates(&mut candidates, options.sort, options.limit);
@@ -871,6 +898,23 @@ mod tests {
         assert_eq!(target.kind, "rust_target");
         assert_eq!(target.declared_by, "homeboy:builtin_artifact_paths");
         assert!(repo.path().join("target/debug/app").exists());
+    }
+
+    #[test]
+    fn worktree_artifact_cleanup_removes_rebuildable_output_and_preserves_source() {
+        let repo = git_repo();
+        write_file(&repo.path().join("target/debug/app"), "artifact");
+        write_file(&repo.path().join("src/lib.rs"), "changed source");
+
+        let output = cleanup_worktree_artifacts(repo.path()).expect("cleanup worktree artifacts");
+
+        assert_eq!(output.worktree_count, 1);
+        assert_eq!(output.applied_count, 1);
+        assert!(!repo.path().join("target").exists());
+        assert_eq!(
+            fs::read_to_string(repo.path().join("src/lib.rs")).expect("source remains"),
+            "changed source"
+        );
     }
 
     #[test]

--- a/docs/commands/cleanup.md
+++ b/docs/commands/cleanup.md
@@ -22,7 +22,7 @@ Use `--sort size` to review the largest artifacts first, `--limit N` to bound th
 
 The JSON output includes worktree identity, candidate paths, estimated bytes, skipped reasons, applied rows, and a `summary` object. The terminal summary shows bounded candidate rows and points to the JSON output for full large reviews. `summary.invocation_reclaimed_bytes` reports bytes reclaimed by the current command, `summary.remaining_candidate_bytes` reports cleanup candidates still present after the command, and `summary.cumulative_session_reclaimed_bytes` carries the local cumulative total for repeated `--apply` runs against the same repository. Cleanup refuses unsafe path declarations and skips artifact paths that contain tracked or staged source changes.
 
-Regular status/cleanup disk-pressure integration is tracked separately from this command surface; use `homeboy cleanup artifacts --sort size --limit 10` as the explicit review path until that integration lands.
+Regular `homeboy cleanup` includes `repo-artifacts` inventory. After an agent-task provider exits, Homeboy also cleans declared rebuildable artifacts from that exact detached attempt worktree before applying its existing source-state and commit safety guard. Active sibling worktrees are not scanned by this lifecycle step.
 
 ## Shared Cargo Targets
 


### PR DESCRIPTION
Closes #7443

## Summary
- add exact-worktree artifact cleanup without touching active sibling worktrees
- reclaim declared rebuildable output when terminal attempts are finalized
- preserve source changes and commits while removing rebuildable artifacts

## How to test
1. Run `cargo test -p homeboy-core cleanup::tests`.
2. Run the targeted agent-task terminal cleanup test.
3. Run the affected scheduler concurrency test serially.
4. Run `cargo fmt --check`.

Targeted verification passed. The broader scheduler group contains unrelated long-running timeout coverage and did not complete within ten minutes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol via Kimaki/OpenCode
- **Used for:** Implemented lifecycle-aware artifact convergence and tests in collaboration with Chris.