### PR TITLE
fix: repoint audit source_policies at extracted homeboy-code-audit crate

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -132,13 +132,13 @@
         "description": "Core boundary leak (core-agnostic-source) configured ecosystem term `{term}` appears at line {line} in {classification} context `{context}`",
         "exclude_path_contains": [
           "crates/homeboy-core/src/execution_contract.rs",
-          "crates/homeboy-core/src/code_audit/conventions/",
-          "crates/homeboy-core/src/code_audit/comment_blocks.rs",
-          "crates/homeboy-core/src/code_audit/comment_hygiene.rs",
-          "crates/homeboy-core/src/code_audit/core_fingerprint/mod.rs",
-          "crates/homeboy-core/src/code_audit/core_fingerprint/relationships.rs",
-          "crates/homeboy-core/src/code_audit/detectors/test_coverage.rs",
-          "crates/homeboy-core/src/code_audit/detectors/global_env_guard.rs",
+          "crates/homeboy-code-audit/src/conventions/",
+          "crates/homeboy-code-audit/src/comment_blocks.rs",
+          "crates/homeboy-code-audit/src/comment_hygiene.rs",
+          "crates/homeboy-code-audit/src/core_fingerprint/mod.rs",
+          "crates/homeboy-code-audit/src/core_fingerprint/relationships.rs",
+          "crates/homeboy-code-audit/src/detectors/test_coverage.rs",
+          "crates/homeboy-code-audit/src/detectors/global_env_guard.rs",
           "crates/homeboy-core/src/runner/tool_registry.rs",
           "crates/homeboy-core/src/cleanup.rs",
           "crates/homeboy-core/src/cleanup/self_artifacts.rs",
@@ -276,15 +276,15 @@
         "default_match": "token",
         "description": "Core boundary leak (detector-agnostic-source) configured ecosystem term `{term}` appears at line {line} in {classification} context `{context}`",
         "exclude_path_contains": [
-          "crates/homeboy-core/src/code_audit/detectors/test_coverage.rs",
-          "crates/homeboy-core/src/code_audit/detectors/global_env_guard.rs"
+          "crates/homeboy-code-audit/src/detectors/test_coverage.rs",
+          "crates/homeboy-code-audit/src/detectors/global_env_guard.rs"
         ],
         "id": "detector-agnostic-source",
         "ignore_after_line_equals": [
           "#[cfg(test)]"
         ],
         "include_path_contains": [
-          "crates/homeboy-core/src/code_audit/detectors/"
+          "crates/homeboy-code-audit/src/detectors/"
         ],
         "kind": "core_boundary_leak",
         "suggestion": "Move ecosystem-specific behavior into extension metadata/rules, or add an explicit audit allowlist for intentional examples.",


### PR DESCRIPTION
## Summary
The `code_audit` module was extracted from `homeboy-core` into the new `homeboy-code-audit` crate, but `audit.source_policies` in `homeboy.json` still pointed at the old `crates/homeboy-core/src/code_audit/*` paths.

The `detector-agnostic-source` policy's only `include_path_contains` entry (`crates/homeboy-core/src/code_audit/detectors/`) matched **zero files** after the move, so `validate_source_roots` fail-closed:

```
Invalid argument 'audit.source_policies': configured source root(s) matched
zero files: detector-agnostic-source: crates/homeboy-core/src/code_audit/detectors/.
```

That aborts the whole-tree audit with exit code 2 **before** any findings are produced.

## Why it matters
This is why the **Audit Debt** workflow (`audit-debt.yml`) never populated its "code factory" roadmap. Its only run to date (manual `workflow_dispatch`, 2026-07-20) failed at the `review audit` step, and the action correctly refused to file issues:

> Cannot file categorized issues without structured JSON. The underlying command failure should be addressed before re-running.

Result: **zero** `homeboy-ci` bot-authored tracking issues have ever been created on the homeboy repo (data-machine's audit auto-filing works fine — it runs through a different, healthy path).

## The fix
Repoint all 10 stale `source_policies` paths from `crates/homeboy-core/src/code_audit/` → `crates/homeboy-code-audit/src/`.

- Every new path is verified to exist on disk in the new crate.
- JSON validated.
- Scope is limited to the live `source_policies` config. The `convention_exception_globs` / `audit_baseline` entries use the portable `src/core/...` path convention (regenerated by `homeboy audit-baseline`) and are intentionally left untouched.

## Verification
- `grep -c 'crates/homeboy-core/src/code_audit/'` → 0 remaining
- `grep -c 'crates/homeboy-code-audit/src/'` → 10
- All 10 target paths confirmed present on disk
- `python3 -c "json.load(...)"` → valid JSON

After merge, the weekly Audit Debt sweep (Mondays 07:00 UTC, or manual `workflow_dispatch`) should run to completion and begin filing/refreshing the deduplicated `audit:*` tracking issues.