### PR TITLE
feat(audit): detect literals that bypass an existing named constant

### DIFF
--- a/crates/contracts/homeboy-audit-contract/src/finding_kind.rs
+++ b/crates/contracts/homeboy-audit-contract/src/finding_kind.rs
@@ -43,6 +43,11 @@ pub enum AuditFinding {
     /// catches hand-rolled wrappers like per-module `git_output` helpers that
     /// map failures onto different error enums.
     SkeletonDuplicate,
+    /// A raw string literal whose value is byte-identical to a named constant
+    /// already defined elsewhere in the codebase — the constant was bypassed
+    /// with a hand-typed copy. Editing the constant leaves these copies stale,
+    /// so they should reference the constant instead.
+    ConstantBypassLiteral,
     /// Function parameter is declared but never used in the function body.
     /// When call-site data is available, this means no callers pass a value
     /// for this position — truly dead, safe to remove.
@@ -223,6 +228,7 @@ impl AuditFinding {
             "cross_name_duplicate",
             "near_duplicate",
             "skeleton_duplicate",
+            "constant_bypass_literal",
             "unused_parameter",
             "ignored_parameter",
             "dead_code_marker",

--- a/crates/homeboy-code-audit/src/descriptor_runtime.rs
+++ b/crates/homeboy-code-audit/src/descriptor_runtime.rs
@@ -1,7 +1,7 @@
 use super::detectors::layer_ownership::run as run_layer_ownership;
 use super::detectors::{
-    aggregate_construction, command_status_contracts, config_key_usage, dead_guard,
-    deprecation_age, enum_dispatch_contracts, facade_passthrough, global_env_guard,
+    aggregate_construction, command_status_contracts, config_key_usage, constant_bypass,
+    dead_guard, deprecation_age, enum_dispatch_contracts, facade_passthrough, global_env_guard,
     mutating_resource_access, parallel_runner_setup, public_registry_exposure, redirect_validation,
     remote_execution_preflight, repeated_literal_shape, requested_detectors, shared_scaffolding,
     source_policy, test_coverage, test_topology, test_wiring, thin_command_adapter,
@@ -56,6 +56,7 @@ fn run_fingerprint_descriptor(
                 .detector_profile
                 .repeated_literal_shape_extensions,
         ),
+        FingerprintDetectorRunner::ConstantBypass => constant_bypass::run(context.all_fingerprints),
         FingerprintDetectorRunner::SharedScaffolding => {
             shared_scaffolding::run(context.all_fingerprints)
         }

--- a/crates/homeboy-code-audit/src/detectors/constant_bypass.rs
+++ b/crates/homeboy-code-audit/src/detectors/constant_bypass.rs
@@ -1,0 +1,225 @@
+//! Constant-bypass literal detection.
+//!
+//! Finds raw string literals whose value is byte-identical to a named string
+//! constant already defined elsewhere in the codebase. The constant is the
+//! canonical spelling — a hand-typed copy silently rots when the constant
+//! changes (a schema-version bump, a renamed metadata key, a moved path), so
+//! the copy should reference the constant instead.
+//!
+//! This is a first-pass, always-on detector. It complements the config-driven
+//! `ConstantBackedSlugLiteral` (which only fires for constant patterns a
+//! component explicitly registers) by discovering bypasses automatically from
+//! the constants the codebase already defines.
+//!
+//! Language scope: the constant-declaration and literal scans use conservative
+//! patterns that match the C-family `const NAME: T = "value"` /
+//! `const NAME = "value"` shapes (Rust, TS, Go-ish, PHP `const`). It reads only
+//! from `FileFingerprint::content`, so no fingerprint-model change is required.
+
+use std::collections::HashMap;
+
+use regex::Regex;
+
+use super::super::conventions::AuditFinding;
+use super::super::findings::{Finding, Severity};
+use super::super::fingerprint::FileFingerprint;
+use super::super::walker::is_test_path;
+
+/// Minimum constant-value length worth flagging. Short values (`"workspace"`,
+/// `"snapshot"`) collide with serde tags, enum spellings, and unrelated
+/// domain words, so flagging them is noise. Schema/path/key strings — the
+/// valuable cases — are comfortably longer.
+const MIN_VALUE_LEN: usize = 12;
+
+pub(crate) fn run(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    detect_constant_bypass_literals(fingerprints)
+}
+
+/// `const NAME: &str = "value";` and `const NAME = "value";` (and `static`).
+/// Captures the constant name (1) and its string value (2).
+fn const_decl_regex() -> &'static Regex {
+    static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+        Regex::new(
+            r#"(?m)\b(?:pub(?:\([^)]*\))?\s+)?(?:const|static)\s+([A-Z][A-Z0-9_]+)\s*(?::\s*&(?:'static\s+)?str\s*)?=\s*"([^"\\]{4,})"\s*;"#,
+        )
+        .expect("valid const-decl regex")
+    });
+    &RE
+}
+
+/// A recorded string constant: where it is defined and under what name.
+struct ConstDef {
+    name: String,
+    file: String,
+    /// 1-indexed line of the definition, so we never flag the definition itself.
+    line: usize,
+}
+
+fn detect_constant_bypass_literals(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    // value -> definition. First definition wins; a value defined under two
+    // names is itself a smell, but we report against one canonical name.
+    let mut consts: HashMap<String, ConstDef> = HashMap::new();
+    for fp in fingerprints {
+        if is_test_path(&fp.relative_path) {
+            continue;
+        }
+        for caps in const_decl_regex().captures_iter(&fp.content) {
+            let name = caps[1].to_string();
+            let value = caps[2].to_string();
+            if value.len() < MIN_VALUE_LEN {
+                continue;
+            }
+            let line = line_of_match(&fp.content, caps.get(0).unwrap().start());
+            consts.entry(value).or_insert(ConstDef {
+                name,
+                file: fp.relative_path.clone(),
+                line,
+            });
+        }
+    }
+
+    if consts.is_empty() {
+        return Vec::new();
+    }
+
+    let mut findings = Vec::new();
+    for fp in fingerprints {
+        if is_test_path(&fp.relative_path) {
+            continue;
+        }
+        for (offset, literal) in string_literals(&fp.content) {
+            let Some(def) = consts.get(&literal) else {
+                continue;
+            };
+            let line = line_of_match(&fp.content, offset);
+            // Never flag the constant's own definition line.
+            if fp.relative_path == def.file && line == def.line {
+                continue;
+            }
+            // Skip the const-declaration line itself in any file (a re-export
+            // `const OTHER: &str = SAME_VALUE;` is legitimate, though rare).
+            if is_const_decl_line(&fp.content, offset) {
+                continue;
+            }
+            findings.push(Finding {
+                convention: "constant_bypass_literal".to_string(),
+                severity: Severity::Warning,
+                file: fp.relative_path.clone(),
+                description: format!(
+                    "Literal \"{}\" duplicates constant `{}` (defined in {})",
+                    truncate(&literal),
+                    def.name,
+                    def.file
+                ),
+                suggestion: format!(
+                    "Reference `{}` instead of hand-typing its value; editing the \
+                     constant will not otherwise update this copy.",
+                    def.name
+                ),
+                kind: AuditFinding::ConstantBypassLiteral,
+            });
+        }
+    }
+
+    findings.sort_by(|a, b| {
+        a.file
+            .cmp(&b.file)
+            .then_with(|| a.description.cmp(&b.description))
+    });
+    findings
+}
+
+/// Extract `"..."` string-literal values with their byte offset. A tolerant
+/// character scanner that tracks string state and skips escapes, so quoted
+/// braces/quotes inside a literal do not confuse it. Line and block comments
+/// are ignored.
+fn string_literals(content: &str) -> Vec<(usize, String)> {
+    let bytes = content.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
+                // line comment
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i += 2;
+            }
+            b'"' => {
+                let start = i;
+                i += 1;
+                let val_start = i;
+                while i < bytes.len() {
+                    if bytes[i] == b'\\' {
+                        i += 2;
+                        continue;
+                    }
+                    if bytes[i] == b'"' {
+                        break;
+                    }
+                    i += 1;
+                }
+                if i <= bytes.len() && i > val_start {
+                    if let Ok(val) = std::str::from_utf8(&bytes[val_start..i.min(bytes.len())]) {
+                        // Only record literals with no escapes; an escaped value
+                        // will not byte-match a plain constant string anyway.
+                        if !val.contains('\\') {
+                            out.push((start, val.to_string()));
+                        }
+                    }
+                }
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    out
+}
+
+/// 1-indexed line number of a byte offset.
+fn line_of_match(content: &str, offset: usize) -> usize {
+    content[..offset.min(content.len())]
+        .bytes()
+        .filter(|&b| b == b'\n')
+        .count()
+        + 1
+}
+
+/// Whether the line containing `offset` is itself a `const`/`static` string
+/// declaration (so we don't flag the canonical definition or a re-export).
+fn is_const_decl_line(content: &str, offset: usize) -> bool {
+    let line_start = content[..offset.min(content.len())]
+        .rfind('\n')
+        .map(|p| p + 1)
+        .unwrap_or(0);
+    let line_end = content[offset.min(content.len())..]
+        .find('\n')
+        .map(|p| offset + p)
+        .unwrap_or(content.len());
+    let line = &content[line_start..line_end.min(content.len())];
+    let t = line.trim_start();
+    t.starts_with("const ")
+        || t.starts_with("static ")
+        || t.starts_with("pub const ")
+        || t.starts_with("pub static ")
+        || t.starts_with("pub(crate) const ")
+        || t.starts_with("pub(crate) static ")
+}
+
+fn truncate(s: &str) -> String {
+    if s.len() <= 48 {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..48])
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/homeboy-code-audit/src/detectors/constant_bypass/tests.rs
+++ b/crates/homeboy-code-audit/src/detectors/constant_bypass/tests.rs
@@ -1,0 +1,82 @@
+use super::*;
+use crate::conventions::Language;
+
+fn fp(path: &str, content: &str) -> FileFingerprint {
+    FileFingerprint {
+        relative_path: path.to_string(),
+        language: Language::Rust,
+        content: content.to_string(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn flags_literal_duplicating_a_constant_defined_elsewhere() {
+    let def = fp(
+        "src/sync.rs",
+        r#"const WORKSPACE_METADATA_FILE: &str = ".homeboy/runner-workspace.json";"#,
+    );
+    let user = fp(
+        "src/harvest.rs",
+        "fn go() {\n    workspace.join(\".homeboy/runner-workspace.json\");\n}\n",
+    );
+    let findings = detect_constant_bypass_literals(&[&def, &user]);
+    assert_eq!(findings.len(), 1, "one bypass in harvest.rs");
+    assert_eq!(findings[0].kind, AuditFinding::ConstantBypassLiteral);
+    assert_eq!(findings[0].file, "src/harvest.rs");
+    assert!(findings[0].description.contains("WORKSPACE_METADATA_FILE"));
+    assert!(findings[0].description.contains("src/sync.rs"));
+}
+
+#[test]
+fn does_not_flag_the_constant_definition_itself() {
+    let def = fp(
+        "src/schema.rs",
+        r#"pub const AGENT_TASK_AGGREGATE_SCHEMA: &str = "homeboy/agent-task-aggregate/v1";"#,
+    );
+    // Only the definition exists; nobody bypasses it.
+    assert!(detect_constant_bypass_literals(&[&def]).is_empty());
+}
+
+#[test]
+fn ignores_short_values_below_the_length_floor() {
+    let def = fp("src/a.rs", r#"const MODE: &str = "snapshot";"#);
+    let user = fp("src/b.rs", "fn f() { let m = \"snapshot\"; }");
+    assert!(
+        detect_constant_bypass_literals(&[&def, &user]).is_empty(),
+        "short idiomatic values must not be flagged"
+    );
+}
+
+#[test]
+fn ignores_test_files_as_both_source_and_site() {
+    let def = fp(
+        "src/schema.rs",
+        r#"const LONG_SCHEMA_KEY: &str = "homeboy/some-schema/v1";"#,
+    );
+    let test_site = fp(
+        "src/foo/tests.rs",
+        "fn t() { assert_eq!(x, \"homeboy/some-schema/v1\"); }",
+    );
+    assert!(
+        detect_constant_bypass_literals(&[&def, &test_site]).is_empty(),
+        "a literal inside a test file must not be flagged"
+    );
+}
+
+#[test]
+fn re_export_const_line_is_not_flagged() {
+    let def = fp(
+        "src/a.rs",
+        r#"const CANONICAL_METADATA_KEY: &str = "controller_runtime_key";"#,
+    );
+    // A second const with the same value on its own decl line is not a bypass.
+    let reexport = fp(
+        "src/b.rs",
+        r#"const ALIAS_METADATA_KEY: &str = "controller_runtime_key";"#,
+    );
+    assert!(
+        detect_constant_bypass_literals(&[&def, &reexport]).is_empty(),
+        "a constant declaration line is not a bypass site"
+    );
+}

--- a/crates/homeboy-code-audit/src/detectors/mod.rs
+++ b/crates/homeboy-code-audit/src/detectors/mod.rs
@@ -2,6 +2,7 @@ pub(super) mod aggregate_construction;
 pub(super) mod artifact_portability;
 pub(super) mod command_status_contracts;
 pub(super) mod config_key_usage;
+pub(super) mod constant_bypass;
 pub(super) mod dead_guard;
 pub(super) mod deprecation_age;
 pub(super) mod enum_dispatch_contracts;

--- a/crates/homeboy-code-audit/src/execution_plan.rs
+++ b/crates/homeboy-code-audit/src/execution_plan.rs
@@ -108,6 +108,7 @@ pub(crate) enum FingerprintDetectorRunner {
     ShadowModules,
     FacadePassthrough,
     LiteralShapes,
+    ConstantBypass,
     SharedScaffolding,
     AggregateConstruction,
 }
@@ -343,6 +344,15 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         timing_id: "detector.literal_shapes",
         log_label: "Literal shapes",
         log_summary: "repeated inline array literals",
+    },
+    DetectorDescriptor {
+        id: "constant_bypass",
+        findings: &[AuditFinding::ConstantBypassLiteral],
+        access: DetectorAccess::Discovery,
+        runtime: DetectorRuntime::Fingerprint(FingerprintDetectorRunner::ConstantBypass),
+        timing_id: "detector.constant_bypass",
+        log_label: "Constant bypass",
+        log_summary: "literals duplicating a named constant",
     },
     DetectorDescriptor {
         id: "deprecation_age",


### PR DESCRIPTION
Closes #9233.

## The gap

There was no **generic, always-on** detector for a raw string literal whose value is byte-identical to a `const`/`static` already defined in the codebase — a hand-typed copy of the canonical spelling. When the constant changes (a schema-version bump, a renamed metadata key, a moved path), the copies silently rot. `ConstantBackedSlugLiteral` exists but is **config-driven** — it only fires for patterns a component explicitly registers; nothing discovers bypasses from the constants the codebase already defines.

Empirically (see #9233): **132 constants** have their value hand-typed as a raw literal elsewhere, including schema-version strings.

## The detector

Builtin `ConstantBypassLiteral`:

1. Collect string constants (`const|static NAME: &str = "value"`) from non-test fingerprints -> `value -> (name, file, line)`.
2. Scan raw string literals; when a literal equals a known constant's value (and isn't the definition or a const-decl line), flag it with the constant's name and location.
3. Scans `FileFingerprint::content` directly — same approach as `repeated_literal_shape`, **no fingerprint-model change**.

**Noise controls** (validated against the repo):
- **12-char value floor** — short idiomatic values (`"workspace"`, `"snapshot"`) collide with serde tags / enum spellings and are excluded.
- test files skipped as both constant source and bypass site,
- constant-declaration lines never flagged (a second `const OTHER = <same value>` re-export isn't a bypass).

Wired through the descriptor table the codebase already uses: one `FingerprintDetectorRunner` variant + one `DetectorDescriptor` row + one dispatch arm.

## Validated against this repo

Running it surfaces **273 findings**, dominated by exactly the valuable cases:

```
14x  AGENT_TASK_AGGREGATE_SCHEMA          (schema version — latent mismatch hazard)
29x  CONTROLLER_RUNTIME_METADATA_KEY
10x  ACTIONABLE_METADATA_KEY
 7x  AGENT_TASK_RUN_PLAN_LIFECYCLE_EVENT_SCHEMA
 5x  WORKSPACE_METADATA_FILE              (the .homeboy/runner-workspace.json case that motivated #9233)
 …   DISPATCH_RESULT_SCHEMA, EVIDENCE_MANIFEST_SCHEMA, AGENT_TASK_PROMOTION_REPORT_SCHEMA, …
```

Schema-version strings hand-typed instead of referencing their constant are the standout — a real correctness hazard, not just cosmetics.

## Testing

- 5 unit tests: flags a real bypass, ignores the definition, respects the length floor, skips test files, ignores re-export const lines.
- **796 audit + 18 contract tests green**; `homeboy-refactor` still compiles against the new finding kind.

## Language-agnosticism note

This first pass uses conservative C-family `const`/`static` declaration patterns and scans `content` directly (the chosen small-blast-radius path). A follow-up can move constant extraction behind a grammar `[patterns.string_constant]` so non-Rust extensions participate; the detector's grouping/filtering logic is already language-neutral.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Identified the gap (#9233), designed and implemented the detector + descriptor wiring, tuned the length floor from real-repo output, and validated 273 findings dominated by schema-version bypasses. Chris reviews and owns.