### PR TITLE
Fix stale runner admission during Cook handoff

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -290,6 +290,8 @@ pub fn run_cook<E>(
 where
     E: AgentTaskExecutorAdapter + Clone,
 {
+    let _runtime_generation =
+        homeboy_core::runtime_promotion::pin_cook_generation(&options.cook_id)?;
     // A configured provider is controller authority. Resolve it before an
     // external runner can spend a provider attempt; explicit transports are
     // caller-owned overrides and retain their existing behavior.
@@ -1127,7 +1129,12 @@ mod tests {
             _derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
         ) -> Result<()> {
             self.dispatches.fetch_add(1, Ordering::SeqCst);
-            Err(Error::internal_unexpected("fixture transport disconnected").with_retryable(true))
+            Err(Error::new(
+                homeboy_core::error::ErrorCode::RunnerLabTransportFailure,
+                "fixture transport disconnected",
+                serde_json::json!({ "phase": "lab_handoff" }),
+            )
+            .with_retryable(true))
         }
     }
 
@@ -1796,68 +1803,82 @@ mod tests {
 
     #[test]
     fn cook_batch_preserves_order_concurrency_and_failure_isolation() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let barrier = Arc::new(Barrier::new(2));
-            let entered = Arc::new(AtomicUsize::new(0));
-            let first = batch_cook_options(
-                "first",
-                Arc::new(BatchAttemptDispatcher {
-                    barrier: Arc::clone(&barrier),
-                    entered: Arc::clone(&entered),
-                    fail: true,
-                }),
-            );
-            let second = batch_cook_options(
-                "second",
-                Arc::new(BatchAttemptDispatcher {
-                    barrier,
-                    entered: Arc::clone(&entered),
-                    fail: false,
-                }),
-            );
-            // The batch owns concurrent dispatch, not concurrent controller
-            // admission; materialize both durable run identities first.
-            agent_task_lifecycle::submit_plan(&first.initial_plan, Some(&first.initial_run_id))
-                .expect("submit first attempt");
-            agent_task_lifecycle::submit_plan(&second.initial_plan, Some(&second.initial_run_id))
-                .expect("submit second attempt");
-            let result = run_cook_batch(
-                AgentTaskCookBatchOptions {
-                    batch_id: "fixture-batch".to_string(),
-                    cooks: vec![first, second],
-                    max_concurrency: 2,
-                },
-                UnusedExecutor,
-            )
-            .expect("batch completes despite an individual cook failure");
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let status = context
+            .controller_runtime_command(homeboy_core::test_support::TestBinary::CurrentTest)
+            .args([
+                "--ignored",
+                "--exact",
+                "agent_task_service::cook::tests::cook_batch_preserves_order_concurrency_and_failure_isolation_process",
+            ])
+            .status()
+            .expect("run process-isolated cook batch");
+        assert!(status.success());
+    }
 
-            assert_eq!(entered.load(Ordering::SeqCst), 2);
-            assert_eq!(result.exit_code, 1);
-            assert_eq!(result.value.status, "failed");
-            assert_eq!(result.value.total, 2);
-            assert_eq!(result.value.succeeded, 1);
-            assert_eq!(result.value.failed, 1);
-            assert_eq!(result.value.cooks[0].cook_id, "first");
-            assert_eq!(result.value.cooks[0].exit_code, 1);
-            assert_eq!(
-                result.value.cooks[0]
-                    .result
-                    .as_ref()
-                    .expect("failed cook report")
-                    .status,
-                "pre_execution_failure"
-            );
-            assert_eq!(result.value.cooks[1].cook_id, "second");
-            assert_eq!(result.value.cooks[1].exit_code, 0);
-            assert_eq!(
-                result.value.cooks[1]
-                    .result
-                    .as_ref()
-                    .expect("successful cook report")
-                    .status,
-                "in_flight"
-            );
-        });
+    #[test]
+    #[ignore = "invoked by cook_batch_preserves_order_concurrency_and_failure_isolation"]
+    fn cook_batch_preserves_order_concurrency_and_failure_isolation_process() {
+        let barrier = Arc::new(Barrier::new(2));
+        let entered = Arc::new(AtomicUsize::new(0));
+        let first = batch_cook_options(
+            "first",
+            Arc::new(BatchAttemptDispatcher {
+                barrier: Arc::clone(&barrier),
+                entered: Arc::clone(&entered),
+                fail: true,
+            }),
+        );
+        let second = batch_cook_options(
+            "second",
+            Arc::new(BatchAttemptDispatcher {
+                barrier,
+                entered: Arc::clone(&entered),
+                fail: false,
+            }),
+        );
+        // The batch owns concurrent dispatch, not concurrent controller
+        // admission; materialize both durable run identities first.
+        agent_task_lifecycle::submit_plan(&first.initial_plan, Some(&first.initial_run_id))
+            .expect("submit first attempt");
+        agent_task_lifecycle::submit_plan(&second.initial_plan, Some(&second.initial_run_id))
+            .expect("submit second attempt");
+        let result = run_cook_batch(
+            AgentTaskCookBatchOptions {
+                batch_id: "fixture-batch".to_string(),
+                cooks: vec![first, second],
+                max_concurrency: 2,
+            },
+            UnusedExecutor,
+        )
+        .expect("batch completes despite an individual cook failure");
+
+        assert_eq!(entered.load(Ordering::SeqCst), 2);
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.value.status, "failed");
+        assert_eq!(result.value.total, 2);
+        assert_eq!(result.value.succeeded, 1);
+        assert_eq!(result.value.failed, 1);
+        assert_eq!(result.value.cooks[0].cook_id, "first");
+        assert_eq!(result.value.cooks[0].exit_code, 1);
+        assert_eq!(
+            result.value.cooks[0]
+                .result
+                .as_ref()
+                .expect("failed cook report")
+                .status,
+            "pre_execution_failure"
+        );
+        assert_eq!(result.value.cooks[1].cook_id, "second");
+        assert_eq!(result.value.cooks[1].exit_code, 0);
+        assert_eq!(
+            result.value.cooks[1]
+                .result
+                .as_ref()
+                .expect("successful cook report")
+                .status,
+            "in_flight"
+        );
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -181,8 +181,6 @@ where
         .and_then(|task| task.workspace.root.as_ref())
         .map(std::path::PathBuf::from);
     let task_base_sha = source_worktree_path.as_deref().and_then(git_head_sha);
