### PR TITLE
refactor(audit): source inline test-region marker from Language, not hardcoded

### DIFF
--- a/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs
+++ b/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs
@@ -27,7 +27,7 @@ use super::super::conventions::AuditFinding;
 use super::super::findings::{Finding, Severity};
 use super::super::fingerprint::FileFingerprint;
 use super::super::walker::{
-    cfg_test_regions, crate_of_path, is_test_path, offset_in_cfg_test_region,
+    crate_of_path, inline_test_regions, is_test_path, offset_in_test_region,
     visibility_is_crate_public,
 };
 
@@ -165,9 +165,10 @@ fn detect_command_wrapper_bypass(fingerprints: &[&FileFingerprint]) -> Vec<Findi
         // a freshly-built repo), not production command drift. `is_test_path`
         // only excludes whole test files, so compute the file's cfg(test) byte
         // ranges here and skip matches that fall inside them.
-        let test_regions = cfg_test_regions(&fp.content);
+        let test_regions =
+            inline_test_regions(&fp.content, fp.language.inline_test_region_markers());
         for m in argvec_regex().find_iter(&fp.content) {
-            if offset_in_cfg_test_region(m.start(), &test_regions) {
+            if offset_in_test_region(m.start(), &test_regions) {
                 continue;
             }
             let inner = argvec_regex()

--- a/crates/homeboy-code-audit/src/detectors/constant_bypass.rs
+++ b/crates/homeboy-code-audit/src/detectors/constant_bypass.rs
@@ -24,7 +24,7 @@ use super::super::conventions::AuditFinding;
 use super::super::findings::{Finding, Severity};
 use super::super::fingerprint::FileFingerprint;
 use super::super::walker::{
-    cfg_test_regions, crate_of_path, is_test_path, offset_in_cfg_test_region,
+    crate_of_path, inline_test_regions, is_test_path, offset_in_test_region,
     visibility_is_crate_public,
 };
 
@@ -103,9 +103,10 @@ fn detect_constant_bypass_literals(fingerprints: &[&FileFingerprint]) -> Vec<Fin
         // Literals inside inline `#[cfg(test)]` blocks of a production file are
         // test data/fixtures, not production constant drift. `is_test_path` only
         // excludes whole test files, so skip matches inside cfg(test) regions.
-        let test_regions = cfg_test_regions(&fp.content);
+        let test_regions =
+            inline_test_regions(&fp.content, fp.language.inline_test_region_markers());
         for (offset, literal) in string_literals(&fp.content) {
-            if offset_in_cfg_test_region(offset, &test_regions) {
+            if offset_in_test_region(offset, &test_regions) {
                 continue;
             }
             let Some(def) = consts.get(&literal) else {

--- a/crates/homeboy-code-audit/src/duplication.rs
+++ b/crates/homeboy-code-audit/src/duplication.rs
@@ -18,7 +18,7 @@ use super::conventions::{AuditFinding, Language};
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
 use super::idiomatic::is_trivial_method;
-use super::walker::{cfg_test_regions, is_test_path};
+use super::walker::{inline_test_regions, is_test_path};
 use homeboy_audit_contract::DuplicationDetectorConfig;
 
 // `DuplicateGroup` now lives in the shared audit contract; re-exported so
@@ -127,7 +127,7 @@ pub(crate) fn detect_duplicate_groups(fingerprints: &[&FileFingerprint]) -> Vec<
 fn inline_test_context_methods(fingerprints: &[&FileFingerprint]) -> HashSet<(String, String)> {
     let mut out = HashSet::new();
     for fp in fingerprints {
-        let regions = cfg_test_regions(&fp.content);
+        let regions = inline_test_regions(&fp.content, fp.language.inline_test_region_markers());
         if regions.is_empty() {
             continue;
         }

--- a/crates/homeboy-code-audit/src/walker.rs
+++ b/crates/homeboy-code-audit/src/walker.rs
@@ -135,54 +135,62 @@ pub(crate) fn count_unclaimed_source_files(root: &Path) -> usize {
     codebase_scan::walk_files(root, &config).len()
 }
 
-/// Byte ranges `(start, end)` of inline `#[cfg(test)]` blocks in `content`.
+/// Byte ranges `(start, end)` of inline test-region blocks in `content` for a
+/// given language, using the language's `inline_test_region_markers()`.
 ///
 /// `is_test_path` only classifies whole test *files*. Detectors that scan raw
-/// file content (constant-bypass, command-wrapper-bypass, …) also need to skip
-/// matches inside inline `#[cfg(test)] mod tests { … }` / `#[cfg(test)] fn … {}`
-/// blocks of production files, where literals and raw commands are test
-/// fixtures rather than production code.
+/// file content (constant-bypass, command-wrapper-bypass, duplication, …) also
+/// need to skip matches inside inline test blocks of production files (Rust's
+/// `#[cfg(test)] mod tests { … }`), where literals/commands/fixtures are test
+/// scaffolding rather than production code. Languages with no inline test
+/// marker (test code lives in separate files) yield no regions.
 ///
-/// Matches the `#[cfg(test)]` attribute, then brace-matches the block that
-/// follows it. Attribute-only items with no block (`#[cfg(test)] use …;`) are
-/// ignored. Ranges span attribute→closing brace.
-pub(crate) fn cfg_test_regions(content: &str) -> Vec<(usize, usize)> {
-    const ATTR: &str = "#[cfg(test)]";
+/// For each marker occurrence, brace-matches the block that follows it. Marker
+/// occurrences with no following block are ignored. Ranges span marker→closing
+/// brace. The concrete marker syntax is sourced from the agnostic language home
+/// so this helper carries no hardcoded language token.
+pub(crate) fn inline_test_regions(content: &str, markers: &[&str]) -> Vec<(usize, usize)> {
     let bytes = content.as_bytes();
     let mut regions = Vec::new();
-    let mut search_from = 0usize;
-    while let Some(rel) = content[search_from..].find(ATTR) {
-        let attr_start = search_from + rel;
-        // Advance past this attribute regardless of outcome (no infinite loop).
-        search_from = attr_start + ATTR.len();
-
-        let Some(brace_rel) = content[search_from..].find('{') else {
+    for marker in markers {
+        if marker.is_empty() {
             continue;
-        };
-        let open = search_from + brace_rel;
-        let mut depth = 0i32;
-        let mut close = None;
-        for (i, &b) in bytes[open..].iter().enumerate() {
-            if b == b'{' {
-                depth += 1;
-            } else if b == b'}' {
-                depth -= 1;
-                if depth == 0 {
-                    close = Some(open + i);
-                    break;
+        }
+        let mut search_from = 0usize;
+        while let Some(rel) = content[search_from..].find(marker) {
+            let marker_start = search_from + rel;
+            // Advance past this marker regardless of outcome (no infinite loop).
+            search_from = marker_start + marker.len();
+
+            let Some(brace_rel) = content[search_from..].find('{') else {
+                continue;
+            };
+            let open = search_from + brace_rel;
+            let mut depth = 0i32;
+            let mut close = None;
+            for (i, &b) in bytes[open..].iter().enumerate() {
+                if b == b'{' {
+                    depth += 1;
+                } else if b == b'}' {
+                    depth -= 1;
+                    if depth == 0 {
+                        close = Some(open + i);
+                        break;
+                    }
                 }
             }
-        }
-        if let Some(close) = close {
-            regions.push((attr_start, close));
-            search_from = close + 1;
+            if let Some(close) = close {
+                regions.push((marker_start, close));
+                search_from = close + 1;
+            }
         }
     }
+    regions.sort_by_key(|(start, _)| *start);
     regions
 }
 
 /// Whether `offset` falls within any `(start, end)` region.
-pub(crate) fn offset_in_cfg_test_region(offset: usize, regions: &[(usize, usize)]) -> bool {
+pub(crate) fn offset_in_test_region(offset: usize, regions: &[(usize, usize)]) -> bool {
     regions
         .iter()
         .any(|(start, end)| offset >= *start && offset <= *end)
@@ -205,4 +213,40 @@ pub(crate) fn crate_of_path(path: &str) -> Option<&str> {
 /// boundary, so attributing a cross-crate reference to them is a false positive.
 pub(crate) fn visibility_is_crate_public(vis_prefix: &str) -> bool {
     vis_prefix.trim() == "pub"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{crate_of_path, inline_test_regions, offset_in_test_region};
+    use homeboy_engine_primitives::language::Language;
+
+    #[test]
+    fn finds_rust_cfg_test_block_via_language_marker() {
+        let content = "fn prod() {}\n#[cfg(test)]\nmod tests {\n    fn helper() {}\n}\n";
+        let regions = inline_test_regions(content, Language::Rust.inline_test_region_markers());
+        assert_eq!(regions.len(), 1);
+        // The `helper` inside the block is covered; `prod` at the top is not.
+        let helper_off = content.find("fn helper").unwrap();
+        let prod_off = content.find("fn prod").unwrap();
+        assert!(offset_in_test_region(helper_off, &regions));
+        assert!(!offset_in_test_region(prod_off, &regions));
+    }
+
+    #[test]
+    fn no_marker_language_yields_no_regions() {
+        // A PHP file with a brace block and no inline marker must yield no
+        // regions — the markers slice is empty, so nothing is stripped.
+        let content = "<?php\nfunction prod() { return 1; }\n";
+        let regions = inline_test_regions(content, Language::Php.inline_test_region_markers());
+        assert!(regions.is_empty());
+    }
+
+    #[test]
+    fn crate_of_path_extracts_workspace_crate() {
+        assert_eq!(
+            crate_of_path("crates/homeboy-core/src/lib.rs"),
+            Some("homeboy-core")
+        );
+        assert_eq!(crate_of_path("src/lib.rs"), None);
+    }
 }

--- a/crates/homeboy-engine-primitives/src/language.rs
+++ b/crates/homeboy-engine-primitives/src/language.rs
@@ -206,4 +206,56 @@ impl Language {
     pub fn has_framework_lifecycle_dispatch(&self) -> bool {
         matches!(self, Language::Php)
     }
+
+    /// Source markers that open an *inline* test region — a block embedded in a
+    /// production file whose contents are test scaffolding (fixtures, in-file
+    /// unit tests), e.g. Rust's `#[cfg(test)]` module attribute. Detectors that
+    /// scan raw content brace-match the block following each marker so they can
+    /// skip test-only literals/commands/duplicates that `is_test_path` (which
+    /// only classifies whole test *files*) cannot see.
+    ///
+    /// Empty for languages whose test code lives exclusively in separate files
+    /// (handled by [`Self::builtin_test_file_suffixes`]) rather than inline
+    /// blocks — those need no in-file region stripping.
+    ///
+    /// The concrete syntax lives here in the agnostic language home so detector
+    /// implementations under `code_audit::detectors` stay free of hardcoded
+    /// language tokens.
+    pub fn inline_test_region_markers(&self) -> &'static [&'static str] {
+        match self {
+            Language::Rust => &["#[cfg(test)]"],
+            // PHP / JS / TS keep tests in separate files; no inline block marker.
+            Language::Php | Language::JavaScript | Language::TypeScript | Language::Unknown => &[],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Language;
+
+    #[test]
+    fn rust_declares_the_cfg_test_inline_marker() {
+        assert_eq!(
+            Language::Rust.inline_test_region_markers(),
+            &["#[cfg(test)]"]
+        );
+    }
+
+    #[test]
+    fn separate_file_test_languages_declare_no_inline_marker() {
+        // PHP/JS/TS/Unknown keep tests in separate files — no inline block to
+        // strip, so detectors get an empty marker set (and thus no regions).
+        for lang in [
+            Language::Php,
+            Language::JavaScript,
+            Language::TypeScript,
+            Language::Unknown,
+        ] {
+            assert!(
+                lang.inline_test_region_markers().is_empty(),
+                "{lang:?} should declare no inline test-region marker"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Fixes an architectural leak introduced by the recent inline-test-block detector fixes (#9311/#9312/#9339): they hardcoded the Rust token `"#[cfg(test)]"` in a **shared** walker helper, in a **multi-language** audit engine.

## Why this matters
`homeboy-code-audit` is language-agnostic by design (Rust + PHP + JS/TS via grammar profiles), and its own `detector-agnostic-source` policy states ecosystem literals belong in the agnostic language home so detector implementations stay free of hardcoded language tokens (see the `Language::builtin_trivial_method_names` doc: *"The concrete ecosystem literals live here … so detector implementations under `code_audit::detectors` stay free of hardcoded language names"*). The `#[cfg(test)]` string in `walker::cfg_test_regions` violated that — it was Rust syntax baked into shared code used by four detectors.

The right home already existed: `Language` carries per-language capability methods (`lacks_visibility_narrowing`, `has_typesystem_trait_dispatch`, `has_framework_lifecycle_dispatch`) and even a stub `builtin_inline_test_strip_tokens`.

## Change
- Add `Language::inline_test_region_markers()` — `Rust => ["#[cfg(test)]"]`; `Php`/`JavaScript`/`TypeScript`/`Unknown => []` (their tests live in separate files, handled by `builtin_test_file_suffixes`).
- Generalize `walker::cfg_test_regions(content)` → `inline_test_regions(content, markers)` and `offset_in_cfg_test_region` → `offset_in_test_region` (language-neutral names, marker-parameterized, multi-marker aware).
- Each detector now passes `fp.language.inline_test_region_markers()` (`FileFingerprint` already carries `language`). No hardcoded language token remains in the detector/walker layer.

## Correctness
- **Behavior-preserving for Rust** — same marker, same regions.
- Languages without an inline marker now *explicitly* yield no regions (driven by the empty marker set) rather than incidentally, so the behavior is intentional and documented.

## Tests (331 detector + 171 engine-primitives + runtime regression all pass)
- `Language::inline_test_region_markers`: Rust returns the marker; PHP/JS/TS/Unknown return empty.
- `walker`: finds the Rust `#[cfg(test)]` block via the language marker; PHP file yields no regions; `crate_of_path` extraction.

## Note
This addresses the `#[cfg(test)]` marker specifically (the highest-leverage leak — 4 detectors). `crate_of_path` / `visibility_is_crate_public` in `walker.rs` remain Cargo/Rust-specific but are only consulted for `crates/<crate>/`-shaped paths and `pub` prefixes (no-op elsewhere); a follow-up can grammar-source those if a non-Rust component ever needs cross-namespace reachability. Flagged rather than silently left.
