### PR TITLE
Enforce host-scoped Git identity before publication

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -169,12 +169,15 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
             Some(proof),
             false,
             false,
+            None,
         ));
     }
 
     if !options.manual_finalization {
         backend.validate_candidate(&options)?;
     }
+    // An identity mismatch must not create a commit, push, or PR mutation.
+    let git_identity = backend.validate_publication_identity(&options.path)?;
     if commit_required {
         backend.commit_all(&options.path, &options.commit_message)?;
     }
@@ -234,6 +237,7 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
         Some(proof),
         commit_required,
         push_required,
+        Some(git_identity),
     ))
 }
 
@@ -449,6 +453,7 @@ fn publication_proof(
     status: &str,
     adapter_action: &str,
     adapter_ref: Option<String>,
+    git_identity: Option<homeboy_core::git::GitIdentityProof>,
 ) -> AgentTaskPublicationProof {
     let mut target = intent.target.clone();
     target.url = adapter_ref.clone();
@@ -460,6 +465,7 @@ fn publication_proof(
         target,
         adapter_action: (adapter_action != "none").then(|| adapter_action.to_string()),
         adapter_ref,
+        git_identity,
         proof: intent.proof.clone(),
     }
 }
@@ -476,13 +482,19 @@ fn report(
     proof: Option<HomeboyProof>,
     committed: bool,
     pushed: bool,
+    git_identity: Option<homeboy_core::git::GitIdentityProof>,
 ) -> AgentTaskPrFinalizationReport {
     let normalized_gate_results = options.normalized_gate_results.clone();
     let proof =
         proof.unwrap_or_else(|| build_finalization_proof(options, normalized_gate_results.clone()));
     publication_intent.proof = proof.clone();
-    let publication_proof =
-        publication_proof(&publication_intent, status, pr_action, pr_url.clone());
+    let publication_proof = publication_proof(
+        &publication_intent,
+        status,
+        pr_action,
+        pr_url.clone(),
+        git_identity,
+    );
     let finalization_outcome = finalization_outcome(
         &publication_intent,
         &publication_proof,

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -268,6 +268,13 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
         })
     }
 
