### PR TITLE
refactor(lifecycle-contract): add ArtifactRecord::default() and drop construction boilerplate

### DIFF
--- a/crates/contracts/homeboy-lifecycle-contract/src/artifact_contract.rs
+++ b/crates/contracts/homeboy-lifecycle-contract/src/artifact_contract.rs
@@ -49,6 +49,33 @@ fn default_artifact_type() -> String {
     "file".to_string()
 }
 
+impl Default for ArtifactRecord {
+    /// A defaulted record has empty `id`/`run_id`/`kind`/`path`/`created_at`,
+    /// `artifact_type` = `"file"` (matching the serde default so a defaulted and
+    /// a deserialized-with-omitted-type record agree), and every optional field
+    /// `None`/empty/`Value::Null`. Construct with `..Default::default()` and set
+    /// the meaningful fields to drop the boilerplate every call site otherwise
+    /// repeats.
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            run_id: String::new(),
+            kind: String::new(),
+            artifact_type: default_artifact_type(),
+            path: String::new(),
+            url: None,
+            public_url: None,
+            viewer_url: None,
+            viewer_links: Vec::new(),
+            sha256: None,
+            size_bytes: None,
+            mime: None,
+            metadata_json: serde_json::Value::Null,
+            created_at: String::new(),
+        }
+    }
+}
+
 pub const ARTIFACT_CONTRACT_SCHEMA: &str = "homeboy/artifact-contract/v1";
 pub const EVIDENCE_CONTRACT_SCHEMA: &str = "homeboy/evidence-contract/v1";
 
@@ -288,5 +315,40 @@ mod tests {
         assert_eq!(evidence.label, "proof");
         assert_eq!(evidence.target, "https://example.test/proof");
         assert_eq!(evidence.artifact.expect("artifact").artifact_type, "file");
+    }
+
+    #[test]
+    fn artifact_record_default_matches_the_fully_spelled_out_empty_record() {
+        let via_default = ArtifactRecord {
+            id: "frontend_url".to_string(),
+            run_id: "run-1".to_string(),
+            kind: "frontend_url".to_string(),
+            artifact_type: "url".to_string(),
+            path: "https://example.test/".to_string(),
+            created_at: "2026-06-12T00:00:30Z".to_string(),
+            ..Default::default()
+        };
+        let verbose = ArtifactRecord {
+            id: "frontend_url".to_string(),
+            run_id: "run-1".to_string(),
+            kind: "frontend_url".to_string(),
+            artifact_type: "url".to_string(),
+            path: "https://example.test/".to_string(),
+            url: None,
+            public_url: None,
+            viewer_url: None,
+            viewer_links: Vec::new(),
+            sha256: None,
+            size_bytes: None,
+            mime: None,
+            metadata_json: serde_json::Value::Null,
+            created_at: "2026-06-12T00:00:30Z".to_string(),
+        };
+        assert_eq!(via_default, verbose);
+    }
+
+    #[test]
+    fn artifact_record_default_artifact_type_is_file() {
+        assert_eq!(ArtifactRecord::default().artifact_type, "file");
     }
 }

