### PR TITLE
feat(error): add ergonomic invalid_argument constructors and migrate homeboy-fuzz

### DIFF
--- a/crates/homeboy-error/src/lib.rs
+++ b/crates/homeboy-error/src/lib.rs
@@ -429,6 +429,27 @@ impl Error {
         Self::validation_invalid_argument_with_evidence(field, problem, id, tried, None)
     }
 
+    /// Ergonomic shorthand for the common invalid-argument case: just the field
+    /// and the problem, with no offending id and no suggested alternatives.
+    ///
+    /// Equivalent to `validation_invalid_argument(field, problem, None, None)` —
+    /// most call sites carry those two trailing `None`s as pure scaffolding.
+    pub fn invalid_argument(field: impl Into<String>, problem: impl Into<String>) -> Self {
+        Self::validation_invalid_argument(field, problem, None, None)
+    }
+
+    /// Ergonomic shorthand for an invalid argument that names the offending id
+    /// (e.g. a path or value) but has no suggested alternatives.
+    ///
+    /// Equivalent to `validation_invalid_argument(field, problem, Some(id), None)`.
+    pub fn invalid_argument_for(
+        field: impl Into<String>,
+        problem: impl Into<String>,
+        id: impl Into<String>,
+    ) -> Self {
+        Self::validation_invalid_argument(field, problem, Some(id.into()), None)
+    }
+
     /// Same as [`Self::validation_invalid_argument`] but attaches captured
     /// [`CommandEvidence`] (resolved command, cwd, exit code, stdout/stderr) so
     /// command-backed validation failures (e.g. the release `preflight.test`
@@ -1129,5 +1150,33 @@ impl Error {
             ),
             _ => self,
         }
+    }
+}
+
+#[cfg(test)]
+mod ergonomic_constructor_tests {
+    use super::*;
+
+    #[test]
+    fn invalid_argument_equals_the_verbose_none_none_form() {
+        let short = Error::invalid_argument("field", "problem");
+        let verbose = Error::validation_invalid_argument("field", "problem", None, None);
+        assert_eq!(short.code, verbose.code);
+        assert_eq!(short.message, verbose.message);
+        assert_eq!(short.details, verbose.details);
+    }
+
+    #[test]
+    fn invalid_argument_for_equals_the_verbose_some_id_none_form() {
+        let short = Error::invalid_argument_for("field", "problem", "the-id");
+        let verbose = Error::validation_invalid_argument(
+            "field",
+            "problem",
+            Some("the-id".to_string()),
+            None,
+        );
+        assert_eq!(short.code, verbose.code);
+        assert_eq!(short.message, verbose.message);
+        assert_eq!(short.details, verbose.details);
     }
 }

--- a/crates/homeboy-fuzz/src/coverage_reconciliation_persistence.rs
+++ b/crates/homeboy-fuzz/src/coverage_reconciliation_persistence.rs
@@ -35,11 +35,10 @@ pub fn persist_fuzz_coverage_reconciliation(
         )
     })?;
     let request: crate::FuzzExecutionRequest = serde_json::from_str(&raw).map_err(|error| {
-        homeboy_core::Error::validation_invalid_argument(
+        homeboy_core::Error::invalid_argument_for(
             "fuzz_execution_request",
             format!("failed to parse fuzz execution request for coverage reconciliation: {error}"),
-            Some(execution_request_path.display().to_string()),
-            None,
+            execution_request_path.display().to_string(),
         )
     })?;
     let reconciliation = reconcile_fuzz_coverage(&request, campaign);

--- a/crates/homeboy-fuzz/src/parse.rs
+++ b/crates/homeboy-fuzz/src/parse.rs
@@ -24,14 +24,13 @@ pub fn parse_fuzz_results_file(path: &Path) -> Result<FuzzCampaign> {
         )
     })?;
     if campaign.schema != FUZZ_CAMPAIGN_SCHEMA {
-        return Err(Error::validation_invalid_argument(
+        return Err(Error::invalid_argument_for(
             "schema",
             format!(
                 "fuzz results schema must be {FUZZ_CAMPAIGN_SCHEMA}, got {}",
                 campaign.schema
             ),
-            Some(campaign.schema),
-            None,
+            campaign.schema,
         ));
     }
     Ok(campaign)
@@ -41,12 +40,7 @@ pub fn parse_fuzz_case_log_file(path: &Path) -> Result<Vec<FuzzCaseLogEntry>> {
     let contents = std::fs::read_to_string(path)
         .map_err(|err| Error::internal_io(err.to_string(), Some(path.display().to_string())))?;
     let entries = parse_fuzz_case_log_contents(&contents).map_err(|message| {
-        Error::validation_invalid_argument(
-            "case_log",
-            message,
-            Some(path.display().to_string()),
-            None,
-        )
+        Error::invalid_argument_for("case_log", message, path.display().to_string())
     })?;
     Ok(entries)
 }
@@ -118,14 +112,13 @@ pub fn parse_fuzz_result_envelope_file(path: &Path) -> Result<FuzzResultEnvelope
         )
     })?;
     if envelope.schema != FUZZ_RESULT_ENVELOPE_SCHEMA {
-        return Err(Error::validation_invalid_argument(
+        return Err(Error::invalid_argument_for(
             "schema",
             format!(
                 "fuzz result envelope schema must be {FUZZ_RESULT_ENVELOPE_SCHEMA}, got {}",
                 envelope.schema
             ),
-            Some(envelope.schema),
-            None,
+            envelope.schema,
         ));
     }
     Ok(envelope)
@@ -145,12 +138,7 @@ pub fn parse_fuzz_target_inventory_file(path: &Path) -> Result<FuzzTargetInvento
         )
     })?;
     FuzzTargetInventory::from_value(value).map_err(|message| {
-        Error::validation_invalid_argument(
-            "inventory",
-            message,
-            Some(path.display().to_string()),
-            None,
-        )
+        Error::invalid_argument_for("inventory", message, path.display().to_string())
     })
 }
 
