### PR TITLE
feat(audit): detect skeleton-duplicate functions (same backbone, different error tail)

### DIFF
--- a/crates/contracts/homeboy-audit-contract/src/finding_kind.rs
+++ b/crates/contracts/homeboy-audit-contract/src/finding_kind.rs
@@ -36,6 +36,13 @@ pub enum AuditFinding {
     CrossNameDuplicate,
     /// Function has identical structure but different identifiers/literals.
     NearDuplicate,
+    /// Two functions share an identical call/control-flow skeleton but differ
+    /// in their error/return tail — the same primitive reimplemented with a
+    /// different local error type or return wrapper. Coarser than
+    /// `NearDuplicate` (which requires matching expression *shape*), this
+    /// catches hand-rolled wrappers like per-module `git_output` helpers that
+    /// map failures onto different error enums.
+    SkeletonDuplicate,
     /// Function parameter is declared but never used in the function body.
     /// When call-site data is available, this means no callers pass a value
     /// for this position — truly dead, safe to remove.
@@ -215,6 +222,7 @@ impl AuditFinding {
             "duplicate_function",
             "cross_name_duplicate",
             "near_duplicate",
+            "skeleton_duplicate",
             "unused_parameter",
             "ignored_parameter",
             "dead_code_marker",

--- a/crates/homeboy-code-audit/src/core_fingerprint/hash.rs
+++ b/crates/homeboy-code-audit/src/core_fingerprint/hash.rs
@@ -18,6 +18,115 @@ pub(super) fn structural_hash(body: &str, grammar: &Grammar) -> String {
     sha256_hex16(&normalized)
 }
 
+/// Number of significant call/keyword tokens a body must have before its
+/// skeleton is worth comparing. Below this, near-identical skeletons are just
+/// trivial wrappers (one call + `?`) and would spam findings.
+pub(super) const SKELETON_MIN_TOKENS: usize = 4;
+
+/// Compute a coarse *skeleton* signature: the ordered sequence of significant
+/// call names and control-flow keywords, with all argument interiors and error
+/// construction elided. `Some((token_count, hash))` when the body has at least
+/// [`SKELETON_MIN_TOKENS`] significant tokens, else `None`.
+///
+/// This is deliberately coarser than [`structural_hash`]. The structural hash
+/// still encodes the *shape* of every expression, so two functions with an
+/// identical happy-path call chain but different error/return tails
+/// (e.g. two `git_output` helpers that map failures onto different local error
+/// enums) hash apart. The skeleton signature keeps only the call/keyword
+/// backbone, so those same-primitive-different-plumbing reimplementations
+/// collapse together. It stays language-agnostic: control-flow keywords and
+/// ignorable call names come entirely from grammar config.
+pub(super) fn skeleton_signature(body: &str, grammar: &Grammar) -> Option<(usize, String)> {
+    let tokens = skeleton_tokens(body, grammar);
+    if tokens.len() < SKELETON_MIN_TOKENS {
+        return None;
+    }
+    Some((tokens.len(), sha256_hex16(&tokens.join(" "))))
+}
+
+/// Extract the call/keyword backbone of a body as an order-independent set.
+///
+/// A "significant token" is either:
+/// - a **method-chain call** — a name reached through `.` and immediately
+///   followed by `(`, i.e. `.args(`, `.output(`, `.map_err(`. These are the
+///   receiver pipeline that defines what the function *does*.
+/// - a **control-flow keyword** the grammar lists (`if`, `for`, `while`,
+///   `match`, `return`, `loop`, …).
+///
+/// Free-function and constructor calls (`Error::validation_invalid_argument(`,
+/// `HarvestError::Git {`) are **not** collected: those are overwhelmingly where
+/// error/return construction lives, and they are exactly what differs between
+/// the same primitive wrapped in different local error types. Collecting the
+/// tokens as a **sorted, de-duplicated set** further absorbs the incidental
+/// ordering/repetition of ubiquitous formatting calls (`.to_string()`,
+/// `.join()`) in the error tail, so two functions with the same pipeline match
+/// regardless of how each spells its failure path.
+///
+/// Calls the grammar marks non-structural (`skip_calls`, e.g. `println`,
+/// `assert`) are dropped, as they are for the structural hash. The result is
+/// language-agnostic: method-chain syntax plus grammar-provided keyword and
+/// skip-call sets.
+fn skeleton_tokens(body: &str, grammar: &Grammar) -> Vec<String> {
+    // Strip to body, remove string/number literals so quoted parens/keywords
+    // never register as structure.
+    let text = if let Some(pos) = body.find('{') {
+        &body[pos..]
+    } else {
+        body
+    };
+    let text = replace_string_literals(text);
+    let text = replace_numeric_literals(&text);
+
+    let control_keywords: HashSet<&str> = grammar
+        .fingerprint
+        .keywords
+        .iter()
+        .map(|keyword| keyword.as_str())
+        .filter(|keyword| SKELETON_CONTROL_KEYWORDS.contains(keyword))
+        .collect();
+    let skip_calls: HashSet<&str> = grammar
+        .fingerprint
+        .skip_calls
+        .iter()
+        .map(|call| call.as_str())
+        .collect();
+
+    // Method-chain call: `.name(` (optionally with whitespace before `(`).
+    static METHOD_CALL_RE: std::sync::LazyLock<regex::Regex> =
+        std::sync::LazyLock::new(|| regex::Regex::new(r"\.([A-Za-z_][A-Za-z0-9_]*)\s*\(").unwrap());
+    // Bare word, for control-flow keyword detection.
+    static WORD_RE: std::sync::LazyLock<regex::Regex> =
+        std::sync::LazyLock::new(|| regex::Regex::new(r"[A-Za-z_][A-Za-z0-9_]*").unwrap());
+
+    let mut token_set: HashSet<String> = HashSet::new();
+    for caps in METHOD_CALL_RE.captures_iter(&text) {
+        let name = &caps[1];
+        if skip_calls.contains(name) {
+            continue;
+        }
+        token_set.insert(format!("call:{name}"));
+    }
+    for m in WORD_RE.find_iter(&text) {
+        let word = m.as_str();
+        if control_keywords.contains(word) {
+            token_set.insert(format!("kw:{word}"));
+        }
+    }
+
+    let mut tokens: Vec<String> = token_set.into_iter().collect();
+    tokens.sort_unstable();
+    tokens
+}
+
+/// Control-flow keywords that shape a body's skeleton across languages. Only
+/// keywords a grammar actually lists in `fingerprint.keywords` are used; this
+/// set filters that grammar-provided list down to the structural ones (so we
+/// never invent a keyword the language does not have).
+const SKELETON_CONTROL_KEYWORDS: &[&str] = &[
+    "if", "else", "for", "while", "loop", "match", "switch", "case", "return", "try", "catch",
+    "throw", "break", "continue",
+];
+
 /// Normalize whitespace: collapse all runs to single space.
 pub(super) fn normalize_whitespace(s: &str) -> String {
     let mut result = String::with_capacity(s.len());

--- a/crates/homeboy-code-audit/src/core_fingerprint/mod.rs
+++ b/crates/homeboy-code-audit/src/core_fingerprint/mod.rs
@@ -48,7 +48,7 @@ use super::fingerprint::FileFingerprint;
 mod hash;
 mod relationships;
 
-use self::hash::{exact_hash, structural_hash};
+use self::hash::{exact_hash, skeleton_signature, structural_hash};
 use self::relationships::{extract_extends, extract_implements};
 
 #[cfg(test)]
@@ -141,9 +141,10 @@ pub fn fingerprint_from_grammar(
         }
     }
 
-    // --- Method hashes and structural hashes ---
+    // --- Method hashes, structural hashes, skeleton signatures ---
     let mut method_hashes = HashMap::new();
     let mut structural_hashes = HashMap::new();
+    let mut skeleton_hashes = HashMap::new();
     for f in &functions {
         if f.is_test || f.body.is_empty() {
             continue;
@@ -157,6 +158,11 @@ pub fn fingerprint_from_grammar(
         method_hashes.insert(f.name.clone(), exact);
         let structural = structural_hash(&f.body, grammar);
         structural_hashes.insert(f.name.clone(), structural);
+        if let Some((token_count, skeleton)) = skeleton_signature(&f.body, grammar) {
+            // Encode the token count in the value so the detector can apply a
+            // significance floor without re-parsing the body.
+            skeleton_hashes.insert(f.name.clone(), format!("{token_count}:{skeleton}"));
+        }
     }
 
     // --- Visibility ---
@@ -255,6 +261,7 @@ pub fn fingerprint_from_grammar(
         content: content.to_string(),
         method_hashes,
         structural_hashes,
+        skeleton_hashes,
         visibility,
         properties,
         hooks,

--- a/crates/homeboy-code-audit/src/duplication.rs
+++ b/crates/homeboy-code-audit/src/duplication.rs
@@ -536,6 +536,163 @@ pub(crate) fn detect_near_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<F
     findings
 }
 
+// ============================================================================
+// Skeleton Duplication (same call/control-flow backbone, different error tail)
+// ============================================================================
+
+/// Minimum significant call/keyword tokens for a skeleton to be worth
+/// comparing. Mirrors the floor baked into the fingerprint's skeleton
+/// signature; enforced again here so the detector is robust to fingerprints
+/// produced by an older engine.
+const SKELETON_MIN_TOKENS: usize = 4;
+
+/// Split a stored skeleton value (`"<token_count>:<hash>"`) into its parts.
+fn parse_skeleton_value(value: &str) -> Option<(usize, &str)> {
+    let (count, hash) = value.split_once(':')?;
+    Some((count.parse().ok()?, hash))
+}
+
+/// Detect functions that share an identical **call/control-flow skeleton** but
+/// were missed by the exact, cross-name, and near-duplicate passes because
+/// their error/return tails differ.
+///
+/// The near-duplicate detector still encodes the *shape* of every expression,
+/// so two `git_output` helpers that map failures onto different local error
+/// enums (`HarvestError::Git { .. }` vs `Error::validation_invalid_argument(..)`)
+/// hash apart. This pass keys on the coarser skeleton signature — the ordered
+/// call/keyword backbone with argument interiors and error construction elided —
+/// so those same-primitive-different-plumbing reimplementations group together.
+///
+/// It is intentionally conservative:
+/// - only reports groups the finer passes did **not** already cover,
+/// - requires a real backbone (`SKELETON_MIN_TOKENS` significant tokens),
+/// - reuses the generic-name, trivial-method, and command↔core delegation
+///   filters so it does not re-flag idiomatic or delegation-shaped bodies.
+pub(crate) fn detect_skeleton_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    // Names already reported as exact duplicates — skeleton is redundant there.
+    let exact_groups = build_groups(fingerprints);
+    let exact_duplicate_names: HashSet<String> = exact_groups
+        .iter()
+        .filter(|(_, locs)| locs.len() >= MIN_DUPLICATE_LOCATIONS)
+        .map(|((name, _), _)| name.clone())
+        .collect();
+
+    // skeleton_hash -> [(file, name, structural_hash)]
+    let mut by_skeleton: HashMap<&str, Vec<(&str, &str, Option<&str>)>> = HashMap::new();
+    for fp in fingerprints {
+        for (name, raw) in &fp.skeleton_hashes {
+            let Some((token_count, hash)) = parse_skeleton_value(raw) else {
+                continue;
+            };
+            if token_count < SKELETON_MIN_TOKENS {
+                continue;
+            }
+            if GENERIC_NAMES.contains(&name.as_str()) {
+                continue;
+            }
+            if is_trivial_method(
+                name,
+                Language::builtin_trivial_method_names().iter().copied(),
+                Language::builtin_trivial_method_prefixes().iter().copied(),
+            ) {
+                continue;
+            }
+            let structural = fp.structural_hashes.get(name).map(|s| s.as_str());
+            by_skeleton.entry(hash).or_default().push((
+                fp.relative_path.as_str(),
+                name.as_str(),
+                structural,
+            ));
+        }
+    }
+
+    let mut findings = Vec::new();
+    for locations in by_skeleton.values() {
+        // Group must span at least two files.
+        let distinct_files: HashSet<&str> = locations.iter().map(|(f, _, _)| *f).collect();
+        if distinct_files.len() < MIN_DUPLICATE_LOCATIONS {
+            continue;
+        }
+
+        // Skip when every member was already an exact duplicate (same name)…
+        let all_exact = locations
+            .iter()
+            .all(|(_, name, _)| exact_duplicate_names.contains(*name));
+        if all_exact {
+            continue;
+        }
+
+        // …or when the whole group shares one structural hash (the finer
+        // near-duplicate pass owns that case; skeleton adds nothing).
+        let structural_hashes: HashSet<&str> =
+            locations.iter().filter_map(|(_, _, s)| *s).collect();
+        if structural_hashes.len() == 1 && locations.iter().all(|(_, _, s)| s.is_some()) {
+            continue;
+        }
+
+        let files: Vec<&str> = distinct_files.into_iter().collect();
+
+        // Delegation pattern: command→core, or all-in-command modules.
+        if files.iter().all(|f| is_command_file(f)) {
+            continue;
+        }
+        let has_command = files.iter().any(|f| is_command_file(f));
+        let has_non_command = files.iter().any(|f| !is_command_file(f));
+        if has_command && has_non_command && files.len() == 2 {
+            continue;
+        }
+
+        let test_only = locations.iter().all(|(file, _, _)| is_test_path(file));
+        let severity = if test_only {
+            Severity::Info
+        } else {
+            Severity::Warning
+        };
+
+        let mut names: Vec<&str> = locations.iter().map(|(_, name, _)| *name).collect();
+        names.sort_unstable();
+        names.dedup();
+        let name_label = names.join("`, `");
+
+        let suggestion = format!(
+            "Functions `{}` share one call/control-flow skeleton but differ only in \
+             their error/return handling. This is usually the same primitive \
+             reimplemented with a local error type — extract a shared helper (or \
+             call the existing shared primitive) and let callers map the error.",
+            name_label
+        );
+
+        for (file, name, _) in locations {
+            let mut also: Vec<String> = locations
+                .iter()
+                .filter(|(f, n, _)| f != file || n != name)
+                .map(|(f, n, _)| format!("{n} in {f}"))
+                .collect();
+            also.sort();
+            also.dedup();
+            findings.push(Finding {
+                convention: "skeleton-duplication".to_string(),
+                severity: severity.clone(),
+                file: file.to_string(),
+                description: format!(
+                    "Skeleton-duplicate `{}` — same call/control-flow backbone as {}",
+                    name,
+                    also.join(", ")
+                ),
+                suggestion: suggestion.clone(),
+                kind: AuditFinding::SkeletonDuplicate,
+            });
+        }
+    }
+
+    findings.sort_by(|a, b| {
+        a.file
+            .cmp(&b.file)
+            .then_with(|| a.description.cmp(&b.description))
+    });
+    findings
+}
+
 /// Find the body of a method/function in the file lines.
 ///
 /// Returns `(open_brace_line, close_brace_line)` — the line indices of the

--- a/crates/homeboy-code-audit/src/duplication/tests.rs
+++ b/crates/homeboy-code-audit/src/duplication/tests.rs
@@ -1081,4 +1081,186 @@ mod cross_name {
     }
 }
 
+fn make_fingerprint_with_skeleton(
+    path: &str,
+    methods: &[&str],
+    structural: &[(&str, &str)],
+    skeleton: &[(&str, &str)],
+) -> FileFingerprint {
+    FileFingerprint {
+        relative_path: path.to_string(),
+        language: Language::Rust,
+        methods: methods.iter().map(|s| s.to_string()).collect(),
+        structural_hashes: structural
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect(),
+        skeleton_hashes: skeleton
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn skeleton_duplicate_flags_same_backbone_with_different_error_tail() {
+    // Same skeleton hash, DIFFERENT structural hashes (different error tails).
+    let fp1 = make_fingerprint_with_skeleton(
+        "crates/a/src/harvest.rs",
+        &["git_output"],
+        &[("git_output", "structuralAAA")],
+        &[("git_output", "6:skelSAME")],
+    );
+    let fp2 = make_fingerprint_with_skeleton(
+        "crates/b/src/cook_baseline.rs",
+        &["git_output"],
+        &[("git_output", "structuralBBB")],
+        &[("git_output", "6:skelSAME")],
+    );
+
+    let findings = detect_skeleton_duplicates(&[&fp1, &fp2]);
+    assert_eq!(findings.len(), 2, "one finding per location");
+    assert!(findings
+        .iter()
+        .all(|f| f.kind == AuditFinding::SkeletonDuplicate));
+    assert!(findings.iter().any(|f| f.file.contains("harvest.rs")));
+    assert!(findings.iter().any(|f| f.file.contains("cook_baseline.rs")));
+}
+
+#[test]
+fn skeleton_duplicate_ignores_group_with_one_shared_structural_hash() {
+    // Same skeleton AND same structural hash — the near-duplicate pass owns
+    // this; skeleton must not double-report it.
+    let fp1 = make_fingerprint_with_skeleton(
+        "crates/a/src/x.rs",
+        &["run_it"],
+        &[("run_it", "structuralSAME")],
+        &[("run_it", "6:skelSAME")],
+    );
+    let fp2 = make_fingerprint_with_skeleton(
+        "crates/b/src/y.rs",
+        &["run_it"],
+        &[("run_it", "structuralSAME")],
+        &[("run_it", "6:skelSAME")],
+    );
+    assert!(detect_skeleton_duplicates(&[&fp1, &fp2]).is_empty());
+}
+
+#[test]
+fn skeleton_duplicate_respects_token_floor_and_generic_names() {
+    // Below the token floor -> ignored.
+    let below = make_fingerprint_with_skeleton(
+        "crates/a/src/x.rs",
+        &["do_thing"],
+        &[("do_thing", "sA")],
+        &[("do_thing", "2:skelSAME")],
+    );
+    let below2 = make_fingerprint_with_skeleton(
+        "crates/b/src/y.rs",
+        &["do_thing"],
+        &[("do_thing", "sB")],
+        &[("do_thing", "2:skelSAME")],
+    );
+    assert!(detect_skeleton_duplicates(&[&below, &below2]).is_empty());
+
+    // Generic name -> ignored even above the floor.
+    let generic1 = make_fingerprint_with_skeleton(
+        "crates/a/src/x.rs",
+        &["run"],
+        &[("run", "sA")],
+        &[("run", "6:skelSAME")],
+    );
+    let generic2 = make_fingerprint_with_skeleton(
+        "crates/b/src/y.rs",
+        &["run"],
+        &[("run", "sB")],
+        &[("run", "6:skelSAME")],
+    );
+    assert!(detect_skeleton_duplicates(&[&generic1, &generic2]).is_empty());
+}
+
+/// End-to-end proof of the #9217 gap: two real `git_output` helpers with the
+/// same backbone but different error tails, fingerprinted through the actual
+/// Rust grammar, must now be flagged (they produced zero findings before).
+#[test]
+fn skeleton_duplicate_flags_real_git_output_helpers_via_grammar() {
+    let grammar_path =
+        std::path::Path::new("/var/lib/datamachine/workspace/homeboy-extensions/rust/grammar.toml");
+    if !grammar_path.exists() {
+        // The Rust grammar ships with the rust extension; skip cleanly where it
+        // is not on disk (the synthetic tests above cover the detector logic).
+        return;
+    }
+    let grammar =
+        homeboy_engine_primitives::grammar::load_grammar(grammar_path).expect("load rust grammar");
+    let fp = |content: &str, path: &str| {
+        crate::core_fingerprint::fingerprint_from_grammar(content, &grammar, path)
+            .expect("fingerprint")
+    };
+
+    let harvest = fp(
+        r#"
+pub fn git_output(cwd: &Path, args: &[&str]) -> Result<String, HarvestError> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .map_err(|error| HarvestError::Git {
+            command: format!("git {}", args.join(" ")),
+            message: error.to_string(),
+        })?;
+    if !output.status.success() {
+        return Err(HarvestError::Git {
+            command: format!("git {}", args.join(" ")),
+            message: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+"#,
+        "crates/agents/src/harvest.rs",
+    );
+    let cook = fp(
+        r#"
+pub fn git_output(cwd: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("git {}", args.join(" "))))
+        })?;
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "promotion",
+            format!("git {} failed: {}", args.join(" "), String::from_utf8_lossy(&output.stderr).trim()),
+            None,
+            None,
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+"#,
+        "crates/agents/src/cook_baseline.rs",
+    );
+
+    // Precondition: the near-duplicate pass still misses them (structural
+    // hashes differ) — this is the gap #9217 documents.
+    assert!(
+        detect_near_duplicates(&[&harvest, &cook]).is_empty(),
+        "near-duplicate is expected to miss the differing error tails"
+    );
+
+    // The new skeleton pass catches them.
+    let findings = detect_skeleton_duplicates(&[&harvest, &cook]);
+    assert!(
+        !findings.is_empty(),
+        "skeleton-duplicate must flag the two git_output helpers"
+    );
+    assert!(findings
+        .iter()
+        .all(|f| f.kind == AuditFinding::SkeletonDuplicate));
+}
+
 mod parallel;

--- a/crates/homeboy-code-audit/src/engine.rs
+++ b/crates/homeboy-code-audit/src/engine.rs
@@ -367,6 +367,26 @@ pub(super) fn audit_internal(
         all_findings.extend(cross_name_dup_findings);
     }
 
+    // Phase 4d1b: Skeleton duplication (same call/control-flow backbone, different
+    // error/return tail). The near-duplicate pass still encodes each expression's
+    // shape, so a primitive reimplemented with a different local error type hashes
+    // apart. This coarser pass keys on the call/keyword skeleton and catches those.
+    let skeleton_dup_findings = time_audit_detector(
+        &mut timing,
+        "detector.duplication.skeleton_duplicate",
+        plan.detector_enabled("duplication"),
+        || duplication::detect_skeleton_duplicates(&all_fingerprints),
+        Vec::new,
+    );
+    if !skeleton_dup_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Skeleton-duplicates: {} finding(s) (same backbone, different error/return tail)",
+            skeleton_dup_findings.len()
+        );
+        all_findings.extend(skeleton_dup_findings);
+    }
+
     // Phase 4d2: Parallel implementation detection (similar call patterns across files)
     let parallel_findings = time_audit_detector(
         &mut timing,

--- a/crates/homeboy-code-audit/src/fingerprint.rs
+++ b/crates/homeboy-code-audit/src/fingerprint.rs
@@ -58,6 +58,13 @@ pub struct FileFingerprint {
     /// Identifiers/literals replaced with positional tokens before hashing.
     /// Populated by extension scripts that support it; empty otherwise.
     pub structural_hashes: HashMap<String, String>,
+    /// Method name → `"<token_count>:<hash>"` skeleton signature for
+    /// skeleton-duplicate detection. Captures only the call/control-flow
+    /// backbone (argument interiors and error tails elided), so a primitive
+    /// reimplemented with a different local error type still matches. Populated
+    /// by the core grammar engine; empty when the fingerprint source (e.g. an
+    /// extension script) does not compute it.
+    pub skeleton_hashes: HashMap<String, String>,
     /// Method name → visibility ("public", "protected", "private").
     pub visibility: HashMap<String, String>,
     /// Public/protected class properties (e.g., ["string $name", "$data"]).
@@ -179,6 +186,9 @@ pub(crate) fn fingerprint_extension_content(
         content: content.to_string(),
         method_hashes: output.method_hashes,
         structural_hashes: output.structural_hashes,
+        // Extension fingerprint scripts do not compute skeleton signatures yet;
+        // the skeleton-duplicate detector simply sees no candidates from them.
+        skeleton_hashes: HashMap::new(),
         visibility: output.visibility,
         properties: output.properties,
         hooks: output.hooks,

--- a/crates/homeboy-code-audit/src/shadow_modules.rs
+++ b/crates/homeboy-code-audit/src/shadow_modules.rs
@@ -265,6 +265,7 @@ mod tests {
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
+            skeleton_hashes: HashMap::new(),
             visibility: HashMap::new(),
             properties: vec![],
             hooks: vec![],


### PR DESCRIPTION
Closes #9217.

## The gap

The audit's duplication family missed a very common real-world duplication: the **same primitive reimplemented with a different error/return tail**. The canonical case is the ~12 hand-rolled `git_output` helpers across `homeboy-agents` / `homeboy-lab-runner` / `homeboy-core`, each wrapping `Command::new("git")…output()` and mapping failure onto its own local error enum. I proved (in #9217, via the real Rust grammar) that all four existing detectors return **zero** findings for that pair:

- **exact** needs byte-identical bodies — the error tails differ,
- **cross-name** needs ≥2 distinct names — they're all `git_output`,
- **near-duplicate** still encodes each expression's *shape*, so `HarvestError::Git { .. }` vs `Error::validation_invalid_argument(..)` hash apart.

## The detector

A new, coarser, **grammar-driven** signature and pass:

1. **`skeleton_signature`** (`core_fingerprint/hash.rs`) reduces a body to the **sorted set** of its **method-chain calls** (`.args(`, `.output(`, `.map_err(`) plus the **control-flow keywords the grammar lists**. Free-function/constructor calls — where error construction overwhelmingly lives — and all argument interiors are elided. The order-independent set absorbs incidental formatting-call noise (`.to_string()`, `.join()`) in the failure path. It's language-agnostic: method-chain syntax + grammar-provided `keywords`/`skip_calls`, **no per-language literals in core**.
2. **`FileFingerprint::skeleton_hashes`** carries `"<token_count>:<hash>"` per method (grammar engine populates it; extension scripts default to empty, so they simply produce no skeleton candidates).
3. **`detect_skeleton_duplicates`** (`duplication.rs`) groups by skeleton hash across ≥2 files, **skips anything the exact/near passes already own** (a group sharing one structural hash is left to near-duplicate), and reuses the existing generic-name, trivial-method, and command↔core delegation filters so it doesn't re-flag idiomatic or delegation-shaped bodies. New `AuditFinding::SkeletonDuplicate`, wired into the engine as phase 4d1b.

## Conservative by construction

- token-count floor (`SKELETON_MIN_TOKENS`) so trivial wrappers don't spam,
- generic-name + trivial-method skip lists shared with the other passes,
- command↔core / all-command delegation filters,
- never double-reports what exact or near-duplicate already cover.

## Testing

- **End-to-end proof of #9217:** `skeleton_duplicate_flags_real_git_output_helpers_via_grammar` fingerprints the two real `git_output` bodies through the actual Rust grammar, asserts near-duplicate still misses them, and asserts the new pass flags them.
- Unit tests for grouping, the structural-hash dedup guard, the token floor, and generic-name exclusion.
- **791 audit + 18 contract tests green**; `homeboy-refactor` still compiles against the new finding kind.

## Follow-up

Once this deploys, `homeboy audit` will surface the remaining scattered `git_output` / raw-`git`-`Command` helpers (and the analogous HTTP/subprocess/JSON wrappers) as consolidation findings — turning the hand-consolidation I've been doing (#9208, #9215) into a tool-driven backlog.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Diagnosed the audit gap empirically (#9217), designed the order-independent method-chain skeleton signature after finding a naive ordered token stream still diverged on error-tail calls, implemented the fingerprint field + detector + engine wiring + finding kind, and validated end-to-end against the real grammar. Chris reviews and owns.