### PR TITLE
Persist candidate adoption progress before verification

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
@@ -177,6 +177,7 @@ fn reconstruct_record(run: &RunRecord) -> Result<AgentTaskRunRecord> {
         latest_executor_evidence: None,
         lifecycle,
         lab_handoff: None,
+        candidate_adoption: None,
         metadata: json!({
             "lifecycle_reconstruction": {
                 "source": "observation_status_and_durable_plan",

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -374,6 +374,7 @@ where
         latest_executor_evidence: None,
         lifecycle: lifecycle_for_submitted_plan(plan),
         lab_handoff: None,
+        candidate_adoption: None,
         metadata,
     };
     store::write_record(&record)?;
@@ -873,6 +874,9 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     let resolved_run_id = resolve_run_id(run_id)?;
     let _ = reconcile_deferred_candidate(&resolved_run_id)?;
     let mut record = store::read_record(&resolved_run_id)?;
+    if reconcile_candidate_adoption(&mut record) {
+        store::write_record(&record)?;
+    }
     if reconcile_pending_runner_submission_intent(&resolved_run_id)? {
         record = store::read_record(&resolved_run_id)?;
     }
@@ -1010,6 +1014,164 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
         }
     }
     Ok(record)
+}
+
+/// Claim or resume the one controller-owned candidate adoption for a run. The
+/// record is written before promotion can invoke a workspace provider or gate.
+pub fn start_candidate_adoption(
+    run_id: &str,
+    candidate_sha: &str,
+    ai_model: &str,
+    active_gate: &str,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let candidate_sha = candidate_sha.to_string();
+    let ai_model = ai_model.to_string();
+    let active_gate = active_gate.to_string();
+    let mut conflict = false;
+    let record = store::mutate_record(&run_id, |record| {
+        let now = now_timestamp();
+        if let Some(existing) = record.candidate_adoption.as_mut() {
+            if existing.state == "verification_running" {
+                if homeboy_core::process::pid_is_running(existing.owner_pid) {
+                    conflict = true;
+                    return false;
+                }
+                existing.state = "interrupted".to_string();
+                existing.phase = "owner_stale".to_string();
+                existing.updated_at = now.clone();
+                existing.terminal_error = Some("adoption owner process is not running".to_string());
+            }
+            if existing.state == "interrupted"
+                && existing.candidate_sha == candidate_sha
+                && existing.ai_model == ai_model
+            {
+                existing.state = "verification_running".to_string();
+                existing.phase = "verification".to_string();
+                existing.active_gate = active_gate.clone();
+                existing.owner_pid = std::process::id();
+                existing.heartbeat_at = now.clone();
+                existing.updated_at = now.clone();
+                existing.resume_count += 1;
+                existing.terminal_error = None;
+                record.updated_at = Some(now);
+                return true;
+            }
+            if existing.state == "verification_running" || existing.state == "interrupted" {
+                conflict = true;
+                return false;
+            }
+        }
+        record.candidate_adoption = Some(AgentTaskCandidateAdoptionAttempt {
+            candidate_sha: candidate_sha.clone(),
+            ai_model: ai_model.clone(),
+            state: "verification_running".to_string(),
+            phase: "verification".to_string(),
+            active_gate: active_gate.clone(),
+            started_at: now.clone(),
+            updated_at: now.clone(),
+            owner_pid: std::process::id(),
+            heartbeat_at: now.clone(),
+            resume_count: 0,
+            terminal_error: None,
+            completed_at: None,
+        });
+        record.updated_at = Some(now);
+        true
+    })?;
+    let record = match record {
+        Some(record) => record,
+        None => store::read_record(&run_id)?,
+    };
+    if conflict {
+        return Err(Error::validation_invalid_argument(
+            "candidate_ref",
+            "candidate adoption conflicts with an existing durable attempt; use its immutable candidate SHA and model after recovery",
+            Some(candidate_sha),
+            None,
+        ));
+    }
+    let attempt = record.candidate_adoption.as_ref().ok_or_else(|| {
+        Error::internal_unexpected("candidate adoption claim did not persist a durable attempt")
+    })?;
+    if attempt.state != "verification_running"
+        || attempt.owner_pid != std::process::id()
+        || attempt.candidate_sha != candidate_sha
+        || attempt.ai_model != ai_model
+    {
+        return Err(Error::validation_invalid_argument(
+            "candidate_ref",
+            "candidate adoption conflicts with an existing durable attempt; use its immutable candidate SHA and model after recovery",
+            Some(candidate_sha),
+            None,
+        ));
+    }
+    Ok(record)
+}
+
+pub fn checkpoint_candidate_adoption(run_id: &str, phase: &str, active_gate: &str) -> Result<()> {
+    let run_id = sanitize_run_id(run_id);
+    store::mutate_record(&run_id, |record| {
+        let Some(attempt) = record.candidate_adoption.as_mut() else {
+            return false;
+        };
+        if attempt.state != "verification_running" {
+            return false;
+        }
+        let now = now_timestamp();
+        attempt.phase = phase.to_string();
+        attempt.active_gate = active_gate.to_string();
+        attempt.updated_at = now.clone();
+        attempt.heartbeat_at = now.clone();
+        record.updated_at = Some(now);
+        true
+    })?;
+    Ok(())
+}
+
+pub fn finish_candidate_adoption(
+    run_id: &str,
+    error: Option<String>,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let record = store::mutate_record(&run_id, |record| {
+        let Some(attempt) = record.candidate_adoption.as_mut() else {
+            return false;
+        };
+        let now = now_timestamp();
+        attempt.updated_at = now.clone();
+        attempt.heartbeat_at = now.clone();
+        attempt.completed_at = Some(now.clone());
+        attempt.terminal_error = error.clone();
+        attempt.state = if error.is_some() {
+            "failed"
+        } else {
+            "completed"
+        }
+        .to_string();
+        attempt.phase = "terminal".to_string();
+        record.updated_at = Some(now);
+        true
+    })?;
+    Ok(record.unwrap_or(store::read_record(&run_id)?))
+}
+
+fn reconcile_candidate_adoption(record: &mut AgentTaskRunRecord) -> bool {
+    let Some(attempt) = record.candidate_adoption.as_mut() else {
+        return false;
+    };
+    if attempt.state != "verification_running"
+        || homeboy_core::process::pid_is_running(attempt.owner_pid)
+    {
+        return false;
+    }
+    let now = now_timestamp();
+    attempt.state = "interrupted".to_string();
+    attempt.phase = "owner_stale".to_string();
+    attempt.updated_at = now.clone();
+    attempt.terminal_error = Some("adoption owner process is not running; rerun adopt with the recorded candidate SHA to resume".to_string());
+    record.updated_at = Some(now);
+    true
 }
 
 /// Refresh accepted runner handoffs and expire unbound controller handoffs before

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -108,8 +108,31 @@ pub struct AgentTaskRunRecord {
     pub lifecycle: RunLifecycleRecord,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lab_handoff: Option<AgentTaskLabHandoff>,
+    /// Controller-owned progress for an externally prepared candidate being
+    /// verified against this durable cook run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub candidate_adoption: Option<AgentTaskCandidateAdoptionAttempt>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskCandidateAdoptionAttempt {
+    pub candidate_sha: String,
+    pub ai_model: String,
+    pub state: String,
+    pub phase: String,
+    pub active_gate: String,
+    pub started_at: String,
+    pub updated_at: String,
+    pub owner_pid: u32,
+    pub heartbeat_at: String,
+    #[serde(default)]
+    pub resume_count: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<String>,
 }
 
 /// Durable authority for a controller-to-Lab runner handoff. This lives on the

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -769,6 +769,7 @@ fn detached_runner_failure_transitions_parent_and_task_terminal() {
         latest_executor_evidence: None,
         lifecycle: lifecycle_for_submitted_plan(&plan),
         lab_handoff: None,
+        candidate_adoption: None,
         metadata: json!({ "runner_id": "homeboy-lab", "runner_job_id": "job-123" }),
     };
     record.tasks[0].state = AgentTaskState::Running;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -17,6 +17,91 @@ use homeboy_core::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};
 use std::sync::{Arc, Mutex};
 
