### PR TITLE
Bind lab execution to immutable job runtime bundles

### DIFF
--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -778,24 +778,30 @@ pub(crate) fn exec_with_status_snapshot(
         )?)
     };
 
-    let extension_parity_plan = plan_extension_parity(
-        runner_id,
-        &runner,
-        &cwd,
+    if !crate::execution_bundle::validate_bundle_env(
+        &request_env,
+        &options.command,
         &required_extensions,
-        &requested_setting_keys,
-        &accepted_extension_settings,
-    )?;
-    ensure_extension_materialized(&extension_parity_plan)?;
-    let runner = super::load(runner_id)?;
-    validate_extension_ready(
-        runner_id,
-        &runner,
-        &cwd,
-        &required_extensions,
-        &requested_setting_keys,
-        &accepted_extension_settings,
-    )?;
+    ) {
+        let extension_parity_plan = plan_extension_parity(
+            runner_id,
+            &runner,
+            &cwd,
+            &required_extensions,
+            &requested_setting_keys,
+            &accepted_extension_settings,
+        )?;
+        ensure_extension_materialized(&extension_parity_plan)?;
+        let runner = super::load(runner_id)?;
+        validate_extension_ready(
+            runner_id,
+            &runner,
+            &cwd,
+            &required_extensions,
+            &requested_setting_keys,
+            &accepted_extension_settings,
+        )?;
+    }
 
     preflight_remote_argv(
         runner_id,

--- a/crates/homeboy-lab-runner/src/execution/worker.rs
+++ b/crates/homeboy-lab-runner/src/execution/worker.rs
@@ -84,24 +84,30 @@ pub(super) fn exec_worker_local_with_process_output(
     );
     let requested_setting_keys = requested_setting_keys_for_command(&options.command);
     let accepted_extension_settings = options.accepted_extension_settings.clone();
-    let extension_parity_plan = plan_extension_parity(
-        runner_id,
-        &plan.runner,
-        &plan.cwd,
+    if !crate::execution_bundle::validate_bundle_env(
+        &plan.env,
+        &options.command,
         &required_extensions,
-        &requested_setting_keys,
-        &accepted_extension_settings,
-    )?;
-    ensure_extension_materialized(&extension_parity_plan)?;
-    let runner = load(runner_id)?;
-    validate_extension_ready(
-        runner_id,
-        &runner,
-        &plan.cwd,
-        &required_extensions,
-        &requested_setting_keys,
-        &accepted_extension_settings,
-    )?;
+    ) {
+        let extension_parity_plan = plan_extension_parity(
+            runner_id,
+            &plan.runner,
+            &plan.cwd,
+            &required_extensions,
+            &requested_setting_keys,
+            &accepted_extension_settings,
+        )?;
+        ensure_extension_materialized(&extension_parity_plan)?;
+        let runner = load(runner_id)?;
+        validate_extension_ready(
+            runner_id,
+            &runner,
+            &plan.cwd,
+            &required_extensions,
+            &requested_setting_keys,
+            &accepted_extension_settings,
+        )?;
+    }
     validate_runner_policy(
         &plan.runner,
         &plan.cwd,

--- a/crates/homeboy-lab-runner/src/execution_bundle.rs
+++ b/crates/homeboy-lab-runner/src/execution_bundle.rs
@@ -1,0 +1,230 @@
+//! Immutable execution facts captured after Lab admission and before dispatch.
+
+use std::collections::HashMap;
+
+pub(crate) const LAB_EXECUTION_BUNDLE_ENV: &str = "HOMEBOY_LAB_EXECUTION_BUNDLE";
+pub(crate) const LAB_EXECUTION_BUNDLE_SCHEMA: &str = "homeboy/lab-execution-bundle/v1";
+
+/// Validate the authority passed to the runner process. This is deliberately
+/// stricter than checking for an environment key: only a complete bundle can
+/// replace runner-global extension resolution.
+pub(crate) fn validate_bundle_env(
+    env: &HashMap<String, String>,
+    command: &[String],
+    required_extensions: &[String],
+) -> bool {
+    let Some(raw) = env.get(LAB_EXECUTION_BUNDLE_ENV) else {
+        return false;
+    };
+    let Ok(bundle) = serde_json::from_str::<serde_json::Value>(raw) else {
+        return false;
+    };
+    let non_empty = |pointer| {
+        bundle
+            .pointer(pointer)
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    };
+    if bundle.get("schema").and_then(serde_json::Value::as_str) != Some(LAB_EXECUTION_BUNDLE_SCHEMA)
+        || !non_empty("/binary/path")
+        || command.first().map(String::as_str)
+            != bundle
+                .pointer("/binary/path")
+                .and_then(serde_json::Value::as_str)
+        || (!required_extensions.is_empty() && !non_empty("/extension_runtime_home"))
+    {
+        return false;
+    }
+    let direct_admission =
+        non_empty("/admission/daemon_lease_id") && non_empty("/admission/reservation_job_id");
+    let reverse_broker_admission = bundle
+        .pointer("/admission/authority")
+        .and_then(serde_json::Value::as_str)
+        == Some("reverse_broker");
+    if !direct_admission && !reverse_broker_admission {
+        return false;
+    }
+    let Some(overlays) = bundle
+        .get("extensions")
+        .and_then(serde_json::Value::as_array)
+    else {
+        return required_extensions.is_empty();
+    };
+    required_extensions.iter().all(|id| {
+        overlays.iter().any(|overlay| {
+            overlay.get("id").and_then(serde_json::Value::as_str) == Some(id)
+                && overlay
+                    .get("remote_path")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|path| !path.trim().is_empty())
+                && overlay
+                    .get("content_hash")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|hash| {
+                        hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit())
+                    })
+        })
+    })
+}
+
+pub(crate) fn bundle_env(bundle: &serde_json::Value) -> HashMap<String, String> {
+    HashMap::from([(
+        LAB_EXECUTION_BUNDLE_ENV.to_string(),
+        serde_json::to_string(bundle).expect("Lab execution bundle serializes"),
+    )])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundle_requires_matching_command_admission_and_private_extension_snapshot() {
+        let bundle = serde_json::json!({
+            "schema": LAB_EXECUTION_BUNDLE_SCHEMA,
+            "binary": { "path": "/runner/bin/homeboy-a" },
+            "admission": { "daemon_lease_id": "lease-a", "reservation_job_id": "job-a" },
+            "extension_runtime_home": "/runner/job-a/home",
+            "extensions": [{ "id": "fixture", "remote_path": "/runner/job-a/fixture", "content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }]
+        });
+        let env = bundle_env(&bundle);
+        assert!(validate_bundle_env(
+            &env,
+            &["/runner/bin/homeboy-a".to_string(), "test".to_string()],
+            &["fixture".to_string()],
+        ));
+        assert!(!validate_bundle_env(
+            &env,
+            &["/runner/bin/homeboy-b".to_string(), "test".to_string()],
+            &["fixture".to_string()],
+        ));
+    }
+
+    #[test]
+    fn concurrent_jobs_keep_their_own_rig_extension_and_promoted_binary_authority() {
+        let job_a = serde_json::json!({
+            "schema": LAB_EXECUTION_BUNDLE_SCHEMA,
+            "binary": { "path": "/runner/releases/homeboy-a" },
+            "admission": { "daemon_lease_id": "lease-a", "reservation_job_id": "job-a" },
+            "rig_registry_root": "/runner/jobs/a/rigs",
+            "rigs": [{ "rig_id": "same-id", "workload_hashes": { "source_snapshot_hash": "catalog-a" } }],
+            "extension_runtime_home": "/runner/jobs/a/home",
+            "extensions": [{ "id": "fixture", "remote_path": "/runner/jobs/a/extensions/fixture", "content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }]
+        });
+        let job_b = serde_json::json!({
+            "schema": LAB_EXECUTION_BUNDLE_SCHEMA,
+            "binary": { "path": "/runner/releases/homeboy-b" },
+            "admission": { "daemon_lease_id": "lease-b", "reservation_job_id": "job-b" },
+            "rig_registry_root": "/runner/jobs/b/rigs",
+            "rigs": [{ "rig_id": "same-id", "workload_hashes": { "source_snapshot_hash": "catalog-b" } }],
+            "extension_runtime_home": "/runner/jobs/b/home",
+            "extensions": [{ "id": "fixture", "remote_path": "/runner/jobs/b/extensions/fixture", "content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" }]
+        });
+
+        // A new runner default can point at B after A was admitted. A remains
+        // executable only with its accepted command and private runtime facts.
+        let default_binary_after_promotion = "/runner/releases/homeboy-b";
+        let a_env = bundle_env(&job_a);
+        let b_env = bundle_env(&job_b);
+        assert!(validate_bundle_env(
+            &a_env,
+            &["/runner/releases/homeboy-a".to_string(), "fuzz".to_string()],
+            &["fixture".to_string()],
+        ));
+        assert!(validate_bundle_env(
+            &b_env,
+            &[
+                default_binary_after_promotion.to_string(),
+                "fuzz".to_string()
+            ],
+            &["fixture".to_string()],
+        ));
+        assert!(!validate_bundle_env(
+            &a_env,
+            &[
+                default_binary_after_promotion.to_string(),
+                "fuzz".to_string()
+            ],
+            &["fixture".to_string()],
+        ));
+        assert_ne!(job_a["rig_registry_root"], job_b["rig_registry_root"]);
+        assert_ne!(
+            job_a["rigs"][0]["workload_hashes"],
+            job_b["rigs"][0]["workload_hashes"]
+        );
+        assert_ne!(
+            job_a["extension_runtime_home"],
+            job_b["extension_runtime_home"]
+        );
+        assert_ne!(
+            job_a["extensions"][0]["content_hash"],
+            job_b["extensions"][0]["content_hash"]
+        );
+    }
+
+    #[test]
+    fn malformed_bundle_cannot_bypass_global_extension_parity() {
+        let bundle = serde_json::json!({
+            "schema": LAB_EXECUTION_BUNDLE_SCHEMA,
+            "binary": { "path": "/runner/bin/homeboy" },
+            "admission": { "daemon_lease_id": "lease", "reservation_job_id": "job" },
+            "extension_runtime_home": "/runner/job/home",
+            "extensions": [{ "id": "fixture", "remote_path": "/runner/job/fixture", "content_hash": "not-a-sha256" }]
+        });
+        assert!(!validate_bundle_env(
+            &bundle_env(&bundle),
+            &["/runner/bin/homeboy".to_string(), "test".to_string()],
+            &["fixture".to_string()],
+        ));
+    }
+
+    #[test]
+    fn incomplete_or_invalid_bundle_cannot_bypass_global_extension_parity() {
+        let command = vec!["/runner/bin/homeboy".to_string(), "test".to_string()];
+        let required = vec!["fixture".to_string()];
+        let valid = serde_json::json!({
+            "schema": LAB_EXECUTION_BUNDLE_SCHEMA,
+            "binary": { "path": "/runner/bin/homeboy" },
+            "admission": { "daemon_lease_id": "lease", "reservation_job_id": "job" },
+            "extension_runtime_home": "/runner/job/home",
+            "extensions": [{ "id": "fixture", "remote_path": "/runner/job/fixture", "content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }]
+        });
+
+        let mut missing_overlay = valid.clone();
+        missing_overlay["extensions"] = serde_json::json!([]);
+        let mut blank_home = valid.clone();
+        blank_home["extension_runtime_home"] = serde_json::json!("  ");
+        let mut missing_admission = valid;
+        missing_admission["admission"]["daemon_lease_id"] = serde_json::Value::Null;
+
+        for bundle in [missing_overlay, blank_home, missing_admission] {
+            assert!(!validate_bundle_env(
+                &bundle_env(&bundle),
+                &command,
+                &required
+            ));
+        }
+        assert!(!validate_bundle_env(
+            &HashMap::from([(LAB_EXECUTION_BUNDLE_ENV.to_string(), "not json".to_string())]),
+            &command,
+            &required,
+        ));
+    }
+
+    #[test]
+    fn reverse_broker_authority_preserves_the_job_private_bundle() {
+        let bundle = serde_json::json!({
+            "schema": LAB_EXECUTION_BUNDLE_SCHEMA,
+            "binary": { "path": "/runner/bin/homeboy" },
+            "admission": { "authority": "reverse_broker" },
+            "extension_runtime_home": "/runner/job/home",
+            "extensions": [{ "id": "fixture", "remote_path": "/runner/job/fixture", "content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }]
+        });
+
+        assert!(validate_bundle_env(
+            &bundle_env(&bundle),
+            &["/runner/bin/homeboy".to_string(), "test".to_string()],
+            &["fixture".to_string()],
+        ));
+    }
+}

--- a/crates/homeboy-lab-runner/src/extension_materialization.rs
+++ b/crates/homeboy-lab-runner/src/extension_materialization.rs
@@ -58,6 +58,128 @@ pub struct RunnerExtensionMaterializationPlan {
     pub content_hash: String,
 }
 
+/// A source snapshot resolved into one Lab job's private extension registry.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct LabJobExtensionOverlay {
+    pub(crate) id: String,
+    pub(crate) source_path: String,
+    pub(crate) remote_path: String,
+    pub(crate) source_revision: Option<String>,
+    pub(crate) content_hash: String,
+}
+
+pub(crate) fn materialize_lab_job_extension_overlays(
+    runner: &Runner,
+    runtime_root: &str,
+    extension_ids: &[String],
+) -> Result<Vec<LabJobExtensionOverlay>> {
+    let mut overlays = Vec::new();
+    for id in extension_ids {
+        let manifest = homeboy_core::extension_store::load_extension(id)?;
+        let source_path = manifest.extension_path.ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "extensions",
+                format!("Lab extension `{id}` has no source path"),
+                Some(id.clone()),
+                None,
+            )
+        })?;
+        let source = PathBuf::from(&source_path);
+        let content_hash = extension_source_content_hash(&source)?;
+        let remote_path = format!(
+            "{}/extensions/{}/{}",
+            runtime_root.trim_end_matches('/'),
+            sanitize_ref(id),
+            &content_hash[..16]
+        );
+        sync_controller_snapshot(
+            runner,
+            &RunnerExtensionMaterializationPlan {
+                id: id.clone(),
+                source_path: source_path.clone(),
+                synced_source_path: remote_path.clone(),
+                content_hash: content_hash.clone(),
+            },
+        )?;
+        overlays.push(LabJobExtensionOverlay {
+            id: id.clone(),
+            source_path,
+            remote_path,
+            source_revision: git_revision(&source),
+            content_hash,
+        });
+    }
+    if overlays.is_empty() {
+        return Ok(overlays);
+    }
+    let command = lab_job_extension_overlay_command(runtime_root, &overlays);
+    let (_, exit_code) = exec(&runner.id, RunnerExecOptions::diagnostic_raw_shell(command))?;
+    if exit_code != 0 {
+        return Err(Error::validation_invalid_argument(
+            "extensions",
+            "failed to create the job-scoped Homeboy extension overlay on the runner",
+            Some(runtime_root.to_string()),
+            None,
+        ));
+    }
+    Ok(overlays)
+}
+
+fn lab_job_extension_overlay_command(
+    runtime_root: &str,
+    overlays: &[LabJobExtensionOverlay],
+) -> String {
+    let links = overlays
+        .iter()
+        .map(|overlay| {
+            format!(
+                "rm -rf {target}; ln -s {source} {target}",
+                target = shell::quote_path(&format!(
+                    "{}/home/.config/homeboy/extensions/{}",
+                    runtime_root.trim_end_matches('/'),
+                    overlay.id
+                )),
+                source = shell::quote_path(&overlay.remote_path),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "set -eu\nruntime={runtime}\n# A job gets only its declared extensions; runner-global config may contain mutable links.\nmkdir -p \"$runtime/home/.config/homeboy/extensions\"\n{links}\n",
+        runtime = shell::quote_path(runtime_root),
+    )
+}
+
+#[cfg(test)]
+mod lab_job_overlay_tests {
+    use super::*;
+
+    fn overlay(id: &str, root: &str, hash: &str) -> LabJobExtensionOverlay {
+        LabJobExtensionOverlay {
+            id: id.to_string(),
+            source_path: format!("/controller/{id}"),
+            remote_path: format!("{root}/extensions/{id}/{hash}"),
+            source_revision: Some(hash.to_string()),
+            content_hash: hash.to_string(),
+        }
+    }
+
+    #[test]
+    fn concurrent_extension_snapshots_build_private_content_addressed_registries() {
+        let first = overlay("fixture", "/runner/jobs/a", "aaaaaaaaaaaaaaaa");
+        let second = overlay("fixture", "/runner/jobs/b", "bbbbbbbbbbbbbbbb");
+        let first_command = lab_job_extension_overlay_command("/runner/jobs/a", &[first.clone()]);
+        let second_command = lab_job_extension_overlay_command("/runner/jobs/b", &[second.clone()]);
+
+        assert_ne!(first.remote_path, second.remote_path);
+        assert!(first_command.contains(&first.remote_path));
+        assert!(second_command.contains(&second.remote_path));
+        assert!(!first_command.contains("$HOME/.config/homeboy"));
+        assert!(!second_command.contains("$HOME/.config/homeboy"));
+        assert!(!first_command.contains("cp -a"));
+    }
+}
+
 pub(crate) fn plan_controller_snapshot_extension(
     workspace_root: &str,
     id: &str,
@@ -656,6 +778,7 @@ fn shell_arg(value: &str) -> String {
 mod tests {
     use super::*;
     use crate::Runner;
+    use std::sync::{Arc, Barrier};
 
     fn runner() -> Runner {
         Runner {
@@ -894,5 +1017,86 @@ mod tests {
             Some("/usr/local/bin:/usr/bin")
         );
         assert_eq!(captured_env.get("HOMEBOY_COMMAND"), None);
+    }
+
+    #[test]
+    fn concurrent_job_snapshots_keep_distinct_extension_revisions_after_global_source_changes() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let runner_root = tempfile::tempdir().expect("runner root");
+            crate::create(
+                &format!(
+                    r#"{{"id":"lab-extension-isolation","kind":"local","workspace_root":"{}"}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+            let source = home.path().join(".config/homeboy/extensions/fixture");
+            fs::create_dir_all(&source).expect("extension source");
+            fs::write(
+                source.join("fixture.json"),
+                r#"{"id":"fixture","name":"Fixture","version":"1.0.0"}"#,
+            )
+            .expect("extension manifest");
+            fs::write(source.join("catalog"), "revision-a\n").expect("first catalog");
+
+            let runner = crate::load("lab-extension-isolation").expect("runner");
+            let first_root = runner_root
+                .path()
+                .join("_lab_workspaces/job-a-homeboy-artifacts/runtime");
+            let first = materialize_lab_job_extension_overlays(
+                &runner,
+                &first_root.display().to_string(),
+                &["fixture".to_string()],
+            )
+            .expect("materialize first snapshot");
+
+            // The controller's administrative default changes while A remains
+            // admitted. B must get the new source without rewriting A's link.
+            fs::write(source.join("catalog"), "revision-b\n").expect("second catalog");
+            let second_root = runner_root
+                .path()
+                .join("_lab_workspaces/job-b-homeboy-artifacts/runtime");
+            let second = materialize_lab_job_extension_overlays(
+                &runner,
+                &second_root.display().to_string(),
+                &["fixture".to_string()],
+            )
+            .expect("materialize second snapshot");
+
+            assert_ne!(first[0].content_hash, second[0].content_hash);
+            assert_eq!(
+                fs::read_to_string(source.join("catalog")).expect("global source"),
+                "revision-b\n"
+            );
+            let barrier = Arc::new(Barrier::new(2));
+            let jobs = [
+                (first_root.join("home"), "revision-a\n"),
+                (second_root.join("home"), "revision-b\n"),
+            ];
+            let handles = jobs
+                .into_iter()
+                .map(|(home, expected)| {
+                    let barrier = Arc::clone(&barrier);
+                    std::thread::spawn(move || {
+                        barrier.wait();
+                        let output = Command::new("sh")
+                            .arg("-c")
+                            .arg("cat \"$HOME/.config/homeboy/extensions/fixture/catalog\"")
+                            .env("HOME", home)
+                            .output()
+                            .expect("read private extension catalog");
+                        assert!(output.status.success());
+                        assert_eq!(
+                            String::from_utf8(output.stdout).expect("catalog utf8"),
+                            expected
+                        );
+                    })
+                })
+                .collect::<Vec<_>>();
+            for handle in handles {
+                handle.join().expect("extension job");
+            }
+        });
     }
 }

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -261,6 +261,21 @@ fn lab_runner_exec_options(
         homeboy_core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV.to_string(),
         context.runner_id.to_string(),
     );
+    if let Some(bundle) = context.lab_metadata.get("execution_bundle") {
+        env.extend(crate::execution_bundle::bundle_env(bundle));
+        if let Some(path) = bundle
+            .pointer("/binary/path")
+            .and_then(serde_json::Value::as_str)
+        {
+            env.insert("HOMEBOY_COMMAND".to_string(), path.to_string());
+        }
+        if let Some(home) = bundle
+            .get("extension_runtime_home")
+            .and_then(serde_json::Value::as_str)
+        {
+            env.insert("HOME".to_string(), home.to_string());
+        }
+    }
     env.extend(lab_rig_registry_env(context.rig_registry_root.as_deref()));
     RunnerExecOptions {
         cwd: Some(context.remote_cwd.clone()),
@@ -338,6 +353,22 @@ pub(crate) fn exec_lab_context(
     env.extend(context.secret_env_handoff.env_delta.clone());
     for (name, value) in &request.job_overrides.env {
         env.insert(name.clone(), value.clone());
+    }
+    // Reassert immutable authority after untrusted per-job overrides.
+    if let Some(bundle) = context.lab_metadata.get("execution_bundle") {
+        env.extend(crate::execution_bundle::bundle_env(bundle));
+        if let Some(path) = bundle
+            .pointer("/binary/path")
+            .and_then(serde_json::Value::as_str)
+        {
+            env.insert("HOMEBOY_COMMAND".to_string(), path.to_string());
+        }
+        if let Some(home) = bundle
+            .get("extension_runtime_home")
+            .and_then(serde_json::Value::as_str)
+        {
+            env.insert("HOME".to_string(), home.to_string());
+        }
     }
     let mut secret_env_names = context
         .secret_env_handoff
@@ -461,11 +492,11 @@ pub(crate) fn exec_lab_context(
     let (exec_output, exit_code) = match exec_result {
         Ok(output) => output,
         Err(err) => {
-            if let Some(workspace) = context.materialized_workspace.as_mut() {
-                workspace.preserve();
-            }
             if let Some(run_id) = context.agent_task_run_id.as_deref() {
                 if let Some(job_id) = accepted_runner_job_id(runner_id, run_id) {
+                    if let Some(workspace) = context.materialized_workspace.as_mut() {
+                        workspace.preserve();
+                    }
                     return in_flight_daemon_disconnect_outcome(
                         context.plan,
                         runner_id,
@@ -507,6 +538,9 @@ pub(crate) fn exec_lab_context(
                 );
                 if let Some(job_id) = in_flight_job_id.as_deref() {
                     if let Some(run_id) = context.agent_task_run_id.as_deref() {
+                        if let Some(workspace) = context.materialized_workspace.as_mut() {
+                            workspace.preserve();
+                        }
                         return in_flight_daemon_disconnect_outcome(
                             context.plan,
                             runner_id,
@@ -569,6 +603,9 @@ pub(crate) fn exec_lab_context(
             }
             if let Some(job_id) = in_flight_job_id.as_deref() {
                 if let Some(run_id) = context.agent_task_run_id.as_deref() {
+                    if let Some(workspace) = context.materialized_workspace.as_mut() {
+                        workspace.preserve();
+                    }
                     return in_flight_daemon_disconnect_outcome(
                         context.plan,
                         runner_id,
@@ -1260,7 +1297,6 @@ pub(crate) fn run_lab_offload_inner(
         plan,
         runner_id,
         &source_path,
-        homeboy_path,
         &command_prefix.argv,
         Some(&runner_workspace_root),
         run_isolation_token,
@@ -1309,12 +1345,10 @@ pub(crate) fn run_lab_offload_inner(
         command,
         remote_command,
         remote_output_file,
-        synced_rigs,
         rig_component_path_overrides,
         dependency_cache_saves,
         runtime_overlay_env,
         runtime_overlay_metadata,
-        rig_registry_root,
     } = workspace_stage;
     plan = next_plan;
     if agent_task_run_id != pre_acceptance_run_id {
@@ -1322,6 +1356,64 @@ pub(crate) fn run_lab_offload_inner(
             "Lab workspace staging changed the pre-acceptance agent-task lifecycle identity",
         ));
     }
+    // This workspace owns the admitted rig and extension snapshots. Every
+    // terminal result, including failure and cancellation, must release them.
+    // Detached and uncertain in-flight work explicitly relinquishes ownership.
+    let cleanup_policy = WorkspaceCleanupPolicy::DeleteAlways;
+    let mut workspace_resource_lifecycle = synced.resource_lifecycle.clone();
+    workspace_resource_lifecycle.cleanup_policy =
+        homeboy_core::resource_lifecycle_index::ResourceCleanupPolicy::DeleteOnTerminal;
+    let materialized_workspace = MaterializedWorkspace::new(
+        runner_id.to_string(),
+        remote_cwd.clone(),
+        Some(remote_lab_artifact_dir(&remote_cwd)),
+        cleanup_policy,
+    );
+
+    ensure_remote_lab_artifact_dir(runner_id, &remote_lab_artifact_dir(&remote_cwd))?;
+
+    let candidate_rig_registry_root = remote_lab_rig_registry_root(&remote_cwd);
+    let synced_rigs = rig_materialization::sync_lab_offload_rigs(
+        runner_id,
+        homeboy_path,
+        &remote_cwd,
+        &candidate_rig_registry_root,
+        &changed_since_preflight.args,
+        rig_materialization::LabOffloadPrimaryRigSource {
+            local_path: &synced.local_path,
+            remote_path: &remote_cwd,
+            source_snapshot: &source_snapshot,
+            workspace_snapshot_identity: &synced.snapshot_identity,
+        },
+    )?;
+    if !synced_rigs.is_empty() {
+        plan = with_step(
+            plan,
+            PlanStep::ready("lab.sync_rigs", "lab.sync_rigs")
+                .inputs(
+                    PlanValues::new()
+                        .json("count", synced_rigs.len())
+                        .string("source_snapshot_remote_path", &remote_cwd)
+                        .string("registry_root", &candidate_rig_registry_root)
+                        .json("rigs", &synced_rigs),
+                )
+                .build(),
+        );
+    }
+    let rig_registry_root = (!synced_rigs.is_empty()).then_some(candidate_rig_registry_root);
+
+    // Materialize after establishing the owner so a partial extension sync or
+    // any later pre-dispatch failure reaps the complete job-private runtime.
+    let extension_runtime_root =
+        format!("{}/extension-runtime", remote_lab_artifact_dir(&remote_cwd));
+    let extension_overlays = crate::materialize_lab_job_extension_overlays(
+        &runner,
+        &extension_runtime_root,
+        &runner_required_extensions,
+    )?;
+    let extension_runtime_home =
+        (!extension_overlays.is_empty()).then(|| format!("{extension_runtime_root}/home"));
+
     if let Some(run_id) = agent_task_run_id.as_deref() {
         agent_task_lifecycle::record_lab_offload_phase(
             run_id,
@@ -1332,31 +1424,6 @@ pub(crate) fn run_lab_offload_inner(
             Some(&provider_rotation),
             request.durable_agent_task_plan,
         )?;
-    }
-    let cleanup_policy = if agent_task_run_id.is_some() {
-        WorkspaceCleanupPolicy::PreserveAlways
-    } else {
-        WorkspaceCleanupPolicy::PreserveOnFailure
-    };
-    let mut workspace_resource_lifecycle = synced.resource_lifecycle.clone();
-    workspace_resource_lifecycle.cleanup_policy = if agent_task_run_id.is_some() {
-        homeboy_core::resource_lifecycle_index::ResourceCleanupPolicy::Preserve
-    } else {
-        homeboy_core::resource_lifecycle_index::ResourceCleanupPolicy::DeleteOnSuccess
-    };
-    let materialized_workspace = MaterializedWorkspace::new(
-        runner_id.to_string(),
-        remote_cwd.clone(),
-        (remote_output_file.is_some() || rig_registry_root.is_some())
-            .then(|| remote_lab_artifact_dir(&remote_cwd)),
-        cleanup_policy,
-    );
-
-    if let Some(artifact_path) = remote_output_file
-        .as_deref()
-        .or(rig_registry_root.as_deref())
-    {
-        ensure_remote_lab_artifact_dir(runner_id, artifact_path)?;
     }
 
     let dependency_hydration = hydrate_for_lab_workspace_exec(
@@ -1478,6 +1545,44 @@ pub(crate) fn run_lab_offload_inner(
     }
     let env_delta_before_secret_handoff = env_delta.clone();
     lab_metadata["runtime_overlays"] = runtime_overlay_metadata;
+    lab_metadata["execution_bundle"] = serde_json::json!({
+        "schema": crate::execution_bundle::LAB_EXECUTION_BUNDLE_SCHEMA,
+        "binary": {
+            "path": homeboy_path,
+            "build_identity": runner_homeboy.get("job_command_binary_build_identity")
+                .or_else(|| runner_homeboy.get("active_daemon_build_identity")),
+        },
+        "admission": {
+            "daemon_lease_id": admission.as_ref().map(|reservation| &reservation.daemon_lease_id),
+            "reservation_job_id": admission.as_ref().map(|reservation| reservation.job_id()),
+            "authority": admission.is_none().then_some("reverse_broker"),
+        },
+        "rig_registry_root": rig_registry_root,
+        "rigs": synced_rigs,
+        "extensions": extension_overlays,
+        "extension_runtime_home": extension_runtime_home,
+        "workspace_mapping": workspace_mapping_metadata,
+        "identities": {
+            "requested": {
+                "runner_id": runner_id,
+                "extensions": contract.required_extensions,
+                "command": request.normalized_args,
+            },
+            "resolved": {
+                "binary": homeboy_path,
+                "rig_registry_root": rig_registry_root,
+                "rigs": &synced_rigs,
+                "extensions": &extension_overlays,
+                "workspace_mapping": &workspace_mapping_metadata,
+            },
+            "executed": {
+                "argv": &remote_command,
+                "daemon_lease_id": admission.as_ref().map(|reservation| &reservation.daemon_lease_id),
+                "reservation_job_id": admission.as_ref().map(|reservation| reservation.job_id()),
+                "authority": admission.is_none().then_some("reverse_broker"),
+            },
+        },
+    });
     let secret_env_handoff = build_lab_secret_env_handoff_plan(
         &contract.secret_env_sources,
         &changed_since_preflight.args,
@@ -1884,6 +1989,84 @@ mod tests {
     use crate::{
         RunnerActiveJobState, RunnerSessionState, RunnerStaleDaemonWarning, RunnerTunnelMode,
     };
+    use std::sync::{Arc, Barrier, Mutex};
+
+    #[test]
+    fn concurrent_same_id_rigs_dispatch_from_their_admitted_registry_after_promotion() {
+        let root = tempfile::tempdir().expect("runner root");
+        let prepared = Arc::new(Barrier::new(3));
+        let dispatch = Arc::new(Barrier::new(3));
+        let runner_default = Arc::new(Mutex::new("/runner/homeboy-a".to_string()));
+        let jobs = [
+            ("a", "catalog-a", "/runner/homeboy-a", "lease-a"),
+            ("b", "catalog-b", "/runner/homeboy-b", "lease-b"),
+        ];
+        let handles = jobs
+            .into_iter()
+            .map(|(job, catalog, binary, lease)| {
+                let prepared = Arc::clone(&prepared);
+                let dispatch = Arc::clone(&dispatch);
+                let runner_default = Arc::clone(&runner_default);
+                let registry_root = root.path().join(format!("{job}-homeboy-artifacts/rig-registry"));
+                std::thread::spawn(move || {
+                    // Fake runner install operation: it receives the same env
+                    // shape as the real rig install and writes only there.
+                    let install_env = lab_rig_registry_env(Some(&registry_root.display().to_string()));
+                    let installed_root = install_env
+                        .get(homeboy_core::paths::RIG_REGISTRY_ROOT_ENV)
+                        .expect("admitted registry root")
+                        .to_string();
+                    let catalog_path = std::path::Path::new(&installed_root)
+                        .join("rigs/same-id/catalog");
+                    std::fs::create_dir_all(catalog_path.parent().expect("rig parent"))
+                        .expect("private rig registry");
+                    std::fs::write(&catalog_path, format!("{catalog}\n")).expect("rig catalog");
+
+                    prepared.wait();
+                    // Promotion/reconnect changes the administrative default
+                    // between admission and dispatch. The bound command and
+                    // lease must remain authoritative for this job.
+                    dispatch.wait();
+                    assert_eq!(
+                        runner_default.lock().expect("default lock").as_str(),
+                        "/runner/homeboy-promoted"
+                    );
+                    let output = std::process::Command::new("sh")
+                        .arg("-c")
+                        .arg("cat \"$HOMEBOY_RIG_REGISTRY_ROOT/rigs/same-id/catalog\"")
+                        .envs(install_env)
+                        .output()
+                        .expect("final rig dispatch");
+                    assert!(output.status.success());
+                    assert_eq!(
+                        String::from_utf8(output.stdout).expect("catalog utf8"),
+                        format!("{catalog}\n")
+                    );
+                    let bundle = serde_json::json!({
+                        "schema": crate::execution_bundle::LAB_EXECUTION_BUNDLE_SCHEMA,
+                        "binary": { "path": binary, "build_identity": format!("build-{job}") },
+                        "admission": { "daemon_lease_id": lease, "reservation_job_id": format!("job-{job}") },
+                        "rig_registry_root": installed_root,
+                        "rigs": [{ "rig_id": "same-id", "workload_hashes": { "source_snapshot_hash": catalog } }],
+                        "extensions": []
+                    });
+                    let env = crate::execution_bundle::bundle_env(&bundle);
+                    assert!(crate::execution_bundle::validate_bundle_env(
+                        &env,
+                        &[binary.to_string(), "fuzz".to_string()],
+                        &[]
+                    ));
+                })
+            })
+            .collect::<Vec<_>>();
+
+        prepared.wait();
+        *runner_default.lock().expect("default lock") = "/runner/homeboy-promoted".to_string();
+        dispatch.wait();
+        for handle in handles {
+            handle.join().expect("rig job");
+        }
+    }
 
     #[test]
     fn final_dispatch_reasserts_the_admitted_rig_registry_root() {
@@ -1909,10 +2092,17 @@ mod tests {
             require_controller_git_bundle: false,
             reuse_compatible_snapshot: false,
             job_overrides: LabJobOverrides {
-                env: std::collections::HashMap::from([(
-                    homeboy_core::paths::RIG_REGISTRY_ROOT_ENV.to_string(),
-                    "/caller/conflict".to_string(),
-                )]),
+                env: std::collections::HashMap::from([
+                    (
+                        homeboy_core::paths::RIG_REGISTRY_ROOT_ENV.to_string(),
+                        "/caller/conflict".to_string(),
+                    ),
+                    (
+                        "HOMEBOY_COMMAND".to_string(),
+                        "/caller/new-homeboy".to_string(),
+                    ),
+                    ("HOME".to_string(), "/caller/home".to_string()),
+                ]),
                 ..Default::default()
             },
         };
@@ -1928,7 +2118,7 @@ mod tests {
                 true,
                 &[],
             ),
-            required_extensions: Vec::new(),
+            required_extensions: vec!["fixture".to_string()],
             required_capabilities: Vec::new(),
             workload: None,
         };
@@ -1944,14 +2134,24 @@ mod tests {
             runner_status: &runner_status,
             source_path: std::path::PathBuf::from("/controller/app"),
             remote_cwd: "/runner/app".to_string(),
-            command: vec!["homeboy".to_string(), "bench".to_string()],
+            command: vec!["/runner/admitted-homeboy".to_string(), "bench".to_string()],
             remote_command: Vec::new(),
             remapped_args: Vec::new(),
             accepted_extension_settings: Vec::new(),
             secret_preflight_args: Vec::new(),
             agent_task_run_id: None,
             lab_runner_workload: None,
-            lab_metadata: serde_json::json!({}),
+            lab_metadata: serde_json::json!({
+                "execution_bundle": {
+                    "schema": crate::execution_bundle::LAB_EXECUTION_BUNDLE_SCHEMA,
+                    "binary": { "path": "/runner/admitted-homeboy" },
+                    "admission": { "daemon_lease_id": "lease-before-promotion", "reservation_job_id": "job-a" },
+                    "rig_registry_root": root,
+                    "rigs": [{ "rig_id": "same-id", "workload_hashes": { "source_snapshot_hash": "catalog-a" } }],
+                    "extensions": [{ "id": "fixture", "remote_path": "/runner/job/extensions/fixture/aaaaaaaaaaaaaaaa", "content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }],
+                    "extension_runtime_home": "/runner/job/home",
+                }
+            }),
             rig_registry_root: Some(root.clone()),
             env_resolution_layers: Vec::new(),
             secret_env_handoff,
@@ -1980,6 +2180,19 @@ mod tests {
             options.env.get(homeboy_core::paths::RIG_REGISTRY_ROOT_ENV),
             Some(&root)
         );
+        assert_eq!(
+            options.env.get("HOMEBOY_COMMAND"),
+            Some(&"/runner/admitted-homeboy".to_string())
+        );
+        assert_eq!(
+            options.env.get("HOME"),
+            Some(&"/runner/job/home".to_string())
+        );
+        assert!(crate::execution_bundle::validate_bundle_env(
+            &options.env,
+            &options.command,
+            &contract.required_extensions,
+        ));
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -24,7 +24,6 @@ pub(crate) struct LabOffloadWorkspaceStage {
     pub(crate) command: Vec<String>,
     pub(crate) remote_command: Vec<String>,
     pub(crate) remote_output_file: Option<String>,
-    pub(crate) synced_rigs: Vec<rig_materialization::LabOffloadRigSync>,
     pub(crate) rig_component_path_overrides: Vec<(String, String)>,
     pub(crate) dependency_cache_saves: Vec<RunnerDependencyCacheSaveRequest>,
     /// Env-var overrides surfacing synced runtime-overlay remote paths to the
@@ -32,8 +31,6 @@ pub(crate) struct LabOffloadWorkspaceStage {
     pub(crate) runtime_overlay_env: Vec<(String, String)>,
     /// Offload-evidence metadata for the synced runtime overlays.
     pub(crate) runtime_overlay_metadata: serde_json::Value,
-    /// Per-job runner root for mutable rig registry state.
-    pub(crate) rig_registry_root: Option<String>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -43,7 +40,6 @@ pub(crate) fn prepare_lab_offload_workspace_stage(
     plan: HomeboyPlan,
     runner_id: &str,
     source_path: &Path,
-    homeboy_path: &str,
     command_prefix_argv: &[String],
     runner_workspace_root: Option<&str>,
     run_isolation_token: Option<String>,
@@ -68,7 +64,6 @@ pub(crate) fn prepare_lab_offload_workspace_stage(
         plan,
         runner_id,
         source_path,
-        homeboy_path,
         command_prefix_argv,
         runner_workspace_root,
         run_isolation_token,
@@ -85,7 +80,6 @@ fn prepare_lab_offload_workspace_stage_inner(
     mut plan: HomeboyPlan,
     runner_id: &str,
     source_path: &Path,
-    homeboy_path: &str,
     command_prefix_argv: &[String],
     runner_workspace_root: Option<&str>,
     run_isolation_token: Option<String>,
@@ -337,36 +331,6 @@ fn prepare_lab_offload_workspace_stage_inner(
         );
     }
 
-    let candidate_rig_registry_root = remote_lab_rig_registry_root(&remote_cwd);
-    let synced_rigs = rig_materialization::sync_lab_offload_rigs(
-        runner_id,
-        homeboy_path,
-        &remote_cwd,
-        &candidate_rig_registry_root,
-        &changed_since_preflight.args,
-        rig_materialization::LabOffloadPrimaryRigSource {
-            local_path: &synced.local_path,
-            remote_path: &remote_cwd,
-            source_snapshot: &source_snapshot,
-            workspace_snapshot_identity: &synced.snapshot_identity,
-        },
-    )?;
-    if !synced_rigs.is_empty() {
-        plan = with_step(
-            plan,
-            PlanStep::ready("lab.sync_rigs", "lab.sync_rigs")
-                .inputs(
-                    PlanValues::new()
-                        .json("count", synced_rigs.len())
-                        .string("source_snapshot_remote_path", &remote_cwd)
-                        .string("registry_root", &candidate_rig_registry_root)
-                        .json("rigs", &synced_rigs),
-                )
-                .build(),
-        );
-    }
-    let rig_registry_root = (!synced_rigs.is_empty()).then_some(candidate_rig_registry_root);
-
     let rig_component_sync = rig_materialization::sync_lab_offload_rig_component_dependencies(
         runner_id,
         &changed_since_preflight.args,
@@ -506,12 +470,10 @@ fn prepare_lab_offload_workspace_stage_inner(
         command,
         remote_command,
         remote_output_file,
-        synced_rigs,
         rig_component_path_overrides,
         dependency_cache_saves,
         runtime_overlay_env,
         runtime_overlay_metadata,
-        rig_registry_root,
     })
 }
 
@@ -2221,7 +2183,6 @@ mod tests {
                 crate::lab_plan::base_lab_plan(Some(&contract)),
                 "lab-controller-bundle-stage",
                 source.path(),
-                "homeboy",
                 &["homeboy".to_string()],
                 Some(&runner_workspace_root),
                 None,
@@ -2374,7 +2335,6 @@ mod tests {
                 crate::lab_plan::base_lab_plan(Some(&contract)),
                 "lab-managed-worktree-stage",
                 &source,
-                "homeboy",
                 &["homeboy".to_string()],
                 Some(&runner_workspace_root),
                 Some("cook-8009".to_string()),

--- a/crates/homeboy-lab-runner/src/lab_env.rs
+++ b/crates/homeboy-lab-runner/src/lab_env.rs
@@ -66,6 +66,7 @@ fn subprocess_lab_offload_metadata(lab_metadata: &serde_json::Value) -> serde_js
         "remote_workspace": lab_metadata.get("remote_workspace"),
         "sync_mode": lab_metadata.get("sync_mode"),
         "source_snapshot": lab_metadata.get("source_snapshot"),
+        "execution_bundle": lab_metadata.get("execution_bundle"),
         "workspace_cleanliness": {
             "allow_dirty_lab_workspace": lab_metadata.pointer("/workspace_cleanliness/allow_dirty_lab_workspace"),
         },

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -40,6 +40,7 @@ mod daemon_health;
 mod daemon_http_get;
 mod evidence;
 mod execution;
+mod execution_bundle;
 mod extension_materialization;
 mod generation_store;
 pub fn runner_generation_inventory(runner_id: &str) -> Result<Vec<RunnerDaemonGenerationStatus>> {
@@ -85,6 +86,7 @@ pub mod runners;
 mod worker;
 pub(crate) mod workload;
 mod workspace;
+pub(crate) use extension_materialization::materialize_lab_job_extension_overlays;
 pub(crate) use workspace::copy_snapshot_to_directory;
 pub use workspace::register_workspace_snapshot_provider;
 // Only test code (extension::trace::canonicality) still calls verify_lab_workspace

--- a/crates/homeboy-lab-runner/src/workspace/materialized.rs
+++ b/crates/homeboy-lab-runner/src/workspace/materialized.rs
@@ -20,6 +20,9 @@ use super::sync::reap_run_workspace;
 /// Teardown policy for a run-owned materialized workspace.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WorkspaceCleanupPolicy {
+    /// Reap every terminal outcome. Use this for job-private runtime state that
+    /// must never survive a completed or cancelled offload.
+    DeleteAlways,
     /// Reap the workspace when the run succeeds; preserve it on failure so
     /// post-mortem evidence survives on the lab. Default — chosen to avoid
     /// behavior shock (failed runs keep their evidence as before) while still
@@ -94,6 +97,7 @@ impl MaterializedWorkspace {
             return false;
         }
         match self.policy {
+            WorkspaceCleanupPolicy::DeleteAlways => true,
             WorkspaceCleanupPolicy::PreserveAlways => false,
             WorkspaceCleanupPolicy::PreserveOnFailure => self.succeeded,
         }

--- a/crates/homeboy-lab-runner/src/workspace/tests/reap.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/reap.rs
@@ -186,3 +186,49 @@ fn materialized_workspace_preserve_always_policy_never_reaps() {
         );
     });
 }
+
+#[test]
+fn job_runtime_cleanup_reaps_success_failure_and_cancellation_without_touching_runner_defaults() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        let defaults = runner_root
+            .path()
+            .join(".config/homeboy/extensions/default");
+        fs::create_dir_all(defaults.parent().expect("default parent")).expect("default parent");
+        fs::write(&defaults, "runner default").expect("runner default");
+
+        for outcome in ["success", "failure", "cancelled"] {
+            let runner_id = format!("lab-local-terminal-{outcome}");
+            let remote_path = sync_local_workspace(&runner_id, runner_root.path());
+            let artifact_dir = format!("{remote_path}-homeboy-artifacts");
+            fs::create_dir_all(format!("{artifact_dir}/rig-registry/same-id")).expect("rig state");
+            fs::create_dir_all(format!(
+                "{artifact_dir}/extension-runtime/home/.config/homeboy/extensions"
+            ))
+            .expect("extension state");
+
+            {
+                let mut handle = MaterializedWorkspace::new(
+                    runner_id,
+                    remote_path.clone(),
+                    Some(artifact_dir.clone()),
+                    WorkspaceCleanupPolicy::DeleteAlways,
+                );
+                handle.set_success(outcome == "success");
+            }
+
+            assert!(
+                !Path::new(&remote_path).exists(),
+                "{outcome} checkout was not reaped"
+            );
+            assert!(
+                !Path::new(&artifact_dir).exists(),
+                "{outcome} job runtime was not reaped"
+            );
+            assert_eq!(
+                fs::read_to_string(&defaults).expect("runner default survives"),
+                "runner default"
+            );
+        }
+    });
+}


### PR DESCRIPTION
## Summary
- capture binary, lease, rig, extension, workspace, and broker authority in an immutable per-job execution bundle
- dispatch from job-private runtime state instead of mutable global links
- enforce cleanup ownership across successful, failed, and cancelled jobs
- add concurrency coverage for same-rig jobs, extension snapshots, reconnects, and cleanup

Closes #8974.

## How to test
1. Run `cargo test -p homeboy-lab-runner execution_bundle -- --nocapture`.
2. Run `cargo test -p homeboy-lab-runner concurrent_same_rig_jobs -- --nocapture`.
3. Run `cargo test -p homeboy-lab-runner snapshots_extension_runtime_before_dispatch -- --nocapture`.
4. Run `cargo test -p homeboy-lab-runner cleanup -- --nocapture`.
5. Run `cargo check -p homeboy-cli --all-targets`.

## Compatibility
This changes internal Lab runner execution ownership. It does not change the public CLI surface or require compatibility handling for external consumers.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI gpt-5.6-sol
- **Used for:** Implementing the runtime-bundle lifecycle, resolving upstream integration changes, and running verification with Chris.