### PR TITLE
Rebuild transient cook baselines on retry

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2929,7 +2929,8 @@ pub fn mark_resuming(run_id: &str) -> Result<AgentTaskRunRecord> {
 
 pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRunRecord> {
     let source = store::read_record(&resolve_run_id(run_id)?)?;
-    let plan = load_controller_plan(&source.run_id)?;
+    let mut plan = load_controller_plan(&source.run_id)?;
+    restore_initial_cook_candidate_workspace(&mut plan)?;
     let mut retry = submit_plan(&plan, requested_run_id)?;
     let metadata = retry.ensure_metadata_object();
     if let Some(route) =
@@ -2966,6 +2967,40 @@ pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRu
     metadata.insert("retry_requested_at".to_string(), json!(now_timestamp()));
     store::write_record(&retry)?;
     Ok(retry)
+}
+
+/// Cook's first dirty-candidate baseline is process-local and removed after a
+/// failed admission. A retry returns to the durable source checkout; scheduler
+/// preflight verifies its recorded tree before it creates a fresh attempt.
+fn restore_initial_cook_candidate_workspace(plan: &mut AgentTaskPlan) -> Result<()> {
+    for task in &mut plan.tasks {
+        let Some(baseline) = task.metadata.get("cook_initial_candidate_baseline") else {
+            continue;
+        };
+        let source_root = baseline
+            .get("source_root")
+            .and_then(Value::as_str)
+            .filter(|path| !path.trim().is_empty())
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "workspace.metadata.cook_initial_candidate_baseline.source_root",
+                    "retry cannot reconstruct the original Cook candidate workspace",
+                    None,
+                    None,
+                )
+            })?;
+        if !std::path::Path::new(source_root).is_dir() {
+            return Err(Error::validation_invalid_argument(
+                "workspace.metadata.cook_initial_candidate_baseline.source_root",
+                format!("retry source workspace no longer exists: {source_root}"),
+                None,
+                None,
+            ));
+        }
+        task.workspace.root = Some(source_root.to_string());
+        task.executor.remap_workspace_root(source_root);
+    }
+    Ok(())
 }
 
 pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {

--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use sha2::{Digest, Sha256};
 
-use super::harvest::git_is_repository;
+use super::harvest::{git_is_repository, git_output_raw};
 use super::*;
 
 /// Immutable provenance for one scheduler execution. Controller-local callers
@@ -275,6 +275,8 @@ pub(super) fn prepare_committed_harvest(
     let status = git_output(root, &["status", "--porcelain", "--untracked-files=all"])?;
     let candidate_baseline = if status.trim().is_empty() {
         None
+    } else if let Some(baseline) = verified_initial_cook_candidate_baseline(root, request)? {
+        Some(baseline)
     } else {
         Some(verified_gate_feedback_baseline(root, request, &status)?)
     };
@@ -283,6 +285,86 @@ pub(super) fn prepare_committed_harvest(
         source_provenance,
         candidate_baseline,
     })
+}
+
+fn verified_initial_cook_candidate_baseline(
+    root: &Path,
+    request: &AgentTaskRequest,
+) -> Result<Option<CandidateBaseline>, HarvestError> {
+    let Some(baseline) = request.metadata.get("cook_initial_candidate_baseline") else {
+        return Ok(None);
+    };
+    let commit = baseline
+        .get("commit")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| HarvestError::CandidateBaselineMismatch {
+            message: "initial Cook candidate baseline has no commit".to_string(),
+        })?;
+    let expected_tree = baseline
+        .get("tree")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| HarvestError::CandidateBaselineMismatch {
+            message: "initial Cook candidate baseline has no tree".to_string(),
+        })?;
+    let source_root = baseline
+        .get("source_root")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| HarvestError::CandidateBaselineMismatch {
+            message: "initial Cook candidate baseline has no source workspace".to_string(),
+        })?;
+    if root != Path::new(source_root) {
+        return Err(HarvestError::CandidateBaselineMismatch {
+            message: "initial Cook candidate retry did not restore its recorded source workspace"
+                .to_string(),
+        });
+    }
+    let parent = git_output(root, &["rev-parse", &format!("{commit}^")])?;
+    if git_output(root, &["rev-parse", "HEAD^{tree}"])?
+        != git_output(root, &["rev-parse", &format!("{parent}^{{tree}}")])?
+    {
+        return Err(HarvestError::CandidateBaselineMismatch {
+            message: "initial Cook candidate source HEAD changed before retry".to_string(),
+        });
+    }
+    let index = tempfile::NamedTempFile::new().map_err(|error| HarvestError::Git {
+        command: "create initial Cook candidate verification index".to_string(),
+        message: error.to_string(),
+    })?;
+    let index_path = index.path().display().to_string();
+    git_output_with_env(root, &["read-tree", "HEAD"], &index_path)?;
+    git_output_with_env(root, &["add", "--all"], &index_path)?;
+    let actual_tree = git_output_with_env(root, &["write-tree"], &index_path)?;
+    if actual_tree != expected_tree {
+        return Err(HarvestError::CandidateBaselineMismatch {
+            message: "initial Cook candidate workspace changed after admission failure".to_string(),
+        });
+    }
+    Ok(Some(CandidateBaseline {
+        patch: git_output_raw(root, &["diff", "--binary", "--full-index", "HEAD", commit])?,
+    }))
+}
+
+fn git_output_with_env(
+    root: &Path,
+    args: &[&str],
+    index_path: &str,
+) -> Result<String, HarvestError> {
+    let output = Command::new("git")
+        .args(args)
+        .env("GIT_INDEX_FILE", index_path)
+        .current_dir(root)
+        .output()
+        .map_err(|error| HarvestError::Git {
+            command: format!("git {}", args.join(" ")),
+            message: error.to_string(),
+        })?;
+    if !output.status.success() {
+        return Err(HarvestError::Git {
+            command: format!("git {}", args.join(" ")),
+            message: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 fn verified_gate_feedback_baseline(

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -753,6 +753,11 @@ where
                 if let Some(baseline) = initial_baseline.as_ref() {
                     for task in &mut dispatch_plan.tasks {
                         task.workspace.root = Some(baseline.path.display().to_string());
+                        task.metadata["cook_initial_candidate_baseline"] = serde_json::json!({
+                            "source_root": options.source_worktree_path,
+                            "commit": baseline.capability.commit(),
+                            "tree": baseline.capability.tree(),
+                        });
                     }
                 }
                 if let Some(dispatcher) = &options.attempt_dispatcher {
@@ -1420,6 +1425,60 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct SucceedingExecutor;
+
+    impl AgentTaskExecutorAdapter for SucceedingExecutor {
+        fn execute(
+            &self,
+            request: crate::agent_task::AgentTaskRequest,
+            _context: crate::agent_task_scheduler::AgentTaskExecutionContext,
+        ) -> crate::agent_task::AgentTaskOutcome {
+            let root = std::path::PathBuf::from(
+                request
+                    .workspace
+                    .root
+                    .as_deref()
+                    .expect("provider receives attempt workspace"),
+            );
+            std::fs::write(root.join("provider.txt"), "completed\n")
+                .expect("write provider change");
+            let git = |args: &[&str]| {
+                assert!(Command::new("git")
+                    .args(args)
+                    .current_dir(&root)
+                    .status()
+                    .expect("run provider git")
+                    .success());
+            };
+            git(&["add", "provider.txt"]);
+            git(&[
+                "-c",
+                "user.name=Homeboy",
+                "-c",
+                "user.email=homeboy@localhost",
+                "commit",
+                "-m",
+                "provider change",
+            ]);
+            crate::agent_task::AgentTaskOutcome {
+                schema: crate::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: request.task_id,
+                status: crate::agent_task::AgentTaskOutcomeStatus::Succeeded,
+                summary: Some("fixture provider succeeded".to_string()),
+                failure_classification: None,
+                artifacts: Vec::new(),
+                typed_artifacts: Vec::new(),
+                evidence_refs: Vec::new(),
+                diagnostics: Vec::new(),
+                outputs: Value::Null,
+                workflow: None,
+                follow_up: None,
+                metadata: Value::Null,
+            }
+        }
+    }
+
     #[derive(Debug)]
     struct BatchAttemptDispatcher {
         barrier: Arc<Barrier>,
@@ -1722,6 +1781,69 @@ mod tests {
                 retry.metadata["retry_origin"]["pre_execution_failure"]["phase"],
                 "controller_admission"
             );
+        });
+    }
+
+    #[test]
+    fn retry_after_admission_failure_rebuilds_clean_initial_candidate_baseline() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("temp source root");
+            let source = temp.path().join("source");
+            std::fs::create_dir(&source).expect("create source");
+            let git = |args: &[&str]| {
+                assert!(Command::new("git")
+                    .args(args)
+                    .current_dir(&source)
+                    .status()
+                    .expect("run git")
+                    .success());
+            };
+            git(&["init"]);
+            git(&["config", "user.email", "agent@example.test"]);
+            git(&["config", "user.name", "Agent"]);
+            std::fs::write(source.join("fixture.txt"), "base\n").expect("write base");
+            git(&["add", "fixture.txt"]);
+            git(&["commit", "-m", "base"]);
+            std::fs::write(source.join("fixture.txt"), "dirty candidate\n")
+                .expect("write dirty candidate");
+
+            let run_id = "cook-admission-retry-attempt-1";
+            let mut options = batch_cook_options(
+                "cook-admission-retry",
+                Arc::new(AdmissionFailingAttemptDispatcher {
+                    message: "controller generation is held by another cook",
+                }),
+            );
+            options.initial_run_id = run_id.to_string();
+            options.source_worktree_path = Some(source.clone());
+            options.provider_command = Some("fixture-provider".to_string());
+            options.initial_plan.tasks[0].workspace.root = Some(source.display().to_string());
+
+            run_cook(options, UnusedExecutor).expect("persist admission failure");
+            let failed_plan = agent_task_lifecycle::load_plan(run_id).expect("failed plan");
+            let transient_root = std::path::PathBuf::from(
+                failed_plan.tasks[0]
+                    .workspace
+                    .root
+                    .as_deref()
+                    .expect("baseline root"),
+            );
+            assert!(!transient_root.exists(), "initial baseline was cleaned up");
+
+            let retry = agent_task_lifecycle::retry(run_id, Some("cook-admission-retry-2"))
+                .expect("retry rematerializes source workspace");
+            let retry_plan = agent_task_lifecycle::load_plan(&retry.run_id).expect("retry plan");
+            assert_eq!(
+                retry_plan.tasks[0].workspace.root.as_deref(),
+                Some(source.to_str().expect("UTF-8 source path"))
+            );
+
+            let result = crate::agent_task_service::execution::run_submitted(
+                retry.run_id,
+                SucceedingExecutor,
+            )
+            .expect("retry reaches a real Git workspace");
+            assert_eq!(result.exit_code, 0, "{:#?}", result.value);
         });
     }
 


### PR DESCRIPTION
## Summary

- persist the original source checkout, synthetic candidate commit, and candidate tree when cook creates a transient dirty-worktree baseline
- restore that durable source identity when retrying a pre-execution failed cook
- verify source HEAD and the complete dirty tree before reconstructing the candidate baseline
- fail closed when the source checkout is missing or changed
- preserve gate-feedback baseline handling and isolated attempt-workspace harvesting

Fixes #9167.

## Root cause

Cook replaced the task workspace with a process-local initial-baseline directory before persisting a pre-execution failure. Cleanup removed that directory, but `agent-task retry <run-id> --run` later reused the stale path and failed committed-change harvest with `ENOENT`.

## How to test

1. Check out this branch from a fresh clone.
2. Run `cargo test -p homeboy-agents retry_after_admission_failure_rebuilds_clean_initial_candidate_baseline --lib -- --nocapture`.
3. Run `cargo test -p homeboy-agents gate_feedback_baseline_allows_only_the_recorded_candidate_and_harvests_remediation_delta --lib -- --nocapture`.
4. Run `cargo check -p homeboy-agents`.
5. Run `cargo fmt --check`.
6. Run `git diff --check origin/main...HEAD`.
7. For lifecycle verification, start a cook from a dirty adopted worktree while controller admission is occupied, let the first run fail before provider dispatch, release contention, and run the emitted `agent-task retry <failed-run-id> --run`; confirm committed harvest reaches a reconstructed Git attempt workspace instead of the deleted initial-baseline path.

## Compatibility

The new metadata is internal and additive. Clean-worktree cooks, gate-feedback retries, provider budgets, and existing fail-closed harvest behavior are unchanged. Runs created before this change do not contain the new durable baseline recipe and must be submitted as a fresh cook after upgrading.

## Verification

- Admission-failure retry regression: passed
- Existing gate-feedback baseline regression: passed
- Affected crate check: passed
- Formatting and diff checks: passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with GPT-5.6 Sol
- **Used for:** Reproduced the retry failure through Homeboy, implemented the durable baseline reconstruction and deterministic tests in an isolated recovery worktree, and verified the result with Chris.