### PR TITLE
Resume gates for applied promotions

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -172,13 +172,15 @@ fn validate_resume_provenance(
     target_path: &Path,
     previous: &Value,
 ) -> Result<()> {
+    let previous_status = previous.get("status").and_then(Value::as_str);
     if !matches!(
-        previous.get("status").and_then(Value::as_str),
+        previous_status,
         Some("gate_failed" | "verification_pending")
-    ) {
+    ) && !(options.gates.rerun_completed_gates && previous_status == Some("applied"))
+    {
         return Err(Error::validation_invalid_argument(
             "promotion",
-            "promotion resume requires a durable post-apply promotion",
+            "promotion resume requires a durable post-apply promotion or an explicit completed-gate rerun for an applied promotion",
             None,
             None,
         ));

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -800,6 +800,65 @@ fn resume_promoted_patch_rebuilds_green_proof_from_pending_post_apply_checkpoint
 }
 
 #[test]
+fn resume_applied_promotion_reruns_gates_for_exact_dirty_candidate() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let target = temp.path().join("target");
+    std::fs::create_dir(&target).expect("target");
+    git(&target, &["init"]);
+    git(&target, &["config", "user.email", "test@example.com"]);
+    git(&target, &["config", "user.name", "Test"]);
+    std::fs::create_dir_all(target.join("src")).expect("src");
+    std::fs::write(target.join("src/lib.rs"), "old\n").expect("base");
+    git(&target, &["add", "."]);
+    git(&target, &["commit", "-m", "base"]);
+    std::fs::write(target.join("src/lib.rs"), "new\n").expect("apply candidate");
+    let candidate =
+        crate::agent_task_promotion::candidate_fingerprint(target.to_string_lossy().as_ref())
+            .expect("candidate fingerprint");
+    let (source_path, source) = write_patch_source(&temp);
+    let options = |rerun_completed_gates| AgentTaskPromotionOptions {
+        source: source.clone(),
+        source_run_id: Some("run-9392".to_string()),
+        source_path: Some(source_path.clone()),
+        source_worktree_path: None,
+        base_ref: None,
+        task_base_sha: None,
+        candidate_ref: None,
+        to_worktree: "repo@fix-9392".to_string(),
+        task_id: None,
+        artifact_id: None,
+        dry_run: false,
+        gates: VerifyGateOptions {
+            verify: vec!["true".to_string()],
+            rerun_completed_gates,
+            ..Default::default()
+        },
+        provider_command: None,
+        provider_invocation: None,
+    };
+    let previous = serde_json::json!({
+        "schema": "homeboy/agent-task-promotion-report/v1",
+        "status": "applied",
+        "source_run_id": "run-9392",
+        "source": { "task_id": "task-1" },
+        "to_worktree": "repo@fix-9392",
+        "target": { "worktree": "repo@fix-9392", "path": target },
+        "patch_artifact": { "id": "patch", "kind": "patch", "sha256": sha256_hex(VALID_PATCH) },
+        "provenance": { "candidate": candidate },
+    });
+
+    let rejected = resume_promoted_patch(options(false), &target, &previous)
+        .expect_err("applied promotion requires explicit gate rerun");
+    assert!(rejected.message.contains("explicit completed-gate rerun"));
+
+    let report = resume_promoted_patch(options(true), &target, &previous)
+        .expect("exact applied candidate resumes gates");
+    assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
+    assert_eq!(report.gate_results.len(), 1);
+    assert_eq!(report.provenance["resumed_post_apply_promotion"], true);
+}
+
+#[test]
 fn promotion_options_keep_flat_verify_gate_serialized_shape() {
     // #4910: the shared VerifyGateOptions is `#[serde(flatten)]`-embedded so
     // the historical flat `verify` / `private_verify` / `private_gate_reveal`

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -271,10 +271,7 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
             .and_then(|record| record.metadata.get("latest_promotion").cloned())
     });
     let report = if let Some(previous) = previous_promotion.filter(|previous| {
-        matches!(
-            previous.get("status").and_then(Value::as_str),
-            Some("gate_failed" | "verification_pending")
-        )
+        promotion_is_resumable(previous, promotion_options.gates.rerun_completed_gates)
     }) {
         let target_path = previous
             .pointer("/target/path")
@@ -336,6 +333,14 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
     }
 
     Ok((value, exit_code))
+}
+
+pub(crate) fn promotion_is_resumable(previous: &Value, rerun_completed_gates: bool) -> bool {
+    matches!(
+        previous.get("status").and_then(Value::as_str),
+        Some("gate_failed" | "verification_pending")
+    ) || (rerun_completed_gates
+        && previous.get("status").and_then(Value::as_str) == Some("applied"))
 }
 
 pub(crate) fn adopt_candidate(args: AdoptArgs) -> CmdResult<Value> {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -40,6 +40,16 @@ fn promotion_source_reads_bare_json_file_path() {
 }
 
 #[test]
+fn applied_promotion_resume_requires_explicit_gate_rerun() {
+    let applied = json!({ "status": "applied" });
+    let failed = json!({ "status": "gate_failed" });
+
+    assert!(!review::promotion_is_resumable(&applied, false));
+    assert!(review::promotion_is_resumable(&applied, true));
+    assert!(review::promotion_is_resumable(&failed, false));
+}
+
+#[test]
 fn review_reports_queued_run_without_chat_state() {
     with_temp_home(|| {
         agent_task_lifecycle::submit_plan(&test_plan(), Some("run-review-queued"))


### PR DESCRIPTION
## Summary

- route an `applied` promotion through checkpoint resume only when `--rerun-completed-gates` is explicit
- retain default dirty-worktree rejection for fresh promotion attempts
- retain reverse-apply, source/artifact identity, exact candidate fingerprint, and verified-base checks before rerunning gates
- persist normalized gate results for normal durable finalization

Closes #9392.

## Why

A successfully applied promotion without declared gates could not be finalized because durable finalization requires normalized gate proof. Retrying with `--verify --rerun-completed-gates` entered fresh promotion preflight and rejected the correctly dirty target before the existing checkpoint resume validator could prove it was unchanged.

## How to test

1. Run `cargo test -p homeboy-agents resume_applied_promotion_reruns_gates_for_exact_dirty_candidate --no-fail-fast`.
2. Run `cargo test -p homeboy-cli applied_promotion_resume_requires_explicit_gate_rerun --no-fail-fast`.
3. Apply a promotion without `--verify`.
4. Rerun it with `--rerun-completed-gates --verify <command>` and confirm Homeboy verifies the patch by reverse apply, matches the exact durable candidate fingerprint, runs the gate, and records a green applied report.
5. Repeat without `--rerun-completed-gates` and confirm the dirty target remains rejected.
6. Modify the target after the first promotion and confirm checkpoint resume fails closed on fingerprint mismatch.

## Verification

- Applied dirty-candidate resume test: 1 passed.
- CLI opt-in eligibility test: 1 passed.
- All four changed files pass direct `rustfmt --check`.
- Repository-wide `cargo fmt --all --check` reports pre-existing formatting drift in `crates/contracts/homeboy-lab-contract/src/lab/handoff.rs` on current main; this PR does not touch that file.

## Compatibility

This is opt-in through the existing `--rerun-completed-gates` flag. Existing applied promotions are not resumed by default, fresh dirty destinations remain rejected, and no CLI flags or persisted schemas change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Reproduction, implementation, deterministic tests, and PR preparation
