### PR TITLE
Isolate inherited adoption gate failures

### DIFF
--- a/crates/homeboy-agents/src/agent_task_cook_loop.rs
+++ b/crates/homeboy-agents/src/agent_task_cook_loop.rs
@@ -550,6 +550,38 @@ mod tests {
     }
 
     #[test]
+    fn accepted_inherited_failure_completes_without_hiding_a_regression() {
+        let mut inherited = failed_gate();
+        inherited.status = AgentTaskGateStatus::AcceptedInheritedFailure;
+        let accepted = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report(AgentTaskPromotionStatus::Applied, vec![inherited]),
+            attempt: 1,
+            max_attempts: 1,
+            source_run_id: Some("run-inherited".to_string()),
+            current_diff: String::new(),
+            metadata: Value::Null,
+        });
+        assert_eq!(accepted.status, AgentTaskCookLoopStatus::GreenCompleted);
+        assert!(accepted.failed_gates.is_empty());
+
+        let regression = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report(
+                AgentTaskPromotionStatus::GateFailed,
+                vec![failed_gate()],
+            ),
+            attempt: 1,
+            max_attempts: 1,
+            source_run_id: Some("run-regression".to_string()),
+            current_diff: String::new(),
+            metadata: Value::Null,
+        });
+        assert_eq!(regression.status, AgentTaskCookLoopStatus::RetriesExhausted);
+        assert_eq!(regression.failed_gates.len(), 1);
+    }
+
+    #[test]
     fn no_changed_files_are_terminal_noop_feedback() {
         let report = evaluate_cook_loop(AgentTaskCookLoopOptions {
             source_request: source_request(),

--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -60,8 +61,20 @@ pub struct AgentTaskGateReport {
     pub stderr: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_evidence: Option<AgentTaskGateFailureEvidence>,
+    /// The same command's result against the immutable base when candidate
+    /// adoption needs to distinguish inherited failures from regressions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub baseline_comparison: Option<AgentTaskGateBaselineComparison>,
     #[serde(default, skip_serializing_if = "AgentTaskGateEnvironment::is_empty")]
     pub environment: AgentTaskGateEnvironment,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskGateBaselineComparison {
+    pub base_ref: String,
+    pub exit_code: i32,
+    pub failure_fingerprint: String,
+    pub matches_candidate_failure: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -89,6 +102,9 @@ impl AgentTaskGateEnvironment {
 pub enum AgentTaskGateStatus {
     Succeeded,
     Failed,
+    /// The candidate command failed, but the identical failure was reproduced
+    /// against the controller-recorded immutable baseline.
+    AcceptedInheritedFailure,
 }
 
 /// Canonical bridge from the binary agent-task gate status to the shared
@@ -100,6 +116,7 @@ impl From<AgentTaskGateStatus> for HomeboyGateStatus {
         match status {
             AgentTaskGateStatus::Succeeded => HomeboyGateStatus::Passed,
             AgentTaskGateStatus::Failed => HomeboyGateStatus::Failed,
+            AgentTaskGateStatus::AcceptedInheritedFailure => HomeboyGateStatus::Passed,
         }
     }
 }
@@ -147,7 +164,9 @@ impl AgentTaskGateReport {
             id.clone(),
             "agent_task.gate",
             match status {
-                AgentTaskGateStatus::Succeeded => PlanStepStatus::Success,
+                AgentTaskGateStatus::Succeeded | AgentTaskGateStatus::AcceptedInheritedFailure => {
+                    PlanStepStatus::Success
+                }
                 AgentTaskGateStatus::Failed => PlanStepStatus::Failed,
             },
         )
@@ -168,8 +187,105 @@ impl AgentTaskGateReport {
             stdout: stdout.into(),
             stderr: stderr.into(),
             failure_evidence,
+            baseline_comparison: None,
             environment,
         }
+    }
+
+    pub(crate) fn accept_inherited_failure(&mut self) {
+        self.status = AgentTaskGateStatus::AcceptedInheritedFailure;
+        let gate_result = HomeboyGateResult::new(
+            self.id.clone(),
+            self.id.clone(),
+            HomeboyGateKind::Command,
+            HomeboyGateStatus::Passed,
+        )
+        .summary(
+            "candidate failure matches the immutable baseline; no candidate regression detected",
+        )
+        .visibility(self.visibility)
+        .reveal_policy(self.reveal_policy)
+        .retryable(false);
+        self.step = PlanStep::builder(self.id.clone(), "agent_task.gate", PlanStepStatus::Success)
+            .inputs(PlanValues::new().json("command", &self.command))
+            .output_value("exit_code", serde_json::json!(self.exit_code))
+            .output_value("accepted_inherited_failure", serde_json::json!(true))
+            .gate_result(gate_result)
+            .build();
+    }
+}
+
+/// Normalize only transport-noise that cannot identify a command failure. The
+/// comparison remains fail-closed: a changed substantive line is a regression.
+pub(crate) fn failure_fingerprint(stdout: &str, stderr: &str) -> String {
+    [stdout, stderr]
+        .into_iter()
+        .flat_map(str::lines)
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod baseline_tests {
+    use super::{
+        failure_fingerprint, run_gate_command_with_timeout, AgentTaskGateRevealPolicy,
+        AgentTaskGateStatus, AgentTaskGateVisibility,
+    };
+    use std::time::Duration;
+
+    #[test]
+    fn matching_baseline_failure_is_distinct_from_a_new_failure() {
+        let baseline = failure_fingerprint("test alpha ... FAILED\n", "");
+        let matching_candidate = failure_fingerprint("test alpha ... FAILED\n", "");
+        let regressed_candidate =
+            failure_fingerprint("test alpha ... FAILED\ntest beta ... FAILED\n", "");
+
+        assert_eq!(baseline, matching_candidate);
+        assert_ne!(baseline, regressed_candidate);
+    }
+
+    #[test]
+    fn bounded_baseline_gate_is_cancelled() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let report = run_gate_command_with_timeout(
+            temp.path(),
+            1,
+            "sleep 1",
+            AgentTaskGateVisibility::Visible,
+            AgentTaskGateRevealPolicy::FullEvidence,
+            temp.path(),
+            Duration::from_millis(20),
+        )
+        .expect("bounded gate report");
+
+        assert_eq!(report.status, AgentTaskGateStatus::Failed);
+        assert_eq!(report.exit_code, 124);
+        assert!(report.stderr.contains("was cancelled"));
+    }
+
+    #[test]
+    fn bounded_baseline_gate_reaps_background_descendants_before_reader_join() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let marker = temp.path().join("descendant-survived");
+        let report = run_gate_command_with_timeout(
+            temp.path(),
+            1,
+            &format!(
+                "(sleep 0.2; touch '{}') & while :; do sleep 1; done",
+                marker.display()
+            ),
+            AgentTaskGateVisibility::Visible,
+            AgentTaskGateRevealPolicy::FullEvidence,
+            temp.path(),
+            Duration::from_millis(20),
+        )
+        .expect("bounded gate report");
+
+        assert_eq!(report.exit_code, 124);
+        std::thread::sleep(Duration::from_millis(300));
+        assert!(!marker.exists(), "background descendant survived timeout");
     }
 }
 
@@ -237,6 +353,82 @@ pub(crate) fn run_gate_command_with_policy_and_runtime_tmpdir(
     let failure_evidence = (!output.status.success())
         .then(|| gate_failure_evidence(command, exit_code, &stdout, &stderr));
 
+    Ok(AgentTaskGateReport::new(
+        format!("gate-{index}"),
+        command_vec,
+        exit_code,
+        stdout,
+        stderr,
+        failure_evidence,
+        visibility,
+        reveal_policy,
+        environment,
+    ))
+}
+
+/// Run a comparison gate with a hard wall-clock limit. The bounded path keeps
+/// candidate adoption inspectable instead of allowing a known-red baseline to
+/// consume an unbounded second broad-suite run.
+pub(crate) fn run_gate_command_with_timeout(
+    cwd: &Path,
+    index: usize,
+    command: &str,
+    visibility: AgentTaskGateVisibility,
+    reveal_policy: AgentTaskGateRevealPolicy,
+    runtime_tmpdir: &Path,
+    timeout: Duration,
+) -> Result<AgentTaskGateReport> {
+    let command_vec = vec!["sh".to_string(), "-lc".to_string(), command.to_string()];
+    let environment = selected_gate_environment(command);
+    let mut process = Command::new("sh");
+    process
+        .args(["-lc", command])
+        .current_dir(cwd)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    process
+        .env("TMPDIR", runtime_tmpdir)
+        .env("TEMP", runtime_tmpdir)
+        .env("TMP", runtime_tmpdir);
+    for variable in &environment.sanitized {
+        process.env_remove(&variable.name);
+    }
+    homeboy_core::engine::command::isolate_process_tree(&mut process);
+    let mut child = process.spawn().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("run bounded deterministic gate {command}")),
+        )
+    })?;
+    let started = std::time::Instant::now();
+    let mut timed_out = false;
+    let output = homeboy_core::engine::command::wait_with_bounded_output_until_cancelled(
+        &mut child,
+        1024 * 1024,
+        || {
+            timed_out = started.elapsed() >= timeout;
+            timed_out
+        },
+    )
+    .map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("run bounded deterministic gate {command}")),
+        )
+    })?;
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let mut stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let exit_code = if timed_out {
+        stderr.push_str(&format!(
+            "\nbaseline gate exceeded {} ms and was cancelled",
+            timeout.as_millis()
+        ));
+        124
+    } else {
+        output.status.code().unwrap_or(1)
+    };
+    let failure_evidence =
+        (exit_code != 0).then(|| gate_failure_evidence(command, exit_code, &stdout, &stderr));
     Ok(AgentTaskGateReport::new(
         format!("gate-{index}"),
         command_vec,
@@ -462,6 +654,19 @@ mod tests {
         assert_eq!(report.exit_code, 0);
         assert_eq!(report.stdout, "ok");
         assert!(report.failure_evidence.is_none());
+    }
+
+    #[test]
+    fn accepted_inherited_failure_rebuilds_the_embedded_plan_step() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut report = run_gate_command(temp.path(), 1, "exit 1").expect("failed gate");
+
+        report.accept_inherited_failure();
+
+        assert_eq!(report.status, AgentTaskGateStatus::AcceptedInheritedFailure);
+        let step = serde_json::to_value(&report.step).expect("serialize step");
+        assert_eq!(step["status"], "success");
+        assert_eq!(step["outputs"]["accepted_inherited_failure"], true);
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -16,6 +16,10 @@ use crate::agent_task_finalization::{
     AgentTaskPrFinalizationBackend, RealAgentTaskPrFinalizationBackend,
 };
 use crate::agent_task_gate::VerifyGateOptions;
+use crate::agent_task_gate::{
+    failure_fingerprint, run_gate_command_with_timeout, AgentTaskGateBaselineComparison,
+    AgentTaskGateStatus,
+};
 use crate::agent_task_lifecycle;
 use crate::agent_task_promotion::resolve_candidate_revision;
 use crate::agent_task_promotion::{
@@ -284,6 +288,20 @@ fn adopt_cook_candidate_with_dispatcher_and_backend<B: AgentTaskPrFinalizationBa
             return Err(error);
         }
     };
+    let task_base_sha = options.task_base_sha.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "task_base_sha",
+            "candidate adoption requires the recorded immutable task base for baseline-aware verification",
+            None,
+            None,
+        )
+    })?;
+    compare_adoption_gate_failures_to_base(
+        &mut promotion,
+        source_worktree,
+        task_base_sha,
+        &record.run_id,
+    )?;
     // The adopted candidate did not run through this cook's provider lifecycle.
     // Bind its declared model to the authenticated promotion instead of inferring
     // one from the immutable execution plan.