+    fn validate_publication_identity(
+        &mut self,
+        path: &str,
+    ) -> Result<homeboy_core::git::GitIdentityProof> {
+        homeboy_core::git::validate_publication_identity(path)
+    }
+
     fn commit_all(&mut self, path: &str, message: &str) -> Result<()> {
         let output = commit_at(None, Some(message), CommitOptions::default(), Some(path))?;
         if !output.success {

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -31,6 +31,7 @@ struct MockBackend {
     existing_pr: Option<AgentTaskPrRef>,
     create_error: bool,
     push_error: bool,
+    identity_error: bool,
     hydrate_error: bool,
     hydrate_run_id: Option<String>,
     lifecycle: Option<RunLifecycleRecord>,
@@ -150,6 +151,26 @@ impl AgentTaskPrFinalizationBackend for MockBackend {
     fn publication_base_sha(&mut self, _path: &str, _base: &str) -> Result<Option<String>> {
         self.publication_observed_after_pr_lookup = self.pr_lookup_complete;
         Ok(self.publication_base_sha.clone())
+    }
+
+    fn validate_publication_identity(
+        &mut self,
+        _path: &str,
+    ) -> Result<homeboy_core::git::GitIdentityProof> {
+        if self.identity_error {
+            return Err(Error::validation_invalid_argument(
+                "git_identity",
+                "effective repository-local Git identity does not match the origin host policy",
+                None,
+                Some(vec!["configure_repository_local_identity".to_string()]),
+            ));
+        }
+        Ok(homeboy_core::git::GitIdentityProof {
+            host: "git.example.test".to_string(),
+            name: "Homeboy Bot".to_string(),
+            email: "bot@example.test".to_string(),
+            scope: "repository_local".to_string(),
+        })
     }
 
     fn commit_all(&mut self, _path: &str, _message: &str) -> Result<()> {
@@ -281,6 +302,30 @@ fn creates_new_pr_after_green_gates() {
     assert!(report.finalization_outcome.committed);
     assert!(report.finalization_outcome.pushed);
     assert!(report.finalization_outcome.published);
+    assert_eq!(
+        report
+            .publication_proof
+            .git_identity
+            .as_ref()
+            .map(|proof| proof.host.as_str()),
+        Some("git.example.test")
+    );
+}
+
+#[test]
+fn finalization_rejects_identity_mismatch_before_any_publication_mutation() {
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        identity_error: true,
+        ..Default::default()
+    };
+
+    let error = finalize_pr_with_backend(options(), &mut backend).expect_err("identity mismatch");
+
+    assert!(error.message.contains("repository-local Git identity"));
+    assert!(!backend.committed);
+    assert!(!backend.pushed);
+    assert!(!backend.created);
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_finalization/types.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/types.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::*;
+use homeboy_core::git::GitIdentityProof;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskGateResult {
@@ -108,6 +109,8 @@ pub struct AgentTaskPublicationProof {
     pub adapter_action: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub adapter_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_identity: Option<GitIdentityProof>,
     pub proof: HomeboyProof,
 }
 
@@ -298,6 +301,8 @@ pub trait AgentTaskPrFinalizationBackend {
             AgentTaskPrCandidateState::Dirty { changed_files }
         })
     }
+    /// Validates the host-scoped repository-local identity before publication mutates Git state.
+    fn validate_publication_identity(&mut self, path: &str) -> Result<GitIdentityProof>;
     fn commit_all(&mut self, path: &str, message: &str) -> Result<()>;
     fn push_branch(&mut self, path: &str, head: &str) -> Result<()>;
     fn find_open_pr(

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3195,6 +3195,17 @@ mod tests {
         fn changed_files(&mut self, _path: &str) -> Result<Vec<String>> {
             Ok(vec!["src/lib.rs".to_string()])
         }
+        fn validate_publication_identity(
+            &mut self,
+            _path: &str,
+        ) -> Result<homeboy_core::git::GitIdentityProof> {
+            Ok(homeboy_core::git::GitIdentityProof {
+                host: "git.example.test".to_string(),
+                name: "Homeboy Bot".to_string(),
+                email: "bot@example.test".to_string(),
+                scope: "repository_local".to_string(),
+            })
+        }
         fn commit_all(&mut self, _path: &str, _message: &str) -> Result<()> {
             self.committed = true;
             Ok(())

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -61,6 +61,13 @@ pub struct HomeboyConfig {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub github_hosts: HashMap<String, crate::component::GithubHostConfig>,
 
+    /// Expected repository-local Git commit identity keyed by remote hostname.
+    ///
+    /// Homeboy checks this policy immediately before publication mutations. The
+    /// hostname comes from the repository's origin URL, keeping this provider-agnostic.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub git_hosts: HashMap<String, GitHostConfig>,
+
     /// Extension and executor settings addressed through `/settings/...`.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub settings: HashMap<String, Value>,
@@ -140,6 +147,7 @@ impl Default for HomeboyConfig {
             notifications: NotificationConfig::default(),
             worktree_providers: HashMap::new(),
             github_hosts: HashMap::new(),
+            git_hosts: HashMap::new(),
             settings: HashMap::new(),
             release_gate: ReleaseGateConfig::default(),
             retention: RetentionConfig::default(),
@@ -148,6 +156,12 @@ impl Default for HomeboyConfig {
             resident_services: Vec::new(),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct GitHostConfig {
+    pub name: String,
+    pub email: String,
 }
 
 /// Safe default retention windows for resources created by Homeboy commands.

--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -94,6 +94,8 @@ pub use primitives_query::{
     short_head_revision, status_porcelain, status_porcelain_bytes, toplevel,
 };
 
+use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::path::Path;
 use std::process::Command;
 
@@ -107,9 +109,108 @@ pub const BOT_NAME: &str = "homeboy-ci[bot]";
 pub const BOT_EMAIL: &str = "266378653+homeboy-ci[bot]@users.noreply.github.com";
 
 /// Parsed git identity (name + email).
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GitIdentity {
     pub name: String,
     pub email: String,
+}
+
+/// Evidence that the repository-local identity matched its origin-host policy.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GitIdentityProof {
+    pub host: String,
+    pub name: String,
+    pub email: String,
+    pub scope: String,
+}
+
+/// Validate the repository-local identity selected for the origin host.
+pub fn validate_publication_identity(path: &str) -> crate::error::Result<GitIdentityProof> {
+    let remote = git_config(path, &["config", "--get", "remote.origin.url"])?;
+    let host = remote_host(&remote).ok_or_else(|| {
+        identity_error(
+            "origin remote does not contain a usable hostname",
+            json!({ "origin": remote, "remediation": [] }),
+        )
+    })?;
+    let config = crate::defaults::load_config();
+    let Some(expected) = config.git_hosts.get(&host) else {
+        return Ok(GitIdentityProof {
+            host,
+            name: git_config(path, &["config", "--get", "user.name"])?,
+            email: git_config(path, &["config", "--get", "user.email"])?,
+            scope: "effective_unrestricted".to_string(),
+        });
+    };
+    if expected.name.trim().is_empty() || expected.email.trim().is_empty() {
+        return Err(identity_error(
+            "configured Git identity policy requires non-empty name and email",
+            json!({ "host": host, "remediation": [{ "kind": "complete_host_policy" }] }),
+        ));
+    }
+
+    let name = git_config(path, &["config", "--local", "--get", "user.name"])?;
+    let email = git_config(path, &["config", "--local", "--get", "user.email"])?;
+    if name != expected.name || email != expected.email {
+        return Err(identity_error(
+            "effective repository-local Git identity does not match the origin host policy",
+            json!({
+                "host": host,
+                "expected": { "name": expected.name, "email": expected.email },
+                "actual": { "name": name, "email": email },
+                "remediation": [{
+                    "kind": "configure_repository_local_identity",
+                    "commands": [
+                        format!("git -C {} config --local user.name {:?}", path, expected.name),
+                        format!("git -C {} config --local user.email {:?}", path, expected.email)
+                    ]
+                }]
+            }),
+        ));
+    }
+    Ok(GitIdentityProof {
+        host,
+        name,
+        email,
+        scope: "repository_local".to_string(),
+    })
+}
+
+fn git_config(path: &str, args: &[&str]) -> crate::error::Result<String> {
+    let output = execute_git(path, args)
+        .map_err(|error| crate::error::Error::git_command_failed(error.to_string()))?;
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).trim().to_string());
+    }
+    Ok(String::new())
+}
+
+fn remote_host(remote: &str) -> Option<String> {
+    let authority = remote
+        .trim()
+        .strip_prefix("https://")
+        .or_else(|| remote.trim().strip_prefix("http://"))
+        .or_else(|| remote.trim().strip_prefix("ssh://"))
+        .or_else(|| remote.trim().split_once('@').map(|(_, value)| value))?;
+    let host = authority
+        .split('@')
+        .next_back()?
+        .split('/')
+        .next()?
+        .split(':')
+        .next()?
+        .trim();
+    (!host.is_empty()).then(|| host.to_string())
+}
+
+fn identity_error(message: &str, details: serde_json::Value) -> crate::error::Error {
+    crate::error::Error {
+        code: crate::error::ErrorCode::ValidationInvalidArgument,
+        message: message.to_string(),
+        details,
+        hints: Vec::new(),
+        retryable: Some(false),
+    }
 }
 
 /// Parse a `--git-identity` value into name + email.
@@ -213,6 +314,10 @@ pub(crate) fn run_resolved_git(
 #[cfg(test)]
 mod identity_tests {
     use super::*;
+    use crate::defaults::{save_config, GitHostConfig, HomeboyConfig};
+    use crate::test_support::with_isolated_home;
+    use std::collections::HashMap;
+    use std::process::Command;
 
     #[test]
     fn bot_shorthand() {
@@ -240,6 +345,131 @@ mod identity_tests {
         let id = parse_git_identity(Some("My Service"));
         assert_eq!(id.name, "My Service");
         assert_eq!(id.email, BOT_EMAIL);
+    }
+
+    #[test]
+    fn publication_identity_unrestricted_host_preserves_effective_identity() {
+        with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let repo = temp.path();
+            for args in [
+                vec!["init"],
+                vec![
+                    "remote",
+                    "add",
+                    "origin",
+                    "git@git.example.test:owner/repo.git",
+                ],
+                vec!["config", "user.name", "Existing Author"],
+                vec!["config", "user.email", "author@example.test"],
+            ] {
+                let status = Command::new("git")
+                    .args(args)
+                    .current_dir(repo)
+                    .status()
+                    .expect("run git");
+                assert!(status.success());
+            }
+
+            let proof = validate_publication_identity(repo.to_str().expect("path"))
+                .expect("unrestricted host");
+
+            assert_eq!(proof.host, "git.example.test");
+            assert_eq!(proof.name, "Existing Author");
+            assert_eq!(proof.email, "author@example.test");
+            assert_eq!(proof.scope, "effective_unrestricted");
+        });
+    }
+
+    #[test]
+    fn publication_identity_configured_host_requires_repository_local_identity() {
+        with_isolated_home(|_| {
+            let temp = identity_test_repo();
+            save_identity_policy();
+
+            let error = validate_publication_identity(temp.path().to_str().expect("path"))
+                .expect_err("repository-local identity is required");
+
+            assert_eq!(error.details["host"], "git.example.test");
+            assert_eq!(
+                error.details["remediation"][0]["kind"],
+                "configure_repository_local_identity"
+            );
+        });
+    }
+
+    #[test]
+    fn publication_identity_configured_host_rejects_incorrect_identity() {
+        with_isolated_home(|_| {
+            let temp = identity_test_repo();
+            save_identity_policy();
+            run_identity_git(temp.path(), &["config", "user.name", "Wrong Author"]);
+            run_identity_git(temp.path(), &["config", "user.email", "wrong@example.test"]);
+
+            let error = validate_publication_identity(temp.path().to_str().expect("path"))
+                .expect_err("incorrect identity");
+
+            assert_eq!(error.details["actual"]["name"], "Wrong Author");
+            assert_eq!(error.details["expected"]["name"], "Expected Author");
+        });
+    }
+
+    #[test]
+    fn publication_identity_configured_host_accepts_correct_identity() {
+        with_isolated_home(|_| {
+            let temp = identity_test_repo();
+            save_identity_policy();
+            run_identity_git(temp.path(), &["config", "user.name", "Expected Author"]);
+            run_identity_git(
+                temp.path(),
+                &["config", "user.email", "expected@example.test"],
+            );
+
+            let proof = validate_publication_identity(temp.path().to_str().expect("path"))
+                .expect("correct identity");
+
+            assert_eq!(proof.name, "Expected Author");
+            assert_eq!(proof.email, "expected@example.test");
+            assert_eq!(proof.scope, "repository_local");
+        });
+    }
+
+    fn identity_test_repo() -> tempfile::TempDir {
+        let temp = tempfile::tempdir().expect("tempdir");
+        run_identity_git(temp.path(), &["init"]);
+        run_identity_git(
+            temp.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "git@git.example.test:owner/repo.git",
+            ],
+        );
+        temp
+    }
+
+    fn save_identity_policy() {
+        save_config(&HomeboyConfig {
+            git_hosts: HashMap::from([(
+                "git.example.test".to_string(),
+                GitHostConfig {
+                    name: "Expected Author".to_string(),
+                    email: "expected@example.test".to_string(),
+                },
+            )]),
+            ..HomeboyConfig::default()
+        })
+        .expect("save config");
+    }
+
+    fn run_identity_git(path: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .status()
+            .expect("run git");
+        assert!(status.success());
     }
 }
 


### PR DESCRIPTION
## Summary
Validate configured host-specific repository-local Git identities before agent-task publication mutations and record the resolved identity in publication proof.

## What changed
- Add generic git\_hosts identity policy, enforce configured hosts before commit/push/PR mutation, preserve unrestricted-host behavior, and persist identity proof.

## How to test
1. Run `cargo test -p homeboy-core publication_identity`; expect Four unrestricted and configured-host identity cases pass.
2. Run `cargo test -p homeboy-agents agent_task_finalization`; expect All 44 finalization tests pass.

## Compatibility
Unrestricted hosts retain existing behavior. Configured hosts now fail closed before mutation when repository-local user.name or user.email is missing or incorrect; this is an intentional publication safety gate for external automation consumers.

## Evidence
- Base unchanged since verification: main remains at 048e40c63a686e034ffb889f0778c8546fe3be99.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/9369
- Verified finalization base: main at 048e40c63a686e034ffb889f0778c8546fe3be99
- finalization-tests: Passed
- identity-tests: Passed
- package-format: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** AI-assisted
- **Model:** openai/gpt-5.6-terra
- **Used for:** Drafted implementation and tests; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy#9369
