### PR TITLE
fix(agents): exclude Homeboy runner metadata from candidate patches

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
@@ -5,6 +5,16 @@ use sha2::{Digest, Sha256};
 
 use super::*;
 
+/// Git pathspecs excluding Homeboy-owned runner workspace metadata from captured
+/// candidate patches. The runner writes `.homeboy/runner-workspace.json` (and
+/// scratch under `.homeboy/`) after the snapshot baseline is established, so it
+/// is checkout drift rather than provider output — including it produces a patch
+/// that deletes/rewrites runner metadata and cannot be promoted cleanly. (#8534)
+const HARVEST_METADATA_EXCLUDE_PATHSPECS: &[&str] = &[
+    ":(exclude).homeboy/runner-workspace.json",
+    ":(exclude).homeboy/lab-at-files/**",
+];
+
 pub(super) fn harvest_committed_patch(
     outcome: &mut AgentTaskOutcome,
     running: &RunningTask,
@@ -28,22 +38,27 @@ pub(super) fn harvest_uncommitted_patch(
     }
     // This checkout belongs solely to this dispatch. Staging all changes makes
     // Git's binary patch generation include tracked, staged, and untracked files.
+    // Homeboy-owned runner metadata is excluded from the diff so it never lands
+    // in a candidate patch as checkout drift. (#8534)
     git_output(root, &["add", "--all"])?;
-    let patch = git_output_raw(
-        root,
-        &[
-            "diff",
-            "--cached",
-            "--binary",
-            "--full-index",
-            "--find-renames",
-            "HEAD",
-        ],
-    )?;
+    let mut uncommitted_patch_args = vec![
+        "diff",
+        "--cached",
+        "--binary",
+        "--full-index",
+        "--find-renames",
+        "HEAD",
+        "--",
+        ".",
+    ];
+    uncommitted_patch_args.extend_from_slice(HARVEST_METADATA_EXCLUDE_PATHSPECS);
+    let patch = git_output_raw(root, &uncommitted_patch_args)?;
     if patch.trim().is_empty() {
         return Ok(());
     }
-    let changed_files = git_changed_files(root, &["diff", "--cached", "--name-only", "HEAD"])?;
+    let mut uncommitted_changed_args = vec!["diff", "--cached", "--name-only", "HEAD", "--", "."];
+    uncommitted_changed_args.extend_from_slice(HARVEST_METADATA_EXCLUDE_PATHSPECS);
+    let changed_files = git_changed_files(root, &uncommitted_changed_args)?;
     let path = attempt_patch_path(running, "uncommitted")?;
     std::fs::write(&path, patch.as_bytes()).map_err(|error| HarvestError::ArtifactWrite {
         path: path.clone(),
@@ -205,17 +220,18 @@ fn harvest_committed_patch_with_metadata(
             head,
         });
     }
-    let patch = git_output_raw(
-        root,
-        &[
-            "diff",
-            "--binary",
-            "--full-index",
-            "--find-renames",
-            base,
-            "HEAD",
-        ],
-    )?;
+    let mut committed_patch_args = vec![
+        "diff",
+        "--binary",
+        "--full-index",
+        "--find-renames",
+        base,
+        "HEAD",
+        "--",
+        ".",
+    ];
+    committed_patch_args.extend_from_slice(HARVEST_METADATA_EXCLUDE_PATHSPECS);
+    let patch = git_output_raw(root, &committed_patch_args)?;
     if patch.trim().is_empty() {
         return Ok(());
     }
@@ -236,7 +252,9 @@ fn harvest_committed_patch_with_metadata(
         Vec::new(),
     ));
     let commits = collect_metadata(root, &range)?;
-    let changed_files = git_changed_files(root, &["diff", "--name-only", base, "HEAD"])?;
+    let mut committed_changed_args = vec!["diff", "--name-only", base, "HEAD", "--", "."];
+    committed_changed_args.extend_from_slice(HARVEST_METADATA_EXCLUDE_PATHSPECS);
+    let changed_files = git_changed_files(root, &committed_changed_args)?;
     outcome
         .artifacts
         .last_mut()
@@ -838,6 +856,116 @@ mod committed_harvest_tests {
             diagnostic.class == "agent_task.committed_harvest_git_failed"
                 && diagnostic.data["command"] == "git log injected metadata failure"
         }));
