### PR TITLE
Lease runner admission reservations

### DIFF
--- a/crates/homeboy-core/src/api_jobs/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/mod.rs
@@ -10,6 +10,7 @@ mod summary;
 // resolving. The job store / persistence / remote-runner behavior stays here.
 use homeboy_api_jobs_contract::types;
 
+pub(crate) use persistence::timestamp_ms;
 pub use remote_runner::{
     JobArtifactMetadata, RemoteRunnerJobClaim, RemoteRunnerJobRequest, RemoteRunnerJobResult,
     RemoteRunnerSubmissionLookup, RunnerJobLifecycleMetadata, RunnerJobProjectionCancelRequest,

--- a/crates/homeboy-core/src/api_jobs/persistence.rs
+++ b/crates/homeboy-core/src/api_jobs/persistence.rs
@@ -458,7 +458,7 @@ pub(super) fn job_not_found(job_id: Uuid) -> Error {
     Error::validation_invalid_argument("job_id", "job not found", Some(job_id.to_string()), None)
 }
 
-pub(super) fn timestamp_ms() -> u64 {
+pub(crate) fn timestamp_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("system clock must be after unix epoch")

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -583,6 +583,7 @@ impl JobStore {
                 job: job.clone(),
                 events: Vec::new(),
                 admission_idempotency_key: None,
+                admission_lease: None,
                 remote_runner: Some(StoredRemoteRunnerJob {
                     // Durable broker state intentionally contains only the
                     // redacted request. The runner hydrates named references

--- a/crates/homeboy-core/src/api_jobs/store.rs
+++ b/crates/homeboy-core/src/api_jobs/store.rs
@@ -32,6 +32,17 @@ use crate::source_snapshot::SourceSnapshot;
 /// child identity. The child is normally spawned immediately after admission;
 /// a longer-lived record means no child was durably confirmed.
 const LOCAL_CHILD_RESERVATION_LEASE_MS: u64 = 60_000;
+/// Admissions protect the controller-to-daemon handoff window. A stopped
+/// controller must eventually stop consuming daemon replacement capacity.
+pub(crate) const ADMISSION_RESERVATION_LEASE_MS: u64 = 30_000;
+
+#[derive(Debug, Clone)]
+pub(crate) struct AdmissionReservation {
+    pub(crate) job: Job,
+    pub(crate) token: String,
+    pub(crate) expires_at_ms: u64,
+    pub(crate) created: bool,
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct JobStore {
@@ -72,6 +83,8 @@ pub(super) struct StoredJob {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) admission_idempotency_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) admission_lease: Option<AdmissionLease>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) remote_runner: Option<remote_runner::StoredRemoteRunnerJob>,
     /// Typed execution identity for a daemon-local child submitted on behalf of
     /// a remote runner. This lets `/jobs` project the accepted runner job without
@@ -80,6 +93,14 @@ pub(super) struct StoredJob {
     pub(super) local_runner: Option<LocalRunnerJob>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) local_child: Option<LocalChildExecution>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct AdmissionLease {
+    token: String,
+    expires_at_ms: u64,
+    #[serde(default)]
+    renewals: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -455,9 +476,59 @@ impl JobStore {
         .0
     }
 
-    /// Reserve one daemon admission per caller-owned handoff identity. This is
-    /// separate from executable-job deduplication because an admission is a
-    /// short-lived pre-handoff guard, not the runner child itself.
+    /// Create or renew a caller-owned admission under one store lock. Replays
+    /// renew only the live reservation; terminal identities are never revived.
+    pub(crate) fn create_or_renew_admission_at(
+        &self,
+        metadata: Value,
+        idempotency_key: &str,
+        now: u64,
+    ) -> Result<AdmissionReservation> {
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        if let Some(stored) = inner
+            .jobs
+            .values_mut()
+            .filter(|stored| stored.admission_idempotency_key.as_deref() == Some(idempotency_key))
+            .min_by_key(|stored| (stored.job.created_at_ms, stored.job.id))
+        {
+            if stored.job.status.is_terminal() {
+                return Err(Error::validation_invalid_argument(
+                    "idempotency_key",
+                    "admission idempotency key belongs to a terminal reservation",
+                    Some(idempotency_key.to_string()),
+                    None,
+                ));
+            }
+            let lease = stored.admission_lease.as_mut().ok_or_else(|| {
+                Error::internal_unexpected("active admission reservation is missing its lease")
+            })?;
+            lease.expires_at_ms = now.saturating_add(ADMISSION_RESERVATION_LEASE_MS);
+            lease.renewals = lease.renewals.saturating_add(1);
+            stored.job.updated_at_ms = now;
+            let reservation = AdmissionReservation {
+                job: stored.job.clone(),
+                token: lease.token.clone(),
+                expires_at_ms: lease.expires_at_ms,
+                created: false,
+            };
+            drop(inner);
+            self.persist()?;
+            return Ok(reservation);
+        }
+        drop(inner);
+        self.create_admission_inner(metadata, Some(idempotency_key.to_string()), now)
+    }
+
+    pub(crate) fn create_admission_at(
+        &self,
+        metadata: Value,
+        now: u64,
+    ) -> Result<AdmissionReservation> {
+        self.create_admission_inner(metadata, None, now)
+    }
+
+    /// Legacy, tokenless admission used only by pre-lease protocol clients
+    /// during a rolling daemon upgrade.
     pub(crate) fn create_or_reuse_active_admission(
         &self,
         metadata: Value,
@@ -471,6 +542,165 @@ impl JobStore {
             None,
             Some(idempotency_key.to_string()),
         )
+    }
+
+    fn create_admission_inner(
+        &self,
+        metadata: Value,
+        idempotency_key: Option<String>,
+        now: u64,
+    ) -> Result<AdmissionReservation> {
+        let (job, created) = self.create_or_reuse_active_local_runner_job(
+            "runner.admission",
+            None,
+            Some(metadata),
+            None,
+            None,
+            idempotency_key.clone(),
+        );
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let stored = inner.jobs.get_mut(&job.id).expect("admission exists");
+        if !created {
+            let (token, expires_at_ms) = {
+                let lease = stored.admission_lease.as_mut().ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "idempotency_key",
+                        "admission idempotency key belongs to a legacy reservation",
+                        idempotency_key.clone(),
+                        None,
+                    )
+                })?;
+                lease.expires_at_ms = now.saturating_add(ADMISSION_RESERVATION_LEASE_MS);
+                lease.renewals = lease.renewals.saturating_add(1);
+                (lease.token.clone(), lease.expires_at_ms)
+            };
+            stored.job.updated_at_ms = now;
+            let reservation = AdmissionReservation {
+                job: stored.job.clone(),
+                token,
+                expires_at_ms,
+                created: false,
+            };
+            drop(inner);
+            self.persist()?;
+            return Ok(reservation);
+        }
+        let lease = AdmissionLease {
+            token: Uuid::new_v4().to_string(),
+            expires_at_ms: now.saturating_add(ADMISSION_RESERVATION_LEASE_MS),
+            renewals: 0,
+        };
+        stored.admission_lease = Some(lease.clone());
+        drop(inner);
+        self.persist()?;
+        Ok(AdmissionReservation {
+            job,
+            token: lease.token,
+            expires_at_ms: lease.expires_at_ms,
+            created,
+        })
+    }
+
+    pub(crate) fn renew_admission_at(
+        &self,
+        job_id: Uuid,
+        token: &str,
+        now: u64,
+    ) -> Result<AdmissionReservation> {
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let stored = inner
+            .jobs
+            .get_mut(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?;
+        let (token, expires_at_ms) = {
+            let lease = Self::admission_lease_for_live_job(stored, token, now)?;
+            lease.expires_at_ms = now.saturating_add(ADMISSION_RESERVATION_LEASE_MS);
+            lease.renewals = lease.renewals.saturating_add(1);
+            (lease.token.clone(), lease.expires_at_ms)
+        };
+        stored.job.updated_at_ms = now;
+        let reservation = AdmissionReservation {
+            job: stored.job.clone(),
+            token,
+            expires_at_ms,
+            created: false,
+        };
+        drop(inner);
+        self.persist()?;
+        Ok(reservation)
+    }
+
+    pub(crate) fn release_admission_at(&self, job_id: Uuid, token: &str, now: u64) -> Result<Job> {
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let stored = inner
+            .jobs
+            .get_mut(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?;
+        let lease = stored.admission_lease.as_ref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "job_id",
+                "job is not an admission reservation",
+                Some(job_id.to_string()),
+                None,
+            )
+        })?;
+        if lease.token != token {
+            return Err(Error::validation_invalid_argument(
+                "admission_token",
+                "admission reservation token does not match",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        if !stored.job.status.is_terminal() {
+            stored.job.status = JobStatus::Cancelled;
+            stored.job.updated_at_ms = now;
+            stored.job.finished_at_ms = Some(now);
+            stored.job.stale_reason = Some("admission reservation released".to_string());
+        }
+        let job = stored.job.clone();
+        drop(inner);
+        self.persist()?;
+        Ok(job)
+    }
+
+    pub(crate) fn admission_is_leased(&self, job_id: Uuid) -> Result<bool> {
+        let inner = self.inner.lock().expect("job store mutex poisoned");
+        let stored = inner
+            .jobs
+            .get(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?;
+        Ok(stored.admission_lease.is_some())
+    }
+
+    pub(crate) fn reconcile_expired_admissions_at(&self, now: u64) -> Result<Vec<Uuid>> {
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let expired = inner
+            .jobs
+            .values_mut()
+            .filter_map(|stored| {
+                let lease = stored.admission_lease.as_ref()?;
+                if !stored.job.status.is_terminal() && lease.expires_at_ms <= now {
+                    stored.job.status = JobStatus::Failed;
+                    stored.job.updated_at_ms = now;
+                    stored.job.finished_at_ms = Some(now);
+                    stored.job.stale_reason =
+                        Some("admission reservation lease expired".to_string());
+                    Some(stored.job.id)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        drop(inner);
+        if !expired.is_empty() {
+            self.persist()?;
+        }
+        Ok(expired)
+    }
+
+    pub(crate) fn reconcile_expired_admissions(&self) -> Result<Vec<Uuid>> {
+        self.reconcile_expired_admissions_at(timestamp_ms())
     }
 
     /// Insert a new queued local-runner job, or reuse the existing non-terminal
@@ -563,6 +793,7 @@ impl JobStore {
                 job: job.clone(),
                 events: Vec::new(),
                 admission_idempotency_key,
+                admission_lease: None,
                 remote_runner: None,
                 local_runner,
                 local_child: None,
@@ -581,6 +812,38 @@ impl JobStore {
                 .expect("newly-created job must be readable after insert"),
             true,
         )
+    }
+
+    fn admission_lease_for_live_job<'a>(
+        stored: &'a mut StoredJob,
+        token: &str,
+        now: u64,
+    ) -> Result<&'a mut AdmissionLease> {
+        let lease = stored.admission_lease.as_mut().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "job_id",
+                "job is not an admission reservation",
+                Some(stored.job.id.to_string()),
+                None,
+            )
+        })?;
+        if lease.token != token {
+            return Err(Error::validation_invalid_argument(
+                "admission_token",
+                "admission reservation token does not match",
+                Some(stored.job.id.to_string()),
+                None,
+            ));
+        }
+        if stored.job.status.is_terminal() || lease.expires_at_ms <= now {
+            return Err(Error::validation_invalid_argument(
+                "job_id",
+                "admission reservation is terminal or expired",
+                Some(stored.job.id.to_string()),
+                None,
+            ));
+        }
+        Ok(lease)
     }
 
     pub fn get(&self, job_id: Uuid) -> Result<Job> {

--- a/crates/homeboy-core/src/api_jobs/tests/part_a.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_a.rs
@@ -6,7 +6,9 @@ use std::fs;
 use serde_json::json;
 
 use super::persistence::recovered_terminal_from_result;
-use super::store::{LinkedDurableRunResolution, RecoveredTerminalJob};
+use super::store::{
+    LinkedDurableRunResolution, RecoveredTerminalJob, ADMISSION_RESERVATION_LEASE_MS,
+};
 use super::*;
 use crate::secret_env_plan::SecretEnvPlan;
 use crate::source_snapshot::SourceSnapshot;
@@ -87,6 +89,110 @@ fn expired_local_child_reservation_releases_capacity_and_persists_retryable_fail
                 data["reason"] == "local_child_reservation_expired" && data["retryable"] == true
             })
     }));
