### PR TITLE
fix: stop changed-scope Lab bundle hydration from over-fetching unrelated history

### DIFF
--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -482,9 +482,13 @@ mod tests {
         let (port, server) = serve_health("lease-live", 42, Duration::from_millis(125));
         let session = session_for_health_endpoint(port, "lease-live", 42);
 
+        // Liveness splits its budget across three attempts and reserves half of
+        // each (`remaining / attempts_left / 2`), so a single probe only gets a
+        // fraction of the total timeout. The overall budget must be large enough
+        // that one probe still exceeds the endpoint's 125ms response time.
         assert!(session_is_live_with_timeout(
             &session,
-            Duration::from_millis(200)
+            Duration::from_millis(1500)
         ));
         server.join().expect("server");
     }

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -494,6 +494,20 @@ fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
         let broker_url = format!("http://{addr}");
 
         let stable_run_id = "agent-task-run-123";
+        // The reverse-broker submission records a submission request against the
+        // controller's durable run, so materialize that controller proxy record
+        // first (mirroring the controller submitting the plan before the runner
+        // handoff) rather than leaving the submission to fail on a missing record.
+        homeboy_agents::agent_task_lifecycle::record_lab_offload_planned(
+            homeboy_agents::agent_task_lifecycle::LabOffloadProxyPlan {
+                run_id: stable_run_id,
+                runner_id: "lab",
+                remote_workspace: "/srv/homeboy/project",
+                remote_command: &["homeboy".to_string(), "test".to_string()],
+                durable_plan: None,
+            },
+        )
+        .expect("controller proxy run recorded before reverse-broker handoff");
         let (output, exit_code) = exec_via_reverse_broker(
             &ssh_runner(),
             &broker_url,

--- a/crates/homeboy-lab-runner/src/resource_metrics.rs
+++ b/crates/homeboy-lab-runner/src/resource_metrics.rs
@@ -864,7 +864,12 @@ mod tests {
         )
         .expect_err("callback failure returns");
 
-        assert!(error.message.contains("persist child identity"));
+        // `Error::internal_io` carries a fixed "IO error" message and puts the
+        // formatted cause in `details["error"]`, so assert the child-identity
+        // failure surfaces there rather than on the top-level message.
+        assert!(error.details["error"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("persist child identity")));
         assert!(!homeboy_core::process::pid_is_running(
             pid.load(Ordering::SeqCst)
         ));

--- a/crates/homeboy-lab-runner/src/workspace/git.rs
+++ b/crates/homeboy-lab-runner/src/workspace/git.rs
@@ -429,8 +429,16 @@ fn refetch_controller_bundle_commits(
     remote: &str,
     refs: &[String],
 ) -> Result<()> {
+    // Fetch only the closure of the requested refs. `--refetch` was used here to
+    // reapply the partial-clone filter, but it "fetches all objects as a fresh
+    // clone would" (git-fetch(1)), re-pulling objects reachable from unrelated
+    // refs the server happens to pack alongside the requested ones. That
+    // over-fetch is non-deterministic and violated the changed-scope contract
+    // that the controller must hydrate only the promised base/head closure.
+    // Naming the exact refs completes their closure through the promisor
+    // transport without re-fetching unrelated history.
     let output = Command::new("git")
-        .args(["fetch", "--refetch", "--no-tags", "--filter=blob:none"])
+        .args(["fetch", "--no-tags", "--filter=blob:none"])
         .arg(remote)
         .args(refs)
         .current_dir(local_path)

--- a/crates/homeboy-lab-runner/src/workspace/tests/git.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/git.rs
@@ -16,7 +16,10 @@ fn changed_since_retry_route_materializes_private_unavailable_origin_from_bundle
         let author = tempfile::tempdir().expect("author tempdir");
         let source = tempfile::tempdir().expect("source tempdir");
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
-        git(origin.path(), &["init", "--bare"]);
+        // Initialize the bare origin on `main` so its HEAD symref matches the
+        // author's branch; without it git falls back to the host default branch
+        // (often `master`), breaking base-ref resolution against the origin.
+        git(origin.path(), &["init", "--bare", "-b", "main"]);
         git(origin.path(), &["config", "uploadpack.allowFilter", "true"]);
         git(author.path(), &["init", "-b", "main"]);
         git(author.path(), &["config", "user.email", "test@example.com"]);


### PR DESCRIPTION
## Summary

A flaky lab-runner test (`changed_since_retry_route_materializes_private_unavailable_origin_from_bundle`, ~1 in 3) turned out to be a **real production bug**, not a bad assertion. The controller's changed-scope bundle hydration ran:

```sh
git fetch --refetch --no-tags --filter=blob:none <promisor-remote> <base> <head>
```

Per git-fetch(1), **`--refetch`** *"fetches all objects as a fresh clone would"* instead of negotiating away what is already local. Under a partial clone this re-pulled objects reachable from **unrelated refs** whenever the server packed them alongside the requested closure — a non-deterministic over-fetch that violated the changed-scope contract: *the controller must hydrate only the promised base/head closure*.

The test asserted exactly that contract (`the controller must not hydrate unrelated refs`) and caught the leak intermittently.

## Fix

Drop `--refetch` and fetch only the named refs:

```sh
git fetch --no-tags --filter=blob:none <promisor-remote> <base> <head>
```

Naming the exact refs completes their closure through the promisor transport without dragging in unrelated history. This is a **correctness and bundle-size** fix for the changed-scope Lab offload.

**Validation:** the previously-flaky test passes 8/8, and the full `workspace::tests::git` (15) and git-backed snapshot (4) suites pass — the closure repair still works without the over-fetch.

## Also: four latent test fixes from the same sweep

- **`changed_since_retry_...`**: the bare origin was `git init --bare` without `-b main`, so its HEAD fell back to the host default branch (often `master`) — base-ref resolution against origin broke. Initialize it on `main`. (This VPS/CI has no `init.defaultBranch` set.)
- **`reverse_broker_exec_detached_surfaces_persisted_run_id`**: the reverse-broker submission records a submission request against the controller's durable run, so materialize that controller proxy record first (mirroring the controller submitting the plan before the runner handoff).
- **`child_started_failure_kills_and_reaps_the_spawned_child`**: `Error::internal_io` carries a fixed `"IO error"` message and puts the cause in `details["error"]`; assert the child-identity failure there instead of on `.message`.
- **`session_health_accepts_a_healthy_endpoint_after_one_hundred_milliseconds`**: liveness splits its budget across three attempts and reserves half of each (`remaining / attempts_left / 2`), so the 200ms budget left no single probe longer than the 125ms endpoint response; widen the budget.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Investigated a flaky changed-scope hydration test; on the prompt to question the *operation* rather than the test, traced the non-determinism to `git fetch --refetch` over-fetching unrelated partial-clone history and fixed the fetch scope, then repaired four adjacent latent test failures. Chris reviews and owns the change.