+#[test]
+fn candidate_adoption_status_persists_running_stale_resume_and_completion() {
+    with_isolated_home(|_| {
+        let record = submit_plan(&test_plan(), Some("adoption-progress")).expect("submit");
+        let candidate = "a3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1";
+
+        start_candidate_adoption(
+            &record.run_id,
+            candidate,
+            "openai/gpt-5.6-terra",
+            "cargo test",
+        )
+        .expect("claim before verifier starts");
+        let running = status(&record.run_id).expect("status exposes active adoption");
+        let adoption = running
+            .candidate_adoption
+            .expect("durable adoption attempt");
+        assert_eq!(adoption.state, "verification_running");
+        assert_eq!(adoption.candidate_sha, candidate);
+        assert_eq!(adoption.active_gate, "cargo test");
+
+        let duplicate = start_candidate_adoption(
+            &record.run_id,
+            candidate,
+            "openai/gpt-5.6-terra",
+            "cargo test",
+        )
+        .expect_err("live duplicate is rejected");
+        assert_eq!(duplicate.details["field"], "candidate_ref");
+
+        rewrite_record_for_test(&record.run_id, |record| {
+            record
+                .candidate_adoption
+                .as_mut()
+                .expect("attempt")
+                .owner_pid = u32::MAX;
+        })
+        .expect("make owner stale without sleeping");
+        let interrupted = status(&record.run_id).expect("status reconciles stale owner");
+        assert_eq!(
+            interrupted.candidate_adoption.expect("attempt").state,
+            "interrupted"
+        );
+
+        for (other_candidate, other_model) in [
+            (
+                "b3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1",
+                "openai/gpt-5.6-terra",
+            ),
+            (candidate, "openai/gpt-5.6-sol"),
+        ] {
+            let conflict = start_candidate_adoption(
+                &record.run_id,
+                other_candidate,
+                other_model,
+                "cargo test",
+            )
+            .expect_err("interrupted attempt only resumes with exact candidate and model");
+            assert_eq!(conflict.details["field"], "candidate_ref");
+        }
+
+        start_candidate_adoption(
+            &record.run_id,
+            candidate,
+            "openai/gpt-5.6-terra",
+            "cargo test",
+        )
+        .expect("same immutable candidate resumes");
+        checkpoint_candidate_adoption(&record.run_id, "finalization", "finalize pull request")
+            .expect("finalization checkpoint");
+        let finalizing = status(&record.run_id).expect("finalization status");
+        let adoption = finalizing.candidate_adoption.expect("attempt");
+        assert_eq!(adoption.phase, "finalization");
+        assert_eq!(adoption.active_gate, "finalize pull request");
+        finish_candidate_adoption(&record.run_id, None).expect("terminal completion");
+        let completed = status(&record.run_id).expect("completed status");
+        let adoption = completed
+            .candidate_adoption
+            .expect("terminal attempt retained");
+        assert_eq!(adoption.state, "completed");
+        assert_eq!(adoption.resume_count, 1);
+        assert!(adoption.completed_at.is_some());
+    });
+}
+
 #[cfg(unix)]
 #[test]
 fn artifact_recovery_rejects_wrong_hash_and_identity_without_record_mutation() {

--- a/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
@@ -125,6 +125,10 @@ fn ensure_clean_source(cwd: &Path) -> Result<()> {
     ))
 }
 