@@ -379,6 +397,130 @@ fn adopt_cook_candidate_with_dispatcher_and_backend<B: AgentTaskPrFinalizationBa
         None,
         exit_code,
     ))
+}
+
+/// Candidate adoption can prove that an otherwise-red broad command is
+/// inherited only by executing the identical command at the recorded base.
+/// A changed failure fingerprint is deliberately still a hard gate failure.
+fn compare_adoption_gate_failures_to_base(
+    promotion: &mut AgentTaskPromotionReport,
+    source_worktree: &std::path::Path,
+    task_base_sha: &str,
+    run_id: &str,
+) -> Result<()> {
+    if !promotion.status.gate_failed() {
+        return Ok(());
+    }
+    let baseline_root = tempfile::tempdir().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("create candidate-adoption gate baseline".to_string()),
+        )
+    })?;
+    let baseline_path = baseline_root.path().join("base");
+    let output = std::process::Command::new("git")
+        .args(["worktree", "add", "--detach"])
+        .arg(&baseline_path)
+        .arg(task_base_sha)
+        .current_dir(source_worktree)
+        .output()
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("materialize candidate-adoption gate baseline".to_string()),
+            )
+        })?;
+    if !output.status.success() {
+        return Err(Error::internal_io(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            Some("materialize immutable candidate-adoption gate baseline".to_string()),
+        ));
+    }
+    let baseline_result = (|| -> Result<bool> {
+        // Match promotion's dependency and isolated-runtime setup before the
+        // base command is allowed to serve as comparison evidence.
+        homeboy_core::hygiene::materialize_worktree_dependencies(&baseline_path)?;
+        let mut all_failures_inherited = true;
+        let failed_gate_count = promotion
+            .deterministic_gates
+            .iter()
+            .filter(|gate| gate.status == AgentTaskGateStatus::Failed)
+            .count();
+        if failed_gate_count == 0 {
+            return Ok(false);
+        }
+        let mut compared = 0;
+        for (index, gate) in promotion.deterministic_gates.iter_mut().enumerate() {
+            if gate.status != AgentTaskGateStatus::Failed {
+                continue;
+            }
+            compared += 1;
+            agent_task_lifecycle::checkpoint_candidate_adoption(
+                run_id,
+                "baseline_verification",
+                &format!("baseline gate {compared}/{failed_gate_count}"),
+            )?;
+            let command = gate.command.last().cloned().unwrap_or_default();
+            let baseline_run_dir = homeboy_core::engine::run_dir::RunDir::create()?;
+            let baseline_runtime = homeboy_core::engine::invocation::InvocationGuard::acquire(
+                &baseline_run_dir,
+                &homeboy_core::engine::invocation::InvocationRequirements::default(),
+            )?;
+            let baseline = run_gate_command_with_timeout(
+                &baseline_path,
+                index + 1,
+                &command,
+                gate.visibility,
+                gate.reveal_policy,
+                &baseline_runtime.context().tmp_dir,
+                std::time::Duration::from_secs(5 * 60),
+            )?;
+            let candidate_fingerprint = failure_fingerprint(&gate.stdout, &gate.stderr);
+            let baseline_fingerprint = failure_fingerprint(&baseline.stdout, &baseline.stderr);
+            let matches = baseline.status == AgentTaskGateStatus::Failed
+                && candidate_fingerprint == baseline_fingerprint;
+            gate.baseline_comparison = Some(AgentTaskGateBaselineComparison {
+                base_ref: task_base_sha.to_string(),
+                exit_code: baseline.exit_code,
+                failure_fingerprint: baseline_fingerprint,
+                matches_candidate_failure: matches,
+            });
+            all_failures_inherited &= matches;
+            if matches {
+                gate.accept_inherited_failure();
+            }
+        }
+        Ok(all_failures_inherited)
+    })();
+    let cleanup = std::process::Command::new("git")
+        .args(["worktree", "remove", "--force"])
+        .arg(&baseline_path)
+        .current_dir(source_worktree)
+        .status()
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("remove candidate-adoption gate baseline".to_string()),
+            )
+        })?;
+    if !cleanup.success() {
+        return Err(Error::internal_io(
+            "git worktree remove failed".to_string(),
+            Some("remove candidate-adoption gate baseline".to_string()),
+        ));
+    }
+    let all_failures_inherited = baseline_result?;
+    if all_failures_inherited {
+        promotion.status = crate::agent_task_promotion::AgentTaskPromotionStatus::Applied;
+        for result in &mut promotion.gate_results {
+            if result.status == homeboy_core::gate::HomeboyGateStatus::Failed {
+                result.status = homeboy_core::gate::HomeboyGateStatus::Passed;
+                result.summary = "candidate failure matches the immutable baseline; no candidate regression detected".to_string();
+                result.retryable = Some(false);
+            }
+        }
+    }
+    Ok(())
 }
 
 fn candidate_adoption_source(

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -248,6 +248,39 @@ fn signal_process_group(root_pid: u32, signal: libc::c_int) -> io::Result<()> {
 }
 
 #[cfg(unix)]
+fn descendant_pids(root_pid: u32) -> io::Result<Vec<u32>> {
+    let output = Command::new("ps").args(["-axo", "pid=,ppid="]).output()?;
+    let parents: Vec<(u32, u32)> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            Some((fields.next()?.parse().ok()?, fields.next()?.parse().ok()?))
+        })
+        .collect();
+    let mut descendants = vec![root_pid];
+    let mut cursor = 0;
+    while cursor < descendants.len() {
+        let parent = descendants[cursor];
+        descendants.extend(
+            parents
+                .iter()
+                .filter_map(|(pid, ppid)| (*ppid == parent).then_some(*pid)),
+        );
+        cursor += 1;
+    }
+    Ok(descendants)
+}
+
+#[cfg(unix)]
+fn signal_pids(pids: &[u32], signal: libc::c_int) {
+    for pid in pids {
+        unsafe {
+            let _ = libc::kill(*pid as libc::pid_t, signal);
+        }
+    }
+}
+
+#[cfg(unix)]
 fn process_group_is_running(root_pid: u32) -> bool {
     unsafe { libc::kill(-(root_pid as libc::pid_t), 0) == 0 }
 }
