### PR TITLE
fix(report): redact visual-compare artifact paths in reviewer-facing output

### DIFF
--- a/crates/homeboy-cli/src/commands/report/browser_evidence_compare/implementation/render.rs
+++ b/crates/homeboy-cli/src/commands/report/browser_evidence_compare/implementation/render.rs
@@ -262,6 +262,12 @@ fn render_visual_compare(out: &mut String, variant: &BrowserEvidenceVariantCompa
             .collect::<Vec<_>>()
             .join("; ");
         let _ = writeln!(out, "- Artifacts: {}", rendered);
+        let _ = writeln!(
+            out,
+            "- Note: visual-compare artifact paths are local/relative operator notes, not \
+             public URLs. Do not hand-build tunnel URLs from these names; resolve a \
+             reviewer-facing URL with `homeboy tunnel artifact-origin inspect --path <file>`."
+        );
     }
     out.push('\n');
 }

--- a/crates/homeboy-cli/src/commands/report/browser_evidence_compare/implementation/visual.rs
+++ b/crates/homeboy-cli/src/commands/report/browser_evidence_compare/implementation/visual.rs
@@ -14,6 +14,7 @@ pub(in crate::commands::report::browser_evidence_compare) fn attach_visual_compa
     options: &VisualCompareOptions,
     baseline_label: &str,
     candidate_label: &str,
+    include_local_paths: bool,
 ) -> homeboy::core::Result<()> {
     for variant in variants {
         let Some(local_variant) = local_variants
@@ -43,6 +44,7 @@ pub(in crate::commands::report::browser_evidence_compare) fn attach_visual_compa
             &candidate_screenshot,
             baseline_label,
             candidate_label,
+            include_local_paths,
         )?;
         variant.visual_compare = Some(result);
     }
@@ -109,6 +111,7 @@ fn run_visual_compare_provider(
     candidate_screenshot: &str,
     baseline_label: &str,
     candidate_label: &str,
+    include_local_paths: bool,
 ) -> homeboy::core::Result<VisualCompareResult> {
     let value = homeboy::core::browser_visual_compare::run_visual_compare_provider(
         &homeboy::core::browser_visual_compare::VisualCompareProviderRequest {
@@ -122,10 +125,40 @@ fn run_visual_compare_provider(
             provider_args: &options.provider_args,
         },
     )?;
-    Ok(visual_compare_result_from_value(&value, artifacts_dir))
+    Ok(visual_compare_result_from_value(
+        &value,
+        artifacts_dir,
+        include_local_paths,
+    ))
 }
 
-fn visual_compare_result_from_value(value: &Value, artifacts_dir: &Path) -> VisualCompareResult {
+/// Redact a provider-emitted artifact path for reviewer-facing reports.
+///
+/// The visual-compare provider returns absolute local paths. Handing those to
+/// a reviewer/agent invites hand-built, wrong-shape tunnel URLs (the failure
+/// that produced 404s against the artifact origin). When local paths are
+/// suppressed we strip to a path relative to the visual-compare artifacts
+/// directory, mirroring `parse::artifact_ref`'s root-relative redaction.
+fn redact_visual_artifact_target(
+    path: &str,
+    artifacts_dir: &Path,
+    include_local_paths: bool,
+) -> String {
+    if include_local_paths {
+        return path.to_string();
+    }
+    Path::new(path)
+        .strip_prefix(artifacts_dir)
+        .unwrap_or_else(|_| Path::new(path))
+        .display()
+        .to_string()
+}
+
+fn visual_compare_result_from_value(
+    value: &Value,
+    artifacts_dir: &Path,
+    include_local_paths: bool,
+) -> VisualCompareResult {
     let metrics = value.get("metrics").and_then(Value::as_object);
     let artifacts = value
         .get("artifacts")
@@ -140,7 +173,11 @@ fn visual_compare_result_from_value(value: &Value, artifacts_dir: &Path) -> Visu
                         .or_else(|| value.as_str())?;
                     Some(ArtifactRef {
                         label: label.clone(),
-                        target: path.to_string(),
+                        target: redact_visual_artifact_target(
+                            path,
+                            artifacts_dir,
+                            include_local_paths,
+                        ),
                     })
                 })
                 .collect::<BTreeSet<_>>()
@@ -148,6 +185,14 @@ fn visual_compare_result_from_value(value: &Value, artifacts_dir: &Path) -> Visu
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
+    let artifacts_directory = if include_local_paths {
+        artifacts_dir.to_string_lossy().to_string()
+    } else {
+        artifacts_dir
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_else(|| artifacts_dir.to_string_lossy().to_string())
+    };
     VisualCompareResult {
         status: value
             .get("status")
@@ -165,7 +210,79 @@ fn visual_compare_result_from_value(value: &Value, artifacts_dir: &Path) -> Visu
         dimension_mismatch: metrics
             .and_then(|metrics| metrics.get("visual_dimension_mismatch"))
             .and_then(Value::as_bool),
-        artifacts_directory: artifacts_dir.to_string_lossy().to_string(),
+        artifacts_directory,
         artifacts,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider_value(artifacts_dir: &Path) -> Value {
+        serde_json::json!({
+            "status": "compared",
+            "metrics": { "visual_mismatch_ratio": 0.5153_f64 },
+            "artifacts": {
+                "candidate": { "path": artifacts_dir.join("candidate.png").display().to_string() },
+                "diff": { "path": artifacts_dir.join("diff.png").display().to_string() },
+            }
+        })
+    }
+
+    #[test]
+    fn redacts_absolute_provider_paths_to_relative_when_local_paths_suppressed() {
+        let artifacts_dir = Path::new("/home/chubes/work/visual-compare/27-university-department");
+        let result =
+            visual_compare_result_from_value(&provider_value(artifacts_dir), artifacts_dir, false);
+
+        // No absolute path leaks to the reviewer-facing report.
+        for artifact in &result.artifacts {
+            assert!(
+                !artifact.target.starts_with('/'),
+                "leaked absolute path: {}",
+                artifact.target
+            );
+        }
+        let candidate = result
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.label == "candidate")
+            .expect("candidate artifact");
+        assert_eq!(candidate.target, "candidate.png");
+        // artifacts_directory is reduced to the slug, not an absolute path.
+        assert_eq!(result.artifacts_directory, "27-university-department");
+    }
+
+    #[test]
+    fn keeps_absolute_provider_paths_when_local_paths_included() {
+        let artifacts_dir = Path::new("/home/chubes/work/visual-compare/27-university-department");
+        let result =
+            visual_compare_result_from_value(&provider_value(artifacts_dir), artifacts_dir, true);
+
+        let candidate = result
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.label == "candidate")
+            .expect("candidate artifact");
+        assert_eq!(
+            candidate.target,
+            artifacts_dir.join("candidate.png").display().to_string()
+        );
+        assert_eq!(
+            result.artifacts_directory,
+            artifacts_dir.display().to_string()
+        );
+    }
+
+    #[test]
+    fn redact_helper_leaves_unrelated_paths_untouched() {
+        // A provider path outside artifacts_dir (unexpected) is left as-is
+        // rather than mangled, so nothing silently corrupts the reference.
+        let artifacts_dir = Path::new("/a/b/c");
+        assert_eq!(
+            redact_visual_artifact_target("/x/y/z.png", artifacts_dir, false),
+            "/x/y/z.png"
+        );
     }
 }

