### PR TITLE
Stage Lab handoff before cook preacceptance

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -620,6 +620,12 @@ impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
         // Stage the controller-owned identity before Lab preflight. A rejected
         // handoff can then terminalize this record with a retryable diagnosis.
         agent_task_lifecycle::submit_plan(&plan, Some(run_id))?;
+        stage_controller_lab_handoff_before_preacceptance(
+            run_id,
+            &self.runner_id,
+            &provider_args,
+            &plan,
+        )?;
         let outcome = match lab_routing::dispatch_lab_offload(
             LabRoutingRequest {
                 command: lab_offload_command(&provider_cli.command)?,
@@ -702,6 +708,27 @@ impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
             LabRouteOutcome::InFlight(_) => Ok(()),
         }
     }
+}
+
+/// Establish controller authority before Lab routing can reconcile a runner
+/// snapshot. Lab source staging and preflight may observe an accepted daemon
+/// job before the offload executor reaches its later proxy-recording step.
+fn stage_controller_lab_handoff_before_preacceptance(
+    run_id: &str,
+    runner_id: &str,
+    remote_command: &[String],
+    plan: &homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,
+) -> homeboy::core::Result<()> {
+    agent_task_lifecycle::record_lab_offload_planned(agent_task_lifecycle::LabOffloadProxyPlan {
+        run_id,
+        runner_id,
+        // Lab replaces this controller-side placeholder with its materialized
+        // workspace once it reaches the executor.
+        remote_workspace: "pending",
+        remote_command,
+        durable_plan: Some(plan),
+    })?;
+    Ok(())
 }
 
 fn attach_verified_cook_baseline(

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -95,6 +95,52 @@ fn lab_cook_child_invocation_consumes_controller_runner_placement() {
 }
 
 #[test]
+fn cook_dispatch_stages_pending_handoff_before_lab_preacceptance() {
+    crate::test_support::with_isolated_home(|_| {
+        let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
+            "cook-preacceptance-order",
+            vec![serde_json::from_value(serde_json::json!({
+                "task_id": "task",
+                "executor": { "backend": "fixture" },
+                "instructions": "exercise controller handoff staging"
+            }))
+            .expect("task")],
+        );
+        let dispatcher = LabCookAttemptDispatcher {
+            runner_id: "missing-homeboy-lab".to_string(),
+            allow_local_fallback: false,
+            allow_dirty_lab_workspace: false,
+            skip_deps_hydration: false,
+            detach_after_handoff: false,
+            source_path: None,
+            job_overrides: runners::LabJobOverrides::default(),
+        };
+
+        let error =
+            crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher::dispatch_attempt(
+                &dispatcher,
+                plan,
+                "cook-preacceptance-order",
+                None,
+            )
+            .expect_err("missing Lab target rejects after controller staging");
+
+        assert!(!error.message.is_empty());
+        let record = agent_task_lifecycle::status("cook-preacceptance-order")
+            .expect("controller record remains inspectable after preacceptance failure");
+        let handoff = record.lab_handoff.expect("pending controller handoff");
+        assert_eq!(handoff.runner_id, "missing-homeboy-lab");
+        let handoff = serde_json::to_value(handoff).expect("serialize typed handoff");
+        assert_eq!(handoff["state"], "pending");
+        assert_eq!(handoff["authority"], "controller");
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["phase"],
+            "lab_handoff_preacceptance"
+        );
+    });
+}
+
+#[test]
 fn non_lab_command_continues_local_dispatch() {
     // route_after_parse mutates the process-global LAB_OFFLOAD_METADATA_ENV,
     // so hold the env lock to serialize against tests that assert on it.


### PR DESCRIPTION
## Summary
- establish the controller-owned pending Lab handoff immediately after the durable cook plan is submitted
- stage that authority before Lab source preparation or preacceptance snapshots can reconcile
- retain the later idempotent proxy update that adds the materialized remote workspace
- cover the actual cook dispatcher ordering and preserve conflicting accepted-job rejection

Fixes #9340

## How to test
1. Run `cargo test -p homeboy-cli cook_dispatch_stages_pending_handoff_before_lab_preacceptance --quiet`.
2. Run `cargo test -p homeboy-agents runner_snapshot_rejects_conflicting_bound_lab_job_identity --lib --quiet`.
3. Run `cargo fmt --check && git diff --check`.
4. Dispatch a clean managed worktree with `homeboy agent-task cook --to-worktree <handle> --cwd <path> --task-url <issue> --runner homeboy-lab --prompt <task> ...`.
5. Confirm it proceeds past `lab_handoff_preacceptance` into provider execution.

## Compatibility
- No public CLI or extension path changes.
- Existing later proxy staging remains idempotent and enriches the placeholder workspace.
- Already-bound snapshots from a different runner job remain fail-closed.

## Evidence
- PR #9345 initialized pending handoffs inside the proxy helper but a post-merge live replay still reached snapshot validation before that helper ran.
- Run `agent-task-8c40bf61-3e9a-49de-8d80-a53e079eb1e1-attempt-1-b9c5fa10` reproduced the failure on accepted main `4a57291e16d9` with zero provider executions.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Reproduced the first repair against the live Lab, identified the route-level ordering gap, implemented deterministic dispatcher coverage, and verified the fix with Chris.