### PR TITLE
Resolve Lab runner executable build identity

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -991,6 +991,22 @@ pub(crate) fn status_for_admission(runner_id: &str) -> Result<RunnerStatusReport
     })
 }
 
+/// Resolve the immutable identity of the executable that will start runner-side
+/// Homeboy jobs. Lab admission uses this instead of the controller build when
+/// validating a direct SSH daemon.
+pub(crate) fn configured_runner_homeboy_build_identity(
+    runner: &Runner,
+    homeboy: &str,
+) -> Result<Option<String>> {
+    let Some((_server_id, _server, client)) = resolve_ssh_runner(runner)? else {
+        return Ok(None);
+    };
+
+    Ok(remote_homeboy_identity(&client, homeboy)
+        .ok()
+        .and_then(|identity| identity.build_identity))
+}
+
 fn status_for_admission_with<Status, Reconnect>(
     runner_id: &str,
     mut status_fn: Status,

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -182,6 +182,14 @@ fn connect_with_orphan_adoption_and_live_lease(
         ));
     };
     let version = identity.version.clone();
+    let Some(configured_build_identity) = identity.build_identity.clone() else {
+        return Ok(failed_connect(
+            runner_id,
+            session_path,
+            RunnerFailureKind::MissingRemoteHomeboy,
+            unverifiable_configured_identity_message(homeboy),
+        ));
+    };
     // A malformed local record is not ownership evidence. It remains fail
     // closed unless an operator supplies an exact live-lease expectation.
     let previous_session = match read_session_or_live_peer(runner_id) {
@@ -278,7 +286,7 @@ fn connect_with_orphan_adoption_and_live_lease(
                     runner_id,
                     session_path,
                     RunnerFailureKind::DaemonStartupFailure,
-                    format!("remote Homeboy {}: {message}", identity.display),
+                    format!("remote Homeboy {configured_build_identity}: {message}"),
                 ));
             }
         };
