### PR TITLE
fix(agent-task): admit fanout run-plan child cooks to Lab (#9375)

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
@@ -665,12 +665,13 @@ fn agent_task_fanout_submit_batch_requires_explicit_runner_under_lab_placement()
 
 #[test]
 fn agent_task_fanout_run_plan_coordination_is_controller_local() {
+    // `--runner` implies Lab placement and is mutually exclusive with an
+    // explicit `--placement` at parse time (#9002), so a runner-pinned fanout
+    // uses `--runner` alone.
     let normalized = vec![
         "homeboy".to_string(),
         "--runner".to_string(),
         "homeboy-lab".to_string(),
-        "--placement".to_string(),
-        "lab".to_string(),
         "agent-task".to_string(),
         "fanout".to_string(),
         "run-plan".to_string(),
@@ -685,7 +686,6 @@ fn agent_task_fanout_run_plan_coordination_is_controller_local() {
     // their own Lab placement (#8045).
     let command = lab_offload_command(&cli.command).unwrap().unwrap();
     assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
-    assert_eq!(cli.placement, crate::cli_surface::Placement::Lab);
     assert_eq!(command.hot_label, "agent-task fanout run-plan");
     assert!(!command.is_portable());
     assert!(!command.routing_policy.default_lab_offload);
@@ -698,12 +698,13 @@ fn agent_task_fanout_run_plan_coordination_is_controller_local() {
 
 #[test]
 fn agent_task_fanout_cook_batch_run_plan_keeps_cook_coordinators_local() {
+    // `--runner` implies Lab placement and conflicts with an explicit
+    // `--placement` at parse time (#9002); the runner-pinned coordinator uses
+    // `--runner` alone.
     let normalized = vec![
         "homeboy".to_string(),
         "--runner".to_string(),
         "homeboy-lab".to_string(),
-        "--placement".to_string(),
-        "lab".to_string(),
         "agent-task".to_string(),
         "fanout".to_string(),
         "cook-batch".to_string(),
@@ -718,7 +719,6 @@ fn agent_task_fanout_cook_batch_run_plan_keeps_cook_coordinators_local() {
 
     let command = lab_offload_command(&cli.command).unwrap().unwrap();
     assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
-    assert_eq!(cli.placement, crate::cli_surface::Placement::Lab);
     assert_eq!(command.hot_label, "agent-task fanout cook-batch");
     assert!(!command.is_portable());
     assert!(!command.routing_policy.default_lab_offload);

--- a/crates/homeboy-cli/src/commands/utils/resource_policy.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy.rs
@@ -209,6 +209,24 @@ pub fn hot_command(command: &Commands) -> Option<HotCommand> {
         });
     }
 
+    // The batch-cook fanout coordinator keeps durable batch state, worktree
+    // ownership, promotion, gates, and finalization on the controller, but each
+    // independent child provider attempt is Lab-eligible (routed by
+    // `run_split_placement_fanout`). Treat `fanout run-plan` like a verified
+    // cook: a controller-owned coordinator whose provider work can be admitted
+    // under warm/hot CPU load when an explicit ready `--runner` is selected,
+    // rather than refusing the whole batch as local-only (#9375). Memory and
+    // process pressure remain hard local safety gates via
+    // `admits_warm_runner_coordination`.
+    if is_lab_offloadable_fanout_coordinator(command) {
+        return Some(HotCommand {
+            label: "agent-task fanout run-plan",
+            lab_offload_supported: true,
+            lab_offload_unsupported_reason: None,
+            allows_warm_runner_coordination: true,
+        });
+    }
+
     let contract = command.lab_contract()?;
 
     match contract.portability {
@@ -237,6 +255,27 @@ fn is_controller_owned_fanout_coordination(command: &Commands) -> bool {
         Commands::AgentTask(agent_task::AgentTaskArgs {
             command: agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
                 command: agent_task::AgentTaskFanoutCommand::CookBatch(_),
+            }),
+        })
+    )
+}
+
+/// The `fanout run-plan` coordinator executes a materialized batch-cook plan:
+/// it owns the durable batch record, worktrees, promotion, gates, and
+/// finalization, but dispatches each independent child provider attempt to a
+/// selected Lab runner (`run_split_placement_fanout`). Unlike `cook-batch`
+/// (which is unconditionally controller-local planning/coordination and is
+/// filtered out earlier so it never refuses), `run-plan` previously fell
+/// through to the generic local-only contract and refused on a warm/hot
+/// controller — stranding a validated batch that a ready Lab runner could
+/// serve (#9375). Recognize it here so its provider attempts can be admitted
+/// under warm-runner coordination.
+fn is_lab_offloadable_fanout_coordinator(command: &Commands) -> bool {
+    matches!(
+        command,
+        Commands::AgentTask(agent_task::AgentTaskArgs {
+            command: agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
+                command: agent_task::AgentTaskFanoutCommand::RunPlan(_),
             }),
         })
     )
@@ -762,6 +801,75 @@ mod tests {
         assert!(command.lab_offload_supported);
         assert!(command.allows_warm_runner_coordination);
         assert_eq!(command.label, "agent-task cook/run-plan/retry --run");
+    }
+
+    #[test]
+    fn fanout_run_plan_coordinator_can_offload_its_child_provider_attempts() {
+        // A validated batch-cook fanout run-plan must not be refused as
+        // local-only under resource policy: the coordinator stays on the
+        // controller while each child provider attempt is Lab-eligible (#9375).
+        let cli = Cli::parse_from([
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "run-plan",
+            "--input",
+            "@batch-cook-plan.json",
+        ]);
+        let command = hot_command(&cli.command).expect("fanout run-plan is resource managed");
+        assert!(command.lab_offload_supported);
+        assert!(command.allows_warm_runner_coordination);
+        assert!(command.lab_offload_unsupported_reason.is_none());
+        assert_eq!(command.label, "agent-task fanout run-plan");
+    }
+
+    #[test]
+    fn runner_pinned_fanout_run_plan_admits_an_explicit_ready_runner_on_warm_or_hot_controller() {
+        // With an explicit ready runner, the fanout coordinator is admitted on a
+        // warm/hot controller so its child cooks can execute on Lab, instead of
+        // the whole batch being forced local (#9375).
+        let cli = Cli::parse_from([
+            "homeboy",
+            "--runner",
+            "homeboy-lab",
+            "agent-task",
+            "fanout",
+            "run-plan",
+            "--input",
+            "@batch-cook-plan.json",
+        ]);
+        let command = hot_command(&cli.command).expect("fanout run-plan is resource managed");
+        assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+        let ready = ready_lab();
+
+        for recommendation in [ResourceRecommendation::Warm, ResourceRecommendation::Hot] {
+            let mut resources = coordination_resources();
+            resources.recommendation = recommendation;
+            resources.load.recommendation = recommendation;
+            assert!(admits_warm_runner_coordination(
+                command,
+                &resources,
+                Some("homeboy-lab"),
+                Some(&ready),
+            ));
+        }
+
+        // Without an explicit runner, or with an unavailable one, the warm/hot
+        // controller still declines — preserving the memory/process safety
+        // boundary shared with the single-cook coordinator.
+        let resources = coordination_resources();
+        assert!(!admits_warm_runner_coordination(
+            command,
+            &resources,
+            None,
+            Some(&ready),
+        ));
+        assert!(!admits_warm_runner_coordination(
+            command,
+            &resources,
+            Some("missing-lab"),
+            Some(&ready),
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #9375. A validated `homeboy/agent-task-batch-cook-fanout-plan/v1` run-plan could not run its child cooks on an available Lab runner: on a warm/hot controller `agent-task fanout run-plan` was refused with *"Lab routing is not offered because this command is currently local-only under resource policy"*, and the only continuation offered was `--placement local`.

## Root cause

The child-cook Lab-routing architecture the issue asks for **already exists** — `run_split_placement_fanout` (added in #8456) dispatches each independent child provider attempt to a selected Lab runner while the coordinator keeps durable batch state, worktree ownership, promotion, gates, and finalization on the controller.

The bug was upstream of it: `resource_policy::hot_command` special-cases a verified single `cook` (controller-owned coordinator whose provider attempt is Lab-eligible → `allows_warm_runner_coordination: true`), but **`fanout run-plan` had no such branch**. It fell through to the generic local-only contract, so `preflight_hot_command` refused it non-interactively *before* routing could ever dispatch the child cooks.

## Fix

- Recognize `agent-task fanout run-plan` in `hot_command` as a controller-owned coordinator whose child provider attempts are Lab-eligible, returning `allows_warm_runner_coordination: true`. This mirrors the verified-cook precedent exactly:
  - An explicit ready `--runner` admits the batch coordinator under warm/hot CPU load; `run_split_placement_fanout` then routes each child cook to Lab.
  - Memory and process pressure remain hard local safety gates via `admits_warm_runner_coordination` (unchanged).
  - `cook-batch` (planning/coordination) is still filtered out earlier and unaffected.

## Tests

- `fanout_run_plan_coordinator_can_offload_its_child_provider_attempts` — asserts the coordinator is `lab_offload_supported` + `allows_warm_runner_coordination`. **Proven** to catch the bug: temp-disabling the new branch fails it at `assert!(command.lab_offload_supported)`.
- `runner_pinned_fanout_run_plan_admits_an_explicit_ready_runner_on_warm_or_hot_controller` — asserts warm/hot admission with an explicit ready runner, and rejection without a runner / with an unavailable one.

Also repaired two **pre-existing broken** tests in the same fanout-run-plan-coordination area (`agent_task_fanout_run_plan_coordination_is_controller_local`, `agent_task_fanout_cook_batch_run_plan_keeps_cook_coordinators_local`) that passed the now-illegal `--runner` + `--placement lab` combination (mutually exclusive at parse time since #9002).

## Notes / out of scope

- `agent_task_fanout_submit_batch_requires_explicit_runner_under_lab_placement` fails identically on clean `origin/main` (verified in isolation) — a separate pre-existing failure unrelated to this change; left untouched.
- Per the repo's build policy, heavy `cargo test --workspace` runs are left to CI. Verified locally with `cargo check -p homeboy-cli --lib`, `cargo fmt`, and the targeted `resource_policy` / `route::tests::handoff` test modules.