### PR TITLE
refactor: replace two duplicate git_output helpers with core::git::output_optional

### DIFF
--- a/crates/homeboy-core/src/component/inventory/path_diagnostics.rs
+++ b/crates/homeboy-core/src/component/inventory/path_diagnostics.rs
@@ -1,6 +1,6 @@
 use crate::component::Component;
 use crate::engine::shell::quote_path;
-use crate::git::{run_git, run_git_output};
+use crate::git::{output_optional, run_git_output};
 use crate::transient_workspace_policy::TransientWorkspacePolicy;
 use std::path::{Path, PathBuf};
 
@@ -75,15 +75,15 @@ pub(super) fn local_path_diagnostic_for(
             .map(|path| path.to_string_lossy().to_string()),
         branch: git_root_path
             .as_ref()
-            .and_then(|path| git_output(path, &["rev-parse", "--abbrev-ref", "HEAD"])),
+            .and_then(|path| output_optional(path, &["rev-parse", "--abbrev-ref", "HEAD"])),
         head: git_root_path
             .as_ref()
-            .and_then(|path| git_output(path, &["rev-parse", "--short", "HEAD"])),
+            .and_then(|path| output_optional(path, &["rev-parse", "--short", "HEAD"])),
         remote_url: git_root_path
             .as_ref()
-            .and_then(|path| git_output(path, &["config", "--get", "remote.origin.url"])),
+            .and_then(|path| output_optional(path, &["config", "--get", "remote.origin.url"])),
         upstream: git_root_path.as_ref().and_then(|path| {
-            git_output(
+            output_optional(
                 path,
                 &["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
             )
@@ -127,15 +127,6 @@ pub(super) fn detect_git_root(path: &Path) -> Option<PathBuf> {
         None
     } else {
         Some(PathBuf::from(raw))
-    }
-}
-
-fn git_output(path: &Path, args: &[&str]) -> Option<String> {
-    let value = run_git(path, args, "git metadata").ok()?.trim().to_string();
-    if value.is_empty() {
-        None
-    } else {
-        Some(value)
     }
 }
 

--- a/crates/homeboy-release/src/deploy/types.rs
+++ b/crates/homeboy-release/src/deploy/types.rs
@@ -8,6 +8,7 @@ use homeboy_core::artifact_inputs::ResolvedArtifactInput;
 use homeboy_core::component::Component;
 use homeboy_core::config;
 use homeboy_core::error::Result;
+use homeboy_core::git::output_optional;
 use homeboy_core::is_zero_u32;
 use homeboy_core::paths as base_path;
 use homeboy_core::phase_timing::PhaseTimingReport;
@@ -581,20 +582,20 @@ impl ComponentDeployResult {
     pub(super) fn with_source_identity(mut self, component: &Component, head_deploy: bool) -> Self {
         let path = Path::new(&component.local_path);
         self.local_path = Some(component.local_path.clone());
-        self.git_branch = git_output(path, &["branch", "--show-current"]);
-        self.git_head = git_output(path, &["rev-parse", "HEAD"]);
-        self.upstream_branch = git_output(path, &["rev-parse", "--abbrev-ref", "@{upstream}"])
+        self.git_branch = output_optional(path, &["branch", "--show-current"]);
+        self.git_head = output_optional(path, &["rev-parse", "HEAD"]);
+        self.upstream_branch = output_optional(path, &["rev-parse", "--abbrev-ref", "@{upstream}"])
             .or_else(|| homeboy_core::git::default_remote_branch(path));
         self.upstream_head = self
             .upstream_branch
             .as_deref()
-            .and_then(|upstream| git_output(path, &["rev-parse", upstream]));
+            .and_then(|upstream| output_optional(path, &["rev-parse", upstream]));
         self.is_worktree = detect_linked_worktree(path);
         self.behind_upstream = self
             .upstream_branch
             .as_deref()
             .and_then(|upstream| {
-                git_output(
+                output_optional(
                     path,
                     &[
                         "rev-list",
@@ -632,24 +633,9 @@ impl ComponentDeployResult {
     }
 }
 
-fn git_output(path: &Path, args: &[&str]) -> Option<String> {
-    std::process::Command::new("git")
-        .args(args)
-        .current_dir(path)
-        .stdin(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .ok()
-        .filter(|output| output.status.success())
-        .and_then(|output| {
-            let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            (!value.is_empty()).then_some(value)
-        })
-}
-
 fn detect_linked_worktree(path: &Path) -> Option<bool> {
-    let git_dir = git_output(path, &["rev-parse", "--path-format=absolute", "--git-dir"])?;
-    let common_dir = git_output(
+    let git_dir = output_optional(path, &["rev-parse", "--path-format=absolute", "--git-dir"])?;
+    let common_dir = output_optional(
         path,
         &["rev-parse", "--path-format=absolute", "--git-common-dir"],
     )?;


### PR DESCRIPTION
## Summary
`homeboy-core::git` already exposes the canonical *"run git, return trimmed non-empty stdout or `None`"* primitive (`git::output_optional` / `output_optional_bytes`). Yet the same helper is **hand-rolled ~20 times** across the workspace under the name `git_output`, with drifting return types (`Option<String>` / `Result<String>` / `String`).

This is the first slice of consolidating that sprawl: delete the two copies that are **byte-for-byte equivalent** to `output_optional` and point their call sites at the canonical primitive.

## Changes
- `homeboy-release/src/deploy/types.rs` — the local `git_output` is an identical `Command`-based impl; 7 call sites now use `homeboy_core::git::output_optional`.
- `homeboy-core/src/component/inventory/path_diagnostics.rs` — its `git_output` wrapped `run_git` with the same empty-string→`None` semantics; call sites use the sibling `git::output_optional`.

**-36 lines**, behavior-identical.

## Scope discipline
Deliberately left the copies that are **not** drop-in equivalent, for per-copy verification rather than a blind mass-replace:
- `controller_runtime`'s `git_output` uses `-C <path>` (not `current_dir`) and returns `Some("")` on empty output (vs `output_optional`'s `None`) — a real behavioral difference.
- The test-module `git_output` helpers return `String` / panic on failure — different semantics for fixtures.

Follow-up PRs can migrate the `-> Result<String>` copies onto `git::run_git` and verify each remaining one individually.

## Verification (local, VPS-safe)
- `cargo check -p homeboy-release --lib` — clean
- `cargo check -p homeboy-core --lib` — clean (0 errors)
- `cargo fmt` — clean