### PR TITLE
Fix stale Lab workspace metadata poisoning handoff

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/sync.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync.rs
@@ -34,8 +34,9 @@ use super::types::{
     RunnerWorkspaceMetadata, RunnerWorkspacePruneEntry, RunnerWorkspacePruneOptions,
     RunnerWorkspacePruneOutput, RunnerWorkspacePruneSkippedEntry,
     RunnerWorkspaceSnapshotAppliedFilters, RunnerWorkspaceSnapshotEntry,
-    RunnerWorkspaceSnapshotFilters, RunnerWorkspaceSnapshotsOutput, RunnerWorkspaceSyncMode,
-    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput, DEFAULT_EXCLUDES,
+    RunnerWorkspaceSnapshotFilters, RunnerWorkspaceSnapshotInvalidMetadata,
+    RunnerWorkspaceSnapshotsOutput, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
+    RunnerWorkspaceSyncOutput, DEFAULT_EXCLUDES,
 };
 use super::util::{
     deterministic_remote_path, git_output, parent_remote_path, ssh_client_for_runner,
@@ -843,7 +844,7 @@ pub fn workspace_snapshots(
     validate_absolute_path("workspace_root", workspace_root)?;
     let lab_workspaces_root = format!("{}/_lab_workspaces", workspace_root.trim_end_matches('/'));
     let limit = filters.limit.max(1);
-    let mut snapshots = match runner.kind {
+    let (mut snapshots, skipped_invalid_metadata) = match runner.kind {
         RunnerKind::Local => workspace_snapshots_local(Path::new(&lab_workspaces_root))?,
         RunnerKind::Ssh => workspace_snapshots_ssh(&runner, &lab_workspaces_root)?,
     };
@@ -870,6 +871,7 @@ pub fn workspace_snapshots(
                 limit,
             },
             snapshots,
+            skipped_invalid_metadata,
         },
         0,
     ))
@@ -941,11 +943,17 @@ fn list_ssh_lab_workspaces(
     Ok(paths.into_iter().take(limit).collect())
 }
 
-fn workspace_snapshots_local(root: &Path) -> Result<Vec<RunnerWorkspaceSnapshotEntry>> {
+fn workspace_snapshots_local(
+    root: &Path,
+) -> Result<(
+    Vec<RunnerWorkspaceSnapshotEntry>,
+    Vec<RunnerWorkspaceSnapshotInvalidMetadata>,
+)> {
     if !root.is_dir() {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), Vec::new()));
     }
     let mut snapshots = Vec::new();
+    let mut skipped_invalid_metadata = Vec::new();
     for entry in fs::read_dir(root).map_err(|err| {
         Error::internal_io(
             err.to_string(),
@@ -965,20 +973,30 @@ fn workspace_snapshots_local(root: &Path) -> Result<Vec<RunnerWorkspaceSnapshotE
         let Ok(content) = fs::read_to_string(&metadata_path) else {
             continue;
         };
-        let metadata: RunnerWorkspaceMetadata = serde_json::from_str(&content).map_err(|err| {
-            Error::internal_json(err.to_string(), Some(metadata_path.display().to_string()))
-        })?;
+        let metadata: RunnerWorkspaceMetadata = match serde_json::from_str(&content) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                skipped_invalid_metadata.push(invalid_workspace_metadata(
+                    &metadata_path.display().to_string(),
+                    error,
+                ));
+                continue;
+            }
+        };
         if let Some(snapshot) = workspace_snapshot_entry(metadata) {
             snapshots.push(snapshot);
         }
     }
-    Ok(snapshots)
+    Ok((snapshots, skipped_invalid_metadata))
 }
 
 fn workspace_snapshots_ssh(
     runner: &super::super::Runner,
     root: &str,
-) -> Result<Vec<RunnerWorkspaceSnapshotEntry>> {
+) -> Result<(
+    Vec<RunnerWorkspaceSnapshotEntry>,
+    Vec<RunnerWorkspaceSnapshotInvalidMetadata>,
+)> {
     let (_server, mut client) = ssh_client_for_runner(runner)?;
     client.env.extend(runner.env.clone());
     let command = workspace_snapshot_scan_command(root);
@@ -990,6 +1008,7 @@ fn workspace_snapshots_ssh(
         )));
     }
     let mut snapshots = Vec::new();
+    let mut skipped_invalid_metadata = Vec::new();
     for line in output.stdout.lines() {
         let parts = line.splitn(2, '\t').collect::<Vec<_>>();
         if parts.len() != 2 {
@@ -998,13 +1017,41 @@ fn workspace_snapshots_ssh(
         let decoded = base64::engine::general_purpose::STANDARD
             .decode(parts[1])
             .map_err(|err| Error::internal_json(err.to_string(), None))?;
-        let metadata: RunnerWorkspaceMetadata = serde_json::from_slice(&decoded)
-            .map_err(|err| Error::internal_json(err.to_string(), Some(parts[0].to_string())))?;
+        let metadata: RunnerWorkspaceMetadata = match serde_json::from_slice(&decoded) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                skipped_invalid_metadata.push(invalid_workspace_metadata(parts[0], error));
+                continue;
+            }
+        };
         if let Some(snapshot) = workspace_snapshot_entry(metadata) {
             snapshots.push(snapshot);
         }
     }
