### PR TITLE
Supervise durable artifact origins

### DIFF
--- a/crates/homeboy-cli/src/commands/tunnel.rs
+++ b/crates/homeboy-cli/src/commands/tunnel.rs
@@ -21,7 +21,10 @@ use homeboy_tunnel::{
     ServiceTunnelStatus, ServiceTunnelTarget, ServiceTunnelTunnelBackend, StartServiceTunnelSpec,
 };
 use std::collections::BTreeMap;
+use std::net::TcpListener;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 
 use super::{CmdResult, DynamicSetArgs};
 use crate::command_contract::{
@@ -336,6 +339,27 @@ enum TunnelArtifactOriginCommand {
         /// Artifact root to serve. Defaults to Homeboy's configured artifact root.
         #[arg(long)]
         root: Option<PathBuf>,
+
+        /// Preview ingress/broker URL. With --public-host, keeps a durable
+        /// outbound reverse connection open for this artifact origin.
+        #[arg(long, requires = "public_host")]
+        ingress: Option<String>,
+
+        /// Exact public host claimed by the durable artifact origin.
+        #[arg(long, requires = "ingress")]
+        public_host: Option<String>,
+
+        /// Environment variable containing the reverse-client bearer token.
+        #[arg(
+            long,
+            default_value = "HOMEBOY_PREVIEW_TUNNEL_TOKEN",
+            requires = "ingress"
+        )]
+        token_env: String,
+
+        /// Long-poll timeout in seconds for ingress request claims.
+        #[arg(long, default_value_t = 1, requires = "ingress")]
+        poll_timeout: u64,
     },
     /// Print the artifact origin root and public URL mapping without starting a server
     Status {
@@ -445,12 +469,59 @@ pub fn run(args: TunnelArgs, _global: &super::GlobalArgs) -> CmdResult<TunnelOut
 
 fn run_artifact_origin(command: TunnelArtifactOriginCommand) -> CmdResult<TunnelOutput> {
     match command {
-        TunnelArtifactOriginCommand::Serve { bind, root } => {
-            let status = artifacts::status(
-                bind.clone(),
-                root.clone().unwrap_or(homeboy::core::artifacts::root()?),
-            );
-            artifacts::serve(ArtifactOriginServeSpec { bind, root })?;
+        TunnelArtifactOriginCommand::Serve {
+            bind,
+            root,
+            ingress,
+            public_host,
+            token_env,
+            poll_timeout,
+        } => {
+            let root = root.unwrap_or(homeboy::core::artifacts::root()?);
+            let status = artifacts::status(bind.clone(), root.clone());
+            if let (Some(ingress), Some(public_host)) = (ingress, public_host) {
+                let listener = TcpListener::bind(&bind).map_err(|err| {
+                    homeboy::core::Error::internal_io(err.to_string(), Some(bind.clone()))
+                })?;
+                let origin_bind = bind.clone();
+                std::thread::spawn(move || {
+                    if let Err(err) = artifacts::serve_listener(origin_bind, root, listener) {
+                        eprintln!("homeboy durable artifact origin failed: {}", err.message);
+                    }
+                });
+                let stop = Arc::new(AtomicBool::new(false));
+                homeboy::core::process::install_shutdown_handler(
+                    stop.clone(),
+                    "durable artifact origin",
+                )?;
+                let ready = serde_json::json!({
+                    "command": "tunnel.artifact-origin.serve",
+                    "root": status.root,
+                    "origin_bind": bind,
+                    "ingress": ingress,
+                    "public_host": public_host,
+                    "token_env": token_env,
+                    "durable_publication": true,
+                });
+                preview_client::supervise_with_ready(
+                    PreviewClientStartSpec {
+                        ingress,
+                        public_host,
+                        local_origin: format!("http://{bind}"),
+                        session_id: Some("artifact-origin".to_string()),
+                        token_env,
+                        poll_timeout_secs: poll_timeout,
+                        ready_stdout: false,
+                    },
+                    stop,
+                    move || println!("ready {ready}"),
+                )?;
+            } else {
+                artifacts::serve(ArtifactOriginServeSpec {
+                    bind,
+                    root: Some(root),
+                })?;
+            }
             Ok((
                 TunnelOutput {
                     command: "tunnel.artifact_origin.serve".to_string(),

--- a/crates/homeboy-core/src/artifact_origin.rs
+++ b/crates/homeboy-core/src/artifact_origin.rs
@@ -56,10 +56,20 @@ pub fn serve(spec: ArtifactOriginServeSpec) -> Result<ArtifactOriginStatus> {
     let root = spec.root.unwrap_or(paths::artifact_root()?);
     let listener = TcpListener::bind(&spec.bind)
         .map_err(|err| Error::internal_io(err.to_string(), Some(spec.bind.clone())))?;
+    serve_listener(spec.bind, root, listener)
+}
+
+/// Serve an already-bound listener so a supervising owner can establish
+/// listener readiness before it opens a reverse connection.
+pub fn serve_listener(
+    bind: String,
+    root: PathBuf,
+    listener: TcpListener,
+) -> Result<ArtifactOriginStatus> {
     eprintln!(
         "homeboy artifact origin serving {} on {}",
         root.display(),
-        spec.bind
+        bind
     );
     for stream in listener.incoming() {
         match stream {
@@ -71,10 +81,10 @@ pub fn serve(spec: ArtifactOriginServeSpec) -> Result<ArtifactOriginStatus> {
                     }
                 });
             }
-            Err(err) => return Err(Error::internal_io(err.to_string(), Some(spec.bind))),
+            Err(err) => return Err(Error::internal_io(err.to_string(), Some(bind))),
         }
     }
-    Ok(status(spec.bind, root))
+    Ok(status(bind, root))
 }
 
 pub fn status(bind: String, root: PathBuf) -> ArtifactOriginStatus {

--- a/crates/homeboy-core/src/artifacts.rs
+++ b/crates/homeboy-core/src/artifacts.rs
@@ -35,8 +35,8 @@ pub use super::artifact_manifest::{
     RUN_ARTIFACT_STATUS_FILE,
 };
 pub use super::artifact_origin::{
-    inspect, serve, status, status_with_command, ArtifactOriginInspect, ArtifactOriginServeSpec,
-    ArtifactOriginStatus,
+    inspect, serve, serve_listener, status, status_with_command, ArtifactOriginInspect,
+    ArtifactOriginServeSpec, ArtifactOriginStatus,
 };
 pub use super::artifact_postprocess::{
     describe_artifact_postprocess_plan, record_artifact_postprocess_outputs,

--- a/crates/homeboy-tunnel/src/preview_client/mod.rs
+++ b/crates/homeboy-tunnel/src/preview_client/mod.rs
@@ -31,6 +31,29 @@ use headers::{
 use homeboy_core::{Error, Result};
 
 pub fn start(spec: PreviewClientStartSpec) -> Result<PreviewClientReport> {
+    let stop = Arc::new(AtomicBool::new(false));
+    homeboy_core::process::install_shutdown_handler(stop.clone(), "preview client")?;
+    supervise(spec, stop)
+}
+
+/// Keep one reverse client registered until the caller requests shutdown.
+pub fn supervise(
+    spec: PreviewClientStartSpec,
+    stop: Arc<AtomicBool>,
+) -> Result<PreviewClientReport> {
+    supervise_with_ready(spec, stop, || {})
+}
+
+/// Supervise a reverse client and notify its owner after the first successful
+/// registration. Reconnects preserve readiness without emitting it again.
+pub fn supervise_with_ready<F>(
+    spec: PreviewClientStartSpec,
+    stop: Arc<AtomicBool>,
+    on_ready: F,
+) -> Result<PreviewClientReport>
+where
+    F: FnOnce(),
+{
     validate_start_spec(&spec)?;
     let token = std::env::var(&spec.token_env).map_err(|_| {
         Error::validation_invalid_argument(
@@ -49,8 +72,6 @@ pub fn start(spec: PreviewClientStartSpec) -> Result<PreviewClientReport> {
         ));
     }
 
-    let stop = Arc::new(AtomicBool::new(false));
-    homeboy_core::process::install_shutdown_handler(stop.clone(), "preview client")?;
     let client = Client::builder()
         .timeout(Duration::from_secs(spec.poll_timeout_secs.max(1) + 5))
         .build()
@@ -63,7 +84,34 @@ pub fn start(spec: PreviewClientStartSpec) -> Result<PreviewClientReport> {
     if spec.ready_stdout {
         println!("ready https://{}", spec.public_host);
     }
+    on_ready();
+
+    let mut registered = true;
+    let mut reconnect_delay = Duration::from_millis(250);
     while !stop.load(Ordering::SeqCst) {
+        if !registered {
+            match register_session(&client, &spec, &token) {
+                Ok(()) => {
+                    registered = true;
+                    reconnect_delay = Duration::from_millis(250);
+                }
+                Err(err) => {
+                    eprintln!(
+                        "{}",
+                        json!({
+                            "command": "tunnel.preview_client.start",
+                            "event": "register_failed",
+                            "public_host": spec.public_host,
+                            "error": err.message,
+                            "retry_delay_ms": reconnect_delay.as_millis(),
+                        })
+                    );
+                    sleep_until_cancelled(&stop, reconnect_delay);
+                    reconnect_delay = (reconnect_delay * 2).min(Duration::from_secs(10));
+                    continue;
+                }
+            }
+        }
         match poll_next_request(&client, &spec, &token) {
             Ok(Some(request)) => {
                 let response_client = client.clone();
@@ -101,11 +149,25 @@ pub fn start(spec: PreviewClientStartSpec) -> Result<PreviewClientReport> {
                         "error": err.message,
                     })
                 );
-                thread::sleep(Duration::from_secs(1));
+                registered = false;
+                sleep_until_cancelled(&stop, reconnect_delay);
+                reconnect_delay = (reconnect_delay * 2).min(Duration::from_secs(10));
             }
         }
     }
-    close_session(&client, &spec, &token)?;
+    if registered {
+        if let Err(err) = close_session(&client, &spec, &token) {
+            eprintln!(
+                "{}",
+                json!({
+                    "command": "tunnel.preview_client.start",
+                    "event": "close_failed",
+                    "public_host": spec.public_host,
+                    "error": err.message,
+                })
+            );
+        }
+    }
 
     Ok(PreviewClientReport {
         command: "tunnel.preview_client.start",
@@ -115,6 +177,13 @@ pub fn start(spec: PreviewClientStartSpec) -> Result<PreviewClientReport> {
         registered: true,
         stopped: true,
     })
+}
+
+fn sleep_until_cancelled(stop: &AtomicBool, duration: Duration) {
+    let deadline = std::time::Instant::now() + duration;
+    while !stop.load(Ordering::SeqCst) && std::time::Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(25));
+    }
 }
 
 pub fn diagnose_auth(

--- a/crates/homeboy-tunnel/src/preview_ingress_tests.rs
+++ b/crates/homeboy-tunnel/src/preview_ingress_tests.rs
@@ -1,10 +1,13 @@
 use super::preview_ingress::*;
 use crate::native_preview_token_sha256;
+use crate::preview_client::{self, PreviewClientStartSpec};
 use base64::Engine;
 use homeboy_core::test_support;
 use serde_json::json;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
@@ -199,6 +202,112 @@ fn reverse_channel_client_serves_public_request() {
             browser_response.contains("console.log('ok');"),
             "{browser_response}"
         );
+    });
+}
+
+#[test]
+fn durable_reverse_client_reregisters_after_session_disconnect() {
+    test_support::with_isolated_home(|_| {
+        let token = "durable-artifact-token";
+        std::env::set_var("HOMEBOY_TEST_DURABLE_ARTIFACT_TOKEN", token);
+        std::env::set_var(
+            "HOMEBOY_TEST_DURABLE_ARTIFACT_TOKEN_SHA256",
+            native_preview_token_sha256(token),
+        );
+        let origin = TcpListener::bind("127.0.0.1:0").expect("bind artifact origin");
+        let origin_port = origin.local_addr().expect("origin address").port();
+        thread::spawn(move || loop {
+            let (mut stream, _) = origin.accept().expect("accept artifact request");
+            let mut request = [0_u8; 4096];
+            let read = stream.read(&mut request).expect("read artifact request");
+            assert!(String::from_utf8_lossy(&request[..read]).contains("/artifacts/proof.png"));
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: 8\r\n\r\nPNGproof")
+                .expect("write artifact");
+        });
+
+        let ingress = TcpListener::bind("127.0.0.1:0").expect("reserve ingress port");
+        let ingress_port = ingress.local_addr().expect("ingress address").port();
+        thread::spawn(move || {
+            serve_listener(
+                PreviewIngressServeSpec {
+                    bind: format!("127.0.0.1:{ingress_port}"),
+                    domain: "example.com".to_string(),
+                    public_host_pattern: "*-tunnel.example.com".to_string(),
+                    token_sha256_env: "HOMEBOY_TEST_DURABLE_ARTIFACT_TOKEN_SHA256".to_string(),
+                },
+                ingress,
+            )
+            .expect("serve ingress");
+        });
+        thread::sleep(Duration::from_millis(100));
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let client_stop = stop.clone();
+        let ready_count = Arc::new(AtomicUsize::new(0));
+        let client_ready_count = ready_count.clone();
+        let client = thread::spawn(move || {
+            preview_client::supervise_with_ready(
+                PreviewClientStartSpec {
+                    ingress: format!("http://127.0.0.1:{ingress_port}"),
+                    public_host: "artifacts-tunnel.example.com".to_string(),
+                    local_origin: format!("http://127.0.0.1:{origin_port}"),
+                    session_id: Some("artifact-origin".to_string()),
+                    token_env: "HOMEBOY_TEST_DURABLE_ARTIFACT_TOKEN".to_string(),
+                    poll_timeout_secs: 1,
+                    ready_stdout: false,
+                },
+                client_stop,
+                move || {
+                    client_ready_count.fetch_add(1, Ordering::SeqCst);
+                },
+            )
+        });
+
+        let artifact_request = || {
+            let deadline = std::time::Instant::now() + Duration::from_secs(3);
+            loop {
+                let browser = thread::spawn(move || {
+                    raw_http_request(
+                        ingress_port,
+                        "GET /artifacts/proof.png HTTP/1.1\r\nHost: artifacts-tunnel.example.com\r\n\r\n",
+                    )
+                });
+                let response = browser.join().expect("artifact response");
+                if !response.contains("missing_session") || std::time::Instant::now() >= deadline {
+                    break response;
+                }
+                thread::sleep(Duration::from_millis(25));
+            }
+        };
+        let first = artifact_request();
+        assert!(
+            first.contains("200 OK") && first.ends_with("PNGproof"),
+            "{first}"
+        );
+        assert_eq!(ready_count.load(Ordering::SeqCst), 1);
+
+        let closed = http_request(
+            ingress_port,
+            "POST",
+            "/preview/client/close",
+            "homeboy-health-tunnel.example.com",
+            Some(token),
+            json!({ "public_host": "artifacts-tunnel.example.com" }).to_string(),
+        );
+        assert!(closed.contains("200 OK"), "{closed}");
+        let reconnected = artifact_request();
+        assert!(
+            reconnected.contains("200 OK") && reconnected.ends_with("PNGproof"),
+            "{reconnected}"
+        );
+        assert_eq!(ready_count.load(Ordering::SeqCst), 1);
+
+        stop.store(true, Ordering::SeqCst);
+        client
+            .join()
+            .expect("supervisor completed")
+            .expect("clean shutdown");
     });
 }
 

--- a/docs/commands/tunnel.md
+++ b/docs/commands/tunnel.md
@@ -47,12 +47,20 @@ local-only URL such as `localhost` or `127.0.0.1`. Treat filesystem paths and
 local-only URLs as operator notes; mirror the artifact root or route it through a
 reviewer-reachable tunnel before pasting links into PRs, issues, or reports.
 
-Serve the artifact root behind an operator-managed TLS/proxy/tunnel:
+Run the artifact root and its outbound reverse connection as one long-lived service. This is the durable artifact-publication contract for a systemd unit or Homeboy-managed service:
 
 ```sh
-HOMEBOY_PUBLIC_ARTIFACT_BASE_URL=https://homeboy-artifacts-tunnel.dev.example.com \
-  homeboy tunnel artifact-origin serve --bind 127.0.0.1:7351
+HOMEBOY_PUBLIC_ARTIFACT_BASE_URL=https://artifacts-tunnel.example.com \
+HOMEBOY_PREVIEW_TUNNEL_TOKEN='<configured-secret>' \
+  homeboy tunnel artifact-origin serve \
+  --root /srv/homeboy-artifacts \
+  --bind 127.0.0.1:7351 \
+  --ingress https://preview-ingress.example.com \
+  --public-host artifacts-tunnel.example.com \
+  --token-env HOMEBOY_PREVIEW_TUNNEL_TOKEN
 ```
+
+The process prints a structured `ready` record containing the artifact root, origin bind, ingress URL, exact public host, and token environment-variable name. It keeps serving while the reverse client reconnects with bounded backoff after a disconnected or restarted ingress. The default one-second long poll bounds service shutdown latency; `--poll-timeout` can tune it.
 
 For Lab-generated Workflow Bench artifacts, publish the bundle under the configured artifact root first, then inspect, then serve:
 


### PR DESCRIPTION
## Summary

- let `tunnel artifact-origin serve` own the static artifact server and reverse client as one process
- re-register the reverse client after ingress session loss with bounded backoff
- emit readiness only after initial registration succeeds and keep shutdown best-effort
- document the durable service command

Closes #6736.

## Why

The preview ingress removes an in-memory reverse session when the client disconnects. Completed-run artifact URLs therefore returned `404 missing_session` even though the artifact still existed. A durable artifact origin must keep reconnecting instead of treating the first session as permanent.

## How to test

1. Run `cargo fmt --check`.
2. Run `cargo test -p homeboy-tunnel --lib --no-fail-fast`.
3. Run `cargo test -p homeboy-cli commands::tunnel::tests -- --test-threads=1`.
4. Start a preview ingress and local artifact root using the command documented in `docs/commands/tunnel.md`.
5. Request an artifact through the public host, close its ingress session through `/preview/client/close`, then request the artifact again. Confirm the second request succeeds after automatic re-registration.

## Compatibility

Existing local-only `homeboy tunnel artifact-origin serve --bind ...` usage is unchanged. The new ingress, public-host, token-env, and poll-timeout options are additive. No artifact record schema or public URL derivation behavior changes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Root-cause investigation, implementation, tests, documentation, and review
