### PR TITLE
fix(discovery): ignore generated .homeboy-build manifests in duplicate scan

### DIFF
--- a/crates/homeboy-core/src/component/resolution.rs
+++ b/crates/homeboy-core/src/component/resolution.rs
@@ -772,7 +772,21 @@ fn collect_portable_config_paths_for_id(
 fn should_skip_portable_duplicate_scan_dir(path: &Path) -> bool {
     matches!(
         path.file_name().and_then(|name| name.to_str()),
-        Some(".git" | ".homeboy" | "target" | "node_modules" | "vendor")
+        // `.homeboy-build`/`.homeboy-bin` hold reconstructable Homeboy build
+        // artifacts, which can contain a *copy* of a component's `homeboy.json`
+        // (e.g. `.homeboy-build/<component>/homeboy.json`). Scanning them makes a
+        // single component appear declared by multiple manifests and fails
+        // discovery ("declared by multiple homeboy.json files"). They are not
+        // source declarations, so exclude them from the duplicate scan. (#8210)
+        Some(
+            ".git"
+                | ".homeboy"
+                | ".homeboy-build"
+                | ".homeboy-bin"
+                | "target"
+                | "node_modules"
+                | "vendor"
+        )
     )
 }
 
@@ -883,6 +897,20 @@ mod tests {
             .hints
             .iter()
             .any(|hint| hint.message.contains("--path <component-dir>")));
+    }
+
+    #[test]
+    fn generated_homeboy_build_manifest_does_not_trigger_duplicate_ids() {
+        // A component repo with a reconstructable `.homeboy-build/<component>/`
+        // copy of its `homeboy.json` must still resolve: the build artifact is
+        // not a second source declaration. (#8210)
+        let repo = tempfile::tempdir().expect("repo");
+        git(repo.path(), &["init"]);
+        write_portable(repo.path(), "fixture");
+        write_portable(&repo.path().join(".homeboy-build/fixture"), "fixture");
+
+        validate_duplicate_portable_component_ids("fixture", repo.path(), None)
+            .expect("a generated .homeboy-build manifest must not count as a duplicate");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #8210.

## Problem

After a tagged deployment, a component repo can hold a reconstructable `.homeboy-build/<component>/homeboy.json` copy alongside its canonical root `homeboy.json`. The portable-component duplicate-ID scan recursed into `.homeboy-build`, found the copy, and failed discovery:

```
Component id 'extrachill-api' is declared by multiple homeboy.json files:
- .../extrachill-api/.homeboy-build/extrachill-api/homeboy.json
- .../extrachill-api/homeboy.json
```

This broke project-wide checks like `homeboy deploy <project> --check`.

## Root cause

`should_skip_portable_duplicate_scan_dir` (`crates/homeboy-core/src/component/resolution.rs`) skipped `.git`, `.homeboy`, `target`, `node_modules`, `vendor` — but **not** `.homeboy-build`. So `collect_portable_config_paths_for_id` walked into the generated build tree and counted its manifest copy as a second declaration.

(The `.homeboy-build` entry in `codebase_scan::ALWAYS_SKIP_DIRS` governs the audit/file-walk, a different scan — it does not affect this component-discovery dedup walk.)

## Fix

Add `.homeboy-build` and its sibling `.homeboy-bin` to the duplicate-scan skip list. These hold Homeboy-owned reconstructable build artifacts (already excluded from source snapshots), not source component declarations. Genuine duplicate **source** manifests still fail as before.

## Testing

- New `generated_homeboy_build_manifest_does_not_trigger_duplicate_ids`: a repo with `.homeboy-build/fixture/homeboy.json` alongside the root manifest resolves cleanly.
- Existing `duplicate_portable_ids_error_for_id_only_resolution_scope` (real duplicate still errors) and `explicit_path_disambiguates_duplicate_portable_ids` still pass.
- Full `component::resolution` suite (36 tests) green.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** While triaging stale issues, confirmed #8210 was still real (the duplicate-scan skip list omitted `.homeboy-build`, unlike the file-walk skip list) and added the exclusion + regression test. Chris reviews and owns the change.