### PR TITLE
refactor(core): derive Default for RunRecord and drop construction boilerplate

### DIFF
--- a/crates/homeboy-core/src/observation/evidence_report.rs
+++ b/crates/homeboy-core/src/observation/evidence_report.rs
@@ -769,11 +769,8 @@ mod tests {
             finished_at: Some("2026-06-12T00:01:00Z".to_string()),
             status: "pass".to_string(),
             command: Some("homeboy trace".to_string()),
-            cwd: None,
             homeboy_version: Some("test-version".to_string()),
-            git_sha: None,
-            rig_id: None,
-            metadata_json: Value::Null,
+            ..Default::default()
         }
     }
 

--- a/crates/homeboy-core/src/observation/records.rs
+++ b/crates/homeboy-core/src/observation/records.rs
@@ -65,7 +65,7 @@ impl NewRunRecord {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct RunRecord {
     pub id: String,
     pub kind: String,
@@ -179,6 +179,32 @@ mod tests {
 
         assert_eq!(record.kind, "lint");
         assert_eq!(record.metadata_json, serde_json::json!({}));
+    }
+
+    #[test]
+    fn run_record_default_matches_the_fully_spelled_out_empty_record() {
+        let via_default = RunRecord {
+            id: "run-1".to_string(),
+            kind: "agent-task".to_string(),
+            started_at: "2026-07-16T00:00:00Z".to_string(),
+            status: "running".to_string(),
+            ..Default::default()
+        };
+        let verbose = RunRecord {
+            id: "run-1".to_string(),
+            kind: "agent-task".to_string(),
+            component_id: None,
+            started_at: "2026-07-16T00:00:00Z".to_string(),
+            finished_at: None,
+            status: "running".to_string(),
+            command: None,
+            cwd: None,
+            homeboy_version: None,
+            git_sha: None,
+            rig_id: None,
+            metadata_json: serde_json::Value::Null,
+        };
+        assert_eq!(via_default, verbose);
     }
 
     #[test]

--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -262,16 +262,9 @@ mod tests {
         RunRecord {
             id: id.to_string(),
             kind: "agent-task".to_string(),
-            component_id: None,
             started_at: "2026-07-16T00:00:00Z".to_string(),
-            finished_at: None,
             status: "running".to_string(),
-            command: None,
-            cwd: None,
-            homeboy_version: None,
-            git_sha: None,
-            rig_id: None,
-            metadata_json: Value::Null,
+            ..Default::default()
         }
     }
 

--- a/crates/homeboy-core/src/observation/runs_service/tests.rs
+++ b/crates/homeboy-core/src/observation/runs_service/tests.rs
@@ -396,14 +396,10 @@ fn labeled_run(id: &str, command: &str, metadata: Value) -> RunRecord {
         kind: "bench.matrix".into(),
         component_id: Some("homeboy".into()),
         started_at: "2026-06-26T00:00:00Z".into(),
-        finished_at: None,
         status: "fail".into(),
         command: Some(command.into()),
-        cwd: None,
-        homeboy_version: None,
-        git_sha: None,
-        rig_id: None,
         metadata_json: metadata,
+        ..Default::default()
     }
 }
 
@@ -614,12 +610,9 @@ fn lab_labeled_run(id: &str, kind: &str, label: &str, job_id: &str) -> RunRecord
         kind: kind.to_string(),
         component_id: Some("homeboy".to_string()),
         started_at: "2026-07-18T00:00:00Z".to_string(),
-        finished_at: None,
         status: "running".to_string(),
         command: Some(format!("homeboy {kind} --run-id {label}")),
         cwd: Some("/tmp/homeboy-fixture".to_string()),
-        homeboy_version: None,
-        git_sha: None,
         rig_id: Some("studio".to_string()),
         metadata_json: serde_json::json!({
             "requested_run_id": label,
@@ -628,6 +621,7 @@ fn lab_labeled_run(id: &str, kind: &str, label: &str, job_id: &str) -> RunRecord
                 "remote_job": { "id": job_id }
             }
         }),
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
## Summary
Next slice of the struct-construction simplification pass — this one lands in **core**. `RunRecord` has **12 fields** but only `id`/`kind`/`started_at`/`status` are typically meaningful at a construction site; the other 8 are `Option` fields defaulting to `None` (plus `metadata_json` → `Value::Null`). It's built **~89×** across the codebase, with test helpers repeating identical `None` boilerplate.

## Change
Every field type already impls `Default` (`String`, `Option`, `serde_json::Value`), so a plain **`#[derive(Default)]`** suffices — no hand-impl needed (unlike `AgentTaskOutcome`/`AgentTaskArtifact`, whose `schema` field needs a non-empty constant default). Sites now write only the meaningful fields + `..Default::default()`.

## Proof it's behavior-preserving
`run_record_default_matches_the_fully_spelled_out_empty_record` — `..Default::default()` is byte-identical (`PartialEq`) to the fully-spelled empty record.

## First migration batch
Migrated the default-heavy test helpers in `runner_evidence`, `runs_service`, and `evidence_report`. Their surrounding assertions are unchanged and still pass. **The DB row-hydration paths that legitimately set every field stay as-is** — no point forcing `..Default::default()` where every field is meaningful.

## Verification (VPS-safe)
- `cargo check -p homeboy-core --lib` — clean
- `cargo test`: new equivalence test + 26 runs_service tests + evidence_report test — all pass
- `cargo fmt` — clean

## Context
Part of "stabilize + simplify before inviting external users." Follows #9081, #9086, #9087. Note: `Project` (66×) and `Component` (202×) were checked and already derive `Default` — deprioritized as pure call-site cleanup rather than new-primitive work.