### PR TITLE
fix: repair latent homeboy-core symbol-graph, version, and daemon /exec tests

### DIFF
--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -2297,7 +2297,16 @@ mod tests {
     use std::process::Command;
     use std::sync::Arc;
 
-    struct EnqueueTestDriver;
+    pub(super) struct EnqueueTestDriver;
+
+    /// Register the enqueue test driver for daemon `/exec` tests. The daemon
+    /// `/exec` endpoint routes through the `RunnerExecDriver` hook (#8632), whose
+    /// real implementation lives in the extracted runner crate (#8698). Core's
+    /// daemon tests must register a driver or the endpoint fails closed with a
+    /// 400 (`runner subsystem is unavailable`).
+    pub(super) fn register_enqueue_test_driver() {
+        runner_exec_driver::register_runner_exec_driver(Arc::new(EnqueueTestDriver));
+    }
 
     #[test]
     fn admission_reservation_blocks_daemon_replacement_until_released() {

--- a/crates/homeboy-core/src/engine/symbol_graph.rs
+++ b/crates/homeboy-core/src/engine/symbol_graph.rs
@@ -679,15 +679,18 @@ mod tests {
     #[test]
     fn import_matches_module_variants() {
         // Direct match
-        assert!(import_matches_module("core::fixer", "core::fixer"));
-        // With crate prefix
-        assert!(import_matches_module("crate::fixer", "core::fixer"));
-        // Source has crate prefix
-        assert!(import_matches_module("core::fixer", "crate::fixer"));
-        // Both have crate prefix
+        assert!(import_matches_module("refactor::fixer", "refactor::fixer"));
+        // Import has crate:: prefix, source does not
+        assert!(import_matches_module("crate::fixer", "fixer"));
+        // Source has crate:: prefix, import does not
+        assert!(import_matches_module("fixer", "crate::fixer"));
+        // Both have crate:: prefix
         assert!(import_matches_module("crate::fixer", "crate::fixer"));
+        // `crate::` is this crate's root; after the crate extraction a bare
+        // `core::` prefix is a distinct module, not a crate synonym.
+        assert!(!import_matches_module("crate::fixer", "core::fixer"));
         // No match
-        assert!(!import_matches_module("core::fixer", "core::other"));
+        assert!(!import_matches_module("refactor::fixer", "refactor::other"));
     }
 
     #[test]
@@ -701,8 +704,7 @@ mod tests {
         };
 
         let rewrite =
-            compute_import_rewrite(&import, "walk_source_files", "core::refactor::transform")
-                .unwrap();
+            compute_import_rewrite(&import, "walk_source_files", "refactor::transform").unwrap();
         assert_eq!(
             rewrite.replacement,
             "use crate::refactor::transform::walk_source_files;"
@@ -724,7 +726,7 @@ mod tests {
         };
 
         let rewrite =
-            compute_import_rewrite(&import, "module_path_from_file", "core::symbol_graph").unwrap();
+            compute_import_rewrite(&import, "module_path_from_file", "symbol_graph").unwrap();
 
         // Should keep remaining in old group and add new import
         assert!(rewrite

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1029,7 +1029,12 @@ fn routes_health_version_and_config_paths() {
 
     let version = route("GET", "/version");
     assert_eq!(version.status_code, 200);
-    assert_eq!(version.body["version"], env!("CARGO_PKG_VERSION"));
+    // The daemon reports the product version, not homeboy-core's crate version
+    // (which is a fixed `0.1.0` after the workspace crate split).
+    assert_eq!(
+        version.body["version"],
+        homeboy_product_identity::product_version()
+    );
 
     let paths = route("GET", "/config/paths");
     assert_eq!(paths.status_code, 200);
@@ -1082,6 +1087,7 @@ fn routes_read_only_http_api_contract() {
 
 #[test]
 fn cancelling_daemon_exec_job_terminates_process_tree() {
+    super::tests::register_enqueue_test_driver();
     let _home = create_lab_local_runner();
     let store = JobStore::default();
     let cwd = std::env::temp_dir().join(format!("homeboy-daemon-cancel-{}", std::process::id()));
@@ -1646,6 +1652,7 @@ fn create_lab_local_runner() -> HomeGuard {
 
 #[test]
 fn routes_exec_body_to_daemon_job() {
+    super::tests::register_enqueue_test_driver();
     let _home = create_lab_local_runner();
     let store = JobStore::default();
     let response = route_with_job_store_and_body(
@@ -1690,6 +1697,7 @@ fn routes_exec_body_to_daemon_job() {
 
 #[test]
 fn routes_exec_preserves_path_materialization_plan_on_job_metadata() {
+    super::tests::register_enqueue_test_driver();
     let _home = create_lab_local_runner();
     let store = JobStore::default();
     let cwd = std::env::current_dir()


### PR DESCRIPTION
## Summary

Sweeping `homeboy-core` (~1537 lib tests) for clean-checkout failures surfaced ~25 red tests. This PR fixes the three clusters with clear, confident root causes (7 tests).

### Symbol-graph import rewrites (3)
`compute_rewrite_simple_import`, `compute_rewrite_grouped_import`, `import_matches_module_variants` used the old `crate::core::`-prefixed module layout that predates the workspace crate split.
- `compute_import_rewrite` prepends `crate::` to its target module, so a target `core::refactor::transform` now correctly yields `crate::core::refactor::...`; the fixtures should pass the current `refactor::transform`.
- `import_matches_module` no longer treats a bare `core::` as a `crate::` synonym now that `crate::` is this crate's own root — updated the variants accordingly (and assert the non-equivalence).

### Daemon `/version` drift (1)
`routes_health_version_and_config_paths` asserted `env!("CARGO_PKG_VERSION")`, which is homeboy-core's fixed `0.1.0` crate version after the split, but the endpoint returns the **product** version. Assert against `homeboy_product_identity::product_version()`.

### Daemon `/exec` enqueue tests (3)
The daemon `/exec` endpoint routes through the `RunnerExecDriver` hook (#8632) whose implementation was extracted into the runner crate (#8698), so core's daemon tests hit the fail-closed **400** (`runner subsystem is unavailable`). Added a `register_enqueue_test_driver()` helper (exposing the existing `EnqueueTestDriver`) and registered it in the enqueue-path tests (`routes_exec_body_to_daemon_job`, `routes_exec_preserves_path_materialization_plan_on_job_metadata`, `cancelling_daemon_exec_job_terminates_process_tree`).

## Testing

- `cargo fmt`; all 7 fixed tests verified passing individually.
- Test-only changes plus a `pub(super)` helper; no production behavior modified.

## Scope note

The remaining ~18 core failures are deeper, extraction-era classes left for follow-up:
- daemon **exec-result** tests (env application, capture patch, failed command) need a driver that runs the *real* command, not the enqueue stub — arguably these belong in the runner crate now.
- daemon **file-API** tests need a runner-workspace-root **provider** test double (another hook extracted to the runner crate).
- `api_jobs`, `lab_routing`, `deps_provider`, `setup`, `fleet` clusters — a mix of provider-registration (component-script/build/install runners) and assertion drift.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Swept homeboy-core lib tests, classified ~25 failures into clusters, and fixed the three with unambiguous root causes (module-path drift, version-source drift, and the extracted `/exec` driver hook). Chris reviews and owns the change.