### PR TITLE
Drop legacy remote artifact promotion

### DIFF
--- a/crates/homeboy-core/src/observation/store/artifacts.rs
+++ b/crates/homeboy-core/src/observation/store/artifacts.rs
@@ -209,41 +209,26 @@ impl ObservationStore {
         })?;
         let size_bytes = i64::try_from(staged_metadata.len()).ok();
         let sha256 = Some(crate::artifact_metadata::sha256_file(&staged_path)?);
-        let existing = self.get_artifact(&id)?;
-        let replacing_remote_projection = existing
-            .as_ref()
-            .filter(|artifact| {
-                artifact.artifact_type == "remote_file"
-                    && artifact.run_id == run_id
-                    && artifact.kind == kind
-                    && artifact.size_bytes == size_bytes
-                    && artifact.sha256 == sha256
-            })
-            .map(|artifact| artifact.created_at.clone());
-        if let Some(existing) = existing {
-            if replacing_remote_projection.is_none() {
-                let existing_path = Path::new(&existing.path);
-                let existing_matches = existing.run_id == run_id
-                    && existing.kind == kind
-                    && existing.size_bytes == size_bytes
-                    && existing.sha256 == sha256
-                    && fs::metadata(existing_path)
-                        .map(|value| value.is_file())
-                        .unwrap_or(false)
-                    && crate::artifact_metadata::sha256_file(existing_path).ok() == sha256;
-                fs::remove_file(&staged_path).ok();
-                if existing_matches {
-                    return Ok(existing);
-                }
-                return Err(Error::validation_invalid_argument(
-                    "artifact_id",
-                    format!(
-                        "stable artifact id '{id}' already records different content or ownership"
-                    ),
-                    Some(id),
-                    None,
-                ));
+        if let Some(existing) = self.get_artifact(&id)? {
+            let existing_path = Path::new(&existing.path);
+            let existing_matches = existing.run_id == run_id
+                && existing.kind == kind
+                && existing.size_bytes == size_bytes
+                && existing.sha256 == sha256
+                && fs::metadata(existing_path)
+                    .map(|value| value.is_file())
+                    .unwrap_or(false)
+                && crate::artifact_metadata::sha256_file(existing_path).ok() == sha256;
+            fs::remove_file(&staged_path).ok();
+            if existing_matches {
+                return Ok(existing);
             }
+            return Err(Error::validation_invalid_argument(
+                "artifact_id",
+                format!("stable artifact id '{id}' already records different content or ownership"),
+                Some(id),
+                None,
+            ));
         }
         let published_new_file = match fs::hard_link(&staged_path, &stored_path) {
             Ok(()) => true,
@@ -279,9 +264,7 @@ impl ObservationStore {
                 )
             })?;
         }
