### PR TITLE
Start Lab handoff lease at runner submission

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -960,15 +960,23 @@ pub fn record_lab_offload_submission_request(
     let run_id = sanitize_run_id(run_id);
     let _lock = LabHandoffLock::lock(&run_id)?;
     let mut record = store::read_record(&run_id)?;
+    if record.state.is_terminal() {
+        return Ok(record);
+    }
     let submission_key = request.submission_key().ok_or_else(|| {
         Error::internal_unexpected("Lab runner submission request has no stable submission key")
     })?;
     let replay_request = request.redacted_for_durable_replay();
     let payload_fingerprint = replay_request.submission_payload_fingerprint()?;
-    if let Some(handoff) = record.lab_handoff.as_mut() {
-        handoff.submission_key = Some(submission_key.to_string());
-        handoff.payload_fingerprint = Some(payload_fingerprint.clone());
-    }
+    let now = chrono::Utc::now();
+    let mut handoff = AgentTaskLabHandoff::pending(
+        &replay_request.runner_id,
+        now.to_rfc3339(),
+        (now + chrono::Duration::seconds(lab_handoff_acceptance_timeout_seconds())).to_rfc3339(),
+    );
+    handoff.submission_key = Some(submission_key.to_string());
+    handoff.payload_fingerprint = Some(payload_fingerprint.clone());
+    record.lab_handoff = Some(handoff.clone());
     let metadata = record.ensure_metadata_object();
     metadata.insert(
         "runner_submission_intent".to_string(),
@@ -978,6 +986,14 @@ pub fn record_lab_offload_submission_request(
             "payload_fingerprint": payload_fingerprint,
             "runner_id": replay_request.runner_id,
             "replay_request": replay_request,
+        }),
+    );
+    metadata.insert(
+        "handoff_acceptance".to_string(),
+        json!({
+            "state": "pending",
+            "started_at": handoff.submitted_at,
+            "deadline_at": handoff.acceptance_deadline_at,
         }),
     );
     store::write_record(&record)?;
@@ -999,7 +1015,7 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     if reconcile_pending_runner_submission_intent(&resolved_run_id)? {
         record = store::read_record(&resolved_run_id)?;
     }
-    if record.has_expired_pending_lab_handoff(chrono::Utc::now()) {
+    if has_expired_pending_runner_submission_intent(&record, chrono::Utc::now()) {
         let _ = expire_unaccepted_lab_handoff(&resolved_run_id)?;
         record = store::read_record(&resolved_run_id)?;
     }
@@ -1153,7 +1169,7 @@ pub fn reconcile_active_lab_runner_handoffs() -> Result<usize> {
             accepted_run_ids.push(record.run_id);
         } else if has_pending_runner_submission_intent(&record) {
             pending_intent_run_ids.push(record.run_id);
-        } else if record.has_expired_pending_lab_handoff(now) {
+        } else if has_expired_pending_runner_submission_intent(&record, now) {
             expired_run_ids.push(record.run_id);
         }
     }
