### PR TITLE
refactor(core): extract daemon lease staleness/freshness logic into daemon_lease

### DIFF
--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -33,6 +33,7 @@ mod artifact_download;
 mod broker_config;
 mod completion_tracker;
 mod control;
+mod daemon_lease;
 mod patch_capture;
 mod remote_runner;
 pub mod runner_exec_driver;
@@ -44,6 +45,7 @@ pub use control::{
     reconcile_dead_lease_orphans, reconcile_leaseless_orphans, recover_missing_child_identity,
     recover_missing_lease_state, start_background, supervise, ArtifactFetchOutcome,
 };
+use daemon_lease::{daemon_state_identity, freshness_report_from_validation, validate_lease_file};
 use patch_capture::{capture_baseline, capture_patch_report};
 
 pub const DEFAULT_ADDR: &str = "127.0.0.1:0";
@@ -51,7 +53,7 @@ pub const DEFAULT_ADDR: &str = "127.0.0.1:0";
 static DAEMON_JOB_STORE: OnceLock<JobStore> = OnceLock::new();
 static DAEMON_RUNTIME_SNAPSHOT: OnceLock<DaemonRuntimeSnapshot> = OnceLock::new();
 
-const DAEMON_LEASE_SCHEMA: &str = "homeboy.daemon.session_lease.v1";
+pub(crate) const DAEMON_LEASE_SCHEMA: &str = "homeboy.daemon.session_lease.v1";
 const DAEMON_STARTUP_TOKEN_ENV: &str = "HOMEBOY_DAEMON_STARTUP_TOKEN";
 const RUNTIME_PATH_FILE_LIMIT: usize = 2_000;
 const RUNTIME_PATH_SUFFIXES: &[&str] = &["_COMPONENT_PATH", "_PROVIDER_PATH", "_RUNTIME_PATH"];
@@ -359,17 +361,6 @@ pub struct DaemonRuntimePathSnapshot {
     pub fingerprint: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct DaemonLeaseValidation {
-    state: Option<DaemonState>,
-    running: bool,
-    fresh: bool,
-    reachable: bool,
-    stale_reason: Option<String>,
-    stale_reason_code: Option<DaemonStaleReasonCode>,
-    invalid_pid: Option<u32>,
-}
-
 /// The only pre-schema lease shape that can be repaired during daemon start.
 /// Keeping this separate from `DaemonState` prevents legacy data from becoming
 /// a supported format for normal reads, status, or stop operations.
@@ -605,7 +596,7 @@ pub fn read_status() -> Result<DaemonStatus> {
     })
 }
 
