### PR TITLE
fix(lab): persist verified runner selection

### DIFF
--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -384,27 +384,14 @@ pub fn refresh_homeboy_binary(
     }
 
     promotion_lease.assert_generation()?;
-    // Only a reconnect replaces the daemon, so it is the only mode allowed to
-    // change the runner-global daemon control binary. A non-reconnecting
-    // refresh materializes a command build for a workflow without creating
-    // stale-daemon drift for unrelated jobs.
-    let promote_daemon_binary = options.reconnect;
+    // Selection belongs to the controller-owned runner registry. It must be
+    // persisted after the candidate has been verified, whether or not this
+    // invocation also replaces the active daemon.
     let bootstrap = if disconnected_ssh {
         ssh_bootstrap_promote_with(
             &plan,
             || Ok(exec_output.stdout.clone()),
-            |homeboy_path| {
-                if !promote_daemon_binary {
-                    return Ok(Vec::new());
-                }
-                homeboy_core::config::with_config_lock(|| {
-                    let patch = refreshed_runner_patch(&plan.runner_id, homeboy_path)?;
-                    match merge(Some(&plan.runner_id), &patch.to_string(), &[])? {
-                        MergeOutput::Single(result) => Ok(result.updated_fields),
-                        MergeOutput::Bulk(_) => Ok(Vec::new()),
-                    }
-                })
-            },
+            |homeboy_path| promote_verified_runner_binary(&plan.runner_id, homeboy_path),
         )
     } else {
         let identity = parse_identity(&exec_output.stdout)?;
@@ -416,17 +403,7 @@ pub fn refresh_homeboy_binary(
                 None,
             )
         })?;