+}
+
+#[test]
+fn admission_leases_create_renew_expire_and_release_capacity_with_an_injected_clock() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open_without_reconciliation(&path).expect("open store");
+    let now = 10_000;
+    let reservation = store
+        .create_admission_at(json!({ "admission": { "state": "reserved" } }), now)
+        .expect("create admission");
+    assert!(reservation.created);
+    assert_eq!(store.active_runner_jobs().len(), 1);
+
+    let renewed = store
+        .renew_admission_at(
+            reservation.job.id,
+            &reservation.token,
+            now + ADMISSION_RESERVATION_LEASE_MS - 1,
+        )
+        .expect("renew before first expiry");
+    assert!(renewed.expires_at_ms > now + ADMISSION_RESERVATION_LEASE_MS);
+    assert!(store
+        .reconcile_expired_admissions_at(now + ADMISSION_RESERVATION_LEASE_MS)
+        .expect("first interval remains live")
+        .is_empty());
+    assert_eq!(store.active_runner_jobs().len(), 1);
+
+    assert_eq!(
+        store
+            .reconcile_expired_admissions_at(renewed.expires_at_ms)
+            .expect("expire renewed admission"),
+        vec![reservation.job.id]
+    );
+    assert_eq!(store.active_runner_jobs().len(), 0);
+    assert_eq!(
+        store.get(reservation.job.id).expect("expired job").status,
+        JobStatus::Failed
+    );
+    assert_eq!(
+        JobStore::active_count_at_path(&path).expect("persisted active count"),
+        0
+    );
+}
+
+#[test]
+fn admission_lease_rejects_wrong_tokens_and_terminal_idempotency_replays() {
+    let store = JobStore::default();
+    let now = 10_000;
+    let reservation = store
+        .create_or_renew_admission_at(json!({}), "attempt-1", now)
+        .expect("create keyed admission");
+    let replay = store
+        .create_or_renew_admission_at(json!({}), "attempt-1", now + 1)
+        .expect("renew live idempotency replay");
+    assert_eq!(replay.job.id, reservation.job.id);
+    assert!(!replay.created);
+    assert!(store
+        .renew_admission_at(reservation.job.id, "wrong", now + 2)
+        .is_err());
+    let released = store
+        .release_admission_at(reservation.job.id, &reservation.token, now + 2)
+        .expect("release admission");
+    assert_eq!(released.status, JobStatus::Cancelled);
+    assert_eq!(
+        store
+            .release_admission_at(reservation.job.id, &reservation.token, now + 3)
+            .expect("idempotent release")
+            .status,
+        JobStatus::Cancelled
+    );
+    assert!(store
+        .create_or_renew_admission_at(json!({}), "attempt-1", now + 4)
+        .is_err());
+}
+
+#[test]
+fn admission_lease_races_have_one_terminal_outcome() {
+    let store = JobStore::default();
+    let now = 10_000;
+    let reservation = store
+        .create_admission_at(json!({}), now)
+        .expect("create admission");
+    let store_for_renew = store.clone();
+    let token = reservation.token.clone();
+    let job_id = reservation.job.id;
+    let renew = std::thread::spawn(move || {
+        store_for_renew.renew_admission_at(job_id, &token, now + ADMISSION_RESERVATION_LEASE_MS)
+    });
+    let store_for_release = store.clone();
+    let token = reservation.token.clone();
+    let release = std::thread::spawn(move || {
+        store_for_release.release_admission_at(job_id, &token, now + ADMISSION_RESERVATION_LEASE_MS)
+    });
+    let store_for_expiry = store.clone();
+    let expiry = std::thread::spawn(move || {
+        store_for_expiry.reconcile_expired_admissions_at(now + ADMISSION_RESERVATION_LEASE_MS)
+    });
+    let _ = renew.join().expect("renew thread");
+    let _ = release.join().expect("release thread");
+    let _ = expiry.join().expect("expiry thread");
+    let terminal = store.get(job_id).expect("job remains durable");
+    assert!(terminal.status.is_terminal());
+    assert!(store.active_runner_jobs().is_empty());
 }
 
 #[test]

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -1011,6 +1011,7 @@ where
     // A restart cannot resume the thread that owned a pre-spawn reservation.
     // Expire only reservations that never recorded a child identity.
     job_store.reconcile_expired_local_child_reservations()?;
