### PR TITLE
fix(agents): remove duplicate Lab snapshot binder

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2148,7 +2148,6 @@ pub(crate) fn reconcile_runner_job_snapshot(
             preserve_terminal_runner_identity(record, &event)?;
         }
     }
-    bind_pending_lab_handoff_snapshot(record, snapshot);
     validate_runner_job_snapshot(record, snapshot)?;
     let mut reconciled = record.clone();
     reconciled.record_runner_reachable();
@@ -2471,49 +2470,6 @@ fn validate_runner_job_snapshot(
         Some(record.run_id.clone()),
         None,
     ))
-}
-
-/// A daemon snapshot is acceptance evidence for a controller-owned pending
-/// handoff. Bind that identity before validating the snapshot so an absent
-/// controller field never becomes an empty-string comparison.
-fn bind_pending_lab_handoff_snapshot(
-    record: &mut AgentTaskRunRecord,
-    snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
-) {
-    if record.runner_job_id().is_some() {
-        return;
-    }
-    let Some(pending_handoff) = record
-        .lab_handoff
-        .as_ref()
-        .filter(|handoff| {
-            handoff.state == AgentTaskLabHandoffState::Pending
-                && handoff.authority == AgentTaskLabHandoffAuthority::Controller
-                && snapshot
-                    .job
-                    .target_runner_id
-                    .as_deref()
-                    .is_none_or(|runner_id| runner_id == handoff.runner_id)
-        })
-        .cloned()
-    else {
-        return;
-    };
-
-    let runner_job_id = snapshot.job.id.to_string();
-    let accepted_at = now_timestamp();
-    record.lab_handoff = Some(pending_handoff.accepted(&runner_job_id, accepted_at.clone()));
-    let metadata = record.ensure_metadata_object();
-    metadata.insert("runner_id".to_string(), json!(&pending_handoff.runner_id));
-    metadata.insert("runner_job_id".to_string(), json!(&runner_job_id));
-    metadata.insert(
-        "handoff_acceptance".to_string(),
-        json!({
-            "state": "accepted",
-            "accepted_at": accepted_at,
-            "runner_job_id": runner_job_id,
-        }),
-    );
 }
 
 fn validate_terminal_child_identity(


### PR DESCRIPTION
## Summary
- Remove the redundant pending Lab handoff snapshot binder introduced independently by #9238.
- Keep #9241's stricter binder as the single authoritative implementation.
- Restore compilation for `homeboy-agents` and downstream Lab runner work.

Fixes #9249.

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-agents preacceptance_snapshot -- --nocapture`.
3. Run `cargo test -p homeboy-agents runner_snapshot -- --nocapture`.
4. Run `cargo check -p homeboy-lab-runner`.

## Compatibility
No public contract changes. This removes a duplicate private implementation while preserving the stricter merged behavior and its fail-closed identity checks.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Diagnosed the duplicate merged implementation, prepared the minimal removal, and ran focused verification.