### PR TITLE
Canonicalize release-set attachment identity

### DIFF
--- a/crates/contracts/homeboy-component-contract/src/model.rs
+++ b/crates/contracts/homeboy-component-contract/src/model.rs
@@ -346,6 +346,12 @@ impl From<Component> for RawComponent {
 }
 
 impl Component {
+    /// Return a stable serialization suitable for comparing resolved component
+    /// configuration across independently loaded snapshots.
+    pub fn canonical_identity(&self) -> serde_json::Result<String> {
+        serde_json::to_value(self).and_then(|value| serde_json::to_string(&canonical_json(value)))
+    }
+
     pub fn new(
         id: String,
         local_path: String,
@@ -505,6 +511,23 @@ impl Component {
                 "Homeboy does not execute component-level build_command.".to_string(),
             ]),
         ))
+    }
+}
+
+fn canonical_json(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Array(values) => {
+            serde_json::Value::Array(values.into_iter().map(canonical_json).collect())
+        }
+        serde_json::Value::Object(values) => serde_json::Value::Object(
+            values
+                .into_iter()
+                .map(|(key, value)| (key, canonical_json(value)))
+                .collect::<std::collections::BTreeMap<_, _>>()
+                .into_iter()
+                .collect(),
+        ),
+        value => value,
     }
 }
 

--- a/crates/homeboy-cli/src/commands/deploy.rs
+++ b/crates/homeboy-cli/src/commands/deploy.rs
@@ -394,7 +394,8 @@ fn apply_release_set(
     args.preflighted_component_identities = active
         .iter()
         .map(|(entry, component)| {
-            serde_json::to_string(component)
+            component
+                .canonical_identity()
                 .map(|identity| (entry.id.clone(), identity))
                 .map_err(|error| homeboy::core::Error::internal_io(
                     format!("Failed to encode release-set component '{}': {error}", entry.id),

--- a/crates/homeboy-release/src/deploy/orchestration/mod.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/mod.rs
@@ -467,7 +467,7 @@ fn validate_preflighted_component_identities(
         let Some(expected_path) = config.preflighted_source_paths.get(&component.id) else {
             continue;
         };
-        let actual_identity = serde_json::to_string(component).map_err(|error| {
+        let actual_identity = component.canonical_identity().map_err(|error| {
             Error::internal_io(
                 format!(
                     "Failed to encode effective component '{}': {error}",
@@ -1354,6 +1354,115 @@ mod tests {
             result.results[0].deployed_ref.as_deref(),
             Some("feature/deploy (HEAD)")
         );
+    }
+
+    #[test]
+    fn release_set_dry_run_accepts_unchanged_managed_worktree_attachment() {
+        let source = TempDir::new().expect("source repo");
+        init_repo_with_tag_gap(source.path());
+        let worktree_root = TempDir::new().expect("worktree root");
+        let attachment = worktree_root.path().join("fixture");
+        run_git(
+            source.path(),
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                attachment.to_str().expect("attachment path"),
+                "v1.0.0",
+            ],
+        );
+
+        let mut preflighted = artifact_component(
+            "fixture",
+            attachment.to_str().expect("attachment path"),
+            "dist/fixture.zip",
+        );
+        let mut preflight_settings = HashMap::new();
+        preflight_settings.insert("first".to_string(), serde_json::json!(1));
+        preflight_settings.insert("second".to_string(), serde_json::json!(2));
+        preflighted.extensions = Some(HashMap::from([(
+            "fixture-packager".to_string(),
+            homeboy_core::component::ScopedExtensionConfig {
+                settings: preflight_settings,
+                ..Default::default()
+            },
+        )]));
+
+        // Loading the attachment again reconstructs map-backed config with a
+        // different insertion order while preserving the effective component.
+        let mut loaded = preflighted.clone();
+        let mut loaded_settings = HashMap::new();
+        loaded_settings.insert("second".to_string(), serde_json::json!(2));
+        loaded_settings.insert("first".to_string(), serde_json::json!(1));
+        loaded.extensions = Some(HashMap::from([(
+            "fixture-packager".to_string(),
+            homeboy_core::component::ScopedExtensionConfig {
+                settings: loaded_settings,
+                ..Default::default()
+            },
+        )]));
+
+        let mut config = base_deploy_config();
+        config.dry_run = true;
+        config.requested_refs =
+            std::collections::BTreeMap::from([("fixture".to_string(), "v1.0.0".to_string())]);
+        config.resolved_refs = std::collections::BTreeMap::from([(
+            "fixture".to_string(),
+            git_stdout(source.path(), &["rev-parse", "v1.0.0"]),
+        )]);
+        config.preflighted_source_paths = std::collections::BTreeMap::from([(
+            "fixture".to_string(),
+            preflighted.local_path.clone(),
+        )]);
+        config.preflighted_component_identities = std::collections::BTreeMap::from([(
+            "fixture".to_string(),
+            preflighted
+                .canonical_identity()
+                .expect("preflight identity"),
+        )]);
+
+        validate_preflighted_component_identities(&[loaded.clone()], &config)
+            .expect("unchanged attachment must pass the release-set guard");
+        let result = run_dry_run_mode(
+            &[loaded],
+            &HashMap::new(),
+            &HashMap::new(),
+            &Project::default(),
+            "",
+            &config,
+        )
+        .expect("unchanged attachment must reach exact-ref dry-run planning");
+
+        assert_eq!(result.results.len(), 1);
+        assert_eq!(result.results[0].status, "planned");
+    }
+
+    #[test]
+    fn release_set_attachment_drift_fails_before_dry_run_materialization() {
+        let component = artifact_component("fixture", "/source/fixture", "dist/fixture.zip");
+        let mut config = base_deploy_config();
+        config.dry_run = true;
+        config.preflighted_source_paths = std::collections::BTreeMap::from([(
+            "fixture".to_string(),
+            component.local_path.clone(),
+        )]);
+        config.preflighted_component_identities = std::collections::BTreeMap::from([(
+            "fixture".to_string(),
+            component.canonical_identity().expect("preflight identity"),
+        )]);
+
+        let mut changed_path = component.clone();
+        changed_path.local_path = "/source/other-fixture".to_string();
+        let err = validate_preflighted_component_identities(&[changed_path], &config)
+            .expect_err("path drift must fail before dry-run planning");
+        assert!(err.message.contains("changed after release-set preflight"));
+
+        let mut changed_config = component;
+        changed_config.remote_path = "wp-content/plugins/changed".to_string();
+        let err = validate_preflighted_component_identities(&[changed_config], &config)
+            .expect_err("config drift must fail before dry-run planning");
+        assert!(err.message.contains("changed after release-set preflight"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- canonicalize effective component configuration before release-set identity comparison
- preserve fail-closed path and real configuration drift checks
- allow unchanged project attachments to pass multi-ref dry-run validation

## Root cause
Release-set preflight compared raw JSON serializations containing maps. Equivalent component reloads could serialize map keys in a different order and falsely report attachment drift.

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-release release_set_ --lib`; expect both attachment identity tests to pass.
3. Run `cargo test -p homeboy-cli deploy`; expect deploy command tests to pass.
4. Configure a project attachment and run a single-project multi-ref release-set dry run twice; expect unchanged attachments to pass and any path/config mutation to fail before deployment planning.

## Compatibility
Only object-key ordering is normalized. Arrays retain order and actual component/path changes remain release-blocking.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with GPT-5.6 Sol
- **Used for:** Reproduced, implemented, reviewed, and tested the released attachment-identity fix with Chris.

Closes #9205
Relates to #8177