### PR TITLE
fix(audit): command_wrapper_bypass only attributes reachable cross-crate helpers

### DIFF
--- a/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs
+++ b/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs
@@ -50,13 +50,30 @@ fn argvec_regex() -> &'static Regex {
 /// helpers inside `#[cfg(test)] mod tests { fn head() … }`, impl methods — are
 /// excluded. Canonical command wrappers are module-level; indented one-call
 /// helpers are almost always test fixtures and would otherwise seed the map
-/// with git-setup arg-vectors. Group 1 is the name.
+/// with git-setup arg-vectors. Group 1 is the visibility prefix (`pub` /
+/// `pub(...)` / empty); group 2 is the name.
 fn fn_decl_regex() -> &'static Regex {
     static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-        Regex::new(r"(?m)^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?(?:unsafe\s+)?(?:const\s+)?fn\s+([a-z_][a-z0-9_]*)\s*[(<]")
+        Regex::new(r"(?m)^(pub(?:\([^)]*\))?\s+)?(?:async\s+)?(?:unsafe\s+)?(?:const\s+)?fn\s+([a-z_][a-z0-9_]*)\s*[(<]")
             .expect("valid fn regex")
     });
     &RE
+}
+
+/// A wrapper is *reachable* from another crate only if it is `pub` (crate-wide
+/// `pub` — a helper visible outside its own crate). `pub(crate)`, `pub(super)`,
+/// `pub(in …)`, and private helpers are unreachable across a crate boundary, so
+/// attributing a cross-crate raw command to them is a false positive.
+fn visibility_is_crate_public(vis_prefix: &str) -> bool {
+    let vis = vis_prefix.trim();
+    vis == "pub"
+}
+
+/// The crate name for a `crates/<crate>/…` path, else `None` (non-workspace
+/// layout — fall back to conservative behavior).
+fn crate_of_path(path: &str) -> Option<&str> {
+    let rest = path.strip_prefix("crates/")?;
+    rest.split('/').next().filter(|s| !s.is_empty())
 }
 
 /// Parse the inner string elements of an arg-vector match into a canonical key.
@@ -99,6 +116,10 @@ struct WrapperDef {
     /// Byte offset of the arg-vector literal in the wrapper body, so we never
     /// flag the wrapper's own definition.
     argv_offset: usize,
+    /// Whether the wrapper is crate-`pub` — required to attribute a bypass from
+    /// a different crate. A private/`pub(crate)` helper is unreachable
+    /// cross-crate, so flagging it there is a false positive.
+    is_public: bool,
 }
 
 fn detect_command_wrapper_bypass(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
@@ -109,7 +130,7 @@ fn detect_command_wrapper_bypass(fingerprints: &[&FileFingerprint]) -> Vec<Findi
         if is_test_path(&fp.relative_path) {
             continue;
         }
-        for (name, body, body_offset) in thin_wrapper_bodies(&fp.content) {
+        for (name, is_public, body, body_offset) in thin_wrapper_bodies(&fp.content) {
             // A thin wrapper's body contains exactly one arg-vector literal.
             let matches: Vec<_> = argvec_regex().find_iter(&body).collect();
             if matches.len() != 1 {
@@ -138,6 +159,7 @@ fn detect_command_wrapper_bypass(fingerprints: &[&FileFingerprint]) -> Vec<Findi
                 name: name.clone(),
                 file: fp.relative_path.clone(),
                 argv_offset: body_offset + m.start(),
+                is_public,
             });
         }
     }
@@ -174,6 +196,21 @@ fn detect_command_wrapper_bypass(fingerprints: &[&FileFingerprint]) -> Vec<Findi
             if fp.relative_path == def.file && m.start() == def.argv_offset {
                 continue;
             }
