### PR TITLE
Project bench environment into rig workloads

### DIFF
--- a/crates/homeboy-cli/src/commands/bench/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/mod.rs
@@ -83,7 +83,7 @@ for scenario in $selected; do
     artifacts=", \"artifacts\": { \"visual_comparison_dir\": { \"path\": \"$visual_comparison_dir\", \"type\": \"directory\" } }"
   fi
   cat >> "$HOMEBOY_BENCH_RESULTS_FILE" <<JSON
-    $comma{ "id": "$scenario", "iterations": ${HOMEBOY_BENCH_ITERATIONS:-0}, "metrics": { "p95_ms": 1.0, "warmup_iterations": ${HOMEBOY_BENCH_WARMUP_ITERATIONS:--1} }$artifacts }
+    $comma{ "id": "$scenario", "iterations": ${HOMEBOY_BENCH_ITERATIONS:-0}, "metrics": { "p95_ms": 1.0, "warmup_iterations": ${HOMEBOY_BENCH_WARMUP_ITERATIONS:--1}, "bench_env_projected": $(if [ "$BENCH_ENV_PROJECTION" = "present" ]; then printf 1; else printf 0; fi) }$artifacts }
 JSON
   comma=",
 "

--- a/crates/homeboy-cli/src/commands/bench/tests/scenario_run_tests.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/scenario_run_tests.rs
@@ -1,6 +1,48 @@
 use super::*;
 
 #[test]
+fn local_rig_workloads_receive_dotted_and_typed_bench_env_settings() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let component = tempfile::TempDir::new().expect("component");
+        install_rig_package(home, "env-projection-rig", "studio", component.path());
+
+        for setting_args in [
+            SettingArgs {
+                setting: vec![(
+                    "bench_env.BENCH_ENV_PROJECTION".to_string(),
+                    "present".to_string(),
+                )],
+                ..Default::default()
+            },
+            SettingArgs {
+                setting_json: vec![(
+                    "bench_env".to_string(),
+                    serde_json::json!({ "BENCH_ENV_PROJECTION": "present" }),
+                )],
+                ..Default::default()
+            },
+        ] {
+            let mut args = run_args(None, vec!["env-projection-rig".to_string()], Vec::new());
+            args.run.setting_args = setting_args;
+            let (output, exit_code) =
+                run(args, &GlobalArgs {}).expect("local rig bench should run");
+
+            assert_eq!(exit_code, 0);
+            let BenchOutput::Single(output) = output else {
+                panic!("expected single bench output");
+            };
+            assert_eq!(
+                output.results.expect("results").scenarios[0]
+                    .metrics
+                    .get("bench_env_projected"),
+                Some(1.0),
+            );
+        }
+    });
+}
+
+#[test]
 fn single_rig_run_records_installed_rig_package_evidence_in_metadata() {
     with_isolated_home(|home| {
         write_bench_extension(home);

--- a/crates/homeboy-extension/src/bench/run/runner.rs
+++ b/crates/homeboy-extension/src/bench/run/runner.rs
@@ -204,6 +204,13 @@ pub(crate) fn build_runner(
     .passthrough(false)
     .stderr_passthrough(bench_progress_enabled());
 
+    // Rig workloads receive bench_env as direct child-process variables. Add
+    // these before runner and CI environment so those explicit scopes retain
+    // their established override precedence.
+    for (key, value) in bench_env_vars(&args.settings, &args.settings_json) {
+        runner = runner.env(&key, &value);
+    }
+
     for (key, value) in &args.ci_env {
         runner = runner.env(key, value);
     }
@@ -235,6 +242,34 @@ pub(crate) fn build_runner(
     }
 
     Ok(runner)
+}
+
+fn bench_env_vars(
+    settings: &[(String, String)],
+    settings_json: &[(String, serde_json::Value)],
+) -> Vec<(String, String)> {
+    let mut env = settings
+        .iter()
+        .filter_map(|(key, value)| {
+            key.strip_prefix("bench_env.")
+                .filter(|key| !key.is_empty() && !key.contains('.'))
+                .map(|key| (key.to_string(), value.clone()))
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    if let Some((_, serde_json::Value::Object(values))) = settings_json
+        .iter()
+        .rev()
+        .find(|(key, _)| key == "bench_env")
+    {
+        for (key, value) in values {
+            if let Some(value) = value.as_str() {
+                env.insert(key.clone(), value.to_string());
+            }
+        }
+    }
+
+    env.into_iter().collect()
 }
 
 pub(crate) fn clear_responsiveness_file(run_dir: &RunDir) -> Result<()> {
@@ -269,6 +304,39 @@ pub(crate) fn bench_progress_env_value() -> &'static str {
         "1"
     } else {
         "0"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bench_env_vars_projects_string_values_only() {
+        assert_eq!(
+            bench_env_vars(
+                &[],
+                &[(
+                    "bench_env".to_string(),
+                    serde_json::json!({ "FIXTURE": "/tmp/source.fig", "RETRIES": 2 }),
+                )]
+            ),
+            vec![("FIXTURE".to_string(), "/tmp/source.fig".to_string())]
+        );
+    }
+
+    #[test]
+    fn bench_env_vars_normalizes_dotted_overrides_before_typed_json() {
+        assert_eq!(
+            bench_env_vars(
+                &[("bench_env.FIXTURE".to_string(), "dotted".to_string())],
+                &[(
+                    "bench_env".to_string(),
+                    serde_json::json!({ "FIXTURE": "typed" })
+                )],
+            ),
+            vec![("FIXTURE".to_string(), "typed".to_string())]
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
Project rig bench\_env settings into benchmark workload child processes.

## What changed
- Forward dotted and typed string-valued bench\_env settings while preserving existing runner and CI override precedence.

## How to test
1. Run `cargo test -p homeboy-cli local_rig_workloads_receive_dotted_and_typed_bench_env_settings`; expect passes.
2. Run `cargo test -p homeboy-extension bench_env_vars`; expect passes.

## Compatibility
No extension-path or backwards-compatibility impact; existing CI and runner environment precedence is preserved.

## Evidence
- Base advanced after verification: verified main at cfb26a9b7346c2409fa0d3a14afd4e1a3c8c5320; publication observed 05e69d3357e167ab66a5d3d724165d0abef919c0. Candidate ancestry was validated against the verified snapshot.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/9075
- Verified finalization base: main at cfb26a9b7346c2409fa0d3a14afd4e1a3c8c5320
- targeted-tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Drafted, reviewed, and verified the implementation and regression coverage with Chris.

## Source relationships
- Closes Extra-Chill/homeboy#9075
