### PR TITLE
test: prove agent-task record health stays bounded with many malformed records

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
@@ -1,7 +1,7 @@
 use super::*;
 use homeboy_core::observation::{ObservationStore, RunRecord};
 
-const HEALTH_SAMPLE_LIMIT: usize = 20;
+pub(crate) const HEALTH_SAMPLE_LIMIT: usize = 20;
 const QUARANTINE_KEY: &str = "agent_task_lifecycle_quarantine";
 
 pub(crate) fn diagnose_run(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -1344,6 +1344,60 @@ fn list_records_skips_malformed_observation_records() {
 }
 
 #[test]
+fn record_health_summary_stays_bounded_with_many_malformed_records() {
+    with_isolated_home(|_| {
+        // A state directory full of historical malformed agent-task records must
+        // not produce unbounded per-record output. The health summary aggregates
+        // every malformed record into a total count while capping the retained
+        // samples, so read-only activity/upgrade output stays bounded. (#8397)
+        let malformed_count = crate::agent_task_lifecycle::health::HEALTH_SAMPLE_LIMIT * 3;
+        let store = homeboy_core::observation::ObservationStore::open_initialized()
+            .expect("observation store");
+        for index in 0..malformed_count {
+            store
+                .upsert_imported_run(&homeboy_core::observation::RunRecord {
+                    id: format!("bad-run-{index}"),
+                    kind: "agent-task".to_string(),
+                    component_id: None,
+                    started_at: "2026-01-01T00:00:00Z".to_string(),
+                    finished_at: None,
+                    status: "running".to_string(),
+                    command: None,
+                    cwd: None,
+                    homeboy_version: None,
+                    git_sha: None,
+                    rig_id: None,
+                    // A record with the observation schema but no `agent_task_run`
+                    // metadata is classified as MissingMetadata (malformed).
+                    metadata_json: json!({
+                        "schema": "homeboy/agent-task-observation-record/v1"
+                    }),
+                })
+                .expect("malformed record inserted");
+        }
+
+        let health = record_health_summary().expect("health summary");
+
+        // Every malformed record is counted…
+        assert_eq!(health.malformed, malformed_count);
+        // …but the retained sample set stays bounded regardless of volume.
+        assert!(
+            health.samples.len() <= crate::agent_task_lifecycle::health::HEALTH_SAMPLE_LIMIT,
+            "samples ({}) must not exceed HEALTH_SAMPLE_LIMIT ({})",
+            health.samples.len(),
+            crate::agent_task_lifecycle::health::HEALTH_SAMPLE_LIMIT
+        );
+        // Each retained sample carries an actionable remediation command.
+        for sample in &health.samples {
+            assert!(
+                !sample.remediation.is_empty(),
+                "each malformed sample must carry a remediation hint"
+            );
+        }
+    });
+}
+
+#[test]
 fn artifact_refs_omit_evidence_refs_with_empty_uri() {
     let outcomes = vec![outcome_with_refs(
         "task-a",


### PR DESCRIPTION
Closes #8397.

## Context

#8397 asked to stop read-only activity/upgrade output from emitting hundreds of unbounded per-record warnings (`skipping malformed agent-task run status ...: IO error`) when a state directory holds many malformed historical records.

Investigating current `main`, that behavior is **already implemented**: the malformed-record scan (`lifecycle_store::read_records_with_health`) no longer warns per record. It aggregates every malformed/legacy/conflicting/quarantined record into an `AgentTaskRecordHealthSummary` with per-class counts, a `samples` list capped at `HEALTH_SAMPLE_LIMIT` (20), and a per-item `remediation` command. `activity_provider` consumes that summary, and malformed records are silently skipped from listings (`list_records_skips_malformed_observation_records`).

Mapping to #8397's acceptance criteria:

- ✅ Keep malformed records fail-safe — skipped, never fatal.
- ✅ Aggregate diagnostics by error class and store instead of printing one warning per record — `AgentTaskRecordHealthSummary` counts + `record_health_item`.
- ✅ Emit a bounded sample plus total count and a remediation command — `samples` capped, per-class totals, `remediation` per item.
- ✅ Preserve clean structured stdout/stderr contracts — no per-record logging in the scan path.
- ⬜ **"Add coverage proving output remains bounded with a large malformed-record fixture"** — the one criterion without direct test coverage.

## Change

This PR adds that missing coverage (the behavior itself needs no change):

- `record_health_summary_stays_bounded_with_many_malformed_records` inserts `3 × HEALTH_SAMPLE_LIMIT` malformed observation records and asserts the summary counts **every** one (`malformed == total`) while `samples.len() <= HEALTH_SAMPLE_LIMIT` and each retained sample carries a non-empty remediation hint.
- `HEALTH_SAMPLE_LIMIT` is now `pub(crate)` so the test asserts against the real bound, not a magic number.

With this, all of #8397's acceptance criteria are satisfied and provably locked in, so the issue can be closed.

## Testing

- New test passes (60 malformed records → count 60, samples ≤ 20, all remediations present).
- Sibling malformed-record tests (`list_records_skips_malformed_observation_records`, `malformed_typed_pending_handoff_is_health_malformed_and_unreconciled`) still pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Verified #8397's behavior was already implemented via the record-health aggregation, identified the one uncovered acceptance criterion (bounded output under a large malformed fixture), and added that test. Chris reviews and owns the change.