### PR TITLE
Ignore runner-owned metadata during committed harvest preflight

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 
 use sha2::{Digest, Sha256};
 
-use super::harvest::{git_is_repository, git_output_raw, git_output_with_env};
+use super::harvest::{
+    git_is_repository, git_output_raw, git_output_with_env, git_status_ignoring_runner_metadata,
+    RUNNER_METADATA_EXCLUDE_PATHSPECS,
+};
 use super::*;
 
 /// Immutable provenance for one scheduler execution. Controller-local callers
@@ -107,7 +110,7 @@ impl AttemptWorkspace {
         // source-state guard decides whether the worktree itself is removable.
         homeboy_core::cleanup::cleanup_worktree_artifacts(&self.root)
             .map_err(|error| format!("cannot cleanup rebuildable artifacts: {}", error.message))?;
-        let status = git_output(&self.root, &["status", "--porcelain=v1"])
+        let status = git_status_ignoring_runner_metadata(&self.root)
             .map_err(|error| format!("cannot inspect attempt workspace state: {error:?}"))?;
         if !status.trim().is_empty() {
             return Err("attempt workspace has uncommitted changes".to_string());
@@ -272,7 +275,7 @@ pub(super) fn prepare_committed_harvest(
             message: "Git top-level does not exactly match the managed workspace root".to_string(),
         });
     }
