### PR TITLE
Fix retained Lab daemon generation reconciliation

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1092,10 +1092,11 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
     // A Cook handoff can cross controller identities after readiness accepted a
     // direct SSH tunnel. Reuse that still-live tunnel rather than treating the
     // controller-local record lookup as a daemon disconnect.
-    let session = read_session_or_live_peer(runner_id)?;
-    super::generation_store::reconcile(runner_id, session.as_ref())?;
+    let mut session = read_session_or_live_peer(runner_id)?;
     let state = session_state(session.as_ref());
     let connected = state == RunnerSessionState::Connected;
+    reconcile_session_metadata_with_observed_daemon(&runner, &mut session, connected)?;
+    super::generation_store::reconcile(runner_id, session.as_ref())?;
     let stale_daemon = stale_daemon_warning(&runner, session.as_ref(), connected)?;
     let mut daemon_freshness = runner_daemon_freshness(&runner, session.as_ref(), connected)?
         .or_else(|| remote_daemon_recovery_freshness(runner_id, &runner));
@@ -2021,6 +2022,72 @@ fn stale_daemon_warning(
         )
         .with_runtime_paths(&runner.id, stale_runtime_paths, changed_runtime_paths),
     ))
+}
+
+/// A daemon endpoint and configured executable jointly provide stronger evidence
+/// than a session record written by a prior controller generation.
+fn reconcile_session_metadata_with_observed_daemon(
+    runner: &Runner,
+    session: &mut Option<RunnerSession>,
+    connected: bool,
+) -> Result<()> {
+    if !connected || runner.kind != RunnerKind::Ssh {
+        return Ok(());
+    }
+    let Some(current_session) = session.as_mut() else {
+        return Ok(());
+    };
+    if current_session.mode != RunnerTunnelMode::DirectSsh {
+        return Ok(());
+    }
+    let Some(local_url) = current_session.local_url.as_deref() else {
+        return Ok(());
+    };
+    let homeboy = remote_runner_homeboy_path(runner, "runner status metadata reconciliation")?;
+    let Some((_, _, client)) = resolve_ssh_runner(runner)? else {
+        return Ok(());
+    };
+    let Ok(configured) = remote_homeboy_identity(&client, homeboy) else {
+        return Ok(());
+    };
+    let Ok(observed_version) = daemon_http_version(local_url) else {
+        return Ok(());
+    };
+    let Ok(observed_identity) = daemon_http_identity(local_url) else {
+        return Ok(());
+    };
+    if !reconcile_session_metadata(
+        current_session,
+        &observed_version,
+        &observed_identity,
+        &configured,
+    ) {
+        return Ok(());
+    }
+    write_session(current_session)
+}
+
+fn reconcile_session_metadata(
+    session: &mut RunnerSession,
+    observed_version: &str,
+    observed_identity: &str,
+    configured: &RemoteHomeboyIdentity,
+) -> bool {
+    if !versions_match(observed_version, &configured.version)
+        || compare_identities(
+            Some(observed_identity),
+            configured.build_identity.as_deref(),
+        ) != IdentityComparison::Match
+    {
+        return false;
+    }
+    let version = normalize_homeboy_version_owned(observed_version);
+    let identity = observed_identity.trim();
+    let changed = session.homeboy_version != version
+        || session.homeboy_build_identity.as_deref() != Some(identity);
+    session.homeboy_version = version;
+    session.homeboy_build_identity = Some(identity.to_string());
+    changed
 }
 
 fn daemon_runtime_is_current(

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -133,6 +133,38 @@ fn reconciles_multiple_stale_generation_leases_to_one_authoritative_idle_lease()
 }
 
 #[test]
