### PR TITLE
Consume Lab admission on execution handoff

### DIFF
--- a/crates/homeboy-core/src/api_jobs/store.rs
+++ b/crates/homeboy-core/src/api_jobs/store.rs
@@ -764,7 +764,8 @@ impl JobStore {
                     matches!(stored.job.status, JobStatus::Queued | JobStatus::Running)
                 })
                 .filter(|stored| {
-                    stored.admission_idempotency_key.as_deref() == Some(idempotency_key)
+                    (local_runner.is_none() || stored.job.operation != "runner.admission")
+                        && stored.admission_idempotency_key.as_deref() == Some(idempotency_key)
                 })
                 .min_by_key(|stored| (stored.job.created_at_ms, stored.job.id))
                 .map(|stored| stored.job.clone())
@@ -787,18 +788,35 @@ impl JobStore {
                 return (existing, false);
             }
         }
+        let consumes_admission = local_runner.is_some();
         inner.jobs.insert(
             job.id,
             StoredJob {
                 job: job.clone(),
                 events: Vec::new(),
-                admission_idempotency_key,
+                admission_idempotency_key: admission_idempotency_key.clone(),
                 admission_lease: None,
                 remote_runner: None,
                 local_runner,
                 local_child: None,
             },
         );
+        if let (Some(idempotency_key), true) =
+            (admission_idempotency_key.as_deref(), consumes_admission)
+        {
+            for stored in inner.jobs.values_mut() {
+                if stored.job.operation == "runner.admission"
+                    && matches!(stored.job.status, JobStatus::Queued | JobStatus::Running)
+                    && stored.admission_idempotency_key.as_deref() == Some(idempotency_key)
+                {
+                    stored.job.status = JobStatus::Cancelled;
+                    stored.job.updated_at_ms = now;
+                    stored.job.finished_at_ms = Some(now);
+                    stored.job.stale_reason =
+                        Some("admission reservation consumed by runner execution".to_string());
+                }
+            }
+        }
         drop(inner);
 
         if let Some(metadata) = metadata {
@@ -2110,6 +2128,7 @@ impl JobStore {
         metadata: Option<Value>,
         path_materialization_plan: Option<PathMaterializationPlan>,
         local_runner: LocalRunnerJob,
+        admission_idempotency_key: Option<String>,
         capacity: usize,
         run: F,
     ) -> JobRunner
@@ -2123,7 +2142,7 @@ impl JobStore {
             metadata,
             path_materialization_plan,
             Some(local_runner.clone()),
-            None,
+            admission_idempotency_key,
         );
         let job_id = job.id;
         // An idempotent resubmission reused an already-enqueued job that already

--- a/crates/homeboy-core/src/api_jobs/tests/part_a.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_a.rs
@@ -385,6 +385,7 @@ fn capacity_queued_agent_task_spawns_once_after_claiming_an_idle_slot() {
         None,
         None,
         local_runner(),
+        None,
         1,
         move |job| {
             job.start_with_reserved_child_identity(
@@ -412,6 +413,7 @@ fn capacity_queued_agent_task_spawns_once_after_claiming_an_idle_slot() {
         None,
         None,
         local_runner(),
+        None,
         1,
         move |job| {
             job.start_with_reserved_child_identity(
@@ -461,6 +463,7 @@ fn capacity_queued_agent_task_persists_typed_failure_before_child_identity() {
             cwd: Some("/runner/worktree".to_string()),
             lifecycle: None,
         },
+        None,
         1,
         move |_job| {
             Err::<serde_json::Value, _>(Error::internal_io(
@@ -779,6 +782,7 @@ fn capacity_queued_local_runner_enqueue_dedupes_on_durable_run_id() {
             None,
             None,
             local_runner("dup-run"),
+            None,
             usize::MAX,
             {
                 let wait = wait;
@@ -797,6 +801,7 @@ fn capacity_queued_local_runner_enqueue_dedupes_on_durable_run_id() {
             None,
             None,
             local_runner("dup-run"),
+            None,
             usize::MAX,
             move |_job| Ok(serde_json::json!({})),
         );
@@ -824,6 +829,7 @@ fn capacity_queued_local_runner_enqueue_dedupes_on_durable_run_id() {
             None,
             None,
             local_runner("other-run"),
+            None,
             usize::MAX,
             move |_job| Ok(serde_json::json!({})),
         );

--- a/crates/homeboy-core/src/daemon.rs
+++ b/crates/homeboy-core/src/daemon.rs
@@ -1996,6 +1996,9 @@ fn enqueue_exec_job(
             Some(run_ref_metadata),
             path_materialization_plan.clone(),
             local_runner,
+            lifecycle
+                .as_ref()
+                .and_then(|lifecycle| lifecycle.durable_run_id.clone()),
             capacity,
             move |job| {
                 let mut plan = plan;
@@ -2318,6 +2321,72 @@ mod tests {
                 0,
                 "a failed or timed-out handoff leaves no active admission job"
             );
+        });
+    }
+
+    #[test]
+    fn direct_daemon_exec_consumes_its_matching_admission_before_returning_identity() {
+        with_isolated_home(|_| {
+            register_enqueue_test_driver();
+            let lease_id = "lease-direct-handoff";
+            let run_id = "cook-9061-attempt-1";
+            write_test_lease(lease_id);
+            let store = JobStore::default();
+            let reservation = reserve_admission(
+                Some(json!({
+                    "runner_id": "lab",
+                    "command": "homeboy agent-task run-plan",
+                    "expected_daemon_lease_id": lease_id,
+                    "idempotency_key": run_id,
+                    "admission_lease_protocol": 1,
+                })),
+                &store,
+            )
+            .expect("reserve controller handoff");
+            let admission_id = reservation["job"]["id"]
+                .as_str()
+                .expect("admission identity")
+                .to_string();
+
+            let accepted = enqueue_exec_job(
+                Some(json!({
+                    "runner_id": "lab",
+                    "cwd": "/tmp",
+                    "command": ["homeboy", "agent-task", "run-plan"],
+                    "idempotency_key": run_id,
+                    "lifecycle": {
+                        "durable_run_id": run_id,
+                        "source": "runner-daemon",
+                        "kind": "runner.exec",
+                    },
+                })),
+                &store,
+            )
+            .expect("daemon accepts execution");
+            let execution_id = accepted["job"]["id"].as_str().expect("execution identity");
+
+            assert_ne!(execution_id, admission_id);
+            assert_eq!(
+                store
+                    .get(uuid::Uuid::parse_str(&admission_id).expect("admission UUID"))
+                    .expect("admission record")
+                    .status,
+                JobStatus::Cancelled,
+                "accepting the execution must release its capacity reservation"
+            );
+            assert_eq!(
+                store
+                    .active_runner_jobs()
+                    .iter()
+                    .filter(|job| job.operation == "runner.exec")
+                    .count(),
+                1,
+                "one durable attempt creates exactly one active provider execution"
+            );
+            assert!(store
+                .active_runner_jobs()
+                .iter()
+                .all(|job| { job.operation != "runner.admission" || job.job_id != admission_id }));
         });
     }
 


### PR DESCRIPTION
## Summary
Atomically consume direct-daemon Lab admission reservations when the durable runner execution job is created.

## What changed
- Pass the durable attempt key into runner execution creation and terminalize the matching admission reservation in the same persisted job-store snapshot.
- Preserve admission-only replay behavior and concrete pre-acceptance submission errors.
- Cover reservation-to-execution identity, single execution, and admission cleanup with deterministic regressions.

## How to test
1. Run `cargo test -p homeboy-core consumes_its_matching_admission --quiet`; expect The focused admission-to-execution behavior test passes..

## Compatibility
No public CLI or extension contract changes. Existing admission-only idempotency and pre-acceptance error behavior are preserved.

## Evidence
- Base unchanged since verification: main remains at e7ac7dfed543d9f219920a8c293811f2f6acdf73.
- CI expected: Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/9061
- Verified finalization base: main at e7ac7dfed543d9f219920a8c293811f2f6acdf73
- admission-regression: Passed
- direct-handoff: Passed
- pr-review: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab admission handoff gap, implemented the atomic admission-to-execution transition, and added deterministic regression coverage; Chris reviewed and owns the change.

## Source relationships
- Closes #9061
