### PR TITLE
Bound controller runtime fixture costs in tests

### DIFF
--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -30,6 +30,28 @@ const ADMISSION_LOCK_ATTEMPTS: usize = 500;
 const ADMISSION_LOCK_RETRY: Duration = Duration::from_millis(10);
 static ADMISSION_LOCK_PROCESS_GUARDS: OnceLock<Mutex<BTreeMap<PathBuf, &'static Mutex<()>>>> =
     OnceLock::new();
+#[cfg(all(unix, any(test, feature = "test-support")))]
+static TEST_CONTROLLER_FIXTURE_DIGESTS: OnceLock<
+    Mutex<BTreeMap<TestExecutableFileIdentity, String>>,
+> = OnceLock::new();
+#[cfg(all(test, unix))]
+static TEST_CONTROLLER_FIXTURE_DIGEST_CALLS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// A source fixture is immutable for a hermetic test context. Include inode and
+/// change time so replacing or modifying a path cannot reuse its prior digest.
+#[cfg(all(unix, any(test, feature = "test-support")))]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct TestExecutableFileIdentity {
+    path: PathBuf,
+    device: u64,
+    inode: u64,
+    size: u64,
+    modified_seconds: i64,
+    modified_nanoseconds: i64,
+    changed_seconds: i64,
+    changed_nanoseconds: i64,
+}
 
 /// Report-only retention inventory for immutable controller runtime pins.
 ///
@@ -450,7 +472,7 @@ fn current_executable() -> Result<PathBuf> {
 }
 
 fn pin_executable(executable: &Path, identity: &str) -> Result<Value> {
-    let digest = executable_digest(executable)?;
+    let digest = controller_executable_digest(executable)?;
     let pinned_path = pinned_path(identity, &digest)?;
     publish_pin(executable, &pinned_path, &digest)?;
 
@@ -1024,7 +1046,7 @@ fn validate_pin(runtime: &Value) -> Result<()> {
             None,
         ));
     }
-    let actual = executable_digest(path)?;
+    let actual = test_candidate_or_executable_digest(path)?;
     if actual != expected {
         return Err(Error::validation_invalid_argument(
             "controller_runtime",
@@ -1037,7 +1059,7 @@ fn validate_pin(runtime: &Value) -> Result<()> {
     }
     let identity =
         required_runtime_string(runtime, "/originating/build_identity", "build identity")?;
-    verify_self_identity(path, identity)?;
+    verify_self_identity(path, identity, Some(&actual))?;
     Ok(())
 }
 
@@ -1052,7 +1074,7 @@ fn verify_artifact(path: &Path, expected: &str, identity: &str) -> Result<()> {
             None,
         ));
     }
