### PR TITLE
refactor(agents): share one scheduler-side Git runner

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use sha2::{Digest, Sha256};
 
-use super::harvest::{git_is_repository, git_output_raw};
+use super::harvest::{git_is_repository, git_output_raw, git_output_with_env};
 use super::*;
 
 /// Immutable provenance for one scheduler execution. Controller-local callers
@@ -331,9 +331,10 @@ fn verified_initial_cook_candidate_baseline(
         message: error.to_string(),
     })?;
     let index_path = index.path().display().to_string();
-    git_output_with_env(root, &["read-tree", "HEAD"], &index_path)?;
-    git_output_with_env(root, &["add", "--all"], &index_path)?;
-    let actual_tree = git_output_with_env(root, &["write-tree"], &index_path)?;
+    let index_env: &[(&str, &str)] = &[("GIT_INDEX_FILE", index_path.as_str())];
+    git_output_with_env(root, &["read-tree", "HEAD"], index_env)?;
+    git_output_with_env(root, &["add", "--all"], index_env)?;
+    let actual_tree = git_output_with_env(root, &["write-tree"], index_env)?;
     if actual_tree != expected_tree {
         return Err(HarvestError::CandidateBaselineMismatch {
             message: "initial Cook candidate workspace changed after admission failure".to_string(),
@@ -342,29 +343,6 @@ fn verified_initial_cook_candidate_baseline(
     Ok(Some(CandidateBaseline {
         patch: git_output_raw(root, &["diff", "--binary", "--full-index", "HEAD", commit])?,
     }))
-}
-
-fn git_output_with_env(
-    root: &Path,
-    args: &[&str],
-    index_path: &str,
-) -> Result<String, HarvestError> {
-    let output = Command::new("git")
-        .args(args)
-        .env("GIT_INDEX_FILE", index_path)
-        .current_dir(root)
-        .output()
-        .map_err(|error| HarvestError::Git {
-            command: format!("git {}", args.join(" ")),
-            message: error.to_string(),
-        })?;
-    if !output.status.success() {
-        return Err(HarvestError::Git {
-            command: format!("git {}", args.join(" ")),
-            message: String::from_utf8_lossy(&output.stderr).trim().to_string(),
-        });
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 fn verified_gate_feedback_baseline(

--- a/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
@@ -429,8 +429,29 @@ pub(crate) fn git_output(cwd: &Path, args: &[&str]) -> Result<String, HarvestErr
 /// Preserve byte-sensitive Git output such as patches. Metadata callers use
 /// `git_output` so commit IDs and status values stay normalized.
 pub(crate) fn git_output_raw(cwd: &Path, args: &[&str]) -> Result<String, HarvestError> {
+    git_output_raw_with_env(cwd, args, &[])
+}
+
+/// Trimmed Git output with extra environment (e.g. `GIT_INDEX_FILE` for a
+/// scratch index). This is the single scheduler-side Git runner; no-env and
+/// byte-preserving callers delegate here so the command/error shape stays
+/// identical across the harvest and attempt-workspace paths.
+pub(crate) fn git_output_with_env(
+    cwd: &Path,
+    args: &[&str],
+    env: &[(&str, &str)],
+) -> Result<String, HarvestError> {
+    Ok(git_output_raw_with_env(cwd, args, env)?.trim().to_string())
+}
+
+fn git_output_raw_with_env(
+    cwd: &Path,
+    args: &[&str],
+    env: &[(&str, &str)],
+) -> Result<String, HarvestError> {
     let output = Command::new("git")
         .args(args)
+        .envs(env.iter().copied())
         .current_dir(cwd)
         .output()
         .map_err(|error| HarvestError::Git {


### PR DESCRIPTION
## What

The agent-task scheduler had **two** implementations of the same Git runner:

- `harvest.rs::git_output_raw` — run git, check status, map stderr to `HarvestError::Git`.
- `attempt_workspace.rs::git_output_with_env` — a line-for-line copy of the same body, differing **only** by hard-coding `.env("GIT_INDEX_FILE", index_path)`.

Two copies of the same run/check/map-error logic is drift waiting to happen (a fix to one wouldn't reach the other).

## Change

`harvest` now owns a single env-capable runner. `git_output_raw`, `git_output`, and a new shared `git_output_with_env` all delegate to one private `git_output_raw_with_env`. `attempt_workspace` imports the shared `git_output_with_env` (it already imported `git_output_raw`/`git_is_repository` from the same sibling module) and passes `GIT_INDEX_FILE` explicitly as an env pair, deleting its ~22-line duplicate.

## Not changed

Behaviour is identical — same command construction, same status check, same `HarvestError::Git` shape, same trimming semantics. The `GIT_INDEX_FILE` still scopes the `read-tree`/`add`/`write-tree` initial-candidate-baseline verification exactly as before; the byte-preserving `git_output_raw` diff path is untouched.

## Testing

- `retry_after_admission_failure_rebuilds_clean_initial_candidate_baseline` (the test that drives the `GIT_INDEX_FILE` read-tree/add/write-tree path through the now-shared helper) — passes.
- `gate_feedback_baseline_rejects_mismatched_or_extra_dirty_changes` (byte-preserving diff via `git_output_raw`) — passes.
- `harvest` (7), `candidate_baseline` (3), `attempt_workspace` (3) suites green.

## Context

This is one cut in a larger duplication: there are ~12 private `git_output` helpers scattered across `homeboy-agents` / `homeboy-lab-runner` / `homeboy-core`, several re-implementing what `homeboy_core::git` primitives already provide. This PR collapses the two that were *identical and in the same module tree* — the safe, unambiguous case. The cross-crate ones carry different return/error types and are better consolidated one at a time behind their own review.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Inventoried the duplicated Git-runner helpers, identified the two identical same-crate implementations as the safe consolidation, merged them behind one env-capable runner, and verified the `GIT_INDEX_FILE` path and byte-preserving path are behaviour-preserving. Chris reviews and owns the change.