### PR TITLE
Diagnose actual stale runner identity drift

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -29,7 +29,7 @@ use super::session::{
     RunnerActiveJobSource, RunnerActiveJobState, RunnerChangedRuntimePath, RunnerConnectReport,
     RunnerDisconnectReport, RunnerFailureKind, RunnerLeaselessRecoveryContract,
     RunnerLeaselessRecoveryEvidence, RunnerSession, RunnerSessionRole, RunnerSessionState,
-    RunnerStaleDaemonWarning, RunnerStatusReport, RunnerTunnelMode,
+    RunnerStaleDaemonWarning, RunnerStaleRuntimePath, RunnerStatusReport, RunnerTunnelMode,
 };
 use super::{load, remote_runner_homeboy_path, Runner, RunnerKind};
 use homeboy_core::broker_auth;
@@ -1752,12 +1752,14 @@ fn stale_daemon_warning(
         .and_then(|local_url| daemon_http_runtime_loaded_paths(local_url).ok())
         .map(|loaded| changed_runtime_paths(&runner.env, &loaded))
         .unwrap_or_default();
-    if versions_match(&observed_session_version, &current_version)
-        && versions_match(&session.homeboy_version, &current_version)
-        && identity_comparison == IdentityComparison::Match
-        && stale_runtime_paths.is_empty()
-        && changed_runtime_paths.is_empty()
-    {
+    if daemon_runtime_is_current(
+        &observed_session_version,
+        &session.homeboy_version,
+        &current_version,
+        identity_comparison,
+        &stale_runtime_paths,
+        &changed_runtime_paths,
+    ) {
         return Ok(None);
     }
     Ok(Some(
@@ -1775,6 +1777,21 @@ fn stale_daemon_warning(
         )
         .with_runtime_paths(&runner.id, stale_runtime_paths, changed_runtime_paths),
     ))
+}
+
+fn daemon_runtime_is_current(
+    observed_daemon_version: &str,
+    session_version: &str,
+    command_version: &str,
+    identity_comparison: IdentityComparison,
+    stale_runtime_paths: &[RunnerStaleRuntimePath],
+    changed_runtime_paths: &[RunnerChangedRuntimePath],
+) -> bool {
+    versions_match(observed_daemon_version, command_version)
+        && versions_match(session_version, command_version)
+        && identity_comparison == IdentityComparison::Match
+        && stale_runtime_paths.is_empty()
+        && changed_runtime_paths.is_empty()
 }
 
 fn unverifiable_configured_identity_message(homeboy: &str) -> String {

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -365,6 +365,97 @@ fn identity_comparison_distinguishes_match_unverifiable_and_mismatch() {
 }
 
 #[test]
+fn equal_version_build_identity_and_runtime_paths_are_current() {
+    assert!(daemon_runtime_is_current(
+        "0.296.3",
+        "homeboy 0.296.3",
+        "0.296.3",
+        IdentityComparison::Match,
+        &[],
+        &[],
+    ));
+}
+
+#[test]
+fn equal_versions_with_different_build_identities_are_stale_and_name_both_builds() {
+    let warning = RunnerStaleDaemonWarning::new(
+        "homeboy-lab",
+        "0.296.3".to_string(),
+        "0.296.3".to_string(),
+        Some("homeboy 0.296.3+daemon-build".to_string()),
+        Some("homeboy 0.296.3+job-build".to_string()),
+    );
+
+    assert!(!daemon_runtime_is_current(
+        "0.296.3",
+        "0.296.3",
+        "0.296.3",
+        IdentityComparison::Mismatch,
+        &[],
+        &[],
+    ));
+    assert!(warning.message.contains("build identity"));
+    assert!(warning.message.contains("homeboy 0.296.3+daemon-build"));
+    assert!(warning.message.contains("homeboy 0.296.3+job-build"));
+    assert!(!warning.message.contains("version `0.296.3` differs"));
+}
+
+#[test]
+fn runtime_path_drift_is_stale_and_names_the_changed_generation() {
+    let warning = RunnerStaleDaemonWarning::new(
+        "homeboy-lab",
+        "0.296.3".to_string(),
+        "0.296.3".to_string(),
+        Some("homeboy 0.296.3+same-build".to_string()),
+        Some("homeboy 0.296.3+same-build".to_string()),
+    )
+    .with_runtime_paths(
+        "homeboy-lab",
+        vec![RunnerStaleRuntimePath {
+            env: "HOMEBOY_EXTENSION_PATH".to_string(),
+            path: "/srv/extensions".to_string(),
+            loaded_fingerprint: "sha256:old".to_string(),
+            current_fingerprint: "sha256:new".to_string(),
+        }],
+        Vec::new(),
+    );
+
+    assert!(!daemon_runtime_is_current(
+        "0.296.3",
+        "0.296.3",
+        "0.296.3",
+        IdentityComparison::Match,
+        &warning.stale_runtime_paths,
+        &warning.changed_runtime_paths,
+    ));
+    assert!(warning.message.contains("HOMEBOY_EXTENSION_PATH"));
+    assert!(warning.message.contains("sha256:old"));
+    assert!(warning.message.contains("sha256:new"));
+}
+
+#[test]
+fn differing_versions_are_stale_and_name_both_versions() {
+    let warning = RunnerStaleDaemonWarning::new(
+        "homeboy-lab",
+        "0.296.2".to_string(),
+        "0.296.3".to_string(),
+        Some("homeboy 0.296.2+old".to_string()),
+        Some("homeboy 0.296.3+new".to_string()),
+    );
+
+    assert!(!daemon_runtime_is_current(
+        "0.296.2",
+        "0.296.2",
+        "0.296.3",
+        IdentityComparison::Mismatch,
+        &[],
+        &[],
+    ));
+    assert!(warning.message.contains("version `0.296.2`"));
+    assert!(warning.message.contains("version `0.296.3`"));
+}
+
+#[test]
 fn release_only_self_identity_remains_unverifiable() {
     let identity = parse_self_identity_output(
         r#"{"success":true,"data":{"version":"0.294.0","display":"homeboy 0.294.0"}}"#,

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -648,10 +648,8 @@ fn connected_runner_not_ready_reason(
             ));
         }
         return Some(format!(
-            "connected runner `{runner_id}` daemon is stale (severity={}): active daemon control plane reports {}, but the job command binary reports {}; stale runner runtimes can return malformed or misleading provider output; refresh with `{restart}`",
-            warning.severity,
-            warning.active_daemon_control_plane_version,
-            warning.job_command_binary_version
+            "connected runner `{runner_id}` daemon is stale (severity={}): {}; refresh with `{restart}`",
+            warning.severity, warning.message
         ));
     }
 

--- a/crates/homeboy-lab-runner/src/runtime_materialization_status.rs
+++ b/crates/homeboy-lab-runner/src/runtime_materialization_status.rs
@@ -99,8 +99,17 @@ impl RuntimeMaterializationStatus {
         let job_binary = self.job_command_binary_display()?;
         let severity = self.stale_daemon_severity?;
         let refresh = self.stale_daemon_refresh_command.as_deref()?;
+        let reason = self
+            .active_daemon
+            .build_identity
+            .as_deref()
+            .zip(self.job_command_binary_build_identity.as_deref())
+            .map(|(active, job)| {
+                format!("active daemon build `{active}`, job command build `{job}`")
+            })
+            .unwrap_or_else(|| "inspect the runner stale-daemon diagnostic".to_string());
         Some(format!(
-            "Runner `{}` stale daemon severity={severity}: active daemon control plane is `{active_daemon}`, but the job command binary is `{job_binary}`. Refresh with `{refresh}` before using runner/Lab status as version evidence.",
+            "Runner `{}` stale daemon severity={severity}: {reason}; active daemon control plane is `{active_daemon}`, job command binary is `{job_binary}`. Refresh with `{refresh}` before using runner/Lab status as version evidence.",
             self.runner_id
         ))
     }

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -571,6 +571,20 @@ impl RunnerStaleDaemonWarning {
             shell::quote_arg(runner_id),
             homeboy_product_identity::product_version()
         )];