+pub(crate) fn resolve_candidate_revision(cwd: &Path, requested: &str) -> Result<String> {
+    resolve_candidate(cwd, Some(requested))
+}
+
 fn resolve_candidate(cwd: &Path, requested: Option<&str>) -> Result<String> {
     let candidate = requested.unwrap_or("HEAD");
     git_stdout(

--- a/crates/homeboy-agents/src/agent_task_promotion/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/mod.rs
@@ -11,6 +11,7 @@
 
 mod apply;
 mod committed_changes;
+pub(crate) use committed_changes::resolve_candidate_revision;
 mod fingerprint;
 mod patch;
 mod promote;

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -17,6 +17,7 @@ use crate::agent_task_finalization::{
 };
 use crate::agent_task_gate::VerifyGateOptions;
 use crate::agent_task_lifecycle;
+use crate::agent_task_promotion::resolve_candidate_revision;
 use crate::agent_task_promotion::{
     promote_with_checkpoint, AgentTaskPromotionOptions, AgentTaskPromotionReport,
 };
@@ -212,7 +213,36 @@ fn adopt_cook_candidate_with_dispatcher_and_backend<B: AgentTaskPrFinalizationBa
         ));
     }
     let (source, source_path, recovery) = candidate_adoption_source(&record, &source_request)?;
