### PR TITLE
Make extension refresh replacement atomic

### DIFF
--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -81,11 +81,11 @@ pub use pr_refresh::{
 };
 pub(crate) use primitives::list_tracked_markdown_files;
 pub use primitives::{
-    clone_repo, clone_repo_at_ref, commit_staged_with_author, default_branch_name,
-    default_remote_branch, get_component_path_prefix, get_git_root, git_probe_path,
-    has_staged_changes, is_workdir_clean_or_not_git, pull_repo, resolve_default_remote, run_git,
-    run_git_output, run_git_output_with_env, run_git_with_env, run_git_with_env_timeout, stage_all,
-    update_to_remote_default_branch,
+    clone_repo, clone_repo_at_ref, clone_repo_at_ref_with_timeout, commit_staged_with_author,
+    default_branch_name, default_remote_branch, get_component_path_prefix, get_git_root,
+    git_probe_path, has_staged_changes, is_workdir_clean_or_not_git, pull_repo,
+    resolve_default_remote, run_git, run_git_output, run_git_output_with_env, run_git_with_env,
+    run_git_with_env_timeout, stage_all, update_to_remote_default_branch,
 };
 pub use primitives::{is_git_repo, is_tracked_path};
 pub use primitives_query::{

--- a/crates/homeboy-core/src/git/primitives.rs
+++ b/crates/homeboy-core/src/git/primitives.rs
@@ -52,6 +52,35 @@ pub fn clone_repo_at_ref(url: &str, target_dir: &Path, revision: Option<&str>) -
     Ok(())
 }
 
+/// Clone a git repository and optionally check out a ref, enforcing one deadline
+/// across each remote Git stage.
+pub fn clone_repo_at_ref_with_timeout(
+    url: &str,
+    target_dir: &Path,
+    revision: Option<&str>,
+    timeout: Duration,
+) -> Result<()> {
+    run_git_with_env_timeout(
+        Path::new("."),
+        &["clone", url, &target_dir.to_string_lossy()],
+        "git clone",
+        &[],
+        timeout,
+    )?;
+
+    if let Some(revision) = revision {
+        run_git_with_env_timeout(
+            target_dir,
+            &["checkout", "--quiet", revision],
+            "git checkout",
+            &[],
+            timeout,
+        )?;
+    }
+
+    Ok(())
+}
+
 /// Pull latest changes in a git repository.
 pub fn pull_repo(repo_dir: &Path) -> Result<()> {
     run_git(repo_dir, &["pull"], "git pull")?;

--- a/crates/homeboy-extension/src/execution.rs
+++ b/crates/homeboy-extension/src/execution.rs
@@ -63,6 +63,8 @@ pub struct ExtensionSetupResult {
     pub exit_code: i32,
 }
 
+const EXTENSION_SETUP_TIMEOUT: Duration = Duration::from_secs(300);
+
 /// Run a extension's setup command (if defined).
 pub fn run_setup(extension_id: &str) -> Result<ExtensionSetupResult> {
     let extension = load_extension(extension_id)?;
@@ -94,11 +96,24 @@ pub fn run_setup(extension_id: &str) -> Result<ExtensionSetupResult> {
     ];
 
     let command = template::render(setup_command, &vars);
-    let exit_code = execute_local_command_interactive(&command, Some(extension_path), None);
+    let output = execute_local_command_passthrough_with_timeout(
+        &command,
+        Some(extension_path),
+        None,
+        EXTENSION_SETUP_TIMEOUT,
+    );
+    let exit_code = output.exit_code;
 
     if exit_code != 0 {
         return Err(Error::internal_io(
-            format!("Setup command failed with exit code {}", exit_code),
+            if output.timed_out {
+                format!(
+                    "Setup command timed out after {}s",
+                    EXTENSION_SETUP_TIMEOUT.as_secs()
+                )
+            } else {
+                format!("Setup command failed with exit code {}", exit_code)
+            },
             Some("extension setup".to_string()),
         ));
     }

--- a/crates/homeboy-extension/src/lifecycle/install_sources.rs
+++ b/crates/homeboy-extension/src/lifecycle/install_sources.rs
@@ -126,7 +126,12 @@ pub(super) fn install_from_url(
         })?;
     }
 
-    git::clone_repo_at_ref(url, &temp_dir, revision)?;
+    git::clone_repo_at_ref_with_timeout(
+        url,
+        &temp_dir,
+        revision,
+        super::EXTENSION_SOURCE_PREPARE_TIMEOUT,
+    )?;
 
     // Capture source revision before resolve_cloned_extension may discard .git
     // (monorepo installs extract only the subdirectory, losing git history).

--- a/crates/homeboy-extension/src/lifecycle/mod.rs
+++ b/crates/homeboy-extension/src/lifecycle/mod.rs
@@ -3,8 +3,11 @@ use homeboy_core::git;
 use homeboy_core::paths;
 use homeboy_engine_primitives::identifier;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use super::load_extension;
