### PR TITLE
feat(audit): detect cross-name duplication — same body under different names (#9074)

### DIFF
--- a/crates/contracts/homeboy-audit-contract/src/finding_kind.rs
+++ b/crates/contracts/homeboy-audit-contract/src/finding_kind.rs
@@ -30,6 +30,10 @@ pub enum AuditFinding {
     DirectorySprawl,
     /// Function body is duplicated across files.
     DuplicateFunction,
+    /// Two functions with *different names* have identical normalized bodies —
+    /// the same logic reimplemented under a local name (often a copy of an
+    /// existing shared primitive). Name-keyed duplicate detection misses this.
+    CrossNameDuplicate,
     /// Function has identical structure but different identifiers/literals.
     NearDuplicate,
     /// Function parameter is declared but never used in the function body.
@@ -209,6 +213,7 @@ impl AuditFinding {
             "high_item_count",
             "directory_sprawl",
             "duplicate_function",
+            "cross_name_duplicate",
             "near_duplicate",
             "unused_parameter",
             "ignored_parameter",

--- a/crates/homeboy-code-audit/src/duplication.rs
+++ b/crates/homeboy-code-audit/src/duplication.rs
@@ -183,6 +183,101 @@ pub(crate) fn detect_duplicates(
 }
 
 // ============================================================================
+// Cross-Name Duplication (same body, different names)
+// ============================================================================
+
+/// Minimum body lines for a cross-name duplicate to be worth flagging. A shared
+/// primitive reimplemented under local names is valuable to consolidate even
+/// when it is small, so this floor is lower than the near-duplicate floor — but
+/// still excludes truly trivial one/two-line bodies.
+const CROSS_NAME_MIN_BODY_LINES: usize = 1;
+
+/// Detect functions with **different names** but **identical normalized bodies**.
+///
+/// The exact- and near-duplicate detectors key on `(method_name, hash)`, so a
+/// primitive copied under a local name — e.g. a `git_output` that is byte-for-
+/// byte `homeboy_core::git::output_optional` — is invisible to them even though
+/// the body hash is name-independent. This pass groups method bodies by hash
+/// alone and flags groups that span two or more *distinct names*: the classic
+/// "you reimplemented an existing shared function under a new name" case.
+///
+/// `already_flagged_names` are method names already reported by the same-name
+/// exact detector; a cross-name group is still reported (its value is the
+/// *cross-name* link), but same-name-only groups are left to `detect_duplicates`.
+pub(crate) fn detect_cross_name_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    // hash -> list of (file, method_name)
+    let mut by_body: HashMap<&str, Vec<(&str, &str)>> = HashMap::new();
+    for fp in fingerprints {
+        for (name, hash) in &fp.method_hashes {
+            // Skip generic-named helpers and trivial bodies to control noise.
+            if GENERIC_NAMES.contains(&name.as_str()) {
+                continue;
+            }
+            if count_body_lines(fp, name) < CROSS_NAME_MIN_BODY_LINES {
+                continue;
+            }
+            by_body
+                .entry(hash.as_str())
+                .or_default()
+                .push((fp.relative_path.as_str(), name.as_str()));
+        }
+    }
+
+    let mut findings = Vec::new();
+    for locations in by_body.values() {
+        let distinct_names: HashSet<&str> = locations.iter().map(|(_, name)| *name).collect();
+        // Only interesting when the same body appears under at least two
+        // different names — that is what the name-keyed detectors miss. Require
+        // at least two locations overall as well.
+        if distinct_names.len() < 2 || locations.len() < MIN_DUPLICATE_LOCATIONS {
+            continue;
+        }
+
+        let test_only = locations.iter().all(|(file, _)| is_test_path(file));
+        let severity = if test_only {
+            Severity::Info
+        } else {
+            Severity::Warning
+        };
+
+        let mut name_list: Vec<&str> = distinct_names.into_iter().collect();
+        name_list.sort();
+        let names_joined = name_list.join("`, `");
+
+        // One finding per location, listing the others it duplicates.
+        let mut sorted_locations = locations.clone();
+        sorted_locations.sort();
+        for (file, name) in &sorted_locations {
+            let others: Vec<String> = sorted_locations
+                .iter()
+                .filter(|(f, n)| !(f == file && n == name))
+                .map(|(f, n)| format!("`{n}` in {f}"))
+                .collect();
+            findings.push(Finding {
+                convention: "duplication".to_string(),
+                severity: severity.clone(),
+                file: file.to_string(),
+                description: format!(
+                    "Function `{name}` has the same body as differently-named functions: {}",
+                    others.join(", ")
+                ),
+                suggestion: format!(
+                    "`{name}` reimplements the same logic as `{names_joined}`. Consolidate onto one shared function (prefer an existing exported primitive) and delete the copies."
+                ),
+                kind: AuditFinding::CrossNameDuplicate,
+            });
+        }
+    }
+
+    findings.sort_by(|a, b| {
+        a.file
+            .cmp(&b.file)
+            .then_with(|| a.description.cmp(&b.description))
+    });
+    findings
+}
+
+// ============================================================================
 // Near-Duplicate Detection (structural similarity)
 // ============================================================================
 

--- a/crates/homeboy-code-audit/src/duplication/tests.rs
+++ b/crates/homeboy-code-audit/src/duplication/tests.rs
@@ -1005,4 +1005,80 @@ fn rebuild_twice(items: &[Item]) -> Result<()> {
     }
 }
 
+mod cross_name {
+    use super::*;
+
+    fn fingerprint_with_body(path: &str, name: &str, hash: &str) -> FileFingerprint {
+        // A multi-line body so count_body_lines clears CROSS_NAME_MIN_BODY_LINES.
+        let content = format!(
+            "fn {name}(path: &Path, args: &[&str]) -> Option<String> {{\n    let out = run(path, args);\n    out.filter(|value| !value.is_empty())\n}}\n"
+        );
+        FileFingerprint {
+            relative_path: path.to_string(),
+            language: Language::Rust,
+            methods: vec![name.to_string()],
+            method_hashes: [(name.to_string(), hash.to_string())].into_iter().collect(),
+            content,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn flags_identical_body_under_different_names() {
+        // The git_output-vs-output_optional case: same body hash, different names,
+        // different files — invisible to the name-keyed detectors.
+        let fp1 = fingerprint_with_body("src/release/deploy.rs", "git_output", "bodyhash-1");
+        let fp2 = fingerprint_with_body("src/core/git.rs", "output_optional", "bodyhash-1");
+
+        let findings = detect_cross_name_duplicates(&[&fp1, &fp2]);
+        assert_eq!(findings.len(), 2, "one finding per location");
+        assert!(findings
+            .iter()
+            .all(|f| f.kind == AuditFinding::CrossNameDuplicate));
+        // Each finding should name the other differently-named copy.
+        assert!(findings
+            .iter()
+            .any(|f| f.description.contains("output_optional")));
+        assert!(findings
+            .iter()
+            .any(|f| f.description.contains("git_output")));
+    }
+
+    #[test]
+    fn does_not_flag_same_name_only_duplicates() {
+        // Same name + same hash is a plain duplicate (detect_duplicates' job),
+        // not a cross-name reimplementation — this pass must ignore it.
+        let fp1 = fingerprint_with_body("src/a.rs", "git_output", "bodyhash-2");
+        let fp2 = fingerprint_with_body("src/b.rs", "git_output", "bodyhash-2");
+
+        let findings = detect_cross_name_duplicates(&[&fp1, &fp2]);
+        assert!(
+            findings.is_empty(),
+            "single-name duplicates are not cross-name findings"
+        );
+    }
+
+    #[test]
+    fn does_not_flag_different_bodies() {
+        let fp1 = fingerprint_with_body("src/a.rs", "alpha", "hash-a");
+        let fp2 = fingerprint_with_body("src/b.rs", "beta", "hash-b");
+
+        let findings = detect_cross_name_duplicates(&[&fp1, &fp2]);
+        assert!(findings.is_empty(), "different bodies must not be linked");
+    }
+
+    #[test]
+    fn skips_generic_named_helpers() {
+        // `status`/`run`/etc. are on the generic-name skip list — too noisy.
+        let fp1 = fingerprint_with_body("src/a.rs", "status", "hash-g");
+        let fp2 = fingerprint_with_body("src/b.rs", "run", "hash-g");
+
+        let findings = detect_cross_name_duplicates(&[&fp1, &fp2]);
+        assert!(
+            findings.is_empty(),
+            "generic-named helpers are excluded to control noise"
+        );
+    }
+}
+
 mod parallel;

--- a/crates/homeboy-code-audit/src/engine.rs
+++ b/crates/homeboy-code-audit/src/engine.rs
@@ -347,6 +347,26 @@ pub(super) fn audit_internal(
         all_findings.extend(near_dup_findings);
     }
 
+    // Phase 4d1: Cross-name duplication (same body under different names).
+    // The exact/near-duplicate detectors key on the method name, so a shared
+    // primitive reimplemented under a local name is invisible to them. This pass
+    // groups bodies by hash regardless of name.
+    let cross_name_dup_findings = time_audit_detector(
+        &mut timing,
+        "detector.duplication.cross_name_duplicate",
+        plan.detector_enabled("duplication"),
+        || duplication::detect_cross_name_duplicates(&all_fingerprints),
+        Vec::new,
+    );
+    if !cross_name_dup_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Cross-name duplicates: {} finding(s) (identical bodies under different names)",
+            cross_name_dup_findings.len()
+        );
+        all_findings.extend(cross_name_dup_findings);
+    }
+
     // Phase 4d2: Parallel implementation detection (similar call patterns across files)
     let parallel_findings = time_audit_detector(
         &mut timing,


### PR DESCRIPTION
## Summary
Fixes the audit-engine blind spot found in **#9074**: the duplication detectors are **name-keyed**, so a shared primitive reimplemented under a *local* name is structurally invisible to them — even though the body hash is name-independent. That's exactly why ~29 copies of `git_output` (several byte-for-byte `homeboy_core::git::output_optional`) accumulated *despite* the audit engine.

## Change
New **`detect_cross_name_duplicates`** detector in `duplication.rs`:
- Groups method bodies by `exact_hash` **regardless of name** (inverting the `method_hashes` map the engine already computes).
- Flags a group only when the same body appears under **two or more distinct names** — the "you reimplemented an existing shared function under a new name" case. Same-name-only groups are left to `detect_duplicates`.
- Wired into the audit engine (`engine.rs`) as a new duplication phase, gated by the same `detector_enabled("duplication")` switch.
- Emits a new `AuditFinding::CrossNameDuplicate` kind (added to `homeboy-audit-contract`, with `all_names()` + serde round-trip intact).

### Noise control
- Skips the existing `GENERIC_NAMES` list (`run`, `status`, `get`, `find`, `read`, `write`, `resolve`, …).
- Skips bodies below a small line floor.
- Requires ≥2 locations and ≥2 distinct names.

## Why this matters
Per #9074, the manual `git_output` dedup (PR #9073) treats the symptom; **this treats the cause.** With this detector, the next time someone copies `output_optional` under a local name, the audit flags it — and it will immediately surface the remaining `git_output` copies plus any other primitive reimplemented under a different name across the workspace.

## Verification (local, VPS-safe)
- `cargo check` clean on `homeboy-audit-contract`, `homeboy-code-audit`, `homeboy-core`, `homeboy-cli`, `homeboy-refactor` — the new enum variant breaks no exhaustive match anywhere.
- `cargo test -p homeboy-audit-contract` — enum `all_names`/serde round-trip tests pass.
- 4 new detector tests: flags the `git_output`-vs-`output_optional` case; does **not** flag same-name-only duplicates, different bodies, or generic-named helpers.
- `cargo fmt` — clean.

Closes #9074.