### PR TITLE
Publish authenticated external candidate adoptions

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -521,6 +521,7 @@ fn report(
 enum DurablePublicationEligibility {
     ProviderRun,
     PreProviderCandidateAdoptionRecovery,
+    AuthenticatedExternalCandidateAdoption,
 }
 
 fn validate_durable_publication_eligibility(
@@ -566,7 +567,46 @@ fn validate_durable_publication_eligibility(
         return Ok(DurablePublicationEligibility::PreProviderCandidateAdoptionRecovery);
     }
 
-    Err(Error::validation_invalid_argument("run_id", "durable run must have succeeded execution and succeeded provider runtime before publication; the only exception is an applied, green, fingerprinted candidate-adoption recovery with durable zero-execution pre-provider transport provenance", None, None))
+    // An externally prepared commit has no successful provider runtime to
+    // attest. Its authenticated adoption promotion supplies equivalent,
+    // candidate-bound evidence instead.
+    let committed_change_provenance = promotion.provenance["change_source"] == "local_commits"
+        && promotion
+            .provenance
+            .get("commit_range")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|range| range.rsplit_once(".."))
+            .is_some_and(|(_, candidate)| Some(candidate) == candidate_head)
+        && promotion
+            .provenance
+            .get("commits")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|commits| !commits.is_empty());
+    let candidate_is_bound = candidate_ref.is_some_and(|candidate_ref| {
+        is_git_commit_identity(candidate_ref)
+            && candidate_head.is_some_and(|candidate_head| {
+                is_full_git_commit_identity(candidate_head)
+                    && (candidate_ref == candidate_head
+                        || candidate_head.starts_with(candidate_ref))
+            })
+    });
+    let authenticated_external_adoption = promotion.status
+        == crate::agent_task_promotion::AgentTaskPromotionStatus::Applied
+        && promotion.provenance["adoption"]["source_run_id"]
+            == promotion.source.run_id.clone().unwrap_or_default()
+        && candidate_is_bound
+        && adoption_model.is_some_and(is_concrete_model)
+        && committed_change_provenance
+        && !promotion.gate_results.is_empty()
+        && promotion
+            .gate_results
+            .iter()
+            .all(|gate| gate.status == HomeboyGateStatus::Passed);
+    if authenticated_external_adoption {
+        return Ok(DurablePublicationEligibility::AuthenticatedExternalCandidateAdoption);
+    }
+
+    Err(Error::validation_invalid_argument("run_id", "durable run must have succeeded execution and succeeded provider runtime before publication; the only exceptions are an applied, green, fingerprinted candidate-adoption recovery with durable zero-execution pre-provider transport provenance or an applied, green, committed-change-provenance-bound authenticated external candidate adoption", None, None))
 }
 
 fn is_concrete_model(value: &str) -> bool {
@@ -584,6 +624,10 @@ fn is_concrete_model(value: &str) -> bool {
 }
 
 fn is_git_commit_identity(value: &str) -> bool {
+    (7..=64).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_full_git_commit_identity(value: &str) -> bool {
     matches!(value.len(), 40 | 64) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -896,6 +896,90 @@ fn durable_finalization_accepts_only_authenticated_pre_provider_candidate_adopti
 }
 
 #[test]
+fn durable_finalization_accepts_only_authenticated_external_candidate_adoption() {
+    let partial_lifecycle = RunLifecycleRecord {
+        execution: RunExecutionLifecycle {
+            state: RunExecutionState::PartialFailure,
+            started_at: None,
+            finished_at: Some("2026-01-01T00:00:00Z".to_string()),
+            updated_at: None,
+        },
+        ..RunLifecycleRecord::default()
+    };
+    let finalize = |gate_proof: AgentTaskPrDurableGateProof| {
+        let mut backend = MockBackend {
+            changed_files: vec!["src/lib.rs".to_string()],
+            lifecycle: Some(partial_lifecycle.clone()),
+            gate_proof: Some(gate_proof),
+            ..Default::default()
+        };
+        let mut finalization_options = options();
+        finalization_options.manual_finalization = false;
+        finalization_options.changed_files = vec!["src/lib.rs".to_string()];
+        let report = finalize_pr_with_backend(finalization_options, &mut backend);
+        (report, backend)
+    };
+
+    let mut accepted_proof = external_adoption_gate_proof();
+    accepted_proof.promotion.changed_files = vec!["src/lib.rs".to_string()];
+    let (report, backend) = finalize(accepted_proof);
+    assert_eq!(
+        report.expect("authenticated adoption publishes").status,
+        "review_ready"
+    );
+    assert!(backend.committed && backend.pushed && backend.created);
+
+    let mut abbreviated_proof = external_adoption_gate_proof();
+    abbreviated_proof.promotion.changed_files = vec!["src/lib.rs".to_string()];
+    abbreviated_proof.promotion.provenance["adoption"]["candidate_ref"] = json!("7f76933ef");
+    let (report, backend) = finalize(abbreviated_proof);
+    assert_eq!(
+        report
+            .expect("fingerprinted abbreviated candidate publishes")
+            .status,
+        "review_ready"
+    );
+    assert!(backend.committed && backend.pushed && backend.created);
+
+    let rejected = |proof: AgentTaskPrDurableGateProof| {
+        let (result, backend) = finalize(proof);
+        assert!(result.is_err());
+        assert!(!backend.committed && !backend.pushed && !backend.created);
+    };
+
+    rejected(successful_gate_proof());
+
+    let mut missing_candidate = external_adoption_gate_proof();
+    missing_candidate.promotion.provenance["candidate"] = serde_json::Value::Null;
+    rejected(missing_candidate);
+
+    let mut mismatched_candidate = external_adoption_gate_proof();
+    mismatched_candidate.promotion.provenance["candidate"]["fingerprint"]["head"] =
+        json!("0000000000000000000000000000000000000000");
+    rejected(mismatched_candidate);
+
+    let mut non_prefix_candidate = external_adoption_gate_proof();
+    non_prefix_candidate.promotion.provenance["adoption"]["candidate_ref"] = json!("7f76933e0");
+    rejected(non_prefix_candidate);
+
+    let mut missing_model = external_adoption_gate_proof();
+    missing_model.promotion.provenance["adoption"]["ai_model"] = serde_json::Value::Null;
+    rejected(missing_model);
+
+    let mut mismatched_source = external_adoption_gate_proof();
+    mismatched_source.promotion.provenance["adoption"]["source_run_id"] = json!("other-run");
+    rejected(mismatched_source);
+
+    let mut missing_commit_binding = external_adoption_gate_proof();
+    missing_commit_binding.promotion.provenance["commit_range"] = json!("base..other");
+    rejected(missing_commit_binding);
+
+    let mut non_green = external_adoption_gate_proof();
+    non_green.promotion.gate_results[0].status = HomeboyGateStatus::Failed;
+    rejected(non_green);
+}
+
+#[test]
 fn durable_finalization_publishes_clean_synced_recovered_candidate() {
     let mut gate_proof = successful_gate_proof();
     gate_proof.promotion.changed_files = vec!["src/lib.rs".to_string()];
@@ -1543,6 +1627,17 @@ fn pre_provider_adoption_gate_proof() -> AgentTaskPrDurableGateProof {
             }
         }
     });
