### PR TITLE
fix: align scheduler attempt-workspace tests with the #8579 retention policy

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/concurrency.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/concurrency.rs
@@ -658,6 +658,10 @@ pub(super) mod concurrency_tests {
 
     #[test]
     fn retry_uses_clean_isolated_workspace_after_permission_denial() {
+        // Attempt worktrees are now retained when they hold work (#8579), so
+        // isolate the controller-scratch home to keep those retained checkouts
+        // out of the developer's real `~/.local/share/homeboy`.
+        let _home = homeboy_core::test_support::HomeGuard::new();
         let temp = tempfile::tempdir().expect("tempdir");
         let source = temp.path().join("source");
         let target = temp.path().join("target");
@@ -698,7 +702,15 @@ pub(super) mod concurrency_tests {
         assert_eq!(workspaces.len(), 2);
         assert_ne!(workspaces[0], workspaces[1]);
         assert!(workspaces.iter().all(|workspace| workspace != &source));
-        assert!(workspaces.iter().all(|workspace| !workspace.exists()));
+        // Attempt worktrees are intentionally retained for lifecycle cleanup when
+        // they still hold work (#8579): attempt 1 left uncommitted changes and
+        // attempt 2 committed beyond its base. The work itself is preserved as a
+        // promoted patch artifact (asserted below), so scheduler cleanup does not
+        // force-remove the checkouts and records a retention diagnostic instead.
+        assert!(aggregate.outcomes[0]
+            .diagnostics
+            .iter()
+            .any(|diagnostic| { diagnostic.class == "agent_task.attempt_workspace_retained" }));
         assert!(Command::new("git")
             .args(["status", "--porcelain"])
             .current_dir(&source)

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
@@ -304,9 +304,17 @@ mod provider_rotation_tests {
             .path
             .as_deref()
             .is_some_and(|path| path.contains("agent-task/attempt-patches/run-8081/task-1")));
+        // The first attempt left an uncommitted candidate (captured above as a
+        // promoted patch artifact), so scheduler cleanup retains its checkout for
+        // lifecycle cleanup rather than force-removing it (#8579). The second,
+        // cleanly-succeeding attempt holds no work and its checkout is retired.
         assert!(
-            !roots[0].exists() && !roots[1].exists(),
-            "attempt checkouts are retired after their executor threads stop"
+            roots[0].exists(),
+            "attempt with a retained uncommitted candidate keeps its checkout for lifecycle cleanup"
+        );
+        assert!(
+            !roots[1].exists(),
+            "clean succeeding attempt checkout is retired after its executor thread stops"
         );
     }
 


### PR DESCRIPTION
## Summary

Continuing the sweep for tests that are **red on a clean `main` checkout**, two agent-task scheduler tests fail deterministically (serially, not just under parallelism):

- `retry_uses_clean_isolated_workspace_after_permission_denial`
- `rotation_preserves_uncommitted_candidate_and_dispatches_next_provider_from_clean_baseline`

Both assert the **pre-#8579** behavior where every attempt checkout was force-removed after its executor thread stopped.

## Root cause (not a code regression — an intentional policy the tests missed)

#8579 ("Unify scheduler attempt cleanup ownership") deliberately changed `AttemptWorkspace::cleanup`:
- `git worktree remove --force` → `git worktree remove`, and
- a checkout with **uncommitted changes** or **commits beyond its base** is now **retained for lifecycle cleanup** (recording an `agent_task.attempt_workspace_retained` diagnostic) instead of being force-removed.

The work itself is preserved as a promoted **patch artifact** — which both tests already assert (`task-1-attempt-2-committed-changes`, `task-1-attempt-1-uncommitted-changes`). Only the workspace-existence assertions were stale. I confirmed by instrumenting the tests: the retained checkouts carry exactly the "N commit(s) beyond its base" / "uncommitted changes" cleanup outcomes #8579 introduced.

## Change (test-only)

- **retry:** both attempts hold work (attempt 1 uncommitted, attempt 2 committed), so both checkouts are retained. Assert the `attempt_workspace_retained` diagnostic instead of non-existence, and wrap the test in a `HomeGuard` so the now-retained checkouts land in an isolated home rather than the developer's real `~/.local/share/homeboy`.
- **rotation:** the failed first attempt's uncommitted candidate is retained while the cleanly-succeeding second attempt's checkout is retired — assert exactly that split.

No production behavior changes.

## Testing

- `cargo check -p homeboy-agents --lib --tests` clean, `cargo fmt`.
- Both tests pass serially; a sibling rotation test (`rotation_adopts_only_the_explicit_portable_candidate`) still passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Reproduced the two deterministic scheduler test failures, instrumented them to capture the retained-checkout cleanup outcomes, traced the behavior change to #8579's intentional cleanup-ownership policy, and updated the stale assertions (plus isolated the retry test's home). Chris reviews and owns the change.