### PR TITLE
refactor(agents): add AgentTaskArtifact::default() and drop construction boilerplate

### DIFF
--- a/crates/homeboy-agents/src/agent_task/artifacts.rs
+++ b/crates/homeboy-agents/src/agent_task/artifacts.rs
@@ -117,6 +117,31 @@ pub struct AgentTaskArtifact {
     pub metadata: Value,
 }
 
+impl Default for AgentTaskArtifact {
+    /// A defaulted artifact carries the current artifact schema and empty
+    /// `id`/`kind`, with every optional field `None`/`Value::Null`. Construct
+    /// with `..Default::default()` and set the meaningful fields (`id`, `kind`,
+    /// and whatever else applies) to drop the ~10 lines of `None`/`Value::Null`
+    /// boilerplate every call site otherwise repeats.
+    fn default() -> Self {
+        Self {
+            schema: artifact_schema(),
+            id: String::new(),
+            kind: String::new(),
+            name: None,
+            label: None,
+            role: None,
+            semantic_key: None,
+            path: None,
+            url: None,
+            mime: None,
+            size_bytes: None,
+            sha256: None,
+            metadata: Value::Null,
+        }
+    }
+}
+
 impl AgentTaskArtifact {
     pub fn display_label(&self) -> Option<&str> {
         self.label
@@ -191,4 +216,39 @@ pub struct AgentTaskFollowUp {
     pub body: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub uri: Option<String>,
+}
+
+#[cfg(test)]
+mod default_construction_tests {
+    use super::*;
+
+    #[test]
+    fn default_matches_the_fully_spelled_out_empty_artifact() {
+        let via_default = AgentTaskArtifact {
+            id: "artifact-1".to_string(),
+            kind: "report".to_string(),
+            ..Default::default()
+        };
+        let verbose = AgentTaskArtifact {
+            schema: artifact_schema(),
+            id: "artifact-1".to_string(),
+            kind: "report".to_string(),
+            name: None,
+            label: None,
+            role: None,
+            semantic_key: None,
+            path: None,
+            url: None,
+            mime: None,
+            size_bytes: None,
+            sha256: None,
+            metadata: Value::Null,
+        };
+        assert_eq!(via_default, verbose);
+    }
+
+    #[test]
+    fn default_carries_the_current_artifact_schema() {
+        assert_eq!(AgentTaskArtifact::default().schema, artifact_schema());
+    }
 }

--- a/crates/homeboy-agents/src/agent_task_aggregate.rs
+++ b/crates/homeboy-agents/src/agent_task_aggregate.rs
@@ -629,15 +629,10 @@ mod tests {
                 "timed-out",
                 AgentTaskOutcomeStatus::CandidateRecoverable,
                 vec![AgentTaskArtifact {
-                    schema: "homeboy/agent-task-artifact/v1".to_string(),
                     id: "uncommitted-changes".to_string(),
                     kind: "patch".to_string(),
-                    name: None,
-                    label: None,
                     role: Some("patch".to_string()),
-                    semantic_key: None,
                     path: Some(patch_path.display().to_string()),
-                    url: None,
                     mime: Some("text/x-patch".to_string()),
                     size_bytes: Some(patch.len() as u64),
                     sha256: Some(sha256),
@@ -650,6 +645,7 @@ mod tests {
                         "repository_identity": "repository-identity",
                         "workspace_identity": "workspace-identity"
                     }),
+                    ..Default::default()
                 }],
             )
         };
@@ -675,15 +671,10 @@ mod tests {
                 id,
                 AgentTaskOutcomeStatus::CandidateRecoverable,
                 vec![AgentTaskArtifact {
-                    schema: "homeboy/agent-task-artifact/v1".to_string(),
                     id: format!("{id}-patch"),
                     kind: "patch".to_string(),
-                    name: None,
-                    label: None,
                     role: Some("patch".to_string()),
-                    semantic_key: None,
                     path: Some(patch_path.display().to_string()),
-                    url: None,
                     mime: Some("text/x-patch".to_string()),
                     size_bytes: Some(size_bytes),
                     sha256: Some(sha256.to_string()),
@@ -692,6 +683,7 @@ mod tests {
                         "base_ref": "base-fingerprint", "provider_backend": "provider",
                         "repository_identity": "repository-identity", "workspace_identity": "workspace-identity"
                     }),
+                    ..Default::default()
                 }],
             )
         };
@@ -940,19 +932,14 @@ mod tests {
 
     fn artifact(id: &str, kind: &str, metadata: Value) -> AgentTaskArtifact {
         AgentTaskArtifact {
-            schema: super::super::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
             id: id.to_string(),
             kind: kind.to_string(),
             name: Some(format!("{id}.txt")),
-            label: None,
-            role: None,
-            semantic_key: None,
             path: Some(format!("artifacts/{id}.txt")),
-            url: None,
-            mime: None,
             size_bytes: Some(12),
             sha256: Some(format!("sha256:{id}")),
             metadata,
+            ..Default::default()
         }
     }
 }

