### PR TITLE
Ignore runner staging in snapshot cleanliness verification

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/provenance.rs
+++ b/crates/homeboy-lab-runner/src/workspace/provenance.rs
@@ -228,9 +228,21 @@ fn verify_exact_snapshot_git_checkout(
     if git(workspace, &["rev-parse", "HEAD"])? != provenance.source_revision {
         return Err("snapshot-git HEAD does not match the verified source revision".to_string());
     }
+    // The staged checkout is also the runner's execution container. Its
+    // reserved bookkeeping and @file paths are excluded from the verified
+    // content hash, so they must not be reclassified as source dirt here.
+    // All non-reserved paths still have to match the captured source state.
     let dirty = !git(
         workspace,
-        &["status", "--porcelain", "--untracked-files=all"],
+        &[
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+            "--",
+            ".",
+            ":(exclude).homeboy/runner-workspace.json",
+            ":(exclude).homeboy/lab-at-files/**",
+        ],
     )?
     .is_empty();
     if dirty != provenance.source_dirty {

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -214,7 +214,7 @@ fn git_backed_snapshot_reports_checkout_provenance_for_committed_harvest() {
             &synced.remote_path,
             Path::new(&synced.remote_path),
             snapshot,
-            lab,
+            lab.clone(),
         )
         .expect("committed-harvest provenance");
         super::super::provenance::verify_lab_workspace_git_root(
@@ -222,6 +222,43 @@ fn git_backed_snapshot_reports_checkout_provenance_for_committed_harvest() {
             &provenance,
         )
         .expect("committed-harvest Git root");
+
+        // Agent-task @plan staging is runner-owned execution state, not a
+        // source change. It can be staged by a runtime, so exercise the exact
+        // committed-harvest verifier with that state present.
+        let at_file =
+            Path::new(&synced.remote_path).join(".homeboy/lab-at-files/agent-task-plan.json");
+        fs::create_dir_all(at_file.parent().expect("@file parent")).expect("create @file parent");
+        fs::write(&at_file, "{}\n").expect("write staged agent-task plan");
+        std::process::Command::new("git")
+            .args([
+                "add",
+                "--force",
+                ".homeboy/lab-at-files/agent-task-plan.json",
+            ])
+            .current_dir(&synced.remote_path)
+            .status()
+            .expect("stage runner-owned plan");
+        super::super::provenance::verify_lab_workspace_git_root(
+            Path::new(&synced.remote_path),
+            &provenance,
+        )
+        .expect("runner-owned agent-task plan does not dirty the verified snapshot");
+
+        fs::write(
+            Path::new(&synced.remote_path).join("unexpected.txt"),
+            "unexpected\n",
+        )
+        .expect("write unexpected source change");
+        let error = super::super::provenance::verify_lab_workspace_git_root(
+            Path::new(&synced.remote_path),
+            &provenance,
+        )
+        .expect_err("unexpected source change remains dirty");
+        assert!(
+            error.contains("content hash") || error.contains("cleanliness does not match"),
+            "unexpected source change must remain bound to provenance: {error}"
+        );
     });
 }
 


### PR DESCRIPTION
## Summary

Align exact-Git cleanliness verification with the reserved runner paths already excluded from workspace content identity.

Closes #9033.

## Root cause

Lab stages runner-owned metadata and remapped `@file` inputs inside the exact-Git checkout before runner-side `agent-task run-plan` performs committed-change harvest verification. Workspace content identity already excludes those reserved paths, but the Git cleanliness probe counted them as source dirt and rejected a clean source snapshot before provider execution.

## What changed

- Exclude `.homeboy/runner-workspace.json` and `.homeboy/lab-at-files/**` from the exact-Git status cleanliness probe.
- Keep HEAD, content-hash, and all non-reserved source-cleanliness checks unchanged.
- Extend committed-harvest regression coverage to accept staged runner inputs and still reject an unexpected source mutation.

## How to test

1. Run `cargo test -p homeboy-lab-runner workspace::provenance::tests -- --nocapture`; expect 15 passing tests.
2. Run `cargo test -p homeboy-lab-runner workspace::tests::snapshot -- --nocapture`; expect 51 passing tests.
3. Run `git diff --check`; expect no output.

All commands pass. The immutable candidate was also adopted through Homeboy and passed both recorded deterministic gates before manual PR publication.

## Compatibility

Backwards compatible. Strict HEAD, content-hash, and non-reserved source-cleanliness checks remain enforced. The exclusion is limited to the two runner-owned path families already omitted from workspace content identity.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab committed-harvest regression, implemented the bounded provenance fix, and added deterministic regression coverage with Chris reviewing and owning the change.