### PR TITLE
Deduplicate detached Lab admission handoffs

### DIFF
--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -582,6 +582,7 @@ impl JobStore {
             StoredJob {
                 job: job.clone(),
                 events: Vec::new(),
+                admission_idempotency_key: None,
                 remote_runner: Some(StoredRemoteRunnerJob {
                     // Durable broker state intentionally contains only the
                     // redacted request. The runner hydrates named references

--- a/crates/homeboy-core/src/api_jobs/store.rs
+++ b/crates/homeboy-core/src/api_jobs/store.rs
@@ -70,6 +70,8 @@ pub(super) struct StoredJob {
     pub(super) job: Job,
     pub(super) events: Vec<JobEvent>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) admission_idempotency_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) remote_runner: Option<remote_runner::StoredRemoteRunnerJob>,
     /// Typed execution identity for a daemon-local child submitted on behalf of
     /// a remote runner. This lets `/jobs` project the accepted runner job without
@@ -448,8 +450,27 @@ impl JobStore {
             metadata,
             path_materialization_plan,
             local_runner,
+            None,
         )
         .0
+    }
+
+    /// Reserve one daemon admission per caller-owned handoff identity. This is
+    /// separate from executable-job deduplication because an admission is a
+    /// short-lived pre-handoff guard, not the runner child itself.
+    pub(crate) fn create_or_reuse_active_admission(
+        &self,
+        metadata: Value,
+        idempotency_key: &str,
+    ) -> (Job, bool) {
+        self.create_or_reuse_active_local_runner_job(
+            "runner.admission",
+            None,
+            Some(metadata),
+            None,
+            None,
+            Some(idempotency_key.to_string()),
+        )
     }
 
     /// Insert a new queued local-runner job, or reuse the existing non-terminal
@@ -468,6 +489,7 @@ impl JobStore {
         metadata: Option<Value>,
         path_materialization_plan: Option<PathMaterializationPlan>,
         local_runner: Option<LocalRunnerJob>,
+        admission_idempotency_key: Option<String>,
     ) -> (Job, bool) {
         let now = timestamp_ms();
         let runner_job_projection = metadata
@@ -504,7 +526,22 @@ impl JobStore {
         };
 
         let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        if let Some(durable_run_id) = durable_run_id.as_deref() {
+        if let Some(idempotency_key) = admission_idempotency_key.as_deref() {
+            if let Some(existing) = inner
+                .jobs
+                .values()
+                .filter(|stored| {
+                    matches!(stored.job.status, JobStatus::Queued | JobStatus::Running)
+                })
+                .filter(|stored| {
+                    stored.admission_idempotency_key.as_deref() == Some(idempotency_key)
+                })
+                .min_by_key(|stored| (stored.job.created_at_ms, stored.job.id))
+                .map(|stored| stored.job.clone())
+            {
+                return (existing, false);
+            }
+        } else if let Some(durable_run_id) = durable_run_id.as_deref() {
             if let Some(existing) = inner
                 .jobs
                 .values()
@@ -525,6 +562,7 @@ impl JobStore {
             StoredJob {
                 job: job.clone(),
                 events: Vec::new(),
+                admission_idempotency_key,
                 remote_runner: None,
                 local_runner,
                 local_child: None,
@@ -1822,6 +1860,7 @@ impl JobStore {
             metadata,
             path_materialization_plan,
             Some(local_runner.clone()),
+            None,
         );
         let job_id = job.id;
         // An idempotent resubmission reused an already-enqueued job that already

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -1555,29 +1555,48 @@ fn reserve_admission(
                 None,
             )
         })?;
+    let idempotency_key = body
+        .get("idempotency_key")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
     let daemon_lease = heartbeat_lease()?;
     validate_admission_lease(expected_daemon_lease_id, &daemon_lease.lease_id)?;
-    let job = job_store.create_with_source_snapshot_metadata_and_path_materialization_plan(
-        "runner.admission",
-        None,
-        Some(json!({
-            "runner_job_projection": {
-                "runner_id": runner_id,
-                "command": command,
-                "cwd": serde_json::Value::Null,
-                "source": "runner-daemon",
-                "kind": "runner.admission",
-                "lifecycle": serde_json::Value::Null,
-            },
-            "admission": {
-                "runner_id": runner_id,
-                "state": "reserved",
-                "daemon_lease_id": daemon_lease.lease_id.clone(),
-            },
-        })),
-        None,
-    );
-    Ok(json!({ "job": job, "daemon_lease_id": daemon_lease.lease_id }))
+    let metadata = json!({
+        "runner_job_projection": {
+            "runner_id": runner_id,
+            "command": command,
+            "cwd": serde_json::Value::Null,
+            "source": "runner-daemon",
+            "kind": "runner.admission",
+            "lifecycle": serde_json::Value::Null,
+        },
+        "admission": {
+            "runner_id": runner_id,
+            "state": "reserved",
+            "daemon_lease_id": daemon_lease.lease_id.clone(),
+            "idempotency_key": idempotency_key,
+        },
+    });
+    let (job, created) = match idempotency_key {
+        Some(idempotency_key) => {
+            job_store.create_or_reuse_active_admission(metadata, idempotency_key)
+        }
+        None => (
+            job_store.create_with_source_snapshot_metadata_and_path_materialization_plan(
+                "runner.admission",
+                None,
+                Some(metadata),
+                None,
+            ),
+            true,
+        ),
+    };
+    Ok(json!({
+        "job": job,
+        "daemon_lease_id": daemon_lease.lease_id,
+        "idempotent_resubmission": !created,
+    }))
 }
 
 fn validate_admission_lease(expected_lease_id: &str, actual_lease_id: &str) -> Result<()> {
@@ -2371,6 +2390,50 @@ mod tests {
                 0
             );
             assert!(store.active_runner_jobs().is_empty());
+        });
+    }
+
+    #[test]
+    fn admission_reservation_dedupes_a_detached_run_and_releases_it() {
+        with_isolated_home(|_| {
+            let lease_id = "lease-deduped-admission";
+            write_test_lease(lease_id);
+            let store = JobStore::default();
+            let request = || {
+                Some(json!({
+                    "runner_id": "lab",
+                    "command": "homeboy agent-task run-plan",
+                    "expected_daemon_lease_id": lease_id,
+                    "idempotency_key": "mdi-134-bootstrap-hash-attempt-1",
+                }))
+            };
+
+            let first = reserve_admission(request(), &store).expect("reserve admission");
+            let replay = reserve_admission(request(), &store).expect("dedupe admission replay");
+            let job_id = first["job"]["id"].as_str().expect("reservation job ID");
+
+            assert_eq!(replay["job"]["id"], job_id);
+            assert_eq!(replay["idempotent_resubmission"], true);
+            assert_eq!(
+                store
+                    .list()
+                    .into_iter()
+                    .filter(|job| job.operation == "runner.admission")
+                    .count(),
+                1,
+                "one durable attempt creates exactly one admission reservation"
+            );
+
+            let released = release_admission(&format!("/admissions/{job_id}/release"), &store)
+                .expect("release reservation after failed handoff");
+            assert_eq!(released["job"]["status"], "cancelled");
+            assert_eq!(
+                daemon_freshness_report(&store)
+                    .expect("freshness after release")
+                    .active_jobs,
+                0,
+                "a failed or timed-out handoff leaves no active admission job"
+            );
         });
     }
 

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -437,6 +437,7 @@ pub(crate) fn reserve_daemon_admission(
     local_url: &str,
     command: &str,
     expected_daemon_lease_id: &str,
+    idempotency_key: Option<&str>,
 ) -> Result<DaemonAdmissionReservation> {
     let client = Client::builder()
         .no_proxy()
@@ -453,6 +454,7 @@ pub(crate) fn reserve_daemon_admission(
             "runner_id": runner_id,
             "command": command,
             "expected_daemon_lease_id": expected_daemon_lease_id,
+            "idempotency_key": idempotency_key,
         }),
         DaemonPostOptions::default(),
     )?;

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1249,6 +1249,7 @@ pub(crate) fn run_lab_offload_inner(
             local_url,
             &redact_argv_shell_display(&command_prefix.argv),
             expected_daemon_lease_id,
+            pre_acceptance_run_id.as_deref(),
         )
     })
     .transpose()?;


