### PR TITLE
fix(agents): give Lab snapshot job-identity binding a single owner

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -13,6 +13,21 @@ pub(crate) fn reconcile_runner_job_snapshot(
     record: &mut AgentTaskRunRecord,
     snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
 ) -> Result<()> {
+    // Single owner of pre-acceptance binding: bind a still-pending controller
+    // handoff to this snapshot's daemon job before any validation or projection,
+    // then advance a freshly-bound queued proxy to running. Every reconcile path
+    // (transport-proxy, runner-job-state, terminal-evidence recovery) flows
+    // through here, so binding cannot diverge across callers. Both steps no-op
+    // once the run is already bound / no longer queued.
+    bind_pending_lab_handoff_snapshot(record, snapshot)?;
+    if record.state == AgentTaskRunState::Queued {
+        set_run_state(record, AgentTaskRunState::Running);
+        for task in &mut record.tasks {
+            if task.state == AgentTaskState::Queued {
+                task.state = AgentTaskState::Running;
+            }
+        }
+    }
     if record.state.is_terminal() {
         // A transport-only terminal result can arrive before the daemon has
         // published the inner agent-task aggregate. Adopt that later evidence

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
@@ -197,15 +197,8 @@ pub(crate) fn reconcile_transport_proxy_snapshot(
     record: &mut AgentTaskRunRecord,
     snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
 ) -> Result<()> {
-    bind_pending_lab_handoff_snapshot(record, snapshot)?;
-    if record.state == AgentTaskRunState::Queued {
-        set_run_state(record, AgentTaskRunState::Running);
-        for task in &mut record.tasks {
-            if task.state == AgentTaskState::Queued {
-                task.state = AgentTaskState::Running;
-            }
-        }
-    }
+    // Binding and the queued -> running transition now live at the top of
+    // `reconcile_runner_job_snapshot` so every reconcile path shares one owner.
     reconcile_runner_job_snapshot(record, snapshot)
 }
 
@@ -213,7 +206,16 @@ pub(crate) fn reconcile_transport_proxy_snapshot(
 /// the controller has not yet recorded its child job ID. Bind that identity
 /// before validating the snapshot so the pre-acceptance handoff converges to
 /// the same state as an acknowledged daemon response.
-fn bind_pending_lab_handoff_snapshot(
+///
+/// This is the single owner of pre-acceptance handoff binding: it runs at the
+/// top of `reconcile_runner_job_snapshot`, so every reconcile path converges on
+/// one binding decision instead of each caller binding independently.
+///
+/// A daemon job is created with `target_runner_id: None` and only gains a runner
+/// once claimed, so a snapshot polled before the claim legitimately has no
+/// target. Accept an absent target (the expected-Lab handoff is authority) and
+/// only reject a target that names a *different* runner.
+pub(crate) fn bind_pending_lab_handoff_snapshot(
     record: &mut AgentTaskRunRecord,
     snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
 ) -> Result<()> {
@@ -232,7 +234,12 @@ fn bind_pending_lab_handoff_snapshot(
     let Some(runner_id) = runner_id else {
         return Ok(());
     };
-    if snapshot.job.target_runner_id.as_deref() != Some(runner_id.as_str()) {
+    if snapshot
+        .job
+        .target_runner_id
+        .as_deref()
+        .is_some_and(|target| target != runner_id)
+    {
         return Ok(());
     }
     let remote_workspace = record

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -552,6 +552,44 @@ fn preacceptance_snapshot_binds_the_accepted_daemon_job_before_validation() {
 }
 
 #[test]
+fn preacceptance_snapshot_binds_a_pre_claim_job_without_a_target_runner() {
+    // A daemon job is created with `target_runner_id: None` and only gains a
+    // runner once claimed, so a snapshot polled before the claim legitimately
+    // has no target. The expected-Lab controller handoff is the binding
+    // authority: an absent target must still bind (regression for a strict
+    // `!=` check that silently skipped this pre-claim window).
+    with_isolated_home(|_| {
+        let run_id = "cook-preacceptance-no-target";
+        let plan = test_plan();
+        let mut record = record_lab_offload_phase(
+            run_id,
+            "homeboy-lab",
+            "lab_handoff_preacceptance",
+            Some("/runner/workspace/homeboy"),
+            None,
+            None,
+            Some(&plan),
+        )
+        .expect("persist pending controller handoff");
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
+        snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
+        snapshot.job.target_runner_id = None;
+        snapshot.events.clear();
+
+        reconcile_transport_proxy_snapshot(&mut record, &snapshot)
+            .expect("pre-claim daemon snapshot binds before validation");
+
+        let accepted_job_id = snapshot.job.id.to_string();
+        assert_eq!(record.runner_job_id(), Some(accepted_job_id.as_str()));
+        assert_eq!(
+            record.lab_handoff.as_ref().expect("handoff").state,
+            AgentTaskLabHandoffState::Accepted
+        );
+        assert_eq!(record.metadata["handoff_acceptance"]["state"], "accepted");
+    });
+}
+
+#[test]
 fn preacceptance_snapshot_rejects_a_different_bound_daemon_job() {
     with_isolated_home(|_| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];


### PR DESCRIPTION
Closes #9273.

## Summary
The "when is the Lab snapshot job identity bound onto the controller record?" logic had **no single owner**, which produced a recurring cluster of ~12 identity/bind fixes. This gives it one owner and closes a latent binding gap.

## Root cause (from #9273)
`reconcile_runner_job_snapshot` has three callers, but only `reconcile_transport_proxy_snapshot` ran the pre-acceptance binder first. Two parallel PRs added a same-named `bind_pending_lab_handoff_snapshot` in two different reconcile paths with different acceptance criteria (#9241 strict, #9238 lenient); #9251 removed one. The result was coherent but fragile — binding responsibility lived *outside* `reconcile_runner_job_snapshot`, in one of its callers, which is exactly how the duplicate arose.

## Fix
**1. Single binding owner.** Move the pre-acceptance bind — and the `queued -> running` transition it precedes — to the top of `reconcile_runner_job_snapshot`. Every reconcile path (`reconcile_transport_proxy_snapshot`, `reconcile_runner_job_state`, `recover_terminal_transport_proxy_evidence`) now converges on one binding decision. Both steps no-op once the run is already bound / no longer queued, so the other two callers (guarded by an already-set `runner_job_id`) are behavior-identical.

**2. Latent gap.** `Job.target_runner_id` is `Option<String>` and is `None` until a job is claimed (`api_jobs/store.rs` creates jobs with `target_runner_id: None`; a runner is assigned on claim). A snapshot polled *before* the claim legitimately has no target, but the surviving binder used a strict `!=` check that silently skipped binding it. Now: accept an absent target (the expected-Lab controller handoff is the binding authority) and only reject a target that names a *different* runner.

## Verification
- `cargo check -p homeboy-agents --lib --tests` — clean (no warnings on the changed files).
- `cargo fmt` — no changes.
- New regression test `preacceptance_snapshot_binds_a_pre_claim_job_without_a_target_runner`, **proven to fail against the strict `!=` match and pass with the lenient one** (temp-reverted the match and confirmed the failure).
- All existing binding/handoff/projection tests pass in isolation:
  - `preacceptance_snapshot_binds_the_accepted_daemon_job_before_validation`
  - `preacceptance_snapshot_rejects_a_different_bound_daemon_job`
  - `runner_snapshot_binds_pending_lab_handoff_before_validation`
  - `pending_handoff_rejects_acceptance_from_a_different_runner_without_mutation`
  - `controller_proxy_is_queued_before_handoff_then_binds_runner_child`
  - `transport_proxy_snapshot_reconciliation_advances_queued_lifecycle`
  - `disconnected_proxy_projects_terminal_child_aggregate_once_reachable`

## Why this is now clean
The recent decomposition (#9256/#9258/#9260) isolated the binder in `lifecycle_transport_proxy.rs` and the projection in `lifecycle_runner_projection.rs`, which is what made "give it a single owner" a small, surgical change rather than surgery on a 3,700-line file.