### PR TITLE
fix(agents): dedupe colliding bind_pending_lab_handoff_snapshot definitions

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2148,7 +2148,7 @@ pub(crate) fn reconcile_runner_job_snapshot(
             preserve_terminal_runner_identity(record, &event)?;
         }
     }
-    bind_pending_lab_handoff_snapshot(record, snapshot);
+    bind_pending_lab_handoff_snapshot(record, snapshot)?;
     validate_runner_job_snapshot(record, snapshot)?;
     let mut reconciled = record.clone();
     reconciled.record_runner_reachable();
@@ -2471,49 +2471,6 @@ fn validate_runner_job_snapshot(
         Some(record.run_id.clone()),
         None,
     ))
-}
-
-/// A daemon snapshot is acceptance evidence for a controller-owned pending
-/// handoff. Bind that identity before validating the snapshot so an absent
-/// controller field never becomes an empty-string comparison.
-fn bind_pending_lab_handoff_snapshot(
-    record: &mut AgentTaskRunRecord,
-    snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
-) {
-    if record.runner_job_id().is_some() {
-        return;
-    }
-    let Some(pending_handoff) = record
-        .lab_handoff
-        .as_ref()
-        .filter(|handoff| {
-            handoff.state == AgentTaskLabHandoffState::Pending
-                && handoff.authority == AgentTaskLabHandoffAuthority::Controller
-                && snapshot
-                    .job
-                    .target_runner_id
-                    .as_deref()
-                    .is_none_or(|runner_id| runner_id == handoff.runner_id)
-        })
-        .cloned()
-    else {
-        return;
-    };
-
-    let runner_job_id = snapshot.job.id.to_string();
-    let accepted_at = now_timestamp();
-    record.lab_handoff = Some(pending_handoff.accepted(&runner_job_id, accepted_at.clone()));
-    let metadata = record.ensure_metadata_object();
-    metadata.insert("runner_id".to_string(), json!(&pending_handoff.runner_id));
-    metadata.insert("runner_job_id".to_string(), json!(&runner_job_id));
-    metadata.insert(
-        "handoff_acceptance".to_string(),
-        json!({
-            "state": "accepted",
-            "accepted_at": accepted_at,
-            "runner_job_id": runner_job_id,
-        }),
-    );
 }
 
 fn validate_terminal_child_identity(


### PR DESCRIPTION
## Summary
- Fixes a **compile break on `main`**: `E0428: the name bind_pending_lab_handoff_snapshot is defined multiple times`, which broke the `Build` and `Windows Build` gates.
- Two PRs merged close together each added a function with that exact name to `lifecycle_ops.rs` — green individually, colliding once both landed:
  - **#9241** ("bind Lab snapshot job identity") — `-> Result<()>`, rebuilds the record via the durable, `LabHandoffLock`-guarded `record_detached_lab_run`. Called from `reconcile_transport_proxy_snapshot`.
  - **#9238** ("Bind Lab snapshot identity before validation", #9206) — `-> ()`, mutates `lab_handoff` in place (`pending_handoff.accepted(..)`) + metadata, no store lock/persistence. Called from `reconcile_runner_job_snapshot`.

## Resolution
Keep **#9241's** durable, locked implementation as the single definition — it is strictly more robust, and both PRs' *mismatch* tests actually rely on `record_detached_lab_run`'s fail-closed conflict rejection. Details:
- Removed #9238's inline `()` duplicate.
- #9238's call site in `reconcile_runner_job_snapshot` now uses `?` (its 3 production callers get the binding — the broadest correct coverage).
- #9241's call in `reconcile_transport_proxy_snapshot` is retained (that path also flows through `reconcile_runner_job_snapshot`; the repeat call is idempotent via the early `runner_job_id().is_some()` guard).
- Verified both PRs' guards converge: their binding tests all set a matching `target_runner_id`, and their mismatch tests trip the `runner_job_id().is_some()` early return, so #9241's stricter `target_runner_id` check satisfies both suites.

## Testing
All **four** binding tests from both PRs pass unchanged:
- `runner_snapshot_binds_pending_lab_handoff_before_validation` (#9241)
- `runner_snapshot_rejects_conflicting_bound_lab_job_identity` (#9241)
- `preacceptance_snapshot_binds_the_accepted_daemon_job_before_validation` (#9238)
- `preacceptance_snapshot_rejects_a_different_bound_daemon_job` (#9238)

`cargo check -p homeboy-agents --lib` clean (E0428 gone); `cargo fmt` clean.

### Note on an unrelated failure
`handoff_and_proxy::cook_lab_handoff_controller_reads_ignore_runner_plan_projection` fails in this module, but it is **pre-existing and unrelated**: it exercises `status()` reading a deleted controller plan file (expects `InternalIoError`), a code path this diff does not touch (the diff is only the dedup: one `?` + removing the duplicate fn). It could not surface on `main` before because `main` did not compile due to this very E0428 collision. Flagging separately rather than folding an unrelated fix into this one.