### PR TITLE
fix: skip fully-local refs when hydrating controller bundle commits

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/git.rs
+++ b/crates/homeboy-lab-runner/src/workspace/git.rs
@@ -429,6 +429,25 @@ fn refetch_controller_bundle_commits(
     remote: &str,
     refs: &[String],
 ) -> Result<()> {
+    // Only fetch refs whose local object closure is actually incomplete. A
+    // changed-scope run selects the clean worktree HEAD alongside the resolved
+    // base, but that HEAD can be a new *local-only* commit that was never pushed
+    // (#8309). The promisor remote cannot serve it — `git fetch <remote> <sha>`
+    // fails with "upload-pack: not our ref <sha>" — and it does not need to,
+    // because a locally-authored commit is already fully present. Fetching only
+    // the refs with missing objects hydrates the promised base/ancestry closure
+    // through the promisor transport while leaving fully-local commits alone.
+    let mut incomplete_refs = Vec::new();
+    for git_ref in refs {
+        if ref_has_missing_objects(local_path, git_ref)? {
+            incomplete_refs.push(git_ref.clone());
+        }
+    }
+
+    if incomplete_refs.is_empty() {
+        return Ok(());
+    }
+
     // Fetch only the closure of the requested refs. `--refetch` was used here to
     // reapply the partial-clone filter, but it "fetches all objects as a fresh
     // clone would" (git-fetch(1)), re-pulling objects reachable from unrelated
@@ -440,7 +459,7 @@ fn refetch_controller_bundle_commits(
     let output = Command::new("git")
         .args(["fetch", "--no-tags", "--filter=blob:none"])
         .arg(remote)
-        .args(refs)
+        .args(&incomplete_refs)
         .current_dir(local_path)
         .output()
         .map_err(|err| {
@@ -457,6 +476,47 @@ fn refetch_controller_bundle_commits(
         "refetch controller git bundle commits failed: {}",
         String::from_utf8_lossy(&output.stderr)
     )))
+}
+
+/// Report whether `git_ref`'s local object closure is missing any objects.
+///
+/// Walks the ref with lazy fetching disabled so a partial clone *reports* absent
+/// promisor objects instead of silently fetching them. A ref that is fully
+/// present locally (e.g. a new local-only commit that was never pushed) reports
+/// no missing objects and must not be requested from the promisor remote, which
+/// cannot serve an unpushed commit. A ref that cannot be resolved at all (its
+/// tip commit is itself absent) is treated as incomplete so the promisor fetch
+/// can attempt to hydrate it.
+pub(super) fn ref_has_missing_objects(local_path: &Path, git_ref: &str) -> Result<bool> {
+    let output = Command::new("git")
+        .args([
+            "-c",
+            "core.commitGraph=false",
+            "rev-list",
+            "--objects",
+            "--no-object-names",
+            "--missing=print",
+        ])
+        .arg(git_ref)
+        .env("GIT_NO_LAZY_FETCH", "1")
+        .current_dir(local_path)
+        .output()
+        .map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some("probe controller bundle ref objects".to_string()),
+            )
+        })?;
+
+    // The tip commit itself is absent locally: rev-list cannot walk the ref, so
+    // treat it as incomplete and let the promisor fetch hydrate it.
+    if !output.status.success() {
+        return Ok(true);
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .any(|line| line.starts_with('?')))
 }
 
 fn promisor_remote(local_path: &Path) -> Result<Option<String>> {

--- a/crates/homeboy-lab-runner/src/workspace/tests/git.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/git.rs
@@ -4,7 +4,9 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 
 use super::git;
-use crate::workspace::git::{git_bundle_install_command, git_snapshot, materialize_git_command};
+use crate::workspace::git::{
+    git_bundle_install_command, git_snapshot, materialize_git_command, ref_has_missing_objects,
+};
 use crate::workspace::sync::sync_workspace;
 use crate::workspace::types::{RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions};
 use crate::workspace::util::git_output;
@@ -238,6 +240,184 @@ fn changed_since_retry_route_materializes_private_unavailable_origin_from_bundle
             "M file.txt"
         );
     });
