### PR TITLE
refactor(release): add ReleaseStepResult::default() and drop construction boilerplate

### DIFF
--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -305,11 +305,7 @@ fn run_default_branch_preflight(
             id: step.id.clone(),
             step_type: step.kind.clone(),
             status: ReleaseStepStatus::Success,
-            missing: Vec::new(),
-            warnings: Vec::new(),
-            hints: Vec::new(),
-            data: None,
-            error: None,
+            ..Default::default()
         },
         Err(err) => failed_result(&step.id, &step.kind, err),
     }
@@ -324,11 +320,7 @@ fn run_working_tree_preflight(
             id: step.id.clone(),
             step_type: step.kind.clone(),
             status: ReleaseStepStatus::Success,
-            missing: Vec::new(),
-            warnings: Vec::new(),
-            hints: Vec::new(),
-            data: None,
-            error: None,
+            ..Default::default()
         },
         Err(err) => failed_result(&step.id, &step.kind, err),
     }
@@ -351,11 +343,7 @@ fn run_remote_sync_preflight(
             id: step.id.clone(),
             step_type: step.kind.clone(),
             status: ReleaseStepStatus::Success,
-            missing: Vec::new(),
-            warnings: Vec::new(),
-            hints: Vec::new(),
-            data: None,
-            error: None,
+            ..Default::default()
         },
         Err(err) => failed_result(&step.id, &step.kind, err),
     }
@@ -403,16 +391,13 @@ fn run_bump_policy_preflight(step: &PlanStep) -> ReleaseStepResult {
         id: step.id.clone(),
         step_type: step.kind.clone(),
         status: ReleaseStepStatus::Success,
-        missing: Vec::new(),
-        warnings: Vec::new(),
-        hints: Vec::new(),
         data: Some(serde_json::json!({
             "requested": requested,
             "recommended": recommended,
             "underbump": underbump,
             "force_lower_bump": force_lower_bump,
         })),
-        error: None,
+        ..Default::default()
     }
 }
 
@@ -516,11 +501,7 @@ fn run_changelog_bootstrap_preflight(
             id: step.id.clone(),
             step_type: step.kind.clone(),
             status: ReleaseStepStatus::Success,
-            missing: Vec::new(),
-            warnings: Vec::new(),
-            hints: Vec::new(),
-            data: None,
-            error: None,
+            ..Default::default()
         },
         Err(err) => failed_result(&step.id, &step.kind, err),
     }

--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -52,11 +52,9 @@ pub(crate) fn step_success(
         id: id.to_string(),
         step_type: step_type.to_string(),
         status: ReleaseStepStatus::Success,
-        missing: Vec::new(),
-        warnings: Vec::new(),
         hints,
         data,
-        error: None,
+        ..Default::default()
     }
 }
 
@@ -72,11 +70,10 @@ pub(crate) fn step_failed(
         id: id.to_string(),
         step_type: step_type.to_string(),
         status: ReleaseStepStatus::Failed,
-        missing: Vec::new(),
-        warnings: Vec::new(),
         hints,
         data,
         error,
+        ..Default::default()
     }
 }
 
@@ -91,11 +88,9 @@ pub(crate) fn step_skipped(
         id: id.to_string(),
         step_type: step_type.to_string(),
         status: ReleaseStepStatus::Skipped,
-        missing: Vec::new(),
         warnings: vec![warning.into()],
-        hints: Vec::new(),
         data,
-        error: None,
+        ..Default::default()
     }
 }
 

--- a/crates/homeboy-release/src/release/types.rs
+++ b/crates/homeboy-release/src/release/types.rs
@@ -192,6 +192,27 @@ pub struct ReleaseStepResult {
     pub error: Option<String>,
 }
 
+impl Default for ReleaseStepResult {
+    /// A defaulted step has empty `id`/`step_type`, `Failed` status, and every
+    /// collection/optional field empty. `Failed` is the deliberate status
+    /// default: a not-yet-populated step must never read as `Success`. Construct
+    /// with `..Default::default()` and set the meaningful fields (`id`,
+    /// `step_type`, `status`, and whatever else applies) to drop the
+    /// `Vec::new()`/`None` boilerplate the step builders otherwise repeat.
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            step_type: String::new(),
+            status: ReleaseStepStatus::Failed,
+            missing: Vec::new(),
+            warnings: Vec::new(),
+            hints: Vec::new(),
+            data: None,
+            error: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ReleaseStepStatus {
@@ -500,6 +521,39 @@ mod tests {
         let plan = ReleasePlan::new("demo", true, Vec::new(), None, Vec::new(), Vec::new());
 
         assert_eq!(plan.component_id(), Some("demo"));
+    }
+
+    #[test]
+    fn release_step_result_default_matches_the_fully_spelled_out_step() {
+        let via_default = ReleaseStepResult {
+            id: "build".to_string(),
+            step_type: "build".to_string(),
+            status: ReleaseStepStatus::Success,
+            ..Default::default()
+        };
+        let verbose = ReleaseStepResult {
+            id: "build".to_string(),
+            step_type: "build".to_string(),
+            status: ReleaseStepStatus::Success,
+            missing: Vec::new(),
+            warnings: Vec::new(),
+            hints: Vec::new(),
+            data: None,
+            error: None,
+        };
+        // ReleaseStepResult has no PartialEq; compare via canonical serialization.
+        assert_eq!(
+            serde_json::to_value(&via_default).unwrap(),
+            serde_json::to_value(&verbose).unwrap()
+        );
+    }
+
+    #[test]
+    fn release_step_result_default_status_is_failed_never_success() {
+        assert_eq!(
+            ReleaseStepResult::default().status,
+            ReleaseStepStatus::Failed
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Next slice of the struct-construction simplification pass. `ReleaseStepResult` has **8 fields** but only `id`/`step_type`/`status` are meaningfully set at most sites; `missing`/`warnings`/`hints` default to empty `Vec` and `data`/`error` to `None`. It's built **~26×**, with the step builders (`step_success`/`step_failed`/`step_skipped`) and preflight dispatchers repeating the same `Vec::new()`/`None` boilerplate.

## Change
Implement `Default` (**hand-impl, not derive**, because `ReleaseStepStatus` has no `Default`; `status` defaults to `Failed` so a not-yet-populated step can never read as `Success`). Sites now write only the meaningful fields + `..Default::default()`.

## Proof it's behavior-preserving
- `release_step_result_default_matches_the_fully_spelled_out_step` — equivalent to the fully-spelled step (compared via canonical serialization, since the struct has no `PartialEq`)
- `release_step_result_default_status_is_failed_never_success` — guards the safe-default invariant

## First migration batch
Migrated the 3 step builders + the identical success-result preflight dispatchers + a `data`-carrying site. Sites keep any non-default field (e.g. `data: Some(json!(...))`) explicit. The surrounding executor/dispatch tests (**132 total**) are unchanged and still pass.

> Note: I initially tried a quick regex script to bulk-migrate the dispatch sites and it mangled the ones with multi-line `data: Some(json!({...}))` values (nested braces) — reverted and did those by hand. That brace-depth problem is *exactly* what the `collapse-defaults` engine capability (#9104) handles correctly, and why the remaining ~15 sites are best left for the tool once it lands rather than hand-churned here.

## Verification (VPS-safe)
- `cargo check -p homeboy-release --lib` — clean
- `cargo test`: 2 new tests + 21 dispatch + 111 executor tests — all pass
- `cargo fmt` — clean

## Context
Follows #9081/#9086/#9087/#9092/#9096. Sixth struct in the campaign. Decision tree holds: hand-impl `Default` because a field (`status`) needs a specific non-default value.