### PR TITLE
fix(agents): persist configured rotation model on the initial cook attempt (#9013)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -119,6 +119,15 @@ where
                 request.limits.execution_deadline_unix_ms = execution_deadline_unix_ms;
                 if let Some(policy) = plan_rotation.as_ref() {
                     AgentTaskScheduleSupport::apply_rotation_policy_limits(&mut request, policy);
+                    // Backfill the initial attempt's model from the first entry
+                    // so a configured model default is persisted before the run
+                    // and finalization does not fail after publishing (#9013).
+                    if let Some(entry) = policy.entries.first() {
+                        AgentTaskScheduleSupport::apply_initial_rotation_entry_model(
+                            &mut request,
+                            entry,
+                        );
+                    }
                 }
                 ScheduledTask {
                     workspace_key: AgentTaskScheduleSupport::workspace_key(&request),

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -1188,6 +1188,46 @@ impl AgentTaskScheduleSupport {
     /// the dispatch provider-config layering. Also copies the policy-level
     /// liveness limit into the request so the provider runner can enforce it
     /// per attempt.
+    /// Backfill the initial attempt's model from the first rotation entry (#9013).
+    ///
+    /// The first configured rotation entry describes the initial attempt (later
+    /// entries are failover). `apply_rotation_entry` only runs when rotating *to*
+    /// a new entry after a failure, so a cook that relied on a configured
+    /// `rotation.entries` default (no explicit `--model`) executed with no model,
+    /// persisted `provider_model: null`, and then failed finalization *after*
+    /// publishing a PR.
+    ///
+    /// This deliberately only backfills the **model** — not backend, selector,
+    /// provider_config, or adoption. Those fields carry failover-specific
+    /// semantics (e.g. an entry may switch provider or adopt a prior candidate)
+    /// that must not reshape the initial attempt; only the missing model
+    /// identity is needed for durable provenance. An explicit `--model` on the
+    /// request always wins.
+    pub(super) fn apply_initial_rotation_entry_model(
+        request: &mut AgentTaskRequest,
+        entry: &AgentTaskProviderRotationEntry,
+    ) {
+        if request.executor.model.is_some() {
+            return;
+        }
+        // Only backfill from an entry that targets the same backend the initial
+        // attempt will actually run (or a backend-agnostic entry). A failover
+        // entry for a different provider must not lend its model to this backend.
+        if let Some(entry_backend) = entry.backend.as_deref() {
+            if entry_backend != request.executor.backend {
+                return;
+            }
+        }
+        if let Some(model) = &entry.model {
+            request.executor.model = Some(model.clone());
+            if let Some(selection) = request.executor.runtime_selection.as_mut() {
+                if selection.model.is_none() {
+                    selection.model = Some(model.clone());
+                }
+            }
+        }
+    }
+
     pub(super) fn apply_rotation_entry(
         request: &mut AgentTaskRequest,
         entry: &AgentTaskProviderRotationEntry,

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
@@ -474,6 +474,70 @@ mod provider_rotation_tests {
     }
 
     #[test]
+    fn initial_attempt_applies_the_first_rotation_entry_model() {
+        // #9013: with a configured `rotation.entries` default and no explicit
+        // --model, the first entry describes the initial attempt. Its model must
+        // be applied to the very first request so it is persisted before
+        // execution — otherwise the cook runs with a null model and fails
+        // finalization after publishing a PR.
+        let executor = RotationScriptedExecutor::new(vec![success()]);
+        let observed = Arc::clone(&executor.observed);
+        let scheduler = AgentTaskScheduler::new(executor);
+        let mut plan = plan_with_tasks(1);
+        assert!(
+            plan.tasks[0].executor.model.is_none(),
+            "fixture starts with no explicit model"
+        );
+        plan.options.rotation = Some(rotation_policy(vec![AgentTaskProviderRotationEntry {
+            backend: None,
+            selector: None,
+            model: Some("configured-default-model".to_string()),
+            provider_config: json!({}),
+            adoption: None,
+        }]));
+        enable_rotation(&mut plan);
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        let observed = observed.lock().expect("observed requests");
+        assert_eq!(
+            observed[0].executor.model.as_deref(),
+            Some("configured-default-model"),
+            "the initial attempt must carry the configured rotation-entry model"
+        );
+    }
+
+    #[test]
+    fn initial_attempt_preserves_an_explicit_model_over_the_first_rotation_entry() {
+        // The initial application only fills gaps: an explicit --model already on
+        // the request wins over the configured entry default.
+        let executor = RotationScriptedExecutor::new(vec![success()]);
+        let observed = Arc::clone(&executor.observed);
+        let scheduler = AgentTaskScheduler::new(executor);
+        let mut plan = plan_with_tasks(1);
+        plan.tasks[0].executor.model = Some("explicit-cli-model".to_string());
+        plan.options.rotation = Some(rotation_policy(vec![AgentTaskProviderRotationEntry {
+            backend: None,
+            selector: None,
+            model: Some("configured-default-model".to_string()),
+            provider_config: json!({}),
+            adoption: None,
+        }]));
+        enable_rotation(&mut plan);
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        let observed = observed.lock().expect("observed requests");
+        assert_eq!(
+            observed[0].executor.model.as_deref(),
+            Some("explicit-cli-model"),
+            "an explicit model must not be overridden by the rotation-entry default"
+        );
+    }
+
+    #[test]
     fn one_provider_execution_budget_never_rotates() {
         let executor = RotationScriptedExecutor::new(vec![provider_failure(), success()]);
         let calls = Arc::clone(&executor.calls);


### PR DESCRIPTION
## Summary
Closes #9013. An OpenCode-backed `agent-task cook` could complete generation, verification, promotion, push two commits, and open a green PR — then return exit 2 with `durable provider metadata must record a concrete model before publication`. The failure landed **after** irreversible publication side effects.

## Root cause
The first configured `rotation.entries` entry describes the *initial* attempt (later entries are failover). But `apply_rotation_entry` only runs when rotating *to* a new entry after a failure (`engine.rs`). So on the initial attempt, when `--model` was omitted and the model came from a configured rotation-entry default, `executor.model` stayed `None`, harvest persisted `provider_model: null`, and finalization's `durable_model` check failed — after the PR was already opened.

## Fix
Backfill the initial attempt's model from the first rotation entry before the run. Deliberately **model-only**:
- backend / selector / provider_config / adoption carry **failover-specific** semantics (an entry may switch provider or adopt a prior candidate) that must not reshape the initial attempt — applying them wholesale changes initial provider selection.
- an explicit `--model` on the request always wins (gap-fill only).
- an entry pinned to a **different backend** than the initial attempt does not lend its model.

This ensures the configured model is persisted before provider execution, so a successful published cook returns success.

## Tests (proven)
In `tests/scheduling_tests/provider_rotation.rs`:
- `initial_attempt_applies_the_first_rotation_entry_model` — the initial request carries the configured model. **Fails on the prior code** with a null model (verified by temp-reverting to the limits-only path).
- `initial_attempt_preserves_an_explicit_model_over_the_first_rotation_entry` — an explicit model is not overridden.

`cargo check -p homeboy-agents --lib --tests` clean; `cargo fmt` applied. Note: 3 rotation tests (`rotation_adopts_only_the_explicit_portable_candidate`, `rotation_preserves_uncommitted_candidate_...`, `timed_out_attempt_rotates_...`) fail **identically on clean `origin/main`** in this environment (git/provider-exec setup) — pre-existing, unrelated to this change.