### PR TITLE
refactor: replace pr_refresh's local git_output with git::run_git_output

### DIFF
--- a/crates/homeboy-core/src/git/pr_refresh.rs
+++ b/crates/homeboy-core/src/git/pr_refresh.rs
@@ -132,24 +132,28 @@ pub fn pr_refresh(
 
     let strategy = resolve_strategy(root, options.strategy, &branch)?;
     let update = match strategy {
-        PrRefreshStrategy::Rebase => {
-            git_output(root, &["rebase", &format!("origin/{}", pr.base_ref_name)])
-        }
-        PrRefreshStrategy::Merge => git_output(
+        PrRefreshStrategy::Rebase => super::run_git_output(
+            root,
+            &["rebase", &format!("origin/{}", pr.base_ref_name)],
+            "pr refresh",
+        ),
+        PrRefreshStrategy::Merge => super::run_git_output(
             root,
             &[
                 "merge",
                 "--no-edit",
                 &format!("origin/{}", pr.base_ref_name),
             ],
+            "pr refresh",
         ),
-        PrRefreshStrategy::FfOnly => git_output(
+        PrRefreshStrategy::FfOnly => super::run_git_output(
             root,
             &[
                 "merge",
                 "--ff-only",
                 &format!("origin/{}", pr.base_ref_name),
             ],
+            "pr refresh",
         ),
         PrRefreshStrategy::Auto => unreachable!("auto strategy resolved before update"),
     }?;
@@ -372,7 +376,7 @@ fn status_porcelain(root: &Path) -> Result<String> {
 }
 
 fn git_stdout_optional(root: &Path, args: &[&str]) -> Result<Option<String>> {
-    let output = git_output(root, args)?;
+    let output = super::run_git_output(root, args, "pr refresh")?;
     if output.status.success() {
         Ok(Some(
             String::from_utf8_lossy(&output.stdout).trim().to_string(),
@@ -388,7 +392,7 @@ fn git_stdout(root: &Path, args: &[&str], label: &str) -> Result<String> {
 }
 
 fn git_checked(root: &Path, args: &[&str], label: &str) -> Result<std::process::Output> {
-    let output = git_output(root, args)?;
+    let output = super::run_git_output(root, args, "pr refresh")?;
     if output.status.success() {
         Ok(output)
     } else {
@@ -397,14 +401,6 @@ fn git_checked(root: &Path, args: &[&str], label: &str) -> Result<std::process::
             String::from_utf8_lossy(&output.stderr)
         )))
     }
-}
-
-fn git_output(root: &Path, args: &[&str]) -> Result<std::process::Output> {
-    Command::new("git")
-        .args(args)
-        .current_dir(root)
-        .output()
-        .map_err(|e| Error::git_command_failed(format!("git failed: {e}")))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
Third slice of the `git_output` consolidation — the `Result<std::process::Output>` family.

`pr_refresh.rs` (which lives **inside `core::git`**) hand-rolled a `git_output` that just runs `git <args>` in a directory and returns the raw `Output` — a weaker copy of its sibling primitive `git::run_git_output`, which does exactly that but produces **richer command-failure diagnostics** (command / cwd / exit code / stdout / stderr).

## Change
Point all 5 call sites at `super::run_git_output` (with a `"pr refresh"` context label) and delete the local copy. The callers only branch on `Ok`/`Err` and read `Output.status`/`.stdout`, so the richer error is transparent to them.

## Scope note
The `Result<String>` `git_output` family (`workspace/util`, `agent_task_finalization/backend`, `offload_changed_since`, `cook`) is a **bigger, higher-risk** migration — those have 60+ call sites and custom / domain-specific error construction (`validation_invalid_argument`, env support) that would need per-copy preservation. Left for a dedicated pass rather than a rushed change. `checkout_guard`'s copy already delegates to a core release-runner (`execute_git_for_release`), so it's not a plain duplicate.

## Verification (local, VPS-safe)
- `cargo check -p homeboy-core --lib` — clean
- `cargo test -p homeboy-core --lib pr_refresh` — 3 pass
- `cargo fmt` — clean