### PR TITLE
Let immutable adoption bypass provider patch selection

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -392,7 +392,8 @@ pub(super) fn promote_with_provider_and_checkpoint(
         ));
     }
 
-    if outcome.status == AgentTaskOutcomeStatus::CandidateRecoverable
+    if options.candidate_ref.is_none()
+        && outcome.status == AgentTaskOutcomeStatus::CandidateRecoverable
         && outcome
             .artifacts
             .iter()

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
@@ -742,27 +742,29 @@ fn promote_materializes_worktree_dependencies_before_verify_gate() {
 }
 
 #[test]
-fn explicit_candidate_commit_adoption_promotes_and_records_green_gate_handoff() {
+fn explicit_candidate_adoption_ignores_recoverable_provider_patch_selection() {
     let (temp, repo, base, candidate) = adopted_commit_repo();
     let mut provider = FakePromotionWorkspaceProvider {
         workspace_path: Some(repo.clone()),
         ..Default::default()
     };
 
-    let report = promote_with_provider(
-        adopted_commit_options(
-            &temp,
-            &repo,
-            base,
-            candidate.clone(),
-            VerifyGateOptions {
-                verify: vec!["cargo test --lib".to_string()],
-                ..Default::default()
-            },
-        ),
-        &mut provider,
-    )
-    .expect("candidate adoption promotes");
+    let mut options = adopted_commit_options(
+        &temp,
+        &repo,
+        base,
+        candidate.clone(),
+        VerifyGateOptions {
+            verify: vec!["cargo test --lib".to_string()],
+            ..Default::default()
+        },
+    );
+    let mut source: Value = serde_json::from_str(&options.source).expect("adoption outcome");
+    source["status"] = Value::String("candidate_recoverable".to_string());
+    options.source = source.to_string();
+
+    let report = promote_with_provider(options, &mut provider)
+        .expect("recoverable candidate adoption promotes committed changes");
 
     assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
     assert_eq!(


### PR DESCRIPTION
## Summary

Allow explicit immutable commit adoption to derive its change from `candidate_ref` before applying provider patch-artifact cardinality requirements. Ordinary recoverable-candidate promotion still requires exactly one actionable patch artifact.

Closes #9041.

## Root cause

`promote_with_provider_and_checkpoint()` validated every `CandidateRecoverable` outcome for exactly one actionable provider patch before reaching the explicit `candidate_ref` adoption branch. A no-change review of an externally prepared commit therefore made `agent-task adopt` fail even though adoption intentionally derives its patch from the immutable commit.

## How to test

1. Run `cargo test -p homeboy-agents explicit_candidate_adoption_ignores_recoverable_provider_patch_selection --quiet`.
2. Run `cargo test -p homeboy-agents promote_recoverable_candidate_rejects_zero_actionable_patches --quiet`.
3. Run `cargo test -p homeboy-agents promote_recoverable_candidate_rejects_multiple_actionable_patches --quiet`.
4. Run `cargo fmt --package homeboy-agents -- --check`.
5. Run `git diff --check`.

All five commands pass.

The broader `cargo test -p homeboy-agents agent_task_promotion::tests -- --nocapture` run produced 47 passes and 7 failures in unrelated shared fixtures: missing test `origin` remotes, unavailable extension runner registration, and global projection/status expectations. The focused adoption and ordinary patch-cardinality regressions pass independently.

## Compatibility

Backwards compatible. The exact-one-actionable-patch rule remains unchanged for ordinary `CandidateRecoverable` promotion. Only explicit immutable `candidate_ref` adoption bypasses provider artifact selection and continues through existing committed-change validation, gates, and finalization.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the adoption ordering defect, implemented the bounded condition change, and added deterministic regression coverage with Chris reviewing and owning the change.