### PR TITLE
fix: update three lab-runner tests that drifted from current behavior

### DIFF
--- a/crates/homeboy-lab-runner/src/runtime_materialization_status.rs
+++ b/crates/homeboy-lab-runner/src/runtime_materialization_status.rs
@@ -229,9 +229,11 @@ mod tests {
         assert!(hint.contains("homeboy 0.259.0+daemon"));
         assert!(hint.contains("job command binary"));
         assert!(hint.contains("homeboy 0.262.0+binary"));
-        assert!(hint.contains(
-            "homeboy runner disconnect homeboy-lab && homeboy runner connect homeboy-lab"
-        ));
+        // The refresh hint now names the `refresh-homeboy --reconnect` recovery
+        // command. Assert its stable shape rather than the embedded `--ref`
+        // version, which tracks the current release and would re-rot the test.
+        assert!(hint.contains("homeboy runner refresh-homeboy homeboy-lab"));
+        assert!(hint.contains("--reconnect"));
     }
 
     fn report(stale_daemon: Option<RunnerStaleDaemonWarning>) -> RunnerStatusReport {

--- a/crates/homeboy-lab-runner/src/workload.rs
+++ b/crates/homeboy-lab-runner/src/workload.rs
@@ -1167,9 +1167,13 @@ mod tests {
             true,
         )
         .expect_err("a genuinely different dispatched command must fail");
-        assert_eq!(err.details["field"], "runner_workload.kind.command_label");
-        assert!(err.message.contains("runtime refresh"));
-        assert!(err.message.contains("trace"));
+        // `runtime refresh` (Workspace family) and `trace` (Quality family) are
+        // different workload families, so the mismatch surfaces as a command
+        // family drift rather than a label drift (#7972 canonicalizes same-family
+        // labels but still enforces the family).
+        assert_eq!(err.details["field"], "runner_workload.kind.command_family");
+        assert!(err.message.contains("Workspace"));
+        assert!(err.message.contains("Quality"));
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/workspace/tests/materializer.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/materializer.rs
@@ -20,7 +20,7 @@ fn workspace_materializer_builds_snapshot_atomic_replace_command() {
     assert!(command.contains("parent=/srv/homeboy/_lab_workspaces"));
     assert!(command.contains("dest=/srv/homeboy/_lab_workspaces/homeboy-abc"));
     assert!(command.contains("trap 'rm -rf \"$tmp\"' EXIT"));
-    assert!(command.contains("tar -C \"$tmp\" -xf -"));
+    assert!(command.contains("tar -p -C \"$tmp\" -xf -"));
     assert!(command.contains("rm -rf \"$dest\" && mv \"$tmp\" \"$dest\""));
     assert!(command.contains("owner_path=$parent"));
     assert!(command.contains("chown -R \"$owner\" $dest"));


### PR DESCRIPTION
## Summary

Continuing the sweep for tests **red on a clean `main` checkout**, `homeboy-lab-runner` has a cluster of stale tests. This PR fixes the three I verified with high confidence (captured the current behavior at runtime and matched it):

- **`workspace_materializer_builds_snapshot_atomic_replace_command`** — the tar extraction command gained a `-p` (preserve-permissions) flag; the assertion still expected `tar -C "$tmp" -xf -`. Updated to `tar -p -C "$tmp" -xf -`.

- **`stale_status_renders_control_plane_and_job_binary_hint`** — the stale-daemon hint now names the `refresh-homeboy ... --reconnect` recovery command instead of `runner disconnect && runner connect`. I assert the **stable** command shape (`homeboy runner refresh-homeboy homeboy-lab` + `--reconnect`) rather than the embedded `--ref <version>`, which tracks the current release (it rendered `--ref v0.296.2`) and would re-rot the test on the next release.

- **`lab_runner_workload_validation_uses_runtime_refresh_command_identity`** — `runtime refresh` (Workspace family) vs `trace` (Quality family) now surfaces as a **command-family** drift, not a label drift, after #7972 canonicalized same-family labels while still enforcing the family. Assert the `command_family` field and the `Workspace`/`Quality` family names (the actual error: `runner workload command family \`Workspace\` does not match dispatched command family \`Quality\``).

## Testing

- `cargo fmt`; each fixed test verified passing individually.
- Test-only changes; no production behavior modified.

## Scope note

`homeboy-lab-runner` has ~11 more deterministically-failing tests on a clean checkout, but they are a different, deeper class — git/fixture-environment dependent (e.g. a `homeboy_refresh` test copies `CARGO_MANIFEST_DIR/build.rs`, which no longer exists after the crate was extracted; several exercise real `git` bundle/clone flows) and need per-test behavioral work. Left for a dedicated follow-up rather than rushed here.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Swept homeboy-lab-runner lib tests, classified the 14 deterministic failures, and fixed the three with unambiguous assertion drift by instrumenting each to capture current behavior (avoiding re-hardcoding the release version in the hint test). Chris reviews and owns the change.