### PR TITLE
fix(audit): constant_bypass_literal skips inline #[cfg(test)] blocks

### DIFF
--- a/crates/homeboy-code-audit/src/detectors/constant_bypass.rs
+++ b/crates/homeboy-code-audit/src/detectors/constant_bypass.rs
@@ -23,7 +23,7 @@ use regex::Regex;
 use super::super::conventions::AuditFinding;
 use super::super::findings::{Finding, Severity};
 use super::super::fingerprint::FileFingerprint;
-use super::super::walker::is_test_path;
+use super::super::walker::{cfg_test_regions, is_test_path, offset_in_cfg_test_region};
 
 /// Minimum constant-value length worth flagging. Short values (`"workspace"`,
 /// `"snapshot"`) collide with serde tags, enum spellings, and unrelated
@@ -87,7 +87,14 @@ fn detect_constant_bypass_literals(fingerprints: &[&FileFingerprint]) -> Vec<Fin
         if is_test_path(&fp.relative_path) {
             continue;
         }
+        // Literals inside inline `#[cfg(test)]` blocks of a production file are
+        // test data/fixtures, not production constant drift. `is_test_path` only
+        // excludes whole test files, so skip matches inside cfg(test) regions.
+        let test_regions = cfg_test_regions(&fp.content);
         for (offset, literal) in string_literals(&fp.content) {
+            if offset_in_cfg_test_region(offset, &test_regions) {
+                continue;
+            }
             let Some(def) = consts.get(&literal) else {
                 continue;
             };

--- a/crates/homeboy-code-audit/src/detectors/constant_bypass/tests.rs
+++ b/crates/homeboy-code-audit/src/detectors/constant_bypass/tests.rs
@@ -80,3 +80,42 @@ fn re_export_const_line_is_not_flagged() {
         "a constant declaration line is not a bypass site"
     );
 }
+
+#[test]
+fn ignores_literals_inside_inline_cfg_test_blocks() {
+    let def = fp(
+        "src/a.rs",
+        r#"pub const NOTIFICATION_ROUTE_METADATA_KEY: &str = "notification_route_key";"#,
+    );
+    // The only reuse of the value is inside the file's inline test module —
+    // test data, not production drift.
+    let production_with_inline_tests = fp(
+        "src/route.rs",
+        "fn prod() {\n    do_something();\n}\n\n#[cfg(test)]\nmod tests {\n    fn setup() {\n        let key = \"notification_route_key\";\n    }\n}\n",
+    );
+    assert!(
+        detect_constant_bypass_literals(&[&def, &production_with_inline_tests]).is_empty(),
+        "literals inside inline #[cfg(test)] blocks are test data, not bypasses"
+    );
+}
+
+#[test]
+fn still_flags_production_literal_alongside_an_inline_test_block() {
+    let def = fp(
+        "src/a.rs",
+        r#"pub const NOTIFICATION_ROUTE_METADATA_KEY: &str = "notification_route_key";"#,
+    );
+    // Same file has a REAL production bypass plus a test-only reuse; only the
+    // production site is flagged.
+    let mixed = fp(
+        "src/route.rs",
+        "fn prod() {\n    let key = \"notification_route_key\";\n}\n\n#[cfg(test)]\nmod tests {\n    fn setup() {\n        let k = \"notification_route_key\";\n    }\n}\n",
+    );
+    let findings = detect_constant_bypass_literals(&[&def, &mixed]);
+    assert_eq!(
+        findings.len(),
+        1,
+        "the production literal is flagged, the inline-test one is not"
+    );
+    assert_eq!(findings[0].file, "src/route.rs");
+}

--- a/crates/homeboy-code-audit/src/walker.rs
+++ b/crates/homeboy-code-audit/src/walker.rs
@@ -134,3 +134,56 @@ pub(crate) fn count_unclaimed_source_files(root: &Path) -> usize {
 
     codebase_scan::walk_files(root, &config).len()
 }
