### PR TITLE
refactor(agents): match runner terminal events by canonical identity, not raw JSON equality

### DIFF
--- a/crates/contracts/homeboy-lab-contract/src/lab/handoff.rs
+++ b/crates/contracts/homeboy-lab-contract/src/lab/handoff.rs
@@ -139,6 +139,29 @@ impl RunnerJobIdentity {
     }
 }
 
+impl RunnerJobIdentity {
+    /// Project a serialized dispatch-identity JSON object onto the canonical
+    /// tuple. Accepts the same field names as [`AgentTaskDispatchIdentity`]
+    /// (`run_id`/`persisted_run_id`, `runner_id`, `runner_job_id`), preferring
+    /// the persisted run id. Returns `None` when the value is not a
+    /// dispatch-identity object. Used to compare handoff identities that are
+    /// still carried as raw JSON without depending on exact `Value` equality.
+    pub fn from_dispatch_value(value: &serde_json::Value) -> Option<RunnerJobIdentity> {
+        let object = value.as_object()?;
+        let string = |key: &str| object.get(key).and_then(serde_json::Value::as_str);
+        let run_id = string("persisted_run_id")
+            .or_else(|| string("run_id"))?
+            .to_string();
+        let runner_id = string("runner_id")?.to_string();
+        let runner_job_id = string("runner_job_id")?.to_string();
+        Some(RunnerJobIdentity {
+            run_id,
+            runner_id,
+            runner_job_id,
+        })
+    }
+}
+
 impl AgentTaskDispatchIdentity {
     /// Project this dispatch identity onto the canonical run/runner/job tuple.
     /// Prefers the persisted run id (the controller's durable run) and falls
@@ -403,5 +426,53 @@ mod runner_job_identity_tests {
             handoff_id: None,
         };
         assert_eq!(identity.runner_job_identity().run_id, "transport-run");
+    }
+
+    #[test]
+    fn from_dispatch_value_projects_the_canonical_tuple() {
+        let value = serde_json::json!({
+            "runner_id": "runner-a",
+            "runner_job_id": "job-1",
+            "persisted_run_id": "persisted-run",
+            "run_id": "transport-run",
+        });
+        let identity = RunnerJobIdentity::from_dispatch_value(&value).expect("projectable");
+        assert_eq!(identity.run_id, "persisted-run");
+        assert_eq!(identity.runner_id, "runner-a");
+        assert_eq!(identity.runner_job_id, "job-1");
+    }
+
+    #[test]
+    fn from_dispatch_value_matches_across_cosmetic_field_differences() {
+        // Two serialized identities that name the same job but differ in
+        // incidental fields (an extra handoff_id, a missing transport run_id)
+        // must still match on the canonical tuple — this is the robustness the
+        // typed comparison buys over brittle raw-`Value` equality.
+        let stored = serde_json::json!({
+            "runner_id": "runner-a",
+            "runner_job_id": "job-1",
+            "persisted_run_id": "persisted-run",
+            "run_id": "persisted-run",
+        });
+        let replayed = serde_json::json!({
+            "runner_id": "runner-a",
+            "runner_job_id": "job-1",
+            "persisted_run_id": "persisted-run",
+            "handoff_id": "handoff-xyz",
+        });
+        assert_ne!(stored, replayed, "raw Value equality would reject this pair");
+        let stored_identity = RunnerJobIdentity::from_dispatch_value(&stored).expect("stored");
+        let replayed_identity = RunnerJobIdentity::from_dispatch_value(&replayed).expect("replayed");
+        assert!(stored_identity.matches(&replayed_identity));
+    }
+
+    #[test]
+    fn from_dispatch_value_rejects_a_non_identity_object() {
+        assert!(RunnerJobIdentity::from_dispatch_value(&serde_json::json!("not-an-object")).is_none());
+        assert!(
+            RunnerJobIdentity::from_dispatch_value(&serde_json::json!({ "runner_id": "a" }))
+                .is_none(),
+            "missing runner_job_id / run_id must not project"
+        );
     }
 }

--- a/crates/homeboy-agents/src/agent_task_controller_service/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/mod.rs
@@ -622,10 +622,27 @@ fn replay_runner_terminal_event(
             None,
         )
     })?;
-    let action = record
-        .next_actions
-        .iter()
-        .find(|action| lab_runner_handoff_identity(action).as_ref() == Some(&identity));
+    // Match the terminal event to its controller action by canonical
+    // run/runner/job identity rather than exact JSON equality — the stored and
+    // replayed identity objects can differ in cosmetic fields (extra keys,
+    // handoff_id) while naming the same job. Fall back to raw `Value` equality
+    // only when a side is not a projectable dispatch-identity object.
+    let event_identity =
+        homeboy_core::lab_contract::RunnerJobIdentity::from_dispatch_value(&identity);
+    let action = record.next_actions.iter().find(|action| {
+        let Some(stored) = lab_runner_handoff_identity(action) else {
+            return false;
+        };
+        match (
+            event_identity.as_ref(),
+            homeboy_core::lab_contract::RunnerJobIdentity::from_dispatch_value(&stored),
+        ) {
+            (Some(event_identity), Some(stored_identity)) => {
+                event_identity.matches(&stored_identity)
+            }
+            _ => stored == identity,
+        }
+    });
     let Some(action) = action else {
         return Err(Error::validation_invalid_argument(
             "payload.identity",


### PR DESCRIPTION
## Why
Follows up #9379 (canonical `RunnerJobIdentity`, now merged to `main`). Continues migrating hand-rolled identity comparisons onto the canonical type — this targets the most fragile remaining site: `replay_runner_terminal_event` matched a terminal event to its controller action by **exact `serde_json::Value` equality** of the two handoff identities.

That's brittle: the stored diagnostic identity and the replayed event identity can name the same run/runner/job while differing in incidental fields (extra `handoff_id`, missing transport `run_id`, key ordering) — and raw `Value` equality would then spuriously fail to find the action.

## What
- Add `RunnerJobIdentity::from_dispatch_value(&Value)` — projects a serialized dispatch-identity object onto the canonical run/runner/job tuple (preferring persisted run id).
- Route the action `find` through it: match on the tuple, falling back to raw `Value` equality only when a side is not a projectable dispatch-identity object.

## Behavior-preserving + more robust
- The full runner-terminal `apply_event` flow (including the duplicate-replay idempotency case) still passes — verified by the 6 `dispatch_execute_tests` and the full 71-test `agent_task_controller_service` suite.
- New contract unit tests cover the projection, the cosmetic-field tolerance (two identities that differ only in incidental fields still match), and rejection of non-identity objects.