### PR TITLE
fix: make controller-to-daemon submission durably idempotent

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -2,6 +2,15 @@ use super::*;
 
 pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunRecord> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    // A pending POST may have been accepted despite a lost response. Resolve
+    // its key before cancellation so the original job is cancelled rather than
+    // left running on the runner. Preparing intents have no replay request and
+    // deliberately do not reach this lookup.
+    if record.state == AgentTaskRunState::Queued
+        && super::lifecycle_ops::bind_pending_runner_submission_if_accepted(&record.run_id)?
+    {
+        record = store::read_record(&record.run_id)?;
+    }
     if record.state == AgentTaskRunState::Cancelled {
         return Ok(record);
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1,6 +1,5 @@
 use super::*;
-use homeboy_core::api_jobs::{RemoteRunnerJobRequest, RunnerJobLifecycleMetadata};
-use homeboy_core::secret_env_plan::SecretEnvPlan;
+use homeboy_core::api_jobs::RemoteRunnerJobRequest;
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 
@@ -805,12 +804,16 @@ pub fn record_lab_offload_submission_intent(
     let run_id = sanitize_run_id(run_id);
     let _lock = LabHandoffLock::lock(&run_id)?;
     let mut record = store::read_record(&run_id)?;
-    let submission_key = format!("agent-task:{runner_id}:{run_id}");
+    let submission_key = format!("agent-task:v1:{runner_id}:{run_id}");
+    if let Some(handoff) = record.lab_handoff.as_mut() {
+        handoff.submission_key = Some(submission_key.clone());
+        handoff.payload_fingerprint = None;
+    }
     let metadata = record.ensure_metadata_object();
     metadata.insert(
         "runner_submission_intent".to_string(),
         json!({
-            "state": "pending",
+            "state": "preparing",
             "submission_key": submission_key,
             "runner_id": runner_id,
             "ordering": "broker_fifo",
@@ -827,6 +830,39 @@ pub fn record_lab_offload_submission_intent(
     metadata.insert(
         "phase_activity".to_string(),
         json!("durable broker submission intent recorded; waiting for runner capacity"),
+    );
+    store::write_record(&record)?;
+    Ok(record)
+}
+
+/// Replace a preflight intent with the exact normalized, redacted request that
+/// will cross the broker boundary. This is the final durable write before POST.
+pub fn record_lab_offload_submission_request(
+    run_id: &str,
+    request: &RemoteRunnerJobRequest,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let _lock = LabHandoffLock::lock(&run_id)?;
+    let mut record = store::read_record(&run_id)?;
+    let submission_key = request.submission_key().ok_or_else(|| {
+        Error::internal_unexpected("Lab runner submission request has no stable submission key")
+    })?;
+    let replay_request = request.redacted_for_durable_replay();
+    let payload_fingerprint = replay_request.submission_payload_fingerprint()?;
+    if let Some(handoff) = record.lab_handoff.as_mut() {
+        handoff.submission_key = Some(submission_key.to_string());
+        handoff.payload_fingerprint = Some(payload_fingerprint.clone());
+    }
+    let metadata = record.ensure_metadata_object();
+    metadata.insert(
+        "runner_submission_intent".to_string(),
+        json!({
+            "state": "pending",
+            "submission_key": submission_key,
+            "payload_fingerprint": payload_fingerprint,
+            "runner_id": replay_request.runner_id,
+            "replay_request": replay_request,
+        }),
     );
     store::write_record(&record)?;
     Ok(record)
@@ -1021,7 +1057,19 @@ pub fn reconcile_active_lab_runner_handoffs() -> Result<usize> {
 }
 
 fn has_pending_runner_submission_intent(record: &AgentTaskRunRecord) -> bool {
-    record.runner_job_id().is_none()
+    record.state == AgentTaskRunState::Queued
+        && record.runner_job_id().is_none()
+        && record.lab_handoff.as_ref().is_some_and(|handoff| {
+            handoff.state == AgentTaskLabHandoffState::Pending
+                && handoff.authority == AgentTaskLabHandoffAuthority::Controller
+                && handoff
+                    .acceptance_deadline_at
+                    .as_deref()
+                    .and_then(|timestamp| chrono::DateTime::parse_from_rfc3339(timestamp).ok())
+                    .is_some_and(|deadline| {
+                        deadline.with_timezone(&chrono::Utc) > chrono::Utc::now()
+                    })
+        })
         && record
             .metadata
             .pointer("/runner_submission_intent/state")
@@ -1058,71 +1106,33 @@ pub fn reconcile_pending_runner_submission_intent(run_id: &str) -> Result<bool> 
     let submission_key = string("submission_key").ok_or_else(|| {
         Error::internal_unexpected("pending runner submission intent has no submission key")
     })?;
-    let workload = intent
-        .get("canonical_workload")
-        .and_then(Value::as_object)
-        .ok_or_else(|| {
-            Error::internal_unexpected("pending runner submission intent has no canonical workload")
+    let mut request: RemoteRunnerJobRequest =
+        serde_json::from_value(intent.get("replay_request").cloned().ok_or_else(|| {
+            Error::internal_unexpected(
+                "pending runner submission intent has no complete replay request",
+            )
+        })?)
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse runner replay request".to_string()),
+            )
         })?;
-    let cwd = workload
-        .get("remote_workspace")
-        .and_then(Value::as_str)
-        .filter(|value| !value.trim().is_empty())
-        .map(str::to_string)
-        .ok_or_else(|| {
-            Error::internal_unexpected("pending runner submission intent has no remote workspace")
-        })?;
-    let command = workload
-        .get("remote_command")
-        .and_then(Value::as_array)
-        .ok_or_else(|| {
-            Error::internal_unexpected("pending runner submission intent has no remote command")
-        })?
-        .iter()
-        .map(|value| {
-            value.as_str().map(str::to_string).ok_or_else(|| {
-                Error::internal_unexpected(
-                    "pending runner submission intent has invalid remote command",
-                )
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-    let secret_env_names = intent
-        .get("secret_env_names")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(Value::as_str)
-        .map(str::to_string)
-        .collect::<Vec<_>>();
-    let request = RemoteRunnerJobRequest {
-        runner_id: runner_id.clone(),
-        project_id: None,
-        operation: "runner.exec".to_string(),
-        command: command.clone(),
-        cwd: Some(cwd.clone()),
-        env: Default::default(),
-        secret_env_names: secret_env_names.clone(),
-        secret_env_plan: SecretEnvPlan::from_secret_env_names(secret_env_names),
-        env_materialization: None,
-        capture_patch: false,
-        source_snapshot: None,
-        path_materialization_plan: None,
-        require_paths: Vec::new(),
-        lab_runner_workload: None,
-        lifecycle: Some(RunnerJobLifecycleMetadata {
-            source: Some("reverse-broker-reconciliation".to_string()),
-            kind: Some("agent-task".to_string()),
-            durable_run_id: Some(run_id.clone()),
-            active_child_count: None,
-            active_cell_count: None,
-        }),
-        metadata: Some(json!({
-            "submission_key": submission_key,
-            "durable_run_id": run_id,
-            "reconciled_from": "durable_detached_handoff_intent",
-        })),
-    };
+    if request.runner_id != runner_id {
+        return Err(Error::internal_unexpected(
+            "runner replay request does not match pending runner",
+        ));
+    }
+    let cwd = request.cwd.clone().unwrap_or_default();
+    let command = request.command.clone();
+    let mut metadata = request.metadata.take().unwrap_or_else(|| json!({}));
+    if !metadata.is_object() {
+        metadata = json!({});
+    }
+    metadata["submission_key"] = json!(submission_key);
+    metadata["durable_run_id"] = json!(run_id);
+    metadata["reconciled_from"] = json!("durable_detached_handoff_intent");
+    request.metadata = Some(metadata);
     match runner_continuation::with_runner_continuation(|provider| {
         provider.submit_reverse_broker_job(&runner_id, request)
     }) {
@@ -1147,6 +1157,90 @@ pub fn reconcile_pending_runner_submission_intent(run_id: &str) -> Result<bool> 
                 true
             })?;
             Ok(false)
+        }
+    }
+}
+
+/// Resolve a possibly accepted submission without replaying it. This is used
+/// only after the acceptance deadline or an operator cancellation request:
+/// those paths must never create new runner work.
+pub(crate) fn bind_pending_runner_submission_if_accepted(run_id: &str) -> Result<bool> {
+    let run_id = sanitize_run_id(run_id);
+    let record = store::read_record(&run_id)?;
+    if record.runner_job_id().is_some()
+        || record
+            .metadata
+            .pointer("/runner_submission_intent/state")
+            .and_then(Value::as_str)
+            != Some("pending")
+    {
+        return Ok(false);
+    }
+    let intent = record
+        .metadata
+        .get("runner_submission_intent")
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            Error::internal_unexpected("pending runner submission intent is malformed")
+        })?;
+    let string = |key: &str| {
+        intent
+            .get(key)
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string)
+    };
+    let runner_id = string("runner_id").ok_or_else(|| {
+        Error::internal_unexpected("pending runner submission intent has no runner id")
+    })?;
+    let submission_key = string("submission_key").ok_or_else(|| {
+        Error::internal_unexpected("pending runner submission intent has no submission key")
+    })?;
+    let request: RemoteRunnerJobRequest =
+        serde_json::from_value(intent.get("replay_request").cloned().ok_or_else(|| {
+            Error::internal_unexpected(
+                "pending runner submission intent has no complete replay request",
+            )
+        })?)
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse runner replay request".to_string()),
+            )
+        })?;
+    if request.runner_id != runner_id {
+        return Err(Error::internal_unexpected(
+            "runner replay request does not match pending runner",
+        ));
+    }
+    let lookup = runner_continuation::with_runner_continuation(|provider| {
+        provider.lookup_reverse_broker_submission(&runner_id, &submission_key)
+    });
+    match lookup {
+        Ok(homeboy_core::api_jobs::RemoteRunnerSubmissionLookup::Accepted { job }) => {
+            record_detached_lab_run(DetachedLabRunRecord {
+                run_id: &run_id,
+                runner_id: &runner_id,
+                runner_job_id: &job.id.to_string(),
+                remote_workspace: request.cwd.as_deref().unwrap_or_default(),
+                remote_command: &request.command,
+            })?;
+            Ok(true)
+        }
+        Ok(
+            homeboy_core::api_jobs::RemoteRunnerSubmissionLookup::Absent
+            | homeboy_core::api_jobs::RemoteRunnerSubmissionLookup::Expired { .. },
+        ) => Ok(false),
+        Err(error) => {
+            let _ = store::mutate_record(&run_id, |record| {
+                record.ensure_metadata_object()["runner_submission_intent"]["last_lookup_error"] = json!({
+                    "code": error.code.as_str(),
+                    "message": error.message.clone(),
+                    "retryable": true,
+                });
+                true
+            })?;
+            Err(error)
         }
     }
 }
