### PR TITLE
Persist provider execution reservations

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -529,12 +529,16 @@ fn validate_durable_publication_eligibility(
     promotion: &AgentTaskPromotionReport,
 ) -> Result<DurablePublicationEligibility> {
     use homeboy_core::run_lifecycle_record::{ProviderRuntimeState, RunExecutionState};
-    if lifecycle.execution.state == RunExecutionState::Succeeded
-        && !lifecycle.provider_runtime.is_empty()
+    if !lifecycle.provider_runtime.is_empty()
         && lifecycle
             .provider_runtime
             .iter()
             .all(|runtime| runtime.state == ProviderRuntimeState::Succeeded)
+        && (lifecycle.execution.state == RunExecutionState::Succeeded
+            || (lifecycle.execution.state == RunExecutionState::PartialFailure
+                && lifecycle.provider_runtime.iter().all(|runtime| {
+                    runtime.metadata["evidence_source"] == "durable_provider_execution"
+                })))
     {
         return Ok(DurablePublicationEligibility::ProviderRun);
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -597,6 +597,95 @@ pub fn mark_running(run_id: &str) -> Result<AgentTaskRunRecord> {
     Ok(record)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderExecutionReservation {
+    Acquired,
+    AlreadyReserved,
+}
+
+/// Durably reserve one provider execution before the scheduler blocks on the
+/// backend. A resumed controller must reconcile an existing reservation rather
+/// than dispatching the same `(task_id, attempt)` a second time.
+pub fn reserve_provider_execution(
+    run_id: &str,
+    task: &AgentTaskRequest,
+    attempt: u32,
+) -> Result<ProviderExecutionReservation> {
+    let run_id = sanitize_run_id(run_id);
+    let execution_key = format!("{}:{attempt}", task.task_id);
+    let mut reservation = ProviderExecutionReservation::AlreadyReserved;
+    store::mutate_record(&run_id, |record| {
+        let metadata = record.ensure_metadata_object();
+        let consumed = {
+            let executions = metadata
+                .entry("provider_executions".to_string())
+                .or_insert_with(|| json!([]))
+                .as_array_mut()
+                .expect("provider_executions must be an array");
+            if executions
+                .iter()
+                .any(|execution| execution["key"] == execution_key)
+            {
+                return false;
+            }
+            executions.push(json!({
+                "key": execution_key,
+                "task_id": task.task_id,
+                "attempt": attempt,
+                "backend": task.executor.backend,
+                "model": task.executor.model(),
+                "state": "running",
+                "started_at": now_timestamp(),
+            }));
+            executions.len()
+        };
+        metadata.insert("provider_executions_consumed".to_string(), json!(consumed));
+        reservation = ProviderExecutionReservation::Acquired;
+        true
+    })?;
+    Ok(reservation)
+}
+
+/// Record the provider's terminal result before controller-owned patch
+/// harvesting. Harvesting can fail or be interrupted independently of the
+/// provider execution, so it must not leave this reservation running.
+pub fn record_provider_execution_terminal(
+    run_id: &str,
+    task_id: &str,
+    attempt: u32,
+    state: &str,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let execution_key = format!("{task_id}:{attempt}");
+    let mut found = false;
+    let record = store::mutate_record(&run_id, |record| {
+        let Some(execution) = record
+            .ensure_metadata_object()
+            .get_mut("provider_executions")
+            .and_then(Value::as_array_mut)
+            .and_then(|executions| {
+                executions
+                    .iter_mut()
+                    .find(|execution| execution["key"] == execution_key)
+            })
+        else {
+            return false;
+        };
+        execution["state"] = json!(state);
+        execution["finished_at"] = json!(now_timestamp());
+        found = true;
+        true
+    })?;
+    if !found {
+        return Err(Error::internal_unexpected(
+            "provider execution reached a terminal result without its durable attempt record",
+        ));
+    }
+    record.ok_or_else(|| {
+        Error::internal_unexpected("provider execution terminal record was unchanged")
+    })
+}
+
 #[cfg(test)]
 pub(crate) fn rewrite_record_for_test<F>(run_id: &str, mut rewrite: F) -> Result<AgentTaskRunRecord>
 where

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_record_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_record_ops.rs
@@ -61,12 +61,24 @@ pub(crate) fn update_lifecycle_heartbeat(record: &mut AgentTaskRunRecord) {
 pub(crate) fn update_lifecycle_from_record(record: &mut AgentTaskRunRecord, plan: &AgentTaskPlan) {
     set_run_state(record, record.state);
     record.lifecycle.cleanup = cleanup_lifecycle_for_plan(plan, record.updated_at.clone());
+    let durable_task_ids: std::collections::HashSet<&str> = record.metadata["provider_executions"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|execution| execution["task_id"].as_str())
+        .collect();
     let mut provider_runtime: Vec<ProviderRuntimeLifecycle> = record
         .provider_handles
         .iter()
+        .filter(|handle| !durable_task_ids.contains(handle.task_id.as_str()))
         .map(provider_runtime_for_handle)
         .collect();
     for task in &record.tasks {
+        let durable_executions = provider_executions_for_task(record, &task.task_id);
+        if !durable_executions.is_empty() {
+            provider_runtime.extend(durable_executions);
+            continue;
+        }
         if record
             .provider_handles
             .iter()
@@ -114,6 +126,41 @@ pub(crate) fn update_lifecycle_from_record(record: &mut AgentTaskRunRecord, plan
         policy: Some("retain".to_string()),
         updated_at: record.updated_at.clone(),
     };
+}
+
+fn provider_executions_for_task(
+    record: &AgentTaskRunRecord,
+    task_id: &str,
+) -> Vec<ProviderRuntimeLifecycle> {
+    record.metadata["provider_executions"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|execution| execution["task_id"] == task_id)
+        .filter_map(|execution| {
+            let backend = execution["backend"].as_str()?.to_string();
+            let state = match execution["state"].as_str() {
+                Some("running") => ProviderRuntimeState::Running,
+                Some("succeeded") => ProviderRuntimeState::Succeeded,
+                Some("cancelled") => ProviderRuntimeState::Cancelled,
+                Some("timed_out") | Some("candidate_recoverable") => ProviderRuntimeState::TimedOut,
+                _ => ProviderRuntimeState::Failed,
+            };
+            Some(ProviderRuntimeLifecycle {
+                task_id: task_id.to_string(),
+                backend,
+                state,
+                stream_uri: None,
+                external_runtime_ids: Vec::new(),
+                metadata: json!({
+                    "evidence_source": "durable_provider_execution",
+                    "execution_key": execution["key"],
+                    "attempt": execution["attempt"],
+                    "model": execution["model"],
+                }),
+            })
+        })
+        .collect()
 }
 
 pub(crate) fn cleanup_lifecycle_for_plan(

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -504,6 +504,46 @@ where
                     cancellation: cancellation.clone(),
                 };
 
+                if let Some(run_id) = self.run_id.as_deref() {
+                    match crate::agent_task_lifecycle::reserve_provider_execution(
+                        run_id, &request, attempt,
+                    ) {
+                        Ok(crate::agent_task_lifecycle::ProviderExecutionReservation::Acquired) => {}
+                        Ok(crate::agent_task_lifecycle::ProviderExecutionReservation::AlreadyReserved) => {
+                            let outcome = scratch_allocation_failure(
+                                task_id.clone(),
+                                "provider execution was already reserved by an interrupted controller; reconcile the durable run instead of redispatching".to_string(),
+                            );
+                            release_scratch(&scratch, "provider_execution_already_reserved", &outcome);
+                            events.push(event(&task_id, AgentTaskState::Failed, attempt, outcome.summary.clone()));
+                            record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
+                            continue;
+                        }
+                        Err(error) => {
+                            let outcome = scratch_allocation_failure(
+                            task_id.clone(),
+                            format!(
+                                "could not durably record provider execution: {}",
+                                error.message
+                            ),
+                        );
+                        release_scratch(
+                            &scratch,
+                            "provider_execution_persistence_failed",
+                            &outcome,
+                        );
+                        events.push(event(
+                            &task_id,
+                            AgentTaskState::Failed,
+                            attempt,
+                            outcome.summary.clone(),
+                        ));
+                        record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
+                        continue;
+                        }
+                    }
+                }
+
                 let resource_wait_message = scheduled.resource_wait.as_ref().map(|wait| {
                     format!(
                         "acquired exclusive resource '{}' after waiting {} ms; previous holder '{}'",
@@ -615,6 +655,39 @@ where
                         let _ = join_handle.join();
                     }
                     let mut outcome = result.outcome;
+                    if let Some(run_id) = running_task.run_id.as_deref() {
+                        let terminal_state = match outcome.status {
+                            AgentTaskOutcomeStatus::Succeeded | AgentTaskOutcomeStatus::NoOp => {
+                                "succeeded"
+                            }
+                            AgentTaskOutcomeStatus::Cancelled => "cancelled",
+                            AgentTaskOutcomeStatus::Timeout => "timed_out",
+                            AgentTaskOutcomeStatus::CandidateRecoverable => "candidate_recoverable",
+                            _ => "failed",
+                        };
+                        if let Err(error) =
+                            crate::agent_task_lifecycle::record_provider_execution_terminal(
+                                run_id,
+                                &outcome.task_id,
+                                result.attempt,
+                                terminal_state,
+                            )
+                        {
+                            outcome.status = AgentTaskOutcomeStatus::Failed;
+                            outcome.failure_classification =
+                                Some(AgentTaskFailureClassification::ExecutionFailed);
+                            outcome.summary = Some(format!(
+                                    "provider returned successfully but Homeboy could not durably record it: {}",
+                                    error.message
+                                ));
+                            outcome.diagnostics.push(AgentTaskDiagnostic {
+                                class: "agent_task.provider_execution_persistence_failed"
+                                    .to_string(),
+                                message: error.message,
+                                data: serde_json::Value::Null,
+                            });
+                        }
+                    }
                     attach_candidate_adoption_provenance(
                         &mut outcome,
                         running_task.adoption.as_ref(),

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -680,6 +680,14 @@ impl AgentTaskScheduleSupport {
             }
 
             let mut task = running.remove(index);
+            if let Some(run_id) = task.run_id.as_deref() {
+                let _ = crate::agent_task_lifecycle::record_provider_execution_terminal(
+                    run_id,
+                    &task.task_id,
+                    task.attempt,
+                    "timed_out",
+                );
+            }
             let mut outcome =
                 deferred_timeout_outcome(&task.task_id, timeout_ms, "scheduler_timeout");
             outcome.diagnostics.push(AgentTaskDiagnostic {

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -20,7 +20,7 @@ use homeboy_core::worktree;
 use serde_json::Value;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Barrier, Mutex};
 
 #[test]
 fn cook_usage_reads_scheduler_rotation_metadata_and_decrements_budget() {
@@ -89,6 +89,92 @@ fn service_run_loaded_plan_persists_durable_lifecycle() {
         assert_eq!(record.state, AgentTaskRunState::Succeeded);
         assert_eq!(record.tasks[0].state, AgentTaskState::Succeeded);
         assert!(record.aggregate_path.is_some());
+        assert_eq!(record.metadata["provider_executions_consumed"], 1);
+        assert_eq!(record.lifecycle.provider_runtime.len(), 1);
+        assert_eq!(
+            record.lifecycle.provider_runtime[0].state,
+            homeboy_core::run_lifecycle_record::ProviderRuntimeState::Succeeded
+        );
+        assert_eq!(
+            record.lifecycle.provider_runtime[0].metadata["evidence_source"],
+            "durable_provider_execution"
+        );
+    });
+}
+
+#[test]
+fn provider_execution_reservation_is_exactly_once_and_terminal() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        agent_task_lifecycle::submit_plan(&plan, Some("provider-reservation"))
+            .expect("run submitted");
+        let task = &plan.tasks[0];
+
+        assert_eq!(
+            agent_task_lifecycle::reserve_provider_execution("provider-reservation", task, 1)
+                .expect("first reservation"),
+            agent_task_lifecycle::ProviderExecutionReservation::Acquired
+        );
+        assert_eq!(
+            agent_task_lifecycle::reserve_provider_execution("provider-reservation", task, 1)
+                .expect("restart observes reservation"),
+            agent_task_lifecycle::ProviderExecutionReservation::AlreadyReserved
+        );
+        let calls = Arc::new(AtomicUsize::new(0));
+        AgentTaskScheduler::new(CountingExecutor {
+            calls: Arc::clone(&calls),
+        })
+        .with_run_id("provider-reservation")
+        .run(plan.clone());
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "an existing reservation must be reconciled, never redispatched"
+        );
+        agent_task_lifecycle::record_provider_execution_terminal(
+            "provider-reservation",
+            &task.task_id,
+            1,
+            "cancelled",
+        )
+        .expect("terminal cancellation recorded");
+
+        let record = lifecycle_status("provider-reservation").expect("durable record");
+        assert_eq!(record.metadata["provider_executions_consumed"], 1);
+        assert_eq!(
+            record.metadata["provider_executions"][0]["state"],
+            "cancelled"
+        );
+    });
+}
+
+#[test]
+fn concurrent_schedulers_dispatch_one_reserved_provider_execution() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        agent_task_lifecycle::submit_plan(&plan, Some("concurrent-provider-reservation"))
+            .expect("run submitted");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(2));
+        let mut threads = Vec::new();
+        for _ in 0..2 {
+            let plan = plan.clone();
+            let calls = Arc::clone(&calls);
+            let barrier = Arc::clone(&barrier);
+            threads.push(std::thread::spawn(move || {
+                barrier.wait();
+                AgentTaskScheduler::new(CountingExecutor { calls })
+                    .with_run_id("concurrent-provider-reservation")
+                    .run(plan)
+            }));
+        }
+        for thread in threads {
+            let _ = thread.join().expect("scheduler thread completes");
+        }
+
+        let record = lifecycle_status("concurrent-provider-reservation").expect("durable record");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(record.metadata["provider_executions_consumed"], 1);
     });
 }
 
