### PR TITLE
fix: derive AI disclosure metadata from the selected model

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/catalog.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/catalog.rs
@@ -73,6 +73,51 @@ impl AgentTaskProviderCatalog {
         provider_requires_cwd_git_checkout_with_providers(&self.providers, backend, selector)
     }
 
+    /// Resolve the AI-assistance disclosure string (`ai_tool`) for an effective
+    /// backend/selector/model selection.
+    ///
+    /// This is the single typed disclosure source consumed by direct cook,
+    /// fanout plan/run, and PR finalization so a `--model` override produces a
+    /// correct AI-assistance statement. Resolution order:
+    ///
+    /// 1. The matching provider's profile whose declared `model` equals the
+    ///    effective model — its `ai_disclosure`.
+    /// 2. The provider's `default_ai_disclosure`.
+    /// 3. `None` (callers fall back to their generic default).
+    ///
+    /// A profile without a declared `model` is treated as a wildcard so a
+    /// provider with a single unmodeled profile still supplies its disclosure.
+    pub fn ai_disclosure_for(
+        &self,
+        backend: &str,
+        selector: Option<&str>,
+        model: Option<&str>,
+    ) -> Option<String> {
+        let provider =
+            resolve_provider_for_backend(&self.providers, backend, selector).resolved()?;
+
+        if let Some(model) = model.map(str::trim).filter(|model| !model.is_empty()) {
+            if let Some(disclosure) = provider
+                .cli
+                .profiles
+                .iter()
+                .find(|profile| profile.model.as_deref() == Some(model))
+                .and_then(|profile| profile.ai_disclosure.clone())
+            {
+                return Some(disclosure);
+            }
+        }
+
+        provider.cli.default_ai_disclosure.clone().or_else(|| {
+            provider
+                .cli
+                .profiles
+                .iter()
+                .find(|profile| profile.model.is_none())
+                .and_then(|profile| profile.ai_disclosure.clone())
+        })
+    }
+
     pub fn apply_provider_runner_secret_env_contracts(&self, plan: &mut AgentTaskPlan) {
         apply_provider_runner_secret_env_contracts_with_providers(plan, &self.providers);
     }
