### PR TITLE
Harvest verified filesystem snapshot candidates

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -16,6 +16,22 @@ pub struct HarvestExecutionContext {
 }
 
 impl HarvestExecutionContext {
+    /// Bind a scheduler to the exact paired Lab transport it must verify.
+    pub fn from_lab_transport(
+        source_snapshot: homeboy_core::source_snapshot::SourceSnapshot,
+        lab_offload: serde_json::Value,
+    ) -> homeboy_core::Result<Self> {
+        if !lab_offload.is_object() {
+            return Err(incomplete_transport_error(
+                "Lab offload metadata must be a JSON object".to_string(),
+            ));
+        }
+        Ok(Self {
+            source_snapshot: Some(source_snapshot),
+            lab_offload: Some(lab_offload),
+        })
+    }
+
     pub fn from_current_process() -> homeboy_core::Result<Self> {
         let source = std::env::var(homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV).ok();
         let lab = std::env::var(homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV).ok();
@@ -30,12 +46,12 @@ impl HarvestExecutionContext {
                         "Lab offload metadata must be a JSON object".to_string(),
                     ));
                 }
-                Ok(Self {
-                    source_snapshot: serde_json::from_str(&source).map_err(|error| {
+                Self::from_lab_transport(
+                    serde_json::from_str(&source).map_err(|error| {
                         incomplete_transport_error(format!("invalid source snapshot metadata: {error}"))
                     })?,
-                    lab_offload: Some(lab_offload),
-                })
+                    lab_offload,
+                )
             }
             (source, lab) => Err(incomplete_transport_error(format!(
                 "expected paired non-empty source snapshot and Lab offload metadata (source_snapshot={}, lab_offload={})",
@@ -190,9 +206,10 @@ pub(super) fn prepare_committed_harvest(
                     "snapshot workspace unexpectedly contains root .git metadata".to_string(),
                 ));
             }
-            if provenance.materialization_mode != "snapshot"
-                && provenance.materialization_mode != "snapshot-git"
-            {
+            if !matches!(
+                provenance.materialization_mode.as_str(),
+                "snapshot" | "filesystem_snapshot" | "snapshot-git"
+            ) {
                 return Err(snapshot_harvest_error(format!(
                     "unsupported snapshot materialization mode `{}`",
                     provenance.materialization_mode

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -51,7 +51,7 @@ where
         self
     }
 
-    pub(crate) fn with_harvest_context(mut self, context: HarvestExecutionContext) -> Self {
+    pub fn with_harvest_context(mut self, context: HarvestExecutionContext) -> Self {
         self.harvest_context = context;
         self
     }

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -411,7 +411,10 @@ fn materialize_snapshot_git_baseline(envelope: &RunnerExecutionEnvelope) -> Resu
             Some("parse reverse worker Lab offload metadata".to_string()),
         )
     })?;
-    if lab.get("sync_mode").and_then(serde_json::Value::as_str) != Some("snapshot") {
+    if !matches!(
+        lab.get("sync_mode").and_then(serde_json::Value::as_str),
+        Some("snapshot" | "filesystem_snapshot")
+    ) {
         return Ok(());
     }
     let cwd = dispatch.cwd.as_deref().ok_or_else(|| {

--- a/crates/homeboy-lab-runner/src/workspace/provenance.rs
+++ b/crates/homeboy-lab-runner/src/workspace/provenance.rs
@@ -105,7 +105,9 @@ pub(crate) fn verify_lab_workspace_git_root(
 ) -> std::result::Result<(), String> {
     match provenance.materialization_mode.as_str() {
         "git" => verify_git_materialization_root(workspace, provenance),
-        "snapshot" => verify_synthetic_snapshot_git_baseline(workspace, provenance),
+        "snapshot" | "filesystem_snapshot" => {
+            verify_synthetic_snapshot_git_baseline(workspace, provenance)
+        }
         "snapshot-git" => verify_materialized_snapshot_git_checkout(workspace, provenance),
         mode => Err(format!(
             "unsupported workspace materialization mode `{mode}`"
@@ -408,7 +410,10 @@ pub(crate) fn verify_lab_workspace(
             snapshot.sync_mode
         ));
     }
-    if !matches!(materialization_mode, "git" | "snapshot" | "snapshot-git") {
+    if !matches!(
+        materialization_mode,
+        "git" | "snapshot" | "filesystem_snapshot" | "snapshot-git"
+    ) {
         return Err(format!(
             "has untrusted workspace materialization mode `{materialization_mode}`"
         ));
@@ -613,7 +618,7 @@ fn verify_snapshot_workspace_content(
                 shell::quote_arg(&provenance.runner_id),
                 shell::quote_arg(&provenance.remote_workspace_path),
             ),
-            "snapshot" => format!(
+            "snapshot" | "filesystem_snapshot" => format!(
                 "homeboy runner workspace sync --mode snapshot --path {} {}",
                 shell::quote_arg(
                     provenance
@@ -823,6 +828,19 @@ mod tests {
         WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY, WORKSPACE_CONTENT_PERMISSION_PORTABLE,
     };
     use super::*;
+    use homeboy_agents::agent_task::{
+        AgentTaskExecutor, AgentTaskLimits, AgentTaskOutcome, AgentTaskOutcomeStatus,
+        AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace, AGENT_TASK_OUTCOME_SCHEMA,
+        AGENT_TASK_REQUEST_SCHEMA,
+    };
+    use homeboy_agents::agent_task_scheduler::{
+        AgentTaskExecutionContext, AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskScheduler,
+        HarvestExecutionContext,
+    };
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
 
     fn snapshot(path: &Path) -> SourceSnapshot {
         SourceSnapshot {
@@ -1073,7 +1091,7 @@ mod tests {
 
     #[test]
     fn snapshot_materializations_reject_content_hash_mismatch() {
-        for mode in ["snapshot", "snapshot-git"] {
+        for mode in ["snapshot", "filesystem_snapshot", "snapshot-git"] {
             let workspace = tempfile::tempdir().expect("workspace");
             std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");
             let snapshot = snapshot(workspace.path());
@@ -1218,6 +1236,129 @@ mod tests {
             .expect("candidate patch");
         assert!(uncommitted_patch.contains("-candidate"));
         assert!(uncommitted_patch.contains("+uncommitted candidate"));
+    }
+
+    #[derive(Clone)]
+    struct FilesystemSnapshotProvider {
+        change_workspace: bool,
+        dispatched: Arc<AtomicBool>,
+    }
+
+    impl AgentTaskExecutorAdapter for FilesystemSnapshotProvider {
+        fn execute(
+            &self,
+            request: AgentTaskRequest,
+            _context: AgentTaskExecutionContext,
+        ) -> AgentTaskOutcome {
+            let workspace = PathBuf::from(request.workspace.root.expect("attempt workspace"));
+            assert!(
+                workspace.join(".git").exists(),
+                "provider receives an isolated Git-backed baseline"
+            );
+            if self.change_workspace {
+                std::fs::write(workspace.join("provider-change.txt"), "candidate\n")
+                    .expect("write provider candidate");
+            }
+            self.dispatched.store(true, Ordering::SeqCst);
+            AgentTaskOutcome {
+                schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: request.task_id,
+                status: AgentTaskOutcomeStatus::Succeeded,
+                summary: Some("provider completed".to_string()),
+                failure_classification: None,
+                artifacts: Vec::new(),
+                typed_artifacts: Vec::new(),
+                evidence_refs: Vec::new(),
+                diagnostics: Vec::new(),
+                outputs: serde_json::Value::Null,
+                workflow: None,
+                follow_up: None,
+                metadata: serde_json::Value::Null,
+            }
+        }
+    }
+
+    fn filesystem_snapshot_request(workspace: &Path) -> AgentTaskRequest {
+        AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "filesystem-snapshot-task".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "fake".to_string(),
+                selector: None,
+                runtime_selection: None,
+                required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
+                model: None,
+                config: serde_json::Value::Null,
+            },
+            instructions: "write a candidate".to_string(),
+            inputs: serde_json::Value::Null,
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace {
+                root: Some(workspace.display().to_string()),
+                ..Default::default()
+            },
+            component_contracts: Vec::new(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            artifact_declarations: Vec::new(),
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    #[test]
+    fn filesystem_snapshot_dispatches_providers_and_harvests_only_changed_candidates() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        crate::register_lab_workspace_provenance_provider();
+
+        for (change_workspace, expect_patch) in [(true, true), (false, false)] {
+            let workspace = tempfile::tempdir().expect("workspace");
+            std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");
+            let snapshot = snapshot(workspace.path());
+            let mut lab = lab(workspace.path(), &snapshot);
+            lab["sync_mode"] = serde_json::json!("filesystem_snapshot");
+            let dispatched = Arc::new(AtomicBool::new(false));
+            let scheduler = AgentTaskScheduler::new(FilesystemSnapshotProvider {
+                change_workspace,
+                dispatched: Arc::clone(&dispatched),
+            })
+            .with_run_id(format!("filesystem-snapshot-{change_workspace}"))
+            .with_harvest_context(
+                HarvestExecutionContext::from_lab_transport(snapshot, lab)
+                    .expect("paired Lab transport"),
+            );
+
+            let aggregate = scheduler.run(AgentTaskPlan::new(
+                "filesystem-snapshot-plan",
+                vec![filesystem_snapshot_request(workspace.path())],
+            ));
+
+            assert!(dispatched.load(Ordering::SeqCst), "provider was dispatched");
+            assert_eq!(aggregate.outcomes.len(), 1);
+            let patch = aggregate.outcomes[0]
+                .artifacts
+                .iter()
+                .find(|artifact| artifact.kind == "patch");
+            assert_eq!(
+                patch.is_some(),
+                expect_patch,
+                "only changed attempts harvest a patch"
+            );
+            if let Some(patch) = patch {
+                assert!(
+                    std::fs::read_to_string(patch.path.as_deref().expect("patch path"))
+                        .expect("read candidate patch")
+                        .contains("provider-change.txt")
+                );
+                assert_eq!(
+                    patch.metadata["source_provenance"]["materialization_mode"],
+                    "filesystem_snapshot"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Allow controller-verified filesystem snapshots to reach provider execution and bounded candidate harvesting.

## What changed
- Create and bind a deterministic synthetic Git baseline only after full Lab snapshot provenance verification.
- Harvest provider edits through the existing candidate boundary while rejecting tampered, foreign, excluded, and reserved paths.

## How to test
1. Run `cargo fmt --check`; expect Command exits 0..
2. Run `cargo test -p homeboy-lab-runner workspace::provenance::tests::`; expect All 16 provenance and anti-tamper tests pass..
3. Run `cargo build --bin homeboy`; expect Homeboy binary builds successfully..

## Compatibility
No public CLI contract changes. Existing git and snapshot-git behavior is preserved.

## Evidence
- Base unchanged since verification: main remains at 5baa6a9be72d472230749c9aeb666206ddf25f48.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/9115
- Verified finalization base: main at 5baa6a9be72d472230749c9aeb666206ddf25f48
- cargo build --bin homeboy: Passed
- cargo fmt --check: Passed
- filesystem snapshot provenance tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Audited, rebased, and verified the filesystem snapshot recovery candidate under Chris Huber's direction.

## Source relationships
- Closes Extra-Chill/homeboy#9115