-    let status = git_output(root, &["status", "--porcelain", "--untracked-files=all"])?;
+    let status = git_status_ignoring_runner_metadata(root)?;
     let candidate_baseline = if status.trim().is_empty() {
         None
     } else if let Some(baseline) = verified_initial_cook_candidate_baseline(root, request)? {
@@ -336,7 +339,9 @@ fn verified_initial_cook_candidate_baseline(
     let index_path = index.path().display().to_string();
     let index_env: &[(&str, &str)] = &[("GIT_INDEX_FILE", index_path.as_str())];
     git_output_with_env(root, &["read-tree", "HEAD"], index_env)?;
-    git_output_with_env(root, &["add", "--all"], index_env)?;
+    let mut add_args = vec!["add", "--all", "--", "."];
+    add_args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
+    git_output_with_env(root, &add_args, index_env)?;
     let actual_tree = git_output_with_env(root, &["write-tree"], index_env)?;
     if actual_tree != expected_tree {
         return Err(HarvestError::CandidateBaselineMismatch {
@@ -426,7 +431,9 @@ fn workspace_patch_for_tree(root: &Path, expected_tree: &str) -> Result<String, 
     };
     let head = git(&["rev-parse", "HEAD"])?;
     git(&["read-tree", &head])?;
-    git(&["add", "--all"])?;
+    let mut add_args = vec!["add", "--all", "--", "."];
+    add_args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
+    git(&add_args)?;
     let tree = git(&["write-tree"])?;
     if tree != expected_tree {
         return Err(HarvestError::CandidateBaselineMismatch {
@@ -504,7 +511,7 @@ fn validate_derived_cook_baseline(
             "derived baseline capability does not bind this workspace and task".to_string(),
         ));
     }
-    let status = git_output(root, &["status", "--porcelain", "--untracked-files=all"])?;
+    let status = git_status_ignoring_runner_metadata(root)?;
     if !status.is_empty() {
         return Err(HarvestError::DirtyWorkspace { status });
     }
@@ -869,7 +876,15 @@ mod tests {
         );
         fs::write(source.path().join("tracked.txt"), "candidate").expect("candidate file");
         fs::write(source.path().join("untracked.txt"), "candidate").expect("untracked file");
-        git(source.path(), &["add", "--all"]);
+        fs::create_dir_all(source.path().join(".homeboy/lab-at-files"))
+            .expect("runner metadata directory");
+        fs::write(source.path().join(".homeboy/runner-workspace.json"), "{}")
+            .expect("runner workspace metadata");
+        fs::write(source.path().join(".homeboy/lab-at-files/plan.json"), "{}")
+            .expect("Lab input metadata");
+        let mut add_args = vec!["add", "--all", "--", "."];
+        add_args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
+        git(source.path(), &add_args);
         let tree = git_output(source.path(), &["write-tree"]).expect("candidate tree");
         git(source.path(), &["reset", "--mixed", "HEAD"]);
 
@@ -877,6 +892,56 @@ mod tests {
 
         assert!(patch.contains("tracked.txt"));
         assert!(patch.contains("untracked.txt"));
+        assert!(!patch.contains("runner-workspace.json"));
+        assert!(!patch.contains("lab-at-files"));
+    }
+
+    #[test]
+    fn runner_metadata_is_clean_but_unrelated_untracked_files_are_not() {
+        let workspace = tempfile::tempdir().expect("workspace repository");
+        git(workspace.path(), &["init", "-b", "main"]);
+        fs::write(workspace.path().join("tracked.txt"), "base").expect("base file");
+        git(workspace.path(), &["add", "tracked.txt"]);
+        git(
+            workspace.path(),
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=homeboy@example.test",
+                "commit",
+                "-m",
+                "initial",
+            ],
+        );
+        fs::create_dir_all(workspace.path().join(".homeboy/lab-at-files"))
+            .expect("runner metadata directory");
+        fs::write(
+            workspace.path().join(".homeboy/runner-workspace.json"),
+            "{}",
+        )
+        .expect("runner workspace metadata");
+        fs::write(
+            workspace.path().join(".homeboy/lab-at-files/plan.json"),
+            "{}",
+        )
+        .expect("Lab input metadata");
+
+        assert!(
+            git_status_ignoring_runner_metadata(workspace.path())
+                .expect("runner metadata status")
+                .is_empty(),
+            "runner-owned metadata must not make a candidate workspace dirty"
+        );
+
+        fs::write(workspace.path().join("user-output.txt"), "candidate")
+            .expect("unrelated untracked file");
+        let status = git_status_ignoring_runner_metadata(workspace.path())
+            .expect("candidate workspace status");
+        assert!(
+            status.contains("user-output.txt"),
+            "unrelated untracked files must still fail the cleanliness check: {status}"
+        );
     }
 
     fn git(cwd: &Path, args: &[&str]) {

--- a/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
@@ -10,7 +10,7 @@ use super::*;
 /// scratch under `.homeboy/`) after the snapshot baseline is established, so it
 /// is checkout drift rather than provider output — including it produces a patch
 /// that deletes/rewrites runner metadata and cannot be promoted cleanly. (#8534)
-const HARVEST_METADATA_EXCLUDE_PATHSPECS: &[&str] = &[
+pub(super) const RUNNER_METADATA_EXCLUDE_PATHSPECS: &[&str] = &[
     ":(exclude).homeboy/runner-workspace.json",
     ":(exclude).homeboy/lab-at-files/**",
 ];
@@ -47,8 +47,8 @@ pub(super) fn harvest_uncommitted_patch(
             "--all",
             "--",
             ".",
-            HARVEST_METADATA_EXCLUDE_PATHSPECS[0],
-            HARVEST_METADATA_EXCLUDE_PATHSPECS[1],
+            RUNNER_METADATA_EXCLUDE_PATHSPECS[0],
+            RUNNER_METADATA_EXCLUDE_PATHSPECS[1],
         ],
     )?;
     let mut uncommitted_patch_args = vec![
@@ -61,13 +61,13 @@ pub(super) fn harvest_uncommitted_patch(
         "--",
         ".",
     ];
-    uncommitted_patch_args.extend_from_slice(HARVEST_METADATA_EXCLUDE_PATHSPECS);
+    uncommitted_patch_args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
     let patch = git_output_raw(root, &uncommitted_patch_args)?;
     if patch.trim().is_empty() {
         return Ok(());
     }
     let mut uncommitted_changed_args = vec!["diff", "--cached", "--name-only", "HEAD", "--", "."];
-    uncommitted_changed_args.extend_from_slice(HARVEST_METADATA_EXCLUDE_PATHSPECS);
+    uncommitted_changed_args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
     let changed_files = git_changed_files(root, &uncommitted_changed_args)?;
     let path = attempt_patch_path(running, "uncommitted")?;
     std::fs::write(&path, patch.as_bytes()).map_err(|error| HarvestError::ArtifactWrite {
@@ -240,7 +240,7 @@ fn harvest_committed_patch_with_metadata(
         "--",
         ".",
     ];
-    committed_patch_args.extend_from_slice(HARVEST_METADATA_EXCLUDE_PATHSPECS);
+    committed_patch_args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
     let patch = git_output_raw(root, &committed_patch_args)?;
     if patch.trim().is_empty() {
         return Ok(());
@@ -263,7 +263,7 @@ fn harvest_committed_patch_with_metadata(
     ));
     let commits = collect_metadata(root, &range)?;
     let mut committed_changed_args = vec!["diff", "--name-only", base, "HEAD", "--", "."];
-    committed_changed_args.extend_from_slice(HARVEST_METADATA_EXCLUDE_PATHSPECS);
+    committed_changed_args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
     let changed_files = git_changed_files(root, &committed_changed_args)?;
     outcome
         .artifacts
@@ -420,6 +420,19 @@ pub(super) fn git_is_repository(cwd: &Path) -> Result<bool, HarvestError> {
             message: error.to_string(),
         })?;
     Ok(output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "true")
+}
+
+/// Report workspace changes while excluding state injected by Homeboy's runner.
+pub(super) fn git_status_ignoring_runner_metadata(cwd: &Path) -> Result<String, HarvestError> {
+    let mut args = vec![
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+        "--",
+        ".",
+    ];
+    args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
+    git_output(cwd, &args)
 }
 
 pub(crate) fn git_output(cwd: &Path, args: &[&str]) -> Result<String, HarvestError> {


### PR DESCRIPTION
## Summary

- centralize Homeboy-owned runner metadata pathspec exclusions
- apply them consistently to committed-harvest preflight and candidate tree verification
- preserve fail-closed handling for unrelated user changes

Closes #9239.

## How to test

1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-agents agent_task_scheduler::attempt_workspace::tests`.
3. Confirm the four focused tests pass, including metadata-only cleanliness and unrelated-untracked-file rejection.
4. Run `git diff --check`.

## Evidence

- `cargo fmt --check` passed.
- Four focused scheduler tests passed.
- `git diff --check` passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode and Homeboy
- **Used for:** Reproduced the Lab harvest failure, implemented shared metadata exclusions and fail-closed regression coverage, and verified the candidate with Chris.