### PR TITLE
Prefer Homeboy worktree records for cook targets

### DIFF
--- a/crates/homeboy-agents/src/agent_task_dispatch_plan.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan.rs
@@ -420,21 +420,32 @@ fn resolve_dispatch_workspace(
         return Ok(Some(DispatchWorkspaceTarget::path(path, "workspace-path")));
     }
 
-    if let Some(record) = worktree::resolve_if_present(workspace)? {
-        let root = std::path::PathBuf::from(&record.worktree_path);
+    if let Some(record) = worktree::resolve_workspace_ref_if_present(workspace)? {
+        if record.state() != &worktree::TaskWorktreeState::Active {
+            return Err(Error::validation_invalid_argument(
+                "workspace",
+                format!(
+                    "Homeboy workspace '{}' is no longer active",
+                    record.handle()
+                ),
+                Some(workspace.clone()),
+                None,
+            ));
+        }
+        let root = std::path::PathBuf::from(record.path());
         if !root.is_dir() {
             return Err(Error::validation_invalid_argument(
                 "workspace",
                 format!(
-                    "Homeboy worktree '{}' points at a missing directory {}; recreate or remove the stale record",
-                    record.id,
+                    "Homeboy workspace '{}' points at a missing directory {}; recreate or remove the stale record",
+                    record.handle(),
                     root.display()
                 ),
                 Some(workspace.clone()),
                 None,
             ));
         }
-        return Ok(Some(DispatchWorkspaceTarget::record(record)));
+        return Ok(Some(DispatchWorkspaceTarget::workspace_ref(record)));
     }
 
     let resolution = worktree_providers::resolve_worktree_provider(workspace).map_err(|error| {
@@ -499,6 +510,30 @@ impl DispatchWorkspaceTarget {
                 "kind": kind,
                 "root": root.display().to_string(),
             }),
+        }
+    }
+
+    fn workspace_ref(record: worktree::WorkspaceRefRecord) -> Self {
+        match record {
+            worktree::WorkspaceRefRecord::Task(record) => Self::record(record),
+            worktree::WorkspaceRefRecord::Adopted(record) => {
+                let root = std::path::PathBuf::from(&record.path);
+                Self {
+                    root,
+                    slug: Some(record.handle.clone()),
+                    kind: Some("adopted-workspace".to_string()),
+                    component_id: None,
+                    branch: None,
+                    base_ref: None,
+                    metadata: serde_json::json!({
+                        "kind": "adopted-workspace",
+                        "handle": record.handle,
+                        "root": record.path,
+                        "workspace_kind": record.kind,
+                        "provenance": record.provenance,
+                    }),
+                }
+            }
         }
     }
 

--- a/crates/homeboy-agents/src/agent_task_promotion/apply.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/apply.rs
@@ -115,12 +115,47 @@ pub(crate) fn preflight_configured_workspace_provider_with_config(
     to_workspace: &str,
     config: &homeboy_core::defaults::HomeboyConfig,
 ) -> Result<()> {
+    if resolve_homeboy_workspace(to_workspace)?.is_some() {
+        return Ok(());
+    }
     worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
         to_workspace,
         config,
         None,
     )?;
     Ok(())
+}
+
+fn resolve_homeboy_workspace(to_workspace: &str) -> Result<Option<std::path::PathBuf>> {
+    let Some(record) = homeboy_core::worktree::resolve_workspace_ref_if_present(to_workspace)?
+    else {
+        return Ok(None);
+    };
+    if record.state() != &homeboy_core::worktree::TaskWorktreeState::Active {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "Homeboy workspace '{}' is no longer active",
+                record.handle()
+            ),
+            Some(to_workspace.to_string()),
+            None,
+        ));
+    }
+    let path = std::path::PathBuf::from(record.path());
+    if !path.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "Homeboy workspace '{}' points at a missing directory {}; recreate or remove the stale record",
+                record.handle(),
+                path.display()
+            ),
+            Some(to_workspace.to_string()),
+            None,
+        ));
+    }
+    Ok(Some(path))
 }
 
 /// Apply a promotion-provider request to an already materialized Git workspace.
@@ -419,21 +454,6 @@ impl ExternalPromotionWorkspaceProvider {
                 None,
             )
         })?;
-        let trusted_unpushed_destination = request
-            .trusted_unpushed_candidate_destination
-            .as_ref()
-            .map(
-                |trusted| homeboy_core::worktree_providers::TrustedUnpushedWorktree {
-                    path: trusted.path.clone(),
-                    head: trusted.head.clone(),
-                },
-            );
-        let resolution = worktree_providers::resolve_apply_enabled_worktree_provider_with_trusted_unpushed_destination_from_config(
-            &request.to_workspace,
-            &configured_fallback.config,
-            request.gate_feedback_baseline.as_ref(),
-            trusted_unpushed_destination.as_ref(),
-        )?;
         let executable = configured_fallback
             .executable
             .clone()
@@ -448,22 +468,47 @@ impl ExternalPromotionWorkspaceProvider {
                     )
                 })
             })?;
