### PR TITLE
Continue authorized dirty candidates through Lab Cook

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -278,7 +278,10 @@ pub(super) fn prepare_committed_harvest(
     } else if let Some(baseline) = verified_initial_cook_candidate_baseline(root, request)? {
         Some(baseline)
     } else {
-        Some(verified_gate_feedback_baseline(root, request, &status)?)
+        Some(
+            verified_preexisting_cook_baseline(root, request, context)
+                .unwrap_or_else(|| verified_gate_feedback_baseline(root, request, &status))?,
+        )
     };
     Ok(HarvestPreflight {
         base_sha: Some(git_output(root, &["rev-parse", "HEAD"])?),
@@ -343,6 +346,95 @@ fn verified_initial_cook_candidate_baseline(
     Ok(Some(CandidateBaseline {
         patch: git_output_raw(root, &["diff", "--binary", "--full-index", "HEAD", commit])?,
     }))
+}
+
+/// Lab may carry an explicitly authorized initial Cook candidate as a dirty
+/// snapshot. Accept it only when the controller-issued baseline evidence is
+/// also present in the authenticated Lab metadata and reproduces this tree.
+fn verified_preexisting_cook_baseline(
+    root: &Path,
+    request: &AgentTaskRequest,
+    context: &HarvestExecutionContext,
+) -> Option<Result<CandidateBaseline, HarvestError>> {
+    let baseline = request.metadata.get("verified_cook_baseline")?;
+    if baseline
+        .get("preexisting_candidate")
+        .and_then(serde_json::Value::as_bool)
+        != Some(true)
+        || baseline
+            .get("source_task_id")
+            .and_then(serde_json::Value::as_str)
+            != Some(request.task_id.as_str())
+    {
+        return Some(Err(HarvestError::DirtyWorkspace {
+            status: "untrusted Cook baseline contract".to_string(),
+        }));
+    }
+    let Some(snapshot) = context.source_snapshot.as_ref() else {
+        return Some(Err(HarvestError::DirtyWorkspace {
+            status: "Cook baseline contract requires Lab snapshot evidence".to_string(),
+        }));
+    };
+    let Some(lab_baseline) = context
+        .lab_offload
+        .as_ref()
+        .and_then(|metadata| metadata.pointer("/source_provenance/verified_cook_baseline"))
+    else {
+        return Some(Err(HarvestError::DirtyWorkspace {
+            status: "Cook baseline contract is absent from Lab metadata".to_string(),
+        }));
+    };
+    if !snapshot.dirty || lab_baseline != baseline {
+        return Some(Err(HarvestError::DirtyWorkspace {
+            status: "Cook baseline contract does not match the dirty Lab snapshot".to_string(),
+        }));
+    }
+    let Some(expected_tree) = baseline
+        .get("baseline_tree")
+        .and_then(serde_json::Value::as_str)
+    else {
+        return Some(Err(HarvestError::DirtyWorkspace {
+            status: "Cook baseline contract has no baseline tree".to_string(),
+        }));
+    };
+    Some(workspace_patch_for_tree(root, expected_tree).map(|patch| CandidateBaseline { patch }))
+}
+
+fn workspace_patch_for_tree(root: &Path, expected_tree: &str) -> Result<String, HarvestError> {
+    let index = tempfile::NamedTempFile::new().map_err(|error| HarvestError::Git {
+        command: "create Cook baseline Git index".to_string(),
+        message: error.to_string(),
+    })?;
+    let index_path = index.path().display().to_string();
+    let git = |args: &[&str]| {
+        let output = Command::new("git")
+            .args(args)
+            .env("GIT_INDEX_FILE", &index_path)
+            .current_dir(root)
+            .output()
+            .map_err(|error| HarvestError::Git {
+                command: args.join(" "),
+                message: error.to_string(),
+            })?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        } else {
+            Err(HarvestError::CandidateBaselineMismatch {
+                message: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            })
+        }
+    };
+    let head = git(&["rev-parse", "HEAD"])?;
+    git(&["read-tree", &head])?;
+    git(&["add", "--all"])?;
+    let tree = git(&["write-tree"])?;
+    if tree != expected_tree {
+        return Err(HarvestError::CandidateBaselineMismatch {
+            message: "dirty workspace does not reproduce the authorized Cook baseline tree"
+                .to_string(),
+        });
+    }
+    git(&["diff", "--cached", "--binary", "HEAD"])
 }
 
 fn verified_gate_feedback_baseline(
@@ -755,6 +847,36 @@ mod tests {
         let diff = git_output(&attempt_root, &["diff", "--name-only", "HEAD~1", "HEAD"])
             .expect("local diff");
         assert!(diff.contains("f.txt"), "local diff harvest must still work");
+    }
+
+    #[test]
+    fn authorized_cook_baseline_patch_includes_untracked_candidate_files() {
+        let source = tempfile::tempdir().expect("source repository");
+        git(source.path(), &["init", "-b", "main"]);
+        fs::write(source.path().join("tracked.txt"), "base").expect("base file");
+        git(source.path(), &["add", "tracked.txt"]);
+        git(
+            source.path(),
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=homeboy@example.test",
+                "commit",
+                "-m",
+                "initial",
+            ],
+        );
+        fs::write(source.path().join("tracked.txt"), "candidate").expect("candidate file");
+        fs::write(source.path().join("untracked.txt"), "candidate").expect("untracked file");
+        git(source.path(), &["add", "--all"]);
+        let tree = git_output(source.path(), &["write-tree"]).expect("candidate tree");
+        git(source.path(), &["reset", "--mixed", "HEAD"]);
+
+        let patch = workspace_patch_for_tree(source.path(), &tree).expect("authorized baseline");
+
+        assert!(patch.contains("tracked.txt"));
+        assert!(patch.contains("untracked.txt"));
     }
 
     fn git(cwd: &Path, args: &[&str]) {

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -583,7 +583,7 @@ impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
 
     fn dispatch_attempt(
         &self,
-        plan: homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,
+        mut plan: homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,
         run_id: &str,
         derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
     ) -> homeboy::core::Result<()> {
@@ -591,6 +591,9 @@ impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
         // baseline to this retry; only its evidence crosses the Lab boundary.
         let verified_cook_baseline =
             derived_cook_baseline.map(DerivedCookBaselineCapability::verified_baseline_provenance);
+        if let Some(verified_cook_baseline) = verified_cook_baseline.as_ref() {
+            attach_verified_cook_baseline(&mut plan, verified_cook_baseline);
+        }
         let serialized_plan = serde_json::to_string(&plan).map_err(|error| {
             Error::internal_json(
                 error.to_string(),
@@ -697,6 +700,26 @@ impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
                 )]),
             )),
             LabRouteOutcome::InFlight(_) => Ok(()),
+        }
+    }
+}
+
+fn attach_verified_cook_baseline(
+    plan: &mut homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,
+    baseline: &serde_json::Value,
+) {
+    let Some(source_task_id) = baseline
+        .get("source_task_id")
+        .and_then(serde_json::Value::as_str)
+    else {
+        return;
+    };
+    for task in &mut plan.tasks {
+        if task.task_id == source_task_id {
+            if !task.metadata.is_object() {
+                task.metadata = serde_json::json!({});
+            }
+            task.metadata["verified_cook_baseline"] = baseline.clone();
         }
     }
 }

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -750,6 +750,35 @@ fn cook_retry_lab_source_is_the_derived_baseline_not_the_controller_workspace() 
 }
 
 #[test]
