### PR TITLE
refactor: centralize the untyped stale-running metadata keys behind constants and accessors

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -112,10 +112,13 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
         LiveCancellationOutcome::NotRunning => {}
     }
     if was_stale_running {
-        metadata.insert("cancelled_stale_running".to_string(), json!(true));
+        metadata.insert(
+            METADATA_KEY_CANCELLED_STALE_RUNNING.to_string(),
+            json!(true),
+        );
     }
-    metadata.remove("stale_running");
-    metadata.remove("stale_running_reason");
+    metadata.remove(METADATA_KEY_STALE_RUNNING);
+    metadata.remove(METADATA_KEY_STALE_RUNNING_REASON);
 
     store::write_record(&record)?;
     Ok(record)

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1327,7 +1327,7 @@ fn expire_unaccepted_lab_handoff(run_id: &str) -> Result<bool> {
         "phase_activity".to_string(),
         json!("runner handoff acceptance deadline expired before runner acceptance"),
     );
-    metadata.insert("retryable".to_string(), json!(true));
+    metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
     metadata.insert(
         "runner_execution_record".to_string(),
         serde_json::to_value(
@@ -1426,7 +1426,7 @@ pub fn recover_transport_proxy(run_id: &str) -> Result<Option<TransportProxyReco
     };
     let runner_job_id = transport_proxy_runner_job_id(&record);
     let metadata = record.ensure_metadata_object();
-    metadata.insert("retryable".to_string(), json!(true));
+    metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
     metadata.insert("transport_recovery".to_string(), json!("required"));
     metadata.insert("runner_id".to_string(), json!(&runner_id));
 
@@ -2014,8 +2014,8 @@ pub(crate) fn apply_runner_job_terminal_state(
         "retryable".to_string(),
         json!(run_state != AgentTaskRunState::Succeeded),
     );
-    metadata.remove("stale_running");
-    metadata.remove("stale_running_reason");
+    metadata.remove(METADATA_KEY_STALE_RUNNING);
+    metadata.remove(METADATA_KEY_STALE_RUNNING_REASON);
 }
 
 fn record_runner_job_terminal_metadata(
@@ -2491,9 +2491,9 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
         )
         .unwrap_or(Value::Null),
     );
-    metadata.insert("retryable".to_string(), json!(true));
-    metadata.remove("stale_running");
-    metadata.remove("stale_running_reason");
+    metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
+    metadata.remove(METADATA_KEY_STALE_RUNNING);
+    metadata.remove(METADATA_KEY_STALE_RUNNING_REASON);
     store::write_record(&record)?;
     Ok(record)
 }
@@ -2620,7 +2620,7 @@ fn record_lab_offload_proxy(
     if !remote_command.is_empty() {
         metadata.insert("remote_command".to_string(), json!(remote_command));
     }
-    metadata.insert("retryable".to_string(), json!(true));
+    metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
     metadata.insert(
         "runner_execution_record".to_string(),
         serde_json::to_value(
@@ -2651,7 +2651,7 @@ fn fail_missing_lab_attempt_plan(record: &mut AgentTaskRunRecord, error: &Error)
             "error": error.message,
         }),
     );
-    metadata.insert("retryable".to_string(), json!(true));
+    metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
     store::write_record(record)
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -13,6 +13,19 @@ pub const AGENT_TASK_RECORD_HEALTH_SCHEMA: &str = "homeboy/agent-task-record-hea
 pub const AGENT_TASK_RECORD_RECONCILIATION_SCHEMA: &str =
     "homeboy/agent-task-record-reconciliation/v1";
 