@@ -136,6 +181,81 @@ mod tests {
 
         assert_ne!(empty, changed);
         assert!(empty.starts_with("resolved:"));
+    }
+
+    fn disclosure_provider() -> AgentTaskExecutorProvider {
+        // Deserialize from JSON so schema-string and other required defaults are
+        // populated the same way discovery populates them.
+        serde_json::from_value(serde_json::json!({
+            "id": "test.opencode",
+            "backend": "opencode",
+            "cli": {
+                "default_ai_disclosure": "OpenCode (GPT-5.5)",
+                "profiles": [
+                    {
+                        "name": "terra",
+                        "model": "openai/gpt-5.6-terra",
+                        "ai_disclosure": "OpenCode (GPT-5.6 Terra)"
+                    },
+                    {
+                        "name": "sol",
+                        "model": "openai/gpt-5.6-sol",
+                        "ai_disclosure": "OpenCode (GPT-5.6 Sol)"
+                    }
+                ]
+            }
+        }))
+        .expect("valid provider fixture")
+    }
+
+    fn disclosure_catalog() -> AgentTaskProviderCatalog {
+        AgentTaskProviderCatalog {
+            providers: vec![disclosure_provider()],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn ai_disclosure_for_uses_the_model_matching_profile() {
+        let catalog = disclosure_catalog();
+        assert_eq!(
+            catalog
+                .ai_disclosure_for("opencode", None, Some("openai/gpt-5.6-terra"))
+                .as_deref(),
+            Some("OpenCode (GPT-5.6 Terra)"),
+            "a model override must derive its matching profile disclosure"
+        );
+        assert_eq!(
+            catalog
+                .ai_disclosure_for("opencode", None, Some("openai/gpt-5.6-sol"))
+                .as_deref(),
+            Some("OpenCode (GPT-5.6 Sol)")
+        );
+    }
+
+    #[test]
+    fn ai_disclosure_for_falls_back_to_provider_default() {
+        let catalog = disclosure_catalog();
+        // No model and an unknown model both fall back to the provider default.
+        assert_eq!(
+            catalog.ai_disclosure_for("opencode", None, None).as_deref(),
+            Some("OpenCode (GPT-5.5)")
+        );
+        assert_eq!(
+            catalog
+                .ai_disclosure_for("opencode", None, Some("openai/unknown-model"))
+                .as_deref(),
+            Some("OpenCode (GPT-5.5)")
+        );
+    }
+
+    #[test]
+    fn ai_disclosure_for_unknown_backend_is_none() {
+        let catalog = disclosure_catalog();
+        assert_eq!(
+            catalog.ai_disclosure_for("no-such-backend", None, Some("m")),
+            None
+        );
     }
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -674,7 +674,12 @@ impl BatchCookSpec {
                 commit_message,
                 source_refs: self.task_url.clone().into_iter().collect(),
                 protected_branches: self.protected_branches.clone(),
-                ai_tool: self.ai_tool.clone(),
+                ai_tool: resolve_ai_tool_disclosure(
+                    &self.ai_tool,
+                    self.backend.as_deref(),
+                    self.selector.as_deref(),
+                    self.model.as_deref(),
+                ),
                 ai_model: self
                     .model
                     .clone()
@@ -1074,7 +1079,45 @@ fn default_ai_tool() -> String {
                 .flat_map(|provider| provider.cli.profiles.iter())
                 .find_map(|profile| profile.ai_disclosure.clone())
         })
-        .unwrap_or_else(|| "AI-assisted".to_string())
+        .unwrap_or_else(|| GENERIC_AI_DISCLOSURE.to_string())
+}
+
+/// Generic fallback disclosure used when no provider supplies one. Also the
+/// sentinel that marks `ai_tool` as "not explicitly overridden by the operator",
+/// so a `--model` selection can derive a concrete disclosure instead.
+const GENERIC_AI_DISCLOSURE: &str = "AI-assisted";
+
+/// Resolve the effective `ai_tool` disclosure for a cook.
+///
+/// When the operator explicitly supplied `--ai-tool`, that value is preserved.
+/// Otherwise (`ai_tool` is empty or the generic default) the disclosure is
+/// derived from the effective backend/selector/model via the provider catalog —
+/// the single typed disclosure source — so a `--model` override produces a
+/// correct AI-assistance statement rather than a stale hard-coded default.
+/// (#8404)
+pub(super) fn resolve_ai_tool_disclosure(
+    ai_tool: &str,
+    backend: Option<&str>,
+    selector: Option<&str>,
+    model: Option<&str>,
+) -> String {
+    let is_operator_override =
+        !ai_tool.trim().is_empty() && ai_tool.trim() != GENERIC_AI_DISCLOSURE;
+    if is_operator_override {
+        return ai_tool.to_string();
+    }
+
+    let backend = match backend {
+        Some(backend) if !backend.trim().is_empty() => backend.to_string(),
+        _ => match provider::default_backend().ok().flatten() {
+            Some(backend) => backend,
+            None => return ai_tool.to_string(),
+        },
+    };
+
+    AgentTaskProviderCatalog::discover()
+        .ai_disclosure_for(&backend, selector, model)
+        .unwrap_or_else(|| ai_tool.to_string())
 }
 
 fn default_ai_used_for() -> String {
@@ -1141,6 +1184,34 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn resolve_ai_tool_disclosure_preserves_an_explicit_operator_value() {
+        // An operator-supplied disclosure is preserved verbatim regardless of
+        // the selected model. (#8404)
+        let resolved = resolve_ai_tool_disclosure(
+            "Custom Tool (v2)",
+            Some("opencode"),
+            None,
+            Some("openai/gpt-5.6-terra"),
+        );
+        assert_eq!(resolved, "Custom Tool (v2)");
+    }
+
+    #[test]
+    fn resolve_ai_tool_disclosure_keeps_generic_default_for_an_unknown_backend() {
+        // With no explicit override and a backend the catalog cannot resolve,
+        // the generic default is preserved (nothing to derive from). Using an
+        // explicit unknown backend keeps this deterministic regardless of the
+        // providers installed in the test environment.
+        let resolved = resolve_ai_tool_disclosure(
+            GENERIC_AI_DISCLOSURE,
+            Some("no-such-backend-xyz"),
+            None,
+            Some("openai/gpt-5.6-terra"),
+        );
+        assert_eq!(resolved, GENERIC_AI_DISCLOSURE);
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -213,7 +213,12 @@ where
             commit_message,
             source_refs: args.dispatch.task_url.into_iter().collect(),
             protected_branches: args.protected_branches,
-            ai_tool: args.ai_tool.clone(),
+            ai_tool: super::fanout::resolve_ai_tool_disclosure(
+                &args.ai_tool,
+                args.dispatch.backend.as_deref(),
+                args.dispatch.selector.as_deref(),
+                args.dispatch.model.as_deref(),
+            ),
             ai_model: args
                 .dispatch
                 .model


### PR DESCRIPTION
Fixes #8404.

## Problem

A `fanout cook-batch` plan created with `--backend opencode --model openai/gpt-5.6-terra` still emitted `ai_tool: OpenCode (GPT-5.5)` for every cook. Finalization consumes `ai_tool` for the PR AI-assistance disclosure, so a valid model override produced a materially incorrect statement. The same bug affected direct `cook`.

## Root cause

Both cook entry points set `ai_tool` from the untouched default (`self.ai_tool` / `args.ai_tool`) and only derived the **model** from the tool string (`ai_model_from_tool`) — the backward direction. A `--model` override updated the model but never the human-readable `ai_tool` disclosure.

## Fix

Add a single typed disclosure source in the provider catalog:

- `AgentTaskProviderCatalog::ai_disclosure_for(backend, selector, model)` (homeboy-agents) resolves the disclosure from the matching provider profile's declared `model`, falling back to the provider's `default_ai_disclosure`, then `None`.

Both entry points derive `ai_tool` through a shared `resolve_ai_tool_disclosure` helper that:

- **Preserves an explicit operator `--ai-tool`** value (any non-generic, non-empty value).
- Otherwise derives from the **effective backend/selector/model** after defaults resolve (using `default_backend()` when `--backend` is omitted).

Fanout run (`to_cook_invocation`) and PR finalization already consume the resolved `ai_tool`, so direct cook, fanout plan, fanout run, and finalization now share **one** disclosure source.

## Expected behavior mapped to the issue

- ✅ Derive `ai_tool` from the effective backend/model after defaults and overrides resolve.
- ✅ Preserve explicit operator-provided disclosure when supplied.
- ✅ Direct cook, fanout plan, fanout run, and PR finalization use one typed disclosure source.
- ✅ Contract coverage proving model overrides update generated disclosure text.

## Testing

- `ai_disclosure_for_uses_the_model_matching_profile` — `--model` selects the matching profile's disclosure (Terra/Sol).
- `ai_disclosure_for_falls_back_to_provider_default` — no/unknown model → provider default.
- `ai_disclosure_for_unknown_backend_is_none`.
- `resolve_ai_tool_disclosure_preserves_an_explicit_operator_value` and `..._keeps_generic_default_for_an_unknown_backend` (CLI gating).
- Full `agent_task::fanout` (11) and `agent_task_provider::catalog` (4) suites green.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Traced the disclosure mismatch to `ai_tool` being taken from the default while only the model was derived, added a typed `ai_disclosure_for` catalog resolver, and routed both cook entry points through it while preserving explicit operator overrides. Chris reviews and owns the change.