### PR TITLE
fix(agents): add missing VerifyGateOptions fields in promotion provider test

### DIFF
--- a/tests/agent_task_promotion_provider.rs
+++ b/tests/agent_task_promotion_provider.rs
@@ -138,6 +138,7 @@ fn promotion_gate_binds_a_socket_in_the_short_invocation_tmpdir_for_a_long_run_i
                 private_verify: Vec::new(),
                 private_gate_reveal:
                     homeboy::agents::agent_task_gate::AgentTaskGateRevealPolicy::FullEvidence,
+                ..Default::default()
             },
             provider_command: Some(provider.display().to_string()),
             provider_invocation: None,


### PR DESCRIPTION
## Summary
- Fixes a real compile break on `main`: the `agent_task_promotion_provider` test binary fails with `E0063: missing fields gate_heartbeat_interval_seconds, gate_timeout_seconds and rerun_completed_gates in initializer of VerifyGateOptions`.
- #9212 ("Supervise candidate adoption gates") added those three fields to `VerifyGateOptions` and updated production initializers to spread `..Default::default()`, but missed the `tests/agent_task_promotion_provider.rs` integration-test initializer.
- Result: `Test` + `Workspace Tests Compile` gates fail on main and on every open PR branched before #9212 landed.

## Fix
Add `..Default::default()` to the test's `VerifyGateOptions` initializer, matching the production sites. Audited all other `VerifyGateOptions { ... }` initializers in the repo — this was the only missed one.

## Note on open PRs
The three currently-open PRs (#9220, #9222, #9224) are red on `Workspace Tests Compile` for this exact reason — they inherited the broken base. Once this lands they should go green after a rebase/merge from main (their own diffs don't touch this code). So their red is an inherited/false red, not a genuine problem with their changes.

## Testing
- `cargo fmt -p homeboy` clean.
- Local heavy build skipped per repo RULES.md; CI validates the compile of the previously-broken test binary.