--- a/crates/homeboy-core/src/artifact_links.rs
+++ b/crates/homeboy-core/src/artifact_links.rs
@@ -260,14 +260,7 @@ mod tests {
             id: "artifact-1".to_string(),
             run_id: "run-1".to_string(),
             kind: "preview-after".to_string(),
-            artifact_type: "file".to_string(),
             path: "/tmp/preview.after.json".to_string(),
-            url: None,
-            public_url: None,
-            viewer_url: None,
-            viewer_links: Vec::new(),
-            sha256: None,
-            size_bytes: None,
             mime: Some("application/json".to_string()),
             metadata_json: serde_json::json!({
                 "viewer": {
@@ -282,6 +275,7 @@ mod tests {
                 }
             }),
             created_at: "2026-06-12T00:00:00Z".to_string(),
+            ..Default::default()
         };
 
         let links = viewer_links(&artifact, Some("https://artifacts.example.test/a b.json"));
@@ -370,15 +364,9 @@ mod tests {
                 .path()
                 .display()
                 .to_string(),
-            url: None,
-            public_url: None,
-            viewer_url: None,
-            viewer_links: Vec::new(),
-            sha256: None,
-            size_bytes: None,
-            mime: None,
             metadata_json: serde_json::json!({}),
             created_at: "2026-06-12T00:00:00Z".to_string(),
+            ..Default::default()
         };
 
         assert_eq!(public_artifact_url(&artifact), None);
@@ -390,14 +378,7 @@ mod tests {
             id: "artifact-1".to_string(),
             run_id: "run-1".to_string(),
             kind: "preview-after".to_string(),
-            artifact_type: "file".to_string(),
             path: "/tmp/preview.after.json".to_string(),
-            url: None,
-            public_url: None,
-            viewer_url: None,
-            viewer_links: Vec::new(),
-            sha256: None,
-            size_bytes: None,
             mime: Some("application/json".to_string()),
             metadata_json: serde_json::json!({
                 "viewer": {
@@ -411,6 +392,7 @@ mod tests {
                 }
             }),
             created_at: "2026-06-12T00:00:00Z".to_string(),
+            ..Default::default()
         }
     }
 

--- a/crates/homeboy-core/src/observation/evidence_report.rs
+++ b/crates/homeboy-core/src/observation/evidence_report.rs
@@ -786,13 +786,8 @@ mod tests {
             path: "https://example.test/".to_string(),
             url: Some("https://example.test/".to_string()),
             public_url: Some("https://example.test/".to_string()),
-            viewer_url: None,
-            viewer_links: Vec::new(),
-            sha256: None,
-            size_bytes: None,
-            mime: None,
-            metadata_json: Value::Null,
             created_at: "2026-06-12T00:00:30Z".to_string(),
+            ..Default::default()
         }
     }
 


### PR DESCRIPTION
## Summary
Next slice of the struct-construction simplification pass. `ArtifactRecord` has **14 fields** but only `id`/`run_id`/`kind`/`path`/`created_at` are typically meaningful at a construction site; `artifact_type` defaults to `"file"` and the other 8 fields are almost always `None` / empty / `Value::Null`. It's constructed **~45×** across the codebase, each site repeating the same default boilerplate.

## Change
Implement `Default` (**hand-impl, not derive**, because `artifact_type` must default to `"file"` to match the serde `default_artifact_type` — so a defaulted record and a deserialized-with-omitted-`type` record agree). Sites now write only the meaningful fields + `..Default::default()`.

## Proof it's behavior-preserving
- `artifact_record_default_matches_the_fully_spelled_out_empty_record` — `..Default::default()` is byte-identical (`PartialEq`) to the fully-spelled empty record
- `artifact_record_default_artifact_type_is_file` — guards the serde-matching default

## First migration batch
Migrated **4 full-boilerplate sites** (`evidence_report` + `artifact_links`). Surrounding assertions unchanged and still pass. Sites that set `artifact_type` to a non-default value (e.g. `"directory"`) keep it explicit. Remaining ~41 sites can adopt `..Default::default()` incrementally.

## Verification (VPS-safe)
- `cargo check -p homeboy-lifecycle-contract -p homeboy-core --lib` — clean
- `cargo test`: 2 new equivalence tests (15 contract tests total) + artifact_links (7) + evidence_report tests — all pass
- `cargo fmt` — clean

## Context
Part of "stabilize + simplify before inviting external users." Follows #9081, #9086, #9087, #9092. Decision tree now established: **derive `Default`** when every field's natural default is correct (RunRecord #9092), **hand-impl** when a field needs a specific non-default value — schema constant / status / `artifact_type = "file"` (this PR, #9086, #9087).