### PR TITLE
refactor(agents): extract execution-budget accounting from cook.rs into cook_budget

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -30,11 +30,14 @@ use crate::agent_task_review_dossier::{
     AgentTaskReviewTestStep,
 };
 use crate::agent_task_scheduler::{
-    AgentTaskExecutionBudget, AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskState,
+    AgentTaskExecutionBudget, AgentTaskExecutorAdapter, AgentTaskPlan,
 };
 use homeboy_core::command_invocation::CommandInvocation;
 use homeboy_core::{config, Error, ErrorCode, Result};
 
+use super::cook_budget::{
+    budget_remaining, execution_budget_usage, reserve_remediation_budget, ExecutionBudgetUsage,
+};
 use super::execution::run_loaded_plan_with_derived_cook_baseline;
 use super::AgentTaskRunResult;
 
@@ -1548,101 +1551,6 @@ fn git_output_with_env(
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-#[derive(Debug, Default, Clone, Copy)]
-pub(crate) struct ExecutionBudgetUsage {
-    pub(crate) executions: u32,
-    pub(crate) same_provider_retries: u32,
-    pub(crate) provider_rotations: u32,
-}
-
-impl ExecutionBudgetUsage {
-    fn add(&mut self, other: Self) {
-        self.executions = self.executions.saturating_add(other.executions);
-        self.same_provider_retries = self
-            .same_provider_retries
-            .saturating_add(other.same_provider_retries);
-        self.provider_rotations = self
-            .provider_rotations
-            .saturating_add(other.provider_rotations);
-    }
-}
-
-pub(crate) fn execution_budget_usage(
-    aggregate: &crate::agent_task_scheduler::AgentTaskAggregate,
-) -> ExecutionBudgetUsage {
-    let executions = aggregate
-        .events
-        .iter()
-        .filter(|event| event.state == AgentTaskState::Running)
-        .count()
-        .try_into()
-        .unwrap_or(u32::MAX);
-    let same_provider_retries = aggregate
-        .outcomes
-        .iter()
-        .flat_map(|outcome| &outcome.diagnostics)
-        .filter(|diagnostic| diagnostic.class == "agent_task.retry_attempt")
-        .count()
-        .try_into()
-        .unwrap_or(u32::MAX);
-    let provider_rotations = aggregate
-        .outcomes
-        .iter()
-        .filter_map(provider_rotation_attempts)
-        .map(|attempts| attempts.len().saturating_sub(1) as u32)
-        .fold(0, u32::saturating_add);
-    ExecutionBudgetUsage {
-        executions,
-        same_provider_retries,
-        provider_rotations,
-    }
-}
-
-pub(crate) fn budget_remaining(
-    budget: &AgentTaskExecutionBudget,
-    usage: ExecutionBudgetUsage,
-) -> Option<AgentTaskExecutionBudget> {
-    let max_provider_executions = budget
-        .max_provider_executions
-        .saturating_sub(usage.executions);
-    (max_provider_executions > 0).then(|| {
-        AgentTaskExecutionBudget::new(
-            max_provider_executions,
-            budget
-                .max_same_provider_retries
-                .saturating_sub(usage.same_provider_retries),
-            budget
-                .max_provider_rotations
-                .saturating_sub(usage.provider_rotations),
-        )
-    })
-}
-
-pub(crate) fn reserve_remediation_budget(
-    budget: &AgentTaskExecutionBudget,
-    same_provider: bool,
-) -> std::result::Result<ExecutionBudgetUsage, &'static str> {
-    if budget.max_provider_executions == 0 {
-        return Err("max_provider_executions");
-    }
-    if same_provider {
-        if budget.max_same_provider_retries == 0 {
-            return Err("max_same_provider_retries");
-        }
-        return Ok(ExecutionBudgetUsage {
-            same_provider_retries: 1,
-            ..Default::default()
-        });
-    }
-    if budget.max_provider_rotations == 0 {
-        return Err("max_provider_rotations");
-    }
-    Ok(ExecutionBudgetUsage {
-        provider_rotations: 1,
-        ..Default::default()
-    })
-}
-
 fn terminal_executor_matches(
     aggregate: &crate::agent_task_scheduler::AgentTaskAggregate,
     follow_up: &AgentTaskExecutor,
@@ -1656,7 +1564,7 @@ fn terminal_executor_matches(
     )
 }
 
