### PR TITLE
Bind Lab snapshot job identity before validation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2023,6 +2023,7 @@ pub(crate) fn reconcile_transport_proxy_snapshot(
     record: &mut AgentTaskRunRecord,
     snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
 ) -> Result<()> {
+    bind_pending_lab_handoff_snapshot(record, snapshot)?;
     if record.state == AgentTaskRunState::Queued {
         set_run_state(record, AgentTaskRunState::Running);
         for task in &mut record.tasks {
@@ -2032,6 +2033,54 @@ pub(crate) fn reconcile_transport_proxy_snapshot(
         }
     }
     reconcile_runner_job_snapshot(record, snapshot)
+}
+
+/// A runner snapshot from the expected Lab is durable acceptance evidence when
+/// the controller has not yet recorded its child job ID. Bind that identity
+/// before validating the snapshot so the pre-acceptance handoff converges to
+/// the same state as an acknowledged daemon response.
+fn bind_pending_lab_handoff_snapshot(
+    record: &mut AgentTaskRunRecord,
+    snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
+) -> Result<()> {
+    if record.runner_job_id().is_some() {
+        return Ok(());
+    }
+    let Some(handoff) = record.lab_handoff.as_ref().filter(|handoff| {
+        handoff.state == AgentTaskLabHandoffState::Pending
+            && handoff.authority == AgentTaskLabHandoffAuthority::Controller
+    }) else {
+        return Ok(());
+    };
+    if snapshot.job.target_runner_id.as_deref() != Some(handoff.runner_id.as_str()) {
+        return Ok(());
+    }
+    let remote_workspace = record
+        .metadata
+        .get("remote_workspace")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let remote_command = record
+        .metadata
+        .get("remote_command")
+        .and_then(Value::as_array)
+        .map(|command| {
+            command
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    *record = record_detached_lab_run(DetachedLabRunRecord {
+        run_id: &record.run_id,
+        runner_id: &handoff.runner_id,
+        runner_job_id: &snapshot.job.id.to_string(),
+        remote_workspace: &remote_workspace,
+        remote_command: &remote_command,
+    })?;
+    Ok(())
 }
 
 fn is_transport_proxy(record: &AgentTaskRunRecord) -> bool {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -333,6 +333,66 @@ fn accepted_handoff_replays_idempotently_and_rejects_a_different_identity() {
 }
 
 #[test]
+fn runner_snapshot_binds_pending_lab_handoff_before_validation() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "snapshot-accepted-handoff",
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+            durable_plan: None,
+        })
+        .expect("pending controller handoff");
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
+        snapshot.job.target_runner_id = Some("homeboy-lab".to_string());
+        snapshot.events.clear();
+
+        reconcile_transport_proxy_snapshot(&mut record, &snapshot)
+            .expect("accepted runner snapshot binds the pending handoff");
+
+        assert_eq!(record.state, AgentTaskRunState::Running);
+        assert_eq!(
+            record.runner_job_id(),
+            Some("00000000-0000-0000-0000-000000000123")
+        );
+        assert_eq!(record.metadata["handoff_acceptance"]["state"], "accepted");
+        assert_eq!(
+            status("snapshot-accepted-handoff")
+                .expect("durable handoff")
+                .runner_job_id(),
+            Some("00000000-0000-0000-0000-000000000123")
+        );
+    });
+}
+
+#[test]
+fn runner_snapshot_rejects_conflicting_bound_lab_job_identity() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "snapshot-conflicting-handoff",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000456",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("accepted controller handoff");
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
+        snapshot.job.target_runner_id = Some("homeboy-lab".to_string());
+        snapshot.events.clear();
+
+        let error = reconcile_transport_proxy_snapshot(&mut record, &snapshot)
+            .expect_err("different runner snapshot job is rejected");
+
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert!(error.message.contains("does not match controller job"));
+    });
+}
+
+#[test]
 fn pending_handoff_rejects_acceptance_from_a_different_runner_without_mutation() {
     with_isolated_home(|_| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];


### PR DESCRIPTION
## Summary

- bind the accepted runner job identity when a pending controller-owned Lab handoff first observes its runner snapshot
- validate the bound snapshot through the existing identity checks
- retain fail-closed behavior for a genuinely conflicting non-empty job identity

Fixes https://github.com/Extra-Chill/homeboy/issues/9206

## How to test

1. Check out this branch.
2. Run `cargo fmt --check`.
3. Run `cargo test -p homeboy-agents runner_snapshot_ -- --test-threads=1`.
4. Confirm both `runner_snapshot_binds_pending_lab_handoff_before_validation` and `runner_snapshot_rejects_conflicting_bound_lab_job_identity` pass.

## Compatibility

No public command or configuration contract changes. Existing non-empty runner job identities remain authoritative and mismatches still fail closed. The new binding applies only to a controller-owned pending Lab handoff whose expected runner matches the snapshot target.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode and Homeboy
- **Used for:** Reproduced the Lab handoff failure and drafted the implementation and deterministic regression tests; Chris reviewed and owns the change.