### PR TITLE
fix(agents): retry against the managed worktree, not a cleaned-up baseline

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -1062,11 +1062,85 @@ fn retry_handoff_prefix(args: &[String]) -> Vec<String> {
     rewritten
 }
 
+/// Resolve the durable managed worktree a retry task should continue against.
+///
+/// Returns `Ok(Some(git_root))` when the task carries a Homeboy worktree handle
+/// (its recorded `workspace.slug`) that still resolves to an active checkout,
+/// `Ok(None)` when the task was never anchored to a managed worktree (so the
+/// caller falls back to the recorded `workspace.root`), and a precise
+/// recoverable error when the handle is recorded but no longer usable. This is
+/// what keeps a cleaned-up ephemeral initial-baseline directory from being
+/// mistaken for the canonical continuation workspace (#9195).
+fn retry_task_managed_worktree(
+    task: &homeboy::agents::agent_tasks::AgentTaskRequest,
+) -> homeboy::core::Result<Option<PathBuf>> {
+    let Some(handle) = task
+        .workspace
+        .slug
+        .as_deref()
+        .filter(|handle| !handle.trim().is_empty())
+    else {
+        return Ok(None);
+    };
+
+    let Some(record) = homeboy::core::worktree::resolve_workspace_ref_if_present(handle)? else {
+        // No Homeboy record for this handle: the task was not anchored to a
+        // managed worktree, so leave resolution to the recorded root fallback.
+        return Ok(None);
+    };
+
+    if record.state() != &homeboy::core::worktree::TaskWorktreeState::Active {
+        return Err(Error::validation_invalid_argument(
+            "workspace",
+            format!(
+                "agent-task retry task '{}' managed worktree '{}' is no longer active; its work is unavailable for continuation",
+                task.task_id,
+                record.handle()
+            ),
+            Some(handle.to_string()),
+            Some(vec![
+                "Recreate the worktree with `homeboy worktree add`, or retry against an explicit replacement workspace.".to_string(),
+            ]),
+        ));
+    }
+
+    let path = PathBuf::from(record.path());
+    let git_root = git::repo_root(&path).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "workspace",
+            format!(
+                "agent-task retry task '{}' managed worktree '{}' points at a missing checkout {}",
+                task.task_id,
+                record.handle(),
+                path.display()
+            ),
+            Some(path.display().to_string()),
+            Some(vec![
+                "Recreate the worktree with `homeboy worktree add`, or remove the stale record and retry against an explicit replacement workspace.".to_string(),
+            ]),
+        )
+    })?;
+    Ok(Some(git_root))
+}
+
 fn retry_plan_primary_workspace(
     plan: &homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,
 ) -> homeboy::core::Result<PathBuf> {
     let mut roots = BTreeSet::new();
     for task in &plan.tasks {
+        // The authoritative continuation workspace is the managed worktree the
+        // task was recorded against, not whichever `workspace.root` the original
+        // plan captured. A pre-provider or gate-failed cook may have run against
+        // an ephemeral initial-baseline directory that has since been cleaned
+        // up; trusting that path fails retry with "not inside a git checkout"
+        // even though the durable worktree record still resolves. Prefer the
+        // recorded worktree handle so baseline artifacts stay evidence, never
+        // the canonical continuation workspace (#9195).
+        if let Some(git_root) = retry_task_managed_worktree(task)? {
+            roots.insert(git_root);
+            continue;
+        }
+
         let root = task
             .workspace
             .root
@@ -1094,7 +1168,7 @@ fn retry_plan_primary_workspace(
                     ),
                     Some(path.display().to_string()),
                     Some(vec![
-                        "Retry the task from a plan with a git-backed workspace root.".to_string(),
+                        "Retry the task from a plan with a git-backed workspace root, or record its managed worktree handle so retry can resolve the durable checkout.".to_string(),
                     ]),
                 )
             })?;

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -1211,6 +1211,95 @@ fn retry_handoff_refuses_multiple_task_workspaces() {
 }
 
 #[test]
