### PR TITLE
fix(core): bound extension ready_check recursion with a re-entry guard

### DIFF
--- a/crates/homeboy-core/src/extension_readiness.rs
+++ b/crates/homeboy-core/src/extension_readiness.rs
@@ -16,6 +16,13 @@ pub struct ExtensionReadyStatus {
     pub detail: Option<String>,
 }
 
+/// Environment sentinel set while a `ready_check` runs. A `ready_check` command
+/// can invoke `homeboy` (e.g. `homeboy component show <id>`), which would in turn
+/// re-evaluate readiness and re-run the same `ready_check` — an unbounded
+/// process-spawn recursion (issue #8115). The sentinel lets a nested invocation
+/// detect that it is already inside a `ready_check` and skip re-running it.
+const READY_CHECK_ACTIVE_ENV: &str = "HOMEBOY_EXTENSION_READY_CHECK_ACTIVE";
+
 pub fn extension_ready_status(extension: &ExtensionManifest) -> ExtensionReadyStatus {
     let Some(runtime) = extension.runtime() else {
         return ExtensionReadyStatus {
@@ -33,6 +40,20 @@ pub fn extension_ready_status(extension: &ExtensionManifest) -> ExtensionReadySt
         };
     };
 
+    // Re-entry guard: if we are already inside a `ready_check`, do not run it
+    // again. A `ready_check` that shells back into `homeboy` (component/extension
+    // inspection) would otherwise recurse without bound. Report ready so the
+    // nested inspection completes instead of spawning another check. (#8115)
+    if std::env::var_os(READY_CHECK_ACTIVE_ENV).is_some() {
+        return ExtensionReadyStatus {
+            ready: true,
+            reason: Some("ready_check_reentrant_skipped".to_string()),
+            detail: Some(
+                "ready_check skipped: already evaluating readiness for this extension (re-entrant invocation)".to_string(),
+            ),
+        };
+    }
+
     let Some(extension_path) = extension.extension_path.as_ref() else {
         return ExtensionReadyStatus {
             ready: false,
@@ -47,7 +68,13 @@ pub fn extension_ready_status(extension: &ExtensionManifest) -> ExtensionReadySt
         ("entrypoint", entrypoint.as_str()),
     ];
     let command = template::render(ready_check, &vars);
-    let output = execute_local_command_in_dir(&command, Some(extension_path), None);
+    // Mark the child (and anything it spawns) as running inside a ready_check so
+    // a re-entrant `homeboy` invocation trips the guard above.
+    let output = execute_local_command_in_dir(
+        &command,
+        Some(extension_path),
+        Some(&[(READY_CHECK_ACTIVE_ENV, "1")]),
+    );
 
     if output.success {
         return ExtensionReadyStatus {
@@ -105,4 +132,67 @@ pub fn is_extension_compatible(extension: &ExtensionManifest, project: Option<&P
     }
 
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest_with_ready_check(extension_path: &str, ready_check: &str) -> ExtensionManifest {
+        let mut manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": "fixture",
+            "version": "1.0.0",
+            "executable": {
+                "runtime": {
+                    "ready_check": ready_check
+                }
+            }
+        }))
+        .expect("manifest parses");
+        manifest.id = "fixture".to_string();
+        manifest.extension_path = Some(extension_path.to_string());
+        manifest
+    }
+
+    #[test]
+    fn reentrant_ready_check_is_skipped_without_running_the_command() {
+        // A ready_check that would fail if executed proves the command is never
+        // run when the re-entry sentinel is already set. (#8115)
+        let manifest = manifest_with_ready_check("/tmp", "exit 1");
+        let prior = std::env::var_os(READY_CHECK_ACTIVE_ENV);
+        std::env::set_var(READY_CHECK_ACTIVE_ENV, "1");
+
+        let status = extension_ready_status(&manifest);
+
+        match prior {
+            Some(value) => std::env::set_var(READY_CHECK_ACTIVE_ENV, value),
+            None => std::env::remove_var(READY_CHECK_ACTIVE_ENV),
+        }
+
+        assert!(
+            status.ready,
+            "a re-entrant ready_check must report ready instead of recursing"
+        );
+        assert_eq!(
+            status.reason.as_deref(),
+            Some("ready_check_reentrant_skipped")
+        );
+    }
+
+    #[test]
+    fn ready_check_runs_when_not_reentrant() {
+        let manifest = manifest_with_ready_check("/tmp", "true");
+        let prior = std::env::var_os(READY_CHECK_ACTIVE_ENV);
+        std::env::remove_var(READY_CHECK_ACTIVE_ENV);
+
+        let status = extension_ready_status(&manifest);
+
+        match prior {
+            Some(value) => std::env::set_var(READY_CHECK_ACTIVE_ENV, value),
+            None => std::env::remove_var(READY_CHECK_ACTIVE_ENV),
+        }
+
+        assert!(status.ready, "a passing ready_check reports ready");
+        assert_eq!(status.reason, None);
+    }
 }


### PR DESCRIPTION
Fixes #8115.

## Problem

Inspecting the `wp-codebox` component created a sustained recursive process-spawn loop:

```
homeboy component show wp-codebox
  → node .../check-wp-codebox-runtime-core.mjs   (the extension ready_check)
    → homeboy component show wp-codebox           (re-evaluates readiness)
      → node .../check-...mjs                      (re-runs the same ready_check)
        → ...
```

This pinned an 8-vCPU host at load ~121, with check chains continuing to spawn after the initiating command finished (many reparented to PID 1).

## Root cause

`extension_ready_status` (`crates/homeboy-core/src/extension_readiness.rs`) runs the extension's `ready_check` command. When that command shells back into `homeboy` (component/extension inspection), readiness is re-evaluated and the same `ready_check` runs again — with nothing bounding the recursion.

## Fix

Add a process-environment re-entry guard, generic across all extensions:

- Before running a `ready_check`, if `HOMEBOY_EXTENSION_READY_CHECK_ACTIVE` is already set, skip it and report ready (`ready_check_reentrant_skipped`) so the nested inspection completes instead of spawning another check.
- When running a `ready_check`, set that sentinel in the child's environment so any nested `homeboy` invocation trips the guard.

This bounds the recursion for every extension rather than patching any single ready_check script, matching the issue's expected behavior: readiness checks must be bounded and must not recursively invoke component inspection for the same component.

## Testing

- `reentrant_ready_check_is_skipped_without_running_the_command`: with the sentinel set, a `ready_check` of `exit 1` is *not* run (status is ready with `ready_check_reentrant_skipped`), proving the command is skipped.
- `ready_check_runs_when_not_reentrant`: without the sentinel, a passing `ready_check` runs and reports ready.

## Note

The reported `wordpress.json` `ready_check` still references a since-removed `check-wp-codebox-runtime-core.mjs` script; that stale reference is a separate homeboy-extensions cleanup, but this guard prevents the unbounded recursion regardless of which script a `ready_check` runs.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Traced the recursive spawn to `ready_check` re-entering component inspection and added a generic environment re-entry guard in core so readiness evaluation is bounded for all extensions. Chris reviews and owns the change.