-    Ok(snapshots)
+    Ok((snapshots, skipped_invalid_metadata))
+}
+
+fn invalid_workspace_metadata(
+    source: &str,
+    error: serde_json::Error,
+) -> RunnerWorkspaceSnapshotInvalidMetadata {
+    const MAX_PARSE_ERROR_BYTES: usize = 512;
+
+    let error = error.to_string();
+    let error = if error.len() > MAX_PARSE_ERROR_BYTES {
+        let mut end = MAX_PARSE_ERROR_BYTES;
+        while !error.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}... [truncated]", &error[..end])
+    } else {
+        error
+    };
+    RunnerWorkspaceSnapshotInvalidMetadata {
+        source: source.to_string(),
+        field: WORKSPACE_METADATA_FILE,
+        error,
+    }
 }
 
 pub(super) fn workspace_snapshot_scan_command(root: &str) -> String {

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
@@ -192,6 +192,49 @@ fn workspace_snapshots_render_metadata_for_synced_workspace() {
 }
 
 #[test]
+fn stale_truncated_metadata_does_not_block_current_workspace_sync() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        create_local_runner("lab-local-stale-metadata", runner_root.path());
+        let stale_metadata = runner_root
+            .path()
+            .join("_lab_workspaces/stale-unrelated/.homeboy/runner-workspace.json");
+        fs::create_dir_all(stale_metadata.parent().expect("metadata parent"))
+            .expect("stale workspace parent");
+        fs::write(&stale_metadata, "{\n  \"runner_id\": \"").expect("truncated metadata");
+
+        let source = git_source("homeboy@current-task", "fix/current-task", "source\n");
+        let (synced, _) = sync_workspace(
+            "lab-local-stale-metadata",
+            sync_options(
+                source.path().display().to_string(),
+                Some("current-run".to_string()),
+            ),
+        )
+        .expect("current workspace sync ignores unrelated stale metadata");
+
+        let (output, _) = workspace_snapshots(
+            "lab-local-stale-metadata",
+            RunnerWorkspaceSnapshotFilters {
+                run_id: Some("current-run".to_string()),
+                limit: 10,
+                ..Default::default()
+            },
+        )
+        .expect("current workspace snapshot discovery");
+
+        assert_eq!(output.snapshots.len(), 1);
+        assert_eq!(output.snapshots[0].remote_path, synced.remote_path);
+        assert_eq!(output.skipped_invalid_metadata.len(), 1);
+        let diagnostic = &output.skipped_invalid_metadata[0];
+        assert_eq!(diagnostic.source, stale_metadata.display().to_string());
+        assert_eq!(diagnostic.field, ".homeboy/runner-workspace.json");
+        assert!(diagnostic.error.contains("EOF while parsing a string"));
+        assert!(diagnostic.error.len() <= 512 + "... [truncated]".len());
+    });
+}
+
+#[test]
 fn workspace_snapshots_filters_by_repo_ref_commit_and_run() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let runner_root = tempfile::tempdir().expect("runner root tempdir");

--- a/crates/homeboy-lab-runner/src/workspace/types.rs
+++ b/crates/homeboy-lab-runner/src/workspace/types.rs
@@ -355,6 +355,17 @@ pub struct RunnerWorkspaceSnapshotsOutput {
     pub lab_workspaces_root: String,
     pub filters: RunnerWorkspaceSnapshotAppliedFilters,
     pub snapshots: Vec<RunnerWorkspaceSnapshotEntry>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub skipped_invalid_metadata: Vec<RunnerWorkspaceSnapshotInvalidMetadata>,
+}
+
+/// A stale workspace must not prevent discovery of usable snapshots for a
+/// different task. Retain bounded diagnostics so operators can repair it.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunnerWorkspaceSnapshotInvalidMetadata {
+    pub source: String,
+    pub field: &'static str,
+    pub error: String,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
Prevent unrelated stale Lab workspace metadata from aborting agent-task handoff before provider execution.

## What changed
- Skip malformed snapshot candidates while retaining bounded source, field, and parser diagnostics.

## How to test
1. Run `cargo test -p homeboy-lab-runner stale_truncated_metadata_does_not_block_current_workspace_sync`; expect The stale malformed candidate is skipped and current workspace discovery succeeds..
2. Run `cargo check -p homeboy-lab-runner`; expect The affected crate compiles successfully..
3. Run `rustfmt --edition 2021 --check crates/homeboy-lab-runner/src/workspace/sync.rs crates/homeboy-lab-runner/src/workspace/types.rs crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs`; expect Changed Rust files are formatted..

## Compatibility
The output adds an omitted-when-empty diagnostics field; valid snapshot behavior and existing requests are unchanged.

## Evidence
- Base advanced after verification: verified main at 6bfd992283966291bb7c952932676a47de0dd60e; publication observed e42603783de74b5294bc6ff224c0b657fc7cc99d. Candidate ancestry was validated against the verified snapshot.
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/9057
- Verified finalization base: main at 6bfd992283966291bb7c952932676a47de0dd60e
- cargo-check: Passed
- diff-check: Passed
- format: Passed
- targeted-test: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the stale-workspace JSON poisoning path, implemented bounded isolation and diagnostics, and wrote deterministic regression coverage.

## Source relationships
- Closes #9057
