### PR TITLE
Resolve finalized promotion artifact paths

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -1761,25 +1761,25 @@ fn resolve_artifact_path(
     source_run_id: Option<&str>,
     source_path: Option<&Path>,
 ) -> Result<PathBuf> {
+    if let Some(run_id) = source_run_id {
+        if let Some(projected) =
+            crate::agent_task_lifecycle::verified_controller_artifact_projection_path(
+                run_id, task_id, artifact,
+            )?
+        {
+            return Ok(projected);
+        }
+    }
     let path = artifact.path.as_ref().ok_or_else(|| {
         Error::validation_invalid_argument(
             "artifact.path",
-            "promotion patch artifact must provide a local path",
+            "promotion patch artifact must provide a local path or a verified controller-side artifact projection",
             None,
             None,
         )
     })?;
     let path = PathBuf::from(path);
     if path.is_absolute() {
-        if let Some(run_id) = source_run_id {
-            if let Some(projected) =
-                crate::agent_task_lifecycle::verified_controller_artifact_projection_path(
-                    run_id, task_id, artifact,
-                )?
-            {
-                return Ok(projected);
-            }
-        }
         if !path.is_file() {
             return Err(Error::validation_invalid_argument(
                 "artifact.path",

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -223,6 +223,56 @@ fn promotion_rejects_missing_or_mismatched_recovered_controller_projection() {
 }
 
 #[test]
+fn promotion_uses_recovered_controller_projection_without_public_artifact_path() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let run_id = "recovered-lab-run";
+        let task_id = "implement";
+        let artifact_id = "patch";
+        let mut source: Value = serde_json::from_str(&recovered_runner_aggregate(
+            task_id,
+            artifact_id,
+            &sha256_hex(VALID_PATCH),
+            VALID_PATCH.len(),
+        ))
+        .expect("aggregate JSON");
+        source["outcomes"][0]["artifacts"][0]
+            .as_object_mut()
+            .expect("patch artifact")
+            .remove("path");
+        record_controller_projection(run_id, task_id, artifact_id, VALID_PATCH);
+        let temp = tempfile::tempdir().expect("promotion tempdir");
+        let mut provider = FakePromotionWorkspaceProvider {
+            workspace_path: Some(temp.path().join("target")),
+            ..Default::default()
+        };
+
+        let result = promote_with_provider(
+            AgentTaskPromotionOptions {
+                source: source.to_string(),
+                source_run_id: Some(run_id.to_string()),
+                source_path: None,
+                source_worktree_path: None,
+                base_ref: None,
+                task_base_sha: None,
+                candidate_ref: None,
+                to_worktree: "homeboy@recovered-promotion".to_string(),
+                task_id: Some(task_id.to_string()),
+                artifact_id: Some(artifact_id.to_string()),
+                dry_run: false,
+                gates: VerifyGateOptions::default(),
+                provider_command: None,
+                provider_invocation: None,
+            },
+            &mut provider,
+        )
+        .expect("controller projection is promoted without a public artifact path");
+
+        assert_eq!(result.status, AgentTaskPromotionStatus::Applied);
+        assert_eq!(provider.apply_calls.len(), 1);
+    });
+}
+
+#[test]
 fn promote_recoverable_candidate_rejects_mismatched_run_provenance() {
     let temp = tempfile::tempdir().expect("tempdir");
     let (source_path, source) = recoverable_patch_source(&temp, 1);


### PR DESCRIPTION
## Summary

- resolve controller-owned artifact projections before requiring a public artifact path
- preserve direct and relative artifact path fallback behavior
- verify the controller projection against the aggregate SHA-256 and size before promotion
- cover pathless durable runner artifacts and existing fail-closed mismatch behavior

Closes #9381.

## Why

Reconciled durable runner outcomes intentionally expose reviewer-safe public artifacts without a host-local `path`. Their authoritative controller-finalized file is recorded separately in the observation store. Promotion required the public path before consulting that store, making a valid recovered candidate impossible to promote.

## How to test

1. Run `cargo test -p homeboy-agents recovered_controller_projection --no-fail-fast`.
2. Reconcile a detached Lab outcome whose public patch artifact has SHA-256 and size but no `path`.
3. Run `homeboy agent-task promote <run-id> --to-worktree <handle> --task-id <task-id> --artifact-id patch`.
4. Confirm promotion consumes the matching controller-finalized projection and applies the patch.
5. Alter the projection bytes and confirm promotion fails closed on the SHA-256/size mismatch.

## Verification

- `cargo test -p homeboy-agents recovered_controller_projection --no-fail-fast`: 2 passed.
- `cargo fmt --all --check` currently reports pre-existing formatting drift in `crates/homeboy-agents/src/agent_task_controller_service/actions.rs` on `origin/main`; this PR does not touch that file and its two changed files are formatted.

## Compatibility

This adds the controller-projection resolution path before existing direct/relative path handling. Existing local artifacts retain their current fallback behavior. Durable artifacts remain bound to run, task, logical artifact ID, kind, SHA-256, and size. No public CLI flags or schemas change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Reproduction, implementation, deterministic tests, and PR preparation
