### PR TITLE
Recover cooks after preflight failure

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -702,11 +702,20 @@ where
     } else {
         options
     };
+    materialize_initial_cook_attempt(&options)?;
     // Transport readiness can serialize on a reconnect/runtime-promotion
     // lease. Complete it before entering the provider-attempt loop so that
     // waiting for a shared Lab session never consumes a cook attempt.
     if let Some(dispatcher) = &options.attempt_dispatcher {
-        dispatcher.prepare_for_cook()?;
+        if let Err(error) = dispatcher.prepare_for_cook() {
+            agent_task_lifecycle::record_pre_execution_failure(
+                &options.initial_run_id,
+                &options.initial_plan,
+                dispatcher.pre_execution_failure_phase(),
+                &error,
+            )?;
+            return Err(error);
+        }
     }
     let max_attempts = options.max_attempts.max(1);
     let mut attempts = Vec::new();
@@ -724,15 +733,16 @@ where
         };
         let needs_execution = agent_task_lifecycle::status(&run_id)
             .map(|record| {
-                !matches!(
+                (!matches!(
                     record.state,
                     agent_task_lifecycle::AgentTaskRunState::Succeeded
                         | agent_task_lifecycle::AgentTaskRunState::PartialFailure
                         | agent_task_lifecycle::AgentTaskRunState::Failed
                         | agent_task_lifecycle::AgentTaskRunState::Cancelled
-                ) && !record.lab_handoff.as_ref().is_some_and(|handoff| {
-                    handoff.state == agent_task_lifecycle::AgentTaskLabHandoffState::Accepted
-                })
+                ) || retryable_pre_execution_failure(&record))
+                    && !record.lab_handoff.as_ref().is_some_and(|handoff| {
+                        handoff.state == agent_task_lifecycle::AgentTaskLabHandoffState::Accepted
+                    })
             })
             .unwrap_or(true);
         if needs_execution {
@@ -783,6 +793,16 @@ where
             })();
             if let Err(error) = execution {
                 let record = match agent_task_lifecycle::status(&run_id) {
+                    Ok(record)
+                        if record.state == agent_task_lifecycle::AgentTaskRunState::Queued =>
+                    {
+                        let phase = pre_execution_failure_phase(
+                            &error,
+                            options.attempt_dispatcher.as_deref(),
+                        );
+                        record_pre_execution_failure(&plan, &run_id, &error, phase)?;
+                        agent_task_lifecycle::status(&run_id).ok()
+                    }
                     Ok(record) => Some(record),
                     Err(_) => {
                         let phase = pre_execution_failure_phase(
@@ -1159,6 +1179,35 @@ where
     ))
 }
 
+/// Persist the controller-owned initial attempt before transport preparation so
+/// runner eligibility failures remain addressable through the cook alias.
+fn materialize_initial_cook_attempt(options: &AgentTaskCookServiceOptions) -> Result<()> {
+    if agent_task_lifecycle::run_record_exists(&options.initial_run_id)? {
+        return Ok(());
+    }
+    match agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&options.initial_run_id)) {
+        Ok(_) => {
+            agent_task_lifecycle::record_cook_attempt(&options.cook_id, 1, &options.initial_run_id)
+                .map(|_| ())
+        }
+        Err(error) => {
+            // `submit_plan` persists admission failures before returning them.
+            if agent_task_lifecycle::run_record_exists(&options.initial_run_id)? {
+                agent_task_lifecycle::record_cook_attempt(
+                    &options.cook_id,
+                    1,
+                    &options.initial_run_id,
+                )?;
+            }
+            Err(error)
+        }
+    }
+}
+
+fn retryable_pre_execution_failure(record: &agent_task_lifecycle::AgentTaskRunRecord) -> bool {
+    record.metadata["pre_execution_failure"]["retryable"] == Value::Bool(true)
+}
+
 #[derive(Debug)]
 struct PreExecutionFailureDetails {
     retryable: bool,
@@ -1241,9 +1290,10 @@ fn record_pre_execution_failure(
     error: &Error,
     phase: &str,
 ) -> Result<()> {
-    if agent_task_lifecycle::submit_plan(plan, Some(run_id)).is_ok() {
-        agent_task_lifecycle::record_pre_execution_failure(run_id, plan, phase, error)?;
+    if !agent_task_lifecycle::run_record_exists(run_id)? {
+        agent_task_lifecycle::submit_plan(plan, Some(run_id))?;
     }
+    agent_task_lifecycle::record_pre_execution_failure(run_id, plan, phase, error)?;
     Ok(())
 }
 
@@ -1520,7 +1570,8 @@ mod tests {
                     "fixture runner is unavailable",
                     None,
                     None,
-                ));
+                )
+                .with_retryable(true));
             }
             Ok(())
         }
