### PR TITLE
fix(audit): near_duplicate skips all-test-code scaffolding groups

### DIFF
--- a/crates/homeboy-code-audit/src/duplication.rs
+++ b/crates/homeboy-code-audit/src/duplication.rs
@@ -463,6 +463,7 @@ fn count_body_lines(fp: &FileFingerprint, method_name: &str) -> usize {
 pub(crate) fn detect_near_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
     let structural_groups = build_structural_groups(fingerprints);
     let exact_groups = build_groups(fingerprints);
+    let inline_test_methods = inline_test_context_methods(fingerprints);
 
     // Collect exact-duplicate (name, hash) pairs for exclusion
     let exact_duplicate_names: std::collections::HashSet<String> = exact_groups
@@ -481,6 +482,17 @@ pub(crate) fn detect_near_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<F
 
         // Skip if already an exact duplicate
         if exact_duplicate_names.contains(method_name) {
+            continue;
+        }
+
+        // Skip test scaffolding: when every location is test code (a whole test
+        // file or a method inside an inline `#[cfg(test)]` block), structural
+        // similarity across per-module fixtures (`make_fp`, `git_repo`, …) is
+        // expected and not an actionable production near-duplicate.
+        if file_hashes
+            .iter()
+            .all(|(file, _)| is_test_location(method_name, file, &inline_test_methods))
+        {
             continue;
         }
 

--- a/crates/homeboy-code-audit/src/duplication/tests.rs
+++ b/crates/homeboy-code-audit/src/duplication/tests.rs
@@ -289,6 +289,66 @@ mod near_duplicates {
     }
 
     #[test]
+    fn near_duplicate_skips_inline_test_scaffolding() {
+        // `make_fp` is a structurally-similar fixture inside the inline
+        // `#[cfg(test)]` block of two production files. Per-module test
+        // scaffolding sharing structure is expected — not an actionable
+        // near-duplicate — so no finding is emitted.
+        let content_a = "fn prod() {}\n#[cfg(test)]\nmod tests {\n    fn make_fp() -> Fp {\n        let base = Fp::default();\n        let x = base.with(A);\n        x\n    }\n}\n";
+        let content_b = "fn other() {}\n#[cfg(test)]\nmod tests {\n    fn make_fp() -> Fp {\n        let base = Fp::default();\n        let x = base.with(B);\n        x\n    }\n}\n";
+
+        let fp1 = make_fp_with_content(
+            "src/core/a.rs",
+            content_a,
+            &[("make_fp", "hash_a")],
+            &[("make_fp", "SAME_STRUCT")],
+        );
+        let fp2 = make_fp_with_content(
+            "src/core/b.rs",
+            content_b,
+            &[("make_fp", "hash_b")],
+            &[("make_fp", "SAME_STRUCT")],
+        );
+
+        let findings = detect_near_duplicates(&[&fp1, &fp2]);
+
+        assert!(
+            findings.is_empty(),
+            "inline cfg(test) fixture near-duplication is test scaffolding, got: {:?}",
+            findings.iter().map(|f| &f.description).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn near_duplicate_still_flags_production_structural_twins_alongside_tests() {
+        // A production near-duplicate must still be flagged even though the
+        // scaffolding skip exists — the skip only fires when ALL locations are
+        // test code.
+        let content_a = "fn cache_path() -> Option<PathBuf> {\n    let base = paths::homeboy().ok()?;\n    let file = base.join(CACHE_A);\n    Some(file)\n}\n";
+        let content_b = "fn cache_path() -> Option<PathBuf> {\n    let base = paths::homeboy().ok()?;\n    let file = base.join(CACHE_B);\n    Some(file)\n}\n";
+
+        let fp1 = make_fp_with_content(
+            "src/core/a.rs",
+            content_a,
+            &[("cache_path", "hash_a")],
+            &[("cache_path", "SAME_STRUCT")],
+        );
+        let fp2 = make_fp_with_content(
+            "src/core/b.rs",
+            content_b,
+            &[("cache_path", "hash_b")],
+            &[("cache_path", "SAME_STRUCT")],
+        );
+
+        let findings = detect_near_duplicates(&[&fp1, &fp2]);
+        assert_eq!(
+            findings.len(),
+            2,
+            "production structural twins still flagged"
+        );
+    }
+
+    #[test]
     fn near_duplicate_skips_exact_duplicates() {
         // If exact hashes match, exact-duplicate detector already handles it
         let fp1 = make_fingerprint_with_structural(


### PR DESCRIPTION
## Summary
Removes test-scaffolding noise from `near_duplicate` (55-finding category). `detect_near_duplicates` had **no test-code exclusion at all**, so structurally-similar per-module fixtures were emitted as near-duplicate findings.

## Problem
Test fixtures like `make_fp`, `git_repo`, `event_with_data` live in inline `#[cfg(test)]` blocks across many modules and legitimately share structure (same shape, different constants). `detect_near_duplicates` flagged them as "structurally identical — consider extracting shared logic," which is not actionable for per-module test scaffolding.

From the first Audit Debt sweep: **10 of 55 unique `near_duplicate` findings had both sites inside inline `#[cfg(test)]` blocks.** (Unlike `detect_duplicates`, this detector had no `is_test_path` check either.)

## Fix
Reuse the existing `inline_test_context_methods` + `is_test_location` (added for the `duplicate_function` fix, #9339, and already language-agnostic via the `Language::inline_test_region_markers` refactor). When *every* location in a structural group is test code — a whole test file **or** a method inside an inline `#[cfg(test)]` block — skip the group. Production near-duplicates, and mixed groups where at least one site is production, are unaffected.

## Tests (79 duplication + 331 detector + runtime regression all pass)
- `near_duplicate_skips_inline_test_scaffolding` — `make_fp` fixtures across two production files' cfg(test) blocks → no finding.
- `near_duplicate_still_flags_production_structural_twins_alongside_tests` — production structural twins still flagged (the skip only fires when ALL locations are test).

## Impact
Cuts ~18% of `near_duplicate` findings as test-scaffolding noise, so the (already Info-severity, advisory) category reflects genuine production near-duplication worth parameterizing. Consistent with the inline-cfg(test) awareness across the duplication detectors.
