### PR TITLE
fix(release): report canonical GitHub release URL

### DIFF
--- a/crates/homeboy-release/src/release/executor/github_release/mod.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/mod.rs
@@ -50,5 +50,6 @@ pub(crate) use repair::{
 };
 #[cfg(test)]
 pub(crate) use results::{
-    create_failed_result, not_created_result, upload_failed_result, upload_success_result,
+    create_failed_result, not_created_result, published_release_url, upload_failed_result,
+    upload_success_result,
 };

--- a/crates/homeboy-release/src/release/executor/github_release/results.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/results.rs
@@ -9,6 +9,23 @@ use super::repair::{
     existing_draft_repair_hints, repair_data, repair_hints, GitHubReleaseRepairCommands,
 };
 
+pub(crate) fn published_release_url(
+    github: &GitHubRepo,
+    tag: &str,
+    _draft_response: &str,
+    publish_response: &str,
+) -> String {
+    let published_url = publish_response.trim();
+    if !published_url.is_empty() {
+        return published_url.to_string();
+    }
+
+    format!(
+        "https://{}/{}/{}/releases/tag/{}",
+        github.host, github.owner, github.repo, tag
+    )
+}
+
 /// A successful but no-op result for an idempotent retry where the GitHub
 /// Release object already exists. The release exists, so this is `Success`.
 pub(super) fn skipped_result(
@@ -167,6 +184,7 @@ pub(crate) fn upload_success_result(
     github: &GitHubRepo,
     artifact_count: usize,
 ) -> ReleaseStepResult {
+    let url = published_release_url(github, tag, "", "");
     step_success(
         "github.release",
         "github.release",
@@ -176,6 +194,7 @@ pub(crate) fn upload_success_result(
             "host": github.host,
             "owner": github.owner,
             "repo": github.repo,
+            "url": url,
             "artifact_count": artifact_count,
         })),
         Vec::new(),

--- a/crates/homeboy-release/src/release/executor/github_release/run.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/run.rs
@@ -14,8 +14,8 @@ use super::notes::{
 };
 use super::repair::{gh_auth_failure_message, github_release_repair_commands, log_repair_commands};
 use super::results::{
-    create_failed_result, not_created_result, skipped_result, upload_failed_result,
-    upload_success_result,
+    create_failed_result, not_created_result, published_release_url, skipped_result,
+    upload_failed_result, upload_success_result,
 };
 use super::{
     gh_failure_detail, gh_release_metadata, github_release_upload_timeout, run_gh_command,
@@ -391,7 +391,8 @@ pub(crate) fn run_github_release(
         ));
     }
 