-    // Keep this cook on one runtime generation through provider work and PR finalization.
-    let _runtime_generation = homeboy::core::runtime_promotion::pin_cook_generation(&cook_id)?;
     let title = args
         .title
         .clone()

--- a/crates/homeboy-core/src/runtime_promotion.rs
+++ b/crates/homeboy-core/src/runtime_promotion.rs
@@ -112,6 +112,7 @@ pub fn acquire(operation: &str, target: impl Into<String>) -> Result<RuntimeProm
     let pid = std::process::id();
     let generation = current_generation();
     let subprocess_capability = subprocess_capability_from_env();
+    ensure_no_foreign_generation_pin(&root, pid, subprocess_capability.as_ref())?;
 
     match acquire_lease_dir_with_retry(
         || create_lease_dir(&path),
@@ -256,9 +257,10 @@ pub fn pin_cook_generation(cook_id: &str) -> Result<RuntimeGenerationPinGuard> {
     prune_pins(&root)?;
     let pid = std::process::id();
     let path = root.join(format!(
-        "{}-{}.json",
+        "{}-{}-{}.json",
         paths::sanitize_path_segment(cook_id),
-        pid
+        pid,
+        uuid::Uuid::new_v4(),
     ));
     let pin = RuntimeGenerationPin {
         pid,
@@ -414,6 +416,47 @@ fn prune_pins(root: &Path) -> Result<()> {
     Ok(())
 }
 
+/// A running Cook pins its controller generation so a concurrent refresh cannot
+/// replace the configured job binary while that Cook is selecting a generation.
+/// The owning process may still acquire nested leases for its own handoff.
+fn ensure_no_foreign_generation_pin(
+    root: &Path,
+    pid: u32,
+    subprocess_capability: Option<&SubprocessLeaseCapability>,
+) -> Result<()> {
+    let pins = root.join(PIN_DIR);
+    if !pins.exists() {
+        return Ok(());
+    }
+    prune_pins(&pins)?;
+    for entry in fs::read_dir(&pins).map_err(io("read runtime generation pins"))? {
+        let path = entry.map_err(io("read runtime generation pin"))?.path();
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(pin) = serde_json::from_str::<RuntimeGenerationPin>(&content) else {
+            continue;
+        };
+        if pin.pid != pid
+            && !subprocess_capability.is_some_and(|capability| capability.owner_pid == pin.pid)
+        {
+            return Err(Error::new(
+                ErrorCode::RuntimePromotionContended,
+                format!(
+                    "runtime promotion is blocked by active Cook `{}` on generation `{}`",
+                    pin.cook_id, pin.generation
+                ),
+                serde_json::json!({
+                    "cook_id": pin.cook_id,
+                    "generation": pin.generation,
+                    "holder_pid": pin.pid,
+                }),
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn current_generation() -> String {
     build_identity::current().display
 }
@@ -536,6 +579,30 @@ mod tests {
         assert_eq!(error.code, ErrorCode::InternalIoError);
         assert_eq!(create_calls, 1);
         assert_eq!(read_calls, 1);
+    }
+
+    #[test]
+    fn duplicate_cook_pins_keep_the_remaining_guard_live() {
+        crate::test_support::with_isolated_home(|_| {
+            let first = pin_cook_generation("duplicate-cook").expect("first cook pin");
+            let second = pin_cook_generation("duplicate-cook").expect("second cook pin");
+            let pins = paths::runtime_promotion_dir()
+                .expect("runtime promotion directory")
+                .join(PIN_DIR);
+            assert_eq!(
+                fs::read_dir(&pins).expect("list pins").count(),
+                2,
+                "each concurrent cook guard owns a distinct pin"
+            );
+
+            drop(first);
+            assert_eq!(
+                fs::read_dir(&pins).expect("list remaining pin").count(),
+                1,
+                "dropping one duplicate cook guard must retain the other pin"
+            );
+            assert!(second.path.exists(), "the second guard still owns its pin");
+        });
     }
 
     #[test]

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -122,6 +122,26 @@ impl HermeticTestContext {
             .env("HOMEBOY_NO_UPDATE_CHECK", "1");
         command
     }
+
+    /// Build an isolated command with the deterministic controller-runtime
+    /// fixture required by tests that submit or resume agent-task work.
+    pub fn controller_runtime_command(&self, binary: TestBinary) -> Command {
+        let mut command = self.command(binary);
+        command
+            .env(
+                crate::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV,
+                TEST_DAEMON_BINARY_SHA,
+            )
+            .env(
+                crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV,
+                test_controller_fixture(),
+            )
+            .env(
+                crate::controller_runtime::TEST_CONTROLLER_RUNTIME_IDENTITY_ENV,
+                crate::build_identity::current().display,
+            );
+        command
+    }
 }
 
 impl Default for HermeticTestContext {

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1097,8 +1097,15 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
     let state = session_state(session.as_ref());
     let connected = state == RunnerSessionState::Connected;
     let stale_daemon = stale_daemon_warning(&runner, session.as_ref(), connected)?;
-    let mut daemon_freshness = runner_daemon_freshness(&runner, session.as_ref(), connected)?
-        .or_else(|| remote_daemon_recovery_freshness(runner_id, &runner));
+    let local_daemon_freshness = runner_daemon_freshness(&runner, session.as_ref(), connected)?;
+    // A direct tunnel health response proves this session is safe for new
+    // admission. Keep active jobs on prior generations, but make status and
+    // Cook agree on this freshly verified endpoint.
+    if let (Some(session), Some(_)) = (session.as_ref(), local_daemon_freshness.as_ref()) {
+        super::generation_store::reconcile_admission_session(runner_id, session)?;
+    }
+    let mut daemon_freshness =
+        local_daemon_freshness.or_else(|| remote_daemon_recovery_freshness(runner_id, &runner));
     let active_job_source = session.as_ref().and_then(active_runner_job_source);
     let direct_daemon_active_jobs =
         matches!(active_job_source, Some(RunnerActiveJobSource::DirectDaemon))

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -625,7 +625,16 @@ where
         Err(error) if daemon_submission_connection_was_lost(&error) => {
             let accepted_session = accepted_session.ok_or(error)?;
             let recovered_endpoint = recover(accepted_session)?;
-            submit(&recovered_endpoint)
+            submit(&recovered_endpoint).map_err(|retry_error| {
+                if daemon_submission_connection_was_lost(&retry_error) {
+                    recovered_admission_transport_error(
+                        &accepted_session.runner_id,
+                        "lost the replacement admission tunnel before daemon acceptance",
+                    )
+                } else {
+                    retry_error
+                }
+            })
         }
         Err(error) => Err(error),
     }
@@ -643,52 +652,40 @@ fn recovered_daemon_submission_endpoint(
     runner_id: &str,
     accepted_session: &RunnerSession,
 ) -> Result<String> {
-    let accepted_lease = accepted_session
-        .remote_daemon_lease_id
-        .as_deref()
-        .filter(|lease| !lease.is_empty())
-        .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "runner",
-                format!(
-                    "runner `{runner_id}` lost its submission tunnel without a proven daemon lease; refusing to submit through a replacement session"
-                ),
-                Some(runner_id.to_string()),
-                None,
-            )
-        })?;
+    if accepted_session.mode != crate::RunnerTunnelMode::DirectSsh {
+        return Err(recovered_admission_transport_error(
+            runner_id,
+            "lost its direct admission tunnel before daemon acceptance",
+        ));
+    }
     let recovered = crate::connection::status_for_admission(runner_id)?;
     let session = recovered
         .session
         .filter(|_| recovered.connected)
         .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "runner",
-                format!("runner `{runner_id}` did not recover a connected daemon session"),
-                Some(runner_id.to_string()),
-                None,
+            recovered_admission_transport_error(
+                runner_id,
+                "did not recover a healthy daemon admission session",
             )
         })?;
-    if session.mode != crate::RunnerTunnelMode::DirectSsh
-        || session.remote_daemon_lease_id.as_deref() != Some(accepted_lease)
-    {
-        return Err(Error::validation_invalid_argument(
-            "runner",
-            format!(
-                "runner `{runner_id}` recovered a different daemon lease; refusing to submit a request proven for lease `{accepted_lease}`"
-            ),
-            Some(runner_id.to_string()),
-            None,
+    if session.mode != crate::RunnerTunnelMode::DirectSsh {
+        return Err(recovered_admission_transport_error(
+            runner_id,
+            "recovered a non-direct session for direct Lab admission",
         ));
     }
     session.local_url.ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "runner",
-            format!("runner `{runner_id}` recovered without a direct daemon endpoint"),
-            Some(runner_id.to_string()),
-            None,
-        )
+        recovered_admission_transport_error(runner_id, "recovered without a direct daemon endpoint")
     })
+}
+
+fn recovered_admission_transport_error(runner_id: &str, reason: &str) -> Error {
+    Error::new(
+        ErrorCode::RunnerLabTransportFailure,
+        format!("runner `{runner_id}` {reason}"),
+        json!({ "runner_id": runner_id, "phase": "lab_handoff" }),
+    )
+    .with_retryable(true)
 }
 
 pub(super) fn preflight_runner_capability_plan(

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -770,7 +770,11 @@ pub(crate) fn exec_with_status_snapshot(
     let connected = if should_force_diagnostic_ssh(&runner, &options) {
         None
     } else {
-        Some(execution_status(runner_id, status_snapshot)?)
+        Some(execution_status(
+            runner_id,
+            status_snapshot,
+            options.detach_after_handoff,
+        )?)
     };
 
     let extension_parity_plan = plan_extension_parity(
@@ -901,15 +905,7 @@ pub(crate) fn exec_with_status_snapshot(
             options.path_materialization_plan,
             options.diagnostic_ssh_timeout,
         ),
-        RunnerTransport::Unavailable => Err(Error::validation_invalid_argument(
-            "runner",
-            "runner is not connected to a daemon; run `homeboy runner connect <runner-id>` or pass `--ssh` for explicit SSH diagnostics",
-            Some(runner.id.clone()),
-            Some(vec![
-                "Daemon-backed execution preserves job metadata and artifact discovery.".to_string(),
-                "SSH execution is intended for MVP diagnostics and must be explicit.".to_string(),
-            ]),
-        )),
+        RunnerTransport::Unavailable => Err(unavailable_daemon_admission_error(&runner.id)),
     };
     result.map(|(mut output, exit_code)| {
         append_runner_exec_binary_diagnostics(&mut output, &runner, connected.session.as_ref());
@@ -918,11 +914,38 @@ pub(crate) fn exec_with_status_snapshot(
     })
 }
 
+fn unavailable_daemon_admission_error(runner_id: &str) -> Error {
+    Error::new(
+        ErrorCode::RunnerLabTransportFailure,
+        format!(
+            "runner `{runner_id}` has no healthy daemon admission session; reconnect it before retrying the Lab handoff"
+        ),
+        json!({ "runner_id": runner_id, "phase": "lab_handoff" }),
+    )
+    .with_retryable(true)
+    .with_hint(format!(
+        "Run `homeboy runner status {runner_id}` to inspect the current admission session."
+    ))
+}
+
 fn execution_status(
     runner_id: &str,
     status_snapshot: Option<RunnerStatusReport>,
+    reconcile_direct_admission: bool,
 ) -> Result<RunnerStatusReport> {
     match status_snapshot {
+        // A preflight snapshot may point at a generation whose local tunnel
+        // disappeared during reconnect. Direct admission must always use the
+        // current health-checked session instead of that cached endpoint.
+        Some(status)
+            if reconcile_direct_admission
+                && status
+                    .session
+                    .as_ref()
+                    .is_some_and(|session| session.mode == RunnerTunnelMode::DirectSsh) =>
+        {
+            crate::connection::status_for_admission(runner_id)
+        }
         Some(status) if status.connected => Ok(status),
         Some(status) => {
             if status

--- a/crates/homeboy-lab-runner/src/execution/tests/exec.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/exec.rs
@@ -48,32 +48,56 @@ fn daemon_submission_recovers_a_lost_tunnel_before_resending_to_the_same_lease()
 }
 
 #[test]
-fn daemon_submission_refuses_recovery_when_the_lease_changes() {
+fn daemon_submission_retries_once_against_a_fresh_admission_generation() {
     let accepted = direct_daemon_session("lease-old", "http://127.0.0.1:1");
-    let submissions = std::cell::Cell::new(0);
-    let result = submit_daemon_exec_with_session_recovery(
+    let submitted = std::cell::RefCell::new(Vec::new());
+    let response = submit_daemon_exec_with_session_recovery(
         "http://127.0.0.1:1",
         Some(&accepted),
-        |_| {
-            submissions.set(submissions.get() + 1);
-            Err(connect_error())
+        |endpoint| {
+            submitted.borrow_mut().push(endpoint.to_string());
+            if submitted.borrow().len() == 1 {
+                Err(connect_error())
+            } else {
+                Ok(DaemonHttpTextResponse {
+                    status_code: 200,
+                    body: "{}".to_string(),
+                })
+            }
         },
         |session| {
             assert_eq!(session.remote_daemon_lease_id.as_deref(), Some("lease-old"));
-            Err(Error::new(
-                homeboy_core::error::ErrorCode::InternalUnexpected,
-                "runner `lab` recovered a different daemon lease; refusing to submit a request proven for lease `lease-old`",
-                json!({}),
-            ))
+            Ok("http://127.0.0.1:2".to_string())
         },
+    )
+    .expect("an unaccepted request can retry once through the current generation");
+
+    assert_eq!(response.status_code, 200);
+    assert_eq!(
+        submitted.into_inner(),
+        ["http://127.0.0.1:1", "http://127.0.0.1:2"]
     );
-    let error = match result {
+}
+
+#[test]
+fn replacement_admission_transport_loss_remains_retryable() {
+    let accepted = direct_daemon_session("lease-old", "http://127.0.0.1:1");
+    let result = match submit_daemon_exec_with_session_recovery(
+        "http://127.0.0.1:1",
+        Some(&accepted),
+        |_| Err(connect_error()),
+        |_| Ok("http://127.0.0.1:2".to_string()),
+    ) {
         Err(error) => error,
-        Ok(_) => panic!("a replacement daemon cannot receive the old session's submission"),
+        Ok(_) => panic!("the second tunnel loss must remain a transport failure"),
     };
 
-    assert_eq!(submissions.get(), 1);
-    assert!(error.message.contains("different daemon lease"));
+    assert_eq!(
+        result.code,
+        homeboy_core::error::ErrorCode::RunnerLabTransportFailure
+    );
+    assert_eq!(result.retryable, Some(true));
+    assert_eq!(result.details["phase"], "lab_handoff");
 }
 
 fn direct_daemon_session(lease: &str, local_url: &str) -> RunnerSession {
@@ -179,6 +203,18 @@ fn generic_runner_exec_rejects_a_mismatched_persisted_run_identity() {
 }
 
 #[test]
+fn unavailable_direct_admission_fails_closed_as_retryable_transport() {
+    let error = unavailable_daemon_admission_error("homeboy-lab");
+
+    assert_eq!(error.code, ErrorCode::RunnerLabTransportFailure);
+    assert_eq!(error.retryable, Some(true));
+    assert_eq!(error.details["phase"], "lab_handoff");
+    assert!(error
+        .message
+        .contains("no healthy daemon admission session"));
+}
+
+#[test]
 fn generic_runner_exec_accepts_its_explicit_persisted_run_identity() {
     validate_generic_exec_mirror_run_id(true, Some("requested-run"), Some("requested-run"))
         .expect("matching identity remains valid");
@@ -210,7 +246,7 @@ fn refresh_execution_uses_the_connected_preflight_session_without_a_second_looku
         last_seen_at: None,
         leaseless_recovery_evidence: None,
     });
-    let resolved = execution_status("unresolvable-runner", Some(status.clone()))
+    let resolved = execution_status("unresolvable-runner", Some(status.clone()), false)
         .expect("the refresh transaction keeps its authoritative preflight session");
 
     assert_eq!(resolved.runner_id, "homeboy-lab");

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -1,3 +1,4 @@
+use std::fs::OpenOptions;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -21,11 +22,65 @@ fn path(runner_id: &str) -> Result<PathBuf> {
         .join("generations.json"))
 }
 
+/// Serialize read-modify-write registry updates independently for each runner.
+/// A status reconciliation and `/exec` acceptance can arrive concurrently.
+fn with_registry_lock<T>(runner_id: &str, operation: impl FnOnce() -> Result<T>) -> Result<T> {
+    let lock_path = path(runner_id)?.with_extension("lock");
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("create generation lock directory".to_string()),
+            )
+        })?;
+    }
+    let lock = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|error| {
+            Error::internal_io(error.to_string(), Some("open generation lock".to_string()))
+        })?;
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsRawFd;
+        if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX) } != 0 {
+            return Err(Error::internal_io(
+                std::io::Error::last_os_error().to_string(),
+                Some("lock generation registry".to_string()),
+            ));
+        }
+    }
+    let result = operation();
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsRawFd;
+        let _ = unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_UN) };
+    }
+    result
+}
+
 fn legacy_generation(session: &RunnerSession) -> String {
     session
         .remote_daemon_lease_id
         .clone()
         .unwrap_or_else(|| "legacy".to_string())
+}
+
+#[cfg(test)]
+const LEGACY_MIGRATION_SYNC_DIR_ENV: &str = "HOMEBOY_LEGACY_GENERATION_MIGRATION_SYNC_DIR";
+
+#[cfg(test)]
+fn pause_legacy_migration_before_lock() {
+    let Some(sync_dir) = std::env::var_os(LEGACY_MIGRATION_SYNC_DIR_ENV) else {
+        return;
+    };
+    let sync_dir = PathBuf::from(sync_dir);
+    std::fs::write(sync_dir.join("migration-ready"), "ready").expect("signal legacy migration");
+    while !sync_dir.join("allow-migration").exists() {
+        std::thread::sleep(Duration::from_millis(10));
+    }
 }
 
 pub(crate) fn read(
@@ -51,6 +106,35 @@ pub(crate) fn read(
             format!("generation registry must match runner-scoped path `{runner_id}`"),
         )),
         Err(error) => recover_missing_runner_id(runner_id, &path, &raw, error),
