### PR TITLE
fix(release): auto-detect bump from conventional commits instead of failing on 'none' (#7598)

### DIFF
--- a/crates/homeboy-release/src/release/planning_semver.rs
+++ b/crates/homeboy-release/src/release/planning_semver.rs
@@ -39,20 +39,43 @@ pub(super) fn build_semver_recommendation(
         }));
     }
 
-    let requested = git::SemverBump::parse(requested_bump).ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "bump_type",
-            format!("Invalid bump type: {}", requested_bump),
-            None,
-            Some(vec![
-                "Use one of: patch, minor, major, or an explicit version like 2.0.0".to_string(),
-            ]),
-        )
-    })?;
-
-    let is_underbump = recommended
-        .map(|r| requested.rank() < r.rank())
-        .unwrap_or(false);
+    // Auto-detect mode: no explicit `--bump` was given (`requested_bump ==
+    // "none"`). When conventional commits recommend a bump, that recommendation
+    // IS the effective bump — parsing the sentinel "none" as an explicit bump
+    // would fail with a spurious `Invalid bump type: none` even though there are
+    // releasable commits (#7598). Only a genuinely absent recommendation reaches
+    // here (the no-recommendation case returned above), so this is never an
+    // underbump.
+    let (requested, is_underbump) = if requested_bump == "none" {
+        let recommended = recommended.ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "bump_type",
+                "Could not determine a version bump from commit history. Pass an explicit --bump (patch, minor, major, or a version like 2.0.0).",
+                None,
+                Some(vec![
+                    "Use conventional-commit prefixes (fix:, feat:, feat!:) so the bump can be auto-detected".to_string(),
+                    "Or force a specific bump: homeboy release <component> --bump patch".to_string(),
+                ]),
+            )
+        })?;
+        (recommended, false)
+    } else {
+        let requested = git::SemverBump::parse(requested_bump).ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "bump_type",
+                format!("Invalid bump type: {}", requested_bump),
+                None,
+                Some(vec![
+                    "Use one of: patch, minor, major, or an explicit version like 2.0.0"
+                        .to_string(),
+                ]),
+            )
+        })?;
+        let is_underbump = recommended
+            .map(|r| requested.rank() < r.rank())
+            .unwrap_or(false);
+        (requested, is_underbump)
+    };
 
     Ok(Some(ReleaseSemverRecommendation {
         latest_tag: latest_tag.clone(),
@@ -370,6 +393,67 @@ mod tests {
             recommendation.is_none(),
             "internal no-op bump sentinel should let the planner build a skip plan"
         );
+    }
+
+    #[test]
+    fn none_request_with_fix_commits_recommends_patch_without_erroring() {
+        // #7598: with no explicit --bump (requested_bump == "none") and only
+        // conventional `fix:` commits since the last tag, auto-detection must
+        // resolve to a patch bump — not fail with `Invalid bump type: none`.
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "README.md", "initial", "chore: initial");
+        run_git(dir, &["tag", "v1.11.3"]);
+        commit_file(
+            dir,
+            "a.txt",
+            "a",
+            "fix: correct community profile visual bugs (#145)",
+        );
+        commit_file(
+            dir,
+            "b.txt",
+            "b",
+            "fix: align concert/music-fan cards (#146)",
+        );
+        let component = Component {
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+
+        let release_scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
+        let recommendation = build_semver_recommendation(&component, "none", &release_scope)
+            .expect("auto-detected patch bump must not error")
+            .expect("releasable fix commits must yield a recommendation");
+
+        assert_eq!(recommendation.recommended_bump.as_deref(), Some("patch"));
+        assert_eq!(recommendation.requested_bump, "patch");
+        assert!(
+            !recommendation.is_underbump,
+            "auto-detection cannot underbump its own recommendation"
+        );
+    }
+
+    #[test]
+    fn none_request_with_feat_commits_recommends_minor() {
+        // Auto-detection must also lift a `feat:` to minor, not just patch.
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "README.md", "initial", "chore: initial");
+        run_git(dir, &["tag", "v1.0.0"]);
+        commit_file(dir, "f.txt", "f", "feat: add a capability");
+        let component = Component {
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+
+        let release_scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
+        let recommendation = build_semver_recommendation(&component, "none", &release_scope)
+            .expect("auto-detected minor bump must not error")
+            .expect("releasable feat commit must yield a recommendation");
+
+        assert_eq!(recommendation.recommended_bump.as_deref(), Some("minor"));
+        assert_eq!(recommendation.requested_bump, "minor");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Closes #7598. `homeboy release` without an explicit `--bump` failed with `Invalid bump type: none` even when every commit since the last tag used a valid conventional-commit `fix:` prefix (which should auto-detect a **patch** bump). The release only succeeded after passing `--bump patch` by hand.

## Root cause
With no `--bump`, the sentinel bump type `"none"` flows into `build_semver_recommendation`. It early-returns cleanly only when there are **no** releasable commits. When commits *do* recommend a bump, the code fell through to `git::SemverBump::parse(requested_bump)` — parsing the literal `"none"`, which is not a valid keyword — and errored (`planning_semver.rs`). So a fully auto-detectable release was rejected.

## Fix
Resolve the effective bump in auto-detect mode from the commit-derived recommendation:
- When `requested_bump == "none"` and commits recommend a bump, **use that recommendation** (never flagged as an underbump — auto-detection can't underbump itself).
- Only a genuinely undeterminable bump (commits present, but no recommendation) errors now, with an **actionable** message pointing at conventional-commit prefixes or an explicit `--bump`.
- The existing no-commits / non-releasable-only paths still return no recommendation, so the planner builds its skip plan unchanged.

## Tests (proven)
- `none_request_with_fix_commits_recommends_patch_without_erroring` — `fix:` commits under a `--bump`-less release auto-detect to patch. **Fails on the prior code** with the exact `Invalid bump type: none` (verified by temp-disabling the fix).
- `none_request_with_feat_commits_recommends_minor` — `feat:` auto-detects to minor.
- Existing `none_request_with_only_non_releasable_commits_returns_no_recommendation` and the planner suite still pass.

`cargo check -p homeboy-release --lib --tests` clean; full `planning_semver` (16) and `planner` (8) test modules green; `cargo fmt` applied.