### PR TITLE
refactor(cli): resolve a task's declared source root in one place

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -886,28 +886,37 @@ fn materialize_agent_task_run_handoff(
     }))
 }
 
+/// The single place that reads a task's declared source root, in priority
+/// order: `workspace.root`, then `executor.config.workspace_root`, then
+/// `metadata.workspace.root`. Both the run and retry handoff paths resolve the
+/// primary checkout from this one chain so they never drift apart.
+fn task_declared_source_root(
+    task: &homeboy::agents::agent_tasks::AgentTaskRequest,
+) -> Option<&str> {
+    task.workspace
+        .root
+        .as_deref()
+        .or_else(|| {
+            task.executor
+                .config
+                .get("workspace_root")
+                .and_then(serde_json::Value::as_str)
+        })
+        .or_else(|| {
+            task.metadata
+                .get("workspace")
+                .and_then(|workspace| workspace.get("root"))
+                .and_then(serde_json::Value::as_str)
+        })
+        .filter(|root| !root.trim().is_empty())
+}
+
 fn plan_primary_workspace(
     plan: &homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,
 ) -> homeboy::core::Result<PathBuf> {
     let mut roots = BTreeSet::new();
     for task in &plan.tasks {
-        let root = task
-            .workspace
-            .root
-            .as_deref()
-            .or_else(|| {
-                task.executor
-                    .config
-                    .get("workspace_root")
-                    .and_then(serde_json::Value::as_str)
-            })
-            .or_else(|| {
-                task.metadata
-                    .get("workspace")
-                    .and_then(|workspace| workspace.get("root"))
-                    .and_then(serde_json::Value::as_str)
-            });
-        if let Some(root) = root.filter(|root| !root.trim().is_empty()) {
+        if let Some(root) = task_declared_source_root(task) {
             roots.insert(PathBuf::from(root));
         }
     }
@@ -1141,23 +1150,7 @@ fn retry_plan_primary_workspace(
             continue;
         }
 
-        let root = task
-            .workspace
-            .root
-            .as_deref()
-            .or_else(|| {
-                task.executor
-                    .config
-                    .get("workspace_root")
-                    .and_then(serde_json::Value::as_str)
-            })
-            .or_else(|| {
-                task.metadata
-                    .get("workspace")
-                    .and_then(|workspace| workspace.get("root"))
-                    .and_then(serde_json::Value::as_str)
-            });
-        if let Some(root) = root.filter(|root| !root.trim().is_empty()) {
+        if let Some(root) = task_declared_source_root(task) {
             let path = PathBuf::from(root);
             let git_root = git::repo_root(&path).ok_or_else(|| {
                 Error::validation_invalid_argument(


### PR DESCRIPTION
## What

Both Lab-handoff workspace resolvers in `route.rs` carried a **byte-for-byte identical** three-tier fallback for a task's declared source root:

```
workspace.root  ->  executor.config.workspace_root  ->  metadata.workspace.root   (drop blanks)
```

`plan_primary_workspace` (run handoff) and `retry_plan_primary_workspace` (retry handoff, added in #9203) each inlined it. Two copies of the same precedence rule is exactly the kind of duplication that drifts: a fix to one path silently diverges from the other.

This extracts the chain into one `task_declared_source_root(task) -> Option<&str>` and calls it from both sites. `get("workspace_root")` now appears **once** in the file instead of twice.

## Not changed

Behaviour is identical:
- run path still collects distinct roots and requires exactly one,
- retry path still prefers the managed worktree (#9203) before falling back to the declared root,
- the 0 / 1 / many validation and its (deliberately distinct) run-vs-retry error messages are untouched.

I intentionally did **not** collapse the two `match roots.len()` blocks — they share a shape but carry different validation semantics and different operator-facing diagnostics, so merging them would trade real, useful error messages for indirection. The genuine duplication was the source-root precedence chain; that is what's consolidated.

## Result

Net **-7 lines** (27 insertions / 34 deletions), one duplicated fallback chain removed, single source of truth for source-root precedence.

## Testing

- `retry` suite in the crate (11 tests, both handoff paths) green.
- One unrelated test (`controller_proxy_run_resumes_on_its_recorded_runner_workspace`) fails on this branch **and identically on clean origin/main** (verified by stashing the change) — it depends on a runner subprocess writing a continuation file in this environment, not on this refactor.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Enumerated the workspace source-root re-derivation sites, identified the two identical inline fallback chains as the real duplication (vs. the superficially-similar len-matching, deliberately left alone), extracted the shared resolver, and verified behaviour preservation. Chris reviews and owns the change.