+    }
+}
+
+/// Read while the caller already holds this runner's registry lock. Legacy
+/// migration stays inside that transaction instead of attempting a re-entrant
+/// `flock` acquisition.
+fn read_locked(
+    runner_id: &str,
+    legacy: Option<&RunnerSession>,
+) -> Result<Option<RollingGenerations<RunnerSession>>> {
+    let path = path(runner_id)?;
+    if !path.exists() {
+        return Ok(legacy
+            .map(|session| RollingGenerations::new(legacy_generation(session), session.clone())));
+    }
+    let raw = std::fs::read_to_string(&path).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+    })?;
+    let value: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))?;
+    validate_registry_shape(&value)?;
+    match serde_json::from_str::<GenerationRegistry<RunnerSession>>(&raw) {
+        Ok(registry) if registry.runner_id == runner_id => Ok(Some(registry.generations)),
+        Ok(registry) => Err(Error::config_invalid_value(
+            "runner_id",
+            Some(registry.runner_id),
+            format!("generation registry must match runner-scoped path `{runner_id}`"),
+        )),
+        Err(error) => recover_missing_runner_id_unlocked(runner_id, &path, &raw, error),
     }
 }
 
@@ -99,6 +183,47 @@ pub(crate) fn write(
 /// exact shape when every persisted endpoint independently confirms this path.
 /// The normal atomic writer retains every ownership map during the rewrite.
 fn recover_missing_runner_id(
+    runner_id: &str,
+    _path: &std::path::Path,
+    _raw: &str,
+    deserialize_error: serde_json::Error,
+) -> Result<Option<RollingGenerations<RunnerSession>>> {
+    #[cfg(test)]
+    pause_legacy_migration_before_lock();
+
+    // Migration is a registry mutation too. Reload after acquiring the same
+    // runner lock used by job admission so an older legacy snapshot cannot
+    // overwrite ownership accepted by a concurrent controller.
+    with_registry_lock(runner_id, || {
+        let path = path(runner_id)?;
+        let raw = std::fs::read_to_string(&path).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+        })?;
+        let value: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))?;
+        validate_registry_shape(&value)?;
+        match serde_json::from_str::<GenerationRegistry<RunnerSession>>(&raw) {
+            Ok(registry) if registry.runner_id == runner_id => Ok(Some(registry.generations)),
+            Ok(registry) => Err(Error::config_invalid_value(
+                "runner_id",
+                Some(registry.runner_id),
+                format!("generation registry must match runner-scoped path `{runner_id}`"),
+            )),
+            Err(current_error) => recover_missing_runner_id_unlocked(
+                runner_id,
+                &path,
+                &raw,
+                if value.get("runner_id").is_some() {
+                    current_error
+                } else {
+                    deserialize_error
+                },
+            ),
+        }
+    })
+}
+
+fn recover_missing_runner_id_unlocked(
     runner_id: &str,
     path: &std::path::Path,
     raw: &str,
@@ -161,6 +286,52 @@ pub(crate) fn admission_session(
             .get(&generations.admission_owner)
             .map(|generation| generation.endpoint.clone())
     }))
