### PR TITLE
Exclude runner metadata from provider delta baselines

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
@@ -40,7 +40,17 @@ pub(super) fn harvest_uncommitted_patch(
     // Git's binary patch generation include tracked, staged, and untracked files.
     // Homeboy-owned runner metadata is excluded from the diff so it never lands
     // in a candidate patch as checkout drift. (#8534)
-    git_output(root, &["add", "--all"])?;
+    git_output(
+        root,
+        &[
+            "add",
+            "--all",
+            "--",
+            ".",
+            HARVEST_METADATA_EXCLUDE_PATHSPECS[0],
+            HARVEST_METADATA_EXCLUDE_PATHSPECS[1],
+        ],
+    )?;
     let mut uncommitted_patch_args = vec![
         "diff",
         "--cached",

--- a/crates/homeboy-lab-runner/src/workspace/provenance.rs
+++ b/crates/homeboy-lab-runner/src/workspace/provenance.rs
@@ -15,6 +15,11 @@ const LAB_SOURCE_SNAPSHOT_SYNC_MODE: &str = "lab_offload";
 const SYNTHETIC_SNAPSHOT_BASELINE_REF: &str = "refs/heads/homeboy-snapshot-baseline";
 const SYNTHETIC_SNAPSHOT_AUTHOR: &str = "Homeboy Snapshot <snapshot@homeboy.invalid> 0 +0000";
 const CONTENT_MANIFEST_DIFFERENCE_LIMIT: usize = 8;
+const SYNTHETIC_BASELINE_PATHS: &[&str] = &[
+    ".",
+    ":(exclude).homeboy/runner-workspace.json",
+    ":(exclude).homeboy/lab-at-files/**",
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct VerifiedLabWorkspaceProvenance {
@@ -75,7 +80,17 @@ pub(crate) fn materialize_verified_lab_snapshot_git_baseline(
             "--initial-branch=homeboy-snapshot-baseline",
         ],
     )?;
-    git(materialized_workspace_path, &["add", "--all"])?;
+    git(
+        materialized_workspace_path,
+        &[
+            "add",
+            "--all",
+            "--",
+            SYNTHETIC_BASELINE_PATHS[0],
+            SYNTHETIC_BASELINE_PATHS[1],
+            SYNTHETIC_BASELINE_PATHS[2],
+        ],
+    )?;
     let tree = git(materialized_workspace_path, &["write-tree"])?;
     let message = synthetic_snapshot_baseline_message(&provenance);
     let commit = git_with_env(
@@ -177,7 +192,15 @@ fn verify_materialized_snapshot_git_checkout(
     }
     if !git(
         workspace,
-        &["status", "--porcelain", "--untracked-files=all"],
+        &[
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+            "--",
+            SYNTHETIC_BASELINE_PATHS[0],
+            SYNTHETIC_BASELINE_PATHS[1],
+            SYNTHETIC_BASELINE_PATHS[2],
+        ],
     )?
     .is_empty()
     {
@@ -1236,6 +1259,121 @@ mod tests {
             .expect("candidate patch");
         assert!(uncommitted_patch.contains("-candidate"));
         assert!(uncommitted_patch.contains("+uncommitted candidate"));
+    }
+
+    #[test]
+    fn synthetic_baseline_captures_only_provider_delta_for_clean_and_dirty_snapshots() {
+        for dirty in [false, true] {
+            let workspace = tempfile::tempdir().expect("runner workspace");
+            let authoritative = tempfile::tempdir().expect("authoritative workspace");
+            let source_contents = if dirty {
+                "source dirty\n"
+            } else {
+                "baseline\n"
+            };
+            std::fs::write(workspace.path().join("file.txt"), source_contents)
+                .expect("snapshot source");
+            std::fs::create_dir_all(workspace.path().join(".homeboy"))
+                .expect("runner metadata directory");
+            std::fs::write(
+                workspace.path().join(".homeboy/runner-workspace.json"),
+                "runner-owned metadata\n",
+            )
+            .expect("runner metadata");
+            let mut snapshot = snapshot(workspace.path());
+            snapshot.dirty = dirty;
+            let mut lab = lab(workspace.path(), &snapshot);
+            lab["workspace_cleanliness"] = serde_json::json!({
+                "allow_dirty_lab_workspace": dirty,
+            });
+            let baseline = materialize_verified_lab_snapshot_git_baseline(
+                &workspace.path().display().to_string(),
+                workspace.path(),
+                snapshot.clone(),
+                lab,
+            )
+            .expect("synthetic baseline");
+
+            assert!(
+                !git(workspace.path(), &["ls-tree", "-r", "--name-only", "HEAD"])
+                    .expect("list baseline tree")
+                    .contains(".homeboy/runner-workspace.json"),
+                "runner metadata is never part of the synthetic baseline"
+            );
+            std::fs::write(
+                workspace.path().join("provider-edit.txt"),
+                "provider edit\n",
+            )
+            .expect("provider edit");
+            git(
+                workspace.path(),
+                &[
+                    "add",
+                    "--all",
+                    "--",
+                    SYNTHETIC_BASELINE_PATHS[0],
+                    SYNTHETIC_BASELINE_PATHS[1],
+                    SYNTHETIC_BASELINE_PATHS[2],
+                ],
+            )
+            .expect("stage provider delta");
+            let patch = git(
+                workspace.path(),
+                &[
+                    "diff",
+                    "--cached",
+                    "--binary",
+                    "--full-index",
+                    &baseline,
+                    "--",
+                    SYNTHETIC_BASELINE_PATHS[0],
+                    SYNTHETIC_BASELINE_PATHS[1],
+                    SYNTHETIC_BASELINE_PATHS[2],
+                ],
+            )
+            .expect("provider delta");
+            assert!(patch.contains("provider-edit.txt"));
+            assert!(!patch.contains("runner-workspace.json"));
+            assert!(!patch.contains("source dirty"));
+
+            std::fs::write(authoritative.path().join("file.txt"), "baseline\n")
+                .expect("authoritative baseline");
+            git(authoritative.path(), &["init", "--quiet", "-b", "main"])
+                .expect("initialize authoritative source");
+            git(authoritative.path(), &["add", "file.txt"]).expect("stage authoritative baseline");
+            git(
+                authoritative.path(),
+                &[
+                    "-c",
+                    "user.name=Homeboy Test",
+                    "-c",
+                    "user.email=test@homeboy.invalid",
+                    "commit",
+                    "--quiet",
+                    "-m",
+                    "baseline",
+                ],
+            )
+            .expect("commit authoritative baseline");
+            std::fs::write(authoritative.path().join("file.txt"), source_contents)
+                .expect("authoritative source state");
+            let patch_path = authoritative.path().join("provider.patch");
+            std::fs::write(&patch_path, format!("{patch}\n")).expect("candidate patch");
+            git(
+                authoritative.path(),
+                &[
+                    "apply",
+                    "--whitespace=nowarn",
+                    patch_path.to_str().expect("patch path"),
+                ],
+            )
+            .expect("apply provider delta");
+            assert_eq!(
+                std::fs::read_to_string(authoritative.path().join("provider-edit.txt"))
+                    .expect("applied provider edit"),
+                "provider edit\n"
+            );
+        }
     }
 
     #[derive(Clone)]

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -1304,7 +1304,7 @@ fn synthetic_git_checkout_command(
         .unwrap_or_default();
 
     format!(
-        "git -C {remote_path} init && git -C {remote_path} config user.email homeboy-snapshot@localhost && git -C {remote_path} config user.name 'Homeboy Snapshot' && git -C {remote_path} add -A && env GIT_AUTHOR_NAME='Homeboy Snapshot' GIT_AUTHOR_EMAIL=homeboy-snapshot@localhost GIT_COMMITTER_NAME='Homeboy Snapshot' GIT_COMMITTER_EMAIL=homeboy-snapshot@localhost GIT_AUTHOR_DATE='1970-01-01T00:00:00Z' GIT_COMMITTER_DATE='1970-01-01T00:00:00Z' git -C {remote_path} commit --allow-empty -m {message} --no-gpg-sign && git -C {remote_path} notes --ref=homeboy-snapshot add -m {note} HEAD{set_remote}",
+        "git -C {remote_path} init && git -C {remote_path} config user.email homeboy-snapshot@localhost && git -C {remote_path} config user.name 'Homeboy Snapshot' && git -C {remote_path} add -A -- . ':(exclude).homeboy/runner-workspace.json' ':(exclude).homeboy/lab-at-files/**' && env GIT_AUTHOR_NAME='Homeboy Snapshot' GIT_AUTHOR_EMAIL=homeboy-snapshot@localhost GIT_COMMITTER_NAME='Homeboy Snapshot' GIT_COMMITTER_EMAIL=homeboy-snapshot@localhost GIT_AUTHOR_DATE='1970-01-01T00:00:00Z' GIT_COMMITTER_DATE='1970-01-01T00:00:00Z' git -C {remote_path} commit --allow-empty -m {message} --no-gpg-sign && git -C {remote_path} notes --ref=homeboy-snapshot add -m {note} HEAD{set_remote}",
         message = shell::quote_arg(&format!("Homeboy snapshot {snapshot}")),
         note = shell::quote_arg(&format!("snapshot_identity={snapshot}\nsource_head={source_head}\nsource_dirty={source_dirty}")),
     )


### PR DESCRIPTION
## Summary

- exclude Homeboy-owned runner metadata from provider snapshot baselines and harvested deltas
- preserve both clean and dirty source state while computing the provider-owned change
- add regression coverage for committed and uncommitted candidates so `.homeboy/runner-workspace.json` cannot leak into promotion patches

## Root cause

The snapshot baseline used for provider delta calculation included Homeboy-owned runtime metadata. When Lab cleanup removed that metadata, harvest interpreted the removal as a provider-authored deletion and included it in the candidate patch. Promotion then failed because the destination worktree never contained that runner-only file.

## How to test

1. Run `cargo test -p homeboy-lab-runner synthetic_baseline_captures_only_provider_delta_for_clean_and_dirty_snapshots --lib --quiet`.
2. Run `cargo test -p homeboy-lab-runner verified_snapshot_baseline_supports_committed_and_uncommitted_candidate_harvesting --lib --quiet`.
3. Run `cargo test -p homeboy-agents committed_harvest_tests --lib --quiet`.
4. Run `rustfmt --edition 2021 --check crates/homeboy-agents/src/agent_task_scheduler/harvest.rs crates/homeboy-lab-runner/src/workspace/provenance.rs crates/homeboy-lab-runner/src/workspace/snapshot.rs`.
5. Run `git diff --check origin/main...HEAD`.

## Evidence

- All focused test commands pass.
- Changed-file formatting and diff checks pass.
- The Lab runtime packaging defect encountered during orchestration is tracked separately in #9201.

Fixes #8534

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with `openai/gpt-5.6-sol`
- **Used for:** We diagnosed the promotion failure, prepared and reviewed the bounded implementation, added regression coverage, and verified the candidate together.