### PR TITLE
Stop the exact stale runner daemon owner during reconnect

### DIFF
--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -417,7 +417,7 @@ fn validate_remote_lease_bound_daemon_stop_output(
 
 pub(super) fn remote_lease_bound_daemon_stop_command(homeboy: &str, lease_id: &str) -> String {
     format!(
-        "{} daemon stop --lease-id {}",
+        "{} daemon stop --force --lease-id {}",
         shell::quote_arg(homeboy),
         shell::quote_arg(lease_id)
     )
@@ -671,6 +671,17 @@ mod tests {
                 .expect("the stopped lease is replaced on reconnect"),
             remote_daemon::RemoteDaemonConnectAction::Start,
             "refresh must start a replacement rather than reattach the stale lease"
+        );
+    }
+
+    #[test]
+    fn lease_bound_ssh_stop_uses_the_exact_stale_owner_primitive() {
+        assert_eq!(
+            remote_lease_bound_daemon_stop_command(
+                "/srv/homeboy builds/current/homeboy",
+                "lease with spaces",
+            ),
+            "'/srv/homeboy builds/current/homeboy' daemon stop --force --lease-id 'lease with spaces'"
         );
     }
 


### PR DESCRIPTION
## Summary
- use the existing exact-owner stale-daemon stop primitive in the runner SSH fallback
- keep the fallback lease-bound, zero-active-job-bound, startup-token/PID-bound, and termination-verified
- cover command quoting and required `--force` selection

Closes #9121.

## Why

After runner binary promotion, ordinary `daemon stop --lease-id` intentionally refuses to signal the old live daemon because its binary identity is stale. The reconnect fallback was therefore prescribing a command incapable of recovering the state it was designed for.

`daemon stop --force --lease-id` selects Homeboy's existing stale-owner recovery path. It still fails closed for active jobs, mismatched leases, reused PIDs, missing startup-token ownership, or unverified termination.

## How to test

1. Run `cargo test -p homeboy-lab-runner lease_bound_ssh_stop_uses_the_exact_stale_owner_primitive`.
2. Run `cargo test -p homeboy-lab-runner transport_drop_uses_bounded_ssh_stop_for_exact_live_owner`.
3. Run `cargo test -p homeboy-lab-runner transport_drop_refuses_mismatch_or_active_jobs_without_ssh_stop`.
4. Run `cargo test -p homeboy-core force_stop_matching_zero_job_stale_daemon_is_terminated_and_verified`.
5. Run `cargo test -p homeboy-core force_stop_active_jobs_block_signaling`.
6. Run `cargo test -p homeboy-core force_stop_matching_lease_cannot_signal_a_reused_pid`.
7. Run `cargo check -p homeboy-lab-runner && cargo fmt --check && git diff --check origin/main...HEAD`.

## Backwards compatibility

The generated SSH fallback now requests forced stale-owner recovery. Safety constraints are unchanged: only the exact lease-owned process with zero active jobs and matching startup-token identity can be signaled. Routine daemon stop behavior and extension paths are unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Root-cause tracing, implementation, regression tests, and verification under Chris Huber's direction.