### PR TITLE
Fix explicit runner terminal status projection

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1952,9 +1952,40 @@ pub(crate) fn reconcile_runner_job_snapshot(
     Ok(())
 }
 
-/// A terminal daemon transport result is not an agent-task result on its own.
-/// Keep the controller record live until the daemon publishes the aggregate
-/// lifecycle event, which is the single authoritative terminal projection.
+/// Project an authoritative terminal daemon snapshot into its persisted run.
+/// The daemon calls this before returning a foreground `runner exec --run-id`,
+/// so its caller never reports a terminal command while the durable run remains
+/// active. Replaying the same terminal snapshot is a no-op once projected.
+pub fn project_terminal_runner_result(
+    run_id: &str,
+    snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
+) -> Result<bool> {
+    if !matches!(
+        snapshot.job.status,
+        homeboy_core::api_jobs::JobStatus::Succeeded
+            | homeboy_core::api_jobs::JobStatus::Failed
+            | homeboy_core::api_jobs::JobStatus::Cancelled
+    ) {
+        return Ok(false);
+    }
+
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    validate_runner_job_snapshot(&record, snapshot)?;
+    if let Some(event) = terminal_runner_lifecycle_event(&record, snapshot)? {
+        if store::read_aggregate(&record.run_id).ok().as_ref() == Some(&event.aggregate) {
+            return Ok(false);
+        }
+        project_terminal_runner_lifecycle_event(&mut record, snapshot, &event)?;
+        return Ok(true);
+    }
+    if record.state.is_terminal() {
+        return Ok(false);
+    }
+    project_terminal_runner_job_snapshot(&mut record, snapshot);
+    store::write_record(&record)?;
+    Ok(true)
+}
+
 fn record_pending_runner_synchronization(
     record: &mut AgentTaskRunRecord,
     snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
@@ -1980,6 +2011,66 @@ fn record_pending_runner_synchronization(
     );
 }
 