+}
+
+#[test]
+fn changed_since_bundle_includes_a_local_only_head_over_a_promisor_base() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let origin = tempfile::tempdir().expect("origin tempdir");
+        let author = tempfile::tempdir().expect("author tempdir");
+        let source = tempfile::tempdir().expect("source tempdir");
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        git(origin.path(), &["init", "--bare", "-b", "main"]);
+        git(origin.path(), &["config", "uploadpack.allowFilter", "true"]);
+        git(author.path(), &["init", "-b", "main"]);
+        git(author.path(), &["config", "user.email", "test@example.com"]);
+        git(author.path(), &["config", "user.name", "Test User"]);
+        fs::write(author.path().join("base-only.txt"), "base\n").expect("write base file");
+        git(author.path(), &["add", "."]);
+        git(author.path(), &["commit", "-m", "base"]);
+        let base = git_output(author.path(), &["rev-parse", "HEAD"]).expect("base revision");
+        let base_blob = git_output(author.path(), &["rev-parse", "HEAD:base-only.txt"])
+            .expect("base blob revision");
+        git(
+            author.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                &format!("file://{}", origin.path().display()),
+            ],
+        );
+        // Only the base is ever pushed. The head commit stays local-only.
+        git(author.path(), &["push", "origin", "main"]);
+
+        // Partial clone of the pushed base into the controller source checkout.
+        git(
+            source.path(),
+            &[
+                "clone",
+                "--filter=blob:none",
+                &format!("file://{}", origin.path().display()),
+                ".",
+            ],
+        );
+        git(source.path(), &["config", "user.email", "test@example.com"]);
+        git(source.path(), &["config", "user.name", "Test User"]);
+        // Create a NEW commit locally and never push it — this is the clean
+        // worktree HEAD that a changed-since run selects. It is fully present in
+        // the local object database but absent from the promisor remote. The
+        // head drops `base-only.txt` so the working tree no longer needs the
+        // promisor blob, letting the fixture evict it below. (#8309)
+        fs::remove_file(source.path().join("base-only.txt")).expect("remove base file");
+        fs::write(source.path().join("file.txt"), "head\n").expect("write head file");
+        git(source.path(), &["add", "-A"]);
+        git(source.path(), &["commit", "-m", "local-only head"]);
+        let head = git_output(source.path(), &["rev-parse", "HEAD"]).expect("head revision");
+        assert_ne!(head, base, "the head must be a distinct local-only commit");
+
+        // Point origin at an unreachable URL so materialization must use the
+        // controller bundle fallback rather than a network clone.
+        git(source.path(), &["remote", "rename", "origin", "controller"]);
+        git(
+            source.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://127.0.0.1:1/example-org/private-source.git",
+            ],
+        );
+        // Retain a commit-graph so a stale promisor entry survives pack removal.
+        git(source.path(), &["commit-graph", "write", "--reachable"]);
+
+        crate::create(
+            &format!(
+                r#"{{"id":"lab-local-only-head","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+
+        // Evict the promisor packs so the base blob is genuinely absent locally;
+        // the controller must hydrate it through the promisor transport while
+        // leaving the local-only head untouched.
+        remove_local_packs(source.path());
+        assert!(
+            git_without_lazy_fetch(source.path(), &["cat-file", "-e", &base_blob]).is_err(),
+            "the fixture must omit the promised base blob locally"
+        );
+        assert!(
+            git_without_lazy_fetch(
+                source.path(),
+                &["cat-file", "-e", &format!("{head}^{{commit}}")]
+            )
+            .is_ok(),
+            "the local-only head must remain fully present after pack eviction"
+        );
+
+        let sync_result = sync_workspace(
+            "lab-local-only-head",
+            RunnerWorkspaceSyncOptions {
+                path: source.path().display().to_string(),
+                mode: RunnerWorkspaceSyncMode::Git,
+                controller_routed_git: false,
+                changed_since_base: Some(base.clone()),
+                git_fetch_refs: Vec::new(),
+                snapshot_includes: Vec::new(),
+                allow_dirty_lab_workspace: false,
+                run_isolation_token: None,
+            },
+        );
+
+        let (output, exit_code) = sync_result
+            .expect("a local-only head over a promisor base must materialize from a bundle");
+        assert_eq!(exit_code, 0);
+
+        let remote = Path::new(&output.remote_path);
+        // The bundle is self-contained: both the local-only head and the
+        // hydrated base (with ancestry) are present on the runner.
+        assert_eq!(git_output(remote, &["rev-parse", "HEAD"]).unwrap(), head);
+        assert_eq!(git_output(remote, &["rev-parse", &base]).unwrap(), base);
+        assert_eq!(
+            git_output(remote, &["merge-base", &base, "HEAD"]).unwrap(),
+            base
+        );
+        assert_eq!(
+            git_output(remote, &["cat-file", "-e", &base_blob]).unwrap(),
+            ""
+        );
+        assert_eq!(
+            fs::read_to_string(remote.join("file.txt")).expect("read synced file"),
+            "head\n"
+        );
+        assert!(git_output(remote, &["status", "--porcelain=v1"])
+            .expect("read final checkout status")
+            .is_empty());
+    });
+}
+
+#[test]
+fn ref_missing_object_probe_skips_a_fully_local_commit_but_flags_an_evicted_base() {
+    let author = tempfile::tempdir().expect("author tempdir");
+    let source = tempfile::tempdir().expect("source tempdir");
+    git(author.path(), &["init", "-b", "main"]);
+    git(author.path(), &["config", "user.email", "test@example.com"]);
+    git(author.path(), &["config", "user.name", "Test User"]);
+    fs::write(author.path().join("base-only.txt"), "base\n").expect("write base file");
+    git(author.path(), &["add", "."]);
+    git(author.path(), &["commit", "-m", "base"]);
+
+    // Clone, then author a new local-only commit that drops the base file.
+    git(
+        source.path(),
+        &["clone", &format!("file://{}", author.path().display()), "."],
+    );
+    git(source.path(), &["config", "user.email", "test@example.com"]);
+    git(source.path(), &["config", "user.name", "Test User"]);
+    let base = git_output(source.path(), &["rev-parse", "HEAD"]).expect("base revision");
+    fs::remove_file(source.path().join("base-only.txt")).expect("remove base file");
+    fs::write(source.path().join("file.txt"), "head\n").expect("write head file");
+    git(source.path(), &["add", "-A"]);
+    git(source.path(), &["commit", "-m", "local-only head"]);
+    let head = git_output(source.path(), &["rev-parse", "HEAD"]).expect("head revision");
+
+    // A fully-local commit has a complete object closure: it must be skipped so
+    // the promisor remote is never asked for an unpushed commit. (#8309)
+    assert!(
+        !ref_has_missing_objects(source.path(), &head).expect("probe local-only head"),
+        "a fully-local commit must report no missing objects"
+    );
+
+    // Evict packs so the base commit's objects are absent locally; the probe
+    // must flag it so the promisor fetch still hydrates the promised base.
+    remove_local_packs(source.path());
+    git(source.path(), &["config", "remote.origin.promisor", "true"]);
+    assert!(
+        ref_has_missing_objects(source.path(), &base).expect("probe evicted base"),
+        "a ref whose objects were evicted must report missing objects"
+    );
 }
 
 fn remove_local_packs(path: &Path) {


### PR DESCRIPTION
Fixes #8309.

## Problem

`homeboy review test --placement lab --changed-since origin/trunk` failed before runner execution when the clean source worktree HEAD was a new **local-only** commit:

```
refetch controller git bundle commits failed: fatal: remote error: upload-pack: not our ref e32d407b...
```

A changed-scope run selects the worktree HEAD alongside the resolved base and, on a partial (promisor) controller checkout, hydrates their object closure through the promisor transport before bundling. The refetch named the HEAD commit explicitly — but an unpushed local commit isn't advertised by the remote, so `upload-pack` rejected it and the run died before any bundle was produced.

## Root cause

This is the counterpart to #9106. That change made `refetch_controller_bundle_commits` name exact refs (fixing a non-deterministic over-fetch). Naming the refs then surfaced this latent bug: the ref list includes the local-only HEAD, and the promisor remote cannot serve a commit that was authored locally and never pushed.

A locally-authored commit is already fully present in the object database, so it neither *can* nor *needs to* be fetched from the remote — only refs whose local closure is genuinely incomplete (the promised base/ancestry a partial clone lacks) should be fetched.

## Fix

`refetch_controller_bundle_commits` now probes each requested ref with a new `ref_has_missing_objects` helper — a lazy-fetch-disabled (`GIT_NO_LAZY_FETCH=1`) `rev-list --objects --missing=print` walk — and fetches **only** the refs whose local object closure is incomplete. A fully-local commit reports zero missing objects and is skipped; a ref whose tip commit is itself absent is treated as incomplete so the promisor fetch can still hydrate it.

This preserves #9106's promised base/ancestry hydration (the base still gets fetched) while never asking the promisor for an unpushed local commit.

## Expected behavior mapped to the issue

1. ✅ A clean local-only HEAD plus resolved base produces a self-contained bundle containing both commits and required ancestry (integration test).
2. ✅ Missing base objects are still hydrated before bundling (the probe flags them; #9106 behavior preserved).
3. The exact `upload-pack: not our ref` rejection is a real-transport (upload-pack server) behavior and is not reproducible over git's permissive local `file://` transport, which resolves any SHA present in the caller's own object store. The fix therefore targets the root cause — never request a fully-local ref from the promisor — and is locked in by the probe test below rather than a server-rejection fixture.

## Testing

- `ref_missing_object_probe_skips_a_fully_local_commit_but_flags_an_evicted_base` — directly proves a fully-local commit reports no missing objects (skipped) while an evicted base reports missing (fetched). This is the discriminating test for the fix.
- `changed_since_bundle_includes_a_local_only_head_over_a_promisor_base` — end-to-end: a partial-clone source with a local-only HEAD over a promisor base materializes from a controller bundle; the runner checkout has HEAD, the hydrated base, correct ancestry (`merge-base == base`), and a clean tree.
- Full `workspace::tests::git` suite (17 tests) green, including the #9106 promised-object test.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Traced the `upload-pack: not our ref` failure to #9106's exact-ref refetch requesting an unpushed local HEAD from the promisor, and scoped the refetch to only object-incomplete refs. Chris reviews and owns the change.