### PR TITLE
Make runner job cancellation idempotent

### DIFF
--- a/crates/homeboy-core/src/api_jobs/store.rs
+++ b/crates/homeboy-core/src/api_jobs/store.rs
@@ -1984,6 +1984,12 @@ impl JobStore {
                 .jobs
                 .get_mut(&job_id)
                 .ok_or_else(|| job_not_found(job_id))?;
+            // Cancellation may be retried after the daemon has already recorded it.
+            // It is a no-op so callers receive the authoritative terminal job without
+            // adding a duplicate cancellation event.
+            if stored.job.status == JobStatus::Cancelled && next_status == JobStatus::Cancelled {
+                return Ok(stored.job.clone());
+            }
             validate_transition(stored.job.status, next_status)?;
 
             let now = timestamp_ms();

--- a/crates/homeboy-core/src/api_jobs/tests/part_a.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_a.rs
@@ -828,6 +828,28 @@ fn test_cancel() {
 }
 
 #[test]
+fn cancelling_a_cancelled_job_is_a_noop() {
+    let store = JobStore::default();
+    let job = store.create("bench");
+
+    let cancelled = store.cancel(job.id, "user requested").expect("job cancels");
+    let events_after_first_cancel = store.events(job.id).expect("events are readable");
+
+    let repeated = store
+        .cancel(job.id, "repeated request")
+        .expect("repeated cancellation succeeds");
+
+    assert_eq!(repeated.id, cancelled.id);
+    assert_eq!(repeated.status, JobStatus::Cancelled);
+    assert_eq!(repeated.finished_at_ms, cancelled.finished_at_ms);
+    assert_eq!(
+        store.events(job.id).expect("events are readable").len(),
+        events_after_first_cancel.len(),
+        "repeated cancellation must not add another status event"
+    );
+}
+
+#[test]
 fn test_job_id() {
     let store = JobStore::default();
     let runner = store.run_background("test", |job| Ok(job.job_id().to_string()));

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -491,6 +491,76 @@ fn generic_job_cancel_remains_unscoped_for_operator_compatibility() {
 }
 
 #[test]
+fn generic_job_cancel_is_idempotent_without_duplicating_events() {
+    let store = JobStore::default();
+    let job = store.create("audit");
+    let path = format!("/jobs/{}/cancel", job.id);
+
+    let first = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Post,
+            path: path.clone(),
+            body: None,
+        },
+        &store,
+    )
+    .expect("first cancellation succeeds");
+    let events_after_first_cancel = store.events(job.id).expect("events");
+
+    let repeated = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Post,
+            path,
+            body: None,
+        },
+        &store,
+    )
+    .expect("repeated cancellation succeeds");
+
+    assert_eq!(first.endpoint, "jobs.cancel");
+    assert_eq!(repeated.endpoint, "jobs.cancel");
+    assert_eq!(first.body["job"]["status"], "cancelled");
+    assert_eq!(repeated.body["job"]["status"], "cancelled");
+    assert_eq!(
+        store.events(job.id).expect("events").len(),
+        events_after_first_cancel.len(),
+        "repeated cancellation must preserve the original event log"
+    );
+
+    let completed = store.create("completed-audit");
+    store.start(completed.id).expect("job starts");
+    store.complete(completed.id, None).expect("job completes");
+    let completed_error = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Post,
+            path: format!("/jobs/{}/cancel", completed.id),
+            body: None,
+        },
+        &store,
+    )
+    .expect_err("completed jobs remain non-cancellable");
+    assert_eq!(
+        completed_error.code,
+        crate::ErrorCode::ValidationInvalidArgument
+    );
+
+    let unknown_error = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Post,
+            path: format!("/jobs/{}/cancel", uuid::Uuid::new_v4()),
+            body: None,
+        },
+        &store,
+    )
+    .expect_err("unknown jobs retain their structured validation error");
+    assert_eq!(
+        unknown_error.code,
+        crate::ErrorCode::ValidationInvalidArgument
+    );
+    assert_eq!(unknown_error.details["field"], "job_id");
+}
+
+#[test]
 fn runs_list_includes_active_runner_jobs() {
     with_isolated_home(|_home| {
         let _xdg = XdgGuard::unset();


### PR DESCRIPTION
## Summary
Treat repeated cancellation of an already-cancelled runner job as a successful no-op while preserving terminal job state and event history.

## What changed
- Return the authoritative cancelled job for Cancelled-to-Cancelled transitions without persisting a duplicate status event.
- Cover store and HTTP daemon behavior, completed-job rejection, unknown jobs, and coexistence with admission idempotency.

## How to test
1. Run `cargo test -p homeboy-core cancelling_a_cancelled_job_is_a_noop`; expect Repeated store cancellation passes without duplicate events..
2. Run `cargo test -p homeboy-core generic_job_cancel_is_idempotent_without_duplicating_events`; expect The HTTP cancellation boundary passes for repeated, completed, and unknown jobs..
3. Run `cargo test -p homeboy-core daemon::tests::admission_reservation_dedupes_a_detached_run_and_releases_it`; expect The merged admission idempotency behavior remains green..

## Compatibility
No CLI removal or extension-path change. Repeating cancellation now succeeds idempotently instead of returning validation/internal failure; completed and unknown jobs preserve their existing structured errors.

## Evidence
- Base advanced after verification: verified main at d60cb1a1d64b2ff9f5d682696ac61b9921dc63b8; publication observed 68414cbc7e28fcb91f33fb1465614c26d2dcd2b8. Candidate ancestry was validated against the verified snapshot.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/9132
- Verified finalization base: main at d60cb1a1d64b2ff9f5d682696ac61b9921dc63b8
- focused-tests: Passed
- format: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed repeated-cancellation failure, implemented idempotent transition handling and deterministic tests, and reviewed integration with #9140; Chris owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#9132
