### PR TITLE
fix: authorize exact chained promotion baselines

### DIFF
--- a/crates/homeboy-agents/src/agent_task_candidate_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_candidate_baseline.rs
@@ -33,8 +33,14 @@ pub fn register() {
 /// by its durable promotion artifact, without mutating its real Git index.
 pub(crate) fn validate_gate_feedback_candidate_baseline(
     root: &Path,
-    cook_loop: &Value,
+    baseline: &Value,
 ) -> Result<String> {
+    if baseline.get("schema").and_then(Value::as_str)
+        == Some("homeboy/agent-task-promotion-chain-baseline/v1")
+    {
+        return validate_promotion_chain_baseline(root, baseline);
+    }
+    let cook_loop = baseline;
     let artifact = cook_loop
         .get("patch_artifact")
         .and_then(Value::as_object)
@@ -71,6 +77,37 @@ pub(crate) fn validate_gate_feedback_candidate_baseline(
         ));
     }
     Ok(current_diff)
+}
+
+/// A follow-up candidate is allowed to reuse a dirty destination only when its
+/// complete tree is the controller-verified source tree used to cook that
+/// candidate. This works for materialized snapshots whose HEAD is synthetic.
+fn validate_promotion_chain_baseline(root: &Path, baseline: &Value) -> Result<String> {
+    let expected_tree = baseline
+        .get("source_tree")
+        .and_then(Value::as_str)
+        .filter(|tree| valid_git_object_id(tree))
+        .ok_or_else(|| invalid("promotion-chain baseline has no valid source tree"))?;
+    let prior_artifact = baseline
+        .pointer("/prior_patch_artifact/sha256")
+        .and_then(Value::as_str)
+        .filter(|sha256| valid_sha256(sha256))
+        .ok_or_else(|| invalid("promotion-chain baseline has no valid prior patch artifact"))?;
+    let actual_tree = workspace_tree(root)?;
+    if actual_tree != expected_tree {
+        return Err(invalid(
+            "promotion-chain destination differs from the follow-up source snapshot",
+        ));
+    }
+    Ok(format!("promotion-chain:{prior_artifact}:{actual_tree}"))
+}
+
+fn valid_sha256(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn valid_git_object_id(value: &str) -> bool {
+    matches!(value.len(), 40 | 64) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn verify_patch_is_present(root: &Path, patch: &str) -> Result<()> {
@@ -188,6 +225,44 @@ mod tests {
                 .expect("layered candidate baseline"),
             current_diff
         );
+    }
+
+    #[test]
+    fn promotion_chain_accepts_only_the_exact_source_tree() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        git(temp.path(), &["init", "-b", "main"]);
+        git(temp.path(), &["config", "user.name", "Homeboy Test"]);
+        git(
+            temp.path(),
+            &["config", "user.email", "homeboy@example.test"],
+        );
+        std::fs::write(temp.path().join("tracked.txt"), "base\n").expect("base file");
+        git(temp.path(), &["add", "tracked.txt"]);
+        git(temp.path(), &["commit", "-m", "base"]);
+        std::fs::write(temp.path().join("tracked.txt"), "v1\n").expect("v1 file");
+        let source_tree = workspace_tree(temp.path()).expect("v1 tree");
+        let baseline = serde_json::json!({
+            "schema": "homeboy/agent-task-promotion-chain-baseline/v1",
+            "source_tree": source_tree,
+            "prior_patch_artifact": { "sha256": "a".repeat(64) }
+        });
+
+        assert!(validate_gate_feedback_candidate_baseline(temp.path(), &baseline).is_ok());
+
+        std::fs::write(temp.path().join("tracked.txt"), "base\n").expect("clean base file");
+        let error = validate_gate_feedback_candidate_baseline(temp.path(), &baseline)
+            .expect_err("clean base cannot accept a delta requiring v1");
+        assert!(error
+            .message
+            .contains("differs from the follow-up source snapshot"));
+
+        std::fs::write(temp.path().join("tracked.txt"), "v1\n").expect("restore v1 file");
+        std::fs::write(temp.path().join("unrelated.txt"), "drift\n").expect("drift file");
+        let error = validate_gate_feedback_candidate_baseline(temp.path(), &baseline)
+            .expect_err("unrelated dirty content rejected");
+        assert!(error
+            .message
+            .contains("differs from the follow-up source snapshot"));
     }
 
     fn git(root: &Path, args: &[&str]) -> String {

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -104,7 +104,7 @@ pub fn resume_promoted_patch(
     let gates = run_promotion_gates(&options, &mut provider, target_path)?;
     let target =
         AgentTaskPromotionTarget::from_worktree(options.to_worktree.clone(), Some(target_path));
-    let candidate = if gates.status == AgentTaskPromotionStatus::Applied {
+    let candidate = if gates.status.patch_promoted() {
         Some(crate::agent_task_promotion::candidate_fingerprint(
             &target_path.display().to_string(),
         )?)
@@ -482,6 +482,12 @@ pub(super) fn promote_with_provider_and_checkpoint(
     }
     let gate_feedback_baseline =
         gate_feedback_baseline_for_artifact(&source_for_provenance, &outcome, &artifact)?;
+    let promotion_chain_baseline =
+        promotion_chain_baseline_for_artifact(&source_for_provenance, &outcome, &artifact)?;
+    let destination_baseline = promotion_chain_baseline
+        .as_ref()
+        .or(gate_feedback_baseline.as_ref())
+        .cloned();
     let patch_path = resolve_artifact_path(
         &artifact,
         &outcome.task_id,
@@ -575,7 +581,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
             patch: Some(normalized_patch.content.clone()),
             patch_path: provider_patch_path,
             changed_files: changed_files.clone(),
-            gate_feedback_baseline,
+            gate_feedback_baseline: destination_baseline,
             dry_run: options.dry_run,
             trusted_unpushed_candidate_destination: None,
         })?;
@@ -619,7 +625,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
     };
     let (gates, verified_base) = verified_base;
     let operator_notification = promotion_notification(gates.status, &target);
-    let candidate = if gates.status == AgentTaskPromotionStatus::Applied {
+    let candidate = if gates.status.patch_promoted() {
         applied_worktree_path
             .as_deref()
             .map(|path| {
@@ -653,9 +659,92 @@ pub(super) fn promote_with_provider_and_checkpoint(
             "worktree_path": applied_worktree_path,
             "dependencies_materialized": gates.dependencies_materialized,
             "candidate": candidate,
+            "destination_baseline": candidate,
+            "prior_baseline": promotion_chain_baseline,
         }),
         operator_notification,
     })
+}
+
+fn promotion_chain_baseline_for_artifact(
+    source: &Value,
+    outcome: &AgentTaskOutcome,
+    selected: &AgentTaskArtifact,
+) -> Result<Option<Value>> {
+    let canonical = outcome
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.id == selected.id)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "artifact_id",
+                "selected patch artifact is missing from canonical outcome artifacts",
+                None,
+                None,
+            )
+        })?;
+    let source_provenance = source_canonical_artifact(source, &outcome.task_id, &canonical.id)?
+        .and_then(|artifact| {
+            artifact.pointer("/metadata/source_provenance/verified_cook_baseline")
+        });
+    let provenance = source_provenance.or_else(|| {
+        canonical
+            .metadata
+            .pointer("/source_provenance/verified_cook_baseline")
+    });
+    let Some(provenance) = provenance else {
+        return Ok(None);
+    };
+    if source_provenance.is_some()
+        && canonical
+            .metadata
+            .pointer("/source_provenance/verified_cook_baseline")
+            != source_provenance
+    {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            "canonical patch artifact source baseline provenance changed during source deserialization",
+            Some(canonical.id.clone()),
+            None,
+        ));
+    }
+    let source_tree = provenance
+        .get("baseline_tree")
+        .and_then(Value::as_str)
+        .filter(|tree| valid_git_object_id(tree))
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "artifact_id",
+                "follow-up patch artifact has no valid verified source tree",
+                Some(canonical.id.clone()),
+                None,
+            )
+        })?;
+    let prior_sha256 = provenance
+        .get("promoted_patch_artifact_sha256")
+        .and_then(Value::as_str)
+        .filter(|sha256| valid_sha256(sha256))
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "artifact_id",
+                "follow-up patch artifact has no valid prior promoted artifact identity",
+                Some(canonical.id.clone()),
+                None,
+            )
+        })?;
+    Ok(Some(json!({
+        "schema": "homeboy/agent-task-promotion-chain-baseline/v1",
+        "source_tree": source_tree,
+        "prior_patch_artifact": {
+            "sha256": prior_sha256,
+            "source_run_id": provenance.get("source_run_id"),
+            "source_task_id": provenance.get("source_task_id"),
+        },
+    })))
+}
+
+fn valid_git_object_id(value: &str) -> bool {
+    matches!(value.len(), 40 | 64) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn has_pre_provider_transport_recovery_eligibility(outcome: &AgentTaskOutcome) -> bool {
@@ -986,6 +1075,7 @@ fn promote_committed_changes(
             "commit_range": committed_patch.commit_range,
             "commits": committed_patch.commits,
             "candidate": candidate,
+            "destination_baseline": candidate,
         }),
         operator_notification,
     })
