### PR TITLE
fix(runner): bind foreground Lab handoffs

### DIFF
--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -163,10 +163,11 @@ pub(super) fn exec_via_reverse_broker(
         &command,
     )?;
     if let Some(run_id) = run_id.as_deref() {
-        // A detached handoff must durably transition its controller projection
-        // before the response can be lost. Reconciliation reuses this same
-        // operation after an intent-only crash.
-        if detach_after_handoff {
+        // Every portable agent-task run is a controller-owned Lab handoff.
+        // Persist the accepted daemon job before foreground cook or retry can
+        // validate a runner snapshot; metadata-only binding leaves the typed
+        // handoff pending and loses that identity at preacceptance (#9240).
+        if !run_id_owns_generic_exec {
             homeboy_agents::agent_task_lifecycle::record_detached_lab_run(
                 homeboy_agents::agent_task_lifecycle::DetachedLabRunRecord {
                     run_id,
@@ -176,19 +177,13 @@ pub(super) fn exec_via_reverse_broker(
                     remote_command: &command,
                 },
             )?;
-        } else if run_id_owns_generic_exec {
+        } else {
             homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
                 run_id,
                 &runner.id,
                 &job.id.to_string(),
                 &cwd,
                 &command,
-            )?;
-        } else {
-            homeboy_agents::agent_task_lifecycle::record_runner_job_identity(
-                run_id,
-                &runner.id,
-                &job.id.to_string(),
             )?;
         }
     }

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -191,13 +191,13 @@ pub(super) fn exec_via_daemon(
         // The daemon has durably accepted this child. Bind it before waiting so
         // a lost controller still leaves cancellation and reconciliation with a
         // concrete runner job identity.
-        if detach_after_handoff {
-            // A detached handoff must durably transition the controller's pending
-            // Lab handoff to accepted before the response can be lost, exactly as
-            // the reverse-broker path does. Binding only the metadata runner job
-            // id (below) leaves the typed handoff pending, so `runner_job_id()`
-            // — which reads the accepted handoff first — reports no bound job and
-            // the controller can expire or re-dispatch an already-accepted run.
+        if !run_id_owns_generic_exec {
+            // Every portable agent-task run is a controller-owned Lab handoff,
+            // including foreground cook and retry attempts. Persist the daemon
+            // acceptance before either runner-result preacceptance path can read
+            // the controller record. Metadata-only binding leaves the typed
+            // handoff pending and can expose a valid snapshot to validation with
+            // no accepted controller job identity (#9240).
             homeboy_agents::agent_task_lifecycle::record_detached_lab_run(
                 homeboy_agents::agent_task_lifecycle::DetachedLabRunRecord {
                     run_id,
@@ -207,19 +207,13 @@ pub(super) fn exec_via_daemon(
                     remote_command: &command,
                 },
             )?;
-        } else if run_id_owns_generic_exec {
+        } else {
             homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
                 run_id,
                 &runner.id,
                 &job.id.to_string(),
                 &cwd,
                 &command,
-            )?;
-        } else {
-            homeboy_agents::agent_task_lifecycle::record_runner_job_identity(
-                run_id,
-                &runner.id,
-                &job.id.to_string(),
             )?;
         }
     }

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -708,6 +708,79 @@ fn direct_daemon_detached_handoff_returns_while_the_workload_remains_running() {
     });
 }
 
+#[test]
+fn foreground_portable_cook_binds_the_daemon_job_before_terminal_projection() {
+    foreground_portable_run_binds_the_daemon_job_before_terminal_projection(
+        "cook-preacceptance-attempt-1",
+    );
+}
+
+#[test]
+fn foreground_portable_retry_binds_the_daemon_job_before_terminal_projection() {
+    foreground_portable_run_binds_the_daemon_job_before_terminal_projection(
+        "retry-preacceptance-attempt-1",
+    );
+}
+
+fn foreground_portable_run_binds_the_daemon_job_before_terminal_projection(run_id: &str) {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        crate::register_runner_daemon_exec_driver();
+        // Both controller entrypoints execute the same portable `run-plan`
+        // child without --detach-after-handoff. Its daemon acceptance must
+        // nevertheless bind the typed controller handoff before terminal
+        // projection validates the runner snapshot (#9240).
+        homeboy_agents::agent_task_lifecycle::record_lab_offload_phase(
+            run_id,
+            "lab",
+            "dispatching",
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("persist portable controller proxy");
+        let workspace = tempfile::tempdir().expect("workspace");
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let daemon_url = format!("http://{}", listener.local_addr().expect("address"));
+        std::thread::spawn(move || {
+            let _ = homeboy_core::daemon::serve_listener(listener);
+        });
+
+        let (output, exit_code) = exec_via_daemon(
+            &ssh_runner(),
+            &daemon_url,
+            None,
+            workspace.path().display().to_string(),
+            None,
+            vec!["sh".to_string(), "-c".to_string(), "true".to_string()],
+            Default::default(),
+            Vec::new(),
+            false,
+            None,
+            None,
+            Vec::new(),
+            None,
+            Some(run_id.to_string()),
+            false,
+            true,
+            false,
+            false,
+            None,
+        )
+        .expect("foreground portable handoff");
+
+        assert_eq!(exit_code, 0);
+        let record = homeboy_agents::agent_task_lifecycle::status(run_id)
+            .expect("terminal projection keeps controller record readable");
+        assert_eq!(record.runner_id(), Some("lab"));
+        assert_eq!(record.runner_job_id(), output.job_id.as_deref());
+        assert!(record.lab_handoff.is_some_and(|handoff| {
+            handoff.state
+                == homeboy_agents::agent_task_lifecycle::AgentTaskLabHandoffState::Accepted
+        }));
+    });
+}
+
 struct ReleaseBlockedWorkload(std::path::PathBuf);
 
 impl Drop for ReleaseBlockedWorkload {


### PR DESCRIPTION
## Summary

Closes #9240.

Foreground portable Lab jobs recorded only metadata-level runner identity after daemon or reverse-broker acceptance. The typed controller handoff therefore remained pending, so cook and retry preacceptance validated a real runner snapshot against no accepted controller job identity.

This change persists the accepted typed Lab handoff for every non-generic agent-task run before waiting for terminal projection. Generic `runner exec --run-id` retains its separate identity path, and mismatched non-empty identities remain rejected.

## Verification

1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-lab-runner foreground_portable_cook_binds_the_daemon_job_before_terminal_projection -- --test-threads=1`.
3. Run `cargo test -p homeboy-lab-runner foreground_portable_retry_binds_the_daemon_job_before_terminal_projection -- --test-threads=1`.
4. Run `cargo test -p homeboy-agents preacceptance_snapshot_rejects_a_different_bound_daemon_job -- --test-threads=1`.

All targeted checks pass. The broader `homeboy-lab-runner --lib` run reached 1,163 passing tests with seven failures in unchanged connection, workspace, and worker areas; those are not presented as verification for this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with `openai/gpt-5.6-sol`
- **Used for:** Investigated the foreground cook/retry handoff path, implemented the typed identity binding, and added regression tests. Chris reviews and owns the change.
