### PR TITLE
fix(audit): duplicate_function treats inline cfg(test) fixtures as test code

### DIFF
--- a/crates/homeboy-code-audit/src/duplication.rs
+++ b/crates/homeboy-code-audit/src/duplication.rs
@@ -18,7 +18,7 @@ use super::conventions::{AuditFinding, Language};
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
 use super::idiomatic::is_trivial_method;
-use super::walker::is_test_path;
+use super::walker::{cfg_test_regions, is_test_path};
 use homeboy_audit_contract::DuplicationDetectorConfig;
 
 // `DuplicateGroup` now lives in the shared audit contract; re-exported so
@@ -117,11 +117,53 @@ pub(crate) fn detect_duplicate_groups(fingerprints: &[&FileFingerprint]) -> Vec<
 /// `convention_methods` are excluded — identical implementations across convention-
 /// following files are expected behavior (e.g. `__construct`, `checkPermission`,
 /// interface methods with identical bodies).
+/// Set of `(method_name, file)` pairs whose definition sits inside an inline
+/// `#[cfg(test)]` region of a production file. These are test fixtures
+/// (`make_fp`, `git_repo`, `local_client`, …) that `is_test_path` — which only
+/// classifies whole test *files* — cannot see. Duplication among them is
+/// per-module test scaffolding, not production copy-paste, so it should be
+/// treated the same as `is_test_path` duplication (Info severity, test-helper
+/// suggestion).
+fn inline_test_context_methods(fingerprints: &[&FileFingerprint]) -> HashSet<(String, String)> {
+    let mut out = HashSet::new();
+    for fp in fingerprints {
+        let regions = cfg_test_regions(&fp.content);
+        if regions.is_empty() {
+            continue;
+        }
+        for method_name in fp.method_hashes.keys() {
+            // Find the method's `fn <name>` declaration offset; flag it when it
+            // falls inside a cfg(test) region.
+            let needle = format!("fn {}", method_name);
+            if let Some(pos) = fp.content.find(&needle) {
+                if regions
+                    .iter()
+                    .any(|(start, end)| pos >= *start && pos <= *end)
+                {
+                    out.insert((method_name.clone(), fp.relative_path.clone()));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Whether a duplicate location is test code — either a whole test file
+/// (`is_test_path`) or a method defined inside an inline `#[cfg(test)]` block.
+fn is_test_location(
+    method_name: &str,
+    file: &str,
+    inline_test_methods: &HashSet<(String, String)>,
+) -> bool {
+    is_test_path(file) || inline_test_methods.contains(&(method_name.to_string(), file.to_string()))
+}
+
 pub(crate) fn detect_duplicates(
     fingerprints: &[&FileFingerprint],
     convention_methods: &std::collections::HashSet<String>,
 ) -> Vec<Finding> {
     let hash_groups = build_groups(fingerprints);
+    let inline_test_methods = inline_test_context_methods(fingerprints);
     let mut findings = Vec::new();
 
     for ((method_name, _hash), locations) in &hash_groups {
@@ -134,7 +176,9 @@ pub(crate) fn detect_duplicates(
             continue;
         }
 
-        let test_only_duplicate = locations.iter().all(|file| is_test_path(file));
+        let test_only_duplicate = locations
+            .iter()
+            .all(|file| is_test_location(method_name, file, &inline_test_methods));
         let severity = if test_only_duplicate {
             Severity::Info
         } else {
@@ -205,6 +249,7 @@ const CROSS_NAME_MIN_BODY_LINES: usize = 1;
 /// exact detector; a cross-name group is still reported (its value is the
 /// *cross-name* link), but same-name-only groups are left to `detect_duplicates`.
 pub(crate) fn detect_cross_name_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    let inline_test_methods = inline_test_context_methods(fingerprints);
     // hash -> list of (file, method_name)
     let mut by_body: HashMap<&str, Vec<(&str, &str)>> = HashMap::new();
     for fp in fingerprints {
@@ -233,7 +278,9 @@ pub(crate) fn detect_cross_name_duplicates(fingerprints: &[&FileFingerprint]) ->
             continue;
         }
 
-        let test_only = locations.iter().all(|(file, _)| is_test_path(file));
+        let test_only = locations
+            .iter()
+            .all(|(file, name)| is_test_location(name, file, &inline_test_methods));
         let severity = if test_only {
             Severity::Info
         } else {

--- a/crates/homeboy-code-audit/src/duplication/tests.rs
+++ b/crates/homeboy-code-audit/src/duplication/tests.rs
@@ -72,6 +72,54 @@ fn duplicate_functions_under_tests_are_info_findings() {
 }
 
 #[test]
+fn duplicate_helpers_in_inline_cfg_test_blocks_are_info_findings() {
+    // `make_fp` is a fixture duplicated across the inline `#[cfg(test)]` blocks
+    // of two PRODUCTION files. `is_test_path` cannot see it (the files aren't
+    // test-path files), but it is still test scaffolding — Info, not Warning.
+    let mut fp1 = make_fingerprint("src/a.rs", &["make_fp"], &[("make_fp", "h1")]);
+    fp1.content =
+        "fn prod() {}\n\n#[cfg(test)]\nmod tests {\n    fn make_fp() -> Fp { Fp::default() }\n}\n"
+            .to_string();
+    let mut fp2 = make_fingerprint("src/b.rs", &["make_fp"], &[("make_fp", "h1")]);
+    fp2.content =
+        "fn other() {}\n\n#[cfg(test)]\nmod tests {\n    fn make_fp() -> Fp { Fp::default() }\n}\n"
+            .to_string();
+
+    let findings = detect_duplicates(&[&fp1, &fp2], &std::collections::HashSet::new());
+
+    assert_eq!(findings.len(), 2);
+    assert!(
+        findings.iter().all(|f| f.severity == Severity::Info),
+        "inline cfg(test) fixture duplication is test-only (Info), got: {:?}",
+        findings
+            .iter()
+            .map(|f| (&f.file, &f.severity))
+            .collect::<Vec<_>>()
+    );
+    assert!(findings
+        .iter()
+        .all(|f| f.suggestion.contains("shared test helper")));
+}
+
+#[test]
+fn production_duplicate_alongside_inline_test_still_warns() {
+    // The same function name duplicated in PRODUCTION scope (not inside a
+    // cfg(test) block) must stay Warning — the inline-test relaxation is scoped.
+    let mut fp1 = make_fingerprint("src/a.rs", &["helper"], &[("helper", "h9")]);
+    fp1.content = "fn helper() -> u8 { 1 }\n".to_string();
+    let mut fp2 = make_fingerprint("src/b.rs", &["helper"], &[("helper", "h9")]);
+    fp2.content = "fn helper() -> u8 { 1 }\n".to_string();
+
+    let findings = detect_duplicates(&[&fp1, &fp2], &std::collections::HashSet::new());
+
+    assert_eq!(findings.len(), 2);
+    assert!(
+        findings.iter().all(|f| f.severity == Severity::Warning),
+        "production duplicates remain Warning"
+    );
+}
+
+#[test]
 fn no_duplicates_different_hashes() {
     let fp1 = make_fingerprint("src/a.rs", &["process"], &[("process", "hash_a")]);
     let fp2 = make_fingerprint("src/b.rs", &["process"], &[("process", "hash_b")]);


### PR DESCRIPTION
## Summary
Fixes a severity/misclassification FP in `duplicate_function` (55-finding category): test fixtures duplicated across inline `#[cfg(test)]` blocks were flagged at Warning severity as if they were production copy-paste.

## Problem
`detect_duplicates` / `detect_cross_name_duplicates` downgrade a duplicate to **Info** severity (with a "consider a shared test helper" suggestion) only when *all* locations are `is_test_path` — i.e. whole test *files*. But common fixtures like `make_fp`, `git_repo`, `local_client` live inside inline `#[cfg(test)] mod tests { … }` blocks of **production** `.rs` files. `is_test_path` can't see those, so they were emitted at **Warning** severity — the "extract to a shared module and import it" suggestion, which is wrong for per-module test scaffolding.

From the first Audit Debt sweep: **14 of 55 unique `duplicate_function` findings (25%) had both sites inside inline `#[cfg(test)]` blocks.** (`test_methods` can't help — it deliberately only tracks `#[test]`-attributed fns, not fixture helpers.)

## Fix
Add `inline_test_context_methods`: a method whose `fn <name>` declaration offset falls inside a `cfg_test_regions` span is test scaffolding. `is_test_location` treats those (plus `is_test_path` files) as test, so an all-test-location duplicate downgrades to Info with the shared-test-helper suggestion. Production duplicates are unaffected.

## Tests (77 duplication + 331 detector + runtime regression all pass)
- `duplicate_helpers_in_inline_cfg_test_blocks_are_info_findings` — `make_fp` across two production files' cfg(test) blocks → Info + test-helper suggestion.
- `production_duplicate_alongside_inline_test_still_warns` — production-scope duplicate stays Warning (the relaxation is scoped).

## Impact
Correctly reclassifies ~25% of `duplicate_function` findings as test scaffolding (Info) rather than production copy-paste (Warning), so the Warning-level findings reflect genuine production duplication worth extracting. Consistent with the inline-cfg(test) awareness already added to command_wrapper_bypass and constant_bypass.
