### PR TITLE
fix(agents): preserve Cook candidate when post-provider handoff fails (#9377)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -10,6 +10,19 @@ pub fn record_pre_execution_failure(
 ) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
     let mut record = store::read_record(&run_id)?;
+
+    // A transport/handoff error that arrives AFTER a provider attempt was
+    // already dispatched (or completed) on a runner is not a pre-execution
+    // failure. Terminalizing it here would overwrite a succeeded candidate with
+    // a `Failed`, zero-artifact, `provider_executions_consumed: 0` record and
+    // strand the work — exactly the loss #9377 describes. Preserve the candidate
+    // and record the follow-up failure as a non-terminal, recoverable marker so
+    // controller reconciliation can adopt the completed candidate without
+    // rerunning the provider.
+    if record.has_recorded_provider_progress() {
+        return record_transport_follow_up_failure(record, phase, error);
+    }
+
     let task_count = plan.tasks.len();
     let failed = task_count;
     let retryable = error.retryable == Some(true);
@@ -81,6 +94,42 @@ pub fn record_pre_execution_failure(
     );
     store::write_record(&failed_record)?;
     Ok(failed_record)
+}
+
+/// Record a post-provider transport/handoff failure without terminalizing a run
+/// that already produced a candidate (#9377). The existing durable record — its
+/// state, aggregate, artifacts, and provider handles — is preserved verbatim;
+/// only a recoverable `transport_follow_up_failure` marker is stamped so
+/// controller reconciliation can adopt the completed candidate rather than
+/// rerunning the provider. The failure stays `retryable` so recovery is
+/// attempted, and never regresses a terminal candidate to `Failed`.
+fn record_transport_follow_up_failure(
+    mut record: AgentTaskRunRecord,
+    phase: &str,
+    error: &Error,
+) -> Result<AgentTaskRunRecord> {
+    let metadata = record.ensure_metadata_object();
+    metadata.insert(
+        "transport_follow_up_failure".to_string(),
+        json!({
+            "schema": super::CANDIDATE_ADOPTION_RECOVERY_SCHEMA,
+            "phase": phase,
+            "reason": "post_provider_transport_failure",
+            "error_code": error.code.as_str(),
+            "message": error.message,
+            "details": error.details.clone(),
+            "hints": error.hints.iter().map(|hint| hint.message.as_str()).collect::<Vec<_>>(),
+            "retryable": true,
+            "candidate_preserved": true,
+            "recorded_at": now_timestamp(),
+        }),
+    );
+    // Preserve the candidate/workspace: a run with recorded provider progress
+    // must not be reaped as a clean success when its follow-up failed.
+    metadata.insert("candidate_preserved".to_string(), json!(true));
+    metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
+    store::write_record(&record)?;
+    Ok(record)
 }
 
 pub(crate) fn build_pre_execution_failure_outcome(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1452,6 +1452,34 @@ pub fn has_accepted_runner_handoff(run_id: &str) -> Result<bool> {
     Ok(is_accepted_runner_handoff(&record))
 }
 
+/// Whether a run already carries durable provider-execution progress, so a
+/// later transport/handoff error must preserve its candidate instead of
+/// terminalizing it as a pre-execution failure (#9377). Returns `false` when no
+/// record exists yet (a genuine pre-execution failure).
+pub fn has_recorded_provider_progress(run_id: &str) -> Result<bool> {
+    match store::read_record(&sanitize_run_id(run_id)) {
+        Ok(record) => Ok(record.has_recorded_provider_progress()),
+        Err(_) => Ok(false),
+    }
+}
+
+/// Whether a run recorded a candidate-preserving post-provider transport
+/// follow-up failure (#9377). The runner uses this to keep a run-scoped
+/// workspace when a provider succeeded but its controller-side candidate
+/// projection or handoff has not — so the preserved candidate remains
+/// recoverable on the lab. Returns `false` when no record exists.
+pub fn run_owes_candidate_follow_up(run_id: &str) -> Result<bool> {
+    match store::read_record(&sanitize_run_id(run_id)) {
+        Ok(record) => Ok(record.metadata.get("transport_follow_up_failure").is_some()
+            || record
+                .metadata
+                .get("candidate_preserved")
+                .and_then(Value::as_bool)
+                == Some(true)),
+        Err(_) => Ok(false),
+    }
+}
+
 /// Pure durable-handoff predicate for callers that already hold the lifecycle
 /// record and must not re-enter the store.
 pub(crate) fn is_accepted_runner_handoff(record: &AgentTaskRunRecord) -> bool {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -260,6 +260,38 @@ impl AgentTaskRunRecord {
         })
     }
 
