### PR TITLE
fix(agents): keep recovery readers bounded

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1750,7 +1750,7 @@ pub fn list_records() -> Result<Vec<AgentTaskRunRecord>> {
 
 pub fn list_records_with_health() -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)>
 {
-    let (records, health) = store::read_records_with_health()?;
+    let (records, health) = read_records_with_health()?;
     let mut refreshed = Vec::new();
     for record in records {
         if let Ok(record) = status(&record.run_id) {
@@ -1767,6 +1767,24 @@ pub fn list_records_with_health() -> Result<(Vec<AgentTaskRunRecord>, AgentTaskR
             .then_with(|| right.run_id.cmp(&left.run_id))
     });
     Ok((refreshed, health))
+}
+
+/// Read the durable registry snapshot without runner reconciliation. Bounded
+/// recovery readers use this path so disconnected historical runner mirrors
+/// cannot delay access to controller-owned state.
+pub fn read_records_with_health() -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)>
+{
+    let (mut records, health) = store::read_records_with_health()?;
+    records.sort_by(|left, right| {
+        right
+            .updated_at
+            .as_ref()
+            .unwrap_or(&right.submitted_at)
+            .cmp(left.updated_at.as_ref().unwrap_or(&left.submitted_at))
+            .then_with(|| right.submitted_at.cmp(&left.submitted_at))
+            .then_with(|| right.run_id.cmp(&left.run_id))
+    });
+    Ok((records, health))
 }
 
 /// Resolve an aggregate artifact back to its controller-owned durable run.

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -2,7 +2,7 @@
 //! reporting. Pure move out of the former `agent_task_service.rs` god-file.
 
 use crate::agent_task::{AgentTaskRequest, AgentTaskSourceRef};
-use crate::agent_task_lifecycle::{self, AgentTaskRunRecord};
+use crate::agent_task_lifecycle::{self, AgentTaskRecordHealthSummary, AgentTaskRunRecord};
 use crate::agent_task_scheduler::AgentTaskState;
 use homeboy_core::Result;
 use serde_json::Value;
