### PR TITLE
refactor(agents): route promotion lab-offload provenance through the canonical runner-id accessor

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -73,16 +73,14 @@ pub fn promote_with_checkpoint(
     if let Some(provenance) = provider.provenance() {
         report.provenance["worktree_provider"] = provenance.clone();
     }
-    if let Ok(runner_id) = std::env::var(homeboy_core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV) {
-        if !runner_id.trim().is_empty() {
-            report.provenance["lab_offload"] = json!({
-                "runner_id": runner_id,
-                "source_aggregate": report.source.path,
-                "source_artifact": report.patch_artifact.path,
-                "target_worktree": report.to_worktree,
-                "target_workspace": report.target.path,
-            });
-        }
+    if let Some(runner_id) = crate::agent_task_lifecycle::execution_runner_id() {
+        report.provenance["lab_offload"] = json!({
+            "runner_id": runner_id,
+            "source_aggregate": report.source.path,
+            "source_artifact": report.patch_artifact.path,
+            "target_worktree": report.to_worktree,
+            "target_workspace": report.target.path,
+        });
     }
     Ok(report)
 }


### PR DESCRIPTION
## Why
Re-auditing the twice-reopened **#8748** ("Route agent-task promotion through an explicitly selected Lab runner") surfaced its recurring failure mode: **runner intent leaks into preflight from multiple independent sources**, and each fix (#8773 → #8794 → #8845) plugged one source before the next reopen found another.

`agent_task_lifecycle::execution_runner_id()` is the canonical reader of the `HOMEBOY_LAB_EXECUTION_RUNNER_ID` env var — empty-trimmed, `Option`-returning — and is already the shared accessor used by `lifecycle_ops` and `failure_recording`. But `promote_with_checkpoint` re-inlined the same `std::env::var(...) + trim().is_empty()` idiom instead of calling it. That's a scattered re-read of runner intent: exactly the drift surface behind #8748.

## What
Route promotion's `lab_offload` provenance stamp through `execution_runner_id()`, so the env-var semantics (name, trimming, empty handling) have a single definition. Same consolidation shape as #9319 (candidate-adoption recovery marker).

## Behavior
Behavior-preserving. `execution_runner_id()` returns `env::var(LAB_EXECUTION_RUNNER_ID_ENV).ok().filter(|id| !id.trim().is_empty())` — byte-identical to the previous inline `if let Ok(runner_id) { if !runner_id.trim().is_empty() { ... } }`.

## Verification
- `cargo check -p homeboy-agents --lib` — clean, no new warnings.
- `cargo fmt` — clean.
- Diff is a single file, 8 insertions / 10 deletions.