### PR TITLE
Reconnect direct admission when concurrent rotation removes session

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1267,7 +1267,7 @@ where
         || status
             .session
             .as_ref()
-            .is_none_or(|session| session.mode != RunnerTunnelMode::DirectSsh)
+            .is_some_and(|session| session.mode != RunnerTunnelMode::DirectSsh)
     {
         return Ok(status);
     }

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -224,6 +224,64 @@ fn admission_reconnects_a_lost_tunnel_to_the_same_proven_daemon() {
 }
 
 #[test]
+fn admission_reconnects_when_concurrent_rotation_removes_the_session() {
+    let session = direct_ssh_session("lease-current");
+    let mut disconnected = admission_status(&session, false);
+    disconnected.session = None;
+    let connected = admission_status(&session, true);
+    let mut statuses = [disconnected, connected].into_iter();
+    let mut reconnects = 0;
+
+    let admitted = status_for_admission_with(
+        "homeboy-lab",
+        |_| Ok(statuses.next().expect("admission status")),
+        |_| {
+            reconnects += 1;
+            Ok(())
+        },
+    )
+    .expect("admission reconnects after the session disappears");
+
+    assert_eq!(reconnects, 1);
+    assert!(admitted.connected);
+    assert_eq!(
+        admitted
+            .session
+            .as_ref()
+            .and_then(|session| session.remote_daemon_lease_id.as_deref()),
+        Some("lease-current")
+    );
+}
+
+#[test]
+fn admission_does_not_reconnect_a_known_reverse_session() {
+    let mut session = direct_ssh_session("lease-reverse");
+    session.mode = RunnerTunnelMode::Reverse;
+    let status = admission_status(&session, false);
+    let mut reconnects = 0;
+
+    let admitted = status_for_admission_with(
+        "homeboy-lab",
+        |_| Ok(status.clone()),
+        |_| {
+            reconnects += 1;
+            Ok(())
+        },
+    )
+    .expect("known reverse admission remains caller-owned");
+
+    assert_eq!(reconnects, 0);
+    assert!(!admitted.connected);
+    assert_eq!(
+        admitted
+            .session
+            .as_ref()
+            .map(|session| session.mode.clone()),
+        Some(RunnerTunnelMode::Reverse)
+    );
+}
+
+#[test]
 fn admission_refuses_a_lease_mismatch_without_retrying_status() {
     let session = direct_ssh_session("lease-recorded");
     let calls = std::cell::Cell::new(0);


### PR DESCRIPTION
## Summary
- reconnect direct SSH admission when a concurrent generation rotation removes the local session record
- preserve existing behavior for known reverse sessions
- keep lease mismatch recovery fail-closed

## Why
A shared Lab runner can rotate between a successful `runner connect` and the next `runner exec`. When status was disconnected with no session, `status_for_admission_with()` treated the missing session as non-direct and returned without invoking its existing reconnect transaction. Execution then selected an unavailable transport before daemon acceptance.

Closes #9356.

## How to test
1. Run `cargo test -p homeboy-lab-runner admission_ --lib -- --test-threads=1`.
2. Run `cargo fmt --check`.
3. Run `cargo clippy -p homeboy-lab-runner --lib`.
4. Connect a direct SSH runner, rotate its generation from another controller so the original session disappears, and run `homeboy runner exec <runner> -- true`; verify the command reconnects to current admission instead of returning `runner.lab_transport_failure`.

## Compatibility
This changes internal direct SSH admission recovery only. Known reverse sessions retain their existing caller-owned behavior, and lease mismatches remain fail-closed. No public command or extension contract changes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Model:** `openai/gpt-5.6-sol`
- **Used for:** Diagnosed the live concurrent-generation admission race, implemented the minimal owning-layer fix, added deterministic regression coverage, and verified the change with Chris Huber.