### PR TITLE
Bind controller job identity before Lab snapshot preacceptance

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1884,6 +1884,7 @@ pub(crate) fn reconcile_runner_job_snapshot(
             preserve_terminal_runner_identity(record, &event)?;
         }
     }
+    bind_pending_lab_handoff_snapshot(record, snapshot);
     validate_runner_job_snapshot(record, snapshot)?;
     let mut reconciled = record.clone();
     reconciled.record_runner_reachable();
@@ -2206,6 +2207,49 @@ fn validate_runner_job_snapshot(
         Some(record.run_id.clone()),
         None,
     ))
+}
+
+/// A daemon snapshot is acceptance evidence for a controller-owned pending
+/// handoff. Bind that identity before validating the snapshot so an absent
+/// controller field never becomes an empty-string comparison.
+fn bind_pending_lab_handoff_snapshot(
+    record: &mut AgentTaskRunRecord,
+    snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
+) {
+    if record.runner_job_id().is_some() {
+        return;
+    }
+    let Some(pending_handoff) = record
+        .lab_handoff
+        .as_ref()
+        .filter(|handoff| {
+            handoff.state == AgentTaskLabHandoffState::Pending
+                && handoff.authority == AgentTaskLabHandoffAuthority::Controller
+                && snapshot
+                    .job
+                    .target_runner_id
+                    .as_deref()
+                    .is_none_or(|runner_id| runner_id == handoff.runner_id)
+        })
+        .cloned()
+    else {
+        return;
+    };
+
+    let runner_job_id = snapshot.job.id.to_string();
+    let accepted_at = now_timestamp();
+    record.lab_handoff = Some(pending_handoff.accepted(&runner_job_id, accepted_at.clone()));
+    let metadata = record.ensure_metadata_object();
+    metadata.insert("runner_id".to_string(), json!(&pending_handoff.runner_id));
+    metadata.insert("runner_job_id".to_string(), json!(&runner_job_id));
+    metadata.insert(
+        "handoff_acceptance".to_string(),
+        json!({
+            "state": "accepted",
+            "accepted_at": accepted_at,
+            "runner_job_id": runner_job_id,
+        }),
+    );
 }
 
 fn validate_terminal_child_identity(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -458,6 +458,65 @@ fn detached_cook_attempt_proxy_advances_after_daemon_acceptance() {
 }
 
 #[test]
+fn preacceptance_snapshot_binds_the_accepted_daemon_job_before_validation() {
+    with_isolated_home(|_| {
+        let run_id = "cook-preacceptance-snapshot";
+        let plan = test_plan();
+        let mut record = record_lab_offload_phase(
+            run_id,
+            "homeboy-lab",
+            "lab_handoff_preacceptance",
+            Some("/runner/workspace/homeboy"),
+            None,
+            None,
+            Some(&plan),
+        )
+        .expect("persist pending controller handoff");
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
+        snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
+        snapshot.job.target_runner_id = Some("homeboy-lab".to_string());
+        snapshot.events.clear();
+
+        reconcile_transport_proxy_snapshot(&mut record, &snapshot)
+            .expect("accepted daemon snapshot binds before validation");
+
+        let accepted_job_id = snapshot.job.id.to_string();
+        assert_eq!(record.runner_job_id(), Some(accepted_job_id.as_str()));
+        assert_eq!(
+            record.lab_handoff.as_ref().expect("handoff").state,
+            AgentTaskLabHandoffState::Accepted
+        );
+        assert_eq!(record.metadata["handoff_acceptance"]["state"], "accepted");
+    });
+}
+
+#[test]
+fn preacceptance_snapshot_rejects_a_different_bound_daemon_job() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "cook-preacceptance-mismatch",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        })
+        .expect("persist accepted controller handoff");
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        snapshot.job.id =
+            uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000456").expect("snapshot job id");
+        snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
+        snapshot.events.clear();
+
+        let error = reconcile_transport_proxy_snapshot(&mut record, &snapshot)
+            .expect_err("different accepted daemon job fails closed");
+
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert!(error.message.contains("does not match controller job"));
+    });
+}
+
+#[test]
 fn missing_lab_attempt_plan_is_recovered_before_handoff_or_terminalized() {
     with_isolated_home(|_| {
         let run_id = "cook-8096-attempt-1";


### PR DESCRIPTION
## Summary

- bind an accepted daemon snapshot's job identity to a controller-authorized pending Lab handoff before snapshot validation
- retain fail-closed behavior when an already-bound non-empty job identity conflicts
- cover both preacceptance adoption and mismatch rejection through lifecycle reconciliation tests

Closes #9206.

## Root cause

Lab handoff preacceptance reconciled a daemon snapshot before the pending handoff had persisted its accepted runner job ID. Snapshot validation converted the absent controller identity to an empty string and rejected the real snapshot job as a mismatch before any provider executed.

The fix treats the first matching daemon snapshot as acceptance evidence only when the record has a controller-authorized pending handoff and the snapshot targets the expected runner. Existing accepted identities continue through the original strict comparison.

## How to test

1. Check out this branch and run `cargo fmt --check`.
2. Run `cargo test -p homeboy-agents preacceptance_snapshot -- --nocapture` and confirm both adoption and mismatch tests pass.
3. Run `cargo test -p homeboy-agents agent_task_lifecycle::tests::handoff_and_proxy -- --skip cook_lab_handoff_controller_reads_ignore_runner_plan_projection --test-threads=1` and confirm all 31 selected lifecycle tests pass.
4. With a connected Lab runner, start an `agent-task cook` against a clean managed worktree and confirm handoff advances beyond `lab_handoff_preacceptance` instead of comparing the snapshot job ID with an empty controller job ID.

## Compatibility

No CLI or serialized contract changes. Pending controller-owned handoffs now persist the runner job identity from matching daemon acceptance evidence. Records with an existing different job identity still fail closed.

## Test-suite note

`cook_lab_handoff_controller_reads_ignore_runner_plan_projection` currently fails identically on `main` because its missing-controller-plan expectation observes a completed aggregate. It does not execute the changed snapshot-binding path and is excluded from the scoped lifecycle command above.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.6 Sol and GPT-5.6 Terra)
- **Used for:** Diagnosed the Lab handoff failure, drafted the repair and regression tests, and reviewed the candidate with Chris Huber.
