### PR TITLE
fix(audit): command_wrapper_bypass skips inline #[cfg(test)] blocks

### DIFF
--- a/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs
+++ b/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs
@@ -151,7 +151,16 @@ fn detect_command_wrapper_bypass(fingerprints: &[&FileFingerprint]) -> Vec<Findi
         if is_test_path(&fp.relative_path) {
             continue;
         }
+        // Raw arg-vectors inside inline `#[cfg(test)] mod tests { … }` blocks of
+        // a production file are test fixtures (e.g. `git rev-parse HEAD` to read
+        // a freshly-built repo), not production command drift. `is_test_path`
+        // only excludes whole test files, so compute the file's cfg(test) byte
+        // ranges here and skip matches that fall inside them.
+        let test_regions = cfg_test_regions(&fp.content);
         for m in argvec_regex().find_iter(&fp.content) {
+            if offset_in_any_region(m.start(), &test_regions) {
+                continue;
+            }
             let inner = argvec_regex()
                 .captures(&fp.content[m.start()..m.end()])
                 .and_then(|c| c.get(1))
@@ -238,6 +247,59 @@ fn thin_wrapper_bodies(content: &str) -> Vec<(String, String, usize)> {
         out.push((name, body.to_string(), body_start));
     }
     out
+}
+
+/// Byte ranges (start..end) of inline `#[cfg(test)]` blocks in `content`.
+///
+/// Matches a `#[cfg(test)]` attribute, then brace-matches the module/item that
+/// follows it. Both `#[cfg(test)] mod tests { … }` and `#[cfg(test)] fn … { … }`
+/// are covered. Ranges span from the attribute to the closing brace so any
+/// arg-vector inside is skipped by the finding pass.
+fn cfg_test_regions(content: &str) -> Vec<(usize, usize)> {
+    let bytes = content.as_bytes();
+    let mut regions = Vec::new();
+    let mut search_from = 0usize;
+    while let Some(rel) = content[search_from..].find("#[cfg(test)]") {
+        let attr_start = search_from + rel;
+        // Advance past this attribute for the next iteration regardless of
+        // whether we find a brace (avoids infinite loops on malformed input).
+        search_from = attr_start + "#[cfg(test)]".len();
+
+        // Find the first `{` after the attribute (skips `mod tests`, `fn …`,
+        // where-clauses, etc.). If none, the attribute closes an item with no
+        // block (e.g. `#[cfg(test)] use …;`) — nothing to exclude.
+        let Some(brace_rel) = content[search_from..].find('{') else {
+            continue;
+        };
+        let open = search_from + brace_rel;
+        let mut depth = 0i32;
+        let mut close = None;
+        for (i, &b) in bytes[open..].iter().enumerate() {
+            if b == b'{' {
+                depth += 1;
+            } else if b == b'}' {
+                depth -= 1;
+                if depth == 0 {
+                    close = Some(open + i);
+                    break;
+                }
+            }
+        }
+        if let Some(close) = close {
+            regions.push((attr_start, close));
+            // Continue searching after this block so sibling test modules and
+            // nested cfg(test) items are still discovered.
+            search_from = close + 1;
+        }
+    }
+    regions
+}
+
+/// Whether `offset` falls within any `(start, end)` region.
+fn offset_in_any_region(offset: usize, regions: &[(usize, usize)]) -> bool {
+    regions
+        .iter()
+        .any(|(start, end)| offset >= *start && offset <= *end)
 }
 
 #[cfg(test)]

--- a/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass/tests.rs
+++ b/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass/tests.rs
@@ -86,3 +86,44 @@ fn does_not_treat_a_dynamic_arg_wrapper_as_canonical() {
         "a wrapper taking a dynamic arg is not a fixed-command canonical wrapper"
     );
 }
