### PR TITLE
Normalize agent-task log events

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/conversion.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/conversion.rs
@@ -262,6 +262,10 @@ pub(crate) fn normalize_progress_events(
             event_type: "agent_task.state_changed".to_string(),
             status: event.state,
             message: event.message.clone(),
+            provider: None,
+            phase: None,
+            activity: None,
+            heartbeat_at_ms: None,
             progress: json!({
                 "attempt": event.attempt,
             }),

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -3058,26 +3058,38 @@ fn restore_initial_cook_candidate_workspace(plan: &mut AgentTaskPlan) -> Result<
 }
 
 pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
+    logs_with_raw(run_id, false)
+}
+
+pub fn logs_with_raw(run_id: &str, include_raw: bool) -> Result<AgentTaskRunLog> {
     // Status reconciliation fetches the live daemon snapshot for a bound Lab
     // child, making executor progress visible before the child is terminal.
     let record = status(run_id)?;
     let run_id = record.run_id.clone();
-    let (events, artifact_refs) = match store::read_aggregate(&run_id) {
+    let (events, artifact_refs, raw_events) = match store::read_aggregate(&run_id) {
         Ok(aggregate) => {
             let refs = artifact_refs_for_outcomes(&aggregate.outcomes);
-            (aggregate.events, refs)
+            (aggregate.events, refs, Vec::new())
         }
-        Err(_) => (
-            runner_job_progress_events(&record).unwrap_or_else(|| queued_events(&record.tasks)),
-            record.artifact_refs.clone(),
-        ),
+        Err(_) => {
+            let raw_events = runner_job_raw_events(&record);
+            (
+                runner_job_progress_events(&record).unwrap_or_else(|| queued_events(&record.tasks)),
+                record.artifact_refs.clone(),
+                raw_events,
+            )
+        }
     };
-    let normalized_events = normalize_progress_events(&run_id, &events, &artifact_refs);
+    let events = if raw_events.is_empty() {
+        normalize_progress_events(&run_id, &events, &artifact_refs)
+    } else {
+        normalize_runner_job_events(&run_id, &raw_events, &record, &artifact_refs)
+    };
     Ok(AgentTaskRunLog {
         schema: schemas::RUN_LOG.to_string(),
         run_id,
         events,
-        normalized_events,
+        raw_events: include_raw.then_some(raw_events).unwrap_or_default(),
     })
 }
 
@@ -3095,10 +3107,95 @@ fn runner_job_progress_events(record: &AgentTaskRunRecord) -> Option<Vec<AgentTa
                 task_id: task_id.clone(),
                 state: AgentTaskState::Running,
                 attempt: 0,
-                message: serde_json::to_string(event).ok(),
+                message: event
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .or_else(|| {
+                        event
+                            .pointer("/data/message")
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                    }),
             })
             .collect(),
     )
