### PR TITLE
refactor: derive Default for RunnerJobLifecycleMetadata and collapse redundant field constructions

### DIFF
--- a/crates/contracts/homeboy-api-jobs-contract/src/metadata.rs
+++ b/crates/contracts/homeboy-api-jobs-contract/src/metadata.rs
@@ -25,7 +25,7 @@ pub struct JobArtifactMetadata {
     pub metadata: Option<Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RunnerJobLifecycleMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -1986,13 +1986,7 @@ fn enqueue_exec_job(
     );
     if let Some(durable_run_id) = canonical_durable_run_id {
         lifecycle
-            .get_or_insert_with(|| RunnerJobLifecycleMetadata {
-                source: None,
-                kind: None,
-                durable_run_id: None,
-                active_child_count: None,
-                active_cell_count: None,
-            })
+            .get_or_insert_with(RunnerJobLifecycleMetadata::default)
             .durable_run_id = Some(durable_run_id);
     }
     let summary = json!({

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -93,8 +93,7 @@ pub(super) fn exec_via_reverse_broker(
             source: Some("reverse-broker".to_string()),
             kind: Some("runner.exec".to_string()),
             durable_run_id: run_id.clone(),
-            active_child_count: None,
-            active_cell_count: None,
+            ..Default::default()
         }),
         require_paths: require_paths.clone(),
     };

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -80,8 +80,7 @@ pub(super) fn exec_via_daemon(
         source: Some("runner-daemon".to_string()),
         kind: Some("runner.exec".to_string()),
         durable_run_id: run_id.clone(),
-        active_child_count: None,
-        active_cell_count: None,
+        ..Default::default()
     };
     let payload = json!({
         "runner_id": runner.id,


### PR DESCRIPTION
## Summary
Small cleanup targeting real boilerplate. `RunnerJobLifecycleMetadata` has five `Option` fields but **no `Default` derive**, so every construction spelled out each field even when most were `None` — the all-`None` `get_or_insert_with` in `daemon.rs` listed all five, and the runner/broker exec paths listed the two count fields as `None` purely to satisfy the struct literal.

## Change
Derive `Default` (all fields are `Option`, so `Default` *is* the all-`None` value) and use it:
- `daemon.rs` all-`None` construction → `RunnerJobLifecycleMetadata::default()`
- `execution/daemon.rs` + `broker.rs` → set the meaningful fields, `..Default::default()` for the rest.

Behavior-identical (the `Default` of an all-`Option` struct is all-`None`); removes boilerplate and means future field additions won't require touching these call sites.

## Verification (local, VPS-safe)
- `cargo check -p homeboy-api-jobs-contract` / `-p homeboy-core --lib` / `-p homeboy-lab-runner --lib` `--tests` — all clean
- The idempotency tests that build `RunnerJobLifecycleMetadata` (`active_runner_job_for_durable_run_id_finds_...`, `capacity_queued_local_runner_enqueue_dedupes_...`) pass individually
- `cargo fmt` — clean

> Note: `remote_runner_job_submit_targets_runner_and_project` fails identically on **clean `origin/main`** (`left: 0, right: 1`) — a pre-existing environment issue on this box (passes in CI), unrelated to this change. Confirmed by running it on a clean checkout.