### PR TITLE
refactor(audit): source cross-boundary reachability from Language, not hardcoded

### DIFF
--- a/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs
+++ b/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs
@@ -26,10 +26,8 @@ use regex::Regex;
 use super::super::conventions::AuditFinding;
 use super::super::findings::{Finding, Severity};
 use super::super::fingerprint::FileFingerprint;
-use super::super::walker::{
-    crate_of_path, inline_test_regions, is_test_path, offset_in_test_region,
-    visibility_is_crate_public,
-};
+use super::super::walker::{inline_test_regions, is_test_path, offset_in_test_region};
+use crate::conventions::Language;
 
 /// Minimum arg-vector length to consider. Single-element commands (`["init"]`,
 /// `["fetch"]`) are too generic to attribute to one wrapper.
@@ -117,7 +115,7 @@ fn detect_command_wrapper_bypass(fingerprints: &[&FileFingerprint]) -> Vec<Findi
         if is_test_path(&fp.relative_path) {
             continue;
         }
-        for (name, is_public, body, body_offset) in thin_wrapper_bodies(&fp.content) {
+        for (name, is_public, body, body_offset) in thin_wrapper_bodies(&fp.content, fp.language) {
             // A thin wrapper's body contains exactly one arg-vector literal.
             let matches: Vec<_> = argvec_regex().find_iter(&body).collect();
             if matches.len() != 1 {
@@ -185,18 +183,20 @@ fn detect_command_wrapper_bypass(fingerprints: &[&FileFingerprint]) -> Vec<Findi
                 continue;
             }
             // Only attribute a bypass to a helper the call site can actually
-            // reach. A private/`pub(crate)` helper in a DIFFERENT crate is
-            // unreachable, so suggesting "call it instead" is a false positive.
-            // Same-crate calls are always fine; cross-crate requires `pub`.
-            let call_crate = crate_of_path(&fp.relative_path);
-            let def_crate = crate_of_path(&def.file);
-            let cross_crate = match (call_crate, def_crate) {
+            // reach. A non-boundary-public helper in a DIFFERENT module boundary
+            // (Rust crate) is unreachable, so suggesting "call it instead" is a
+            // false positive. Same-boundary calls are always fine; cross-boundary
+            // requires boundary-public visibility. Boundaries are derived per the
+            // caller's language.
+            let call_boundary = fp.language.module_boundary_of_path(&fp.relative_path);
+            let def_boundary = fp.language.module_boundary_of_path(&def.file);
+            let cross_boundary = match (call_boundary, def_boundary) {
                 (Some(a), Some(b)) => a != b,
-                // Unknown layout on either side — be conservative and treat as
-                // same-crate (do not suppress) to preserve prior behavior.
+                // No derivable boundary on either side — be conservative and
+                // treat as same-boundary (do not suppress) to preserve behavior.
                 _ => false,
             };
-            if cross_crate && !def.is_public {
+            if cross_boundary && !def.is_public {
                 continue;
             }
             let cmd = elems.join(" ");
@@ -231,7 +231,7 @@ fn detect_command_wrapper_bypass(fingerprints: &[&FileFingerprint]) -> Vec<Findi
 /// matching from each `fn` declaration; bounded to short bodies so we only
 /// consider genuine one-call wrappers, not large functions that happen to
 /// contain one arg-vector. `is_public` is true only for crate-`pub` helpers.
-fn thin_wrapper_bodies(content: &str) -> Vec<(String, bool, String, usize)> {
+fn thin_wrapper_bodies(content: &str, language: Language) -> Vec<(String, bool, String, usize)> {
     /// Max characters in a wrapper body — a one-call delegation is tiny; this
     /// keeps us from treating a large function's incidental arg-vector as the
     /// canonical definition.
@@ -242,7 +242,7 @@ fn thin_wrapper_bodies(content: &str) -> Vec<(String, bool, String, usize)> {
     for caps in fn_decl_regex().captures_iter(content) {
         let is_public = caps
             .get(1)
-            .map(|m| visibility_is_crate_public(m.as_str()))
+            .map(|m| language.is_boundary_public_visibility(m.as_str()))
             .unwrap_or(false);
         let name = caps[2].to_string();
         let decl_end = caps.get(0).unwrap().end();

--- a/crates/homeboy-code-audit/src/detectors/constant_bypass.rs
+++ b/crates/homeboy-code-audit/src/detectors/constant_bypass.rs
@@ -23,10 +23,7 @@ use regex::Regex;
 use super::super::conventions::AuditFinding;
 use super::super::findings::{Finding, Severity};
 use super::super::fingerprint::FileFingerprint;
-use super::super::walker::{
-    crate_of_path, inline_test_regions, is_test_path, offset_in_test_region,
-    visibility_is_crate_public,
-};
+use super::super::walker::{inline_test_regions, is_test_path, offset_in_test_region};
 
 /// Minimum constant-value length worth flagging. Short values (`"workspace"`,
 /// `"snapshot"`) collide with serde tags, enum spellings, and unrelated
@@ -74,7 +71,7 @@ fn detect_constant_bypass_literals(fingerprints: &[&FileFingerprint]) -> Vec<Fin
         for caps in const_decl_regex().captures_iter(&fp.content) {
             let is_public = caps
                 .get(1)
-                .map(|m| visibility_is_crate_public(m.as_str()))
+                .map(|m| fp.language.is_boundary_public_visibility(m.as_str()))
                 .unwrap_or(false);
             let name = caps[2].to_string();
             let value = caps[3].to_string();
@@ -123,19 +120,20 @@ fn detect_constant_bypass_literals(fingerprints: &[&FileFingerprint]) -> Vec<Fin
                 continue;
             }
             // Only attribute a literal to a constant the site can reach. A
-            // private/`pub(crate)` constant in a DIFFERENT crate is unreachable,
-            // so "reference it instead" is impossible — a false positive. Same
-            // crate is always fine; cross-crate requires `pub`. (mirrors the
+            // non-boundary-public constant in a DIFFERENT module boundary (Rust
+            // crate) is unreachable, so "reference it instead" is impossible — a
+            // false positive. Same boundary is always fine; cross-boundary
+            // requires boundary-public visibility. (mirrors the
             // command_wrapper_bypass reachability rule)
-            let literal_crate = crate_of_path(&fp.relative_path);
-            let def_crate = crate_of_path(&def.file);
-            let cross_crate = match (literal_crate, def_crate) {
+            let literal_boundary = fp.language.module_boundary_of_path(&fp.relative_path);
+            let def_boundary = fp.language.module_boundary_of_path(&def.file);
+            let cross_boundary = match (literal_boundary, def_boundary) {
                 (Some(a), Some(b)) => a != b,
-                // Unknown layout on either side — conservative: treat as same
-                // crate (do not suppress) to preserve prior behavior.
+                // No derivable boundary on either side — conservative: treat as
+                // same boundary (do not suppress) to preserve prior behavior.
                 _ => false,
             };
-            if cross_crate && !def.is_public {
+            if cross_boundary && !def.is_public {
                 continue;
             }
             findings.push(Finding {

--- a/crates/homeboy-code-audit/src/walker.rs
+++ b/crates/homeboy-code-audit/src/walker.rs
@@ -196,28 +196,9 @@ pub(crate) fn offset_in_test_region(offset: usize, regions: &[(usize, usize)]) -
         .any(|(start, end)| offset >= *start && offset <= *end)
 }
 
-/// The crate name for a `crates/<crate>/…` path, else `None` (non-workspace
-/// layout — callers fall back to conservative behavior).
-///
-/// Used by content-scanning detectors that attribute a caller's raw literal or
-/// command to a canonical definition elsewhere: a cross-crate attribution is
-/// only valid when the definition is reachable from the caller's crate.
-pub(crate) fn crate_of_path(path: &str) -> Option<&str> {
-    let rest = path.strip_prefix("crates/")?;
-    rest.split('/').next().filter(|s| !s.is_empty())
-}
-
-/// Whether a `pub`/`pub(...)` visibility prefix makes a definition reachable
-/// from *another* crate. Only crate-wide `pub` qualifies — `pub(crate)`,
-/// `pub(super)`, `pub(in …)`, and private are unreachable across a crate
-/// boundary, so attributing a cross-crate reference to them is a false positive.
-pub(crate) fn visibility_is_crate_public(vis_prefix: &str) -> bool {
-    vis_prefix.trim() == "pub"
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{crate_of_path, inline_test_regions, offset_in_test_region};
+    use super::{inline_test_regions, offset_in_test_region};
     use homeboy_engine_primitives::language::Language;
 
     #[test]
@@ -239,14 +220,5 @@ mod tests {
         let content = "<?php\nfunction prod() { return 1; }\n";
         let regions = inline_test_regions(content, Language::Php.inline_test_region_markers());
         assert!(regions.is_empty());
-    }
-
-    #[test]
-    fn crate_of_path_extracts_workspace_crate() {
-        assert_eq!(
-            crate_of_path("crates/homeboy-core/src/lib.rs"),
-            Some("homeboy-core")
-        );
-        assert_eq!(crate_of_path("src/lib.rs"), None);
     }
 }

--- a/crates/homeboy-engine-primitives/src/language.rs
+++ b/crates/homeboy-engine-primitives/src/language.rs
@@ -11,7 +11,9 @@
 //! it as `crate::engine::language`, and `code_audit::conventions` re-exports
 //! `Language` for backward compatibility.
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum Language {
     Php,
@@ -228,6 +230,48 @@ impl Language {
             Language::Php | Language::JavaScript | Language::TypeScript | Language::Unknown => &[],
         }
     }
+
+    /// The *reachability boundary* a source file belongs to, derived from its
+    /// path — the unit across which a symbol must be publicly exported to be
+    /// referenced. For Rust that is the Cargo crate (`crates/<crate>/…`).
+    ///
+    /// Returns `None` when the language has no path-derivable boundary (or the
+    /// path does not match its layout). Detectors that attribute a caller's raw
+    /// literal/command to a definition elsewhere use this together with
+    /// [`Self::is_boundary_public_visibility`]: a cross-boundary attribution is
+    /// only valid when the definition is boundary-public. `None` on either side
+    /// means "same boundary" (conservative — do not suppress).
+    ///
+    /// Ecosystem-specific layout lives here in the agnostic language home so
+    /// detectors carry no hardcoded path convention.
+    pub fn module_boundary_of_path<'a>(&self, path: &'a str) -> Option<&'a str> {
+        match self {
+            Language::Rust => {
+                let rest = path.strip_prefix("crates/")?;
+                rest.split('/').next().filter(|s| !s.is_empty())
+            }
+            // PHP autoloads across the whole package; JS/TS resolve via module
+            // paths. Neither has a simple path-derived reachability boundary
+            // that maps to the crate model, so cross-boundary attribution is
+            // not attempted (callers treat this as "same boundary").
+            Language::Php | Language::JavaScript | Language::TypeScript | Language::Unknown => None,
+        }
+    }
+
+    /// Whether a captured visibility prefix makes a symbol reachable *across* a
+    /// [`Self::module_boundary_of_path`] boundary. For Rust only crate-wide
+    /// `pub` qualifies (`pub(crate)`, `pub(super)`, `pub(in …)`, private do
+    /// not). Languages without a crate-style boundary return `false` (their
+    /// cross-boundary attribution is disabled by the `None` boundary above, so
+    /// this is only consulted for Rust in practice).
+    pub fn is_boundary_public_visibility(&self, visibility_prefix: &str) -> bool {
+        match self {
+            Language::Rust => visibility_prefix.trim() == "pub",
+            Language::Php | Language::JavaScript | Language::TypeScript | Language::Unknown => {
+                false
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -240,6 +284,38 @@ mod tests {
             Language::Rust.inline_test_region_markers(),
             &["#[cfg(test)]"]
         );
+    }
+
+    #[test]
+    fn rust_module_boundary_is_the_cargo_crate() {
+        assert_eq!(
+            Language::Rust.module_boundary_of_path("crates/homeboy-core/src/lib.rs"),
+            Some("homeboy-core")
+        );
+        // Non-workspace layout → no derivable boundary.
+        assert_eq!(Language::Rust.module_boundary_of_path("src/lib.rs"), None);
+    }
+
+    #[test]
+    fn non_rust_languages_have_no_path_boundary() {
+        for lang in [Language::Php, Language::JavaScript, Language::TypeScript] {
+            assert_eq!(
+                lang.module_boundary_of_path("crates/x/src/lib.rs"),
+                None,
+                "{lang:?} has no crate-style path boundary"
+            );
+        }
+    }
+
+    #[test]
+    fn rust_boundary_public_visibility_requires_bare_pub() {
+        assert!(Language::Rust.is_boundary_public_visibility("pub "));
+        assert!(!Language::Rust.is_boundary_public_visibility("pub(crate) "));
+        assert!(!Language::Rust.is_boundary_public_visibility("pub(super) "));
+        assert!(!Language::Rust.is_boundary_public_visibility(""));
+        // Non-crate languages never report boundary-public (cross-boundary
+        // attribution is disabled for them via the None boundary).
+        assert!(!Language::Php.is_boundary_public_visibility("public"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Finishes the language-agnostic cleanup begun in #9344. The cross-crate reachability guards in `command_wrapper_bypass` and `constant_bypass` (from #9320/#9329) hardcoded Cargo/Rust specifics in **shared** walker helpers — the exact debt I flagged as follow-up in #9344.

## What was hardcoded
- `walker::crate_of_path` — the `crates/<crate>/` Cargo layout.
- `walker::visibility_is_crate_public` — Rust `pub` semantics.

Both lived in a shared module of a multi-language audit engine, violating the `detector-agnostic-source` doctrine.

## Change
Move both into the agnostic `Language` home as dispatched capabilities, mirroring `inline_test_region_markers` / `lacks_visibility_narrowing` / `has_typesystem_trait_dispatch`:

- `Language::module_boundary_of_path(path)` — the reachability boundary a file belongs to. Rust ⇒ Cargo crate from `crates/<crate>/`; PHP/JS/TS/Unknown ⇒ `None` (no crate-style path boundary → cross-boundary attribution not attempted, callers treat as same-boundary).
- `Language::is_boundary_public_visibility(prefix)` — whether a visibility prefix crosses that boundary. Rust ⇒ bare `pub`; others ⇒ `false`.

Detectors now call `fp.language.module_boundary_of_path(...)` / `.is_boundary_public_visibility(...)`. The two Rust-specific walker helpers are deleted (−30 lines from walker). `Language` gains `Copy` (fieldless enum) so it threads by value like the other capability calls.

## Correctness
- **Behavior-preserving for Rust** — same crate/`pub` semantics.
- The existing cross-crate regression tests (`does_not_flag_cross_crate_literal_of_a_private_constant`, `flags_cross_crate_call_of_a_public_helper`, etc.) pass unchanged through the agnostic path.
- Non-Rust languages get `None` boundary → no cross-boundary suppression attempted (intentional, documented).

## Tests (9 Language + 331 detector + 174 engine-primitives + runtime regression all pass)
- `Language::module_boundary_of_path`: Rust extracts the crate; non-workspace path ⇒ None; PHP/JS/TS ⇒ None.
- `Language::is_boundary_public_visibility`: Rust requires bare `pub`; `pub(crate)`/`pub(super)`/empty ⇒ false; non-Rust ⇒ false.

## Net result
Combined with #9344, the detector/walker layer now carries **no hardcoded language token** — inline-test markers, module boundaries, and visibility are all sourced from the agnostic `Language` home. The audit stays multi-language-correct while the Rust behavior is unchanged.
