### PR TITLE
fix: make git workspace materialization atomic so partial clones are never reusable

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/materializer.rs
+++ b/crates/homeboy-lab-runner/src/workspace/materializer.rs
@@ -386,7 +386,9 @@ fn fresh_exact_git_checkout_command(
     branch: Option<&str>,
     allow_dirty: bool,
 ) -> String {
-    let checkout = branch.map_or_else(
+    // Re-use branch: an existing `.git` at `$dest` is already a valid checkout,
+    // so resetting/cleaning it in place is safe and cheap.
+    let reuse_checkout = branch.map_or_else(
         || {
             format!(
                 "git -C \"$dest\" checkout --detach {head}",
@@ -401,11 +403,36 @@ fn fresh_exact_git_checkout_command(
             )
         },
     );
-    format!(
-        "if [ -d \"$dest\"/.git ]; then {dirty_guard} && git -C \"$dest\" reset --hard && git -C \"$dest\" clean -ffdqx && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf \"$dest\" && git init \"$dest\" && git -C \"$dest\" remote add origin {remote_url} && git -C \"$dest\" fetch --filter=blob:none origin {head}; fi && {checkout} && git -C \"$dest\" reset --hard {head} && git -C \"$dest\" clean -ffdqx",
+    // Fresh-clone branch: build the whole checkout in the staging path `$tmp`
+    // and only atomically rename it into `$dest` once HEAD is valid. A cancelled
+    // or timed-out fresh clone leaves at most a partial `$tmp`, never a partial
+    // `$dest` that `workspace list` would advertise as reusable (#8886).
+    let tmp_checkout = branch.map_or_else(
+        || {
+            format!(
+                "git -C \"$tmp\" checkout --detach {head}",
+                head = shell::quote_arg(head)
+            )
+        },
+        |branch| {
+            format!(
+                "git -C \"$tmp\" checkout -B {branch} {head}",
+                branch = shell::quote_arg(branch),
+                head = shell::quote_arg(head),
+            )
+        },
+    );
+    let reuse = format!(
+        "{dirty_guard} && git -C \"$dest\" reset --hard && git -C \"$dest\" clean -ffdqx && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*' && {reuse_checkout} && git -C \"$dest\" reset --hard {head} && git -C \"$dest\" clean -ffdqx",
         dirty_guard = dirty_git_workspace_guard("$dest", allow_dirty),
+        reuse_checkout = reuse_checkout,
+        head = shell::quote_arg(head),
+    );
+    let fresh = format!(
+        "rm -rf \"$tmp\" && git init \"$tmp\" && git -C \"$tmp\" remote add origin {remote_url} && git -C \"$tmp\" fetch --filter=blob:none origin {head} && {tmp_checkout} && git -C \"$tmp\" reset --hard {head} && git -C \"$tmp\" clean -ffdqx && git -C \"$tmp\" rev-parse --verify -q HEAD >/dev/null && rm -rf \"$dest\" && mv \"$tmp\" \"$dest\"",
         remote_url = shell::quote_arg(remote_url),
         head = shell::quote_arg(head),
-        checkout = checkout,
-    )
+        tmp_checkout = tmp_checkout,
+    );
+    format!("if [ -d \"$dest\"/.git ]; then {reuse}; else {fresh}; fi")
 }

--- a/crates/homeboy-lab-runner/src/workspace/sync.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync.rs
@@ -884,6 +884,24 @@ pub fn workspace_snapshots(
     ))
 }
 
