### PR TITLE
Fix Lab terminal evidence correlation

### DIFF
--- a/crates/homeboy-lab-runner/src/evidence/detail.rs
+++ b/crates/homeboy-lab-runner/src/evidence/detail.rs
@@ -193,20 +193,6 @@ fn lab_artifact_metadata(
     Value::Object(object)
 }
 
-pub(super) fn remote_run_matches_job_window(summary: &Value, job: &Job) -> bool {
-    let Some(started_at) = summary.get("started_at").and_then(Value::as_str) else {
-        return false;
-    };
-    let Ok(started_at) = chrono::DateTime::parse_from_rfc3339(started_at) else {
-        return false;
-    };
-    let started_ms = started_at.timestamp_millis();
-    let job_start = i64::try_from(job.started_at_ms.unwrap_or(job.created_at_ms)).unwrap_or(0);
-    let job_finish =
-        i64::try_from(job.finished_at_ms.unwrap_or(job.updated_at_ms)).unwrap_or(i64::MAX);
-    started_ms >= job_start.saturating_sub(5_000) && started_ms <= job_finish.saturating_add(5_000)
-}
-
 pub(super) fn explicit_observation_run_ids(result: &Value, job: &Job) -> Vec<String> {
     let mut ids = Vec::new();
     for pointer in [
@@ -250,5 +236,12 @@ pub(super) fn explicit_observation_run_ids(result: &Value, job: &Job) -> Vec<Str
             }
         }
     }
