### PR TITLE
fix(runner): allow rolling refresh past Cook pins

### DIFF
--- a/crates/homeboy-core/src/runtime_promotion.rs
+++ b/crates/homeboy-core/src/runtime_promotion.rs
@@ -105,14 +105,42 @@ impl Drop for RuntimeGenerationPinGuard {
 /// and generation. A child process must present the capability explicitly
 /// attached by [`RuntimePromotionLease::authorize_subprocess`].
 pub fn acquire(operation: &str, target: impl Into<String>) -> Result<RuntimePromotionLease> {
-    let target = target.into();
+    acquire_with_pin_policy(operation, target.into(), ForeignPinPolicy::Block)
+}
+
+/// Acquire the global writer lease for a generation-preserving rotation.
+///
+/// The caller must keep existing work routed to its pinned generation while a
+/// validated candidate becomes the owner of future admissions. The writer
+/// lease still serializes concurrent mutations; only the controller Cook pin
+/// barrier is relaxed for this transaction.
+pub fn acquire_for_generation_rotation(
+    operation: &str,
+    target: impl Into<String>,
+) -> Result<RuntimePromotionLease> {
+    acquire_with_pin_policy(operation, target.into(), ForeignPinPolicy::Allow)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ForeignPinPolicy {
+    Block,
+    Allow,
+}
+
+fn acquire_with_pin_policy(
+    operation: &str,
+    target: String,
+    foreign_pin_policy: ForeignPinPolicy,
+) -> Result<RuntimePromotionLease> {
     let root = paths::runtime_promotion_dir()?;
     fs::create_dir_all(&root).map_err(io("create runtime promotion directory"))?;
     let path = root.join(LEASE_DIR);
     let pid = std::process::id();
     let generation = current_generation();
     let subprocess_capability = subprocess_capability_from_env();
-    ensure_no_foreign_generation_pin(&root, pid, subprocess_capability.as_ref())?;
+    if foreign_pin_policy == ForeignPinPolicy::Block {
+        ensure_no_foreign_generation_pin(&root, pid, subprocess_capability.as_ref())?;
+    }
 
     match acquire_lease_dir_with_retry(
         || create_lease_dir(&path),
@@ -602,6 +630,44 @@ mod tests {
                 "dropping one duplicate cook guard must retain the other pin"
             );
             assert!(second.path.exists(), "the second guard still owns its pin");
+        });
+    }
+
+    #[test]
+    fn generation_rotation_retains_writer_serialization_without_waiting_for_foreign_cooks() {
+        crate::test_support::with_isolated_home(|_| {
+            let mut foreign_owner = Command::new("sleep")
+                .arg("30")
+                .spawn()
+                .expect("start live foreign pin owner");
+            let pins = paths::runtime_promotion_dir()
+                .expect("runtime promotion directory")
+                .join(PIN_DIR);
+            fs::create_dir_all(&pins).expect("create pin directory");
+            fs::write(
+                pins.join("foreign-cook.json"),
+                serde_json::to_vec_pretty(&RuntimeGenerationPin {
+                    pid: foreign_owner.id(),
+                    cook_id: "foreign-cook".to_string(),
+                    generation: "existing-generation".to_string(),
+                    started_at: now(),
+                })
+                .expect("serialize foreign pin"),
+            )
+            .expect("write foreign pin");
+
+            let blocked = acquire("controller replacement", "controller")
+                .expect_err("ordinary promotion remains blocked by a foreign Cook");
+            assert_eq!(blocked.code, ErrorCode::RuntimePromotionContended);
+
+            let rotation = acquire_for_generation_rotation("runner rotation", "lab")
+                .expect("generation-preserving rotation can acquire the writer lease");
+            let concurrent = acquire_for_generation_rotation("other rotation", "other")
+                .expect_err("the writer lease still serializes generation rotations");
+            assert_eq!(concurrent.code, ErrorCode::RuntimePromotionContended);
+            drop(rotation);
+            foreign_owner.kill().expect("stop foreign pin owner");
+            foreign_owner.wait().expect("reap foreign pin owner");
         });
     }
 

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -267,7 +267,7 @@ pub fn plan_homeboy_binary_refresh(
 pub fn refresh_homeboy_binary(
     options: HomeboyBinaryRefreshOptions,
 ) -> Result<(HomeboyBinaryRefreshOutput, i32)> {
-    let promotion_lease = homeboy_core::runtime_promotion::acquire(
+    let promotion_lease = homeboy_core::runtime_promotion::acquire_for_generation_rotation(
         "runner binary promotion",
         options.runner_id.clone(),
     )?;


### PR DESCRIPTION
## Summary
- add a scoped promotion lease for generation-preserving rotations
- let `runner refresh-homeboy --reconnect` reach its rolling-generation path while foreign Cooks remain pinned
- retain the default Cook-pin barrier for controller runtime replacement
- retain global writer serialization for concurrent refreshes

Fixes #9351.

## How to test
1. Run `cargo test -p homeboy-core generation_rotation_retains_writer_serialization_without_waiting_for_foreign_cooks`.
2. Run `cargo test -p homeboy-core runtime_promotion`.
3. Run `cargo test -p homeboy-lab-runner homeboy_refresh --lib`.
4. Run `cargo fmt -p homeboy-core -p homeboy-lab-runner -- --check`.

All commands pass. The Homeboy refresh suite reports 50 passing tests.

## Compatibility
The existing `runtime_promotion::acquire()` behavior is unchanged. The new scoped API is used only by runner binary refresh, whose rolling-generation contract already preserves active job, run, and artifact ownership. No public CLI option or output schema changes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Model:** `openai/gpt-5.6-sol`
- **Used for:** Traced the live promotion contention, identified the unreachable rolling-generation path, implemented the scoped lease contract, and added deterministic verification with Chris Huber.