-        let updated_fields = if promote_daemon_binary {
-            homeboy_core::config::with_config_lock(|| {
-                let patch = refreshed_runner_patch(&plan.runner_id, &plan.binary_path)?;
-                match merge(Some(&plan.runner_id), &patch.to_string(), &[])? {
-                    MergeOutput::Single(result) => Ok(result.updated_fields),
-                    MergeOutput::Bulk(_) => Ok(Vec::new()),
-                }
-            })?
-        } else {
-            Vec::new()
-        };
+        let updated_fields = promote_verified_runner_binary(&plan.runner_id, &plan.binary_path)?;
         Ok(SshBootstrapPromotion {
             identity,
             source_sha: source_sha_from_output(&exec_output.stdout),
@@ -1303,6 +1280,22 @@ fn refreshed_runner_patch(runner_id: &str, homeboy_path: &str) -> Result<Value> 
     Ok(serde_json::json!({
         "homeboy_path": homeboy_path,
     }))
+}
+
+/// Persist a verified selection in the controller-owned runner registry.
+/// Runner commands may execute remotely, but registry mutation must remain on
+/// the controller so subsequent jobs use the selected binary.
+fn promote_verified_runner_binary(runner_id: &str, homeboy_path: &str) -> Result<Vec<String>> {
+    homeboy_core::config::with_config_lock(|| {
+        if load(runner_id)?.settings.homeboy_path.as_deref() == Some(homeboy_path) {
+            return Ok(Vec::new());
+        }
+        let patch = refreshed_runner_patch(runner_id, homeboy_path)?;
+        match merge(Some(runner_id), &patch.to_string(), &[])? {
+            MergeOutput::Single(result) => Ok(result.updated_fields),
+            MergeOutput::Bulk(_) => Ok(Vec::new()),
+        }
+    })
 }
 
 fn restore_runner_homeboy_path(runner_id: &str, homeboy_path: Option<&str>) -> Result<()> {

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
@@ -397,15 +397,7 @@ fn ssh_bootstrap_success_promotes_verified_exact_sha_with_provenance() {
         let result = ssh_bootstrap_promote_with(
             &plan,
             || Ok(verified_bootstrap_output("abc123")),
-            |path| {
-                homeboy_core::config::with_config_lock(|| {
-                    let patch = refreshed_runner_patch("lab-local", path)?;
-                    match merge(Some("lab-local"), &patch.to_string(), &[])? {
-                        MergeOutput::Single(result) => Ok(result.updated_fields),
-                        MergeOutput::Bulk(_) => Ok(Vec::new()),
-                    }
-                })
-            },
+            |path| promote_verified_runner_binary("lab-local", path),
         )
         .expect("verified bootstrap promotes");
         assert_eq!(result.source_sha.as_deref(), Some("abc123"));
@@ -418,6 +410,92 @@ fn ssh_bootstrap_success_promotes_verified_exact_sha_with_provenance() {
                 .as_deref(),
             Some("/verified/homeboy")
         );
+    });
+}
+
+#[test]
+fn controller_binary_selection_is_idempotent() {
+    test_support::with_isolated_home(|_| {
+        crate::create(
+            r#"{"id":"lab-local","kind":"local","homeboy_path":"/old"}"#,
+            false,
+        )
+        .expect("runner");
+
+        assert_eq!(
+            promote_verified_runner_binary("lab-local", "/verified/homeboy")
+                .expect("persist controller selection"),
+            ["homeboy_path"]
+        );
+        assert!(
+            promote_verified_runner_binary("lab-local", "/verified/homeboy")
+                .expect("repeat controller selection")
+                .is_empty()
+        );
+        assert_eq!(
+            crate::load("lab-local")
+                .expect("reload controller registry")
+                .settings
+                .homeboy_path
+                .as_deref(),
+            Some("/verified/homeboy")
+        );
+    });
+}
+
+#[test]
+fn verified_selection_persists_on_controller_and_reports_reconnect_required() {
+    test_support::with_isolated_home(|_| {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let binary = fixture.path().join("homeboy");
+        std::fs::write(
+            &binary,
+            "#!/bin/sh\nprintf '%s\\n' '{\"data\":{\"git_commit\":\"exact-remote-sha\",\"git_dirty\":false}}'\n",
+        )
+        .expect("write selected binary");
+        let status = Command::new("chmod")
+            .args(["0755", binary.to_str().expect("binary path")])
+            .status()
+            .expect("make selected binary executable");
+        assert!(status.success());
+        crate::create(
+            r#"{"id":"lab-local","kind":"local","homeboy_path":"/old/homeboy"}"#,
+            false,
+        )
+        .expect("runner");
+        let options = HomeboyBinaryRefreshOptions {
+            runner_id: "lab-local".to_string(),
+            mode: HomeboyBinaryRefreshMode::Select {
+                binary_path: binary.display().to_string(),
+            },
+            source: None,
+            git_ref: None,
+            target_dir: None,
+            reconnect: false,
+            force: false,
+            dry_run: false,
+        };
+
+        let (selected, exit_code) = refresh_homeboy_binary(options.clone()).expect("selection");
+        assert_eq!(exit_code, 0);
+        assert_eq!(selected.updated_fields, ["homeboy_path"]);
+        assert_eq!(selected.selected_binary_path, binary.display().to_string());
+        assert!(!selected.daemon_refreshed);
+        assert!(selected.reconnect_required);
+        assert_eq!(
+            crate::load("lab-local")
+                .expect("reload controller registry")
+                .settings
+                .homeboy_path
+                .as_deref(),
+            binary.to_str()
+        );
+
+        let (repeated, exit_code) = refresh_homeboy_binary(options).expect("repeat selection");
+        assert_eq!(exit_code, 0);
+        assert!(repeated.updated_fields.is_empty());
+        assert!(!repeated.daemon_refreshed);
+        assert!(repeated.reconnect_required);
     });
 }
 


### PR DESCRIPTION
## Summary
- persist a verified runner binary selection in the controller-owned registry even when refresh does not reconnect the daemon
- make repeated selection idempotent
- report that reconnect remains required when the selected binary differs from the active daemon

Closes #6605

## How to test
1. Run `cargo test -p homeboy-lab-runner controller_binary_selection_is_idempotent`.
2. Run `cargo test -p homeboy-lab-runner verified_selection_persists_on_controller_and_reports_reconnect_required`.
3. Run `cargo test -p homeboy-lab-runner ssh_bootstrap_select_promotes_without_materialized_source_sha`.
4. Run `cargo check -p homeboy-lab-runner`.
5. Run `cargo fmt --all -- --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Root-cause analysis, implementation, tests, and verification.