### PR TITLE
fix(audit): constant_bypass_literal only attributes reachable cross-crate constants

### DIFF
--- a/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs
+++ b/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs
@@ -26,7 +26,10 @@ use regex::Regex;
 use super::super::conventions::AuditFinding;
 use super::super::findings::{Finding, Severity};
 use super::super::fingerprint::FileFingerprint;
-use super::super::walker::{cfg_test_regions, is_test_path, offset_in_cfg_test_region};
+use super::super::walker::{
+    cfg_test_regions, crate_of_path, is_test_path, offset_in_cfg_test_region,
+    visibility_is_crate_public,
+};
 
 /// Minimum arg-vector length to consider. Single-element commands (`["init"]`,
 /// `["fetch"]`) are too generic to attribute to one wrapper.
@@ -58,22 +61,6 @@ fn fn_decl_regex() -> &'static Regex {
             .expect("valid fn regex")
     });
     &RE
-}
-
-/// A wrapper is *reachable* from another crate only if it is `pub` (crate-wide
-/// `pub` — a helper visible outside its own crate). `pub(crate)`, `pub(super)`,
-/// `pub(in …)`, and private helpers are unreachable across a crate boundary, so
-/// attributing a cross-crate raw command to them is a false positive.
-fn visibility_is_crate_public(vis_prefix: &str) -> bool {
-    let vis = vis_prefix.trim();
-    vis == "pub"
-}
-
-/// The crate name for a `crates/<crate>/…` path, else `None` (non-workspace
-/// layout — fall back to conservative behavior).
-fn crate_of_path(path: &str) -> Option<&str> {
-    let rest = path.strip_prefix("crates/")?;
-    rest.split('/').next().filter(|s| !s.is_empty())
 }
 
 /// Parse the inner string elements of an arg-vector match into a canonical key.

--- a/crates/homeboy-code-audit/src/detectors/constant_bypass.rs
+++ b/crates/homeboy-code-audit/src/detectors/constant_bypass.rs
@@ -23,7 +23,10 @@ use regex::Regex;
 use super::super::conventions::AuditFinding;
 use super::super::findings::{Finding, Severity};
 use super::super::fingerprint::FileFingerprint;
-use super::super::walker::{cfg_test_regions, is_test_path, offset_in_cfg_test_region};
+use super::super::walker::{
+    cfg_test_regions, crate_of_path, is_test_path, offset_in_cfg_test_region,
+    visibility_is_crate_public,
+};
 
 /// Minimum constant-value length worth flagging. Short values (`"workspace"`,
 /// `"snapshot"`) collide with serde tags, enum spellings, and unrelated
@@ -36,11 +39,12 @@ pub(crate) fn run(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
 }
 
 /// `const NAME: &str = "value";` and `const NAME = "value";` (and `static`).
-/// Captures the constant name (1) and its string value (2).
+/// Captures the visibility prefix (1, `pub`/`pub(...)`/empty), the constant
+/// name (2), and its string value (3).
 fn const_decl_regex() -> &'static Regex {
     static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
         Regex::new(
-            r#"(?m)\b(?:pub(?:\([^)]*\))?\s+)?(?:const|static)\s+([A-Z][A-Z0-9_]+)\s*(?::\s*&(?:'static\s+)?str\s*)?=\s*"([^"\\]{4,})"\s*;"#,
+            r#"(?m)\b(pub(?:\([^)]*\))?\s+)?(?:const|static)\s+([A-Z][A-Z0-9_]+)\s*(?::\s*&(?:'static\s+)?str\s*)?=\s*"([^"\\]{4,})"\s*;"#,
         )
         .expect("valid const-decl regex")
     });
