### PR TITLE
Generate evidence-backed Cook review dossiers

### DIFF
--- a/crates/homeboy-agents/src/agent_task_review_dossier.rs
+++ b/crates/homeboy-agents/src/agent_task_review_dossier.rs
@@ -231,6 +231,12 @@ impl AgentTaskReviewDossier {
                     "each test step needs a runnable command and expected result",
                 );
             }
+            if !reviewer_runnable_command(&step.command) {
+                return invalid(
+                    "how_to_test.command",
+                    "test commands must be reviewer-runnable and cannot contain operator-only references",
+                );
+            }
         }
         for evidence in &self.evidence {
             scalar("evidence.summary", &evidence.summary)?;
@@ -318,7 +324,22 @@ pub fn render_review_dossier(
         let section = match id {
         AgentTaskReviewSectionId::Summary if !dossier.summary.is_empty() => Some(("Summary", prose(&dossier.summary))),
         AgentTaskReviewSectionId::WhatChanged if !dossier.what_changed.is_empty() => Some(("What changed", bullets(&dossier.what_changed))),
-        AgentTaskReviewSectionId::HowToTest if !dossier.how_to_test.is_empty() => Some(("How to test", dossier.how_to_test.iter().enumerate().map(|(i, step)| format!("{}. Run `{}`; expect {}.", i + 1, code(&step.command), prose(&step.expected))).collect::<Vec<_>>().join("\n"))),
+        AgentTaskReviewSectionId::HowToTest => {
+            let steps = dossier
+                .how_to_test
+                .iter()
+                .filter(|step| reviewer_runnable_command(&step.command))
+                .collect::<Vec<_>>();
+            (!steps.is_empty()).then(|| (
+                "How to test",
+                steps
+                    .iter()
+                    .enumerate()
+                    .map(|(i, step)| format!("{}. Run `{}`; expect {}.", i + 1, code(&step.command), prose(&step.expected)))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            ))
+        }
         AgentTaskReviewSectionId::Compatibility if !dossier.compatibility.is_empty() => Some(("Compatibility", prose(&dossier.compatibility))),
         AgentTaskReviewSectionId::Evidence if !dossier.evidence.is_empty() => Some(("Evidence", dossier.evidence.iter().map(|item| match &item.url { Some(url) => format!("- {}: {url}", prose(&item.summary)), None => format!("- {}", prose(&item.summary)) }).collect::<Vec<_>>().join("\n"))),
         AgentTaskReviewSectionId::AiAssistance => Some(("AI assistance", format!("- **AI assistance:** {}\n- **Tool(s):** {}\n- **Model:** {}\n- **Used for:** {}", if dossier.ai_assistance.used { "Yes" } else { "No" }, prose(&dossier.ai_assistance.tool), prose(&dossier.ai_assistance.model), prose(&dossier.ai_assistance.used_for)))),
@@ -373,7 +394,7 @@ fn scalar(field: &str, value: &str) -> Result<()> {
     Ok(())
 }
 fn prose(value: &str) -> String {
-    let mut rendered: String = value
+    let mut rendered: String = reviewer_text(value)
         .chars()
         .flat_map(|character| match character {
             '*' | '_' | '`' | '[' | ']' | '<' | '>' | '!' => {
@@ -394,7 +415,132 @@ fn prose(value: &str) -> String {
     rendered
 }
 fn code(value: &str) -> String {
-    value.replace('`', "'")
+    reviewer_text(value).replace('`', "'")
+}
+
+/// Reviewer-facing bodies must be independently resolvable. Omit operator-only
+/// references rather than publishing local paths or durable runtime identifiers.
+fn reviewer_text(value: &str) -> String {
+    if contains_operator_only_reference(value) {
+        "[operator-only reference omitted]".into()
+    } else {
+        value.into()
+    }
+}
+
+pub fn reviewer_runnable_command(value: &str) -> bool {
+    !value.trim().is_empty() && !contains_operator_only_reference(value)
+}
+
+fn contains_operator_only_reference(value: &str) -> bool {
+    for word in value.split_whitespace() {
+        let normalized = normalize_reviewer_token(word);
+        if reviewer_credential_flag(normalized) {
+            return true;
+        }
+        if operator_only_reference(normalized) {
+            return true;
+        }
+    }
+    false
+}
+
+fn normalize_reviewer_token(value: &str) -> &str {
+    value.trim_matches(|character: char| {
+        matches!(
+            character,
+            '(' | ')' | '[' | ']' | ',' | '.' | ':' | ';' | '\'' | '"'
+        )
+    })
+}
+
+fn reviewer_credential_flag(value: &str) -> bool {
+    matches!(
+        value.to_ascii_lowercase().as_str(),
+        "--token"
+            | "--api-key"
+            | "--api_key"
+            | "--apikey"
+            | "--secret"
+            | "--password"
+            | "--authorization"
+            | "--auth-token"
+            | "--access-token"
+            | "--github-token"
+    )
+}
+
+fn operator_only_reference(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    if let Some((name, assigned_value)) = value.split_once('=') {
+        let name = name
+            .trim_start_matches('-')
+            .to_ascii_lowercase()
+            .replace('-', "_");
+        if [
+            "token",
+            "secret",
+            "password",
+            "apikey",
+            "api_key",
+            "authorization",
+            "auth_token",
+            "access_token",
+            "github_token",
+        ]
+        .contains(&name.as_str())
+            || operator_only_reference(normalize_reviewer_token(assigned_value))
+        {
+            return true;
+        }
+    }
+    if lower.contains("localhost")
+        || lower.starts_with("runner-artifact://")
+        || lower.starts_with("artifact://")
+        || lower.starts_with("homeboy://")
+        || lower.starts_with("file://")
+        || lower.starts_with('/')
+        || lower.starts_with("~/")
+        || lower.contains("/users/")
+        || lower.contains("=/")
+        || lower.contains("=~/")
+        || [
+            "token=",
+            "secret=",
+            "password=",
+            "apikey=",
+            "api_key=",
+            "authorization=",
+        ]
+        .iter()
+        .any(|secret| lower.contains(secret))
+        || is_internal_run_id(value)
+    {
+        return true;
+    }
+    let Ok(url) = reqwest::Url::parse(value) else {
+        return false;
+    };
+    let host = url.host_str().unwrap_or_default();
+    url.scheme() != "https"
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || host == "localhost"
+        || host.ends_with(".local")
+        || host.ends_with(".internal")
+        || host.ends_with(".test")
+        || host.parse::<std::net::IpAddr>().is_ok()
+}
+
+fn is_internal_run_id(value: &str) -> bool {
+    ["agent-task-", "cook-", "run-"].iter().any(|prefix| {
+        value.starts_with(prefix)
+            && value.chars().all(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '-' | '_')
+            })
+            && value.chars().any(|character| character.is_ascii_digit())
+    })
 }
 fn relationship_reference(value: &str) -> String {
     if let Some(rest) = value.strip_prefix("https://github.com/") {
@@ -454,31 +600,17 @@ fn validate_issue_reference(value: &str) -> Result<()> {
     }
 }
 fn is_reviewer_url(value: &str) -> bool {
-    value.starts_with("https://")
+    value.starts_with("https://") && !operator_only_reference(value)
 }
 fn validate_reviewer_url(value: &str) -> Result<()> {
     let url = reqwest::Url::parse(value).map_err(|_| {
         Error::validation_invalid_argument("evidence.url", "evidence URL is invalid", None, None)
     })?;
     let host = url.host_str().unwrap_or_default();
-    if url.scheme() != "https"
-        || host == "localhost"
-        || host
-            .parse::<std::net::IpAddr>()
-            .map(is_non_public_ip)
-            .unwrap_or(false)
-    {
+    if operator_only_reference(value) || host.is_empty() {
         return invalid("evidence.url", "evidence URL must be a public HTTPS URL");
     }
     Ok(())
-}
-fn is_non_public_ip(ip: std::net::IpAddr) -> bool {
-    match ip {
-        std::net::IpAddr::V4(ip) => {
-            ip.is_loopback() || ip.is_private() || ip.is_link_local() || ip.is_unspecified()
-        }
-        std::net::IpAddr::V6(ip) => ip.is_loopback() || ip.is_unspecified(),
-    }
 }
 fn invalid(field: &str, message: &str) -> Result<()> {
     Err(Error::validation_invalid_argument(
@@ -576,6 +708,72 @@ mod tests {
         value.evidence.push(AgentTaskReviewEvidence {
             summary: "local".into(),
             url: Some("https://localhost/a".into()),
+        });
+        assert!(value.validate(&default_profile()).is_err());
+    }
+
+    #[test]
+    fn renderer_omits_operator_only_references() {
+        let mut value = dossier();
+        value.summary = "Inspect http://localhost:8888 at /Users/chris/repo using runner-artifact://gate and agent-task-1234".into();
+        value.how_to_test[0].command =
+            "cargo test --manifest-path /tmp/repo/Cargo.toml file:///private/repo".into();
+        value.evidence.push(AgentTaskReviewEvidence {
+            summary:
+                "Durable evidence homeboy://agent-task/run/agent-task-1234 from cook-8058-attempt-1"
+                    .into(),
+            url: None,
+        });
+
+        let body = render_review_dossier(&value, &default_profile());
+
+        for forbidden in [
+            "localhost",
+            "/Users/chris/repo",
+            "runner-artifact://",
+            "homeboy://",
+            "agent-task-1234",
+            "cook-8058-attempt-1",
+            "/tmp/repo",
+            "file:///private/repo",
+        ] {
+            assert!(!body.contains(forbidden), "leaked {forbidden}: {body}");
+        }
+        assert!(!body.contains("## How to test"));
+    }
+
+    #[test]
+    fn reviewer_sanitization_rejects_assignment_values_and_space_delimited_credentials() {
+        for value in [
+            "root=/private/repo",
+            "path=~/workspace",
+            "BASE_URL=http://127.0.0.1:8080 cargo test",
+            "--source=file:///private/repo cargo test",
+            "API_URL=https://token@example.com/path cargo test",
+            "--token ghp_secret cargo test",
+            "https://token@example.com/evidence",
+            "https://example.com/evidence?token=secret",
+            "--report=https://example.com/evidence?api_key=secret cargo test",
+            "https://10.0.0.1/evidence",
+            "https://192.168.1.1/evidence",
+            "https://172.16.0.1/evidence",
+            "https://review.internal/evidence",
+            "https://review.local/evidence",
+            "https://review.test/evidence",
+            "API_KEY=secret cargo test",
+        ] {
+            assert!(!reviewer_runnable_command(value), "accepted {value}");
+            assert_eq!(
+                reviewer_text(value),
+                "[operator-only reference omitted]",
+                "rendered unsafe reviewer claim: {value}"
+            );
+        }
+
+        let mut value = dossier();
+        value.evidence.push(AgentTaskReviewEvidence {
+            summary: "private".into(),
+            url: Some("https://example.com/evidence?token=secret".into()),
         });
         assert!(value.validate(&default_profile()).is_err());
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -2984,6 +2984,7 @@ mod tests {
             "target": {"worktree": "homeboy@8058", "path": "/repo"},
             "patch_artifact": {"id": "patch", "kind": "patch", "path": "patch"},
             "changed_files": ["src/lib.rs"],
+            "deterministic_gates": [{"id": "gate", "visibility": "visible", "reveal_policy": "full_evidence", "status": "succeeded", "command": ["sh", "-lc", "cargo test --locked agent_task_promotion --lib"], "exit_code": 0}],
             "gate_results": [{"id": "gate", "name": "cargo test --locked agent_task_promotion --lib", "kind": "command", "status": "passed"}],
             "operator_notification": {"status": "completed", "message": "complete"},
             "verified_base": {"base": "main", "sha": "verified-base"},
@@ -3072,7 +3073,12 @@ mod tests {
                 "## AI assistance",
                 "openai/gpt-5.6-terra",
                 "Verified finalization base: main at verified-base",
-                "1. Run `cargo test --locked agent_task_promotion --lib`; expect passes.",
+                "Verified candidate changed 1 file(s): src/lib.rs.",
+                "Cook completed 1 deterministic verification gate(s) before finalization.",
+                "1. Run `cargo test --locked agent_task_promotion --lib`; expect passes as recorded by Cook's deterministic gate.",
+                "Compatibility impact is unknown from durable task and promotion evidence.",
+                "Verified candidate scope: 1 changed file(s): src/lib.rs.",
+                "Cook deterministic verification: 1 gate(s) completed green.",
             ] {
                 assert!(
                     backend.body.contains(section),
@@ -3093,6 +3099,53 @@ mod tests {
                 );
             }
             assert!(backend.committed && backend.pushed && backend.created);
+        });
+    }
+
+    #[test]
+    fn cook_rejects_test_claim_without_matching_durable_gate() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let run_id = "cook-8058-mismatch";
+            let plan = AgentTaskPlan::new("cook-8058", Vec::new());
+            agent_task_lifecycle::submit_plan(&plan, Some(run_id)).unwrap();
+            let options = AgentTaskCookServiceOptions {
+                cook_id: "cook-8058".to_string(),
+                initial_run_id: run_id.to_string(),
+                initial_plan: AgentTaskPlan::new("cook-8058", Vec::new()),
+                to_worktree: "homeboy@8058".to_string(),
+                source_worktree_path: None,
+                provider_command: None,
+                provider_invocation: None,
+                gates: VerifyGateOptions {
+                    verify: vec!["cargo test unsupported".to_string()],
+                    private_verify: Vec::new(),
+                    private_gate_reveal: Default::default(),
+                },
+                max_attempts: 1,
+                no_finalize: false,
+                base: "main".to_string(),
+                task_base_sha: Some("task-candidate-base".to_string()),
+                head: Some("fix/8058".to_string()),
+                title: "Close #8058".to_string(),
+                commit_message: "test".to_string(),
+                source_refs: Vec::new(),
+                protected_branches: vec!["main".to_string()],
+                ai_tool: "OpenCode".to_string(),
+                ai_model: Some("openai/gpt-5.6-terra".to_string()),
+                ai_used_for: "Drafted test coverage.".to_string(),
+                attempt_dispatcher: None,
+                harvest_context: crate::agent_task_scheduler::HarvestExecutionContext::default(),
+            };
+            let error = finalize_cook_pr_with_backend(
+                &options,
+                run_id,
+                &promotion(run_id),
+                &mut CaptureBackend::default(),
+            )
+            .expect_err("unsupported test claim is rejected");
+            assert!(error
+                .message
+                .contains("matching successful visible durable gate"));
         });
     }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -24,7 +24,7 @@ use crate::agent_task_promotion::{
 };
 use crate::agent_task_review_dossier::{
     resolve_review_profile, AgentTaskReviewAiAssistance, AgentTaskReviewDossier,
-    AgentTaskReviewTestStep,
+    AgentTaskReviewEvidence, AgentTaskReviewTestStep,
 };
 use homeboy_core::{config, Error, Result};
 
@@ -295,35 +295,7 @@ pub(crate) fn finalize_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
                     .map(|record| record.lifecycle),
             },
             ai_used_for: options.ai_used_for.clone(),
-            review_dossier: AgentTaskReviewDossier {
-                schema: "homeboy/agent-task-review-dossier/v1".to_string(),
-                summary: options.title.clone(),
-                what_changed: vec!["Applies the verified agent-task candidate.".to_string()],
-                how_to_test: options
-                    .gates
-                    .verify
-                    .iter()
-                    .cloned()
-                    .map(|command| AgentTaskReviewTestStep {
-                        command,
-                        expected: "passes".to_string(),
-                    })
-                    .collect(),
-                compatibility: "No compatibility impact was recorded by the cook workflow."
-                    .to_string(),
-                evidence: Vec::new(),
-                ai_assistance: AgentTaskReviewAiAssistance {
-                    used: true,
-                    tool: options.ai_tool.clone(),
-                    model: options
-                        .ai_model
-                        .clone()
-                        .unwrap_or_else(|| "not recorded".to_string()),
-                    used_for: options.ai_used_for.clone(),
-                },
-                source_relationships: Vec::new(),
-                overrides: Vec::new(),
-            },
+            review_dossier: cook_review_dossier(options, promotion)?,
             review_profile: resolve_review_profile(&path)?,
             manual_finalization: false,
             protected_branches: options.protected_branches.clone(),
@@ -331,6 +303,107 @@ pub(crate) fn finalize_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
         backend,
     )?;
     Ok(serde_json::to_value(report).unwrap_or(Value::Null))
+}
+
+fn cook_review_dossier(
+    options: &AgentTaskCookServiceOptions,
+    promotion: &AgentTaskPromotionReport,
+) -> Result<AgentTaskReviewDossier> {
+    let changed_files = promotion.changed_files.join(", ");
+    let changed_file_count = promotion.changed_files.len();
+    let gate_count = promotion.gate_results.len();
+    let task_summary = options
+        .initial_plan
+        .tasks
+        .iter()
+        .find_map(|task| {
+            task.instructions
+                .lines()
+                .map(str::trim)
+                .find(|line| !line.is_empty())
+        })
+        .unwrap_or("No single-line task objective was retained in durable task evidence.");
+    let adoption = promotion.provenance.get("adoption").is_some();
+    let how_to_test = options
+        .gates
+        .verify
+        .iter()
+        .map(|command| {
+            let matched = promotion.deterministic_gates.iter().any(|gate| {
+                gate.status == crate::agent_task_gate::AgentTaskGateStatus::Succeeded
+                    && gate.visibility == homeboy_core::gate::HomeboyGateVisibility::Visible
+                    && gate.command.as_slice() == ["sh", "-lc", command]
+            });
+            if !matched {
+                return Err(Error::validation_invalid_argument(
+                    "verification",
+                    "Cook cannot publish a test command without matching successful visible durable gate evidence",
+                    Some(command.clone()),
+                    None,
+                ));
+            }
+            if !crate::agent_task_review_dossier::reviewer_runnable_command(command) {
+                return Err(Error::validation_invalid_argument(
+                    "verification",
+                    "Cook cannot publish a test command containing an operator-only reference",
+                    Some(command.clone()),
+                    None,
+                ));
+            }
+            Ok(AgentTaskReviewTestStep {
+                command: command.clone(),
+                expected: "passes as recorded by Cook's deterministic gate".to_string(),
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(AgentTaskReviewDossier {
+        schema: "homeboy/agent-task-review-dossier/v1".to_string(),
+        summary: options.title.clone(),
+        what_changed: vec![
+            format!("Task objective: {task_summary}"),
+            format!(
+                "Verified candidate changed {changed_file_count} file(s): {changed_files}."
+            ),
+            format!(
+                "Cook completed {gate_count} deterministic verification gate(s) before finalization."
+            ),
+            if adoption {
+                "Candidate adoption provenance: an immutable candidate was adopted through the recorded Cook workflow and passed the recorded gates.".to_string()
+            } else {
+                "Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.".to_string()
+            },
+        ],
+        how_to_test,
+        compatibility: format!(
+            "Compatibility impact is unknown from durable task and promotion evidence. The candidate is bounded to {changed_file_count} changed file(s): {changed_files}; review externally consumed interfaces in this scope."
+        ),
+        evidence: vec![
+            AgentTaskReviewEvidence {
+                summary: format!(
+                    "Verified candidate scope: {changed_file_count} changed file(s): {changed_files}."
+                ),
+                url: None,
+            },
+            AgentTaskReviewEvidence {
+                summary: format!(
+                    "Cook deterministic verification: {gate_count} gate(s) completed green."
+                ),
+                url: None,
+            },
+        ],
+        ai_assistance: AgentTaskReviewAiAssistance {
+            used: true,
+            tool: options.ai_tool.clone(),
+            model: options
+                .ai_model
+                .clone()
+                .unwrap_or_else(|| "not recorded".to_string()),
+            used_for: options.ai_used_for.clone(),
+        },
+        source_relationships: Vec::new(),
+        overrides: Vec::new(),
+    })
 }
 
 pub(crate) fn cook_report(


### PR DESCRIPTION
## Summary
- derive Cook PR summaries, changed-file scope, verification steps, provenance, and bounded compatibility statements from durable evidence
- publish test commands only when they exactly match successful visible gate evidence
- reject unsafe or operator-only reviewer claims instead of emitting broken instructions
- sanitize local paths, private hosts, credentials, assigned URLs, and secret-bearing query values

Closes #8058

## How to test
1. Run `cargo test -p homeboy-agents agent_task_review_dossier --lib`.
2. Run `cargo test -p homeboy-agents cook_rejects_test_claim_without_matching_durable_gate --lib`.
3. Run `cargo test -p homeboy-agents cook_successful_concrete_attempt_publishes_reviewer_body --lib`.
4. Run `cargo fmt --check`.

## Compatibility
Custom dossier sections remain supported. Cook finalization now rejects reviewer test claims that cannot be matched to durable green evidence or safely rendered for a fresh checkout.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Implementation, reviewer-evidence review, regression testing, and PR drafting