### PR DESCRIPTION
## Summary
Make direct Lab admission reservations idempotent per durable handoff attempt so detached cooks cannot create duplicate queued reservations.

## What changed
- Propagate the durable pre-acceptance run ID as an admission idempotency key and atomically reuse an active matching reservation.
- Preserve reservation release on failed or timed-out handoffs and add hermetic daemon/Lab lifecycle coverage.

## How to test
1. Run `cargo test -p homeboy-core admission_reservation_dedupes_a_detached_run_and_releases_it --locked`; expect The focused daemon admission test passes..
2. Run `cargo test -p homeboy-core admission_reservation_blocks_daemon_replacement_until_released --locked`; expect The existing daemon replacement reservation test passes..
3. Run `cargo test -p homeboy-lab-runner --lib lab::offload::tests::workspace_sync::controller_wait_expiry_identifies_only_the_durable_handoff --locked`; expect The Lab handoff timeout test passes..

## Compatibility
No public CLI removal or extension-path change. The daemon admission payload gains an optional idempotency key; callers that omit it retain existing behavior.

## Evidence
- Base advanced after verification: verified main at 5baa6a9be72d472230749c9aeb666206ddf25f48; publication observed 96ca07839a33a8f4826653f9bed057568bc3e0fc. Candidate ancestry was validated against the verified snapshot.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/9131
- Verified finalization base: main at 5baa6a9be72d472230749c9aeb666206ddf25f48
- focused-tests: Passed
- format: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the failed Homeboy handoff, implemented the recovery candidate and deterministic tests, and reviewed the result; Chris owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#9131