@@ -279,10 +312,16 @@ pub fn terminate_process_tree_and_reap(child: &mut Child) -> io::Result<ExitStat
     #[cfg(unix)]
     {
         let root_pid = child.id();
+        // Shells can put background jobs in a distinct process group. Snapshot
+        // descendants before terminating the root so those jobs cannot retain
+        // output pipes and strand capture-reader joins.
+        let descendants = descendant_pids(root_pid)?;
         signal_process_group(root_pid, libc::SIGTERM)?;
+        signal_pids(&descendants, libc::SIGTERM);
         let mut status = child.try_wait()?;
         if !wait_for_process_group_exit(child, root_pid, PROCESS_TREE_TERM_GRACE, &mut status)? {
             signal_process_group(root_pid, libc::SIGKILL)?;
+            signal_pids(&descendants, libc::SIGKILL);
             if !wait_for_process_group_exit(child, root_pid, PROCESS_TREE_KILL_GRACE, &mut status)?
             {
                 if status.is_none() {


### PR DESCRIPTION
## Summary
- compare failed candidate gates against the immutable task base SHA in an equivalent materialized environment
- represent proven inherited failures as a typed accepted outcome while preserving their original nonzero evidence
- keep candidate-introduced or changed failures blocking
- bound baseline gate execution, terminate descendants, report progress, and clean temporary worktrees on all paths

Closes #8964

## How to test
1. Run `cargo test -p homeboy-agents baseline_tests --lib`.
2. Run `cargo test -p homeboy-agents accepted_inherited_failure_completes_without_hiding_a_regression --lib`.
3. Run `cargo fmt --check`.

## Compatibility
Green gates and true candidate regressions retain their existing behavior. Only failures proven identical against the immutable base are accepted, and all typed gate and plan-step projections agree on that outcome.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Implementation, adversarial baseline-isolation review, regression testing, and PR drafting