### PR TITLE
Use one Lab routing argument in reverse cook flows

### DIFF
--- a/crates/homeboy-cli/src/commands/utils/resource_policy.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy.rs
@@ -298,7 +298,12 @@ pub fn rerun_command(
     rerun.push(args[0].clone());
     if command.lab_offload_supported {
         if let Some(runner_id) = default_runner {
-            if !args.iter().any(|arg| arg == "--runner") {
+            if !args.iter().any(|arg| {
+                arg == "--runner"
+                    || arg.starts_with("--runner=")
+                    || arg == "--placement"
+                    || arg.starts_with("--placement=")
+            }) {
                 rerun.push("--runner".to_string());
                 rerun.push(runner_id.to_string());
             }
@@ -790,6 +795,27 @@ mod tests {
         assert_eq!(
             rerun.as_deref(),
             Some("homeboy --runner homeboy-lab review test homeboy")
+        );
+    }
+
+    #[test]
+    fn portable_rerun_preserves_explicit_placement_without_runner() {
+        let rerun = rerun_command(
+            lab_supported_hot("review test"),
+            &[
+                "homeboy".to_string(),
+                "--placement".to_string(),
+                "local".to_string(),
+                "review".to_string(),
+                "test".to_string(),
+                "homeboy".to_string(),
+            ],
+            Some("homeboy-lab"),
+        );
+
+        assert_eq!(
+            rerun.as_deref(),
+            Some("homeboy --placement local review test homeboy")
         );
     }
 

--- a/tests/reverse_cook_queue_acceptance.rs
+++ b/tests/reverse_cook_queue_acceptance.rs
@@ -116,8 +116,6 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
         .args([
             "--runner",
             "lab",
-            "--placement",
-            "lab",
             "--detach-after-handoff",
             "agent-task",
             "cook",


### PR DESCRIPTION
Closes #9040

## Summary
- remove conflicting placement from the reverse-cook acceptance fixture
- prevent production rerun construction from adding a runner when placement is explicit
- preserve detached queue acceptance and exactly-once completion assertions

## How to test
1. Run `cargo test -p homeboy-cli portable_rerun_preserves_explicit_placement_without_runner --no-fail-fast`.
2. Run `cargo test --test reverse_cook_queue_acceptance --no-fail-fast`.
3. Run scoped formatting and `git diff --check`.

Both tests passed, including the full reverse-cook acceptance fixture.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol via Kimaki/OpenCode
- **Used for:** Repaired fixture and production routing construction in collaboration with Chris.