### PR TITLE
feat: make the exec idempotency key an explicit controller-asserted field

### DIFF
--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -420,6 +420,13 @@ struct ExecRequest {
     lifecycle: Option<RunnerJobLifecycleMetadata>,
     #[serde(default)]
     metadata: Option<serde_json::Value>,
+    /// Explicit, controller-asserted idempotency key. When present, the daemon
+    /// dedupes `/exec` on this key directly rather than reconstructing one from
+    /// nested lifecycle/metadata. Optional for compatibility with controllers
+    /// that predate the field — those fall back to the `durable_run_id`
+    /// extraction.
+    #[serde(default)]
+    idempotency_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1872,6 +1879,30 @@ fn method_not_allowed() -> HttpResponse {
     }
 }
 
+/// Resolve the effective exec idempotency key the daemon dedupes on.
+///
+/// Prefers the explicit, controller-asserted `idempotency_key`; falls back to
+/// the `durable_run_id` reconstructed from nested lifecycle/metadata for
+/// controllers that predate the explicit field. Empty/whitespace keys are
+/// ignored so a blank assertion never masks the fallback.
+fn resolve_exec_idempotency_key(
+    explicit_key: Option<&str>,
+    run_ref_metadata: Option<&serde_json::Value>,
+) -> Option<String> {
+    explicit_key
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            run_ref_metadata
+                .and_then(|metadata| metadata.get("durable_run_id"))
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|key| !key.is_empty())
+                .map(str::to_string)
+        })
+}
+
 fn enqueue_exec_job(
     body: Option<serde_json::Value>,
     job_store: &JobStore,
@@ -1939,17 +1970,20 @@ fn enqueue_exec_job(
     let path_materialization_plan = request.path_materialization_plan.clone();
 
     let mut lifecycle = request.lifecycle.take();
-    let canonical_durable_run_id = exec_request_run_ref_metadata(
-        lifecycle.as_ref(),
-        request.lab_runner_workload.as_ref(),
-        request.metadata.as_ref(),
-    )
-    .and_then(|metadata| {
-        metadata
-            .get("durable_run_id")
-            .and_then(serde_json::Value::as_str)
-            .map(str::to_string)
-    });
+    // Prefer the explicit, controller-asserted idempotency key. Fall back to
+    // reconstructing the durable run id from nested lifecycle/metadata for
+    // controllers that predate the explicit field. Either way the resolved key
+    // is folded into the lifecycle's `durable_run_id` below, which is what the
+    // job-store dedup guard keys on.
+    let canonical_durable_run_id = resolve_exec_idempotency_key(
+        request.idempotency_key.as_deref(),
+        exec_request_run_ref_metadata(
+            lifecycle.as_ref(),
+            request.lab_runner_workload.as_ref(),
+            request.metadata.as_ref(),
+        )
+        .as_ref(),
+    );
     if let Some(durable_run_id) = canonical_durable_run_id {
         lifecycle
             .get_or_insert_with(|| RunnerJobLifecycleMetadata {
@@ -2228,6 +2262,40 @@ mod tests {
     use crate::daemon::runner_exec_driver::{
         self, DaemonExecOutput, PreparedDaemonExec, RunnerExecDriver, RunnerExecPrepareRequest,
     };
+
+    #[test]
+    fn resolve_exec_idempotency_key_prefers_the_explicit_controller_key() {
+        let metadata = json!({ "durable_run_id": "run-from-metadata" });
+
+        // Explicit key wins over the metadata-reconstructed run id.
+        assert_eq!(
+            resolve_exec_idempotency_key(Some("explicit-run"), Some(&metadata)).as_deref(),
+            Some("explicit-run")
+        );
+
+        // The explicit key works on its own, even with no nested metadata — the
+        // whole point of asserting it up front instead of reconstructing it.
+        assert_eq!(
+            resolve_exec_idempotency_key(Some("explicit-run"), None).as_deref(),
+            Some("explicit-run")
+        );
+
+        // A blank/whitespace explicit key does not mask the metadata fallback.
+        assert_eq!(
+            resolve_exec_idempotency_key(Some("   "), Some(&metadata)).as_deref(),
+            Some("run-from-metadata")
+        );
+
+        // No explicit key falls back to the reconstructed durable run id.
+        assert_eq!(
+            resolve_exec_idempotency_key(None, Some(&metadata)).as_deref(),
+            Some("run-from-metadata")
+        );
+
+        // Nothing to key on at all.
+        assert_eq!(resolve_exec_idempotency_key(None, None), None);
+        assert_eq!(resolve_exec_idempotency_key(None, Some(&json!({}))), None);
+    }
     use crate::test_support::with_isolated_home;
     #[cfg(unix)]
     use std::os::unix::process::CommandExt;

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -98,6 +98,11 @@ pub(super) fn exec_via_daemon(
         "runner_workload": lab_runner_workload.clone(),
         "metadata": runner_exec_request_metadata(run_id.as_deref(), "daemon"),
         "lifecycle": lifecycle,
+        // Explicit, first-class idempotency key the daemon dedupes `/exec` on.
+        // The controller asserts it up front instead of the daemon having to
+        // reconstruct it from nested lifecycle/metadata, so a resubmission after
+        // a transport drop is a safe no-op. Uses the durable run id when present.
+        "idempotency_key": run_id,
     });
     let response = submit_daemon_exec_with_session_recovery(
         local_url,


### PR DESCRIPTION
## Summary
The fuller slice of the `/exec` idempotency work (after #9036 + #9039). Those made the daemon dedupe on a `durable_run_id` — but the daemon had to **reconstruct** that key by spelunking nested `lifecycle`/`metadata`. That's implicit and fragile: a submission path that doesn't populate the nested structure just right **silently loses dedup**.

## The fix
Make the key first-class and controller-asserted:
- **`ExecRequest`** gains an explicit `idempotency_key: Option<String>`. The controller asserts it up front in the `/exec` payload (from the durable run id).
- **`enqueue_exec_job`** resolves the effective key via a new `resolve_exec_idempotency_key`: **prefer the explicit key**, else fall back to the reconstructed `durable_run_id` for controllers that predate the field. Blank/whitespace keys are ignored so a stray empty assertion never masks the fallback. The resolved key is folded into `lifecycle.durable_run_id` — which is what the job-store dedup guard already keys on — so **no change to the store layer**.

## Backward compatible
The field is `#[serde(default)]`; older controllers (and any in-flight requests) keep working through the metadata fallback. New controllers get robust, explicit dedup that no longer depends on nested-metadata shape.

## Verification (local, VPS-safe)
- `cargo check -p homeboy-core --lib` / `-p homeboy-lab-runner --lib` — clean
- New unit test `resolve_exec_idempotency_key_prefers_the_explicit_controller_key`: explicit key wins over metadata; works standalone with **no** nested metadata; blank key falls back; no-key/empty-metadata → `None`.
- `cargo test -p homeboy-core --lib daemon::tests::` — 8 pass
- `cargo test -p homeboy-core --lib api_jobs::` — 101 pass
- `cargo fmt` — clean

Builds on #9036 + #9039 (merged). This closes the "controller asserts the key rather than the daemon guessing it" gap noted as the remaining surface-#1 work.