### PR TITLE
feat(audit): detect raw commands that bypass a thin-wrapper helper

### DIFF
--- a/crates/contracts/homeboy-audit-contract/src/finding_kind.rs
+++ b/crates/contracts/homeboy-audit-contract/src/finding_kind.rs
@@ -48,6 +48,12 @@ pub enum AuditFinding {
     /// with a hand-typed copy. Editing the constant leaves these copies stale,
     /// so they should reference the constant instead.
     ConstantBypassLiteral,
+    /// A raw subprocess call whose literal argument vector is byte-identical to
+    /// the one wrapped by an existing thin helper — the command analog of
+    /// `ConstantBypassLiteral`. The caller re-invoked the primitive raw instead
+    /// of calling the helper (e.g. `git ["rev-parse","HEAD"]` when `head_sha`
+    /// exists), so the command spelling can drift out of one place.
+    CommandWrapperBypass,
     /// Function parameter is declared but never used in the function body.
     /// When call-site data is available, this means no callers pass a value
     /// for this position — truly dead, safe to remove.
@@ -229,6 +235,7 @@ impl AuditFinding {
             "near_duplicate",
             "skeleton_duplicate",
             "constant_bypass_literal",
+            "command_wrapper_bypass",
             "unused_parameter",
             "ignored_parameter",
             "dead_code_marker",

--- a/crates/homeboy-code-audit/src/descriptor_runtime.rs
+++ b/crates/homeboy-code-audit/src/descriptor_runtime.rs
@@ -1,11 +1,11 @@
 use super::detectors::layer_ownership::run as run_layer_ownership;
 use super::detectors::{
-    aggregate_construction, command_status_contracts, config_key_usage, constant_bypass,
-    dead_guard, deprecation_age, enum_dispatch_contracts, facade_passthrough, global_env_guard,
-    mutating_resource_access, parallel_runner_setup, public_registry_exposure, redirect_validation,
-    remote_execution_preflight, repeated_literal_shape, requested_detectors, shared_scaffolding,
-    source_policy, test_coverage, test_topology, test_wiring, thin_command_adapter,
-    unbounded_output_capture, wrapper_inference,
+    aggregate_construction, command_status_contracts, command_wrapper_bypass, config_key_usage,
+    constant_bypass, dead_guard, deprecation_age, enum_dispatch_contracts, facade_passthrough,
+    global_env_guard, mutating_resource_access, parallel_runner_setup, public_registry_exposure,
+    redirect_validation, remote_execution_preflight, repeated_literal_shape, requested_detectors,
+    shared_scaffolding, source_policy, test_coverage, test_topology, test_wiring,
+    thin_command_adapter, unbounded_output_capture, wrapper_inference,
 };
 use super::doc_drift::detect_doc_drift;
 use super::reference::{fingerprint_component_reference_files, fingerprint_reference_paths};
@@ -57,6 +57,9 @@ fn run_fingerprint_descriptor(
                 .repeated_literal_shape_extensions,
         ),
         FingerprintDetectorRunner::ConstantBypass => constant_bypass::run(context.all_fingerprints),
+        FingerprintDetectorRunner::CommandWrapperBypass => {
+            command_wrapper_bypass::run(context.all_fingerprints)
+        }
         FingerprintDetectorRunner::SharedScaffolding => {
             shared_scaffolding::run(context.all_fingerprints)
         }

--- a/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs
+++ b/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs
@@ -1,0 +1,244 @@
+//! Command-wrapper-bypass detection.
+//!
+//! Finds raw subprocess calls whose literal argument vector is byte-identical
+//! to the arg-vector wrapped by an existing thin helper — e.g. hand-rolling
+//! `git_output(path, &["rev-parse", "HEAD"])` when `head_sha(path)` already
+//! exists and is literally `output_optional(git_root, &["rev-parse", "HEAD"])`.
+//!
+//! This is the command-invocation analog of the constant-bypass detector: a
+//! canonical wrapper exists, but callers re-invoke the primitive raw, so the
+//! command spelling (flags, arg order) drifts and cannot be fixed in one place.
+//!
+//! Auto-discovery, no config: a "thin wrapper" is a function whose body is a
+//! single call passing a literal all-string arg-vector. The detector records
+//! `argvec -> (helper_name, file)` from those, then flags any other site that
+//! passes the same literal arg-vector.
+//!
+//! It reads only `FileFingerprint::content`, so no fingerprint-model change is
+//! required. Arg-vector recognition uses the C-family `&["a", "b"]` slice
+//! literal; a follow-up can source the array-literal shape from grammar config
+//! for non-Rust languages.
+
+use std::collections::HashMap;
+
+use regex::Regex;
+
+use super::super::conventions::AuditFinding;
+use super::super::findings::{Finding, Severity};
+use super::super::fingerprint::FileFingerprint;
+use super::super::walker::is_test_path;
+
+/// Minimum arg-vector length to consider. Single-element commands (`["init"]`,
+/// `["fetch"]`) are too generic to attribute to one wrapper.
+const MIN_ARGV_LEN: usize = 2;
+
+pub(crate) fn run(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    detect_command_wrapper_bypass(fingerprints)
+}
+
+/// A literal all-string slice: `&["a", "b", ...]`. Group 1 is the inner list.
+fn argvec_regex() -> &'static Regex {
+    static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+        Regex::new(r#"&\[\s*("(?:[^"\\]|\\.)*"\s*(?:,\s*"(?:[^"\\]|\\.)*"\s*)*),?\s*\]"#)
+            .expect("valid arg-vector regex")
+    });
+    &RE
+}
+
+/// A **module-level** `fn NAME` declaration. Anchored to the start of a line
+/// (optionally through `pub`/`pub(...)`), so nested functions — test-module
+/// helpers inside `#[cfg(test)] mod tests { fn head() … }`, impl methods — are
+/// excluded. Canonical command wrappers are module-level; indented one-call
+/// helpers are almost always test fixtures and would otherwise seed the map
+/// with git-setup arg-vectors. Group 1 is the name.
+fn fn_decl_regex() -> &'static Regex {
+    static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+        Regex::new(r"(?m)^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?(?:unsafe\s+)?(?:const\s+)?fn\s+([a-z_][a-z0-9_]*)\s*[(<]")
+            .expect("valid fn regex")
+    });
+    &RE
+}
+
+/// Parse the inner string elements of an arg-vector match into a canonical key.
+fn argvec_elements(inner: &str) -> Vec<String> {
+    static ELEM: std::sync::LazyLock<Regex> =
+        std::sync::LazyLock::new(|| Regex::new(r#""((?:[^"\\]|\\.)*)""#).unwrap());
+    ELEM.captures_iter(inner)
+        .map(|c| c[1].to_string())
+        .collect()
+}
+
+/// Name tokens that mark a call as a subprocess/exec sink. A wrapper body whose
+/// call contains one of these is running a command; one that calls e.g.
+/// `array_len` / `discover_named_files` is a data accessor and its arg-vector is
+/// a path/key list, not a command. Kept generic (not git-specific) so any
+/// exec-wrapping helper qualifies.
+const EXEC_SINK_TOKENS: &[&str] = &[
+    "git", "run", "output", "command", "cmd", "exec", "spawn", "stdout", "capture", "shell",
+    "process", "invoke",
+];
+
+/// Whether a wrapper body passes its arg-vector to an exec sink.
+fn wraps_exec_sink(body: &str) -> bool {
+    static CALL_RE: std::sync::LazyLock<Regex> =
+        std::sync::LazyLock::new(|| Regex::new(r"([a-z_][a-z0-9_]*)\s*\(").unwrap());
+    CALL_RE.captures_iter(body).any(|c| {
+        let call = &c[1];
+        EXEC_SINK_TOKENS.iter().any(|tok| {
+            call == *tok
+                || call.starts_with(&format!("{tok}_"))
+                || call.ends_with(&format!("_{tok}"))
+                || call.contains(tok)
+        })
+    })
+}
+
+struct WrapperDef {
+    name: String,
+    file: String,
+    /// Byte offset of the arg-vector literal in the wrapper body, so we never
+    /// flag the wrapper's own definition.
+    argv_offset: usize,
+}
+
+fn detect_command_wrapper_bypass(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    // argvec-key -> canonical wrapper.
+    let mut wrappers: HashMap<Vec<String>, WrapperDef> = HashMap::new();
+
+    for fp in fingerprints {
+        if is_test_path(&fp.relative_path) {
+            continue;
+        }
+        for (name, body, body_offset) in thin_wrapper_bodies(&fp.content) {
+            // A thin wrapper's body contains exactly one arg-vector literal.
+            let matches: Vec<_> = argvec_regex().find_iter(&body).collect();
+            if matches.len() != 1 {
+                continue;
+            }
+            // The arg-vector must be passed to a subprocess/exec sink, not a
+            // data accessor. `array_len(v, &["aggregate","outcomes"])` reads a
+            // JSON path — that literal is not a command. Recognize exec sinks by
+            // name token so a JSON-path or config-key arg-vector never seeds the
+            // command-wrapper map.
+            if !wraps_exec_sink(&body) {
+                continue;
+            }
+            let m = matches[0];
+            let elems = argvec_elements(
+                argvec_regex()
+                    .captures(&body[m.start()..m.end()])
+                    .and_then(|c| c.get(1))
+                    .map(|g| g.as_str())
+                    .unwrap_or(""),
+            );
+            if elems.len() < MIN_ARGV_LEN {
+                continue;
+            }
+            wrappers.entry(elems).or_insert(WrapperDef {
+                name: name.clone(),
+                file: fp.relative_path.clone(),
+                argv_offset: body_offset + m.start(),
+            });
+        }
+    }
+
+    if wrappers.is_empty() {
+        return Vec::new();
+    }
+
+    let mut findings = Vec::new();
+    for fp in fingerprints {
+        if is_test_path(&fp.relative_path) {
+            continue;
+        }
+        for m in argvec_regex().find_iter(&fp.content) {
+            let inner = argvec_regex()
+                .captures(&fp.content[m.start()..m.end()])
+                .and_then(|c| c.get(1))
+                .map(|g| g.as_str())
+                .unwrap_or("");
+            let elems = argvec_elements(inner);
+            let Some(def) = wrappers.get(&elems) else {
+                continue;
+            };
+            // Never flag the wrapper's own arg-vector.
+            if fp.relative_path == def.file && m.start() == def.argv_offset {
+                continue;
+            }
+            let cmd = elems.join(" ");
+            findings.push(Finding {
+                convention: "command_wrapper_bypass".to_string(),
+                severity: Severity::Warning,
+                file: fp.relative_path.clone(),
+                description: format!(
+                    "Raw command `{}` duplicates helper `{}` (defined in {})",
+                    cmd, def.name, def.file
+                ),
+                suggestion: format!(
+                    "Call `{}` instead of assembling the raw argument vector; \
+                     the helper is the one place the command spelling is defined.",
+                    def.name
+                ),
+                kind: AuditFinding::CommandWrapperBypass,
+            });
+        }
+    }
+
+    findings.sort_by(|a, b| {
+        a.file
+            .cmp(&b.file)
+            .then_with(|| a.description.cmp(&b.description))
+    });
+    findings
+}
+
+/// Yield `(fn_name, body_text, body_start_offset)` for functions whose body is
+/// small enough to be a thin wrapper (few statements). Uses brace matching from
+/// each `fn` declaration; bounded to short bodies so we only consider genuine
+/// one-call wrappers, not large functions that happen to contain one arg-vector.
+fn thin_wrapper_bodies(content: &str) -> Vec<(String, String, usize)> {
+    /// Max characters in a wrapper body — a one-call delegation is tiny; this
+    /// keeps us from treating a large function's incidental arg-vector as the
+    /// canonical definition.
+    const MAX_BODY_CHARS: usize = 160;
+
+    let bytes = content.as_bytes();
+    let mut out = Vec::new();
+    for caps in fn_decl_regex().captures_iter(content) {
+        let name = caps[1].to_string();
+        let decl_end = caps.get(0).unwrap().end();
+        // Find the opening brace of the body after the signature.
+        let Some(brace_rel) = content[decl_end..].find('{') else {
+            continue;
+        };
+        let open = decl_end + brace_rel;
+        // Match to the closing brace.
+        let mut depth = 0i32;
+        let mut close = None;
+        for (i, &b) in bytes[open..].iter().enumerate() {
+            if b == b'{' {
+                depth += 1;
+            } else if b == b'}' {
+                depth -= 1;
+                if depth == 0 {
+                    close = Some(open + i);
+                    break;
+                }
+            }
+        }
+        let Some(close) = close else { continue };
+        let body_start = open + 1;
+        if close <= body_start {
+            continue;
+        }
+        let body = &content[body_start..close];
+        if body.len() > MAX_BODY_CHARS {
+            continue;
+        }
+        out.push((name, body.to_string(), body_start));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass/tests.rs
+++ b/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass/tests.rs
@@ -1,0 +1,88 @@
+use super::*;
+use crate::conventions::Language;
+
+fn fp(path: &str, content: &str) -> FileFingerprint {
+    FileFingerprint {
+        relative_path: path.to_string(),
+        language: Language::Rust,
+        content: content.to_string(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn flags_raw_argvector_that_bypasses_a_thin_wrapper() {
+    let helper = fp(
+        "src/git/primitives_query.rs",
+        "pub fn head_sha(git_root: &Path) -> Option<String> {\n    output_optional(git_root, &[\"rev-parse\", \"HEAD\"])\n}\n",
+    );
+    let user = fp(
+        "src/finalization/backend.rs",
+        "fn go(path: &str) {\n    let head = git_output(path, &[\"rev-parse\", \"HEAD\"])?;\n}\n",
+    );
+    let findings = detect_command_wrapper_bypass(&[&helper, &user]);
+    assert_eq!(findings.len(), 1, "one bypass in backend.rs");
+    assert_eq!(findings[0].kind, AuditFinding::CommandWrapperBypass);
+    assert_eq!(findings[0].file, "src/finalization/backend.rs");
+    assert!(findings[0].description.contains("head_sha"));
+    assert!(findings[0].description.contains("rev-parse HEAD"));
+}
+
+#[test]
+fn does_not_flag_the_wrapper_definition_itself() {
+    let helper = fp(
+        "src/git/primitives_query.rs",
+        "pub fn head_sha(git_root: &Path) -> Option<String> {\n    output_optional(git_root, &[\"rev-parse\", \"HEAD\"])\n}\n",
+    );
+    assert!(
+        detect_command_wrapper_bypass(&[&helper]).is_empty(),
+        "the wrapper's own arg-vector is not a bypass"
+    );
+}
+
+#[test]
+fn ignores_single_element_generic_commands() {
+    let helper = fp(
+        "src/git/x.rs",
+        "pub fn init_repo(p: &Path) -> Result<()> {\n    run(p, &[\"init\"])\n}\n",
+    );
+    let user = fp("src/y.rs", "fn f(p: &str) { run(p, &[\"init\"]); }");
+    assert!(
+        detect_command_wrapper_bypass(&[&helper, &user]).is_empty(),
+        "single-arg commands are too generic to attribute to one wrapper"
+    );
+}
+
+#[test]
+fn ignores_test_files() {
+    let helper = fp(
+        "src/git/x.rs",
+        "pub fn head_sha(p: &Path) -> Option<String> {\n    output_optional(p, &[\"rev-parse\", \"HEAD\"])\n}\n",
+    );
+    let test_site = fp(
+        "src/foo/tests.rs",
+        "fn t(p: &str) { let h = git(p, &[\"rev-parse\", \"HEAD\"]); }",
+    );
+    assert!(
+        detect_command_wrapper_bypass(&[&helper, &test_site]).is_empty(),
+        "raw arg-vectors inside test files are not flagged"
+    );
+}
+
+#[test]
+fn does_not_treat_a_dynamic_arg_wrapper_as_canonical() {
+    // `rev_parse(ref)` passes a NON-literal element, so it is not a fixed
+    // canonical command and must not seed the wrapper map.
+    let dynamic = fp(
+        "src/git/x.rs",
+        "pub fn rev_parse(root: &Path, git_ref: &str) -> Option<String> {\n    output_optional(root, &[\"rev-parse\", git_ref])\n}\n",
+    );
+    let user = fp(
+        "src/y.rs",
+        "fn f(p: &str) { let x = git(p, &[\"rev-parse\", \"HEAD\"]); }",
+    );
+    assert!(
+        detect_command_wrapper_bypass(&[&dynamic, &user]).is_empty(),
+        "a wrapper taking a dynamic arg is not a fixed-command canonical wrapper"
+    );
+}

--- a/crates/homeboy-code-audit/src/detectors/mod.rs
+++ b/crates/homeboy-code-audit/src/detectors/mod.rs
@@ -1,6 +1,7 @@
 pub(super) mod aggregate_construction;
 pub(super) mod artifact_portability;
 pub(super) mod command_status_contracts;
+pub(super) mod command_wrapper_bypass;
 pub(super) mod config_key_usage;
 pub(super) mod constant_bypass;
 pub(super) mod dead_guard;

--- a/crates/homeboy-code-audit/src/execution_plan.rs
+++ b/crates/homeboy-code-audit/src/execution_plan.rs
@@ -109,6 +109,7 @@ pub(crate) enum FingerprintDetectorRunner {
     FacadePassthrough,
     LiteralShapes,
     ConstantBypass,
+    CommandWrapperBypass,
     SharedScaffolding,
     AggregateConstruction,
 }
@@ -353,6 +354,15 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         timing_id: "detector.constant_bypass",
         log_label: "Constant bypass",
         log_summary: "literals duplicating a named constant",
+    },
+    DetectorDescriptor {
+        id: "command_wrapper_bypass",
+        findings: &[AuditFinding::CommandWrapperBypass],
+        access: DetectorAccess::Discovery,
+        runtime: DetectorRuntime::Fingerprint(FingerprintDetectorRunner::CommandWrapperBypass),
+        timing_id: "detector.command_wrapper_bypass",
+        log_label: "Command wrapper bypass",
+        log_summary: "raw commands duplicating a thin-wrapper helper",
     },
     DetectorDescriptor {
         id: "deprecation_age",


### PR DESCRIPTION
Closes #9236.

## The gap

The command-invocation analog of the constant-bypass detector (#9235). `homeboy_core::git::head_sha` is literally:

```rust
pub fn head_sha(git_root: &Path) -> Option<String> { output_optional(git_root, &["rev-parse", "HEAD"]) }
```

…yet **73+ non-test sites** hand-roll `git_output(path, &["rev-parse", "HEAD"])` and bypass it (plus `toplevel`, `current_branch`, `status_porcelain`, …). The command spelling drifts and can't be fixed in one place. This is also the structurally-detectable face of the "same value re-derived across 151 sites" churn.

## The detector

Builtin `CommandWrapperBypass`, **auto-discovering, no config**:

1. A "thin wrapper" = a module-level function whose body is a single call passing a **literal all-string arg-vector** to an **exec sink**. Record `argvec -> (helper, file)`.
2. Scan other sites passing the same literal arg-vector; flag them: *"raw command `git rev-parse HEAD` duplicates helper `head_sha` (defined in …); call the helper."*
3. Reads `FileFingerprint::content` directly — no fingerprint-model change.

Mirrors #9235 (discover the canonical thing, flag the raw copies), lifted from string *values* to command *arg-vectors*.

## Precision, tuned against the real repo

Two false-positive classes surfaced during validation and were closed:

- **Indented test helpers** (`fn head()` / `fn init_git_repository()` inside `#[cfg(test)] mod`) were seeding the map with git-setup arg-vectors. Fixed with a **module-level `^fn` anchor** — canonical wrappers are top-level; nested one-call helpers are test fixtures.
- **Data accessors** — `array_len(payload, &["aggregate","outcomes"])` passes a JSON *path*, not a command. Fixed with an **exec-sink guard**: the wrapped call must contain an exec name token (`git`/`run`/`output`/`command`/`exec`/…).

Plus: min arg-vector length 2 (single-arg commands too generic), test files skipped, the wrapper's own arg-vector never flagged.

## Validated

165 findings against this repo, **all genuine command bypasses**:

```
102x  git_revision       (rev-parse HEAD; itself duplicated across 2 files + head_sha)
 33x  status_porcelain
 13x  toplevel
  7x  git_dirty
  6x  current_branch
  2x  head_sha_short / stage_all
```

## Testing

- 5 unit tests: flags a real bypass, ignores the wrapper definition, ignores single-arg commands, skips test files, and does **not** treat a dynamic-arg wrapper (`rev_parse(git_ref)`) as a fixed-command canonical.
- **802 audit + 18 contract tests green**; `homeboy-refactor` compiles against the new finding kind.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Refined the re-derivation churn into a structurally-detectable command-bypass gap (#9236), built the auto-discovery detector mirroring #9235, and tuned two false-positive classes (test-helper wrappers, JSON-path accessors) from real-repo output down to 165 clean findings. Chris reviews and owns.