+
+pub(crate) const EXTENSION_SOURCE_PREPARE_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(Debug, Clone)]
 pub struct InstallResult {
@@ -138,12 +141,11 @@ pub struct RefreshResult {
     pub uninstalled_previous: bool,
 }
 
-/// Refresh a single extension from a source: uninstall any existing install,
-/// then reinstall from the given source/revision.
+/// Refresh a single extension from a source.
 ///
 /// This is the core-owned replacement for CI's hardcoded
-/// "uninstall (if present) then install" shell sequence. It is idempotent and
-/// safe to re-run: a missing prior install is not an error.
+/// "uninstall (if present) then install" shell sequence. Existing installs use
+/// the transactional replacement path so a failed preparation leaves them live.
 pub fn refresh(
     source: &str,
     id_override: Option<&str>,
@@ -163,15 +165,23 @@ pub fn refresh(
     let install_source = durable_refresh_source(source, &extension_id)?;
 
     let extension_dir = paths::extension(&extension_id)?;
-    let uninstalled_previous = if std::fs::symlink_metadata(&extension_dir).is_ok() {
-        uninstall(&extension_id)?;
-        true
+    let uninstalled_previous = std::fs::symlink_metadata(&extension_dir).is_ok();
+    let installed = if uninstalled_previous {
+        let replaced = crate::repair::replace_with_revision(
+            &install_source,
+            Some(&extension_id),
+            effective_revision,
+        )?;
+        InstallResult {
+            extension_id: replaced.extension_id,
+            url: replaced.source,
+            path: replaced.new_path,
+            manifest_path: replaced.manifest_path,
+            source_revision: replaced.source_revision,
+        }
     } else {
-        false
+        install_with_revision(&install_source, Some(&extension_id), effective_revision)?
     };
-
-    let installed =
-        install_with_revision(&install_source, Some(&extension_id), effective_revision)?;
 
     Ok(RefreshResult {
         extension_id: installed.extension_id,
@@ -787,6 +797,50 @@ exec '{}' "$@"
             assert_eq!(
                 load_extension("alpha").expect("reinstalled").version,
                 "2.0.0"
+            );
+        });
+    }
+
+    #[test]
+    fn refresh_preserves_existing_install_when_replacement_setup_fails() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let old_source = home.join("old-source");
+            let invalid_source = home.join("invalid-source");
+            write_extension_fixture_with_version(&old_source, "wordpress", "1.0.0");
+            fs::create_dir_all(invalid_source.join("wordpress")).expect("replacement source");
+            fs::write(
+                invalid_source.join("wordpress/wordpress.json"),
+                r#"{"name":"wordpress extension","version":"2.0.0","executable":{"runtime":{"setup_command":"false"}}}"#,
+            )
+            .expect("failing replacement manifest");
+
+            install(
+                &old_source.join("wordpress").to_string_lossy(),
+                Some("wordpress"),
+            )
+            .expect("pre-install");
+
+            let err = refresh(&invalid_source.to_string_lossy(), Some("wordpress"), None)
+                .expect_err("refresh should reject the invalid replacement");
+
+            assert!(!err.message.is_empty());
+            let installed_path = home.join(".config/homeboy/extensions/wordpress");
+            assert_eq!(
+                fs::read_link(&installed_path).expect("preserved extension link"),
+                old_source.join("wordpress")
+            );
+            assert_eq!(
+                load_extension("wordpress")
+                    .expect("preserved extension")
+                    .version,
+                "1.0.0"
+            );
+            assert!(
+                !home
+                    .join(".config/homeboy/extensions/.replace-link-tmp-wordpress")
+                    .exists(),
+                "failed refresh should not leave a replacement link"
             );
         });
     }

--- a/crates/homeboy-extension/src/repair.rs
+++ b/crates/homeboy-extension/src/repair.rs
@@ -74,7 +74,12 @@ fn replace_from_url(
     clean_replace_temp(&staged_dir)?;
     clean_replace_temp(&backup_dir)?;
 
-    if let Err(err) = git::clone_repo_at_ref(url, &clone_dir, revision) {
+    if let Err(err) = git::clone_repo_at_ref_with_timeout(
+        url,
+        &clone_dir,
+        revision,
+        super::lifecycle::EXTENSION_SOURCE_PREPARE_TIMEOUT,
+    ) {
         let _ = clean_replace_temp(&clone_dir);
         return Err(err.with_hint(format!(
             "Homeboy cloned into a fresh replace temp directory and removed it after failure. If git still reports corrupt tmp_pack files, inspect disk/git health and remove stale replace clone temps with: rm -rf {}",


### PR DESCRIPTION
Closes #9098.

## Summary
- stage and validate extension replacements before removing the installed extension
- bound remote clone/checkout and setup execution
- restore the prior install when replacement setup or validation fails
- preserve first-time refresh behavior and idempotent same-source refreshes

## Root cause
`extension refresh` uninstalled first and only then cloned/prepared the replacement. An unbounded clone or setup left no installed extension. The same unbounded clone path could also hang a recovery `extension install`.

## Compatibility
The change is additive to lifecycle safety. Existing extension paths and manifests are unchanged. Setup commands are now bounded to five minutes and remote source preparation to two minutes.

## How to test
1. Run `cargo test -p homeboy-extension lifecycle::tests::refresh_`.
2. Run `cargo fmt --check`.
3. Install a known extension revision with the built Homeboy binary.
4. Refresh the same source/ref and confirm the extension remains installed and reports the requested source revision.
5. Use a replacement whose setup fails and confirm the prior installed extension remains available.

## Real recovery evidence
The repaired binary restored the missing `cloudflare-workers` extension from `Extra-Chill/homeboy-extensions@ebe41751`, then refreshed the same revision successfully.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** We diagnosed the failed refresh lifecycle, implemented bounded atomic replacement, reviewed the patch, and verified deterministic and real recovery paths.
