### PR TITLE
fix(lab): make cook --placement lab rejection actionable (#9373)

### DIFF
--- a/crates/homeboy-cli/src/commands/contract_lab_routing.rs
+++ b/crates/homeboy-cli/src/commands/contract_lab_routing.rs
@@ -26,7 +26,7 @@ use crate::command_contract::{
 const AGENT_TASK_COOK_MISSING_VERIFY_GATE_REASON: &str =
     "agent-task cook requires at least one deterministic --verify or --private-verify gate";
 pub(crate) const AGENT_TASK_COOK_COORDINATOR_CONTROLLER_REASON: &str =
-    "agent-task cook is a controller-owned coordinator: it resolves the managed target, ingests provider artifacts, promotes candidates, runs deterministic gates, and finalizes. Offload the materialized agent-task run-plan provider attempt instead.";
+    "agent-task cook is a controller-owned coordinator: it resolves the managed target, ingests provider artifacts, promotes candidates, runs deterministic gates, and finalizes. Its provider attempt is routed to the configured Lab runner automatically, so `--placement lab` is unnecessary; pass `--runner <runner-id>` to pin a specific Lab runner for that attempt.";
 pub(crate) const AGENT_TASK_PROMOTION_RUN_CONTROLLER_REASON: &str =
     "agent-task promote with a durable run id is controller-owned: it resolves authoritative lifecycle state and finalized artifact projections on the controller.";
 const AGENT_TASK_FANOUT_COOK_BATCH_DRY_RUN_CONTROLLER_REASON: &str =

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -732,11 +732,11 @@ pub(super) fn resolve_lab_runner_selection_from_placement(
     if let Some(runner_id) = explicit_runner {
         if let LabCommandPortability::LocalOnly(reason) = command.portability {
             let message = format!("--runner is unavailable for this hot command. {reason}");
-            return Err(Error::validation_invalid_argument(
+            return Err(local_only_flag_rejection(
                 "runner",
                 message,
                 Some(runner_id.to_string()),
-                Some(vec![resolve_lab_runner_hint().hint]),
+                command.hot_label,
             ));
         }
 
@@ -748,11 +748,22 @@ pub(super) fn resolve_lab_runner_selection_from_placement(
     }
 
     if placement == homeboy_cli_contract::Placement::Lab && !command.is_portable() {
-        return Err(Error::validation_invalid_argument(
+        // Surface the command's own local-only reason rather than a generic
+        // "portable commands are ..." hint. For a controller-owned coordinator
+        // like cook, `--placement lab` is a contradiction the operator should
+        // not have to reverse-engineer: the coordinator stays local by design
+        // while its provider attempt already routes to Lab automatically (#9373).
+        let reason = match command.portability {
+            LabCommandPortability::LocalOnly(reason) => reason,
+            LabCommandPortability::Portable => "this command runs on the controller",
+        };
+        let message =
+            format!("--placement lab is unavailable for this local-only command. {reason}");
+        return Err(local_only_flag_rejection(
             "placement",
-            "--placement lab is unavailable for this local-only command",
+            message,
             None,
-            Some(vec![resolve_lab_runner_hint().hint]),
+            command.hot_label,
         ));
     }
 
@@ -816,6 +827,38 @@ pub(super) fn resolve_lab_runner_selection_from_placement(
         .transpose()
 }
 
+/// Build an actionable rejection when `--placement lab` or `--runner` is passed
+/// to a controller-owned, local-only command.
+///
+/// The generic "portable commands are ..." hint left operators guessing which
+/// spelling was correct (#9373). This surfaces command-specific remediation so
+/// runtime behavior and guidance agree: for a cook/agent-task coordinator it
+/// explains that the coordinator stays local while its provider attempt already
+/// routes to Lab automatically, and points at the real levers
+/// (`--runner <runner-id>` to pin the Lab runner, `fanout` for waves).
+fn local_only_flag_rejection(
+    field: &'static str,
+    message: String,
+    value: Option<String>,
+    hot_label: &str,
+) -> Error {
+    let mut hints = Vec::new();
+    if hot_label.starts_with("agent-task cook") || hot_label.starts_with("agent-task fanout") {
+        hints.push(
+            "The cook coordinator is controller-owned by design; its provider attempt already routes to the configured Lab runner automatically — no --placement lab needed.".to_string(),
+        );
+        hints.push(
+            "To pin a specific Lab runner for the provider attempt, pass `--runner <runner-id>` (not `--placement lab`).".to_string(),
+        );
+        hints.push(
+            "To fan out many independent cooks in one operation, use `homeboy agent-task fanout` so the batch coordinator dispatches each child cook's provider attempt to Lab.".to_string(),
+        );
+    } else {
+        hints.push(resolve_lab_runner_hint().hint);
+    }
+    Error::validation_invalid_argument(field, message, value, Some(hints))
+}
+
 fn fail_if_local_bench_denied(command: &LabOffloadCommand, denied: bool) -> Result<()> {
     if !denied || command.hot_label != "bench" {
         return Ok(());
@@ -869,4 +912,131 @@ pub(super) fn status_tunnel_mode(status: &RunnerStatusReport) -> RunnerTunnelMod
         .session
         .as_ref()
         .map_or(RunnerTunnelMode::DirectSsh, |session| session.mode.clone())
+}
+
+#[cfg(test)]
+mod placement_rejection_tests {
+    use super::*;
+    use homeboy_core::lab_contract::LabCommandContract;
+
+    fn local_only_command(hot_label: &'static str, reason: &'static str) -> LabOffloadCommand {
+        LabOffloadCommand {
+            command: LabCommandContract::local_only(hot_label, reason),
+            required_extensions: Vec::new(),
+            required_capabilities: Vec::new(),
+            workload: None,
+        }
+    }
+
+    fn hints(error: &Error) -> Vec<String> {
+        error
+            .details
+            .get("tried")
+            .and_then(|value| value.as_array())
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter_map(|entry| entry.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn placement_lab_on_cook_yields_cook_aware_remediation() {
+        // #9373: `--placement lab` on the controller-owned cook coordinator must
+        // not just report a generic "portable commands are ..." hint. It must
+        // explain that the provider attempt already routes to Lab and point at
+        // the correct lever (`--runner`), so guidance and runtime agree.
+        let command = local_only_command(
+            "agent-task cook/run-plan/retry --run",
+            "agent-task cook is a controller-owned coordinator.",
+        );
+
+        let error = resolve_lab_runner_selection_from_placement(
+            &command,
+            None,
+            homeboy_cli_contract::Placement::Lab,
+            false,
+            false,
+            None,
+        )
+        .expect_err("--placement lab must be rejected for a local-only cook");
+
+        assert_eq!(error.details["field"].as_str(), Some("placement"));
+        assert!(
+            error.details["problem"]
+                .as_str()
+                .is_some_and(|problem| problem.contains("controller-owned coordinator")),
+            "problem must carry the command's own reason: {}",
+            error.details["problem"]
+        );
+        let hints = hints(&error);
+        assert!(
+            hints
+                .iter()
+                .any(|hint| hint.contains("--runner <runner-id>")),
+            "cook remediation must name --runner, got {hints:?}"
+        );
+        assert!(
+            hints
+                .iter()
+                .any(|hint| hint.contains("routes to the configured Lab runner automatically")),
+            "cook remediation must explain automatic Lab routing, got {hints:?}"
+        );
+        assert!(
+            hints.iter().any(|hint| hint.contains("fanout")),
+            "cook remediation must point at fanout for waves, got {hints:?}"
+        );
+    }
+
+    #[test]
+    fn explicit_runner_on_cook_yields_cook_aware_remediation() {
+        let command = local_only_command(
+            "agent-task cook/run-plan/retry --run",
+            "agent-task cook is a controller-owned coordinator.",
+        );
+
+        let error = resolve_lab_runner_selection_from_placement(
+            &command,
+            Some("homeboy-lab"),
+            homeboy_cli_contract::Placement::Auto,
+            false,
+            false,
+            None,
+        )
+        .expect_err("--runner must be rejected for a local-only cook coordinator");
+
+        assert_eq!(error.details["field"].as_str(), Some("runner"));
+        let hints = hints(&error);
+        assert!(
+            hints
+                .iter()
+                .any(|hint| hint.contains("--runner <runner-id>")),
+            "cook remediation must name --runner, got {hints:?}"
+        );
+    }
+
+    #[test]
+    fn placement_lab_on_non_cook_local_only_keeps_generic_hint() {
+        // A non-agent-task local-only command must retain the generic
+        // portable-commands hint rather than cook-specific remediation.
+        let command = local_only_command("some-other-command", "this command runs locally.");
+
+        let error = resolve_lab_runner_selection_from_placement(
+            &command,
+            None,
+            homeboy_cli_contract::Placement::Lab,
+            false,
+            false,
+            None,
+        )
+        .expect_err("--placement lab must be rejected for a local-only command");
+
+        let hints = hints(&error);
+        assert!(
+            !hints.iter().any(|hint| hint.contains("fanout")),
+            "non-cook remediation must not mention fanout, got {hints:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Addresses the still-live guidance/runtime contradiction in #9373: a normal operator passing global `--placement lab` (or `--runner`) to a controller-owned **cook** coordinator got a bare rejection —

```
--placement lab is unavailable for this local-only command
```

— followed by only a generic "portable commands are ..." hint. Homeboy docs recommend `--placement lab` for cook waves, so this left operators reverse-engineering the correct spelling with no signal that cook *does* route its provider attempt to Lab automatically.

## What changed

- `resolve_lab_runner_selection_from_placement` (both the `--placement lab` and `--runner` local-only rejection sites) now surface the command's **own** local-only reason and route through a new `local_only_flag_rejection` helper.
- For a cook / agent-task coordinator (`hot_label` starts with `agent-task cook`/`agent-task fanout`), the remediation is cook-aware:
  - the coordinator is controller-owned by design; its provider attempt already routes to the configured Lab runner automatically — no `--placement lab` needed;
  - pass `--runner <runner-id>` to pin a specific Lab runner for that attempt;
  - use `homeboy agent-task fanout` to fan out many independent cooks in one operation.
- Non-agent-task local-only commands keep the existing generic portable-commands hint.
- `AGENT_TASK_COOK_COORDINATOR_CONTROLLER_REASON` is updated to state the same thing, so **guidance and runtime behavior agree** (a #9373 acceptance requirement).

## Scope note

This is the placement-guidance slice of #9373. The larger pieces of that issue already landed on main and are intentionally **not** duplicated here:
- Queueable controller-generation admission + dead-owner reclaim → #9232 / #9277 (fixes the collision + `owned by unavailable` complaints).
- Fanout run-plan child cooks admitted to Lab → #9375 / #9384.

So this PR is `Refs #9373` rather than `Fixes` — it closes the remaining placement-contradiction gap without re-treading merged work.

## Tests

New `placement_rejection_tests` in `lab_selection.rs`:
- `placement_lab_on_cook_yields_cook_aware_remediation` — `--placement lab` on a local-only cook surfaces the command reason + names `--runner`, automatic Lab routing, and `fanout`.
- `explicit_runner_on_cook_yields_cook_aware_remediation` — `--runner` on a local-only cook gets the same cook-aware remediation.
- `placement_lab_on_non_cook_local_only_keeps_generic_hint` — a non-cook local-only command does **not** get cook remediation.

All three proven to catch the bug via temp-disable of the cook branch (the two cook tests fail, the non-cook test still passes). The 9 sibling `contract_lab_routing_tests` pass; one pre-existing unrelated failure in that file (`agent_task_promote_with_runner_only_source_remains_lab_portable`, a clap `--runner`/`--placement` ArgumentConflict) fails identically on clean `origin/main`.