@@ -1198,6 +1292,11 @@ pub fn candidate_adoption_recovery_outcome(
 }
 
 fn expire_unaccepted_lab_handoff(run_id: &str) -> Result<bool> {
+    // An expired pending request may have been accepted immediately before its
+    // response was lost. Querying its key is read-only; never replay here.
+    if bind_pending_runner_submission_if_accepted(run_id)? {
+        return Ok(true);
+    }
     let _lock = LabHandoffLock::lock(run_id)?;
     // Re-read while holding the handoff lock: an accepted job is runner-owned
     // and must never be terminalized by controller deadline recovery.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -107,6 +107,10 @@ pub struct AgentTaskLabHandoff {
     pub authority: AgentTaskLabHandoffAuthority,
     pub runner_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub submission_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_fingerprint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runner_job_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub submitted_at: Option<String>,
@@ -369,6 +373,8 @@ impl AgentTaskLabHandoff {
             state: AgentTaskLabHandoffState::Pending,
             authority: AgentTaskLabHandoffAuthority::Controller,
             runner_id: runner_id.to_string(),
+            submission_key: None,
+            payload_fingerprint: None,
             runner_job_id: None,
             submitted_at: Some(submitted_at),
             acceptance_deadline_at: Some(acceptance_deadline_at),
@@ -382,6 +388,8 @@ impl AgentTaskLabHandoff {
             state: AgentTaskLabHandoffState::Accepted,
             authority: AgentTaskLabHandoffAuthority::RunnerDaemon,
             runner_id: self.runner_id.clone(),
+            submission_key: self.submission_key.clone(),
+            payload_fingerprint: self.payload_fingerprint.clone(),
             runner_job_id: Some(runner_job_id.to_string()),
             submitted_at: self.submitted_at.clone(),
             acceptance_deadline_at: self.acceptance_deadline_at.clone(),
@@ -395,6 +403,8 @@ impl AgentTaskLabHandoff {
             state: AgentTaskLabHandoffState::Expired,
             authority: AgentTaskLabHandoffAuthority::Controller,
             runner_id: self.runner_id.clone(),
+            submission_key: self.submission_key.clone(),
+            payload_fingerprint: self.payload_fingerprint.clone(),
             runner_job_id: None,
             submitted_at: self.submitted_at.clone(),
             acceptance_deadline_at: self.acceptance_deadline_at.clone(),
@@ -490,6 +500,8 @@ impl AgentTaskLabHandoff {
                     state: AgentTaskLabHandoffState::Accepted,
                     authority: AgentTaskLabHandoffAuthority::RunnerDaemon,
                     runner_id,
+                    submission_key: None,
+                    payload_fingerprint: None,
                     runner_job_id: Some(runner_job_id),
                     submitted_at: acceptance.get("started_at").and_then(optional_timestamp),
                     acceptance_deadline_at: acceptance
@@ -507,6 +519,8 @@ impl AgentTaskLabHandoff {
                     state: AgentTaskLabHandoffState::Expired,
                     authority: AgentTaskLabHandoffAuthority::Controller,
                     runner_id,
+                    submission_key: None,
+                    payload_fingerprint: None,
                     runner_job_id: None,
                     submitted_at: None,
                     acceptance_deadline_at: None,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
@@ -14,7 +14,9 @@
 
 use std::sync::Mutex;
 
-use homeboy_core::api_jobs::{Job, RemoteRunnerJobRequest, RunnerJobLogSnapshot};
+use homeboy_core::api_jobs::{
+    Job, RemoteRunnerJobRequest, RemoteRunnerSubmissionLookup, RunnerJobLogSnapshot,
+};
 use homeboy_core::error::{Error, Result};
 
 /// Runner-side operations the agent-task lifecycle needs when reconciling or
@@ -48,6 +50,16 @@ pub trait RunnerContinuationProvider: Send + Sync {
         runner_id: &str,
         request: RemoteRunnerJobRequest,
     ) -> Result<Job>;
+
+    fn lookup_reverse_broker_submission(
+        &self,
+        _runner_id: &str,
+        _submission_key: &str,
+    ) -> Result<RemoteRunnerSubmissionLookup> {
+        Err(Error::internal_unexpected(
+            "runner subsystem is unavailable: cannot look up reverse broker submission",
+        ))
+    }
 }
 
 /// Default provider used when the runner subsystem is not present. Behaves like

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
@@ -12,7 +12,9 @@ use crate::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
     AGENT_TASK_AGGREGATE_SCHEMA,
 };
-use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStore, RemoteRunnerJobRequest};
+use homeboy_core::api_jobs::{
+    Job, JobEvent, JobEventKind, JobStore, RemoteRunnerJobRequest, RemoteRunnerSubmissionLookup,
+};
 use homeboy_core::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};
 use std::sync::{Arc, Mutex, Once};
@@ -58,6 +60,7 @@ pub(super) fn fake_controller_artifact(
 pub(super) struct IntentReplayProvider {
     store: JobStore,
     submitted: Arc<Mutex<Vec<uuid::Uuid>>>,
+    lookups: Arc<Mutex<Vec<String>>>,
     fail_after_accept_once: Arc<Mutex<bool>>,
 }
 
@@ -105,6 +108,42 @@ impl RunnerContinuationProvider for IntentReplayProvider {
             ));
         }
         Ok(job)
+    }
+
+    fn lookup_reverse_broker_submission(
+        &self,
+        _runner_id: &str,
+        submission_key: &str,
+    ) -> Result<RemoteRunnerSubmissionLookup> {
+        self.lookups
+            .lock()
+            .expect("lookup log")
+            .push(submission_key.to_string());
+        Ok(self.store.lookup_remote_runner_submission(submission_key))
+    }
+}
+
+pub(super) fn replay_request(run_id: &str, command: &[String]) -> RemoteRunnerJobRequest {
+    RemoteRunnerJobRequest {
+        runner_id: "homeboy-lab".to_string(),
+        project_id: None,
+        operation: "runner.exec".to_string(),
+        command: command.to_vec(),
+        cwd: Some("/runner/workspace/homeboy".to_string()),
+        env: Default::default(),
+        secret_env_names: Vec::new(),
+        secret_env_plan: Default::default(),
+        env_materialization: None,
+        capture_patch: false,
+        source_snapshot: None,
+        path_materialization_plan: None,
+        require_paths: Vec::new(),
+        lab_runner_workload: None,
+        lifecycle: None,
+        metadata: Some(json!({
+            "submission_key": format!("agent-task:v1:homeboy-lab:{run_id}"),
+            "durable_run_id": run_id,
+        })),
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -152,12 +152,14 @@ fn detached_cook_intent_reconciliation_converges_both_crash_windows_without_secr
     with_isolated_home(|_| {
         let store = JobStore::default();
         let submitted = Arc::new(Mutex::new(Vec::new()));
+        let lookups = Arc::new(Mutex::new(Vec::new()));
         let fail_after_accept_once = Arc::new(Mutex::new(false));
         // Scope the provider to this test so it cannot leak into later tests and
         // make lifecycle results order-dependent (#8964).
         let _runner = RunnerContinuationTestGuard::install(Box::new(IntentReplayProvider {
             store: store.clone(),
             submitted: Arc::clone(&submitted),
+            lookups: Arc::clone(&lookups),
             fail_after_accept_once: Arc::clone(&fail_after_accept_once),
         }));
         let command = vec![
@@ -185,6 +187,8 @@ fn detached_cook_intent_reconciliation_converges_both_crash_windows_without_secr
                 &["HOMEBOY_TEST_REVERSE_SECRET".to_string()],
             )
             .expect("persist redacted pre-submit intent");
+            record_lab_offload_submission_request(run_id, &replay_request(run_id, &command))
+                .expect("persist exact request before post");
 
             if post_accept_fault {
                 *fail_after_accept_once.lock().expect("fault flag") = true;
@@ -214,6 +218,228 @@ fn detached_cook_intent_reconciliation_converges_both_crash_windows_without_secr
         let persisted = serde_json::to_string(&store.get(submitted[0]).expect("broker job"))
             .expect("broker JSON");
         assert!(!persisted.contains("secret-value"));
+        assert!(lookups.lock().expect("lookup log").is_empty());
+    });
+}
+
+#[test]
+fn cancelled_or_expired_pending_handoff_never_submits_new_runner_work() {
+    with_isolated_home(|_| {
+        let submitted = Arc::new(Mutex::new(Vec::new()));
+        let lookups = Arc::new(Mutex::new(Vec::new()));
+        register_runner_continuation_provider(Box::new(IntentReplayProvider {
+            store: JobStore::default(),
+            submitted: Arc::clone(&submitted),
+            lookups: Arc::clone(&lookups),
+            fail_after_accept_once: Arc::new(Mutex::new(false)),
+        }));
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+
+        for run_id in ["cancel-before-admission", "expire-before-admission"] {
+            record_lab_offload_planned(LabOffloadProxyPlan {
+                run_id,
+                runner_id: "homeboy-lab",
+                remote_workspace: "/runner/workspace/homeboy",
+                remote_command: &command,
+                durable_plan: None,
+            })
+            .expect("record Lab admission");
+            record_lab_offload_submission_intent(
+                run_id,
+                "homeboy-lab",
+                "/runner/workspace/homeboy",
+                &command,
+                &[],
+            )
+            .expect("persist intent");
+        }
+
+        cancel_run("cancel-before-admission", Some("operator cancelled"))
+            .expect("cancel before daemon acceptance");
+        rewrite_record_for_test("expire-before-admission", |record| {
+            record
+                .lab_handoff
+                .as_mut()
+                .expect("handoff")
+                .acceptance_deadline_at = Some("2000-01-01T00:00:00+00:00".to_string());
+        })
+        .expect("expire handoff");
+
+        assert!(
+            !reconcile_pending_runner_submission_intent("cancel-before-admission")
+                .expect("cancelled handoff is not submitted")
+        );
+        assert!(
+            !reconcile_pending_runner_submission_intent("expire-before-admission")
+                .expect("expired handoff is not submitted")
+        );
+        assert!(submitted.lock().expect("submission log").is_empty());
+        assert!(lookups.lock().expect("lookup log").is_empty());
+    });
+}
+
+#[test]
+fn preparing_crash_never_submits_or_queries_the_runner() {
+    with_isolated_home(|_| {
+        let submitted = Arc::new(Mutex::new(Vec::new()));
+        let lookups = Arc::new(Mutex::new(Vec::new()));
+        register_runner_continuation_provider(Box::new(IntentReplayProvider {
+            store: JobStore::default(),
+            submitted: Arc::clone(&submitted),
+            lookups: Arc::clone(&lookups),
+            fail_after_accept_once: Arc::new(Mutex::new(false)),
+        }));
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+        record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "preparing-crash",
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+            durable_plan: None,
+        })
+        .expect("planned handoff");
+        record_lab_offload_submission_intent(
+            "preparing-crash",
+            "homeboy-lab",
+            "/runner/workspace/homeboy",
+            &command,
+            &[],
+        )
+        .expect("preparing intent");
+
+        assert!(!reconcile_pending_runner_submission_intent("preparing-crash").expect("no replay"));
+        assert_eq!(
+            status("preparing-crash").expect("status").state,
+            AgentTaskRunState::Queued
+        );
+        assert!(submitted.lock().expect("submitted").is_empty());
+        assert!(lookups.lock().expect("lookups").is_empty());
+    });
+}
+
+#[test]
+fn expired_or_cancelled_pending_submission_binds_and_cancels_the_accepted_job() {
+    with_isolated_home(|_| {
+        let store = JobStore::default();
+        let submitted = Arc::new(Mutex::new(Vec::new()));
+        let lookups = Arc::new(Mutex::new(Vec::new()));
+        register_runner_continuation_provider(Box::new(IntentReplayProvider {
+            store: store.clone(),
+            submitted: Arc::clone(&submitted),
+            lookups: Arc::clone(&lookups),
+            fail_after_accept_once: Arc::new(Mutex::new(false)),
+        }));
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+
+        for run_id in ["accepted-then-expired", "accepted-then-cancelled"] {
+            record_lab_offload_planned(LabOffloadProxyPlan {
+                run_id,
+                runner_id: "homeboy-lab",
+                remote_workspace: "/runner/workspace/homeboy",
+                remote_command: &command,
+                durable_plan: None,
+            })
+            .expect("planned handoff");
+            record_lab_offload_submission_intent(
+                run_id,
+                "homeboy-lab",
+                "/runner/workspace/homeboy",
+                &command,
+                &[],
+            )
+            .expect("preparing intent");
+            let request = replay_request(run_id, &command);
+            record_lab_offload_submission_request(run_id, &request).expect("pending request");
+            let job = store
+                .submit_remote_runner_job(request)
+                .expect("accepted broker job");
+
+            if run_id == "accepted-then-expired" {
+                rewrite_record_for_test(run_id, |record| {
+                    record
+                        .lab_handoff
+                        .as_mut()
+                        .expect("handoff")
+                        .acceptance_deadline_at = Some("2000-01-01T00:00:00+00:00".to_string());
+                })
+                .expect("expire deadline");
+                let record = status(run_id).expect("late acceptance reconciliation");
+                let job_id = job.id.to_string();
+                assert_eq!(record.runner_job_id(), Some(job_id.as_str()));
+                assert_eq!(record.state, AgentTaskRunState::Running);
+            } else {
+                let cancellation_store = store.clone();
+                let _guard = crate::agent_task_lifecycle::cancellation::test_cancel_hook::install(
+                    Box::new({
+                        let expected_job_id = job.id.to_string();
+                        move |runner_id, job_id, durable_run_id| {
+                            assert_eq!(runner_id, "homeboy-lab");
+                            assert_eq!(job_id, expected_job_id);
+                            assert_eq!(durable_run_id, "accepted-then-cancelled");
+                            Ok((cancellation_store.get(job.id).expect("job"), Vec::new()))
+                        }
+                    }),
+                );
+                let record =
+                    cancel_run(run_id, Some("operator cancellation")).expect("cancel bound job");
+                assert_eq!(record.state, AgentTaskRunState::Cancelled);
+                let job_id = job.id.to_string();
+                assert_eq!(record.runner_job_id(), Some(job_id.as_str()));
+            }
+        }
+        record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "absent-after-deadline",
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+            durable_plan: None,
+        })
+        .expect("planned absent handoff");
+        record_lab_offload_submission_intent(
+            "absent-after-deadline",
+            "homeboy-lab",
+            "/runner/workspace/homeboy",
+            &command,
+            &[],
+        )
+        .expect("preparing absent handoff");
+        record_lab_offload_submission_request(
+            "absent-after-deadline",
+            &replay_request("absent-after-deadline", &command),
+        )
+        .expect("pending absent handoff");
+        rewrite_record_for_test("absent-after-deadline", |record| {
+            record
+                .lab_handoff
+                .as_mut()
+                .expect("handoff")
+                .acceptance_deadline_at = Some("2000-01-01T00:00:00+00:00".to_string());
+        })
+        .expect("expire absent handoff");
+        let absent = status("absent-after-deadline").expect("absent reconciliation");
+        assert_eq!(absent.state, AgentTaskRunState::Cancelled);
+        assert!(absent.runner_job_id().is_none());
+        assert!(submitted.lock().expect("submitted").is_empty());
+        let lookups = lookups.lock().expect("lookups");
+        for run_id in [
+            "accepted-then-expired",
+            "accepted-then-cancelled",
+            "absent-after-deadline",
+        ] {
+            assert!(lookups.contains(&format!("agent-task:v1:homeboy-lab:{run_id}")));
+        }
     });
 }
 
