### PR TITLE
refactor(agents): extract JSON field-access helpers from controller actions god file

### DIFF
--- a/crates/homeboy-agents/src/agent_task_controller_service/actions.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/actions.rs
@@ -1,5 +1,9 @@
 //! Split from `agent_task_controller_service` god file (#5208). Structural move only.
 #![allow(unused_imports)]
+use super::field_access::{
+    find_failure_context, find_string_field, find_value_field, nested_string_field, string_field,
+    FailureContext,
+};
 use super::*;
 use std::fs;
 use std::io::{self, Read};
@@ -313,9 +317,8 @@ pub(super) fn accepted_lab_runner_handoff_identity(execution: &Value) -> Result<
     // Lab handoff. Route the run/runner/job tuple through the shared
     // `RunnerJobIdentity` so this agrees with the terminal-projection and
     // snapshot validators rather than re-deriving the comparison here.
-    let declared = homeboy_core::lab_contract::RunnerJobIdentity::new(
-        run_id, runner_id, runner_job_id,
-    );
+    let declared =
+        homeboy_core::lab_contract::RunnerJobIdentity::new(run_id, runner_id, runner_job_id);
     let persisted_matches = persisted.has_accepted_lab_handoff()
         && persisted.lab_handoff.as_ref().is_some_and(|handoff| {
             homeboy_core::lab_contract::RunnerJobIdentity::new(
@@ -438,108 +441,6 @@ fn first_action_diagnostic_message(
         .diagnostics
         .first()
         .map(|diagnostic| diagnostic.message.clone())
-}
-
-#[derive(Default)]
-struct FailureContext {
-    diagnostic: Option<String>,
-    task_id: Option<String>,
-    provider: Option<String>,
-    failure_phase: Option<String>,
-    runtime_context: Option<Value>,
-    replay_command: Option<String>,
-}
-
-fn find_failure_context(value: &Value) -> Option<FailureContext> {
-    match value {
-        Value::Object(map) => {
-            if let Some(Value::Array(diagnostics)) = map.get("diagnostics") {
-                if let Some(diagnostic) = diagnostics.iter().find_map(Value::as_object) {
-                    let message = diagnostic
-                        .get("message")
-                        .and_then(Value::as_str)
-                        .map(str::to_string);
-                    if message.is_some() {
-                        return Some(FailureContext {
-                            diagnostic: message,
-                            task_id: string_field(value, "task_id"),
-                            provider: diagnostic
-                                .get("provider")
-                                .and_then(Value::as_str)
-                                .map(str::to_string)
-                                .or_else(|| nested_string_field(diagnostic, "data", "provider"))
-                                .or_else(|| nested_string_field(diagnostic, "data", "provider_id")),
-                            failure_phase: diagnostic
-                                .get("phase")
-                                .and_then(Value::as_str)
-                                .map(str::to_string)
-                                .or_else(|| nested_string_field(diagnostic, "data", "phase"))
-                                .or_else(|| {
-                                    diagnostic
-                                        .get("class")
-                                        .and_then(Value::as_str)
-                                        .map(str::to_string)
-                                }),
-                            runtime_context: diagnostic
-                                .get("data")
-                                .and_then(|data| data.get("runtime_context"))
-                                .cloned()
-                                .or_else(|| find_value_field(value, "runtime_context")),
-                            replay_command: diagnostic
-                                .get("data")
-                                .and_then(|data| string_field(data, "replay_command"))
-                                .or_else(|| find_string_field(value, "replay_command")),
-                        });
-                    }
-                }
-            }
-            map.values().find_map(find_failure_context)
-        }
-        Value::Array(items) => items.iter().find_map(find_failure_context),
-        _ => None,
-    }
-}
-
-fn string_field(value: &Value, field: &str) -> Option<String> {
-    value.get(field).and_then(Value::as_str).map(str::to_string)
-}
-
-fn nested_string_field(
-    map: &serde_json::Map<String, Value>,
-    parent: &str,
-    field: &str,
-) -> Option<String> {
-    map.get(parent)?.get(field)?.as_str().map(str::to_string)
-}
-
-fn find_string_field(value: &Value, field: &str) -> Option<String> {
-    match value {
-        Value::Object(map) => map
-            .get(field)
-            .and_then(Value::as_str)
-            .map(str::to_string)
-            .or_else(|| {
-                map.values()
-                    .find_map(|value| find_string_field(value, field))
-            }),
-        Value::Array(items) => items
-            .iter()
-            .find_map(|value| find_string_field(value, field)),
-        _ => None,
-    }
-}
-
-fn find_value_field(value: &Value, field: &str) -> Option<Value> {
-    match value {
-        Value::Object(map) => map.get(field).cloned().or_else(|| {
-            map.values()
-                .find_map(|value| find_value_field(value, field))
-        }),
-        Value::Array(items) => items
-            .iter()
-            .find_map(|value| find_value_field(value, field)),
-        _ => None,
-    }
 }
 
 pub(super) fn execute_claimed_controller_action<E, D>(

--- a/crates/homeboy-agents/src/agent_task_controller_service/field_access.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/field_access.rs
@@ -1,0 +1,112 @@
+//! JSON field-access helpers for controller action records.
+//!
+//! Small, pure navigators over `serde_json::Value` used to pull diagnostic /
+//! failure context out of loosely-typed action payloads (`string_field`,
+//! `nested_string_field`, `find_string_field`, `find_value_field`, and the
+//! `FailureContext` summary). Extracted from the controller-service `actions`
+//! god file to isolate the generic value-navigation utilities from the action
+//! execution logic.
+
+use serde_json::Value;
+
+#[derive(Default)]
+pub(super) struct FailureContext {
+    pub(super) diagnostic: Option<String>,
+    pub(super) task_id: Option<String>,
+    pub(super) provider: Option<String>,
+    pub(super) failure_phase: Option<String>,
+    pub(super) runtime_context: Option<Value>,
+    pub(super) replay_command: Option<String>,
+}
+
+pub(super) fn find_failure_context(value: &Value) -> Option<FailureContext> {
+    match value {
+        Value::Object(map) => {
+            if let Some(Value::Array(diagnostics)) = map.get("diagnostics") {
+                if let Some(diagnostic) = diagnostics.iter().find_map(Value::as_object) {
+                    let message = diagnostic
+                        .get("message")
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
+                    if message.is_some() {
+                        return Some(FailureContext {
+                            diagnostic: message,
+                            task_id: string_field(value, "task_id"),
+                            provider: diagnostic
+                                .get("provider")
+                                .and_then(Value::as_str)
+                                .map(str::to_string)
+                                .or_else(|| nested_string_field(diagnostic, "data", "provider"))
+                                .or_else(|| nested_string_field(diagnostic, "data", "provider_id")),
+                            failure_phase: diagnostic
+                                .get("phase")
+                                .and_then(Value::as_str)
+                                .map(str::to_string)
+                                .or_else(|| nested_string_field(diagnostic, "data", "phase"))
+                                .or_else(|| {
+                                    diagnostic
+                                        .get("class")
+                                        .and_then(Value::as_str)
+                                        .map(str::to_string)
+                                }),
+                            runtime_context: diagnostic
+                                .get("data")
+                                .and_then(|data| data.get("runtime_context"))
+                                .cloned()
+                                .or_else(|| find_value_field(value, "runtime_context")),
+                            replay_command: diagnostic
+                                .get("data")
+                                .and_then(|data| string_field(data, "replay_command"))
+                                .or_else(|| find_string_field(value, "replay_command")),
+                        });
+                    }
+                }
+            }
+            map.values().find_map(find_failure_context)
+        }
+        Value::Array(items) => items.iter().find_map(find_failure_context),
+        _ => None,
+    }
+}
+
+pub(super) fn string_field(value: &Value, field: &str) -> Option<String> {
+    value.get(field).and_then(Value::as_str).map(str::to_string)
+}
+
+pub(super) fn nested_string_field(
+    map: &serde_json::Map<String, Value>,
+    parent: &str,
+    field: &str,
+) -> Option<String> {
+    map.get(parent)?.get(field)?.as_str().map(str::to_string)
+}
+
+pub(super) fn find_string_field(value: &Value, field: &str) -> Option<String> {
+    match value {
+        Value::Object(map) => map
+            .get(field)
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .or_else(|| {
+                map.values()
+                    .find_map(|value| find_string_field(value, field))
+            }),
+        Value::Array(items) => items
+            .iter()
+            .find_map(|value| find_string_field(value, field)),
+        _ => None,
+    }
+}
+
+pub(super) fn find_value_field(value: &Value, field: &str) -> Option<Value> {
+    match value {
+        Value::Object(map) => map.get(field).cloned().or_else(|| {
+            map.values()
+                .find_map(|value| find_value_field(value, field))
+        }),
+        Value::Array(items) => items
+            .iter()
+            .find_map(|value| find_value_field(value, field)),
+        _ => None,
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_controller_service/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/mod.rs
@@ -57,6 +57,7 @@ mod action_state;
 mod actions;
 mod artifacts;
 mod dispatch_defaults;
+mod field_access;
 pub mod loop_spec_validation_provider;
 mod pr_ownership;
 mod proof;


### PR DESCRIPTION
## Summary
Peels a cohesive utility cluster out of `agent_task_controller_service/actions.rs` — a **1950-line god file** flagged for `god_file` **and** `high_item_count` (58 top-level items vs. 30).

## What moved
The pure JSON value-navigation helpers used to pull diagnostic/failure context out of loosely-typed action payloads:
`string_field`, `nested_string_field`, `find_string_field`, `find_value_field`, `find_failure_context`, and the `FailureContext` summary struct → `field_access.rs`.

## Clean seam
- These are generic navigators over `serde_json::Value` with **no dependency on action-execution state** — they only touch `Value`.
- Self-contained: the cluster references only itself + stdlib.
- Marked `pub(super)` (plus `FailureContext`'s fields, which the failure-summary builder reads) and imported back into `actions.rs`.

## Verification
- `cargo check -p homeboy-agents --lib` clean.
- **All 81 `agent_task_controller_service` tests pass** — behavior preserved.
- `actions.rs`: **1958 → 1859 lines**; `field_access.rs`: 112.

## Note
A focused first cut on this file. The larger run-command execution cluster (`execute_run_command_action` + process-group/IO/artifact helpers, ~300 lines) is a further candidate seam, but it shares a mid-block helper (`sanitize_loop_action_id`, also used by the dispatch-identity path) and cfg-gated platform functions, so it warrants its own careful pass rather than being bundled here.
