### PR TITLE
refactor(refactor): push struct definition-finding down to language extensions

### DIFF
--- a/crates/homeboy-refactor/src/collapse.rs
+++ b/crates/homeboy-refactor/src/collapse.rs
@@ -34,8 +34,6 @@ use homeboy_core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
 use homeboy_core::Error;
 use homeboy_extension as extension;
 
-use crate::propagate::{extract_struct_source, find_struct_definition};
-
 // ============================================================================
 // Types
 // ============================================================================
@@ -82,58 +80,60 @@ pub fn collapse(config: &CollapseConfig) -> Result<CollapseResult, Error> {
     let root = config.root;
     let struct_name = config.struct_name;
 
-    // Step 1: Find the struct definition file.
-    let def_file = if let Some(f) = config.definition_file {
-        PathBuf::from(f)
-    } else {
-        find_struct_definition(struct_name, root)?
-    };
-    let def_path = if def_file.is_absolute() {
-        def_file.clone()
-    } else {
-        root.join(&def_file)
-    };
-    let def_content = std::fs::read_to_string(&def_path).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some(format!(
-                "read struct definition from {}",
-                def_path.display()
-            )),
-        )
-    })?;
+    // Discover every refactor-capable extension. The collapse dispatch is
+    // language-generic: any language whose refactor extension implements
+    // `collapse_struct_defaults` (and `find_definition`) participates. Nothing
+    // here is Rust-specific — definition-finding and source-block extraction are
+    // delegated to the language extension, so no struct syntax is parsed here.
+    let refactor_exts = crate::definition::refactor_capable_extensions()?;
 
-    // Step 2: Extract the struct source block (field names/types/defaults).
-    let struct_source = extract_struct_source(struct_name, &def_content).ok_or_else(|| {
-        Error::invalid_argument_for(
-            "struct_name",
-            format!(
-                "Could not find struct `{}` in {}",
-                struct_name,
-                def_path.display()
-            ),
+    // Step 1 & 2: Locate the struct definition and extract its source block
+    // (field names/types/defaults) via the language extension. When
+    // `--definition` is supplied the file is known but the source-block
+    // extraction is still language-specific, so it goes through the extension too.
+    let (def_file, struct_source) = if let Some(f) = config.definition_file {
+        let def_file = PathBuf::from(f);
+        let def_path = if def_file.is_absolute() {
+            def_file.clone()
+        } else {
+            root.join(&def_file)
+        };
+        let def_content = std::fs::read_to_string(&def_path).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!(
+                    "read struct definition from {}",
+                    def_path.display()
+                )),
+            )
+        })?;
+        let relative = def_file
+            .strip_prefix(root)
+            .unwrap_or(&def_file)
+            .to_string_lossy()
+            .to_string();
+        let source = crate::definition::extract_definition_source(
             struct_name,
+            &def_content,
+            &relative,
+            &refactor_exts,
         )
-    })?;
-
-    // Step 3: Discover every refactor-capable extension and the file extensions
-    // it handles. The collapse dispatch is language-generic: any language whose
-    // refactor extension implements a `collapse_struct_defaults` command
-    // participates. The Rust extension is the first implementer, but nothing
-    // here is Rust-specific — a Go/Swift/PHP refactor extension that grows the
-    // same command is picked up automatically.
-    let refactor_exts: Vec<extension::ExtensionManifest> = extension::load_all_extensions()
-        .unwrap_or_default()
-        .into_iter()
-        .filter(|m| m.refactor_script().is_some() && !m.provided_file_extensions().is_empty())
-        .collect();
-
-    if refactor_exts.is_empty() {
-        return Err(Error::invalid_argument(
-            "extension",
-            "No extension with refactor capability found. Install a language refactor extension (e.g. the Rust extension).",
-        ));
-    }
+        .ok_or_else(|| {
+            Error::invalid_argument_for(
+                "struct_name",
+                format!(
+                    "Could not find struct `{}` in {}",
+                    struct_name,
+                    def_path.display()
+                ),
+                struct_name,
+            )
+        })?;
+        (def_file, source)
+    } else {
+        let located = crate::definition::find_definition(struct_name, root, &refactor_exts)?;
+        (located.file, located.source)
+    };
 
     let def_relative = def_file
         .strip_prefix(root)

