### PR TITLE
fix(test-support): set git identity in fixture command helpers

### DIFF
--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -745,6 +745,10 @@ pub fn run_git_fixture_command(repo: &Path, args: &[&str]) {
     let output = Command::new("git")
         .args(args)
         .current_dir(repo)
+        .env("GIT_AUTHOR_NAME", "homeboy-test")
+        .env("GIT_AUTHOR_EMAIL", "homeboy-test@example.invalid")
+        .env("GIT_COMMITTER_NAME", "homeboy-test")
+        .env("GIT_COMMITTER_EMAIL", "homeboy-test@example.invalid")
         .output()
         .expect("git fixture command");
     assert!(
@@ -779,6 +783,10 @@ pub fn git_fixture_output(repo: &Path, args: &[&str]) -> String {
     let output = Command::new("git")
         .args(args)
         .current_dir(repo)
+        .env("GIT_AUTHOR_NAME", "homeboy-test")
+        .env("GIT_AUTHOR_EMAIL", "homeboy-test@example.invalid")
+        .env("GIT_COMMITTER_NAME", "homeboy-test")
+        .env("GIT_COMMITTER_EMAIL", "homeboy-test@example.invalid")
         .output()
         .expect("git fixture command");
     assert!(


### PR DESCRIPTION
## Summary
- Fixes red main: the `reverse_cook_queue_acceptance` Test job failed on CI with `fatal: empty ident name (Author identity unknown)`.
- Root cause: only `run_git_template_command` injected `GIT_AUTHOR_*` / `GIT_COMMITTER_*` env vars. The **public** fixture helpers tests call to make additional commits (`run_git_fixture_command`, `git_fixture_output`) did not, so on GitHub Actions runners (no global git identity) any `git commit` through them aborted.
- Passed locally (dev machines have global git config) but reddened main on CI.

## Fix
Inject the same `homeboy-test` identity in `run_git_fixture_command` and `git_fixture_output`, matching `run_git_template_command`. All three git spawns in `test_support.rs` now provide identity, so fixture commits succeed regardless of host git configuration.

## Evidence
Failing CI (run 29759225540) panic at `crates/homeboy-core/src/test_support.rs:750`:
```
git fixture command ["commit", "-m", "ignore runner workspace"] failed:
stderr=Author identity unknown ... fatal: empty ident name ... not allowed
```
Failure was deterministic (finished in 0.02s at fixture setup), not a timing flake.

## Testing
- `cargo fmt -p homeboy-core` clean.
- Local heavy builds skipped per repo RULES.md; letting CI validate compile + the `reverse_cook_queue_acceptance` test.