### PR TITLE
Preserve internal symlinks in Lab snapshots

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -50,7 +50,8 @@ fn is_reserved_runner_workspace_path(relative: &str) -> bool {
 pub use homeboy_source_snapshot_contract::workspace_content_identity::{
     workspace_content_hash_algorithm, WorkspaceContentManifest, WorkspaceContentManifestEntry,
     WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY, WORKSPACE_CONTENT_PERMISSION_PORTABLE,
-    WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE, WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
+    WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
+    WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
 };
 
 pub(crate) const WORKSPACE_CONTENT_DIAGNOSTIC_PATH_LIMIT: usize = 192;
@@ -1339,14 +1340,10 @@ pub(super) fn snapshot_archive_command(
     target_command: &str,
     excludes: &[String],
 ) -> String {
-    // `-h`/`--dereference` follows symlinks and archives their target contents
-    // instead of recording the link itself. Controller-native workspaces often
-    // wire local dependencies into the tree via symlinks (e.g. a `.ci/<dep>`
-    // entry pointing at a sibling checkout/worktree). Archiving those as plain
-    // links produces a runner snapshot whose links dangle, so embedded plan
-    // paths that traverse a symlinked dependency resolve to missing files on the
-    // runner. Dereferencing materializes the real dependency contents into the
-    // snapshot so offloaded plans find them at the remapped path (#3913).
+    // A Git-backed snapshot overlays this archive onto an exact checkout. Keep
+    // links whose resolved targets stay in the source tree so tracked Git links
+    // retain their identity. Materialize only external dependency links: their
+    // targets are unavailable at the runner, but plans may traverse them (#3913).
     let root_anchored = excludes
         .iter()
         .filter(|pattern| pattern.starts_with("./"))
@@ -1357,13 +1354,27 @@ pub(super) fn snapshot_archive_command(
         .cloned()
         .collect::<Vec<_>>();
     let archive = format!(
-        "COPYFILE_DISABLE=1 tar --no-xattrs -h -C {src} {exclude} -cf -",
+        "COPYFILE_DISABLE=1 tar --no-xattrs -C \"$stage/source\" {exclude} -cf -",
+        exclude = tar_exclude_args(&excludes),
+    );
+    let source_archive = format!(
+        "COPYFILE_DISABLE=1 tar --no-xattrs -C {src} {exclude} -cf -",
         src = shell::quote_arg(&local_path.display().to_string()),
         exclude = tar_exclude_args(&excludes),
     );
+    let prepare = |source_stream: &str| {
+        format!(
+        "root=$(pwd -P) && stage=$(mktemp -d \"${{TMPDIR:-/tmp}}/homeboy-snapshot.XXXXXX\") && trap 'rm -rf \"$stage\"' EXIT && mkdir -p \"$stage/source\" && {source_stream} | tar --no-xattrs -C \"$stage/source\" -xf - && export root stage && find \"$stage/source\" -type l -exec sh -c {resolve} sh {{}} \\;",
+        resolve = shell::quote_arg(&format!("stage_link=$1; relative=${{stage_link#\"$stage/source\"/}}; original=\"$root/$relative\"; target=$(realpath \"$original\") || exit; case \"$target\" in \"$root\"|\"$root\"/*) ;; *) rm -f \"$stage_link\" && mkdir -p \"$(dirname \"$stage_link\")\" && COPYFILE_DISABLE=1 tar --no-xattrs -h -C \"$root\" {} -cf - \"$relative\" | tar --no-xattrs -C \"$stage/source\" -xf - ;; esac", tar_exclude_args(&excludes))),
+    )
+    };
 
     if root_anchored.is_empty() {
-        return format!("{archive} . | {target_command}");
+        let prepare = prepare(&format!("{source_archive} ."));
+        return format!(
+            "(cd {src} && {prepare} && {archive} .) | {target_command}",
+            src = shell::quote_arg(&local_path.display().to_string())
+        );
     }
 
     let root_filter = root_anchored
@@ -1371,8 +1382,10 @@ pub(super) fn snapshot_archive_command(
         .map(|pattern| format!("! -path {}", shell::quote_arg(pattern)))
         .collect::<Vec<_>>()
         .join(" ");
+    let root_input = format!("find . -mindepth 1 -maxdepth 1 {root_filter} -print0",);
+    let prepare = prepare(&format!("({root_input}) | {source_archive} --null -T -"));
     format!(
-        "(cd {src} && find . -mindepth 1 -maxdepth 1 {root_filter} -print0) | {archive} --null -T - | {target_command}",
+        "(cd {src} && {prepare} && ({root_input}) | {archive} --null -T -) | {target_command}",
         src = shell::quote_arg(&local_path.display().to_string()),
     )
 }

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -1125,7 +1125,7 @@ fn snapshot_archive_command_disables_extended_attributes() {
 }
 
 #[test]
-fn snapshot_archive_command_dereferences_symlinked_dependencies() {
+fn snapshot_archive_command_selectively_dereferences_external_symlinked_dependencies() {
     // Symlinked plan dependencies (e.g. a `.ci/<dep>` link to a sibling
     // checkout) must be materialized into the runner snapshot so offloaded
     // plans whose embedded paths traverse the symlink resolve on the runner
@@ -1137,9 +1137,97 @@ fn snapshot_archive_command_dereferences_symlinked_dependencies() {
     );
 
     assert!(
-        command.contains("tar --no-xattrs -h "),
-        "snapshot tar must dereference symlinks: {command}"
+        command.contains("find \"$stage/source\" -type l -exec sh -c"),
+        "snapshot archive must inspect symlink targets: {command}"
     );
+    assert!(command.contains("tar --no-xattrs -h -C \"$root\""));
+    assert!(
+        !command.contains("cp -a . \"$stage/source\""),
+        "the staging tree must be populated by the exclusion-filtered tar stream: {command}"
+    );
+    assert!(
+        command.contains("tar --no-xattrs -C \"$stage/source\""),
+        "the final snapshot archive must preserve internal symlink entries: {command}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn git_backed_snapshot_preserves_tracked_internal_file_and_directory_links() {
+    use std::os::unix::fs::symlink;
+
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let controller = tempfile::tempdir().expect("controller");
+        let source = controller.path().join("source");
+        let runner_root = tempfile::tempdir().expect("runner root");
+        fs::create_dir_all(source.join("shared")).expect("shared directory");
+        fs::create_dir_all(source.join("links")).expect("links directory");
+        fs::write(source.join("shared/helper.mjs"), "export default 1;\n").expect("helper");
+        fs::write(source.join("shared/tool.mjs"), "export default 2;\n").expect("tool");
+        symlink("../shared/helper.mjs", source.join("links/helper.mjs"))
+            .expect("internal file link");
+        symlink("../shared", source.join("links/shared")).expect("internal directory link");
+        git(&source, &["init", "-b", "main"]);
+        git(&source, &["add", "."]);
+        git(
+            &source,
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=test@homeboy.invalid",
+                "commit",
+                "-m",
+                "source",
+            ],
+        );
+
+        crate::create(
+            &format!(
+                r#"{{"id":"lab-internal-links","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+        let (output, _) = sync_workspace(
+            "lab-internal-links",
+            RunnerWorkspaceSyncOptions {
+                path: source.display().to_string(),
+                mode: RunnerWorkspaceSyncMode::Snapshot,
+                ..Default::default()
+            },
+        )
+        .expect("materialize Git-backed snapshot");
+        let remote = Path::new(&output.remote_path);
+
+        assert!(remote
+            .join("links/helper.mjs")
+            .symlink_metadata()
+            .expect("file link metadata")
+            .file_type()
+            .is_symlink());
+        assert!(remote
+            .join("links/shared")
+            .symlink_metadata()
+            .expect("directory link metadata")
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            fs::read_link(remote.join("links/helper.mjs")).expect("file link target"),
+            Path::new("../shared/helper.mjs")
+        );
+        assert_eq!(
+            fs::read_link(remote.join("links/shared")).expect("directory link target"),
+            Path::new("../shared")
+        );
+        assert!(
+            git_output(remote, &["status", "--porcelain=v1"])
+                .expect("remote status")
+                .is_empty(),
+            "tracked internal links must not change the exact Git checkout"
+        );
+    });
 }
 
 #[test]
@@ -1783,14 +1871,26 @@ fn copy_snapshot_materializes_symlinked_dependency_contents() {
     let source = controller.path().join("primary");
     let dependency = controller.path().join("dependency");
     let dependency_file = dependency.join("packages/cli/dist/index.js");
+    let excluded_dependency_file = dependency.join("generated-state/secret.txt");
     std::fs::create_dir_all(dependency_file.parent().unwrap()).expect("dependency dir");
+    std::fs::create_dir_all(excluded_dependency_file.parent().unwrap())
+        .expect("excluded dependency dir");
     std::fs::write(&dependency_file, "#!/usr/bin/env node\n").expect("dependency file");
+    std::fs::write(&excluded_dependency_file, "controller-only\n")
+        .expect("excluded dependency file");
     std::fs::create_dir_all(source.join(".ci")).expect("ci dir");
     std::os::unix::fs::symlink(&dependency, source.join(".ci/dep")).expect("dep symlink");
 
     let destination = controller.path().join("snapshot");
-    crate::workspace::snapshot::copy_snapshot_to_directory(&source, &destination, &[])
-        .expect("copy snapshot");
+    crate::workspace::snapshot::copy_snapshot_to_directory(
+        &source,
+        &destination,
+        &[
+            "generated-state".to_string(),
+            "generated-state/**".to_string(),
+        ],
+    )
+    .expect("copy snapshot");
 
     let materialized = destination.join(".ci/dep/packages/cli/dist/index.js");
     assert!(
@@ -1800,5 +1900,11 @@ fn copy_snapshot_materializes_symlinked_dependency_contents() {
     assert_eq!(
         std::fs::read_to_string(&materialized).expect("materialized dependency file"),
         "#!/usr/bin/env node\n"
+    );
+    assert!(
+        !destination
+            .join(".ci/dep/generated-state/secret.txt")
+            .exists(),
+        "snapshot exclusions must also apply inside dereferenced dependencies"
     );
 }


### PR DESCRIPTION
## Summary
Preserve internal symlinks in Lab snapshots

## What changed
- Applies the verified agent-task candidate.

## How to test
1. Run `cargo fmt --check && cargo test -p homeboy-lab-runner workspace::tests::snapshot -- --nocapture`; expect passes.

## Compatibility
No compatibility impact was recorded by the cook workflow.

## Evidence
- Base unchanged since verification: main remains at a1f9b5eb0db488aece70cf4a7cea8bc3ada79d97.
- CI expected: Homeboy CI after push
- Durable run execution: PartialFailure
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/9070
- Verified finalization base: main at a1f9b5eb0db488aece70cf4a7cea8bc3ada79d97
- gate-1: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.6-sol)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab snapshot symlink contract collision, implemented selective materialization, and added deterministic coverage with Chris reviewing and owning the change.