@@ -53,6 +57,10 @@ struct ConstDef {
     file: String,
     /// 1-indexed line of the definition, so we never flag the definition itself.
     line: usize,
+    /// Whether the constant is crate-`pub` — required to attribute a bypass from
+    /// a different crate. A private/`pub(crate)` constant is unreachable
+    /// cross-crate, so flagging a literal there is a false positive.
+    is_public: bool,
 }
 
 fn detect_constant_bypass_literals(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
@@ -64,8 +72,12 @@ fn detect_constant_bypass_literals(fingerprints: &[&FileFingerprint]) -> Vec<Fin
             continue;
         }
         for caps in const_decl_regex().captures_iter(&fp.content) {
-            let name = caps[1].to_string();
-            let value = caps[2].to_string();
+            let is_public = caps
+                .get(1)
+                .map(|m| visibility_is_crate_public(m.as_str()))
+                .unwrap_or(false);
+            let name = caps[2].to_string();
+            let value = caps[3].to_string();
             if value.len() < MIN_VALUE_LEN {
                 continue;
             }
@@ -74,6 +86,7 @@ fn detect_constant_bypass_literals(fingerprints: &[&FileFingerprint]) -> Vec<Fin
                 name,
                 file: fp.relative_path.clone(),
                 line,
+                is_public,
             });
         }
     }