+}
+
+fn runner_job_raw_events(record: &AgentTaskRunRecord) -> Vec<Value> {
+    record
+        .metadata
+        .get("runner_job_events")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn normalize_runner_job_events(
+    run_id: &str,
+    raw_events: &[Value],
+    record: &AgentTaskRunRecord,
+    artifact_refs: &[AgentTaskArtifactRef],
+) -> Vec<AgentTaskEventEnvelope> {
+    let task_id = record
+        .tasks
+        .first()
+        .map(|task| task.task_id.clone())
+        .unwrap_or_else(|| record.run_id.clone());
+    let provider = record
+        .provider_handles
+        .first()
+        .map(|handle| handle.backend.clone());
+
+    raw_events
+        .iter()
+        .enumerate()
+        .map(|(index, raw)| {
+            let data = raw.get("data").cloned().unwrap_or(Value::Null);
+            let kind = raw
+                .get("kind")
+                .and_then(Value::as_str)
+                .unwrap_or("progress");
+            let phase =
+                string_field(&data, "phase").or_else(|| string_field(&record.metadata, "phase"));
+            let activity = string_field(&data, "activity")
+                .or_else(|| string_field(&data, "status_note"))
+                .or_else(|| string_field(&data, "progress"));
+            AgentTaskEventEnvelope {
+                schema: schemas::EVENT.to_string(),
+                run_id: run_id.to_string(),
+                task_id: task_id.clone(),
+                // The lifecycle cursor is positional and has always been one-based.
+                sequence: (index + 1) as u64,
+                event_type: format!("agent_task.runner_{kind}"),
+                status: AgentTaskState::Running,
+                message: raw
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .or_else(|| string_field(&data, "message")),
+                provider: string_field(&data, "provider")
+                    .or_else(|| string_field(&data, "backend"))
+                    .or_else(|| provider.clone()),
+                phase,
+                activity,
+                heartbeat_at_ms: matches!(kind, "progress" | "status")
+                    .then(|| raw.get("timestamp_ms").and_then(Value::as_u64))
+                    .flatten(),
+                progress: json!({ "attempt": 0 }),
+                artifact_refs: artifact_refs
+                    .iter()
+                    .filter(|reference| reference.task_id == task_id)
+                    .cloned()
+                    .collect(),
+                metadata: data,
+            }
+        })
+        .collect()
+}
+
+fn string_field(value: &Value, key: &str) -> Option<String> {
+    value.get(key).and_then(Value::as_str).map(str::to_string)
 }
 
 pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub(crate) mod schemas {
     pub(crate) const RUN: &str = "homeboy/agent-task-run/v1";
-    pub(crate) const RUN_LOG: &str = "homeboy/agent-task-run-log/v1";
+    pub(crate) const RUN_LOG: &str = "homeboy/agent-task-run-log/v2";
     pub(crate) const EVENT: &str = "homeboy/agent-task-event/v1";
     pub(crate) const RUN_STATUS: &str = "homeboy/agent-task-run-status/v1";
     pub(crate) const RUN_ARTIFACTS: &str = "homeboy/agent-task-run-artifacts/v1";
@@ -860,9 +860,11 @@ pub struct AgentTaskRunProviderHandle {
 pub struct AgentTaskRunLog {
     pub schema: String,
     pub run_id: String,
-    pub events: Vec<AgentTaskProgressEvent>,
+    /// The canonical consumer event stream. v1 exposed the same information
+    /// twice as `events` and `normalized_events`.
+    pub events: Vec<AgentTaskEventEnvelope>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub normalized_events: Vec<AgentTaskEventEnvelope>,
+    pub raw_events: Vec<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -876,6 +878,14 @@ pub struct AgentTaskEventEnvelope {
     pub status: AgentTaskState,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub heartbeat_at_ms: Option<u64>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub progress: Value,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -754,7 +754,11 @@ fn logs_expose_mirrored_live_runner_events_before_terminal_aggregate() {
             kind: JobEventKind::Progress,
             timestamp_ms: 42,
             message: Some("provider started".to_string()),
-            data: Some(json!({"provider": "openai/gpt-5.6-terra"})),
+            data: Some(json!({
+                "provider": "openai/gpt-5.6-terra",
+                "phase": "implementing",
+                "activity": "editing lifecycle projection"
+            })),
         }]);
         store::write_record(&record).expect("persist mirrored event");
 
@@ -765,6 +769,28 @@ fn logs_expose_mirrored_live_runner_events_before_terminal_aggregate() {
             .message
             .as_deref()
             .is_some_and(|message| message.contains("provider started")));
+        assert_eq!(
+            log.events[0].provider.as_deref(),
+            Some("openai/gpt-5.6-terra")
+        );
+        assert_eq!(log.events[0].phase.as_deref(), Some("implementing"));
+        assert_eq!(
+            log.events[0].activity.as_deref(),
+            Some("editing lifecycle projection")
+        );
+        assert_eq!(log.events[0].heartbeat_at_ms, Some(42));
+        assert!(log.raw_events.is_empty(), "raw transport is opt-in");
+
+        let raw_log = logs_with_raw("live-runner-events", true).expect("raw logs resolve");
+        assert_eq!(
+            raw_log.events[0].metadata["provider"],
+            "openai/gpt-5.6-terra"
+        );
+        assert_eq!(raw_log.raw_events.len(), 1);
+        assert_eq!(
+            raw_log.raw_events[0]["data"]["activity"],
+            "editing lifecycle projection"
+        );
     });
 }
 
@@ -1333,7 +1359,7 @@ fn lifecycle_store_round_trips_record_log_artifacts_and_lifecycle_contract() {
             ArtifactRetentionStatus::Retained
         );
         assert_eq!(log.schema, schemas::RUN_LOG);
