### PR TITLE
Fix fuzz workload environment providers

### DIFF
--- a/crates/homeboy-cli/src/commands/fuzz/execution.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/execution.rs
@@ -29,9 +29,8 @@ use super::types::{
     FuzzPlanStrategy, FuzzRunArgs, FuzzRunOutput, FuzzRunnerContract, FuzzWorkloadOutput,
 };
 use super::workloads::{
-    build_target_inventory, fuzz_invocation_requirements, fuzz_workloads, load_rig,
-    resolve_component_id, resolve_fuzz_context, resolve_profile_workload_id, select_workload,
-    FuzzRigContext,
+    build_target_inventory, fuzz_execution_inputs, fuzz_workloads, load_rig, resolve_component_id,
+    resolve_fuzz_context, resolve_profile_workload_id, select_workload, FuzzRigContext,
 };
 
 pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOutput, i32)> {
@@ -89,8 +88,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         args.run_id.clone(),
         args.inventory.as_deref(),
     )?;
-    let invocation_requirements =
-        fuzz_invocation_requirements(rig_context.as_ref(), ctx.extension_id.as_deref());
+    let workload_inputs = fuzz_execution_inputs(rig_context.as_ref(), ctx.extension_id.as_deref());
     let run_dir = RunDir::create()?;
     let rig_id = rig_context.as_ref().map(|context| context.spec.id.clone());
     let workload_id = selected_workload
@@ -114,7 +112,8 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         &args,
         rig_context.as_ref(),
         selected_workload,
-        invocation_requirements,
+        workload_inputs.env_provider_extensions,
+        workload_inputs.invocation_requirements,
         &run_dir,
         &execution_request_path,
         sequence_plan_path.as_deref(),
@@ -1145,6 +1144,7 @@ fn run_fuzz_extension_script(
     args: &FuzzRunArgs,
     rig_context: Option<&FuzzRigContext>,
     workload: Option<&FuzzWorkloadOutput>,
+    env_provider_extensions: Vec<String>,
     invocation_requirements: InvocationRequirements,
     run_dir: &RunDir,
     execution_request_path: &Path,
@@ -1196,6 +1196,7 @@ fn run_fuzz_extension_script(
         .settings_json(&args.setting_args.setting_json)
         .path_override(args.comp.path.clone())
         .with_run_dir(run_dir)
+        .env_provider_extensions(&env_provider_extensions)
         .invocation_requirements(invocation_requirements)
         .timeout(fuzz_max_duration(args.max_duration.as_deref())?)
         .script_args(&args.args);

--- a/crates/homeboy-cli/src/commands/fuzz/workloads.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/workloads.rs
@@ -330,6 +330,30 @@ mod tests {
             Some("/workspace/current")
         );
     }
+
+    #[test]
+    fn fuzz_execution_inputs_preserve_workload_env_providers() {
+        let context = FuzzRigContext {
+            spec: serde_json::from_value(serde_json::json!({
+                "id": "package-fuzz",
+                "fuzz_workloads": {
+                    "generic-runtime": [{
+                        "path": "/tmp/workload.json",
+                        "env_provider_extensions": ["environment-helper"]
+                    }]
+                }
+            }))
+            .expect("parse rig spec"),
+            package_root: None,
+        };
+
+        let inputs = fuzz_execution_inputs(Some(&context), Some("generic-runtime"));
+
+        assert_eq!(
+            inputs.env_provider_extensions,
+            vec!["environment-helper".to_string()]
+        );
+    }
 }
 
 pub(super) fn fuzz_workloads(
@@ -378,11 +402,11 @@ pub(super) fn fuzz_workloads(
     workloads
 }
 
-pub(super) fn fuzz_invocation_requirements(
+pub(super) fn fuzz_execution_inputs(
     rig_context: Option<&FuzzRigContext>,
     extension_id: Option<&str>,
-) -> InvocationRequirements {
-    fuzz_rig_workload_inputs(rig_context, extension_id).invocation_requirements
+) -> rig::RigExtensionWorkloadInputs {
+    fuzz_rig_workload_inputs(rig_context, extension_id)
 }
 
 fn fuzz_rig_workload_inputs(


### PR DESCRIPTION
## Summary
Propagate rig-declared fuzz workload environment providers into ExtensionRunner.

## What changed
- Fuzz execution now preserves both environment-provider extensions and invocation requirements from the selected rig workload.

## How to test
1. Run `cargo fmt --package homeboy-cli -- --check`; expect Command exits successfully..
2. Run `cargo test -p homeboy-cli commands::fuzz --lib`; expect All 134 fuzz tests pass..

## Compatibility
No backward-compatibility impact: workloads without environment providers retain their existing behavior.

## Evidence
- Base unchanged since verification: main remains at 6808c42cc876102ca2409af956dfa96b424651c8.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8962
- Verified finalization base: main at 6808c42cc876102ca2409af956dfa96b424651c8
- homeboy-cli-format: Passed
- homeboy-cli-fuzz-tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the fuzz environment-provider propagation defect, prepared the minimal fix and regression coverage, and verified the focused test suite.

## Source relationships
- Closes #8962