@@ -220,7 +220,30 @@ pub fn discover_runs_with_options(
     filter: AgentTaskDiscoveryFilter,
     options: AgentTaskDiscoveryOptions,
 ) -> Result<AgentTaskDiscoveryReport> {
-    let (mut records, record_health) = agent_task_lifecycle::list_records_with_health()?;
+    let (records, record_health) = agent_task_lifecycle::read_records_with_health()?;
+    discovery_report(filter, options, records, record_health)
+}
+
+/// Discovery for an operator-requested reconciliation. Unlike ordinary bounded
+/// readers, this refreshes runner-backed records before classifying candidates.
+pub(crate) fn discover_runs_with_reconciliation(
+    filter: AgentTaskDiscoveryFilter,
+) -> Result<AgentTaskDiscoveryReport> {
+    let (records, record_health) = agent_task_lifecycle::list_records_with_health()?;
+    discovery_report(
+        filter,
+        AgentTaskDiscoveryOptions::default(),
+        records,
+        record_health,
+    )
+}
+
+fn discovery_report(
+    filter: AgentTaskDiscoveryFilter,
+    options: AgentTaskDiscoveryOptions,
+    mut records: Vec<AgentTaskRunRecord>,
+    record_health: AgentTaskRecordHealthSummary,
+) -> Result<AgentTaskDiscoveryReport> {
     let is_active = filter == AgentTaskDiscoveryFilter::Active;
     if is_active {
         records.retain(|record| {

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -4,7 +4,9 @@
 use crate::agent_task_lifecycle;
 use homeboy_core::Result;
 
-use super::discovery::{discover_runs, AgentTaskDiscoveryFilter, AgentTaskLiveness};
+use super::discovery::{
+    discover_runs_with_reconciliation, AgentTaskDiscoveryFilter, AgentTaskLiveness,
+};
 
 /// Report returned by [`reconcile_stale_active_runs`]. Lists every active run
 /// that was classified non-active, and for the reconcilable ones records the
@@ -44,7 +46,7 @@ pub struct AgentTaskReconcileRun {
 /// work) are never touched. With `dry_run`, candidates are reported but no
 /// record is mutated so an operator can preview the blast radius first.
 pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileReport> {
-    let report = discover_runs(AgentTaskDiscoveryFilter::Active)?;
+    let report = discover_runs_with_reconciliation(AgentTaskDiscoveryFilter::Active)?;
 
     let mut runs = Vec::new();
     let mut reconciled = 0usize;

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -609,7 +609,7 @@ fn discovery_active_filters_to_queued_and_running_runs() {
 }
 
 #[test]
-fn discovery_active_marks_runner_backed_running_run_as_stale_retryable() {
+fn discovery_active_reads_runner_backed_record_without_reconciliation() {
     with_isolated_home(|_| {
         agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-runner-stale"))
             .expect("submitted");
@@ -632,12 +632,10 @@ fn discovery_active_marks_runner_backed_running_run_as_stale_retryable() {
 
         assert_eq!(run.runner_id.as_deref(), Some("homeboy-lab"));
         assert_eq!(run.runner_job_id.as_deref(), Some("job-123"));
-        assert_eq!(run.stale, Some(true));
-        assert_eq!(
-            run.stale_reason.as_deref(),
-            Some("runner_job_unverified_after_daemon_restart")
-        );
-        assert_eq!(run.retryable, Some(true));
+        assert_eq!(run.stale, None);
+        assert_eq!(run.stale_reason, None);
+        assert_eq!(run.retryable, None);
+        assert_eq!(run.liveness, Some(AgentTaskLiveness::Active));
     });
 }
 

--- a/crates/homeboy-cli/src/commands/runs/handlers.rs
+++ b/crates/homeboy-cli/src/commands/runs/handlers.rs
@@ -36,8 +36,6 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
     }
 
     let store = ObservationStore::open_initialized()?;
-    runs_service::refresh_running_mirrored_daemon_evidence_best_effort(&store);
-    reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
     // `--running` is shorthand for `--status running`; the two are mutually
     // exclusive at the CLI layer so this never overrides an explicit status.
     let status = if args.running {

--- a/crates/homeboy-cli/src/commands/runs/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/tests/mod.rs
@@ -3,6 +3,7 @@
 mod export_import;
 
 use super::handlers::{artifact_get, artifacts, env, show_run};
+use super::reconcile::{reconcile_runs, RunsReconcileArgs};
 use super::{
     bench_compare, dead_owned_run, findings, latest, list_runs, runs_dossier, RunsArtifactGetArgs,
     RunsListArgs, RunsOutput, HOSTED_BLUEPRINT_VIEWER,
@@ -117,7 +118,7 @@ fn run_list_filters_kind_component_rig_and_status() {
 }
 
 #[test]
-fn run_list_reconciles_owned_dead_running_runs_before_listing() {
+fn run_list_reads_durable_record_without_reconciliation() {
     with_isolated_home(|_home| {
         let _xdg = XdgGuard::unset();
         let store = ObservationStore::open_initialized().expect("store");
@@ -146,9 +147,43 @@ fn run_list_reconciles_owned_dead_running_runs_before_listing() {
         };
         assert_eq!(output.runs.len(), 1);
         assert_eq!(output.runs[0].id, "dead-owned-run");
-        assert_eq!(output.runs[0].status, "stale");
-        assert!(output.runs[0].finished_at.is_some());
-        assert_eq!(output.runs[0].status_note, None);
+        assert_eq!(output.runs[0].status, "running");
+        assert!(output.runs[0].finished_at.is_none());
+        assert_eq!(
+            output.runs[0].status_note.as_deref(),
+            Some("owner process is not running; run may be stale; run `homeboy runs reconcile`")
+        );
+
+        let stored = store
+            .get_run("dead-owned-run")
+            .expect("get run")
+            .expect("run exists");
+        assert_eq!(stored.status, "running");
+        assert!(stored.metadata_json["homeboy_reconciled"].is_null());
+    });
+}
+
+#[test]
+fn runs_reconcile_explicitly_reconciles_owned_dead_running_runs() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        store
+            .import_run(&dead_owned_run("dead-owned-run"))
+            .expect("import stale fixture");
+
+        let (output, _) = reconcile_runs(RunsReconcileArgs {
+            dry_run: false,
+            limit: 20,
+        })
+        .expect("reconcile");
+
+        let RunsOutput::Reconcile(output) = output else {
+            panic!("expected reconcile output");
+        };
+        assert_eq!(output.reconciled.len(), 1);
+        assert_eq!(output.reconciled[0].id, "dead-owned-run");
+        assert_eq!(output.reconciled[0].status, "stale");
 
         let stored = store
             .get_run("dead-owned-run")


### PR DESCRIPTION
## Summary
- make `agent-task active`, `list`, and `latest` read controller-owned durable snapshots without runner reconciliation
- stop `runs list` from synchronously refreshing and reconciling unrelated historical mirrors
- preserve runner hydration and stale-run mutation behind explicit reconcile commands

## Context
An interrupted Lab Cook left the operator unable to determine whether dispatch had registered: every canonical agent-task reader exceeded two minutes, while `runs list --limit 10` spent its budget refreshing unrelated disconnected and missing historical daemon jobs.

Closes #9353

## How to test
1. Run `cargo test -p homeboy-agents discovery_active_reads_runner_backed_record_without_reconciliation --lib`.
2. Run `cargo test -p homeboy-agents reconcile_dry_run_reports_but_does_not_cancel_stale_runs --lib`.
3. Run `cargo test -p homeboy-cli run_list_reads_durable_record_without_reconciliation --lib`.
4. Run `cargo test -p homeboy-cli runs_reconcile_explicitly_reconciles_owned_dead_running_runs --lib`.
5. Run `cargo fmt --check`.
6. Run `git diff --check origin/main...HEAD`.

Expected: bounded readers preserve durable running state without transport access; explicit reconcile still identifies and transitions stale owned runs.

## Backwards compatibility
This intentionally changes read-side behavior: list/latest commands no longer perform implicit runner reconciliation or stale-run mutation. External callers that relied on a read command to reconcile state must invoke the existing explicit reconcile command. Output schemas are unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed the control-plane hang, implemented bounded read paths and explicit reconciliation coverage, and verified the focused tests.