@@ -308,7 +316,7 @@ fn connect_with_orphan_adoption_and_live_lease(
         let recovery = decode_leaseless_recovery(envelope.data)?;
         recovery_evidence = Some(leaseless_recovery_evidence(
             contract,
-            &identity.display,
+            &configured_build_identity,
             recovery.clone(),
         ));
         leaseless_recovery = Some(recovery);
@@ -330,7 +338,7 @@ fn connect_with_orphan_adoption_and_live_lease(
             remote_daemon_pid: Some(replacement.pid),
             remote_daemon_lease_id: Some(replacement.lease_id.clone()),
             homeboy_version: version.clone(),
-            homeboy_build_identity: Some(identity.display.clone()),
+            homeboy_build_identity: Some(configured_build_identity.clone()),
             connected_at: Utc::now().to_rfc3339(),
             worker_identity: None,
             worker_pid: None,
@@ -344,7 +352,7 @@ fn connect_with_orphan_adoption_and_live_lease(
         homeboy,
         runner_id,
         previous_session.as_ref(),
-        &identity.display,
+        &configured_build_identity,
         orphan_lease_id,
         confirmed_no_pid_job_ids,
         live_lease_expectation,
@@ -366,7 +374,7 @@ fn connect_with_orphan_adoption_and_live_lease(
     let expected_identity = daemon
         .build_identity
         .clone()
-        .unwrap_or(identity.display.clone());
+        .unwrap_or(configured_build_identity.clone());
     let (local_port, tunnel_pid, local_url, daemon) = match connect_remote_daemon(
         &server,
         &client,
@@ -391,7 +399,7 @@ fn connect_with_orphan_adoption_and_live_lease(
         homeboy,
         live_lease_expectation,
         &daemon,
-        &identity.display,
+        &configured_build_identity,
     ) {
         return Ok(session_write_failure_report(
             runner_id,
@@ -419,8 +427,8 @@ fn connect_with_orphan_adoption_and_live_lease(
         tunnel_pid,
         remote_daemon_pid: daemon.pid,
         remote_daemon_lease_id,
-        homeboy_version: version,
-        homeboy_build_identity: Some(identity.display),
+        homeboy_version: expected_version,
+        homeboy_build_identity: Some(expected_identity),
         connected_at: Utc::now().to_rfc3339(),
         worker_identity: None,
         worker_pid: None,
@@ -1696,10 +1704,11 @@ fn stale_daemon_warning(
     let Some((_server_id, _server, client)) = resolve_ssh_runner(runner)? else {
         return Ok(None);
     };
-    let current_identity = match remote_homeboy_identity(&client, homeboy) {
-        Ok(identity) => identity,
-        Err(_) => return Ok(None),
-    };
+    let current_identity =
+        remote_homeboy_identity(&client, homeboy).unwrap_or_else(|_| RemoteHomeboyIdentity {
+            version: session.homeboy_version.clone(),
+            build_identity: None,
+        });
     let current_version = current_identity.version.clone();
     let observed_session_version = session
         .local_url
@@ -1712,6 +1721,10 @@ fn stale_daemon_warning(
         .and_then(|local_url| daemon_http_identity(local_url).ok())
         .filter(|identity| !identity.trim().is_empty());
     let session_identity = daemon_identity.or_else(|| session.homeboy_build_identity.clone());
+    let identity_comparison = compare_identities(
+        session_identity.as_deref(),
+        current_identity.build_identity.as_deref(),
+    );
     let stale_runtime_paths = session
         .local_url
         .as_deref()
@@ -1725,7 +1738,7 @@ fn stale_daemon_warning(
         .unwrap_or_default();
     if versions_match(&observed_session_version, &current_version)
         && versions_match(&session.homeboy_version, &current_version)
-        && identities_match(session_identity.as_deref(), Some(&current_identity.display))
+        && identity_comparison == IdentityComparison::Match
         && stale_runtime_paths.is_empty()
         && changed_runtime_paths.is_empty()
     {
@@ -1737,10 +1750,22 @@ fn stale_daemon_warning(
             observed_session_version,
             current_version,
             session_identity,
-            Some(current_identity.display),
+            current_identity.build_identity,
+        )
+        .with_identity_unverifiable(
+            &runner.id,
+            homeboy,
+            identity_comparison == IdentityComparison::Unverifiable,
         )
         .with_runtime_paths(&runner.id, stale_runtime_paths, changed_runtime_paths),
     ))
+}
+
+fn unverifiable_configured_identity_message(homeboy: &str) -> String {
+    format!(
+        "configured runner executable `{homeboy}` did not report an immutable build identity; run `{} self identity` on the runner and ensure it reports `git_commit` or an exact `display`, then retry. If the binary is stale, run `homeboy runner refresh-homeboy <runner-id> --reconnect`",
+        shell::quote_arg(homeboy),
+    )
 }
 
 fn stale_reattach_warning_for_report(

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -47,7 +47,7 @@ pub(super) fn remote_homeboy_version(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct RemoteHomeboyIdentity {
     pub(super) version: String,
-    pub(super) display: String,
+    pub(super) build_identity: Option<String>,
 }
 
 pub(super) fn remote_homeboy_identity(
@@ -65,7 +65,7 @@ pub(super) fn remote_homeboy_identity(
     let version = remote_homeboy_version(client, homeboy)?;
     Ok(RemoteHomeboyIdentity {
         version: normalize_homeboy_version_owned(&version),
-        display: version,
+        build_identity: None,
     })
 }
 
@@ -77,21 +77,51 @@ pub(super) fn parse_self_identity_output(output: &str) -> Option<RemoteHomeboyId
         .get("display")
         .and_then(Value::as_str)
         .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(version);
+        .filter(|value| immutable_build_identity(value));
     if version.is_empty() {
         return None;
     }
+    let build_identity = display.map(str::to_string).or_else(|| {
+        let commit = data
+            .get("git_commit")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())?;
+        let dirty = data
+            .get("git_dirty")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        Some(format!(
+            "homeboy {}+{}{}",
+            normalize_homeboy_version_owned(version),
+            commit,
+            if dirty { "-dirty" } else { "" }
+        ))
+    });
     Some(RemoteHomeboyIdentity {
         version: version.to_string(),
-        display: display.to_string(),
+        build_identity,
     })
 }
 
-pub(super) fn identities_match(left: Option<&str>, right: Option<&str>) -> bool {
+fn immutable_build_identity(identity: &str) -> bool {
+    normalize_homeboy_version_owned(identity)
+        .split_once('+')
+        .is_some_and(|(version, commit)| !version.is_empty() && !commit.is_empty())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum IdentityComparison {
+    Match,
+    Mismatch,
+    Unverifiable,
+}
+
+pub(super) fn compare_identities(left: Option<&str>, right: Option<&str>) -> IdentityComparison {
     match (left, right) {
-        (Some(left), Some(right)) => versions_match(left, right),
-        _ => false,
+        (Some(left), Some(right)) if versions_match(left, right) => IdentityComparison::Match,
+        (Some(_), Some(_)) => IdentityComparison::Mismatch,
+        _ => IdentityComparison::Unverifiable,
     }
 }
 

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -472,7 +472,7 @@ fn runner_connect_persists_recovery_evidence_after_daemon_failure() {
             r#"#!/bin/sh
 case "$1 $2" in
   "self identity")
-printf '%s\n' '{"success":true,"data":{"version":"0.284.0","display":"test"}}'
+printf '%s\n' '{"success":true,"data":{"version":"0.284.0","display":"homeboy 0.284.0+test"}}'
 ;;
 "daemon reconcile-leaseless-orphans")
 if [ "$3" = "--help" ]; then
@@ -546,7 +546,7 @@ esac
             evidence.contract,
             RunnerLeaselessRecoveryContract::ConfirmNoDaemonOwner
         );
-        assert_eq!(evidence.remote_command_identity, "test");
+        assert_eq!(evidence.remote_command_identity, "homeboy 0.284.0+test");
         assert_eq!(
             evidence
                 .recovery

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -331,7 +331,67 @@ fn parses_self_identity_json_envelope() {
     .expect("identity");
 
     assert_eq!(identity.version, "0.228.13");
-    assert_eq!(identity.display, "homeboy 0.228.13+19a41cd5102d");
+    assert_eq!(
+        identity.build_identity.as_deref(),
+        Some("homeboy 0.228.13+19a41cd5102d")
+    );
+}
+
+#[test]
+fn resolves_immutable_identity_from_commit_when_display_is_release_only() {
+    let identity = parse_self_identity_output(
+        r#"{"success":true,"data":{"version":"0.294.0","git_commit":"19a41cd5102d","git_dirty":false,"display":"homeboy 0.294.0"}}"#,
+    )
+    .expect("identity");
+
+    assert_eq!(
+        identity.build_identity.as_deref(),
+        Some("homeboy 0.294.0+19a41cd5102d")
+    );
+}
+
+#[test]
+fn identity_comparison_distinguishes_match_unverifiable_and_mismatch() {
+    let exact = Some("homeboy 0.294.0+19a41cd5102d");
+    assert_eq!(compare_identities(exact, exact), IdentityComparison::Match);
+    assert_eq!(
+        compare_identities(exact, None),
+        IdentityComparison::Unverifiable
+    );
+    assert_eq!(
+        compare_identities(exact, Some("homeboy 0.294.0+different")),
+        IdentityComparison::Mismatch
+    );
+}
+
+#[test]
+fn release_only_self_identity_remains_unverifiable() {
+    let identity = parse_self_identity_output(
+        r#"{"success":true,"data":{"version":"0.294.0","display":"homeboy 0.294.0"}}"#,
+    )
+    .expect("version remains available");
+
+    assert_eq!(identity.build_identity, None);
+}
+
+#[test]
+fn unverifiable_identity_warning_is_actionable_without_claiming_a_mismatch() {
+    let warning = RunnerStaleDaemonWarning::new(
+        "homeboy-lab",
+        "0.294.0".to_string(),
+        "0.294.0".to_string(),
+        Some("homeboy 0.294.0+19a41cd5102d".to_string()),
+        None,
+    )
+    .with_identity_unverifiable("homeboy-lab", "/opt/homeboy", true);
+
+    assert!(warning.message.contains("could not be verified"));
+    assert!(!warning.message.contains("different Homeboy build"));
+    assert!(warning.message.contains("/opt/homeboy self identity"));
+    assert_eq!(
+        warning.recovery_commands,
+        ["homeboy runner refresh-homeboy homeboy-lab --reconnect"]
+    );
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -1,7 +1,9 @@
 #![cfg(test)]
 
 use super::*;
-use crate::{RunnerActiveJobState, RunnerSessionState, RunnerStatusReport};
+use crate::{
+    RunnerActiveJobState, RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport,
+};
 use crate::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};
 use homeboy_core::test_support;
 
@@ -150,6 +152,30 @@ fn refreshed_daemon_verification_accepts_the_post_start_health_window() {
     )
     .expect("the persisted connected session identifies the requested daemon commit");
     assert_eq!(retries, 1, "the initial tunnel health race is retried once");
+}
+
+#[test]
+fn refreshed_daemon_verification_converges_after_exact_identity_refresh() {
+    let mut stale = refreshed_daemon_status(true, Some("homeboy 0.294.0+oldcommit"));
+    stale.stale_daemon = Some(RunnerStaleDaemonWarning::new(
+        "lab",
+        "0.294.0".to_string(),
+        "0.294.0".to_string(),
+        Some("homeboy 0.294.0+oldcommit".to_string()),
+        Some("homeboy 0.294.0+19a41cd5102d".to_string()),
+    ));
+    let converged = refreshed_daemon_status(true, Some("homeboy 0.294.0+19a41cd5102d"));
+    let mut statuses = [stale, converged].into_iter();
+    let mut retries = 0;
+
+    verify_refreshed_daemon_identity_with(
+        "lab",
+        "19a41cd5102d",
+        || Ok(statuses.next().expect("refresh convergence status")),
+        || retries += 1,
+    )
+    .expect("refresh converges once daemon and configured executable identities match");
+    assert_eq!(retries, 1);
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -877,7 +877,7 @@ pub(crate) fn run_lab_offload_inner(
 ) -> Result<LabOffloadOutcome> {
     let runner_id = &selection.runner_id;
     let runner = load(runner_id)?;
-    let runner_status = status_for_admission(runner_id)?;
+    let mut runner_status = status_for_admission(runner_id)?;
     if runner.kind != super::super::super::RunnerKind::Ssh {
         return Err(Error::validation_invalid_argument(
             "runner",
@@ -1034,13 +1034,47 @@ pub(crate) fn run_lab_offload_inner(
     }
     let homeboy_path = remote_runner_homeboy_path(&runner, "Lab offload preflight")?;
     let require_exact_runner_version = require_exact_runner_version(&runner.settings);
+    let configured_build_identity =
+        configured_runner_homeboy_build_identity(&runner, homeboy_path)?;
+    if runner_status
+        .session
+        .as_ref()
+        .is_some_and(|session| session.mode == RunnerTunnelMode::DirectSsh)
+        && runner_status.stale_daemon.is_none()
+    {
+        let session = runner_status
+            .session
+            .as_ref()
+            .expect("checked direct SSH session");
+        let active_identity = session.homeboy_build_identity.clone();
+        if configured_build_identity.as_deref() != active_identity.as_deref() {
+            runner_status.stale_daemon = Some(
+                RunnerStaleDaemonWarning::new(
+                    runner_id,
+                    session.homeboy_version.clone(),
+                    session.homeboy_version.clone(),
+                    active_identity,
+                    configured_build_identity.clone(),
+                )
+                .with_identity_unverifiable(
+                    runner_id,
+                    homeboy_path,
+                    configured_build_identity.is_none(),
+                ),
+            );
+        }
+    }
     let runner_homeboy = lab_runner_homeboy_metadata(runner_id, homeboy_path, &runner_status);
     plan = with_step(
         plan,
         PlanStep::builder(
             "lab.runner_homeboy",
             "lab.runner_homeboy",
-            if lab_runner_homeboy_has_blocking_drift(&runner_status, require_exact_runner_version) {
+            if lab_runner_homeboy_has_blocking_drift_against_configured_identity(
+                &runner_status,
+                configured_build_identity.as_deref(),
+                require_exact_runner_version,
+            ) {
                 PlanStepStatus::Failed
             } else {
                 PlanStepStatus::Ready
@@ -1071,7 +1105,11 @@ pub(crate) fn run_lab_offload_inner(
                 shell::quote_arg(runner_id)
             ))
     );
-    if lab_runner_homeboy_has_blocking_drift(&runner_status, require_exact_runner_version) {
+    if lab_runner_homeboy_has_blocking_drift_against_configured_identity(
+        &runner_status,
+        configured_build_identity.as_deref(),
+        require_exact_runner_version,
+    ) {
         return Err(stale_runner_homeboy_error(
             runner_id,
             homeboy_path,

--- a/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
@@ -366,6 +366,37 @@ pub(crate) fn lab_runner_homeboy_has_blocking_drift(
     status: &RunnerStatusReport,
     require_exact: bool,
 ) -> bool {
+    lab_runner_homeboy_has_blocking_drift_against_configured_identity(status, None, require_exact)
+}
+
+/// Direct SSH runners execute jobs with their configured executable rather
+/// than the controller binary. When that executable's immutable identity is
+/// available, it is the authoritative admission comparison for the active
+/// daemon. An unavailable identity fails closed.
+pub(crate) fn lab_runner_homeboy_has_blocking_drift_against_configured_identity(
+    status: &RunnerStatusReport,
+    configured_build_identity: Option<&str>,
+    require_exact: bool,
+) -> bool {
+    if status
+        .session
+        .as_ref()
+        .is_some_and(|session| session.mode == RunnerTunnelMode::DirectSsh)
+    {
+        let Some(configured_build_identity) = configured_build_identity else {
+            return true;
+        };
+        let Some(active_daemon_identity) = status
+            .session
+            .as_ref()
+            .and_then(|session| session.homeboy_build_identity.as_deref())
+        else {
+            return true;
+        };
+        return canonical_build_identity(active_daemon_identity)
+            != canonical_build_identity(configured_build_identity);
+    }
+
     // Build-identity drift within the runner (active daemon control plane vs the
     // configured job command binary) is an internal-inconsistency signal that is
     // always blocking regardless of the controller↔runner version policy.

--- a/crates/homeboy-lab-runner/src/lab/offload/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/mod.rs
@@ -104,17 +104,18 @@ use super::super::lab_workspaces::{
 };
 use super::super::offload_changed_since::LabOffloadChangedSincePreflight;
 use super::super::{
-    dependency_cache_save, evaluate_lab_runner_capabilities_for_runner, exec,
-    exec_with_status_snapshot, lab_offload_changed_since_ref, lab_offload_metadata,
+    configured_runner_homeboy_build_identity, dependency_cache_save,
+    evaluate_lab_runner_capabilities_for_runner, exec, exec_with_status_snapshot,
+    lab_offload_changed_since_ref, lab_offload_metadata,
     lab_offload_metadata_with_workspace_mapping, load, plan_managed_runner_source_syncs,
     preflight_lab_offload_changed_since, prepare_git_lab_offload_changed_since,
     prepare_lab_runner_capability, remote_runner_homeboy_path, reuse_compatible_snapshot_workspace,
     rig_materialization, status, status_for_admission, sync_workspace, LabRunnerGateDecision,
     MaterializedWorkspace, Runner, RunnerAvailability, RunnerCapabilityPreflight,
     RunnerDependencyCacheSaveOutput, RunnerDependencyCacheSaveRequest, RunnerExecOptions,
-    RunnerFileTransfer, RunnerStatusReport, RunnerWorkspaceApplyOutput, RunnerWorkspaceOutputPaths,
-    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
-    WorkspaceCleanupPolicy,
+    RunnerFileTransfer, RunnerStaleDaemonWarning, RunnerStatusReport, RunnerTunnelMode,
+    RunnerWorkspaceApplyOutput, RunnerWorkspaceOutputPaths, RunnerWorkspaceSyncMode,
+    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput, WorkspaceCleanupPolicy,
 };
 
 #[cfg(test)]

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
@@ -868,6 +868,42 @@ fn matching_full_build_identities_have_no_drift_under_strict_mode() {
 }
 
 #[test]
+fn direct_runner_admission_accepts_matching_configured_build_identity() {
+    let identity = "homeboy 0.295.0+b03d659866d1";
+    let mut status = status_with_runner_version("homeboy-lab", "0.295.0");
+    let session = status.session.as_mut().expect("runner session");
+    session.mode = RunnerTunnelMode::DirectSsh;
+    session.homeboy_build_identity = Some(identity.to_string());
+
+    assert!(
+        !lab_runner_homeboy_has_blocking_drift_against_configured_identity(
+            &status,
+            Some(identity),
+            true,
+        )
+    );
+}
+
+#[test]
+fn direct_runner_admission_fails_closed_for_mismatched_or_unverifiable_configured_identity() {
+    let mut status = status_with_runner_version("homeboy-lab", "0.295.0");
+    let session = status.session.as_mut().expect("runner session");
+    session.mode = RunnerTunnelMode::DirectSsh;
+    session.homeboy_build_identity = Some("homeboy 0.295.0+b03d659866d1".to_string());
+
+    assert!(
+        lab_runner_homeboy_has_blocking_drift_against_configured_identity(
+            &status,
+            Some("homeboy 0.295.0+different"),
+            false,
+        )
+    );
+    assert!(
+        lab_runner_homeboy_has_blocking_drift_against_configured_identity(&status, None, false,)
+    );
+}
+
+#[test]
 fn same_semver_with_different_build_identity_is_refused() {
     let mut status =
         status_with_runner_version("homeboy-lab", homeboy_product_identity::product_version());

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -104,13 +104,15 @@ pub(crate) use command_path::normalize_runner_command_env_for_homeboy_path;
 pub use command_path::preflight_remote_argv_path_translation;
 pub(crate) use connection::daemon_endpoint_identity;
 pub(crate) use connection::disconnect_with_force;
+pub(crate) use connection::{
+    configured_runner_homeboy_build_identity, local_live_session, status_for_admission,
+};
 pub use connection::{
     connect, connect_reverse, connect_with_leaseless_orphan_reconciliation,
     connect_with_live_lease_adoption, connect_with_orphan_adoption, connect_with_recovery,
     disconnect, reverse_broker_artifact, reverse_broker_artifact_content, reverse_broker_reconcile,
     runner_artifact_content, status, statuses, submit_reverse_broker_job,
 };
-pub(crate) use connection::{local_live_session, status_for_admission};
 mod upgrade_runners;
 pub use availability_provider::register as register_runner_availability_provider;
 pub use continuation_provider::register as register_runner_continuation_provider;

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -589,6 +589,26 @@ impl RunnerStaleDaemonWarning {
         }
     }
 
+    pub fn with_identity_unverifiable(
+        mut self,
+        runner_id: &str,
+        configured_executable: &str,
+        unverifiable: bool,
+    ) -> Self {
+        if unverifiable {
+            self.message = format!(
+                "connected runner daemon build identity could not be verified against configured executable `{configured_executable}`; run `{} self identity` on the runner and ensure it reports `git_commit` or an exact `display`, then run recovery_commands if needed",
+                shell::quote_arg(configured_executable),
+            );
+            self.recovery_commands = vec![format!(
+                "homeboy runner refresh-homeboy {} --reconnect",
+                shell::quote_arg(runner_id),
+            )];
+            self.refresh_command = self.recovery_commands.join(" && ");
+        }
+        self
+    }
+
     pub fn with_runtime_paths(
         mut self,
         runner_id: &str,


### PR DESCRIPTION
## Summary
Resolve configured runner executables to immutable build identities so aligned Lab daemons are admitted while real or unverifiable mismatches remain fail-closed.

## What changed
- Reconstruct exact configured executable identities from self identity commit metadata instead of treating release-only displays as immutable identities.
- Distinguish matching, mismatching, and unverifiable identities with specific recovery diagnostics.
- Allow Lab offload when the refreshed daemon and configured executable have the same immutable build while preserving genuine mismatch rejection.

## How to test
1. Run `cargo test -p homeboy-lab-runner connection::tests::session::identity_comparison_distinguishes_match_unverifiable_and_mismatch --lib`; expect The identity comparison regression passes for matching, mismatch, and unverifiable states..
2. Run `cargo test -p homeboy-lab-runner refreshed_daemon_verification_converges_after_exact_identity_refresh --lib`; expect The refresh convergence regression passes..
3. Run `homeboy runner refresh-homeboy <runner> --ref <release> --reconnect`; expect A subsequent pinned Lab cook reaches provider execution when daemon and executable identities match..

## Compatibility
No CLI input changes. Runner identity validation is stricter for unverifiable executables and now accepts only resolved immutable matches; genuinely mismatched builds remain blocked.

## Evidence
- Base unchanged since verification: main remains at 6808c42cc876102ca2409af956dfa96b424651c8.
- CI expected: Homeboy CI
- Durable run execution: PartialFailure
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/9084
- Verified finalization base: main at 6808c42cc876102ca2409af956dfa96b424651c8
- gate-1: Passed
- gate-2: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the immutable runner identity mismatch, implemented identity resolution and Lab admission fixes, and added deterministic regression coverage; Chris reviewed and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#9084
