### PR TITLE
Fix aligned Lab cook readiness

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -33,7 +33,7 @@ use crate::agent_task_scheduler::{
     AgentTaskExecutionBudget, AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskState,
 };
 use homeboy_core::command_invocation::CommandInvocation;
-use homeboy_core::{config, Error, Result};
+use homeboy_core::{config, Error, ErrorCode, Result};
 
 use super::execution::run_loaded_plan_with_derived_cook_baseline;
 use super::AgentTaskRunResult;
@@ -720,6 +720,16 @@ where
                     promotion: None,
                     feedback: None,
                 });
+                if is_deterministic_pre_execution_failure(&error) {
+                    return Ok(cook_report(
+                        cook_id,
+                        "policy_failure",
+                        attempts,
+                        None,
+                        Some(error.to_string()),
+                        1,
+                    ));
+                }
                 if attempt == max_attempts {
                     return Ok(cook_report(
                         cook_id,
@@ -1061,6 +1071,18 @@ where
         Some("cook attempt budget exhausted".to_string()),
         1,
     ))
+}
+
+fn is_deterministic_pre_execution_failure(error: &Error) -> bool {
+    matches!(
+        error.code,
+        ErrorCode::ConfigInvalidJson
+            | ErrorCode::ConfigInvalidValue
+            | ErrorCode::ValidationMissingArgument
+            | ErrorCode::ValidationInvalidArgument
+            | ErrorCode::ValidationInvalidJson
+            | ErrorCode::ValidationMultipleErrors
+    )
 }
 
 /// Pre-execution failures happen before a provider can receive work. Persist a
@@ -2546,6 +2568,33 @@ mod tests {
                 .as_str()
                 .expect("failure message")
                 .contains("hash mismatch"));
+        });
+    }
+
+    #[test]
+    fn cook_does_not_retry_deterministic_pre_provider_input_failures() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let run_id = "cook-invalid-input-attempt-1";
+            let mut options = batch_cook_options(
+                "cook-invalid-input",
+                Arc::new(AdmissionFailingAttemptDispatcher {
+                    message: "invalid controller-owned Lab handoff input",
+                }),
+            );
+            options.provider_command = Some("fixture-provider".to_string());
+            options.initial_run_id = run_id.to_string();
+            options.max_attempts = 2;
+
+            let result = run_cook(options, UnusedExecutor)
+                .expect("cook returns the persisted input failure");
+
+            assert_eq!(result.exit_code, 1);
+            assert_eq!(result.value.status, "policy_failure");
+            assert_eq!(result.value.attempts.len(), 1);
+            assert_eq!(result.value.history_run_ids, vec![run_id]);
+            let record = agent_task_lifecycle::status(run_id).expect("attempt exists");
+            assert!(record.provider_handles.is_empty());
+            assert_eq!(record.metadata["provider_executions_consumed"], 0);
         });
     }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
@@ -245,10 +245,9 @@ pub(crate) const REQUIRE_EXACT_RUNNER_VERSION_ENV: &str = "HOMEBOY_REQUIRE_EXACT
 /// Classification of controller↔runner Homeboy version drift for the Lab
 /// offload dispatch gate.
 ///
-/// Patch-level drift within the same `MAJOR.MINOR` is wire-compatible: the
-/// runner daemon and the controller speak the same provider/job contract, so
-/// the run can proceed with a warning. `MAJOR`/`MINOR` drift can genuinely
-/// change that contract and is refused.
+/// Patch-level drift within the same `MAJOR.MINOR` is wire-compatible when
+/// build provenance is unavailable. A complete build identity is authoritative:
+/// a differing identity is refused even when its semver matches.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RunnerHomeboyVersionDrift {
     /// Controller and runner report the same version (no drift).
@@ -308,26 +307,44 @@ fn parse_major_minor(version: &str) -> Option<(u64, u64)> {
     parse_version_triplet(version).map(|(major, minor, _patch)| (major, minor))
 }
 
