### PR TITLE
fix: keep a runner-owned retry portable instead of failing the Lab handoff (#8390)

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -971,18 +971,14 @@ fn materialize_agent_task_retry_handoff(
     // Use the same resolution `retry` applies (a cook id resolves to its latest
     // run). A plain exact-match here let a resolvable id fall through and ship an
     // unrunnable `agent-task retry <id>` to a runner with no such record (#8390).
+    //
+    // When the id does NOT resolve to a controller record, the retry is not the
+    // controller's to materialize: it stays portable so the runner reads the run
+    // from its own store (a runner-owned retry). Returning `None` here preserves
+    // that behavior; only a resolvable controller record is materialized into a
+    // self-contained run-plan handoff.
     if !agent_task_lifecycle::run_record_exists_resolved(&retry.run_id)? {
-        return Err(Error::validation_invalid_argument(
-            "run_id",
-            format!(
-                "agent-task retry --run cannot resolve a durable controller run record for `{}`; Lab offload needs the controller record to materialize the replacement run-plan",
-                retry.run_id
-            ),
-            Some(retry.run_id.clone()),
-            Some(vec![
-                "Inspect the run with `homeboy agent-task status <run-id>` and retry an existing run or cook id.".to_string(),
-            ]),
-        ));
+        return Ok(None);
     }
 
     let source_plan = agent_task_lifecycle::load_controller_plan(&retry.run_id)?;


### PR DESCRIPTION
## Summary

Completes the Lab-offloaded retry materialization contract for #8390.

The Lab retry handoff (introduced in #8986) began failing loudly when it could not resolve a controller-side durable run record — to avoid shipping an unrunnable `agent-task retry <id>` to a runner with no such record. That turned out to be **too aggressive**: a retry whose id has no controller record is a legitimate **runner-owned retry** (the runner reads the run from its own store), and it must stay portable so the raw retry argv reaches the runner unchanged.

This regression was caught by the pre-existing `lab_owned_retry_is_not_read_from_the_controller_store` test, which asserts `materialize_agent_task_retry_handoff` returns `None` for a run that is not in the controller store — but #8986 made it return `Err`. (The test wasn't in the changed scope of #8986's CI run, so the conflict landed latent on main.)

## Change

`materialize_agent_task_retry_handoff` now returns `Ok(None)` (portable) when the id does not resolve to a controller record, instead of erroring. A **resolvable** id — including a cook id that resolves to its latest run — still materializes a self-contained `run-plan --plan <inline> --record-run-id <new>` handoff, so #8986's core fix (never shipping unrunnable args for a *resolvable* controller run) is preserved.

The two behaviors are locked in by existing coverage:
- **Runner-owned (unresolvable) → portable `None`:** `lab_owned_retry_is_not_read_from_the_controller_store` (now passing again).
- **Controller-owned (resolvable) → materialized run-plan:** `cook_to_worktree_provider_workspace_survives_failed_attempt_and_lab_retry` and `controller_owned_run_materializes_plan_for_lab_execution`.

Together this satisfies #8390's acceptance criteria: a controller-created failed run materializes its exact durable plan and immutable execution inputs into a self-contained Lab run-plan; materialization is explicit and bounded; the whole typed plan round-trips (preserving provider budget, workspace, verification, promotion, and finalization contracts); local retry is unchanged; and deterministic coverage proves a controller-created failed run retries on a Lab runner.

## Testing

- `cargo check -p homeboy-cli --lib --tests` — clean (EXIT 0), `cargo fmt`.
- `lab_owned_retry_is_not_read_from_the_controller_store`, `controller_owned_run_materializes_plan_for_lab_execution`, `retry_handoff_refuses_multiple_task_workspaces`, `retry_handoff_identifies_an_original_plan_without_a_workspace` all pass.
- `cook_to_worktree_provider_workspace_survives_failed_attempt_and_lab_retry` (the controller-failed-run → Lab-retry E2E) passes.

Heavy workspace build/test intentionally left to CI per repo policy.

Fixes #8390

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Verified #8986 had already materialized the retry plan, found a latent regression where its loud-failure path broke the runner-owned-retry contract, restored portable `None` for unresolvable ids while preserving resolvable-record materialization, and confirmed via the existing Lab-retry test surface. Chris reviews and owns the change.