--- a/crates/homeboy-refactor/src/definition.rs
+++ b/crates/homeboy-refactor/src/definition.rs
@@ -1,0 +1,167 @@
+//! Language-generic struct/item definition discovery.
+//!
+//! Finding *where* a struct is defined and extracting its source block is
+//! language-specific analysis — `pub struct Name { .. }` is Rust syntax, a PHP
+//! class or a Go type looks nothing like it. So that analysis does **not** live
+//! here. This module owns only the language-agnostic parts: walking candidate
+//! files (by the extensions a refactor extension handles) and asking each
+//! language extension, via the `find_definition` command, whether a given file
+//! defines the named item and what its source block is.
+//!
+//! The Rust extension answers `find_definition` by matching `pub struct Name`
+//! and brace-balancing the body; a PHP/Go/Swift extension answers the same
+//! command with its own class/type syntax. Nothing in this file is
+//! Rust-specific — that was previously not true (`homeboy-refactor` hardcoded
+//! `format!("pub struct {} ", ..)`), which this module removes so the refactor
+//! engine stays language-agnostic end to end.
+
+use std::path::{Path, PathBuf};
+
+use homeboy_core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use homeboy_core::Error;
+use homeboy_extension as extension;
+
+/// A located definition: the file it lives in and its extracted source block.
+pub(crate) struct LocatedDefinition {
+    /// Path to the file containing the definition, relative to `root` when the
+    /// scan produced a path under `root` (absolute otherwise).
+    pub file: PathBuf,
+    /// The full source block of the definition (attributes/doc comments +
+    /// braced body), as extracted by the owning language extension.
+    pub source: String,
+}
+
+/// Enumerate installed extensions that advertise a refactor script and handle at
+/// least one file extension. Shared by definition-finding and the
+/// propagate/collapse scans so they agree on which languages participate.
+pub(crate) fn refactor_capable_extensions() -> Result<Vec<extension::ExtensionManifest>, Error> {
+    let exts: Vec<extension::ExtensionManifest> = extension::load_all_extensions()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|m| m.refactor_script().is_some() && !m.provided_file_extensions().is_empty())
+        .collect();
+
+    if exts.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "extension",
+            "No extension with refactor capability found. Install a language refactor extension (e.g. the Rust extension).",
+            None,
+            None,
+        ));
+    }
+    Ok(exts)
+}
+
+/// Extract a definition's source block from a file whose content is already in
+/// hand, by asking each refactor extension's `find_definition` command. Returns
+/// `None` if no extension recognizes the item in this content.
+///
+/// Used when the caller supplied an explicit `--definition` file: the file is
+/// known, but the *source block* extraction is still language-specific.
+pub(crate) fn extract_definition_source(
+    struct_name: &str,
+    file_content: &str,
+    file_relative: &str,
+    exts: &[extension::ExtensionManifest],
+) -> Option<String> {
+    if !file_content.contains(struct_name) {
+        return None;
+    }
+    for ext_manifest in exts {
+        let cmd = serde_json::json!({
+            "command": "find_definition",
+            "struct_name": struct_name,
+            "file_content": file_content,
+            "file_path": file_relative,
+        });
+        let Some(result) = extension::run_refactor_script(ext_manifest, &cmd) else {
+            continue;
+        };
+        let defines = result
+            .get("defines")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if defines {
+            if let Some(source) = result.get("struct_source").and_then(|v| v.as_str()) {
+                return Some(source.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Find the file that defines `struct_name` by scanning the codebase and asking
+/// each refactor extension's `find_definition` command. Returns both the file
+/// path and the extracted source block (so callers need not re-read/re-parse).
+///
+/// The file walk is language-agnostic (driven by the extensions each refactor
+/// extension handles); the definition recognition is delegated to the language
+/// extension.
+pub(crate) fn find_definition(
+    struct_name: &str,
+    root: &Path,
+    exts: &[extension::ExtensionManifest],
+) -> Result<LocatedDefinition, Error> {
+    for ext_manifest in exts {
+        let handled_exts: Vec<String> = ext_manifest.provided_file_extensions().to_vec();
+        let scan_config = ScanConfig {
+            extensions: ExtensionFilter::Only(handled_exts.clone()),
+            skip_hidden: true,
+            ..Default::default()
+        };
+        let files = codebase_scan::walk_files(root, &scan_config);
+
+        for file_path in &files {
+            let Ok(content) = std::fs::read_to_string(file_path) else {
+                continue;
+            };
+            // Cheap pre-filter before paying for a script invocation.
+            if !content.contains(struct_name) {
+                continue;
+            }
+            let relative = file_path
+                .strip_prefix(root)
+                .unwrap_or(file_path)
+                .to_string_lossy()
+                .to_string();
+
+            let cmd = serde_json::json!({
+                "command": "find_definition",
+                "struct_name": struct_name,
+                "file_content": content,
+                "file_path": relative,
+            });
+            let Some(result) = extension::run_refactor_script(ext_manifest, &cmd) else {
+                continue;
+            };
+            let defines = result
+                .get("defines")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if !defines {
+                continue;
+            }
+            let Some(source) = result.get("struct_source").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            return Ok(LocatedDefinition {
+                file: file_path.clone(),
+                source: source.to_string(),
+            });
+        }
+    }
+
+    Err(Error::validation_invalid_argument(
+        "struct_name",
+        format!(
+            "Could not find a definition for `{}` under {}",
+            struct_name,
+            root.display()
+        ),
+        None,
+        Some(vec![format!(
+            "homeboy refactor propagate --struct-name {} --definition src/path/to/file.rs",
+            struct_name
+        )]),
+    ))
+}

--- a/crates/homeboy-refactor/src/lib.rs
+++ b/crates/homeboy-refactor/src/lib.rs
@@ -12,6 +12,7 @@ pub mod audit_fixability_provider;
 pub mod auto;
 pub mod collapse;
 pub mod decompose;
+mod definition;
 pub mod edit_op_tagged;
 pub mod move_items;
 pub mod plan;

--- a/crates/homeboy-refactor/src/propagate.rs
+++ b/crates/homeboy-refactor/src/propagate.rs
@@ -11,10 +11,10 @@
 //! extensions it handles and sends candidate files to that extension's
 //! `propagate_struct_fields` command. Any language whose refactor extension
 //! implements that command participates automatically — nothing in the scan
-//! loop is Rust-specific. Today only the Rust extension implements it;
-//! `find_struct_definition`/`extract_struct_source` parse Rust struct syntax, so
-//! a non-Rust implementation would supply its own definition source via
-//! `--definition`.
+//! loop is Rust-specific. Definition-finding and source-block extraction are
+//! also delegated to the language extension (via the `find_definition` command
+//! in [`crate::definition`]), so no struct syntax is parsed in this crate. Today
+//! only the Rust extension implements these commands.
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -79,65 +79,61 @@ pub fn propagate(config: &PropagateConfig) -> Result<PropagateResult, Error> {
     let root = config.root;
     let struct_name = config.struct_name;
 
-    // Step 1: Find the struct definition file
-    let def_file = if let Some(f) = config.definition_file {
-        PathBuf::from(f)
-    } else {
-        find_struct_definition(struct_name, root)?
-    };
+    // Discover every refactor-capable extension. Propagation is language-generic:
+    // any language whose refactor extension implements `propagate_struct_fields`
+    // (and `find_definition`) participates. Nothing below is Rust-specific — the
+    // Rust extension is merely the first implementer. Definition-finding and
+    // source extraction are delegated to the language extension via the
+    // `find_definition` command, so no struct syntax is parsed in this crate.
+    let refactor_exts = crate::definition::refactor_capable_extensions()?;
 
-    let def_path = if def_file.is_absolute() {
-        def_file.clone()
-    } else {
-        root.join(&def_file)
-    };
-
-    let def_content = std::fs::read_to_string(&def_path).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some(format!(
-                "read struct definition from {}",
-                def_path.display()
-            )),
+    // Step 1 & 2: Locate the struct definition and extract its source block.
+    // When `--definition` is supplied the file is known but the source-block
+    // extraction is still language-specific, so it goes through the extension too.
+    let (def_file, struct_source) = if let Some(f) = config.definition_file {
+        let def_file = PathBuf::from(f);
+        let def_path = if def_file.is_absolute() {
+            def_file.clone()
+        } else {
+            root.join(&def_file)
+        };
+        let def_content = std::fs::read_to_string(&def_path).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!(
+                    "read struct definition from {}",
+                    def_path.display()
+                )),
+            )
+        })?;
+        let relative = def_file
+            .strip_prefix(root)
+            .unwrap_or(&def_file)
+            .to_string_lossy()
+            .to_string();
+        let source = crate::definition::extract_definition_source(
+            struct_name,
+            &def_content,
+            &relative,
+            &refactor_exts,
         )
-    })?;
-
-    // Step 2: Extract the struct source block
-    let struct_source = extract_struct_source(struct_name, &def_content).ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "struct_name",
-            format!(
-                "Could not find struct `{}` in {}",
-                struct_name,
-                def_path.display()
-            ),
-            None,
-            None,
-        )
-    })?;
-
-    // Step 3: Discover every refactor-capable extension and the file extensions
-    // it handles. Propagation is language-generic: any language whose refactor
-    // extension implements the `propagate_struct_fields` command participates.
-    // The Rust extension is the first implementer, but nothing in the loop below
-    // is Rust-specific — a Go/Swift/PHP refactor extension that grows the same
-    // command is picked up automatically. (`find_struct_definition`/
-    // `extract_struct_source` currently parse Rust struct syntax; a non-Rust
-    // implementation would supply its own definition source via `--definition`.)
-    let refactor_exts: Vec<extension::ExtensionManifest> = extension::load_all_extensions()
-        .unwrap_or_default()
-        .into_iter()
-        .filter(|m| m.refactor_script().is_some() && !m.provided_file_extensions().is_empty())
-        .collect();
-
-    if refactor_exts.is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "extension",
-            "No extension with refactor capability found. Install a language refactor extension (e.g. the Rust extension).",
-            None,
-            None,
-        ));
-    }
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "struct_name",
+                format!(
+                    "Could not find struct `{}` in {}",
+                    struct_name,
+                    def_path.display()
+                ),
+                None,
+                None,
+            )
+        })?;
+        (def_file, source)
+    } else {
+        let located = crate::definition::find_definition(struct_name, root, &refactor_exts)?;
+        (located.file, located.source)
+    };
 
     let def_relative = def_file
         .strip_prefix(root)
