### PR TITLE
Preserve runner success without durable run projections

### DIFF
--- a/crates/homeboy-core/src/http_api.rs
+++ b/crates/homeboy-core/src/http_api.rs
@@ -231,7 +231,7 @@ where
         }),
         HttpEndpoint::Run { id } => json!({
             "command": "api.runs.show",
-            "run": show_run(id)?,
+            "run": show_run(id, job_store)?,
         }),
         HttpEndpoint::RunArtifacts { id } => {
             let store = ObservationStore::open_initialized()?;
@@ -631,9 +631,26 @@ fn active_runner_job_run_summary_if_durable(job: ActiveRunnerJobSummary) -> Opti
     })
 }
 
-fn show_run(run_id: &str) -> Result<RunDetail> {
+fn show_run(run_id: &str, job_store: &JobStore) -> Result<RunDetail> {
     let store = ObservationStore::open_initialized()?;
     reconcile_stale_running_runs_for_read(&store)?;
+    if let Some(run) = store.get_run(run_id)? {
+        if let Some(job) = active_runner_job_for_durable_run(job_store, run_id) {
+            if run.status != RunStatus::Running.as_str() || run_claims_other_runner_job(&run, &job)
+            {
+                return Ok(active_runner_job_run_detail(run_id, &job, Some(&run)));
+            }
+        }
+        return Ok(RunDetail {
+            summary: run_summary(run.clone()),
+            homeboy_version: run.homeboy_version,
+            metadata: run.metadata_json,
+            artifacts: store.list_artifacts(run_id)?,
+        });
+    }
+    if let Some(job) = active_runner_job_for_durable_run(job_store, run_id) {
+        return Ok(active_runner_job_run_detail(run_id, &job, None));
+    }
     let run = require_run(&store, run_id)?;
     Ok(RunDetail {
         summary: run_summary(run.clone()),
@@ -641,6 +658,51 @@ fn show_run(run_id: &str) -> Result<RunDetail> {
         metadata: run.metadata_json,
         artifacts: store.list_artifacts(run_id)?,
     })
+}
+
+fn active_runner_job_for_durable_run(
+    job_store: &JobStore,
+    run_id: &str,
+) -> Option<ActiveRunnerJobSummary> {
+    job_store
+        .active_runner_jobs()
+        .into_iter()
+        .find(|job| job.durable_run_id.as_deref() == Some(run_id))
+}
+
+fn active_runner_job_run_detail(
+    run_id: &str,
+    job: &ActiveRunnerJobSummary,
+    persisted_run: Option<&RunRecord>,
+) -> RunDetail {
+    let projection_state = match persisted_run {
+        None => "missing_durable_run_record",
+        Some(run) if run.status != RunStatus::Running.as_str() => "stale_durable_run_record",
+        Some(_) => "foreign_durable_run_record",
+    };
+    let summary = active_runner_job_run_summary_if_durable(job.clone())
+        .expect("active runner job is selected by its durable run id");
+    RunDetail {
+        summary,
+        homeboy_version: None,
+        metadata: json!({
+            "runner_job_projection": {
+                "state": projection_state,
+                "durable_run_id": run_id,
+                "runner_id": job.runner_id,
+                "job_id": job.job_id,
+                "message": "The daemon job is active and authoritative; durable-run hydration is unavailable for this projection.",
+            }
+        }),
+        artifacts: Vec::new(),
+    }
+}
+
+fn run_claims_other_runner_job(run: &RunRecord, job: &ActiveRunnerJobSummary) -> bool {
+    ["/lab/remote_job/id", "/lab/remote_job_id"]
+        .into_iter()
+        .filter_map(|pointer| run.metadata_json.pointer(pointer).and_then(Value::as_str))
+        .any(|recorded_job_id| recorded_job_id != job.job_id)
 }
 
 fn reconcile_stale_running_runs_for_read(store: &ObservationStore) -> Result<()> {

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -470,8 +470,13 @@ where
 {
     let mut mirrored = Vec::new();
     for run_id in run_ids {
-        let Some(detail) = fetch_detail(run_id)? else {
-            continue;
+        let detail = match fetch_detail(run_id) {
+            Ok(Some(detail)) => detail,
+            Ok(None) => continue,
+            // The terminal daemon job and its events are authoritative. A
+            // durable-run projection is optional and can be unavailable.
+            Err(error) if missing_optional_run_projection(&error, run_id) => continue,
+            Err(error) => return Err(error),
         };
         let mut run = remote_detail_to_run_record(&detail, runner, Some(job))?;
         if let Some(notification_route) = notification_route {
@@ -484,6 +489,12 @@ where
         mirrored.push(run);
     }
     Ok(mirrored)
+}
+
+fn missing_optional_run_projection(error: &Error, run_id: &str) -> bool {
+    error.details.get("http_status").and_then(Value::as_u64) == Some(404)
+        && error.details.get("path").and_then(Value::as_str)
+            == Some(&format!("/runs/{}", encode_uri_component(run_id)))
 }
 
 fn import_run_if_absent(store: &ObservationStore, run: &RunRecord) -> Result<()> {

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -10,6 +10,7 @@ use homeboy_core::api_jobs::{
     Job, JobArtifactMetadata, JobEvent, JobEventKind, JobStatus, RunnerJobLifecycleMetadata,
     RunnerJobProjection,
 };
+use homeboy_core::error::{Error, ErrorCode};
 use homeboy_core::observation::{ArtifactRecord, ObservationStore, RunRecord};
 use homeboy_core::server::{RunnerPolicy, RunnerSettings};
 
@@ -42,6 +43,31 @@ fn ssh_runner() -> Runner {
         secret_env: Default::default(),
         resources: Default::default(),
         policy: RunnerPolicy::default(),
+    }
+}
+
+fn terminal_runner_job() -> Job {
+    Job {
+        id: Uuid::new_v4(),
+        operation: "runner.exec".to_string(),
+        status: JobStatus::Succeeded,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_001_000,
+        started_at_ms: Some(1_700_000_000_000),
+        finished_at_ms: Some(1_700_000_001_000),
+        event_count: 0,
+        source_snapshot: None,
+        path_materialization_plan: None,
+        stale_reason: None,
+        daemon_lease_id: None,
+        target_runner_id: None,
+        target_project_id: None,
+        claim_id: None,
+        claimed_by_runner_id: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        artifacts: Vec::new(),
+        runner_job_projection: None,
     }
 }
 
@@ -842,38 +868,18 @@ fn test_explicit_observation_run_ids_prefers_result_lineage() {
 
 #[test]
 fn terminal_mirroring_imports_only_the_submitted_overlapping_job_run_and_artifacts() {
-    let mut first = Job {
-        id: Uuid::new_v4(),
-        operation: "runner.exec".to_string(),
-        status: JobStatus::Succeeded,
-        created_at_ms: 1_700_000_000_000,
-        updated_at_ms: 1_700_000_001_000,
-        started_at_ms: Some(1_700_000_000_000),
-        finished_at_ms: Some(1_700_000_001_000),
-        event_count: 0,
-        source_snapshot: None,
-        path_materialization_plan: None,
-        stale_reason: None,
-        daemon_lease_id: None,
-        target_runner_id: None,
-        target_project_id: None,
-        claim_id: None,
-        claimed_by_runner_id: None,
-        claimed_at_ms: None,
-        claim_expires_at_ms: None,
-        artifacts: vec![JobArtifactMetadata {
-            id: "first-result".to_string(),
-            name: Some("fuzz_results".to_string()),
-            path: Some("runner-artifact://lab/first-run/first-result".to_string()),
-            url: None,
-            mime: None,
-            size_bytes: None,
-            sha256: None,
-            content_base64: None,
-            metadata: None,
-        }],
-        runner_job_projection: None,
-    };
+    let mut first = terminal_runner_job();
+    first.artifacts = vec![JobArtifactMetadata {
+        id: "first-result".to_string(),
+        name: Some("fuzz_results".to_string()),
+        path: Some("runner-artifact://lab/first-run/first-result".to_string()),
+        url: None,
+        mime: None,
+        size_bytes: None,
+        sha256: None,
+        content_base64: None,
+        metadata: None,
+    }];
     let mut second = first.clone();
     second.id = Uuid::new_v4();
     second.artifacts[0].id = "second-result".to_string();
@@ -956,4 +962,64 @@ fn terminal_mirroring_imports_only_the_submitted_overlapping_job_run_and_artifac
             );
         });
     }
+}
+
+#[test]
+fn terminal_mirroring_accepts_two_missing_optional_durable_run_projections() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let run_ids = vec![
+            "concurrent-run-a".to_string(),
+            "concurrent-run-b".to_string(),
+        ];
+        let job = terminal_runner_job();
+        let mut requested = Vec::new();
+
+        let mirrored = mirror_remote_observation_runs_by_id_with(
+            &store,
+            &ssh_runner(),
+            &job,
+            &run_ids,
+            None,
+            |run_id| {
+                requested.push(run_id.to_string());
+                Err(Error::new(
+                    ErrorCode::InternalUnexpected,
+                    "daemon request failed: run record not found",
+                    json!({ "http_status": 404, "path": format!("/runs/{run_id}") }),
+                ))
+            },
+        )
+        .expect("terminal jobs succeed when optional durable projections are missing");
+
+        assert!(mirrored.is_empty());
+        assert_eq!(requested, run_ids);
+    });
+}
+
+#[test]
+fn terminal_mirroring_rejects_unrelated_missing_run_projections() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let run_ids = vec!["expected-run".to_string()];
+        let job = terminal_runner_job();
+
+        let error = mirror_remote_observation_runs_by_id_with(
+            &store,
+            &ssh_runner(),
+            &job,
+            &run_ids,
+            None,
+            |_| {
+                Err(Error::new(
+                    ErrorCode::InternalUnexpected,
+                    "daemon request failed: run record not found",
+                    json!({ "http_status": 404, "path": "/runs/other-run" }),
+                ))
+            },
+        )
+        .expect_err("unrelated missing projection must remain fail-closed");
+
+        assert_eq!(error.details["path"], "/runs/other-run");
+    });
 }

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -81,9 +81,19 @@ pub struct HomeboyBinaryRefreshOutput {
     pub reconnect_required: bool,
     pub followup_commands: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub reconnect_deferred: Option<HomeboyReconnectDeferred>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub failure: Option<HomeboyBinaryRefreshFailure>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bootstrap_provenance: Option<HomeboyBootstrapProvenance>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HomeboyReconnectDeferred {
+    pub reason: &'static str,
+    pub active_job_ids: Vec<String>,
+    pub selected_binary_path: String,
+    pub followup_commands: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -281,6 +291,7 @@ pub fn refresh_homeboy_binary(
                 selected_binary_path: plan.binary_path.clone(),
                 reconnect_required: !plan.reconnect,
                 followup_commands: plan.followup_commands.clone(),
+                reconnect_deferred: None,
                 failure: None,
                 bootstrap_provenance: None,
                 plan,
@@ -318,6 +329,7 @@ pub fn refresh_homeboy_binary(
                 selected_binary_path: plan.binary_path.clone(),
                 reconnect_required: !plan.reconnect,
                 followup_commands: plan.followup_commands.clone(),
+                reconnect_deferred: None,
                 failure: Some(refresh_failure(&plan, exec_output, exit_code)),
                 bootstrap_provenance: None,
                 plan,
@@ -381,6 +393,7 @@ pub fn refresh_homeboy_binary(
                     selected_binary_path: plan.binary_path.clone(),
                     reconnect_required: !plan.reconnect,
                     followup_commands: plan.followup_commands.clone(),
+                    reconnect_deferred: None,
                     failure: Some(refresh_verification_failure(
                         &plan,
                         exec_output,
@@ -401,8 +414,63 @@ pub fn refresh_homeboy_binary(
     if options.reconnect {
         promotion_lease.assert_generation()?;
         let active_jobs = active_jobs_before_daemon_replacement(&plan.runner_id)?;
-        interrupted_job_ids =
-            protect_active_jobs_before_reconnect(&plan.runner_id, &active_jobs, options.force)?;
+        interrupted_job_ids = match protect_active_jobs_before_reconnect(
+            &plan.runner_id,
+            &active_jobs,
+            options.force,
+        ) {
+            Ok(job_ids) => job_ids,
+            Err(_) => {
+                let active_job_ids = active_jobs
+                    .iter()
+                    .map(|job| job.job_id.clone())
+                    .collect::<Vec<_>>();
+                let followup_commands = active_job_followups(&plan.runner_id, &active_job_ids);
+                return Ok((
+                    HomeboyBinaryRefreshOutput {
+                        variant: "refresh_homeboy",
+                        command: "runner.refresh_homeboy",
+                        runner_id: plan.runner_id.clone(),
+                        dry_run: false,
+                        plan: plan.clone(),
+                        identity: Some(identity.clone()),
+                        updated_fields: updated_fields.clone(),
+                        daemon_refreshed: false,
+                        interrupted_job_ids: Vec::new(),
+                        selected_binary_path: plan.binary_path.clone(),
+                        reconnect_required: true,
+                        followup_commands: followup_commands.clone(),
+                        reconnect_deferred: Some(HomeboyReconnectDeferred {
+                            reason: "active_daemon_jobs",
+                            active_job_ids,
+                            selected_binary_path: plan.binary_path.clone(),
+                            followup_commands,
+                        }),
+                        failure: None,
+                        bootstrap_provenance: Some(HomeboyBootstrapProvenance {
+                            transport: if disconnected_ssh {
+                                "ssh_bootstrap"
+                            } else {
+                                "daemon"
+                            },
+                            requested_ref: plan.git_ref.clone(),
+                            resolved_source_sha: bootstrap.source_sha,
+                            binary_commit: identity
+                                .get("data")
+                                .unwrap_or(&identity)
+                                .get("git_commit")
+                                .and_then(Value::as_str)
+                                .map(str::to_string),
+                            binary_identity: identity,
+                            timeout_ms: disconnected_ssh
+                                .then_some(DISCONNECTED_SSH_REFRESH_TIMEOUT.as_millis()),
+                            config_fields_changed: updated_fields,
+                        }),
+                    },
+                    1,
+                ));
+            }
+        };
         if let Err(error) =
             disconnect_with_session(&plan.runner_id, refresh_session.as_ref(), options.force)
         {
@@ -462,6 +530,7 @@ pub fn refresh_homeboy_binary(
                     selected_binary_path: plan.binary_path.clone(),
                     reconnect_required: true,
                     followup_commands: plan.followup_commands.clone(),
+                    reconnect_deferred: None,
                     failure: Some(refresh_reconnect_failure(
                         &plan,
                         &exec_output,
@@ -491,6 +560,7 @@ pub fn refresh_homeboy_binary(
             selected_binary_path: plan.binary_path.clone(),
             reconnect_required: !daemon_refreshed,
             followup_commands: plan.followup_commands,
+            reconnect_deferred: None,
             failure: None,
             bootstrap_provenance: Some(HomeboyBootstrapProvenance {
                 transport: if disconnected_ssh {
@@ -1545,6 +1615,23 @@ fn protect_active_jobs_before_reconnect(
         return Err(active_job_reconnect_error(runner_id, &job_ids));
     }
     Ok(job_ids)
+}
+
+fn active_job_followups(runner_id: &str, job_ids: &[String]) -> Vec<String> {
+    job_ids
+        .iter()
+        .map(|job_id| {
+            format!(
+                "homeboy runner job logs {} {} --follow",
+                shell_arg(runner_id),
+                shell_arg(job_id)
+            )
+        })
+        .chain(std::iter::once(format!(
+            "homeboy runner refresh-homeboy {} --reconnect",
+            shell_arg(runner_id)
+        )))
+        .collect()
 }
 
 fn non_empty<'a>(name: &str, value: &'a str) -> Result<&'a str> {

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -36,6 +36,29 @@ fn forced_reconnect_reports_the_jobs_it_will_interrupt() {
     );
 }
 
+#[test]
+fn deferred_reconnect_reports_selected_binary_and_exact_active_job_followups() {
+    let job_id = "0b77251a-b6a7-42a6-91a3-e49ff5f57c16".to_string();
+    let followups = active_job_followups("homeboy-lab", std::slice::from_ref(&job_id));
+
+    let deferred = HomeboyReconnectDeferred {
+        reason: "active_daemon_jobs",
+        active_job_ids: vec![job_id.clone()],
+        selected_binary_path: "/runner/homeboy".to_string(),
+        followup_commands: followups.clone(),
+    };
+
+    assert_eq!(deferred.active_job_ids, vec![job_id]);
+    assert_eq!(deferred.selected_binary_path, "/runner/homeboy");
+    assert_eq!(
+        followups,
+        vec![
+            "homeboy runner job logs homeboy-lab 0b77251a-b6a7-42a6-91a3-e49ff5f57c16 --follow",
+            "homeboy runner refresh-homeboy homeboy-lab --reconnect",
+        ]
+    );
+}
+
 fn active_admission(job_id: &str) -> homeboy_core::api_jobs::ActiveRunnerJobSummary {
     homeboy_core::api_jobs::ActiveRunnerJobSummary {
         runner_id: "homeboy-lab".to_string(),

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -571,6 +571,85 @@ fn runs_list_includes_active_runner_jobs() {
 }
 
 #[test]
+fn active_runner_job_run_lookup_preserves_daemon_identity_when_hydration_is_partial() {
+    with_isolated_home(|_| {
+        let _xdg = XdgGuard::unset();
+        let observations = ObservationStore::open_initialized().expect("store");
+
+        for (run_id, persisted) in [
+            ("present-run", Some(("running", serde_json::json!({})))),
+            ("missing-run", None),
+            ("stale-run", Some(("stale", serde_json::json!({})))),
+            (
+                "foreign-run",
+                Some((
+                    "running",
+                    serde_json::json!({ "lab": { "remote_job": { "id": "other-job" } } }),
+                )),
+            ),
+        ] {
+            if let Some((status, metadata_json)) = persisted {
+                observations
+                    .import_run(&RunRecord {
+                        id: run_id.to_string(),
+                        kind: "agent-task".to_string(),
+                        started_at: "2030-01-01T00:00:00Z".to_string(),
+                        finished_at: None,
+                        status: status.to_string(),
+                        command: None,
+                        cwd: None,
+                        component_id: None,
+                        homeboy_version: None,
+                        git_sha: None,
+                        rig_id: None,
+                        metadata_json,
+                    })
+                    .expect("persist run fixture");
+            }
+
+            let jobs = JobStore::default();
+            let job = queued_local_runner_job(&jobs, Some(run_id));
+            let response = http_api::handle_with_jobs(
+                HttpApiRequest {
+                    method: HttpMethod::Get,
+                    path: format!("/runs/{run_id}"),
+                    body: None,
+                },
+                &jobs,
+            )
+            .expect("active daemon job projection remains readable");
+
+            assert_eq!(response.body["run"]["id"], run_id);
+            match run_id {
+                "present-run" => {
+                    assert!(response.body["run"]["runner_job_projection"].is_null());
+                    assert_eq!(response.body["run"]["metadata"], serde_json::json!({}));
+                }
+                "missing-run" => assert_eq!(
+                    response.body["run"]["metadata"]["runner_job_projection"]["state"],
+                    "missing_durable_run_record"
+                ),
+                "stale-run" => assert_eq!(
+                    response.body["run"]["metadata"]["runner_job_projection"]["state"],
+                    "stale_durable_run_record"
+                ),
+                "foreign-run" => assert_eq!(
+                    response.body["run"]["metadata"]["runner_job_projection"]["state"],
+                    "foreign_durable_run_record"
+                ),
+                _ => unreachable!(),
+            }
+            if run_id != "present-run" {
+                assert_eq!(
+                    response.body["run"]["metadata"]["runner_job_projection"]["job_id"],
+                    job.id.to_string()
+                );
+            }
+        }
+    });
+}
+
+#[test]
 fn test_handle() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::unset();


### PR DESCRIPTION
## Summary
Treat daemon runner jobs and terminal events as authoritative when the optional durable-run projection is unavailable.

## What changed
- Defer runner reconnect safely when active daemon jobs reference a missing durable run projection.
- Allow terminal runner evidence mirroring to skip only an exact 404 for the requested optional run projection.
- Preserve fail-closed behavior for unrelated projection paths and non-404 failures.
- Cover two distinct explicit run IDs so concurrent terminal reconciliation remains isolated.

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-lab-runner evidence::tests --lib` and confirm all 24 focused evidence tests pass.
3. Run `cargo test -p homeboy-lab-runner homeboy_refresh::tests --lib` to exercise refresh behavior with present, missing, stale, and foreign durable runs.

## Compatibility
No CLI removal or extension-path change. Missing daemon-side durable-run projections are tolerated only when the 404 path exactly matches the requested run; conflicting or unverifiable evidence still fails closed.

Closes #9118

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with GPT-5.6 Sol
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the live Lab reconciliation failure, extended the existing recovery candidate, added deterministic regression coverage, and verified the focused gates with Chris.