### PR TITLE
fix: preserve the primary test result when the failure sidecar is malformed

### DIFF
--- a/crates/homeboy-extension/src/test/run.rs
+++ b/crates/homeboy-extension/src/test/run.rs
@@ -315,7 +315,15 @@ fn run_main_test_workflow_inner(
         .transpose()?
         .flatten();
 
-    let failure_analysis_input = parse_failures_file(&failures_file)?;
+    // The failure sidecar is optional enrichment: it feeds `--analyze` findings
+    // and failure classification, but the primary execution result (success,
+    // counts, phase, raw output) is already resolved above. A malformed sidecar
+    // must not replace that primary result with a JSON parse error and mask the
+    // real underlying failure (e.g. a pre-test runtime/bind failure whose
+    // structured evidence the runner already reported). Degrade to no
+    // enrichment and attach the parse problem as a secondary diagnostic. (#8489)
+    let (failure_analysis_input, sidecar_diagnostic) =
+        parse_optional_failure_sidecar(&failures_file);
     let findings = failure_analysis_input
         .as_ref()
         .and_then(homeboy_findings_from_test_analysis_input);
@@ -374,6 +382,12 @@ fn run_main_test_workflow_inner(
     }
 
     let mut hints = Vec::new();
+
+    // Surface an ignored malformed failure sidecar as a secondary diagnostic so
+    // the degraded classification is visible without masking the primary result.
+    if let Some(diagnostic) = sidecar_diagnostic {
+        hints.push(diagnostic);
+    }
 
     if status == "failed" && args.passthrough_args.is_empty() {
         hints.push(format!(
@@ -523,6 +537,28 @@ fn run_main_test_workflow_inner(
         raw_output,
         extension_phase_timings: output.extension_phase_timings,
     })
+}
+
+/// Parse the optional failure sidecar, degrading gracefully on malformed data.
+///
+/// Returns the parsed enrichment input (or `None` when absent/unparseable) and
+/// an optional secondary diagnostic describing an ignored malformed sidecar. A
+/// malformed sidecar never propagates as an error: the primary execution result
+/// is already resolved and must not be replaced by a sidecar parse failure that
+/// masks the real underlying failure. (#8489)
+fn parse_optional_failure_sidecar(
+    failures_file: &Path,
+) -> (Option<TestAnalysisInput>, Option<String>) {
+    match parse_failures_file(failures_file) {
+        Ok(input) => (input, None),
+        Err(error) => {
+            let diagnostic = format!(
+                "Ignored a malformed test-failures sidecar ({}); the primary run result is preserved. Re-run with --analyze after the extension emits a valid sidecar for failure classification.",
+                error.message
+            );
+            (None, Some(diagnostic))
+        }
+    }
 }
 
 struct TestCheckoutGuard {
@@ -1069,6 +1105,68 @@ mod tests {
         assert_eq!(json["test_counts"]["failed"], 1);
         assert_eq!(json["failure"]["category"], "findings");
         assert_clean(repo.path());
+    }
+
+    #[test]
+    fn malformed_failure_sidecar_is_ignored_with_a_diagnostic_not_an_error() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let sidecar = temp.path().join("test-failures.json");
+        // A malformed failure object — here `source_line` is a string where a
+        // number is required — the kind of schema-invalid sidecar a failed
+        // recipe can emit. It must not abort the run and mask the real failure. (#8489)
+        std::fs::write(
+            &sidecar,
+            r#"[{"test_id":"bootstrap","message":"input.materialize timeout","error_type":"timeout","source_line":"not-a-number"}]"#,
+        )
+        .expect("write malformed sidecar");
+
+        let (input, diagnostic) = parse_optional_failure_sidecar(&sidecar);
+
+        assert!(
+            input.is_none(),
+            "a malformed sidecar must not yield enrichment input"
+        );
+        let diagnostic = diagnostic.expect("a malformed sidecar must attach a diagnostic");
+        assert!(
+            diagnostic.contains("malformed test-failures sidecar"),
+            "diagnostic: {diagnostic}"
+        );
+        assert!(
+            diagnostic.contains("primary run result is preserved"),
+            "diagnostic: {diagnostic}"
+        );
+    }
+
+    #[test]
+    fn valid_failure_sidecar_parses_without_a_diagnostic() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let sidecar = temp.path().join("test-failures.json");
+        std::fs::write(
+            &sidecar,
+            r#"[{"test_id":"SomeTest::method","message":"assertion failed","error_type":"assertion"}]"#,
+        )
+        .expect("write valid sidecar");
+
+        let (input, diagnostic) = parse_optional_failure_sidecar(&sidecar);
+
+        let input = input.expect("a valid sidecar must yield enrichment input");
+        assert_eq!(input.failures.len(), 1);
+        assert_eq!(input.failures[0].error_type, "assertion");
+        assert!(
+            diagnostic.is_none(),
+            "a valid sidecar must not attach a diagnostic"
+        );
+    }
+
+    #[test]
+    fn absent_failure_sidecar_yields_no_input_and_no_diagnostic() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let sidecar = temp.path().join("does-not-exist.json");
+
+        let (input, diagnostic) = parse_optional_failure_sidecar(&sidecar);
+
+        assert!(input.is_none());
+        assert!(diagnostic.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Addresses the Homeboy-side half of #8489.

## Problem

When a test extension emits a malformed `test-failures.json` (e.g. a WP Codebox recipe that fails before PHPUnit and produces a schema-invalid sidecar), Homeboy parsed it with `?` and replaced the **entire** execution result with:

```
Malformed test failures JSON ...: duplicate field `error_type`
```

The summary became `JSON error` with zero tests — masking the actual runtime/bind failure and its phase evidence that the runner had already reported.

## Root cause

The failure sidecar is **optional enrichment**: it feeds `--analyze` findings and failure classification, but the primary execution result (success, counts, phase, raw output) is already resolved before the sidecar is read. Parsing it with `?` let a malformed-sidecar parse error abort the whole workflow and replace the primary result.

## Fix

Route the sidecar through a new `parse_optional_failure_sidecar` helper that degrades gracefully:

- On success → parsed enrichment input, no diagnostic.
- On parse failure → **no** enrichment input plus an optional secondary diagnostic, surfaced as a hint. The error is never propagated.

The primary run result, its classification, phase, and raw output are preserved; `--analyze` and machine JSON output stay parseable.

### Boundary

This resilience is **language/platform-agnostic** and lives in the extension-host crate (`homeboy-extension`) — no `homeboy-core` changes, and no PHPUnit/WordPress/Rust-specific knowledge. Emitting schema-valid sidecars with exactly one canonical `error_type` remains the owning extension's responsibility (the WordPress bucket in `homeboy-extensions`), which is the separate half of #8489's acceptance criteria.

## Acceptance criteria mapped

- ✅ A malformed optional sidecar cannot replace the primary execution result; it is attached as a secondary diagnostic.
- ✅ Pre-PHPUnit failures retain their original classification and phase (the primary result is untouched).
- ✅ `review test --analyze` and machine JSON output remain parseable.
- ⏳ "Every generated failure object has one `error_type`" is the extension-side half (homeboy-extensions), not this crate.

## Testing

- `malformed_failure_sidecar_is_ignored_with_a_diagnostic_not_an_error` — a schema-invalid sidecar (a `source_line` string where a number is required) yields no input + a "primary run result is preserved" diagnostic instead of an error.
- `valid_failure_sidecar_parses_without_a_diagnostic` — a well-formed sidecar still parses cleanly, no diagnostic.
- `absent_failure_sidecar_yields_no_input_and_no_diagnostic` — a missing sidecar is a no-op.
- Full `test::` module suite (119 tests) green.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Traced the masked-failure behavior to the `?` on the optional failure-sidecar parse and made it degrade to a secondary diagnostic while preserving the primary result, keeping the change agnostic (no core, no PHPUnit specifics). Chris reviews and owns the change.