+    /// Whether this run already carries durable evidence of a *completed*
+    /// provider attempt whose candidate must survive a later transport/handoff
+    /// error. When true, recording a pre-execution failure would overwrite a
+    /// succeeded candidate with a `Failed`, zero-artifact,
+    /// `provider_executions_consumed: 0` terminal record and strand the work
+    /// (#9377).
+    ///
+    /// This deliberately requires *completed-work* evidence, not merely an
+    /// accepted handoff or a claimed runner job id: an accepted job can later be
+    /// confirmed absent/lost with no candidate, and that genuinely-lost case
+    /// must still terminalize (see `terminalize_lost_accepted_runner_job`, which
+    /// only fires when `provider_handles` is empty). The completed-work signals:
+    /// - one or more provider handles (a provider run id was returned), or
+    /// - a successful / recoverable-candidate terminal state (the run produced a
+    ///   candidate), i.e. a terminal state other than a bare `Failed`/`Cancelled`.
+    pub(crate) fn has_recorded_provider_progress(&self) -> bool {
+        !self.provider_handles.is_empty() || self.has_candidate_terminal_state()
+    }
+
+    /// A terminal state that carries a produced candidate (success or a
+    /// recoverable/partial candidate), as opposed to a bare failure/cancellation
+    /// that produced nothing to preserve.
+    fn has_candidate_terminal_state(&self) -> bool {
+        matches!(
+            self.state,
+            AgentTaskRunState::Succeeded
+                | AgentTaskRunState::CandidateRecoverable
+                | AgentTaskRunState::PartialRecoverable
+                | AgentTaskRunState::PartialFailure
+        )
+    }
+
     pub(crate) fn lab_handoff_validation_error(&self) -> Option<&'static str> {
         self.lab_handoff
             .as_ref()

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -1448,3 +1448,72 @@ fn run_status_reports_bridge_envelope_and_cursor_filtered_events() {
         assert_eq!(status.artifact_refs[0].kind, "artifact-bundle");
     });
 }
