### PR TITLE
Bind pending Lab handoff before snapshots

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2244,6 +2244,15 @@ fn record_lab_offload_proxy(
     if record.state.is_terminal() {
         return Ok(record);
     }
+    if record.lab_handoff.is_none() {
+        let now = chrono::Utc::now();
+        record.lab_handoff = Some(AgentTaskLabHandoff::pending(
+            runner_id,
+            now.to_rfc3339(),
+            (now + chrono::Duration::seconds(lab_handoff_acceptance_timeout_seconds()))
+                .to_rfc3339(),
+        ));
+    }
     let metadata = record.ensure_metadata_object();
     metadata.insert("kind".to_string(), json!("lab_offload_controller_proxy"));
     // This record is the controller's durable projection of a runner handoff.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -688,6 +688,11 @@ fn preacceptance_snapshot_binds_the_accepted_daemon_job_before_validation() {
             Some(&plan),
         )
         .expect("persist pending controller handoff");
+        assert_eq!(
+            record.lab_handoff.as_ref().expect("pending handoff").state,
+            AgentTaskLabHandoffState::Pending,
+            "the controller must establish typed acceptance authority before a staging snapshot can arrive"
+        );
         let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
         snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
         snapshot.job.target_runner_id = Some("homeboy-lab".to_string());


### PR DESCRIPTION
## Summary
- persist typed pending controller handoff authority when creating an unbound Lab proxy
- let existing snapshot reconciliation bind the first accepted daemon job before identity validation
- preserve fail-closed rejection when a different job is already bound

Fixes #9340

## How to test
1. Run `cargo test -p homeboy-agents preacceptance_snapshot_binds_the_accepted_daemon_job_before_validation --lib --quiet`.
2. Run `cargo test -p homeboy-agents preacceptance_snapshot_rejects_a_different_bound_daemon_job --lib --quiet`.
3. Run `cargo fmt --check && git diff --check`.
4. From a clean managed worktree, dispatch `homeboy agent-task cook --to-worktree <handle> --cwd <path> --task-url <issue-url> --runner homeboy-lab --prompt <task> ...` and confirm the cook proceeds past `lab_handoff_preacceptance` into provider execution.

## Compatibility
- Existing accepted handoffs and mismatched-job rejection are unchanged.
- The change only fills the previously missing typed pending handoff on unbound controller proxies.
- No extension paths or public CLI syntax change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Diagnosed the real pre-provider control-plane failure, implemented the pending-handoff lifecycle fix and regression assertion, and verified targeted behavior with Chris.