-fn provider_rotation_attempts(
+pub(crate) fn provider_rotation_attempts(
     outcome: &crate::agent_task::AgentTaskOutcome,
 ) -> Option<Vec<crate::agent_task_scheduler::AgentTaskProviderRotationAttempt>> {
     serde_json::from_value(
@@ -2052,6 +1960,7 @@ mod tests {
     use crate::agent_task_finalization::{
         AgentTaskPrDurableGateProof, AgentTaskPrFinalizationBackend, AgentTaskPrRef,
     };
+    use crate::agent_task_scheduler::AgentTaskState;
     use homeboy_core::run_lifecycle_record::{
         ProviderRuntimeLifecycle, ProviderRuntimeState, RunExecutionLifecycle, RunExecutionState,
         RunLifecycleRecord,

--- a/crates/homeboy-agents/src/agent_task_service/cook_budget.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_budget.rs
@@ -1,0 +1,105 @@
+//! Execution-budget accounting for cook attempts.
+//!
+//! Extracted from `cook.rs`: the math that tallies how much of an
+//! `AgentTaskExecutionBudget` a cook aggregate has consumed
+//! (`execution_budget_usage`), computes what budget remains for a follow-up
+//! attempt (`budget_remaining`), and reserves budget for a remediation attempt
+//! (`reserve_remediation_budget`). Pure functions over aggregate/budget data —
+//! no I/O — which is why they lift cleanly out of the cook orchestration file.
+
+use crate::agent_task_scheduler::{AgentTaskAggregate, AgentTaskExecutionBudget, AgentTaskState};
+
+use super::cook::provider_rotation_attempts;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct ExecutionBudgetUsage {
+    pub(crate) executions: u32,
+    pub(crate) same_provider_retries: u32,
+    pub(crate) provider_rotations: u32,
+}
+
+impl ExecutionBudgetUsage {
+    pub(crate) fn add(&mut self, other: Self) {
+        self.executions = self.executions.saturating_add(other.executions);
+        self.same_provider_retries = self
+            .same_provider_retries
+            .saturating_add(other.same_provider_retries);
+        self.provider_rotations = self
+            .provider_rotations
+            .saturating_add(other.provider_rotations);
+    }
+}
+
+pub(crate) fn execution_budget_usage(aggregate: &AgentTaskAggregate) -> ExecutionBudgetUsage {
+    let executions = aggregate
+        .events
+        .iter()
+        .filter(|event| event.state == AgentTaskState::Running)
+        .count()
+        .try_into()
+        .unwrap_or(u32::MAX);
+    let same_provider_retries = aggregate
+        .outcomes
+        .iter()
+        .flat_map(|outcome| &outcome.diagnostics)
+        .filter(|diagnostic| diagnostic.class == "agent_task.retry_attempt")
+        .count()
+        .try_into()
+        .unwrap_or(u32::MAX);
+    let provider_rotations = aggregate
+        .outcomes
+        .iter()
+        .filter_map(provider_rotation_attempts)
+        .map(|attempts| attempts.len().saturating_sub(1) as u32)
+        .fold(0, u32::saturating_add);
+    ExecutionBudgetUsage {
+        executions,
+        same_provider_retries,
+        provider_rotations,
+    }
+}
+
+pub(crate) fn budget_remaining(
+    budget: &AgentTaskExecutionBudget,
+    usage: ExecutionBudgetUsage,
+) -> Option<AgentTaskExecutionBudget> {
+    let max_provider_executions = budget
+        .max_provider_executions
+        .saturating_sub(usage.executions);
+    (max_provider_executions > 0).then(|| {
+        AgentTaskExecutionBudget::new(
+            max_provider_executions,
+            budget
+                .max_same_provider_retries
+                .saturating_sub(usage.same_provider_retries),
+            budget
+                .max_provider_rotations
+                .saturating_sub(usage.provider_rotations),
+        )
+    })
+}
+
+pub(crate) fn reserve_remediation_budget(
+    budget: &AgentTaskExecutionBudget,
+    same_provider: bool,
+) -> std::result::Result<ExecutionBudgetUsage, &'static str> {
+    if budget.max_provider_executions == 0 {
+        return Err("max_provider_executions");
+    }
+    if same_provider {
+        if budget.max_same_provider_retries == 0 {
+            return Err("max_same_provider_retries");
+        }
+        return Ok(ExecutionBudgetUsage {
+            same_provider_retries: 1,
+            ..Default::default()
+        });
+    }
+    if budget.max_provider_rotations == 0 {
+        return Err("max_provider_rotations");
+    }
+    Ok(ExecutionBudgetUsage {
+        provider_rotations: 1,
+        ..Default::default()
+    })
+}

--- a/crates/homeboy-agents/src/agent_task_service/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_service/mod.rs
@@ -6,6 +6,7 @@
 //! `crate::agent_task_service::*` unchanged.
 
 mod cook;
+mod cook_budget;
 mod cook_recipe;
 mod discovery;
 mod execution;
@@ -13,6 +14,7 @@ mod reconcile;
 mod status_support;
 
 pub use cook::*;
+pub use cook_budget::*;
 pub use cook_recipe::*;
 pub use discovery::*;
 pub use execution::*;


### PR DESCRIPTION
## Summary
First carve of the `cook.rs` god-file. At **3575 lines**, `cook.rs` mixes candidate adoption, execution, promotion, finalization, baseline materialization, and budget math — the kind of file that's hard to navigate and reason about. This starts decomposing it along its natural seams.

This carve lifts the **execution-budget accounting** into a new `cook_budget` module: `ExecutionBudgetUsage` + `execution_budget_usage` / `budget_remaining` / `reserve_remediation_budget`. These are pure functions over aggregate/budget data with **no I/O**, so they're the cleanest, lowest-risk cluster to extract first.

## Details
- New `cook_budget.rs` (105 lines), registered in `mod.rs` alongside the existing concern submodules (this module was already split from a former god-module — same pattern).
- `provider_rotation_attempts` (shared with the executor-identity cluster) is made `pub(crate)` and referenced from the new module via `super::cook`.
- **Pure move, no behavior change**: the fns keep `pub(crate)` visibility and are re-exported through `mod.rs`'s `pub use`, so `crate::agent_task_service::*` call sites (including `tests.rs`) resolve unchanged.
- `cook.rs`: **−97 lines** (3575 → 3484).

## Verification (VPS-safe)
- `cargo check -p homeboy-agents --lib` — clean, no new warnings
- The budget test (`cook_usage_reads_scheduler_rotation_metadata_and_decrements_budget`) passes
- `cargo fmt` — clean

## Context
First of several planned carves (baseline materialization, promotion/finalization are the next natural clusters). Each is a behavior-preserving extraction — the win is **navigability**, not LOC reduction. Part of the "stabilize + simplify before external users" effort.