### PR TITLE
Materialize versioned runner runtime generations

### DIFF
--- a/crates/homeboy-core/src/agent_runtime_manifest.rs
+++ b/crates/homeboy-core/src/agent_runtime_manifest.rs
@@ -10,7 +10,7 @@ use homeboy_extension_contract::{ExtensionManifest, RequirementsConfig};
 
 pub const AGENT_RUNTIME_MANIFEST_SCHEMA: &str = "homeboy/agent-runtime-manifest/v1";
 pub const AGENT_RUNTIME_MATERIALIZATION_PLAN_SCHEMA: &str =
-    "homeboy/agent-runtime-materialization-plan/v1";
+    "homeboy/agent-runtime-materialization-plan/v2";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentRuntimeDiscoveryDiagnostic {
@@ -65,6 +65,12 @@ pub struct AgentRuntimeManifest {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct AgentRuntimeMaterializationContract {
+    /// Runtime-local sources are copied into a job-scoped, content-addressed
+    /// generation. `source_roots` remains the legacy runner-global contract.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtime_sources: Vec<AgentRuntimeMaterializationSource>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub preparation: Vec<AgentRuntimePreparationAction>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub source_roots: Vec<homeboy_agents_contract::AgentTaskProviderRunnerSource>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -89,6 +95,8 @@ pub struct AgentRuntimeMaterializationContract {
 impl AgentRuntimeMaterializationContract {
     fn is_empty(&self) -> bool {
         self.source_roots.is_empty()
+            && self.runtime_sources.is_empty()
+            && self.preparation.is_empty()
             && self.dependencies.is_empty()
             && self.executable_requirements.is_empty()
             && self.readiness_checks.is_empty()
@@ -97,6 +105,41 @@ impl AgentRuntimeMaterializationContract {
             && self.workspace.is_none()
             && self.extra.is_empty()
     }
+}
+
+/// A reproducible input for a runtime generation. A source is either a
+/// controller-local checkout (which Lab snapshots) or an immutable remote.
+/// No credentials, environment values, or shell snippets belong here.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentRuntimeMaterializationSource {
+    pub id: String,
+    pub locator: AgentRuntimeSourceLocator,
+    pub content_identity: String,
+    pub destination_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AgentRuntimeSourceLocator {
+    LocalPath {
+        path: String,
+    },
+    Git {
+        remote_url: String,
+        revision: String,
+    },
+}
+
+/// A bounded argv-only build step run inside the isolated generation root.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentRuntimePreparationAction {
+    pub argv: Vec<String>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub cwd: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub expected_outputs: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_identity: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -254,6 +297,14 @@ pub struct AgentRuntimeMaterializationPlan {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_path: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtime_sources: Vec<AgentRuntimeMaterializationSource>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub preparation: Vec<AgentRuntimePreparationAction>,
+    /// Stable identity for the requested source/build recipe. Lab uses this as
+    /// the generation key, never a mutable checkout path.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub generation_identity: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub source_roots: Vec<homeboy_agents_contract::AgentTaskProviderRunnerSource>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependencies: Vec<AgentRuntimeMaterializationDependency>,
@@ -330,6 +381,23 @@ pub fn runtime_materialization_plan(
         })
         .collect();
 
+    let mut runtime_sources = manifest.materialization.runtime_sources.clone();
+    if runtime_sources.is_empty() {
+        if let (Some(path), Some(revision)) = (manifest.runtime_path.as_ref(), revision.as_ref()) {
+            runtime_sources.push(AgentRuntimeMaterializationSource {
+                id: "controller-runtime".to_string(),
+                locator: AgentRuntimeSourceLocator::LocalPath { path: path.clone() },
+                content_identity: revision.clone(),
+                destination_path: "runtime".to_string(),
+            });
+        }
+    }
+    let generation_identity = runtime_generation_identity(
+        &manifest.id,
+        &runtime_sources,
+        &manifest.materialization.preparation,
+    );
+
     AgentRuntimeMaterializationPlan {
         schema: AGENT_RUNTIME_MATERIALIZATION_PLAN_SCHEMA.to_string(),
         runtime_id: manifest.id.clone(),
@@ -347,6 +415,9 @@ pub fn runtime_materialization_plan(
         // materializer that verifies the selected object may report it current.
         freshness: AgentRuntimeFreshness::Unverifiable,
         runtime_path: manifest.runtime_path.clone(),
+        runtime_sources,
+        preparation: manifest.materialization.preparation.clone(),
+        generation_identity,
         source_roots,
         dependencies: manifest.materialization.dependencies.clone(),
         executable_requirements: manifest.materialization.executable_requirements.clone(),
@@ -354,6 +425,132 @@ pub fn runtime_materialization_plan(
         env_passthrough,
         workspace: manifest.materialization.workspace.clone(),
     }
+}
+
+/// Validate declarations before a controller hands them to Lab. This is kept in
+/// core so every producer and consumer agrees on the safe, portable shape.
+pub fn validate_runtime_materialization_plan(plan: &AgentRuntimeMaterializationPlan) -> Result<()> {
+    let mut source_ids = std::collections::BTreeSet::new();
+    let mut destinations = std::collections::BTreeSet::new();
+    for source in &plan.runtime_sources {
+        if source.id.trim().is_empty() || source.content_identity.trim().is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "runtime_sources",
+                "runtime source requires id and content_identity",
+                None,
+                None,
+            ));
+        }
+        if !source_ids.insert(&source.id) {
+            return Err(Error::validation_invalid_argument(
+                "runtime_sources.id",
+                "runtime source IDs must be unique",
+                Some(source.id.clone()),
+                None,
+            ));
+        }
+        if !is_immutable_revision(&source.content_identity) {
+            return Err(Error::validation_invalid_argument(
+                "runtime_sources.content_identity",
+                "runtime source content identity must be an immutable revision",
+                Some(source.content_identity.clone()),
+                None,
+            ));
+        }
+        validate_runtime_relative_path(
+            "runtime_sources.destination_path",
+            &source.destination_path,
+        )?;
+        if !destinations.insert(&source.destination_path) {
+            return Err(Error::validation_invalid_argument(
+                "runtime_sources.destination_path",
+                "runtime source destinations must be unique",
+                Some(source.destination_path.clone()),
+                None,
+            ));
+        }
+        match &source.locator {
+            AgentRuntimeSourceLocator::LocalPath { path } if Path::new(path).is_absolute() => {}
+            AgentRuntimeSourceLocator::LocalPath { .. } => {
+                return Err(Error::validation_invalid_argument(
+                    "runtime_sources.locator.path",
+                    "controller-local runtime source path must be absolute",
+                    None,
+                    None,
+                ))
+            }
+            AgentRuntimeSourceLocator::Git {
+                remote_url,
+                revision,
+            } => {
+                if remote_url.trim().is_empty()
+                    || remote_url.contains('@')
+                    || !is_immutable_revision(revision)
+                    || revision != &source.content_identity
+                {
+                    return Err(Error::validation_invalid_argument(
+                        "runtime_sources.locator",
+                        "runtime git source requires a sanitized remote and a revision matching its immutable content identity",
+                        None,
+                        None,
+                    ));
+                }
+            }
+        }
+    }
+    for action in &plan.preparation {
+        if action.argv.is_empty()
+            || action
+                .argv
+                .iter()
+                .any(|arg| arg.is_empty() || arg.contains('\0'))
+        {
+            return Err(Error::validation_invalid_argument(
+                "preparation.argv",
+                "runtime preparation requires a non-empty argv without NUL bytes",
+                None,
+                None,
+            ));
+        }
+        validate_runtime_relative_path("preparation.cwd", &action.cwd)?;
+        for output in &action.expected_outputs {
+            validate_runtime_relative_path("preparation.expected_outputs", output)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_runtime_relative_path(field: &str, value: &str) -> Result<()> {
+    let path = Path::new(value);
+    if value.trim().is_empty()
+        || path.is_absolute()
+        || path.components().any(|part| {
+            matches!(
+                part,
+                std::path::Component::ParentDir
+                    | std::path::Component::RootDir
+                    | std::path::Component::Prefix(_)
+            )
+        })
+    {
+        return Err(Error::validation_invalid_argument(
+            field,
+            "runtime materialization paths must be non-empty relative paths without traversal",
+            Some(value.to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn runtime_generation_identity(
+    runtime_id: &str,
+    sources: &[AgentRuntimeMaterializationSource],
+    preparation: &[AgentRuntimePreparationAction],
+) -> String {
+    use sha2::{Digest, Sha256};
+    let encoded = serde_json::to_vec(&(runtime_id, sources, preparation)).unwrap_or_default();
+    format!("sha256:{:x}", Sha256::digest(encoded))
 }
 
 fn runtime_source_revision(path: &Path) -> Option<String> {
@@ -729,4 +926,103 @@ fn agent_runtime_core_incompatible_diagnostic(
         extension_id: extension_id.map(str::to_string),
         path: path.map(str::to_string),
     })
+}
+
+#[cfg(test)]
+mod materialization_tests {
+    use super::*;
+
+    fn plan() -> AgentRuntimeMaterializationPlan {
+        AgentRuntimeMaterializationPlan {
+            schema: AGENT_RUNTIME_MATERIALIZATION_PLAN_SCHEMA.to_string(),
+            runtime_id: "runtime".to_string(),
+            selected_identity: Default::default(),
+            provider_id: "provider".to_string(),
+            source_selector: "test".to_string(),
+            source_revision: None,
+            freshness: Default::default(),
+            runtime_path: None,
+            runtime_sources: vec![AgentRuntimeMaterializationSource {
+                id: "source".to_string(),
+                locator: AgentRuntimeSourceLocator::LocalPath {
+                    path: "/tmp/runtime-source".to_string(),
+                },
+                content_identity: "0123456789abcdef0123456789abcdef01234567".to_string(),
+                destination_path: "runtime".to_string(),
+            }],
+            preparation: vec![AgentRuntimePreparationAction {
+                argv: vec!["build".to_string()],
+                cwd: "runtime".to_string(),
+                expected_outputs: vec!["runtime/bin/tool".to_string()],
+                runtime_identity: Some("tool@1".to_string()),
+            }],
+            generation_identity: "sha256:test".to_string(),
+            source_roots: Vec::new(),
+            dependencies: Vec::new(),
+            executable_requirements: Vec::new(),
+            readiness_checks: Vec::new(),
+            env_passthrough: Vec::new(),
+            workspace: None,
+        }
+    }
+
+    #[test]
+    fn runtime_materialization_contract_accepts_bounded_noop() {
+        assert!(validate_runtime_materialization_plan(&plan()).is_ok());
+    }
+
+    #[test]
+    fn runtime_materialization_contract_rejects_path_traversal_and_unsafe_argv() {
+        let mut invalid = plan();
+        invalid.runtime_sources[0].destination_path = "../shared".to_string();
+        assert!(validate_runtime_materialization_plan(&invalid).is_err());
+
+        let mut invalid = plan();
+        invalid.preparation[0].cwd = "/shared".to_string();
+        assert!(validate_runtime_materialization_plan(&invalid).is_err());
+
+        let mut invalid = plan();
+        invalid.preparation[0].argv = vec!["run\0bad".to_string()];
+        assert!(validate_runtime_materialization_plan(&invalid).is_err());
+    }
+
+    #[test]
+    fn runtime_materialization_contract_rejects_ambiguous_source_identity() {
+        let mut invalid = plan();
+        invalid
+            .runtime_sources
+            .push(invalid.runtime_sources[0].clone());
+        assert!(validate_runtime_materialization_plan(&invalid).is_err());
+
+        let mut invalid = plan();
+        invalid.runtime_sources[0].content_identity = "mutable".to_string();
+        assert!(validate_runtime_materialization_plan(&invalid).is_err());
+
+        let mut invalid = plan();
+        invalid.runtime_sources[0].locator = AgentRuntimeSourceLocator::Git {
+            remote_url: "https://example.test/runtime.git".to_string(),
+            revision: "ffffffffffffffffffffffffffffffffffffffff".to_string(),
+        };
+        assert!(validate_runtime_materialization_plan(&invalid).is_err());
+    }
+
+    #[test]
+    fn runtime_generation_identity_changes_with_source_revision() {
+        let first = plan();
+        let mut second = first.clone();
+        second.runtime_sources[0].content_identity =
+            "ffffffffffffffffffffffffffffffffffffffff".to_string();
+        assert_ne!(
+            runtime_generation_identity(
+                &first.runtime_id,
+                &first.runtime_sources,
+                &first.preparation
+            ),
+            runtime_generation_identity(
+                &second.runtime_id,
+                &second.runtime_sources,
+                &second.preparation
+            )
+        );
+    }
 }

--- a/crates/homeboy-core/src/observation/runs_service/mod.rs
+++ b/crates/homeboy-core/src/observation/runs_service/mod.rs
@@ -260,6 +260,7 @@ pub fn retain_terminal_runs(
                 continue;
             }
             let records = store.list_artifacts(run_id)?;
+            let run = store.get_run(run_id)?;
             let artifact_root = crate::artifacts::root()?;
             for row in artifacts.rows.iter().filter(|row| row.action == "remove") {
                 let artifact = records
@@ -269,6 +270,11 @@ pub fn retain_terminal_runs(
                         Error::internal_unexpected("retention artifact disappeared before deletion")
                     })?;
                 remove_persisted_artifact_record_bytes(artifact, &artifact_root)?;
+                if let Some(run) = run.as_ref() {
+                    runner_evidence::with_runner_evidence(|provider| {
+                        provider.retire_durable_result_owner(run, Some(&artifact.id))
+                    })?;
+                }
             }
         }
         for directory in &lifecycle_directories {
@@ -295,6 +301,13 @@ pub fn retain_terminal_runs(
             .filter(|run_id| !retained.contains(run_id))
             .cloned()
             .collect::<Vec<_>>();
+        for run_id in &deleted {
+            if let Some(run) = store.get_run(run_id)? {
+                runner_evidence::with_runner_evidence(|provider| {
+                    provider.retire_durable_result_owner(&run, None)
+                })?;
+            }
+        }
         store.delete_terminal_runs(&deleted)?;
     }
     Ok(TerminalRunRetentionOutcome {

--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -56,6 +56,17 @@ pub struct RemoteArtifactDownloadInfo {
 /// runner layer and registered at startup; core calls it without depending on
 /// runner behavior.
 pub trait RunnerEvidenceProvider: Send + Sync {
+    /// Release generation routing claims only after the durable observation
+    /// lifecycle has removed the corresponding run or artifact provenance.
+    /// Optional runner support keeps core retention generic and bounded.
+    fn retire_durable_result_owner(
+        &self,
+        _run: &RunRecord,
+        _artifact_id: Option<&str>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     /// Mirror the run from a connected runner, if one owns it.
     fn mirror_connected_runner_run(&self, run_id: &str) -> Result<Option<RunRecord>>;
 

--- a/crates/homeboy-lab-runner/src/evidence/provider.rs
+++ b/crates/homeboy-lab-runner/src/evidence/provider.rs
@@ -19,6 +19,33 @@ use homeboy_core::observation::RunRecord;
 pub struct RunnerEvidence;
 
 impl RunnerEvidenceProvider for RunnerEvidence {
+    fn retire_durable_result_owner(
+        &self,
+        run: &RunRecord,
+        artifact_id: Option<&str>,
+    ) -> Result<()> {
+        let runner_id = run
+            .metadata_json
+            .pointer("/lab_offload/runner_id")
+            .or_else(|| run.metadata_json.pointer("/lab/runner/id"))
+            .and_then(Value::as_str);
+        let Some(runner_id) = runner_id else {
+            return Ok(());
+        };
+        let session = super::super::connection::status(runner_id)
+            .ok()
+            .and_then(|report| report.session);
+        if let Some(artifact_id) = artifact_id {
+            super::super::generation_store::retire_artifact_owner(
+                runner_id,
+                session.as_ref(),
+                artifact_id,
+            )
+        } else {
+            super::super::generation_store::retire_run_owner(runner_id, session.as_ref(), &run.id)
+        }
+    }
+
     fn mirror_connected_runner_run(&self, run_id: &str) -> Result<Option<RunRecord>> {
         super::mirror::mirror_connected_runner_run(run_id)
     }

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -344,6 +344,14 @@ pub(super) fn exec_via_daemon(
         )?;
     }
     let artifacts = job.artifacts.clone();
+    if let Some(session) = accepted_session.as_ref() {
+        super::super::generation_store::record_job_artifacts(
+            &runner.id,
+            session,
+            &job_id,
+            artifacts.iter().map(|artifact| artifact.id.clone()),
+        )?;
+    }
     let mutation_artifacts = mutation_artifacts_from_job(&job, &result);
     if print_handoff_output {
         print_lab_offload_handoff(

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::paths;
 
+use crate::rolling_generation::RollingResultOwnerRetirement;
 use crate::{RollingGenerations, RunnerDaemonGenerationStatus, RunnerSession};
 
 /// The durable generation registry is scoped to one runner. Keep this wrapper
@@ -505,7 +506,7 @@ fn reconcile_with(
     let Some(generations) = read(runner_id, legacy)? else {
         return Ok(());
     };
-    let drained = generations
+    let zero_job_generations = generations
         .generations
         .iter()
         .filter_map(|(generation, entry)| {
@@ -516,7 +517,44 @@ fn reconcile_with(
             (operations.active_jobs(&session) == Some(0)).then_some((generation, session))
         })
         .collect::<Vec<_>>();
-    let retired = drained
+    // Settle authoritative zero-job observations under the registry lock. The
+    // endpoint stop remains outside this lock because it is remote I/O.
+    let stoppable = with_registry_lock(runner_id, || {
+        let Some(mut generations) = read_locked(runner_id, legacy)? else {
+            return Ok(Vec::new());
+        };
+        for (generation, _) in &zero_job_generations {
+            let draining = generations
+                .generations
+                .get(generation)
+                .is_some_and(|entry| entry.drain_state == crate::RollingDrainState::Draining);
+            if draining {
+                generations
+                    .generations
+                    .get_mut(generation)
+                    .expect("generation was checked")
+                    .active_jobs = 0;
+                generations
+                    .job_owners
+                    .retain(|_, owner| owner != generation);
+            }
+        }
+        let stoppable = zero_job_generations
+            .iter()
+            .filter_map(|(generation, _)| {
+                generations.generations.get(generation).and_then(|entry| {
+                    (entry.drain_state == crate::RollingDrainState::Draining
+                        && entry.active_jobs == 0
+                        && !generations.has_result_owners(generation))
+                    .then_some((generation.clone(), entry.endpoint.clone()))
+                })
+            })
+            .collect::<Vec<_>>();
+        write(runner_id, &generations)?;
+        Ok(stoppable)
+    })?;
+
+    let stopped = stoppable
         .into_iter()
         .filter_map(|(generation, session)| {
             if operations.stop(&session) {
@@ -533,13 +571,14 @@ fn reconcile_with(
         let Some(mut generations) = read_locked(runner_id, legacy)? else {
             return Ok(());
         };
-        for generation in &retired {
+        for generation in &stopped {
             if generations
                 .generations
                 .get(generation)
                 .is_some_and(|entry| {
                     entry.drain_state == crate::RollingDrainState::Draining
                         && entry.active_jobs == 0
+                        && !generations.has_result_owners(generation)
                 })
             {
                 generations.generations.remove(generation);
@@ -617,6 +656,66 @@ pub(crate) fn record_job_artifacts(
         }
         write(runner_id, &generations)
     })
+}
+
+/// Release a durable run's generation routing claim after terminal retention
+/// removes the run record. Reconciliation remains fail-closed and only stops a
+/// drained, zero-job endpoint after its final owner is gone.
+pub(crate) fn retire_run_owner(
+    runner_id: &str,
+    legacy: Option<&RunnerSession>,
+    run_id: &str,
+) -> Result<()> {
+    retire_result_owner(runner_id, legacy, RollingResultOwnerRetirement::Run(run_id))
+}
+
+/// Release one artifact routing claim after its owning lifecycle has consumed,
+/// finalized, or pruned the artifact.
+pub(crate) fn retire_artifact_owner(
+    runner_id: &str,
+    legacy: Option<&RunnerSession>,
+    artifact_id: &str,
+) -> Result<()> {
+    retire_result_owner(
+        runner_id,
+        legacy,
+        RollingResultOwnerRetirement::Artifact(artifact_id),
+    )
+}
+
+fn retire_result_owner(
+    runner_id: &str,
+    legacy: Option<&RunnerSession>,
+    retirement: RollingResultOwnerRetirement<'_>,
+) -> Result<()> {
+    with_registry_lock(runner_id, || {
+        let Some(mut generations) = read_locked(runner_id, legacy)? else {
+            return Ok(());
+        };
+        generations.retire_result_owner(retirement);
+        // Persist before network reconciliation; a restart can retry an unreachable
+        // endpoint without restoring an owner whose lifecycle was already removed.
+        write(runner_id, &generations)
+    })?;
+    reconcile(runner_id, legacy)
+}
+
+/// Reconcile a bounded page of authoritative retained result ids. This repairs
+/// stale registry claims after controller restart without guessing retention.
+pub(crate) fn reconcile_result_owners(
+    runner_id: &str,
+    legacy: Option<&RunnerSession>,
+    retained_run_ids: &std::collections::BTreeSet<String>,
+    retained_artifact_ids: &std::collections::BTreeSet<String>,
+) -> Result<()> {
+    with_registry_lock(runner_id, || {
+        let Some(mut generations) = read_locked(runner_id, legacy)? else {
+            return Ok(());
+        };
+        generations.reconcile_result_owners(retained_run_ids, retained_artifact_ids);
+        write(runner_id, &generations)
+    })?;
+    reconcile(runner_id, legacy)
 }
 
 pub(crate) fn activate(
@@ -1174,7 +1273,7 @@ mod tests {
     }
 
     #[test]
-    fn atomic_rewrites_keep_runner_identity_through_promotion_and_drain() {
+    fn draining_generation_keeps_result_routing_after_zero_job_reconciliation() {
         test_support::with_isolated_home(|_| {
             let a = session("lease-a", "daemon-a", Some(101));
             let b = session("lease-b", "daemon-b", Some(202));
@@ -1213,6 +1312,21 @@ mod tests {
             let drained = persisted_registry("runner-a");
             assert_eq!(drained["runner_id"], "runner-a");
             assert_eq!(drained["admission_owner"], "build-b");
+            assert!(drained["job_owners"].get("job-a").is_none());
+            assert_eq!(drained["run_owners"]["run-a"], "lease-a");
+            assert_eq!(drained["artifact_owners"]["artifact-a"], "lease-a");
+            assert_eq!(
+                endpoint_session("runner-a", None, Some("run-a"), None, Some(&b))
+                    .expect("route retained run"),
+                Some(a.clone())
+            );
+            assert_eq!(
+                endpoint_session("runner-a", None, None, Some("artifact-a"), Some(&b))
+                    .expect("route retained artifact"),
+                Some(a)
+            );
+            assert!(operations.stopped_leases.borrow().is_empty());
+            assert!(operations.terminated_pids.borrow().is_empty());
         });
     }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1275,21 +1275,6 @@ pub(crate) fn run_lab_offload_inner(
     }
 
     let capability_preflight: Option<RunnerCapabilityPreflight> = capability_plan.map(Into::into);
-    let admission = direct_daemon_admission_coordinates(
-        runner_id,
-        &selection.mode,
-        runner_status.session.as_ref(),
-    )?
-    .map(|(local_url, expected_daemon_lease_id)| {
-        reserve_daemon_admission(
-            runner_id,
-            local_url,
-            &redact_argv_shell_display(&command_prefix.argv),
-            expected_daemon_lease_id,
-            pre_acceptance_run_id.as_deref(),
-        )
-    })
-    .transpose()?;
     let workspace_sync_timer = overhead.phase(LabOffloadPhase::WorkspaceSync);
     let workspace_stage = match prepare_lab_offload_workspace_stage(
         &request,
@@ -1338,12 +1323,12 @@ pub(crate) fn run_lab_offload_inner(
         workspace_mapping,
         path_materialization_plan,
         source_snapshot,
-        remapped_args,
+        mut remapped_args,
         agent_task_run_id,
         runner_required_extensions,
         accepted_extension_settings,
-        command,
-        remote_command,
+        mut command,
+        mut remote_command,
         remote_output_file,
         rig_component_path_overrides,
         dependency_cache_saves,
@@ -1414,6 +1399,60 @@ pub(crate) fn run_lab_offload_inner(
     let extension_runtime_home =
         (!extension_overlays.is_empty()).then(|| format!("{extension_runtime_root}/home"));
 
+    // Runtime sources have now been synchronized to the runner, but no daemon
+    // admission exists yet. Materialization can therefore fail atomically
+    // without creating a reserved or submitted job.
+    let workspace_remaps = workspace_mapping
+        .iter()
+        .map(|entry| {
+            (
+                entry.local_path().to_string(),
+                entry.remote_path().to_string(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut runtime_operations = RunnerRuntimeMaterializerOperations::new(runner.clone());
+    let resolved_runtime = resolve_lab_agent_runtime(
+        &mut runtime_operations,
+        &runner,
+        &remapped_args,
+        &workspace_remaps,
+        agent_task_run_id.as_deref().unwrap_or("lab-offload"),
+    )?;
+    let runtime_generation = resolved_runtime
+        .as_ref()
+        .map(|resolved| resolved.generation.clone());
+    let runtime_env = resolved_runtime
+        .as_ref()
+        .map(|resolved| resolved.env.clone())
+        .unwrap_or_default();
+    if let Some(resolved) = resolved_runtime {
+        let prior_args = remapped_args.clone();
+        remapped_args = resolved.args;
+        // The policy is conventionally encoded as
+        // `--resolved-provider-policy=<json>`, not as bare JSON. Replace every
+        // changed argument so both direct and reverse daemon transports execute
+        // the runner-local generation rather than the controller declaration.
+        rewrite_dispatched_runtime_args(
+            &prior_args,
+            &remapped_args,
+            &mut command,
+            &mut remote_command,
+        );
+        plan = with_step(
+            plan,
+            PlanStep::ready(
+                "lab.materialize_agent_runtime",
+                "lab.materialize_agent_runtime",
+            )
+            .inputs(PlanValues::new().json("generation", &runtime_generation))
+            .build(),
+        );
+    }
+    let runtime_evidence = runtime_generation
+        .as_ref()
+        .map(|generation| runtime_execution_evidence(generation, &remapped_args, runner_id))
+        .transpose()?;
     if let Some(run_id) = agent_task_run_id.as_deref() {
         agent_task_lifecycle::record_lab_offload_phase(
             run_id,
@@ -1543,8 +1582,110 @@ pub(crate) fn run_lab_offload_inner(
     for (name, value) in &runtime_overlay_env {
         env_delta.insert(name.clone(), value.clone());
     }
+    // These are job-scoped provider inputs. They never update the runner's
+    // global environment or a previously admitted generation.
+    for (name, value) in &runtime_env {
+        env_delta.insert(name.clone(), value.clone());
+    }
     let env_delta_before_secret_handoff = env_delta.clone();
     lab_metadata["runtime_overlays"] = runtime_overlay_metadata;
+    lab_metadata["resolved_agent_runtime_generation"] =
+        serde_json::to_value(&runtime_generation).unwrap_or(serde_json::json!(null));
+    lab_metadata["runtime_evidence"] =
+        serde_json::to_value(&runtime_evidence).unwrap_or(serde_json::json!(null));
+    let secret_env_handoff = build_lab_secret_env_handoff_plan(
+        &contract.secret_env_sources,
+        &changed_since_preflight.args,
+        env_delta,
+    )?;
+    lab_metadata["secret_env_handoff"] = secret_env_handoff.diagnostics.clone();
+    let mut lab_runner_workload = build_lab_runner_workload_for_dispatched_command(
+        LabRunnerWorkloadBuildInput {
+            plan: &plan,
+            command: &contract,
+            capture_patch: request.capture_patch,
+            mutation_flag: request.mutation_flag,
+            allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
+            runner_id,
+            runner_mode: status_tunnel_mode(&runner_status).metadata_value(),
+            assignment_source: selection.source.metadata_value(),
+            status: "offloaded",
+            remote_workspace: Some(&remote_cwd),
+            fallback_reason: None,
+            workspace_mapping_ref: path_materialization_plan.mapping_ref(),
+            proof_id: lab_metadata
+                .get("proof")
+                .and_then(|proof| proof.get("id"))
+                .and_then(|id| id.as_str()),
+        },
+        &command,
+    );
+    lab_runner_workload.agent_task =
+        lab_runner_workload_agent_task_from_command(&command, agent_task_run_id.as_deref());
+    lab_runner_workload.required_extensions = runner_required_extensions.clone();
+    lab_runner_workload.required_secrets.secret_env_plan =
+        secret_env_handoff.secret_env_plan.clone();
+    lab_metadata["runner_workload"] =
+        serde_json::to_value(&lab_runner_workload).unwrap_or(serde_json::json!(null));
+    // Preserve the evidence with the serialized workload envelope as well as
+    // Lab metadata, so direct and reverse runner evidence retain the exact
+    // dispatch identity without widening the stable workload contract.
+    lab_metadata["runner_workload"]["runtime_evidence"] =
+        serde_json::to_value(&runtime_evidence).unwrap_or(serde_json::json!(null));
+    lab_metadata["rig_component_path_env"] = rig_component_path_env;
+    lab_metadata["declared_dependency_paths_env"] = declared_dependency_paths_env;
+    lab_metadata["rig_component_path_overrides"] =
+        rig_component_path_overrides_metadata(&rig_component_path_overrides);
+    lab_metadata["settings_env"] =
+        settings_env_diagnostics(&remapped_args, &secret_env_handoff.env_delta);
+    lab_metadata["runner_homeboy"] = runner_homeboy.clone();
+    lab_metadata["source_checkout"] = source_checkout.clone();
+    lab_metadata["job_scoped_overrides"] = job_scoped_overrides_metadata(&request.job_overrides);
+    lab_metadata["rig_sync"] = serde_json::json!({
+        "step": "lab.sync_rigs",
+        "synced_count": synced_rigs.len(),
+        "source_snapshot_remote_path": remote_cwd,
+        "registry_root": rig_registry_root,
+        "rigs": synced_rigs,
+        "selected_before_remote_settings_resolution": true,
+    });
+    lab_metadata["workspace_cleanliness"] = serde_json::json!({
+        "schema": "homeboy/lab-workspace-cleanliness/v1",
+        "mode": sync_mode.label(),
+        "remote_workspace": remote_cwd,
+        "status": synced.workspace_cleanliness,
+        "allow_dirty_lab_workspace": request.allow_dirty_lab_workspace,
+    });
+    attach_lab_offload_overhead(&mut lab_metadata, &overhead);
+    lab_metadata["lab_host_telemetry"] = host_telemetry.before_metadata();
+    let secret_env_delta = secret_env_handoff
+        .env_delta
+        .iter()
+        .filter(|(name, value)| env_delta_before_secret_handoff.get(*name) != Some(*value))
+        .map(|(name, value)| (name.clone(), value.clone()))
+        .collect::<std::collections::HashMap<_, _>>();
+    let path_remaps = path_remaps_from_materialization_plan(
+        &path_materialization_plan,
+        Some((&source_path, &remote_cwd)),
+    );
+    // Reserve only after every local/pre-dispatch preparation, including runtime
+    // publication, succeeded. The reservation's Drop implementation releases
+    // the lease if the subsequent provider preflight rejects the handoff.
+    let admission = direct_daemon_admission_coordinates(
+        runner_id,
+        &selection.mode,
+        runner_status.session.as_ref(),
+    )?
+    .map(|(local_url, expected_daemon_lease_id)| {
+        reserve_daemon_admission(
+            runner_id,
+            local_url,
+            &redact_argv_shell_display(&command_prefix.argv),
+            expected_daemon_lease_id,
+            agent_task_run_id.as_deref(),
+        )
+    })
+    .transpose()?;
     lab_metadata["execution_bundle"] = serde_json::json!({
         "schema": crate::execution_bundle::LAB_EXECUTION_BUNDLE_SCHEMA,
         "binary": {
@@ -1583,84 +1724,6 @@ pub(crate) fn run_lab_offload_inner(
             },
         },
     });
-    let secret_env_handoff = build_lab_secret_env_handoff_plan(
-        &contract.secret_env_sources,
-        &changed_since_preflight.args,
-        env_delta,
-    )?;
-    lab_metadata["secret_env_handoff"] = secret_env_handoff.diagnostics.clone();
-    let mut lab_runner_workload = build_lab_runner_workload_for_dispatched_command(
-        LabRunnerWorkloadBuildInput {
-            plan: &plan,
-            command: &contract,
-            capture_patch: request.capture_patch,
-            mutation_flag: request.mutation_flag,
-            allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
-            runner_id,
-            runner_mode: status_tunnel_mode(&runner_status).metadata_value(),
-            assignment_source: selection.source.metadata_value(),
-            status: "offloaded",
-            remote_workspace: Some(&remote_cwd),
-            fallback_reason: None,
-            workspace_mapping_ref: path_materialization_plan.mapping_ref(),
-            proof_id: lab_metadata
-                .get("proof")
-                .and_then(|proof| proof.get("id"))
-                .and_then(|id| id.as_str()),
-        },
-        &command,
-    );
-    lab_runner_workload.agent_task =
-        lab_runner_workload_agent_task_from_command(&command, agent_task_run_id.as_deref());
-    lab_runner_workload.required_extensions = runner_required_extensions.clone();
-    lab_runner_workload.required_secrets.secret_env_plan =
-        secret_env_handoff.secret_env_plan.clone();
-    lab_metadata["runner_workload"] =
-        serde_json::to_value(&lab_runner_workload).unwrap_or(serde_json::json!(null));
-    lab_metadata["rig_component_path_env"] = rig_component_path_env;
-    lab_metadata["declared_dependency_paths_env"] = declared_dependency_paths_env;
-    lab_metadata["rig_component_path_overrides"] =
-        rig_component_path_overrides_metadata(&rig_component_path_overrides);
-    lab_metadata["settings_env"] =
-        settings_env_diagnostics(&remapped_args, &secret_env_handoff.env_delta);
-    lab_metadata["runner_homeboy"] = runner_homeboy.clone();
-    if let Some(admission) = admission.as_ref() {
-        lab_metadata["admission_reservation"] = serde_json::json!({
-            "job_id": admission.job_id(),
-            "daemon_lease_id": admission.daemon_lease_id,
-            "status": "reserved",
-            "release_policy": "best_effort_on_context_exit_after_terminal_or_detached_handoff",
-        });
-    }
-    lab_metadata["source_checkout"] = source_checkout.clone();
-    lab_metadata["job_scoped_overrides"] = job_scoped_overrides_metadata(&request.job_overrides);
-    lab_metadata["rig_sync"] = serde_json::json!({
-        "step": "lab.sync_rigs",
-        "synced_count": synced_rigs.len(),
-        "source_snapshot_remote_path": remote_cwd,
-        "registry_root": rig_registry_root,
-        "rigs": synced_rigs,
-        "selected_before_remote_settings_resolution": true,
-    });
-    lab_metadata["workspace_cleanliness"] = serde_json::json!({
-        "schema": "homeboy/lab-workspace-cleanliness/v1",
-        "mode": sync_mode.label(),
-        "remote_workspace": remote_cwd,
-        "status": synced.workspace_cleanliness,
-        "allow_dirty_lab_workspace": request.allow_dirty_lab_workspace,
-    });
-    attach_lab_offload_overhead(&mut lab_metadata, &overhead);
-    lab_metadata["lab_host_telemetry"] = host_telemetry.before_metadata();
-    let secret_env_delta = secret_env_handoff
-        .env_delta
-        .iter()
-        .filter(|(name, value)| env_delta_before_secret_handoff.get(*name) != Some(*value))
-        .map(|(name, value)| (name.clone(), value.clone()))
-        .collect::<std::collections::HashMap<_, _>>();
-    let path_remaps = path_remaps_from_materialization_plan(
-        &path_materialization_plan,
-        Some((&source_path, &remote_cwd)),
-    );
     exec_lab_context(LabDispatchExecutionContext {
         request: &request,
         selection: &selection,
@@ -1718,6 +1781,26 @@ pub(crate) fn run_lab_offload_inner(
         print_handoff: true,
         detach_after_handoff: request.detach_after_handoff,
     })
+}
+
+/// Keep the generated direct command and the reverse-transport command in
+/// lockstep when resolving a controller policy into a runner generation.
+fn rewrite_dispatched_runtime_args(
+    prior_args: &[String],
+    resolved_args: &[String],
+    command: &mut [String],
+    remote_command: &mut [String],
+) {
+    for (prior, resolved) in prior_args.iter().zip(resolved_args) {
+        if prior == resolved {
+            continue;
+        }
+        for arg in command.iter_mut().chain(remote_command.iter_mut()) {
+            if *arg == *prior {
+                *arg = resolved.clone();
+            }
+        }
+    }
 }
 
 fn direct_daemon_admission_coordinates<'a>(
@@ -2066,6 +2149,25 @@ mod tests {
         for handle in handles {
             handle.join().expect("rig job");
         }
+    }
+
+    #[test]
+    fn resolved_runtime_policy_rewrites_direct_and_reverse_transport_commands() {
+        let controller_policy =
+            "--resolved-provider-policy={\"runtime_identity\":{\"runtime_path\":\"/controller/runtime\"}}"
+                .to_string();
+        let runner_policy =
+            "--resolved-provider-policy={\"runtime_identity\":{\"runtime_path\":\"/runner/generation/runtime\"}}"
+                .to_string();
+        let prior = vec!["agent-task".to_string(), controller_policy.clone()];
+        let resolved = vec!["agent-task".to_string(), runner_policy.clone()];
+        let mut direct = vec!["homeboy".to_string(), controller_policy.clone()];
+        let mut reverse = vec!["homeboy".to_string(), controller_policy];
+
+        rewrite_dispatched_runtime_args(&prior, &resolved, &mut direct, &mut reverse);
+
+        assert_eq!(direct[1], runner_policy);
+        assert_eq!(reverse[1], runner_policy);
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab/offload/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/mod.rs
@@ -117,6 +117,9 @@ use super::super::{
     RunnerWorkspaceApplyOutput, RunnerWorkspaceOutputPaths, RunnerWorkspaceSyncMode,
     RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput, WorkspaceCleanupPolicy,
 };
+use crate::runtime_materializer::{
+    resolve_lab_agent_runtime, runtime_execution_evidence, RunnerRuntimeMaterializerOperations,
+};
 
 #[cfg(test)]
 pub(super) use inner::accepted_runner_job_id_with;

--- a/crates/homeboy-lab-runner/src/lab/provider_preflight.rs
+++ b/crates/homeboy-lab-runner/src/lab/provider_preflight.rs
@@ -49,7 +49,7 @@ pub(super) fn preflight_agent_task_provider_on_runner(
         return Ok(());
     };
     if let Some(identity) = selection.runtime_identity.as_ref() {
-        return validate_controller_runtime_identity(identity, &selection);
+        validate_controller_runtime_identity(identity, &selection)?;
     }
 
     let mut command = command_prefix.to_vec();
@@ -129,8 +129,15 @@ pub(super) fn preflight_agent_task_provider_on_runner(
     // (`resolve_provider_for_backend`) that execution-time selection uses. This
     // guarantees discovery and preflight can never disagree about whether a
     // listed provider is selectable for the requested backend/selector.
-    let mut runner_unavailable_reason =
-        runner_provider_unavailable_reason(&runner_providers, &selection);
+    let mut runner_unavailable_reason = selection
+        .runtime_identity
+        .as_ref()
+        .and_then(|identity| {
+            (!resolved_materialized_runtime(identity))
+                .then(|| exact_runtime_requirement_reason(&runner_providers, identity))
+                .flatten()
+        })
+        .or_else(|| runner_provider_unavailable_reason(&runner_providers, &selection));
     let mut refresh_result = None;
 
     if local_available
@@ -160,8 +167,15 @@ pub(super) fn preflight_agent_task_provider_on_runner(
             )?;
             if probe.exit_code == 0 {
                 if let Ok(providers) = parse_agent_task_providers_output(&probe.stdout) {
-                    runner_unavailable_reason =
-                        runner_provider_unavailable_reason(&providers, &selection);
+                    runner_unavailable_reason = selection
+                        .runtime_identity
+                        .as_ref()
+                        .and_then(|identity| {
+                            (!resolved_materialized_runtime(identity))
+                                .then(|| exact_runtime_requirement_reason(&providers, identity))
+                                .flatten()
+                        })
+                        .or_else(|| runner_provider_unavailable_reason(&providers, &selection));
                 }
             }
         }
@@ -182,6 +196,59 @@ pub(super) fn preflight_agent_task_provider_on_runner(
     }
 
     Ok(())
+}
+
+/// A v2 plan that Lab has rewritten to its immutable generation is already
+/// source-revision validated by the materializer. Requiring discovery to
+/// advertise that new path would incorrectly reject the job-scoped provider
+/// copy; legacy plans retain the exact advertised-runtime requirement.
+fn resolved_materialized_runtime(
+    identity: &homeboy_core::agent_task_config::ResolvedAgentTaskRuntimeIdentity,
+) -> bool {
+    let Ok(plan) = serde_json::from_value::<
+        homeboy_core::agent_runtime_manifest::AgentRuntimeMaterializationPlan,
+    >(identity.materialization_plan.clone()) else {
+        return false;
+    };
+    plan.schema == "homeboy/agent-runtime-materialization-plan/v2"
+        && plan.runtime_path.is_some()
+        && plan.source_revision.as_deref() == Some(identity.source_revision.as_str())
+}
+
+/// A controller pin is only compatible when the runner advertises the same
+/// provider and immutable materialization revision. Provider availability alone
+/// cannot prove that a runner will execute the controller-selected runtime.
+fn exact_runtime_requirement_reason(
+    providers: &[AgentTaskExecutorProvider],
+    identity: &homeboy_core::agent_task_config::ResolvedAgentTaskRuntimeIdentity,
+) -> Option<String> {
+    let Some(provider) = providers
+        .iter()
+        .find(|provider| provider.id == identity.provider_id)
+    else {
+        return Some(format!(
+            "runner does not advertise controller-selected provider `{}`",
+            identity.provider_id
+        ));
+    };
+    let Some(plan) = provider.extra.get("runtime_materialization_plan") else {
+        return Some(format!(
+            "runner provider `{}` has no runtime materialization declaration; it cannot prove the required runtime revision `{}`",
+            identity.provider_id, identity.source_revision
+        ));
+    };
+    let runner_revision = plan
+        .get("source_revision")
+        .and_then(serde_json::Value::as_str);
+    if runner_revision == Some(identity.source_revision.as_str()) {
+        return None;
+    }
+    Some(format!(
+        "runner provider `{}` does not advertise required runtime revision `{}` (advertised `{}`); materialize the controller-selected runtime before retrying",
+        identity.provider_id,
+        identity.source_revision,
+        runner_revision.unwrap_or("missing")
+    ))
 }
 
 /// Resolve the requested backend/selector against the runner-reported provider
@@ -463,6 +530,49 @@ fn validate_controller_runtime_identity(
             )),
             None,
         ));
+    }
+    // Older controller policies did not carry the v2 declaration. They remain
+    // usable only through the exact runner-advertised revision check above.
+    let Some(plan) = serde_json::from_value::<
+        homeboy_core::agent_runtime_manifest::AgentRuntimeMaterializationPlan,
+    >(identity.materialization_plan.clone())
+    .ok() else {
+        return Ok(());
+    };
+    if plan.runtime_sources.is_empty() {
+        return Ok(());
+    }
+    homeboy_core::agent_runtime_manifest::validate_runtime_materialization_plan(&plan)?;
+    // A published v2 generation has already verified and rewritten its source
+    // locators on the selected runner. Re-checking those paths on the
+    // controller would both be wrong and reintroduce controller-path coupling.
+    if plan.runtime_path.is_some() {
+        return Ok(());
+    }
+    for source in &plan.runtime_sources {
+        if let homeboy_core::agent_runtime_manifest::AgentRuntimeSourceLocator::LocalPath { path } =
+            &source.locator
+        {
+            let source_path = Path::new(path);
+            if !source_path.is_dir() {
+                return Err(Error::validation_invalid_argument(
+                    "resolved-provider-policy",
+                    "controller runtime source is unavailable before Lab submission",
+                    Some(path.clone()),
+                    None,
+                ));
+            }
+            if homeboy_core::git::head_sha(source_path).as_deref()
+                != Some(source.content_identity.as_str())
+            {
+                return Err(Error::validation_invalid_argument(
+                    "resolved-provider-policy",
+                    "controller runtime source no longer matches its declared content identity",
+                    Some(source.id.clone()),
+                    None,
+                ));
+            }
+        }
     }
     Ok(())
 }
@@ -890,6 +1000,41 @@ mod tests {
         assert!(error
             .message
             .contains("does not match the requested provider"));
+    }
+
+    #[test]
+    fn exact_runtime_requirement_accepts_only_the_controller_revision() {
+        let identity = homeboy_core::agent_task_config::ResolvedAgentTaskRuntimeIdentity {
+            runtime_id: "runtime".to_string(),
+            provider_id: "provider".to_string(),
+            source_selector: "extension:provider".to_string(),
+            source_revision: "0123456789abcdef0123456789abcdef01234567".to_string(),
+            freshness: homeboy_core::agent_task_config::ResolvedAgentTaskRuntimeFreshness::Pinned,
+            provider: serde_json::Value::Null,
+            materialization_plan: serde_json::Value::Null,
+        };
+        let mut provider: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+            "id": "provider",
+            "backend": "test",
+            "argv": ["provider"],
+        }))
+        .expect("provider");
+        provider.extra.insert(
+            "runtime_materialization_plan".to_string(),
+            serde_json::json!({ "source_revision": identity.source_revision }),
+        );
+        assert_eq!(
+            exact_runtime_requirement_reason(&[provider.clone()], &identity),
+            None
+        );
+
+        provider.extra.insert(
+            "runtime_materialization_plan".to_string(),
+            serde_json::json!({ "source_revision": "ffffffffffffffffffffffffffffffffffffffff" }),
+        );
+        let error = exact_runtime_requirement_reason(&[provider], &identity)
+            .expect("stale runner runtime rejects before submission");
+        assert!(error.contains("controller-selected runtime"));
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -75,6 +75,7 @@ mod resource_metrics;
 mod rig_materialization;
 mod rolling_generation;
 mod runtime_materialization_status;
+pub mod runtime_materializer;
 mod runtime_overlay_freshness;
 mod session;
 mod source_materialization;

--- a/crates/homeboy-lab-runner/src/rolling_generation.rs
+++ b/crates/homeboy-lab-runner/src/rolling_generation.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
@@ -40,6 +40,15 @@ pub enum RollingDrainState {
 pub enum RollingStart {
     Start,
     AlreadyActive,
+}
+
+/// A durable result lifecycle has explicitly released its routing claim.
+/// These events are intentionally separate from job completion: terminal jobs
+/// can retain their producing generation until run and artifact retention ends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RollingResultOwnerRetirement<'a> {
+    Run(&'a str),
+    Artifact(&'a str),
 }
 
 impl<E> RollingGenerations<E> {
@@ -144,6 +153,36 @@ impl<E> RollingGenerations<E> {
         true
     }
 
+    /// Release one durable result owner only after its owning lifecycle has
+    /// consumed, finalized, or pruned it. The registry reconciler decides whether
+    /// the now-unowned endpoint can safely stop and retire.
+    pub fn retire_result_owner(&mut self, retirement: RollingResultOwnerRetirement<'_>) -> bool {
+        let removed = match retirement {
+            RollingResultOwnerRetirement::Run(id) => self.run_owners.remove(id),
+            RollingResultOwnerRetirement::Artifact(id) => self.artifact_owners.remove(id),
+        };
+        removed.is_some()
+    }
+
+    /// Bounded stale-retention reconciliation only removes result owners whose
+    /// durable records are absent from the supplied authoritative retention set.
+    /// A caller controls the bound by passing at most one retention page.
+    pub fn reconcile_result_owners(
+        &mut self,
+        retained_run_ids: &BTreeSet<String>,
+        retained_artifact_ids: &BTreeSet<String>,
+    ) -> bool {
+        let runs_before = self.run_owners.len();
+        let artifacts_before = self.artifact_owners.len();
+        self.run_owners
+            .retain(|id, _| retained_run_ids.contains(id));
+        self.artifact_owners
+            .retain(|id, _| retained_artifact_ids.contains(id));
+        let released =
+            runs_before != self.run_owners.len() || artifacts_before != self.artifact_owners.len();
+        released
+    }
+
     pub fn endpoint_owner(
         &self,
         job_id: Option<&str>,
@@ -154,6 +193,16 @@ impl<E> RollingGenerations<E> {
             .and_then(|id| self.job_owner(id))
             .or_else(|| run_id.and_then(|id| self.run_owners.get(id).map(String::as_str)))
             .or_else(|| artifact_id.and_then(|id| self.artifact_owners.get(id).map(String::as_str)))
+    }
+
+    /// A drained daemon remains routable while durable run or artifact evidence
+    /// still identifies it as the producing generation.
+    pub fn has_result_owners(&self, generation: &str) -> bool {
+        self.run_owners.values().any(|owner| owner == generation)
+            || self
+                .artifact_owners
+                .values()
+                .any(|owner| owner == generation)
     }
 
     /// Returns true if the completion retired a drained generation.
@@ -194,10 +243,17 @@ impl<E> RollingGenerations<E> {
 
     fn retire_drained(&mut self) -> bool {
         let before = self.generations.len();
+        let admission_owner = self.admission_owner.clone();
+        let result_owners = self
+            .run_owners
+            .values()
+            .chain(self.artifact_owners.values())
+            .collect::<BTreeSet<_>>();
         self.generations.retain(|generation, entry| {
-            generation == &self.admission_owner
+            generation == &admission_owner
                 || entry.drain_state != RollingDrainState::Draining
                 || entry.active_jobs != 0
+                || result_owners.contains(generation)
         });
         self.generations.len() != before
     }
@@ -314,6 +370,43 @@ mod tests {
             restored.endpoint_owner(None, None, Some("artifact-a")),
             Some("A")
         );
+    }
+
+    #[test]
+    fn result_owners_retain_until_each_explicit_lifecycle_retirement() {
+        let mut generations = RollingGenerations::new("A", "endpoint-a");
+        generations.admit_job("job-a");
+        assert!(generations.record_run("job-a", "run-a"));
+        assert!(generations.record_artifact("job-a", "artifact-a"));
+        generations.begin("B", "endpoint-b");
+        generations.activate("B");
+        assert!(!generations.complete_job("job-a"));
+        assert!(generations.generations.contains_key("A"));
+
+        assert!(generations.retire_result_owner(RollingResultOwnerRetirement::Run("run-a")));
+        assert!(generations.generations.contains_key("A"));
+        assert!(
+            generations.retire_result_owner(RollingResultOwnerRetirement::Artifact("artifact-a"))
+        );
+        assert!(generations.generations.contains_key("A"));
+    }
+
+    #[test]
+    fn bounded_retention_reconciliation_releases_only_missing_owners() {
+        let mut generations = RollingGenerations::new("A", "endpoint-a");
+        generations.admit_job("job-a");
+        assert!(generations.record_run("job-a", "run-a"));
+        assert!(generations.record_artifact("job-a", "artifact-a"));
+        generations.begin("B", "endpoint-b");
+        generations.activate("B");
+        assert!(!generations.complete_job("job-a"));
+
+        assert!(generations
+            .reconcile_result_owners(&BTreeSet::from(["run-a".to_string()]), &BTreeSet::new(),));
+        assert!(generations.artifact_owners.is_empty());
+        assert!(generations.generations.contains_key("A"));
+        assert!(generations.reconcile_result_owners(&BTreeSet::new(), &BTreeSet::new()));
+        assert!(generations.generations.contains_key("A"));
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/runtime_materializer.rs
+++ b/crates/homeboy-lab-runner/src/runtime_materializer.rs
@@ -1,0 +1,1530 @@
+//! Isolated, content-addressed agent-runtime generation materialization.
+//!
+//! This module deliberately does not select or offload a provider. Its caller
+//! supplies an already validated v2 plan and consumes the resolved generation.
+
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use serde::{Deserialize, Serialize};
+
+use homeboy_agents::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy;
+use homeboy_agents::agent_tasks::provider::AgentTaskExecutorProvider;
+use homeboy_core::agent_runtime_manifest::{
+    validate_runtime_materialization_plan, AgentRuntimeMaterializationPlan,
+    AgentRuntimeSourceLocator,
+};
+use homeboy_core::error::{Error, Result};
+
+use crate::{copy_snapshot_to_directory, exec, Runner, RunnerExecOptions, RunnerKind};
+
+const RECORD_FILE: &str = ".homeboy-agent-runtime-generation.json";
+const STAGING_SUFFIX: &str = ".staging";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedAgentRuntimeGeneration {
+    pub generation_identity: String,
+    pub content_identity: String,
+    pub immutable_root: String,
+    pub runtime_path: String,
+    pub provider_id: String,
+    pub requested_runtime_id: String,
+    pub requested_source_revision: Option<String>,
+    pub resolved_source_identities: Vec<ResolvedAgentRuntimeSourceIdentity>,
+    pub publication: AgentRuntimeGenerationPublication,
+    pub cleanup: AgentRuntimeGenerationCleanup,
+}
+
+/// Serializable, versioned proof of the runtime identity at each handoff.
+/// `executed` is derived from the rewritten dispatch argument, never from the
+/// original controller declaration, so it proves direct and reverse paths use
+/// the same immutable generation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentRuntimeExecutionEvidence {
+    pub schema: String,
+    pub requested: AgentRuntimeEvidenceIdentity,
+    pub resolved: AgentRuntimeEvidenceIdentity,
+    pub executed: AgentRuntimeEvidenceIdentity,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentRuntimeEvidenceIdentity {
+    pub runtime_id: String,
+    pub provider_id: String,
+    pub source_revision: Option<String>,
+    pub content_identity: String,
+    pub build_identity: String,
+    pub runtime_path: String,
+    pub generation: String,
+    pub admission: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedAgentRuntimeSourceIdentity {
+    pub id: String,
+    pub requested_content_identity: String,
+    pub resolved_content_identity: String,
+    pub destination_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRuntimeGenerationPublication {
+    Reused,
+    Published,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRuntimeGenerationCleanup {
+    Immutable,
+    StagingRemoved,
+}
+
+/// The only runtime mutation allowed at Lab handoff: a copy of the
+/// controller-selected provider, pointed at the immutable generation for this
+/// job. The runner's discovered provider and every active generation remain
+/// untouched.
+#[derive(Debug, Clone)]
+pub(crate) struct LabResolvedAgentRuntime {
+    pub(crate) args: Vec<String>,
+    pub(crate) env: Vec<(String, String)>,
+    pub(crate) generation: ResolvedAgentRuntimeGeneration,
+}
+
+/// Resolve a v2 controller runtime declaration after its source workspaces have
+/// reached the runner. Older declarations deliberately return `None`: their
+/// caller retains the exact advertised-runtime preflight contract.
+pub(crate) fn resolve_lab_agent_runtime(
+    operations: &mut impl AgentRuntimeMaterializerOperations,
+    runner: &Runner,
+    args: &[String],
+    workspace_remaps: &[(String, String)],
+    job_or_run_id: &str,
+) -> Result<Option<LabResolvedAgentRuntime>> {
+    let Some((policy_index, raw_policy)) = resolved_provider_policy_arg(args) else {
+        return Ok(None);
+    };
+    let mut policy: ResolvedAgentTaskProviderPolicy =
+        serde_json::from_str(raw_policy).map_err(|error| {
+            Error::validation_invalid_argument(
+                "resolved-provider-policy",
+                "Lab received an invalid controller provider policy",
+                Some(error.to_string()),
+                None,
+            )
+        })?;
+    let Some(identity) = policy.runtime_identity.as_mut() else {
+        return Ok(None);
+    };
+    let mut plan: AgentRuntimeMaterializationPlan =
+        match serde_json::from_value::<AgentRuntimeMaterializationPlan>(
+            identity.materialization_plan.clone(),
+        ) {
+            Ok(plan)
+                if plan.schema == "homeboy/agent-runtime-materialization-plan/v2"
+                    && !plan.runtime_sources.is_empty() =>
+            {
+                plan
+            }
+            _ => return Ok(None),
+        };
+    // Runtime sources are controller-owned immutable inputs, not workspace
+    // aliases. In particular, a reverse runner must not receive a controller
+    // path merely because the normal command workspace was synchronized.
+    let _ = workspace_remaps;
+    let generation =
+        materialize_agent_runtime_generation(operations, &plan, runner, job_or_run_id)?;
+    let mut provider: AgentTaskExecutorProvider = serde_json::from_value(identity.provider.clone())
+        .map_err(|error| {
+            Error::validation_invalid_argument(
+                "resolved-provider-policy",
+                "Lab received an invalid controller-selected provider",
+                Some(error.to_string()),
+                None,
+            )
+        })?;
+    if provider.id != identity.provider_id || provider.id != generation.provider_id {
+        return Err(Error::validation_invalid_argument(
+            "resolved-provider-policy",
+            "materialized runtime provider does not match the controller-selected provider",
+            Some(generation.provider_id.clone()),
+            None,
+        ));
+    }
+    provider.runtime_path = Some(generation.runtime_path.clone());
+    identity.provider = serde_json::to_value(provider).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize resolved Lab provider".to_string()),
+        )
+    })?;
+    plan.runtime_path = Some(generation.runtime_path.clone());
+    // The policy crosses the runner boundary after this point. Replace every
+    // controller locator with its published runner generation path so reverse
+    // submission can neither observe nor accidentally reuse controller paths.
+    for source in &mut plan.runtime_sources {
+        source.locator = AgentRuntimeSourceLocator::LocalPath {
+            path: Path::new(&generation.immutable_root)
+                .join(&source.destination_path)
+                .display()
+                .to_string(),
+        };
+    }
+    identity.materialization_plan = serde_json::to_value(plan).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize resolved Lab runtime plan".to_string()),
+        )
+    })?;
+    let raw_policy = serde_json::to_string(&policy).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize resolved Lab provider policy".to_string()),
+        )
+    })?;
+    let mut args = args.to_vec();
+    args[policy_index] = raw_policy;
+    Ok(Some(LabResolvedAgentRuntime {
+        args,
+        env: vec![
+            (
+                "HOMEBOY_RUNTIME_PATH".to_string(),
+                generation.runtime_path.clone(),
+            ),
+            (
+                "HOMEBOY_AGENT_RUNTIME_PATH".to_string(),
+                generation.runtime_path.clone(),
+            ),
+        ],
+        generation,
+    }))
+}
+
+fn resolved_provider_policy_arg(args: &[String]) -> Option<(usize, &str)> {
+    args.iter().enumerate().find_map(|(index, arg)| {
+        arg.strip_prefix("--resolved-provider-policy=")
+            .map(|value| (index, value))
+            .or_else(|| {
+                (arg == "--resolved-provider-policy")
+                    .then(|| args.get(index + 1).map(|value| (index + 1, value.as_str())))
+                    .flatten()
+            })
+    })
+}
+
+/// Construct evidence only after the final dispatch argv has been rewritten.
+/// This is the pre-submit equality gate: a mismatched policy fails before a
+/// daemon admission can occur.
+pub(crate) fn runtime_execution_evidence(
+    generation: &ResolvedAgentRuntimeGeneration,
+    executed_args: &[String],
+    admission: &str,
+) -> Result<AgentRuntimeExecutionEvidence> {
+    let (_, raw_policy) = resolved_provider_policy_arg(executed_args).ok_or_else(|| {
+        invalid(
+            "executed_runtime",
+            "materialized runtime dispatch has no resolved provider policy",
+        )
+    })?;
+    let policy: ResolvedAgentTaskProviderPolicy =
+        serde_json::from_str(raw_policy).map_err(|_| {
+            invalid(
+                "executed_runtime",
+                "materialized runtime dispatch has an invalid resolved provider policy",
+            )
+        })?;
+    let identity = policy.runtime_identity.ok_or_else(|| {
+        invalid(
+            "executed_runtime",
+            "materialized runtime dispatch has no runtime identity",
+        )
+    })?;
+    let plan: AgentRuntimeMaterializationPlan =
+        serde_json::from_value(identity.materialization_plan)
+            .map_err(|_| invalid("executed_runtime", "executed runtime plan is invalid"))?;
+    let executed = AgentRuntimeEvidenceIdentity {
+        runtime_id: plan.runtime_id.clone(),
+        provider_id: identity.provider_id,
+        source_revision: plan.source_revision.clone(),
+        content_identity: generation.content_identity.clone(),
+        build_identity: generation.generation_identity.clone(),
+        runtime_path: plan.runtime_path.unwrap_or_default(),
+        generation: generation.generation_identity.clone(),
+        admission: admission.to_string(),
+    };
+    let resolved = AgentRuntimeEvidenceIdentity {
+        runtime_id: generation.requested_runtime_id.clone(),
+        provider_id: generation.provider_id.clone(),
+        source_revision: generation.requested_source_revision.clone(),
+        content_identity: generation.content_identity.clone(),
+        build_identity: generation.generation_identity.clone(),
+        runtime_path: generation.runtime_path.clone(),
+        generation: generation.generation_identity.clone(),
+        admission: admission.to_string(),
+    };
+    if executed != resolved {
+        return Err(invalid(
+            "executed_runtime",
+            "executed runtime identity does not equal the resolved immutable generation",
+        ));
+    }
+    Ok(AgentRuntimeExecutionEvidence {
+        schema: "homeboy/agent-runtime-execution-evidence/v1".to_string(),
+        requested: AgentRuntimeEvidenceIdentity {
+            runtime_id: generation.requested_runtime_id.clone(),
+            provider_id: generation.provider_id.clone(),
+            source_revision: generation.requested_source_revision.clone(),
+            content_identity: generation.content_identity.clone(),
+            build_identity: generation.generation_identity.clone(),
+            runtime_path: String::new(),
+            generation: generation.generation_identity.clone(),
+            admission: "requested".to_string(),
+        },
+        resolved,
+        executed,
+    })
+}
+
+/// Small boundary around runner storage and process execution. It makes the
+/// materialization transaction deterministic to test without selecting a Lab
+/// transport or mutating a controller source checkout.
+pub trait AgentRuntimeMaterializerOperations {
+    fn generation_root(&mut self, runner: &Runner, generation_identity: &str) -> Result<PathBuf>;
+    fn source_exists(&mut self, source: &Path) -> Result<bool>;
+    fn source_revision(&mut self, source: &Path) -> Result<String>;
+    fn snapshot_source(&mut self, source: &Path, destination: &Path) -> Result<()>;
+    fn create_dir_all(&mut self, path: &Path) -> Result<()>;
+    fn path_exists(&mut self, path: &Path) -> Result<bool>;
+    fn read_record(&mut self, root: &Path) -> Result<Option<ResolvedAgentRuntimeGeneration>>;
+    fn write_record(
+        &mut self,
+        root: &Path,
+        generation: &ResolvedAgentRuntimeGeneration,
+    ) -> Result<()>;
+    fn run_argv(&mut self, runner: &Runner, argv: &[String], cwd: &Path) -> Result<()>;
+    fn rename_publish(&mut self, staging: &Path, destination: &Path) -> Result<()>;
+    fn remove_tree(&mut self, path: &Path) -> Result<()>;
+}
+
+/// Injectable boundary for the runner-facing half of runtime materialization.
+/// Local snapshot construction remains local, while every remote command and
+/// transfer is recorded or executed through this transport.
+pub trait RunnerRuntimeMaterializerTransport {
+    fn exec(&self, runner: &Runner, argv: Vec<String>, cwd: String) -> Result<i32>;
+    fn ensure_directory(&self, runner: &Runner, path: &str) -> Result<()>;
+    fn upload_file(&self, runner: &Runner, local_path: &str, remote_path: &str) -> Result<()>;
+    fn download_file(&self, runner: &Runner, remote_path: &str, local_path: &str) -> Result<()>;
+}
+
+pub struct NativeRunnerRuntimeMaterializerTransport;
+
+impl RunnerRuntimeMaterializerTransport for NativeRunnerRuntimeMaterializerTransport {
+    fn exec(&self, runner: &Runner, argv: Vec<String>, cwd: String) -> Result<i32> {
+        exec(
+            &runner.id,
+            RunnerExecOptions::raw_command(argv).with_cwd(cwd),
+        )
+        .map(|(_, exit_code)| exit_code)
+    }
+
+    fn ensure_directory(&self, runner: &Runner, path: &str) -> Result<()> {
+        crate::RunnerFileTransfer::for_runner(runner, crate::status(&runner.id).ok().as_ref())?
+            .ensure_directory(path)
+    }
+
+    fn upload_file(&self, runner: &Runner, local_path: &str, remote_path: &str) -> Result<()> {
+        crate::RunnerFileTransfer::for_runner(runner, crate::status(&runner.id).ok().as_ref())?
+            .upload_file(local_path, remote_path)
+    }
+
+    fn download_file(&self, runner: &Runner, remote_path: &str, local_path: &str) -> Result<()> {
+        crate::RunnerFileTransfer::for_runner(runner, crate::status(&runner.id).ok().as_ref())?
+            .download_file(remote_path, local_path)
+    }
+}
+
+/// Production operations backed by the runner workspace snapshot and exec
+/// primitives.
+pub struct RunnerRuntimeMaterializerOperations<T = NativeRunnerRuntimeMaterializerTransport> {
+    runner: Runner,
+    transport: T,
+}
+
+impl RunnerRuntimeMaterializerOperations<NativeRunnerRuntimeMaterializerTransport> {
+    pub(crate) fn new(runner: Runner) -> Self {
+        Self {
+            runner,
+            transport: NativeRunnerRuntimeMaterializerTransport,
+        }
+    }
+}
+
+impl<T: RunnerRuntimeMaterializerTransport> RunnerRuntimeMaterializerOperations<T> {
+    #[cfg(test)]
+    fn with_transport(runner: Runner, transport: T) -> Self {
+        Self { runner, transport }
+    }
+
+    fn remote_exec(&self, argv: Vec<String>, cwd: Option<&Path>) -> Result<()> {
+        let exit_code = self.transport.exec(
+            &self.runner,
+            argv,
+            cwd.map(|path| path.display().to_string())
+                .or_else(|| self.runner.workspace_root.clone())
+                .unwrap_or_else(|| ".".to_string()),
+        )?;
+        (exit_code == 0).then_some(()).ok_or_else(|| {
+            invalid(
+                "runtime_materialization",
+                "remote runtime materialization command failed",
+            )
+        })
+    }
+
+    fn remote_archive_snapshot(&self, source: &Path, destination: &Path) -> Result<()> {
+        let temp = tempfile::tempdir().map_err(io("create runtime snapshot directory"))?;
+        let snapshot = temp.path().join("snapshot");
+        copy_snapshot_to_directory(source, &snapshot, &[])?;
+        let archive = temp.path().join("runtime.tar.gz");
+        let status = std::process::Command::new("tar")
+            .args(["-czf"])
+            .arg(&archive)
+            .args(["-C"])
+            .arg(&snapshot)
+            .arg(".")
+            .status()
+            .map_err(io("archive runtime snapshot"))?;
+        if !status.success() {
+            return Err(invalid(
+                "runtime_sources",
+                "could not archive runtime snapshot",
+            ));
+        }
+        let archive_path = destination.with_extension("runtime.tar.gz");
+        let parent = destination.parent().ok_or_else(|| {
+            invalid(
+                "runtime_sources.destination_path",
+                "runtime destination has no parent",
+            )
+        })?;
+        self.transport
+            .ensure_directory(&self.runner, &parent.display().to_string())?;
+        self.transport.upload_file(
+            &self.runner,
+            &archive.display().to_string(),
+            &archive_path.display().to_string(),
+        )?;
+        self.remote_exec(
+            vec![
+                "mkdir".to_string(),
+                "-p".to_string(),
+                destination.display().to_string(),
+            ],
+            None,
+        )?;
+        let unpack = self.remote_exec(
+            vec![
+                "tar".to_string(),
+                "-xzf".to_string(),
+                archive_path.display().to_string(),
+                "-C".to_string(),
+                destination.display().to_string(),
+            ],
+            None,
+        );
+        let remove = self.remote_exec(
+            vec![
+                "rm".to_string(),
+                "-f".to_string(),
+                archive_path.display().to_string(),
+            ],
+            None,
+        );
+        unpack.and(remove)
+    }
+}
+
+impl<T: RunnerRuntimeMaterializerTransport> AgentRuntimeMaterializerOperations
+    for RunnerRuntimeMaterializerOperations<T>
+{
+    fn generation_root(&mut self, runner: &Runner, generation_identity: &str) -> Result<PathBuf> {
+        let workspace_root = runner.workspace_root.as_deref().ok_or_else(|| {
+            invalid(
+                "runner.workspace_root",
+                "runtime materialization requires runner.workspace_root",
+            )
+        })?;
+        Ok(Path::new(workspace_root)
+            .join("agent-runtime-generations")
+            .join(generation_path_component(generation_identity)?))
+    }
+
+    fn source_revision(&mut self, source: &Path) -> Result<String> {
+        homeboy_core::git::head_sha(source).ok_or_else(|| {
+            invalid(
+                "runtime_sources",
+                "runtime source has no immutable git revision",
+            )
+        })
+    }
+
+    fn source_exists(&mut self, source: &Path) -> Result<bool> {
+        Ok(source.exists())
+    }
+
+    fn snapshot_source(&mut self, source: &Path, destination: &Path) -> Result<()> {
+        // A local source is never a path contract for a remote runner. Snapshot
+        // it first, then transfer one immutable archive into the runner staging
+        // root through the selected transport.
+        if self.runner.kind == RunnerKind::Local {
+            copy_snapshot_to_directory(source, destination, &[])
+        } else {
+            self.remote_archive_snapshot(source, destination)
+        }
+    }
+
+    fn create_dir_all(&mut self, path: &Path) -> Result<()> {
+        if self.runner.kind == RunnerKind::Local {
+            fs::create_dir_all(path).map_err(io("create runtime generation directory"))
+        } else {
+            self.remote_exec(
+                vec![
+                    "mkdir".to_string(),
+                    "-p".to_string(),
+                    path.display().to_string(),
+                ],
+                None,
+            )
+        }
+    }
+
+    fn path_exists(&mut self, path: &Path) -> Result<bool> {
+        if self.runner.kind == RunnerKind::Local {
+            Ok(path.exists())
+        } else {
+            Ok(self
+                .remote_exec(
+                    vec![
+                        "test".to_string(),
+                        "-e".to_string(),
+                        path.display().to_string(),
+                    ],
+                    None,
+                )
+                .is_ok())
+        }
+    }
+
+    fn read_record(&mut self, root: &Path) -> Result<Option<ResolvedAgentRuntimeGeneration>> {
+        if self.runner.kind != RunnerKind::Local {
+            let temp =
+                tempfile::NamedTempFile::new().map_err(io("create runtime record download"))?;
+            let record = root.join(RECORD_FILE);
+            if !self.path_exists(&record)? {
+                return Ok(None);
+            }
+            self.transport.download_file(
+                &self.runner,
+                &record.display().to_string(),
+                &temp.path().display().to_string(),
+            )?;
+            let bytes =
+                fs::read(temp.path()).map_err(io("read downloaded runtime generation record"))?;
+            return serde_json::from_slice(&bytes).map(Some).map_err(|error| {
+                Error::validation_invalid_json(
+                    error,
+                    Some("parse runtime generation record".to_string()),
+                    None,
+                )
+            });
+        }
+        let path = root.join(RECORD_FILE);
+        match fs::read(&path) {
+            Ok(bytes) => serde_json::from_slice(&bytes).map(Some).map_err(|error| {
+                Error::validation_invalid_json(
+                    error,
+                    Some("parse runtime generation record".to_string()),
+                    None,
+                )
+            }),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(io("read runtime generation record")(error)),
+        }
+    }
+
+    fn write_record(
+        &mut self,
+        root: &Path,
+        generation: &ResolvedAgentRuntimeGeneration,
+    ) -> Result<()> {
+        let bytes = serde_json::to_vec(generation).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize runtime generation record".to_string()),
+            )
+        })?;
+        if self.runner.kind == RunnerKind::Local {
+            fs::write(root.join(RECORD_FILE), bytes).map_err(io("write runtime generation record"))
+        } else {
+            let temp =
+                tempfile::NamedTempFile::new().map_err(io("create runtime record upload"))?;
+            fs::write(temp.path(), bytes).map_err(io("write runtime generation record"))?;
+            self.transport.upload_file(
+                &self.runner,
+                &temp.path().display().to_string(),
+                &root.join(RECORD_FILE).display().to_string(),
+            )
+        }
+    }
+
+    fn run_argv(&mut self, runner: &Runner, argv: &[String], cwd: &Path) -> Result<()> {
+        let exit_code = self
+            .transport
+            .exec(runner, argv.to_vec(), cwd.display().to_string())?;
+        if exit_code == 0 {
+            Ok(())
+        } else {
+            Err(invalid(
+                "preparation.argv",
+                &format!("runtime preparation exited with status {exit_code}"),
+            ))
+        }
+    }
+
+    fn rename_publish(&mut self, staging: &Path, destination: &Path) -> Result<()> {
+        if self.runner.kind == RunnerKind::Local {
+            fs::rename(staging, destination).map_err(io("publish runtime generation"))
+        } else {
+            self.remote_exec(
+                vec![
+                    "mv".to_string(),
+                    staging.display().to_string(),
+                    destination.display().to_string(),
+                ],
+                None,
+            )
+        }
+    }
+
+    fn remove_tree(&mut self, path: &Path) -> Result<()> {
+        if self.runner.kind != RunnerKind::Local {
+            return self.remote_exec(
+                vec![
+                    "rm".to_string(),
+                    "-rf".to_string(),
+                    path.display().to_string(),
+                ],
+                None,
+            );
+        }
+        match fs::remove_dir_all(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(io("remove runtime generation staging directory")(error)),
+        }
+    }
+}
+
+/// Materialize one exact generation. The process-global guard closes the
+/// same-process race; runtime-promotion serializes competing controller
+/// processes before any staging root is created.
+pub fn materialize_agent_runtime_generation(
+    operations: &mut impl AgentRuntimeMaterializerOperations,
+    plan: &AgentRuntimeMaterializationPlan,
+    runner: &Runner,
+    _job_or_run_id: &str,
+) -> Result<ResolvedAgentRuntimeGeneration> {
+    validate_plan_for_materialization(plan)?;
+    let _promotion = homeboy_core::runtime_promotion::acquire(
+        "agent runtime materialization",
+        format!("{}:{}", runner.id, plan.generation_identity),
+    )?;
+    materialize_generation_with_operations(operations, plan, runner)
+}
+
+fn materialize_generation_with_operations(
+    operations: &mut impl AgentRuntimeMaterializerOperations,
+    plan: &AgentRuntimeMaterializationPlan,
+    runner: &Runner,
+) -> Result<ResolvedAgentRuntimeGeneration> {
+    let _same_process = generation_lock()
+        .lock()
+        .expect("runtime generation lock poisoned");
+    let root = operations.generation_root(runner, &plan.generation_identity)?;
+    if let Some(existing) = operations.read_record(&root)? {
+        if generation_matches(plan, &root, &existing, operations)? {
+            return Ok(ResolvedAgentRuntimeGeneration {
+                publication: AgentRuntimeGenerationPublication::Reused,
+                cleanup: AgentRuntimeGenerationCleanup::Immutable,
+                ..existing
+            });
+        }
+        return Err(invalid(
+            "generation_identity",
+            "existing runtime generation is incompatible or invalid",
+        ));
+    }
+
+    let staging = staging_root(&root)?;
+    operations.remove_tree(&staging)?;
+    let result = materialize_staging(operations, plan, runner, &root, &staging);
+    match result {
+        Ok(generation) => {
+            if let Err(error) = operations.rename_publish(&staging, &root) {
+                let _ = operations.remove_tree(&staging);
+                return Err(error);
+            }
+            Ok(generation)
+        }
+        Err(error) => {
+            let _ = operations.remove_tree(&staging);
+            Err(error)
+        }
+    }
+}
+
+fn materialize_staging(
+    operations: &mut impl AgentRuntimeMaterializerOperations,
+    plan: &AgentRuntimeMaterializationPlan,
+    runner: &Runner,
+    root: &Path,
+    staging: &Path,
+) -> Result<ResolvedAgentRuntimeGeneration> {
+    operations.create_dir_all(staging)?;
+    let mut sources = Vec::with_capacity(plan.runtime_sources.len());
+    for source in &plan.runtime_sources {
+        let destination = safe_join(staging, &source.destination_path)?;
+        let resolved = match &source.locator {
+            AgentRuntimeSourceLocator::LocalPath { path } => {
+                let source_path = Path::new(path);
+                if !operations.source_exists(source_path)? {
+                    return Err(invalid(
+                        "runtime_sources.locator.path",
+                        "runtime source is unavailable",
+                    ));
+                }
+                let resolved = operations.source_revision(source_path)?;
+                if resolved != source.content_identity {
+                    return Err(invalid(
+                        "runtime_sources.content_identity",
+                        "runtime source revision does not match the requested content identity",
+                    ));
+                }
+                operations.snapshot_source(source_path, &destination)?;
+                resolved
+            }
+            AgentRuntimeSourceLocator::Git {
+                remote_url,
+                revision,
+            } => {
+                // `revision` is validated as the source content identity before
+                // this transaction. Every remote operation is argv-only and the
+                // detached checkout proves the fetched object is that identity.
+                operations.run_argv(
+                    runner,
+                    &[
+                        "git".to_string(),
+                        "clone".to_string(),
+                        "--no-checkout".to_string(),
+                        remote_url.clone(),
+                        destination.display().to_string(),
+                    ],
+                    staging,
+                )?;
+                operations.run_argv(
+                    runner,
+                    &[
+                        "git".to_string(),
+                        "-C".to_string(),
+                        destination.display().to_string(),
+                        "fetch".to_string(),
+                        "--depth".to_string(),
+                        "1".to_string(),
+                        "origin".to_string(),
+                        revision.clone(),
+                    ],
+                    staging,
+                )?;
+                operations.run_argv(
+                    runner,
+                    &[
+                        "git".to_string(),
+                        "-C".to_string(),
+                        destination.display().to_string(),
+                        "checkout".to_string(),
+                        "--detach".to_string(),
+                        revision.clone(),
+                    ],
+                    staging,
+                )?;
+                revision.clone()
+            }
+        };
+        sources.push(ResolvedAgentRuntimeSourceIdentity {
+            id: source.id.clone(),
+            requested_content_identity: source.content_identity.clone(),
+            resolved_content_identity: resolved,
+            destination_path: source.destination_path.clone(),
+        });
+    }
+    for action in &plan.preparation {
+        let cwd = safe_join(staging, &action.cwd)?;
+        if !operations.path_exists(&cwd)? {
+            return Err(invalid(
+                "preparation.cwd",
+                "runtime preparation cwd does not exist",
+            ));
+        }
+        operations.run_argv(runner, &action.argv, &cwd)?;
+        for output in &action.expected_outputs {
+            if !operations.path_exists(&safe_join(staging, output)?)? {
+                return Err(invalid(
+                    "preparation.expected_outputs",
+                    "runtime preparation did not produce an expected output",
+                ));
+            }
+        }
+    }
+    let runtime_destination = plan.runtime_sources[0].destination_path.clone();
+    let runtime_path = safe_join(staging, &runtime_destination)?;
+    if !operations.path_exists(&runtime_path)? {
+        return Err(invalid(
+            "runtime_path",
+            "materialized runtime path is missing",
+        ));
+    }
+    let generation = ResolvedAgentRuntimeGeneration {
+        generation_identity: plan.generation_identity.clone(),
+        content_identity: plan.generation_identity.clone(),
+        immutable_root: root.display().to_string(),
+        runtime_path: root.join(runtime_destination).display().to_string(),
+        provider_id: plan.provider_id.clone(),
+        requested_runtime_id: plan.runtime_id.clone(),
+        requested_source_revision: plan.source_revision.clone(),
+        resolved_source_identities: sources,
+        publication: AgentRuntimeGenerationPublication::Published,
+        cleanup: AgentRuntimeGenerationCleanup::Immutable,
+    };
+    operations.write_record(staging, &generation)?;
+    Ok(generation)
+}
+
+fn generation_matches(
+    plan: &AgentRuntimeMaterializationPlan,
+    root: &Path,
+    generation: &ResolvedAgentRuntimeGeneration,
+    operations: &mut impl AgentRuntimeMaterializerOperations,
+) -> Result<bool> {
+    let sources_match = generation
+        .resolved_source_identities
+        .iter()
+        .zip(&plan.runtime_sources)
+        .all(|(resolved, requested)| {
+            resolved.id == requested.id
+                && resolved.requested_content_identity == requested.content_identity
+                && resolved.resolved_content_identity == requested.content_identity
+                && resolved.destination_path == requested.destination_path
+        });
+    Ok(generation.generation_identity == plan.generation_identity
+        && generation.provider_id == plan.provider_id
+        && generation.requested_runtime_id == plan.runtime_id
+        && generation.resolved_source_identities.len() == plan.runtime_sources.len()
+        && sources_match
+        && operations.path_exists(root)?
+        && operations.path_exists(Path::new(&generation.runtime_path))?)
+}
+
+fn validate_plan_for_materialization(plan: &AgentRuntimeMaterializationPlan) -> Result<()> {
+    validate_runtime_materialization_plan(plan)?;
+    if plan.generation_identity.trim().is_empty() || plan.runtime_sources.is_empty() {
+        return Err(invalid(
+            "generation_identity",
+            "runtime materialization requires a generation identity and source",
+        ));
+    }
+    for action in &plan.preparation {
+        if action
+            .argv
+            .iter()
+            .any(|arg| arg.contains('\n') || arg.contains('\r'))
+        {
+            return Err(invalid(
+                "preparation.argv",
+                "runtime preparation argv cannot contain line breaks",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn safe_join(root: &Path, relative: &str) -> Result<PathBuf> {
+    let path = Path::new(relative);
+    if relative.trim().is_empty()
+        || path.is_absolute()
+        || path.components().any(|part| {
+            matches!(
+                part,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(invalid(
+            "runtime materialization path",
+            "path must be a non-empty relative path without traversal",
+        ));
+    }
+    Ok(root.join(path))
+}
+
+fn generation_path_component(identity: &str) -> Result<&str> {
+    let component = identity.strip_prefix("sha256:").unwrap_or(identity);
+    if component.len() != 64 || !component.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(invalid(
+            "generation_identity",
+            "generation identity must be a sha256 content address",
+        ));
+    }
+    Ok(component)
+}
+
+fn staging_root(root: &Path) -> Result<PathBuf> {
+    let name = root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            invalid(
+                "generation_identity",
+                "generation path has no valid file name",
+            )
+        })?;
+    Ok(root.with_file_name(format!(".{name}{STAGING_SUFFIX}")))
+}
+
+fn generation_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn invalid(field: &str, message: &str) -> Error {
+    Error::validation_invalid_argument(field, message, None, None)
+}
+
+fn io(context: &'static str) -> impl FnOnce(std::io::Error) -> Error {
+    move |error| Error::internal_io(error.to_string(), Some(context.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::thread;
+
+    use homeboy_core::agent_runtime_manifest::{
+        AgentRuntimeMaterializationPlan, AgentRuntimeMaterializationSource,
+        AgentRuntimePreparationAction,
+    };
+    use homeboy_core::server::{RunnerPolicy, RunnerSettings};
+
+    fn evidence_generation() -> ResolvedAgentRuntimeGeneration {
+        ResolvedAgentRuntimeGeneration {
+            generation_identity: "a".repeat(64),
+            content_identity: "b".repeat(64),
+            immutable_root: "/runner/generation".to_string(),
+            runtime_path: "/runner/generation/runtime".to_string(),
+            provider_id: "provider-a".to_string(),
+            requested_runtime_id: "runtime-a".to_string(),
+            requested_source_revision: Some("c".repeat(40)),
+            resolved_source_identities: Vec::new(),
+            publication: AgentRuntimeGenerationPublication::Published,
+            cleanup: AgentRuntimeGenerationCleanup::Immutable,
+        }
+    }
+
+    fn evidence_args(generation: &ResolvedAgentRuntimeGeneration) -> Vec<String> {
+        let plan = AgentRuntimeMaterializationPlan {
+            schema: "homeboy/agent-runtime-materialization-plan/v2".to_string(),
+            runtime_id: generation.requested_runtime_id.clone(),
+            selected_identity: Default::default(),
+            provider_id: generation.provider_id.clone(),
+            source_selector: "test".to_string(),
+            source_revision: generation.requested_source_revision.clone(),
+            freshness: Default::default(),
+            runtime_path: Some(generation.runtime_path.clone()),
+            runtime_sources: Vec::new(),
+            preparation: Vec::new(),
+            generation_identity: generation.generation_identity.clone(),
+            source_roots: Vec::new(),
+            dependencies: Vec::new(),
+            executable_requirements: Vec::new(),
+            readiness_checks: Vec::new(),
+            env_passthrough: Vec::new(),
+            workspace: None,
+        };
+        let policy = ResolvedAgentTaskProviderPolicy {
+            backend: "test".to_string(),
+            selector: None,
+            model: None,
+            rotation: None,
+            rotation_starts_with_first_entry: false,
+            retry: Default::default(),
+            liveness_timeout_ms: None,
+            runtime_identity: Some(homeboy_core::agent_task_config::ResolvedAgentTaskRuntimeIdentity {
+                runtime_id: generation.requested_runtime_id.clone(),
+                provider_id: generation.provider_id.clone(),
+                source_selector: "test".to_string(),
+                source_revision: generation.requested_source_revision.clone().unwrap(),
+                freshness: homeboy_core::agent_task_config::ResolvedAgentTaskRuntimeFreshness::Unverifiable,
+                provider: serde_json::Value::Null,
+                materialization_plan: serde_json::to_value(plan).unwrap(),
+            }),
+        };
+        vec![format!(
+            "--resolved-provider-policy={}",
+            serde_json::to_string(&policy).unwrap()
+        )]
+    }
+
+    #[test]
+    fn runtime_evidence_roundtrips_and_rejects_mismatch_before_submission() {
+        let generation = evidence_generation();
+        let args = evidence_args(&generation);
+        let evidence =
+            runtime_execution_evidence(&generation, &args, "runner-a").expect("evidence");
+        let restored: AgentRuntimeExecutionEvidence =
+            serde_json::from_value(serde_json::to_value(&evidence).unwrap()).expect("roundtrip");
+        assert_eq!(restored, evidence);
+
+        let mut mismatched = evidence_args(&generation);
+        mismatched[0] = mismatched[0].replace(&generation.runtime_path, "/wrong/runtime");
+        assert!(runtime_execution_evidence(&generation, &mismatched, "runner-a").is_err());
+    }
+
+    #[derive(Clone, Default)]
+    struct RecorderTransport {
+        events: Arc<Mutex<Vec<String>>>,
+        fail_preparation: bool,
+    }
+
+    impl RecorderTransport {
+        fn events(&self) -> Vec<String> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+
+    impl RunnerRuntimeMaterializerTransport for RecorderTransport {
+        fn exec(&self, _: &Runner, argv: Vec<String>, cwd: String) -> Result<i32> {
+            self.events
+                .lock()
+                .unwrap()
+                .push(format!("exec cwd={cwd} argv={}", argv.join("|")));
+            let missing_record = argv.first().is_some_and(|command| command == "test")
+                && argv.last().is_some_and(|path| path.ends_with(RECORD_FILE));
+            let failed_preparation =
+                self.fail_preparation && argv.first().is_some_and(|command| command == "prepare");
+            Ok(i32::from(missing_record || failed_preparation))
+        }
+
+        fn ensure_directory(&self, _: &Runner, path: &str) -> Result<()> {
+            self.events
+                .lock()
+                .unwrap()
+                .push(format!("ensure-directory {path}"));
+            Ok(())
+        }
+
+        fn upload_file(&self, _: &Runner, local_path: &str, remote_path: &str) -> Result<()> {
+            self.events
+                .lock()
+                .unwrap()
+                .push(format!("upload {local_path} -> {remote_path}"));
+            Ok(())
+        }
+
+        fn download_file(&self, _: &Runner, remote_path: &str, local_path: &str) -> Result<()> {
+            self.events
+                .lock()
+                .unwrap()
+                .push(format!("download {remote_path} -> {local_path}"));
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct FakeOperations {
+        _tempdir: Arc<tempfile::TempDir>,
+        base: Arc<PathBuf>,
+        revisions: Arc<HashMap<PathBuf, String>>,
+        fail_prepare: bool,
+        snapshots: Arc<Mutex<usize>>,
+    }
+
+    impl AgentRuntimeMaterializerOperations for FakeOperations {
+        fn generation_root(&mut self, _: &Runner, identity: &str) -> Result<PathBuf> {
+            Ok(self
+                .base
+                .join("generations")
+                .join(generation_path_component(identity)?))
+        }
+        fn source_exists(&mut self, source: &Path) -> Result<bool> {
+            Ok(self.revisions.contains_key(source))
+        }
+        fn source_revision(&mut self, source: &Path) -> Result<String> {
+            self.revisions
+                .get(source)
+                .cloned()
+                .ok_or_else(|| invalid("source", "missing source"))
+        }
+        fn snapshot_source(&mut self, _: &Path, destination: &Path) -> Result<()> {
+            *self.snapshots.lock().unwrap() += 1;
+            fs::create_dir_all(destination).map_err(io("fake snapshot"))
+        }
+        fn create_dir_all(&mut self, path: &Path) -> Result<()> {
+            fs::create_dir_all(path).map_err(io("fake mkdir"))
+        }
+        fn path_exists(&mut self, path: &Path) -> Result<bool> {
+            Ok(path.exists() || self.revisions.contains_key(path))
+        }
+        fn read_record(&mut self, root: &Path) -> Result<Option<ResolvedAgentRuntimeGeneration>> {
+            match fs::read(root.join(RECORD_FILE)) {
+                Ok(bytes) => serde_json::from_slice(&bytes)
+                    .map(Some)
+                    .map_err(|error| Error::internal_json(error.to_string(), None)),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+                Err(error) => Err(io("fake record")(error)),
+            }
+        }
+        fn write_record(
+            &mut self,
+            root: &Path,
+            generation: &ResolvedAgentRuntimeGeneration,
+        ) -> Result<()> {
+            fs::write(
+                root.join(RECORD_FILE),
+                serde_json::to_vec(generation).unwrap(),
+            )
+            .map_err(io("fake record"))
+        }
+        fn run_argv(&mut self, _: &Runner, _: &[String], _: &Path) -> Result<()> {
+            if self.fail_prepare {
+                Err(invalid("preparation", "forced preparation failure"))
+            } else {
+                Ok(())
+            }
+        }
+        fn rename_publish(&mut self, staging: &Path, destination: &Path) -> Result<()> {
+            fs::rename(staging, destination).map_err(io("fake publish"))
+        }
+        fn remove_tree(&mut self, path: &Path) -> Result<()> {
+            match fs::remove_dir_all(path) {
+                Ok(()) => Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(io("fake remove")(error)),
+            }
+        }
+    }
+
+    // The production entrypoint also owns a machine-global promotion lease.
+    // Unit tests exercise the engine's generation-scoped lock directly so they
+    // remain isolated from unrelated parallel runner lease tests.
+    fn materialize_agent_runtime_generation(
+        operations: &mut impl AgentRuntimeMaterializerOperations,
+        plan: &AgentRuntimeMaterializationPlan,
+        runner: &Runner,
+        _: &str,
+    ) -> Result<ResolvedAgentRuntimeGeneration> {
+        validate_plan_for_materialization(plan)?;
+        materialize_generation_with_operations(operations, plan, runner)
+    }
+
+    #[test]
+    fn compatible_generation_is_a_no_op() {
+        let (mut operations, runner, plan) = fixture("a", false);
+        let first =
+            materialize_agent_runtime_generation(&mut operations, &plan, &runner, "run-a").unwrap();
+        let second =
+            materialize_agent_runtime_generation(&mut operations, &plan, &runner, "run-b").unwrap();
+        assert_eq!(
+            first.publication,
+            AgentRuntimeGenerationPublication::Published
+        );
+        assert_eq!(
+            second.publication,
+            AgentRuntimeGenerationPublication::Reused
+        );
+        assert_eq!(*operations.snapshots.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn stale_generation_materializes_and_publishes() {
+        let (mut operations, runner, plan) = fixture("b", false);
+        let generation =
+            materialize_agent_runtime_generation(&mut operations, &plan, &runner, "run").unwrap();
+        assert_eq!(
+            generation.publication,
+            AgentRuntimeGenerationPublication::Published
+        );
+        assert!(Path::new(&generation.runtime_path).is_dir());
+        assert!(Path::new(&generation.immutable_root)
+            .join(RECORD_FILE)
+            .is_file());
+    }
+
+    #[test]
+    fn preparation_failure_removes_staging_and_publishes_nothing() {
+        let (mut operations, runner, plan) = fixture("c", true);
+        let root = operations
+            .generation_root(&runner, &plan.generation_identity)
+            .unwrap();
+        assert!(
+            materialize_agent_runtime_generation(&mut operations, &plan, &runner, "run").is_err()
+        );
+        assert!(!root.exists());
+        assert!(!staging_root(&root).unwrap().exists());
+    }
+
+    #[test]
+    fn unavailable_source_rejects_without_publication() {
+        let (mut operations, runner, mut plan) = fixture("d", false);
+        plan.runtime_sources[0].locator = AgentRuntimeSourceLocator::LocalPath {
+            path: operations.base.join("gone").display().to_string(),
+        };
+        let root = operations
+            .generation_root(&runner, &plan.generation_identity)
+            .unwrap();
+        assert!(
+            materialize_agent_runtime_generation(&mut operations, &plan, &runner, "run").is_err()
+        );
+        assert!(!root.exists());
+    }
+
+    #[test]
+    fn concurrent_identical_requirements_dedupe() {
+        let (operations, runner, plan) = fixture("e", false);
+        let left = {
+            let mut operations = operations.clone();
+            let runner = runner.clone();
+            let plan = plan.clone();
+            thread::spawn(move || {
+                materialize_agent_runtime_generation(&mut operations, &plan, &runner, "one")
+            })
+        };
+        let right = {
+            let mut operations = operations.clone();
+            let runner = runner.clone();
+            thread::spawn(move || {
+                materialize_agent_runtime_generation(&mut operations, &plan, &runner, "two")
+            })
+        };
+        let publications = [
+            left.join().unwrap().unwrap().publication,
+            right.join().unwrap().unwrap().publication,
+        ];
+        assert!(publications.contains(&AgentRuntimeGenerationPublication::Published));
+        assert!(publications.contains(&AgentRuntimeGenerationPublication::Reused));
+        assert_eq!(*operations.snapshots.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn concurrent_distinct_revisions_use_isolated_roots() {
+        let (operations, runner, left_plan) = fixture("f", false);
+        let mut right_plan = left_plan.clone();
+        right_plan.generation_identity = format!("sha256:{}", "b".repeat(64));
+        right_plan.runtime_sources[0].content_identity = "b".repeat(40);
+        let source = match &right_plan.runtime_sources[0].locator {
+            AgentRuntimeSourceLocator::LocalPath { path } => PathBuf::from(path),
+            _ => unreachable!(),
+        };
+        let mut right_operations = operations.clone();
+        Arc::make_mut(&mut right_operations.revisions).insert(source, "b".repeat(40));
+        let left = {
+            let mut operations = operations.clone();
+            let runner = runner.clone();
+            thread::spawn(move || {
+                materialize_agent_runtime_generation(&mut operations, &left_plan, &runner, "one")
+            })
+        };
+        let right = {
+            let runner = runner.clone();
+            thread::spawn(move || {
+                materialize_agent_runtime_generation(
+                    &mut right_operations,
+                    &right_plan,
+                    &runner,
+                    "two",
+                )
+            })
+        };
+        let left = left.join().unwrap().unwrap();
+        let right = right.join().unwrap().unwrap();
+        assert_ne!(left.immutable_root, right.immutable_root);
+        assert!(Path::new(&left.immutable_root).is_dir());
+        assert!(Path::new(&right.immutable_root).is_dir());
+    }
+
+    #[test]
+    fn rejects_traversal_and_unsafe_argv() {
+        let (mut operations, runner, mut plan) = fixture("g", false);
+        plan.runtime_sources[0].destination_path = "../escape".to_string();
+        assert!(
+            materialize_agent_runtime_generation(&mut operations, &plan, &runner, "run").is_err()
+        );
+        let (_, _, mut plan) = fixture("h", false);
+        plan.preparation[0].argv = vec!["tool\nargument".to_string()];
+        assert!(validate_plan_for_materialization(&plan).is_err());
+    }
+
+    #[test]
+    fn ssh_production_adapter_plans_snapshot_preparation_checks_and_atomic_publish() {
+        let (tempdir, runner, plan) = ssh_fixture("a");
+        let recorder = RecorderTransport::default();
+        let mut operations =
+            RunnerRuntimeMaterializerOperations::with_transport(runner.clone(), recorder.clone());
+
+        let generation =
+            materialize_agent_runtime_generation(&mut operations, &plan, &runner, "run-ssh")
+                .expect("materialize SSH runtime");
+        let events = recorder.events();
+        let root = format!(
+            "/runner/workspace/agent-runtime-generations/{}",
+            generation_path_component(&plan.generation_identity).unwrap()
+        );
+
+        assert!(events
+            .iter()
+            .any(|event| event.starts_with("ensure-directory ")));
+        assert!(events.iter().any(|event| event.contains("upload ")));
+        assert!(events
+            .iter()
+            .any(|event| event.contains("argv=mkdir|-p") && event.contains(".staging/runtime")));
+        assert!(events
+            .iter()
+            .any(|event| event.contains("argv=tar|-xzf") && event.contains(".staging/runtime")));
+        assert!(events.iter().any(|event| event
+            .contains("exec cwd=/runner/workspace/agent-runtime-generations")
+            && event.contains("argv=prepare")));
+        assert!(events
+            .iter()
+            .any(|event| event.contains("argv=test|-e") && event.contains(".staging/runtime")));
+        assert!(
+            events
+                .iter()
+                .any(|event| event.contains("argv=mv|") && event.contains(&root)),
+            "expected atomic publish for {root}; events: {events:?}"
+        );
+        assert_eq!(generation.immutable_root, root);
+        drop(tempdir);
+    }
+
+    #[test]
+    fn ssh_production_adapter_rejects_unavailable_source_before_transfer_or_preparation() {
+        let (tempdir, runner, mut plan) = ssh_fixture("b");
+        plan.runtime_sources[0].locator = AgentRuntimeSourceLocator::LocalPath {
+            path: tempdir.path().join("missing").display().to_string(),
+        };
+        let recorder = RecorderTransport::default();
+        let mut operations =
+            RunnerRuntimeMaterializerOperations::with_transport(runner.clone(), recorder.clone());
+
+        assert!(
+            materialize_agent_runtime_generation(&mut operations, &plan, &runner, "run-ssh")
+                .is_err()
+        );
+        let events = recorder.events();
+        assert!(!events.iter().any(|event| event.starts_with("upload ")));
+        assert!(!events.iter().any(|event| event.contains("argv=prepare")));
+        assert!(!events.iter().any(|event| event.contains("argv=mv|")));
+    }
+
+    #[test]
+    fn git_source_materializes_with_immutable_argv_checkout() {
+        let (tempdir, runner, mut plan) = ssh_fixture("a");
+        let revision = plan.runtime_sources[0].content_identity.clone();
+        plan.runtime_sources[0].locator = AgentRuntimeSourceLocator::Git {
+            remote_url: "https://example.test/runtime.git".to_string(),
+            revision: revision.clone(),
+        };
+        let recorder = RecorderTransport::default();
+        let mut operations =
+            RunnerRuntimeMaterializerOperations::with_transport(runner.clone(), recorder.clone());
+
+        let generation =
+            materialize_agent_runtime_generation(&mut operations, &plan, &runner, "run-ssh")
+                .expect("materialize immutable git runtime");
+        let events = recorder.events();
+
+        assert!(events.iter().any(|event| {
+            event.contains("argv=git|clone|--no-checkout|https://example.test/runtime.git")
+        }));
+        assert!(events.iter().any(|event| {
+            event.contains("argv=git|-C")
+                && event.contains("fetch|--depth|1|origin")
+                && event.contains(&revision)
+        }));
+        assert!(events.iter().any(|event| {
+            event.contains("argv=git|-C")
+                && event.contains("checkout|--detach")
+                && event.contains(&revision)
+        }));
+        assert_eq!(
+            generation.resolved_source_identities[0].resolved_content_identity,
+            revision
+        );
+        drop(tempdir);
+    }
+
+    #[test]
+    fn ssh_production_adapter_removes_staging_without_publish_when_preparation_fails() {
+        let (tempdir, runner, plan) = ssh_fixture("c");
+        let recorder = RecorderTransport {
+            fail_preparation: true,
+            ..Default::default()
+        };
+        let mut operations =
+            RunnerRuntimeMaterializerOperations::with_transport(runner.clone(), recorder.clone());
+
+        assert!(
+            materialize_agent_runtime_generation(&mut operations, &plan, &runner, "run-ssh")
+                .is_err()
+        );
+        let events = recorder.events();
+        assert!(events
+            .iter()
+            .any(|event| event.contains("argv=rm|-rf") && event.contains(".staging")));
+        assert!(!events.iter().any(|event| event.contains("argv=mv|")));
+        drop(tempdir);
+    }
+
+    fn ssh_fixture(seed: &str) -> (tempfile::TempDir, Runner, AgentRuntimeMaterializationPlan) {
+        let tempdir = tempfile::tempdir().unwrap();
+        let source = tempdir.path().join("source");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("runtime.txt"), "runtime").unwrap();
+        for args in [
+            &["init"][..],
+            &["add", "."][..],
+            &[
+                "-c",
+                "user.email=test@example.com",
+                "-c",
+                "user.name=Test",
+                "commit",
+                "-m",
+                "runtime",
+            ][..],
+        ] {
+            let status = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&source)
+                .status()
+                .unwrap();
+            assert!(status.success());
+        }
+        let revision = homeboy_core::git::head_sha(&source).unwrap();
+        let runner = Runner {
+            id: format!("runner-ssh-{seed}"),
+            kind: RunnerKind::Ssh,
+            server_id: Some("server-ssh".to_string()),
+            workspace_root: Some("/runner/workspace".to_string()),
+            settings: RunnerSettings::default(),
+            env: Default::default(),
+            secret_env: Default::default(),
+            resources: Default::default(),
+            policy: RunnerPolicy::default(),
+        };
+        let plan = AgentRuntimeMaterializationPlan {
+            schema: "homeboy/agent-runtime-materialization-plan/v2".to_string(),
+            runtime_id: "runtime".to_string(),
+            selected_identity: Default::default(),
+            provider_id: "provider".to_string(),
+            source_selector: "test".to_string(),
+            source_revision: Some(revision.clone()),
+            freshness: Default::default(),
+            runtime_path: None,
+            runtime_sources: vec![AgentRuntimeMaterializationSource {
+                id: "runtime".to_string(),
+                locator: AgentRuntimeSourceLocator::LocalPath {
+                    path: source.display().to_string(),
+                },
+                content_identity: revision,
+                destination_path: "runtime".to_string(),
+            }],
+            preparation: vec![AgentRuntimePreparationAction {
+                argv: vec!["prepare".to_string()],
+                cwd: "runtime".to_string(),
+                expected_outputs: vec!["runtime".to_string()],
+                runtime_identity: None,
+            }],
+            generation_identity: format!("sha256:{}", seed.repeat(64)[..64].to_string()),
+            source_roots: vec![],
+            dependencies: vec![],
+            executable_requirements: vec![],
+            readiness_checks: vec![],
+            env_passthrough: vec![],
+            workspace: None,
+        };
+        (tempdir, runner, plan)
+    }
+
+    fn fixture(
+        seed: &str,
+        fail_prepare: bool,
+    ) -> (FakeOperations, Runner, AgentRuntimeMaterializationPlan) {
+        let tempdir = Arc::new(tempfile::tempdir().unwrap());
+        let base = Arc::new(tempdir.path().to_path_buf());
+        let source = base.join("source");
+        fs::create_dir_all(&source).unwrap();
+        let revision = format!("{seed:0<40}");
+        let source_path = source.display().to_string();
+        let operations = FakeOperations {
+            _tempdir: tempdir,
+            base: base.clone(),
+            revisions: Arc::new(HashMap::from([(source.clone(), revision.clone())])),
+            fail_prepare,
+            snapshots: Arc::new(Mutex::new(0)),
+        };
+        let runner = Runner {
+            id: format!("runner-{seed}"),
+            kind: RunnerKind::Local,
+            server_id: None,
+            workspace_root: Some(base.display().to_string()),
+            settings: RunnerSettings::default(),
+            env: Default::default(),
+            secret_env: Default::default(),
+            resources: Default::default(),
+            policy: RunnerPolicy::default(),
+        };
+        let plan = AgentRuntimeMaterializationPlan {
+            schema: "homeboy/agent-runtime-materialization-plan/v2".to_string(),
+            runtime_id: "runtime".to_string(),
+            selected_identity: Default::default(),
+            provider_id: "provider".to_string(),
+            source_selector: "test".to_string(),
+            source_revision: Some(revision.clone()),
+            freshness: Default::default(),
+            runtime_path: None,
+            runtime_sources: vec![AgentRuntimeMaterializationSource {
+                id: "runtime".to_string(),
+                locator: AgentRuntimeSourceLocator::LocalPath { path: source_path },
+                content_identity: revision,
+                destination_path: "runtime".to_string(),
+            }],
+            preparation: vec![AgentRuntimePreparationAction {
+                argv: vec!["prepare".to_string()],
+                cwd: "runtime".to_string(),
+                expected_outputs: vec![],
+                runtime_identity: None,
+            }],
+            generation_identity: format!("sha256:{}", seed.repeat(64)[..64].to_string()),
+            source_roots: vec![],
+            dependencies: vec![],
+            executable_requirements: vec![],
+            readiness_checks: vec![],
+            env_passthrough: vec![],
+            workspace: None,
+        };
+        (operations, runner, plan)
+    }
+}


### PR DESCRIPTION
## Summary
- define a versioned runtime materialization contract with immutable source and revision validation
- materialize content-addressed local and SSH runtime generations with atomic publication and rollback
- delay job admission until materialization succeeds and record requested, resolved, and executed runtime evidence
- preserve durable generation ownership across jobs, runs, artifacts, restarts, rotation, and retirement

Closes #8012.

## How to test
1. Run `cargo test -p homeboy-lab-runner runtime_materializer -- --nocapture`.
2. Run `cargo test -p homeboy-lab-runner provider_preflight -- --nocapture`.
3. Run `cargo test -p homeboy-lab-runner generation_store -- --nocapture`.
4. Run `cargo test -p homeboy-lab-runner rolling_generation -- --nocapture`.
5. Run `cargo test -p homeboy-lab-runner evidence -- --nocapture`.
6. Run `cargo check -p homeboy-cli --all-targets`.

## Compatibility
The runtime manifest gains versioned materialization and evidence fields. Existing internal readers continue through serde defaults; no public CLI command is removed or renamed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI gpt-5.6-sol
- **Used for:** Implementing runtime convergence, generation ownership, SSH transport tests, upstream integration, and verification with Chris.