### PR TITLE
Make runner binary selection workflow-safe

### DIFF
--- a/crates/homeboy-lab-runner/src/command_path.rs
+++ b/crates/homeboy-lab-runner/src/command_path.rs
@@ -46,10 +46,10 @@ pub(crate) fn normalize_runner_command_env_for_homeboy_path(
         return;
     };
     prepend_path_entry(env, parent);
-    env.insert(
-        "HOMEBOY_COMMAND".to_string(),
-        homeboy_path.display().to_string(),
-    );
+    // A durable runner job can pin its command binary. Configuration selects
+    // the daemon control binary only when the job did not make that selection.
+    env.entry("HOMEBOY_COMMAND".to_string())
+        .or_insert_with(|| homeboy_path.display().to_string());
 }
 
 fn prepend_path_entry(env: &mut HashMap<String, String>, entry: &str) {
@@ -677,6 +677,33 @@ mod tests {
         normalize_runner_command_env(&mut env);
 
         assert_eq!(env.get("PATH").map(String::as_str), Some("/custom/bin"));
+    }
+
+    #[test]
+    fn explicit_job_binary_is_not_replaced_by_runner_configuration() {
+        let mut env = HashMap::from([(
+            "HOMEBOY_COMMAND".to_string(),
+            "/build-b/homeboy".to_string(),
+        )]);
+
+        normalize_runner_command_env_for_homeboy_path(&mut env, Some("/build-a/homeboy"));
+
+        assert_eq!(
+            env.get("HOMEBOY_COMMAND"),
+            Some(&"/build-b/homeboy".to_string())
+        );
+    }
+
+    #[test]
+    fn configured_binary_is_used_when_job_does_not_select_one() {
+        let mut env = HashMap::new();
+
+        normalize_runner_command_env_for_homeboy_path(&mut env, Some("/build-a/homeboy"));
+
+        assert_eq!(
+            env.get("HOMEBOY_COMMAND"),
+            Some(&"/build-a/homeboy".to_string())
+        );
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -67,6 +67,14 @@ pub(super) fn exec_via_reverse_broker(
     )?;
     let redaction_env = env.clone();
     let redaction_secret_env_names = secret_env_names.clone();
+    let mut env = env;
+    // Snapshot the configured command binary into the durable job. A later
+    // daemon refresh must not redirect work that has already been accepted.
+    if !env.contains_key("HOMEBOY_COMMAND") {
+        if let Some(homeboy_path) = runner.settings.homeboy_path.as_deref() {
+            env.insert("HOMEBOY_COMMAND".to_string(), homeboy_path.to_string());
+        }
+    }
     let mut request = RemoteRunnerJobRequest {
         runner_id: runner.id.clone(),
         project_id,

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -82,6 +82,15 @@ pub(super) fn exec_via_daemon(
         durable_run_id: run_id.clone(),
         ..Default::default()
     };
+    let mut env = env;
+    // `/exec` persists this environment with the accepted job. Snapshot the
+    // command binary now so a later runner refresh cannot redirect queued or
+    // running direct-daemon work.
+    if !env.contains_key("HOMEBOY_COMMAND") {
+        if let Some(homeboy_path) = runner.settings.homeboy_path.as_deref() {
+            env.insert("HOMEBOY_COMMAND".to_string(), homeboy_path.to_string());
+        }
+    }
     let payload = json!({
         "runner_id": runner.id,
         "runner": runner,

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -94,6 +94,8 @@ pub struct HomeboyReconnectDeferred {
     pub active_job_ids: Vec<String>,
     pub selected_binary_path: String,
     pub followup_commands: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ownership_contention: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -376,6 +378,7 @@ pub fn refresh_homeboy_binary(
                     active_job_ids,
                     selected_binary_path: plan.binary_path.clone(),
                     followup_commands,
+                    ownership_contention: None,
                 }),
                 failure: None,
                 bootstrap_provenance: None,
@@ -478,7 +481,34 @@ pub fn refresh_homeboy_binary(
             options.force,
         ) {
             Ok(job_ids) => job_ids,
-            Err(_) => unreachable!("reconnect admission was checked before binary promotion"),
+            Err(_) => {
+                let deferred = defer_reconnect_after_promotion_race(
+                    &plan.runner_id,
+                    &plan.binary_path,
+                    previous_homeboy_path.as_deref(),
+                    &active_jobs,
+                )?;
+                return Ok((
+                    HomeboyBinaryRefreshOutput {
+                        variant: "refresh_homeboy",
+                        command: "runner.refresh_homeboy",
+                        runner_id: plan.runner_id.clone(),
+                        dry_run: false,
+                        plan: plan.clone(),
+                        identity: Some(identity),
+                        updated_fields: Vec::new(),
+                        daemon_refreshed: false,
+                        interrupted_job_ids: Vec::new(),
+                        selected_binary_path: plan.binary_path.clone(),
+                        reconnect_required: true,
+                        followup_commands: deferred.followup_commands.clone(),
+                        reconnect_deferred: Some(deferred),
+                        failure: None,
+                        bootstrap_provenance: None,
+                    },
+                    1,
+                ));
+            }
         };
         if let Err(error) =
             disconnect_with_session(&plan.runner_id, refresh_session.as_ref(), options.force)
@@ -1259,6 +1289,33 @@ fn restore_runner_homeboy_path_if_selected(
         match merge(Some(runner_id), &patch.to_string(), &[])? {
             MergeOutput::Single(_) | MergeOutput::Bulk(_) => Ok(true),
         }
+    })
+}
+
+fn defer_reconnect_after_promotion_race(
+    runner_id: &str,
+    selected_homeboy_path: &str,
+    previous_homeboy_path: Option<&str>,
+    active_jobs: &[homeboy_core::api_jobs::ActiveRunnerJobSummary],
+) -> Result<HomeboyReconnectDeferred> {
+    let active_job_ids = active_jobs
+        .iter()
+        .map(|job| job.job_id.clone())
+        .collect::<Vec<_>>();
+    let restored = restore_runner_homeboy_path_if_selected(
+        runner_id,
+        selected_homeboy_path,
+        previous_homeboy_path,
+    )?;
+    let ownership_contention = (!restored).then(|| format!(
+        "runner `{runner_id}` binary selection changed after this promotion selected `{selected_homeboy_path}`; preserving the newer owner while reconnect remains deferred"
+    ));
+    Ok(HomeboyReconnectDeferred {
+        reason: "active_daemon_jobs",
+        active_job_ids: active_job_ids.clone(),
+        selected_binary_path: selected_homeboy_path.to_string(),
+        followup_commands: active_job_followups(runner_id, &active_job_ids),
+        ownership_contention,
     })
 }
 

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -1364,45 +1364,6 @@ where
     reconnect(previous_homeboy_path)
 }
 
-fn rollback_refresh_error<T>(
-    runner_id: &str,
-    previous_homeboy_path: Option<&str>,
-    primary_error: Error,
-) -> Result<T> {
-    rollback_refresh_error_with(primary_error, || {
-        restore_runner_homeboy_path(runner_id, previous_homeboy_path)
-    })
-}
-
-/// Once the old daemon has been stopped, restoring only the configured binary
-/// leaves no valid controller session. Restore and reconnect as one
-/// compensation step so a later request cannot carry stale lease proof.
-fn rollback_refresh_connect_error<T>(
-    runner_id: &str,
-    previous_homeboy_path: Option<&str>,
-    primary_error: Error,
-) -> Result<T> {
-    rollback_refresh_connect_error_with(
-        primary_error,
-        || restore_runner_homeboy_path(runner_id, previous_homeboy_path),
-        || {
-            let (report, exit_code) =
-                connect_with_orphan_adoption(runner_id, None, &[], false, None, None, None)?;
-            if exit_code != 0 || !report.connected {
-                return Err(Error::validation_invalid_argument(
-                    "reconnect",
-                    report.failure_message.unwrap_or_else(|| {
-                        "rollback reconnect did not persist an active daemon session".to_string()
-                    }),
-                    Some(runner_id.to_string()),
-                    None,
-                ));
-            }
-            Ok(())
-        },
-    )
-}
-
 fn rollback_refresh_connect_error_with<T, Restore, Reconnect>(
     primary_error: Error,
     restore: Restore,

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -338,6 +338,52 @@ pub fn refresh_homeboy_binary(
         ));
     }
 
+    // A reconnect replaces the daemon control plane. Prove it is admissible
+    // before selecting the new global binary: a deferred refresh must leave
+    // the active daemon and its configured control binary untouched.
+    let deferred_active_jobs = if options.reconnect {
+        promotion_lease.assert_generation()?;
+        let active_jobs = active_jobs_before_daemon_replacement(&plan.runner_id)?;
+        match protect_active_jobs_before_reconnect(&plan.runner_id, &active_jobs, options.force) {
+            Ok(_) => None,
+            Err(_) => Some(active_jobs),
+        }
+    } else {
+        None
+    };
+    if let Some(active_jobs) = deferred_active_jobs {
+        let active_job_ids = active_jobs
+            .iter()
+            .map(|job| job.job_id.clone())
+            .collect::<Vec<_>>();
+        let followup_commands = active_job_followups(&plan.runner_id, &active_job_ids);
+        return Ok((
+            HomeboyBinaryRefreshOutput {
+                variant: "refresh_homeboy",
+                command: "runner.refresh_homeboy",
+                runner_id: plan.runner_id.clone(),
+                dry_run: false,
+                plan: plan.clone(),
+                identity: parse_identity(&exec_output.stdout).ok(),
+                updated_fields: Vec::new(),
+                daemon_refreshed: false,
+                interrupted_job_ids: Vec::new(),
+                selected_binary_path: plan.binary_path.clone(),
+                reconnect_required: true,
+                followup_commands: followup_commands.clone(),
+                reconnect_deferred: Some(HomeboyReconnectDeferred {
+                    reason: "active_daemon_jobs",
+                    active_job_ids,
+                    selected_binary_path: plan.binary_path.clone(),
+                    followup_commands,
+                }),
+                failure: None,
+                bootstrap_provenance: None,
+            },
+            1,
+        ));
+    }
+
     promotion_lease.assert_generation()?;
     // Only a reconnect replaces the daemon, so it is the only mode allowed to
     // change the runner-global daemon control binary. A non-reconnecting
@@ -432,65 +478,19 @@ pub fn refresh_homeboy_binary(
             options.force,
         ) {
             Ok(job_ids) => job_ids,
-            Err(_) => {
-                let active_job_ids = active_jobs
-                    .iter()
-                    .map(|job| job.job_id.clone())
-                    .collect::<Vec<_>>();
-                let followup_commands = active_job_followups(&plan.runner_id, &active_job_ids);
-                return Ok((
-                    HomeboyBinaryRefreshOutput {
-                        variant: "refresh_homeboy",
-                        command: "runner.refresh_homeboy",
-                        runner_id: plan.runner_id.clone(),
-                        dry_run: false,
-                        plan: plan.clone(),
-                        identity: Some(identity.clone()),
-                        updated_fields: updated_fields.clone(),
-                        daemon_refreshed: false,
-                        interrupted_job_ids: Vec::new(),
-                        selected_binary_path: plan.binary_path.clone(),
-                        reconnect_required: true,
-                        followup_commands: followup_commands.clone(),
-                        reconnect_deferred: Some(HomeboyReconnectDeferred {
-                            reason: "active_daemon_jobs",
-                            active_job_ids,
-                            selected_binary_path: plan.binary_path.clone(),
-                            followup_commands,
-                        }),
-                        failure: None,
-                        bootstrap_provenance: Some(HomeboyBootstrapProvenance {
-                            transport: if disconnected_ssh {
-                                "ssh_bootstrap"
-                            } else {
-                                "daemon"
-                            },
-                            requested_ref: plan.git_ref.clone(),
-                            resolved_source_sha: bootstrap.source_sha,
-                            binary_commit: identity
-                                .get("data")
-                                .unwrap_or(&identity)
-                                .get("git_commit")
-                                .and_then(Value::as_str)
-                                .map(str::to_string),
-                            binary_identity: identity,
-                            timeout_ms: disconnected_ssh
-                                .then_some(DISCONNECTED_SSH_REFRESH_TIMEOUT.as_millis()),
-                            config_fields_changed: updated_fields,
-                        }),
-                    },
-                    1,
-                ));
-            }
+            Err(_) => unreachable!("reconnect admission was checked before binary promotion"),
         };
         if let Err(error) =
             disconnect_with_session(&plan.runner_id, refresh_session.as_ref(), options.force)
         {
-            return rollback_refresh_error(
-                &plan.runner_id,
-                previous_homeboy_path.as_deref(),
-                error,
-            );
+            return rollback_refresh_error_with(error, || {
+                restore_runner_homeboy_path_if_selected(
+                    &plan.runner_id,
+                    &plan.binary_path,
+                    previous_homeboy_path.as_deref(),
+                )
+                .map(|_| ())
+            });
         }
         let (report, connect_exit_code) = match connect_with_orphan_adoption(
             &plan.runner_id,
@@ -503,11 +503,39 @@ pub fn refresh_homeboy_binary(
         ) {
             Ok(result) => result,
             Err(error) => {
-                return rollback_refresh_connect_error(
-                    &plan.runner_id,
-                    previous_homeboy_path.as_deref(),
+                return rollback_refresh_connect_error_with(
                     error,
-                )
+                    || {
+                        restore_runner_homeboy_path_if_selected(
+                            &plan.runner_id,
+                            &plan.binary_path,
+                            previous_homeboy_path.as_deref(),
+                        )
+                        .map(|_| ())
+                    },
+                    || {
+                        let (report, exit_code) = connect_with_orphan_adoption(
+                            &plan.runner_id,
+                            None,
+                            &[],
+                            false,
+                            None,
+                            None,
+                            None,
+                        )?;
+                        if exit_code != 0 || !report.connected {
+                            return Err(Error::validation_invalid_argument(
+                                "reconnect",
+                                report.failure_message.unwrap_or_else(|| {
+                                    "rollback reconnect did not persist an active daemon session".to_string()
+                                }),
+                                Some(plan.runner_id.clone()),
+                                None,
+                            ));
+                        }
+                        Ok(())
+                    },
+                );
             }
         };
         let daemon_identity_verification = (connect_exit_code == 0)
@@ -1210,6 +1238,26 @@ fn restore_runner_homeboy_path(runner_id: &str, homeboy_path: Option<&str>) -> R
         let patch = serde_json::json!({ "homeboy_path": homeboy_path });
         match merge(Some(runner_id), &patch.to_string(), &[])? {
             MergeOutput::Single(_) | MergeOutput::Bulk(_) => Ok(()),
+        }
+    })
+}
+
+/// Restore only if this promotion still owns the selected value. A later
+/// serialized transaction may have selected another binary after this one
+/// failed; compensation must never overwrite that newer owner.
+fn restore_runner_homeboy_path_if_selected(
+    runner_id: &str,
+    selected_homeboy_path: &str,
+    previous_homeboy_path: Option<&str>,
+) -> Result<bool> {
+    homeboy_core::config::with_config_lock(|| {
+        let runner = load(runner_id)?;
+        if runner.settings.homeboy_path.as_deref() != Some(selected_homeboy_path) {
+            return Ok(false);
+        }
+        let patch = serde_json::json!({ "homeboy_path": previous_homeboy_path });
+        match merge(Some(runner_id), &patch.to_string(), &[])? {
+            MergeOutput::Single(_) | MergeOutput::Bulk(_) => Ok(true),
         }
     })
 }

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -339,11 +339,19 @@ pub fn refresh_homeboy_binary(
     }
 
     promotion_lease.assert_generation()?;