+
+#[test]
+fn ignores_argvectors_inside_inline_cfg_test_blocks() {
+    let helper = fp(
+        "src/git/x.rs",
+        "pub fn head_sha(p: &Path) -> Option<String> {\n    output_optional(p, &[\"rev-parse\", \"HEAD\"])\n}\n",
+    );
+    // A production file whose ONLY raw arg-vector lives in its inline
+    // `#[cfg(test)] mod tests { … }` block — a fixture reading a freshly-built
+    // repo, not production command drift.
+    let production_with_inline_tests = fp(
+        "src/agent/materialization.rs",
+        "fn prod(p: &str) {\n    do_something(p);\n}\n\n#[cfg(test)]\nmod tests {\n    fn setup(p: &str) {\n        let head = git(p, &[\"rev-parse\", \"HEAD\"]);\n    }\n}\n",
+    );
+    assert!(
+        detect_command_wrapper_bypass(&[&helper, &production_with_inline_tests]).is_empty(),
+        "raw arg-vectors inside inline #[cfg(test)] blocks are test fixtures, not bypasses"
+    );
+}
+
+#[test]
+fn still_flags_production_argvector_alongside_an_inline_test_block() {
+    let helper = fp(
+        "src/git/x.rs",
+        "pub fn head_sha(p: &Path) -> Option<String> {\n    output_optional(p, &[\"rev-parse\", \"HEAD\"])\n}\n",
+    );
+    // Same file has a REAL production bypass plus a test-only arg-vector; only
+    // the production site is flagged, proving the cfg(test) skip is scoped to
+    // the test region and doesn't suppress legitimate findings.
+    let mixed = fp(
+        "src/agent/materialization.rs",
+        "fn prod(p: &str) {\n    let head = git(p, &[\"rev-parse\", \"HEAD\"]);\n}\n\n#[cfg(test)]\nmod tests {\n    fn setup(p: &str) {\n        let h = git(p, &[\"rev-parse\", \"HEAD\"]);\n    }\n}\n",
+    );
+    let findings = detect_command_wrapper_bypass(&[&helper, &mixed]);
+    assert_eq!(
+        findings.len(),
+        1,
+        "the production bypass is flagged, the inline-test one is not"
+    );
+    assert_eq!(findings[0].file, "src/agent/materialization.rs");
+}


### PR DESCRIPTION
## Summary
Fixes a false-positive class in the `command_wrapper_bypass` detector, found by reading the first live homeboy Audit Debt sweep.

## Problem
The detector excluded whole test *files* (`is_test_path`) but still flagged raw arg-vectors inside **inline `#[cfg(test)] mod tests { … }` blocks of production files**. Those are test fixtures — e.g. `git(p, &["rev-parse", "HEAD"])` reading a freshly-built repo — not production command drift.

Concrete evidence: in `audit: command wrapper bypass (175)`, five findings in `crates/homeboy-agents/src/agent_task_config_materialization.rs` (lines 522/551/586/627/663) were all `git::run_git(repo.path(), &["rev-parse", "HEAD"], "head")` calls sitting inside that file's `#[cfg(test)] mod tests` (starts line 510). Pure false positives. The detector's own doc comment even states the intent to exclude "test-module helpers inside `#[cfg(test)] mod tests`" — the finding pass just didn't enforce it.

## Fix
Compute each file's `#[cfg(test)]` byte ranges (matching the attribute, then brace-matching the block it guards — the same technique already used by `thin_wrapper_bodies`) and skip arg-vector matches that fall inside them. Handles both `#[cfg(test)] mod tests { … }` and `#[cfg(test)] fn … { … }`, plus attribute-only items with no block. Production bypasses in the same file are still flagged.

## Tests
Two new regression tests (all 7 detector tests + 321 detector-suite tests pass):
- `ignores_argvectors_inside_inline_cfg_test_blocks` — a production file whose only raw arg-vector is in its inline test block → no finding.
- `still_flags_production_argvector_alongside_an_inline_test_block` — a real production bypass plus a test-only one in the same file → exactly one finding (the production site), proving the skip is region-scoped.

`cargo check`/`fmt` clean; runtime regression test (`audit_runtime_regression_*`) unaffected. Full build → CI per repo policy.

## Impact
Removes a recurring false-positive source from the highest-signal audit category, so the `command_wrapper_bypass` issue reflects genuine production drift only — pairs with the dedup/fixability rendering fixes (#9309) to make the audit surface trustworthy.