### PR TITLE
Fix runner-local run-plan routing

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -518,6 +518,8 @@ fn runner_resident_run_plan_does_not_require_a_second_controller_session() {
     ]);
     let normalized = vec![
         "homeboy".to_string(),
+        "--placement".to_string(),
+        "local".to_string(),
         "agent-task".to_string(),
         "run-plan".to_string(),
         "--plan".to_string(),

--- a/crates/homeboy-lab-runner/src/execution/process.rs
+++ b/crates/homeboy-lab-runner/src/execution/process.rs
@@ -386,6 +386,11 @@ pub(crate) fn prepare_daemon_local_process(
     env.insert(RUNNER_HOSTED_EXEC_ENV.to_string(), "1".to_string());
     env.insert(RUNNER_PLACEMENT_RESOLVED_ENV.to_string(), "1".to_string());
     env.insert(RUNNER_ID_ENV.to_string(), runner.id.clone());
+    // Execution provenance is distinct from the dispatch markers above. It
+    // survives CLI routing so runner-local agent-task plans do not open a
+    // second controller-to-runner handoff.
+    env.entry(homeboy_core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV.to_string())
+        .or_insert_with(|| runner.id.clone());
     env.extend(resolve_runner_secret_env_for_plan(
         &runner.secret_env,
         &secret_env_plan,

--- a/crates/homeboy-lab-runner/src/execution/tests/prepare.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/prepare.rs
@@ -301,6 +301,13 @@ fn daemon_worker_marks_nested_cook_as_runner_hosted() {
             plan.env.get(RUNNER_ID_ENV).map(String::as_str),
             Some("homeboy-lab")
         );
+        assert_eq!(
+            plan.env
+                .get(homeboy_core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV)
+                .map(String::as_str),
+            Some("homeboy-lab"),
+            "daemon-local execution retains the runner provenance needed by nested run-plan"
+        );
     });
 }
 


### PR DESCRIPTION
## Summary
- preserve the daemon execution runner ID in runner-local process environments
- keep nested `agent-task run-plan` execution on the runner instead of attempting a second controller handoff
- cover both environment preparation and CLI routing regressions

Fixes #9349

## How to test
1. Run `cargo test -p homeboy-lab-runner daemon_worker_marks_nested_cook_as_runner_hosted`.
2. Run `cargo test -p homeboy-cli runner_resident_run_plan_does_not_require_a_second_controller_session`.
3. Run `cargo check -p homeboy-lab-runner -p homeboy-cli`.
4. Run `cargo fmt --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause analysis, implementation, regression tests, and verification.