### PR TITLE
fix(agents): distinguish missing controller job identity from mismatch (#9240)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -135,6 +135,14 @@ pub fn project_terminal_runner_result(
     }
 
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    // Bind a still-pending controller handoff to this authoritative terminal
+    // snapshot's daemon job before validating identity (issue #9240). An
+    // accepted Lab job can reach a terminal daemon snapshot before the
+    // controller has persisted the accepted runner job id; binding here
+    // establishes that identity from the same evidence rather than rejecting a
+    // valid terminal snapshot against an empty controller job id. No-ops once
+    // the run is already bound.
+    bind_pending_lab_handoff_snapshot(&mut record, snapshot)?;
     validate_runner_job_snapshot(&record, snapshot)?;
     if let Some(event) = terminal_runner_lifecycle_event(&record, snapshot)? {
         if store::read_aggregate(&record.run_id).ok().as_ref() == Some(&event.aggregate) {
@@ -358,7 +366,28 @@ fn validate_runner_job_snapshot(
     record: &AgentTaskRunRecord,
     snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
 ) -> Result<()> {
-    let expected_job_id = record.runner_job_id().unwrap_or_default();
+    // Distinguish "controller identity not yet established" from a genuine
+    // identity mismatch. When the controller has never persisted an accepted
+    // runner job id, `runner_job_id()` is `None` and comparing a valid runner
+    // snapshot UUID against an empty string spuriously rejects it as a mismatch
+    // (issue #9240: "runner snapshot job <uuid> does not match controller job "
+    // — the blank trailing value is the missing-identity signal, not a mismatch).
+    // Callers must bind or propagate the accepted Lab job id before validation;
+    // surface the absence as its own diagnostic so it is fixed at the source
+    // instead of being presented as a runner mismatch and classified as a
+    // non-retryable runner error.
+    let Some(expected_job_id) = record.runner_job_id() else {
+        return Err(Error::validation_invalid_argument(
+            "runner_job_id",
+            format!(
+                "controller run has no accepted runner job identity to validate runner snapshot job {} against; \
+                 the accepted Lab handoff job id must be bound before snapshot validation",
+                snapshot.job.id
+            ),
+            Some(record.run_id.clone()),
+            None,
+        ));
+    };
     if expected_job_id == snapshot.job.id.to_string() {
         return Ok(());
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -616,6 +616,88 @@ fn preacceptance_snapshot_rejects_a_different_bound_daemon_job() {
 }
 
 #[test]
+fn foreground_terminal_projection_binds_a_pending_handoff_before_validation() {
+    // Issue #9240: an accepted Lab job can reach an authoritative terminal
+    // daemon snapshot before the controller has persisted its accepted runner
+    // job id. `project_terminal_runner_result` must bind the still-pending
+    // controller handoff to that snapshot's daemon job before validating
+    // identity, rather than rejecting a valid terminal snapshot against an empty
+    // controller job id.
+    with_isolated_home(|_| {
+        let run_id = "cook-terminal-preacceptance-bind";
+        let plan = test_plan();
+        let record = record_lab_offload_phase(
+            run_id,
+            "homeboy-lab",
+            "lab_handoff_preacceptance",
+            Some("/runner/workspace/homeboy"),
+            None,
+            None,
+            Some(&plan),
+        )
+        .expect("persist pending controller handoff");
+        assert!(
+            record.runner_job_id().is_none(),
+            "handoff must still be unbound before the terminal snapshot arrives"
+        );
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
+        let accepted_job_id = snapshot.job.id.to_string();
+        // Point the terminal child lifecycle event at this controller run so the
+        // downstream child-identity validation sees the run/job the bind
+        // establishes from the same snapshot.
+        let identity = &mut snapshot.events[0].data.as_mut().expect("event data")["identity"];
+        identity["run_id"] = json!(run_id);
+        identity["persisted_run_id"] = json!(run_id);
+
+        let projected = project_terminal_runner_result(run_id, &snapshot)
+            .expect("terminal snapshot binds the pending handoff before validation");
+        assert!(
+            projected,
+            "authoritative terminal snapshot projects the run"
+        );
+
+        let bound = status(run_id).expect("bound terminal projection");
+        assert_eq!(bound.runner_job_id(), Some(accepted_job_id.as_str()));
+        assert_eq!(bound.state, AgentTaskRunState::Succeeded);
+    });
+}
+
+#[test]
+fn snapshot_validation_reports_missing_controller_identity_distinctly() {
+    // Issue #9240: when the controller has never established an accepted runner
+    // job identity and no pending handoff can bind one, snapshot validation must
+    // surface the missing identity as its own diagnostic instead of comparing a
+    // valid runner UUID against an empty string and presenting it as a spurious
+    // "does not match controller job " mismatch.
+    with_isolated_home(|_| {
+        let run_id = "cook-terminal-no-identity";
+        let plan = test_plan();
+        // A freshly submitted run has no lab handoff and no metadata
+        // runner_job_id: there is no controller identity to validate against and
+        // no pending handoff to bind one from.
+        let record = submit_plan(&plan, Some(run_id)).expect("submitted");
+        assert!(record.lab_handoff.is_none());
+        assert!(record.runner_job_id().is_none());
+
+        let snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
+        let error = project_terminal_runner_result(&record.run_id, &snapshot)
+            .expect_err("missing controller identity fails closed with a distinct diagnostic");
+
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert!(
+            error.message.contains("no accepted runner job identity"),
+            "expected a missing-identity diagnostic, got: {}",
+            error.message
+        );
+        assert!(
+            !error.message.contains("does not match controller job"),
+            "missing identity must not be presented as a runner mismatch: {}",
+            error.message
+        );
+    });
+}
+
+#[test]
 fn missing_lab_attempt_plan_is_recovered_before_handoff_or_terminalized() {
     with_isolated_home(|_| {
         let run_id = "cook-8096-attempt-1";


### PR DESCRIPTION
## Summary
Closes #9240. A Lab-offloaded `agent-task cook` could fail in `lab_handoff_preacceptance` **before any provider ran**, because a valid runner snapshot UUID was validated against an *empty* controller job id and rejected as a runner mismatch:

```
Invalid argument `runner_job_id`: runner snapshot job <uuid> does not match controller job 
```

The blank trailing value was the real signal — the controller had not yet established an accepted runner job identity — but the comparison presented it as a non-retryable runner mismatch (and provider executions consumed stayed zero).

## Root cause
`validate_runner_job_snapshot` used `record.runner_job_id().unwrap_or_default()`, collapsing the "no controller identity yet" case (`None`) into an empty string and comparing a valid snapshot UUID against `""`. On the terminal-projection path (`project_terminal_runner_result`), the record was validated **without first binding** a still-pending controller handoff, so an accepted Lab job that reached a terminal daemon snapshot before the controller persisted its runner job id was rejected instead of bound.

## Changes
- **`validate_runner_job_snapshot`**: when the controller has no accepted runner job id, return a **distinct missing-identity diagnostic** ("controller run has no accepted runner job identity …") instead of a spurious `does not match controller job ` mismatch. A genuinely *different* non-empty id still fails closed as before.
- **`project_terminal_runner_result`**: bind a still-pending controller handoff to the authoritative terminal snapshot's daemon job **before** identity validation (reusing the single-owner `bind_pending_lab_handoff_snapshot` from #9276). No-ops once already bound; the existing target-runner guard prevents misbinding.

## Acceptance criteria mapping (#9240)
- ✅ A matching runner snapshot is accepted.
- ✅ A different non-empty job id is rejected (unchanged `does not match controller job` path).
- ✅ **Missing controller identity produces a specific lifecycle diagnostic rather than being presented as a runner mismatch.**
- ✅ Deterministic coverage for the pre-claim/terminal binding path.

## Tests (proven)
- `snapshot_validation_reports_missing_controller_identity_distinctly` — **fails on prior code** with the exact `does not match controller job ` string; passes with the fix producing the distinct diagnostic.
- `foreground_terminal_projection_binds_a_pending_handoff_before_validation` — proves a pre-claim pending handoff now binds against the terminal snapshot before validation.
- Existing preacceptance (6) + terminal-projection tests pass. One neighboring test (`cook_lab_handoff_controller_reads_ignore_runner_plan_projection`) is a **pre-existing flake** — fails identically on clean `origin/main` (at a different line), unrelated to this change.

Related: #9276 (single binding owner), #9261 (follow-on: accepted-then-absent detached handoff).