### PR TITLE
Reconcile idle stale runner generations

### DIFF
--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -231,6 +231,67 @@ pub(super) enum RemoteDaemonWorkEvidence {
     AuthoritativelyIdle,
 }
 
+/// Return the one live lease that may replace a ledger containing only stale
+/// leases. The remote daemon status and typed jobs endpoint are authoritative;
+/// a persisted lease is never used to stop a different daemon.
+pub(super) fn authoritative_idle_lease_for_stale_generations(
+    status: &RemoteDaemonStatus,
+    persisted_leases: &[String],
+) -> std::result::Result<Option<String>, String> {
+    if persisted_leases.is_empty() {
+        return Ok(None);
+    }
+    let daemon = status.daemon.as_ref().ok_or_else(|| {
+        "authoritative daemon reconciliation cannot prove a live daemon lease and PID".to_string()
+    })?;
+    let lease_id = daemon
+        .lease_id
+        .as_deref()
+        .filter(|lease| !lease.is_empty())
+        .ok_or_else(|| {
+            "authoritative daemon reconciliation cannot prove the live daemon lease".to_string()
+        })?;
+    if persisted_leases
+        .iter()
+        .any(|persisted| persisted == lease_id)
+    {
+        return Ok(None);
+    }
+    if daemon.pid.is_none()
+        || !status.reachable
+        || status.endpoint_probe_error.is_some()
+        || status.active_jobs != 0
+        || !status.work_evidence.is_authoritatively_idle()
+    {
+        return Err(
+            "authoritative daemon reconciliation requires a reachable lease/PID, successful endpoint probes, and zero typed active jobs"
+                .to_string(),
+        );
+    }
+    Ok(Some(lease_id.to_string()))
+}
+
+/// A stop is complete only when the remote state is absent or explicitly proves
+/// the exact stopped lease is dead. A new lease is a recovery race, not success.
+pub(super) fn authoritative_lease_stop_confirmed(
+    status: &RemoteDaemonStatus,
+    expected_lease_id: &str,
+) -> std::result::Result<(), String> {
+    match status.daemon.as_ref() {
+        None => Ok(()),
+        Some(daemon)
+            if daemon.lease_id.as_deref() == Some(expected_lease_id)
+                && status.stale_reason_code == Some(DaemonStaleReasonCode::PidDead) =>
+        {
+            Ok(())
+        }
+        Some(daemon) => Err(format!(
+            "authoritative daemon ownership changed during reconciliation (expected lease `{expected_lease_id}`, observed lease `{}`); stale generations were retained",
+            daemon.lease_id.as_deref().unwrap_or("unavailable")
+        )),
+    }
+}
+
 impl RemoteDaemonWorkEvidence {
     fn from_unresolved_count(count: usize) -> Self {
         if count == 0 {

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -133,6 +133,44 @@ fn reconciles_multiple_stale_generation_leases_to_one_authoritative_idle_lease()
 }
 
 #[test]
+fn stale_generation_reconciliation_requires_every_ledger_entry_to_be_direct_and_leased() {
+    let first = direct_ssh_session("lease-a");
+    let second = direct_ssh_session("lease-b");
+    let mut mixed = direct_ssh_session("lease-b");
+    mixed.mode = RunnerTunnelMode::Reverse;
+    let mut missing = direct_ssh_session("lease-b");
+    missing.remote_daemon_lease_id = None;
+    let mut empty = direct_ssh_session("lease-b");
+    empty.remote_daemon_lease_id = Some(String::new());
+
+    assert_eq!(
+        super::super::stop_transport_recovery::eligible_stale_generation_leases(&[first, second]),
+        Some(vec!["lease-a".to_string(), "lease-b".to_string()])
+    );
+    assert_eq!(
+        super::super::stop_transport_recovery::eligible_stale_generation_leases(&[
+            direct_ssh_session("lease-a"),
+            mixed,
+        ]),
+        None
+    );
+    assert_eq!(
+        super::super::stop_transport_recovery::eligible_stale_generation_leases(&[
+            direct_ssh_session("lease-a"),
+            missing,
+        ]),
+        None
+    );
+    assert_eq!(
+        super::super::stop_transport_recovery::eligible_stale_generation_leases(&[
+            direct_ssh_session("lease-a"),
+            empty,
+        ]),
+        None
+    );
+}
+
+#[test]
 fn stale_generation_reconciliation_refuses_active_jobs_changed_lease_or_unproven_owner() {
     let mut active = idle_stale_status(RemoteDaemonWorkEvidence::AuthoritativelyIdle);
     active.active_jobs = 1;

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -115,6 +115,64 @@ fn replaces_idle_stale_daemon_when_typed_jobs_are_zero_without_lease_recovery_ev
 }
 
 #[test]
+fn reconciles_multiple_stale_generation_leases_to_one_authoritative_idle_lease() {
+    let status = idle_stale_status(RemoteDaemonWorkEvidence::AuthoritativelyIdle);
+
+    assert_eq!(
+        authoritative_idle_lease_for_stale_generations(
+            &status,
+            &[
+                "lease-a".to_string(),
+                "lease-b".to_string(),
+                "lease-c".to_string()
+            ],
+        )
+        .expect("authoritative idle lease is bounded"),
+        Some("lease-stale".to_string())
+    );
+}
+
+#[test]
+fn stale_generation_reconciliation_refuses_active_jobs_changed_lease_or_unproven_owner() {
+    let mut active = idle_stale_status(RemoteDaemonWorkEvidence::AuthoritativelyIdle);
+    active.active_jobs = 1;
+    let changed = idle_stale_status(RemoteDaemonWorkEvidence::AuthoritativelyIdle);
+    let mut unproven = idle_stale_status(RemoteDaemonWorkEvidence::AuthoritativelyIdle);
+    unproven.endpoint_probe_error = Some("identity unavailable".to_string());
+
+    assert!(
+        authoritative_idle_lease_for_stale_generations(&active, &["lease-a".to_string()]).is_err()
+    );
+    assert_eq!(
+        authoritative_idle_lease_for_stale_generations(&changed, &["lease-stale".to_string()])
+            .expect("matching lease remains under normal fencing"),
+        None
+    );
+    assert!(
+        authoritative_idle_lease_for_stale_generations(&unproven, &["lease-a".to_string()])
+            .is_err()
+    );
+}
+
+#[test]
+fn stale_generation_reconciliation_refuses_a_lease_change_after_stop() {
+    let stopped = remote_daemon_status_for_test_with_reason(
+        false,
+        false,
+        0,
+        "lease-stale",
+        4444,
+        Some(DaemonStaleReasonCode::PidDead),
+    );
+    let changed = remote_daemon_status_for_test(true, true, 0, "lease-raced", 5555);
+
+    assert!(authoritative_lease_stop_confirmed(&stopped, "lease-stale").is_ok());
+    assert!(authoritative_lease_stop_confirmed(&changed, "lease-stale")
+        .expect_err("a new lease during recovery is not the stopped lease")
+        .contains("ownership changed"));
+}
+
+#[test]
 fn idle_stale_replacement_fails_closed_for_active_or_inconsistent_typed_jobs() {
     let configured = "homeboy 0.289.0+configured";
     let mut freshness_active = idle_stale_status(RemoteDaemonWorkEvidence::AuthoritativelyIdle);

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -62,6 +62,24 @@ pub(crate) fn disconnect_with_session(
         // generations have their own lease and tunnel, so teardown is complete
         // only after every persisted endpoint is resolved independently.
         let generations = super::super::generation_store::live_sessions(runner_id, Some(session))?;
+        if reconcile_authoritative_idle_stale_generations(runner_id, &generations)? {
+            super::super::generation_store::clear(runner_id)?;
+            let ownership = read_ownership(runner_id)?;
+            if should_stop_remote_daemon(
+                session,
+                ownership.as_ref(),
+                has_live_peer_session(session)?,
+            ) {
+                remove_ownership(runner_id)?;
+            }
+            remove_session(runner_id)?;
+            return Ok(RunnerDisconnectReport {
+                runner_id: runner_id.to_string(),
+                disconnected: true,
+                session: Some(session.clone()),
+                session_path: session_path(runner_id)?.display().to_string(),
+            });
+        }
         let mut unresolved = Vec::new();
         for generation in generations {
             if generation.mode == RunnerTunnelMode::DirectSsh {
@@ -100,6 +118,84 @@ pub(crate) fn disconnect_with_session(
         session,
         session_path: session_path(runner_id)?.display().to_string(),
     })
+}
+
+/// A refresh can inherit a ledger from interrupted rotations while the remote
+/// runner has one different, authoritative idle daemon. Reconcile only after
+/// the remote status and typed jobs probe prove the exact lease is safe to stop.
+fn reconcile_authoritative_idle_stale_generations(
+    runner_id: &str,
+    generations: &[RunnerSession],
+) -> Result<bool> {
+    let persisted_leases = generations
+        .iter()
+        .filter(|generation| generation.mode == RunnerTunnelMode::DirectSsh)
+        .filter_map(|generation| generation.remote_daemon_lease_id.clone())
+        .collect::<Vec<_>>();
+    if persisted_leases.is_empty() {
+        return Ok(false);
+    }
+    let runner = load(runner_id)?;
+    let homeboy = remote_runner_homeboy_path(&runner, "runner stale-generation reconciliation")?;
+    let Some((_, _, client)) = remote_daemon::resolve_ssh_runner(&runner)? else {
+        return Ok(false);
+    };
+    let mut status = remote_daemon::remote_daemon_status(&client, homeboy).map_err(|error| {
+        Error::validation_invalid_argument(
+            "disconnect",
+            format!("authoritative daemon reconciliation probe failed: {error}"),
+            Some(runner_id.to_string()),
+            None,
+        )
+    })?;
+    remote_daemon::probe_remote_daemon_endpoint(&client, &mut status);
+    let Some(lease_id) =
+        remote_daemon::authoritative_idle_lease_for_stale_generations(&status, &persisted_leases)
+            .map_err(|error| {
+            Error::validation_invalid_argument(
+                "disconnect",
+                format!("{error}; stale generations were retained"),
+                Some(runner_id.to_string()),
+                None,
+            )
+        })?
+    else {
+        return Ok(false);
+    };
+    remote_daemon::remote_daemon_force_stop(&client, homeboy, &lease_id).map_err(|error| {
+        Error::validation_invalid_argument(
+            "disconnect",
+            format!("authoritative lease-bound daemon stop failed: {error}"),
+            Some(runner_id.to_string()),
+            None,
+        )
+    })?;
+    let mut final_status =
+        remote_daemon::remote_daemon_status(&client, homeboy).map_err(|error| {
+            Error::validation_invalid_argument(
+                "disconnect",
+                format!("authoritative daemon re-probe after stop failed: {error}"),
+                Some(runner_id.to_string()),
+                None,
+            )
+        })?;
+    remote_daemon::probe_remote_daemon_endpoint(&client, &mut final_status);
+    remote_daemon::authoritative_lease_stop_confirmed(&final_status, &lease_id).map_err(
+        |error| {
+            Error::validation_invalid_argument(
+                "disconnect",
+                error,
+                Some(runner_id.to_string()),
+                None,
+            )
+        },
+    )?;
+    for generation in generations {
+        if let Some(pid) = generation.tunnel_pid {
+            terminate_pid(pid);
+        }
+    }
+    Ok(true)
 }
 
 fn should_stop_remote_daemon(

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -127,11 +127,9 @@ fn reconcile_authoritative_idle_stale_generations(
     runner_id: &str,
     generations: &[RunnerSession],
 ) -> Result<bool> {
-    let persisted_leases = generations
-        .iter()
-        .filter(|generation| generation.mode == RunnerTunnelMode::DirectSsh)
-        .filter_map(|generation| generation.remote_daemon_lease_id.clone())
-        .collect::<Vec<_>>();
+    let Some(persisted_leases) = eligible_stale_generation_leases(generations) else {
+        return Ok(false);
+    };
     if persisted_leases.is_empty() {
         return Ok(false);
     }
@@ -196,6 +194,24 @@ fn reconcile_authoritative_idle_stale_generations(
         }
     }
     Ok(true)
+}
+
+/// Clearing the ledger is safe only when every generation is represented by a
+/// lease-bearing direct SSH endpoint. Any other generation remains on the
+/// normal per-generation disconnect path.
+pub(in crate::connection) fn eligible_stale_generation_leases(
+    generations: &[RunnerSession],
+) -> Option<Vec<String>> {
+    generations
+        .iter()
+        .map(|generation| {
+            (generation.mode == RunnerTunnelMode::DirectSsh)
+                .then_some(generation.remote_daemon_lease_id.as_deref())
+                .flatten()
+                .filter(|lease_id| !lease_id.is_empty())
+                .map(str::to_string)
+        })
+        .collect()
 }
 
 fn should_stop_remote_daemon(


### PR DESCRIPTION
## Summary
- Reconcile multiple stale persisted direct-SSH generations when they all resolve to one different authoritative idle daemon.
- Fence recovery on exact lease ownership, reachable endpoint evidence, typed zero-job proof, and post-stop identity verification.
- Retire stale generation/session state only after the exact authoritative stop is confirmed.

Closes https://github.com/Extra-Chill/homeboy/issues/9262

## What changed
- Added authoritative idle-lease selection and stop-confirmation primitives.
- Added bounded disconnect-time reconciliation before ordinary per-generation teardown.
- Required every generation in the cleared ledger to be direct SSH with a nonempty persisted lease.
- Preserved fail-closed behavior for active jobs, mixed/missing leases, changed ownership, unreachable probes, and transport failures.

## How to test
1. Run `cargo test -p homeboy-lab-runner connection::tests::recovery`; expect 47 passing tests.
2. Run `cargo test -p homeboy-lab-runner homeboy_refresh::tests`; expect 50 passing tests.
3. Run `cargo test -p homeboy-lab-runner generation_store::tests`; expect 9 passing tests.
4. Run `cargo fmt --check`.
5. Run `cargo clippy -p homeboy-lab-runner --tests`; expect success with existing workspace warnings only.
6. Run `git diff --check origin/main...HEAD`.

## Live evidence
Before publication, a controller built from this repair recovered the reported idle authoritative lease, reconnected `homeboy-lab`, and produced a fresh v0.298.0 daemon accepting jobs with zero active work. Recovery retained fail-closed behavior throughout review and deterministic testing.

## Compatibility
This changes only stale direct-SSH runner generation recovery. Normal matching-lease disconnect, active generation draining, broker/reverse sessions, and active-job protection retain their existing behavior. The new path is additive and executes only when every retained generation is direct SSH and lease-bearing, none matches the authoritative daemon, and the daemon is authoritatively idle.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Model:** openai/gpt-5.6-sol
- **Used for:** Root-cause analysis, implementation, safety review, deterministic tests, rebase, and live recovery verification with Chris Huber.