### PR TITLE
fix(upgrade): bootstrap source candidate over installed target (#9371)

### DIFF
--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -932,6 +932,90 @@ pub(crate) fn active_binary_path() -> Result<PathBuf> {
     })
 }
 
+/// Resolve the build identity of the *installed target* controller binary — the
+/// one `active_binary_path` selects on PATH — rather than the in-process
+/// candidate returned by `build_identity::current()`.
+///
+/// A source-built candidate that invokes *itself* must compare its source
+/// against the installed binary it is trying to replace. Comparing against the
+/// candidate's own identity always reports "same identity" and produces a no-op
+/// upgrade (#9371). This queries the installed target's `--version` so the
+/// source-upgrade decision evaluates the real replacement target.
+///
+/// Returns `None` when the installed target cannot be identified (missing binary,
+/// unverifiable `--version`, or an identity string that does not parse), which
+/// keeps the decision on the safe `IdentityUnavailable` path.
+pub(crate) fn installed_target_build_identity(
+) -> Result<Option<homeboy_core::build_identity::BuildIdentity>> {
+    let target_path = active_binary_path()?;
+    let candidate_path = std::env::current_exe().ok();
+
+    // When the invoking binary *is* the installed target, the in-process
+    // identity is authoritative and needs no re-exec. This also preserves the
+    // normal installed-binary invocation contract unchanged.
+    if let Some(candidate) = candidate_path.as_deref() {
+        if paths_identify_same_binary(candidate, &target_path) {
+            return Ok(Some(homeboy_core::build_identity::current()));
+        }
+    }
+
+    let Some(info) = active_binary_info_at(&target_path)? else {
+        return Ok(None);
+    };
+    Ok(info
+        .build_identity
+        .as_deref()
+        .and_then(parse_build_identity_display))
+}
+
+/// Treat two paths as the same binary when they canonicalize to the same file.
+/// Falls back to a raw comparison when canonicalization fails (e.g. a path that
+/// no longer exists), which biases toward the safe "re-exec the target" branch.
+fn paths_identify_same_binary(a: &Path, b: &Path) -> bool {
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => a == b,
+    }
+}
+
+/// Reconstruct a `BuildIdentity` from a controller `--version` display string of
+/// the form `homeboy <version>[+<commit>[-dirty]]` (the exact format
+/// `homeboy_product_identity` emits). Returns `None` for an unrecognizable
+/// string so callers can fall back to the safe unverifiable-replacement path.
+pub(crate) fn parse_build_identity_display(
+    display: &str,
+) -> Option<homeboy_core::build_identity::BuildIdentity> {
+    let display = display.trim();
+    // Take the last whitespace-delimited token so a leading product name
+    // (`homeboy 0.298.1+abc`) is tolerated without hard-coding it.
+    let token = display.split_whitespace().last()?;
+
+    let (version, commit, dirty) = match token.split_once('+') {
+        Some((version, remainder)) => {
+            let (commit, dirty) = match remainder.strip_suffix("-dirty") {
+                Some(commit) => (commit, Some(true)),
+                None => (remainder, Some(false)),
+            };
+            let commit = (!commit.is_empty()).then(|| commit.to_string());
+            // A `+` with no commit yields no verifiable commit identity.
+            let dirty = commit.as_ref().and(dirty);
+            (version.to_string(), commit, dirty)
+        }
+        None => (token.to_string(), None, None),
+    };
+
+    // Validate the version is semver-parseable; an unparseable version cannot
+    // participate in the deterministic decision and must stay unverifiable.
+    semver::Version::parse(version.trim_start_matches('v')).ok()?;
+
+    Some(homeboy_core::build_identity::BuildIdentity {
+        display: display.to_string(),
+        version,
+        git_commit: commit,
+        git_dirty: dirty,
+    })
+}
+
 pub(crate) fn upgrade_verification_result(
     method: InstallMethod,
     force: bool,

--- a/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
@@ -344,6 +344,47 @@ fn parses_plain_homeboy_version_output_as_build_identity() {
 }
 
 #[test]
+fn parses_build_identity_display_with_commit() {
+    // The installed target's `--version` string is reconstructed so the
+    // source-upgrade decision can compare against it rather than the invoking
+    // candidate (#9371).
+    let identity =
+        parse_build_identity_display("homeboy 0.298.1+4a57291e16d9").expect("parseable identity");
+
+    assert_eq!(identity.version, "0.298.1");
+    assert_eq!(identity.git_commit.as_deref(), Some("4a57291e16d9"));
+    assert_eq!(identity.git_dirty, Some(false));
+    assert_eq!(identity.display, "homeboy 0.298.1+4a57291e16d9");
+}
+
+#[test]
+fn parses_build_identity_display_with_dirty_commit() {
+    let identity =
+        parse_build_identity_display("homeboy 0.298.1+4a57291e16d9-dirty").expect("parseable");
+
+    assert_eq!(identity.version, "0.298.1");
+    assert_eq!(identity.git_commit.as_deref(), Some("4a57291e16d9"));
+    assert_eq!(identity.git_dirty, Some(true));
+}
+
+#[test]
+fn parses_plain_build_identity_display_without_commit() {
+    let identity = parse_build_identity_display("homeboy 0.298.1").expect("parseable");
+
+    assert_eq!(identity.version, "0.298.1");
+    assert_eq!(identity.git_commit, None);
+    assert_eq!(identity.git_dirty, None);
+}
+
+#[test]
+fn rejects_unparseable_build_identity_display() {
+    // A non-semver version cannot participate in the deterministic decision and
+    // must stay on the safe unverifiable path rather than pretend to parse.
+    assert!(parse_build_identity_display("homeboy not-a-version").is_none());
+    assert!(parse_build_identity_display("").is_none());
+}
+
+#[test]
 fn verify_retry_succeeds_after_transient_unreadable_binary() {
     // Issue #3463: the swap succeeded but the first read-back of the new
     // binary returns nothing (racing the just-replaced binary). A later

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -8,7 +8,8 @@ use std::process::Command;
 
 use super::constants::{GITHUB_RELEASES_API, VERSION};
 use super::execution::{
-    execute_upgrade, prepare_source_workspace_for_upgrade, resolve_source_workspace,
+    execute_upgrade, installed_target_build_identity, prepare_source_workspace_for_upgrade,
+    resolve_source_workspace,
 };
 use super::services;
 use super::types::*;
@@ -157,8 +158,6 @@ pub fn run_upgrade_with_method(
             .unwrap_or_else(|| "active controller".to_string()),
     )?;
     let install_method = method_override.unwrap_or_else(detect_install_method);
-    let previous_version = current_version().to_string();
-    let previous_build_identity = Some(build_identity::current().display);
 
     if install_method == InstallMethod::Unknown {
         return Err(Error::validation_invalid_argument(
@@ -180,6 +179,23 @@ pub fn run_upgrade_with_method(
     // Source upgrades converge on the requested build, not merely the latest
     // released semver. A distinct, verifiable source build at the same semver
     // must therefore bypass the release-version no-op path.
+    //
+    // The decision compares the source against the *installed target* binary,
+    // not the invoking candidate's in-process identity. A source-built candidate
+    // invoking itself would otherwise always match its own identity and no-op,
+    // leaving the older installed controller in place — the promotion-policy
+    // bootstrap catch-22 in #9371. When the invoking binary *is* the installed
+    // target (the normal path) the target identity is the current identity, so
+    // this is a no-op for ordinary upgrades.
+    let (target_version, target_identity) = resolve_source_upgrade_target(
+        install_method == InstallMethod::Source && !force && source_path.is_some(),
+        current_version(),
+    );
+    // Report the *replaced* controller as the previous identity, so a candidate
+    // that bootstraps over an older installed target surfaces the target it
+    // superseded rather than its own build.
+    let previous_version = target_version.clone();
+    let previous_build_identity = Some(target_identity.display.clone());
     let source_upgrade_decision =
         (install_method == InstallMethod::Source && !force && source_path.is_some())
             .then(|| {
@@ -190,8 +206,8 @@ pub fn run_upgrade_with_method(
                 // work. A dirty source tree is never an acceptable controller.
                 prepare_source_workspace_for_upgrade(source_path)?;
                 Ok(source_upgrade_decision(
-                    &previous_version,
-                    &build_identity::current(),
+                    &target_version,
+                    &target_identity,
                     source_path,
                 ))
             })
@@ -990,6 +1006,33 @@ impl SourceUpgradeDecision {
     }
 }
 
+/// Resolve the (version, identity) pair the source-upgrade decision compares
+/// against. This is the *installed target* controller, so a candidate binary
+/// invoking itself evaluates replacement of the binary it is trying to promote
+/// over rather than comparing against its own identity (#9371).
+///
+/// Falls back to the in-process identity when the source path is not engaged, or
+/// when the installed target cannot be identified — both keep the existing,
+/// safe behavior. The fallback for an unverifiable target still routes through
+/// the decision's `IdentityUnavailable` no-op rather than promoting blindly.
+fn resolve_source_upgrade_target(
+    source_upgrade_engaged: bool,
+    previous_version: &str,
+) -> (String, build_identity::BuildIdentity) {
+    let current = build_identity::current();
+    if !source_upgrade_engaged {
+        return (previous_version.to_string(), current);
+    }
+
+    match installed_target_build_identity() {
+        Ok(Some(target)) => (target.version.clone(), target),
+        // No verifiable installed target: keep comparing against the in-process
+        // identity. The decision then reports SameIdentity/IdentityUnavailable
+        // and no-ops, which is the safe outcome for an unknown target.
+        Ok(None) | Err(_) => (previous_version.to_string(), current),
+    }
+}
+
 fn source_upgrade_decision(
     active_version: &str,
     active_identity: &build_identity::BuildIdentity,
@@ -1434,6 +1477,56 @@ version = "0.0.0"
             Some(decision),
             false
         ));
+    }
+
+    #[test]
+    fn source_matching_candidate_still_promotes_over_a_different_installed_target() {
+        // #9371 catch-22: a source-built candidate B invoking itself compared
+        // its source against its own in-process identity, reported SameIdentity,
+        // and no-op'd — leaving the older installed target A in place. The
+        // decision must instead compare against the *installed target*.
+        let source = tempdir().expect("source");
+        init_git_source(source.path(), "0.298.1");
+        let candidate_commit = source_build_identity(source.path())
+            .expect("source identity")
+            .git_commit
+            .expect("source commit");
+
+        // Comparing the source against the CANDIDATE's own identity (the buggy
+        // pre-#9371 behavior) is a SameIdentity no-op: the source built this
+        // very binary.
+        let against_candidate = source_upgrade_decision(
+            "0.298.1",
+            &active_identity(&candidate_commit),
+            source.path(),
+        );
+        assert_eq!(against_candidate, SourceUpgradeDecision::SameIdentity);
+        assert!(!against_candidate.upgrades());
+
+        // Comparing against the older INSTALLED TARGET (A, a different commit)
+        // correctly promotes — this is the managed bootstrap path.
+        let against_target = source_upgrade_decision(
+            "0.298.1",
+            &active_identity("installed-target-a"),
+            source.path(),
+        );
+        assert_eq!(against_target, SourceUpgradeDecision::DifferentIdentity);
+        assert!(against_target.upgrades());
+        assert!(controller_replacement_proceeds(
+            false,
+            Some(against_target),
+            false
+        ));
+    }
+
+    #[test]
+    fn resolve_source_upgrade_target_falls_back_to_current_identity_when_not_engaged() {
+        // When source upgrade is not engaged, the target resolution must not
+        // re-exec any binary and simply reports the in-process identity so
+        // ordinary (non-source) upgrades are unchanged.
+        let (version, identity) = resolve_source_upgrade_target(false, "9.9.9");
+        assert_eq!(version, "9.9.9");
+        assert_eq!(identity, build_identity::current());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #9371. A source-built controller candidate could not use `homeboy upgrade --method source` to replace an older installed controller — the classic promotion-policy bootstrap catch-22 (e.g. #9355 must be installed before Homeboy can apply the fixed policy).

The root cause: `source_upgrade_decision` compared the source checkout against the **invoking candidate's own** in-process identity (`build_identity::current()`). When candidate B ran `./target/release/homeboy upgrade --source-path $PWD`, the source built to B's identity and `current()` was also B → `SameIdentity` → soft no-op (`upgraded: false`), leaving the installed target A untouched. Recovery required an out-of-band `cargo install --force`.

## Fix

The decision now compares the source against the **installed target** binary, not the candidate:

- `installed_target_build_identity()` resolves the target via `active_binary_path()` (PATH-first) and reads its identity by executing its `--version`, reconstructing a `BuildIdentity` via a new `parse_build_identity_display()` (reverses the `homeboy <ver>+<commit>[-dirty]` format).
- When the invoking binary **is** the installed target (the ordinary upgrade path), target identity == current identity → behavior unchanged (criterion 4).
- An unverifiable target falls back to the safe in-process comparison, which routes through the decision's `IdentityUnavailable` no-op.
- Reported `previous_version` / `previous_build_identity` now reflect the **replaced** installed target, so an operator sees what was superseded (criterion 5).

Runtime-promotion lease (writer serialization + generation ownership), atomic replacement, service restart, and rollback are all retained — the change is confined to *which identity* the decision compares against, upstream of the existing promotion machinery (criterion 3).

## Acceptance criteria

- [x] 1. Source upgrade distinguishes the invoking candidate from the installed target binary.
- [x] 2. A candidate promotes itself over the installed target without an out-of-band Cargo install.
- [x] 3. Runtime-promotion locking, generation safety, atomic replacement, restart, and rollback retained.
- [x] 4. Normal invocation through the installed binary is unchanged.
- [x] 5. Deterministic tests cover candidate-vs-target identity resolution and post-promotion reporting.

## Tests

- `parse_build_identity_display_*` — reconstruct a target's identity from its `--version` (commit / dirty / plain / unparseable-rejection).
- `source_matching_candidate_still_promotes_over_a_different_installed_target` — proves the #9371 catch-22: a source matching the **candidate** is a `SameIdentity` no-op, but the same source vs an older **installed target** correctly `DifferentIdentity`-promotes.
- `resolve_source_upgrade_target_falls_back_to_current_identity_when_not_engaged` — non-source upgrades never re-exec and stay on the in-process identity.

All 107 crate lib tests pass single-threaded. Note: one pre-existing test (`synthetic_snapshot_uses_recorded_source_identity_for_parity`) can flake under high-parallelism git contention (a HOME/git-config auto-detect race in a fixture that predates this change); it passes in isolation and single-threaded.

## Notes

This PR targets the #9371 source-upgrade bootstrap specifically. It was branched under the `fix/9373-...` name while investigating the sibling parallel-Cook issue (#9373); the diff is scoped entirely to source-upgrade target resolution.