+    job_store.reconcile_expired_admissions()?;
     let _ = daemon_runtime_snapshot();
     let loopback_bind = local_addr.ip().is_loopback();
 
@@ -1046,6 +1047,7 @@ const LOCAL_CHILD_RESERVATION_RECONCILE_INTERVAL_SECS: u64 = 5;
 fn spawn_local_child_reservation_reconciler(job_store: JobStore) {
     std::thread::spawn(move || loop {
         let _ = job_store.reconcile_expired_local_child_reservations();
+        let _ = job_store.reconcile_expired_admissions();
         std::thread::sleep(std::time::Duration::from_secs(
             LOCAL_CHILD_RESERVATION_RECONCILE_INTERVAL_SECS,
         ));
@@ -1239,8 +1241,14 @@ where
             Err(err) => error_response(400, err),
         },
         ("POST", path) if path.starts_with("/admissions/") && path.ends_with("/release") => {
-            match release_admission(path, job_store) {
+            match release_admission(path, body, job_store) {
                 Ok(body) => daemon_endpoint_response("admissions.release", body),
+                Err(err) => error_response(400, err),
+            }
+        }
+        ("POST", path) if path.starts_with("/admissions/") && path.ends_with("/renew") => {
+            match renew_admission(path, body, job_store) {
+                Ok(body) => daemon_endpoint_response("admissions.renew", body),
                 Err(err) => error_response(400, err),
             }
         }
@@ -1370,24 +1378,51 @@ fn reserve_admission(
             "idempotency_key": idempotency_key,
         },
     });
-    let (job, created) = match idempotency_key {
-        Some(idempotency_key) => {
-            job_store.create_or_reuse_active_admission(metadata, idempotency_key)
-        }
-        None => (
-            job_store.create_with_source_snapshot_metadata_and_path_materialization_plan(
-                "runner.admission",
-                None,
-                Some(metadata),
-                None,
+    // Lease protocol is opt-in so an older controller can finish an admission
+    // after a daemon upgrade. New controllers also tolerate old daemons that
+    // ignore this field and return the legacy response shape.
+    let lease_protocol_v1 = body
+        .get("admission_lease_protocol")
+        .and_then(serde_json::Value::as_u64)
+        == Some(1);
+    if !lease_protocol_v1 {
+        let (job, created) = match idempotency_key {
+            Some(idempotency_key) => {
+                job_store.create_or_reuse_active_admission(metadata, idempotency_key)
+            }
+            None => (
+                job_store.create_with_source_snapshot_metadata_and_path_materialization_plan(
+                    "runner.admission",
+                    None,
+                    Some(metadata),
+                    None,
+                ),
+                true,
             ),
-            true,
-        ),
+        };
+        return Ok(json!({
+            "job": job,
+            "daemon_lease_id": daemon_lease.lease_id,
+            "idempotent_resubmission": !created,
+        }));
+    }
+    let reservation = match idempotency_key {
+        Some(idempotency_key) => job_store.create_or_renew_admission_at(
+            metadata,
+            idempotency_key,
+            crate::api_jobs::timestamp_ms(),
+        )?,
+        None => job_store.create_admission_at(metadata, crate::api_jobs::timestamp_ms())?,
     };
     Ok(json!({
-        "job": job,
+        "job": reservation.job,
         "daemon_lease_id": daemon_lease.lease_id,
-        "idempotent_resubmission": !created,
+        "idempotent_resubmission": !reservation.created,
+        "admission_token": reservation.token,
+        "lease": {
+            "expires_at_ms": reservation.expires_at_ms,
+            "renewable": true,
+        },
     }))
 }
 
@@ -1405,37 +1440,92 @@ fn validate_admission_lease(expected_lease_id: &str, actual_lease_id: &str) -> R
     ))
 }
 
