### PR TITLE
fix(agents): deny executor git push from the attempt checkout

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -1268,7 +1268,37 @@ pub(super) fn provider_command_env(
         )
         .map_err(ProviderCommandEnvError::Secret)?,
     );
+    // Enforce the executor git-mutation boundary: strip git push credentials so a
+    // provider cannot push a candidate to a real remote from its isolated attempt
+    // checkout before Homeboy's verification/promotion/finalization. Homeboy
+    // harvests candidates via local `git diff` and performs its own commit/push
+    // from a separate finalization worktree, so the provider never needs network
+    // git. Appended last so these override any inherited auth env. (#8486)
+    env.extend(git_mutation_boundary_env());
     Ok(env)
+}
+
+/// Environment that denies a provider the ability to authenticate a `git push`.
+///
+/// Blocks every credential path: no askpass helper, no interactive terminal
+/// prompt, no system config, and an empty `credential.helper` (which resets any
+/// inherited helper list) so a cached-credential helper cannot supply a token.
+/// A push to an authenticated remote (production `origin`) then fails regardless
+/// of the remote name used, so this holds even if a provider adds a new remote.
+fn git_mutation_boundary_env() -> Vec<(String, String)> {
+    vec![
+        ("GIT_ASKPASS".to_string(), "/bin/false".to_string()),
+        ("GIT_TERMINAL_PROMPT".to_string(), "0".to_string()),
+        ("GIT_CONFIG_NOSYSTEM".to_string(), "1".to_string()),
+        // Inject `credential.helper=` via git's environment config so it resets
+        // any inherited helper list (git-config(1) empty-helper semantics).
+        ("GIT_CONFIG_COUNT".to_string(), "1".to_string()),
+        (
+            "GIT_CONFIG_KEY_0".to_string(),
+            "credential.helper".to_string(),
+        ),
+        ("GIT_CONFIG_VALUE_0".to_string(), String::new()),
+    ]
 }
 
 fn agent_tool_dispatch_command() -> String {

--- a/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
@@ -715,3 +715,33 @@ fn provider_command_env_exposes_generic_agent_tool_contracts() {
         AgentToolExecutionLocation::Disabled
     );
 }
+
+#[test]
+fn provider_command_env_strips_git_push_credentials() {
+    // The provider environment must deny git push credentials so an executor
+    // cannot push a candidate to a real remote before verification. (#8486)
+    let (request, provider) = request("task-1", "minimal-provider".to_string());
+    let env = provider_command_env(&request, &provider).expect("provider env");
+    let env: BTreeMap<String, String> = env.into_iter().collect();
+
+    assert_eq!(
+        env.get("GIT_ASKPASS").map(String::as_str),
+        Some("/bin/false")
+    );
+    assert_eq!(
+        env.get("GIT_TERMINAL_PROMPT").map(String::as_str),
+        Some("0")
+    );
+    assert_eq!(
+        env.get("GIT_CONFIG_NOSYSTEM").map(String::as_str),
+        Some("1")
+    );
+    // An empty `credential.helper` via git's environment config resets any
+    // inherited helper list, so a cached-credential helper cannot supply a token.
+    assert_eq!(env.get("GIT_CONFIG_COUNT").map(String::as_str), Some("1"));
+    assert_eq!(
+        env.get("GIT_CONFIG_KEY_0").map(String::as_str),
+        Some("credential.helper")
+    );
+    assert_eq!(env.get("GIT_CONFIG_VALUE_0").map(String::as_str), Some(""));
+}

--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -403,6 +403,15 @@ pub(super) fn prepare_attempt_workspace(
         &root,
         &["worktree", "add", "--detach", &attempt_root_string, base],
     )?;
