### PR TITLE
fix(cli): allow read-only agent-task cooks to skip the verify gate (#7608)

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -106,12 +106,24 @@ pub(crate) fn run_cook_with_executor_and_dispatcher<E>(
 where
     E: AgentTaskExecutorAdapter + Clone,
 {
-    if !args.gates.has_deterministic_gate() {
+    // Deterministic gates exist to make *publication* safe: a green gate is the
+    // proof a cook may commit, push, and open a PR. A `--no-finalize` cook does
+    // none of those, so a gate is not meaningful there — read-only/exploratory
+    // cooks legitimately have nothing to verify. The promotion lifecycle already
+    // treats an empty gate set as a vacuously-green run
+    // (`run_promotion_gates` -> `PromotionGateRun::without_gates`), so relaxing
+    // the requirement here is safe end to end (#7608). Finalizing cooks still
+    // require a gate, but now say so with a copy-pasteable example instead of a
+    // bare rejection.
+    if !args.gates.has_deterministic_gate() && !args.no_finalize {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "verify",
-            "agent-task cook requires at least one deterministic --verify or --private-verify gate",
+            "agent-task cook requires at least one deterministic --verify or --private-verify gate before it can commit, push, and open a PR",
             None,
-            None,
+            Some(vec![
+                "Provide a gate, e.g. --verify \"cargo test\" (or --private-verify for a secret gate).".to_string(),
+                "For a read-only or exploratory cook with nothing to verify, pass --no-finalize (skips commit, push, and PR); a no-op gate like --verify true also works.".to_string(),
+            ]),
         ));
     }
     if args.dispatch.core.queue_only {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -1594,3 +1594,107 @@ fn run_plan_rejects_component_worktree_without_branch() {
         assert!(message.contains("requires branch"));
     });
 }
+
+/// Build cook args toggling whether a `--verify` gate and `--no-finalize` are
+/// present, so the gate-requirement validation (#7608) can be exercised both
+/// ways. The run id is fixed; callers rely only on the early gate check.
+fn gate_requirement_cook_args(
+    source: &std::path::Path,
+    with_verify: bool,
+    no_finalize: bool,
+) -> AgentTaskCookArgs {
+    let mut args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+        "--prompt".to_string(),
+        "read-only exploration".to_string(),
+        "--cwd".to_string(),
+        source.display().to_string(),
+        "--to-worktree".to_string(),
+        source.display().to_string(),
+        "--backend".to_string(),
+        "fixture".to_string(),
+        "--run-id".to_string(),
+        "cook-gate-requirement".to_string(),
+    ];
+    if with_verify {
+        args.push("--verify".to_string());
+        args.push("true".to_string());
+    }
+    if no_finalize {
+        args.push("--no-finalize".to_string());
+    }
+    let cli = Cli::parse_from(args);
+    let Commands::AgentTask(agent_task) = cli.command else {
+        panic!("agent-task command");
+    };
+    let AgentTaskCommand::Cook(cook) = agent_task.command else {
+        panic!("cook command");
+    };
+    cook
+}
+
+#[test]
+fn cook_without_gate_but_with_no_finalize_passes_the_gate_requirement() {
+    // #7608: a read-only / exploratory `--no-finalize` cook has nothing to
+    // publish, so it must not be rejected for lacking a deterministic gate.
+    // It should get past the gate-requirement check; whatever it fails on
+    // afterwards, it must NOT be the "requires ... --verify" rejection.
+    with_temp_home(|| {
+        let source = tempfile::tempdir().expect("source checkout");
+        init_runtime_component_checkout(source.path());
+
+        let result = run_cook_with_executor(
+            gate_requirement_cook_args(source.path(), false, true),
+            CapturingExecutor::default(),
+        );
+
+        if let Err(error) = result {
+            assert!(
+                !error.message.contains("deterministic") && !error.message.contains("--verify"),
+                "a --no-finalize cook must not be rejected for a missing gate, got: {}",
+                error.message
+            );
+        }
+    });
+}
+
+#[test]
+fn cook_without_gate_and_finalizing_reports_actionable_gate_error() {
+    // #7608: a finalizing cook (no --no-finalize) still requires a gate, but
+    // the rejection must be actionable — naming the flag and giving
+    // copy-pasteable next steps rather than a bare validation stub.
+    with_temp_home(|| {
+        let source = tempfile::tempdir().expect("source checkout");
+        init_runtime_component_checkout(source.path());
+
+        let error = run_cook_with_executor(
+            gate_requirement_cook_args(source.path(), false, false),
+            CapturingExecutor::default(),
+        )
+        .expect_err("finalizing cook without a gate is rejected");
+
+        assert_eq!(error.details["field"], "verify");
+        assert!(
+            error.message.contains("--verify") || error.message.contains("--private-verify"),
+            "error should name the verify flag: {}",
+            error.message
+        );
+        let hints = error.details["tried"]
+            .as_array()
+            .expect("actionable remediation hints");
+        assert!(
+            hints
+                .iter()
+                .any(|hint| hint.as_str().is_some_and(|hint| hint.contains("--verify"))),
+            "a hint must give a copy-pasteable --verify example: {hints:?}"
+        );
+        assert!(
+            hints.iter().any(|hint| hint
+                .as_str()
+                .is_some_and(|hint| hint.contains("--no-finalize"))),
+            "a hint must point read-only cooks at --no-finalize: {hints:?}"
+        );
+    });
+}


### PR DESCRIPTION
## Summary
Closes #7608. `agent-task cook` hard-required at least one `--verify`/`--private-verify` gate, rejecting a **read-only or exploratory cook** before dispatch with a bare validation stub — which, combined with no happy-path output, read like "nothing happened."

## Root cause & reasoning
Deterministic gates exist to make **publication** safe: a green gate is the proof a cook may commit, push, and open a PR. A `--no-finalize` cook does none of those, so a gate is not meaningful there — read-only cooks legitimately have nothing to verify. The promotion lifecycle **already** treats an empty gate set as a vacuously-green run (`run_promotion_gates` → `PromotionGateRun::without_gates` in `agent_task_promotion/promote.rs`), so relaxing the CLI-level requirement for `--no-finalize` is safe end to end — no downstream stage assumes a gate exists.

## Changes (both fix shapes from the issue)
- **Relax:** skip the gate requirement when `--no-finalize` is set.
- **Actionable error:** for finalizing cooks, keep the requirement but return an error that names the flag and gives copy-pasteable next steps — a `--verify "cargo test"` example and the `--no-finalize` path for read-only cooks — through the command-result envelope (`tried` hints), instead of a bare rejection.

## Tests (proven)
Both in `crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs`:
- `cook_without_gate_but_with_no_finalize_passes_the_gate_requirement` — a `--no-finalize` cook without a gate clears the requirement. **Fails on the prior code** with the exact `agent-task cook requires ... --verify` rejection (verified by temp-reverting the guard).
- `cook_without_gate_and_finalizing_reports_actionable_gate_error` — a finalizing cook without a gate returns `field: "verify"` plus actionable `tried` hints containing a `--verify` example and the `--no-finalize` guidance.

`cargo check -p homeboy-cli --lib --tests` clean; `cargo fmt` applied.