+        let message = if !same_homeboy_version(&session_homeboy_version, &current_homeboy_version) {
+            format!(
+                "connected runner daemon control plane version `{session_homeboy_version}` differs from configured job command binary version `{current_homeboy_version}`; run recovery_commands in order when runner active jobs are drained"
+            )
+        } else if let (Some(session_identity), Some(current_identity)) = (
+            session_homeboy_build_identity.as_deref(),
+            current_homeboy_build_identity.as_deref(),
+        ) {
+            format!(
+                "connected runner daemon control plane build identity `{session_identity}` differs from configured job command binary build identity `{current_identity}`; run recovery_commands in order when runner active jobs are drained"
+            )
+        } else {
+            "connected runner daemon runtime requires explicit identity verification; run recovery_commands in order when runner active jobs are drained".to_string()
+        };
         Self {
             severity: "warning",
             active_daemon_control_plane_version: session_homeboy_version.clone(),
@@ -582,7 +596,7 @@ impl RunnerStaleDaemonWarning {
             session_homeboy_build_identity,
             current_homeboy_build_identity,
             refresh_command: recovery_commands.join(" && "),
-            message: "connected runner daemon control plane was started by a different Homeboy build than the configured job command binary; run recovery_commands in order when runner active jobs are drained".to_string(),
+            message,
             stale_runtime_paths: Vec::new(),
             changed_runtime_paths: Vec::new(),
             recovery_commands,
@@ -618,7 +632,22 @@ impl RunnerStaleDaemonWarning {
         self.stale_runtime_paths = stale_runtime_paths;
         self.changed_runtime_paths = changed_runtime_paths;
         if !self.stale_runtime_paths.is_empty() || !self.changed_runtime_paths.is_empty() {
-            self.message = "connected runner daemon runtime paths are stale; run recovery_commands after active jobs are drained to replace the active daemon with the configured runtime paths".to_string();
+            let stale_paths = self.stale_runtime_paths.iter().map(|path| {
+                format!(
+                    "{} at `{}` fingerprint `{}` -> `{}`",
+                    path.env, path.path, path.loaded_fingerprint, path.current_fingerprint
+                )
+            });
+            let changed_paths = self.changed_runtime_paths.iter().map(|path| {
+                format!(
+                    "{} path `{:?}` -> `{:?}`",
+                    path.env, path.loaded_path, path.configured_path
+                )
+            });
+            self.message = format!(
+                "connected runner daemon runtime paths are stale: {}; run recovery_commands after active jobs are drained to replace the active daemon with the configured runtime paths",
+                stale_paths.chain(changed_paths).collect::<Vec<_>>().join("; ")
+            );
             self.recovery_commands = vec![format!(
                 "homeboy runner refresh-homeboy {} --ref v{} --reconnect",
                 shell::quote_arg(runner_id),
@@ -627,6 +656,14 @@ impl RunnerStaleDaemonWarning {
         }
         self
     }
+}
+
+fn same_homeboy_version(left: &str, right: &str) -> bool {
+    left.trim().strip_prefix("homeboy ").unwrap_or(left.trim())
+        == right
+            .trim()
+            .strip_prefix("homeboy ")
+            .unwrap_or(right.trim())
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/homeboy-lab-runner/src/upgrade_runners/reporting.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/reporting.rs
@@ -108,7 +108,7 @@ pub fn runner_upgrade_final_detail(
             remediation
         };
         parts.push(format!(
-            "connected runner daemon is stale: active daemon control plane reports {}, job command binary reports {}; refresh with `{}`",
+            "connected runner daemon remains stale after runner diagnosis (control-plane version {}, job command binary version {}); refresh with `{}`",
             stale_daemon.session_homeboy_version,
             stale_daemon.current_homeboy_version,
             remediation


### PR DESCRIPTION
## Summary
- treat equal daemon/session/command versions as current when build identity and runtime paths also match
- report the actual differing build identities, versions, or runtime path fingerprints instead of presenting equal versions as the cause
- carry the actionable diagnostic through Lab admission, status, and runner-upgrade reporting
- add deterministic equal-version, identity-drift, path-drift, and version-drift coverage

Closes #9124.

## How to test
1. Run `cargo test -p homeboy-lab-runner connection::tests::session::`.
2. Confirm all equal-version and stale identity/path/version cases pass.
3. Run `rustfmt --edition 2021 --check crates/homeboy-lab-runner/src/connection.rs crates/homeboy-lab-runner/src/connection/tests/session.rs crates/homeboy-lab-runner/src/lab_selection.rs crates/homeboy-lab-runner/src/runtime_materialization_status.rs crates/homeboy-lab-runner/src/session.rs crates/homeboy-lab-runner/src/upgrade_runners/reporting.rs`.

## Backwards compatibility
No public extension path or serialized field is removed. Stale-runner diagnostics become more specific, and equal versions no longer independently produce a misleading version-mismatch explanation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Reviewed the implementation against the reported runtime failure, rebased it onto current main, ran deterministic coverage, and prepared the PR.