-        assert_eq!(log.events[0].state, AgentTaskState::Succeeded);
+        assert_eq!(log.events[0].status, AgentTaskState::Succeeded);
         assert_eq!(artifact_report.schema, schemas::RUN_ARTIFACTS);
         assert_eq!(artifact_report.artifacts[0].id, "patch");
         assert_eq!(artifact_report.evidence_refs[0].kind, "transcript");
@@ -1529,14 +1555,16 @@ fn logs_include_normalized_event_envelopes() {
 
         let log = logs("run-event-envelope").expect("logs");
 
-        assert_eq!(log.normalized_events.len(), 2);
-        assert_eq!(log.normalized_events[0].schema, schemas::EVENT);
-        assert_eq!(log.normalized_events[0].run_id, "run-event-envelope");
-        assert_eq!(log.normalized_events[0].task_id, "task-a");
-        assert_eq!(log.normalized_events[0].sequence, 1);
-        assert_eq!(log.normalized_events[0].status, AgentTaskState::Running);
-        assert_eq!(log.normalized_events[1].message.as_deref(), Some("ok"));
-        assert_eq!(log.normalized_events[1].artifact_refs.len(), 1);
+        assert_eq!(log.schema, "homeboy/agent-task-run-log/v2");
+        assert_eq!(log.events.len(), 2);
+        assert_eq!(log.events[0].schema, schemas::EVENT);
+        assert_eq!(log.events[0].run_id, "run-event-envelope");
+        assert_eq!(log.events[0].task_id, "task-a");
+        assert_eq!(log.events[0].sequence, 1);
+        assert_eq!(log.events[0].status, AgentTaskState::Running);
+        assert_eq!(log.events[1].message.as_deref(), Some("ok"));
+        assert_eq!(log.events[1].artifact_refs.len(), 1);
+        assert!(log.raw_events.is_empty());
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -729,7 +729,7 @@ fn terminal_projection_is_reader_complete_when_interrupted_after_commit_and_retr
             )
         });
         assert_eq!(status_record.state, AgentTaskRunState::Succeeded);
-        assert_eq!(log.events[0].state, AgentTaskState::Succeeded);
+        assert_eq!(log.events[0].status, AgentTaskState::Succeeded);
         assert!(artifacts.artifacts.is_empty());
 
         reconcile_runner_job_snapshot(&mut record, &snapshot).expect("idempotent retry");
@@ -1069,8 +1069,8 @@ fn pre_dispatch_failure_persists_failed_run_without_provider_handle() {
         assert_eq!(loaded.state, AgentTaskRunState::Failed);
         assert_eq!(loaded.tasks[0].state, AgentTaskState::Failed);
         assert!(loaded.provider_handles.is_empty());
-        assert_eq!(log.events[1].state, AgentTaskState::Failed);
-        assert_eq!(mirrored_log.events[1].state, AgentTaskState::Failed);
+        assert_eq!(log.events[1].status, AgentTaskState::Failed);
+        assert_eq!(mirrored_log.events[1].status, AgentTaskState::Failed);
         assert_eq!(loaded.metadata["provider_run_ids"], serde_json::json!([]));
         assert_eq!(
             loaded.artifact_refs[0].kind,
@@ -1155,7 +1155,7 @@ fn record_completed_run_exposes_logs_and_artifacts() {
         let artifacts = artifacts(&record.run_id).expect("artifacts");
 
         assert_eq!(record.state, AgentTaskRunState::Succeeded);
-        assert_eq!(log.events[0].state, AgentTaskState::Succeeded);
+        assert_eq!(log.events[0].status, AgentTaskState::Succeeded);
         assert_eq!(artifacts.artifacts[0].id, "patch");
         assert_eq!(artifacts.evidence_refs[0].kind, "transcript");
     });

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1773,7 +1773,7 @@ mod tests {
                 0
             );
             assert_eq!(
-                logs.events.last().map(|event| event.state),
+                logs.events.last().map(|event| event.status),
                 Some(AgentTaskState::Failed)
             );
             assert_eq!(retry.metadata["retry_of"], run_id);

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -347,6 +347,10 @@ pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
     agent_task_lifecycle::logs(run_id)
 }
 