@@ -253,6 +339,15 @@ fn service_persists_timed_out_run_record_and_evidence_refs() {
         assert_eq!(record.tasks[0].state, AgentTaskState::TimedOut);
         assert_eq!(record.totals.as_ref().expect("totals").timed_out, 1);
         assert!(record.aggregate_path.is_some());
+        assert_eq!(record.metadata["provider_executions_consumed"], 1);
+        assert_eq!(
+            record.metadata["provider_executions"][0]["state"],
+            "timed_out"
+        );
+        assert_eq!(
+            record.lifecycle.provider_runtime[0].state,
+            homeboy_core::run_lifecycle_record::ProviderRuntimeState::TimedOut
+        );
         assert!(record
             .artifact_refs
             .iter()
@@ -894,6 +989,35 @@ impl AgentTaskExecutorAdapter for TimeoutExecutor {
 
 struct CapturingExecutor {
     observed_request: Arc<Mutex<Option<AgentTaskRequest>>>,
+}
+
+struct CountingExecutor {
+    calls: Arc<AtomicUsize>,
+}
+
+impl AgentTaskExecutorAdapter for CountingExecutor {
+    fn execute(
+        &self,
+        request: AgentTaskRequest,
+        _context: AgentTaskExecutionContext,
+    ) -> AgentTaskOutcome {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: request.task_id,
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: Some("ok".to_string()),
+            failure_classification: None,
+            artifacts: Vec::new(),
+            typed_artifacts: Vec::new(),
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            outputs: Value::Null,
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        }
+    }
 }
 
 struct RotationThenSuccess {


### PR DESCRIPTION
## Summary
- reserve provider attempts atomically before backend dispatch
- project truthful terminal provider states into durable lifecycle records
- keep failed or cancelled runs ineligible for publication while allowing the intended successful recovery projection
- add concurrent scheduler coverage proving one provider dispatch per attempt

Closes #9180

## How to test
1. Run `cargo test -p homeboy-agents agent_task_service::tests::concurrent_schedulers_dispatch_one_reserved_provider_execution --lib`.
2. Run `cargo test -p homeboy-agents agent_task_finalization --lib`.
3. Run `cargo fmt --check`.

## Compatibility
Existing successful Cook behavior is preserved. Interrupted reservations now require reconciliation instead of redispatching provider work, preventing duplicate external side effects. Failed and cancelled lifecycle states remain publication-ineligible.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Implementation, adversarial code review, regression testing, and PR drafting