-        let workspace = resolution.worktree.path;
+        let workspace = if let Some(path) = resolve_homeboy_workspace(&request.to_workspace)? {
+            self.provenance = Some(serde_json::json!({
+                "id": "homeboy",
+                "handle": request.to_workspace,
+                "path": path,
+            }));
+            path
+        } else {
+            let trusted_unpushed_destination = request
+                .trusted_unpushed_candidate_destination
+                .as_ref()
+                .map(
+                    |trusted| homeboy_core::worktree_providers::TrustedUnpushedWorktree {
+                        path: trusted.path.clone(),
+                        head: trusted.head.clone(),
+                    },
+                );
+            let resolution = worktree_providers::resolve_apply_enabled_worktree_provider_with_trusted_unpushed_destination_from_config(
+            &request.to_workspace,
+            &configured_fallback.config,
+            request.gate_feedback_baseline.as_ref(),
+            trusted_unpushed_destination.as_ref(),
+        )?;
+            let workspace = resolution.worktree.path;
+            self.provenance = Some(serde_json::json!({
+                "id": resolution.provider_id,
+                "handle": resolution.worktree.handle,
+                "path": workspace,
+            }));
+            std::path::PathBuf::from(workspace)
+        };
         self.invocation = Some(CommandInvocation {
             argv: vec![
                 executable.display().to_string(),
                 "agent-task".to_string(),
                 "promotion-provider".to_string(),
                 "--workspace".to_string(),
-                workspace.clone(),
+                workspace.display().to_string(),
             ],
             ..Default::default()
         });
-        self.provenance = Some(serde_json::json!({
-            "id": resolution.provider_id,
-            "handle": resolution.worktree.handle,
-            "path": workspace,
-        }));
         Ok(())
     }
 

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -33,6 +33,7 @@ use homeboy_core::defaults::{
     WorktreeProviderListResultMapping,
 };
 use homeboy_core::lab_contract::AgentTaskDispatchIdentity;
