### PR TITLE
refactor: centralize run terminality on AgentTaskRunState::is_terminal()

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -642,7 +642,7 @@ pub fn record_run_aggregate(
 /// before the controller finalized its artifact-byte projection.
 pub fn reconcile_terminal_artifact_projection(run_id: &str) -> Result<bool> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
-    if !is_terminal_run_state(record.state) {
+    if !record.state.is_terminal() {
         return Ok(false);
     }
 
@@ -888,7 +888,7 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
         record.plan_path = controller_plan_path;
         store::write_record(&record)?;
     }
-    if !is_terminal_run_state(record.state) {
+    if !record.state.is_terminal() {
         if let Ok(aggregate) = store::read_aggregate(&record.run_id) {
             let aggregate_path = store::aggregate_path(&record.run_id)
                 .map(|path| path.display().to_string())
@@ -929,7 +929,7 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
             );
         }
     }
-    if is_terminal_run_state(record.state) {
+    if record.state.is_terminal() {
         if let Ok(aggregate) = store::read_aggregate(&record.run_id) {
             if !crate::agent_task_lifecycle::terminal_artifact_projection_is_verified(
                 &record, &aggregate,
@@ -1465,7 +1465,7 @@ pub fn recover_transport_proxy(run_id: &str) -> Result<Option<TransportProxyReco
 /// job snapshot and cannot dispatch or resume provider work.
 pub fn recover_terminal_transport_proxy_evidence(run_id: &str) -> Result<bool> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
-    if !is_terminal_run_state(record.state) {
+    if !record.state.is_terminal() {
         return Ok(false);
     }
     let (Some(runner_id), Some(runner_job_id)) = (
@@ -1615,7 +1615,7 @@ pub(crate) fn reconcile_runner_job_snapshot(
     record: &mut AgentTaskRunRecord,
     snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
 ) -> Result<()> {
-    if is_terminal_run_state(record.state) {
+    if record.state.is_terminal() {
         // A transport-only terminal result can arrive before the daemon has
         // published the inner agent-task aggregate. Adopt that later evidence
         // when it proves the same controller run rather than losing its patch.
@@ -1891,18 +1891,6 @@ fn validate_terminal_child_identity(
         Some(record.run_id.clone()),
         None,
     ))
-}
-
-fn is_terminal_run_state(state: AgentTaskRunState) -> bool {
-    matches!(
-        state,
-        AgentTaskRunState::Succeeded
-            | AgentTaskRunState::CandidateRecoverable
-            | AgentTaskRunState::PartialRecoverable
-            | AgentTaskRunState::PartialFailure
-            | AgentTaskRunState::Failed
-            | AgentTaskRunState::Cancelled
-    )
 }
 
 fn aggregate_projection_plan(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -735,6 +735,28 @@ pub enum AgentTaskRunState {
     Cancelled,
 }
 
+impl AgentTaskRunState {
+    /// Whether this is a terminal run state — the run has finished (successfully,
+    /// with a recoverable candidate, partially, or by failure/cancellation) and
+    /// will not transition further on its own.
+    ///
+    /// The single definition of run terminality. Every place that used to
+    /// enumerate this set inline (`matches!(state, Succeeded | CandidateRecoverable
+    /// | ...)`) delegates here, so adding or reclassifying a run state cannot
+    /// leave a stale copy behind.
+    pub(crate) fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            AgentTaskRunState::Succeeded
+                | AgentTaskRunState::CandidateRecoverable
+                | AgentTaskRunState::PartialRecoverable
+                | AgentTaskRunState::PartialFailure
+                | AgentTaskRunState::Failed
+                | AgentTaskRunState::Cancelled
+        )
+    }
+}
+
 /// Canonical projection of a run's aggregate state onto the generic
 /// `RunExecutionState` carried by `RunLifecycleRecord`. The two enums share
 /// every agent-task variant 1:1 (`RunExecutionState` additionally models the

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -376,17 +376,13 @@ fn run_status(state: AgentTaskRunState) -> &'static str {
 }
 
 fn terminal_finished_at(record: &AgentTaskRunRecord) -> Option<String> {
-    match record.state {
-        AgentTaskRunState::Succeeded
-        | AgentTaskRunState::CandidateRecoverable
-        | AgentTaskRunState::PartialRecoverable
-        | AgentTaskRunState::PartialFailure
-        | AgentTaskRunState::Failed
-        | AgentTaskRunState::Cancelled => record
+    if record.state.is_terminal() {
+        record
             .updated_at
             .clone()
-            .or_else(|| Some(record.submitted_at.clone())),
-        AgentTaskRunState::Queued | AgentTaskRunState::Running => None,
+            .or_else(|| Some(record.submitted_at.clone()))
+    } else {
+        None
     }
 }
 


### PR DESCRIPTION
## Summary
More consolidation of the state-representation drift that feeds the agent-task churn (stabilization surface #3). The set of **terminal** `AgentTaskRunState` variants (`Succeeded`, `CandidateRecoverable`, `PartialRecoverable`, `PartialFailure`, `Failed`, `Cancelled`) was enumerated **inline in multiple places**:
- `is_terminal_run_state` in `lifecycle_ops.rs`
- `terminal_finished_at` in `lifecycle_store.rs`

both hand-listing the same six variants. Adding or reclassifying a run state means finding and updating every copy — a missed one silently misclassifies terminality.

## Change
Give the enum a single `AgentTaskRunState::is_terminal()` method and delegate to it:
- Replace the private `is_terminal_run_state` helper (5 call sites) with `record.state.is_terminal()` and delete the helper.
- Replace the `terminal_finished_at` 6-variant match with `if record.state.is_terminal()`.

Run terminality now has **one authoritative definition on the type itself**, so it cannot drift.

## A divergence this surfaces (deliberately untouched)
`set_run_state`'s `finished_at` condition lists only **5** of the 6 terminal variants — it omits `CandidateRecoverable`. That's a pre-existing divergence from the canonical terminal set. I've **left it untouched**: whether a `CandidateRecoverable` run should stamp `finished_at` is a semantic question separate from this mechanical consolidation. It's now visible as an explicit difference from `is_terminal()` rather than buried in a third hand-copied list — a reviewer can decide if it's intentional.

## Verification (local, VPS-safe)
- `cargo check -p homeboy-agents --lib` — clean
- `lifecycle_store_round_trips_record_log_artifacts_and_lifecycle_contract` (exercises `terminal_finished_at`) — passes individually
- `durable_finalization_rejects_model_less_terminal_record_without_mutation` — passes individually

> Behavior-preserving mechanical consolidation. Tests are slow + share runtime state (#8964), so individual runs are the reliable signal.