### PR TITLE
fix: register the component-script runner in every runner-dependent deps test

### DIFF
--- a/tests/deps_test.rs
+++ b/tests/deps_test.rs
@@ -7,6 +7,14 @@ use tempfile::tempdir;
 // a separate crate registered at binary startup via `cli_runtime`. Integration
 // tests that exercise extension-backed dependency behavior must register those
 // providers explicitly (registration is an idempotent Mutex-backed slot).
+//
+// Every test that reaches an extension-backed runner path (a `script_stack_component`
+// whose scripts report dependencies, or a `deps::update` that runs a provider
+// install script) registers the runners itself rather than relying on a sibling
+// test having populated the process-global slot first. Depending on that leak
+// made results order- and scope-dependent: under a changed-scope/differential
+// test run that excludes a registering sibling, these tests failed with "no
+// component-script runner registered" (#8964).
 fn register_component_script_runner() {
     homeboy_extension::component_script::register_component_script_runner();
     homeboy_extension::build::register_component_build_runner();
@@ -97,6 +105,7 @@ fn status_prefers_neutral_adapter_manifest_over_builtin_manifests() {
 
 #[test]
 fn neutral_adapter_manifest_discovers_install_command_and_runs_update_install() {
+    register_component_script_runner();
     let dir = tempdir().unwrap();
     let root = dir.path();
     let root_path = root.display().to_string();
@@ -522,6 +531,7 @@ esac
 #[test]
 #[ignore = "integration test mutates real composer manifests/locks and shells out to composer"]
 fn update_with_constraint_changes_manifest_and_lock_for_local_path_package() {
+    register_component_script_runner();
     if std::process::Command::new("composer")
         .arg("--version")
         .output()


### PR DESCRIPTION
## Summary

Two `deps_test` integration tests reach an extension-backed runner path (a `deps::update` that runs a provider install script) **without registering the component-script runner themselves**. They relied on a sibling test having already populated the process-global runner slot in the same test binary.

That cross-test leak makes results order- and scope-dependent. Under a changed-scope / differential test run that excludes a registering sibling, the runner-using tests fail before exercising any behavior with:

```text
no component-script runner registered; the extension subsystem is not available
```

This was observed as a `homeboy / Test` gate failure (`deps_test.rs`: `stack_plan_derives_edges_from_provider_reported_dependency_identities`, `stack_plan_keeps_explicit_edge_config_when_provider_edge_matches`, `update_runs_component_provider_install_and_optional_rebuild`).

## Change

Audited every `deps_test` test that reaches an extension-backed runner path (a `script_stack_component` whose scripts report dependencies, or a `deps::update` that runs a provider install script). Three already self-registered; two did not:

- `neutral_adapter_manifest_discovers_install_command_and_runs_update_install`
- `update_with_constraint_changes_manifest_and_lock_for_local_path_package`

Both now register the runner explicitly, so no runner-dependent test depends on cross-test global state. Registration is an idempotent Mutex-backed slot, so it is safe regardless of order. Tests that only build plans (`stack_component`, dry-run apply) do not touch the runner and are intentionally left unchanged.

## Testing

- `cargo test -p homeboy --test deps_test` — full binary green (10 passed, 1 ignored).
- Each runner-dependent test passes alone.

**Reproduction note:** the failing tests pass locally in every configuration I ran (whole binary, individually, repeated), because within a single `cargo test` binary the first registering test populates the global slot for the rest. The failure surfaces under CI's changed-scope/differential test selection, which can run a runner-dependent test without a registering sibling. This change is defensive isolation hardening that removes the cross-test dependency at its root; it matches the isolation contract of #8964.

Refs #8964

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Traced the CI `no component-script runner registered` failure to runner-dependent deps tests relying on a sibling test's process-global registration, audited which tests actually reach the runner, and added self-registration to the two that were missing it. Chris reviews and owns the change.