@@ -289,111 +285,6 @@ pub fn propagate(config: &PropagateConfig) -> Result<PropagateResult, Error> {
 // ============================================================================
 // Internal helpers
 // ============================================================================
-
-/// Find the file containing a struct definition by scanning the codebase.
-pub(crate) fn find_struct_definition(struct_name: &str, root: &Path) -> Result<PathBuf, Error> {
-    let pattern = format!("pub struct {} ", struct_name);
-    let pattern_brace = format!("pub struct {} {{", struct_name);
-    let pattern_crate = format!("pub(crate) struct {} ", struct_name);
-    let pattern_crate_brace = format!("pub(crate) struct {} {{", struct_name);
-
-    let scan_config = ScanConfig {
-        extensions: ExtensionFilter::Only(vec!["rs".to_string()]),
-        skip_hidden: true,
-        ..Default::default()
-    };
-    let files = codebase_scan::walk_files(root, &scan_config);
-
-    for file_path in &files {
-        let Ok(content) = std::fs::read_to_string(file_path) else {
-            continue;
-        };
-        if content.contains(&pattern)
-            || content.contains(&pattern_brace)
-            || content.contains(&pattern_crate)
-            || content.contains(&pattern_crate_brace)
-        {
-            return Ok(file_path.clone());
-        }
-    }
-
-    Err(Error::validation_invalid_argument(
-        "struct_name",
-        format!(
-            "Could not find struct `{}` in any .rs file under {}",
-            struct_name,
-            root.display()
-        ),
-        None,
-        Some(vec![format!(
-            "homeboy refactor propagate --struct-name {} --definition src/path/to/file.rs",
-            struct_name
-        )]),
-    ))
-}
-
-/// Extract the full struct source block (including doc comments and attributes)
-/// from file content.
-pub(crate) fn extract_struct_source(struct_name: &str, content: &str) -> Option<String> {
-    let lines: Vec<&str> = content.lines().collect();
-
-    let struct_pattern = format!("struct {} ", struct_name);
-    let struct_pattern_brace = format!("struct {} {{", struct_name);
-    let mut start_line = None;
-
-    for (i, line) in lines.iter().enumerate() {
-        if line.contains(&struct_pattern) || line.contains(&struct_pattern_brace) {
-            // Walk backwards to include attributes and doc comments
-            let mut actual_start = i;
-            for j in (0..i).rev() {
-                let trimmed = lines[j].trim();
-                if trimmed.starts_with('#')
-                    || trimmed.starts_with("///")
-                    || trimmed.starts_with("//!")
-                {
-                    actual_start = j;
-                } else if trimmed.is_empty() {
-                    if j > 0
-                        && (lines[j - 1].trim().starts_with('#')
-                            || lines[j - 1].trim().starts_with("///"))
-                    {
-                        actual_start = j;
-                    } else {
-                        break;
-                    }
-                } else {
-                    break;
-                }
-            }
-            start_line = Some(actual_start);
-            break;
-        }
-    }
-
-    let start = start_line?;
-
-    // Find the closing brace
-    let mut depth = 0i32;
-    let mut found_open = false;
-    let mut end_line = start;
-
-    for (i, line_content) in lines.iter().enumerate().skip(start) {
-        for ch in line_content.chars() {
-            if ch == '{' {
-                depth += 1;
-                found_open = true;
-            } else if ch == '}' {
-                depth -= 1;
-            }
-        }
-        if found_open && depth == 0 {
-            end_line = i;
-            break;
-        }
-    }
-
-    Some(lines[start..=end_line].join("\n"))
-}
 
 /// Extract field information from propagation edits.
 ///


### PR DESCRIPTION
## Summary
Removes the **Rust-parsing island** from `homeboy-refactor`. The crate previously hardcoded Rust struct syntax — `find_struct_definition` built `format!("pub struct {} ", name)` patterns and `extract_struct_source` brace-walked a Rust struct body — inside the crate whose whole design goal is a *language-generic* refactor engine.

The dispatch loop was already generic (it enumerates refactor-capable extensions and delegates `collapse_struct_defaults` / `propagate_struct_fields`), but **definition discovery was still Rust-pinned**. Consequences: `collapse-defaults`/`propagate` could never auto-detect a definition in PHP/Go/Swift, and core carried language analysis it is supposed to delegate.

> Context: this was flagged while exploring whether the refactor engine applies to a PHP/WordPress codebase (Data Machine). `extract_shared` (fully in the WordPress extension) works there, but `collapse`/`propagate` couldn't — precisely because definition-finding assumed `pub struct`. This closes that gap.

## Changes
- **New `definition.rs`** — the language-agnostic parts only:
  - `refactor_capable_extensions()` — shared extension enumeration.
  - `find_definition()` — walk candidate files (by the extensions each refactor extension handles), ask each file via the `find_definition` command whether it defines the item and get its source block.
  - `extract_definition_source()` — for the explicit `--definition` path (file known, but source-block extraction is still language-specific).
- **`propagate.rs` / `collapse.rs`** — drop the two Rust-parsing helpers; route definition-finding + source extraction through `definition.rs`. **No struct syntax is parsed in this crate anymore.**

Any language whose refactor extension implements `find_definition` (plus the existing propagate/collapse commands) now participates with zero changes here.

## Behavior preserved on Rust
The Rust extension's `find_definition` matches the old `pub`/`pub(crate) struct` patterns and the same attribute/doc backward-walk + brace-balanced extraction. Verified end-to-end against a real homeboy struct (`ReleaseStepResult`): the extension locates it and returns the identical 17-line source block. `cargo check` + `cargo fmt` clean.

## Dependency
Depends on **homeboy-extensions#2314** (the `find_definition` command). Merge that first.

## Testing note
Consistent with the existing architecture, the `collapse`/`propagate` engine functions have no Rust integration tests — the analysis is tested in the extension's Python suite (extended in #2314: 17 tests pass) and exercised end-to-end. The Rust side is thin dispatch; contract parity between the two sides was verified by direct invocation.