### PR TITLE
fix(lab-runner): scope synthetic snapshot cleanliness check to source paths

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/provenance.rs
+++ b/crates/homeboy-lab-runner/src/workspace/provenance.rs
@@ -329,9 +329,24 @@ fn verify_synthetic_snapshot_git_baseline(
     if git(workspace, &["rev-parse", SYNTHETIC_SNAPSHOT_BASELINE_REF])? != head {
         return Err("synthetic snapshot baseline ref does not match HEAD".to_string());
     }
+    // The synthetic baseline commits only the source content: reserved runner
+    // bookkeeping and @file paths are deliberately excluded from the staged tree
+    // (see `materialize_verified_lab_snapshot_git_baseline`). Scope the
+    // cleanliness check to the same paths so those excluded, still-present files
+    // are not reclassified as untracked dirt. This mirrors the exclusions used
+    // by `verify_materialized_snapshot_git_checkout` and
+    // `verify_exact_snapshot_git_checkout`.
     if !git(
         workspace,
-        &["status", "--porcelain", "--untracked-files=all"],
+        &[
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+            "--",
+            SYNTHETIC_BASELINE_PATHS[0],
+            SYNTHETIC_BASELINE_PATHS[1],
+            SYNTHETIC_BASELINE_PATHS[2],
+        ],
     )?
     .is_empty()
     {
@@ -1374,6 +1389,65 @@ mod tests {
                 "provider edit\n"
             );
         }
+    }
+
+    #[test]
+    fn verify_synthetic_baseline_ignores_reserved_runner_files() {
+        // The synthetic baseline excludes reserved runner bookkeeping from its
+        // committed tree, so those files remain present but untracked in the
+        // working tree. The baseline verifier must not reclassify them as dirt,
+        // otherwise the committed-change harvest fails with "synthetic snapshot
+        // Git workspace is not clean" even though the source content is pristine.
+        let workspace = tempfile::tempdir().expect("runner workspace");
+        std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");
+        std::fs::create_dir_all(workspace.path().join(".homeboy"))
+            .expect("runner metadata directory");
+        std::fs::write(
+            workspace.path().join(".homeboy/runner-workspace.json"),
+            "runner-owned metadata\n",
+        )
+        .expect("runner metadata");
+        std::fs::create_dir_all(workspace.path().join(".homeboy/lab-at-files"))
+            .expect("lab @file directory");
+        std::fs::write(
+            workspace.path().join(".homeboy/lab-at-files/handoff.json"),
+            "at-file payload\n",
+        )
+        .expect("lab @file payload");
+
+        let snapshot = snapshot(workspace.path());
+        let lab = lab(workspace.path(), &snapshot);
+        materialize_verified_lab_snapshot_git_baseline(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot.clone(),
+            lab.clone(),
+        )
+        .expect("synthetic baseline");
+
+        // Reserved files remain on disk but excluded from the baseline tree.
+        assert!(workspace
+            .path()
+            .join(".homeboy/runner-workspace.json")
+            .exists());
+        assert!(
+            !git(workspace.path(), &["ls-tree", "-r", "--name-only", "HEAD"])
+                .expect("baseline tree")
+                .contains(".homeboy/runner-workspace.json")
+        );
+
+        let provenance = verify_lab_workspace(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot,
+            lab,
+        )
+        .expect("verify provenance");
+
+        // The harvest provenance check must succeed despite the untracked
+        // reserved runner files.
+        verify_lab_workspace_git_root(workspace.path(), &provenance)
+            .expect("synthetic baseline verifies as clean with reserved runner files present");
     }
 
     #[derive(Clone)]


### PR DESCRIPTION
## Summary
- Fixes the `detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once` failure on `main` (the deepest of three layered breaks — see context below).
- The Lab-offload committed-change harvest failed with `synthetic snapshot Git workspace is not clean` even when the source was pristine, aborting the cook with `agent_task.committed_harvest_git_failed`.

## Root cause
`materialize_verified_lab_snapshot_git_baseline` deliberately **excludes** reserved runner bookkeeping (`.homeboy/runner-workspace.json`, `.homeboy/lab-at-files/**`) from the synthetic baseline's committed tree (`SYNTHETIC_BASELINE_PATHS`). Those files stay present but untracked in the working tree.

But `verify_synthetic_snapshot_git_baseline` checked cleanliness with an **unscoped** `git status --porcelain --untracked-files=all`, so it reclassified the excluded reserved files as untracked dirt and rejected the baseline.

The two sibling verifiers (`verify_materialized_snapshot_git_checkout`, `verify_exact_snapshot_git_checkout`) already scope their status checks to the same paths — this one was simply missing the exclusions.

## Fix
Scope the cleanliness check to `SYNTHETIC_BASELINE_PATHS`, matching the siblings.

## Testing
- New regression test `verify_synthetic_baseline_ignores_reserved_runner_files`: materializes a baseline with reserved runner files present and asserts the verifier accepts it. **Proven to fail** against the original unscoped check with the exact production error `"synthetic snapshot Git workspace is not clean"`, and passes with the fix.
- Full `workspace::provenance::tests` module run: all pass except one pre-existing, unrelated failure (`filesystem_snapshot_dispatches_providers_and_harvests_only_changed_candidates` — fails identically on clean `origin/main` with `agent_task.controller_scratch_allocation_failed: run record not found`, a separate scheduler-test issue, not touched here).
- `cargo fmt` clean.

## Context: this is the 3rd of three layered breaks on main
1. #9214 (merged) — git identity missing in fixture helpers; the reverse-cook test died at `git commit` setup, masking everything downstream.
2. #9225 (merged) — `VerifyGateOptions` missing-fields E0063 compile break from #9212.
3. **This PR** — with the git-identity fix in place, the test finally runs the cook and exposes this pre-existing harvest cleanliness bug.