+    push_unique_string(
+        &mut ids,
+        job.runner_job_projection
+            .as_ref()
+            .and_then(|projection| projection.lifecycle.as_ref())
+            .and_then(|lifecycle| lifecycle.durable_run_id.as_deref()),
+    );
     ids
 }

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -440,22 +440,45 @@ fn mirror_remote_observation_runs_by_id(
     run_ids: &[String],
     notification_route: Option<&NotificationRoute>,
 ) -> Result<Vec<RunRecord>> {
+    mirror_remote_observation_runs_by_id_with(
+        store,
+        runner,
+        job,
+        run_ids,
+        notification_route,
+        |run_id| {
+            let detail_data = daemon_api_get(
+                &runner.id,
+                &format!("/runs/{}", encode_uri_component(run_id)),
+            )?;
+            let detail_body = canonical_daemon_body(&detail_data, "runner run detail response")?;
+            Ok(detail_body.get("run").cloned())
+        },
+    )
+}
+
+pub(super) fn mirror_remote_observation_runs_by_id_with<F>(
+    store: &ObservationStore,
+    runner: &Runner,
+    job: &Job,
+    run_ids: &[String],
+    notification_route: Option<&NotificationRoute>,
+    mut fetch_detail: F,
+) -> Result<Vec<RunRecord>>
+where
+    F: FnMut(&str) -> Result<Option<Value>>,
+{
     let mut mirrored = Vec::new();
     for run_id in run_ids {
-        let detail_data = daemon_api_get(
-            &runner.id,
-            &format!("/runs/{}", encode_uri_component(run_id)),
-        )?;
-        let detail_body = canonical_daemon_body(&detail_data, "runner run detail response")?;
-        let Some(detail) = detail_body.get("run") else {
+        let Some(detail) = fetch_detail(run_id)? else {
             continue;
         };
-        let mut run = remote_detail_to_run_record(detail, runner, Some(job))?;
+        let mut run = remote_detail_to_run_record(&detail, runner, Some(job))?;
         if let Some(notification_route) = notification_route {
             notification_route.insert_into_metadata(&mut run.metadata_json);
         }
         import_run_if_absent(store, &run)?;
-        for artifact in remote_detail_artifacts(detail, runner, &run.id)? {
+        for artifact in remote_detail_artifacts(&detail, runner, &run.id)? {
             import_mirrored_artifact(store, &artifact)?;
         }
         mirrored.push(run);

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -15,7 +15,6 @@ use super::super::execution::{canonical_daemon_body, daemon_api_get, result_even
 use super::super::{load, Runner};
 use super::detail::{
     explicit_observation_run_ids, remote_detail_artifacts, remote_detail_to_run_record,
-    remote_run_matches_job_window,
 };
 use super::tokens::{is_retrievable_runner_artifact, runner_artifact_token};
 use super::util::{
@@ -428,38 +427,10 @@ fn mirror_remote_observation_runs(
         );
     }
 
-    let data = daemon_api_get(&runner.id, "/runs?limit=100")?;
-    let body = canonical_daemon_body(&data, "runner runs response")?;
-    let Some(remote_runs) = body.get("runs").and_then(Value::as_array) else {
-        return Ok(Vec::new());
-    };
-    let mut mirrored = Vec::new();
-    for summary in remote_runs {
-        let Some(run_id) = summary.get("id").and_then(Value::as_str) else {
-            continue;
-        };
-        if !remote_run_matches_job_window(summary, job) {
-            continue;
-        }
-        let detail_data = daemon_api_get(
-            &runner.id,
-            &format!("/runs/{}", encode_uri_component(run_id)),
-        )?;
-        let detail_body = canonical_daemon_body(&detail_data, "runner run detail response")?;
-        let Some(detail) = detail_body.get("run") else {
-            continue;
-        };
-        let mut run = remote_detail_to_run_record(detail, runner, Some(job))?;
-        if let Some(notification_route) = notification_route {
-            notification_route.insert_into_metadata(&mut run.metadata_json);
-        }
-        import_run_if_absent(store, &run)?;
-        for artifact in remote_detail_artifacts(detail, runner, &run.id)? {
-            import_mirrored_artifact(store, &artifact)?;
-        }
-        mirrored.push(run);
-    }
-    Ok(mirrored)
+    // A timestamp window can contain unrelated concurrent runner work. Without
+    // a result, artifact, or submitted durable-run reference, the job mirror is
+    // the only evidence whose ownership is proven.
+    Ok(Vec::new())
 }
 
 fn mirror_remote_observation_runs_by_id(

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -6,7 +6,10 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::{Runner, RunnerKind};
-use homeboy_core::api_jobs::{Job, JobArtifactMetadata, JobEvent, JobEventKind, JobStatus};
+use homeboy_core::api_jobs::{
+    Job, JobArtifactMetadata, JobEvent, JobEventKind, JobStatus, RunnerJobLifecycleMetadata,
+    RunnerJobProjection,
+};
 use homeboy_core::observation::{ArtifactRecord, ObservationStore, RunRecord};
 use homeboy_core::server::{RunnerPolicy, RunnerSettings};
 
@@ -834,5 +837,70 @@ fn test_explicit_observation_run_ids_prefers_result_lineage() {
             "run-from-job".to_string(),
             "run-from-ref".to_string(),
         ]
+    );
+}
+
+#[test]
+fn terminal_mirroring_keeps_overlapping_jobs_and_artifacts_bound_to_their_durable_runs() {
+    let mut first = Job {
+        id: Uuid::new_v4(),
+        operation: "runner.exec".to_string(),
+        status: JobStatus::Succeeded,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_001_000,
+        started_at_ms: Some(1_700_000_000_000),
+        finished_at_ms: Some(1_700_000_001_000),
+        event_count: 0,
+        source_snapshot: None,
+        path_materialization_plan: None,
+        stale_reason: None,
+        daemon_lease_id: None,
+        target_runner_id: None,
+        target_project_id: None,
+        claim_id: None,
+        claimed_by_runner_id: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        artifacts: vec![JobArtifactMetadata {
+            id: "first-result".to_string(),
+            name: Some("fuzz_results".to_string()),
+            path: Some("runner-artifact://lab/first-run/first-result".to_string()),
+            url: None,
+            mime: None,
+            size_bytes: None,
+            sha256: None,
+            content_base64: None,
+            metadata: None,
+        }],
+        runner_job_projection: None,
+    };
+    let mut second = first.clone();
+    second.id = Uuid::new_v4();
+    second.artifacts[0].id = "second-result".to_string();
+    second.artifacts[0].path = Some("runner-artifact://lab/second-run/second-result".to_string());
+
+    for (job, run_id) in [(&mut first, "first-run"), (&mut second, "second-run")] {
+        job.runner_job_projection = Some(RunnerJobProjection {
+            runner_id: "lab".to_string(),
+            command: "homeboy fuzz run".to_string(),
+            cwd: Some("/srv/homeboy/project".to_string()),
+            source: "runner-daemon".to_string(),
+            kind: "runner.exec".to_string(),
+            lifecycle: Some(RunnerJobLifecycleMetadata {
+                durable_run_id: Some(run_id.to_string()),
+                ..Default::default()
+            }),
+        });
+    }
+
+    // Both jobs occupy the same terminal window. Each terminal mirror must use
+    // its accepted durable run and artifact reference, never the other job's.
+    assert_eq!(
+        explicit_observation_run_ids(&json!({}), &first),
+        vec!["first-run".to_string()]
+    );
+    assert_eq!(
+        explicit_observation_run_ids(&json!({}), &second),
+        vec!["second-run".to_string()]
     );
 }

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -19,8 +19,8 @@ use super::detail::{
 use super::download::{content_disposition_filename, download_remote_artifact};
 use super::mirror::{
     bounded_remote_events, import_mirrored_artifact_with_downloader, mirror_job_run,
-    mirrored_patch_result, primary_mirrored_run, MIRRORED_REMOTE_EVENT_LIMIT,
-    MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT,
+    mirror_remote_observation_runs_by_id_with, mirrored_patch_result, primary_mirrored_run,
+    MIRRORED_REMOTE_EVENT_LIMIT, MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT,
 };
 use super::tokens::{
     is_reportable_artifact_evidence_path, is_retrievable_runner_artifact, runner_artifact_token,
@@ -841,7 +841,7 @@ fn test_explicit_observation_run_ids_prefers_result_lineage() {
 }
 
 #[test]
-fn terminal_mirroring_keeps_overlapping_jobs_and_artifacts_bound_to_their_durable_runs() {
+fn terminal_mirroring_imports_only_the_submitted_overlapping_job_run_and_artifacts() {
     let mut first = Job {
         id: Uuid::new_v4(),
         operation: "runner.exec".to_string(),
@@ -893,14 +893,67 @@ fn terminal_mirroring_keeps_overlapping_jobs_and_artifacts_bound_to_their_durabl
         });
     }
 
-    // Both jobs occupy the same terminal window. Each terminal mirror must use
-    // its accepted durable run and artifact reference, never the other job's.
-    assert_eq!(
-        explicit_observation_run_ids(&json!({}), &first),
-        vec!["first-run".to_string()]
-    );
-    assert_eq!(
-        explicit_observation_run_ids(&json!({}), &second),
-        vec!["second-run".to_string()]
-    );
+    for (job, expected_run, other_run, artifact_id) in [
+        (&first, "first-run", "second-run", "first-result"),
+        (&second, "second-run", "first-run", "second-result"),
+    ] {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let runner = ssh_runner();
+            let details = std::collections::HashMap::from([
+                (
+                    "first-run",
+                    json!({
+                        "id": "first-run",
+                        "kind": "fuzz",
+                        "started_at": "2023-11-14T22:13:20Z",
+                        "finished_at": "2023-11-14T22:13:21Z",
+                        "status": "pass",
+                        "artifacts": [{"id": "first-result", "kind": "fuzz_results"}]
+                    }),
+                ),
+                (
+                    "second-run",
+                    json!({
+                        "id": "second-run",
+                        "kind": "fuzz",
+                        "started_at": "2023-11-14T22:13:20Z",
+                        "finished_at": "2023-11-14T22:13:21Z",
+                        "status": "fail",
+                        "artifacts": [{"id": "second-result", "kind": "fuzz_results"}]
+                    }),
+                ),
+            ]);
+
+            let run_ids = explicit_observation_run_ids(&json!({}), job);
+            let mirrored = mirror_remote_observation_runs_by_id_with(
+                &store,
+                &runner,
+                job,
+                &run_ids,
+                None,
+                |run_id| Ok(details.get(run_id).cloned()),
+            )
+            .expect("mirror submitted terminal run");
+
+            assert_eq!(mirrored.len(), 1);
+            assert_eq!(mirrored[0].id, expected_run);
+            assert_eq!(
+                mirrored[0].metadata_json["lab"]["remote_job_id"],
+                job.id.to_string()
+            );
+            assert!(store
+                .get_run(other_run)
+                .expect("other run lookup")
+                .is_none());
+            assert_eq!(
+                store
+                    .get_artifact(artifact_id)
+                    .expect("artifact lookup")
+                    .expect("mirrored artifact")
+                    .run_id,
+                expected_run
+            );
+        });
+    }
 }


### PR DESCRIPTION
Closes #9113

## Summary
- bind terminal evidence mirroring to the submitted job's explicit durable run identity
- remove timestamp-window discovery that could import unrelated concurrent runs
- verify overlapping jobs import only their own run and artifact records

## How to test
1. Check out this branch.
2. Run `cargo test -p homeboy-lab-runner terminal_mirroring_imports_only_the_submitted_overlapping_job_run_and_artifacts --lib`.
3. Run `cargo test -p homeboy-lab-runner evidence::tests --lib`.
4. Run `cargo fmt --check`.

## Compatibility
This intentionally stops mirroring remote runs whose ownership is inferred only from an overlapping timestamp. Submitted jobs with explicit result, artifact, or durable-run lineage continue to mirror normally. No public command or serialized contract changes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Root-cause analysis, implementation, regression coverage, and verification in collaboration with Chris Huber.