+}
+
+/// Promote the direct session that status has just health-checked. The
+/// controller session is the admission authority for new work; older entries
+/// remain draining so their owned jobs keep their original endpoints.
+pub(crate) fn reconcile_admission_session(runner_id: &str, session: &RunnerSession) -> Result<()> {
+    if session.mode != crate::RunnerTunnelMode::DirectSsh {
+        return Ok(());
+    }
+    let Some(lease_id) = session
+        .remote_daemon_lease_id
+        .as_deref()
+        .filter(|lease_id| !lease_id.is_empty())
+    else {
+        return Err(Error::validation_invalid_argument(
+            "runner",
+            format!(
+                "runner `{runner_id}` has a healthy direct daemon tunnel without a lease; refusing unbound admission"
+            ),
+            Some(runner_id.to_string()),
+            None,
+        ));
+    };
+    with_registry_lock(runner_id, || {
+        let Some(mut generations) = read_locked(runner_id, Some(session))? else {
+            return Ok(());
+        };
+        let generation = generations
+            .generations
+            .iter()
+            .find_map(|(generation, entry)| {
+                (entry.endpoint.remote_daemon_lease_id.as_deref() == Some(lease_id))
+                    .then_some(generation.clone())
+            })
+            .unwrap_or_else(|| lease_id.to_string());
+        if !generations.generations.contains_key(&generation) {
+            generations.begin(generation.clone(), session.clone());
+        }
+        generations.activate(&generation);
+        generations
+            .generations
+            .get_mut(&generation)
+            .expect("generation was inserted or found")
+            .endpoint = session.clone();
+        write(runner_id, &generations)
+    })
 }
 
 pub(crate) fn job_session(
@@ -236,16 +407,18 @@ pub(crate) fn live_sessions(
 }
 
 pub(crate) fn clear(runner_id: &str) -> Result<()> {
-    let path = path(runner_id)?;
-    if path.exists() {
-        std::fs::remove_file(&path).map_err(|error| {
-            Error::internal_io(
-                error.to_string(),
-                Some(format!("delete {}", path.display())),
-            )
-        })?;
-    }
-    Ok(())
+    with_registry_lock(runner_id, || {
+        let path = path(runner_id)?;
+        if path.exists() {
+            std::fs::remove_file(&path).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("delete {}", path.display())),
+                )
+            })?;
+        }
+        Ok(())
+    })
 }
 
 trait GenerationEndpointOperations {
@@ -318,7 +491,7 @@ fn reconcile_with(
     legacy: Option<&RunnerSession>,
     operations: &impl GenerationEndpointOperations,
 ) -> Result<()> {
-    let Some(mut generations) = read(runner_id, legacy)? else {
+    let Some(generations) = read(runner_id, legacy)? else {
         return Ok(());
     };
     let drained = generations
@@ -332,25 +505,50 @@ fn reconcile_with(
             (operations.active_jobs(&session) == Some(0)).then_some((generation, session))
         })
         .collect::<Vec<_>>();
-    for (generation, session) in drained {
-        if operations.stop(&session) {
-            if let Some(pid) = session.tunnel_pid {
-                operations.terminate_tunnel(pid);
+    let retired = drained
+        .into_iter()
+        .filter_map(|(generation, session)| {
+            if operations.stop(&session) {
+                if let Some(pid) = session.tunnel_pid {
+                    operations.terminate_tunnel(pid);
+                }
+                Some(generation)
+            } else {
+                None
             }
-            generations.generations.remove(&generation);
-            generations
-                .job_owners
-                .retain(|_, owner| owner != &generation);
+        })
+        .collect::<Vec<_>>();
+    with_registry_lock(runner_id, || {
+        let Some(mut generations) = read_locked(runner_id, legacy)? else {
+            return Ok(());
+        };
+        for generation in &retired {
+            if generations
+                .generations
+                .get(generation)
+                .is_some_and(|entry| {
+                    entry.drain_state == crate::RollingDrainState::Draining
+                        && entry.active_jobs == 0
+                })
+            {
+                generations.generations.remove(generation);
+                generations
+                    .job_owners
+                    .retain(|_, owner| owner != generation);
+            }
         }
-    }
-    write(runner_id, &generations)
+        write(runner_id, &generations)
+    })
 }
 
 pub(crate) fn record_job(runner_id: &str, session: &RunnerSession, job_id: &str) -> Result<()> {
-    let mut generations = read(runner_id, Some(session))?
-        .unwrap_or_else(|| RollingGenerations::new(legacy_generation(session), session.clone()));
-    generations.admit_job(job_id);
-    write(runner_id, &generations)
+    with_registry_lock(runner_id, || {
+        let mut generations = read_locked(runner_id, Some(session))?.unwrap_or_else(|| {
+            RollingGenerations::new(legacy_generation(session), session.clone())
+        });
+        generations.admit_job(job_id);
+        write(runner_id, &generations)
+    })
 }
 
 pub(crate) fn record_job_run(
@@ -359,11 +557,13 @@ pub(crate) fn record_job_run(
     job_id: &str,
     run_id: &str,
 ) -> Result<()> {
-    let Some(mut generations) = read(runner_id, Some(legacy))? else {
-        return Ok(());
-    };
-    generations.record_run(job_id, run_id);
-    write(runner_id, &generations)
+    with_registry_lock(runner_id, || {
+        let Some(mut generations) = read_locked(runner_id, Some(legacy))? else {
+            return Ok(());
+        };
+        generations.record_run(job_id, run_id);
+        write(runner_id, &generations)
+    })
 }
 
 pub(crate) fn record_job_artifacts(
@@ -372,13 +572,16 @@ pub(crate) fn record_job_artifacts(
     job_id: &str,
     artifact_ids: impl IntoIterator<Item = String>,
 ) -> Result<()> {
-    let Some(mut generations) = read(runner_id, Some(legacy))? else {
-        return Ok(());
-    };
-    for artifact_id in artifact_ids {
-        generations.record_artifact(job_id, artifact_id);
-    }
-    write(runner_id, &generations)
+    let artifact_ids = artifact_ids.into_iter().collect::<Vec<_>>();
+    with_registry_lock(runner_id, || {
+        let Some(mut generations) = read_locked(runner_id, Some(legacy))? else {
+            return Ok(());
+        };
+        for artifact_id in artifact_ids {
+            generations.record_artifact(job_id, artifact_id);
+        }
+        write(runner_id, &generations)
+    })
 }
 
 pub(crate) fn activate(
@@ -388,25 +591,28 @@ pub(crate) fn activate(
     candidate: RunnerSession,
     draining_job_ids: &[String],
 ) -> Result<()> {
-    let mut generations = read(runner_id, Some(current))?
-        .unwrap_or_else(|| RollingGenerations::new(legacy_generation(current), current.clone()));
-    let draining_owner = legacy_generation(current);
-    // Legacy sessions have no ledger yet. Pin authoritative active work before
-    // activation because `activate` retires zero-job drains immediately.
-    for job_id in draining_job_ids {
-        if generations
-            .job_owners
-            .insert(job_id.clone(), draining_owner.clone())
-            .is_none()
-        {
-            if let Some(draining) = generations.generations.get_mut(&draining_owner) {
-                draining.active_jobs += 1;
+    with_registry_lock(runner_id, || {
+        let mut generations = read_locked(runner_id, Some(current))?.unwrap_or_else(|| {
+            RollingGenerations::new(legacy_generation(current), current.clone())
+        });
+        let draining_owner = legacy_generation(current);
+        // Legacy sessions have no ledger yet. Pin authoritative active work before
+        // activation because `activate` retires zero-job drains immediately.
+        for job_id in draining_job_ids {
+            if generations
+                .job_owners
+                .insert(job_id.clone(), draining_owner.clone())
+                .is_none()
+            {
+                if let Some(draining) = generations.generations.get_mut(&draining_owner) {
+                    draining.active_jobs += 1;
+                }
             }
         }
-    }
-    generations.begin(generation.clone(), candidate);
-    generations.activate(&generation);
-    write(runner_id, &generations)
+        generations.begin(generation.clone(), candidate);
+        generations.activate(&generation);
+        write(runner_id, &generations)
+    })
 }
 
 /// Remove an unactivated candidate from the durable ledger. This is safe to
@@ -416,13 +622,15 @@ pub(crate) fn rollback_candidate(
     legacy: &RunnerSession,
     generation: &str,
 ) -> Result<()> {
-    let Some(mut generations) = read(runner_id, Some(legacy))? else {
-        return Ok(());
-    };
-    if generations.rollback(generation) {
-        write(runner_id, &generations)?;
-    }
-    Ok(())
+    with_registry_lock(runner_id, || {
+        let Some(mut generations) = read_locked(runner_id, Some(legacy))? else {
+            return Ok(());
+        };
+        if generations.rollback(generation) {
+            write(runner_id, &generations)?;
+        }
+        Ok(())
+    })
 }
 
 /// Undo a candidate that was activated locally but could not be durably
@@ -432,25 +640,28 @@ pub(crate) fn rollback_activation(
     current: &RunnerSession,
     generation: &str,
 ) -> Result<()> {
-    let Some(mut generations) = read(runner_id, Some(current))? else {
-        return Ok(());
-    };
-    let previous = legacy_generation(current);
-    if generations.admission_owner == generation {
-        generations.generations.remove(generation);
-        if let Some(entry) = generations.generations.get_mut(&previous) {
-            entry.drain_state = crate::RollingDrainState::Admitting;
-            generations.admission_owner = previous;
+    with_registry_lock(runner_id, || {
+        let Some(mut generations) = read_locked(runner_id, Some(current))? else {
+            return Ok(());
+        };
+        let previous = legacy_generation(current);
+        if generations.admission_owner == generation {
+            generations.generations.remove(generation);
+            if let Some(entry) = generations.generations.get_mut(&previous) {
+                entry.drain_state = crate::RollingDrainState::Admitting;
+                generations.admission_owner = previous;
+            }
+        } else {
+            generations.rollback(generation);
         }
-    } else {
-        generations.rollback(generation);
-    }
-    write(runner_id, &generations)
+        write(runner_id, &generations)
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use std::cell::RefCell;
+    use std::time::{Duration, Instant};
 
     use homeboy_core::test_support;
     use serde_json::json;
@@ -516,6 +727,203 @@ mod tests {
         let raw = std::fs::read_to_string(path(runner_id).expect("registry path"))
             .expect("read registry");
         serde_json::from_str(&raw).expect("parse registry")
+    }
+
+    const PROCESS_SYNC_DIR_ENV: &str = "HOMEBOY_GENERATION_STORE_PROCESS_SYNC_DIR";
+
+    fn process_sync_dir() -> std::path::PathBuf {
+        std::env::var_os(PROCESS_SYNC_DIR_ENV)
+            .map(std::path::PathBuf::from)
+            .expect("process-isolated generation-store sync directory")
+    }
+
+    fn wait_for_process_file(path: &std::path::Path) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !path.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for process fixture signal `{}`",
+                path.display()
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    fn generation_store_process(
+        context: &homeboy_core::test_support::HermeticTestContext,
+        test: &str,
+        sync_dir: &std::path::Path,
+    ) -> std::process::Command {
+        let mut command = context.command(homeboy_core::test_support::TestBinary::CurrentTest);
+        command
+            .args(["--ignored", "--exact", test])
+            .env(PROCESS_SYNC_DIR_ENV, sync_dir);
+        command
+    }
+
+    #[test]
+    fn process_isolated_reconciliation_preserves_concurrent_job_admission() {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let sync_dir = context.root().join("generation-store-sync");
+        std::fs::create_dir_all(&sync_dir).expect("create process sync directory");
+
+        assert!(generation_store_process(
+            &context,
+            "generation_store::tests::process_seed_draining_generation",
+            &sync_dir,
+        )
+        .status()
+        .expect("seed process")
+        .success());
+
+        let mut reconciliation = generation_store_process(
+            &context,
+            "generation_store::tests::process_reconcile_draining_generation",
+            &sync_dir,
+        )
+        .spawn()
+        .expect("start reconciliation process");
+        wait_for_process_file(&sync_dir.join("remote-check-complete"));
+
+        assert!(generation_store_process(
+            &context,
+            "generation_store::tests::process_record_fresh_job",
+            &sync_dir,
+        )
+        .status()
+        .expect("record process")
+        .success());
+        std::fs::write(sync_dir.join("allow-commit"), "proceed").expect("release reconciliation");
+        assert!(reconciliation
+            .wait()
+            .expect("reconciliation process")
+            .success());
+
+        let registry = std::fs::read_to_string(
+            context
+                .config_dir()
+                .join("runner-sessions/runner-a/generations.json"),
+        )
+        .expect("read process-isolated registry");
+        let registry: serde_json::Value = serde_json::from_str(&registry).expect("parse registry");
+        assert_eq!(
+            registry["job_owners"]["accepted-during-reconcile"], "lease-fresh",
+            "the locked reconciliation commit reloads after remote work"
+        );
+    }
+
+    #[test]
+    fn process_isolated_legacy_migration_preserves_concurrent_job_admission() {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let sync_dir = context.root().join("legacy-migration-sync");
+        std::fs::create_dir_all(&sync_dir).expect("create process sync directory");
+
+        assert!(generation_store_process(
+            &context,
+            "generation_store::tests::process_seed_legacy_generation",
+            &sync_dir,
+        )
+        .status()
+        .expect("seed legacy process")
+        .success());
+
+        let mut migration = generation_store_process(
+            &context,
+            "generation_store::tests::process_migrate_legacy_generation",
+            &sync_dir,
+        )
+        .env(LEGACY_MIGRATION_SYNC_DIR_ENV, &sync_dir)
+        .spawn()
+        .expect("start migration process");
+        wait_for_process_file(&sync_dir.join("migration-ready"));
+
+        assert!(generation_store_process(
+            &context,
+            "generation_store::tests::process_record_fresh_job",
+            &sync_dir,
+        )
+        .status()
+        .expect("record process")
+        .success());
+        std::fs::write(sync_dir.join("allow-migration"), "proceed").expect("release migration");
+        assert!(migration.wait().expect("migration process").success());
+
+        let registry = std::fs::read_to_string(
+            context
+                .config_dir()
+                .join("runner-sessions/runner-a/generations.json"),
+        )
+        .expect("read migrated registry");
+        let registry: serde_json::Value = serde_json::from_str(&registry).expect("parse registry");
+        assert_eq!(registry["runner_id"], "runner-a");
+        assert_eq!(
+            registry["job_owners"]["accepted-during-reconcile"], "lease-fresh",
+            "a stale legacy migration must reload rather than erase accepted ownership"
+        );
+    }
+
+    #[test]
+    #[ignore = "invoked by process_isolated_reconciliation_preserves_concurrent_job_admission"]
+    fn process_seed_draining_generation() {
+        let stale = session("lease-stale", "daemon-stale", Some(101));
+        let fresh = session("lease-fresh", "daemon-fresh", Some(202));
+        let mut generations = RollingGenerations::new("lease-fresh", fresh);
+        generations.begin("lease-stale", stale);
+        write("runner-a", &generations).expect("seed draining generation");
+    }
+
+    #[test]
+    #[ignore = "invoked by process_isolated_legacy_migration_preserves_concurrent_job_admission"]
+    fn process_seed_legacy_generation() {
+        let fresh = session("lease-fresh", "daemon-fresh", Some(202));
+        homeboy_core::engine::local_files::write_json_file(
+            &path("runner-a").expect("registry path"),
+            &RollingGenerations::new("lease-fresh", fresh),
+        )
+        .expect("seed legacy registry without runner identity");
+    }
+
+    #[test]
+    #[ignore = "invoked by process_isolated_legacy_migration_preserves_concurrent_job_admission"]
+    fn process_migrate_legacy_generation() {
+        read("runner-a", None).expect("migrate legacy registry");
+    }
+
+    #[test]
+    #[ignore = "invoked by process_isolated_reconciliation_preserves_concurrent_job_admission"]
+    fn process_record_fresh_job() {
+        let fresh = session("lease-fresh", "daemon-fresh", Some(202));
+        record_job("runner-a", &fresh, "accepted-during-reconcile")
+            .expect("record job accepted during reconciliation");
+    }
+
+    #[test]
+    #[ignore = "invoked by process_isolated_reconciliation_preserves_concurrent_job_admission"]
+    fn process_reconcile_draining_generation() {
+        struct ProcessBlockingOperations(std::path::PathBuf);
+
+        impl GenerationEndpointOperations for ProcessBlockingOperations {
+            fn active_jobs(&self, _: &RunnerSession) -> Option<u64> {
+                std::fs::write(self.0.join("remote-check-complete"), "checked")
+                    .expect("signal remote drain check");
+                wait_for_process_file(&self.0.join("allow-commit"));
+                Some(0)
+            }
+
+            fn stop(&self, _: &RunnerSession) -> bool {
+                true
+            }
+
+            fn terminate_tunnel(&self, _: u32) {}
+        }
+
+        let fresh = session("lease-fresh", "daemon-fresh", Some(202));
+        reconcile_with(
+            "runner-a",
+            Some(&fresh),
+            &ProcessBlockingOperations(process_sync_dir()),
+        )
+        .expect("reconcile after remote drain check");
     }
 
     #[test]
@@ -668,6 +1076,42 @@ mod tests {
                 std::fs::read_to_string(registry_path).expect("read unsupported registry"),
                 r#"{"runner_id":"runner-a","unexpected":true}"#
             );
+        });
+    }
+
+    #[test]
+    fn fresh_direct_admission_replaces_a_stale_endpoint_and_preserves_draining_jobs() {
+        test_support::with_isolated_home(|_| {
+            let stale = session("lease-stale", "127.0.0.1:63114", Some(101));
+            let fresh = session("lease-fresh", "127.0.0.1:50575", Some(202));
+            record_job("runner-a", &stale, "active-stale-job").expect("record stale job");
+
+            reconcile_admission_session("runner-a", &fresh).expect("promote fresh admission");
+            record_job("runner-a", &fresh, "fresh-cook-job").expect("record one fresh dispatch");
+
+            assert_eq!(
+                admission_session("runner-a", Some(&fresh)).expect("resolve admission"),
+                Some(fresh.clone()),
+                "new Cook work uses the same endpoint runner status just verified"
+            );
+            assert_eq!(
+                job_session("runner-a", "active-stale-job", Some(&fresh))
+                    .expect("resolve draining job"),
+                Some(stale),
+                "existing work remains pinned to its draining generation"
+            );
+            let projection = status_projection("runner-a", Some(&fresh)).expect("projection");
+            assert!(projection.iter().any(|entry| {
+                entry.admission_owner
+                    && entry.remote_daemon_lease_id.as_deref() == Some("lease-fresh")
+                    && entry.local_url.as_deref() == Some("http://127.0.0.1:50575:4000")
+                    && entry.active_job_count == 1
+            }));
+            assert!(projection.iter().any(|entry| {
+                !entry.admission_owner
+                    && entry.remote_daemon_lease_id.as_deref() == Some("lease-stale")
+                    && entry.active_job_count == 1
+            }));
         });
     }
 


### PR DESCRIPTION
## Summary
- reconcile the generation admission owner to the current healthy direct runner session before Cook handoff
- retry one pre-acceptance transport loss against freshly resolved admission without consuming provider execution budget
- serialize every generation-registry mutation and preserve draining-job ownership during reconciliation and legacy migration
- pin Cook runtime generations across normal and fanout execution with independent guard lifetimes

Closes #9265.

## How to test
1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-lab-runner generation_store::tests::process_isolated_reconciliation_preserves_concurrent_job_admission --lib`.
3. Run `cargo test -p homeboy-lab-runner generation_store::tests::process_isolated_legacy_migration_preserves_concurrent_job_admission --lib`.
4. Run `cargo test -p homeboy-lab-runner execution::tests::exec::daemon_submission_retries_once_against_a_fresh_admission_generation --lib`.
5. Run `cargo test -p homeboy-lab-runner execution::tests::exec::replacement_admission_transport_loss_remains_retryable --lib`.
6. Run `cargo test -p homeboy-agents agent_task_service::cook::tests::cook_retries_retryable_pre_provider_transport_failures_within_attempt_budget --lib`.
7. Run `cargo test -p homeboy-agents agent_task_service::cook::tests::cook_batch_preserves_order_concurrency_and_failure_isolation --lib`.
8. Run `cargo test -p homeboy-core runtime_promotion::tests::duplicate_cook_pins_keep_the_remaining_guard_live --lib`.

## Compatibility
- Existing draining generations and accepted jobs remain bound to their recorded generation.
- Pre-provider handoff failures now use a retryable Lab transport classification instead of terminal `invalid_input` / provider failure.
- No command-line flags or persisted schema versions change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed the stale admission split, implemented the concurrency and retry repair, and drafted deterministic race coverage; Chris reviewed and owns the change.