### PR TITLE
fix(runner): rotate refresh for retained generations

### DIFF
--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -403,6 +403,24 @@ pub(crate) fn status_projection(
     )
 }
 
+/// Report whether a refresh must preserve existing daemon endpoints. Current
+/// daemon activity is queried separately; this covers durable ownership that
+/// remains after a producing job has completed.
+pub(crate) fn requires_generation_preserving_refresh(
+    runner_id: &str,
+    legacy: Option<&RunnerSession>,
+) -> Result<bool> {
+    Ok(read(runner_id, legacy)?.is_some_and(|generations| {
+        generations
+            .generations
+            .values()
+            .any(|generation| generation.active_jobs > 0)
+            || !generations.job_owners.is_empty()
+            || !generations.run_owners.is_empty()
+            || !generations.artifact_owners.is_empty()
+    }))
+}
+
 pub(crate) fn live_sessions(
     runner_id: &str,
     legacy: Option<&RunnerSession>,
@@ -1179,6 +1197,35 @@ mod tests {
             assert_eq!(persisted["job_owners"]["job-a"], "lease-a");
             assert_eq!(persisted["run_owners"]["run-a"], "lease-a");
             assert_eq!(persisted["artifact_owners"]["artifact-a"], "lease-a");
+        });
+    }
+
+    #[test]
+    fn completed_result_ownership_requires_generation_preserving_refresh_until_retired() {
+        test_support::with_isolated_home(|_| {
+            let current = session("lease-a", "daemon-a", Some(101));
+            let mut generations = RollingGenerations::new("lease-a", current.clone());
+            generations.admit_job("job-a");
+            assert!(generations.record_run("job-a", "run-a"));
+            assert!(generations.record_artifact("job-a", "artifact-a"));
+            assert!(!generations.complete_job("job-a"));
+            write("runner-a", &generations).expect("persist retained result ownership");
+
+            assert!(
+                requires_generation_preserving_refresh("runner-a", Some(&current))
+                    .expect("inspect retained ownership"),
+                "completed result owners keep their producing generation routable"
+            );
+
+            generations.retire_result_owner(RollingResultOwnerRetirement::Run("run-a"));
+            generations.retire_result_owner(RollingResultOwnerRetirement::Artifact("artifact-a"));
+            write("runner-a", &generations).expect("persist retired result ownership");
+
+            assert!(
+                !requires_generation_preserving_refresh("runner-a", Some(&current))
+                    .expect("inspect idle generation"),
+                "an idle generation can use ordinary disconnect and reconnect"
+            );
         });
     }
 

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -448,7 +448,15 @@ pub fn refresh_homeboy_binary(
     if options.reconnect {
         promotion_lease.assert_generation()?;
         let active_jobs = active_jobs_before_daemon_replacement(&plan.runner_id)?;
-        if !active_jobs.is_empty() && !options.force {
+        let preserve_generations = super::generation_store::requires_generation_preserving_refresh(
+            &plan.runner_id,
+            refresh_session.as_ref(),
+        )?;
+        if should_rotate_daemon_generation(
+            !active_jobs.is_empty(),
+            preserve_generations,
+            options.force,
+        ) {
             let candidate_identity = identity
                 .get("data")
                 .unwrap_or(&identity)
@@ -673,6 +681,14 @@ pub fn refresh_homeboy_binary(
         },
         0,
     ))
+}
+
+fn should_rotate_daemon_generation(
+    has_active_jobs: bool,
+    preserve_generations: bool,
+    force: bool,
+) -> bool {
+    !force && (has_active_jobs || preserve_generations)
 }
 
 fn refresh_owned_lease(session: super::RunnerSession) -> Option<String> {

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
@@ -592,6 +592,14 @@ fn ssh_bootstrap_identity_mismatch_leaves_config_unchanged() {
 }
 
 #[test]
+fn refresh_rotation_predicate_preserves_owned_generations_without_changing_force_semantics() {
+    assert!(should_rotate_daemon_generation(false, true, false));
+    assert!(should_rotate_daemon_generation(true, false, false));
+    assert!(!should_rotate_daemon_generation(false, false, false));
+    assert!(!should_rotate_daemon_generation(true, true, true));
+}
+
+#[test]
 fn concurrent_runner_config_edit_survives_ssh_bootstrap_promotion() {
     test_support::with_isolated_home(|_| {
         crate::create(r#"{"id":"lab-local","kind":"local","homeboy_path":"/old","env":{"OLD":"1"},"resources":{"dev_sync":{"old":true}}}"#, false).expect("runner");


### PR DESCRIPTION
## Summary
- make `refresh-homeboy` consult durable generation ownership as well as the current daemon job list
- rotate when completed jobs still retain run or artifact routing
- preserve ordinary disconnect/reconnect for a truly idle generation
- keep `--force` interruption behavior unchanged

Fixes #9363.

## How to test
1. Run `cargo test -p homeboy-lab-runner completed_result_ownership_requires_generation_preserving_refresh_until_retired --lib`.
2. Run `cargo test -p homeboy-lab-runner refresh_rotation_predicate_preserves_owned_generations_without_changing_force_semantics --lib`.
3. Run `cargo test -p homeboy-lab-runner homeboy_refresh --lib`.
4. Run `cargo test -p homeboy-lab-runner generation_store --lib`.
5. Run `cargo fmt -p homeboy-lab-runner -- --check`.

All commands pass. The refresh filter reports 52 passing tests; the generation-store filter reports 17 passing tests and 5 intentional subprocess fixtures ignored in the parent process.

## Compatibility
No public CLI or output schema changes. The refresh decision now follows the existing durable generation contract introduced by #9334 and reconciled by #9361. A truly idle generation and explicit `--force` retain their prior paths.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Model:** `openai/gpt-5.6-sol`
- **Used for:** Diagnosed the live post-materialization disconnect failure, traced durable generation ownership, implemented the rotation predicate, and added deterministic verification with Chris Huber.