+pub fn logs_with_raw(run_id: &str) -> Result<AgentTaskRunLog> {
+    agent_task_lifecycle::logs_with_raw(run_id, true)
+}
+
 pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {
     agent_task_lifecycle::artifacts(run_id)
 }

--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -36,9 +36,9 @@ pub use args::{
     AgentTaskFanoutSubmitBatchArgs, AgentTaskLoopArgs, AgentTaskLoopCommand,
     AgentTaskLoopDefineArgs, AgentTaskLoopResumeArgs, AgentTaskLoopStatusArgs, CancelArgs,
     CompileLoopArgs, ContractArgs, ContractFormat, DiagnoseArgs, EvidenceArgs, FinalizePrArgs,
-    GateFeedbackArgs, LatestArgs, ListArgs, PromoteArgs, PromotionProviderArgs, ProvidersArgs,
-    ReconcileRecordsArgs, ReplayProviderBoundaryArgs, RetryArgs, ReviewArgs, RunPlanArgs,
-    RuntimeRecoverArgs, RuntimeValidateArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
+    GateFeedbackArgs, LatestArgs, ListArgs, LogsArgs, PromoteArgs, PromotionProviderArgs,
+    ProvidersArgs, ReconcileRecordsArgs, ReplayProviderBoundaryArgs, RetryArgs, ReviewArgs,
+    RunPlanArgs, RuntimeRecoverArgs, RuntimeValidateArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
 };
 pub(crate) use status::diagnostic_summary_from_aggregate;
 

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -6,7 +6,7 @@ use super::super::super::tool::AgentTaskToolArgs;
 use super::cook::{AgentTaskCookArgs, AgentTaskLoopArgs, PromotionProviderArgs};
 use super::fanout::AgentTaskFanoutArgs;
 use super::lifecycle::{
-    AdoptArgs, CancelArgs, DiagnoseArgs, EvidenceArgs, FinalizePrArgs, GateFeedbackArgs,
+    AdoptArgs, CancelArgs, DiagnoseArgs, EvidenceArgs, FinalizePrArgs, GateFeedbackArgs, LogsArgs,
     PromoteArgs, ReplayProviderBoundaryArgs, RetryArgs, ReviewArgs, RunArgs, RunPlanArgs,
     RuntimeRecoverArgs, RuntimeValidateArgs, StatusArgs, SubmitArgs,
 };
