### PR TITLE
Fix foreground daemon job binding replacement

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -351,7 +351,8 @@ where
         "lifecycle_schema": RUN_LIFECYCLE_RECORD_SCHEMA,
         "note": "submitted tasks are durable; provider run ids are recorded after an executor returns them as generic artifacts or evidence refs"
     });
-    if let Some(runner_id) = execution_runner_id() {
+    let execution_runner_id = execution_runner_id();
+    if let Some(runner_id) = execution_runner_id.as_deref() {
         metadata["runner_id"] = json!(runner_id);
     }
     if let Some(route) = homeboy_core::notification_route::current() {
@@ -378,6 +379,17 @@ where
         adoption_run_id: None,
         metadata,
     };
+    if let Ok(existing) = store::read_record(&run_id) {
+        if execution_runner_id.as_deref() == existing.runner_id() {
+            // A foreground daemon binds its job before launching runner-local
+            // `run-plan`. Keep that transport identity when run-plan replaces
+            // the staged record, or terminal projection cannot join its daemon
+            // snapshot back to the completed agent-task run.
+            if let Some(runner_job_id) = existing.runner_job_id() {
+                record.metadata["runner_job_id"] = json!(runner_job_id);
+            }
+        }
+    }
     store::write_record(&record)?;
 
     // The queue is durable independently of this foreground controller. Status

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -188,6 +188,15 @@ fn lab_handoff_run_plan_executes_with_runner_provenance_after_transport_is_consu
         std::env::set_var(execution_runner, "homeboy-lab");
         std::env::remove_var(transport_runner);
 
+        agent_task_lifecycle::submit_plan(&test_plan(), Some("lab-handoff-run-plan"))
+            .expect("staged runner record");
+        agent_task_lifecycle::record_runner_job_identity(
+            "lab-handoff-run-plan",
+            "homeboy-lab",
+            "foreground-daemon-job",
+        )
+        .expect("foreground daemon binds its job before run-plan");
+
         let result = run_loaded_plan(
             test_plan(),
             Some("lab-handoff-run-plan"),
@@ -210,6 +219,12 @@ fn lab_handoff_run_plan_executes_with_runner_provenance_after_transport_is_consu
 
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.value.totals.succeeded, 1);
+        assert_eq!(
+            lifecycle_status("lab-handoff-run-plan")
+                .expect("completed runner-local record")
+                .runner_job_id(),
+            Some("foreground-daemon-job")
+        );
     });
 }
 


### PR DESCRIPTION
## Summary
- preserve a foreground daemon job binding when runner-local `run-plan` replaces its staged lifecycle record
- require the existing record to belong to the same canonical execution runner before carrying `runner_job_id` forward
- cover the real prebind, record replacement, execution, and terminal-status sequence

Fixes #9240.

## Why
The foreground daemon binds `runner_job_id` before launching `agent-task run-plan`, but `submit_plan()` replaced that staged record and discarded the binding. Provider execution could succeed while terminal projection failed to join the daemon snapshot back to the completed agent-task run.

## How to test
1. Run `cargo test -p homeboy-agents lab_handoff_run_plan_executes_with_runner_provenance_after_transport_is_consumed -- --nocapture --test-threads=1`.
2. Run `cargo test -p homeboy-agents cook_lab_handoff_controller_reads_ignore_runner_plan_projection -- --nocapture --test-threads=1`.
3. Run `cargo check -p homeboy-cli`.
4. Run `cargo fmt --check`.

## Compatibility
This changes only internal lifecycle record replacement. It does not change public CLI arguments or external extension contracts.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause analysis, implementation, regression coverage, and verification.