### PR TITLE
Fix snapshot sync for partial-clone worktrees

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/sync.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync.rs
@@ -127,7 +127,9 @@ pub fn sync_workspace(
                 WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
             )?;
             let git_backed_snapshot = git_output(&local_path, &["rev-parse", "HEAD"]).is_ok();
-            let synthetic_checkout = if git_backed_snapshot {
+            let synthetic_checkout = if options.mode == RunnerWorkspaceSyncMode::SnapshotGit
+                && git_backed_snapshot
+            {
                 match materialize_git_snapshot_from_controller_bundle(
                     &runner,
                     &local_path,
@@ -195,11 +197,16 @@ pub fn sync_workspace(
                 });
                 None
             };
-            if git_backed_snapshot {
-                // Preserve snapshot transport semantics while recording that its
-                // successful result is an exact Git checkout plus overlay.
+            if options.mode == RunnerWorkspaceSyncMode::SnapshotGit && git_backed_snapshot {
+                // Snapshot-git deliberately retains Git metadata for callers
+                // that need a checkout baseline.
                 materialization_plan.actual_materialization_mode =
                     Some(RunnerWorkspaceSyncMode::SnapshotGit.label().to_string());
+            } else if options.mode == RunnerWorkspaceSyncMode::Snapshot {
+                // Plain snapshot mode is a readable filesystem transfer. It
+                // must not require a Git object closure from partial clones.
+                materialization_plan.actual_materialization_mode =
+                    Some("filesystem_snapshot".to_string());
             }
             let metadata = workspace_metadata(
                 &runner.id,
@@ -1093,6 +1100,7 @@ fn workspace_snapshot_entry(
         created_at: metadata.synced_at,
         source_ref: metadata.source_ref,
         source_commit: metadata.source_commit,
+        source_remote_url: metadata.source_remote_url,
         source_dirty: metadata.source_dirty,
         run_id: metadata.run_id,
         job_id: metadata.job_id,
@@ -1156,6 +1164,7 @@ fn workspace_metadata(
         synced_at: chrono::Utc::now().to_rfc3339(),
         source_ref: git_state.ref_name,
         source_commit: git_state.commit,
+        source_remote_url: git_state.remote_url,
         source_dirty: git_state.dirty,
         run_id: run_id.map(str::to_string),
         job_id: None,
@@ -1997,11 +2006,15 @@ fn local_git_state(local_path: &Path) -> LocalGitState {
     let dirty = git_output(local_path, &["status", "--porcelain=v1"])
         .ok()
         .map(|status| !status.trim().is_empty());
+    let remote_url = git_output(local_path, &["config", "--get", "remote.origin.url"])
+        .ok()
+        .filter(|value| !value.trim().is_empty());
 
     LocalGitState {
         commit,
         ref_name,
         dirty,
+        remote_url,
     }
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -108,7 +108,7 @@ use homeboy_core::source_snapshot::SourceSnapshot;
 static PATH_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 #[test]
-fn git_backed_snapshot_reports_checkout_provenance_for_committed_harvest() {
+fn snapshot_git_reports_checkout_provenance_for_committed_harvest() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let source = tempfile::tempdir().expect("source workspace");
         let runner_root = tempfile::tempdir().expect("runner root");
@@ -152,7 +152,7 @@ fn git_backed_snapshot_reports_checkout_provenance_for_committed_harvest() {
             "lab-snapshot-harvest",
             RunnerWorkspaceSyncOptions {
                 path: source.path().display().to_string(),
-                mode: RunnerWorkspaceSyncMode::Snapshot,
+                mode: RunnerWorkspaceSyncMode::SnapshotGit,
                 controller_routed_git: false,
                 changed_since_base: None,
                 git_fetch_refs: Vec::new(),
@@ -163,7 +163,7 @@ fn git_backed_snapshot_reports_checkout_provenance_for_committed_harvest() {
         )
         .expect("materialize local-only committed source");
 
-        assert_eq!(synced.sync_mode, RunnerWorkspaceSyncMode::Snapshot);
+        assert_eq!(synced.sync_mode, RunnerWorkspaceSyncMode::SnapshotGit);
         assert_eq!(
             synced
                 .materialization_plan
@@ -891,7 +891,7 @@ fn workspace_list_reports_recent_lab_workspaces_with_exec_commands() {
 }
 
 #[test]
-fn git_backed_snapshot_sync_falls_back_for_unpublished_commit_and_preserves_dirty_overlay() {
+fn snapshot_git_sync_falls_back_for_unpublished_commit_and_preserves_dirty_overlay() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let source = super::dirty_git_repo();
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
@@ -920,7 +920,7 @@ fn git_backed_snapshot_sync_falls_back_for_unpublished_commit_and_preserves_dirt
             "lab-local-snapshot-git",
             RunnerWorkspaceSyncOptions {
                 path: source.path().display().to_string(),
-                mode: RunnerWorkspaceSyncMode::Snapshot,
+                mode: RunnerWorkspaceSyncMode::SnapshotGit,
                 controller_routed_git: false,
                 changed_since_base: None,
                 git_fetch_refs: Vec::new(),
@@ -933,13 +933,16 @@ fn git_backed_snapshot_sync_falls_back_for_unpublished_commit_and_preserves_dirt
 
         let remote = Path::new(&output.remote_path);
         assert_eq!(exit_code, 0);
-        assert_eq!(output.sync_mode, RunnerWorkspaceSyncMode::Snapshot);
+        assert_eq!(output.sync_mode, RunnerWorkspaceSyncMode::SnapshotGit);
         assert_eq!(
             output.current_workspace.sync_mode,
-            RunnerWorkspaceSyncMode::Snapshot
+            RunnerWorkspaceSyncMode::SnapshotGit
         );
         assert_eq!(output.current_workspace.source_dirty, Some(true));
-        assert_eq!(output.workspace_cleanliness, "snapshot_unique_workspace");
+        assert_eq!(
+            output.workspace_cleanliness,
+            "snapshot_synthetic_git_unique_workspace"
+        );
         assert_eq!(
             fs::read_to_string(remote.join("file.txt")).unwrap(),
             "dirty\n"
@@ -988,7 +991,11 @@ fn git_backed_snapshot_sync_falls_back_for_unpublished_commit_and_preserves_dirt
 }
 
 #[test]
-fn git_backed_snapshot_uses_runner_exact_sha_without_controller_bundle_hydration() {
+fn filesystem_snapshot_of_dirty_partial_clone_avoids_git_bundle_closure() {
+    let _path_guard = PATH_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("PATH lock");
     homeboy_core::test_support::with_isolated_home(|_| {
         let origin = tempfile::tempdir().expect("origin tempdir");
         let author = tempfile::tempdir().expect("author tempdir");
@@ -1034,6 +1041,8 @@ fn git_backed_snapshot_uses_runner_exact_sha_without_controller_bundle_hydration
                 ".",
             ],
         );
+        let source_branch = git_output(source.path(), &["rev-parse", "--abbrev-ref", "HEAD"])
+            .expect("source branch");
         assert!(
             git_output(
                 source.path(),
@@ -1045,6 +1054,7 @@ fn git_backed_snapshot_uses_runner_exact_sha_without_controller_bundle_hydration
         );
         fs::write(source.path().join("file.txt"), "dirty\n").expect("tracked overlay");
         fs::write(source.path().join("untracked.txt"), "untracked\n").expect("untracked overlay");
+        fs::write(source.path().join(".env"), "secret\n").expect("excluded secret");
         crate::create(
             &format!(
                 r#"{{"id":"lab-local-partial-snapshot","kind":"local","workspace_root":"{}"}}"#,
@@ -1054,6 +1064,24 @@ fn git_backed_snapshot_uses_runner_exact_sha_without_controller_bundle_hydration
         )
         .expect("create runner");
 
+        let shim_root = tempfile::tempdir().expect("git shim root");
+        let shim = shim_root.path().join("git");
+        fs::write(
+            &shim,
+            "#!/bin/sh\nfor arg in \"$@\"; do [ \"$arg\" = \"rev-list\" ] && { echo 'git bundle closure enumeration invoked' >&2; exit 91; }; done\nexec /usr/bin/git \"$@\"\n",
+        )
+        .expect("write git shim");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&shim, fs::Permissions::from_mode(0o755))
+                .expect("make shim executable");
+        }
+        let original_path = std::env::var_os("PATH").expect("PATH");
+        let mut paths = vec![shim_root.path().to_path_buf()];
+        paths.extend(std::env::split_paths(&original_path));
+        std::env::set_var("PATH", std::env::join_paths(paths).expect("PATH value"));
+
         let (output, exit_code) = sync_workspace(
             "lab-local-partial-snapshot",
             RunnerWorkspaceSyncOptions {
@@ -1062,25 +1090,20 @@ fn git_backed_snapshot_uses_runner_exact_sha_without_controller_bundle_hydration
                 ..Default::default()
             },
         )
-        .expect("runner resolves published exact SHA");
+        .expect("filesystem snapshot must not enumerate a Git bundle closure");
+        std::env::set_var("PATH", original_path);
 
         let remote = Path::new(&output.remote_path);
         assert_eq!(exit_code, 0);
         assert!(output.materialization_plan.controller_git_bundle.is_none());
-        assert_eq!(git_output(remote, &["rev-parse", "HEAD"]).unwrap(), head);
-        assert!(
-            git_output(
-                remote,
-                &[
-                    "show-ref",
-                    "--verify",
-                    "--quiet",
-                    "refs/remotes/origin/unrelated"
-                ]
-            )
-            .is_err(),
-            "fresh exact-SHA materialization must not fetch every remote branch"
+        assert_eq!(
+            output
+                .materialization_plan
+                .actual_materialization_mode
+                .as_deref(),
+            Some("filesystem_snapshot")
         );
+        assert!(!remote.join(".git").exists());
         assert_eq!(
             fs::read_to_string(remote.join("file.txt")).unwrap(),
             "dirty\n"
@@ -1088,6 +1111,28 @@ fn git_backed_snapshot_uses_runner_exact_sha_without_controller_bundle_hydration
         assert_eq!(
             fs::read_to_string(remote.join("untracked.txt")).unwrap(),
             "untracked\n"
+        );
+        assert!(!remote.join(".env").exists(), "default exclusions apply");
+        assert_eq!(
+            output.current_workspace.source_commit.as_deref(),
+            Some(head.as_str())
+        );
+        assert_eq!(
+            output.current_workspace.source_ref.as_deref(),
+            Some(source_branch.as_str())
+        );
+        let metadata: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(remote.join(".homeboy/runner-workspace.json"))
+                .expect("read workspace metadata"),
+        )
+        .expect("parse workspace metadata");
+        assert_eq!(
+            metadata["actual_materialization_mode"],
+            "filesystem_snapshot"
+        );
+        assert_eq!(
+            metadata["source_remote_url"],
+            format!("file://{}", origin.path().display())
         );
         assert!(
             git_output(
@@ -1194,7 +1239,7 @@ fn git_backed_snapshot_preserves_tracked_internal_file_and_directory_links() {
             "lab-internal-links",
             RunnerWorkspaceSyncOptions {
                 path: source.display().to_string(),
-                mode: RunnerWorkspaceSyncMode::Snapshot,
+                mode: RunnerWorkspaceSyncMode::SnapshotGit,
                 ..Default::default()
             },
         )

--- a/crates/homeboy-lab-runner/src/workspace/types.rs
+++ b/crates/homeboy-lab-runner/src/workspace/types.rs
@@ -401,6 +401,8 @@ pub struct RunnerWorkspaceSnapshotEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_commit: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_remote_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_dirty: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub run_id: Option<String>,
@@ -432,6 +434,8 @@ pub(super) struct RunnerWorkspaceMetadata {
     pub source_ref: Option<String>,
     #[serde(default)]
     pub source_commit: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_remote_url: Option<String>,
     #[serde(default)]
     pub source_dirty: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -465,6 +469,7 @@ pub(super) struct LocalGitState {
     pub(super) commit: Option<String>,
     pub(super) ref_name: Option<String>,
     pub(super) dirty: Option<bool>,
+    pub(super) remote_url: Option<String>,
 }
 
 pub(super) struct GitSnapshot {


### PR DESCRIPTION
## Summary

- make plain `snapshot` mode transfer the readable filesystem without enumerating the Git object closure
- retain exact Git checkout plus overlay behavior under explicit `snapshot-git` mode
- preserve source commit, branch, dirty state, and remote provenance in filesystem snapshots
- verify filesystem snapshot content and provenance before creating an isolated synthetic Git baseline for candidate harvesting
- preserve existing bounded patch harvesting and anti-tamper checks for provider edits, no-op output, and provenance mismatches

Fixes #9101.

## How to test

1. Check out this branch from a fresh clone.
2. Run `cargo test -p homeboy-lab-runner workspace::tests::snapshot:: --lib`.
3. Run `cargo test -p homeboy-lab-runner workspace::provenance::tests:: --lib`.
4. Run `cargo check -p homeboy-agents -p homeboy-lab-runner`.
5. Run `cargo fmt --check`.
6. Run `git diff --check origin/main...HEAD`.
7. Create a dirty `blob:none` partial-clone worktree and run `homeboy runner workspace sync <runner> --path <checkout> --mode snapshot`; confirm it succeeds without promisor hydration, reports `filesystem_snapshot`, preserves tracked and untracked changes, and excludes declared generated/secret paths.
8. Run an issue-linked Lab agent task from that snapshot; confirm provenance verification succeeds, the provider is dispatched, and edits are harvested into a bounded candidate patch.
9. Run the same source with `--mode snapshot-git`; confirm callers that need Git metadata retain Git checkout plus overlay semantics.

## Compatibility

This intentionally narrows plain `snapshot` to filesystem snapshot semantics. Callers that require a Git checkout must select the existing explicit `snapshot-git` mode. Serialized metadata gains an optional `source_remote_url` field and remains compatible with prior records.

## Verification

- Snapshot test suite: 40 passed
- Provenance and filesystem-harvest suite: 17 passed
- `cargo check -p homeboy-agents -p homeboy-lab-runner`: passed
- `cargo fmt --check`: passed
- `git diff --check origin/main...HEAD`: passed
- Live dirty partial-clone snapshot: passed, 564 files transferred with `filesystem_snapshot` and no Git hydration
- Initial live agent task reached runner execution and exposed the now-covered filesystem harvest trust gap; final live rerun follows after refreshing this commit

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with GPT-5.6 Sol
- **Used for:** Diagnosed the partial-clone materialization and candidate-harvest failures, implemented the generic snapshot repair and deterministic tests, and verified the change with Chris.