-    let mut promotion = promote_with_checkpoint(
+    let (adoption_ai_model, ai_model_source) = match adoption.ai_model {
+        Some(model) => (concrete_adoption_ai_model(&model)?, "candidate_input"),
+        None => (
+            concrete_adoption_ai_model(options.ai_model.as_deref().unwrap_or_default())?,
+            "recipe_finalization",
+        ),
+    };
+    let source_worktree = options.source_worktree_path.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "candidate_ref",
+            "candidate adoption requires the recorded source worktree",
+            None,
+            None,
+        )
+    })?;
+    // Resolve the caller input to the commit object before durable ownership is
+    // claimed, then use that immutable SHA for every subsequent operation.
+    let candidate_sha = resolve_candidate_revision(source_worktree, candidate_ref)?;
+    let gate_identity = if options.gates.verify.is_empty() {
+        "promotion verification".to_string()
+    } else {
+        options.gates.verify.join(" && ")
+    };
+    agent_task_lifecycle::start_candidate_adoption(
+        &record.run_id,
+        &candidate_sha,
+        &adoption_ai_model,
+        &gate_identity,
+    )?;
+    let promotion = promote_with_checkpoint(
         AgentTaskPromotionOptions {
             source,
             source_run_id: Some(record.run_id.clone()),
@@ -220,7 +250,7 @@ fn adopt_cook_candidate_with_dispatcher_and_backend<B: AgentTaskPrFinalizationBa
             source_worktree_path: options.source_worktree_path.clone(),
             base_ref: Some(options.base.clone()),
             task_base_sha: options.task_base_sha.clone(),
-            candidate_ref: Some(candidate_ref.to_string()),
+            candidate_ref: Some(candidate_sha.clone()),
             to_worktree: options.to_worktree.clone(),
             task_id: None,
             artifact_id: None,
@@ -236,15 +266,23 @@ fn adopt_cook_candidate_with_dispatcher_and_backend<B: AgentTaskPrFinalizationBa
                     Some("serialize adopted candidate checkpoint".to_string()),
                 )
             })?;
+            agent_task_lifecycle::checkpoint_candidate_adoption(
+                &record.run_id,
+                "post_apply_verification",
+                &gate_identity,
+            )?;
             agent_task_lifecycle::record_promotion(&record.run_id, checkpoint).map(|_| ())
         },
-    )?;
-    let (adoption_ai_model, ai_model_source) = match adoption.ai_model {
-        Some(model) => (concrete_adoption_ai_model(&model)?, "candidate_input"),
-        None => (
-            concrete_adoption_ai_model(options.ai_model.as_deref().unwrap_or_default())?,
-            "recipe_finalization",
-        ),
+    );
+    let mut promotion = match promotion {
+        Ok(promotion) => promotion,
+        Err(error) => {
+            agent_task_lifecycle::finish_candidate_adoption(
+                &record.run_id,
+                Some(error.message.clone()),
+            )?;
+            return Err(error);
+        }
     };
     // The adopted candidate did not run through this cook's provider lifecycle.
     // Bind its declared model to the authenticated promotion instead of inferring