+// Untyped run-record metadata keys for the controller's staleness / runner
+// liveness projection. Centralized so every read and write goes through one
+// name — a typo in any scattered string literal would otherwise silently break
+// staleness detection. (Step toward migrating these flags onto the typed
+// lifecycle state; for now this removes the string-drift hazard without
+// changing the on-disk format.)
+pub(crate) const METADATA_KEY_STALE_RUNNING: &str = "stale_running";
+pub(crate) const METADATA_KEY_STALE_RUNNING_REASON: &str = "stale_running_reason";
+pub(crate) const METADATA_KEY_RUNNER_LIVENESS: &str = "runner_liveness";
+pub(crate) const METADATA_KEY_RETRYABLE: &str = "retryable";
+pub(crate) const METADATA_KEY_RECLAIMED_STALE_RUNNING: &str = "reclaimed_stale_running";
+pub(crate) const METADATA_KEY_CANCELLED_STALE_RUNNING: &str = "cancelled_stale_running";
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentTaskRecordHealthReason {
@@ -233,12 +246,15 @@ impl AgentTaskRunRecord {
         metadata.insert("runner_pid".to_string(), json!(std::process::id()));
         metadata.insert("runner_started_at".to_string(), json!(now_timestamp()));
         if reclaimed_stale {
-            metadata.insert("reclaimed_stale_running".to_string(), json!(true));
+            metadata.insert(
+                METADATA_KEY_RECLAIMED_STALE_RUNNING.to_string(),
+                json!(true),
+            );
         } else {
-            metadata.remove("reclaimed_stale_running");
+            metadata.remove(METADATA_KEY_RECLAIMED_STALE_RUNNING);
         }
-        metadata.remove("stale_running");
-        metadata.remove("stale_running_reason");
+        metadata.remove(METADATA_KEY_STALE_RUNNING);
+        metadata.remove(METADATA_KEY_STALE_RUNNING_REASON);
     }
 
     pub(crate) fn annotate_stale_running(&mut self) {
@@ -259,8 +275,8 @@ impl AgentTaskRunRecord {
         };
         let provider_handle_count = self.provider_handles.len();
         let metadata = self.ensure_metadata_object();
-        metadata.insert("stale_running".to_string(), json!(true));
-        metadata.insert("stale_running_reason".to_string(), json!(reason));
+        metadata.insert(METADATA_KEY_STALE_RUNNING.to_string(), json!(true));
+        metadata.insert(METADATA_KEY_STALE_RUNNING_REASON.to_string(), json!(reason));
         metadata.insert(
             "provider_boundary".to_string(),
             json!({
@@ -268,7 +284,7 @@ impl AgentTaskRunRecord {
                 "provider_handle_count": provider_handle_count,
             }),
         );
-        metadata.insert("retryable".to_string(), json!(true));
+        metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
     }
 
     /// A controller cannot infer progress from a runner connection that is no
@@ -279,23 +295,26 @@ impl AgentTaskRunRecord {
             return;
         }
         let metadata = self.ensure_metadata_object();
-        metadata.insert("runner_liveness".to_string(), json!("disconnected"));
-        metadata.insert("stale_running".to_string(), json!(true));
         metadata.insert(
-            "stale_running_reason".to_string(),
+            METADATA_KEY_RUNNER_LIVENESS.to_string(),
+            json!("disconnected"),
+        );
+        metadata.insert(METADATA_KEY_STALE_RUNNING.to_string(), json!(true));
+        metadata.insert(
+            METADATA_KEY_STALE_RUNNING_REASON.to_string(),
             json!("runner_disconnected"),
         );
-        metadata.insert("retryable".to_string(), json!(true));
+        metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
     }
 
     /// A reachable runner job is authoritative liveness evidence. Clear only
     /// the controller's disconnected/stale projection, not unrelated metadata.
     pub(crate) fn record_runner_reachable(&mut self) {
         let metadata = self.ensure_metadata_object();
-        metadata.insert("runner_liveness".to_string(), json!("reachable"));
-        metadata.remove("stale_running");
-        metadata.remove("stale_running_reason");
-        metadata.remove("retryable");
+        metadata.insert(METADATA_KEY_RUNNER_LIVENESS.to_string(), json!("reachable"));
+        metadata.remove(METADATA_KEY_STALE_RUNNING);
+        metadata.remove(METADATA_KEY_STALE_RUNNING_REASON);
+        metadata.remove(METADATA_KEY_RETRYABLE);
     }
 
     pub(crate) fn owner_process_is_running(&self) -> bool {
@@ -333,6 +352,23 @@ impl AgentTaskRunRecord {
             .get("runner_id")
             .and_then(Value::as_str)
             .filter(|value| !value.trim().is_empty())
+    }
+
+    /// Whether the controller has projected this run as stale (its runner
+    /// backing can no longer be confirmed live). Reads the centralized untyped
+    /// metadata flag.
+    pub(crate) fn is_stale_running(&self) -> bool {
+        self.metadata
+            .get(METADATA_KEY_STALE_RUNNING)
+            .and_then(Value::as_bool)
+            == Some(true)
+    }
+
+    /// The recorded reason a run was projected stale, if any.
+    pub(crate) fn stale_running_reason(&self) -> Option<&str> {
+        self.metadata
+            .get(METADATA_KEY_STALE_RUNNING_REASON)
+            .and_then(Value::as_str)
     }
 
     /// Whether the authoritative agent-task run state (`self.state`) and its

--- a/crates/homeboy-agents/src/agent_task_loop_controller/helpers.rs
+++ b/crates/homeboy-agents/src/agent_task_loop_controller/helpers.rs
@@ -335,17 +335,11 @@ pub(crate) fn refresh_stale_running_child_actions(
             continue;
         };
         let run = agent_task_lifecycle::status(&run_id)?;
-        if run.state != AgentTaskRunState::Running
-            || run.metadata.get("stale_running").and_then(Value::as_bool) != Some(true)
-        {
+        if run.state != AgentTaskRunState::Running || !run.is_stale_running() {
             continue;
         }
 
-        let reason = run
-            .metadata
-            .get("stale_running_reason")
-            .and_then(Value::as_str)
-            .unwrap_or("stale_running");
+        let reason = run.stale_running_reason().unwrap_or("stale_running");
         let action = &mut record.next_actions[index];
         action.status = AgentTaskLoopActionStatus::Pending;
         action.reason = format!(

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -306,7 +306,7 @@ fn classify_liveness(
         return AgentTaskLiveness::Active;
     }
 
-    if metadata_bool(&record.metadata, "stale_running") == Some(true) {
+    if record.is_stale_running() {
         return AgentTaskLiveness::Stale;
     }
 
@@ -403,9 +403,12 @@ fn discovery_run(
         runner_id,
         runner_job_id,
         remote_run_id: metadata_string(&record.metadata, "remote_run_id"),
-        stale: metadata_bool(&record.metadata, "stale_running"),
-        stale_reason: metadata_string(&record.metadata, "stale_running_reason"),
-        retryable: metadata_bool(&record.metadata, "retryable"),
+        stale: metadata_bool(&record.metadata, agent_task_lifecycle::METADATA_KEY_STALE_RUNNING),
+        stale_reason: metadata_string(
+            &record.metadata,
+            agent_task_lifecycle::METADATA_KEY_STALE_RUNNING_REASON,
+        ),
+        retryable: metadata_bool(&record.metadata, agent_task_lifecycle::METADATA_KEY_RETRYABLE),
         liveness,
         source,
         last_update,


### PR DESCRIPTION
## Summary
Second slice of stabilization **surface #3** (state stored in untyped JSON bags that can drift). The controller's staleness / runner-liveness projection lives in untyped run-record metadata — `stale_running`, `stale_running_reason`, `runner_liveness`, `retryable`, `reclaimed_stale_running`, `cancelled_stale_running`. Those keys were **raw string literals scattered across ~6 files** (`records.rs`, `cancellation.rs`, `lifecycle_ops.rs`, `discovery.rs`, `loop_controller/helpers.rs`) with no single source of truth — a typo in any read or write would **silently break staleness detection**.

## Changes
- `METADATA_KEY_*` constants in `records.rs`, referenced by every read and write of these flags.
- Typed `AgentTaskRunRecord::is_stale_running()` / `stale_running_reason()` accessors; `discovery.rs` and `helpers.rs` (which hold the record) now use them instead of hand-rolled `metadata.get("stale_running")` lookups.

## Scope discipline
- **No on-disk format or state-semantics change** — same keys, same values. This removes the string-drift hazard and makes the flag surface discoverable, as a step toward eventually migrating these flags onto the typed lifecycle state.
- Deliberately left the `"stale_running_reason"` **JSON field names in diagnostic/history output payloads** raw — those are an observability schema for operators, not the record metadata flag, so they're a different concern.

## Verification (local, VPS-safe)
- `cargo check -p homeboy-agents --lib` — clean
- `reconcile_cancels_stale_running_record_without_manual_edit` and `discovery_active_marks_runner_backed_running_run_as_stale_retryable` pass **individually** (behavior-preserving).

> Note: the `agent_task_lifecycle` / `agent_task_service` tests are slow (60–90s each) and share runtime state per pre-existing #8964, so the batch times out; individual runs are the reliable signal.