### PR TITLE
fix(lab-runner): parse noisy runner identity output

### DIFF
--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -70,7 +70,7 @@ pub(super) fn remote_homeboy_identity(
 }
 
 pub(super) fn parse_self_identity_output(output: &str) -> Option<RemoteHomeboyIdentity> {
-    let body: Value = serde_json::from_str(output.trim()).ok()?;
+    let body: Value = parse_json_from_mixed_stdout(output).ok()?;
     let data = body.get("data").unwrap_or(&body);
     let version = data.get("version")?.as_str()?.trim();
     let display = data

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -4,6 +4,8 @@ use clap::Parser;
 use std::collections::HashMap;
 use std::io::{Read, Write};
 
+use crate::RunnerAvailability;
+
 use super::*;
 
 #[test]
@@ -334,6 +336,44 @@ fn parses_self_identity_json_envelope() {
     assert_eq!(
         identity.build_identity.as_deref(),
         Some("homeboy 0.228.13+19a41cd5102d")
+    );
+}
+
+#[test]
+fn aligned_runner_identity_protocol_with_shell_preamble_accepts_jobs() {
+    let configured = parse_self_identity_output(
+        "Setting up Swift test infrastructure...\n{\"success\":true,\"data\":{\"version\":\"0.298.0\",\"display\":\"homeboy 0.298.0+9682bf1ad0b2\"}}\n",
+    )
+    .expect("configured runner identity after shell preamble");
+    let daemon = serde_json::json!({
+        "version": "0.298.0",
+        "build_identity": { "display": "homeboy 0.298.0+9682bf1ad0b2" },
+        "runtime_paths": { "loaded": [], "current": [], "stale": [] },
+    });
+    let daemon_version = daemon_version_from_body(&daemon).expect("daemon version");
+    let daemon_identity = daemon_identity_from_body(&daemon).expect("daemon build identity");
+
+    assert!(daemon_runtime_is_current(
+        daemon_version,
+        "0.298.0",
+        &configured.version,
+        compare_identities(Some(daemon_identity), configured.build_identity.as_deref()),
+        &daemon_runtime_stale_paths_from_body(&daemon),
+        &changed_runtime_paths(
+            &HashMap::new(),
+            &daemon_runtime_loaded_paths_from_body(&daemon)
+        ),
+    ));
+    assert!(
+        RunnerAvailability::from_status_parts(
+            "homeboy-lab",
+            true,
+            false,
+            0,
+            &RunnerActiveJobState::Available,
+            None,
+        )
+        .accepts_jobs
     );
 }
 


### PR DESCRIPTION
## Summary

- parse runner `self identity` through Homeboy’s mixed-stdout JSON decoder
- preserve immutable build identity when SSH or extension setup writes preamble text
- prevent exact controller/daemon parity from being rejected as unverifiable stale-daemon drift

## Root cause

The configured runner identity parser required stdout to contain only JSON. Runner commands may prepend setup text before the structured envelope, so strict parsing discarded the immutable build identity. Stale-daemon comparison then failed closed as `Unverifiable`, even when controller, configured binary, active daemon, and session all used the same build.

Fixes #9259.

## How to test

1. Run `cargo test -p homeboy-lab-runner aligned_runner_identity_protocol_with_shell_preamble_accepts_jobs --quiet`.
2. Run `cargo check -p homeboy-lab-runner`.
3. Run `cargo fmt --check`.
4. Confirm the regression fixture parses preamble plus identity JSON, verifies exact version/build parity with empty runtime-path drift, and returns `accepts_jobs=true`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode and Homeboy
- **Used for:** Reproduced and traced the stale-daemon misclassification, implemented the parser repair and deterministic regression, and verified the focused package gates with Chris review.