@@ -106,6 +119,22 @@ fn detect_constant_bypass_literals(fingerprints: &[&FileFingerprint]) -> Vec<Fin
             // Skip the const-declaration line itself in any file (a re-export
             // `const OTHER: &str = SAME_VALUE;` is legitimate, though rare).
             if is_const_decl_line(&fp.content, offset) {
+                continue;
+            }
+            // Only attribute a literal to a constant the site can reach. A
+            // private/`pub(crate)` constant in a DIFFERENT crate is unreachable,
+            // so "reference it instead" is impossible — a false positive. Same
+            // crate is always fine; cross-crate requires `pub`. (mirrors the
+            // command_wrapper_bypass reachability rule)
+            let literal_crate = crate_of_path(&fp.relative_path);
+            let def_crate = crate_of_path(&def.file);
+            let cross_crate = match (literal_crate, def_crate) {
+                (Some(a), Some(b)) => a != b,
+                // Unknown layout on either side — conservative: treat as same
+                // crate (do not suppress) to preserve prior behavior.
+                _ => false,
+            };
+            if cross_crate && !def.is_public {
                 continue;
             }
             findings.push(Finding {

--- a/crates/homeboy-code-audit/src/detectors/constant_bypass/tests.rs
+++ b/crates/homeboy-code-audit/src/detectors/constant_bypass/tests.rs
@@ -119,3 +119,62 @@ fn still_flags_production_literal_alongside_an_inline_test_block() {
     );
     assert_eq!(findings[0].file, "src/route.rs");
 }
+
+#[test]
+fn does_not_flag_cross_crate_literal_of_a_private_constant() {
+    // A private constant in one crate is unreachable from another, so a raw
+    // literal there is not a fixable bypass.
+    let def = fp(
+        "crates/homeboy-cli/src/response.rs",
+        r#"const ACTIONABLE_METADATA_KEY: &str = "_homeboy_actionable";"#,
+    );
+    let user = fp(
+        "crates/homeboy-agents/src/lint.rs",
+        "fn f() {\n    let k = \"_homeboy_actionable\";\n}\n",
+    );
+    assert!(
+        detect_constant_bypass_literals(&[&def, &user]).is_empty(),
+        "a private constant in another crate is unreachable — not a bypass"
+    );
+}
+
+#[test]
+fn flags_cross_crate_literal_of_a_public_constant() {
+    // A `pub` constant in a foundational crate IS reachable, so the raw literal
+    // is a real bypass.
+    let def = fp(
+        "crates/homeboy-engine-primitives/src/template.rs",
+        r#"    pub const COMPONENT_ID: &str = "component_identifier";"#,
+    );
+    let user = fp(
+        "crates/homeboy-agents/src/promotion.rs",
+        "fn f() {\n    let k = \"component_identifier\";\n}\n",
+    );
+    let findings = detect_constant_bypass_literals(&[&def, &user]);
+    assert_eq!(
+        findings.len(),
+        1,
+        "public cross-crate constant is reachable"
+    );
+    assert!(findings[0].description.contains("COMPONENT_ID"));
+}
+
+#[test]
+fn flags_same_crate_literal_of_a_private_constant() {
+    // Within the same crate a private constant is reachable, so the raw literal
+    // is still a bypass.
+    let def = fp(
+        "crates/homeboy-agents/src/keys.rs",
+        r#"const SESSION_META_KEY: &str = "agent_session_metadata";"#,
+    );
+    let user = fp(
+        "crates/homeboy-agents/src/promotion.rs",
+        "fn f() {\n    let k = \"agent_session_metadata\";\n}\n",
+    );
+    let findings = detect_constant_bypass_literals(&[&def, &user]);
+    assert_eq!(
+        findings.len(),
+        1,
+        "same-crate private constant is reachable — still a bypass"
+    );
+}

--- a/crates/homeboy-code-audit/src/walker.rs
+++ b/crates/homeboy-code-audit/src/walker.rs
@@ -187,3 +187,22 @@ pub(crate) fn offset_in_cfg_test_region(offset: usize, regions: &[(usize, usize)
         .iter()
         .any(|(start, end)| offset >= *start && offset <= *end)
 }
+
+/// The crate name for a `crates/<crate>/…` path, else `None` (non-workspace
+/// layout — callers fall back to conservative behavior).
+///
+/// Used by content-scanning detectors that attribute a caller's raw literal or
+/// command to a canonical definition elsewhere: a cross-crate attribution is
+/// only valid when the definition is reachable from the caller's crate.
+pub(crate) fn crate_of_path(path: &str) -> Option<&str> {
+    let rest = path.strip_prefix("crates/")?;
+    rest.split('/').next().filter(|s| !s.is_empty())
+}
+
+/// Whether a `pub`/`pub(...)` visibility prefix makes a definition reachable
+/// from *another* crate. Only crate-wide `pub` qualifies — `pub(crate)`,
+/// `pub(super)`, `pub(in …)`, and private are unreachable across a crate
+/// boundary, so attributing a cross-crate reference to them is a false positive.
+pub(crate) fn visibility_is_crate_public(vis_prefix: &str) -> bool {
+    vis_prefix.trim() == "pub"
+}


### PR DESCRIPTION
## Summary
Mirrors the `command_wrapper_bypass` reachability fix (#9320) for the constant-bypass detector — the largest remaining audit category (351 findings).

## Problem
The detector attributed a raw literal to a matching constant found **anywhere**, including private constants in a different crate. The flagging site cannot reference a private constant from another crate, so "reference the constant instead" is impossible — a false positive.

From the first Audit Debt sweep's `findings.json`: **243 of 351 unique `constant_bypass_literal` findings (69%) were cross-crate**, and a 60-finding sample found **0** pointing at a `pub` constant — all unreachable. This also drives the noise from ubiquitous conventional keys like `"component_id"` (42) and `"homeboy.json"` (35), defined once but re-typed as raw strings across crate boundaries.

## Fix
- Capture the constant's visibility (crate-`pub` vs not) and its crate (from the `crates/<crate>/` path).
- Attribute a cross-crate literal **only when the constant is `pub`**. Same-crate is unaffected (private constants there are reachable → still flagged). Unknown (non-workspace) layouts fall back to prior behavior.
- Promote `crate_of_path` / `visibility_is_crate_public` to `walker.rs` as shared `pub(crate)` helpers and dedup `command_wrapper_bypass` onto them (net -21 lines there).

## Tests (10 constant_bypass + 10 command_wrapper_bypass + 329 detector + runtime regression all pass)
- `does_not_flag_cross_crate_literal_of_a_private_constant`
- `flags_cross_crate_literal_of_a_public_constant`
- `flags_same_crate_literal_of_a_private_constant`

## Impact
Burns down the bulk of the ~243 cross-crate constant findings as unreachable false positives, leaving the same-crate (108) and genuinely-`pub` cross-crate findings — which are actually fixable (you can import the constant). Consistent with the command_wrapper_bypass reachability model, now sharing one implementation.