-        let created_at = replacing_remote_projection
-            .clone()
-            .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+        let created_at = chrono::Utc::now().to_rfc3339();
         let mime = crate::artifact_metadata::content_type_from_path(path);
         let path_string = stored_path.to_string_lossy().to_string();
         let mut artifact = ArtifactRecord {
@@ -304,62 +287,30 @@ impl ObservationStore {
 
         let metadata_json_str = serialize_metadata(&artifact.metadata_json)?;
         let viewer_links_json = serialize_metadata(&serde_json::json!(artifact.viewer_links))?;
-        let persist_result = if replacing_remote_projection.is_some() {
-            execute_with_retry("promote remote artifact record", || {
-                self.connection.execute(
-                    r#"
-                    UPDATE artifacts
-                    SET run_id = ?2, kind = ?3, artifact_type = ?4, path = ?5, url = ?6,
-                        public_url = ?7, viewer_url = ?8, viewer_links_json = ?9,
-                        sha256 = ?10, size_bytes = ?11, mime = ?12, metadata_json = ?13,
-                        created_at = ?14
-                    WHERE id = ?1
-                    "#,
-                    params![
-                        &id,
-                        run_id,
-                        kind,
-                        "file",
-                        &path_string,
-                        Option::<String>::None,
-                        &artifact.public_url,
-                        &artifact.viewer_url,
-                        &viewer_links_json,
-                        &sha256,
-                        size_bytes,
-                        &mime,
-                        &metadata_json_str,
-                        &created_at,
-                    ],
-                )
-            })
-        } else {
-            execute_with_retry("insert artifact record", || {
-                self.connection.execute(
-                    r#"
-                    INSERT INTO artifacts(id, run_id, kind, artifact_type, path, url, public_url, viewer_url, viewer_links_json, sha256, size_bytes, mime, metadata_json, created_at)
-                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
-                    "#,
-                    params![
-                        &id,
-                        run_id,
-                        kind,
-                        "file",
-                        &path_string,
-                        Option::<String>::None,
-                        &artifact.public_url,
-                        &artifact.viewer_url,
-                        &viewer_links_json,
-                        &sha256,
-                        size_bytes,
-                        &mime,
-                        &metadata_json_str,
-                        &created_at,
-                    ],
-                )
-            })
-        };
-        if let Err(error) = persist_result {
+        if let Err(error) = execute_with_retry("insert artifact record", || {
+            self.connection.execute(
+                r#"
+                INSERT INTO artifacts(id, run_id, kind, artifact_type, path, url, public_url, viewer_url, viewer_links_json, sha256, size_bytes, mime, metadata_json, created_at)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+                "#,
+                params![
+                    id,
+                    run_id,
+                    kind,
+                    "file",
+                    path_string,
+                    Option::<String>::None,
+                    artifact.public_url,
+                    artifact.viewer_url,
+                    viewer_links_json,
+                    sha256,
+                    size_bytes,
+                    mime,
+                    metadata_json_str,
+                    created_at,
+                ],
+            )
+        }) {
             if published_new_file {
                 fs::remove_file(&stored_path).ok();
             }
@@ -1157,59 +1108,6 @@ mod tests {
                 .get_artifact("remote-fuzz-results-mismatch")
                 .expect("lookup")
                 .is_none());
-        });
-    }
-
-    #[test]
-    fn verified_fuzz_artifact_promotes_matching_remote_projection_to_local_ownership() {
-        with_isolated_home(|home| {
-            let store = ObservationStore::open_initialized().expect("store");
-            let run = store
-                .start_run(NewRunRecord::builder("fuzz").cwd_path(home.path()).build())
-                .expect("run");
-            let source = home.path().join("fuzz-results.json");
-            fs::write(&source, b"durable fuzz bytes").expect("write source");
-            let size = i64::try_from(fs::metadata(&source).expect("metadata").len())
-                .expect("test size fits i64");
-            let sha256 = crate::artifact_metadata::sha256_file(&source).expect("source hash");
-            store
-                .import_artifact(&ArtifactRecord {
-                    id: "fuzz-results".to_string(),
-                    run_id: run.id.clone(),
-                    kind: "fuzz_results".to_string(),
-                    artifact_type: "remote_file".to_string(),
-                    path: "runner-artifact://lab/remote-run/fuzz-results".to_string(),
-                    url: None,
-                    public_url: None,
-                    viewer_url: None,
-                    viewer_links: Vec::new(),
-                    sha256: Some(sha256.clone()),
-                    size_bytes: Some(size),
-                    mime: Some("application/json".to_string()),
-                    metadata_json: serde_json::json!({ "runner_id": "lab" }),
-                    created_at: "2026-05-16T00:00:01Z".to_string(),
-                })
-                .expect("remote projection");
-
-            let promoted = store
-                .record_verified_artifact_with_id(
-                    &run.id,
-                    "fuzz_results",
-                    &source,
-                    "fuzz-results",
-                    Some(size),
-                    Some(&sha256),
-                    serde_json::json!({ "runner_id": "lab" }),
-                )
-                .expect("promote remote projection");
-
-            assert_eq!(promoted.artifact_type, "file");
-            assert_eq!(promoted.created_at, "2026-05-16T00:00:01Z");
-            fs::remove_file(source).expect("runner cleanup");
-            assert_eq!(
-                fs::read(promoted.path).expect("controller bytes"),
-                b"durable fuzz bytes"
-            );
         });
     }
 

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -521,7 +521,7 @@ where
     F: FnOnce(&str) -> Result<std::path::PathBuf>,
 {
     // Only a fully identified remote artifact has a durable-byte contract.
-    // Leave legacy/incomplete remote references on their existing live-fetch path.
+    // References without integrity metadata remain on the live-fetch path.
     if artifact.artifact_type != "remote_file"
         || artifact.size_bytes.is_none()
         || artifact.sha256.as_deref().is_none_or(str::is_empty)
@@ -537,25 +537,15 @@ where
         {
             return Ok(());
         }
-        if existing.run_id == artifact.run_id
-            && existing.kind == artifact.kind
-            && existing.size_bytes == artifact.size_bytes
-            && existing.sha256 == artifact.sha256
-            && existing.artifact_type == "remote_file"
-        {
-            // Upgrade the matching legacy projection below while the runner is
-            // still available, before terminal retention can remove its bytes.
-        } else {
-            return Err(Error::validation_invalid_argument(
-                "artifact_id",
-                format!(
-                    "mirrored artifact `{}` conflicts with existing controller ownership or integrity metadata",
-                    artifact.id
-                ),
-                Some(artifact.id.clone()),
-                None,
-            ));
-        }
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!(
+                "mirrored artifact `{}` conflicts with existing controller ownership or integrity metadata",
+                artifact.id
+            ),
+            Some(artifact.id.clone()),
+            None,
+        ));
     }
     let downloaded_path = download(&artifact.path)?;
     store.record_verified_artifact_with_id(


### PR DESCRIPTION
## Summary

- remove the compatibility path that upgrades persisted `remote_file` projections
- keep the forward controller-owned artifact contract introduced in #9083
- preserve fail-closed behavior when an artifact ID already has different ownership or integrity metadata

## How to test

1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-core fuzz`.
3. Run `cargo test -p homeboy-lab-runner fuzz`.
4. Confirm fully identified new artifacts are copied into controller ownership and remain retrievable after runner cleanup.
5. Confirm conflicting existing artifact ownership is rejected rather than migrated.

## Compatibility

This intentionally removes the legacy persisted-projection promotion added by #9083. No backwards-compatibility bridge is retained.

Follow-up to #9083.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with GPT-5.6 Sol
- **Used for:** Removed the compatibility behavior, rebased the focused follow-up onto current main, and ran verification. Chris reviewed and owns the change.