### PR TITLE
Preserve gate feedback baseline after promotion failure

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -607,8 +607,8 @@ pub(super) fn promote_with_provider_and_checkpoint(
         options.to_worktree.clone(),
         applied_worktree_path.as_deref(),
     );
-    if let Some(worktree_path) = applied_worktree_path.as_deref() {
-        checkpoint(&post_apply_report(
+    let post_apply = if let Some(worktree_path) = applied_worktree_path.as_deref() {
+        let report = post_apply_report(
             &options,
             &source_kind,
             &outcome,
@@ -624,8 +624,12 @@ pub(super) fn promote_with_provider_and_checkpoint(
             worktree_path,
             &outcome.schema,
             artifact.metadata.clone(),
-        )?)?;
-    }
+        )?;
+        checkpoint(&report)?;
+        Some(report)
+    } else {
+        None
+    };
     let verified_base = if let Some(worktree_path) = applied_worktree_path.as_deref() {
         let verified_base = capture_declared_base(worktree_path, options.base_ref.as_deref())?;
         (
@@ -637,16 +641,15 @@ pub(super) fn promote_with_provider_and_checkpoint(
     };
     let (gates, verified_base) = verified_base;
     let operator_notification = promotion_notification(gates.status, &target);
-    let candidate = if gates.status.patch_promoted() {
-        applied_worktree_path
-            .as_deref()
-            .map(|path| {
-                crate::agent_task_promotion::candidate_fingerprint(&path.display().to_string())
-            })
-            .transpose()?
-    } else {
-        None
-    };
+    // Gates can create incidental files. Feedback must retain the identity that
+    // was captured immediately after applying the provider candidate.
+    let candidate = post_apply
+        .as_ref()
+        .and_then(|report| report.provenance.get("candidate").cloned())
+        .and_then(|value| serde_json::from_value(value).ok());
+    let gate_feedback_baseline = post_apply
+        .as_ref()
+        .and_then(|report| report.provenance.get("gate_feedback_baseline").cloned());
 
     Ok(AgentTaskPromotionReport {
         schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
@@ -673,6 +676,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
             "candidate": candidate,
             "destination_baseline": candidate,
             "prior_baseline": promotion_chain_baseline,
+            "gate_feedback_baseline": gate_feedback_baseline,
         }),
         operator_notification,
     })
@@ -1020,8 +1024,8 @@ fn promote_committed_changes(
         options.to_worktree.clone(),
         applied_worktree_path.as_deref(),
     );
-    if let Some(path) = applied_worktree_path.as_deref() {
-        checkpoint(&post_apply_report(
+    let post_apply = if let Some(path) = applied_worktree_path.as_deref() {
+        let report = post_apply_report(
             options,
             source_kind,
             outcome,
@@ -1039,8 +1043,12 @@ fn promote_committed_changes(
             artifact
                 .map(|artifact| artifact.metadata.clone())
                 .unwrap_or(Value::Null),
-        )?)?;
-    }
+        )?;
+        checkpoint(&report)?;
+        Some(report)
+    } else {
+        None
+    };
     let verified_base = if let Some(path) = applied_worktree_path.as_deref() {
         let verified_base = capture_declared_base(path, options.base_ref.as_deref())?;
         (run_promotion_gates(options, provider, path)?, verified_base)
@@ -1049,16 +1057,13 @@ fn promote_committed_changes(
     };
     let (gates, verified_base) = verified_base;
     let operator_notification = promotion_notification(gates.status, &target);
-    let candidate = if gates.status == AgentTaskPromotionStatus::Applied {
-        applied_worktree_path
-            .as_deref()
-            .map(|path| {
-                crate::agent_task_promotion::candidate_fingerprint(&path.display().to_string())
-            })
-            .transpose()?
-    } else {
-        None
-    };
+    let candidate = post_apply
+        .as_ref()
+        .and_then(|report| report.provenance.get("candidate").cloned())
+        .and_then(|value| serde_json::from_value(value).ok());
+    let gate_feedback_baseline = post_apply
+        .as_ref()
+        .and_then(|report| report.provenance.get("gate_feedback_baseline").cloned());
 
     Ok(AgentTaskPromotionReport {
         schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
@@ -1088,6 +1093,7 @@ fn promote_committed_changes(
             "commits": committed_patch.commits,
             "candidate": candidate,
             "destination_baseline": candidate,
+            "gate_feedback_baseline": gate_feedback_baseline,
         }),
         operator_notification,
     })
@@ -1399,6 +1405,13 @@ fn post_apply_report(
     let candidate =
         crate::agent_task_promotion::candidate_fingerprint(&worktree_path.display().to_string())
             .ok();
+    let gate_feedback_baseline = match candidate.as_ref() {
+        Some(crate::agent_task_promotion::AgentTaskPromotionCandidate::Git { .. }) => Some(json!({
+            "schema": "homeboy/agent-task-gate-feedback-baseline/v1",
+            "current_diff": candidate_current_diff(worktree_path)?,
+        })),
+        _ => None,
+    };
     // A base observation is recorded when the target can reach its remote. The
     // post-apply checkpoint must still survive a transient remote failure so it
     // can protect the already-applied candidate for recovery.
@@ -1425,6 +1438,7 @@ fn post_apply_report(
             "post_apply": true,
             "candidate": candidate,
             "destination_baseline": candidate,
+            "gate_feedback_baseline": gate_feedback_baseline,
             "resume_inputs": {
                 "base_ref": options.base_ref,
                 "task_base_sha": options.task_base_sha,
@@ -1433,6 +1447,42 @@ fn post_apply_report(
         }),
         operator_notification,
     })
+}
+
+/// Capture the complete candidate delta without changing the destination index.
+fn candidate_current_diff(worktree_path: &Path) -> Result<String> {
+    let index = tempfile::NamedTempFile::new().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("create gate-feedback candidate index".to_string()),
+        )
+    })?;
+    let index_path = index.path().display().to_string();
+    for arguments in [vec!["read-tree", "HEAD"], vec!["add", "--all"]] {
+        let output = Command::new("git")
+            .args(arguments)
+            .env("GIT_INDEX_FILE", &index_path)
+            .current_dir(worktree_path)
+            .output()
+            .map_err(|error| Error::git_command_failed(error.to_string()))?;
+        if !output.status.success() {
+            return Err(Error::git_command_failed(
+                String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            ));
+        }
+    }
+    let output = Command::new("git")
+        .args(["diff", "--cached", "--binary", "--full-index", "HEAD"])
+        .env("GIT_INDEX_FILE", index_path)
+        .current_dir(worktree_path)
+        .output()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    if !output.status.success() {
+        return Err(Error::git_command_failed(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 fn persisted_changed_files(

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -865,6 +865,84 @@ fn explicit_candidate_gate_failure_is_recorded_after_normal_promotion_handoff() 
 }
 
 #[test]
+fn gate_failure_preserves_the_pre_gate_candidate_baseline_for_feedback_retry() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir(&workspace).expect("workspace");
+    git(&workspace, &["init", "-b", "main"]);
+    git(&workspace, &["config", "user.email", "test@example.com"]);
+    git(&workspace, &["config", "user.name", "Homeboy Test"]);
+    std::fs::create_dir_all(workspace.join("src")).expect("source directory");
+    std::fs::write(workspace.join("src/lib.rs"), "old\n").expect("base file");
+    git(&workspace, &["add", "."]);
+    git(&workspace, &["commit", "-m", "base"]);
+    let (source_path, source) = write_patch_source(&temp);
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(workspace.clone()),
+        apply_to_git: true,
+        verify_exit_code: 1,
+        ..Default::default()
+    };
+    let mut checkpoint = None;
+    let report = promote_with_provider_and_checkpoint(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("gate-failure-run".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            candidate_ref: None,
+            to_worktree: "fixture@target".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["failing-gate".to_string()],
+                ..Default::default()
+            },
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+        &mut |saved| {
+            checkpoint = Some(saved.clone());
+            Ok(())
+        },
+    )
+    .expect("gate failure is durable promotion evidence");
+
+    assert_eq!(report.status, AgentTaskPromotionStatus::GateFailed);
+    let baseline = report.provenance["gate_feedback_baseline"].clone();
+    assert_eq!(
+        checkpoint.expect("post-apply checkpoint").provenance["gate_feedback_baseline"],
+        baseline
+    );
+    assert!(baseline["current_diff"]
+        .as_str()
+        .is_some_and(|diff| !diff.is_empty()));
+
+    let feedback_baseline = serde_json::json!({
+        "current_diff": baseline["current_diff"],
+        "patch_artifact": report.patch_artifact,
+    });
+    crate::agent_task_candidate_baseline::validate_gate_feedback_candidate_baseline(
+        &workspace,
+        &feedback_baseline,
+    )
+    .expect("exactly matching applied candidate is safe to retry");
+
+    std::fs::write(workspace.join("unrelated.txt"), "drift\n").expect("divergent dirt");
+    assert!(
+        crate::agent_task_candidate_baseline::validate_gate_feedback_candidate_baseline(
+            &workspace,
+            &feedback_baseline,
+        )
+        .is_err()
+    );
+}
+
+#[test]
 fn provider_failure_surfaces_bounded_stdout_and_stderr_evidence() {
     let request = AgentTaskPromotionApplyRequest {
         schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -46,6 +46,17 @@ use super::cook_promotion::{
 use super::execution::run_loaded_plan_with_derived_cook_baseline;
 use super::AgentTaskRunResult;
 
+/// The promotion checkpoint captures this before gates run, when it is the only
+/// complete authorization for reusing the dirty managed destination.
+fn gate_feedback_current_diff(promotion: &AgentTaskPromotionReport) -> String {
+    promotion
+        .provenance
+        .pointer("/gate_feedback_baseline/current_diff")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
 /// Executes one provider attempt while cook retains ownership of promotion,
 /// gates, retries, and finalization.
 pub trait AgentTaskCookAttemptDispatcher: Send + Sync + std::fmt::Debug {
@@ -416,7 +427,7 @@ fn adopt_cook_candidate_with_dispatcher_and_backend<B: AgentTaskPrFinalizationBa
         attempt: 1,
         max_attempts: options.max_attempts,
         source_run_id: Some(record.run_id.clone()),
-        current_diff: String::new(),
+        current_diff: gate_feedback_current_diff(&promotion),
         metadata: serde_json::json!({"adopted_candidate_ref": candidate_ref}),
     });
     let attempt = AgentTaskCookAttemptReport {
@@ -1217,7 +1228,7 @@ where
             attempt,
             max_attempts,
             source_run_id: Some(run_id.clone()),
-            current_diff: String::new(),
+            current_diff: gate_feedback_current_diff(&promotion),
             metadata: Value::Null,
         });
         let feedback_status = feedback.status;

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -548,6 +548,13 @@ pub(crate) fn gate_feedback(args: GateFeedbackArgs) -> CmdResult<Value> {
         .as_deref()
         .map(config::read_json_spec_to_string)
         .transpose()?
+        .or_else(|| {
+            promotion_report
+                .provenance
+                .pointer("/gate_feedback_baseline/current_diff")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
         .unwrap_or_default();
     let report = evaluate_cook_loop(AgentTaskCookLoopOptions {
         source_request,


### PR DESCRIPTION
## Summary

- checkpoint the complete promoted candidate identity before deterministic gates run
- preserve the candidate diff and baseline when gates fail
- expose the durable baseline to Cook retries and `agent-task gate-feedback`

Closes #9204.

## How to test

1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-agents gate_failure_preserves_the_pre_gate_candidate_baseline_for_feedback_retry --lib`.
3. Confirm the focused regression passes.

## Evidence

- `cargo fmt --check` passed.
- The focused gate-feedback baseline regression passed after rebasing onto current `main`.
- The broader `homeboy-agents` suite was started during candidate preparation but exceeded five minutes in unrelated long-running lifecycle tests; no failures were observed before timeout.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode and Homeboy
- **Used for:** Diagnosed the stranded promotion lifecycle, implemented the durable baseline repair and regression coverage, and verified the final candidate with Chris.