### PR TITLE
fix(agents): align lifecycle fixtures with terminal invariants

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -951,13 +951,21 @@ fn cook_lab_handoff_controller_reads_ignore_runner_plan_projection() {
             plan
         );
 
-        std::fs::remove_file(record.plan_path)
-            .expect("remove authoritative controller plan despite projected display path");
-        rewrite_record_for_test(&record.run_id, |record| {
-            record.state = AgentTaskRunState::Running;
+        let missing_plan = record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "cook-lab-missing-controller-plan",
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace",
+            remote_command: &command,
+            durable_plan: Some(&plan),
         })
-        .expect("restore active handoff projection");
-        let error = status(&record.run_id).expect_err("missing controller plan fails closed");
+        .expect("missing-plan fixture persists its controller plan");
+        rewrite_record_for_test(&missing_plan.run_id, |record| {
+            record.plan_path = "/runner/workspace/plan.json".to_string();
+        })
+        .expect("project runner-local plan path");
+        std::fs::remove_file(missing_plan.plan_path)
+            .expect("remove authoritative controller plan despite projected display path");
+        let error = status(&missing_plan.run_id).expect_err("missing controller plan fails closed");
         assert_eq!(error.code, ErrorCode::InternalIoError);
     });
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -966,7 +966,7 @@ fn terminal_lab_artifact_attachment_refuses_runner_provenance_mismatch() {
         })
         .expect_err("artifact provenance must retain its original runner");
         assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
-        assert_eq!(error.details["field"], "run_id");
+        assert_eq!(error.details["field"], "lab_handoff");
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -503,7 +503,7 @@ fn terminal_lab_artifact_attachment_skips_missing_controller_plan_and_preserves_
         let attached = record_detached_lab_run(DetachedLabRunRecord {
             run_id: "agent-task-late-artifact",
             runner_id: "homeboy-lab",
-            runner_job_id: "job-artifact-attach",
+            runner_job_id: "job-original",
             remote_workspace: "/home/lab/agent-task-runs/agent-task-late-artifact",
             remote_command: &command,
         })


### PR DESCRIPTION
## Summary
- isolate the missing-controller-plan assertion in its own active handoff fixture instead of mutating an immutable terminal run
- replay the accepted runner job identity for late artifact attachment
- assert the canonical `lab_handoff` validation field for runner provenance mismatch

## Context
The CI-owned release test gate in run 29785216569 timed out after these lifecycle fixtures diverged from the terminal-state and runner-ownership invariants now enforced by Homeboy. This repairs the fixtures without weakening those production invariants.

Closes #9223

## How to test
1. Run `cargo test -p homeboy-agents cook_lab_handoff_controller_reads_ignore_runner_plan_projection -- --nocapture`.
2. Run `cargo test -p homeboy-agents controller_plan -- --nocapture`.
3. Run `cargo test -p homeboy-agents terminal_lab_artifact_attachment -- --nocapture`.
4. Run `cargo fmt --check`.
5. Run `git diff --check origin/main...HEAD`.

Expected: all targeted lifecycle tests pass, formatting is unchanged, and the diff has no whitespace errors.

## Backwards compatibility
No public API or runtime behavior changes. This PR updates test fixtures to match existing lifecycle invariants.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed the release-test failures, updated the lifecycle fixtures, and verified the focused test suite.