+use homeboy_core::worktree::{self, WorktreeAdoptOptions};
 use homeboy_core::{Error, Result};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -54,6 +55,121 @@ fn configured_promotion_preflight_rejects_missing_provider_before_dispatch() {
     assert!(error
         .message
         .contains("no worktree providers are configured"));
+}
+
+#[cfg(unix)]
+#[test]
+fn adopted_workspace_wins_over_a_rejecting_configured_provider() {
+    use std::os::unix::fs::PermissionsExt;
+
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("adopted workspace");
+        let marker = tempfile::NamedTempFile::new().expect("provider marker");
+        let marker_path = marker.into_temp_path();
+        std::fs::remove_file(&marker_path).expect("remove provider marker");
+        let provider = tempfile::NamedTempFile::new().expect("provider command");
+        std::fs::write(
+            provider.path(),
+            format!("#!/bin/sh\ntouch '{}'\nexit 23\n", marker_path.display()),
+        )
+        .expect("write rejecting provider");
+        let mut permissions = std::fs::metadata(provider.path())
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(provider.path(), permissions).expect("make provider executable");
+
+        worktree::adopt(WorktreeAdoptOptions {
+            handle: "fixture@adopted".to_string(),
+            path: workspace.path().display().to_string(),
+            kind: None,
+            provenance: None,
+        })
+        .expect("adopt workspace");
+
+        let mut config = HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "rejecting".to_string(),
+            WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: true,
+                commands: WorktreeProviderCommands {
+                    resolve: Some(vec![
+                        provider.path().display().to_string(),
+                        "{handle}".to_string(),
+                    ]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(WorktreeProviderListResultMapping {
+                    items: "$.worktrees".to_string(),
+                    handle: "$.handle".to_string(),
+                    path: "$.path".to_string(),
+                    branch: "$.branch".to_string(),
+                    dirty: "$.safety.dirty".to_string(),
+                    unpushed: "$.safety.unpushed".to_string(),
+                    primary: "$.safety.primary".to_string(),
+                }),
+            },
+        );
+
+        preflight_configured_workspace_provider_with_config("fixture@adopted", &config)
+            .expect("Homeboy adopted workspace bypasses provider preflight");
+        assert!(!marker_path.exists(), "provider must not be invoked");
+        let canonical_workspace = workspace
+            .path()
+            .canonicalize()
+            .expect("canonical workspace");
+
+        let mut promotion =
+            ExternalPromotionWorkspaceProvider::from_options_with_config_and_environment(
+                &promotion_options("fixture@adopted"),
+                &config,
+                Some(PathBuf::from("/fixture/homeboy")),
+                None,
+            );
+        let error = promotion
+            .apply_patch(AgentTaskPromotionApplyRequest {
+                schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
+                to_workspace: "fixture@adopted".to_string(),
+                patch: Some(VALID_PATCH.to_string()),
+                patch_path: "changes.patch".to_string(),
+                changed_files: vec!["src/lib.rs".to_string()],
+                gate_feedback_baseline: None,
+                dry_run: false,
+                trusted_unpushed_candidate_destination: None,
+            })
+            .expect_err("fixture executable is not an adapter");
+
+        assert_eq!(
+            promotion
+                .invocation()
+                .expect("adopted workspace invocation")
+                .argv,
+            vec![
+                "/fixture/homeboy".to_string(),
+                "agent-task".to_string(),
+                "promotion-provider".to_string(),
+                "--workspace".to_string(),
+                canonical_workspace.display().to_string(),
+            ]
+        );
+        assert_eq!(promotion.provenance().expect("provenance")["id"], "homeboy");
+        assert_eq!(
+            error.details["worktree_provider"]["path"],
+            canonical_workspace.display().to_string()
+        );
+        assert!(!marker_path.exists(), "provider must not be invoked");
+
+        std::fs::remove_dir_all(workspace.path()).expect("remove adopted workspace");
+        let error = preflight_configured_workspace_provider_with_config("fixture@adopted", &config)
+            .expect_err("stale Homeboy workspace remains fail-closed");
+        assert!(error.message.contains("missing directory"));
+        assert!(
+            !marker_path.exists(),
+            "stale Homeboy record must not fall back"
+        );
+    });
 }
 
 #[test]

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -53,10 +53,35 @@ pub fn resolve_if_present(id: &str) -> Result<Option<TaskWorktreeRecord>> {
 }
 
 pub fn resolve_workspace_ref(handle: &str) -> Result<WorkspaceRefRecord> {
-    if let Ok(record) = read_record(&metadata_dir()?, handle) {
-        return Ok(WorkspaceRefRecord::Task(record));
+    resolve_workspace_ref_if_present(handle)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "workspace_ref",
+            "Workspace handle does not match a Homeboy task worktree or adopted workspace",
+            Some(handle.to_string()),
+            None,
+        )
+    })
+}
+
+/// Returns `None` only when neither Homeboy workspace registry contains the
+/// handle. Corrupt records remain errors so callers never mask them with an
+/// external provider fallback.
+pub fn resolve_workspace_ref_if_present(handle: &str) -> Result<Option<WorkspaceRefRecord>> {
+    let task_path = record_path(&metadata_dir()?, handle);
+    if task_path.exists() {
+        return read_record_path(&task_path)
+            .map(WorkspaceRefRecord::Task)
+            .map(Some);
     }
-    read_adopted_record(&adopted_metadata_dir()?, handle).map(WorkspaceRefRecord::Adopted)
+
+    let adopted_path = record_path(&adopted_metadata_dir()?, handle);
+    if adopted_path.exists() {
+        return read_adopted_record_path(&adopted_path)
+            .map(WorkspaceRefRecord::Adopted)
+            .map(Some);
+    }
+
+    Ok(None)
 }
 
 pub fn remove(options: WorktreeRemoveOptions) -> Result<WorktreeRemoveOutput> {

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -717,12 +717,8 @@ pub(super) fn read_record_path(path: &Path) -> Result<TaskWorktreeRecord> {
         .map_err(|err| Error::internal_json(err.to_string(), Some(path.display().to_string())))
 }
 
-pub(super) fn read_adopted_record(
-    store_dir: &Path,
-    handle: &str,
-) -> Result<AdoptedWorkspaceRecord> {
-    let path = record_path(store_dir, handle);
-    let raw = fs::read_to_string(&path)
+pub(super) fn read_adopted_record_path(path: &Path) -> Result<AdoptedWorkspaceRecord> {
+    let raw = fs::read_to_string(path)
         .map_err(|err| Error::internal_io(err.to_string(), Some(path.display().to_string())))?;
     serde_json::from_str(&raw)
         .map_err(|err| Error::internal_json(err.to_string(), Some(path.display().to_string())))


### PR DESCRIPTION
## Summary

- resolve active Homeboy-owned task and adopted worktree records before consulting configured external providers
- use provider fallback only when no Homeboy record exists
- fail closed for stale Homeboy records instead of silently redirecting through a provider
- preserve existing provider safety validation and promotion targeting

Fixes #9116.

## How to test

1. Check out this branch from a fresh clone.
2. Run `cargo test -p homeboy-core worktree::tests --lib -- --test-threads=1`.
3. Run `cargo test -p homeboy-agents adopted_workspace_wins_over_a_rejecting_configured_provider --lib -- --test-threads=1`.
4. Run `cargo check -p homeboy-core -p homeboy-agents -p homeboy-cli`.
5. Run `cargo fmt --check -p homeboy-core -p homeboy-agents -p homeboy-cli`.
6. Run `git diff --check origin/main...HEAD`.
7. Configure a command worktree provider that rejects a Homeboy-only handle, adopt a checkout with `homeboy worktree adopt example-task <checkout>`, and run cook with `--to-worktree example-task`; confirm the adopted checkout resolves without invoking provider fallback.

## Compatibility

Provider-managed handles without Homeboy records retain existing behavior. Missing, stale, unsafe, primary, dirty, and branch-mismatched targets remain fail-closed.

## Verification

- Homeboy core worktree suite: 20 passed
- Rejecting-provider adopted-worktree regression: passed
- Affected crate checks: passed
- Formatting and diff checks: passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with GPT-5.6 Sol
- **Used for:** Reproduced the resolver precedence failure, implemented the generic fix and deterministic tests, rebased it across current main, and verified it with Chris.