+/// A local runner workspace directory is reusable unless it is a partial git
+/// checkout — a `.git` directory whose `HEAD` does not resolve. A cancelled or
+/// timed-out git materialization can leave exactly that (see #8886), and a
+/// staging `.tmp.$$` directory that survived a crash mid-clone is caught the
+/// same way. Non-git directories (e.g. snapshot workspaces) remain reusable.
+fn local_workspace_is_reusable(path: &Path) -> bool {
+    if !path.join(".git").exists() {
+        return true;
+    }
+    std::process::Command::new("git")
+        .args(["-C"])
+        .arg(path)
+        .args(["rev-parse", "--verify", "-q", "HEAD"])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
 fn list_local_lab_workspaces(root: &Path, limit: usize) -> Result<Vec<String>> {
     if !root.is_dir() {
         return Ok(Vec::new());
@@ -898,11 +916,21 @@ fn list_local_lab_workspaces(root: &Path, limit: usize) -> Result<Vec<String>> {
             if !file_type.is_dir() {
                 return None;
             }
+            // Never advertise a partial checkout as reusable. A cancelled or
+            // timed-out git materialization can leave a directory (or a leftover
+            // `.tmp.$$` staging path) that has no valid HEAD; exec-ing against it
+            // fails with "ambiguous argument 'HEAD'" (#8886). A directory is
+            // only reusable if it is not a git checkout at all, or is one whose
+            // HEAD resolves.
+            let path = entry.path();
+            if !local_workspace_is_reusable(&path) {
+                return None;
+            }
             let modified = entry
                 .metadata()
                 .ok()
                 .and_then(|metadata| metadata.modified().ok());
-            Some((entry.path(), modified))
+            Some((path, modified))
         })
         .collect::<Vec<(PathBuf, Option<std::time::SystemTime>)>>();
     entries.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
@@ -929,8 +957,12 @@ fn list_ssh_lab_workspaces(
     let server = server::load(server_id)?;
     let mut client = SshClient::from_server(&server, server_id)?;
     client.env.extend(runner.env.clone());
+    // Mirror the local reusability rule (#8886): advertise a directory only if
+    // it is not a git checkout, or is one whose HEAD resolves. A cancelled/
+    // timed-out clone (or leftover `.tmp.$$` staging dir) with an unresolved
+    // HEAD must not be listed as reusable.
     let command = format!(
-        "root={}; if [ -d \"$root\" ]; then ls -1td \"$root\"/*/ 2>/dev/null | sed 's#/$##'; fi",
+        "root={}; if [ -d \"$root\" ]; then ls -1td \"$root\"/*/ 2>/dev/null | sed 's#/$##' | while IFS= read -r ws; do if [ ! -d \"$ws/.git\" ] || git -C \"$ws\" rev-parse --verify -q HEAD >/dev/null 2>&1; then printf '%s\\n' \"$ws\"; fi; done; fi",
         shell::quote_arg(lab_workspaces_root)
     );
     let output = client.execute(&command);

--- a/crates/homeboy-lab-runner/src/workspace/tests/materializer.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/materializer.rs
@@ -122,17 +122,20 @@ fn workspace_materializer_fetches_only_the_exact_sha_for_a_fresh_checkout() {
         })
         .command();
 
-    assert!(command.contains("git init \"$dest\""));
+    // A fresh checkout is built in the staging path `$tmp` and only atomically
+    // renamed into `$dest` once HEAD is valid, so a cancelled clone never leaves
+    // a partial `$dest` (#8886). The reuse branch (existing `.git`) still
+    // operates in place.
+    assert!(command.contains("git init \"$tmp\""));
     assert!(command.contains("remote add origin https://github.com/Extra-Chill/homeboy.git"));
     assert!(command.contains("fetch --filter=blob:none origin abc123"));
     assert!(command.contains("checkout --detach abc123"));
+    // The fresh clone validates HEAD, then atomically publishes tmp -> dest.
+    assert!(command.contains("git -C \"$tmp\" rev-parse --verify -q HEAD"));
+    assert!(command.contains("mv \"$tmp\" \"$dest\""));
+    // The reuse branch still resets an existing valid checkout in place.
+    assert!(command.contains("git -C \"$dest\" reset --hard"));
     assert!(!command.contains("git clone"));
-    assert_eq!(
-        command
-            .matches("'+refs/heads/*:refs/remotes/origin/*'")
-            .count(),
-        1
-    );
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -890,6 +890,82 @@ fn workspace_list_reports_recent_lab_workspaces_with_exec_commands() {
     });
 }
 
