### PR TITLE
Project active adoption through Cook alias status

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
@@ -178,6 +178,7 @@ fn reconstruct_record(run: &RunRecord) -> Result<AgentTaskRunRecord> {
         lifecycle,
         lab_handoff: None,
         candidate_adoption: None,
+        adoption_run_id: None,
         metadata: json!({
             "lifecycle_reconstruction": {
                 "source": "observation_status_and_durable_plan",

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -375,6 +375,7 @@ where
         lifecycle: lifecycle_for_submitted_plan(plan),
         lab_handoff: None,
         candidate_adoption: None,
+        adoption_run_id: None,
         metadata,
     };
     store::write_record(&record)?;
@@ -923,16 +924,6 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     if record != before_liveness_reconciliation {
         store::write_record(&record)?;
     }
-    if requested_run_id != record.run_id {
-        if let Ok(index) = store::read_cook_index(&requested_run_id) {
-            let metadata = record.ensure_metadata_object();
-            metadata.insert("cook_alias".to_string(), json!(requested_run_id));
-            metadata.insert(
-                "cook_index".to_string(),
-                serde_json::to_value(index).unwrap_or(Value::Null),
-            );
-        }
-    }
     if record.state.is_terminal() {
         if let Ok(aggregate) = store::read_aggregate(&record.run_id) {
             if !crate::agent_task_lifecycle::terminal_artifact_projection_is_verified(
@@ -1013,7 +1004,70 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
             }
         }
     }
+    if requested_run_id != record.run_id {
+        if let Ok(index) = store::read_cook_index(&requested_run_id) {
+            project_cook_alias_adoption(&mut record, &index)?;
+            let metadata = record.ensure_metadata_object();
+            metadata.insert("cook_alias".to_string(), json!(requested_run_id));
+            metadata.insert(
+                "cook_index".to_string(),
+                serde_json::to_value(index).unwrap_or(Value::Null),
+            );
+        }
+    }
     Ok(record)
+}
+
+fn project_cook_alias_adoption(
+    record: &mut AgentTaskRunRecord,
+    index: &AgentTaskCookIndex,
+) -> Result<()> {
+    let mut selected: Option<(
+        bool,
+        String,
+        usize,
+        String,
+        AgentTaskCandidateAdoptionAttempt,
+    )> = None;
+
+    for (index_order, indexed_attempt) in index.attempts.iter().enumerate() {
+        let Ok(mut attempt_record) = store::read_record(&indexed_attempt.run_id) else {
+            continue;
+        };
+        if reconcile_candidate_adoption(&mut attempt_record) {
+            store::write_record(&attempt_record)?;
+        }
+        let Some(adoption) = attempt_record.candidate_adoption else {
+            continue;
+        };
+        let candidate = (
+            adoption.is_active(),
+            adoption.updated_at.clone(),
+            index_order,
+            indexed_attempt.run_id.clone(),
+            adoption,
+        );
+        let replace = selected.as_ref().is_none_or(|current| {
+            candidate.0 > current.0
+                // Among equally active or inactive attempts, the newest
+                // adoption timestamp wins; index order breaks timestamp ties.
+                || (candidate.0 == current.0
+                    && (candidate.1.as_str(), candidate.2)
+                        > (current.1.as_str(), current.2))
+        });
+        if replace {
+            selected = Some(candidate);
+        }
+    }
+
+    if let Some((_, _, _, adoption_run_id, adoption)) = selected {
+        record.adoption_run_id = Some(adoption_run_id);
+        record.candidate_adoption = Some(adoption);
+    } else {
+        record.adoption_run_id = None;
+        record.candidate_adoption = None;
+    }
+    Ok(())
 }
 
 /// Claim or resume the one controller-owned candidate adoption for a run. The

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -112,6 +112,10 @@ pub struct AgentTaskRunRecord {
     /// verified against this durable cook run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub candidate_adoption: Option<AgentTaskCandidateAdoptionAttempt>,
+    /// Owning run for `candidate_adoption` when status was resolved through a
+    /// Cook alias. Exact run status leaves this unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub adoption_run_id: Option<String>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
 }
@@ -133,6 +137,12 @@ pub struct AgentTaskCandidateAdoptionAttempt {
     pub terminal_error: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub completed_at: Option<String>,
+}
+
+impl AgentTaskCandidateAdoptionAttempt {
+    pub fn is_active(&self) -> bool {
+        self.state == "verification_running"
+    }
 }
 
 /// Durable authority for a controller-to-Lab runner handoff. This lives on the

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -770,6 +770,7 @@ fn detached_runner_failure_transitions_parent_and_task_terminal() {
         lifecycle: lifecycle_for_submitted_plan(&plan),
         lab_handoff: None,
         candidate_adoption: None,
+        adoption_run_id: None,
         metadata: json!({ "runner_id": "homeboy-lab", "runner_job_id": "job-123" }),
     };
     record.tasks[0].state = AgentTaskState::Running;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -18,6 +18,149 @@ use sha2::{Digest, Sha256};
 use std::sync::{Arc, Mutex};
 
 #[test]
+fn cook_alias_status_projects_active_adoption_from_earlier_attempt() {
+    with_isolated_home(|_| {
+        let cook_id = "cook-issue-9168-active";
+        let earlier = submit_plan(&test_plan(), Some("adoption-earlier")).expect("earlier run");
+        record_cook_attempt(cook_id, 1, &earlier.run_id).expect("index earlier run");
+        start_candidate_adoption(
+            &earlier.run_id,
+            "1111111111111111111111111111111111111111",
+            "openai/gpt-5.6-sol",
+            "cargo test",
+        )
+        .expect("start earlier adoption");
+
+        let latest = submit_plan(&test_plan(), Some("adoption-latest")).expect("latest run");
+        record_cook_attempt(cook_id, 2, &latest.run_id).expect("index latest run");
+
+        let unrelated =
+            submit_plan(&test_plan(), Some("adoption-unrelated")).expect("unrelated run");
+        start_candidate_adoption(
+            &unrelated.run_id,
+            "9999999999999999999999999999999999999999",
+            "openai/gpt-5.6-sol",
+            "cargo test",
+        )
+        .expect("start unrelated adoption");
+
+        let projected = status(cook_id).expect("Cook alias status");
+        assert_eq!(projected.run_id, latest.run_id);
+        assert_eq!(projected.state, latest.state);
+        assert_eq!(
+            projected.adoption_run_id.as_deref(),
+            Some(earlier.run_id.as_str())
+        );
+        let adoption = projected.candidate_adoption.expect("projected adoption");
+        assert_eq!(adoption.state, "verification_running");
+        assert_eq!(
+            adoption.candidate_sha,
+            "1111111111111111111111111111111111111111"
+        );
+    });
+}
+
+#[test]
+fn cook_alias_status_has_no_adoption_projection_without_indexed_adoption() {
+    with_isolated_home(|_| {
+        let cook_id = "cook-issue-9168-none";
+        let first = submit_plan(&test_plan(), Some("no-adoption-first")).expect("first run");
+        record_cook_attempt(cook_id, 1, &first.run_id).expect("index first run");
+        let latest = submit_plan(&test_plan(), Some("no-adoption-latest")).expect("latest run");
+        record_cook_attempt(cook_id, 2, &latest.run_id).expect("index latest run");
+
+        let projected = status(cook_id).expect("Cook alias status");
+        assert_eq!(projected.run_id, latest.run_id);
+        assert!(projected.adoption_run_id.is_none());
+        assert!(projected.candidate_adoption.is_none());
+    });
+}
+
+#[test]
+fn cook_alias_status_selects_latest_terminal_adoption_then_index_order() {
+    with_isolated_home(|_| {
+        let cook_id = "cook-issue-9168-terminal";
+        let mut runs = Vec::new();
+        for attempt in 1..=3 {
+            let run = submit_plan(&test_plan(), Some(&format!("terminal-adoption-{attempt}")))
+                .expect("terminal run");
+            record_cook_attempt(cook_id, attempt, &run.run_id).expect("index terminal run");
+            start_candidate_adoption(
+                &run.run_id,
+                &format!("{attempt:040}"),
+                "openai/gpt-5.6-sol",
+                "cargo test",
+            )
+            .expect("start terminal adoption");
+            finish_candidate_adoption(
+                &run.run_id,
+                (attempt != 1).then(|| format!("attempt {attempt} failed")),
+            )
+            .expect("finish terminal adoption");
+            runs.push(run);
+        }
+        for (run, timestamp) in runs.iter().zip([
+            "2026-07-20T12:00:03+00:00",
+            "2026-07-20T12:00:01+00:00",
+            "2026-07-20T12:00:03+00:00",
+        ]) {
+            rewrite_record_for_test(&run.run_id, |record| {
+                record
+                    .candidate_adoption
+                    .as_mut()
+                    .expect("terminal adoption")
+                    .updated_at = timestamp.to_string();
+            })
+            .expect("set deterministic adoption timestamp");
+        }
+
+        let projected = status(cook_id).expect("Cook alias status");
+        assert_eq!(projected.run_id, runs[2].run_id);
+        assert_eq!(
+            projected.adoption_run_id.as_deref(),
+            Some(runs[2].run_id.as_str())
+        );
+        let adoption = projected.candidate_adoption.expect("terminal projection");
+        assert_eq!(adoption.state, "failed");
+        assert_eq!(adoption.candidate_sha, format!("{:040}", 3));
+    });
+}
+
+#[test]
+fn exact_run_id_status_keeps_its_own_adoption_without_alias_projection() {
+    with_isolated_home(|_| {
+        let cook_id = "cook-issue-9168-exact";
+        let earlier = submit_plan(&test_plan(), Some("exact-earlier")).expect("earlier run");
+        record_cook_attempt(cook_id, 1, &earlier.run_id).expect("index earlier run");
+        start_candidate_adoption(
+            &earlier.run_id,
+            "2222222222222222222222222222222222222222",
+            "openai/gpt-5.6-sol",
+            "cargo test",
+        )
+        .expect("start earlier adoption");
+        let latest = submit_plan(&test_plan(), Some("exact-latest")).expect("latest run");
+        record_cook_attempt(cook_id, 2, &latest.run_id).expect("index latest run");
+
+        let exact_earlier = status(&earlier.run_id).expect("exact earlier status");
+        assert_eq!(exact_earlier.run_id, earlier.run_id);
+        assert!(exact_earlier.adoption_run_id.is_none());
+        assert_eq!(
+            exact_earlier
+                .candidate_adoption
+                .expect("own adoption")
+                .candidate_sha,
+            "2222222222222222222222222222222222222222"
+        );
+
+        let exact_latest = status(&latest.run_id).expect("exact latest status");
+        assert_eq!(exact_latest.run_id, latest.run_id);
+        assert!(exact_latest.adoption_run_id.is_none());
+        assert!(exact_latest.candidate_adoption.is_none());
+    });
+}
+
+#[test]
 fn candidate_adoption_status_persists_running_stale_resume_and_completion() {
     with_isolated_home(|_| {
         let record = submit_plan(&test_plan(), Some("adoption-progress")).expect("submit");


### PR DESCRIPTION
## Summary
- project candidate adoption through Cook-alias status even when an earlier indexed attempt owns it
- preserve the Cook index latest attempt as the execution-status record and expose `adoption_run_id` separately
- prefer active adoption; otherwise select terminal adoption by newest update timestamp with Cook-index order as the deterministic tie-breaker
- inspect only attempts listed in the Cook index

Closes #9168.

## How to test
1. Run `cargo test -p homeboy-agents cook_alias_status_projects_active_adoption_from_earlier_attempt --lib`; expect the latest execution attempt to remain primary while an earlier active adoption and its owning run id are projected.
2. Run `cargo test -p homeboy-agents cook_alias_status_has_no_adoption_projection_without_indexed_adoption --lib`; expect no synthetic adoption fields.
3. Run `cargo test -p homeboy-agents cook_alias_status_selects_latest_terminal_adoption_then_index_order --lib`; expect deterministic terminal selection.
4. Run `cargo test -p homeboy-agents exact_run_id_status_keeps_its_own_adoption_without_alias_projection --lib`; expect exact run status to remain unchanged.
5. Run `cargo test -p homeboy-agents candidate_adoption_status_persists_running_stale_resume_and_completion --lib`.
6. Run `cargo check -p homeboy-agents && cargo fmt --check && git diff --check`.

## Compatibility
The serialized run record adds optional, defaulted fields. Existing records deserialize unchanged, exact run-id status semantics are preserved, and Cook-alias execution status still resolves the latest indexed attempt.

## Evidence
- Source tracker: https://github.com/Extra-Chill/homeboy/issues/9168
- Cook run: `agent-task-f6fae3ae-7dab-4c8d-b378-72228929177c`
- The initial Cook produced a recoverable candidate and passed its deterministic gate but publication eligibility rejected the zero-execution run.
- Homeboy then adopted immutable candidate `0be92003005d099bbda24f5eea23fdcb7387f458`; durable adoption completed and finalization reached `review_ready`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode and Homeboy
- **Used for:** Diagnosed the status-projection gap, cooked the implementation and tests, reviewed the candidate, and finalized it through Homeboy adoption.