@@ -1181,24 +1197,64 @@ pub fn reconcile_active_lab_runner_handoffs() -> Result<usize> {
 }
 
 fn has_pending_runner_submission_intent(record: &AgentTaskRunRecord) -> bool {
-    record.state == AgentTaskRunState::Queued
-        && record.runner_job_id().is_none()
-        && record.lab_handoff.as_ref().is_some_and(|handoff| {
-            handoff.state == AgentTaskLabHandoffState::Pending
-                && handoff.authority == AgentTaskLabHandoffAuthority::Controller
-                && handoff
-                    .acceptance_deadline_at
-                    .as_deref()
-                    .and_then(|timestamp| chrono::DateTime::parse_from_rfc3339(timestamp).ok())
-                    .is_some_and(|deadline| {
-                        deadline.with_timezone(&chrono::Utc) > chrono::Utc::now()
-                    })
-        })
+    has_complete_pending_runner_submission_intent(record)
         && record
-            .metadata
-            .pointer("/runner_submission_intent/state")
-            .and_then(Value::as_str)
-            == Some("pending")
+            .lab_handoff
+            .as_ref()
+            .and_then(|handoff| handoff.acceptance_deadline_at.as_deref())
+            .and_then(|timestamp| chrono::DateTime::parse_from_rfc3339(timestamp).ok())
+            .is_some_and(|deadline| deadline.with_timezone(&chrono::Utc) > chrono::Utc::now())
+}
+
+pub(crate) fn has_expired_pending_runner_submission_intent(
+    record: &AgentTaskRunRecord,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    has_complete_pending_runner_submission_intent(record)
+        && record.has_expired_pending_lab_handoff(now)
+}
+
+fn has_complete_pending_runner_submission_intent(record: &AgentTaskRunRecord) -> bool {
+    if record.state != AgentTaskRunState::Queued || record.runner_job_id().is_some() {
+        return false;
+    }
+    let Some(handoff) = record.lab_handoff.as_ref().filter(|handoff| {
+        handoff.state == AgentTaskLabHandoffState::Pending
+            && handoff.authority == AgentTaskLabHandoffAuthority::Controller
+    }) else {
+        return false;
+    };
+    let Some(intent) = record
+        .metadata
+        .get("runner_submission_intent")
+        .and_then(Value::as_object)
+        .filter(|intent| intent.get("state").and_then(Value::as_str) == Some("pending"))
+    else {
+        return false;
+    };
+    let Some(submission_key) = intent
+        .get("submission_key")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return false;
+    };
+    let Some(runner_id) = intent
+        .get("runner_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return false;
+    };
+    let Ok(request) = serde_json::from_value::<RemoteRunnerJobRequest>(
+        intent.get("replay_request").cloned().unwrap_or(Value::Null),
+    ) else {
+        return false;
+    };
+    request.runner_id == runner_id
+        && request.submission_key() == Some(submission_key)
+        && handoff.runner_id == runner_id
+        && handoff.submission_key.as_deref() == Some(submission_key)
 }
 
 /// Replay an unacknowledged durable handoff. A broker that already accepted the