+fn lab_cook_attempt_preserves_authorized_dirty_baseline_in_the_run_plan() {
+    let mut plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
+        "cook-dirty-baseline",
+        vec![serde_json::from_value(serde_json::json!({
+            "task_id": "task",
+            "executor": { "backend": "fixture" },
+            "instructions": "continue",
+            "workspace": { "root": "/runner/workspace" }
+        }))
+        .expect("task")],
+    );
+    let baseline = serde_json::json!({
+        "source_run_id": "cook-dirty-baseline",
+        "source_task_id": "task",
+        "baseline_tree": "0123456789012345678901234567890123456789",
+        "preexisting_candidate": true,
+    });
+
+    super::attach_verified_cook_baseline(&mut plan, &baseline);
+    let serialized = serde_json::to_string(&plan).expect("serialize run plan");
+    let run_plan: serde_json::Value = serde_json::from_str(&serialized).expect("parse run plan");
+
+    assert_eq!(
+        run_plan["tasks"][0]["metadata"]["verified_cook_baseline"],
+        baseline
+    );
+}
+
+#[test]
 fn detached_retry_materializes_failed_plan_and_persists_bounded_preacceptance_failure() {
     crate::test_support::with_isolated_home(|_| {
         let workspace = tempfile::tempdir().expect("workspace");

--- a/tests/agent_task_promotion_provider.rs
+++ b/tests/agent_task_promotion_provider.rs
@@ -138,6 +138,7 @@ fn promotion_gate_binds_a_socket_in_the_short_invocation_tmpdir_for_a_long_run_i
                 private_verify: Vec::new(),
                 private_gate_reveal:
                     homeboy::agents::agent_task_gate::AgentTaskGateRevealPolicy::FullEvidence,
+                ..Default::default()
             },
             provider_command: Some(provider.display().to_string()),
             provider_invocation: None,


### PR DESCRIPTION
## Summary
- record the explicitly authorized initial dirty Cook candidate as a verified tree baseline
- carry that authenticated baseline through Lab source provenance and generated run plans
- reconstruct the candidate patch, including untracked files, only when the Lab snapshot and baseline metadata agree
- keep accidental or changed dirty workspaces fail-closed

Closes #9095

## How to test
1. Run `cargo check -p homeboy-agents -p homeboy-cli`.
2. Run `cargo test -p homeboy-agents agent_task_scheduler::attempt_workspace::tests --lib`.
3. Run `cargo test -p homeboy-cli lab_cook_attempt_preserves_authorized_dirty_baseline_in_the_run_plan --lib`.
4. Run `cargo fmt --check`.

## Compatibility
Default dirty-worktree rejection is unchanged. Continuation is enabled only for a Cook candidate explicitly authorized by the controller and reproduced from matching authenticated Lab snapshot metadata. The previously reported long staging filename failure is already fixed by #9171 and is intentionally excluded from this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Candidate implementation, rebase and conflict resolution, regression verification, and PR drafting