### PR TITLE
fix: repair five more latent lab-runner tests at their root causes

### DIFF
--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -278,7 +278,7 @@ fn materialize_script_records_the_peeled_commit_for_tags_and_direct_commits() {
     std::fs::create_dir_all(source.join("src")).expect("root source directory");
     std::fs::write(
         source.join("src/main.rs"),
-        "fn main() { println!(\"{\\\"data\\\":{\\\"git_commit\\\":\\\"{}\\\",\\\"git_dirty\\\":{}}}\", homeboy_core::git_commit(), homeboy_core::git_dirty()); }\n",
+        "fn main() { println!(\"{{\\\"data\\\":{{\\\"git_commit\\\":\\\"{}\\\",\\\"git_dirty\\\":{}}}}}\", homeboy_core::git_commit(), homeboy_core::git_dirty()); }\n",
     )
     .expect("write root binary");
     std::fs::write(
@@ -286,14 +286,21 @@ fn materialize_script_records_the_peeled_commit_for_tags_and_direct_commits() {
         "[package]\nname = \"homeboy-core\"\nversion = \"0.1.0\"\nedition = \"2021\"\nbuild = \"build.rs\"\n",
     )
     .expect("write core manifest");
-    std::fs::copy(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("build.rs"),
-        core.join("build.rs"),
-    )
-    .expect("copy core build identity script");
+    // The build-identity script lives in the product-identity crate at the
+    // workspace root. After lab-runner was extracted into `crates/homeboy-lab-runner`,
+    // CARGO_MANIFEST_DIR points at this crate (which has no build.rs), so resolve
+    // the real generator from the workspace root instead.
+    let build_identity_script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("crates/homeboy-product-identity/build.rs");
+    std::fs::copy(&build_identity_script, core.join("build.rs"))
+        .expect("copy core build identity script");
+    // The generator emits HOMEBOY_PRODUCT_GIT_* (renamed from HOMEBOY_BUILD_GIT_*),
+    // so the fixture's core crate consumes the current variable names.
     std::fs::write(
         core.join("src/lib.rs"),
-        "pub fn git_commit() -> &'static str { env!(\"HOMEBOY_BUILD_GIT_COMMIT\") }\npub fn git_dirty() -> bool { env!(\"HOMEBOY_BUILD_GIT_DIRTY\") == \"true\" }\n",
+        "pub fn git_commit() -> &'static str { env!(\"HOMEBOY_PRODUCT_GIT_COMMIT\") }\npub fn git_dirty() -> bool { env!(\"HOMEBOY_PRODUCT_GIT_DIRTY\") == \"true\" }\n",
     )
     .expect("write core build identity consumer");
 
@@ -310,6 +317,11 @@ fn materialize_script_records_the_peeled_commit_for_tags_and_direct_commits() {
         assert!(status.success(), "source fixture setup succeeds");
     }
     std::fs::write(source.join("README.md"), "fixture\n").expect("write fixture");
+    // Keep the materialized build tree clean: `cargo build` writes `target/` and
+    // `Cargo.lock` into the clone, and the build-identity generator marks the
+    // build dirty if `git status --porcelain` reports anything. Ignore those
+    // build artifacts so the fixture's source-built binary reports a clean build.
+    std::fs::write(source.join(".gitignore"), "/target\n/Cargo.lock\n").expect("write gitignore");
     for args in [vec!["add", "."], vec!["commit", "-m", "fixture"]] {
         let status = Command::new("git")
             .args(args)

--- a/crates/homeboy-lab-runner/src/validation_dependencies.rs
+++ b/crates/homeboy-lab-runner/src/validation_dependencies.rs
@@ -493,6 +493,12 @@ mod tests {
     #[test]
     fn sync_workspace_runs_validation_dependency_lifecycle_before_materializing() {
         homeboy_core::test_support::with_isolated_home(|_| {
+            // The dependency lifecycle runs component deps/build scripts through the
+            // extension subsystem, which registers its runners at binary startup.
+            // Register them explicitly here so this test does not depend on a
+            // sibling test having populated the process-global runner slots.
+            homeboy_extension::component_script::register_component_script_runner();
+            homeboy_extension::build::register_component_build_runner();
             let workspace_parent = tempfile::tempdir().expect("workspace parent");
             let source = workspace_parent.path().join("host-app");
             let dependency = workspace_parent.path().join("shared-runtime");
@@ -573,6 +579,10 @@ mod tests {
     #[test]
     fn sync_workspace_uses_manifest_id_for_absolute_validation_dependency() {
         homeboy_core::test_support::with_isolated_home(|_| {
+            // Register the extension runners this dependency lifecycle needs (see
+            // the sibling test above) rather than relying on cross-test global state.
+            homeboy_extension::component_script::register_component_script_runner();
+            homeboy_extension::build::register_component_build_runner();
             let workspace_parent = tempfile::tempdir().expect("workspace parent");
             let source = workspace_parent.path().join("host-app");
             let dependency = workspace_parent.path().join("shared-runtime");

--- a/crates/homeboy-lab-runner/src/workspace/tests/git.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/git.rs
@@ -532,6 +532,9 @@ fn git_sync_of_detached_extension_source_preserves_source_revision() {
         );
         let detached_head = git_output(source.path(), &["rev-parse", "HEAD"]).unwrap();
         let detached_short = git_output(source.path(), &["rev-parse", "--short", "HEAD"]).unwrap();
+        // The persisted source-revision record now stores the full commit SHA,
+        // while the install result still surfaces the abbreviated revision.
+        let detached_full = git_output(source.path(), &["rev-parse", "HEAD"]).unwrap();
 
         crate::create(
             &format!(
@@ -582,7 +585,7 @@ fn git_sync_of_detached_extension_source_preserves_source_revision() {
         );
         assert_eq!(
             homeboy_core::extension_update_check::read_source_revision("wordpress").as_deref(),
-            Some(detached_short.as_str())
+            Some(detached_full.as_str())
         );
     });
 }

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -994,7 +994,11 @@ fn git_backed_snapshot_uses_runner_exact_sha_without_controller_bundle_hydration
         let author = tempfile::tempdir().expect("author tempdir");
         let source = tempfile::tempdir().expect("source tempdir");
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
-        git(origin.path(), &["init", "--bare"]);
+        // Initialize the bare origin on `main` so its HEAD symref matches the
+        // branch the author pushes. Without an explicit `-b main`, git falls back
+        // to the host `init.defaultBranch` (often `master`), leaving the partial
+        // clone below with an unborn default branch and no HEAD to inspect.
+        git(origin.path(), &["init", "--bare", "-b", "main"]);
         git(origin.path(), &["config", "uploadpack.allowFilter", "true"]);
         git(author.path(), &["init", "-b", "main"]);
         git(author.path(), &["config", "user.email", "test@example.com"]);


### PR DESCRIPTION
## Summary

Round 2 of the clean-checkout sweep of `homeboy-lab-runner`. Five deterministically-failing tests, each fixed at its real root cause (not by relaxing assertions):

### `materialize_script_records_the_peeled_commit_for_tags_and_direct_commits`
Four stacked breakages, uncovered one at a time:
1. **Path drift:** the fixture copied `CARGO_MANIFEST_DIR/build.rs`, which no longer exists after lab-runner was extracted into `crates/homeboy-lab-runner`. Resolve the build-identity generator from `crates/homeboy-product-identity/build.rs` at the workspace root.
2. **Env-var rename:** that generator emits `HOMEBOY_PRODUCT_GIT_*` (renamed from `HOMEBOY_BUILD_GIT_*`); the fixture's core crate now consumes the current names.
3. **Format-string bug:** the fixture `main.rs` had unescaped `{`/`}` JSON braces (`invalid format string`); escaped them.
4. **Dirty-build:** `cargo build` writes `target/`/`Cargo.lock` into the clone, and the generator marks the build dirty from `git status --porcelain`; added a committed `.gitignore` so the source-built binary reports a clean build.

### `git_backed_snapshot_uses_runner_exact_sha_without_controller_bundle_hydration`
The bare origin was `git init --bare` **without `-b main`**, so its HEAD symref fell back to the host default branch (often `master`) and the `--filter=blob:none` clone had no HEAD to `rev-list`. Initialize the bare origin on `main`.

### `git_sync_of_detached_extension_source_preserves_source_revision`
The persisted source-revision record now stores the **full** commit SHA while the install result still surfaces the **abbreviated** revision. Assert each against the correct form.

### `sync_workspace_runs_validation_dependency_lifecycle_before_materializing` + `sync_workspace_uses_manifest_id_for_absolute_validation_dependency`
The dependency lifecycle runs component deps/build scripts through the extension subsystem's process-global runner slots (`no component-script/build runner registered`). Register the component-script and component-build runners explicitly rather than relying on cross-test global state — the same isolation pattern as the merged deps_test fix.

## Testing

- `cargo fmt`; all five verified passing individually. Test-only; no production behavior changes.

## Scope note

Six lab-runner tests remain red on a clean checkout, in deeper classes: two exercise the daemon/reverse-broker exec path and hit `agent-task run record not found` (needs the record materialized in the test), one is a `session_is_live_with_timeout` timing assertion, one is a `changed_since` git-ref preflight, one is an error-wrapping check, and one (`materialize_failure`) depends on the fake `cargo` winning the PATH race but this host's rustup shim intercepts it. Left for follow-up.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Continued the lab-runner clean-checkout sweep, reproduced and root-caused five failures (peeling back four stacked breakages in the materialize-script fixture), and fixed each at the source. Chris reviews and owns the change.