### PR TITLE
Fix idempotent agent-task artifact projection

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -795,6 +795,60 @@ mod tests {
             .push(artifact("second-patch", "patch", Some("runner-b")));
         assert!(runner_id_from_artifact_provenance(&aggregate).is_err());
     }
+
+    #[test]
+    fn reusable_artifact_rejects_conflicting_persisted_logical_identity() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let store = homeboy_core::observation::ObservationStore::open_initialized()
+                .expect("observation store");
+            let run = store
+                .start_run(
+                    homeboy_core::observation::NewRunRecord::builder("agent-task")
+                        .cwd_path(home.path())
+                        .build(),
+                )
+                .expect("run");
+            let path = home.path().join("patch.diff");
+            let bytes = b"patch";
+            std::fs::write(&path, bytes).expect("patch bytes");
+            let mut artifact = artifact("patch", "patch", None);
+            artifact.size_bytes = Some(bytes.len() as u64);
+            artifact.sha256 = Some(format!("{:x}", sha2::Sha256::digest(bytes)));
+            store
+                .record_artifact_with_id(
+                    &run.id,
+                    "patch",
+                    &path,
+                    "stable-patch",
+                    json!({
+                        "agent_task": {
+                            "task_id": "other-task",
+                            "logical_artifact_id": "patch",
+                        }
+                    }),
+                )
+                .expect("imported artifact");
+
+            let error = reusable_terminal_artifact(
+                &store,
+                &run.id,
+                "task",
+                &artifact,
+                "stable-patch",
+                &json!({
+                    "agent_task": {
+                        "task_id": "task",
+                        "logical_artifact_id": "patch",
+                    }
+                }),
+            )
+            .expect_err("conflicting logical identity must fail closed");
+
+            assert!(error
+                .message
+                .contains("conflicts with terminal artifact projection"));
+        });
+    }
 }
 
 /// Project finalized executor artifacts into the standard observation registry.
@@ -871,7 +925,14 @@ pub(crate) fn project_terminal_artifacts(
                     "runner_provenance": artifact.metadata,
                 }
             });
-            if reusable_terminal_artifact(&store, &record.run_id, artifact, &artifact_id)? {
+            if reusable_terminal_artifact(
+                &store,
+                &record.run_id,
+                &outcome.task_id,
+                artifact,
+                &artifact_id,
+                &metadata,
+            )? {
                 continue;
             }
             if let Some(runner_id) = record.runner_id().filter(|runner_id| {
@@ -1031,8 +1092,10 @@ pub(crate) fn project_terminal_artifacts(
 fn reusable_terminal_artifact(
     store: &homeboy_core::observation::ObservationStore,
     run_id: &str,
+    task_id: &str,
     artifact: &AgentTaskArtifact,
     artifact_id: &str,
+    metadata: &Value,
 ) -> Result<bool> {
     let Some(existing) = store.get_artifact(artifact_id)? else {
         return Ok(false);
@@ -1056,6 +1119,30 @@ fn reusable_terminal_artifact(
             .as_deref()
             == Some(expected_sha256);
     if matches {
+        let existing_task_id = existing
+            .metadata_json
+            .pointer("/agent_task/task_id")
+            .and_then(Value::as_str);
+        let existing_logical_id = existing
+            .metadata_json
+            .pointer("/agent_task/logical_artifact_id")
+            .and_then(Value::as_str);
+        if existing_task_id.is_some_and(|value| value != task_id)
+            || existing_logical_id.is_some_and(|value| value != artifact.id)
+        {
+            return Err(Error::validation_invalid_argument(
+                "artifact_id",
+                format!(
+                    "existing artifact record conflicts with terminal artifact projection: {artifact_id}"
+                ),
+                Some(artifact_id.to_string()),
+                None,
+            ));
+        }
+        // Imported bundles can carry the deterministic artifact id and verified
+        // bytes before terminal reconciliation adds controller lookup metadata.
+        // Stamp that single local record rather than creating a second projection.
+        store.update_artifact_metadata(artifact_id, metadata.clone())?;
         return Ok(true);
     }
 

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -128,6 +128,45 @@ fn bridge_reconciliation_recovers_mixed_runner_artifacts_for_local_promotion_ide
             .to_string(),
         )
         .expect("recovered aggregate");
+        let mut hash = Sha256::new();
+        hash.update(run_id.as_bytes());
+        hash.update([0]);
+        hash.update(task_id.as_bytes());
+        hash.update([0]);
+        hash.update(artifact_id.as_bytes());
+        let imported_id = format!("agent-task-{:x}", hash.finalize());
+        let imported = tempfile::NamedTempFile::new().expect("imported patch");
+        std::fs::write(imported.path(), VALID_PATCH).expect("write imported patch");
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        crate::agent_task_lifecycle::record_detached_lab_run(
+            crate::agent_task_lifecycle::DetachedLabRunRecord {
+                run_id,
+                runner_id: "homeboy-lab",
+                runner_job_id: "job-1",
+                remote_workspace: "/runner/homeboy",
+                remote_command: &command,
+            },
+        )
+        .expect("record detached Lab run");
+        homeboy_core::observation::ObservationStore::open_initialized()
+            .expect("store")
+            .import_artifact(&homeboy_core::observation::ArtifactRecord {
+                id: imported_id,
+                run_id: run_id.to_string(),
+                kind: "patch".to_string(),
+                artifact_type: "file".to_string(),
+                path: imported.path().display().to_string(),
+                url: None,
+                public_url: None,
+                viewer_url: None,
+                viewer_links: Vec::new(),
+                sha256: Some(sha256_hex(VALID_PATCH)),
+                size_bytes: Some(VALID_PATCH.len() as i64),
+                mime: Some("text/x-patch".to_string()),
+                metadata_json: serde_json::json!({ "name": artifact_id }),
+                created_at: "2026-07-19T00:00:00Z".to_string(),
+            })
+            .expect("import matching bundle artifact");
         crate::agent_task_promotion::mirror_agent_task_run_plan_aggregate(
             "@runner-plan.json",
             run_id,


### PR DESCRIPTION
## Summary
- reuse a matching controller-local artifact during terminal reconciliation
- stamp the canonical agent-task lookup metadata required by promotion
- preserve fail-closed behavior for conflicting logical identities or bytes
- cover bridge reconciliation through local promotion end to end

Closes #8655.

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-agents bridge_reconciliation_recovers_mixed_runner_artifacts_for_local_promotion_idempotently --lib`.
3. Run `cargo test -p homeboy-agents reusable_artifact_rejects_conflicting_persisted_logical_identity --lib`.
4. Run `cargo test -p homeboy-agents terminal_reconciliation_rejects_conflicting_directly_imported_artifact --lib`.

## Compatibility
- No public command or serialized schema changes.
- Matching imported artifacts now converge on their verified controller-local record; actual identity or integrity conflicts still fail closed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the controller projection boundary, implemented the repair and regression coverage, and ran targeted verification with Chris reviewing and owning the change.