### PR TITLE
fix(agents): bind pre-acceptance recovery job from planned execution record (#9382)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
@@ -230,7 +230,14 @@ pub(crate) fn bind_pending_lab_handoff_snapshot(
                 && handoff.authority == AgentTaskLabHandoffAuthority::Controller
         })
         .map(|handoff| handoff.runner_id.clone())
-        .or_else(|| record.runner_id().map(str::to_string));
+        .or_else(|| record.runner_id().map(str::to_string))
+        // A proxy interrupted *before* Lab acceptance has neither an accepted
+        // runner_job_id nor a Pending controller handoff — the controller only
+        // recorded its planned execution intent. On recovery the runner accepts
+        // a fresh replacement job; bind it from that durable execution record's
+        // runner so snapshot validation converges instead of rejecting a valid
+        // replacement against an empty controller job id (#9382).
+        .or_else(|| planned_execution_record_runner_id(record));
     let Some(runner_id) = runner_id else {
         return Ok(());
     };
@@ -268,6 +275,38 @@ pub(crate) fn bind_pending_lab_handoff_snapshot(
         remote_command: &remote_command,
     })?;
     Ok(())
+}
+
+/// The runner id recorded on a controller-owned proxy's durable execution
+/// record when it has a planned (pre-acceptance) execution intent but no
+/// accepted runner job yet.
+///
+/// This is the recovery-safe fallback for [`bind_pending_lab_handoff_snapshot`]:
+/// it only yields a runner when the execution record is *planned* (not yet
+/// bound to a job id) and names this exact run, so binding a replacement job
+/// cannot latch onto a terminal or mismatched execution record.
+fn planned_execution_record_runner_id(record: &AgentTaskRunRecord) -> Option<String> {
+    let execution = record
+        .metadata
+        .get("runner_execution_record")
+        .and_then(|value| {
+            serde_json::from_value::<
+                    homeboy_core::runner_execution_envelope::RunnerExecutionRecord,
+                >(value.clone())
+                .ok()
+        })?;
+    if execution.job_id.is_some() {
+        return None;
+    }
+    if execution
+        .agent_task_run_id
+        .as_deref()
+        .is_some_and(|run_id| run_id != record.run_id)
+    {
+        return None;
+    }
+    let runner_id = execution.runner_id.trim();
+    (!runner_id.is_empty()).then(|| runner_id.to_string())
 }
 
 pub(crate) fn is_transport_proxy(record: &AgentTaskRunRecord) -> bool {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -455,6 +455,63 @@ fn runner_snapshot_binds_pending_lab_handoff_before_validation() {
 }
 
 #[test]
+fn preacceptance_snapshot_binds_replacement_job_from_planned_execution_record() {
+    // Issue #9382: a durable Lab-offloaded run interrupted *before* acceptance
+    // has no accepted runner_job_id and — after deadline/recovery handling — no
+    // Pending controller handoff to bind from either. Its runner identity lives
+    // only in the planned `runner_execution_record`. Recovery re-executes the
+    // exact run, the runner accepts a fresh replacement job, and its snapshot
+    // must bind that replacement rather than reject it as "no accepted runner
+    // job identity".
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "preacceptance-recovery",
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+            durable_plan: None,
+        })
+        .expect("planned controller proxy");
+
+        // Simulate the post-interruption recovery state: the pending controller
+        // handoff is gone (deadline/recovery cleared it) AND the metadata
+        // runner_id was not persisted, so the runner identity survives only on
+        // the planned execution record. Without the #9382 fix the binder has no
+        // runner source and validation rejects the replacement job.
+        record.lab_handoff = None;
+        record
+            .metadata
+            .as_object_mut()
+            .expect("metadata object")
+            .remove("runner_id");
+        assert!(record.runner_id().is_none());
+        assert_eq!(
+            record.metadata["runner_execution_record"]["status"],
+            "planned"
+        );
+        assert_eq!(
+            record.metadata["runner_execution_record"]["runner_id"],
+            "homeboy-lab"
+        );
+        store::write_record(&record).expect("persist recovery state");
+
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
+        snapshot.job.target_runner_id = Some("homeboy-lab".to_string());
+        snapshot.events.clear();
+        let replacement_job_id = snapshot.job.id.to_string();
+
+        reconcile_transport_proxy_snapshot(&mut record, &snapshot)
+            .expect("replacement runner snapshot binds the planned execution record");
+
+        assert_eq!(record.state, AgentTaskRunState::Running);
+        assert_eq!(record.runner_job_id(), Some(replacement_job_id.as_str()));
+        assert_eq!(record.metadata["handoff_acceptance"]["state"], "accepted");
+    });
+}
+
+#[test]
 fn runner_snapshot_rejects_conflicting_bound_lab_job_identity() {
     with_isolated_home(|_| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];


### PR DESCRIPTION
## Summary

Fixes #9382. A durable Lab-offloaded agent-task interrupted **before** the runner accepted a job could not be recovered: executing the exact queued run created a replacement runner job, but snapshot validation rejected it with

```
Invalid argument runner_job_id: controller run has no accepted runner job identity to validate runner snapshot job ... against; the accepted Lab handoff job id must be bound before snapshot validation
```

This made the documented durable recovery path unusable for precisely the pre-acceptance interruption it exists to recover.

## Root cause

`bind_pending_lab_handoff_snapshot` (the single owner of pre-acceptance handoff binding) resolves the runner to bind a replacement job against from two sources:
1. a `Pending` + `Controller` lab handoff, or
2. `record.runner_id()` (the handoff or `metadata["runner_id"]`).

After deadline/recovery handling, a pre-acceptance proxy can have **neither** — the Pending handoff was cleared and the metadata runner id is absent — while the runner identity still lives on the planned `runner_execution_record`. With no runner source, binding no-oped and validation rejected the valid replacement.

## Fix

Add a final fallback to the runner-id resolution: the planned `runner_execution_record`'s runner id, gated to be recovery-safe — it only yields a runner when the execution record has **no bound job id** (still planned/pre-acceptance) and names **this exact run**, so a replacement can never latch onto a terminal or mismatched execution record. The existing accepted-job protections (target-runner mismatch, conflicting bound job identity) are untouched.

## Tests

`preacceptance_snapshot_binds_replacement_job_from_planned_execution_record` reproduces the exact #9382 state — a planned proxy with its Pending handoff and metadata runner id removed, runner surviving only on the execution record — and asserts a replacement snapshot binds and validates. Proven to catch the bug via temp-disable of the fallback (the test fails with the original rejection). The sibling binding tests (`runner_snapshot_binds_pending_lab_handoff_before_validation`, `preacceptance_snapshot_binds_the_accepted_daemon_job_before_validation`, `preacceptance_snapshot_binds_a_pre_claim_job_without_a_target_runner`, and the `rejects_*` conflict tests) all still pass.

Note: one pre-existing unrelated failure in this file (`controller_proxy_is_queued_before_handoff_then_binds_runner_child`, asserting `lab_handoff.is_none()` on a `record_lab_offload_planned` result) fails identically on clean `origin/main` on this environment and is not touched by this change.