-    verify_self_identity(path, identity)
+    verify_self_identity(path, identity, Some(&actual))
 }
 
 fn verify_executable(path: &Path, label: &str) -> Result<()> {
@@ -1075,8 +1097,8 @@ fn verify_executable(path: &Path, label: &str) -> Result<()> {
     Ok(())
 }
 
-fn verify_self_identity(path: &Path, expected: &str) -> Result<()> {
-    let actual = executable_identity(path)?;
+fn verify_self_identity(path: &Path, expected: &str, verified_digest: Option<&str>) -> Result<()> {
+    let actual = executable_identity(path, verified_digest)?;
     if actual == expected {
         return Ok(());
     }
@@ -1136,9 +1158,11 @@ fn verify_self_status_identity(path: &Path, expected: &str) -> Result<()> {
     ))
 }
 
-fn executable_identity(path: &Path) -> Result<String> {
+fn executable_identity(path: &Path, verified_digest: Option<&str>) -> Result<String> {
+    #[cfg(not(any(test, feature = "test-support")))]
+    let _ = verified_digest;
     #[cfg(any(test, feature = "test-support"))]
-    if let Some(identity) = test_controller_identity(path) {
+    if let Some(identity) = test_controller_identity(path, verified_digest) {
         return identity;
     }
     let output = Command::new(path)
@@ -1178,10 +1202,10 @@ fn executable_identity(path: &Path) -> Result<String> {
 /// is limited to byte-identical copies of its explicit source executable, so
 /// arbitrary fake controller binaries still execute and fail closed.
 #[cfg(any(test, feature = "test-support"))]
-fn test_controller_identity(path: &Path) -> Option<Result<String>> {
+fn test_controller_identity(path: &Path, verified_digest: Option<&str>) -> Option<Result<String>> {
     let source = std::env::var_os(TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV)?;
     let identity = std::env::var(TEST_CONTROLLER_RUNTIME_IDENTITY_ENV).ok()?;
-    let source_digest = executable_digest(Path::new(&source)).map_err(|error| {
+    let source_digest = test_controller_fixture_digest(Path::new(&source)).map_err(|error| {
         Error::validation_invalid_argument(
             "controller_runtime",
             format!("test controller source cannot be hashed: {error}"),
@@ -1189,7 +1213,10 @@ fn test_controller_identity(path: &Path) -> Option<Result<String>> {
             None,
         )
     });
-    let candidate_digest = executable_digest(path);
+    let candidate_digest = match verified_digest {
+        Some(digest) => Ok(digest.to_string()),
+        None => test_candidate_or_executable_digest(path),
+    };
     match (source_digest, candidate_digest) {
         (Ok(source_digest), Ok(candidate_digest)) if source_digest == candidate_digest => {
             Some(Ok(identity))
@@ -1199,8 +1226,106 @@ fn test_controller_identity(path: &Path) -> Option<Result<String>> {
     }
 }
 
+#[cfg(all(unix, any(test, feature = "test-support")))]
+fn test_controller_fixture_digest(path: &Path) -> Result<String> {
+    let file_identity = test_executable_file_identity(path)?;
+    let cache = TEST_CONTROLLER_FIXTURE_DIGESTS.get_or_init(|| Mutex::new(BTreeMap::new()));
+    if let Some(digest) = cache
+        .lock()
+        .expect("test controller source digest cache is not poisoned")
+        .get(&file_identity)
+        .cloned()
+    {
+        return Ok(digest);
+    }
+
+    #[cfg(test)]
+    TEST_CONTROLLER_FIXTURE_DIGEST_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let digest = executable_digest(path)?;
+    cache
+        .lock()
+        .expect("test controller source digest cache is not poisoned")
+        .insert(file_identity, digest.clone());
+    Ok(digest)
+}
+
+#[cfg(all(not(unix), any(test, feature = "test-support")))]
+fn test_controller_fixture_digest(path: &Path) -> Result<String> {
+    executable_digest(path)
+}
+
+#[cfg(all(unix, any(test, feature = "test-support")))]
+fn test_registered_fixture_digest(path: &Path) -> Option<String> {
+    let file_identity = test_executable_file_identity(path).ok()?;
+    TEST_CONTROLLER_FIXTURE_DIGESTS
+        .get_or_init(|| Mutex::new(BTreeMap::new()))
+        .lock()
+        .expect("test controller fixture digest cache is not poisoned")
+        .get(&file_identity)
+        .cloned()
+}
+
+#[cfg(all(unix, any(test, feature = "test-support")))]
+fn test_executable_file_identity(path: &Path) -> Result<TestExecutableFileIdentity> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = fs::metadata(path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("inspect test controller executable".to_string()),
+        )
+    })?;
+    Ok(TestExecutableFileIdentity {
+        path: path.to_path_buf(),
+        device: metadata.dev(),
+        inode: metadata.ino(),
+        size: metadata.size(),
+        modified_seconds: metadata.mtime(),
+        modified_nanoseconds: metadata.mtime_nsec(),
+        changed_seconds: metadata.ctime(),
+        changed_nanoseconds: metadata.ctime_nsec(),
+    })
+}
+
+#[cfg(all(unix, any(test, feature = "test-support")))]
+fn test_candidate_or_executable_digest(path: &Path) -> Result<String> {
+    test_registered_fixture_digest(path).map_or_else(
+        || {
+            #[cfg(test)]
+            TEST_CONTROLLER_FIXTURE_DIGEST_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            executable_digest(path)
+        },
+        Ok,
+    )
+}
+
+#[cfg(all(not(unix), any(test, feature = "test-support")))]
+fn test_candidate_or_executable_digest(path: &Path) -> Result<String> {
+    executable_digest(path)
+}
+
+#[cfg(not(any(test, feature = "test-support")))]
+fn test_candidate_or_executable_digest(path: &Path) -> Result<String> {
+    executable_digest(path)
+}
+
+#[cfg(all(unix, any(test, feature = "test-support")))]
+fn controller_executable_digest(path: &Path) -> Result<String> {
+    if std::env::var_os(TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV)
+        .is_some_and(|source| Path::new(&source) == path)
+    {
+        return test_controller_fixture_digest(path);
+    }
+    executable_digest(path)
+}
+
+#[cfg(not(all(unix, any(test, feature = "test-support"))))]
+fn controller_executable_digest(path: &Path) -> Result<String> {
+    executable_digest(path)
+}
+
 fn activated_executable_identity(path: &Path) -> Result<String> {
-    executable_identity(path)
+    executable_identity(path, None)
 }
 
 fn executable_digest(path: &Path) -> Result<String> {
@@ -1267,6 +1392,7 @@ fn publish_pin(source: &Path, destination: &Path, expected_digest: &str) -> Resu
     if destination.exists() {
         let actual = executable_digest(destination)?;
         if actual == expected_digest {
+            register_test_fixture_candidate(source, destination, expected_digest);
             return Ok(());
         }
         return Err(Error::validation_invalid_argument(
@@ -1313,12 +1439,14 @@ fn publish_pin(source: &Path, destination: &Path, expected_digest: &str) -> Resu
     match fs::hard_link(&staging, destination) {
         Ok(()) => {
             let _ = fs::remove_file(&staging);
+            register_test_fixture_candidate(source, destination, expected_digest);
             Ok(())
         }
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
             let _ = fs::remove_file(&staging);
             let actual = executable_digest(destination)?;
             if actual == expected_digest {
+                register_test_fixture_candidate(source, destination, expected_digest);
                 Ok(())
             } else {
                 Err(Error::validation_invalid_argument(
@@ -1341,6 +1469,29 @@ fn publish_pin(source: &Path, destination: &Path, expected_digest: &str) -> Resu
         }
     }
 }
+
+#[cfg(all(unix, any(test, feature = "test-support")))]
+fn register_test_fixture_candidate(source: &Path, candidate: &Path, expected_digest: &str) {
+    let Some(configured_source) = std::env::var_os(TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV) else {
+        return;
+    };
+    if Path::new(&configured_source) != source
+        || test_registered_fixture_digest(source).as_deref() != Some(expected_digest)
+    {
+        return;
+    }
+    let Ok(candidate_identity) = test_executable_file_identity(candidate) else {
+        return;
+    };
+    TEST_CONTROLLER_FIXTURE_DIGESTS
+        .get_or_init(|| Mutex::new(BTreeMap::new()))
+        .lock()
+        .expect("test controller fixture digest cache is not poisoned")
+        .insert(candidate_identity, expected_digest.to_string());
+}
+
+#[cfg(not(all(unix, any(test, feature = "test-support"))))]
+fn register_test_fixture_candidate(_source: &Path, _candidate: &Path, _expected_digest: &str) {}
 
 fn required_runtime_string<'a>(runtime: &'a Value, pointer: &str, label: &str) -> Result<&'a str> {
     runtime
@@ -1739,8 +1890,76 @@ mod tests {
                 std::env::current_exe().expect("current test executable")
             );
             assert_eq!(
-                executable_identity(&pinned).expect("fixture identity"),
+                executable_identity(&pinned, None).expect("fixture identity"),
                 build_identity::current().display
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_fixture_identity_cache_reuses_sealed_candidates_and_invalidates_changes() {
+        use std::os::unix::fs::PermissionsExt;
+
+        crate::test_support::with_isolated_home(|_| {
+            TEST_CONTROLLER_FIXTURE_DIGESTS
+                .get_or_init(|| Mutex::new(BTreeMap::new()))
+                .lock()
+                .expect("test controller source digest cache is not poisoned")
+                .clear();
+            TEST_CONTROLLER_FIXTURE_DIGEST_CALLS.store(0, std::sync::atomic::Ordering::Relaxed);
+
+            let runtime = pin_current().expect("pin test controller fixture");
+            let candidate = runtime
+                .pointer("/originating/pinned_executable")
+                .and_then(Value::as_str)
+                .map(PathBuf::from)
+                .expect("pinned candidate");
+            validate_pin(&runtime).expect("first fixture identity validation");
+            validate_pin(&runtime).expect("second fixture identity validation");
+            assert_eq!(
+                TEST_CONTROLLER_FIXTURE_DIGEST_CALLS.load(std::sync::atomic::Ordering::Relaxed),
+                1,
+                "source and sealed candidate avoid additional full reads"
+            );
+
+            fs::set_permissions(&candidate, fs::Permissions::from_mode(0o700))
+                .expect("change candidate mode");
+            validate_pin(&runtime).expect("chmod preserves valid candidate bytes");
+            assert_eq!(
+                TEST_CONTROLLER_FIXTURE_DIGEST_CALLS.load(std::sync::atomic::Ordering::Relaxed),
+                2,
+                "chmod invalidates metadata identity and performs one rehash"
+            );
+
+            fs::write(&candidate, b"mutated candidate").expect("mutate candidate");
+            assert!(
+                validate_pin(&runtime).is_err(),
+                "mutated candidate fails closed"
+            );
+            assert_eq!(
+                TEST_CONTROLLER_FIXTURE_DIGEST_CALLS.load(std::sync::atomic::Ordering::Relaxed),
+                3,
+                "content mutation misses the cache and rehashes before failing"
+            );
+
+            fs::remove_file(&candidate).expect("remove candidate");
+            fs::copy(
+                crate::test_support::controller_runtime_test_executable(),
+                &candidate,
+            )
+            .expect("replace candidate");
+            fs::set_permissions(&candidate, fs::Permissions::from_mode(0o700))
+                .expect("make replacement executable");
+            fs::write(&candidate, b"replacement candidate").expect("replace candidate bytes");
+            assert!(
+                validate_pin(&runtime).is_err(),
+                "replaced candidate fails closed"
+            );
+            assert_eq!(
+                TEST_CONTROLLER_FIXTURE_DIGEST_CALLS.load(std::sync::atomic::Ordering::Relaxed),
+                4,
+                "replacement misses the cache and rehashes before failing"
             );
         });
     }
@@ -1787,7 +2006,7 @@ mod tests {
                 "homeboy 0.288.13+original"
             );
             assert_eq!(
-                executable_identity(&global).expect("global replacement identity"),
+                executable_identity(&global, None).expect("global replacement identity"),
                 "homeboy 0.288.13+replacement"
             );
         });

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -11,6 +11,9 @@ use crate::api_jobs::{Job, JobEventKind, JobStore, RemoteRunnerJobRequest, Remot
 
 static SHARED_EMPTY_GIT_REPO_TEMPLATE: OnceLock<TempDir> = OnceLock::new();
 static SHARED_COMMITTED_GIT_REPO_TEMPLATE: OnceLock<TempDir> = OnceLock::new();
+static SHARED_CONTROLLER_RUNTIME_FIXTURE: OnceLock<TempDir> = OnceLock::new();
+static EXEC_CAPABLE_TEMP_BASE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+static SHORT_EXEC_CAPABLE_TEMP_BASE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
 
 /// An explicit executable selection for a hermetic test command.
 ///
@@ -242,7 +245,7 @@ impl HomeGuard {
         );
         std::env::set_var(
             crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV,
-            test_controller_fixture(context.runtime_dir()),
+            test_controller_fixture(),
         );
         std::env::set_var(
             crate::controller_runtime::TEST_CONTROLLER_RUNTIME_IDENTITY_ENV,
@@ -282,22 +285,17 @@ impl HomeGuard {
 fn short_invocation_tempdir() -> TempDir {
     #[cfg(unix)]
     {
-        for base in short_tempdir_candidates() {
-            let Ok(candidate) = tempfile::Builder::new()
-                .prefix("hb-test-")
-                .tempdir_in(&base)
-            else {
-                continue;
-            };
-            if dir_allows_exec(candidate.path()) {
-                return candidate;
-            }
-            // Not exec-capable (e.g. `noexec` mount) — drop it and try the
-            // next candidate rather than handing back a dir scripts can't run
-            // from.
-        }
+        tempdir_with_cached_exec_base(
+            SHORT_EXEC_CAPABLE_TEMP_BASE.get_or_init(|| Mutex::new(None)),
+            short_tempdir_candidates(),
+            "hb-test-",
+            dir_allows_exec,
+        )
     }
-    TempDir::new().expect("invocation runtime tempdir")
+    #[cfg(not(unix))]
+    {
+        TempDir::new().expect("invocation runtime tempdir")
+    }
 }
 
 /// Ordered short base directories to consider for the invocation runtime root.
@@ -352,6 +350,59 @@ fn dir_allows_exec(dir: &Path) -> bool {
     allowed
 }
 
+/// Reuse a validated base directory, but always create a new child tempdir.
+/// If a cached base disappears or becomes unavailable, retry the normal ordered
+/// probe and replace the cached base only after a successful execution probe.
+#[cfg(unix)]
+fn tempdir_with_cached_exec_base(
+    cache: &Mutex<Option<PathBuf>>,
+    candidates: Vec<PathBuf>,
+    prefix: &str,
+    probe: impl Fn(&Path) -> bool,
+) -> TempDir {
+    let cached = cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    if let Some(base) = cached {
+        if let Ok(directory) = tempfile::Builder::new().prefix(prefix).tempdir_in(&base) {
+            return directory;
+        }
+    }
+
+    for base in candidates {
+        let Ok(directory) = tempfile::Builder::new().prefix(prefix).tempdir_in(&base) else {
+            continue;
+        };
+        if probe(directory.path()) {
+            *cache
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(base);
+            return directory;
+        }
+        // Not exec-capable (e.g. `noexec` mount) — drop it and try the next
+        // candidate rather than handing back a dir scripts cannot run from.
+    }
+    TempDir::new().expect("exec-capable tempdir fallback")
+}
+
+#[cfg(unix)]
+fn exec_capable_tempdir_candidates() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    let push = |path: PathBuf, roots: &mut Vec<PathBuf>| {
+        if path.is_dir() && !roots.contains(&path) {
+            roots.push(path);
+        }
+    };
+    if let Some(tmpdir) = std::env::var_os("TMPDIR") {
+        push(PathBuf::from(tmpdir), &mut roots);
+    }
+    for fixed in ["/tmp", "/var/tmp", "/dev/shm"] {
+        push(PathBuf::from(fixed), &mut roots);
+    }
+    roots
+}
+
 /// Create a tempdir that is guaranteed exec-capable where possible.
 ///
 /// Tests that write a script and then run it (e.g. capability parser scripts)
@@ -367,32 +418,17 @@ fn dir_allows_exec(dir: &Path) -> bool {
 pub fn exec_capable_tempdir() -> TempDir {
     #[cfg(unix)]
     {
-        let mut roots: Vec<PathBuf> = Vec::new();
-        let push = |path: PathBuf, roots: &mut Vec<PathBuf>| {
-            if path.is_dir() && !roots.contains(&path) {
-                roots.push(path);
-            }
-        };
-        if let Some(tmpdir) = std::env::var_os("TMPDIR") {
-            push(PathBuf::from(tmpdir), &mut roots);
-        }
-        for fixed in ["/tmp", "/var/tmp", "/dev/shm"] {
-            push(PathBuf::from(fixed), &mut roots);
-        }
-
-        for base in roots {
-            let Ok(candidate) = tempfile::Builder::new()
-                .prefix("hb-test-")
-                .tempdir_in(&base)
-            else {
-                continue;
-            };
-            if dir_allows_exec(candidate.path()) {
-                return candidate;
-            }
-        }
+        tempdir_with_cached_exec_base(
+            EXEC_CAPABLE_TEMP_BASE.get_or_init(|| Mutex::new(None)),
+            exec_capable_tempdir_candidates(),
+            "hb-test-",
+            dir_allows_exec,
+        )
     }
-    TempDir::new().expect("exec-capable tempdir")
+    #[cfg(not(unix))]
+    {
+        TempDir::new().expect("exec-capable tempdir")
+    }
 }
 
 impl Drop for HomeGuard {
@@ -453,14 +489,39 @@ impl Drop for HomeGuard {
     }
 }
 
-fn test_controller_fixture(directory: &Path) -> PathBuf {
-    let path = directory.join("homeboy-controller-fixture");
-    fs::copy(
-        std::env::current_exe().expect("current test executable"),
-        &path,
-    )
-    .expect("copy controller fixture");
-    path
+fn test_controller_fixture() -> PathBuf {
+    SHARED_CONTROLLER_RUNTIME_FIXTURE
+        .get_or_init(|| {
+            let directory = exec_capable_tempdir();
+            let path = directory.path().join("homeboy-controller-fixture");
+            fs::copy(
+                std::env::current_exe().expect("current test executable"),
+                &path,
+            )
+            .expect("copy controller fixture");
+            make_test_controller_fixture_read_only(&path);
+            directory
+        })
+        .path()
+        .join("homeboy-controller-fixture")
+}
+
+fn make_test_controller_fixture_read_only(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::set_permissions(path, fs::Permissions::from_mode(0o500))
+            .expect("seal controller fixture");
+    }
+    #[cfg(not(unix))]
+    {
+        let mut permissions = fs::metadata(path)
+            .expect("inspect controller fixture")
+            .permissions();
+        permissions.set_readonly(true);
+        fs::set_permissions(path, permissions).expect("seal controller fixture");
+    }
 }
 
 /// Source executable selected by the hermetic controller-runtime test contract.
@@ -996,4 +1057,77 @@ fn write_broker_response(stream: &mut TcpStream, body: serde_json::Value) {
         body.len(), body
     )
     .expect("write broker response");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn cached_exec_base_probes_once_and_creates_distinct_tempdirs() {
+        let base = TempDir::new().expect("temp base");
+        let cache = Mutex::new(None);
+        let probes = std::sync::atomic::AtomicUsize::new(0);
+        let create = || {
+            tempdir_with_cached_exec_base(
+                &cache,
+                vec![base.path().to_path_buf()],
+                "hb-cache-",
+                |_| {
+                    probes.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    true
+                },
+            )
+        };
+
+        let first = create();
+        let second = create();
+
+        assert_eq!(probes.load(std::sync::atomic::Ordering::Relaxed), 1);
+        assert_ne!(first.path(), second.path());
+        assert!(first.path().starts_with(base.path()));
+        assert!(second.path().starts_with(base.path()));
+    }
+
+    #[test]
+    fn isolated_homes_share_the_read_only_controller_fixture_and_not_pins() {
+        let first = with_isolated_home(|_| {
+            let fixture = controller_runtime_test_executable();
+            let runtime = crate::controller_runtime::pin_current().expect("pin first fixture");
+            let pin = runtime["originating"]["pinned_executable"]
+                .as_str()
+                .map(PathBuf::from)
+                .expect("first pinned fixture");
+            (fixture, pin)
+        });
+        let second = with_isolated_home(|_| {
+            let fixture = controller_runtime_test_executable();
+            let runtime = crate::controller_runtime::pin_current().expect("pin second fixture");
+            let pin = runtime["originating"]["pinned_executable"]
+                .as_str()
+                .map(PathBuf::from)
+                .expect("second pinned fixture");
+            (fixture, pin)
+        });
+
+        assert_eq!(first.0, second.0);
+        assert_ne!(
+            first.0,
+            std::env::current_exe().expect("current test executable")
+        );
+        assert_ne!(first.1, second.1);
+        assert!(first.0.is_file());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mode = fs::metadata(&first.0)
+                .expect("fixture metadata")
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o222, 0);
+            assert_ne!(mode & 0o111, 0);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- cache controller fixture digests behind mutation-sensitive file identity
- share one immutable controller fixture per test process while retaining isolated pinned candidates
- cache validated executable temp roots instead of executing capability probes for every isolated HOME
- preserve production executable hashing and fail-closed mutation/replacement checks

Fixes #8964.

## How to test
1. Run `cargo test -p homeboy-core test_support::tests:: --lib`.
2. Run `cargo test -p homeboy-core test_fixture_identity_cache_reuses_sealed_candidates_and_invalidates_changes --lib`.
3. Run `cargo test -p homeboy-agents cook_persists_controller_runtime_mismatch_before_provider_execution --lib`.
4. Run `cargo fmt --check && git diff --check`.

## Verification notes
- All targeted checks pass after rebasing onto current `main`.
- The broad `cargo test -p homeboy-agents --lib` now completes in 17m38s instead of stalling beyond the prior bound: 788 passed and 25 existing lifecycle/configuration tests failed. Those failures are outside the two changed core test-support files and remain baseline cleanup, not acceptance evidence for this focused repair.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode
- **Used for:** Diagnosed native stack samples, implemented the test-support optimization, and drafted deterministic regression coverage.