+    proof
+}
+
+fn external_adoption_gate_proof() -> AgentTaskPrDurableGateProof {
+    let mut proof = pre_provider_adoption_gate_proof();
+    proof.promotion.provenance["adoption"]["recovery"] = serde_json::Value::Null;
+    proof.promotion.provenance["change_source"] = json!("local_commits");
+    proof.promotion.provenance["commit_range"] =
+        json!("base..7f76933ef002d195ee1cc5bf21069e0f40b1c972");
+    proof.promotion.provenance["commits"] =
+        json!([{"sha": "7f76933ef002d195ee1cc5bf21069e0f40b1c972"}]);
     proof
 }
 


### PR DESCRIPTION
## Summary

Add a durable publication eligibility path for authenticated external candidate adoption after committed-change promotion and green deterministic gates.

Closes #9059.

## Root cause

`agent-task adopt` could authenticate and promote an externally prepared immutable commit, but finalization only recognized fully successful provider runs and cancelled zero-execution pre-provider transport recovery. A clean-baseline review recipe therefore remained `PartialRecoverable` and could not publish even after adoption supplied stronger candidate-bound evidence and passed every gate.

## What changed

- Add an explicit `AuthenticatedExternalCandidateAdoption` publication eligibility.
- Require applied promotion, matching source-run provenance, a concrete model, canonical candidate fingerprint binding, local-commit provenance, and non-empty all-green gates.
- Bind commit-range evidence to the canonical full fingerprint head.
- Accept a recorded abbreviated commit ref only when it is a valid 7+ hexadecimal prefix of that canonical head.
- Preserve the stricter cancelled/no-provider-runtime/zero-execution recovery checks for pre-provider transport recovery.
- Keep generic partial or failed provider runs ineligible.

## How to test

1. Run `cargo test -p homeboy-agents durable_finalization_accepts_only_authenticated -- --nocapture`; expect both authenticated-adoption test families to pass.
2. Run `cargo test -p homeboy-agents agent_task_finalization::tests:: -- --nocapture`; expect 34 passing tests.
3. Run `cargo fmt --package homeboy-agents -- --check`; expect success.
4. Run `git diff --check`; expect no output.

All commands pass.

## Compatibility

Backwards compatible. Existing successful-provider and pre-provider recovery publication paths are unchanged. This adds publication only for externally adopted commits carrying the complete existing promotion, fingerprint, model, committed-change, source-run, and gate evidence contract.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the finalization eligibility gap, implemented the evidence-bound publication path, and added positive and negative regression coverage with Chris reviewing and owning the change.