### PR TITLE
refactor(agents): consolidate Lab runner-job identity into one canonical type

### DIFF
--- a/crates/contracts/homeboy-lab-contract/src/lab/handoff.rs
+++ b/crates/contracts/homeboy-lab-contract/src/lab/handoff.rs
@@ -84,6 +84,78 @@ pub struct AgentTaskDispatchIdentity {
     pub handoff_id: Option<String>,
 }
 
+/// The core run/runner/job identity a Lab-offloaded job carries across the
+/// controller, the runner snapshot, and terminal lifecycle events.
+///
+/// This is the canonical shape the whole handoff lifecycle validates against —
+/// previously each call site hand-rolled the same `run_id`/`runner_id`/
+/// `runner_job_id` tuple comparison with subtly different edge-case handling,
+/// which is why identity-binding bugs landed one path at a time (empty-string
+/// compares, missing-id-vs-mismatch confusion, etc). Centralizing the
+/// comparison here gives every consumer one definition of "same job".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerJobIdentity {
+    pub run_id: String,
+    pub runner_id: String,
+    pub runner_job_id: String,
+}
+
+impl RunnerJobIdentity {
+    pub fn new(
+        run_id: impl Into<String>,
+        runner_id: impl Into<String>,
+        runner_job_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            run_id: run_id.into(),
+            runner_id: runner_id.into(),
+            runner_job_id: runner_job_id.into(),
+        }
+    }
+
+    /// Whether every identity field is populated. A partially-established
+    /// identity (e.g. a controller run before its accepted runner job id is
+    /// bound) is not a mismatch — callers should surface "identity not
+    /// established" rather than compare against an empty field (#9240).
+    pub fn is_complete(&self) -> bool {
+        !self.run_id.trim().is_empty()
+            && !self.runner_id.trim().is_empty()
+            && !self.runner_job_id.trim().is_empty()
+    }
+
+    /// Whether two identities name the same run + runner + job.
+    pub fn matches(&self, other: &RunnerJobIdentity) -> bool {
+        self.run_id == other.run_id
+            && self.runner_id == other.runner_id
+            && self.runner_job_id == other.runner_job_id
+    }
+
+    /// A stable, human-readable description used in mismatch diagnostics.
+    pub fn describe(&self) -> String {
+        format!(
+            "run '{}', runner '{}', job '{}'",
+            self.run_id, self.runner_id, self.runner_job_id
+        )
+    }
+}
+
+impl AgentTaskDispatchIdentity {
+    /// Project this dispatch identity onto the canonical run/runner/job tuple.
+    /// Prefers the persisted run id (the controller's durable run) and falls
+    /// back to the transport `run_id`.
+    pub fn runner_job_identity(&self) -> RunnerJobIdentity {
+        RunnerJobIdentity {
+            run_id: self
+                .persisted_run_id
+                .clone()
+                .or_else(|| self.run_id.clone())
+                .unwrap_or_default(),
+            runner_id: self.runner_id.clone(),
+            runner_job_id: self.runner_job_id.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct LabRunnerHandoffFollowCommands {
     pub job_logs: String,
@@ -278,4 +350,58 @@ pub fn run_location_index_path(remote_cwd: &str) -> String {
         "{}{RUNNER_ARTIFACT_ROOT_DIR_SUFFIX}/homeboy-run-location-index.json",
         remote_cwd.trim_end_matches('/')
     )
+}
+
+#[cfg(test)]
+mod runner_job_identity_tests {
+    use super::{AgentTaskDispatchIdentity, RunnerJobIdentity};
+
+    #[test]
+    fn matches_requires_all_three_fields_to_agree() {
+        let a = RunnerJobIdentity::new("run-1", "runner-a", "job-1");
+        assert!(a.matches(&RunnerJobIdentity::new("run-1", "runner-a", "job-1")));
+        assert!(!a.matches(&RunnerJobIdentity::new("run-2", "runner-a", "job-1")));
+        assert!(!a.matches(&RunnerJobIdentity::new("run-1", "runner-b", "job-1")));
+        assert!(!a.matches(&RunnerJobIdentity::new("run-1", "runner-a", "job-2")));
+    }
+
+    #[test]
+    fn is_complete_flags_a_partially_established_identity() {
+        // #9240: a controller run before its accepted runner job id is bound has
+        // an empty job id — that is "not established", not a mismatch. Callers
+        // rely on this to surface the right diagnostic instead of comparing
+        // against an empty field.
+        assert!(RunnerJobIdentity::new("run-1", "runner-a", "job-1").is_complete());
+        assert!(!RunnerJobIdentity::new("run-1", "runner-a", "").is_complete());
+        assert!(!RunnerJobIdentity::new("run-1", "", "job-1").is_complete());
+        assert!(!RunnerJobIdentity::new("", "runner-a", "job-1").is_complete());
+        assert!(!RunnerJobIdentity::new("run-1", "runner-a", "   ").is_complete());
+    }
+
+    #[test]
+    fn dispatch_identity_prefers_persisted_run_id() {
+        let identity = AgentTaskDispatchIdentity {
+            runner_id: "runner-a".to_string(),
+            runner_job_id: "job-1".to_string(),
+            persisted_run_id: Some("persisted-run".to_string()),
+            run_id: Some("transport-run".to_string()),
+            handoff_id: None,
+        };
+        let projected = identity.runner_job_identity();
+        assert_eq!(projected.run_id, "persisted-run");
+        assert_eq!(projected.runner_id, "runner-a");
+        assert_eq!(projected.runner_job_id, "job-1");
+    }
+
+    #[test]
+    fn dispatch_identity_falls_back_to_transport_run_id() {
+        let identity = AgentTaskDispatchIdentity {
+            runner_id: "runner-a".to_string(),
+            runner_job_id: "job-1".to_string(),
+            persisted_run_id: None,
+            run_id: Some("transport-run".to_string()),
+            handoff_id: None,
+        };
+        assert_eq!(identity.runner_job_identity().run_id, "transport-run");
+    }
 }

--- a/crates/homeboy-agents/src/agent_task_controller_service/actions.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/actions.rs
@@ -309,15 +309,23 @@ pub(super) fn accepted_lab_runner_handoff_identity(execution: &Value) -> Result<
     }
 
     let persisted = lifecycle::status(run_id)?;
-    if !persisted.has_accepted_lab_handoff()
-        || persisted
-            .lab_handoff
-            .as_ref()
-            .is_none_or(|persisted_identity| {
-                persisted_identity.runner_id != runner_id
-                    || persisted_identity.runner_job_id.as_deref() != Some(runner_job_id)
-            })
-    {
+    // The action's declared identity must match the run's persisted accepted
+    // Lab handoff. Route the run/runner/job tuple through the shared
+    // `RunnerJobIdentity` so this agrees with the terminal-projection and
+    // snapshot validators rather than re-deriving the comparison here.
+    let declared = homeboy_core::lab_contract::RunnerJobIdentity::new(
+        run_id, runner_id, runner_job_id,
+    );
+    let persisted_matches = persisted.has_accepted_lab_handoff()
+        && persisted.lab_handoff.as_ref().is_some_and(|handoff| {
+            homeboy_core::lab_contract::RunnerJobIdentity::new(
+                persisted.run_id.as_str(),
+                handoff.runner_id.as_str(),
+                handoff.runner_job_id.clone().unwrap_or_default(),
+            )
+            .matches(&declared)
+        });
+    if !persisted_matches {
         return Err(Error::validation_invalid_argument(
             "controller runner handoff identity",
             "Lab handoff identity does not match the persisted run/runner/job binding",

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -407,14 +407,26 @@ fn validate_terminal_child_identity(
     snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
     event: &crate::agent_task_lifecycle::agent_task_lifecycle_event::AgentTaskRunPlanLifecycleEvent,
 ) -> Result<()> {
-    let expected_runner_id = record.runner_id().unwrap_or_default();
-    let expected_job_id = record.runner_job_id().unwrap_or_default();
-    let expected_run_id = record.run_id.as_str();
-    if event.identity.runner_id == expected_runner_id
-        && event.identity.runner_job_id == expected_job_id
-        && snapshot.job.id.to_string() == expected_job_id
-        && event.identity.run_id.as_deref() == Some(expected_run_id)
-        && event.identity.persisted_run_id.as_deref() == Some(expected_run_id)
+    // Canonical run/runner/job identity the controller expects, and the identity
+    // the terminal event carries (built from its *persisted* run id). Comparing
+    // via the shared `RunnerJobIdentity` keeps the runner/job/run tuple check in
+    // lockstep with every other handoff-identity site.
+    let expected = homeboy_core::lab_contract::RunnerJobIdentity::new(
+        record.run_id.as_str(),
+        record.runner_id().unwrap_or_default(),
+        record.runner_job_id().unwrap_or_default(),
+    );
+    let event_identity = homeboy_core::lab_contract::RunnerJobIdentity::new(
+        event.identity.persisted_run_id.clone().unwrap_or_default(),
+        event.identity.runner_id.clone(),
+        event.identity.runner_job_id.clone(),
+    );
+    // Beyond the run/runner/job tuple, the terminal event must also agree on the
+    // raw transport run id (not just the persisted run id) and the snapshot's
+    // own job id, so the whole child projection provably belongs to this run.
+    if expected.matches(&event_identity)
+        && event.identity.run_id.as_deref() == Some(record.run_id.as_str())
+        && snapshot.job.id.to_string() == expected.runner_job_id
     {
         return Ok(());
     }


### PR DESCRIPTION
## Why
The Lab handoff/runner-job identity cluster is the single highest-churn area in the codebase — ~20 recent fix PRs all circle the same concept (bind/reconcile/validate a run+runner+job identity). Root cause isn't any one bug: **the identity has no canonical type or validator**, so every path hand-rolls the same `run_id`/`runner_id`/`runner_job_id` tuple comparison with subtly different edge-case handling. That's why bugs land one path at a time (empty-string compares → #9240, duplicate binders → #9251/#9276, missing-id-vs-mismatch confusion). No audit flags this because each site compiles fine; the duplication is *semantic*.

This is the first, contained step toward the canonical execution-identity model #8283 gestures at — establish the type + validator and route the two worst-duplicated validators through it.

## What
- New `RunnerJobIdentity { run_id, runner_id, runner_job_id }` in the shared `homeboy-lab-contract`:
  - `matches(&other)` — the one definition of "same job".
  - `is_complete()` — distinguishes a *not-yet-established* identity (e.g. a controller run before its accepted runner job id is bound) from a genuine mismatch (the #9240 class), so callers surface the right diagnostic instead of comparing against an empty field.
- `AgentTaskDispatchIdentity::runner_job_identity()` — projects the transport identity onto the canonical tuple, preferring the persisted run id.
- Routed through it: `validate_terminal_child_identity` (lifecycle_runner_projection) and the controller action handoff validator (`accepted_lab_runner_handoff_identity` in actions.rs).

## Behavior-preserving
Verified by the existing identity tests — terminal-projection mismatch rejection, foreground terminal bind, 6 preacceptance tests, and 6 dispatch-execute tests all still pass. New unit tests cover `matches`, `is_complete` (incl. the #9240 empty-id case), and the persisted-vs-transport run-id projection.

Note: 2 `terminal_and_reconcile` tests (`pinned_runtime_recovery_...`, `long_pre_submission_...`) fail **identically on clean `origin/main`** in this environment (build `-dirty` / shared-state flakes) — pre-existing, unrelated to this change.

## Follow-up (not in this PR)
The remaining hand-rolled comparison sites (`lifecycle_ops` runner-id filters, `connection.rs`, `generation_store.rs`) can be migrated incrementally onto the same type; those are single-field filters rather than full-identity validation, so they're deferred to keep this change reviewable.