-    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let draft_response = String::from_utf8_lossy(&output.stdout);
+    let url = published_release_url(&github, &tag, &draft_response, &publish_output.stdout);
     homeboy_core::log_status!("release", "Published verified GitHub Release: {}", url);
     Ok(step_success(
         "github.release",

--- a/crates/homeboy-release/src/release/executor/github_release/tests/result_builders.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/tests/result_builders.rs
@@ -3,7 +3,8 @@
 use crate::release::types::ReleaseStepStatus;
 
 use super::super::{
-    create_failed_result, not_created_result, upload_failed_result, upload_success_result,
+    create_failed_result, not_created_result, published_release_url, upload_failed_result,
+    upload_success_result,
 };
 use super::{data_bool, data_str, test_body, test_repair, test_repo};
 
@@ -147,11 +148,45 @@ fn verified_upload_result_is_successful_only_after_publication() {
     assert_eq!(result.status, ReleaseStepStatus::Success);
     assert_eq!(data_str(&result, "action"), Some("github.release.upload"));
     assert_eq!(
+        data_str(&result, "url"),
+        Some("https://github.com/example-org/studio-web/releases/tag/v0.10.6")
+    );
+    assert_eq!(
         result
             .data
             .as_ref()
             .and_then(|data| data.get("artifact_count"))
             .and_then(|value| value.as_u64()),
         Some(2)
+    );
+}
+
+#[test]
+fn published_release_url_ignores_transient_draft_url() {
+    let url = published_release_url(
+        &test_repo(),
+        "v0.49.4",
+        "https://github.com/example-org/studio-web/releases/tag/untagged-944964b141cb713e104d\n",
+        "",
+    );
+
+    assert_eq!(
+        url,
+        "https://github.com/example-org/studio-web/releases/tag/v0.49.4"
+    );
+}
+
+#[test]
+fn published_release_url_prefers_final_publish_response() {
+    let url = published_release_url(
+        &test_repo(),
+        "v0.49.4",
+        "https://github.com/example-org/studio-web/releases/tag/untagged-944964b141cb713e104d\n",
+        "https://github.com/example-org/studio-web/releases/tag/v0.49.4\n",
+    );
+
+    assert_eq!(
+        url,
+        "https://github.com/example-org/studio-web/releases/tag/v0.49.4"
     );
 }

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -1195,6 +1195,47 @@ mod tests {
         assert!(summary.contains(&"No GitHub Release created".to_string()));
     }
 
+    #[test]
+    fn release_summary_reports_canonical_published_release_url() {
+        let canonical_url =
+            "https://github.com/Extra-Chill/data-machine-events/releases/tag/v0.49.4";
+        let run = ReleaseRun {
+            component_id: "data-machine-events".to_string(),
+            enabled: true,
+            result: ReleaseRunResult {
+                steps: vec![
+                    ReleaseStepResult {
+                        id: "git.tag".to_string(),
+                        step_type: "git.tag".to_string(),
+                        status: ReleaseStepStatus::Success,
+                        data: Some(serde_json::json!({ "tag": "v0.49.4" })),
+                        ..Default::default()
+                    },
+                    ReleaseStepResult {
+                        id: "github.release".to_string(),
+                        step_type: "github.release".to_string(),
+                        status: ReleaseStepStatus::Success,
+                        data: Some(serde_json::json!({
+                            "tag": "v0.49.4",
+                            "url": canonical_url,
+                        })),
+                        ..Default::default()
+                    },
+                ],
+                status: ReleaseStepStatus::Success,
+                warnings: vec![],
+                summary: None,
+                phase_timings: None,
+            },
+        };
+
+        let summary = release_summary_from_run(&run);
+
+        assert!(summary.contains(&format!("Release created: v0.49.4 ({canonical_url})")));
+        assert!(summary.contains(&format!("GitHub Release created: {canonical_url}")));
+        assert!(summary.iter().all(|line| !line.contains("untagged-")));
+    }
+
     // ----- Recover-time orphan-tag warning (issue #2234 ask #3) -----
 
     fn run_in(dir: &std::path::Path, args: &[&str]) -> std::process::Output {


### PR DESCRIPTION
## Summary
- Prefer the final `gh release edit --draft=false` response URL after publication.
- Fall back deterministically to the canonical owner/repo/tag URL when the publish response is empty.
- Include the canonical URL in successful existing-release upload results and cover both user-facing release summary lines.

## Root Cause
Homeboy retained stdout from `gh release create --draft` and wrote it to `github.release` step data after publishing. GitHub can return a transient draft URL at creation time, so successful publication still surfaced the stale `untagged-*` URL in step data and `release_summary`.

## Observed vs Canonical
- Observed: https://github.com/Extra-Chill/data-machine-events/releases/tag/untagged-944964b141cb713e104d
- Canonical: https://github.com/Extra-Chill/data-machine-events/releases/tag/v0.49.4

## Behavior Change
Successful publication no longer uses the draft-create response as its reported URL. Homeboy uses the final publish response when available, otherwise `https://<host>/<owner>/<repo>/releases/tag/<tag>`, so `github.release`, `Release created`, and `GitHub Release created` outputs agree on the published tag URL.

## Verification
- `cargo test -p homeboy-release published_release_url` (3 passed)
- `cargo test -p homeboy-release release_summary_reports_canonical_published_release_url` (passed)
- Changed-file `rustfmt --check` (passed)
- `cargo clippy -p homeboy-release --all-targets` (passed with pre-existing warnings)
- Full `cargo test -p homeboy-release`: 583 passed; 6 unrelated environment/fixture failures in existing deploy guards, extension fixtures, and filesystem group ownership tests
- Strict `cargo clippy -p homeboy-release --all-targets -- -D warnings` is blocked by pre-existing warnings in unchanged `homeboy-paths`

Closes #9216