### PR TITLE
ci: weekly full-tree audit debt sweep that files tracking issues

### DIFF
--- a/.github/workflows/audit-debt.yml
+++ b/.github/workflows/audit-debt.yml
@@ -1,0 +1,80 @@
+# Full-tree audit debt sweep.
+#
+# The PR pipeline (ci.yml) runs a `--profile=pr --changed-since` audit: fast,
+# scoped to the diff, and it only runs the cheap RootOnly detector families.
+# The whole-tree discovery detectors (duplication, dead code, constant/command
+# bypass, god files, …) are deliberately OFF in the PR profile — they need the
+# entire codebase to work and would re-report repo-wide debt on every unrelated
+# PR.
+#
+# Those discovery detectors are the "code factory" roadmap: each finding kind
+# becomes one deduplicated tracking issue (via homeboy-action's auto-issue
+# filing), and the issue closes when that fix kind gets automated. Nothing was
+# ever running the full-tree audit, so that roadmap was never populated. This
+# workflow does — on a weekly cadence, decoupled from releases so a full audit
+# never taxes the release path — and files/refreshes one issue per finding kind.
+#
+# It is advisory only: it never blocks anything (there is no gate), it just
+# keeps the audit-debt issue set current.
+
+name: Audit Debt
+
+on:
+  schedule:
+    # Mondays 07:00 UTC — once a week is plenty for slow-moving structural debt.
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: 'Audit profile to run (full = all discovery detectors).'
+        required: false
+        default: 'full'
+
+concurrency:
+  group: audit-debt
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  full-audit:
+    name: Full-tree audit → tracking issues
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check out Homeboy Action
+        uses: actions/checkout@v6
+        with:
+          repository: Extra-Chill/homeboy-action
+          ref: v2
+          path: .homeboy-action
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
+
+      - uses: ./.homeboy-action
+        with:
+          source: .
+          component: homeboy
+          commands: review audit
+          # Full profile enables the whole-tree discovery detectors. No
+          # --changed-since: this is a deliberate repo-wide sweep.
+          args: --profile=${{ github.event.inputs.profile || 'full' }}
+          # File one deduplicated tracking issue per finding kind. The action
+          # auto-enables this on non-PR events, but set it explicitly so the
+          # intent of this workflow is unambiguous.
+          auto-issue: 'true'
+          # Advisory sweep — never autofix, never push. Findings become the
+          # roadmap; fixes land through their own reviewed PRs.
+          autofix: 'false'
+          app-token: ${{ steps.app-token.outputs.token || '' }}


### PR DESCRIPTION
## Why

You asked whether the new detectors' findings auto-file as tracking issues from main. I traced the pipeline: **they don't — and neither do any of the existing whole-tree discovery detectors.** It's **not a regression**; it's an unbuilt piece.

- The PR pipeline (`ci.yml`) / release gate run `--profile=pr --changed-since`. The PR profile (`execution_plan.rs::includes_detector`) deliberately runs only the cheap `RootOnly` families (`structural`, `layer_ownership`, `test_topology`, …). The **whole-tree discovery detectors** — `duplication` (skeleton lives here), `dead_code`, `constant_bypass`, `command_wrapper_bypass`, god files — are **OFF in PR mode by design** (test: `pr_profile_uses_root_only_detector_families`). They need the entire codebase and would re-report repo-wide debt on every unrelated PR.
- `homeboy-action` **already** files one deduplicated tracking issue per audit finding kind on non-PR events (`scripts/issues/auto-file-categorized-issues.sh` — the "code factory" pattern: a finding kind's issue closes when its fix gets automated).
- **But nothing ever runs the full-tree audit**, so the discovery detectors produce zero findings to file. `gh issue list` for `duplicate`/`god_file` kinds confirms: empty.

## What

A dedicated **weekly** workflow (`audit-debt.yml`) that runs `review audit --profile=full` through `homeboy-action@v2` with auto-issue filing. Mirrors the proven `ci.yml` invocation pattern (checkout → checkout action → app-token → `uses: ./.homeboy-action`, `source: .`).

Deliberate choices, per your call-outs:
- **Separate from the release workflow** — a full-tree audit is expensive and its weekly cadence is unrelated to releases; coupling it would tax every release.
- **Advisory only** — no gate, `autofix: false`. It just keeps the audit-debt issue set current; fixes land through their own reviewed PRs.
- **Deduplicated** — the action updates the count on the existing per-kind issue rather than spamming.

## Effect

Activates the **entire** discovery-detector family, not just my three new ones — the pre-existing `duplication` / `dead_code` / god-file debt starts getting tracked too. My session's detectors (skeleton-duplicate ~261, constant-bypass ~273, command-wrapper-bypass ~165) become the first wave of tracked, deduplicated roadmap issues.

## Verification

- YAML validated (`yaml.safe_load`).
- Confirmed `commands: review audit` overrides the cron→`release` default (`resolve-commands.sh` guards `if [ -n COMMANDS_INPUT ]`).
- Confirmed `auto-issue: 'true'` satisfies the action's Phase 8 filing condition on a `schedule` event.
- All three new finding kinds are in the `AuditFinding` taxonomy, so the categorized-issues script groups them.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Traced why discovery-detector findings weren't auto-filing (PR-profile scoping is intentional; the full-tree sweep was never wired), studied homeboy-action's auto-issue mechanism, and built the decoupled weekly workflow. Chris reviews and owns.