### PR TITLE
Make Lab snapshot identity portable

### DIFF
--- a/crates/contracts/homeboy-source-snapshot-contract/src/workspace_content_identity.rs
+++ b/crates/contracts/homeboy-source-snapshot-contract/src/workspace_content_identity.rs
@@ -41,11 +41,12 @@ pub const WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE: &str = "unix-executable"
 pub const WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE: &str = "unix-owner-executable";
 
 /// The default permission policy for new workspace-content identities.
-#[cfg(unix)]
-pub const WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY: &str =
-    WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE;
-/// The default permission policy for new workspace-content identities.
-#[cfg(not(unix))]
+///
+/// Snapshot archives can cross controller and runner platform boundaries. File
+/// bytes and paths survive that transfer, while Unix mode bits are not a
+/// portable provenance capability. New snapshots therefore use the content-only
+/// policy; explicit Unix policies remain available to verify their versioned
+/// historical contracts.
 pub const WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY: &str = WORKSPACE_CONTENT_PERMISSION_PORTABLE;
 
 /// The algorithm-identity marker string for a permission policy, or `None` if
@@ -99,6 +100,19 @@ mod tests {
     fn portable_policy_marker_is_stable_and_platform_independent() {
         assert_eq!(
             workspace_content_hash_algorithm(WORKSPACE_CONTENT_PERMISSION_PORTABLE).as_deref(),
+            Some("homeboy-workspace-content-v2+portable-content-only")
+        );
+    }
+
+    #[test]
+    fn default_policy_is_portable_across_controller_and_runner_platforms() {
+        assert_eq!(
+            WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+            WORKSPACE_CONTENT_PERMISSION_PORTABLE
+        );
+        assert_eq!(
+            workspace_content_hash_algorithm(WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY)
+                .as_deref(),
             Some("homeboy-workspace-content-v2+portable-content-only")
         );
     }

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -1844,6 +1844,56 @@ fn workspace_content_hash_versions_legacy_any_execute_separately_from_owner_exec
 }
 
 #[test]
+#[cfg(unix)]
+fn snapshot_content_hash_is_portable_when_transport_drops_owner_execute() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let controller = tempfile::tempdir().expect("controller workspace");
+    let runner = tempfile::tempdir().expect("runner workspace");
+    for workspace in [controller.path(), runner.path()] {
+        fs::write(workspace.join("tool"), "#!/bin/sh\necho homeboy\n").expect("tool");
+    }
+    fs::set_permissions(
+        controller.path().join("tool"),
+        fs::Permissions::from_mode(0o755),
+    )
+    .expect("controller permissions");
+    fs::set_permissions(
+        runner.path().join("tool"),
+        fs::Permissions::from_mode(0o644),
+    )
+    .expect("runner permissions");
+
+    assert_ne!(
+        workspace_content_hash_for_policy(
+            controller.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
+        )
+        .expect("controller Unix hash"),
+        workspace_content_hash_for_policy(
+            runner.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
+        )
+        .expect("runner Unix hash"),
+        "Unix mode provenance is not portable through a cross-platform snapshot"
+    );
+    assert_eq!(
+        workspace_content_hash(controller.path(), &[]).expect("controller portable hash"),
+        workspace_content_hash(runner.path(), &[]).expect("runner portable hash"),
+        "new snapshots bind the portable content contract"
+    );
+
+    fs::write(runner.path().join("tool"), "#!/bin/sh\necho changed\n").expect("mutate tool");
+    assert_ne!(
+        workspace_content_hash(controller.path(), &[]).expect("controller portable hash"),
+        workspace_content_hash(runner.path(), &[]).expect("changed runner portable hash"),
+        "portable identity remains fail-closed for content changes"
+    );
+}
+
+#[test]
 fn workspace_content_manifest_contains_every_materialized_path() {
     let workspace = tempfile::tempdir().expect("workspace");
     fs::write(workspace.path().join("a".repeat(193)), "contents\n").expect("long path file");


### PR DESCRIPTION
## Summary

- make new workspace-content identities use the existing portable content-only contract
- retain explicit v1, v2 Unix-executable, and v3 owner-executable verification semantics for persisted evidence
- prove equivalent content hashes identically when cross-platform transport changes owner-execute metadata
- keep portable identity fail-closed for path, structure, symlink, and byte changes

Closes #9221.

## Root cause

The default policy selected `homeboy-workspace-content-v3+unix-owner-executable` on both macOS controllers and Linux runners. Owner-execute mode is not a reliable invariant of the cross-platform snapshot transport, so clean materializations could fail committed-change harvest before provider execution.

New snapshots now declare the existing `homeboy-workspace-content-v2+portable-content-only` contract. Explicit historical policies keep their original meanings, so persisted evidence is never reinterpreted.

## How to test

1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-source-snapshot-contract`.
3. Run `cargo test -p homeboy-lab-runner snapshot_content_hash_is_portable_when_transport_drops_owner_execute`.
4. Run `cargo check -p homeboy-source-snapshot-contract -p homeboy-lab-runner`.
5. Route a clean macOS-controller worktree to a Linux Lab runner and verify committed-change harvest reaches deterministic gates instead of failing workspace provenance.

## Verification

- Formatting passed.
- Source snapshot contract tests passed: 4 tests.
- Focused cross-platform snapshot regression passed.
- A live downstream candidate that previously failed provenance was adopted after installing this commit; Homeboy promoted its three-file patch and passed 38 unit tests plus both TypeScript typechecks.

## Compatibility

New snapshots no longer attest executable mode bits. Paths, structure, symlinks, and file bytes remain bound. Existing explicit Unix policies and persisted v3 snapshots retain strict owner-executable verification.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode and Homeboy
- **Used for:** Diagnosed the live controller-to-Lab failure, drafted the implementation and regression coverage, and verified the repaired control-plane workflow; Chris reviewed and owns the change.