### PR TITLE
fix(lab-runner): update refresh rollback tests to the current API

### DIFF
--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -605,15 +605,21 @@ fn disconnect_failure_after_selection_restores_the_pre_refresh_binary() {
             refreshed_runner_patch("lab-local", "/selected/homeboy").expect("selection patch");
         merge(Some("lab-local"), &patch.to_string(), &[]).expect("select binary");
 
-        let error = rollback_refresh_error::<()>(
-            "lab-local",
-            Some("/stable/homeboy"),
+        let error = rollback_refresh_error_with::<(), _>(
             Error::validation_invalid_argument(
                 "disconnect",
                 "request lease-bound daemon stop: tunnel unavailable",
                 None,
                 None,
             ),
+            || {
+                restore_runner_homeboy_path_if_selected(
+                    "lab-local",
+                    "/selected/homeboy",
+                    Some("/stable/homeboy"),
+                )
+                .map(|_| ())
+            },
         )
         .expect_err("disconnect failure rolls back selection");
         assert!(error.message.contains("lease-bound daemon stop"));
@@ -641,10 +647,16 @@ fn reconnect_error_after_disconnect_restores_the_pre_refresh_binary() {
             refreshed_runner_patch("lab-local", "/selected/homeboy").expect("selection patch");
         merge(Some("lab-local"), &patch.to_string(), &[]).expect("select binary");
 
-        let error = rollback_refresh_error::<()>(
-            "lab-local",
-            Some("/stable/homeboy"),
+        let error = rollback_refresh_error_with::<(), _>(
             Error::internal_io("reconnect transport failed".to_string(), None),
+            || {
+                restore_runner_homeboy_path_if_selected(
+                    "lab-local",
+                    "/selected/homeboy",
+                    Some("/stable/homeboy"),
+                )
+                .map(|_| ())
+            },
         )
         .expect_err("reconnect error rolls back selection");
         assert_eq!(error.details["error"], "reconnect transport failed");


### PR DESCRIPTION
## Problem

The **Workspace Tests Compile** CI job is failing on every open PR:

```
error[E0425]: cannot find function `rollback_refresh_error` in this scope
  --> crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs:608:21
  --> crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs:644:21
```

## Root cause

`rollback_refresh_error(runner_id, previous_binary, error)` was refactored into `rollback_refresh_error_with(error, restore)`, but two test call sites in `homeboy_refresh/tests/part_a.rs` were not updated. Because the break is in a **test target**, source-only builds passed and it merged to `main` — but the workspace test-compile job (which builds test targets) now fails for every branch built against `main`.

## Fix

Update both sites to `rollback_refresh_error_with` with an explicit restore closure (`restore_runner_homeboy_path_if_selected(...)`), mirroring the production rollback path (`homeboy_refresh.rs:516`) and preserving each test's assertion that the runner's `homeboy_path` is restored to its pre-refresh value.

## Testing

- `disconnect_failure_after_selection_restores_the_pre_refresh_binary`, `reconnect_error_after_disconnect_restores_the_pre_refresh_binary`, and `rollback_failure_keeps_the_primary_refresh_error` all pass.
- `cargo test -p homeboy-lab-runner --lib --no-run` compiles clean.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Diagnosed the workspace-test-compile failure as a pre-existing test-only break on `main` (unrelated to the PR that surfaced it) and updated the two stale call sites to the current rollback API. Chris reviews and owns the change.