+fn project_terminal_runner_job_snapshot(
+    record: &mut AgentTaskRunRecord,
+    snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
+) {
+    // Only the explicit foreground runner-exec path reaches this helper.
+    // Detached reconciliation remains pending until its inner aggregate arrives.
+    record.updated_at = Some(now_timestamp());
+    let (run_state, task_state, phase) = match snapshot.job.status {
+        homeboy_core::api_jobs::JobStatus::Succeeded => (
+            AgentTaskRunState::Succeeded,
+            AgentTaskState::Succeeded,
+            "completed",
+        ),
+        homeboy_core::api_jobs::JobStatus::Failed => {
+            (AgentTaskRunState::Failed, AgentTaskState::Failed, "failed")
+        }
+        homeboy_core::api_jobs::JobStatus::Cancelled => (
+            AgentTaskRunState::Cancelled,
+            AgentTaskState::Cancelled,
+            "cancelled",
+        ),
+        homeboy_core::api_jobs::JobStatus::Queued | homeboy_core::api_jobs::JobStatus::Running => {
+            return
+        }
+    };
+    set_run_state(record, run_state);
+    for task in &mut record.tasks {
+        if matches!(task.state, AgentTaskState::Queued | AgentTaskState::Running) {
+            task.state = task_state;
+        }
+    }
+    record_runner_job_terminal_metadata(record, snapshot.job.status, &snapshot.events);
+    let metadata = record.ensure_metadata_object();
+    metadata.insert("phase".to_string(), json!(phase));
+    metadata.insert(
+        "phase_activity".to_string(),
+        json!("authoritative runner daemon result projected"),
+    );
+    metadata.insert("provider_state".to_string(), json!(phase));
+    metadata.insert(
+        "runner_result_synchronization".to_string(),
+        json!({
+            "state": "projected",
+            "runner_job_status": snapshot.job.status,
+        }),
+    );
+    if let Some(handoff) = metadata.get_mut("runner_handoff") {
+        handoff["state"] = json!("terminal");
+    }
+    metadata.insert(
+        METADATA_KEY_RETRYABLE.to_string(),
+        json!(run_state != AgentTaskRunState::Succeeded),
+    );
+    metadata.remove(METADATA_KEY_STALE_RUNNING);
+    metadata.remove(METADATA_KEY_STALE_RUNNING_REASON);
+}
+
+/// Extracts the richer inner agent-task aggregate when the terminal daemon
+/// result includes one. Generic reconciliation retains a transport-only result
+/// as pending; foreground explicit runner execution projects it directly.
 fn terminal_runner_lifecycle_event(
     record: &AgentTaskRunRecord,
     snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -522,11 +522,20 @@ fn terminal_child_projection_rejects_mismatched_persisted_run_identity() {
 }
 
 #[test]
-fn late_inner_aggregate_recovers_patch_after_transport_only_terminal_result() {
+fn transport_only_reconciliation_stays_pending_until_foreground_projection_or_inner_aggregate() {
     with_isolated_home(|_| {
+        let run_id = "foreground-transport-only";
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let inner_patch = b"late aggregate patch";
+        let inner_patch_sha256 = format!("{:x}", sha2::Sha256::digest(inner_patch));
+        let finalized_dir = homeboy_core::paths::artifact_root()
+            .expect("artifact root")
+            .join("executor-finalized");
+        std::fs::create_dir_all(&finalized_dir).expect("controller finalized artifact directory");
+        std::fs::write(finalized_dir.join("inner-patch"), inner_patch)
+            .expect("controller finalized artifact bytes");
         let mut record = record_detached_lab_run(DetachedLabRunRecord {
-            run_id: "agent-task-disconnected-child",
+            run_id,
             runner_id: "homeboy-lab",
             runner_job_id: "00000000-0000-0000-0000-000000000123",
             remote_workspace: "/runner/workspace/repo",
@@ -540,11 +549,29 @@ fn late_inner_aggregate_recovers_patch_after_transport_only_terminal_result() {
         transport_only.events.clear();
         reconcile_runner_job_snapshot(&mut record, &transport_only)
             .expect("transport-only terminal result");
-        assert_eq!(record.state, AgentTaskRunState::Succeeded);
+        assert_eq!(record.state, AgentTaskRunState::Running);
+        assert_eq!(record.metadata["phase"], "awaiting_runner_synchronization");
+        assert_eq!(
+            record.metadata["runner_result_synchronization"]["state"],
+            "pending"
+        );
         assert!(artifacts(&record.run_id)
             .expect("transport-only artifacts")
             .artifacts
             .is_empty());
+
+        assert!(
+            project_terminal_runner_result(&record.run_id, &transport_only)
+                .expect("foreground transport result projects the explicit run")
+        );
+        assert_eq!(record.state, AgentTaskRunState::Running);
+        let projected = status(&record.run_id).expect("foreground terminal projection");
+        assert_eq!(projected.state, AgentTaskRunState::Succeeded);
+        assert_eq!(
+            projected.metadata["runner_result_synchronization"]["state"],
+            "projected"
+        );
+        record = projected;
 
         let mut aggregate = succeeded_aggregate(&test_plan());
         aggregate.outcomes[0].artifacts.push(AgentTaskArtifact {
@@ -556,23 +583,34 @@ fn late_inner_aggregate_recovers_patch_after_transport_only_terminal_result() {
             role: Some("patch".to_string()),
             semantic_key: None,
             path: Some("artifacts/candidate.patch".to_string()),
-            url: Some("homeboy://agent-task/run/agent-task-disconnected-child/artifacts#task=task-a&artifact=inner-patch".to_string()),
+            url: Some(format!(
+                "homeboy://agent-task/run/{run_id}/artifacts#task=task-a&artifact=inner-patch"
+            )),
             mime: Some("text/x-diff".to_string()),
-            size_bytes: Some(18_928),
-            sha256: Some("062f5c460c2dfb279277b75d5a16a04e3178ace1f35ce7b10da5e17441b37071".to_string()),
+            size_bytes: Some(inner_patch.len() as u64),
+            sha256: Some(inner_patch_sha256.clone()),
             metadata: Value::Null,
         });
-        let lifecycle_snapshot = terminal_child_snapshot(&aggregate);
+        let mut lifecycle_snapshot = terminal_child_snapshot(&aggregate);
+        let identity = &mut lifecycle_snapshot.events[0]
+            .data
+            .as_mut()
+            .expect("lifecycle event data")["identity"];
+        identity["run_id"] = json!(run_id);
+        identity["persisted_run_id"] = json!(run_id);
         reconcile_runner_job_snapshot(&mut record, &lifecycle_snapshot)
             .expect("late inner lifecycle evidence is adopted");
 
         let artifacts = artifacts(&record.run_id).expect("controller-visible artifacts");
         assert_eq!(artifacts.artifacts.len(), 1);
         assert_eq!(artifacts.artifacts[0].id, "inner-patch");
-        assert_eq!(artifacts.artifacts[0].size_bytes, Some(18_928));
+        assert_eq!(
+            artifacts.artifacts[0].size_bytes,
+            Some(inner_patch.len() as u64)
+        );
         assert_eq!(
             artifacts.artifacts[0].sha256.as_deref(),
-            Some("062f5c460c2dfb279277b75d5a16a04e3178ace1f35ce7b10da5e17441b37071")
+            Some(inner_patch_sha256.as_str())
         );
         assert_eq!(
             store::read_aggregate(&record.run_id)
@@ -581,8 +619,67 @@ fn late_inner_aggregate_recovers_patch_after_transport_only_terminal_result() {
                 .artifacts[0]
                 .sha256
                 .as_deref(),
-            Some("062f5c460c2dfb279277b75d5a16a04e3178ace1f35ce7b10da5e17441b37071")
+            Some(inner_patch_sha256.as_str())
         );
+    });
+}
+
+#[test]
+fn foreground_terminal_daemon_projection_finishes_success_and_failure_runs_once() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        for (run_id, daemon_status, expected_run, expected_task, expected_execution_status) in [
+            (
+                "foreground-daemon-success",
+                homeboy_core::api_jobs::JobStatus::Succeeded,
+                AgentTaskRunState::Succeeded,
+                AgentTaskState::Succeeded,
+                "succeeded",
+            ),
+            (
+                "foreground-daemon-failure",
+                homeboy_core::api_jobs::JobStatus::Failed,
+                AgentTaskRunState::Failed,
+                AgentTaskState::Failed,
+                "failed",
+            ),
+        ] {
+            record_detached_lab_run(DetachedLabRunRecord {
+                run_id,
+                runner_id: "homeboy-lab",
+                runner_job_id: "00000000-0000-0000-0000-000000000123",
+                remote_workspace: "/runner/workspace/repo",
+                remote_command: &command,
+            })
+            .expect("accepted detached handoff");
+            let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+            snapshot.job.status = daemon_status;
+            snapshot.events.clear();
+
+            assert!(project_terminal_runner_result(run_id, &snapshot)
+                .expect("foreground daemon result is projected"));
+            assert!(!project_terminal_runner_result(run_id, &snapshot)
+                .expect("repeated terminal result is idempotent"));
+
+            let projected = status(run_id).expect("terminal durable run");
+            assert_eq!(projected.state, expected_run);
+            assert_eq!(projected.tasks[0].state, expected_task);
+            assert_eq!(projected.lifecycle.execution.state, expected_run.into());
+            assert!(projected.lifecycle.execution.finished_at.is_some());
+            assert_eq!(
+                projected.metadata["runner_job_status"],
+                json!(daemon_status)
+            );
+            assert_eq!(
+                projected.metadata["runner_execution_record"]["status"],
+                expected_execution_status
+            );
+            assert_eq!(projected.metadata["runner_handoff"]["state"], "terminal");
+            assert_eq!(
+                projected.metadata["runner_result_synchronization"]["state"],
+                "projected"
+            );
+        }
     });
 }
 

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -326,6 +326,15 @@ pub(super) fn exec_via_daemon(
         run_id.as_deref(),
         mirror_run_id.as_deref(),
     )?;
+    if let Some(run_id) = run_id.as_deref() {
+        homeboy_agents::agent_task_lifecycle::project_terminal_runner_result(
+            run_id,
+            &homeboy_core::api_jobs::RunnerJobLogSnapshot {
+                job: job.clone(),
+                events: events.clone(),
+            },
+        )?;
+    }
     let artifacts = job.artifacts.clone();
     let mutation_artifacts = mutation_artifacts_from_job(&job, &result);
     if print_handoff_output {


### PR DESCRIPTION
## Summary

- project authoritative terminal daemon results before foreground `runner exec --run-id` returns
- distinguish generic command stdout from explicitly declared agent-task lifecycle payloads
- keep generic detached task reconciliation waiting for its inner aggregate
- make foreground success, failure, and replay projection coherent and idempotent
- preserve late aggregate and artifact adoption after transport projection

Closes #9189.

## How to test

1. Run `cargo test -p homeboy-agents transport_only_reconciliation_stays_pending_until_foreground_projection_or_inner_aggregate -- --test-threads=1`.
2. Run `cargo test -p homeboy-agents foreground_terminal_daemon_projection_finishes_generic_empty_or_text_stdout_runs_once -- --test-threads=1`.
3. Run `cargo test -p homeboy-agents agent_task_lifecycle::agent_task_lifecycle_event::tests:: -- --test-threads=1`.
4. Run `cargo check -p homeboy-lab-runner`.
5. Connect a daemon-backed runner and run `homeboy runner exec <runner-id> --run-id runner-exec-terminal-repro --raw -- true`.
6. Run `homeboy runs show runner-exec-terminal-repro` and confirm the run, task, lifecycle execution, runner execution record, and daemon evidence are all terminal `succeeded`.
7. Repeat with a plain-text failing command under a new run ID and confirm the durable status is terminal `failed`.

## Verification

- Focused lifecycle and parser tests pass.
- `cargo check -p homeboy-lab-runner` passes.
- `git diff --check origin/main...HEAD` passes.
- The neighboring lifecycle module is 24/26; two unchanged fixture tests fail on the base branch due controller-runtime identity and duplicate handoff-acceptance state.
- Repo-wide `cargo fmt --check` currently reports an unchanged base-branch formatting drift in `crates/homeboy-lab-runner/src/lib.rs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause analysis, implementation, tests, and verification in collaboration with Chris Huber.