--- a/crates/homeboy-cli/src/commands/report/browser_evidence_compare/mod.rs
+++ b/crates/homeboy-cli/src/commands/report/browser_evidence_compare/mod.rs
@@ -112,6 +112,7 @@ pub fn browser_evidence_compare_from_dirs_with_visual_and_adapters(
             &visual_options,
             baseline_label,
             candidate_label,
+            include_local_paths,
         )?;
     }
     let totals = BrowserEvidenceCompareTotals {


### PR DESCRIPTION
## Summary
- The visual-compare section of `report browser-evidence-compare` leaked the provider's raw **absolute filesystem paths** as "Artifacts", bypassing the `include_local_paths` redaction the rest of the report applies.
- Reviewers/agents with only local paths (and no public URL) hand-built wrong-shape tunnel URLs (`/<run-id>/<uuid>-candidate.png`, `/visual-compare/<slug>/...`) that the artifact origin can't resolve — the source of the 404s that got mis-diagnosed as stale serving.

## Follow-up to #9390
#9390 made the artifact origin's 404 *self-correcting* (names resolvable path shapes). This PR fixes the **upstream cause**: the report handed out unusable local paths in the first place.

## Change
- Thread `include_local_paths` into `attach_visual_comparisons` → `visual_compare_result_from_value`.
- New `redact_visual_artifact_target`: when local paths are suppressed (reviewer-facing default), strip visual-compare artifact `target`s to a path **relative to the visual-compare artifacts directory**, mirroring `parse::artifact_ref`'s existing root-relative redaction. `artifacts_directory` is reduced to its slug.
- `render_visual_compare` adds a note: these are local operator paths, not public URLs; resolve a reviewer-facing URL with `homeboy tunnel artifact-origin inspect --path <file>`.
- No behavior change when `--include-local-paths` is set (absolute paths retained).

## Tests (`visual::tests`)
- `redacts_absolute_provider_paths_to_relative_when_local_paths_suppressed` — asserts no absolute path leaks, `candidate.png` relative, `artifacts_directory` reduced to slug.
- `keeps_absolute_provider_paths_when_local_paths_included` — full paths retained under `--include-local-paths`.
- `redact_helper_leaves_unrelated_paths_untouched` — a path outside the artifacts dir is left as-is, not mangled.
- Proven via temp-disable: neutering the redaction makes the suppression test FAIL (absolute path leaks); restoring makes all 3 pass.

_Heavy `cargo build`/full suite left to CI per repo policy; validated locally with `cargo check -p homeboy-cli --lib` + the scoped `visual::tests` module._