+            // Only attribute a bypass to a helper the call site can actually
+            // reach. A private/`pub(crate)` helper in a DIFFERENT crate is
+            // unreachable, so suggesting "call it instead" is a false positive.
+            // Same-crate calls are always fine; cross-crate requires `pub`.
+            let call_crate = crate_of_path(&fp.relative_path);
+            let def_crate = crate_of_path(&def.file);
+            let cross_crate = match (call_crate, def_crate) {
+                (Some(a), Some(b)) => a != b,
+                // Unknown layout on either side — be conservative and treat as
+                // same-crate (do not suppress) to preserve prior behavior.
+                _ => false,
+            };
+            if cross_crate && !def.is_public {
+                continue;
+            }
             let cmd = elems.join(" ");
             findings.push(Finding {
                 convention: "command_wrapper_bypass".to_string(),
@@ -201,11 +238,12 @@ fn detect_command_wrapper_bypass(fingerprints: &[&FileFingerprint]) -> Vec<Findi
     findings
 }
 
-/// Yield `(fn_name, body_text, body_start_offset)` for functions whose body is
-/// small enough to be a thin wrapper (few statements). Uses brace matching from
-/// each `fn` declaration; bounded to short bodies so we only consider genuine
-/// one-call wrappers, not large functions that happen to contain one arg-vector.
-fn thin_wrapper_bodies(content: &str) -> Vec<(String, String, usize)> {
+/// Yield `(fn_name, is_public, body_text, body_start_offset)` for functions
+/// whose body is small enough to be a thin wrapper (few statements). Uses brace
+/// matching from each `fn` declaration; bounded to short bodies so we only
+/// consider genuine one-call wrappers, not large functions that happen to
+/// contain one arg-vector. `is_public` is true only for crate-`pub` helpers.
+fn thin_wrapper_bodies(content: &str) -> Vec<(String, bool, String, usize)> {
     /// Max characters in a wrapper body — a one-call delegation is tiny; this
     /// keeps us from treating a large function's incidental arg-vector as the
     /// canonical definition.
@@ -214,7 +252,11 @@ fn thin_wrapper_bodies(content: &str) -> Vec<(String, String, usize)> {
     let bytes = content.as_bytes();
     let mut out = Vec::new();
     for caps in fn_decl_regex().captures_iter(content) {
-        let name = caps[1].to_string();
+        let is_public = caps
+            .get(1)
+            .map(|m| visibility_is_crate_public(m.as_str()))
+            .unwrap_or(false);
+        let name = caps[2].to_string();
         let decl_end = caps.get(0).unwrap().end();
         // Find the opening brace of the body after the signature.
         let Some(brace_rel) = content[decl_end..].find('{') else {
@@ -244,7 +286,7 @@ fn thin_wrapper_bodies(content: &str) -> Vec<(String, String, usize)> {
         if body.len() > MAX_BODY_CHARS {
             continue;
         }
-        out.push((name, body.to_string(), body_start));
+        out.push((name, is_public, body.to_string(), body_start));
     }
     out
 }

--- a/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass/tests.rs
+++ b/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass/tests.rs
@@ -127,3 +127,58 @@ fn still_flags_production_argvector_alongside_an_inline_test_block() {
     );
     assert_eq!(findings[0].file, "src/agent/materialization.rs");
 }
+
+#[test]
+fn does_not_flag_cross_crate_call_of_a_private_helper() {
+    // A private (`pub(crate)`) thin wrapper in one crate cannot be called from
+    // another crate, so a raw arg-vector there is not a reachable bypass.
+    let helper = fp(
+        "crates/homeboy-lab-runner/src/homeboy_refresh.rs",
+        "pub(crate) fn git_dirty(p: &Path) -> bool {\n    run_git_output(p, &[\"status\", \"--porcelain\"], \"x\")\n}\n",
+    );
+    let caller = fp(
+        "crates/homeboy-agents/src/promotion.rs",
+        "fn f(p: &str) {\n    let s = git_output(p, &[\"status\", \"--porcelain\"]);\n}\n",
+    );
+    assert!(
+        detect_command_wrapper_bypass(&[&helper, &caller]).is_empty(),
+        "a private helper in another crate is unreachable — not a bypass"
+    );
+}
+
+#[test]
+fn flags_cross_crate_call_of_a_public_helper() {
+    // A `pub` helper IS reachable across a crate boundary (e.g. homeboy-core is
+    // a dependency of homeboy-agents), so the raw arg-vector is a real bypass.
+    let helper = fp(
+        "crates/homeboy-core/src/git/primitives_query.rs",
+        "pub fn head_sha(p: &Path) -> Option<String> {\n    output_optional(p, &[\"rev-parse\", \"HEAD\"])\n}\n",
+    );
+    let caller = fp(
+        "crates/homeboy-agents/src/promotion.rs",
+        "fn f(p: &str) {\n    let h = git_output(p, &[\"rev-parse\", \"HEAD\"]);\n}\n",
+    );
+    let findings = detect_command_wrapper_bypass(&[&helper, &caller]);
+    assert_eq!(findings.len(), 1, "public cross-crate helper is reachable");
+    assert!(findings[0].description.contains("head_sha"));
+}
+
+#[test]
+fn flags_same_crate_call_of_a_private_helper() {
+    // Within the SAME crate, a private helper is reachable, so a raw arg-vector
+    // duplicating it is still a bypass.
+    let helper = fp(
+        "crates/homeboy-agents/src/git_util.rs",
+        "fn git_dirty(p: &Path) -> bool {\n    run_git_output(p, &[\"status\", \"--porcelain\"], \"x\")\n}\n",
+    );
+    let caller = fp(
+        "crates/homeboy-agents/src/promotion.rs",
+        "fn f(p: &str) {\n    let s = git_output(p, &[\"status\", \"--porcelain\"]);\n}\n",
+    );
+    let findings = detect_command_wrapper_bypass(&[&helper, &caller]);
+    assert_eq!(
+        findings.len(),
+        1,
+        "same-crate private helper is reachable — still a bypass"
+    );
+}


### PR DESCRIPTION
## Summary
Removes a second false-positive class from `command_wrapper_bypass`: attributing a raw command to a canonical helper the call site **cannot actually reach**.

## Problem
The detector recorded any thin git-wrapper found *anywhere* as "the canonical helper" for its arg-vector, then flagged every other site passing the same arg-vector — **including private helpers in a different crate**. A `pub(crate)`/private helper in crate A is unreachable from crate B, so "call it instead" is a false positive with an impossible suggestion.

Evidence from the first Audit Debt sweep (`audit: command wrapper bypass`): **20 of ~40 unique findings were cross-crate** (18 `homeboy-agents → homeboy-core`, 2 `homeboy-agents → homeboy-lab-runner`). The lab-runner ones point at the **private** `fn git_dirty` in `homeboy_refresh.rs` — `homeboy-agents` literally cannot call it. Following the suggestion is impossible; blindly "fixing" others risks calling a private symbol or one with different error semantics.

## Fix
- The `fn` regex already matched `pub`/`pub(...)` — now **capture** it. `visibility_is_crate_public` treats only bare `pub` as crate-reachable (`pub(crate)`, `pub(super)`, `pub(in …)`, private are not).
- Derive the crate from the `crates/<crate>/…` path (`crate_of_path`).
- Attribute a bypass across a crate boundary **only when the helper is `pub`**. Same-crate calls are unaffected (private helpers there are reachable → still flagged). Non-workspace layouts fall back to prior behavior (conservative).

## Tests (10 cwb tests + 326 detector suite + runtime regression all pass)
- `does_not_flag_cross_crate_call_of_a_private_helper` — the `git_dirty` case → suppressed.
- `flags_cross_crate_call_of_a_public_helper` — `pub head_sha` in core, called from agents → still flagged.
- `flags_same_crate_call_of_a_private_helper` — private helper, same crate → still flagged.

`cargo check`/`fmt` clean; full build → CI.

## Impact
Cuts the `command_wrapper_bypass` false-positive rate roughly in half (the cross-crate-unreachable subset), leaving findings that are genuinely actionable — you can actually call the suggested helper. Stacks with the inline-cfg(test) fixes (#9311/#9312/#9317) to make this the most trustworthy audit category.

## Note
The `homeboy-agents → homeboy-core` (pub, reachable) findings remain — those are real, actionable drift. A future cleanup can migrate those raw `git_output(path, &["rev-parse","HEAD"])?` sites to the typed `git::head_sha`/`run_git_output` helpers, but that's a semantically-sensitive change (Option-vs-Result error handling) best done deliberately, not mechanically.