### PR TITLE
refactor(agents): extract run_command action execution from controller actions god file

### DIFF
--- a/crates/homeboy-agents/src/agent_task_controller_service/actions.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/actions.rs
@@ -4,6 +4,7 @@ use super::field_access::{
     find_failure_context, find_string_field, find_value_field, nested_string_field, string_field,
     FailureContext,
 };
+use super::run_command::{execute_run_command_action, sanitize_loop_action_id};
 use super::*;
 use std::fs;
 use std::io::{self, Read};
@@ -13,7 +14,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 const COMMAND_GATE_DEFAULT_TIMEOUT_SECONDS: u64 = 300;
-const RUN_COMMAND_DEFAULT_TIMEOUT_SECONDS: u64 = 900;
+pub(super) const RUN_COMMAND_DEFAULT_TIMEOUT_SECONDS: u64 = 900;
 const COMMAND_GATE_OUTPUT_CAP_BYTES: usize = 64 * 1024;
 
 pub(super) fn execute_controller_action<E, D>(
@@ -610,333 +611,6 @@ where
             feedback_id,
         } => execute_request_changes_action(record, action, target_run_id, feedback_id.as_deref()),
     }
-}
-
-fn execute_run_command_action(
-    record: &mut AgentTaskLoopControllerRecord,
-    action: &AgentTaskLoopPolicyActionRecord,
-    dedupe_key: &str,
-    entity_id: Option<&str>,
-    request: &Value,
-) -> Result<(Value, i32)> {
-    let request = hydrate_consumed_artifacts(record, request);
-    let request = request_with_required_workflow_artifacts(record, &request);
-    let execution = request.get("execution").unwrap_or(&Value::Null);
-    let command = required_string(execution, "command")?;
-    let args = execution
-        .get("args")
-        .and_then(Value::as_array)
-        .map(|args| {
-            args.iter()
-                .filter_map(Value::as_str)
-                .map(str::to_string)
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-    let required_artifacts = request
-        .get("artifacts")
-        .and_then(Value::as_array)
-        .map(|artifacts| {
-            artifacts
-                .iter()
-                .filter_map(Value::as_str)
-                .map(str::to_string)
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-    let timeout_seconds = execution
-        .get("timeout_seconds")
-        .and_then(Value::as_u64)
-        .filter(|seconds| *seconds > 0)
-        .unwrap_or(RUN_COMMAND_DEFAULT_TIMEOUT_SECONDS);
-
-    let io_dir = loop_action_io_dir(&record.loop_id, &action.action_id)?;
-    fs::create_dir_all(&io_dir).map_err(|error| Error::internal_io(error.to_string(), None))?;
-    let input_path = io_dir.join("input.json");
-    let output_path = io_dir.join("output.json");
-    let input = serde_json::json!({
-        "schema": "homeboy/agent-task-loop-command-input/v1",
-        "loop_id": record.loop_id,
-        "action_id": action.action_id,
-        "dedupe_key": dedupe_key,
-        "entity_id": entity_id,
-        "request": request,
-        "controller": &*record,
-    });
-    write_json_file(&input_path, &input)?;
-
-    let mut process = Command::new(&command);
-    process.args(&args);
-    if let Some(cwd) = execution
-        .get("cwd")
-        .and_then(Value::as_str)
-        .filter(|cwd| !cwd.is_empty())
-    {
-        process.current_dir(cwd);
-    }
-    process.env("HOMEBOY_LOOP_ACTION_INPUT", &input_path);
-    process.env("HOMEBOY_LOOP_ACTION_OUTPUT", &output_path);
-    process.env("HOMEBOY_LOOP_ID", &record.loop_id);
-    process.env("HOMEBOY_LOOP_ACTION_ID", &action.action_id);
-    process.env("HOMEBOY_LOOP_ACTION_DEDUPE_KEY", dedupe_key);
-
-    process.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let output = run_controller_command_with_timeout(process, &command, timeout_seconds)?;
-    let exit_code = output.exit_code.unwrap_or(1);
-    let result = if output_path.exists() {
-        read_json_file(&output_path)?
-    } else {
-        serde_json::json!({})
-    };
-    let artifacts = result.get("artifacts").cloned().unwrap_or(Value::Null);
-    let missing = missing_required_command_artifacts(&required_artifacts, &artifacts);
-    let command_success = exit_code == 0 && missing.is_empty();
-    let effective_exit_code = if command_success { 0 } else { 1 };
-
-    if command_success {
-        record_run_command_outputs(record, action, dedupe_key, entity_id, &request, &artifacts)?;
-    }
-
-    Ok((
-        serde_json::json!({
-            "mode": "run_command",
-            "command": command,
-            "args": args,
-            "input_path": input_path,
-            "output_path": output_path,
-            "timeout_seconds": timeout_seconds,
-            "timed_out": output.timed_out,
-            "exit_code": exit_code,
-            "signal": output.signal,
-            "stdout": String::from_utf8_lossy(&output.stdout.bytes),
-            "stderr": String::from_utf8_lossy(&output.stderr.bytes),
-            "stdout_bytes": output.stdout.total_bytes,
-            "stderr_bytes": output.stderr.total_bytes,
-            "stdout_stored_bytes": output.stdout.bytes.len(),
-            "stderr_stored_bytes": output.stderr.bytes.len(),
-            "stdout_truncated": output.stdout.truncated,
-            "stderr_truncated": output.stderr.truncated,
-            "missing_artifacts": missing,
-            "result": result,
-        }),
-        effective_exit_code,
-    ))
-}
-
-struct ControllerCommandOutput {
-    exit_code: Option<i32>,
-    signal: Option<String>,
-    timed_out: bool,
-    stdout: CappedCommandOutput,
-    stderr: CappedCommandOutput,
-}
-
-fn run_controller_command_with_timeout(
-    mut process: Command,
-    command: &str,
-    timeout_seconds: u64,
-) -> Result<ControllerCommandOutput> {
-    configure_controller_command_process_group(&mut process);
-    let mut child = process.spawn().map_err(|error| {
-        Error::internal_io(
-            format!("failed to execute controller command '{command}': {error}"),
-            None,
-        )
-    })?;
-    let stdout = child.stdout.take().map(read_capped_command_output);
-    let stderr = child.stderr.take().map(read_capped_command_output);
-    let deadline = Instant::now() + Duration::from_secs(timeout_seconds);
-    let mut timed_out = false;
-    let exit_status = loop {
-        if let Some(status) = child.try_wait().map_err(|error| {
-            Error::internal_io(
-                format!("failed to poll controller command '{command}': {error}"),
-                None,
-            )
-        })? {
-            break status;
-        }
-        if Instant::now() >= deadline {
-            timed_out = true;
-            kill_controller_command_process_group(&mut child);
-            break child.wait().map_err(|error| {
-                Error::internal_io(
-                    format!("failed to reap timed out controller command '{command}': {error}"),
-                    None,
-                )
-            })?;
-        }
-        thread::sleep(Duration::from_millis(25));
-    };
-    Ok(ControllerCommandOutput {
-        exit_code: exit_status.code(),
-        signal: exit_status_signal(&exit_status),
-        timed_out,
-        stdout: collect_capped_command_output(stdout, command, "stdout")?,
-        stderr: collect_capped_command_output(stderr, command, "stderr")?,
-    })
-}
-
-#[cfg(unix)]
-fn configure_controller_command_process_group(process: &mut Command) {
-    use std::os::unix::process::CommandExt;
-
-    process.process_group(0);
-}
-
-#[cfg(not(unix))]
-fn configure_controller_command_process_group(_process: &mut Command) {}
-
-#[cfg(unix)]
-fn kill_controller_command_process_group(child: &mut std::process::Child) {
-    let pid = child.id();
-    if pid > i32::MAX as u32 {
-        let _ = child.kill();
-        return;
-    }
-    let pgid = -(pid as i32);
-    unsafe {
-        libc::kill(pgid, libc::SIGKILL);
-    }
-}
-
-#[cfg(not(unix))]
-fn kill_controller_command_process_group(child: &mut std::process::Child) {
-    let _ = child.kill();
-}
-
-#[cfg(unix)]
-fn exit_status_signal(status: &std::process::ExitStatus) -> Option<String> {
-    use std::os::unix::process::ExitStatusExt;
-    status.signal().map(|signal| signal.to_string())
-}
-
-#[cfg(not(unix))]
-fn exit_status_signal(_status: &std::process::ExitStatus) -> Option<String> {
-    None
-}
-
-fn loop_action_io_dir(loop_id: &str, action_id: &str) -> Result<PathBuf> {
-    Ok(homeboy_core::paths::homeboy_data()?
-        .join("agent-task-loop-actions")
-        .join(sanitize_loop_action_id(loop_id))
-        .join(action_id))
-}
-
-fn sanitize_loop_action_id(raw: &str) -> String {
-    raw.chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
-                ch
-            } else {
-                '_'
-            }
-        })
-        .collect()
-}
-
-fn write_json_file(path: &PathBuf, value: &Value) -> Result<()> {
-    let payload = serde_json::to_string_pretty(value)
-        .map_err(|error| Error::internal_json(error.to_string(), None))?;
-    fs::write(path, format!("{payload}\n"))
-        .map_err(|error| Error::internal_io(error.to_string(), None))
-}
-
-fn read_json_file(path: &PathBuf) -> Result<Value> {
-    let payload =
-        fs::read_to_string(path).map_err(|error| Error::internal_io(error.to_string(), None))?;
-    serde_json::from_str(&payload).map_err(|error| Error::internal_json(error.to_string(), None))
-}
-
-fn missing_required_command_artifacts(required: &[String], artifacts: &Value) -> Vec<String> {
-    required
-        .iter()
-        .filter(|artifact| artifacts.get(artifact.as_str()).is_none_or(Value::is_null))
-        .cloned()
-        .collect()
-}
-
-fn record_run_command_outputs(
-    record: &mut AgentTaskLoopControllerRecord,
-    action: &AgentTaskLoopPolicyActionRecord,
-    dedupe_key: &str,
-    entity_id: Option<&str>,
-    request: &Value,
-    artifacts: &Value,
-) -> Result<()> {
-    let run_id = format!("{}:{}", record.loop_id, action.action_id);
-    let artifact_refs = artifact_refs_from_command_result(artifacts);
-    persist_controller_artifacts(&record.loop_id, &action.action_id, artifacts)?;
-    if let Some(entity_id) = entity_id {
-        if let Some(entity) = record.entities.get_mut(entity_id) {
-            entity.artifact_refs.extend(artifact_refs.clone());
-        }
-    }
-    if !record
-        .task_lineage
-        .iter()
-        .any(|lineage| lineage.run_id == run_id)
-    {
-        record.task_lineage.push(AgentTaskLoopTaskLineage {
-            run_id: run_id.clone(),
-            task_id: None,
-            parent_run_id: None,
-            parent_task_id: None,
-            entity_id: entity_id.map(str::to_string),
-            dedupe_key: Some(dedupe_key.to_string()),
-            artifact_refs,
-            inputs: request.clone(),
-            outputs: serde_json::json!({ "artifacts": artifacts }),
-        });
-    }
-    Ok(())
-}
-
-fn persist_controller_artifacts(loop_id: &str, action_id: &str, artifacts: &Value) -> Result<()> {
-    let Some(object) = artifacts.as_object() else {
-        return Ok(());
-    };
-    if object.is_empty() {
-        return Ok(());
-    }
-    let root = homeboy_core::paths::artifact_root()?
-        .join("agent-task-loop-controller")
-        .join(sanitize_loop_action_id(loop_id))
-        .join(action_id);
-    fs::create_dir_all(&root).map_err(|error| Error::internal_io(error.to_string(), None))?;
-    for (artifact_id, artifact) in object {
-        let path = root.join(format!("{}.json", sanitize_loop_action_id(artifact_id)));
-        write_json_file(&path, artifact)?;
-    }
-    Ok(())
-}
-
-fn artifact_refs_from_command_result(artifacts: &Value) -> Vec<AgentTaskLoopArtifactRef> {
-    let Some(object) = artifacts.as_object() else {
-        return Vec::new();
-    };
-    object
-        .iter()
-        .map(|(artifact_id, artifact)| {
-            let uri = artifact
-                .get("artifact_url")
-                .or_else(|| artifact.get("url"))
-                .or_else(|| artifact.get("path"))
-                .and_then(Value::as_str)
-                .unwrap_or(artifact_id)
-                .to_string();
-            AgentTaskLoopArtifactRef {
-                uri,
-                kind: artifact
-                    .get("schema")
-                    .and_then(Value::as_str)
-                    .map(str::to_string),
-                role: None,
-                label: Some(artifact_id.clone()),
-                semantic_key: None,
-            }
-        })
-        .collect()
 }
 
 pub(super) fn execute_retry_action(
@@ -1702,13 +1376,13 @@ pub(super) fn run_command_gate_check(
     })
 }
 
