### PR TITLE
fix: repair latent homeboy-cli surface tests broken by crate extraction

### DIFF
--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -797,8 +797,18 @@ mod tests {
     use super::*;
     use std::collections::BTreeSet;
 
+    /// Repo-root-relative paths (docs/, README.md) resolve from the workspace
+    /// root, not this crate's manifest dir. After homeboy-cli was extracted into
+    /// `crates/homeboy-cli`, `CARGO_MANIFEST_DIR` points at the crate, so these
+    /// surface tests must climb back to the workspace root.
+    fn workspace_root() -> std::path::PathBuf {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+    }
+
     fn command_doc(command: &str) -> String {
-        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let root = workspace_root();
         std::fs::read_to_string(root.join("docs/commands").join(format!("{command}.md")))
             .unwrap_or_else(|error| panic!("failed to read docs for {command}: {error}"))
     }
@@ -870,7 +880,7 @@ mod tests {
 
     #[test]
     fn command_registry_docs_paths_exist_and_are_indexed() {
-        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let root = workspace_root();
         let index = commands_index();
 
         for entry in crate::command_contract::COMMAND_SPECS {
@@ -967,10 +977,8 @@ mod tests {
 
     #[test]
     fn documented_docs_surface_matches_manifest_and_parser() {
-        let readme = std::fs::read_to_string(
-            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("README.md"),
-        )
-        .expect("failed to read README");
+        let readme = std::fs::read_to_string(workspace_root().join("README.md"))
+            .expect("failed to read README");
         let manifest = current_command_safety_manifest();
 
         for argv in [
@@ -995,7 +1003,7 @@ mod tests {
 
     #[test]
     fn core_command_docs_do_not_drift_from_registry() {
-        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let root = workspace_root();
         let registered_docs = crate::command_contract::COMMAND_SPECS
             .iter()
             .filter_map(|entry| entry.docs_slug)
@@ -1024,7 +1032,7 @@ mod tests {
 
     #[test]
     fn non_core_command_doc_registry_paths_exist() {
-        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let root = workspace_root();
         let index = commands_index();
 
         for slug in crate::command_contract::non_core_command_doc_slugs() {

--- a/crates/homeboy-cli/src/command_contract/public_variants.rs
+++ b/crates/homeboy-cli/src/command_contract/public_variants.rs
@@ -500,7 +500,12 @@ mod tests {
 
     #[test]
     fn public_variant_contracts_have_discriminators_or_fixtures() {
-        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        // Golden fixtures live at the workspace root; after homeboy-cli was
+        // extracted into `crates/homeboy-cli`, CARGO_MANIFEST_DIR points at the
+        // crate, so climb back to the workspace root to find them.
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..");
         let fixtures = root.join("tests/fixtures/golden_json_contracts");
 
         for contract in PUBLIC_OUTPUT_VARIANT_CONTRACTS {

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -744,6 +744,7 @@ fn cook_retry_lab_source_is_the_derived_baseline_not_the_controller_workspace() 
             "baseline_commit": "baseline-commit",
             "baseline_tree": "baseline-tree",
             "parent_snapshot_identity": "snapshot:parent",
+            "preexisting_candidate": false,
         })
     );
 }


### PR DESCRIPTION
## Summary

A sweep for tests that are **red on a clean `main` checkout** (they slip past merges that don't wait for the slow Test gate) surfaced several latent `homeboy-cli` library-test failures. All are test-side drift with a common root cause — the homeboy-cli crate was extracted into `crates/homeboy-cli`, so `CARGO_MANIFEST_DIR` moved from the workspace root to the crate, but repo-root-relative test paths weren't updated.

## Failures fixed

**Path drift (workspace root vs crate manifest dir):**
- `cli_surface::tests::command_registry_docs_paths_exist_and_are_indexed`
- `cli_surface::tests::core_command_docs_do_not_drift_from_registry`
- `cli_surface::tests::docs_cover_high_use_command_surfaces`
- `cli_surface::tests::documented_docs_surface_matches_manifest_and_parser`
- `cli_surface::tests::non_core_command_doc_registry_paths_exist`
- `command_contract::public_variants::tests::public_variant_contracts_have_discriminators_or_fixtures`

These read `docs/commands/*.md`, `README.md`, and `tests/fixtures/golden_json_contracts/` from `CARGO_MANIFEST_DIR`, which now resolves to `crates/homeboy-cli/` — where those files don't exist. Added a `workspace_root()` helper (`CARGO_MANIFEST_DIR/../..`) and pointed the reads at it.

**Assertion drift:**
- `cook_retry_lab_source_is_the_derived_baseline_not_the_controller_workspace` asserted a fixed `verified_baseline_provenance()` object that had since gained a `preexisting_candidate` field. Added the field to the expected value.

## Testing

Clean-checkout runs of the repaired tests all pass: `cli_surface::tests` 23/23, the fixture-contract test, and the baseline-provenance test. No production behavior changes — test-only fixes.

## Note

One further latent failure — `cli_runtime::tests::global_runner_for_runs_artifact_get_is_absorbed_into_command_option` — is a different, deeper class (a `runs artifact get --runner` fetch reaching the runner subsystem in a test with no registered provider). It needs behavioral investigation and is intentionally left out of this test-path-drift PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Swept homeboy-cli lib tests for clean-checkout failures, root-caused the docs/fixture path breakage to the crate extraction changing CARGO_MANIFEST_DIR, and repaired the paths plus one stale assertion. Chris reviews and owns the change.