### PR TITLE
Preserve accepted Lab handoff during runner-local plan replacement

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -388,6 +388,12 @@ where
             if let Some(runner_job_id) = existing.runner_job_id() {
                 record.metadata["runner_job_id"] = json!(runner_job_id);
             }
+            if existing.lab_handoff.as_ref().is_some_and(|handoff| {
+                handoff.state == AgentTaskLabHandoffState::Accepted
+                    && handoff.authority == AgentTaskLabHandoffAuthority::RunnerDaemon
+            }) {
+                record.lab_handoff = existing.lab_handoff;
+            }
         }
     }
     store::write_record(&record)?;

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -196,6 +196,19 @@ fn lab_handoff_run_plan_executes_with_runner_provenance_after_transport_is_consu
             "foreground-daemon-job",
         )
         .expect("foreground daemon binds its job before run-plan");
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+        ];
+        agent_task_lifecycle::record_detached_lab_run(agent_task_lifecycle::DetachedLabRunRecord {
+            run_id: "lab-handoff-run-plan",
+            runner_id: "homeboy-lab",
+            runner_job_id: "foreground-daemon-job",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        })
+        .expect("foreground daemon accepts the Lab handoff before run-plan");
 
         let result = run_loaded_plan(
             test_plan(),
@@ -219,11 +232,12 @@ fn lab_handoff_run_plan_executes_with_runner_provenance_after_transport_is_consu
 
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.value.totals.succeeded, 1);
+        let record =
+            lifecycle_status("lab-handoff-run-plan").expect("completed runner-local record");
+        assert_eq!(record.runner_job_id(), Some("foreground-daemon-job"));
         assert_eq!(
-            lifecycle_status("lab-handoff-run-plan")
-                .expect("completed runner-local record")
-                .runner_job_id(),
-            Some("foreground-daemon-job")
+            record.lab_handoff.expect("accepted daemon handoff").state,
+            agent_task_lifecycle::AgentTaskLabHandoffState::Accepted
         );
     });
 }


### PR DESCRIPTION
## Summary
- preserve the typed accepted Lab handoff when runner-local `run-plan` replaces the staged lifecycle record
- retain the runner-daemon authority and accepted state alongside the `runner_job_id` preserved by #9333
- extend the real daemon prebind/accept/run-plan regression through terminal lifecycle status

## Why
PR #9333 fixed foreground daemon job metadata loss. The same record replacement still discarded the typed `lab_handoff`, leaving lifecycle status without the accepted runner-daemon ownership that produced that job identity. This follow-up keeps both projections consistent for the matching execution runner.

Follow-up to #9333 and #9275.

## How to test
1. Run `cargo test -p homeboy-agents lab_handoff_run_plan_executes_with_runner_provenance_after_transport_is_consumed --lib -- --test-threads=1`.
2. Run `cargo test -p homeboy-agents lab_handoff --lib`.
3. Run `cargo clippy -p homeboy-agents --lib`.
4. Run `cargo fmt --check`.

## Compatibility
This changes only internal lifecycle record replacement for an already accepted handoff owned by the same execution runner. Controller-side plan replacement and public CLI contracts are unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Model:** `openai/gpt-5.6-sol`
- **Used for:** Diagnosed the live Lab handoff failure, adapted the repair to current main after #9333, implemented deterministic coverage, and verified the change with Chris Huber.