+    // Only a reconnect replaces the daemon, so it is the only mode allowed to
+    // change the runner-global daemon control binary. A non-reconnecting
+    // refresh materializes a command build for a workflow without creating
+    // stale-daemon drift for unrelated jobs.
+    let promote_daemon_binary = options.reconnect;
     let bootstrap = if disconnected_ssh {
         ssh_bootstrap_promote_with(
             &plan,
             || Ok(exec_output.stdout.clone()),
             |homeboy_path| {
+                if !promote_daemon_binary {
+                    return Ok(Vec::new());
+                }
                 homeboy_core::config::with_config_lock(|| {
                     let patch = refreshed_runner_patch(&plan.runner_id, homeboy_path)?;
                     match merge(Some(&plan.runner_id), &patch.to_string(), &[])? {
@@ -363,13 +371,17 @@ pub fn refresh_homeboy_binary(
                 None,
             )
         })?;
-        let updated_fields = homeboy_core::config::with_config_lock(|| {
-            let patch = refreshed_runner_patch(&plan.runner_id, &plan.binary_path)?;
-            match merge(Some(&plan.runner_id), &patch.to_string(), &[])? {
-                MergeOutput::Single(result) => Ok(result.updated_fields),
-                MergeOutput::Bulk(_) => Ok(Vec::new()),
-            }
-        })?;
+        let updated_fields = if promote_daemon_binary {
+            homeboy_core::config::with_config_lock(|| {
+                let patch = refreshed_runner_patch(&plan.runner_id, &plan.binary_path)?;
+                match merge(Some(&plan.runner_id), &patch.to_string(), &[])? {
+                    MergeOutput::Single(result) => Ok(result.updated_fields),
+                    MergeOutput::Bulk(_) => Ok(Vec::new()),
+                }
+            })?
+        } else {
+            Vec::new()
+        };
         Ok(SshBootstrapPromotion {
             identity,
             source_sha: source_sha_from_output(&exec_output.stdout),

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -659,6 +659,62 @@ fn reconnect_error_after_disconnect_restores_the_pre_refresh_binary() {
 }
 
 #[test]
+fn reconnect_rollback_restores_only_its_own_selected_binary() {
+    test_support::with_isolated_home(|_| {
+        crate::create(
+            r#"{"id":"lab-local","kind":"local","homeboy_path":"/newer/homeboy"}"#,
+            false,
+        )
+        .expect("runner");
+
+        let restored = restore_runner_homeboy_path_if_selected(
+            "lab-local",
+            "/selected/homeboy",
+            Some("/stable/homeboy"),
+        )
+        .expect("compare and restore");
+
+        assert!(!restored);
+        assert_eq!(
+            crate::load("lab-local")
+                .expect("reload")
+                .settings
+                .homeboy_path
+                .as_deref(),
+            Some("/newer/homeboy")
+        );
+    });
+}
+
+#[test]
+fn reconnect_rollback_restores_its_own_selected_binary() {
+    test_support::with_isolated_home(|_| {
+        crate::create(
+            r#"{"id":"lab-local","kind":"local","homeboy_path":"/selected/homeboy"}"#,
+            false,
+        )
+        .expect("runner");
+
+        let restored = restore_runner_homeboy_path_if_selected(
+            "lab-local",
+            "/selected/homeboy",
+            Some("/stable/homeboy"),
+        )
+        .expect("compare and restore");
+
+        assert!(restored);
+        assert_eq!(
+            crate::load("lab-local")
+                .expect("reload")
+                .settings
+                .homeboy_path
+                .as_deref(),
+            Some("/stable/homeboy")
+        );
+    });
+}
+
+#[test]
 fn reconnect_failure_after_stop_restores_and_reconnects_before_returning() {
     let operations = std::cell::RefCell::new(Vec::new());
 

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -46,6 +46,7 @@ fn deferred_reconnect_reports_selected_binary_and_exact_active_job_followups() {
         active_job_ids: vec![job_id.clone()],
         selected_binary_path: "/runner/homeboy".to_string(),
         followup_commands: followups.clone(),
+        ownership_contention: None,
     };
 
     assert_eq!(deferred.active_job_ids, vec![job_id]);
@@ -710,6 +711,69 @@ fn reconnect_rollback_restores_its_own_selected_binary() {
                 .homeboy_path
                 .as_deref(),
             Some("/stable/homeboy")
+        );
+    });
+}
+
+#[test]
+fn post_promotion_active_job_race_restores_prior_selection_without_stopping_daemon() {
+    test_support::with_isolated_home(|_| {
+        crate::create(
+            r#"{"id":"lab-local","kind":"local","homeboy_path":"/selected/homeboy"}"#,
+            false,
+        )
+        .expect("runner");
+
+        let deferred = defer_reconnect_after_promotion_race(
+            "lab-local",
+            "/selected/homeboy",
+            Some("/stable/homeboy"),
+            &[active_admission("job-raced-after-precheck")],
+        )
+        .expect("defer raced reconnect");
+
+        assert_eq!(deferred.reason, "active_daemon_jobs");
+        assert_eq!(deferred.active_job_ids, ["job-raced-after-precheck"]);
+        assert!(deferred.ownership_contention.is_none());
+        assert_eq!(
+            crate::load("lab-local")
+                .expect("reload")
+                .settings
+                .homeboy_path
+                .as_deref(),
+            Some("/stable/homeboy")
+        );
+    });
+}
+
+#[test]
+fn post_promotion_active_job_race_preserves_newer_selector_as_contention() {
+    test_support::with_isolated_home(|_| {
+        crate::create(
+            r#"{"id":"lab-local","kind":"local","homeboy_path":"/newer/homeboy"}"#,
+            false,
+        )
+        .expect("runner");
+
+        let deferred = defer_reconnect_after_promotion_race(
+            "lab-local",
+            "/selected/homeboy",
+            Some("/stable/homeboy"),
+            &[active_admission("job-raced-after-precheck")],
+        )
+        .expect("defer raced reconnect");
+
+        assert!(deferred
+            .ownership_contention
+            .as_deref()
+            .is_some_and(|message| message.contains("preserving the newer owner")));
+        assert_eq!(
+            crate::load("lab-local")
+                .expect("reload")
+                .settings
+                .homeboy_path
+                .as_deref(),
+            Some("/newer/homeboy")
         );
     });
 }


### PR DESCRIPTION
## Summary
Keep concurrent runner workflows from invalidating one another's Homeboy binary identity.

## What changed
- Pin HOMEBOY\_COMMAND into direct-daemon and reverse-broker durable jobs at admission.
- Materialize non-reconnecting workflow binaries without mutating runner-global daemon configuration.
- Make reconnect promotion transactional with pre-admission checks, race-safe compare-and-restore, and ownership contention evidence.

## How to test
1. Run `cargo test -p homeboy-lab-runner homeboy_refresh::tests --quiet`; expect All 50 refresh lifecycle, rollback, and admission-race tests pass..
2. Run `cargo test -p homeboy-lab-runner command_path::tests --quiet`; expect All 12 immutable command-path tests pass..
3. Run `cargo fmt --check`; expect Formatting passes..
4. Run `cargo check -p homeboy-lab-runner`; expect The owning package compiles..

## Compatibility
No public CLI syntax changes. Existing exact-build checks and daemon promotion serialization are preserved.

## Evidence
- Base unchanged since verification: main remains at 6f38420fb19eee3a60b6b017a5ea4fedcd77e5ee.
- CI expected: homeboy / Audit
- CI expected: homeboy / Lint
- CI expected: homeboy / Test
- CI expected: homeboy / Workspace Tests Compile
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/9145
- Verified finalization base: main at 6f38420fb19eee3a60b6b017a5ea4fedcd77e5ee
- cargo check -p homeboy-lab-runner: Passed
- cargo fmt --check: Passed
- git diff --check: Passed
- runner command path tests: Passed
- runner refresh lifecycle tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Designed, implemented, reviewed, and verified immutable per-job binary pinning and transactional runner refresh behavior under Chris Huber's direction.

## Source relationships
- Closes Extra-Chill/homeboy#9145
