### PR TITLE
refactor(audit): dedup command_wrapper_bypass onto shared walker cfg_test_regions

### DIFF
--- a/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs
+++ b/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs
@@ -26,7 +26,7 @@ use regex::Regex;
 use super::super::conventions::AuditFinding;
 use super::super::findings::{Finding, Severity};
 use super::super::fingerprint::FileFingerprint;
-use super::super::walker::is_test_path;
+use super::super::walker::{cfg_test_regions, is_test_path, offset_in_cfg_test_region};
 
 /// Minimum arg-vector length to consider. Single-element commands (`["init"]`,
 /// `["fetch"]`) are too generic to attribute to one wrapper.
@@ -158,7 +158,7 @@ fn detect_command_wrapper_bypass(fingerprints: &[&FileFingerprint]) -> Vec<Findi
         // ranges here and skip matches that fall inside them.
         let test_regions = cfg_test_regions(&fp.content);
         for m in argvec_regex().find_iter(&fp.content) {
-            if offset_in_any_region(m.start(), &test_regions) {
+            if offset_in_cfg_test_region(m.start(), &test_regions) {
                 continue;
             }
             let inner = argvec_regex()
@@ -247,59 +247,6 @@ fn thin_wrapper_bodies(content: &str) -> Vec<(String, String, usize)> {
         out.push((name, body.to_string(), body_start));
     }
     out
-}
-
-/// Byte ranges (start..end) of inline `#[cfg(test)]` blocks in `content`.
-///
-/// Matches a `#[cfg(test)]` attribute, then brace-matches the module/item that
-/// follows it. Both `#[cfg(test)] mod tests { … }` and `#[cfg(test)] fn … { … }`
-/// are covered. Ranges span from the attribute to the closing brace so any
-/// arg-vector inside is skipped by the finding pass.
-fn cfg_test_regions(content: &str) -> Vec<(usize, usize)> {
-    let bytes = content.as_bytes();
-    let mut regions = Vec::new();
-    let mut search_from = 0usize;
-    while let Some(rel) = content[search_from..].find("#[cfg(test)]") {
-        let attr_start = search_from + rel;
-        // Advance past this attribute for the next iteration regardless of
-        // whether we find a brace (avoids infinite loops on malformed input).
-        search_from = attr_start + "#[cfg(test)]".len();
-
-        // Find the first `{` after the attribute (skips `mod tests`, `fn …`,
-        // where-clauses, etc.). If none, the attribute closes an item with no
-        // block (e.g. `#[cfg(test)] use …;`) — nothing to exclude.
-        let Some(brace_rel) = content[search_from..].find('{') else {
-            continue;
-        };
-        let open = search_from + brace_rel;
-        let mut depth = 0i32;
-        let mut close = None;
-        for (i, &b) in bytes[open..].iter().enumerate() {
-            if b == b'{' {
-                depth += 1;
-            } else if b == b'}' {
-                depth -= 1;
-                if depth == 0 {
-                    close = Some(open + i);
-                    break;
-                }
-            }
-        }
-        if let Some(close) = close {
-            regions.push((attr_start, close));
-            // Continue searching after this block so sibling test modules and
-            // nested cfg(test) items are still discovered.
-            search_from = close + 1;
-        }
-    }
-    regions
-}
-
-/// Whether `offset` falls within any `(start, end)` region.
-fn offset_in_any_region(offset: usize, regions: &[(usize, usize)]) -> bool {
-    regions
-        .iter()
-        .any(|(start, end)| offset >= *start && offset <= *end)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
Cleanup follow-up to the audit false-positive fixes. Removes duplicated `#[cfg(test)]`-region logic.

## Context
- #9311 fixed `command_wrapper_bypass` by inlining `cfg_test_regions` / `offset_in_any_region`.
- #9312 fixed `constant_bypass` and introduced the same logic as shared `pub(crate)` helpers in `walker.rs` (`cfg_test_regions` / `offset_in_cfg_test_region`), next to `is_test_path`.

Both are now merged, so `command_wrapper_bypass` no longer needs its own copy.

## Change
Drop the inlined helpers from `command_wrapper_bypass.rs` and use the shared `walker` versions. Net **-55 lines**; both detectors now share one implementation of test-region detection.

## Verification
Behavior-preserving: all 7 `command_wrapper_bypass` tests pass unchanged, including the two inline-`#[cfg(test)]` regression tests (`ignores_argvectors_inside_inline_cfg_test_blocks`, `still_flags_production_argvector_alongside_an_inline_test_block`) — they now exercise the shared helper. `cargo check`/`fmt` clean.

## Note on the broader sweep
I audited every detector using `is_test_path` for the same inline-`#[cfg(test)]` gap. Conclusion: the raw-content byte-offset gap was confined to `command_wrapper_bypass` and `constant_bypass` (both now fixed). The others are either fingerprint/graph-based (`dead_code`, `aggregate_construction` — test handling lives in the fingerprint/reference layer) or cross-file correlation (`config_key_usage` — excluding test occurrences could hide real signal). `repeated_literal_shape` shares the shape but is PHP-array-oriented and doesn't thread literal offsets, so it's a larger, lower-value change deferred. The gap was narrow, not endemic.