+    }
+
+    #[test]
+    fn uncommitted_harvest_excludes_homeboy_runner_metadata_drift() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir(&workspace).expect("workspace");
+        git(&workspace, &["init", "-b", "main"]);
+        git(&workspace, &["config", "user.email", "test@example.com"]);
+        git(&workspace, &["config", "user.name", "Homeboy Test"]);
+        std::fs::write(workspace.join("file.txt"), "base\n").expect("base file");
+        // The runner metadata exists at the baseline; the runner rewrites it after
+        // materialization, which is checkout drift, not provider output. (#8534)
+        std::fs::create_dir_all(workspace.join(".homeboy")).expect(".homeboy dir");
+        std::fs::write(
+            workspace.join(".homeboy/runner-workspace.json"),
+            "{\"stage\":\"baseline\"}\n",
+        )
+        .expect("runner metadata baseline");
+        git(&workspace, &["add", "-A"]);
+        git(&workspace, &["commit", "-m", "base"]);
+        let base = git(&workspace, &["rev-parse", "HEAD"]);
+
+        // The provider edits one file; the runner rewrites its metadata (drift).
+        std::fs::write(workspace.join("file.txt"), "provider change\n").expect("provider edit");
+        std::fs::write(
+            workspace.join(".homeboy/runner-workspace.json"),
+            "{\"stage\":\"final\"}\n",
+        )
+        .expect("runner metadata drift");
+
+        let request = AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "task-1".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "test".to_string(),
+                selector: None,
+                runtime_selection: None,
+                required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
+                model: None,
+                config: serde_json::Value::Null,
+            },
+            instructions: String::new(),
+            inputs: serde_json::Value::Null,
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace {
+                root: Some(workspace.display().to_string()),
+                ..Default::default()
+            },
+            component_contracts: Vec::new(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            artifact_declarations: Vec::new(),
+            metadata: serde_json::Value::Null,
+        };
+        let running = RunningTask {
+            task_id: "task-1".to_string(),
+            request,
+            workspace_key: None,
+            executor_key: "test".to_string(),
+            model_key: None,
+            resource_units: 1,
+            exclusive_resource_keys: Vec::new(),
+            attempt: 1,
+            started_at: Instant::now(),
+            timeout_ms: None,
+            execution_deadline_unix_ms: None,
+            timeout_cancel_requested: false,
+            rotation_index: 0,
+            rotation_attempts: Vec::new(),
+            candidate_artifacts: Vec::new(),
+            retry_attempts: Vec::new(),
+            source_workspace_root: None,
+            _attempt_workspace: None,
+            run_id: Some("metadata-exclude-test".to_string()),
+            artifact_nonce: "test-artifact".to_string(),
+            task_base_sha: Some(base),
+            source_provenance: None,
+            scratch: crate::controller_scratch::ControllerScratchAllocation {
+                path: temp.path().join("controller-scratch"),
+                lease_id: "test-lease-1".to_string(),
+                index_path: temp.path().join("resources.json"),
+            },
+            adoption: None,
+            join_handle: None,
+        };
+        std::fs::create_dir_all(&running.scratch.path).expect("scratch dir");
+
+        let mut outcome = committed_harvest_preflight_outcome("task-1".to_string());
+        outcome.status = AgentTaskOutcomeStatus::Succeeded;
+        harvest_uncommitted_patch(&mut outcome, &running).expect("harvest uncommitted patch");
+
+        let patch_path = outcome.artifacts[0]
+            .path
+            .clone()
+            .expect("uncommitted patch path");
+        let patch = std::fs::read_to_string(&patch_path).expect("read patch");
+        assert!(
+            patch.contains("file.txt") && patch.contains("+provider change"),
+            "the provider edit must be captured: {patch}"
+        );
+        assert!(
+            !patch.contains("runner-workspace.json"),
+            "Homeboy runner metadata drift must be excluded from the candidate patch: {patch}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Addresses the concrete metadata-contamination gap in #8534.

## Problem

A recovered successful Lab candidate patch contained a deletion of `.homeboy/runner-workspace.json` mixed in with the intended task files — a patch that is valid by hash/size but cannot be promoted cleanly.

## Investigation

Tracing the dirty-snapshot flow: the snapshot overlay IS committed as a deterministic baseline (`synthetic_checkout_commit`, `workspace/snapshot.rs`), and the harvest diffs against `task_base_sha` with an ancestor guard on the committed path — so the **provider-write baseline is correct**. The remaining leak is that the harvest `git diff` did **not** exclude Homeboy-owned runner metadata. The runner writes `.homeboy/runner-workspace.json` *after* the baseline (see the "runner adds `.homeboy/runner-workspace.json` after transport" note in `workspace/snapshot.rs`), so its create/rewrite/delete shows up as checkout drift in the candidate patch.

## Fix

Exclude Homeboy-owned metadata pathspecs (`:(exclude).homeboy/runner-workspace.json`, `:(exclude).homeboy/lab-at-files/**`) from both harvest paths in `crates/homeboy-agents/src/agent_task_scheduler/harvest.rs`:

- committed harvest: `git diff base HEAD -- . <excludes>` (patch + changed-files)
- uncommitted harvest: `git diff --cached HEAD -- . <excludes>` (patch + changed-files)

This mirrors the exclusion already applied to snapshot cleanliness checks (`workspace/provenance.rs`) and daemon patch capture (`daemon/patch_capture.rs`), so the candidate patch isolates the provider-only delta (issue acceptance criterion #3).

## Testing

- New `uncommitted_harvest_excludes_homeboy_runner_metadata_drift`: a workspace with `.homeboy/runner-workspace.json` at the baseline that the runner rewrites as drift, plus one provider edit — asserts the captured patch contains the provider change and **not** `runner-workspace.json`.
- Full `harvest` suite (7) green.

## Scope note

This closes the specific, provable metadata-contamination gap from the report. The broader baseline-isolation criteria (provider-write baseline after materialization, promotion applies to the recorded source state) are already handled by the synthetic-snapshot-commit baseline + the committed-path ancestor guard; this PR removes the last source of drift (runner metadata) from the captured delta.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Traced the contaminated-patch flow, confirmed the provider-write baseline is the materialized snapshot commit, and identified + fixed the remaining leak (Homeboy runner metadata not excluded from the harvest diff). Chris reviews and owns the change.