-fn read_termination_evidence() -> Result<Option<DaemonTerminationEvidence>> {
+pub(crate) fn read_termination_evidence() -> Result<Option<DaemonTerminationEvidence>> {
     let path = paths::daemon_termination_file()?;
     match fs::read_to_string(&path) {
         Ok(body) => serde_json::from_str(&body).map(Some).map_err(|error| {
@@ -637,205 +628,6 @@ pub(crate) fn write_termination_evidence(evidence: &DaemonTerminationEvidence) -
     fs::write(&path, body).map_err(|error| {
         Error::internal_io(error.to_string(), Some(format!("write {}", path.display())))
     })
-}
-
-fn daemon_state_identity(state_path: &Path, jobs_path: &Path) -> Result<String> {
-    let mut hasher = Sha256::new();
-    for (label, path) in [
-        (b"daemon-state\0".as_slice(), state_path),
-        (b"daemon-jobs\0".as_slice(), jobs_path),
-    ] {
-        hasher.update(label);
-        match fs::read(path) {
-            Ok(bytes) => {
-                hasher.update([1]);
-                hasher.update(bytes);
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => hasher.update([0]),
-            Err(error) => {
-                return Err(Error::internal_io(
-                    error.to_string(),
-                    Some(format!("read {}", path.display())),
-                ))
-            }
-        }
-    }
-    Ok(format!("sha256:{:x}", hasher.finalize()))
-}
-
-fn validate_lease_file(path: &Path) -> Result<DaemonLeaseValidation> {
-    if !path.exists() {
-        return Ok(DaemonLeaseValidation {
-            running: false,
-            fresh: false,
-            reachable: false,
-            stale_reason: None,
-            stale_reason_code: Some(DaemonStaleReasonCode::LeaseMissing),
-            state: None,
-            invalid_pid: None,
-        });
-    }
-
-    let content = fs::read_to_string(&path)
-        .map_err(|e| Error::internal_io(e.to_string(), Some(format!("read {}", path.display()))))?;
-    let state: DaemonState = match serde_json::from_str(&content) {
-        Ok(state) => state,
-        Err(error) => {
-            return Ok(DaemonLeaseValidation {
-                running: false,
-                fresh: false,
-                reachable: false,
-                stale_reason: Some(format!("invalid daemon lease: {error}")),
-                stale_reason_code: Some(DaemonStaleReasonCode::LeaseCorrupt),
-                state: None,
-                invalid_pid: serde_json::from_str::<serde_json::Value>(&content)
-                    .ok()
-                    .and_then(|value| value.get("pid").and_then(|pid| pid.as_u64()))
-                    .and_then(|pid| u32::try_from(pid).ok()),
-            });
-        }
-    };
-
-    let running = pid_is_running(state.pid);
-    // A dead owner is safe to recover even when its persisted schema was
-    // omitted. Keeping the parsed lease identity makes explicit adoption
-    // possible; a live invalid lease remains protected by schema validation.
-    if !running {
-        return Ok(stale_lease(
-            state,
-            false,
-            DaemonStaleReasonCode::PidDead,
-            "daemon lease pid is not running",
-        ));
-    }
-    if state.schema != DAEMON_LEASE_SCHEMA {
-        return Ok(stale_lease(
-            state,
-            true,
-            DaemonStaleReasonCode::LeaseSchemaMismatch,
-            "unsupported daemon lease schema",
-        ));
-    }
-    let current_identity = build_identity::current();
-    if state.build_identity.version != current_identity.version
-        || state.build_identity.display != current_identity.display
-    {
-        return Ok(stale_lease(
-            state,
-            true,
-            DaemonStaleReasonCode::VersionMismatch,
-            "daemon build identity does not match current Homeboy binary",
-        ));
-    }
-    if state.binary_sha256 != current_binary_sha256()? {
-        return Ok(stale_lease(
-            state,
-            true,
-            DaemonStaleReasonCode::BinaryHashMismatch,
-            "daemon binary hash does not match current Homeboy binary",
-        ));
-    }
-    if let Some(reason) = runtime_snapshot_stale_reason(&state.runtime_paths) {
-        return Ok(stale_lease(
-            state,
-            true,
-            DaemonStaleReasonCode::RuntimePathsDrift,
-            reason,
-        ));
-    }
-
-    Ok(DaemonLeaseValidation {
-        running: true,
-        fresh: true,
-        reachable: true,
-        state: Some(state),
-        stale_reason: None,
-        stale_reason_code: None,
-        invalid_pid: None,
-    })
-}
-
-fn stale_lease(
-    state: DaemonState,
-    running: bool,
-    code: DaemonStaleReasonCode,
-    reason: impl Into<String>,
-) -> DaemonLeaseValidation {
-    DaemonLeaseValidation {
-        running,
-        fresh: false,
-        reachable: running,
-        stale_reason: Some(reason.into()),
-        stale_reason_code: Some(code),
-        state: Some(state),
-        invalid_pid: None,
-    }
-}
-
-fn freshness_report_from_validation(
-    validation: &DaemonLeaseValidation,
-    active_jobs: usize,
-) -> DaemonFreshnessReport {
-    let state = validation.state.as_ref();
-    let restartable = !validation.fresh
-        && active_jobs == 0
-        && !matches!(
-            validation.stale_reason_code,
-            Some(DaemonStaleReasonCode::LeaseCorrupt | DaemonStaleReasonCode::TransportUnreachable)
-        );
-    let repair_plan = if restartable {
-        vec![
-            DaemonRepairStep {
-                code: "daemon_stop".to_string(),
-                command: "homeboy daemon stop".to_string(),
-            },
-            DaemonRepairStep {
-                code: "daemon_start".to_string(),
-                command: "homeboy daemon start".to_string(),
-            },
-        ]
-    } else {
-        Vec::new()
-    };
-    DaemonFreshnessReport {
-        fresh: validation.fresh,
-        stale_reason_code: validation.stale_reason_code,
-        restartable,
-        lease_id: state.map(|state| state.lease_id.clone()),
-        pid: state.map(|state| state.pid),
-        recovery_evidence: None,
-        ownership_evidence: None,
-        adoption_command: None,
-        binary_hash: state.and_then(|state| state.binary_sha256.clone()),
-        daemon_version: state.map(|state| state.build_identity.version.clone()),
-        daemon_build_identity: state.map(|state| state.build_identity.display.clone()),
-        runtime_paths: state.map(|state| state.runtime_paths.clone()),
-        active_jobs,
-        termination_evidence: (!validation.running)
-            .then(read_termination_evidence)
-            .transpose()
-            .ok()
-            .flatten()
-            .flatten(),
-        repair_plan,
-    }
-}
-
-fn runtime_snapshot_stale_reason(snapshot: &DaemonRuntimeSnapshot) -> Option<String> {
-    let stale: Vec<_> = snapshot
-        .paths
-        .iter()
-        .filter(|path| runtime_path_fingerprint(Path::new(&path.path)) != path.fingerprint)
-        .map(|path| path.env.clone())
-        .collect();
-    if stale.is_empty() {
-        None
-    } else {
-        Some(format!(
-            "daemon runtime path fingerprints changed: {}",
-            stale.join(", ")
-        ))
-    }
 }
 
 pub fn stop() -> Result<DaemonStopResult> {
@@ -2682,7 +2474,7 @@ fn is_runtime_path_env(name: &str) -> bool {
             .any(|suffix| name.ends_with(suffix))
 }
 
-fn runtime_path_fingerprint(path: &Path) -> String {
+pub(crate) fn runtime_path_fingerprint(path: &Path) -> String {
     let mut state = RuntimePathFingerprintState::default();
     collect_runtime_path_fingerprint(path, &mut state);
     format!(
@@ -3159,7 +2951,7 @@ fn read_lease_if_identity_matches(
 /// and deterministic; it is never consulted in a released binary run.
 pub const DAEMON_BINARY_SHA_OVERRIDE_ENV: &str = "HOMEBOY_TEST_DAEMON_BINARY_SHA";
 
-fn current_binary_sha256() -> Result<Option<String>> {
+pub(crate) fn current_binary_sha256() -> Result<Option<String>> {
     if let Ok(value) = std::env::var(DAEMON_BINARY_SHA_OVERRIDE_ENV) {
         return Ok((!value.is_empty()).then_some(value));
     }

--- a/crates/homeboy-core/src/daemon/daemon_lease.rs
+++ b/crates/homeboy-core/src/daemon/daemon_lease.rs
@@ -1,0 +1,234 @@
+//! Daemon lease staleness & freshness decision logic.
+//!
+//! Extracted from `daemon.rs`: the pure (no JobStore / HTTP-serving)
+//! machinery that decides whether a daemon session lease is running, fresh,
+//! reachable, or stale, and turns that into a `DaemonFreshnessReport`. This is
+//! the cluster the daemon-recovery bug fixes keep landing in (#9128, #8967,
+//! #8897), so isolating the staleness decision from the serving spine makes it
+//! reviewable and the invariants explicit.
+//!
+//! `DaemonLeaseValidation` is the typed verdict the serving code consumes;
+//! `validate_lease_file` is the entry point.
+
+use std::fs;
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+use super::{
+    current_binary_sha256, read_termination_evidence, runtime_path_fingerprint,
+    DaemonFreshnessReport, DaemonRepairStep, DaemonRuntimeSnapshot, DaemonStaleReasonCode,
+    DaemonState, DAEMON_LEASE_SCHEMA,
+};
+use crate::process::pid_is_running;
+use crate::{build_identity, Error, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DaemonLeaseValidation {
+    pub(crate) state: Option<DaemonState>,
+    pub(crate) running: bool,
+    pub(crate) fresh: bool,
+    pub(crate) reachable: bool,
+    pub(crate) stale_reason: Option<String>,
+    pub(crate) stale_reason_code: Option<DaemonStaleReasonCode>,
+    pub(crate) invalid_pid: Option<u32>,
+}
+
+pub(crate) fn daemon_state_identity(state_path: &Path, jobs_path: &Path) -> Result<String> {
+    let mut hasher = Sha256::new();
+    for (label, path) in [
+        (b"daemon-state\0".as_slice(), state_path),
+        (b"daemon-jobs\0".as_slice(), jobs_path),
+    ] {
+        hasher.update(label);
+        match fs::read(path) {
+            Ok(bytes) => {
+                hasher.update([1]);
+                hasher.update(bytes);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => hasher.update([0]),
+            Err(error) => {
+                return Err(Error::internal_io(
+                    error.to_string(),
+                    Some(format!("read {}", path.display())),
+                ))
+            }
+        }
+    }
+    Ok(format!("sha256:{:x}", hasher.finalize()))
+}
+
+pub(crate) fn validate_lease_file(path: &Path) -> Result<DaemonLeaseValidation> {
+    if !path.exists() {
+        return Ok(DaemonLeaseValidation {
+            running: false,
+            fresh: false,
+            reachable: false,
+            stale_reason: None,
+            stale_reason_code: Some(DaemonStaleReasonCode::LeaseMissing),
+            state: None,
+            invalid_pid: None,
+        });
+    }
+
+    let content = fs::read_to_string(&path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(format!("read {}", path.display()))))?;
+    let state: DaemonState = match serde_json::from_str(&content) {
+        Ok(state) => state,
+        Err(error) => {
+            return Ok(DaemonLeaseValidation {
+                running: false,
+                fresh: false,
+                reachable: false,
+                stale_reason: Some(format!("invalid daemon lease: {error}")),
+                stale_reason_code: Some(DaemonStaleReasonCode::LeaseCorrupt),
+                state: None,
+                invalid_pid: serde_json::from_str::<serde_json::Value>(&content)
+                    .ok()
+                    .and_then(|value| value.get("pid").and_then(|pid| pid.as_u64()))
+                    .and_then(|pid| u32::try_from(pid).ok()),
+            });
+        }
+    };
+
+    let running = pid_is_running(state.pid);
+    // A dead owner is safe to recover even when its persisted schema was
+    // omitted. Keeping the parsed lease identity makes explicit adoption
+    // possible; a live invalid lease remains protected by schema validation.
+    if !running {
+        return Ok(stale_lease(
+            state,
+            false,
+            DaemonStaleReasonCode::PidDead,
+            "daemon lease pid is not running",
+        ));
+    }
+    if state.schema != DAEMON_LEASE_SCHEMA {
+        return Ok(stale_lease(
+            state,
+            true,
+            DaemonStaleReasonCode::LeaseSchemaMismatch,
+            "unsupported daemon lease schema",
+        ));
+    }
+    let current_identity = build_identity::current();
+    if state.build_identity.version != current_identity.version
+        || state.build_identity.display != current_identity.display
+    {
+        return Ok(stale_lease(
+            state,
+            true,
+            DaemonStaleReasonCode::VersionMismatch,
+            "daemon build identity does not match current Homeboy binary",
+        ));
+    }
+    if state.binary_sha256 != current_binary_sha256()? {
+        return Ok(stale_lease(
+            state,
+            true,
+            DaemonStaleReasonCode::BinaryHashMismatch,
+            "daemon binary hash does not match current Homeboy binary",
+        ));
+    }
+    if let Some(reason) = runtime_snapshot_stale_reason(&state.runtime_paths) {
+        return Ok(stale_lease(
+            state,
+            true,
+            DaemonStaleReasonCode::RuntimePathsDrift,
+            reason,
+        ));
+    }
+
+    Ok(DaemonLeaseValidation {
+        running: true,
+        fresh: true,
+        reachable: true,
+        state: Some(state),
+        stale_reason: None,
+        stale_reason_code: None,
+        invalid_pid: None,
+    })
+}
+
+pub(crate) fn stale_lease(
+    state: DaemonState,
+    running: bool,
+    code: DaemonStaleReasonCode,
+    reason: impl Into<String>,
+) -> DaemonLeaseValidation {
+    DaemonLeaseValidation {
+        running,
+        fresh: false,
+        reachable: running,
+        stale_reason: Some(reason.into()),
+        stale_reason_code: Some(code),
+        state: Some(state),
+        invalid_pid: None,
+    }
+}
+
+pub(crate) fn freshness_report_from_validation(
+    validation: &DaemonLeaseValidation,
+    active_jobs: usize,
+) -> DaemonFreshnessReport {
+    let state = validation.state.as_ref();
+    let restartable = !validation.fresh
+        && active_jobs == 0
+        && !matches!(
+            validation.stale_reason_code,
+            Some(DaemonStaleReasonCode::LeaseCorrupt | DaemonStaleReasonCode::TransportUnreachable)
+        );
+    let repair_plan = if restartable {
+        vec![
+            DaemonRepairStep {
+                code: "daemon_stop".to_string(),
+                command: "homeboy daemon stop".to_string(),
+            },
+            DaemonRepairStep {
+                code: "daemon_start".to_string(),
+                command: "homeboy daemon start".to_string(),
+            },
+        ]
+    } else {
+        Vec::new()
+    };
+    DaemonFreshnessReport {
+        fresh: validation.fresh,
+        stale_reason_code: validation.stale_reason_code,
+        restartable,
+        lease_id: state.map(|state| state.lease_id.clone()),
+        pid: state.map(|state| state.pid),
+        recovery_evidence: None,
+        ownership_evidence: None,
+        adoption_command: None,
+        binary_hash: state.and_then(|state| state.binary_sha256.clone()),
+        daemon_version: state.map(|state| state.build_identity.version.clone()),
+        daemon_build_identity: state.map(|state| state.build_identity.display.clone()),
+        runtime_paths: state.map(|state| state.runtime_paths.clone()),
+        active_jobs,
+        termination_evidence: (!validation.running)
+            .then(read_termination_evidence)
+            .transpose()
+            .ok()
+            .flatten()
+            .flatten(),
+        repair_plan,
+    }
+}
+
+pub(crate) fn runtime_snapshot_stale_reason(snapshot: &DaemonRuntimeSnapshot) -> Option<String> {
+    let stale: Vec<_> = snapshot
+        .paths
+        .iter()
+        .filter(|path| runtime_path_fingerprint(Path::new(&path.path)) != path.fingerprint)
+        .map(|path| path.env.clone())
+        .collect();
+    if stale.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "daemon runtime path fingerprints changed: {}",
+            stale.join(", ")
+        ))
+    }
+}


### PR DESCRIPTION
## Summary
`daemon.rs` is a 3372-line god-file, and the recurring **daemon-recovery bugs keep landing in its lease staleness-decision logic** (#9128 lease-bound stops, #8967 fresh-daemon reconnect, #8897 abandoned reservations). This isolates that cluster into a new `daemon/daemon_lease` submodule so the invariants are reviewable in one place, separate from the HTTP-serving spine.

> **This is a behavior-preserving pure move — it fixes no bugs.** The value is that the *next* fix to the lease logic touches one focused 234-line file with the staleness invariants explicit, instead of hunting through a 3372-line file. It sets up the reliability work; it isn't the reliability work.

## What moved
The pure (no `JobStore` / no serving) decision logic:
- `DaemonLeaseValidation` — the typed verdict the serving code consumes
- `validate_lease_file` (entry point), `stale_lease`, `daemon_state_identity`, `freshness_report_from_validation`, `runtime_snapshot_stale_reason`

## Mechanics
- `DaemonLeaseValidation` + its fields become `pub(crate)` (the 6 serving-side call sites read every field — a clean typed interface).
- Shared deps it needs (`DAEMON_LEASE_SCHEMA`, `runtime_path_fingerprint`, `current_binary_sha256`, `read_termination_evidence`) are made `pub(crate)` and referenced via `super::`.
- The serving spine imports `validate_lease_file`/`freshness_report_from_validation`/`daemon_state_identity` back.
- `daemon.rs`: **−214 lines** (3372 → 3164).

## Verification (VPS-safe)
- `cargo check -p homeboy-core --lib --tests` — clean, no unused-import warnings
- The 8 `daemon::tests` (which exercise `validate_lease_file`/freshness) pass (0.7s)
- The 4 real-OS-process/broker batch failures (`daemon_operation_lock_recovers...`, `dead_daemon_recovery...`, `remote_runner_broker_redacts...`) are **pre-existing #8964-class flakes** — verified they fail identically on `origin/main` without this change (stashed diff, re-ran).

## Context
Continues the god-file decomposition (cook.rs → 4 modules). daemon.rs and lifecycle_ops.rs are the buggy areas; carving the lease cluster targets the seam where the bugs cluster. If a latent bug surfaces in the now-isolated logic, it'll be a separate fix PR — not folded silently into this refactor.