### PR TITLE
refactor: add git::output_allow_empty and consolidate the -C keep-empty git_output family

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/apply.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/apply.rs
@@ -13,6 +13,7 @@ use crate::agent_task_gate::{
     AgentTaskGateRevealPolicy, AgentTaskGateVisibility,
 };
 use homeboy_core::command_invocation::CommandInvocation;
+use homeboy_core::git::output_allow_empty;
 use homeboy_core::stream_capture::StreamCaptureMetadata;
 use homeboy_core::{worktree_providers, Error, Result};
 
@@ -794,7 +795,7 @@ pub(crate) fn run_provider_command(
 }
 
 fn validate_provider_workspace_path(path: &Path) -> Result<()> {
-    match git_output(path, &["rev-parse", "--is-inside-work-tree"]) {
+    match output_allow_empty(path, &["rev-parse", "--is-inside-work-tree"]) {
         Some(value) if value == "true" => Ok(()),
         _ => Err(Error::validation_invalid_argument(
             "promotion_provider.response.workspace_path",
@@ -806,17 +807,4 @@ fn validate_provider_workspace_path(path: &Path) -> Result<()> {
             None,
         )),
     }
-}
-
-fn git_output(cwd: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(cwd)
-        .args(args)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }

--- a/crates/homeboy-agents/src/agent_task_promotion/types.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/types.rs
@@ -1,5 +1,4 @@
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -7,6 +6,7 @@ use serde_json::Value;
 use crate::agent_task_gate::{AgentTaskGateReport, VerifyGateOptions};
 use homeboy_core::command_invocation::CommandInvocation;
 use homeboy_core::gate::HomeboyGateResult;
+use homeboy_core::git::output_allow_empty;
 use homeboy_core::stream_capture::StreamCaptureMetadata;
 
 pub const AGENT_TASK_PROMOTION_REPORT_SCHEMA: &str = "homeboy/agent-task-promotion-report/v1";
@@ -210,26 +210,15 @@ impl AgentTaskPromotionTarget {
         Self {
             worktree,
             path: path.map(|path| path.display().to_string()),
-            branch: path.and_then(|path| git_output(path, &["rev-parse", "--abbrev-ref", "HEAD"])),
-            head: path.and_then(|path| git_output(path, &["rev-parse", "HEAD"])),
+            branch: path
+                .and_then(|path| output_allow_empty(path, &["rev-parse", "--abbrev-ref", "HEAD"])),
+            head: path.and_then(|path| output_allow_empty(path, &["rev-parse", "HEAD"])),
             dirty: path.and_then(|path| {
-                git_output(path, &["status", "--porcelain"]).map(|status| !status.is_empty())
+                output_allow_empty(path, &["status", "--porcelain"])
+                    .map(|status| !status.is_empty())
             }),
         }
     }
-}
-
-fn git_output(cwd: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(cwd)
-        .args(args)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 fn promotion_report_schema() -> String {

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -1361,21 +1361,11 @@ fn source_provenance() -> Value {
     let cwd = std::env::current_dir().ok();
     let revision = cwd
         .as_ref()
-        .and_then(|path| git_output(path, ["rev-parse", "HEAD"]));
-    let repository = cwd
-        .as_ref()
-        .and_then(|path| git_output(path, ["config", "--get", "remote.origin.url"]));
+        .and_then(|path| crate::git::output_allow_empty(path, &["rev-parse", "HEAD"]));
+    let repository = cwd.as_ref().and_then(|path| {
+        crate::git::output_allow_empty(path, &["config", "--get", "remote.origin.url"])
+    });
     json!({ "revision": revision, "repository": repository, "verification": "observed_from_process_cwd" })
-}
-
-fn git_output(path: &Path, args: impl IntoIterator<Item = &'static str>) -> Option<String> {
-    Command::new("git")
-        .args(["-C", &path.display().to_string()])
-        .args(args)
-        .output()
-        .ok()
-        .filter(|output| output.status.success())
-        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 fn run_command<const N: usize>(program: &str, args: [&str; N]) -> Result<()> {

--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -89,9 +89,9 @@ pub use primitives::{
 };
 pub use primitives::{is_git_repo, is_tracked_path};
 pub use primitives_query::{
-    current_branch, head_sha, head_sha_short, output_optional, output_optional_bytes,
-    remote_origin_url, remote_url, repo_root, rev_parse, short_head_revision, status_porcelain,
-    status_porcelain_bytes, toplevel,
+    current_branch, head_sha, head_sha_short, output_allow_empty, output_optional,
+    output_optional_bytes, remote_origin_url, remote_url, repo_root, rev_parse,
+    short_head_revision, status_porcelain, status_porcelain_bytes, toplevel,
 };
 
 use std::path::Path;

--- a/crates/homeboy-core/src/git/primitives_query.rs
+++ b/crates/homeboy-core/src/git/primitives_query.rs
@@ -33,6 +33,29 @@ pub fn output_optional(git_root: &Path, args: &[&str]) -> Option<String> {
     (!value.is_empty()).then_some(value)
 }
 
+/// Run a git command (via `git -C <path>`) and return trimmed stdout on success,
+/// *including* the empty string.
+///
+/// Unlike [`output_optional`], a successful command that produces no output
+/// yields `Some("")` rather than `None` — empty output is a valid result for
+/// commands like `git status --porcelain` on a clean tree, and some callers
+/// need to distinguish "ran clean" (`Some("")`) from "failed" (`None`). Callers
+/// that require non-empty output validate it themselves.
+pub fn output_allow_empty(path: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
 /// Get the full HEAD commit SHA from a git directory.
 pub fn head_sha(git_root: &Path) -> Option<String> {
     output_optional(git_root, &["rev-parse", "HEAD"])

--- a/crates/homeboy-lab-runner/src/upgrade_runners/source_checkout.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/source_checkout.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate as runner;
 use crate::Runner;
 use crate::RunnerExecOptions;
+use homeboy_core::git::output_allow_empty;
 use homeboy_core::Result;
 use homeboy_lab_runner_contract::RunnerCapabilityPreflight;
 use homeboy_lab_runner_contract::RunnerKind;
@@ -11,18 +12,17 @@ use homeboy_lab_runner_contract::RunnerWorkspaceSyncOptions;
 use homeboy_upgrade::upgrade::current_version;
 use homeboy_upgrade::upgrade::InstallMethod;
 use std::path::Path;
-use std::process::Command;
 
 pub fn source_checkout_build_identity(source_path: &Path) -> Option<String> {
     // `rev-parse` must produce a commit hash; an empty result means we can't
     // identify the checkout, so treat it as failure.
-    let commit = git_output(source_path, &["rev-parse", "--short=12", "HEAD"])?;
+    let commit = output_allow_empty(source_path, &["rev-parse", "--short=12", "HEAD"])?;
     if commit.trim().is_empty() {
         return None;
     }
     // `git status --porcelain` returns empty output for a clean tree, which is
     // the normal, successful case — empty here must NOT be treated as failure.
-    let status = git_output(source_path, &["status", "--porcelain"])?;
+    let status = output_allow_empty(source_path, &["status", "--porcelain"])?;
     let dirty_suffix = if status.trim().is_empty() {
         ""
     } else {
@@ -35,23 +35,6 @@ pub fn source_checkout_build_identity(source_path: &Path) -> Option<String> {
         commit.trim(),
         dirty_suffix
     ))
-}
-
-pub fn git_output(source_path: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(source_path)
-        .args(args)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    // Return the (possibly empty) stdout on success. Empty output is valid for
-    // commands like `git status --porcelain` on a clean tree; callers that
-    // require non-empty output must validate it themselves.
-    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 pub fn prepare_runner_source_checkout_for_upgrade(


### PR DESCRIPTION
## Summary
Second slice of the `git_output` consolidation — and it surfaced something important: **there are two distinct git-output semantics, not one.**

- Some copies filter empty output to `None` → that's `git::output_optional` (consolidated in PR #9073).
- A **separate family** runs `git -C <path>` and deliberately returns `Some("")` on empty success — because empty output is a *valid* result for commands like `git status --porcelain` on a clean tree, and callers distinguish "ran clean" (`Some("")`) from "failed" (`None`). One copy even documented this in a comment.

`output_optional` is **not** a drop-in for these (it would collapse `Some("")` → `None` and change behavior). Blindly merging them would have been a bug — which is exactly why the earlier PRs left them alone pending per-copy verification.

## Change
Add the missing canonical primitive **`git::output_allow_empty(path, args)`** with the keep-empty semantic, and consolidate the four byte-equivalent copies onto it:
- `lab-runner/upgrade_runners/source_checkout.rs`
- `agents/agent_task_promotion/apply.rs` + `types.rs`
- `core/controller_runtime.rs`

**Net -27 lines**, behavior-preserving.

This is precisely the cross-name reimplementation the new audit detector (#9076) is built to flag — and the fix is the "right" one: not force everything onto a single primitive, but recognize the two legitimate semantics and give each a single shared home.

## Verification (local, VPS-safe)
- `cargo check -p homeboy-core --lib` / `-p homeboy-lab-runner --lib` / `-p homeboy-agents --lib` — all clean
- `cargo test -p homeboy-core --lib git::` — 196 pass
- `cargo fmt` — clean