### PR TITLE
test: run daemon file-API tests against the real workspace-root provider

### DIFF
--- a/crates/homeboy-lab-runner/src/execution/tests/daemon_file_api.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/daemon_file_api.rs
@@ -1,0 +1,118 @@
+//! Daemon file-API tests that require the real runner-workspace-root provider.
+//!
+//! Core's daemon `/files/*` routes resolve a request path against the runner's
+//! configured `workspace_root` through the `RunnerWorkspaceRootProvider` hook,
+//! whose real implementation lives in this runner crate (extracted from core in
+//! Extra-Chill/homeboy#8698). These tests were moved out of `homeboy-core`'s
+//! daemon tests because they need that provider to resolve a runner's workspace
+//! root — which a core-only stub cannot do without becoming a test double. Here
+//! the real provider is registered, so path containment is enforced against the
+//! runner's actual configured root.
+
+use base64::Engine;
+use homeboy_core::api_jobs::JobStore;
+use homeboy_core::daemon::route_with_body;
+use homeboy_core::test_support::HomeGuard;
+
+/// Register the runner-side workspace-root provider the daemon file API resolves
+/// runner roots through. Production wires this at CLI startup; the registration
+/// is an idempotent process-global slot, so registering per test is safe.
+fn register_provider() {
+    crate::register_runner_workspace_root_provider();
+}
+
+fn write_runner_config(id: &str, value: &serde_json::Value) {
+    let dir = homeboy_core::paths::homeboy()
+        .expect("homeboy dir")
+        .join("runners");
+    std::fs::create_dir_all(&dir).expect("create runners dir");
+    std::fs::write(
+        dir.join(format!("{id}.json")),
+        serde_json::to_string_pretty(value).expect("serialize runner"),
+    )
+    .expect("write runner config");
+}
+
+fn file_api_workspace() -> (tempfile::TempDir, std::path::PathBuf) {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    write_runner_config(
+        "file-lab",
+        &serde_json::json!({
+            "id": "file-lab",
+            "kind": "local",
+            "workspace_root": workspace.display().to_string(),
+        }),
+    );
+    (temp, workspace)
+}
+
+#[test]
+fn file_route_rejects_paths_outside_runner_workspace_root() {
+    register_provider();
+    let _home = HomeGuard::new();
+    let (_temp, workspace) = file_api_workspace();
+
+    let response = route_with_body(
+        "POST",
+        "/files/download",
+        Some(serde_json::json!({
+            "runner_id": "file-lab",
+            "path": workspace.join("..").join("secret.txt").display().to_string(),
+        })),
+        &JobStore::default(),
+    );
+
+    assert_eq!(response.status_code, 400);
+    assert_eq!(response.body["details"]["field"], "path");
+    assert!(response.body["message"]
+        .as_str()
+        .expect("message")
+        .contains("workspace_root"));
+}
+
+#[test]
+fn file_routes_upload_and_download_inside_runner_workspace_root() {
+    register_provider();
+    let _home = HomeGuard::new();
+    let (_temp, workspace) = file_api_workspace();
+
+    let upload = route_with_body(
+        "POST",
+        "/files/upload",
+        Some(serde_json::json!({
+            "runner_id": "file-lab",
+            "path": "nested/report.json",
+            "content_base64": base64::engine::general_purpose::STANDARD.encode(br#"{"ok":true}"#),
+        })),
+        &JobStore::default(),
+    );
+    assert_eq!(upload.status_code, 200, "upload body: {}", upload.body);
+    assert_eq!(
+        std::fs::read_to_string(workspace.join("nested/report.json")).expect("uploaded file"),
+        r#"{"ok":true}"#
+    );
+
+    let download = route_with_body(
+        "POST",
+        "/files/download",
+        Some(serde_json::json!({
+            "runner_id": "file-lab",
+            "path": workspace.join("nested/report.json").display().to_string(),
+        })),
+        &JobStore::default(),
+    );
+    assert_eq!(
+        download.status_code, 200,
+        "download body: {}",
+        download.body
+    );
+    let encoded = download.body["body"]["content_base64"]
+        .as_str()
+        .expect("content_base64");
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .expect("decode content");
+    assert_eq!(decoded, br#"{"ok":true}"#);
+}

--- a/crates/homeboy-lab-runner/src/execution/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/mod.rs
@@ -9,6 +9,7 @@ use homeboy_core::error::ErrorCode;
 use homeboy_core::server::{self, RunnerPolicy, RunnerSecretEnvRef, RunnerSettings};
 
 mod daemon_exec;
+mod daemon_file_api;
 mod exec;
 mod handoff;
 mod policy;

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -225,29 +225,6 @@ fn health_route_refreshes_daemon_lease_heartbeat() {
 }
 
 #[test]
-fn file_route_rejects_paths_outside_runner_workspace_root() {
-    let _home = HomeGuard::new();
-    let (_temp, workspace) = file_api_workspace(true);
-
-    let response = route_with_job_store_and_body(
-        "POST",
-        "/files/download",
-        Some(serde_json::json!({
-            "runner_id": "file-lab",
-            "path": workspace.join("..").join("secret.txt").display().to_string(),
-        })),
-        &JobStore::default(),
-    );
-
-    assert_eq!(response.status_code, 400);
-    assert_eq!(response.body["details"]["field"], "path");
-    assert!(response.body["message"]
-        .as_str()
-        .expect("message")
-        .contains("workspace_root"));
-}
-
-#[test]
 fn file_route_requires_broker_submit_auth_for_untrusted_requests() {
     let _home = HomeGuard::new();
     let (_temp, _workspace) = file_api_workspace(true);
@@ -290,50 +267,6 @@ fn file_route_accepts_request_workspace_root_without_runner_config() {
 
     assert_eq!(response.status_code, 200, "mkdir body: {}", response.body);
     assert!(workspace.join("artifacts").is_dir());
-}
-
-#[test]
-fn file_routes_upload_and_download_inside_runner_workspace_root() {
-    let _home = HomeGuard::new();
-    let (_temp, workspace) = file_api_workspace(true);
-
-    let upload = route_with_job_store_and_body(
-        "POST",
-        "/files/upload",
-        Some(serde_json::json!({
-            "runner_id": "file-lab",
-            "path": "nested/report.json",
-            "content_base64": base64::engine::general_purpose::STANDARD.encode(br#"{"ok":true}"#),
-        })),
-        &JobStore::default(),
-    );
-    assert_eq!(upload.status_code, 200, "upload body: {}", upload.body);
-    assert_eq!(
-        std::fs::read_to_string(workspace.join("nested/report.json")).expect("uploaded file"),
-        r#"{"ok":true}"#
-    );
-
-    let download = route_with_job_store_and_body(
-        "POST",
-        "/files/download",
-        Some(serde_json::json!({
-            "runner_id": "file-lab",
-            "path": workspace.join("nested/report.json").display().to_string(),
-        })),
-        &JobStore::default(),
-    );
-    assert_eq!(
-        download.status_code, 200,
-        "download body: {}",
-        download.body
-    );
-    let encoded = download.body["body"]["content_base64"]
-        .as_str()
-        .expect("content_base64");
-    let decoded = base64::engine::general_purpose::STANDARD
-        .decode(encoded)
-        .expect("decode content");
-    assert_eq!(decoded, br#"{"ok":true}"#);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Follow-up to the `/exec` test migration, same pattern. Two `homeboy-core` daemon file-API tests resolve a request path against a runner's configured **workspace root**, which the daemon `/files/*` routes look up through the `RunnerWorkspaceRootProvider` hook. That provider's real implementation lives in the runner crate (extracted from core in #8698), so in `homeboy-core` these tests hit the no-op provider and fail closed with `requires workspace_root` — and a core-only stub would just be a test double.

## Change

Move them to `homeboy-lab-runner`, which registers the real provider (`register_runner_workspace_root_provider`), so path containment is enforced against the runner's **actual** configured root:

- `file_route_rejects_paths_outside_runner_workspace_root`
- `file_routes_upload_and_download_inside_runner_workspace_root`

They dispatch in process through the public `homeboy_core::daemon::route_with_body` router (added when the `/exec` result tests moved over — #9122).

## Testing

- Both pass in lab-runner with the real provider (real path containment + upload/download round-trip).
- The core file-API tests that don't need the provider stay in core and still pass:
  - `file_route_accepts_request_workspace_root_without_runner_config` (path carried in the request)
  - `file_route_requires_broker_submit_auth_for_untrusted_requests` (auth-denied *before* workspace resolution)
- `cargo fmt`.

## Rationale

Same "test real behavior, no doubles" principle: these tests validate workspace-root resolution, whose provider lives in the runner crate now — so the tests belong there, running against the real provider.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Identified the failing core file-API tests need the real runner-workspace-root provider (extracted to the runner crate) and moved them to lab-runner, matching the prior `/exec` migration — no stubs. Chris reviews and owns the change.