### PR TITLE
Allow colon-bearing reviewer commands

### DIFF
--- a/crates/homeboy-agents/src/agent_task_review_dossier.rs
+++ b/crates/homeboy-agents/src/agent_task_review_dossier.rs
@@ -518,6 +518,11 @@ fn operator_only_reference(value: &str) -> bool {
     {
         return true;
     }
+    // `Url::parse` accepts colon-bearing CLI arguments as custom URI schemes.
+    // Only hierarchical references are intended to be URLs in reviewer commands.
+    if !value.contains("://") {
+        return false;
+    }
     let Ok(url) = reqwest::Url::parse(value) else {
         return false;
     };
@@ -776,6 +781,26 @@ mod tests {
             url: Some("https://example.com/evidence?token=secret".into()),
         });
         assert!(value.validate(&default_profile()).is_err());
+    }
+
+    #[test]
+    fn reviewer_commands_allow_colon_bearing_tokens_but_reject_url_references() {
+        for value in [
+            "npm run test:browser-scenarios",
+            "mvn verify -DskipTests=false:test",
+            "cargo test feature:browser-scenarios",
+        ] {
+            assert!(reviewer_runnable_command(value), "rejected {value}");
+        }
+
+        for value in [
+            "curl http://example.com/evidence",
+            "curl https://localhost:8888/evidence",
+            "cargo test file:///private/repo",
+            "cargo test --token secret",
+        ] {
+            assert!(!reviewer_runnable_command(value), "accepted {value}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #9282.

## Summary

- Treat only hierarchical `://` references as URLs in reviewer command validation.
- Allow ordinary colon-bearing CLI tokens such as npm script names.
- Preserve explicit rejection of local paths, artifact schemes, credentials, localhost/internal hosts, IP hosts, and non-HTTPS URLs.

## How to test

1. Run `cargo test -p homeboy-agents agent_task_review_dossier::tests`.
2. Confirm all dossier tests pass, including `npm run test:browser-scenarios` acceptance and real non-HTTPS/local URL rejection.
3. Run `cargo check -p homeboy-agents`.
4. Run `cargo fmt --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause analysis, implementation, regression tests, and verification
