### PR TITLE
fix(runner): keep a durable job recoverable when the daemon poll connection drops (#7928)

### DIFF
--- a/crates/homeboy-lab-runner/src/daemon_health.rs
+++ b/crates/homeboy-lab-runner/src/daemon_health.rs
@@ -7,7 +7,7 @@ pub(super) struct RunnerDaemonHealthFailure {
     pub job_id: Option<String>,
 }
 
-pub(super) fn runner_daemon_health_failure(err: &Error) -> Option<RunnerDaemonHealthFailure> {
+pub(crate) fn runner_daemon_health_failure(err: &Error) -> Option<RunnerDaemonHealthFailure> {
     if !matches!(
         err.code,
         ErrorCode::InternalUnexpected | ErrorCode::InternalJsonError

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -1040,7 +1040,23 @@ pub(super) fn terminal_runner_poll_failure(
     source: Error,
 ) -> Error {
     let job_id = job.id.to_string();
+    // A controller-side daemon transport drop is NOT a terminal job failure:
+    // the durable runner job is still executing remotely, and reconnecting can
+    // resume observing it. Only terminalize when the poll failure is something
+    // other than a recoverable transport drop (an authoritative "job gone" /
+    // decode error the daemon actually returned). Otherwise keep the run
+    // recoverable so a reconnect can pick it back up instead of reporting a
+    // still-running job as failed (#7928).
+    let transient_transport_drop =
+        super::super::daemon_health::runner_daemon_health_failure(&source).is_some();
     let mut error = daemon_job_context_error(&runner.id, &job_id, persisted_run_id, source);
+    if transient_transport_drop {
+        // `daemon_job_context_error` already marks this recoverable
+        // (retryable, status: "recoverable_followup_required") with durable-job
+        // resumption guidance; preserve that instead of forcing a terminal
+        // failure.
+        return error;
+    }
     error.retryable = Some(false);
     error.details["status"] = Value::String("terminal_failure".to_string());
     error.details["reason"] = Value::String("runner_job_unobservable".to_string());

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -463,6 +463,74 @@ fn accepted_job_that_disappears_persists_a_terminal_controller_failure() {
 }
 
 #[test]
+fn transient_daemon_transport_drop_keeps_the_durable_job_recoverable() {
+    // #7928: losing contact with the runner daemon while polling a durable job
+    // is a controller-side transport drop, not a job failure — the remote job
+    // is still executing. The poll failure must stay recoverable (retryable,
+    // "recoverable_followup_required") so a reconnect can resume observing it,
+    // and must NOT persist a terminal mirror or execution record.
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner = ssh_runner();
+        let job = running_job();
+        let job_id = job.id.to_string();
+        let command = vec![
+            "homeboy".to_string(),
+            "runtime".to_string(),
+            "refresh".to_string(),
+        ];
+        let run_id =
+            persist_lab_offload_handoff_run(&runner, "/srv/homeboy/project", &command, &job, None)
+                .expect("accepted handoff mirror");
+
+        // A transport-layer drop: the daemon endpoint became unreachable while
+        // polling. This is the shape `runner_daemon_health_failure` classifies
+        // as a recoverable daemon transport failure.
+        let transport_drop = Error::internal_unexpected(format!(
+            "query runner daemon: error sending request for url (http://127.0.0.1:65201/jobs/{job_id})"
+        ));
+
+        let err = terminal_runner_poll_failure(
+            &runner,
+            "/srv/homeboy/project",
+            &command,
+            &job,
+            "daemon",
+            None,
+            &homeboy_core::source_snapshot::existing_remote(
+                "lab",
+                "/srv/homeboy/project",
+                Some("/srv/homeboy"),
+            ),
+            &[],
+            Some(&run_id),
+            None,
+            transport_drop,
+        );
+
+        assert_eq!(err.code, ErrorCode::RunnerControllerDisconnected);
+        assert_eq!(
+            err.retryable,
+            Some(true),
+            "a transport drop on a durable job must stay retryable"
+        );
+        assert_eq!(err.details["status"], "recoverable_followup_required");
+        assert_ne!(err.details["status"], "terminal_failure");
+
+        // No terminal mirror should have been written — the durable run is not
+        // marked failed by a transport drop.
+        let store = homeboy_core::observation::ObservationStore::open_initialized().expect("store");
+        let run = store
+            .get_run(&run_id)
+            .expect("read mirror")
+            .expect("mirror run exists");
+        assert_ne!(
+            run.status, "fail",
+            "a transient transport drop must not terminalize the durable run"
+        );
+    });
+}
+
+#[test]
 fn daemon_identity_transition_reports_a_restarted_control_plane() {
     let transition = super::super::daemon::daemon_identity_transition(
         Some("homeboy 0.283.1+95ce06c58b95"),


### PR DESCRIPTION
## Summary
Closes #7928. While polling a **known durable** runner job, losing contact with the runner daemon returned exit 2 even though the runner-side job may still be executing:

```
Lost contact with runner `homeboy-lab` daemon while polling known job `...`: query runner daemon: error sending request for url (...)
```

## Root cause
After the resilient poll retry exhausts its transient grace, `terminal_runner_poll_failure` **unconditionally** marked the error `retryable=false` / `status: "terminal_failure"` / `reason: "runner_job_unobservable"` and persisted a terminal mirror run + terminal execution record. But a controller-side transport drop is not a job failure — the remote durable job keeps running, and a reconnect can resume observing it.

## Fix
Only terminalize when the poll failure is something *other* than a recoverable daemon transport drop. When the source error classifies as a daemon transport failure (`runner_daemon_health_failure` — connect/timeout/status/body_decode, or the legacy `query runner daemon` shape), return the already-recoverable `daemon_job_context_error` (retryable, `recoverable_followup_required`, with durable-job resumption guidance) **without** writing any terminal state.

## Tests (proven)
- `transient_daemon_transport_drop_keeps_the_durable_job_recoverable` — a transport drop on a durable job stays retryable, keeps `recoverable_followup_required`, and persists **no** terminal mirror. **Fails on the prior code** (verified by temp-disabling the guard: it terminalized the run).
- `accepted_job_that_disappears_persists_a_terminal_controller_failure` (existing) still passes — an authoritative "job gone" still terminalizes.

`cargo check -p homeboy-lab-runner --lib` clean; full `execution::tests::handoff` module (30 tests) + `daemon_health` classifier tests green; `cargo fmt` applied.