@@ -45,7 +45,7 @@ pub enum AgentTaskCommand {
     Active(ActiveArgs),
     ReconcileRecords(ReconcileRecordsArgs),
     Latest(LatestArgs),
-    Logs(StatusArgs),
+    Logs(LogsArgs),
     Artifacts(StatusArgs),
     Evidence(EvidenceArgs),
     Diagnose(DiagnoseArgs),

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -36,6 +36,13 @@ pub struct StatusArgs {
     pub full: bool,
 }
 #[derive(Args, Debug)]
+pub struct LogsArgs {
+    pub run_id: String,
+    /// Include unprojected runner transport frames under `raw_events` for diagnostics.
+    #[arg(long)]
+    pub raw: bool,
+}
+#[derive(Args, Debug)]
 pub struct EvidenceArgs {
     pub run_id: String,
     #[arg(long = "kind", value_name = "KIND")]

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -19,8 +19,8 @@ use homeboy::runner::runners::{self as runner, RunnerKind};
 
 use super::super::CmdResult;
 use super::args::{
-    CancelArgs, DiagnoseArgs, EvidenceArgs, ReplayProviderBoundaryArgs, RuntimeRecoverArgs,
-    RuntimeValidateArgs, StatusArgs,
+    CancelArgs, DiagnoseArgs, EvidenceArgs, LogsArgs, ReplayProviderBoundaryArgs,
+    RuntimeRecoverArgs, RuntimeValidateArgs, StatusArgs,
 };
 use crate::commands::utils::response::{
     CommandActionableMetadata, CommandAgentTaskRef, CommandNextAction, CommandNextActionKind,
@@ -420,8 +420,12 @@ fn attach_actionable_metadata(value: &mut Value, metadata: CommandActionableMeta
     }
 }
 
-pub(super) fn logs(args: StatusArgs) -> CmdResult<Value> {
-    let log = agent_task_service::logs(&args.run_id)?;
+pub(super) fn logs(args: LogsArgs) -> CmdResult<Value> {
+    let log = if args.raw {
+        agent_task_service_direct::logs_with_raw(&args.run_id)?
+    } else {
+        agent_task_service_direct::logs(&args.run_id)?
+    };
     let mut value = serde_json::to_value(log).unwrap_or(Value::Null);
     enrich_with_diagnostic_summary(&mut value, &args.run_id)?;
     Ok((value, 0))

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -29,11 +29,9 @@ fn controller_proxy_status_and_logs_resolve_before_runner_child_is_known() {
             full: true,
         })
         .expect("controller status resolves");
-        let (logs_value, logs_exit) = logs(StatusArgs {
+        let (logs_value, logs_exit) = logs(LogsArgs {
             run_id: "run-cli-controller-proxy".to_string(),
-            bridge: false,
-            since_cursor: None,
-            full: false,
+            raw: false,
         })
         .expect("controller logs resolve");
 
@@ -313,11 +311,9 @@ fn failed_run_status_logs_and_review_include_outcome_diagnostic_summary() {
             full: false,
         })
         .expect("status loaded");
-        let (logs_value, _) = logs(StatusArgs {
+        let (logs_value, _) = logs(LogsArgs {
             run_id: run_id.to_string(),
-            bridge: false,
-            since_cursor: None,
-            full: false,
+            raw: false,
         })
         .expect("logs loaded");
         let (review_value, _) = review::review(ReviewArgs {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/support.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/support.rs
@@ -14,8 +14,8 @@ pub(in crate::commands::agent_task) use super::super::args::{
     AgentTaskControllerProofArgs, AgentTaskControllerRunFromSpecArgs,
 };
 pub(in crate::commands::agent_task) use super::super::args::{
-    AgentTaskCookArgs, CompileLoopArgs, DiagnoseArgs, EvidenceArgs, ReplayProviderBoundaryArgs,
-    ReviewArgs, RunArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
+    AgentTaskCookArgs, CompileLoopArgs, DiagnoseArgs, EvidenceArgs, LogsArgs,
+    ReplayProviderBoundaryArgs, ReviewArgs, RunArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
 };
 pub(in crate::commands::agent_task) use super::super::controller::{
     apply_controller_event, controller_from_spec, controller_materialize,

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -30,7 +30,7 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 | `list [--limit <n>]` | List durable runs, newest first. |
 | `active [--limit <n>] [--reconcile [--dry-run]]` | List queued and running durable runs, newest first, or reconcile stale active records. |
 | `latest [--limit <n>]` | Show the latest durable run. |
-| `logs <run-id>` | Read durable run scheduler events. |
+| `logs <run-id> [--raw]` | Read the canonical durable event stream; `--raw` adds transport frames for diagnostics. |
 | `artifacts <run-id>` | List artifacts and evidence refs recorded for a completed run. |
 | `replay-provider-boundary <run-id> [--task <task-id>]` | Hydrate the latest raw executor input and print provider-boundary fields without relaunching a provider. |
 | `cancel <run-id>` | Mark a queued or stale-running durable run as cancelled. |


### PR DESCRIPTION
## Summary
Expose one normalized, versioned agent-task log event envelope across local, proxy, and mirrored runner records.

## What changed
- Moves agent-task logs to the documented v2 normalized event schema.
- Preserves raw provider events only through the explicit raw-events option.

## How to test
1. Run `cargo test -p homeboy-agents logs_include_normalized_event_envelopes`; expect The normalized event envelope regression passes..
2. Run `cargo test -p homeboy-agents logs_expose_mirrored_live_runner_events_before_terminal_aggregate`; expect The mirrored live-event regression passes..
3. Run `cargo test -p homeboy-cli controller_proxy_status_and_logs_resolve_before_runner_child_is_known`; expect The controller-proxy CLI regression passes..

## Compatibility
Breaking log-output schema change: consumers of v1 event fields and normalized\_events must migrate to the versioned v2 events envelope; raw events remain available through the explicit raw-events option.

## Evidence
- Base unchanged since verification: main remains at 871902e5f5bebc0f0f30c9ad11db2b8dd63da71a.
- CI expected: Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/9162
- Verified finalization base: main at 871902e5f5bebc0f0f30c9ad11db2b8dd63da71a
- focused: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Drafted implementation, schema migration, tests, documentation, and PR evidence; Chris reviews and owns the change.

## Source relationships
- Closes #9162