-struct CappedCommandOutput {
-    bytes: Vec<u8>,
-    total_bytes: usize,
-    truncated: bool,
+pub(super) struct CappedCommandOutput {
+    pub(super) bytes: Vec<u8>,
+    pub(super) total_bytes: usize,
+    pub(super) truncated: bool,
 }
 
-fn read_capped_command_output<R>(
+pub(super) fn read_capped_command_output<R>(
     mut reader: R,
 ) -> thread::JoinHandle<io::Result<CappedCommandOutput>>
 where
@@ -1737,7 +1411,7 @@ where
     })
 }
 
-fn collect_capped_command_output(
+pub(super) fn collect_capped_command_output(
     handle: Option<thread::JoinHandle<io::Result<CappedCommandOutput>>>,
     command: &str,
     stream: &str,

--- a/crates/homeboy-agents/src/agent_task_controller_service/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/mod.rs
@@ -63,6 +63,7 @@ mod pr_ownership;
 mod proof;
 mod reports;
 mod request;
+mod run_command;
 mod run_failure_summary;
 pub mod runner_availability;
 mod spec;

--- a/crates/homeboy-agents/src/agent_task_controller_service/run_command.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/run_command.rs
@@ -1,0 +1,344 @@
+//! Split from `agent_task_controller_service` god file (#5208). Structural move only.
+//!
+//! Controller `run_command` action execution: runs the configured command with
+//! a timeout under an isolated process group, captures/persists its outputs and
+//! artifacts, and validates required command artifacts.
+#![allow(unused_imports)]
+use std::fs;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use super::actions::{
+    collect_capped_command_output, read_capped_command_output, CappedCommandOutput,
+    RUN_COMMAND_DEFAULT_TIMEOUT_SECONDS,
+};
+use super::*;
+
+pub(super) fn execute_run_command_action(
+    record: &mut AgentTaskLoopControllerRecord,
+    action: &AgentTaskLoopPolicyActionRecord,
+    dedupe_key: &str,
+    entity_id: Option<&str>,
+    request: &Value,
+) -> Result<(Value, i32)> {
+    let request = hydrate_consumed_artifacts(record, request);
+    let request = request_with_required_workflow_artifacts(record, &request);
+    let execution = request.get("execution").unwrap_or(&Value::Null);
+    let command = required_string(execution, "command")?;
+    let args = execution
+        .get("args")
+        .and_then(Value::as_array)
+        .map(|args| {
+            args.iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let required_artifacts = request
+        .get("artifacts")
+        .and_then(Value::as_array)
+        .map(|artifacts| {
+            artifacts
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let timeout_seconds = execution
+        .get("timeout_seconds")
+        .and_then(Value::as_u64)
+        .filter(|seconds| *seconds > 0)
+        .unwrap_or(RUN_COMMAND_DEFAULT_TIMEOUT_SECONDS);
+
+    let io_dir = loop_action_io_dir(&record.loop_id, &action.action_id)?;
+    fs::create_dir_all(&io_dir).map_err(|error| Error::internal_io(error.to_string(), None))?;
+    let input_path = io_dir.join("input.json");
+    let output_path = io_dir.join("output.json");
+    let input = serde_json::json!({
+        "schema": "homeboy/agent-task-loop-command-input/v1",
+        "loop_id": record.loop_id,
+        "action_id": action.action_id,
+        "dedupe_key": dedupe_key,
+        "entity_id": entity_id,
+        "request": request,
+        "controller": &*record,
+    });
+    write_json_file(&input_path, &input)?;
+
+    let mut process = Command::new(&command);
+    process.args(&args);
+    if let Some(cwd) = execution
+        .get("cwd")
+        .and_then(Value::as_str)
+        .filter(|cwd| !cwd.is_empty())
+    {
+        process.current_dir(cwd);
+    }
+    process.env("HOMEBOY_LOOP_ACTION_INPUT", &input_path);
+    process.env("HOMEBOY_LOOP_ACTION_OUTPUT", &output_path);
+    process.env("HOMEBOY_LOOP_ID", &record.loop_id);
+    process.env("HOMEBOY_LOOP_ACTION_ID", &action.action_id);
+    process.env("HOMEBOY_LOOP_ACTION_DEDUPE_KEY", dedupe_key);
+
+    process.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let output = run_controller_command_with_timeout(process, &command, timeout_seconds)?;
+    let exit_code = output.exit_code.unwrap_or(1);
+    let result = if output_path.exists() {
+        read_json_file(&output_path)?
+    } else {
+        serde_json::json!({})
+    };
+    let artifacts = result.get("artifacts").cloned().unwrap_or(Value::Null);
+    let missing = missing_required_command_artifacts(&required_artifacts, &artifacts);
+    let command_success = exit_code == 0 && missing.is_empty();
+    let effective_exit_code = if command_success { 0 } else { 1 };
+
+    if command_success {
+        record_run_command_outputs(record, action, dedupe_key, entity_id, &request, &artifacts)?;
+    }
+
+    Ok((
+        serde_json::json!({
+            "mode": "run_command",
+            "command": command,
+            "args": args,
+            "input_path": input_path,
+            "output_path": output_path,
+            "timeout_seconds": timeout_seconds,
+            "timed_out": output.timed_out,
+            "exit_code": exit_code,
+            "signal": output.signal,
+            "stdout": String::from_utf8_lossy(&output.stdout.bytes),
+            "stderr": String::from_utf8_lossy(&output.stderr.bytes),
+            "stdout_bytes": output.stdout.total_bytes,
+            "stderr_bytes": output.stderr.total_bytes,
+            "stdout_stored_bytes": output.stdout.bytes.len(),
+            "stderr_stored_bytes": output.stderr.bytes.len(),
+            "stdout_truncated": output.stdout.truncated,
+            "stderr_truncated": output.stderr.truncated,
+            "missing_artifacts": missing,
+            "result": result,
+        }),
+        effective_exit_code,
+    ))
+}
+
+struct ControllerCommandOutput {
+    exit_code: Option<i32>,
+    signal: Option<String>,
+    timed_out: bool,
+    stdout: CappedCommandOutput,
+    stderr: CappedCommandOutput,
+}
+
+fn run_controller_command_with_timeout(
+    mut process: Command,
+    command: &str,
+    timeout_seconds: u64,
+) -> Result<ControllerCommandOutput> {
+    configure_controller_command_process_group(&mut process);
+    let mut child = process.spawn().map_err(|error| {
+        Error::internal_io(
+            format!("failed to execute controller command '{command}': {error}"),
+            None,
+        )
+    })?;
+    let stdout = child.stdout.take().map(read_capped_command_output);
+    let stderr = child.stderr.take().map(read_capped_command_output);
+    let deadline = Instant::now() + Duration::from_secs(timeout_seconds);
+    let mut timed_out = false;
+    let exit_status = loop {
+        if let Some(status) = child.try_wait().map_err(|error| {
+            Error::internal_io(
+                format!("failed to poll controller command '{command}': {error}"),
+                None,
+            )
+        })? {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            timed_out = true;
+            kill_controller_command_process_group(&mut child);
+            break child.wait().map_err(|error| {
+                Error::internal_io(
+                    format!("failed to reap timed out controller command '{command}': {error}"),
+                    None,
+                )
+            })?;
+        }
+        thread::sleep(Duration::from_millis(25));
+    };
+    Ok(ControllerCommandOutput {
+        exit_code: exit_status.code(),
+        signal: exit_status_signal(&exit_status),
+        timed_out,
+        stdout: collect_capped_command_output(stdout, command, "stdout")?,
+        stderr: collect_capped_command_output(stderr, command, "stderr")?,
+    })
+}
+
+#[cfg(unix)]
+fn configure_controller_command_process_group(process: &mut Command) {
+    use std::os::unix::process::CommandExt;
+
+    process.process_group(0);
+}
+
+#[cfg(not(unix))]
+fn configure_controller_command_process_group(_process: &mut Command) {}
+
+#[cfg(unix)]
+fn kill_controller_command_process_group(child: &mut std::process::Child) {
+    let pid = child.id();
+    if pid > i32::MAX as u32 {
+        let _ = child.kill();
+        return;
+    }
+    let pgid = -(pid as i32);
+    unsafe {
+        libc::kill(pgid, libc::SIGKILL);
+    }
+}
+
+#[cfg(not(unix))]
+fn kill_controller_command_process_group(child: &mut std::process::Child) {
+    let _ = child.kill();
+}
+
+#[cfg(unix)]
+fn exit_status_signal(status: &std::process::ExitStatus) -> Option<String> {
+    use std::os::unix::process::ExitStatusExt;
+    status.signal().map(|signal| signal.to_string())
+}
+
+#[cfg(not(unix))]
+fn exit_status_signal(_status: &std::process::ExitStatus) -> Option<String> {
+    None
+}
+
+fn loop_action_io_dir(loop_id: &str, action_id: &str) -> Result<PathBuf> {
+    Ok(homeboy_core::paths::homeboy_data()?
+        .join("agent-task-loop-actions")
+        .join(sanitize_loop_action_id(loop_id))
+        .join(action_id))
+}
+
+pub(super) fn sanitize_loop_action_id(raw: &str) -> String {
+    raw.chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn write_json_file(path: &PathBuf, value: &Value) -> Result<()> {
+    let payload = serde_json::to_string_pretty(value)
+        .map_err(|error| Error::internal_json(error.to_string(), None))?;
+    fs::write(path, format!("{payload}\n"))
+        .map_err(|error| Error::internal_io(error.to_string(), None))
+}
+
+fn read_json_file(path: &PathBuf) -> Result<Value> {
+    let payload =
+        fs::read_to_string(path).map_err(|error| Error::internal_io(error.to_string(), None))?;
+    serde_json::from_str(&payload).map_err(|error| Error::internal_json(error.to_string(), None))
+}
+
+fn missing_required_command_artifacts(required: &[String], artifacts: &Value) -> Vec<String> {
+    required
+        .iter()
+        .filter(|artifact| artifacts.get(artifact.as_str()).is_none_or(Value::is_null))
+        .cloned()
+        .collect()
+}
+
+fn record_run_command_outputs(
+    record: &mut AgentTaskLoopControllerRecord,
+    action: &AgentTaskLoopPolicyActionRecord,
+    dedupe_key: &str,
+    entity_id: Option<&str>,
+    request: &Value,
+    artifacts: &Value,
+) -> Result<()> {
+    let run_id = format!("{}:{}", record.loop_id, action.action_id);
+    let artifact_refs = artifact_refs_from_command_result(artifacts);
+    persist_controller_artifacts(&record.loop_id, &action.action_id, artifacts)?;
+    if let Some(entity_id) = entity_id {
+        if let Some(entity) = record.entities.get_mut(entity_id) {
+            entity.artifact_refs.extend(artifact_refs.clone());
+        }
+    }
+    if !record
+        .task_lineage
+        .iter()
+        .any(|lineage| lineage.run_id == run_id)
+    {
+        record.task_lineage.push(AgentTaskLoopTaskLineage {
+            run_id: run_id.clone(),
+            task_id: None,
+            parent_run_id: None,
+            parent_task_id: None,
+            entity_id: entity_id.map(str::to_string),
+            dedupe_key: Some(dedupe_key.to_string()),
+            artifact_refs,
+            inputs: request.clone(),
+            outputs: serde_json::json!({ "artifacts": artifacts }),
+        });
+    }
+    Ok(())
+}
+
+fn persist_controller_artifacts(loop_id: &str, action_id: &str, artifacts: &Value) -> Result<()> {
+    let Some(object) = artifacts.as_object() else {
+        return Ok(());
+    };
+    if object.is_empty() {
+        return Ok(());
+    }
+    let root = homeboy_core::paths::artifact_root()?
+        .join("agent-task-loop-controller")
+        .join(sanitize_loop_action_id(loop_id))
+        .join(action_id);
+    fs::create_dir_all(&root).map_err(|error| Error::internal_io(error.to_string(), None))?;
+    for (artifact_id, artifact) in object {
+        let path = root.join(format!("{}.json", sanitize_loop_action_id(artifact_id)));
+        write_json_file(&path, artifact)?;
+    }
+    Ok(())
+}
+
+fn artifact_refs_from_command_result(artifacts: &Value) -> Vec<AgentTaskLoopArtifactRef> {
+    let Some(object) = artifacts.as_object() else {
+        return Vec::new();
+    };
+    object
+        .iter()
+        .map(|(artifact_id, artifact)| {
+            let uri = artifact
+                .get("artifact_url")
+                .or_else(|| artifact.get("url"))
+                .or_else(|| artifact.get("path"))
+                .and_then(Value::as_str)
+                .unwrap_or(artifact_id)
+                .to_string();
+            AgentTaskLoopArtifactRef {
+                uri,
+                kind: artifact
+                    .get("schema")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                role: None,
+                label: Some(artifact_id.clone()),
+                semantic_key: None,
+            }
+        })
+        .collect()
+}


### PR DESCRIPTION
## Summary
Follow-up to #9387. Continues decomposing `controller_service/actions.rs` (still a `god_file` + `high_item_count` file) by extracting the largest cohesive cluster: the `run_command` action-execution subsystem.

## What moved
`execute_run_command_action` + `run_controller_command_with_timeout`, the cfg-gated process-group `configure`/`kill`/`exit_status_signal` helpers, IO-dir / json-file helpers, artifact capture/persist, and required-artifact validation → `run_command.rs` (~326 lines, contiguous `execute_run_command_action` .. `artifact_refs_from_command_result`).

## Shared-boundary handling
- Two cluster fns are used elsewhere in `actions.rs` — `execute_run_command_action` (action dispatcher) and `sanitize_loop_action_id` (dispatch-identity path). Both `pub(super)`, imported back.
- The cluster reuses a few `actions.rs` helpers (`RUN_COMMAND_DEFAULT_TIMEOUT_SECONDS`, `CappedCommandOutput` + its fields, `read_capped_command_output`, `collect_capped_command_output`) — now `pub(super)`.
- Follows the existing sibling-module convention (`#![allow(unused_imports)]` + `use super::*`).

## Verification
- `cargo check -p homeboy-agents --lib` clean.
- **All 81 `agent_task_controller_service` tests pass single-threaded** — behavior preserved.
- `actions.rs`: **1859 → 1533 lines**; `run_command.rs`: 344.

### Note on test flakiness
The *full parallel* suite showed 7 fan-out tests flapping. Verified this is **pre-existing `with_isolated_home` shared-state contention**, not a regression: each fails-then-passes depending on concurrency, all pass in isolation / single-threaded / module-scoped, and the same races reproduce on clean `main` (stash-verified). CI's isolation handles it.

## Cumulative
`actions.rs` across #9387 + this PR: **1958 → 1533 lines**, two cohesive submodules extracted (`field_access.rs`, `run_command.rs`).
