### PR TITLE
fix(agents): reject out-of-contract remote advance during finalization

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -239,10 +239,32 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
 
         let changed_files = committed_changed_files(path, base_ref)?;
         let local_head = git_output(path, &["rev-parse", "HEAD"])?;
+        let local_head = local_head.trim();
         let remote_head = remote_branch_head(path, head)?;
+
+        // A live remote head that Homeboy's candidate does not contain means the
+        // branch was advanced out of contract — e.g. an executor pushed from its
+        // attempt checkout before finalization. Homeboy exclusively owns the
+        // remote branch; force-pushing over the divergence would clobber those
+        // commits, and a plain push fails with an opaque rejection classified as
+        // a generic policy failure. Refuse with a specific diagnostic so the
+        // out-of-sync state is legible rather than reported as a failed push.
+        // (#8486)
+        if let Some(remote_head) = remote_head.as_deref() {
+            if remote_head != local_head
+                && !remote_head_is_ancestor_of_candidate(path, remote_head, local_head)
+            {
+                return Ok(AgentTaskPrCandidateState::Invalid {
+                    diagnostic: format!(
+                        "remote branch `{head}` advanced to `{remote_head}`, which is not contained in the finalization candidate `{local_head}`; the branch was modified outside Homeboy's finalization (an executor may have pushed from its attempt checkout). Refusing to finalize to avoid clobbering unverified remote commits; reconcile the branch manually before retrying."
+                    ),
+                });
+            }
+        }
+
         Ok(AgentTaskPrCandidateState::Committed {
             changed_files,
-            push_required: remote_head.as_deref() != Some(local_head.trim()),
+            push_required: remote_head.as_deref() != Some(local_head),
         })
     }
 
@@ -388,6 +410,30 @@ fn remote_branch_head(path: &str, head: &str) -> Result<Option<String>> {
         .map(str::to_string))
 }
 
+/// Returns `true` when `remote_head` is contained in the finalization candidate
+/// (`local_head`), i.e. the candidate is a fast-forward over the live remote and
+/// Homeboy's push would not clobber any remote-only commits.
+///
+/// The remote commit may be absent from the local object database (an executor
+/// pushed it directly), so fetch it best-effort first. If it still cannot be
+/// resolved, the divergence cannot be proven safe — treat it as non-ancestor so
+/// finalization fails closed with the out-of-contract diagnostic.
+fn remote_head_is_ancestor_of_candidate(path: &str, remote_head: &str, local_head: &str) -> bool {
+    // Best-effort: bring the remote-only commit into the local object database
+    // so ancestry can be evaluated. Ignore failure; the ancestry check below
+    // fails closed when the object is unavailable.
+    let _ = std::process::Command::new("git")
+        .args(["fetch", "--no-tags", "origin", remote_head])
+        .current_dir(path)
+        .output();
+    std::process::Command::new("git")
+        .args(["merge-base", "--is-ancestor", remote_head, local_head])
+        .current_dir(path)
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
 fn git_output(path: &str, args: &[&str]) -> Result<String> {
     let output = std::process::Command::new("git")
         .args(args)
@@ -525,6 +571,60 @@ mod remote_base_tests {
                 push_required: true,
             }
         );
+    }
+
+    #[test]
+    fn out_of_contract_remote_advance_is_rejected_not_reported_as_committed() {
+        // Homeboy's candidate branch, pushed to origin, then advanced on the
+        // remote out-of-band (an executor pushed a commit not in the candidate).
+        // Finalization must refuse with a specific diagnostic rather than
+        // attempt a push that fails as a generic policy failure. (#8486)
+        let origin = tempfile::tempdir().unwrap();
+        git(origin.path(), &["init", "--bare", "-b", "main"]);
+        let repo = repo();
+        git(
+            repo.path(),
+            &["remote", "add", "origin", origin.path().to_str().unwrap()],
+        );
+        git(repo.path(), &["push", "origin", "main"]);
+        git(repo.path(), &["checkout", "-b", "feature"]);
+        std::fs::write(repo.path().join("candidate.txt"), "candidate").unwrap();
+        git(repo.path(), &["add", "candidate.txt"]);
+        git(repo.path(), &["commit", "-m", "homeboy candidate"]);
+        git(repo.path(), &["push", "origin", "feature"]);
+
+        // A second checkout advances the remote feature branch out-of-band.
+        let other = tempfile::tempdir().unwrap();
+        git(
+            other.path(),
+            &["clone", origin.path().to_str().unwrap(), "."],
+        );
+        git(other.path(), &["config", "user.email", "evil@example.com"]);
+        git(other.path(), &["config", "user.name", "Executor"]);
+        git(other.path(), &["checkout", "feature"]);
+        std::fs::write(other.path().join("out-of-band.txt"), "executor").unwrap();
+        git(other.path(), &["add", "out-of-band.txt"]);
+        git(other.path(), &["commit", "-m", "executor out-of-band push"]);
+        git(other.path(), &["push", "origin", "feature"]);
+
+        let state = RealAgentTaskPrFinalizationBackend
+            .candidate_state(
+                repo.path().to_str().unwrap(),
+                &base("main", "base"),
+                "feature",
+            )
+            .expect("candidate state");
+
+        match state {
+            AgentTaskPrCandidateState::Invalid { diagnostic } => {
+                assert!(
+                    diagnostic.contains("advanced")
+                        && diagnostic.contains("outside Homeboy's finalization"),
+                    "diagnostic must name the out-of-contract remote advance: {diagnostic}"
+                );
+            }
+            other => panic!("expected Invalid for a diverged remote, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Completes #8486 (PR 2 of 2).

## Problem

The issue's second half: *"The cook result must also never report a failed finalization after an untracked executor-side remote mutation."*

When an executor pushed to the branch out-of-band, Homeboy's promotion/finalization saw the managed destination still tracking base while the remote branch had advanced. Finalization classified the candidate as `Committed { push_required: true }`, attempted a plain push, the remote rejected it (diverged), and the opaque `git push failed` surfaced as a generic `policy_failure` — leaving the remote branch and managed destination out of sync ambiguously.

## Fix

`candidate_state` (`agent_task_finalization/backend.rs`) now detects a diverged remote head. When the live remote head is neither equal to nor an ancestor of the finalization candidate, the branch was modified outside Homeboy's finalization, so it returns `AgentTaskPrCandidateState::Invalid` with a specific diagnostic naming the out-of-contract advance. The finalize orchestration already maps `Invalid` to a clear `validation_invalid_argument` refusal, so:

- Homeboy never force-pushes over the divergence (which would clobber the unverified remote commits).
- Homeboy never reports a failed finalization as if the push itself were the problem — the out-of-sync state is legible.

`remote_head_is_ancestor_of_candidate` fetches the remote-only commit best-effort (an executor's push may be absent locally) and fails closed (treats unresolvable as diverged).

## Relationship to #9165

PR 1 (#9165, merged) removes the ability to push out of contract in the first place (git-mutation boundary). This PR makes any pre-existing or legacy out-of-sync state legible rather than an opaque failure — closing the issue's finalization-classification half.

## Testing

- New `out_of_contract_remote_advance_is_rejected_not_reported_as_committed`: a candidate pushed to origin, then advanced out-of-band by a second checkout, is classified `Invalid` with the out-of-contract diagnostic (was `Committed`).
- Full `agent_task_finalization::backend` (9) and `agent_task_finalization` (42) suites green — the legitimate `Committed { push_required }` path is unaffected.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Traced the generic-policy-failure classification to a plain push over a diverged remote, and added ancestry-based divergence detection that refuses with a specific out-of-contract diagnostic. Chris reviews and owns the change.