@@ -165,12 +153,7 @@ pub fn parse_fuzz_action_model_file(path: &Path) -> Result<FuzzActionModel> {
         )
     })?;
     FuzzActionModel::from_value(value).map_err(|message| {
-        Error::validation_invalid_argument(
-            "action_model",
-            message,
-            Some(path.display().to_string()),
-            None,
-        )
+        Error::invalid_argument_for("action_model", message, path.display().to_string())
     })
 }
 
@@ -185,12 +168,7 @@ pub fn parse_fuzz_workload_file(path: &Path) -> Result<FuzzWorkload> {
         )
     })?;
     FuzzWorkload::from_value(value).map_err(|message| {
-        Error::validation_invalid_argument(
-            "workload",
-            message,
-            Some(path.display().to_string()),
-            None,
-        )
+        Error::invalid_argument_for("workload", message, path.display().to_string())
     })
 }
 
@@ -208,12 +186,7 @@ pub fn parse_fuzz_exploration_policy_file(path: &Path) -> Result<FuzzExploration
         )
     })?;
     FuzzExplorationPolicy::from_value(value).map_err(|message| {
-        Error::validation_invalid_argument(
-            "exploration_policy",
-            message,
-            Some(path.display().to_string()),
-            None,
-        )
+        Error::invalid_argument_for("exploration_policy", message, path.display().to_string())
     })
 }
 
@@ -228,12 +201,7 @@ pub fn parse_fuzz_sequence_plan_file(path: &Path) -> Result<FuzzSequencePlan> {
         )
     })?;
     FuzzSequencePlan::from_value(value).map_err(|message| {
-        Error::validation_invalid_argument(
-            "sequence_plan",
-            message,
-            Some(path.display().to_string()),
-            None,
-        )
+        Error::invalid_argument_for("sequence_plan", message, path.display().to_string())
     })
 }
 


### PR DESCRIPTION
## Summary
You asked the right question: we have a whole `homeboy-error` crate — so the fix for repetitive error scaffolding belongs *there*, not at every call site.

`Error::validation_invalid_argument` takes 4 args `(field, problem, id, tried)`. Measured across the workspace: **~2000 call sites**, of which **~1625 pass `tried = None`** (no suggestions), and **~668 of those also pass `id = None`**. Every one carries one or two trailing `None`s (or `Some(x), None`) purely to satisfy the signature.

## Change
Add two shorthand constructors **on the error type** where they belong:
- `Error::invalid_argument(field, problem)` — the field+problem-only case (~668 sites)
- `Error::invalid_argument_for(field, problem, id)` — names the offending id, no suggestions (~951 sites)

Both **delegate to `validation_invalid_argument`**, so the produced error is byte-identical. Two tests assert `code` / `message` / `details` equality against the verbose form — provably equivalent, not just "looks the same."

## Proof migration
Migrated `homeboy-fuzz`'s 9 call sites onto `invalid_argument_for` (`Some(path), None` → just the path). `parse.rs` shrinks accordingly. The remaining ~1600 no-suggestion sites across the workspace can adopt these incrementally (or via the refactor engine) — this PR establishes the constructors + the pattern without a 1600-site mega-diff.

## Verification (local, VPS-safe)
- `cargo check -p homeboy-error` / `-p homeboy-fuzz --lib` — clean
- `cargo test -p homeboy-error` — 2 new equivalence tests pass (shorthand == verbose)
- `cargo test -p homeboy-fuzz --lib` — 39 pass
- `cargo fmt` — clean