### PR TITLE
Fix Lab handoff parsing for controller cook attempts

### DIFF
--- a/crates/homeboy-lab-runner/src/lab_args/agent_task_specs.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/agent_task_specs.rs
@@ -95,9 +95,11 @@ pub(crate) fn materialize_inline_agent_task_json_specs_in_args<T>(
     args: &[String],
     mut sync_inline_json: impl FnMut(AgentTaskInlineJsonSpec<'_>) -> Result<Option<(String, T)>>,
 ) -> Result<(Vec<String>, Vec<AgentTaskSpecWorkspaceEntry<T>>)> {
+    let controller_cook_attempt = agent_task_subcommand_is(args, &["cook"])
+        && has_option_before_passthrough(args, "--attempt-plan");
     let (args, task_entry) = materialize_inline_json_option(
         args,
-        agent_task_subcommand_is(args, &["dispatch", "cook"]),
+        agent_task_subcommand_is(args, &["dispatch", "cook"]) && !controller_cook_attempt,
         "--tasks",
         "agent-task-tasks.json",
         "agent_task_tasks_remapped",
@@ -455,6 +457,20 @@ fn agent_task_subcommand_is(args: &[String], subcommands: &[&str]) -> bool {
 
 fn subcommand_index(args: &[String], command: &str) -> Option<usize> {
     args.iter().position(|arg| arg == command)
+}
+
+/// A controller-generated cook attempt is fully defined by `--attempt-plan`.
+/// Ignore legacy task-input JSON so an unrelated stale payload cannot enter the
+/// Lab handoff materializer or replace the controller's bounded plan.
+fn has_option_before_passthrough(args: &[String], option: &str) -> bool {
+    args.iter()
+        .take_while(|arg| arg.as_str() != "--")
+        .any(|arg| {
+            arg == option
+                || arg
+                    .strip_prefix(option)
+                    .is_some_and(|suffix| suffix.starts_with('='))
+        })
 }
 
 /// Scans `args` for a single `--flag <json>` / `--flag=<json>` occurrence and,

--- a/crates/homeboy-lab-runner/src/lab_args/tests.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/tests.rs
@@ -1647,6 +1647,45 @@ mod materialize_specs_tests {
     }
 
     #[test]
+    fn controller_attempt_plan_ignores_truncated_legacy_tasks_json() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let plan = serde_json::json!({
+            "schema": "homeboy/agent-task-plan/v1",
+            "plan_id": "controller-plan",
+            "tasks": [{ "task_id": "task-1", "instructions": "test" }]
+        })
+        .to_string();
+        let truncated_legacy_tasks = "[\n  {\n    \"prompt\": \"from an old workspace";
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--tasks".to_string(),
+            truncated_legacy_tasks.to_string(),
+            "--attempt-plan".to_string(),
+            plan,
+        ];
+
+        let mut synced = Vec::new();
+        let out = materialize_agent_task_specs_in_args(&args, &[], temp.path(), |spec| {
+            synced.push((spec.role, spec.spec.to_string()));
+            Ok(Some((format!("@/remote/{}", spec.filename), spec.role)))
+        })
+        .expect("authoritative attempt plan must bound Lab handoff parsing");
+
+        assert_eq!(synced.len(), 1);
+        assert_eq!(synced[0].0, "agent_task_attempt_plan_remapped");
+        assert!(!synced[0].1.contains("old workspace"));
+        assert_eq!(out.argv[4], truncated_legacy_tasks);
+        assert_eq!(out.argv[6], "@/remote/agent-task-attempt-plan.json");
+        assert_eq!(out.workspace_entries.len(), 1);
+        assert_eq!(
+            out.workspace_entries[0].step_id,
+            "lab.sync_remapped_agent_task_attempt_plan"
+        );
+    }
+
+    #[test]
     fn materialize_agent_task_specs_remaps_and_stages_cook_attempt_plan_for_runner_harvest() {
         let temp = tempfile::tempdir().expect("tempdir");
         let controller = temp.path().join("controller/worktree");


### PR DESCRIPTION
## Summary

- treat the controller-generated `--attempt-plan` as authoritative for Lab-routed cook attempts
- avoid parsing or materializing stale legacy `--tasks` JSON when an attempt plan is present
- allow failed or cancelled pre-provider transport runs through the existing strictly authenticated candidate-adoption recovery path
- cover truncated legacy payload handling and failed-state recovery eligibility with deterministic tests

Closes #9057.

## How to test

1. Run `cargo test -p homeboy-lab-runner malformed_handoff_json_identifies_its_producer_and_field`.
2. Run `cargo test -p homeboy-lab-runner controller_attempt_plan_ignores_truncated_legacy_tasks_json`.
3. Run `cargo test -p homeboy-agents cook_persists_controller_admission_timeout_before_provider_execution`.
4. Run `cargo test -p homeboy-agents durable_finalization_accepts_only_authenticated_pre_provider_candidate_adoption_recovery`.
5. Run `git diff --check origin/main...HEAD`.
6. Build the CLI with `cargo build --release --bin homeboy`.

All targeted commands and the release build pass locally.

## Compatibility

Legacy `--tasks` remains supported when no controller `--attempt-plan` is supplied. Controller cook attempts now use their bounded plan exclusively. Failed recovery runs qualify only when all existing controls hold: no provider execution, authenticated recovery provenance, exact commit fingerprint, concrete model, and green deterministic gates. No public flags or schemas change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Traced the Lab preacceptance and failed-state adoption mismatches, implemented the bounded recovery rules, and added deterministic regression coverage. Chris reviewed and owns the change.