+
+/// Byte ranges `(start, end)` of inline `#[cfg(test)]` blocks in `content`.
+///
+/// `is_test_path` only classifies whole test *files*. Detectors that scan raw
+/// file content (constant-bypass, command-wrapper-bypass, …) also need to skip
+/// matches inside inline `#[cfg(test)] mod tests { … }` / `#[cfg(test)] fn … {}`
+/// blocks of production files, where literals and raw commands are test
+/// fixtures rather than production code.
+///
+/// Matches the `#[cfg(test)]` attribute, then brace-matches the block that
+/// follows it. Attribute-only items with no block (`#[cfg(test)] use …;`) are
+/// ignored. Ranges span attribute→closing brace.
+pub(crate) fn cfg_test_regions(content: &str) -> Vec<(usize, usize)> {
+    const ATTR: &str = "#[cfg(test)]";
+    let bytes = content.as_bytes();
+    let mut regions = Vec::new();
+    let mut search_from = 0usize;
+    while let Some(rel) = content[search_from..].find(ATTR) {
+        let attr_start = search_from + rel;
+        // Advance past this attribute regardless of outcome (no infinite loop).
+        search_from = attr_start + ATTR.len();
+
+        let Some(brace_rel) = content[search_from..].find('{') else {
+            continue;
+        };
+        let open = search_from + brace_rel;
+        let mut depth = 0i32;
+        let mut close = None;
+        for (i, &b) in bytes[open..].iter().enumerate() {
+            if b == b'{' {
+                depth += 1;
+            } else if b == b'}' {
+                depth -= 1;
+                if depth == 0 {
+                    close = Some(open + i);
+                    break;
+                }
+            }
+        }
+        if let Some(close) = close {
+            regions.push((attr_start, close));
+            search_from = close + 1;
+        }
+    }
+    regions
+}
+
+/// Whether `offset` falls within any `(start, end)` region.
+pub(crate) fn offset_in_cfg_test_region(offset: usize, regions: &[(usize, usize)]) -> bool {
+    regions
+        .iter()
+        .any(|(start, end)| offset >= *start && offset <= *end)
+}


### PR DESCRIPTION
## Summary
Removes the inline-`#[cfg(test)]` false-positive class from the `constant_bypass_literal` detector — the sibling of #9311 (which fixed the same gap in `command_wrapper_bypass`).

## Problem
The detector already skipped whole test files (`is_test_path`) and the const definition/declaration lines, but still flagged string literals inside inline `#[cfg(test)] mod tests { … }` blocks of production files. Those literals are test data/fixtures, not production constant drift.

Concrete evidence from the first Audit Debt sweep: `homeboy-lab-contract/src/notification_route.rs` defines `NOTIFICATION_ROUTE_METADATA_KEY = "notification_route"` and the detector flagged the value's reuse at lines 90/103 — both inside the file's inline `#[cfg(test)] mod tests`.

## Fix
- Add shared `cfg_test_regions` / `offset_in_cfg_test_region` helpers to `walker.rs` (next to `is_test_path`, the natural home for test classification). They brace-match `#[cfg(test)]` blocks and report their byte ranges.
- Use them in `constant_bypass` to skip literals inside cfg(test) regions. Production bypasses in the same file are still flagged.

## Tests
Two new regression tests (7 constant_bypass + 321 detector-suite + runtime regression all pass):
- `ignores_literals_inside_inline_cfg_test_blocks`
- `still_flags_production_literal_alongside_an_inline_test_block` (proves the skip is region-scoped, not blanket).

`cargo check`/`fmt` clean; full build → CI per repo policy.

## Follow-up
#9311 inlined the equivalent logic into `command_wrapper_bypass`. Once both land, a small follow-up can dedup that detector onto these shared `walker` helpers. (Kept separate here to avoid a cross-PR dependency.)

## Impact
`constant_bypass_literal` was the noisiest audit category (668 findings). Combined with the dedup fix (#9309), skipping test-block literals meaningfully cuts its false-positive rate so the count reflects real production drift.