### PR TITLE
fix(issues): dedup audit findings by fingerprint + surface fixability tiers

### DIFF
--- a/crates/homeboy-issues/src/render.rs
+++ b/crates/homeboy-issues/src/render.rs
@@ -73,7 +73,7 @@ pub fn build_findings_from_native_output(
 fn render_audit(data: &Value, context: &IssueRenderContext) -> ReconcileFindingsInput {
     let normalized_findings = normalized_findings(data);
     if !normalized_findings.is_empty() {
-        return render_normalized_findings("audit", normalized_findings, context);
+        return render_normalized_findings("audit", normalized_findings, Some(data), context);
     }
 
     let mut by_kind: BTreeMap<String, Vec<&Value>> = BTreeMap::new();
@@ -156,7 +156,7 @@ fn render_audit_body(
 fn render_lint(data: &Value, context: &IssueRenderContext) -> ReconcileFindingsInput {
     let normalized_findings = normalized_findings(data);
     if !normalized_findings.is_empty() {
-        return render_normalized_findings("lint", normalized_findings, context);
+        return render_normalized_findings("lint", normalized_findings, None, context);
     }
 
     let mut by_category: BTreeMap<String, Vec<&Value>> = BTreeMap::new();
@@ -303,7 +303,7 @@ fn render_lint_body(
 fn render_test(data: &Value, context: &IssueRenderContext) -> ReconcileFindingsInput {
     let normalized_findings = normalized_findings(data);
     if !normalized_findings.is_empty() {
-        return render_normalized_findings("test", normalized_findings, context);
+        return render_normalized_findings("test", normalized_findings, None, context);
     }
 
     let mut groups = BTreeMap::new();
@@ -375,6 +375,7 @@ fn normalized_findings(data: &Value) -> Vec<HomeboyFinding> {
 fn render_normalized_findings(
     command: &str,
     findings: Vec<HomeboyFinding>,
+    data: Option<&Value>,
     context: &IssueRenderContext,
 ) -> ReconcileFindingsInput {
     let mut by_category: BTreeMap<String, Vec<HomeboyFinding>> = BTreeMap::new();
@@ -385,12 +386,28 @@ fn render_normalized_findings(
 
     let mut groups = BTreeMap::new();
     for (category, findings) in by_category {
+        // Dedup identical findings by fingerprint before counting or rendering.
+        // The audit fingerprint (file:kind:convention:normalized_description)
+        // normalizes line numbers away, so repeated occurrences of the same
+        // issue collapse to one entry — otherwise counts and bullet lists are
+        // inflated by pure duplicates.
+        let findings = dedup_findings_by_fingerprint(findings);
+
+        // Fixability is reported per audit kind. Look it up by the group's
+        // representative rule (kind), which is how the audit keys /by_kind.
+        let fixability = data.and_then(|data| {
+            let kind = findings.first().and_then(|f| f.rule.as_deref())?;
+            data.pointer(&format!("/fixability/by_kind/{}", kind))
+        });
+
         groups.insert(
             category.clone(),
             RenderedIssueGroup {
                 count: findings.len(),
                 label: labelize(&category),
-                body: render_normalized_findings_body(command, &category, &findings, context),
+                body: render_normalized_findings_body(
+                    command, &category, &findings, fixability, context,
+                ),
                 confidence: None,
             },
         );
@@ -400,6 +417,23 @@ fn render_normalized_findings(
         command: command.to_string(),
         groups,
     }
+}
+
+/// Deduplicate findings by fingerprint, preserving first-seen order. Findings
+/// without a fingerprint fall back to their full message so they are never
+/// silently merged.
+fn dedup_findings_by_fingerprint(findings: Vec<HomeboyFinding>) -> Vec<HomeboyFinding> {
+    let mut seen = std::collections::HashSet::new();
+    findings
+        .into_iter()
+        .filter(|finding| {
+            let key = finding
+                .fingerprint
+                .clone()
+                .unwrap_or_else(|| finding.message.clone());
+            seen.insert(key)
+        })
+        .collect()
 }
 
 fn finding_category(command: &str, finding: &HomeboyFinding) -> String {
@@ -414,6 +448,7 @@ fn render_normalized_findings_body(
     command: &str,
     category: &str,
     findings: &[HomeboyFinding],
+    fixability: Option<&Value>,
     context: &IssueRenderContext,
 ) -> String {
     let mut out = String::new();
@@ -428,6 +463,7 @@ fn render_normalized_findings_body(
     if let Some(url) = context.run_url.as_deref() {
         let _ = writeln!(out, "\nRun: {}", url);
     }
+    render_fixability(&mut out, fixability);
     let _ = writeln!(out, "\n### Findings");
     for finding in findings.iter().take(20) {
         render_normalized_finding_line(&mut out, finding);

--- a/crates/homeboy-issues/src/render_test.rs
+++ b/crates/homeboy-issues/src/render_test.rs
@@ -393,3 +393,69 @@ fn passing_outputs_produce_no_groups() {
             .is_empty()
     );
 }
+
+#[test]
+fn normalized_audit_findings_dedup_by_fingerprint() {
+    // Three findings share one fingerprint (same file+kind+normalized message,
+    // line numbers normalized away) and one is distinct. The category should
+    // count 2 unique findings, not 4, and render each bullet once.
+    let output = json!({
+        "data": {
+            "passed": false,
+            "status": "failed",
+            "findings": [
+                {"tool": "audit", "rule": "constant_bypass_literal", "category": "constant_bypass_literal",
+                 "message": "Literal \"x\" duplicates constant X at line <line>",
+                 "fingerprint": "f.rs:constant_bypass_literal:conv:dup-x", "file": "f.rs"},
+                {"tool": "audit", "rule": "constant_bypass_literal", "category": "constant_bypass_literal",
+                 "message": "Literal \"x\" duplicates constant X at line <line>",
+                 "fingerprint": "f.rs:constant_bypass_literal:conv:dup-x", "file": "f.rs"},
+                {"tool": "audit", "rule": "constant_bypass_literal", "category": "constant_bypass_literal",
+                 "message": "Literal \"x\" duplicates constant X at line <line>",
+                 "fingerprint": "f.rs:constant_bypass_literal:conv:dup-x", "file": "f.rs"},
+                {"tool": "audit", "rule": "constant_bypass_literal", "category": "constant_bypass_literal",
+                 "message": "Literal \"y\" duplicates constant Y at line <line>",
+                 "fingerprint": "f.rs:constant_bypass_literal:conv:dup-y", "file": "f.rs"}
+            ]
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("audit", output, &IssueRenderContext::default()).unwrap();
+    let group = rendered.groups.get("constant_bypass_literal").unwrap();
+
+    assert_eq!(
+        group.count, 2,
+        "identical fingerprints must collapse to one"
+    );
+    assert!(group.body.contains("2 audit finding(s) in this category."));
+    // The deduped literal appears exactly once as a bullet.
+    assert_eq!(group.body.matches("duplicates constant X").count(), 1);
+    assert_eq!(group.body.matches("duplicates constant Y").count(), 1);
+}
+
+#[test]
+fn normalized_audit_findings_render_fixability_tiers() {
+    // Fixability data keyed by audit kind must surface in the issue body.
+    let output = json!({
+        "data": {
+            "passed": false,
+            "status": "failed",
+            "fixability": {"by_kind": {"dead_code": {"total": 5, "automated": 3, "manual_only": 2}}},
+            "findings": [
+                {"tool": "audit", "rule": "dead_code", "category": "dead_code",
+                 "message": "Public function 'f' is not referenced by any other file",
+                 "fingerprint": "a.rs:dead_code:conv:f", "file": "a.rs"}
+            ]
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("audit", output, &IssueRenderContext::default()).unwrap();
+    let group = rendered.groups.get("dead_code").unwrap();
+
+    assert!(group.body.contains("### Autofix status"));
+    assert!(group.body.contains("Total fixable: 5"));
+    assert!(group.body.contains("Automated: 3"));
+    assert!(group.body.contains("Manual-only: 2"));
+}


### PR DESCRIPTION
## Summary
Two audit-issue quality fixes uncovered by reading the first live homeboy Audit Debt sweep's output (run 29783825173). Both live in the normalized-findings render path in `crates/homeboy-issues/src/render.rs` — the path that actually produced the sweep's issues.

Closes #9307. Closes #9308.

## 1. Dedup findings by fingerprint (#9307)
`render_normalized_findings` counted and rendered **every occurrence** of a finding. Because the audit fingerprint (`file:kind:convention:normalized_description`) normalizes line numbers to `<line>`, repeated occurrences of the same issue share one fingerprint — but they were counted and rendered separately.

Real examples from the sweep:
- `command wrapper bypass (175)`: `rev-parse HEAD duplicates head_sha` rendered **5×** identically.
- `constant bypass literal (668)`: `notification_route` **3×**, `HOMEBOY_SKIP`/`HOMEBOY_STEP`/`HOMEBOY_AGENT_RUNTIME_SECRET_ENV` repeated.

Fix: dedup each category's findings by `fingerprint` (fallback to `message` when absent), preserving first-seen order, **before** setting `count` and before the `take(20)` render. Counts now reflect unique findings; bullet lists no longer repeat.

## 2. Surface fixability tiers (#9308)
`render_normalized_findings_body` never invoked the existing `render_fixability()` helper, so the per-kind autofix summary (total / automated / manual-only) was silently dropped from every real auto-filed issue — even though the audit output carries `/fixability/by_kind/<kind>`.

Fix: thread the `/fixability/by_kind/<kind>` pointer (keyed by the group's representative audit `rule`) into the body renderer and call `render_fixability`. Each issue now shows an **Autofix status** section.

## Tests
Two new regression tests:
- `normalized_audit_findings_dedup_by_fingerprint` — 4 findings (3 sharing a fingerprint + 1 distinct) → count 2, each bullet once.
- `normalized_audit_findings_render_fixability_tiers` — asserts the Autofix status section renders total/automated/manual-only.

All 17 `homeboy-issues` render tests pass. `cargo check -p homeboy-issues --lib` + `cargo fmt` clean. (Full build/test left to CI per repo policy.)

## Impact
The 668/175/etc. category counts were inflated by pure duplicates; deduping makes them honest and the lists readable, and also improves baseline drift accuracy. Fixability tiers turn each issue into a triage card (how many are one-command auto-fixable vs. needing review). Together these directly address the "wall of repeated bullets, no priority signal" papercut.