-fn release_admission(path: &str, job_store: &JobStore) -> Result<serde_json::Value> {
+fn admission_job_id(path: &str, suffix: &str) -> Result<uuid::Uuid> {
     let job_id = path
         .trim_start_matches("/admissions/")
-        .trim_end_matches("/release")
+        .trim_end_matches(suffix)
         .trim_end_matches('/');
-    let job_id = uuid::Uuid::parse_str(job_id).map_err(|error| {
+    uuid::Uuid::parse_str(job_id).map_err(|error| {
         Error::validation_invalid_argument(
             "job_id",
             format!("invalid admission job ID: {error}"),
             Some(job_id.to_string()),
             None,
         )
-    })?;
-    let job = job_store.get(job_id)?;
-    if job.operation != "runner.admission" {
-        return Err(Error::validation_invalid_argument(
-            "job_id",
-            "job is not an admission reservation",
-            Some(job_id.to_string()),
+    })
+}
+
+fn admission_token(body: Option<serde_json::Value>) -> Result<String> {
+    body.and_then(|body| {
+        body.get("admission_token")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+    })
+    .filter(|token| !token.trim().is_empty())
+    .ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "admission_token",
+            "admission reservation requires its opaque token",
             None,
-        ));
-    }
-    let job = if matches!(
-        job.status,
-        JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
-    ) {
-        job
-    } else {
-        job_store.cancel(job_id, "admission reservation released")?
+            None,
+        )
+    })
+}
+
+fn release_admission(
+    path: &str,
+    body: Option<serde_json::Value>,
+    job_store: &JobStore,
+) -> Result<serde_json::Value> {
+    let job_id = admission_job_id(path, "/release")?;
+    let job = match body
+        .and_then(|body| {
+            body.get("admission_token")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+        .filter(|token| !token.trim().is_empty())
+    {
+        Some(token) => {
+            job_store.release_admission_at(job_id, &token, crate::api_jobs::timestamp_ms())?
+        }
+        None => {
+            if job_store.admission_is_leased(job_id)? {
+                return Err(Error::validation_invalid_argument(
+                    "admission_token",
+                    "admission reservation requires its opaque token",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            let job = job_store.get(job_id)?;
+            if job.operation != "runner.admission" {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    "job is not an admission reservation",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            job_store.cancel(job_id, "admission reservation released")?
+        }
     };
     Ok(json!({ "job": job }))
+}
+
+fn renew_admission(
+    path: &str,
+    body: Option<serde_json::Value>,
+    job_store: &JobStore,
+) -> Result<serde_json::Value> {
+    let job_id = admission_job_id(path, "/renew")?;
+    let token = admission_token(body)?;
+    let reservation =
+        job_store.renew_admission_at(job_id, &token, crate::api_jobs::timestamp_ms())?;
+    Ok(json!({
+        "job": reservation.job,
+        "lease": { "expires_at_ms": reservation.expires_at_ms, "renewable": true },
+    }))
 }
 
 fn lifecycle_stop_request(body: Option<serde_json::Value>) -> Result<LifecycleStopRequest> {
@@ -2172,8 +2262,9 @@ mod tests {
             assert_eq!(active_jobs[0].operation, "runner.admission");
             assert_eq!(active_jobs[0].kind, "runner.admission");
 
-            let released = release_admission(&format!("/admissions/{job_id}/release"), &store)
-                .expect("release admission");
+            let released =
+                release_admission(&format!("/admissions/{job_id}/release"), None, &store)
+                    .expect("release admission");
             assert_eq!(released["job"]["status"], "cancelled");
             assert_eq!(
                 daemon_freshness_report(&store)
@@ -2216,8 +2307,9 @@ mod tests {
                 "one durable attempt creates exactly one admission reservation"
             );
 
-            let released = release_admission(&format!("/admissions/{job_id}/release"), &store)
-                .expect("release reservation after failed handoff");
+            let released =
+                release_admission(&format!("/admissions/{job_id}/release"), None, &store)
+                    .expect("release reservation after failed handoff");
             assert_eq!(released["job"]["status"], "cancelled");
             assert_eq!(
                 daemon_freshness_report(&store)

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::mpsc::{self, Sender};
 use std::time::{Duration, Instant};
 
 use reqwest::blocking::Client;
@@ -413,6 +414,9 @@ pub(super) fn exec_via_daemon(
 pub(crate) struct DaemonAdmissionReservation {
     local_url: String,
     job_id: String,
+    token: Option<String>,
+    renewer_stop: Option<Sender<()>>,
+    renewer: Option<std::thread::JoinHandle<()>>,
     pub(crate) daemon_lease_id: String,
 }
 
@@ -424,6 +428,12 @@ impl DaemonAdmissionReservation {
 
 impl Drop for DaemonAdmissionReservation {
     fn drop(&mut self) {
+        if let Some(stop) = self.renewer_stop.take() {
+            let _ = stop.send(());
+        }
+        if let Some(renewer) = self.renewer.take() {
+            let _ = renewer.join();
+        }
         let Ok(client) = Client::builder()
             .no_proxy()
             .timeout(Duration::from_secs(10))
@@ -435,7 +445,11 @@ impl Drop for DaemonAdmissionReservation {
             &client,
             &self.local_url,
             &format!("/admissions/{}/release", self.job_id),
-            &json!({}),
+            &self
+                .token
+                .as_ref()
+                .map(|token| json!({ "admission_token": token }))
+                .unwrap_or_else(|| json!({})),
             DaemonPostOptions::default(),
         );
     }
@@ -464,6 +478,7 @@ pub(crate) fn reserve_daemon_admission(
             "command": command,
             "expected_daemon_lease_id": expected_daemon_lease_id,
             "idempotency_key": idempotency_key,
+            "admission_lease_protocol": 1,
         }),
         DaemonPostOptions::default(),
     )?;
@@ -509,11 +524,61 @@ pub(crate) fn reserve_daemon_admission(
             Some("parse daemon admission job".to_string()),
         )
     })?;
+    let token = body
+        .get("admission_token")
+        .and_then(Value::as_str)
+        .filter(|token| !token.is_empty())
+        .map(str::to_string);
+    let (renewer_stop, renewer) = match token.as_deref() {
+        Some(token) => {
+            let (stop, renewer) = spawn_admission_renewer(
+                local_url.to_string(),
+                job.id.to_string(),
+                token.to_string(),
+            );
+            (Some(stop), Some(renewer))
+        }
+        // Older daemons ignore the opt-in marker and retain their legacy,
+        // explicit-release-only reservation contract.
+        None => (None, None),
+    };
     Ok(DaemonAdmissionReservation {
         local_url: local_url.to_string(),
         job_id: job.id.to_string(),
+        token,
+        renewer_stop,
+        renewer,
         daemon_lease_id: daemon_lease_id.to_string(),
     })
+}
+
+/// Renew at half the daemon's bounded lease interval while staging keeps the
+/// handoff alive. Explicit release remains authoritative when the context ends.
+fn spawn_admission_renewer(
+    local_url: String,
+    job_id: String,
+    token: String,
+) -> (Sender<()>, std::thread::JoinHandle<()>) {
+    let (stop, shutdown) = mpsc::channel();
+    let renewer = std::thread::spawn(move || {
+        while shutdown.recv_timeout(Duration::from_secs(15)).is_err() {
+            let Ok(client) = Client::builder()
+                .no_proxy()
+                .timeout(Duration::from_secs(10))
+                .build()
+            else {
+                continue;
+            };
+            let _ = daemon_post_json_text(
+                &client,
+                &local_url,
+                &format!("/admissions/{job_id}/renew"),
+                &json!({ "admission_token": token }),
+                DaemonPostOptions::default(),
+            );
+        }
+    });
+    (stop, renewer)
 }
 
 /// Recover only a connection that failed before the daemon could answer. A


### PR DESCRIPTION
## Summary

- give runner admission reservations bounded renewable server-side leases
- expire abandoned reservations out of active-job accounting
- retain immediate token-authenticated release and idempotent live renewal
- preserve rolling compatibility through opt-in admission lease protocol negotiation

Fixes #9186.

## Why

Admission cleanup previously depended entirely on a best-effort client destructor. A crashed or disconnected controller could leave a queued durable `runner.admission` job active indefinitely and block daemon maintenance.

## Compatibility

New controllers request `admission_lease_protocol: 1`. Old controllers retain legacy tokenless reservation/release behavior, and new controllers safely fall back when an old daemon omits lease fields. This enables rolling controller/daemon upgrades.

## How to test

1. Check out this branch on a fresh clone.
2. Run `cargo test -p homeboy-core admission_lease --no-fail-fast`; confirm 3 tests pass.
3. Run `cargo test -p homeboy-core admission_reservation --no-fail-fast`; confirm 3 tests pass.
4. Run `cargo check -p homeboy-core -p homeboy-lab-runner`.
5. Run `cargo fmt --check` and `git diff --check origin/main...HEAD`.

## Evidence

- Admission lease tests: 3 passed, 0 failed.
- Admission reservation tests: 3 passed, 0 failed.
- Relevant crate checks, formatting, and diff checks passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Chris Huber and the agent captured the leaked-admission evidence, implemented renewable server-side leases and rolling compatibility, and added deterministic coverage.