### PR TITLE
fix(audit): unused_parameter ignores type-path segments misparsed as params

### DIFF
--- a/crates/homeboy-code-audit/src/core_fingerprint/mod.rs
+++ b/crates/homeboy-code-audit/src/core_fingerprint/mod.rs
@@ -791,6 +791,18 @@ fn detect_unused_params(functions: &[FunctionInfo], grammar: &Grammar) -> Vec<Un
                 continue;
             }
 
+            // Skip type-path segments misparsed as parameter names. When the
+            // grammar mis-captures a multi-line/generic signature, a crate/type
+            // path segment inside a type (e.g. `serde_json` in
+            // `inputs: impl IntoIterator<Item = (String, serde_json::Value)>`)
+            // can surface as a bogus "parameter". A real binding is followed by
+            // a single `:`; a path segment is followed by `::`. If `pname`
+            // appears as a `pname::` path segment in the raw params, it is a
+            // type fragment, not a binding — never flag it. (#unused-param-fp)
+            if is_type_path_segment(&f.params, pname) {
+                continue;
+            }
+
             // Skip params whose type hint is a grammar-declared framework
             // contract type. The parameter exists to satisfy a callback
             // signature, not because the function must use it (#1136).
@@ -815,6 +827,29 @@ fn detect_unused_params(functions: &[FunctionInfo], grammar: &Grammar) -> Vec<Un
     }
 
     unused
+}
+
+/// Whether `name` appears in `params` only as a type-path segment (`name::…`),
+/// i.e. it is a crate/module/type identifier inside a type rather than a real
+/// parameter binding. Real bindings are `name:` (single colon); path segments
+/// are `name::`. Used to discard grammar-misparse false positives where a type
+/// fragment surfaces as a bogus parameter name.
+fn is_type_path_segment(params: &str, name: &str) -> bool {
+    let needle = format!("{}::", name);
+    let mut from = 0;
+    while let Some(rel) = params[from..].find(&needle) {
+        let at = from + rel;
+        // Require a word boundary before `name` so `foo_bar::` doesn't match
+        // when looking for `bar`.
+        let boundary_ok = at == 0
+            || !params.as_bytes()[at - 1].is_ascii_alphanumeric()
+                && params.as_bytes()[at - 1] != b'_';
+        if boundary_ok {
+            return true;
+        }
+        from = at + needle.len();
+    }
+    false
 }
 
 /// A parameter with its (optional) type hint and its name.

--- a/crates/homeboy-code-audit/src/core_fingerprint/tests.rs
+++ b/crates/homeboy-code-audit/src/core_fingerprint/tests.rs
@@ -346,6 +346,42 @@ pub fn settings_json(overrides: &[(String, serde_json::Value)]) -> Self {
 }
 
 #[test]
+fn rust_unused_param_multiline_signature_type_path_not_flagged() {
+    // Multi-line signature where a crate path segment (`serde_json`) sits inside
+    // a generic type. The grammar can mis-capture such signatures and surface
+    // `serde_json` as a bogus parameter; it must never be flagged as unused.
+    let grammar = rust_grammar();
+    let content = r#"
+pub fn ready_labeled(
+    id: impl Into<String>,
+    kind: impl Into<String>,
+    inputs: impl IntoIterator<Item = (String, serde_json::Value)>,
+) -> Self {
+    Self::ready(id, kind).inputs(inputs).build()
+}
+"#;
+
+    let fp = fingerprint_from_grammar(content, &grammar, "src/lib.rs").unwrap();
+
+    assert!(
+        !fp.unused_parameters.iter().any(|p| p.param == "serde_json"),
+        "`serde_json` is a type-path segment, not a parameter. Got: {:?}",
+        fp.unused_parameters
+    );
+}
+
+#[test]
+fn is_type_path_segment_distinguishes_bindings_from_paths() {
+    let params =
+        "id: impl Into<String>, inputs: impl IntoIterator<Item = (String, serde_json::Value)>";
+    assert!(is_type_path_segment(params, "serde_json"));
+    assert!(!is_type_path_segment(params, "inputs"));
+    assert!(!is_type_path_segment(params, "id"));
+    // Word-boundary: `json` must not match inside `serde_json::`.
+    assert!(!is_type_path_segment(params, "json"));
+}
+
+#[test]
 fn rust_unused_param_detection_sees_comparison_usage() {
     let grammar = rust_grammar();
     let content = r#"


### PR DESCRIPTION
## Summary
Removes a false-positive class from `unused_parameter` (89-finding category): crate/type **path segments** inside a type were surfacing as bogus parameter names and then flagged as unused.

## Problem
When the grammar mis-captures a multi-line or generic signature, a path segment from inside a type leaks out as a "parameter." Example:

```rust
pub fn ready_labeled(
    id: impl Into<String>,
    inputs: impl IntoIterator<Item = (String, serde_json::Value)>,  // 'serde_json' extracted as a param
) -> Self { … }
```

`serde_json` is a crate path, not a binding — and it never appears in the body, so it's flagged `unused parameter 'serde_json'`.

From the first Audit Debt sweep's `findings.json`: **21 of 89 unique `unused_parameter` findings (24%) were this FP** — 17 named `serde_json`, plus `homeboy`, `std`, `serde_json_path`, `extension_trace`.

## Root cause
The param *parser* (`split_top_level_commas` / `top_level_param_colon`) is correct on a clean signature — the malformed `params` string comes from the upstream grammar capture of multi-line signatures. Rather than rework the grammar layer, add a precise defensive guard in `detect_unused_params`.

## Fix
`is_type_path_segment`: a real binding is `name:` (single colon); a type-path segment is `name::`. If the candidate appears as `name::` in the raw params string, it's a type fragment, not a parameter binding → skip it. Word-boundary aware so `json` doesn't match inside `serde_json::`.

## Tests (40 core_fingerprint + 326 detector + runtime regression all pass)
- `rust_unused_param_multiline_signature_type_path_not_flagged` — the real `ready_labeled` shape; `serde_json` no longer flagged.
- `is_type_path_segment_distinguishes_bindings_from_paths` — unit: `serde_json`→path, `inputs`/`id`→bindings, `json`→no false match.

## Impact
Burns down ~24% of the `unused_parameter` findings as false positives and stops the class recurring. Genuine unused params (a real binding never used in the body) are unaffected — `unused_param_still_flagged_for_normal_helper_method` and friends still pass.