@@ -1848,7 +1899,7 @@ mod tests {
     }
 
     #[test]
-    fn cook_transport_preparation_failure_does_not_create_a_provider_attempt() {
+    fn cook_transport_preparation_failure_is_durable_and_resumes_after_runner_recovery() {
         homeboy_core::test_support::with_isolated_home(|_| {
             let cook_id = "cook-runner-unavailable";
             let first_run_id = "cook-runner-unavailable-attempt-1";
@@ -1862,15 +1913,30 @@ mod tests {
             options.initial_run_id = first_run_id.to_string();
             options.max_attempts = 2;
 
-            let error = run_cook(options, UnusedExecutor)
+            let error = run_cook(options.clone(), UnusedExecutor)
                 .expect_err("transport preparation is outside the provider-attempt loop");
 
             assert!(error.message.contains("fixture runner is unavailable"));
-            assert!(!agent_task_lifecycle::run_record_exists(first_run_id)
-                .expect("transport failure does not materialize an attempt"));
-            assert!(
-                agent_task_lifecycle::cook_index(cook_id).is_err(),
-                "transport failure must not consume a cook attempt"
+            let blocked = agent_task_lifecycle::status(cook_id)
+                .expect("cook alias exposes the preflight-blocked attempt");
+            assert_eq!(blocked.run_id, first_run_id);
+            assert_eq!(
+                blocked.state,
+                agent_task_lifecycle::AgentTaskRunState::Failed
+            );
+            assert_eq!(
+                blocked.metadata["pre_execution_failure"]["retryable"],
+                Value::Bool(true)
+            );
+
+            let resumed = run_cook(options, UnusedExecutor)
+                .expect("repaired runner resumes the immutable cook attempt");
+            assert_eq!(resumed.value.status, "in_flight");
+            assert_eq!(
+                agent_task_lifecycle::status(cook_id)
+                    .expect("resumed cook alias")
+                    .runner_job_id(),
+                Some("accepted-daemon-job")
             );
         });
     }
@@ -1927,10 +1993,13 @@ mod tests {
                 .expect_err("transport preparation remains outside cook retries");
 
             assert!(error.message.contains("fixture runner is unavailable"));
-            assert!(
-                !agent_task_lifecycle::run_record_exists("cook-runner-exhaustion-attempt-1")
-                    .expect("transport failure does not materialize an attempt")
+            let record = agent_task_lifecycle::status("cook-runner-exhaustion")
+                .expect("transport failure remains inspectable");
+            assert_eq!(
+                record.state,
+                agent_task_lifecycle::AgentTaskRunState::Failed
             );
+            assert_eq!(record.metadata["provider_executions_consumed"], 0);
         });
     }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -159,7 +159,18 @@ pub fn persist_initial_recipe(
         // Harvest transport belongs to the original controller execution. A
         // replay must use that persisted context rather than ambient state.
         expected.harvest_context = existing.harvest_context.clone();
-        if existing != expected || existing.attempts.first() != recipe.attempts.first() {
+        if !recipes_match(&existing, &expected)
+            || !initial_attempt_inputs_match(
+                existing
+                    .attempts
+                    .first()
+                    .expect("validated recipe has attempt"),
+                recipe
+                    .attempts
+                    .first()
+                    .expect("validated recipe has attempt"),
+            )
+        {
             return Err(Error::validation_invalid_argument(
                 "cook_recipe",
                 "durable cook recipe already exists with different execution inputs",
@@ -171,6 +182,55 @@ pub fn persist_initial_recipe(
     }
     write_recipe(&recipe)?;
     Ok(recipe)
+}
+
+/// `homeboy_plan` is a derived execution projection rebuilt by each controller
+/// compile. Compare its typed source inputs, not transient projection details,
+/// when deciding whether a persisted recipe may resume.
+fn recipes_match(left: &AgentTaskCookRecipe, right: &AgentTaskCookRecipe) -> bool {
+    if left.schema != right.schema
+        || left.cook_id != right.cook_id
+        || left.promotion_transport != right.promotion_transport
+        || left.gate_policy != right.gate_policy
+        || left.retry_budget != right.retry_budget
+        || left.finalization != right.finalization
+        || left.source_refs != right.source_refs
+        || left.runtime_generation != right.runtime_generation
+        || left.sensitive_mappings != right.sensitive_mappings
+        || left.harvest_context != right.harvest_context
+        || left.attempts.len() != right.attempts.len()
+    {
+        return false;
+    }
+    left.attempts
+        .iter()
+        .zip(&right.attempts)
+        .all(|(left, right)| attempt_inputs_match(left, right))
+}
+
+fn attempt_inputs_match(
+    left: &AgentTaskCookRecipeAttempt,
+    right: &AgentTaskCookRecipeAttempt,
+) -> bool {
+    left == right
+}
+
+fn initial_attempt_inputs_match(
+    left: &AgentTaskCookRecipeAttempt,
+    right: &AgentTaskCookRecipeAttempt,
+) -> bool {
+    let mut left = left.clone();
+    let mut right = right.clone();
+    // A CLI retry compiles fresh random run and plan identifiers. The persisted
+    // recipe remains authoritative for those identities; user-supplied plan
+    // inputs stay subject to the strict comparison below.
+    left.run_id.clear();
+    right.run_id.clear();
+    left.plan.plan_id.clear();
+    right.plan.plan_id.clear();
+    left.plan.rebuild_homeboy_plan();
+    right.plan.rebuild_homeboy_plan();
+    attempt_inputs_match(&left, &right)
 }
 
 pub fn record_recipe_attempt(

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -1,7 +1,143 @@
 //! Agent-task command run submission, status, run-next, cancel, retry, and resume tests.
 
 use super::support::*;
+use clap::Parser;
+use homeboy::agents::agent_task_service::{
+    AgentTaskCookAttemptDispatcher, DerivedCookBaselineCapability,
+};
+use homeboy::core::{Error, Result};
 use sha2::{Digest, Sha256};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::cli_surface::{Cli, Commands};
+
+use super::super::AgentTaskCommand;
+
+#[derive(Debug)]
+struct RecoverableRunnerDispatcher {
+    unavailable: AtomicBool,
+}
+
+impl AgentTaskCookAttemptDispatcher for RecoverableRunnerDispatcher {
+    fn durable_recipe(&self) -> Result<Value> {
+        Ok(json!({ "kind": "test-recoverable-runner" }))
+    }
+
+    fn prepare_for_cook(&self) -> Result<()> {
+        if self.unavailable.load(Ordering::SeqCst) {
+            return Err(
+                Error::internal_unexpected("fixture runner is unavailable").with_retryable(true)
+            );
+        }
+        Ok(())
+    }
+
+    fn dispatch_attempt(
+        &self,
+        _plan: AgentTaskPlan,
+        run_id: &str,
+        _derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+    ) -> Result<()> {
+        agent_task_lifecycle::record_detached_lab_run(
+            agent_task_lifecycle::DetachedLabRunRecord {
+                run_id,
+                runner_id: "fixture-lab",
+                runner_job_id: "fixture-job",
+                remote_workspace: "/runner/workspace",
+                remote_command: &["homeboy".to_string(), "agent-task".to_string()],
+            },
+        )?;
+        Ok(())
+    }
+}
+
+fn recoverable_runner_cook_args(
+    source: &std::path::Path,
+    title: Option<&str>,
+) -> AgentTaskCookArgs {
+    let mut args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+        "--prompt".to_string(),
+        "exercise durable runner recovery".to_string(),
+        "--cwd".to_string(),
+        source.display().to_string(),
+        "--to-worktree".to_string(),
+        source.display().to_string(),
+        "--backend".to_string(),
+        "fixture".to_string(),
+        "--run-id".to_string(),
+        "cook-cli-preflight-recovery".to_string(),
+        "--verify".to_string(),
+        "true".to_string(),
+        "--no-finalize".to_string(),
+    ];
+    if let Some(title) = title {
+        args.extend(["--title".to_string(), title.to_string()]);
+    }
+    let cli = Cli::parse_from(args);
+    let Commands::AgentTask(agent_task) = cli.command else {
+        panic!("agent-task command");
+    };
+    let AgentTaskCommand::Cook(cook) = agent_task.command else {
+        panic!("cook command");
+    };
+    cook
+}
+
+#[test]
+fn cook_runner_preflight_failure_is_visible_and_resumable_through_public_commands() {
+    with_temp_home(|| {
+        let source = tempfile::tempdir().expect("source checkout");
+        init_runtime_component_checkout(source.path());
+        let dispatcher = Arc::new(RecoverableRunnerDispatcher {
+            unavailable: AtomicBool::new(true),
+        });
+
+        let error = run_cook_with_executor_and_dispatcher(
+            recoverable_runner_cook_args(source.path(), None),
+            CapturingExecutor::default(),
+            Some(dispatcher.clone()),
+        )
+        .expect_err("runner preflight failure");
+        assert!(error.message.contains("fixture runner is unavailable"));
+
+        let (status_value, status_exit) = status(StatusArgs {
+            run_id: "cook-cli-preflight-recovery".to_string(),
+            bridge: false,
+            since_cursor: None,
+            full: true,
+        })
+        .expect("cook status resolves through its public alias");
+        assert_eq!(status_exit, 0);
+        assert_eq!(status_value["state"], "failed");
+        assert_eq!(
+            status_value["metadata"]["pre_execution_failure"]["retryable"],
+            true
+        );
+
+        dispatcher.unavailable.store(false, Ordering::SeqCst);
+        let (resumed, exit_code) = run_cook_with_executor_and_dispatcher(
+            recoverable_runner_cook_args(source.path(), None),
+            CapturingExecutor::default(),
+            Some(dispatcher.clone()),
+        )
+        .expect("same immutable cook resumes after runner repair");
+        assert_eq!(exit_code, 0);
+        assert_eq!(resumed["status"], "in_flight");
+
+        let error = run_cook_with_executor_and_dispatcher(
+            recoverable_runner_cook_args(source.path(), Some("changed immutable title")),
+            CapturingExecutor::default(),
+            Some(dispatcher),
+        )
+        .expect_err("changed immutable cook inputs remain rejected");
+        assert!(error
+            .message
+            .contains("durable cook recipe already exists with different execution inputs"));
+    });
+}
 
 #[test]
 fn controller_proxy_status_and_logs_resolve_before_runner_child_is_known() {


### PR DESCRIPTION
## Summary
Persist cook attempts before runner preparation so retryable pre-execution failures remain inspectable and resumable.

## What changed
- Records the initial durable attempt before transport preparation.
- Normalizes generated run and plan identities when validating an immutable retry recipe.

## How to test
1. Run `cargo test -p homeboy-agents cook_transport_preparation_failure_is_durable_and_resumes_after_runner_recovery`; expect The durable preflight recovery regression passes..

## Compatibility
No external API compatibility impact; existing successful cook behavior is preserved while failed preflight attempts become recoverable.

## Evidence
- Base unchanged since verification: main remains at 871902e5f5bebc0f0f30c9ad11db2b8dd63da71a.
- CI expected: Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/9161
- Verified finalization base: main at 871902e5f5bebc0f0f30c9ad11db2b8dd63da71a
- focused: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Drafted implementation, tests, conflict resolution, and PR evidence; Chris reviews and owns the change.

## Source relationships
- Closes #9161
