### PR TITLE
fix(audit): dead_code recognizes serde/clap attribute helper references

### DIFF
--- a/crates/homeboy-code-audit/src/dead_code.rs
+++ b/crates/homeboy-code-audit/src/dead_code.rs
@@ -233,6 +233,18 @@ pub(crate) fn analyze_dead_code_with_config(
                     continue;
                 }
 
+                // serde/clap invoke helpers by name from inside an attribute
+                // string (`#[serde(deserialize_with = "foo")]`,
+                // `skip_serializing_if = "is_zero"`, `default = "bar"`,
+                // `value_parser = "baz"`). Those are real macro-resolved
+                // references, not calls, so the `foo(` patterns above miss them.
+                // Scanned against raw content because multi-line attributes put
+                // the reference on a continuation line that `blank_comments_…`
+                // would otherwise blank.
+                if references_helper_in_attribute(&fp.content, method) {
+                    continue;
+                }
+
                 findings.push(Finding {
                     convention: "dead_code".to_string(),
                     severity: Severity::Warning,
@@ -252,6 +264,36 @@ pub(crate) fn analyze_dead_code_with_config(
     // Sort by file path for deterministic output
     findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
     findings
+}
+
+/// Whether `method` is referenced by name inside a macro-attribute string —
+/// e.g. `deserialize_with = "method"`, `serialize_with = "method"`,
+/// `skip_serializing_if = "method"`, `default = "method"`,
+/// `with = "method"`, or a clap `value_parser = "method"`.
+///
+/// serde/clap resolve these helpers by name at macro-expansion time, so they
+/// are real references even though no `method(` call appears. Matches the
+/// `<known-attr-key> = "method"` shape in raw content, which also covers
+/// multi-line attributes (where the reference sits on a continuation line).
+fn references_helper_in_attribute(content: &str, method: &str) -> bool {
+    /// Attribute keys that name a function to invoke. Kept narrow so an
+    /// unrelated string literal `foo = "method"` in ordinary code does not
+    /// mask a genuinely dead function.
+    const HELPER_ATTR_KEYS: &[&str] = &[
+        "deserialize_with",
+        "serialize_with",
+        "skip_serializing_if",
+        "default",
+        "with",
+        "value_parser",
+        "getter",
+    ];
+    let quoted = format!("\"{}\"", method);
+    HELPER_ATTR_KEYS.iter().any(|key| {
+        let needle = format!("{} = {}", key, quoted);
+        let needle_tight = format!("{}={}", key, quoted);
+        content.contains(&needle) || content.contains(&needle_tight)
+    })
 }
 
 fn dead_code_finding(
@@ -886,6 +928,88 @@ mod tests {
             findings.iter().any(|f| f.kind == AuditFinding::OrphanedInternal
                 && f.description.contains("dead_helper")),
             "dead_helper is only mentioned in a comment/string, so it must still be flagged as orphaned"
+        );
+    }
+
+    #[test]
+    fn serde_helper_referenced_by_single_line_attribute_not_flagged() {
+        // `is_zero` is used only via `#[serde(skip_serializing_if = "is_zero")]`
+        // — a real macro-resolved reference, never a `is_zero(` call. It must
+        // NOT be flagged as orphaned.
+        let mut fp = make_fingerprint(
+            "src/foo.rs",
+            vec!["public_fn", "is_zero"],
+            vec!["public_fn"],
+            vec!["public_fn"], // is_zero NOT in internal_calls
+            vec![("is_zero", "private")],
+        );
+        // Content omits the `is_zero(` definition so the same-file call
+        // fallback cannot self-match — the ONLY reference is the attribute.
+        fp.content =
+            "struct S {\n    #[serde(skip_serializing_if = \"is_zero\")]\n    n: usize,\n}\n"
+                .to_string();
+
+        let findings = analyze_dead_code(&[&fp], &[]);
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.kind == AuditFinding::OrphanedInternal
+                    && f.description.contains("is_zero")),
+            "is_zero is referenced by a serde attribute — not dead"
+        );
+    }
+
+    #[test]
+    fn serde_helper_referenced_by_multi_line_attribute_not_flagged() {
+        // The reference sits on a continuation line of a multi-line attribute,
+        // which the string-blanking view would blank — so the fix scans raw
+        // content.
+        let mut fp = make_fingerprint(
+            "src/foo.rs",
+            vec!["public_fn", "deserialize_budget_findings"],
+            vec!["public_fn"],
+            vec!["public_fn"],
+            vec![("deserialize_budget_findings", "private")],
+        );
+        // Omit the `deserialize_budget_findings(` definition so the same-file
+        // call fallback cannot self-match — the reference is the multi-line
+        // attribute only.
+        fp.content = "struct S {\n    #[serde(\n        default,\n        \
+             deserialize_with = \"deserialize_budget_findings\",\n        \
+             skip_serializing_if = \"Vec::is_empty\"\n    )]\n    v: Vec<u8>,\n}\n"
+            .to_string();
+
+        let findings = analyze_dead_code(&[&fp], &[]);
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.kind == AuditFinding::OrphanedInternal
+                    && f.description.contains("deserialize_budget_findings")),
+            "multi-line serde deserialize_with reference must count — not dead"
+        );
+    }
+
+    #[test]
+    fn non_helper_attribute_key_does_not_count_as_a_reference() {
+        // `rename = "dead_helper"` names a serialized FIELD, not a helper
+        // function, so it must NOT be treated as a reference — `dead_helper`
+        // stays flagged. (Content deliberately omits a `dead_helper()`
+        // definition so the same-file call fallback doesn't self-match.)
+        let mut fp = make_fingerprint(
+            "src/foo.rs",
+            vec!["public_fn", "dead_helper"],
+            vec!["public_fn"],
+            vec!["public_fn"],
+            vec![("dead_helper", "private")],
+        );
+        fp.content =
+            "struct S {\n    #[serde(rename = \"dead_helper\")]\n    field: u8,\n}\n".to_string();
+
+        let findings = analyze_dead_code(&[&fp], &[]);
+        assert!(
+            findings.iter().any(|f| f.kind == AuditFinding::OrphanedInternal
+                && f.description.contains("dead_helper")),
+            "`rename` is a field-name attribute, not a helper invocation — dead_helper is still dead"
         );
     }
 