+fn converged_idle_generations_rebind_the_normal_disconnect_owner() {
+    let status = idle_stale_status(RemoteDaemonWorkEvidence::AuthoritativelyIdle);
+    let mut session = direct_ssh_session("lease-old");
+    session.remote_daemon_pid = Some(1111);
+    session.remote_daemon_address = Some("127.0.0.1:40501".to_string());
+    let mut second = direct_ssh_session("lease-older");
+    second.remote_daemon_pid = Some(2222);
+    second.remote_daemon_address = Some("127.0.0.1:35831".to_string());
+    let mut third = direct_ssh_session("lease-earliest");
+    third.remote_daemon_address = Some("127.0.0.1:42399".to_string());
+    let daemon = status.daemon.expect("authoritative daemon");
+
+    let rebound = super::super::stop_transport_recovery::rebind_idle_generation_owner(
+        &session,
+        &daemon,
+        daemon.lease_id.clone().expect("lease"),
+    );
+
+    assert_eq!(
+        rebound.remote_daemon_lease_id.as_deref(),
+        Some("lease-stale")
+    );
+    assert_eq!(rebound.remote_daemon_pid, Some(4444));
+    assert_eq!(
+        rebound.remote_daemon_address.as_deref(),
+        Some("127.0.0.1:49152")
+    );
+    assert_ne!(session.remote_daemon_address, second.remote_daemon_address);
+    assert_ne!(second.remote_daemon_address, third.remote_daemon_address);
+}
+
+#[test]
 fn stale_generation_reconciliation_requires_every_ledger_entry_to_be_direct_and_leased() {
     let first = direct_ssh_session("lease-a");
     let second = direct_ssh_session("lease-b");

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -417,6 +417,37 @@ fn equal_version_build_identity_and_runtime_paths_are_current() {
 }
 
 #[test]
+fn observed_matching_daemon_identity_reconciles_stale_session_metadata() {
+    let mut session = direct_ssh_session("lease-live");
+    session.homeboy_version = "0.298.0".to_string();
+    session.homeboy_build_identity = Some("homeboy 0.298.0+old".to_string());
+    let configured = RemoteHomeboyIdentity {
+        version: "0.298.1".to_string(),
+        build_identity: Some("homeboy 0.298.1+7d7b8e656466".to_string()),
+    };
+
+    assert!(reconcile_session_metadata(
+        &mut session,
+        "0.298.1",
+        "homeboy 0.298.1+7d7b8e656466",
+        &configured,
+    ));
+    assert_eq!(session.homeboy_version, "0.298.1");
+    assert_eq!(
+        session.homeboy_build_identity.as_deref(),
+        Some("homeboy 0.298.1+7d7b8e656466")
+    );
+    assert!(daemon_runtime_is_current(
+        "0.298.1",
+        &session.homeboy_version,
+        &configured.version,
+        IdentityComparison::Match,
+        &[],
+        &[],
+    ));
+}
+
+#[test]
 fn equal_versions_with_different_build_identities_are_stale_and_name_both_builds() {
     let warning = RunnerStaleDaemonWarning::new(
         "homeboy-lab",
@@ -956,7 +987,11 @@ fn refresh_disconnect_accepts_local_tunnel_rotation_and_uses_the_current_tunnel(
         let error = disconnect_with_session("homeboy-lab", Some(&recorded), false)
             .expect_err("a local fixture cannot authorize the required SSH re-probe");
         server.join().expect("server");
-        assert!(error.message.contains("runner is not SSH-backed"));
+        assert!(error.message.contains("unresolved daemon generations"));
+        assert!(error
+            .details
+            .to_string()
+            .contains("runner is not SSH-backed"));
         assert!(read_session("homeboy-lab").expect("read session").is_some());
     });
 }

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -32,7 +32,7 @@ pub(crate) fn disconnect_with_session(
     )?;
     promotion_lease.assert_generation()?;
     let local_session = read_session(runner_id)?;
-    let session = match expected_session {
+    let mut session = match expected_session {
         Some(expected_session)
             if local_session.as_ref().is_some_and(|current_session| {
                 same_remote_daemon_ownership(runner_id, expected_session, current_session)
@@ -57,28 +57,30 @@ pub(crate) fn disconnect_with_session(
             ));
         }
     }
-    if let Some(session) = &session {
+    if let Some(session) = &mut session {
         // The legacy controller record names only the admission owner. Drain
         // generations have their own lease and tunnel, so teardown is complete
         // only after every persisted endpoint is resolved independently.
-        let generations = super::super::generation_store::live_sessions(runner_id, Some(session))?;
-        if reconcile_authoritative_idle_stale_generations(runner_id, &generations)? {
-            super::super::generation_store::clear(runner_id)?;
-            let ownership = read_ownership(runner_id)?;
-            if should_stop_remote_daemon(
-                session,
-                ownership.as_ref(),
-                has_live_peer_session(session)?,
-            ) {
-                remove_ownership(runner_id)?;
-            }
-            remove_session(runner_id)?;
-            return Ok(RunnerDisconnectReport {
-                runner_id: runner_id.to_string(),
-                disconnected: true,
-                session: Some(session.clone()),
-                session_path: session_path(runner_id)?.display().to_string(),
-            });
+        let mut generations =
+            super::super::generation_store::live_sessions(runner_id, Some(session))?;
+        let mut reconciled_tunnel_pids = Vec::new();
+        if let Some(authoritative_session) =
+            reconcile_authoritative_idle_stale_generations(runner_id, session, &generations)?
+        {
+            reconciled_tunnel_pids.extend(
+                generations
+                    .iter()
+                    .filter_map(|generation| generation.tunnel_pid),
+            );
+            reconciled_tunnel_pids.sort_unstable();
+            reconciled_tunnel_pids.dedup();
+            *session = authoritative_session.clone();
+            // The one re-probed owner remains for the ordinary lease-bound
+            // disconnect below. Keep the durable ledger and every tunnel until
+            // that stop succeeds so failed recovery remains fully reversible.
+            let mut authoritative_session = authoritative_session;
+            authoritative_session.tunnel_pid = None;
+            generations = vec![authoritative_session];
         }
         let mut unresolved = Vec::new();
         for generation in generations {
@@ -105,6 +107,9 @@ pub(crate) fn disconnect_with_session(
                 Some(unresolved.into_iter().map(|entry| entry.to_string()).collect()),
             ));
         }
+        for pid in reconciled_tunnel_pids {
+            terminate_pid(pid);
+        }
         super::super::generation_store::clear(runner_id)?;
         let ownership = read_ownership(runner_id)?;
         if should_stop_remote_daemon(session, ownership.as_ref(), has_live_peer_session(session)?) {
@@ -125,18 +130,19 @@ pub(crate) fn disconnect_with_session(
 /// the remote status and typed jobs probe prove the exact lease is safe to stop.
 fn reconcile_authoritative_idle_stale_generations(
     runner_id: &str,
+    session: &RunnerSession,
     generations: &[RunnerSession],
-) -> Result<bool> {
+) -> Result<Option<RunnerSession>> {
     let Some(persisted_leases) = eligible_stale_generation_leases(generations) else {
-        return Ok(false);
+        return Ok(None);
     };
     if persisted_leases.is_empty() {
-        return Ok(false);
+        return Ok(None);
     }
     let runner = load(runner_id)?;
     let homeboy = remote_runner_homeboy_path(&runner, "runner stale-generation reconciliation")?;
     let Some((_, _, client)) = remote_daemon::resolve_ssh_runner(&runner)? else {
-        return Ok(false);
+        return Ok(None);
     };
     let mut status = remote_daemon::remote_daemon_status(&client, homeboy).map_err(|error| {
         Error::validation_invalid_argument(
@@ -158,42 +164,24 @@ fn reconcile_authoritative_idle_stale_generations(
             )
         })?
     else {
-        return Ok(false);
+        return Ok(None);
     };
-    remote_daemon::remote_daemon_force_stop(&client, homeboy, &lease_id).map_err(|error| {
-        Error::validation_invalid_argument(
-            "disconnect",
-            format!("authoritative lease-bound daemon stop failed: {error}"),
-            Some(runner_id.to_string()),
-            None,
-        )
-    })?;
-    let mut final_status =
-        remote_daemon::remote_daemon_status(&client, homeboy).map_err(|error| {
-            Error::validation_invalid_argument(
-                "disconnect",
-                format!("authoritative daemon re-probe after stop failed: {error}"),
-                Some(runner_id.to_string()),
-                None,
-            )
-        })?;
-    remote_daemon::probe_remote_daemon_endpoint(&client, &mut final_status);
-    remote_daemon::authoritative_lease_stop_confirmed(&final_status, &lease_id).map_err(
-        |error| {
-            Error::validation_invalid_argument(
-                "disconnect",
-                error,
-                Some(runner_id.to_string()),
-                None,
-            )
-        },
-    )?;
-    for generation in generations {
-        if let Some(pid) = generation.tunnel_pid {
-            terminate_pid(pid);
-        }
-    }
-    Ok(true)
+    let daemon = status.daemon.expect("authoritative lease requires daemon");
+    Ok(Some(rebind_idle_generation_owner(
+        session, &daemon, lease_id,
+    )))
+}
+
+pub(in crate::connection) fn rebind_idle_generation_owner(
+    session: &RunnerSession,
+    daemon: &remote_daemon::RemoteDaemon,
+    lease_id: String,
+) -> RunnerSession {
+    let mut authoritative_session = session.clone();
+    authoritative_session.remote_daemon_lease_id = Some(lease_id);
+    authoritative_session.remote_daemon_pid = daemon.pid;
+    authoritative_session.remote_daemon_address = Some(daemon.address.clone());
+    authoritative_session
 }
 
 /// Clearing the ledger is safe only when every generation is represented by a


### PR DESCRIPTION
## Summary
- reconcile stale persisted session version/build metadata only when the observed daemon and configured executable identities match
- collapse converged, authoritatively idle generation records onto the live daemon owner and stop it through the ordinary lease-bound disconnect path
- retain generation ledgers and tunnels until the authoritative non-force stop succeeds, while preserving fail-closed behavior for active, distinct, or ambiguous ownership

Closes #9280.

## How to test
1. Run `cargo test -p homeboy-lab-runner connection::tests::`.
2. Run `cargo test --workspace --no-run`.
3. Run `cargo fmt --check`.
4. Run `git diff --check origin/main...HEAD`.

Expected results: all 108 connection tests pass, the workspace compiles, formatting is clean, and the patch has no whitespace errors.

## Verification
- `cargo test -p homeboy-lab-runner connection::tests::` - 108 passed
- `cargo test --workspace --no-run` - passed
- `cargo fmt --check` - passed
- `git diff --check origin/main...HEAD` - passed

A full `cargo test -p homeboy-lab-runner` run also reaches 1,170 tests but currently has six unrelated current-main or environment-sensitive fixture failures; the two adjacent failures reproduce before entering the modified connection path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause analysis, implementation, deterministic test coverage, and verification