### PR TITLE
fix(lab-runner): bind tracked unresolved symlinks in workspace content hash

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -236,15 +236,37 @@ fn collect_content_hash_entries_v2(
         let link_metadata = fs::symlink_metadata(&entry_path).map_err(|err| {
             Error::internal_io(err.to_string(), Some("read sync file metadata".to_string()))
         })?;
+        // A symlink whose target resolves is dereferenced so its target content
+        // stays provenance-bound (target drift changes the hash). A symlink whose
+        // target is intentionally unavailable on the controller (e.g. a tracked
+        // `blogs.dir -> /nfs`) is a valid Git workspace shape: bind its target
+        // text deterministically instead of refusing the whole hash. (#8374)
         let resolved = if link_metadata.file_type().is_symlink() {
-            entry_path.canonicalize().map_err(|err| {
-                Error::validation_invalid_argument(
-                    "workspace",
-                    "workspace content hash refused an unresolved symlink",
-                    Some(err.to_string()),
-                    None,
-                )
-            })?
+            match entry_path.canonicalize() {
+                Ok(resolved) => resolved,
+                Err(_) => {
+                    let target = fs::read_link(&entry_path).map_err(|err| {
+                        Error::internal_io(
+                            err.to_string(),
+                            Some("read sync symlink target".to_string()),
+                        )
+                    })?;
+                    let target = target.to_string_lossy().replace('\\', "/");
+                    hasher.update(relative.as_bytes());
+                    hasher.update(b"\0symlink\0");
+                    hasher.update((target.len() as u64).to_le_bytes());
+                    hasher.update(target.as_bytes());
+                    record_workspace_content_manifest_entry(
+                        &mut manifest,
+                        relative,
+                        "symlink",
+                        Some(format!("sha256:{:x}", Sha256::digest(target.as_bytes()))),
+                        Some(target.len() as u64),
+                        None,
+                    );
+                    continue;
+                }
+            }
         } else {
             entry_path.clone()
         };
@@ -436,15 +458,24 @@ fn collect_content_hash_entries_v1(
         let link_metadata = fs::symlink_metadata(&entry_path).map_err(|err| {
             Error::internal_io(err.to_string(), Some("read sync file metadata".to_string()))
         })?;
+        // Resolvable symlinks are dereferenced (target content stays bound); a
+        // tracked symlink with an unavailable target binds its target text
+        // instead of failing the hash. See the v2 collector for rationale. (#8374)
         let resolved = if link_metadata.file_type().is_symlink() {
-            entry_path.canonicalize().map_err(|err| {
-                Error::validation_invalid_argument(
-                    "workspace",
-                    "workspace content hash refused an unresolved symlink",
-                    Some(err.to_string()),
-                    None,
-                )
-            })?
+            match entry_path.canonicalize() {
+                Ok(resolved) => resolved,
+                Err(_) => {
+                    let target = fs::read_link(&entry_path).map_err(|err| {
+                        Error::internal_io(
+                            err.to_string(),
+                            Some("read sync symlink target".to_string()),
+                        )
+                    })?;
+                    let target = target.to_string_lossy().replace('\\', "/");
+                    entries.push((relative, "\0symlink\0", 0, target.into_bytes()));
+                    continue;
+                }
+            }
         } else {
             entry_path.clone()
         };

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -1278,6 +1278,37 @@ fn snapshot_archive_command_selectively_dereferences_external_symlinked_dependen
 
 #[cfg(unix)]
 #[test]
+fn content_hash_binds_tracked_unresolved_symlinks_deterministically() {
+    use std::os::unix::fs::symlink;
+
+    // A tracked symlink whose target is intentionally unavailable on the
+    // controller (e.g. `blogs.dir -> /nfs`) is a valid Git workspace shape and
+    // must not fail content hashing. (#8374)
+    let dir = tempfile::tempdir().expect("workspace");
+    symlink("/nfs", dir.path().join("blogs.dir")).expect("unresolved symlink");
+    fs::write(dir.path().join("regular.txt"), "content\n").expect("regular file");
+
+    let hash = workspace_content_hash(dir.path(), &[])
+        .expect("an unresolved tracked symlink must not fail content hashing");
+    assert!(!hash.is_empty());
+    // Deterministic: re-hashing the same shape yields the same identity.
+    let repeat = workspace_content_hash(dir.path(), &[]).expect("repeat hash");
+    assert_eq!(hash, repeat, "content hash must be deterministic");
+    // The legacy v1 algorithm must also bind it rather than refuse.
+    workspace_content_hash_v1(dir.path(), &[]).expect("v1 must also bind the symlink");
+
+    // The symlink target text is part of the identity: changing it changes hash.
+    let other = tempfile::tempdir().expect("other workspace");
+    symlink("/different-target", other.path().join("blogs.dir")).expect("other symlink");
+    fs::write(other.path().join("regular.txt"), "content\n").expect("regular file");
+    let other_hash = workspace_content_hash(other.path(), &[]).expect("other hash");
+    assert_ne!(
+        hash, other_hash,
+        "a different symlink target must change the content hash"
+    );
+}
+
+#[test]
 fn git_backed_snapshot_preserves_tracked_internal_file_and_directory_links() {
     use std::os::unix::fs::symlink;
 


### PR DESCRIPTION
Fixes #8374.

## Problem

A current-main Lab cook (Automattic/wpcom) failed before provider execution while hashing a clean, exact-revision workspace:

```
workspace content hash refused an unresolved symlink
```

The repository tracks symlinks whose targets are intentionally unavailable on the controller — a valid Git workspace shape:

- `wp-content/blogs.dir -> /nfs`
- `wp-content/themes/default -> pub/kubrick`
- `wp-content/themes/twentyten -> pub/twentyten/`

## Root cause

The content-hash collectors (`crates/homeboy-lab-runner/src/workspace/snapshot.rs`) unconditionally `canonicalize()` every symlink. Canonicalizing an unresolved target errors, so the whole workspace hash was refused.

## Fix

Make symlink binding **conditional** in both the v2 and legacy v1 collectors:

- **Resolvable** symlink → dereferenced as before, so its target *content* stays provenance-bound (target drift changes the hash).
- **Unresolved** symlink → bind its **target text** deterministically as a `symlink` entry instead of failing.

Cycle/traversal safety is unchanged: unresolved links are never followed, and resolvable links keep the existing ancestor-cycle guard.

## Testing

- New `content_hash_binds_tracked_unresolved_symlinks_deterministically`: a `blogs.dir -> /nfs` unresolved symlink hashes successfully, is deterministic across runs, is bound by v1 too, and a different target text changes the hash.
- The existing `workspace_content_hash_rejects_dereferenced_symlink_target_drift` (resolvable-symlink content-drift binding) still passes — my first attempt broke it by binding text unconditionally; the conditional fix preserves both semantics.
- Full `workspace::tests::snapshot` suite (55) green.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Traced the refusal to unconditional symlink canonicalization, and made binding conditional (dereference resolvable targets, bind target text for unresolved ones) while preserving target-drift and cycle semantics. Chris reviews and owns the change.