### PR TITLE
refactor(agents): delegate finalization git_output to canonical run_git

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -5,8 +5,8 @@ use super::{
 use crate::agent_task_promotion::{AgentTaskPromotionCandidate, AgentTaskPromotionReport};
 use homeboy_core::error::{Error, Result};
 use homeboy_core::git::{
-    commit_at, get_uncommitted_changes, pr_create, pr_edit, pr_find, push_at, CommitOptions,
-    PrCreateOptions, PrEditOptions, PrFindOptions, PrState, PushOptions,
+    commit_at, get_uncommitted_changes, pr_create, pr_edit, pr_find, push_at, run_git,
+    CommitOptions, PrCreateOptions, PrEditOptions, PrFindOptions, PrState, PushOptions,
 };
 use homeboy_core::run_lifecycle_record::RunLifecycleRecord;
 use serde::de::DeserializeOwned;
@@ -434,20 +434,18 @@ fn remote_head_is_ancestor_of_candidate(path: &str, remote_head: &str, local_hea
         .unwrap_or(false)
 }
 
+/// Run git and return trimmed stdout. Thin delegation to the canonical
+/// `homeboy_core::git::run_git` so the command spelling and failure handling
+/// live in one place (richer diagnostics: command, cwd, exit code, stderr).
+/// `run_git` returns raw stdout, so trim here to preserve this wrapper's
+/// long-standing trimmed contract for its call sites.
 fn git_output(path: &str, args: &[&str]) -> Result<String> {
-    let output = std::process::Command::new("git")
-        .args(args)
-        .current_dir(path)
-        .output()
-        .map_err(|error| Error::git_command_failed(error.to_string()))?;
-    if !output.status.success() {
-        return Err(Error::git_command_failed(format!(
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr).trim()
-        )));
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    run_git(
+        std::path::Path::new(path),
+        args,
+        &format!("git {}", args.join(" ")),
+    )
+    .map(|stdout| stdout.trim().to_string())
 }
 
 fn is_git_object_id(value: &str) -> bool {


### PR DESCRIPTION
## Summary
The first real production `command_wrapper_bypass` cleanup — done deliberately, preserving semantics.

`agent_task_finalization/backend.rs` hand-rolled a `git_output` wrapper with its own `Command::new("git")` + status-check + error construction. That's exactly the "git command spelling defined in N places" drift the `command_wrapper_bypass` audit flags. `homeboy-core` already exposes the canonical `run_git`.

## Why this is safe (the semantics analysis)
The finding suggested `head_sha`, but that returns `Option<String>` (swallows errors) — migrating call sites to it would lose the `?`-propagated error handling finalization relies on. Wrong target.

The correct canonical is **`homeboy_core::git::run_git`**:
- Same shape: `Result<String>`, runs git, checks `status.success()`, errors on failure.
- **Strictly better**: richer diagnostics (`command`, `cwd`, `exit_code`, `stderr`) and `stdin(null)` to prevent credential-helper hangs.
- One difference: `run_git` returns raw stdout; the local wrapper trimmed.

## Change
Reimplement the local `git_output` as a thin delegation to `run_git`, trimming stdout to preserve its long-standing trimmed contract. **All 6 production call sites are unchanged** — zero call-site blast radius — while the duplicated raw-git invocation is removed and error detail improves.

```rust
fn git_output(path: &str, args: &[&str]) -> Result<String> {
    run_git(Path::new(path), args, &format!("git {}", args.join(" ")))
        .map(|stdout| stdout.trim().to_string())
}
```

## Verification
- `cargo check -p homeboy-agents --lib` clean (no new warnings; backend.rs warning-free).
- **51 finalization tests pass** — they exercise real git operations through these exact call sites (repo init, commit, rev-parse, status).
- `cargo fmt` clean.

## Context
This is the deliberate follow-up to the `command_wrapper_bypass` detector cleanup (#9311/#9317/#9320). The remaining scattered per-module `git_output` wrappers are mostly `#[cfg(test)]` helpers (correctly no longer flagged after #9311); the handful of other production ones can get the same treatment in follow-ups, each verified for matching error semantics rather than mechanically swapped.