### PR TITLE
fix: durably accept the controller Lab handoff on a detached direct-daemon exec

### DIFF
--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -167,7 +167,23 @@ pub(super) fn exec_via_daemon(
         // The daemon has durably accepted this child. Bind it before waiting so
         // a lost controller still leaves cancellation and reconciliation with a
         // concrete runner job identity.
-        if run_id_owns_generic_exec {
+        if detach_after_handoff {
+            // A detached handoff must durably transition the controller's pending
+            // Lab handoff to accepted before the response can be lost, exactly as
+            // the reverse-broker path does. Binding only the metadata runner job
+            // id (below) leaves the typed handoff pending, so `runner_job_id()`
+            // — which reads the accepted handoff first — reports no bound job and
+            // the controller can expire or re-dispatch an already-accepted run.
+            homeboy_agents::agent_task_lifecycle::record_detached_lab_run(
+                homeboy_agents::agent_task_lifecycle::DetachedLabRunRecord {
+                    run_id,
+                    runner_id: &runner.id,
+                    runner_job_id: &job.id.to_string(),
+                    remote_workspace: &cwd,
+                    remote_command: &command,
+                },
+            )?;
+        } else if run_id_owns_generic_exec {
             homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
                 run_id,
                 &runner.id,

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -585,6 +585,10 @@ fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
 #[test]
 fn direct_daemon_detached_handoff_returns_while_the_workload_remains_running() {
     homeboy_core::test_support::with_isolated_home(|_| {
+        // The in-process daemon's /exec endpoint drives runner processes through
+        // the RunnerExecDriver hook (production wires this at CLI startup); register
+        // the runner-side driver so this end-to-end handoff can run the child.
+        crate::register_runner_daemon_exec_driver();
         let run_id = "cook-8332-attempt-1";
         homeboy_agents::agent_task_lifecycle::record_lab_offload_phase(
             run_id,


### PR DESCRIPTION
## Summary

Another flaky/failing lab-runner test turned out to be a **real durability bug**, not a test issue.

A **detached direct-daemon** Lab exec bound only the metadata runner job id and never transitioned the controller's **pending** Lab handoff to **accepted**. The reverse-broker path already does this via `record_detached_lab_run`, but the direct-daemon path was **missing the `detach_after_handoff` branch** and fell through to `record_runner_job_identity`, which writes `metadata.runner_job_id` without touching the typed handoff.

### Why that matters

`AgentTaskRunRecord::runner_job_id()` reads the **accepted handoff first** and only falls back to metadata when no handoff is present. So a still-pending handoff **shadowed** the bound job: the controller record reported *no bound runner job* even though the daemon had durably accepted the child. A controller that lost the response could then **expire or re-dispatch an already-accepted run** — the exact durability failure the typed-handoff authority (#8960/#8824) is meant to prevent.

I confirmed the state by instrumenting the test: `lab_handoff = Pending`, `metadata.runner_job_id = <uuid>`, but `runner_job_id() = None`.

## Fix

Mirror the reverse-broker path in `exec_via_daemon`: on a detached handoff, call `record_detached_lab_run`, which transitions the typed handoff `Pending -> Accepted` with the concrete runner job id before the response can be lost. The non-detached and generic-exec branches are unchanged.

## Testing

- `direct_daemon_detached_handoff_returns_while_the_workload_remains_running` now passes (it asserts the controller record binds the accepted runner job id). It also needed the runner-side `RunnerExecDriver` registered in-test (production wires this at CLI startup) to drive the in-process daemon's `/exec` endpoint.
- The full `execution::tests::handoff` suite — **27 tests** — passes, so the non-detached daemon and broker paths are unaffected.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Investigated a failing detached-daemon handoff test, instrumented the controller record to find a pending handoff shadowing the bound job id, traced it to the daemon path missing the reverse-broker's `record_detached_lab_run` transition, and fixed the asymmetry. Chris reviews and owns the change.