### PR TITLE
Preserve explicit runner exec identity

### DIFF
--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -187,6 +187,11 @@ pub(super) fn exec_via_reverse_broker(
     let persisted_run_id = mirror_evidence
         .then(|| persist_lab_offload_handoff_run(runner, &cwd, &command, &job, run_id.as_deref()))
         .flatten();
+    validate_generic_exec_mirror_run_id(
+        run_id_owns_generic_exec,
+        run_id.as_deref(),
+        persisted_run_id.as_deref(),
+    )?;
     if detach_after_handoff {
         return Ok(detached_handoff_output(
             runner,
@@ -280,6 +285,11 @@ pub(super) fn exec_via_reverse_broker(
     };
     let patch = mirror.as_ref().and_then(|evidence| evidence.patch.clone());
     let mirror_run_id = mirror.as_ref().map(|evidence| evidence.run.id.clone());
+    validate_generic_exec_mirror_run_id(
+        run_id_owns_generic_exec,
+        run_id.as_deref(),
+        mirror_run_id.as_deref(),
+    )?;
     let artifacts = job.artifacts.clone();
     let mutation_artifacts = mutation_artifacts_from_job(&job, &result);
 

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -202,6 +202,11 @@ pub(super) fn exec_via_daemon(
     let persisted_run_id = mirror_evidence
         .then(|| persist_lab_offload_handoff_run(runner, &cwd, &command, &job, run_id.as_deref()))
         .flatten();
+    validate_generic_exec_mirror_run_id(
+        run_id_owns_generic_exec,
+        run_id.as_deref(),
+        persisted_run_id.as_deref(),
+    )?;
     if detach_after_handoff {
         return Ok(detached_handoff_output(
             runner,
@@ -306,6 +311,11 @@ pub(super) fn exec_via_daemon(
     };
     let patch = mirror.as_ref().and_then(|evidence| evidence.patch.clone());
     let mirror_run_id = mirror.as_ref().map(|evidence| evidence.run.id.clone());
+    validate_generic_exec_mirror_run_id(
+        run_id_owns_generic_exec,
+        run_id.as_deref(),
+        mirror_run_id.as_deref(),
+    )?;
     let artifacts = job.artifacts.clone();
     let mutation_artifacts = mutation_artifacts_from_job(&job, &result);
     if print_handoff_output {

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -9,12 +9,12 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use homeboy_core::api_jobs::{Job, JobArtifactMetadata, JobEvent, JobStatus};
 use homeboy_core::engine::command::CommandCaptureMetadata;
 use homeboy_core::env_materialization_plan::EnvMaterializationPlan;
-use homeboy_core::error::{Error, Result};
+use homeboy_core::error::{Error, ErrorCode, Result};
 use homeboy_core::lab_contract::LabRunnerWorkload;
 use homeboy_core::observation::{NewRunRecord, ObservationStore, RunStatus};
 use homeboy_core::runner_execution_envelope::{
@@ -964,13 +964,38 @@ fn refuses_stale_daemon_execution(
 ) -> bool {
     status.connected
         && status.stale_daemon.is_some()
-        // The live daemon probe is authoritative over a controller-scoped
-        // session projection. Missing or stale evidence remains fail-closed.
-        && !status
-            .daemon_freshness
-            .as_ref()
-            .is_some_and(|freshness| freshness.fresh)
         && !allows_idle_stale_daemon_refresh(options, status)
+}
+
+fn validate_generic_exec_mirror_run_id(
+    run_id_owns_generic_exec: bool,
+    requested_run_id: Option<&str>,
+    persisted_run_id: Option<&str>,
+) -> Result<()> {
+    let (true, Some(requested_run_id), Some(persisted_run_id)) =
+        (run_id_owns_generic_exec, requested_run_id, persisted_run_id)
+    else {
+        return Ok(());
+    };
+    if requested_run_id == persisted_run_id {
+        return Ok(());
+    }
+
+    Err(Error::new(
+        ErrorCode::RunnerLabTransportFailure,
+        format!(
+            "runner exec persisted run identity mismatch: requested `{requested_run_id}`, received `{persisted_run_id}`"
+        ),
+        json!({
+            "requested_run_id": requested_run_id,
+            "persisted_run_id": persisted_run_id,
+            "run_id_owns_generic_exec": true,
+        }),
+    )
+    .with_hint(
+        "Treat the explicit runner exec run ID as authoritative; inspect the runner daemon identity before retrying."
+            .to_string(),
+    ))
 }
 
 fn apply_explicit_runner_exec_run_id_env(

--- a/crates/homeboy-lab-runner/src/execution/tests/exec.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/exec.rs
@@ -142,7 +142,7 @@ fn explicit_refresh_keeps_active_or_uncertain_stale_daemons_protected() {
 }
 
 #[test]
-fn runner_exec_accepts_a_fresh_daemon_when_a_scoped_session_projection_is_stale() {
+fn runner_exec_rejects_a_live_daemon_with_an_incompatible_build_identity() {
     let mut status = stale_direct_daemon_status();
     status.daemon_freshness = Some(homeboy_core::daemon::DaemonFreshnessReport {
         fresh: true,
@@ -150,7 +150,7 @@ fn runner_exec_accepts_a_fresh_daemon_when_a_scoped_session_projection_is_stale(
         ..authoritative_drained_freshness()
     });
 
-    assert!(!refuses_stale_daemon_execution(
+    assert!(refuses_stale_daemon_execution(
         &RunnerExecOptions::raw_command(vec!["cargo".to_string()]),
         &status,
     ));
@@ -162,6 +162,28 @@ fn runner_exec_keeps_stale_session_projections_fail_closed_without_fresh_daemon_
         &RunnerExecOptions::raw_command(vec!["cargo".to_string()]),
         &stale_direct_daemon_status(),
     ));
+}
+
+#[test]
+fn generic_runner_exec_rejects_a_mismatched_persisted_run_identity() {
+    let error = validate_generic_exec_mirror_run_id(
+        true,
+        Some("requested-run"),
+        Some("unrelated-active-run"),
+    )
+    .expect_err("explicit generic runner exec identity must fail closed");
+
+    assert_eq!(error.code, ErrorCode::RunnerLabTransportFailure);
+    assert_eq!(error.details["requested_run_id"], "requested-run");
+    assert_eq!(error.details["persisted_run_id"], "unrelated-active-run");
+}
+
+#[test]
+fn generic_runner_exec_accepts_its_explicit_persisted_run_identity() {
+    validate_generic_exec_mirror_run_id(true, Some("requested-run"), Some("requested-run"))
+        .expect("matching identity remains valid");
+    validate_generic_exec_mirror_run_id(false, Some("agent-task-run"), Some("mirrored-run"))
+        .expect("non-generic workflows retain their existing mirror ownership");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- reject ordinary runner execution whenever the connected daemon is marked stale, even when its liveness report is fresh
- retain the narrowly scoped zero-active-job `runner.refresh-homeboy` recovery path
- fail closed on direct-daemon and reverse-broker handoffs when a generic `runner exec --run-id` mirror resolves to a different persisted run

Closes #9111.

## Why

Daemon freshness proves that a daemon is live, not that its binary matches the configured runner executable. Admitting a healthy but incompatible daemon allowed older run-selection behavior to associate a command with an unrelated active run while artifacts remained under the explicit run ID.

## How to test

1. Run `cargo test -p homeboy-lab-runner execution::tests::exec`.
2. Run `cargo test -p homeboy-lab-runner execution::tests::handoff`.
3. Run `cargo check -p homeboy-lab-runner`.
4. Run `cargo fmt --check`.
5. Run `git diff --check origin/main...HEAD`.

## Backwards compatibility

`runner exec` now rejects any connected daemon that status identifies as stale instead of accepting it solely because the daemon liveness probe is fresh. This intentionally tightens behavior: operators must drain and refresh the daemon first. The existing idle, authoritative-zero-job `runner.refresh-homeboy` exception remains available.

No extension paths or public library APIs change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Root-cause tracing, implementation, regression tests, and verification under Chris Huber's direction.