@@ -1398,7 +1454,7 @@ fn expire_unaccepted_lab_handoff(run_id: &str) -> Result<bool> {
     // Re-read while holding the handoff lock: an accepted job is runner-owned
     // and must never be terminalized by controller deadline recovery.
     let record = store::read_record(run_id)?;
-    if !record.has_expired_pending_lab_handoff(chrono::Utc::now()) {
+    if !has_expired_pending_runner_submission_intent(&record, chrono::Utc::now()) {
         return Ok(false);
     }
 
@@ -1737,6 +1793,9 @@ pub fn record_lab_offload_phase(
         &[],
         durable_plan,
     )?;
+    if record.state.is_terminal() {
+        return Ok(record);
+    }
     record.updated_at = Some(now_timestamp());
     let phase_started_at = record.updated_at.clone().unwrap_or_else(now_timestamp);
     let metadata = record.ensure_metadata_object();
@@ -1764,6 +1823,9 @@ pub fn record_lab_offload_phase_executions(
     execution_ids: impl IntoIterator<Item = String>,
 ) -> Result<AgentTaskRunRecord> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    if record.state.is_terminal() {
+        return Ok(record);
+    }
     let execution_ids: Vec<String> = execution_ids
         .into_iter()
         .filter(|id| !id.trim().is_empty())
@@ -1863,6 +1925,19 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
                 record.run_id,
                 accepted.runner_id,
                 accepted.runner_job_id.as_deref().unwrap_or_default(),
+            ),
+            Some(record.run_id.clone()),
+            None,
+        ));
+    }
+    if record.lab_handoff.is_none() && record.runner_id().is_some_and(|id| id != input.runner_id) {
+        return Err(Error::validation_invalid_argument(
+            "runner_id",
+            format!(
+                "Lab handoff for run '{}' is assigned to runner '{}'; refusing acceptance from '{}'",
+                record.run_id,
+                record.runner_id().unwrap_or_default(),
+                input.runner_id,
             ),
             Some(record.run_id.clone()),
             None,
@@ -2097,17 +2172,8 @@ fn record_lab_offload_proxy(
         }
     }
     record.plan_path = store::controller_plan_path(&run_id)?.display().to_string();
-    let pending_handoff = (!record.has_accepted_lab_handoff()).then(|| {
-        let now = chrono::Utc::now();
-        AgentTaskLabHandoff::pending(
-            runner_id,
-            now.to_rfc3339(),
-            (now + chrono::Duration::seconds(lab_handoff_acceptance_timeout_seconds()))
-                .to_rfc3339(),
-        )
-    });
-    if let Some(handoff) = pending_handoff.as_ref() {
-        record.lab_handoff = Some(handoff.clone());
+    if record.state.is_terminal() {
+        return Ok(record);
     }
     let metadata = record.ensure_metadata_object();
     metadata.insert("kind".to_string(), json!("lab_offload_controller_proxy"));
@@ -2115,16 +2181,6 @@ fn record_lab_offload_proxy(
     // It remains controller-owned until a runner-local record is independently
     // discovered, so controller-generated commands must keep resolving here.
     metadata.insert("lifecycle_store_owner".to_string(), json!("controller"));
-    if let Some(handoff) = pending_handoff {
-        metadata.insert(
-            "handoff_acceptance".to_string(),
-            json!({
-                "state": "pending",
-                "started_at": handoff.submitted_at,
-                "deadline_at": handoff.acceptance_deadline_at,
-            }),
-        );
-    }
     metadata.insert("runner_id".to_string(), json!(runner_id));
     if remote_workspace != "pending" {
         metadata.insert("remote_workspace".to_string(), json!(remote_workspace));

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
@@ -220,13 +220,19 @@ fn bind_pending_lab_handoff_snapshot(
     if record.runner_job_id().is_some() {
         return Ok(());
     }
-    let Some(handoff) = record.lab_handoff.as_ref().filter(|handoff| {
-        handoff.state == AgentTaskLabHandoffState::Pending
-            && handoff.authority == AgentTaskLabHandoffAuthority::Controller
-    }) else {
+    let runner_id = record
+        .lab_handoff
+        .as_ref()
+        .filter(|handoff| {
+            handoff.state == AgentTaskLabHandoffState::Pending
+                && handoff.authority == AgentTaskLabHandoffAuthority::Controller
+        })
+        .map(|handoff| handoff.runner_id.clone())
+        .or_else(|| record.runner_id().map(str::to_string));
+    let Some(runner_id) = runner_id else {
         return Ok(());
     };
-    if snapshot.job.target_runner_id.as_deref() != Some(handoff.runner_id.as_str()) {
+    if snapshot.job.target_runner_id.as_deref() != Some(runner_id.as_str()) {
         return Ok(());
     }
     let remote_workspace = record
@@ -249,7 +255,7 @@ fn bind_pending_lab_handoff_snapshot(
         .unwrap_or_default();
     *record = record_detached_lab_run(DetachedLabRunRecord {
         run_id: &record.run_id,
-        runner_id: &handoff.runner_id,
+        runner_id: &runner_id,
         runner_job_id: &snapshot.job.id.to_string(),
         remote_workspace: &remote_workspace,
         remote_command: &remote_command,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -256,7 +256,8 @@ fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
         assert_eq!(planned.state, AgentTaskRunState::Queued);
         assert!(planned.metadata.get("runner_job_id").is_none());
         assert_eq!(planned.metadata["lifecycle_store_owner"], "controller");
-        assert_eq!(planned.metadata["handoff_acceptance"]["state"], "pending");
+        assert!(planned.lab_handoff.is_none());
+        assert!(planned.metadata.get("handoff_acceptance").is_none());
         assert!(load_plan("agent-task-controller-proxy")
             .expect("proxy plan")
             .tasks[0]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -626,6 +626,11 @@ fn cancelled_or_expired_pending_handoff_never_submits_new_runner_work() {
 
         cancel_run("cancel-before-admission", Some("operator cancelled"))
             .expect("cancel before daemon acceptance");
+        record_lab_offload_submission_request(
+            "expire-before-admission",
+            &replay_request("expire-before-admission", &command),
+        )
+        .expect("persist complete pending request");
         rewrite_record_for_test("expire-before-admission", |record| {
             record
                 .lab_handoff

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -422,6 +422,64 @@ fn controller_proxy_records_pre_execution_phase_progress() {
 }
 
 #[test]
+fn long_pre_submission_setup_survives_reconciliation_and_terminal_phase_writes_are_noops() {
+    with_isolated_home(|_| {
+        let run_id = "long-pre-submission-materialization";
+        let plan = test_plan();
+        let materializing = record_lab_offload_phase(
+            run_id,
+            "homeboy-lab",
+            "materializing",
+            None,
+            None,
+            None,
+            Some(&plan),
+        )
+        .expect("persist pre-submission materialization");
+
+        // A setup phase may run longer than the handoff lease because no complete
+        // request has crossed the durable submission boundary yet.
+        assert!(materializing.lab_handoff.is_none());
+        assert!(materializing.metadata.get("handoff_acceptance").is_none());
+        assert_eq!(
+            reconcile_active_lab_runner_handoffs().expect("read-side reconciliation"),
+            0
+        );
+        let hydrating = record_lab_offload_phase(
+            run_id,
+            "homeboy-lab",
+            "hydrating",
+            Some("/runner/workspace/homeboy"),
+            None,
+            None,
+            Some(&plan),
+        )
+        .expect("long setup remains controller-owned");
+        assert_eq!(hydrating.state, AgentTaskRunState::Queued);
+        assert_eq!(hydrating.metadata["phase"], "hydrating");
+
+        let cancelled = cancel_run(run_id, Some("controller cancelled during setup"))
+            .expect("terminalize setup record");
+        let after_terminal_phase = record_lab_offload_phase(
+            run_id,
+            "homeboy-lab",
+            "provider_dispatch",
+            Some("/runner/workspace/homeboy"),
+            None,
+            None,
+            Some(&plan),
+        )
+        .expect("terminal phase write is a no-op");
+        assert_eq!(after_terminal_phase, cancelled);
+        assert!(after_terminal_phase.lab_handoff.is_none());
+        assert!(after_terminal_phase
+            .metadata
+            .get("handoff_acceptance")
+            .is_none());
+    });
+}
+
+#[test]
 fn terminal_lab_artifact_attachment_skips_missing_controller_plan_and_preserves_runner_identity() {
     with_isolated_home(|_| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -298,7 +298,7 @@ fn classify_liveness(
         return AgentTaskLiveness::Unreconciled;
     }
     if record.state != agent_task_lifecycle::AgentTaskRunState::Running {
-        if record.has_expired_pending_lab_handoff(now) {
+        if agent_task_lifecycle::has_expired_pending_runner_submission_intent(record, now) {
             return AgentTaskLiveness::Unreconciled;
         }
         // Queued runs are genuinely pending work unless their controller-owned


### PR DESCRIPTION
Closes #9271.

## Summary

- Keep materialization and hydration as controller-owned setup without an acceptance lease.
- Start the typed Lab handoff lease only when the complete durable runner submission request is recorded.
- Require a complete, consistent submission intent before reconciliation can replay or expire a handoff.
- Preserve terminal lifecycle state against late setup-phase writes.
- Retain exact runner-job binding when a daemon snapshot arrives for an assigned setup proxy.

## Why

A long workspace materialization could exceed the two-minute acceptance timeout before submission began. Read-side reconciliation then cancelled the run, while later phase writes projected a new future deadline onto that terminal record. Provider execution never started.

## How to test

1. Run `cargo test -p homeboy-agents long_pre_submission -- --nocapture`.
2. Confirm `long_pre_submission_setup_survives_reconciliation_and_terminal_phase_writes_are_noops` passes.
3. Run `cargo check -p homeboy-agents`.
4. Run `cargo fmt --check`.

## Verification

- `cargo test -p homeboy-agents long_pre_submission -- --nocapture`
- Focused runner-snapshot identity regression
- `cargo check -p homeboy-agents`
- `cargo fmt --check`

Existing unrelated compiler warnings remain unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause analysis, implementation, deterministic regression coverage, and verification