+fn canonical_build_identity(identity: &str) -> &str {
+    identity
+        .trim()
+        .strip_prefix("homeboy ")
+        .unwrap_or(identity.trim())
+}
+
 /// Classify controller↔runner Homeboy version drift using the same drift
 /// evidence the metadata builder reports (runner session version vs the
 /// compiled controller version).
 pub(crate) fn classify_runner_homeboy_version_drift(
     status: &RunnerStatusReport,
 ) -> RunnerHomeboyVersionDrift {
-    let controller_version = homeboy_product_identity::product_version();
-    let Some(runner_version) = status
-        .session
-        .as_ref()
-        .map(|session| session.homeboy_version.as_str())
-    else {
+    let controller = homeboy_product_identity::build_identity();
+    let Some(session) = status.session.as_ref() else {
         // No connected session means no version evidence to compare; leave
         // connectivity gating to the dedicated preflight checks.
         return RunnerHomeboyVersionDrift::None;
     };
 
-    // Preserve the existing exact-match fast path: byte-identical strings are
-    // unambiguously the same build.
-    if runner_version == controller_version {
+    if let Some(runner_identity) = session.homeboy_build_identity.as_deref() {
+        // Build provenance resolves representation differences between `0.x.y`
+        // and `homeboy 0.x.y+commit` without accepting distinct same-semver builds.
+        return if canonical_build_identity(runner_identity)
+            == canonical_build_identity(&controller.display)
+        {
+            RunnerHomeboyVersionDrift::None
+        } else {
+            RunnerHomeboyVersionDrift::Incompatible
+        };
+    }
+
+    let runner_version = session.homeboy_version.as_str();
+    let controller_version = controller.version.as_str();
+
+    // Version-only sessions do not prove a build, so preserve compatible patch
+    // handling for older runners that cannot report build provenance.
+    if canonical_build_identity(runner_version) == canonical_build_identity(controller_version) {
         return RunnerHomeboyVersionDrift::None;
     }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
@@ -612,7 +612,7 @@ fn status_with_runner_version(runner_id: &str, version: &str) -> RunnerStatusRep
     let mut status = reverse_status(runner_id);
     if let Some(session) = status.session.as_mut() {
         session.homeboy_version = version.to_string();
-        session.homeboy_build_identity = Some(format!("{version}+test"));
+        session.homeboy_build_identity = None;
     }
     status
 }
@@ -849,6 +849,42 @@ fn exact_version_match_has_no_drift() {
     assert!(!lab_runner_homeboy_has_blocking_drift(&status, false));
     assert!(!lab_runner_homeboy_has_blocking_drift(&status, true));
     assert!(lab_runner_homeboy_compatible_drift_warning(&status, false).is_none());
+}
+
+#[test]
+fn matching_full_build_identities_have_no_drift_under_strict_mode() {
+    let mut status = status_with_runner_version("homeboy-lab", "homeboy 0.0.0");
+    status
+        .session
+        .as_mut()
+        .expect("runner session")
+        .homeboy_build_identity = Some(homeboy_product_identity::build_identity().display);
+
+    assert_eq!(
+        classify_runner_homeboy_version_drift(&status),
+        RunnerHomeboyVersionDrift::None
+    );
+    assert!(!lab_runner_homeboy_has_blocking_drift(&status, true));
+}
+
+#[test]
+fn same_semver_with_different_build_identity_is_refused() {
+    let mut status =
+        status_with_runner_version("homeboy-lab", homeboy_product_identity::product_version());
+    status
+        .session
+        .as_mut()
+        .expect("runner session")
+        .homeboy_build_identity = Some(format!(
+        "homeboy {}+different-build",
+        homeboy_product_identity::product_version()
+    ));
+
+    assert_eq!(
+        classify_runner_homeboy_version_drift(&status),
+        RunnerHomeboyVersionDrift::Incompatible
+    );
+    assert!(lab_runner_homeboy_has_blocking_drift(&status, false));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Use canonical full build identity for strict Lab readiness and stop deterministic pre-provider validation failures after one persisted cook attempt.

## What changed
- Matching canonical controller and runner build identities now take precedence over representational semver differences, while differing known build identities remain fail-closed.
- Cook classifies deterministic configuration and validation failures as policy failures after one attempt without spending provider executions.

## How to test
1. Run `cargo test -p homeboy-lab-runner lab::offload::tests::capability_metadata --lib`; expect 29 classifier tests pass.
2. Run `cargo test -p homeboy-agents cook_does_not_retry_deterministic_pre_provider_input_failures --lib`; expect deterministic pre-provider failure stops after one attempt.

## Compatibility
Older runners without full build provenance keep existing semver compatibility behavior; known differing full identities remain blocked.

## Evidence
- Base unchanged since verification: main remains at 3cbe8a813baa42e175936713778d510b382940be.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/9055
- Verified finalization base: main at 3cbe8a813baa42e175936713778d510b382940be
- classifier-tests: Passed
- cook-retry-test: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab cook preacceptance defect, prepared the recovery candidate and tests, and drove Homeboy adoption and finalization; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#9055
