### PR TITLE
refactor(audit): cap skeleton-duplicate group size to cut idiomatic noise

### DIFF
--- a/crates/homeboy-code-audit/src/duplication.rs
+++ b/crates/homeboy-code-audit/src/duplication.rs
@@ -546,6 +546,13 @@ pub(crate) fn detect_near_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<F
 /// produced by an older engine.
 const SKELETON_MIN_TOKENS: usize = 4;
 
+/// Maximum locations a skeleton group may span before it is treated as an
+/// idiomatic shape rather than a reimplemented primitive. A backbone shared by
+/// more than a handful of unrelated functions (trivial accessor/`collect`
+/// chains, uniform JSON builders) is boilerplate, not consolidatable
+/// duplication; primitive-reimplementation clusters are small.
+const SKELETON_MAX_GROUP: usize = 4;
+
 /// Split a stored skeleton value (`"<token_count>:<hash>"`) into its parts.
 fn parse_skeleton_value(value: &str) -> Option<(usize, &str)> {
     let (count, hash) = value.split_once(':')?;
@@ -611,6 +618,17 @@ pub(crate) fn detect_skeleton_duplicates(fingerprints: &[&FileFingerprint]) -> V
         // Group must span at least two files.
         let distinct_files: HashSet<&str> = locations.iter().map(|(f, _, _)| *f).collect();
         if distinct_files.len() < MIN_DUPLICATE_LOCATIONS {
+            continue;
+        }
+
+        // A skeleton shared by *many* unrelated functions is an idiomatic shape
+        // (e.g. `.iter().map().collect()` accessor chains, `json!`-building
+        // helpers), not a reimplemented primitive. Those large groups are noise
+        // — consolidating a dozen unrelated one-liners behind one signature is
+        // never the right call — so cap the group size. Real
+        // primitive-reimplementation clusters (the scattered `git_output` /
+        // `run_git` family) are small and stay well under this ceiling.
+        if locations.len() > SKELETON_MAX_GROUP {
             continue;
         }
 

--- a/crates/homeboy-code-audit/src/duplication/tests.rs
+++ b/crates/homeboy-code-audit/src/duplication/tests.rs
@@ -1148,6 +1148,27 @@ fn skeleton_duplicate_ignores_group_with_one_shared_structural_hash() {
 }
 
 #[test]
+fn skeleton_duplicate_suppresses_large_idiomatic_groups() {
+    // Six functions sharing one skeleton = an idiomatic shape (e.g. an
+    // `.iter().map().collect()` accessor), not a reimplemented primitive.
+    let fps: Vec<FileFingerprint> = (0..6)
+        .map(|i| {
+            make_fingerprint_with_skeleton(
+                &format!("crates/c{i}/src/x{i}.rs"),
+                &[&format!("accessor_{i}")],
+                &[(&format!("accessor_{i}"), &format!("struct{i}"))],
+                &[(&format!("accessor_{i}"), "6:skelSAME")],
+            )
+        })
+        .collect();
+    let refs: Vec<&FileFingerprint> = fps.iter().collect();
+    assert!(
+        detect_skeleton_duplicates(&refs).is_empty(),
+        "a skeleton shared by many unrelated functions must be treated as idiomatic, not duplication"
+    );
+}
+
+#[test]
 fn skeleton_duplicate_respects_token_floor_and_generic_names() {
     // Below the token floor -> ignored.
     let below = make_fingerprint_with_skeleton(


### PR DESCRIPTION
Follow-up to #9222, driven by running the new detector against this repo.

## What running it revealed

I ran `detect_skeleton_duplicates` across `homeboy-agents` / `homeboy-lab-runner` / `homeboy-core` / `homeboy-release` / `homeboy-cli` (1074 files, 763 with skeleton signatures). It produced **399 findings** with a clean signal split:

- **Small groups = real targets.** The scattered git-helper cluster came through exactly as expected — `git_output` ↔ `git_output` ↔ `run_git`, `git_output_with_env` ↔ `git_output_raw_with_env` ↔ `git_with_env`, `git_lines` ↔ `git_changed_files` ↔ `list_tracked_markdown_files`, `run_git` ↔ `checkout_pr_branch` — plus a `write_*` file-writing cluster and a `shell_path_expr` cluster. This is the duplication I'd been consolidating by hand (#9208, #9215), now found automatically.
- **Large groups = idiomatic noise.** A `.iter().map().collect()` accessor like `artifact_ids` matched **13** unrelated Vec-mapping functions; other big groups were uniform `json!`-builders. Consolidating a dozen unrelated one-liners behind one signature is never correct.

## Fix

Cap the group size (`SKELETON_MAX_GROUP = 4`): a skeleton shared by more than a handful of locations is an idiomatic shape, not a reimplemented primitive, so it's dropped. Real primitive-reimplementation clusters are small and stay well under the ceiling.

**Measured effect:** 399 → 261 findings (−138 noise), with **every git-helper cluster surviving** (verified). The remaining set is dominated by the small, actionable clusters.

## Testing

- New `skeleton_duplicate_suppresses_large_idiomatic_groups`: six functions sharing one skeleton are suppressed.
- Full duplication suite (75 tests incl. all skeleton tests) green.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Ran the shipped detector against the real workspace, triaged the 399 findings into real clusters vs idiomatic noise, and added the group-size cap that removes the noise while preserving every git-helper cluster. Chris reviews and owns.