### PR TITLE
fix: harden the run-state projection invariant and stop tests from forging divergent records

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_record_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_record_ops.rs
@@ -38,6 +38,15 @@ pub(crate) fn set_run_state(record: &mut AgentTaskRunRecord, state: AgentTaskRun
         record.lifecycle.execution.finished_at = Some(timestamp.clone());
     }
     record.lifecycle.updated_at = Some(timestamp);
+    // `set_run_state` is the single writer that keeps the authoritative run
+    // state and its generic lifecycle projection in lockstep. Assert the
+    // invariant the record-health check enforces (`ConflictingProjections`) so a
+    // future edit to this setter that breaks the pairing fails fast in dev/tests
+    // rather than silently emitting divergent records.
+    debug_assert!(
+        record.run_state_projections_agree(),
+        "set_run_state must leave run-state projections in agreement"
+    );
 }
 
 pub(crate) fn update_lifecycle_heartbeat(record: &mut AgentTaskRunRecord) {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -335,6 +335,18 @@ impl AgentTaskRunRecord {
             .filter(|value| !value.trim().is_empty())
     }
 
+    /// Whether the authoritative agent-task run state (`self.state`) and its
+    /// generic projection onto the durable lifecycle record
+    /// (`self.lifecycle.execution.state`) agree.
+    ///
+    /// `set_run_state` is the single writer that keeps these in lockstep; this
+    /// predicate is the same condition the record-health check uses to flag
+    /// `ConflictingProjections`. Exposed so callers (and a `debug_assert` in the
+    /// setter) can assert the invariant instead of silently diverging.
+    pub(crate) fn run_state_projections_agree(&self) -> bool {
+        RunExecutionState::from(self.state) == self.lifecycle.execution.state
+    }
+
     fn has_fresh_update(&self) -> bool {
         self.updated_at
             .as_deref()

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -490,7 +490,7 @@ fn discovery_active_marks_runner_backed_running_run_as_stale_retryable() {
         agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-runner-stale"))
             .expect("submitted");
         agent_task_lifecycle::rewrite_record_for_test("run-runner-stale", |record| {
-            record.state = AgentTaskRunState::Running;
+            agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Running);
             record.tasks[0].state = AgentTaskState::Running;
             record.metadata = serde_json::json!({
                 "runner_id": "homeboy-lab",
@@ -528,7 +528,7 @@ fn discovery_active_classifies_liveness_and_source() {
         agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-live-stale"))
             .expect("submitted");
         agent_task_lifecycle::rewrite_record_for_test("run-live-stale", |record| {
-            record.state = AgentTaskRunState::Running;
+            agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Running);
             record.tasks[0].state = AgentTaskState::Running;
             record.metadata = serde_json::json!({
                 "runner_id": "homeboy-lab",
@@ -571,7 +571,7 @@ fn reconcile_dry_run_reports_but_does_not_cancel_stale_runs() {
         agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-reconcile-dry"))
             .expect("submitted");
         agent_task_lifecycle::rewrite_record_for_test("run-reconcile-dry", |record| {
-            record.state = AgentTaskRunState::Running;
+            agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Running);
             record.tasks[0].state = AgentTaskState::Running;
             record.metadata = serde_json::json!({
                 "runner_id": "homeboy-lab",
@@ -598,7 +598,7 @@ fn reconcile_cancels_stale_running_record_without_manual_edit() {
         agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-reconcile-live"))
             .expect("submitted");
         agent_task_lifecycle::rewrite_record_for_test("run-reconcile-live", |record| {
-            record.state = AgentTaskRunState::Running;
+            agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Running);
             record.tasks[0].state = AgentTaskState::Running;
             record.metadata = serde_json::json!({
                 "runner_id": "homeboy-lab",
@@ -687,7 +687,7 @@ fn discovery_runner_backed_run_emits_runner_scoped_commands() {
         agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-runner-commands"))
             .expect("submitted");
         agent_task_lifecycle::rewrite_record_for_test("run-runner-commands", |record| {
-            record.state = AgentTaskRunState::Running;
+            agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Running);
             record.tasks[0].state = AgentTaskState::Running;
             record.metadata = serde_json::json!({
                 "runner_id": "homeboy-lab",


### PR DESCRIPTION
## Summary
First tractable slice of stabilization **surface #3** (run state scattered across representations that disagree). An agent-task run's state lives in two places:
- the authoritative `AgentTaskRunState` (`record.state`)
- its generic projection onto the durable lifecycle record (`record.lifecycle.execution.state`)

`set_run_state` is the **single writer** that keeps them in lockstep; a divergence is exactly what the record-health check flags as `ConflictingProjections`. This makes the invariant explicit and stops tests from manufacturing violations.

## Changes
1. **Assert the invariant on the correct path.** New `AgentTaskRunRecord::run_state_projections_agree()` (the same condition the health check uses) + a `debug_assert!` at the end of `set_run_state`. If a future edit to the setter breaks the pairing, it fails fast in dev/tests instead of silently emitting divergent records.
2. **Stop tests from forging divergent records.** 5 `agent_task_service` tests assigned `record.state = AgentTaskRunState::Running` directly, bypassing `set_run_state` and leaving `record.lifecycle.execution.state` at its default — i.e. forging the exact `ConflictingProjections` records the health check exists to catch. They now go through `set_run_state`, so the fixtures represent valid records.

## The detector still works
The health check must still catch genuinely-divergent records (legacy / corrupt / directly-manipulated). Verified by `record_health_migrates_legacy_and_quarantines_conflicting_projections`, which constructs a conflict **on purpose** (direct `lifecycle.execution.state` write, no setter) — it still detects and quarantines it. My `debug_assert` is only on the *correct* write path, so the detector and the invariant are complementary, not in conflict.

## Verification (local, VPS-safe)
- `cargo check -p homeboy-agents --lib` — clean
- The 5 modified service tests pass individually
- `record_health_migrates_legacy_and_quarantines_conflicting_projections` — passes (detector intact)

> Note: the full `status_and_recovery` batch is very slow (60–180s **per test**) and shares runtime state per pre-existing issue #8964, so it times out as a batch; **individual** runs are the reliable signal and pass. This change does not affect that isolation issue.