@@ -1005,6 +1231,8 @@ fn malformed_typed_pending_handoff_is_health_malformed_and_unreconciled() {
                 state: AgentTaskLabHandoffState::Pending,
                 authority: AgentTaskLabHandoffAuthority::Controller,
                 runner_id: "homeboy-lab".to_string(),
+                submission_key: None,
+                payload_fingerprint: None,
                 runner_job_id: None,
                 submitted_at: Some("invalid".to_string()),
                 acceptance_deadline_at: None,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -150,15 +150,23 @@ fn detached_handoff_persists_redacted_submission_intent_before_broker_ack() {
         )
         .expect("persist intent");
 
-        let pending = status("intent-before-post").expect("pending intent status");
+        let pending = status("intent-before-post").expect("preparing intent status");
         assert_eq!(
             pending.metadata["runner_submission_intent"]["state"],
-            "pending"
+            "preparing"
         );
         assert_eq!(
             pending.metadata["runner_submission_intent"]["submission_key"],
-            "agent-task:homeboy-lab:intent-before-post"
+            "agent-task:v1:homeboy-lab:intent-before-post"
         );
+        assert!(pending.metadata["runner_submission_intent"]
+            .get("replay_request")
+            .is_none());
+        assert!(pending
+            .lab_handoff
+            .as_ref()
+            .and_then(|handoff| handoff.payload_fingerprint.as_deref())
+            .is_none());
         assert_eq!(pending.metadata["phase"], "waiting_for_runner_capacity");
         assert!(!serde_json::to_string(&pending)
             .expect("serialize record")

--- a/crates/homeboy-core/src/api_jobs/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/mod.rs
@@ -12,7 +12,7 @@ use homeboy_api_jobs_contract::types;
 
 pub use remote_runner::{
     JobArtifactMetadata, RemoteRunnerJobClaim, RemoteRunnerJobRequest, RemoteRunnerJobResult,
-    RunnerJobLifecycleMetadata, RunnerJobProjectionCancelRequest,
+    RemoteRunnerSubmissionLookup, RunnerJobLifecycleMetadata, RunnerJobProjectionCancelRequest,
 };
 pub(crate) use runner_job_preparation::with_runner_job_preparation;
 pub use runner_job_preparation::{

--- a/crates/homeboy-core/src/api_jobs/persistence.rs
+++ b/crates/homeboy-core/src/api_jobs/persistence.rs
@@ -183,6 +183,16 @@ pub(super) fn compact_terminal_jobs(
     durable
         .jobs
         .retain(|stored| !removed_job_ids.contains(&stored.job.id));
+    // Keep an explicit tombstone when compaction expires an idempotency key.
+    // Replaying an expired accepted submission must fail closed, never enqueue
+    // a second execution after the original evidence has been pruned.
+    for (key, submission) in std::mem::take(&mut durable.submission_keys) {
+        if removed_job_ids.contains(&submission.job_id) {
+            durable.expired_submission_keys.insert(key, submission);
+        } else {
+            durable.submission_keys.insert(key, submission);
+        }
+    }
     let evidence = JobStoreCompactionEvidence {
         timestamp_ms: timestamp_ms(),
         removed_terminal_jobs,

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -1,16 +1,18 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::Ordering;
 
+use sha2::{Digest, Sha256};
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
 use super::persistence::{apply_event_retention, job_not_found, timestamp_ms, validate_transition};
-use super::store::{JobStore, StoredJob};
+use super::store::{JobStore, RemoteRunnerSubmission, StoredJob};
 use super::types::{Job, JobEvent, JobEventKind, JobStatus};
 use crate::engine::command::CommandCaptureMetadata;
 use crate::env_materialization_plan::EnvMaterializationPlan;
-use crate::error::{Error, Result};
+use crate::error::{Error, ErrorCode, Result};
 use crate::lab_contract::LabRunnerWorkload;
 use crate::runner_execution_envelope::{
     PathMaterializationPlan, RunnerExecutionDispatch, RunnerExecutionEnvelope,
@@ -34,6 +36,14 @@ pub use homeboy_api_jobs_contract::metadata::{JobArtifactMetadata, RunnerJobLife
 pub struct RunnerJobProjectionCancelRequest {
     pub expected_runner_id: String,
     pub expected_durable_run_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum RemoteRunnerSubmissionLookup {
+    Accepted { job: Job },
+    Expired { job_id: Uuid },
+    Absent,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -78,13 +88,54 @@ impl RemoteRunnerJobRequest {
     /// A caller-owned identity makes a retried POST safe across a lost response.
     /// It deliberately lives in metadata so older clients can continue submitting
     /// anonymous jobs while durable handoffs opt into replayable ownership.
-    pub(crate) fn submission_key(&self) -> Option<&str> {
+    pub fn submission_key(&self) -> Option<&str> {
         self.metadata
             .as_ref()
             .and_then(|metadata| metadata.get("submission_key"))
             .and_then(Value::as_str)
             .map(str::trim)
             .filter(|key| !key.is_empty())
+    }
+
+    /// Fingerprint the execution inputs that a lost-response replay can
+    /// reconstruct. Transport, lifecycle, and evidence metadata deliberately
+    /// do not participate in submission identity.
+    pub fn redacted_for_durable_replay(&self) -> Self {
+        let mut request = self.clone();
+        request.normalize();
+        request.public_metadata()
+    }
+
+    pub fn submission_payload_fingerprint(&self) -> Result<String> {
+        let request = self.redacted_for_durable_replay();
+        let bytes = serde_json::to_vec(&serde_json::json!({
+            "schema": "homeboy/remote-runner-submission-payload/v1",
+            "runner_id": request.runner_id,
+            "project_id": request.project_id,
+            "operation": request.operation,
+            "command": request.command,
+            "cwd": request.cwd,
+            "env": request.env,
+            "secret_env_names": request.secret_env_names,
+            "secret_env_plan": request.secret_env_plan,
+            "env_materialization": request.env_materialization,
+            "capture_patch": request.capture_patch,
+            "source_snapshot": request.source_snapshot,
+            "path_materialization_plan": request.path_materialization_plan,
+            "require_paths": request.require_paths,
+            "runner_workload": request.lab_runner_workload,
+            "command_assets": request
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("command_assets")),
+        }))
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("fingerprint runner submission".to_string()),
+            )
+        })?;
+        Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
     }
 
     pub(crate) fn normalize(&mut self) -> SecretEnvPlan {
@@ -196,7 +247,7 @@ impl RemoteRunnerJobRequest {
         envelope
     }
 
-    pub(crate) fn public_metadata(&self) -> Self {
+    pub fn public_metadata(&self) -> Self {
         let mut public = self.clone();
         public
             .env
@@ -387,6 +438,26 @@ pub(super) struct StoredRemoteRunnerJob {
 }
 
 impl JobStore {
+    pub fn lookup_remote_runner_submission(
+        &self,
+        submission_key: &str,
+    ) -> RemoteRunnerSubmissionLookup {
+        let inner = self.inner.lock().expect("job store mutex poisoned");
+        if let Some(submission) = inner.submission_keys.get(submission_key) {
+            if let Some(stored) = inner.jobs.get(&submission.job_id) {
+                return RemoteRunnerSubmissionLookup::Accepted {
+                    job: stored.job.clone(),
+                };
+            }
+        }
+        if let Some(submission) = inner.expired_submission_keys.get(submission_key) {
+            return RemoteRunnerSubmissionLookup::Expired {
+                job_id: submission.job_id,
+            };
+        }
+        RemoteRunnerSubmissionLookup::Absent
+    }
+
     pub fn submit_remote_runner_job(&self, mut request: RemoteRunnerJobRequest) -> Result<Job> {
         if request.runner_id.trim().is_empty() {
             return Err(Error::validation_invalid_argument(
@@ -421,17 +492,65 @@ impl JobStore {
         let now = timestamp_ms();
         let public_request = request.public_metadata();
         let submission_key = request.submission_key().map(str::to_string);
+        let submission_fingerprint = submission_key
+            .as_ref()
+            .map(|_| request.submission_payload_fingerprint())
+            .transpose()?;
         let mut inner = self.inner.lock().expect("job store mutex poisoned");
         if let Some(submission_key) = submission_key.as_deref() {
-            if let Some(existing) = inner.jobs.values().find(|stored| {
-                stored
-                    .remote_runner
-                    .as_ref()
-                    .and_then(|remote| remote.request.submission_key())
-                    == Some(submission_key)
-                    && stored.job.target_runner_id.as_deref() == Some(request.runner_id.as_str())
-            }) {
-                return Ok(existing.job.clone());
+            let fingerprint = submission_fingerprint
+                .as_deref()
+                .expect("key has fingerprint");
+            if let Some(existing) = inner.submission_keys.get(submission_key) {
+                if existing.fingerprint != fingerprint {
+                    return Err(Error::new(
+                        ErrorCode::ValidationInvalidArgument,
+                        "remote runner submission key is already bound to a different normalized payload",
+                        serde_json::json!({
+                            "schema": "homeboy/remote-runner-submission-conflict/v1",
+                            "submission_key": submission_key,
+                            "existing_fingerprint": existing.fingerprint,
+                            "submitted_fingerprint": fingerprint,
+                            "accepted_job_id": existing.job_id,
+                        }),
+                    ));
+                }
+                let job = inner
+                    .jobs
+                    .get(&existing.job_id)
+                    .map(|stored| stored.job.clone())
+                    .ok_or_else(|| {
+                        Error::internal_unexpected(
+                            "durable runner submission index references a missing job",
+                        )
+                    })?;
+                let evidence = serde_json::json!({
+                    "schema": "homeboy/remote-runner-submission/v1",
+                    "submission_key": submission_key,
+                    "payload_fingerprint": fingerprint,
+                    "decision": "replay",
+                    "accepted_job_id": job.id,
+                });
+                drop(inner);
+                self.append_event(
+                    job.id,
+                    JobEventKind::Progress,
+                    Some("remote runner submission replayed".to_string()),
+                    Some(evidence),
+                )?;
+                return Ok(job);
+            }
+            if let Some(expired) = inner.expired_submission_keys.get(submission_key) {
+                return Err(Error::new(
+                    ErrorCode::ValidationInvalidArgument,
+                    "remote runner submission key has expired with its retained job evidence",
+                    serde_json::json!({
+                        "schema": "homeboy/remote-runner-submission-expired/v1",
+                        "submission_key": submission_key,
+                        "payload_fingerprint": expired.fingerprint,
+                        "expired_job_id": expired.job_id,
+                    }),
+                ));
             }
         }
         let job = Job {
@@ -474,19 +593,60 @@ impl JobStore {
                 local_child: None,
             },
         );
-        drop(inner);
-
-        if let Some(metadata) = run_ref_metadata {
-            self.append_status_event_with_data(
-                job.id,
-                JobStatus::Queued,
-                "remote runner job queued",
-                metadata,
-            )?;
-        } else {
-            self.append_status_event(job.id, JobStatus::Queued, "remote runner job queued")?;
+        if let (Some(submission_key), Some(fingerprint)) =
+            (submission_key, submission_fingerprint.clone())
+        {
+            inner.submission_keys.insert(
+                submission_key,
+                RemoteRunnerSubmission {
+                    fingerprint,
+                    job_id: job.id,
+                },
+            );
         }
-        self.get(job.id)
+        let mut evidence = run_ref_metadata.unwrap_or_else(|| serde_json::json!({}));
+        if let (Some(submission_key), Some(fingerprint)) =
+            (request.submission_key(), submission_fingerprint.as_deref())
+        {
+            evidence["submission"] = serde_json::json!({
+                "schema": "homeboy/remote-runner-submission/v1",
+                "submission_key": submission_key,
+                "payload_fingerprint": fingerprint,
+                "decision": "new",
+                "accepted_job_id": job.id,
+            });
+        }
+        let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+        let stored = inner.jobs.get_mut(&job.id).expect("newly inserted job");
+        stored.events.push(JobEvent {
+            sequence,
+            job_id: job.id,
+            kind: JobEventKind::Status,
+            timestamp_ms: now,
+            message: Some("remote runner job queued".to_string()),
+            data: Some(evidence),
+        });
+        stored.job.event_count = stored.events.len();
+        // Persist job creation, queue evidence, and key index as one locked
+        // snapshot. This is the admission commit point used by lost-response
+        // recovery and daemon restart replay.
+        if let Some(persistence) = &self.persistence {
+            let durable = super::store::DurableJobStore {
+                jobs: inner.jobs.values().cloned().collect(),
+                submission_keys: inner.submission_keys.clone(),
+                expired_submission_keys: inner.expired_submission_keys.clone(),
+                compaction: inner.compaction.clone(),
+            };
+            if let Err(error) = super::persistence::write_durable_store(&persistence.path, &durable)
+            {
+                inner.jobs.remove(&job.id);
+                if let Some(submission_key) = request.submission_key() {
+                    inner.submission_keys.remove(submission_key);
+                }
+                return Err(error);
+            }
+        }
+        Ok(job)
     }
 
     pub fn claim_remote_runner_job(

--- a/crates/homeboy-core/src/api_jobs/store.rs
+++ b/crates/homeboy-core/src/api_jobs/store.rs
@@ -52,7 +52,17 @@ pub(super) struct JobStorePersistence {
 #[derive(Debug, Default)]
 pub(super) struct JobStoreInner {
     pub(super) jobs: HashMap<Uuid, StoredJob>,
+    pub(super) submission_keys: HashMap<String, RemoteRunnerSubmission>,
+    pub(super) expired_submission_keys: HashMap<String, RemoteRunnerSubmission>,
     pub(super) compaction: Option<JobStoreCompactionEvidence>,
+}
+
+/// A durable, caller-owned admission identity. The fingerprint makes reuse of a
+/// key with different work fail closed instead of silently selecting a job.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct RemoteRunnerSubmission {
+    pub(super) fingerprint: String,
+    pub(super) job_id: Uuid,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -107,6 +117,10 @@ pub(crate) enum LocalChildStartDiscriminator {
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub(super) struct DurableJobStore {
     pub(super) jobs: Vec<StoredJob>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub(super) submission_keys: HashMap<String, RemoteRunnerSubmission>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub(super) expired_submission_keys: HashMap<String, RemoteRunnerSubmission>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) compaction: Option<JobStoreCompactionEvidence>,
 }
@@ -206,6 +220,8 @@ impl JobStore {
                     .into_iter()
                     .map(|stored| (stored.job.id, stored))
                     .collect(),
+                submission_keys: durable.submission_keys,
+                expired_submission_keys: durable.expired_submission_keys,
                 compaction: durable.compaction,
             })),
             next_event_sequence: Arc::new(AtomicU64::new(next_sequence)),
@@ -331,6 +347,8 @@ impl JobStore {
                     .into_iter()
                     .map(|stored| (stored.job.id, stored))
                     .collect(),
+                submission_keys: durable.submission_keys,
+                expired_submission_keys: durable.expired_submission_keys,
                 compaction: durable.compaction,
             })),
             next_event_sequence: Arc::new(AtomicU64::new(next_sequence)),
@@ -2027,6 +2045,8 @@ impl JobStore {
         if let Some(persistence) = &self.persistence {
             let mut durable = DurableJobStore {
                 jobs: inner.jobs.values().cloned().collect(),
+                submission_keys: inner.submission_keys.clone(),
+                expired_submission_keys: inner.expired_submission_keys.clone(),
                 compaction: inner.compaction.clone(),
             };
             compact_terminal_jobs(
@@ -2302,6 +2322,8 @@ impl JobStore {
         if let Some(persistence) = &self.persistence {
             let mut durable = DurableJobStore {
                 jobs: inner.jobs.values().cloned().collect(),
+                submission_keys: inner.submission_keys.clone(),
+                expired_submission_keys: inner.expired_submission_keys.clone(),
                 compaction: inner.compaction.clone(),
             };
             compact_terminal_jobs(
@@ -2398,6 +2420,8 @@ impl JobStore {
         let mut inner = self.inner.lock().expect("job store mutex poisoned");
         let mut durable = DurableJobStore {
             jobs: inner.jobs.values().cloned().collect(),
+            submission_keys: inner.submission_keys.clone(),
+            expired_submission_keys: inner.expired_submission_keys.clone(),
             compaction: inner.compaction.clone(),
         };
         compact_terminal_jobs(
@@ -2413,6 +2437,8 @@ impl JobStore {
             .cloned()
             .map(|stored| (stored.job.id, stored))
             .collect();
+        inner.submission_keys = durable.submission_keys;
+        inner.expired_submission_keys = durable.expired_submission_keys;
         inner.compaction = durable.compaction;
         Ok(())
     }

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -13,6 +13,26 @@ use crate::source_snapshot::SourceSnapshot;
 use uuid::Uuid;
 
 #[test]
+fn remote_runner_submission_lookup_is_non_mutating() {
+    let store = JobStore::default();
+    let missing = store.lookup_remote_runner_submission("missing-key");
+    assert!(matches!(missing, RemoteRunnerSubmissionLookup::Absent));
+
+    let mut request = remote_runner_request("homeboy-lab", None);
+    request.metadata = Some(json!({ "submission_key": "lookup-key" }));
+    let accepted = store
+        .submit_remote_runner_job(request)
+        .expect("accept runner submission");
+
+    let lookup = store.lookup_remote_runner_submission("lookup-key");
+    assert!(matches!(
+        lookup,
+        RemoteRunnerSubmissionLookup::Accepted { job } if job.id == accepted.id
+    ));
+    assert_eq!(store.events(accepted.id).expect("events").len(), 1);
+}
+
+#[test]
 fn confirmed_recovery_fails_closed_for_unresolved_linked_durable_run() {
     let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
     let mut request = remote_runner_request("homeboy-lab", None);
@@ -1206,6 +1226,157 @@ fn remote_runner_submission_key_replays_one_redacted_durable_job() {
     let persisted = fs::read_to_string(path).expect("read durable store");
     assert!(!persisted.contains("never-persist"));
     assert!(persisted.contains("RUNNER_SECRET_TOKEN"));
+}
+
+#[test]
+fn remote_runner_submission_key_survives_restart_and_rejects_conflicts() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open(&path).expect("durable store");
+    let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
+    request.metadata = Some(json!({
+        "submission_key": "agent-task:v1:restart",
+        "transport": "initial-controller-post",
+        "evidence": { "attempt": 1 },
+    }));
+    let accepted = store
+        .submit_remote_runner_job(request.clone())
+        .expect("first submit");
+    drop(store);
+
+    let restarted = JobStore::open_without_reconciliation(&path).expect("restart store");
+    let mut replay_request = request.clone();
+    replay_request.metadata = Some(json!({
+        "submission_key": "agent-task:v1:restart",
+        "reconciled_from": "durable_detached_handoff_intent",
+        "transport": "controller-recovery",
+    }));
+    let replay = restarted
+        .submit_remote_runner_job(replay_request)
+        .expect("replay");
+    assert_eq!(replay.id, accepted.id);
+    request.command.push("different".to_string());
+    let conflict = restarted
+        .submit_remote_runner_job(request)
+        .expect_err("conflict fails closed");
+    assert_eq!(conflict.code, crate::ErrorCode::ValidationInvalidArgument);
+    assert_eq!(
+        conflict.details["schema"],
+        json!("homeboy/remote-runner-submission-conflict/v1")
+    );
+    assert_eq!(conflict.details["accepted_job_id"], json!(accepted.id));
+}
+
+#[test]
+fn remote_runner_submission_key_concurrent_replay_creates_one_job() {
+    let store = JobStore::default();
+    let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
+    request.metadata = Some(json!({ "submission_key": "agent-task:v1:concurrent" }));
+    let first_store = store.clone();
+    let first_request = request.clone();
+    let first = std::thread::spawn(move || first_store.submit_remote_runner_job(first_request));
+    let second_store = store.clone();
+    let second = std::thread::spawn(move || second_store.submit_remote_runner_job(request));
+    let first = first.join().expect("first thread").expect("first submit");
+    let second = second
+        .join()
+        .expect("second thread")
+        .expect("second submit");
+    assert_eq!(first.id, second.id);
+    assert_eq!(store.list().len(), 1);
+}
+
+#[test]
+fn remote_runner_submission_key_conflicts_on_all_execution_semantic_inputs() {
+    let store = JobStore::default();
+    let mut base = remote_runner_request("homeboy-lab", Some("extrachill"));
+    base.metadata = Some(json!({ "submission_key": "agent-task:v1:semantic-inputs" }));
+    store
+        .submit_remote_runner_job(base.clone())
+        .expect("accept baseline");
+
+    let mut variants = Vec::new();
+    let mut changed_env = base.clone();
+    changed_env
+        .env
+        .insert("PUBLIC_FLAG".to_string(), "changed".to_string());
+    variants.push(changed_env);
+    let mut changed_capture = base.clone();
+    changed_capture.capture_patch = !changed_capture.capture_patch;
+    variants.push(changed_capture);
+    let mut changed_paths = base.clone();
+    changed_paths
+        .require_paths
+        .push("/opt/required".to_string());
+    variants.push(changed_paths);
+    let mut changed_source = base.clone();
+    changed_source.source_snapshot = Some(SourceSnapshot::existing_remote(
+        "homeboy-lab",
+        "/srv/other-source",
+        Some("/srv"),
+    ));
+    variants.push(changed_source);
+    let mut changed_materialization = base;
+    changed_materialization.path_materialization_plan =
+        Some(crate::runner_execution_envelope::PathMaterializationPlan::new([]));
+    variants.push(changed_materialization);
+
+    for request in variants {
+        let error = store
+            .submit_remote_runner_job(request)
+            .expect_err("semantic input reuse fails closed");
+        assert_eq!(
+            error.details["schema"],
+            json!("homeboy/remote-runner-submission-conflict/v1")
+        );
+    }
+}
+
+#[test]
+fn compacted_submission_key_expires_without_creating_a_duplicate() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open_with_retention(&path, 10, 1).expect("durable store");
+    let mut requests = Vec::new();
+    for key in ["agent-task:v1:compact-one", "agent-task:v1:compact-two"] {
+        let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
+        request.metadata = Some(json!({ "submission_key": key }));
+        let job = store
+            .submit_remote_runner_job(request.clone())
+            .expect("submit");
+        store
+            .inner
+            .lock()
+            .expect("store")
+            .jobs
+            .get_mut(&job.id)
+            .expect("job")
+            .job
+            .status = JobStatus::Succeeded;
+        requests.push((key.to_string(), request));
+    }
+    store.persist().expect("compact terminal jobs");
+    let expired_key = store
+        .inner
+        .lock()
+        .expect("store")
+        .expired_submission_keys
+        .keys()
+        .next()
+        .cloned()
+        .expect("compacted submission tombstone");
+    let request = requests
+        .into_iter()
+        .find_map(|(key, request)| (key == expired_key).then_some(request))
+        .expect("expired request");
+    let error = store
+        .submit_remote_runner_job(request)
+        .expect_err("expired replay is explicit");
+    assert_eq!(
+        error.details["schema"],
+        json!("homeboy/remote-runner-submission-expired/v1")
+    );
+    assert_eq!(store.list().len(), 1);
 }
 
 #[test]

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -1310,7 +1310,7 @@ fn remote_runner_submission_key_conflicts_on_all_execution_semantic_inputs() {
         .push("/opt/required".to_string());
     variants.push(changed_paths);
     let mut changed_source = base.clone();
-    changed_source.source_snapshot = Some(SourceSnapshot::existing_remote(
+    changed_source.source_snapshot = Some(crate::source_snapshot::existing_remote(
         "homeboy-lab",
         "/srv/other-source",
         Some("/srv"),

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -126,6 +126,10 @@ pub(in crate::daemon) fn route(
             Ok(body) => daemon_endpoint_response("runner.jobs.submit", body),
             Err(err) => auth_or_bad_request(err),
         },
+        ("POST", "/runner/jobs/submissions/lookup") => match submission_lookup(body, job_store, auth) {
+            Ok(body) => daemon_endpoint_response("runner.jobs.submissions.lookup", body),
+            Err(err) => auth_or_bad_request(err),
+        },
         ("POST", "/runner/jobs/reconcile") => match reconcile(job_store) {
             Ok(body) => daemon_endpoint_response("runner.jobs.reconcile", body),
             Err(err) => error_response(400, err),
@@ -371,6 +375,24 @@ fn enqueue(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) 
             "events": format!("/jobs/{}/events", job.id),
         },
         "request": public_request,
+    }))
+}
+
+#[derive(Deserialize)]
+struct SubmissionLookupRequest {
+    submission_key: String,
+}
+
+fn submission_lookup(
+    body: Option<Value>,
+    job_store: &JobStore,
+    auth: &BrokerAuthContext,
+) -> Result<Value> {
+    auth.authorize(BrokerScope::Submit, None)?;
+    let request: SubmissionLookupRequest = parse_body(body, "remote runner submission lookup")?;
+    Ok(json!({
+        "command": "api.runner.jobs.submissions.lookup",
+        "result": job_store.lookup_remote_runner_submission(&request.submission_key),
     }))
 }
 

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1438,6 +1438,33 @@ pub fn submit_reverse_broker_job(runner_id: &str, request: RemoteRunnerJobReques
     })
 }
 
+pub fn lookup_reverse_broker_submission(
+    runner_id: &str,
+    submission_key: &str,
+) -> Result<homeboy_core::api_jobs::RemoteRunnerSubmissionLookup> {
+    let broker_url = reverse_broker_url(runner_id)?;
+    let client = broker_client("build reverse broker lookup client")?;
+    let response = broker_http::post_json(
+        &client,
+        &broker_url,
+        "/runner/jobs/submissions/lookup",
+        serde_json::json!({ "submission_key": submission_key }),
+        "look up reverse runner submission",
+        broker_auth::broker_submit_token_for_runner(runner_id)?.as_deref(),
+    )?;
+    serde_json::from_value(
+        response.get("result").cloned().ok_or_else(|| {
+            Error::internal_unexpected("reverse broker lookup returned no result")
+        })?,
+    )
+    .map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("parse reverse broker submission lookup".to_string()),
+        )
+    })
+}
+
 pub fn reverse_broker_artifact(runner_id: &str, job_id: &str, artifact_id: &str) -> Result<Value> {
     let broker_url = reverse_broker_url(runner_id)?;
     let artifact_id = homeboy_core::execution_contract::encode_uri_component(artifact_id);

--- a/crates/homeboy-lab-runner/src/continuation_provider.rs
+++ b/crates/homeboy-lab-runner/src/continuation_provider.rs
@@ -61,6 +61,14 @@ impl RunnerContinuationProvider for RunnerContinuation {
     ) -> Result<Job> {
         super::connection::submit_reverse_broker_job(runner_id, request)
     }
+
+    fn lookup_reverse_broker_submission(
+        &self,
+        runner_id: &str,
+        submission_key: &str,
+    ) -> Result<homeboy_core::api_jobs::RemoteRunnerSubmissionLookup> {
+        super::connection::lookup_reverse_broker_submission(runner_id, submission_key)
+    }
 }
 
 /// Register the runner continuation provider with core. Called once at startup.

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -85,7 +85,7 @@ pub(super) fn exec_via_reverse_broker(
             let mut metadata = runner_exec_request_metadata(run_id.as_deref(), "reverse_broker");
             if let Some(run_id) = run_id.as_deref() {
                 metadata["submission_key"] =
-                    serde_json::json!(format!("agent-task:{}:{run_id}", runner.id));
+                    serde_json::json!(format!("agent-task:v1:{}:{run_id}", runner.id));
             }
             metadata
         }),
@@ -107,6 +107,13 @@ pub(super) fn exec_via_reverse_broker(
             "schema": "homeboy/reverse-runner-command-assets/v1",
             "assets": command_assets,
         });
+    }
+    if detach_after_handoff {
+        if let Some(run_id) = run_id.as_deref() {
+            homeboy_agents::agent_task_lifecycle::record_lab_offload_submission_request(
+                run_id, &request,
+            )?;
+        }
     }
     let broker_token = homeboy_core::broker_auth::broker_submit_token_for_runner(&runner.id)?;
     let data = broker_http::post_json(


### PR DESCRIPTION
## Summary

Closes #8966.

Completes the durable submission contract after #9036 introduced active-job deduplication by `durable_run_id`:

- persist a versioned client submission key and normalized payload fingerprint before transport
- atomically map each key to one accepted daemon job across restart
- return the original job for exact sequential or concurrent replay
- reject conflicting key reuse with structured evidence
- query accepted, expired, or absent keys during response-loss recovery
- reconcile timeout, cancellation, and late acceptance without duplicate execution
- preserve terminal tombstones through compaction while keeping secrets out of evidence

## Relationship to #9036

#9036 safely deduplicates active `/exec` resubmissions by `durable_run_id`. Its scope note leaves the wire-level client key and first-attempt daemon enforcement for follow-up. This PR adds that full contract and rebases cleanly on #9036.

## How to test

1. Run `cargo check -p homeboy-core -p homeboy-agents -p homeboy-lab-runner`.
2. Run `cargo test -p homeboy-core remote_runner_submission --lib` and confirm all five replay, conflict, concurrency, lookup, and restart tests pass.
3. Run `cargo test -p homeboy-core compacted_submission_key_expires_without_creating_a_duplicate --lib`.
4. Run `cargo test -p homeboy-agents preparing_crash_never_submits_or_queries_the_runner --lib -- --test-threads=1`.
5. Run `cargo test -p homeboy-agents expired_or_cancelled_pending_submission_binds_and_cancels_the_accepted_job --lib -- --test-threads=1`.
6. Run `cargo test -p homeboy-agents detached_cook_intent_reconciliation_converges_both_crash_windows_without_secret_leakage --lib -- --test-threads=1`.
7. Run `git diff --check origin/main...HEAD`.

## Compatibility

- Existing requests without a submission key retain their current behavior.
- The daemon lookup route and typed lookup result are additive.
- No extension paths or public extension contracts change.
- Terminal compaction now retains bounded submission-key tombstones so old keys fail explicitly instead of creating late duplicates.

## Verification notes

- The focused commands above pass on this branch after rebasing onto current `main`.
- Repository-wide `cargo fmt --check` currently encounters unrelated formatting drift on `main` in `crates/homeboy-lab-runner/src/workspace/snapshot.rs`; every Rust file changed by this PR passes `rustfmt --edition 2021 --check`.
- Broader agent-task test isolation remains tracked in #8964; the focused lifecycle tests are intentionally run serially.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Investigated the transport-loss failure, designed and implemented the durable idempotency contract, wrote deterministic tests, and prepared verification evidence.