### PR TITLE
Fix lost Lab job and runner lease reconciliation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1508,21 +1508,72 @@ fn reconcile_runner_job_state(record: &mut AgentTaskRunRecord) -> Result<()> {
     ) else {
         return Ok(());
     };
-    let snapshot = match super::runner_continuation::with_runner_continuation(|p| {
-        p.runner_job_log_snapshot(&runner_id, &job_id)
+    match super::runner_continuation::with_runner_continuation(|p| {
+        p.reconcile_runner_job(&runner_id, &job_id)
     }) {
-        Ok(snapshot) => snapshot,
-        Err(_) => {
+        super::runner_continuation::RunnerJobReconciliation::Snapshot(snapshot) => {
+            reconcile_runner_job_snapshot(record, &snapshot)
+        }
+        super::runner_continuation::RunnerJobReconciliation::ConfirmedAbsent {
+            checked_generations,
+        } => terminalize_lost_accepted_lab_job(record, checked_generations),
+        super::runner_continuation::RunnerJobReconciliation::UnconfirmedAbsence => {
             let disconnected = super::runner_continuation::with_runner_continuation(|p| {
                 !p.is_runner_connected(&runner_id)
             });
             if disconnected {
                 record.annotate_runner_disconnected();
             }
-            return Ok(());
+            Ok(())
         }
-    };
-    reconcile_runner_job_snapshot(record, &snapshot)
+    }
+}
+
+fn terminalize_lost_accepted_lab_job(
+    record: &mut AgentTaskRunRecord,
+    checked_generations: usize,
+) -> Result<()> {
+    if !record.has_accepted_lab_handoff() || !record.provider_handles.is_empty() {
+        return Ok(());
+    }
+    let plan = store::read_controller_plan(&record.run_id)?;
+    let run_id = record.run_id.clone();
+    let runner_id = record.runner_id().unwrap_or_default().to_string();
+    let runner_job_id = record.runner_job_id().unwrap_or_default().to_string();
+    let mut error = Error::internal_unexpected(format!(
+        "accepted Lab runner job '{runner_job_id}' was not found in any of {checked_generations} authoritative known daemon generation(s)"
+    ))
+    .with_hint(format!("Retry safely: homeboy agent-task retry {run_id} --run"));
+    error.retryable = Some(true);
+    let mut terminal = crate::agent_task_lifecycle::record_pre_execution_failure(
+        &run_id,
+        &plan,
+        "accepted_lab_runner_job_lost",
+        &error,
+    )?;
+    let metadata = terminal.ensure_metadata_object();
+    metadata.insert("phase".to_string(), json!("accepted_lab_runner_job_lost"));
+    metadata.insert(
+        "phase_activity".to_string(),
+        json!("accepted runner job was confirmed absent across authoritative daemon generations"),
+    );
+    metadata.insert("provider_executions_consumed".to_string(), json!(0));
+    metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
+    metadata.insert(
+        "lost_accepted_runner_job".to_string(),
+        json!({
+            "runner_id": runner_id,
+            "runner_job_id": runner_job_id,
+            "checked_generations": checked_generations,
+            "safe_next_action": format!("homeboy agent-task retry {run_id} --run"),
+        }),
+    );
+    if let Some(handoff) = metadata.get_mut("runner_handoff") {
+        handoff["state"] = json!("lost");
+    }
+    store::write_record(&terminal)?;
+    *record = terminal;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
@@ -60,7 +60,9 @@ pub use records::*;
 pub use runner_continuation::{
     clear_runner_continuation_provider_for_test, RunnerContinuationTestGuard,
 };
-pub use runner_continuation::{register_runner_continuation_provider, RunnerContinuationProvider};
+pub use runner_continuation::{
+    register_runner_continuation_provider, RunnerContinuationProvider, RunnerJobReconciliation,
+};
 
 pub(crate) use conversion::*;
 pub(crate) use lifecycle_record_ops::*;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
@@ -19,6 +19,17 @@ use homeboy_core::api_jobs::{
 };
 use homeboy_core::error::{Error, Result};
 
+/// Result of reconciling a runner job across its known daemon generations.
+///
+/// An accepted handoff is terminal only when every authoritative generation
+/// confirms the job is absent. Transport failures remain deliberately
+/// unconfirmed so a transient daemon error cannot discard runner-owned work.
+pub enum RunnerJobReconciliation {
+    Snapshot(RunnerJobLogSnapshot),
+    ConfirmedAbsent { checked_generations: usize },
+    UnconfirmedAbsence,
+}
+
 /// Runner-side operations the agent-task lifecycle needs when reconciling or
 /// resuming a run that was handed off to a remote runner.
 pub trait RunnerContinuationProvider: Send + Sync {
@@ -28,6 +39,16 @@ pub trait RunnerContinuationProvider: Send + Sync {
         runner_id: &str,
         job_id: &str,
     ) -> Result<RunnerJobLogSnapshot>;
+
+    /// Reconcile a job against the daemon generation that owns it and, when
+    /// necessary, other known generations. Providers without generation
+    /// ownership support retain the conservative snapshot-only behavior.
+    fn reconcile_runner_job(&self, runner_id: &str, job_id: &str) -> RunnerJobReconciliation {
+        match self.runner_job_log_snapshot(runner_id, job_id) {
+            Ok(snapshot) => RunnerJobReconciliation::Snapshot(snapshot),
+            Err(_) => RunnerJobReconciliation::UnconfirmedAbsence,
+        }
+    }
 
     /// Whether the runner currently reports a live connection.
     fn is_runner_connected(&self, runner_id: &str) -> bool;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -17,6 +17,92 @@ use homeboy_core::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};
 use std::sync::{Arc, Mutex};
 
+enum TestRunnerReconciliation {
+    Snapshot(homeboy_core::api_jobs::RunnerJobLogSnapshot),
+    ConfirmedAbsent(usize),
+    Unconfirmed,
+}
+
+struct ReconciliationProvider {
+    result: Mutex<Option<TestRunnerReconciliation>>,
+}
+
+impl RunnerContinuationProvider for ReconciliationProvider {
+    fn runner_job_log_snapshot(
+        &self,
+        _runner_id: &str,
+        _job_id: &str,
+    ) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot> {
+        Err(Error::internal_unexpected(
+            "snapshot must use generation reconciliation",
+        ))
+    }
+
+    fn reconcile_runner_job(&self, _runner_id: &str, _job_id: &str) -> RunnerJobReconciliation {
+        match self.result.lock().expect("reconciliation result").take() {
+            Some(TestRunnerReconciliation::Snapshot(snapshot)) => {
+                RunnerJobReconciliation::Snapshot(snapshot)
+            }
+            Some(TestRunnerReconciliation::ConfirmedAbsent(checked_generations)) => {
+                RunnerJobReconciliation::ConfirmedAbsent {
+                    checked_generations,
+                }
+            }
+            Some(TestRunnerReconciliation::Unconfirmed) | None => {
+                RunnerJobReconciliation::UnconfirmedAbsence
+            }
+        }
+    }
+
+    fn is_runner_connected(&self, _runner_id: &str) -> bool {
+        true
+    }
+
+    fn runner_exists(&self, _runner_id: &str) -> bool {
+        true
+    }
+
+    fn run_continuation_exec(
+        &self,
+        _runner_id: &str,
+        _cwd: &str,
+        _command: &[String],
+        _run_id: &str,
+    ) -> Result<i32> {
+        Err(Error::internal_unexpected("not used by reconciliation"))
+    }
+
+    fn submit_reverse_broker_job(
+        &self,
+        _runner_id: &str,
+        _request: RemoteRunnerJobRequest,
+    ) -> Result<Job> {
+        Err(Error::internal_unexpected("not used by reconciliation"))
+    }
+}
+
+fn accepted_detached_handoff(run_id: &str) -> AgentTaskRunRecord {
+    let plan = test_plan();
+    record_lab_offload_phase(
+        run_id,
+        "homeboy-lab",
+        "lab_handoff_preacceptance",
+        Some("/runner/workspace/homeboy"),
+        None,
+        None,
+        Some(&plan),
+    )
+    .expect("persist pending handoff");
+    record_detached_lab_run(DetachedLabRunRecord {
+        run_id,
+        runner_id: "homeboy-lab",
+        runner_job_id: "00000000-0000-0000-0000-000000000123",
+        remote_workspace: "/runner/workspace/homeboy",
+        remote_command: &[],
+    })
+    .expect("accept handoff")
+}
+
 #[test]
 fn submit_plan_persists_queued_status() {
     with_isolated_home(|_| {
@@ -515,6 +601,75 @@ fn detached_cook_attempt_proxy_advances_after_daemon_acceptance() {
             accepted.metadata["runner_execution_record"]["status"],
             "running"
         );
+    });
+}
+
+#[test]
+fn accepted_handoff_adopts_a_job_found_on_another_known_generation() {
+    with_isolated_home(|_| {
+        let run_id = "generation-move-recovery";
+        accepted_detached_handoff(run_id);
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
+        snapshot.job.target_runner_id = Some("homeboy-lab".to_string());
+        snapshot.events.clear();
+        let _provider = RunnerContinuationTestGuard::install(Box::new(ReconciliationProvider {
+            // This represents a 404 on the current generation followed by a
+            // matching snapshot on another generation in the durable ledger.
+            result: Mutex::new(Some(TestRunnerReconciliation::Snapshot(snapshot))),
+        }));
+
+        let reconciled = status(run_id).expect("adopted generation snapshot");
+
+        assert_eq!(reconciled.state, AgentTaskRunState::Running);
+        assert_eq!(reconciled.metadata["runner_job_status"], "running");
+        assert_eq!(reconciled.metadata["provider_executions_consumed"], 0);
+        assert!(reconciled.provider_handles.is_empty());
+    });
+}
+
+#[test]
+fn accepted_handoff_fails_after_confirmed_absence_across_generations() {
+    with_isolated_home(|_| {
+        let run_id = "generation-confirmed-absence";
+        accepted_detached_handoff(run_id);
+        let _provider = RunnerContinuationTestGuard::install(Box::new(ReconciliationProvider {
+            result: Mutex::new(Some(TestRunnerReconciliation::ConfirmedAbsent(2))),
+        }));
+
+        let terminal = status(run_id).expect("terminal lost accepted job");
+
+        assert_eq!(terminal.state, AgentTaskRunState::Failed);
+        assert_eq!(terminal.metadata["phase"], "accepted_lab_runner_job_lost");
+        assert_eq!(
+            terminal.metadata["lost_accepted_runner_job"]["checked_generations"],
+            2
+        );
+        assert_eq!(terminal.metadata["provider_executions_consumed"], 0);
+        assert!(terminal.provider_handles.is_empty());
+        let aggregate = read_aggregate(run_id).expect("failure aggregate");
+        assert!(aggregate.outcomes[0]
+            .summary
+            .as_deref()
+            .is_some_and(|summary| { summary.contains("accepted Lab runner job") }));
+    });
+}
+
+#[test]
+fn accepted_handoff_does_not_terminalize_unconfirmed_generation_absence() {
+    with_isolated_home(|_| {
+        let run_id = "generation-unconfirmed-absence";
+        accepted_detached_handoff(run_id);
+        let _provider = RunnerContinuationTestGuard::install(Box::new(ReconciliationProvider {
+            result: Mutex::new(Some(TestRunnerReconciliation::Unconfirmed)),
+        }));
+
+        let retained = status(run_id).expect("retain unconfirmed handoff");
+
+        assert_eq!(retained.state, AgentTaskRunState::Running);
+        assert!(retained.metadata.get("lost_accepted_runner_job").is_none());
+        assert_eq!(retained.metadata["provider_executions_consumed"], 0);
+        assert!(retained.provider_handles.is_empty());
     });
 }
 

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -673,9 +673,11 @@ fn connect_with_orphan_adoption_and_live_lease(
             .and_then(|e| serde_json::to_value(e).ok()),
     };
     // The tunnel health check above re-proved the exact remote lease and PID.
-    // Refuse a runtime generation change before atomically publishing it.
+    // Persist its generation before the controller session so a later session
+    // drift still has authenticated promotion provenance to reconcile safely.
     if let Err(error) = promotion_lease
         .assert_generation()
+        .and_then(|_| super::generation_store::record_authenticated_admission(runner_id, &session))
         .and_then(|_| write_session(&session))
     {
         return Ok(session_write_failure_report(

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -68,6 +68,42 @@ fn stale_persisted_lease_requires_explicit_live_lease_adoption() {
 }
 
 #[test]
+fn authenticated_promotion_provenance_allows_ordinary_reconnect_after_session_drift() {
+    test_support::with_isolated_home(|_| {
+        let stale = direct_ssh_session("lease-recorded");
+        let mut promoted = direct_ssh_session("lease-live");
+        promoted.remote_daemon_pid = Some(4646);
+        promoted.homeboy_build_identity = Some("homeboy test+configured".to_string());
+        crate::generation_store::record_authenticated_admission("homeboy-lab", &promoted)
+            .expect("authenticated promotion records its admission generation");
+
+        let reconciled = crate::generation_store::admission_session("homeboy-lab", Some(&stale))
+            .expect("read promotion provenance")
+            .expect("promoted admission session");
+        let mut live = remote_daemon_status_for_test(true, true, 0, "lease-live", 4646);
+        live.daemon.as_mut().expect("daemon").build_identity =
+            Some("homeboy test+configured".to_string());
+
+        assert_eq!(
+            remote_daemon_connect_action_for_runner(
+                Some(&reconciled),
+                &live,
+                "homeboy test+configured",
+                "homeboy-lab",
+                None,
+            )
+            .expect("ordinary reconnect uses authenticated promotion provenance"),
+            RemoteDaemonConnectAction::Reattach,
+        );
+        assert_eq!(
+            reconciled.remote_daemon_lease_id.as_deref(),
+            Some("lease-live")
+        );
+        assert_eq!(reconciled.remote_daemon_pid, Some(4646));
+    });
+}
+
+#[test]
 fn explicit_live_lease_adoption_requires_the_exact_current_lease_and_pid() {
     let session = direct_ssh_session("lease-recorded");
     let mut status = remote_daemon_status_for_test(true, true, 0, "lease-live", 4646);

--- a/crates/homeboy-lab-runner/src/continuation_provider.rs
+++ b/crates/homeboy-lab-runner/src/continuation_provider.rs
@@ -5,7 +5,7 @@
 //! behavior directly. This adapter delegates to the runner connection,
 //! execution, and evidence functions.
 
-use homeboy_agents::agent_task_lifecycle::RunnerContinuationProvider;
+use homeboy_agents::agent_task_lifecycle::{RunnerContinuationProvider, RunnerJobReconciliation};
 use homeboy_core::api_jobs::{Job, RemoteRunnerJobRequest, RunnerJobLogSnapshot};
 use homeboy_core::error::Result;
 
@@ -19,6 +19,52 @@ impl RunnerContinuationProvider for RunnerContinuation {
         job_id: &str,
     ) -> Result<RunnerJobLogSnapshot> {
         super::evidence::runner_job_log_snapshot(runner_id, job_id)
+    }
+
+    fn reconcile_runner_job(&self, runner_id: &str, job_id: &str) -> RunnerJobReconciliation {
+        match self.runner_job_log_snapshot(runner_id, job_id) {
+            Ok(snapshot) => return RunnerJobReconciliation::Snapshot(snapshot),
+            Err(error) if !job_not_found(&error, job_id) => {
+                return RunnerJobReconciliation::UnconfirmedAbsence;
+            }
+            Err(_) => {}
+        }
+
+        let Ok(status) = super::connection::status(runner_id) else {
+            return RunnerJobReconciliation::UnconfirmedAbsence;
+        };
+        let Some(session) = status.session.filter(|_| status.connected) else {
+            return RunnerJobReconciliation::UnconfirmedAbsence;
+        };
+        let Ok(generations) = super::generation_store::live_sessions(runner_id, Some(&session))
+        else {
+            return RunnerJobReconciliation::UnconfirmedAbsence;
+        };
+        if generations.is_empty() {
+            return RunnerJobReconciliation::UnconfirmedAbsence;
+        }
+
+        let mut checked_generations = 0;
+        for generation in generations {
+            if generation.local_url.is_none() {
+                return RunnerJobReconciliation::UnconfirmedAbsence;
+            }
+            checked_generations += 1;
+            match super::evidence::runner_job_log_snapshot_for_session(&generation, job_id) {
+                Ok(snapshot) => {
+                    if super::generation_store::record_job(runner_id, &generation, job_id).is_err()
+                    {
+                        return RunnerJobReconciliation::UnconfirmedAbsence;
+                    }
+                    return RunnerJobReconciliation::Snapshot(snapshot);
+                }
+                Err(error) if job_not_found(&error, job_id) => continue,
+                Err(_) => return RunnerJobReconciliation::UnconfirmedAbsence,
+            }
+        }
+        RunnerJobReconciliation::ConfirmedAbsent {
+            checked_generations,
+        }
     }
 
     fn is_runner_connected(&self, runner_id: &str) -> bool {
@@ -69,6 +115,19 @@ impl RunnerContinuationProvider for RunnerContinuation {
     ) -> Result<homeboy_core::api_jobs::RemoteRunnerSubmissionLookup> {
         super::connection::lookup_reverse_broker_submission(runner_id, submission_key)
     }
+}
+
+fn job_not_found(error: &homeboy_core::error::Error, job_id: &str) -> bool {
+    error
+        .details
+        .get("http_status")
+        .and_then(serde_json::Value::as_u64)
+        == Some(404)
+        && error
+            .details
+            .get("path")
+            .and_then(serde_json::Value::as_str)
+            == Some(&format!("/jobs/{job_id}"))
 }
 
 /// Register the runner continuation provider with core. Called once at startup.

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -236,6 +236,29 @@ pub fn runner_job_log_snapshot(runner_id: &str, job_id: &str) -> Result<RunnerJo
     })
 }
 
+pub(crate) fn runner_job_log_snapshot_for_session(
+    session: &crate::RunnerSession,
+    job_id: &str,
+) -> Result<RunnerJobLogSnapshot> {
+    let job_data =
+        crate::execution::daemon_api_get_for_session(session, &format!("/jobs/{job_id}"))?;
+    let events_data =
+        crate::execution::daemon_api_get_for_session(session, &format!("/jobs/{job_id}/events"))?;
+    let job_body = canonical_daemon_body(&job_data, "daemon job response")?;
+    let events_body = canonical_daemon_body(&events_data, "daemon job events response")?;
+    Ok(RunnerJobLogSnapshot {
+        job: serde_json::from_value(job_body["job"].clone()).map_err(|error| {
+            Error::internal_json(error.to_string(), Some("parse daemon job".to_string()))
+        })?,
+        events: serde_json::from_value(events_body["events"].clone()).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse daemon job events".to_string()),
+            )
+        })?,
+    })
+}
+
 pub fn mirrored_runner_job_identity(run: &RunRecord) -> Option<(String, String)> {
     let lab = run.metadata_json.get("lab")?;
     let runner_id = lab

--- a/crates/homeboy-lab-runner/src/evidence/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mod.rs
@@ -19,6 +19,7 @@ pub use tokens::{
 pub use download::{download_remote_artifact, RemoteArtifactDownload};
 
 pub use homeboy_core::api_jobs::RunnerJobLogSnapshot;
+pub(crate) use mirror::runner_job_log_snapshot_for_session;
 pub use mirror::{
     mirror_connected_runner_run, mirror_daemon_evidence, mirror_daemon_job_progress,
     mirror_reverse_broker_evidence, mirrored_runner_job_identity, refresh_mirrored_daemon_evidence,

--- a/crates/homeboy-lab-runner/src/execution/daemon_api.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon_api.rs
@@ -9,7 +9,7 @@ use homeboy_core::error::{Error, ErrorCode, Result};
 
 use super::super::broker_http;
 use super::super::daemon_http_get::{daemon_get, parse_daemon_response_json};
-use super::super::{load, status, RunnerTunnelMode};
+use super::super::{load, status, RunnerSession, RunnerTunnelMode};
 
 #[allow(unused_imports)]
 use super::*;
@@ -94,6 +94,20 @@ fn with_daemon_post_options(request: RequestBuilder, options: DaemonPostOptions)
 
 pub fn daemon_api_get(runner_id: &str, path: &str) -> Result<Value> {
     daemon_api_request(runner_id, path, "GET")
+}
+
+/// Query one known direct-daemon generation without re-resolving ownership.
+/// Generation reconciliation uses this only after a job lookup returned 404.
+pub(crate) fn daemon_api_get_for_session(session: &RunnerSession, path: &str) -> Result<Value> {
+    let local_url = session.local_url.as_deref().ok_or_else(|| {
+        Error::internal_unexpected("known daemon generation has no direct local endpoint")
+    })?;
+    let client = Client::builder()
+        .no_proxy()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|err| Error::internal_unexpected(format!("build daemon HTTP client: {err}")))?;
+    daemon_get(&client, local_url, path)
 }
 
 pub fn daemon_api_post(runner_id: &str, path: &str) -> Result<Value> {

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -80,6 +80,7 @@ use policy::{preflight_remote_argv, remote_execution_preflight};
 // API. `use` re-exports are not counted as structural items.
 use broker::*;
 use daemon::*;
+pub(crate) use daemon_api::daemon_api_get_for_session;
 use daemon_api::*;
 use failure::*;
 use handoff::*;

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -353,6 +353,30 @@ pub(crate) fn record_job(runner_id: &str, session: &RunnerSession, job_id: &str)
     write(runner_id, &generations)
 }
 
+/// Persist a daemon that has already passed the authenticated connection and
+/// endpoint identity checks as the admission owner. This survives controller
+/// session-file drift, while retaining older generations for any work pinned
+/// to them.
+pub(crate) fn record_authenticated_admission(
+    runner_id: &str,
+    session: &RunnerSession,
+) -> Result<()> {
+    let generation = session.remote_daemon_lease_id.as_deref().ok_or_else(|| {
+        Error::internal_unexpected("authenticated daemon session has no lease ID")
+    })?;
+    let mut generations = read(runner_id, None)?
+        .unwrap_or_else(|| RollingGenerations::new(generation, session.clone()));
+    if let Some(entry) = generations.generations.get_mut(generation) {
+        // A reattached daemon gets a fresh local tunnel, so update the endpoint
+        // without disturbing jobs already pinned to this lease.
+        entry.endpoint = session.clone();
+    } else {
+        generations.begin(generation, session.clone());
+    }
+    generations.activate(generation);
+    write(runner_id, &generations)
+}
+
 pub(crate) fn record_job_run(
     runner_id: &str,
     legacy: &RunnerSession,


### PR DESCRIPTION
## Summary

Fixes two recovery gaps found while running a detached Lab fuzz workload:

- Reconciles an accepted Lab handoff when the authoritative daemon later returns `404 job not found`, using generation-aware evidence rather than leaving the durable run permanently `running`.
- Persists authenticated runner-promotion lease/PID/build ownership so an ordinary reconnect can safely recover from controller session drift without manual `--adopt-live-lease`.

Fixes #9261.
Fixes #9268.

The branch originally included a repair for #9240. That commit was dropped during rebase because #9276 and #9310 now provide the centralized identity binding and missing-identity diagnostic on `main`.

## Safety

- Reconciliation remains generation-aware and fails closed when ownership or provenance is unproven.
- Foreign, stale, mismatched, or unreachable daemons still require explicit operator recovery.
- No runner, deployment, or persisted user workload is mutated by these tests.

## How to test

1. Verify accepted handoff reconciliation:
   ```bash
   cargo test -p homeboy-agents accepted_handoff_ -- --nocapture
   ```
2. Verify the upstream preacceptance identity path remains intact:
   ```bash
   cargo test -p homeboy-agents preacceptance_daemon_identity -- --nocapture
   ```
3. Verify promotion provenance survives controller session drift:
   ```bash
   cargo test -p homeboy-lab-runner authenticated_promotion_provenance_allows_ordinary_reconnect_after_session_drift --lib
   ```
4. Compile affected crates and check formatting:
   ```bash
   cargo check -p homeboy-agents -p homeboy-lab-runner
   cargo fmt --check
   git diff --check origin/main...HEAD
   ```

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosing the Lab lifecycle failures, implementing generation-aware reconciliation and authenticated lease persistence, rebasing around upstream ownership changes, and writing deterministic regression coverage.