+fn retry_prefers_managed_worktree_over_cleaned_up_ephemeral_baseline() {
+    crate::test_support::with_isolated_home(|_| {
+        // The authoritative managed worktree the cook was anchored to. It
+        // outlives the attempt and stays a real git checkout.
+        let managed = tempfile::tempdir().expect("managed worktree");
+        git_init(managed.path());
+        homeboy::core::worktree::adopt(homeboy::core::worktree::WorktreeAdoptOptions {
+            handle: "fixture@cook".to_string(),
+            path: managed.path().display().to_string(),
+            kind: None,
+            provenance: None,
+        })
+        .expect("adopt managed worktree");
+
+        // The ephemeral initial-baseline directory the original plan recorded
+        // as workspace.root, then cleaned up before retry.
+        let ephemeral = tempfile::tempdir().expect("ephemeral baseline");
+        let ephemeral_root = ephemeral.path().to_path_buf();
+        git_init(&ephemeral_root);
+        drop(ephemeral); // simulate baseline cleanup: the path no longer exists.
+        assert!(!ephemeral_root.exists());
+
+        // The persisted task still carries both the dead ephemeral root and the
+        // durable managed worktree handle (its slug).
+        let task: homeboy::agents::agent_tasks::AgentTaskRequest =
+            serde_json::from_value(serde_json::json!({
+                "task_id": "cook-task",
+                "executor": { "backend": "fixture" },
+                "instructions": "retry",
+                "workspace": { "root": ephemeral_root, "slug": "fixture@cook" }
+            }))
+            .expect("task");
+        let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
+            "cleaned-up-baseline",
+            vec![task],
+        );
+
+        let resolved = retry_plan_primary_workspace(&plan)
+            .expect("retry resolves the managed worktree despite the cleaned-up baseline");
+        let expected = homeboy::core::git::repo_root(managed.path()).expect("managed git root");
+        assert_eq!(
+            resolved, expected,
+            "retry must continue against the managed worktree, never the deleted ephemeral baseline"
+        );
+    });
+}
+
+#[test]
+fn retry_reports_recoverable_state_when_the_managed_worktree_is_gone() {
+    crate::test_support::with_isolated_home(|_| {
+        // A managed worktree was recorded, then its checkout removed from disk
+        // while the record still points at it.
+        let managed = tempfile::tempdir().expect("managed worktree");
+        let managed_path = managed.path().to_path_buf();
+        git_init(&managed_path);
+        homeboy::core::worktree::adopt(homeboy::core::worktree::WorktreeAdoptOptions {
+            handle: "fixture@gone".to_string(),
+            path: managed_path.display().to_string(),
+            kind: None,
+            provenance: None,
+        })
+        .expect("adopt managed worktree");
+        drop(managed);
+        assert!(!managed_path.exists());
+
+        let task: homeboy::agents::agent_tasks::AgentTaskRequest =
+            serde_json::from_value(serde_json::json!({
+                "task_id": "cook-task",
+                "executor": { "backend": "fixture" },
+                "instructions": "retry",
+                "workspace": { "slug": "fixture@gone" }
+            }))
+            .expect("task");
+        let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
+            "missing-worktree",
+            vec![task],
+        );
+
+        let error = retry_plan_primary_workspace(&plan)
+            .expect_err("a missing managed worktree must return a precise recoverable state");
+        assert!(
+            error.message.contains("points at a missing checkout"),
+            "unexpected error: {}",
+            error.message
+        );
+    });
+}
+
+#[test]
 fn retry_handoff_identifies_an_original_plan_without_a_workspace() {
     crate::test_support::with_isolated_home(|_| {
         let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(


### PR DESCRIPTION
Fixes #9195.

## Problem

`homeboy agent-task retry <run> --run` reconstructs the retry task from the original persisted plan, and `retry_plan_primary_workspace` resolved the continuation checkout from whatever `workspace.root` that plan captured. A pre-provider or gate-failed cook frequently runs against an **ephemeral initial-baseline directory** that is cleaned up after the attempt. Retry then trusted that deleted path and failed before provider execution:

```text
Invalid argument workspace: agent-task retry task workspace is not inside a git checkout
```

…even though the task's authoritative **managed worktree** record still resolved. The baseline artifact was being treated as the canonical continuation workspace.

## Fix

Resolve the managed worktree **first**. New `retry_task_managed_worktree` looks up the task's recorded worktree handle (`workspace.slug`) through `homeboy_core::worktree::resolve_workspace_ref_if_present` — the same durable registry the promotion path adopted in #9148 — and continues the retry against that active checkout. The recorded `workspace.root` baseline is now used only as a fallback for tasks that were never anchored to a managed worktree, so baseline directories stay *evidence*, never the continuation workspace.

Recovery is deterministic and precise:
- handle resolves + active + checkout present -> retry uses the managed worktree
- handle recorded but **inactive** -> recoverable error: *"managed worktree '…' is no longer active; its work is unavailable for continuation"*
- handle recorded but **checkout missing** -> recoverable error: *"managed worktree '…' points at a missing checkout …"*
- no managed-worktree record -> unchanged recorded-root fallback

This maps directly onto the issue's desired contract (persist/prefer the authoritative managed worktree; treat baseline artifacts as evidence; validate identity before dispatch; deterministic recovery when the worktree is unavailable).

## Why this is the right layer

This is the first concrete slice of a broader finding: the cook lifecycle's authoritative baseline/worktree identity was only ever held in **non-serializable** in-memory types (`DerivedCookBaselineCapability`, `CookFollowUpBaseline`, `CandidateBaseline`), while the durable `AgentTaskRunRecord` persisted only a patch pointer. Every reconnect/retry path therefore re-derived identity from `workspace.root` + git and could land on the wrong thing (the shape behind #9195, #9180, #9196). Here retry stops re-deriving and reads the durable worktree registry instead — the authoritative source that already survives cleanup.

## Testing

- `retry_prefers_managed_worktree_over_cleaned_up_ephemeral_baseline`: managed worktree adopted, ephemeral `workspace.root` deleted; asserts retry resolves the managed worktree. **Verified it reproduces #9195 exactly** — with the resolver neutered the test fails with the literal `"agent-task retry task workspace is not inside a git checkout"`.
- `retry_reports_recoverable_state_when_the_managed_worktree_is_gone`: recorded handle whose checkout was removed -> precise recoverable error.
- Full `retry` suite in the crate (11 tests) green, including the existing worktree-provider and detached-retry paths.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Traced the cook baseline/worktree identity model, identified that retry re-derived the workspace from a cleaned-up baseline instead of the durable worktree registry, implemented the managed-worktree-first resolver, and added regression tests (including a neutered-resolver check that reproduces the reported error). Chris reviews and owns the change.