+    // Deny push from the attempt checkout as defense-in-depth for the executor
+    // git-mutation boundary (#8486). The provider produces candidate artifacts
+    // only; Homeboy harvests via local diff and pushes from a separate
+    // finalization worktree. A per-worktree `origin` push URL override rejects
+    // the common `git push origin ...` immediately with a clear reason and,
+    // being worktree-scoped, never affects the shared parent repo. The primary
+    // boundary is credential stripping in the provider environment; this makes
+    // the block explicit and legible for the default remote.
+    block_attempt_worktree_push(&attempt_root);
     // Establish cleanup ownership before anything that can fail below.
     let mut workspace = Arc::new(AttemptWorkspace {
         source_root: root.clone(),
@@ -435,6 +444,31 @@ pub(super) fn prepare_attempt_workspace(
         adoption,
     });
     Ok(Some(workspace))
+}
+
+/// Best-effort per-worktree push block for the attempt checkout.
+///
+/// Sets a worktree-scoped `remote.origin.pushurl` to a sentinel that has no git
+/// transport, so `git push origin ...` from the attempt fails immediately with a
+/// clear reason. `extensions.worktreeConfig` scopes the override to this
+/// worktree so the shared parent repository's remote is never modified. This is
+/// defense-in-depth for the `origin` case; the authoritative boundary is the
+/// credential stripping applied to the provider environment. Failure to set it
+/// is non-fatal — the credential boundary still holds. (#8486)
+fn block_attempt_worktree_push(attempt_root: &Path) {
+    let _ = git_output(
+        attempt_root,
+        &["config", "extensions.worktreeConfig", "true"],
+    );
+    let _ = git_output(
+        attempt_root,
+        &[
+            "config",
+            "--worktree",
+            "remote.origin.pushurl",
+            "homeboy-blocked://agent-task-attempt-may-not-push",
+        ],
+    );
 }
 
 fn apply_gate_feedback_baseline(
@@ -579,6 +613,88 @@ mod tests {
             fs::read_to_string(attempt_root.join("src/lib.rs")).expect("source remains"),
             "changed source"
         );
+    }
+
+    #[test]
+    fn attempt_worktree_push_is_blocked_without_affecting_parent_or_local_reads() {
+        let origin = tempfile::tempdir().expect("origin");
+        git(origin.path(), &["init", "--bare", "-b", "main"]);
+        let source = tempfile::tempdir().expect("source repository");
+        git(source.path(), &["init", "-b", "main"]);
+        git(source.path(), &["config", "user.name", "Homeboy Test"]);
+        git(
+            source.path(),
+            &["config", "user.email", "homeboy@example.test"],
+        );
+        fs::write(source.path().join("f.txt"), "base").expect("source file");
+        git(source.path(), &["add", "f.txt"]);
+        git(source.path(), &["commit", "-m", "initial"]);
+        git(
+            source.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                &format!("file://{}", origin.path().display()),
+            ],
+        );
+        git(source.path(), &["push", "origin", "main"]);
+
+        let attempt_root = source.path().join("attempt");
+        git(
+            source.path(),
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                attempt_root.to_str().expect("attempt path"),
+                "HEAD",
+            ],
+        );
+
+        block_attempt_worktree_push(&attempt_root);
+
+        // A provider commit + push from the attempt is rejected.
+        git(&attempt_root, &["config", "user.name", "Provider"]);
+        git(
+            &attempt_root,
+            &["config", "user.email", "provider@example.test"],
+        );
+        fs::write(attempt_root.join("f.txt"), "executor change").expect("attempt edit");
+        git(&attempt_root, &["commit", "-am", "executor change"]);
+        let push = Command::new("git")
+            .args(["push", "origin", "HEAD:main"])
+            .current_dir(&attempt_root)
+            .output()
+            .expect("run git push");
+        assert!(
+            !push.status.success(),
+            "push from the attempt worktree must be blocked"
+        );
+
+        // The bare origin's main is unchanged (still the base commit).
+        let origin_head = git_output(origin.path(), &["rev-parse", "main"]).expect("origin head");
+        let base_head = git_output(source.path(), &["rev-parse", "main"]).expect("source head");
+        assert_eq!(
+            origin_head, base_head,
+            "the remote branch must not advance from a blocked attempt push"
+        );
+
+        // The parent repo's origin push URL is untouched (block is worktree-scoped).
+        let parent_pushurl = git_output(
+            source.path(),
+            &["config", "--get-all", "remote.origin.pushurl"],
+        )
+        .unwrap_or_default();
+        assert!(
+            parent_pushurl.is_empty(),
+            "parent repo must not inherit the attempt push block, got: {parent_pushurl}"
+        );
+
+        // Homeboy's local diff harvest still works in the attempt.
+        let diff = git_output(&attempt_root, &["diff", "--name-only", "HEAD~1", "HEAD"])
+            .expect("local diff");
+        assert!(diff.contains("f.txt"), "local diff harvest must still work");
     }
 
     fn git(cwd: &Path, args: &[&str]) {


### PR DESCRIPTION
Addresses the core boundary of #8486 (PR 1 of 2).

## Problem

`homeboy agent-task cook` runs its provider in a per-attempt worktree created with `git worktree add --detach` (`crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs`). That worktree **shares the parent repo's `.git`** — remotes and ambient credentials included. A provider could run `git commit && git push origin HEAD:<branch>` and mutate the real remote **before** Homeboy's verification, promotion, and finalization, bypassing the canonical lifecycle and publishing an unverified candidate (the issue reproduced a provider advancing a live PR branch while Homeboy then reported `policy_failure`).

## Why the boundary is safe to enforce

Providers produce candidate artifacts only:
- The attempt checkout is at a **local** base commit (shared `.git`) — no network fetch needed.
- Homeboy harvests the candidate via **local `git diff`** — it never asks the provider to push.
- Homeboy's own commit/push happens in a **separate finalization worktree** (`agent_task_finalization/backend.rs`), not the attempt checkout.
- No git credentials are injected as provider secrets — push ability comes purely from the **ambient** credential environment.

## Fix (enforced independently of prompt compliance)

1. **Strip git push credentials from the provider environment** (the authoritative boundary, `provider_command_env`): `GIT_ASKPASS=/bin/false`, `GIT_TERMINAL_PROMPT=0`, `GIT_CONFIG_NOSYSTEM=1`, and an empty `credential.helper` via git's environment config (which resets any inherited helper list). A push to an authenticated remote then fails whatever remote name is used — including a newly-added one — because none can obtain a token. Not a hook, so `--no-verify` can't bypass it.
2. **Per-worktree `origin` push block** (defense-in-depth, `prepare_attempt_workspace`): a worktree-scoped `remote.origin.pushurl` sentinel rejects `git push origin ...` immediately with a clear reason, scoped via `extensions.worktreeConfig` so the shared parent repository is never modified.

Homeboy's local diff harvest and its separate finalization push are unaffected.

## Mechanism rationale

I empirically evaluated the options: a `pre-push` hook was rejected as the boundary (git silently ignored it in testing, and hooks are `--no-verify`-bypassable). `pushurl`-on-origin alone is bypassable by adding a new remote. Credential stripping is the only boundary that holds for authenticated (production GitHub) remotes regardless of remote name — verified that `git credential fill` fails under this env (`could not read Username ... terminal prompts disabled`).

## Testing

- `provider_command_env_strips_git_push_credentials` — the boundary env vars are present.
- `attempt_worktree_push_is_blocked_without_affecting_parent_or_local_reads` — a commit+push from the attempt worktree fails, the bare origin's branch does **not** advance, the parent repo's push config is **untouched** (worktree-scoped), and local `git diff` harvest still works. Verified this test **fails** when the block is removed (catches the leak).
- Broader `attempt_workspace` (3) and `provider_command` (14) suites green.

## Follow-up (PR 2)

The issue's second half — the cook must not report a *failed finalization* after an untracked executor remote mutation — is a separate finalization-classification change and will be a follow-up PR. This PR removes the ability to perform the mutation in the first place.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Confirmed the boundary was unimplemented, empirically validated that credential-stripping (not hooks) is the enforceable boundary, and implemented the env + worktree-scoped push block with tests proving the leak is closed while harvest/finalization still work. Chris reviews and owns the change.