@@ -1309,6 +1399,7 @@ fn post_apply_report(
             "dependencies_materialized": false,
             "post_apply": true,
             "candidate": candidate,
+            "destination_baseline": candidate,
             "resume_inputs": {
                 "base_ref": options.base_ref,
                 "task_base_sha": options.task_base_sha,

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -348,6 +348,87 @@ fn aggregate_promotion_forwards_canonical_gate_feedback_baseline() {
 }
 
 #[test]
+fn follow_up_promotion_records_and_forwards_verified_chain_baseline() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let patch_path = temp.path().join("follow-up.patch");
+    std::fs::write(&patch_path, VALID_PATCH).expect("write follow-up patch");
+    let prior_sha256 = "b".repeat(64);
+    let source_tree = "c".repeat(40);
+    let source = serde_json::json!({
+        "schema": AGENT_TASK_OUTCOME_SCHEMA,
+        "task_id": "follow-up",
+        "status": "succeeded",
+        "artifacts": [{
+            "schema": AGENT_TASK_ARTIFACT_SCHEMA,
+            "id": "patch",
+            "kind": "patch",
+            "path": patch_path,
+            "size_bytes": VALID_PATCH.len(),
+            "sha256": sha256_hex(VALID_PATCH),
+            "metadata": {
+                "source_provenance": {
+                    "verified_cook_baseline": {
+                        "source_run_id": "v1-run",
+                        "source_task_id": "v1-task",
+                        "promoted_patch_artifact_sha256": prior_sha256,
+                        "baseline_tree": source_tree
+                    }
+                }
+            }
+        }]
+    })
+    .to_string();
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(temp.path().to_path_buf()),
+        ..Default::default()
+    };
+
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("v2-run".to_string()),
+            source_path: None,
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            candidate_ref: None,
+            to_worktree: "fixture@target".to_string(),
+            task_id: Some("follow-up".to_string()),
+            artifact_id: Some("patch".to_string()),
+            dry_run: false,
+            gates: VerifyGateOptions::default(),
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+    )
+    .expect("promote follow-up");
+
+    assert_eq!(
+        provider.apply_calls[0].gate_feedback_baseline,
+        Some(serde_json::json!({
+            "schema": "homeboy/agent-task-promotion-chain-baseline/v1",
+            "source_tree": source_tree,
+            "prior_patch_artifact": {
+                "sha256": prior_sha256,
+                "source_run_id": "v1-run",
+                "source_task_id": "v1-task"
+            }
+        }))
+    );
+    assert_eq!(
+        report.provenance["prior_baseline"]["source_tree"],
+        source_tree
+    );
+    assert_eq!(
+        report.provenance["prior_baseline"]["prior_patch_artifact"]["sha256"],
+        prior_sha256
+    );
+    assert_eq!(report.patch_artifact.id, "patch");
+    assert!(report.provenance["destination_baseline"].is_object());
+}
+
+#[test]
 fn promote_recoverable_candidate_rejects_multiple_actionable_patches() {
     let (result, apply_calls) = promote_recoverable_patch_count(2);
     assert!(result


### PR DESCRIPTION
## Summary

- derive a typed promotion-chain baseline from verified cook provenance
- authorize dirty destination reuse only when its complete Git tree exactly matches the follow-up source snapshot
- link the chain to the prior promoted patch SHA-256
- expose prior and destination baselines in promotion reports
- preserve fail-closed behavior for clean bases requiring an earlier patch and for any unrelated dirty drift

Fixes #9099.

## Why

A follow-up candidate is a delta against the previously promoted candidate. Homeboy rejected the exact prior destination because it was dirty, while a clean destination could not apply the delta. This made iterative cook/review/fix workflows impossible through Homeboy’s own promotion authority.

## How to test

1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-agents agent_task_candidate_baseline --lib`.
3. Run `cargo test -p homeboy-agents follow_up_promotion_records_and_forwards_verified_chain_baseline --lib`.
4. Run `cargo check -p homeboy-agents`.
5. Confirm the baseline test accepts exact v1 content and rejects both a clean base and unrelated dirty drift.
6. Confirm the promotion test forwards the verified source tree and prior patch identity into the provider request and report.

## Backwards compatibility

The new `homeboy/agent-task-promotion-chain-baseline/v1` envelope is additive. Existing gate-feedback baselines retain their current validation path. Dirty destinations without verified chain provenance remain rejected. No extension path or command-line option changes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol with OpenCode
- **Used for:** Root-cause analysis, implementation drafting, safety review, and deterministic test coverage