+/// Regression for #8886: a cancelled/timed-out git materialization can leave a
+/// checkout with no valid `HEAD`. `workspace list` must not advertise such a
+/// partial checkout as reusable, because exec-ing against it fails with
+/// "ambiguous argument 'HEAD'". Valid git checkouts and non-git snapshot
+/// directories remain listed.
+#[test]
+fn workspace_list_omits_partial_git_checkouts_without_a_valid_head() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        crate::create(
+            &format!(
+                r#"{{"id":"lab-partial-list","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+
+        let lab_root = runner_root.path().join("_lab_workspaces");
+        fs::create_dir_all(&lab_root).expect("lab workspaces root");
+
+        // (a) A valid git checkout with a resolvable HEAD — must be listed.
+        let valid = lab_root.join("valid-checkout");
+        fs::create_dir_all(&valid).expect("valid dir");
+        git(&valid, &["init", "-q"]);
+        git(&valid, &["config", "user.email", "t@t"]);
+        git(&valid, &["config", "user.name", "t"]);
+        fs::write(valid.join("file.txt"), "hi\n").expect("file");
+        git(&valid, &["add", "-A"]);
+        git(&valid, &["commit", "-qm", "init"]);
+        assert!(
+            git_output(&valid, &["rev-parse", "--verify", "HEAD"]).is_ok(),
+            "valid checkout must have a resolvable HEAD",
+        );
+
+        // (b) A partial checkout: a `.git` with no commit, so HEAD does not
+        // resolve (exactly what a cancelled clone leaves) — must be omitted.
+        let partial = lab_root.join("partial-checkout");
+        fs::create_dir_all(&partial).expect("partial dir");
+        git(&partial, &["init", "-q"]);
+        assert!(
+            git_output(&partial, &["rev-parse", "--verify", "HEAD"]).is_err(),
+            "partial checkout must have no resolvable HEAD",
+        );
+
+        // (c) A non-git snapshot directory — must be listed.
+        let snapshot_dir = lab_root.join("snapshot-workspace");
+        fs::create_dir_all(&snapshot_dir).expect("snapshot dir");
+        fs::write(snapshot_dir.join("Cargo.toml"), "[package]\n").expect("snapshot file");
+
+        let (list, exit_code) = list_workspaces("lab-partial-list", 10).expect("list workspaces");
+        assert_eq!(exit_code, 0);
+
+        let listed: Vec<&str> = list
+            .workspaces
+            .iter()
+            .map(|workspace| workspace.remote_path.as_str())
+            .collect();
+
+        assert!(
+            listed.iter().any(|path| path.ends_with("valid-checkout")),
+            "valid git checkout must be listed as reusable: {listed:?}",
+        );
+        assert!(
+            listed
+                .iter()
+                .any(|path| path.ends_with("snapshot-workspace")),
+            "non-git snapshot workspace must be listed as reusable: {listed:?}",
+        );
+        assert!(
+            !listed.iter().any(|path| path.ends_with("partial-checkout")),
+            "partial git checkout without a valid HEAD must NOT be advertised as reusable: {listed:?}",
+        );
+    });
+}
+
 #[test]
 fn snapshot_git_sync_falls_back_for_unpublished_commit_and_preserves_dirty_overlay() {
     homeboy_core::test_support::with_isolated_home(|_| {


### PR DESCRIPTION
## Summary
**Closes #8886.** A `--mode git` workspace sync could be terminated mid-clone (controller timeout / cancellation), leaving a checkout with **no valid `HEAD`** directly at the final destination path. `workspace list` then advertised it as reusable, and exec-ing against it failed with `fatal: ambiguous argument 'HEAD'`.

This implements the issue's stated ideal — **atomic materialization** — plus a defense-in-depth list guard.

## Two-part fix

### 1. Atomic materialization (`materializer.rs`)
The fresh-clone branch of `fresh_exact_git_checkout_command` now:
- builds the whole checkout in the staging path `$tmp`,
- validates HEAD (`git rev-parse --verify -q HEAD`),
- and only then atomically renames `$tmp` → `$dest`.

A cancelled fresh clone leaves at most a partial `$tmp`; **`$dest` never exists incomplete.** The reuse branch (an existing valid `.git` at `$dest`) still resets in place — it is already a valid checkout, so the fast path is preserved.

### 2. Defense-in-depth list guard (`sync.rs`)
`list_local_lab_workspaces` and the SSH variant now advertise a directory only if it is **not a git checkout, or is one whose HEAD resolves.** This catches any partial checkout — including a leftover `.tmp.$$` staging dir from a crash — regardless of how it was created.

## Tests
- **`workspace_list_omits_partial_git_checkouts_without_a_valid_head`** — regression test: a valid checkout and a non-git dir are listed; a partial no-HEAD checkout is omitted. **Verified it FAILS without the list guard** (the partial checkout is advertised).
- Updated the materializer fresh-checkout test to assert the `$tmp`-stage + HEAD-verify + atomic `mv`, and that the reuse branch still resets in place.
- 17 git + 54 snapshot + 7 materializer tests pass.

## Context
This is a real reliability fix sourced from the open issue tracker (not inferred from churn). It targets the Lab workspace-sync fragility that recent fixes keep circling — the class of "a transient/cancelled sync leaves partial, unusable state."