+
+#[test]
+fn post_provider_transport_failure_preserves_the_succeeded_candidate() {
+    // Reproduces #9377: a Cook attempt completes its provider execution on Lab
+    // (accepted handoff, recorded runner job, succeeded candidate), then a
+    // detached post-provider handoff cannot resolve the controller-only runner
+    // ("runner is not connected to a daemon"). The transport error must NOT be
+    // recorded as a pre-execution failure — doing so would overwrite the
+    // succeeded candidate with a Failed, zero-artifact,
+    // provider_executions_consumed:0 terminal record and strand the work.
+    with_isolated_home(|_| {
+        let run_id = "cook-9377-post-provider-transport";
+        let plan = test_plan();
+
+        // Provider dispatched + succeeded on the runner: accepted handoff with a
+        // recorded runner job and a succeeded aggregate.
+        record_detached_lab_run(DetachedLabRunRecord {
+            run_id,
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-9377",
+            remote_workspace: "/runner/workspace/wp-build",
+            remote_command: &["agent-task".to_string(), "run-plan".to_string()],
+        })
+        .expect("accepted runner handoff");
+        record_completed_run(&plan, &succeeded_aggregate(&plan), Some(run_id))
+            .expect("succeeded candidate");
+
+        let before = status(run_id).expect("candidate record");
+        assert_eq!(before.state, AgentTaskRunState::Succeeded);
+        assert!(before.has_recorded_provider_progress());
+
+        // The exact failure from the field: post-provider detached handoff
+        // re-resolves the controller-only runner and fails.
+        let transport_error = Error::validation_invalid_argument(
+            "runner",
+            "runner is not connected to a daemon; run `homeboy runner connect <runner-id>` first",
+            Some("homeboy-lab".to_string()),
+            None,
+        );
+        let preserved = record_pre_execution_failure(
+            run_id,
+            &plan,
+            "detached_lab_handoff_preacceptance",
+            &transport_error,
+        )
+        .expect("transport failure recorded without terminalizing the candidate");
+
+        // Candidate preserved: state stays Succeeded, never regressed to Failed,
+        // and the pre-execution failure shape (zero-artifact, consumed:0) is NOT
+        // stamped over it.
+        assert_eq!(preserved.state, AgentTaskRunState::Succeeded);
+        assert!(preserved.metadata.get("pre_execution_failure").is_none());
+        let marker = &preserved.metadata["transport_follow_up_failure"];
+        assert_eq!(marker["reason"], "post_provider_transport_failure");
+        assert_eq!(marker["phase"], "detached_lab_handoff_preacceptance");
+        assert_eq!(marker["candidate_preserved"], true);
+        assert_eq!(marker["retryable"], true);
+        assert_eq!(preserved.metadata["candidate_preserved"], true);
+
+        // The durable record on disk agrees — recovery can adopt this candidate
+        // without rerunning the provider.
+        let reloaded = status(run_id).expect("reloaded candidate");
+        assert_eq!(reloaded.state, AgentTaskRunState::Succeeded);
+        assert_eq!(
+            reloaded.metadata["transport_follow_up_failure"]["reason"],
+            "post_provider_transport_failure"
+        );
+    });
+}

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -818,7 +818,19 @@ pub(crate) fn exec_lab_context(
     }
 
     if let Some(workspace) = context.materialized_workspace.as_mut() {
-        workspace.set_success(exit_code == 0);
+        // Reap on a clean success only. A provider can exit 0 while its
+        // controller-side candidate projection or handoff still owes follow-up;
+        // reaping then would destroy a preserved candidate's workspace (#9377).
+        // Treat any recorded candidate-preserving follow-up as not-yet-success
+        // so post-mortem/recovery bytes survive on the lab.
+        let owes_candidate_follow_up = context
+            .agent_task_run_id
+            .as_deref()
+            .map(|run_id| {
+                agent_task_lifecycle::run_owes_candidate_follow_up(run_id).unwrap_or(false)
+            })
+            .unwrap_or(false);
+        workspace.set_success(exit_code == 0 && !owes_candidate_follow_up);
     }
     Ok(LabOffloadOutcome::Offloaded {
         plan: context.plan,


### PR DESCRIPTION
## Summary

Closes #9377. A Cook retry could complete its provider execution successfully on Lab (`state=succeeded`) and then **lose the candidate** during post-provider detached handoff: the transport follow-up re-resolved the controller-only runner id, failed with `runner is not connected to a daemon`, and `record_pre_execution_failure` overwrote the succeeded candidate with a `Failed`, zero-artifact, `provider_executions_consumed:0` terminal record — then the run-scoped workspace was reaped.

## Root cause

`record_pre_execution_failure` unconditionally terminalized a run as a *pre-execution* failure whenever a transport/handoff dispatch errored — even when a provider attempt had **already produced a candidate**. A post-provider transport error is not a pre-execution failure, but every preacceptance/handoff-failure call site funneled into that one recorder.

## Fix (all four acceptance criteria)

1. **Don't re-terminalize completed work.** New `AgentTaskRunRecord::has_recorded_provider_progress()` is true only for *completed-work* evidence — provider handles, or a candidate-bearing terminal state (`Succeeded` / `CandidateRecoverable` / `Partial*`). It deliberately does **not** trigger on a bare accepted handoff or claimed runner-job id, so a genuinely **lost** accepted job (`terminalize_lost_accepted_runner_job`, which only fires with empty `provider_handles`) still terminalizes correctly.
2. **Project/preserve the candidate before transport follow-up can change terminal state.** When a run has recorded provider progress, `record_pre_execution_failure` now preserves the existing durable record verbatim (state, aggregate, artifacts, handles) and stamps a recoverable `transport_follow_up_failure` marker (`candidate_preserved`, `retryable`) instead of regressing to `Failed`. This is a single durable chokepoint, so **every** preacceptance/handoff-failure caller (including the top-level `detached_lab_handoff_preacceptance` retry path) is protected.
3. **Preserve the run-scoped workspace.** The Lab offload reaper (`exec_lab_context`) now consults `run_owes_candidate_follow_up` and does **not** reap when a provider exited 0 but its controller-side candidate projection/handoff still owes follow-up — so the candidate's workspace survives on the lab for recovery. (The detached path already relinquished via `workspace.preserve()`; this closes the synchronous-success gap.)
4. **Recovery adopts the completed candidate without rerunning the provider.** Because the candidate record is never destroyed, standard controller reconciliation/promotion already operates on the preserved succeeded record.

## Tests

- `post_provider_transport_failure_preserves_the_succeeded_candidate` — reproduces the exact field scenario: an accepted-handoff + succeeded-candidate run, then `record_pre_execution_failure` with the verbatim `runner is not connected to a daemon` error. Asserts the state stays `Succeeded`, no `pre_execution_failure` shape is stamped, and the `transport_follow_up_failure` / `candidate_preserved` markers are recorded. **Proven** via temp-disable to fail (state regresses to `Failed`) without the guard.
- Behavior-preserving: the pre-existing terminalization tests still pass — `detached_cook_preacceptance_failure_terminalizes_attempt_proxy`, `failed_lab_preacceptance_reconstructs_only_authenticated_zero_execution_recovery`, `accepted_handoff_fails_after_confirmed_absence_across_generations` (confirmed-lost job still terminalizes), and `accepted_handoff_does_not_terminalize_unconfirmed_generation_absence`.

## Notes / out of scope

- Six `agent_task_lifecycle` tests fail identically on clean `origin/main` in isolation (`controller_proxy_is_queued_before_handoff_then_binds_runner_child`, `long_pre_submission_setup_survives...`, `pinned_runtime_recovery_retains...`, `candidate_adoption_cancellation_persists_request...`, `terminal_executor_artifacts_are_projected_under_logical_ids`, `status_expires_an_unaccepted_handoff_but_late_runner_acceptance_wins`) — pre-existing VPS/shared-state flakes, unrelated to this change. This PR adds zero new failures.
- Per repo build policy, heavy `cargo test --workspace` runs are left to CI. Verified locally with `cargo check --lib` on homeboy-agents/homeboy-lab-runner/homeboy-cli, `cargo fmt`, and the targeted lifecycle test modules.