@@ -252,7 +290,7 @@ fn adopt_cook_candidate_with_dispatcher_and_backend<B: AgentTaskPrFinalizationBa
     options.ai_model = Some(adoption_ai_model.clone());
     promotion.provenance["adoption"] = serde_json::json!({
         "source_run_id": record.run_id,
-        "candidate_ref": candidate_ref,
+        "candidate_ref": candidate_sha,
         "source_worktree_path": options.source_worktree_path,
         "recorded_task_base": options.task_base_sha,
         "recovery": recovery,
@@ -280,6 +318,10 @@ fn adopt_cook_candidate_with_dispatcher_and_backend<B: AgentTaskPrFinalizationBa
         feedback: Some(feedback.clone()),
     };
     if feedback.status != AgentTaskCookLoopStatus::GreenCompleted {
+        agent_task_lifecycle::finish_candidate_adoption(
+            &record.run_id,
+            Some("adopted candidate did not pass the original deterministic gates".to_string()),
+        )?;
         return Ok(cook_report(
             cook_id.to_string(),
             "gate_failed",
@@ -290,6 +332,7 @@ fn adopt_cook_candidate_with_dispatcher_and_backend<B: AgentTaskPrFinalizationBa
         ));
     }
     if options.no_finalize {
+        agent_task_lifecycle::finish_candidate_adoption(&record.run_id, None)?;
         return Ok(cook_report(
             cook_id.to_string(),
             "green_no_finalize",
@@ -302,8 +345,27 @@ fn adopt_cook_candidate_with_dispatcher_and_backend<B: AgentTaskPrFinalizationBa
             0,
         ));
     }
-    let finalization =
-        finalize_or_load_cook_pr_with_backend(&options, &record.run_id, &promotion, backend)?;
+    agent_task_lifecycle::checkpoint_candidate_adoption(
+        &record.run_id,
+        "finalization",
+        "finalize pull request",
+    )?;
+    let finalization = match finalize_or_load_cook_pr_with_backend(
+        &options,
+        &record.run_id,
+        &promotion,
+        backend,
+    ) {
+        Ok(finalization) => finalization,
+        Err(error) => {
+            agent_task_lifecycle::finish_candidate_adoption(
+                &record.run_id,
+                Some(error.message.clone()),
+            )?;
+            return Err(error);
+        }
+    };
+    agent_task_lifecycle::finish_candidate_adoption(&record.run_id, None)?;
     let status = finalization["status"]
         .as_str()
         .unwrap_or("unknown")
@@ -2178,11 +2240,15 @@ mod tests {
             git(&source, &["commit", "-am", "candidate"]);
             let candidate = git_output(&source, &["rev-parse", "HEAD"]);
             let provider = temp.path().join("promotion-provider.sh");
+            let provider_started = temp.path().join("provider-started");
+            let provider_release = temp.path().join("provider-release");
             std::fs::write(
                 &provider,
                 format!(
-                    "#!/bin/sh\ncat >/dev/null\ngit -C {target} fetch origin {candidate}\ngit -C {target} checkout --detach FETCH_HEAD\nprintf '{{\"schema\":\"homeboy/agent-task-promotion-apply-response/v1\",\"workspace_path\":\"{target}\",\"command_evidence\":[]}}'\n",
+                    "#!/bin/sh\ncat >/dev/null\ntouch {provider_started}\nwhile ! test -f {provider_release}; do sleep 0.01; done\ngit -C {target} fetch origin {candidate}\ngit -C {target} checkout --detach FETCH_HEAD\nprintf '{{\"schema\":\"homeboy/agent-task-promotion-apply-response/v1\",\"workspace_path\":\"{target}\",\"command_evidence\":[]}}'\n",
                     target = target.display(),
+                    provider_started = provider_started.display(),
+                    provider_release = provider_release.display(),
                 ),
             )
             .expect("write promotion provider");
@@ -2261,20 +2327,51 @@ mod tests {
                 .message
                 .contains("candidate revision must equal the recorded source worktree HEAD"));
 
-            let mut backend = CaptureBackend {
-                hydrate_run_id: Some(run_id.to_string()),
-                ..Default::default()
-            };
-            let result = adopt_cook_candidate_with_dispatcher_and_backend(
-                cook_id,
-                &candidate,
-                AgentTaskCandidateAdoptionOptions {
-                    ai_model: Some("openai/gpt-5.6-sol".to_string()),
-                },
-                |_| Ok(None),
-                &mut backend,
-            )
-            .expect("historical recipe adoption succeeds");
+            let candidate_for_thread = candidate.clone();
+            let adoption = std::thread::spawn(move || {
+                let mut backend = CaptureBackend {
+                    hydrate_run_id: Some(run_id.to_string()),
+                    ..Default::default()
+                };
+                let result = adopt_cook_candidate_with_dispatcher_and_backend(
+                    cook_id,
+                    &candidate_for_thread,
+                    AgentTaskCandidateAdoptionOptions {
+                        ai_model: Some("openai/gpt-5.6-sol".to_string()),
+                    },
+                    |_| Ok(None),
+                    &mut backend,
+                );
+                (result, backend)
+            });
+            let provider_started_in_time = (0..500).any(|_| {
+                if provider_started.exists() {
+                    return true;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                false
+            });
+            let running = provider_started_in_time
+                .then(|| agent_task_lifecycle::status(run_id))
+                .transpose();
+            // Always release and join before asserting so a regression cannot
+            // strand the fake provider and hang the test process.
+            std::fs::write(&provider_release, "release").expect("release provider");
+            let adoption_result = adoption.join();
+            assert!(provider_started_in_time, "promotion provider did not start");
+            let running = running
+                .expect("blocked adoption status")
+                .expect("provider started before status capture");
+            let active = running.candidate_adoption.expect("active adoption attempt");
+            assert_eq!(active.state, "verification_running");
+            assert_eq!(active.phase, "verification");
+            assert_eq!(active.active_gate, "test \"$(cat lib.rs)\" = candidate");
+            assert_eq!(active.candidate_sha, candidate);
+            assert_eq!(active.ai_model, "openai/gpt-5.6-sol");
+            assert_eq!(active.owner_pid, std::process::id());
+            assert!(!active.heartbeat_at.is_empty());
+            let (result, backend) = adoption_result.expect("adoption thread completes");
+            let result = result.expect("historical recipe adoption succeeds");
 
             assert_eq!(result.exit_code, 0);
             assert_eq!(result.value.status, "review_ready");
@@ -2310,6 +2407,12 @@ mod tests {
                 promoted.metadata["latest_promotion"]["provenance"]["adoption"]["ai_model_source"],
                 "candidate_input"
             );
+            let adoption = promoted
+                .candidate_adoption
+                .expect("terminal adoption status");
+            assert_eq!(adoption.state, "completed");
+            assert_eq!(adoption.candidate_sha, candidate);
+            assert_eq!(adoption.ai_model, "openai/gpt-5.6-sol");
             assert!(backend.body.contains("- **Tool(s):** test"));
             assert!(backend.body.contains("- **Model:** openai/gpt-5.6-sol"));
             assert!(backend.committed && backend.pushed && backend.created);


### PR DESCRIPTION
## Summary
- claim durable candidate-adoption ownership before promotion or verification starts
- expose immutable SHA, concrete model, phase, active gate, owner, heartbeat, timestamps, resume count, and terminal errors through the existing run record/status projection
- mark dead owners interrupted and permit only exact SHA/model resume while rejecting live or mismatched duplicate attempts
- checkpoint post-apply verification and PR finalization, then terminalize success or failure

Fixes #9146.
Unblocks #9095.

## How to test
1. Run `cargo test -p homeboy-agents candidate_adoption_status_persists_running_stale_resume_and_completion --lib`.
2. Run `cargo test -p homeboy-agents historical_orphan_recipe_adoption_uses_recorded_policy_without_provider_replay --lib`. This synchronized integration test blocks the promotion provider, reads durable status while adoption is active, releases it, and verifies terminal completion.
3. Run `cargo test -p homeboy-agents status_marks_running_run_without_owner_as_stale --lib`.
4. Run `cargo check -p homeboy-agents`.
5. Run `cargo fmt --check && git diff --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode
- **Used for:** Diagnosed the missing lifecycle checkpoint, implemented durable adoption ownership and recovery transitions, and drafted deterministic lifecycle/integration tests.