--- a/crates/homeboy-agents/src/agent_task_artifacts.rs
+++ b/crates/homeboy-agents/src/agent_task_artifacts.rs
@@ -75,21 +75,13 @@ mod tests {
     #[test]
     fn artifact_projection_preserves_safe_relative_path() {
         let artifact = AgentTaskArtifact {
-            schema: "homeboy/agent-task-artifact/v1".to_string(),
             id: "patch".to_string(),
             kind: "patch".to_string(),
-            name: None,
-            label: None,
-            role: None,
-            semantic_key: None,
             path: Some("artifacts/patch.diff".to_string()),
             url: Some(
                 "homeboy://agent-task/run/run-1/artifacts#task=task-1&artifact=patch".to_string(),
             ),
-            mime: None,
-            size_bytes: None,
-            sha256: None,
-            metadata: serde_json::Value::Null,
+            ..Default::default()
         };
         assert_eq!(
             reviewer_facing_artifact(&artifact).path.as_deref(),
@@ -101,19 +93,10 @@ mod tests {
     #[test]
     fn local_only_artifact_projection_omits_operator_local_path() {
         let artifact = AgentTaskArtifact {
-            schema: "homeboy/agent-task-artifact/v1".to_string(),
             id: "local".to_string(),
             kind: "report".to_string(),
-            name: None,
-            label: None,
-            role: None,
-            semantic_key: None,
             path: Some("/private/operator/report.json".to_string()),
-            url: None,
-            mime: None,
-            size_bytes: None,
-            sha256: None,
-            metadata: serde_json::Value::Null,
+            ..Default::default()
         };
         assert_eq!(reviewer_facing_artifact(&artifact).path, None);
         assert_eq!(
@@ -125,21 +108,13 @@ mod tests {
     #[test]
     fn typed_artifact_projection_preserves_safe_embedded_path() {
         let artifact = AgentTaskArtifact {
-            schema: "homeboy/agent-task-artifact/v1".to_string(),
             id: "patch".to_string(),
             kind: "patch".to_string(),
-            name: None,
-            label: None,
-            role: None,
-            semantic_key: None,
             path: Some("artifacts\\patch.diff".to_string()),
             url: Some(
                 "homeboy://agent-task/run/run-1/artifacts#task=task-1&artifact=patch".to_string(),
             ),
-            mime: None,
-            size_bytes: None,
-            sha256: None,
-            metadata: serde_json::Value::Null,
+            ..Default::default()
         };
         let typed = AgentTaskTypedArtifact {
             name: "patch".to_string(),
@@ -162,19 +137,10 @@ mod tests {
     #[test]
     fn projection_clears_unsafe_paths_in_artifacts_bindings_and_lineage() {
         let artifact = AgentTaskArtifact {
-            schema: "homeboy/agent-task-artifact/v1".to_string(),
             id: "report".to_string(),
             kind: "report".to_string(),
-            name: None,
-            label: None,
-            role: None,
-            semantic_key: None,
             path: Some("C:\\controller\\report.json".to_string()),
-            url: None,
-            mime: None,
-            size_bytes: None,
-            sha256: None,
-            metadata: serde_json::Value::Null,
+            ..Default::default()
         };
         let binding = AgentTaskArtifactRunBinding {
             task_id: "task".to_string(),


### PR DESCRIPTION
## Summary
Next slice of the struct-construction simplification pass, same playbook as #9086. `AgentTaskArtifact` has **13 fields** but only `id` + `kind` are ever meaningfully set — `schema` defaults to the artifact schema constant, and the other 10 are almost always `None` / `Value::Null`. It's constructed **~66×** across the codebase, each site hand-spelling the same default boilerplate.

## Change
- Implement `Default for AgentTaskArtifact` (schema = current artifact schema, `id`/`kind` empty, every optional field `None`/`Null`).
- Sites now write only the meaningful fields + `..Default::default()`.

## Proof it's behavior-preserving
- `default_matches_the_fully_spelled_out_empty_artifact` — `..Default::default()` is byte-identical (`PartialEq`) to the fully-spelled empty artifact
- `default_carries_the_current_artifact_schema` — guards the schema default

## First migration batch
Migrated **7 full-boilerplate construction sites** (4 in `agent_task_artifacts`, 3 in `agent_task_aggregate`). Their surrounding assertions are unchanged and still pass — proving the substitution is transparent. Remaining ~59 sites can adopt `..Default::default()` incrementally.

## Verification (VPS-safe)
- `cargo check -p homeboy-agents --lib` — clean
- `cargo test`: 2 new equivalence tests, 4 artifact-projection tests, 12 aggregate tests — all pass
- `cargo fmt` — clean

## Context
Part of "stabilize + simplify before inviting external users." Companion to #9081 (error constructors) and #9086 (`AgentTaskOutcome::default()`).