### PR TITLE
refactor(agents): single source of truth for the candidate-adoption recovery marker

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -559,11 +559,7 @@ fn validate_durable_publication_eligibility(
         && candidate_ref.is_some_and(is_git_commit_identity)
         && candidate_ref == candidate_head
         && adoption_model.is_some_and(is_concrete_model)
-        && recovery.is_some_and(|recovery| {
-            recovery["schema"] == "homeboy/agent-task-candidate-adoption-recovery/v1"
-                && recovery["reason"] == "pre_provider_transport_failure"
-                && recovery["provider_executions_consumed"] == 0
-        })
+        && recovery.is_some_and(crate::agent_task_lifecycle::is_pre_provider_transport_recovery)
         && !promotion.gate_results.is_empty()
         && promotion
             .gate_results

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -149,7 +149,7 @@ fn candidate_adoption_recovery(phase: &str) -> Option<serde_json::Value> {
     )
     .then(|| {
         json!({
-            "schema": "homeboy/agent-task-candidate-adoption-recovery/v1",
+            "schema": super::CANDIDATE_ADOPTION_RECOVERY_SCHEMA,
             "reason": "pre_provider_transport_failure",
             "provider_executions_consumed": 0,
         })

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
@@ -370,8 +370,24 @@ fn no_runner_job_recorded(record: &AgentTaskRunRecord) -> bool {
         && record.metadata["job_id"].is_null()
 }
 
-fn is_pre_provider_transport_recovery(recovery: &Value) -> bool {
-    recovery["schema"] == "homeboy/agent-task-candidate-adoption-recovery/v1"
+/// Schema tag stamped on the pre-provider candidate-adoption recovery marker
+/// produced when a Lab handoff fails before any provider executes. It is the
+/// single source of truth for that marker's identity across the adoption
+/// pipeline (recording, promotion eligibility, publication eligibility).
+pub(crate) const CANDIDATE_ADOPTION_RECOVERY_SCHEMA: &str =
+    "homeboy/agent-task-candidate-adoption-recovery/v1";
+
+/// True when `recovery` is an authenticated pre-provider transport-failure
+/// recovery marker: the exact shape that authorizes adopting an externally
+/// prepared candidate whose original attempt never ran a provider.
+///
+/// This is the *one* definition of that check. The adoption recovery pipeline
+/// validates the same marker at several independent boundaries (candidate
+/// source resolution, promotion eligibility, publication eligibility); routing
+/// them all through here keeps those boundaries from drifting apart — the drift
+/// that made this path regress repeatedly (issue #8983).
+pub(crate) fn is_pre_provider_transport_recovery(recovery: &Value) -> bool {
+    recovery["schema"] == CANDIDATE_ADOPTION_RECOVERY_SCHEMA
         && recovery["reason"] == "pre_provider_transport_failure"
         && recovery["provider_executions_consumed"] == 0
 }

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -769,11 +769,7 @@ fn has_pre_provider_transport_recovery_eligibility(outcome: &AgentTaskOutcome) -
         .get("candidate_adoption_recovery")
         .or_else(|| outcome.outputs.get("candidate_adoption_recovery"));
     eligibility
-        .filter(|value| {
-            value["schema"] == "homeboy/agent-task-candidate-adoption-recovery/v1"
-                && value["reason"] == "pre_provider_transport_failure"
-                && value["provider_executions_consumed"] == 0
-        })
+        .filter(|value| crate::agent_task_lifecycle::is_pre_provider_transport_recovery(value))
         .is_some()
 }
 


### PR DESCRIPTION
## Why
Issue **#8983** ("Allow agent-task adopt to resolve orphaned cook recipes") was **reopened 3×** and cascaded through ~8 sequential fixes (#8987 → #8989 → #8991 → #9005 → #9010 → #9020 → #9029 → #9035). Reading the reopen thread, it wasn't one bug fixed repeatedly — it was a **validation gauntlet** where each fix unblocked one boundary and immediately hit the next.

A structural root cause behind that fragility: the *authenticated pre-provider candidate-adoption recovery* marker is a loosely-typed `serde_json::Value` whose identity — `schema == "homeboy/agent-task-candidate-adoption-recovery/v1"`, `reason == "pre_provider_transport_failure"`, `provider_executions_consumed == 0` — was **re-inlined at three independent validation boundaries**, plus a producer inlining the schema literal:

- `agent_task_promotion/promote.rs` — promotion eligibility
- `agent_task_finalization.rs` — publication eligibility (the #9010/#9020 boundary)
- `agent_task_lifecycle/lifecycle_candidate_adoption.rs` — recovery-outcome reconstruction (had a private `is_pre_provider_transport_recovery` the other two didn't call)
- `agent_task_lifecycle/failure_recording.rs` — the producer

Four copies of the same contract with no shared definition is exactly the drift surface that lets one boundary diverge from another.

## What
- Add `CANDIDATE_ADOPTION_RECOVERY_SCHEMA` as the **one** schema constant.
- Promote `is_pre_provider_transport_recovery()` to `pub(crate)` as the **one** marker predicate.
- Route both consumer boundaries **and** the producer through them.

The schema literal now appears in exactly one place (the const definition).

## Behavior
Behavior-preserving — the predicate logic is byte-for-byte the same; only the scattered copies are unified. This is a stabilization refactor, not a functional change: it removes the duplication class that made #8983 regress boundary-by-boundary, so a future change to the marker's shape updates one definition instead of silently missing a reader.

## Verification
- `cargo check -p homeboy-agents --lib` — clean, zero new warnings (the 3 remaining are pre-existing dead-code, confirmed present on `origin/main`).
- `cargo fmt` — clean.
- Tests that exercise the consolidated predicate, all pass in isolation:
  - `durable_finalization_accepts_only_authenticated_pre_provider_candidate_adoption_recovery`
  - `durable_finalization_accepts_only_authenticated_external_candidate_adoption`
  - `explicit_candidate_adopts_only_durable_pre_provider_transport_failures`
  - the 8 `candidate_adoption` lifecycle tests
  - the full 8-test durable-finalization suite
- 4 `agent_task_promotion::tests::part_c` tests fail **identically on clean `origin/main`** (git-worktree/`master`-vs-`main` fixture flakes at `part_c.rs:331`, "fixture executable is not an adapter") — pre-existing, unrelated to this change.