### PR DESCRIPTION
## Summary
Removes a false-positive class from `dead_code` (the 603-finding category): private functions referenced only via serde/clap **attribute strings** were flagged as orphaned.

## Problem
The `orphaned_internal` check ("private function never called within this file") uses a same-file call fallback that scans for `foo(` / `.foo(`. But serde/clap invoke helpers **by name from inside an attribute string**, never as calls:

```rust
#[serde(skip_serializing_if = "is_zero")]                 // is_zero flagged as dead
#[serde(deserialize_with = "deserialize_string_or_vec")]  // flagged as dead
#[serde(default, deserialize_with = "deserialize_budget_findings", …)]  // multi-line, flagged
```

These are real macro-resolved references. The existing `blank_comments_and_strings` only preserves **single-line** `#[...]` refs and isn't consulted by the orphaned_internal path anyway.

Verified against the first Audit Debt sweep's `findings.json`: `deserialize_empty_as_none`, `deserialize_budget_findings`, `deserialize_string_or_vec`, `is_zero` (and more) were all false-positive `dead_code` findings.

## Fix
Add `references_helper_in_attribute`: scan raw content for `<helper-attr-key> = "method"` where the key names a function to invoke — `deserialize_with`, `serialize_with`, `skip_serializing_if`, `default`, `with`, `value_parser`, `getter`. Raw-content scan (not the blanked view) so **multi-line attributes** are covered. The key allowlist is deliberately narrow so field-name attributes like `rename = "x"` are **not** treated as references (they name a serialized field, not a helper).

## Tests (30 dead_code + runtime regression all pass)
- `serde_helper_referenced_by_single_line_attribute_not_flagged`
- `serde_helper_referenced_by_multi_line_attribute_not_flagged`
- `non_helper_attribute_key_does_not_count_as_a_reference` (negative: `rename` still leaves the fn flagged)

Positive tests deliberately omit the `foo()` definition from content so the same-file call fallback can't self-match — they genuinely exercise the new attribute path.

## Impact
Burns down real false positives in the largest audit category and prevents the whole class recurring across every crate that uses serde/clap helper attributes (which is most of them). Stacks with the earlier audit-quality fixes to keep the `dead_code` count honest.