### PR TITLE
fix(deploy): skip remote-path validation for read-only check/dry-run

### DIFF
--- a/crates/homeboy-release/src/deploy/orchestration/mod.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/mod.rs
@@ -110,7 +110,16 @@ pub(super) fn deploy_components(
         });
     }
 
-    validate_effective_remote_paths(&components, &project, base_path)?;
+    // Remote-path resolution is a pre-mutation guard: it fails closed so a real
+    // deploy never writes to an unresolved destination. Read-only modes
+    // (`--check`, `--dry-run`) return before touching any remote, and a project
+    // can legitimately include a component whose remote path is not resolvable
+    // on this host (e.g. a CLI binary with no `remote_path`). Validating it there
+    // aborts the whole status probe with "Path cannot be empty" before checking
+    // anything. Skip the guard for non-mutating modes. (#8190)
+    if !config.check && !config.dry_run {
+        validate_effective_remote_paths(&components, &project, base_path)?;
+    }
 
     // Release assets are immutable remote inputs. Resolve and verify them before
     // touching any configured checkout, then reuse the same run-scoped bytes for
@@ -751,6 +760,30 @@ mod tests {
 
         assert!(err.message.contains("unsupported legacy build_command"));
         assert_eq!(err.details["field"].as_str(), Some("build_command"));
+    }
+
+    #[test]
+    fn validate_effective_remote_paths_rejects_an_unresolvable_remote_path() {
+        // A component whose remote path cannot be resolved (empty, no root rule)
+        // makes the pre-mutation guard fail closed. Read-only modes gate this
+        // guard off so a project status probe is not aborted by it. (#8190)
+        let component = Component {
+            id: "cli-binary".to_string(),
+            remote_path: String::new(),
+            ..Default::default()
+        };
+        let project = Project {
+            id: "site".to_string(),
+            ..Default::default()
+        };
+
+        let err = validate_effective_remote_paths(&[component], &project, "/var/www/site")
+            .expect_err("an unresolvable remote path must fail the pre-mutation guard");
+        assert!(
+            err.message.contains("Path cannot be empty"),
+            "expected empty-path rejection, got: {}",
+            err.message
+        );
     }
 
     /// Write a component manifest that declares a (missing) required extension.


### PR DESCRIPTION
Fixes #8190.

## Problem

After a successful project deploy, the emitted verification command aborted before checking anything:

```
homeboy deploy extrachill-site --check
Invalid argument 'path': Path cannot be empty
```

## Root cause

`deploy_components` (`crates/homeboy-release/src/deploy/orchestration/mod.rs`) ran `validate_effective_remote_paths(&components, &project, base_path)?` **unconditionally**, before the check/dry-run early return. That guard resolves each component's remote deploy path and fails closed when it can't — but a project can legitimately include a component whose remote path isn't resolvable on this host (e.g. a CLI binary with no `remote_path`). So a read-only status probe aborted with the empty-path error instead of reporting per-component status.

## Fix

Gate the guard on `!config.check && !config.dry_run`. Both are non-mutating modes that return before any remote is touched — checkout, release-artifact materialization, build, and install are all already gated on the same condition, and `--check`/`--dry-run` return via `run_check_mode` / `run_dry_run_mode`. A real deploy still runs the guard and fails closed on an unresolved remote path.

## Testing

- New `validate_effective_remote_paths_rejects_an_unresolvable_remote_path` documents that the guard fails closed on an empty remote path (the pre-mutation behavior we intentionally keep for real deploys and now skip for read-only modes).
- `deploy::orchestration` suite: 55 pass. (Two `default_*_release_guard_*` tests fail identically on clean `main` — pre-existing, unrelated to this change.)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Traced the empty-path abort to an unconditional pre-mutation remote-path guard running before the read-only check/dry-run early return, and gated it to mutating modes only. Chris reviews and owns the change.