### PR TITLE
Preserve reconciled provider models

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/conversion.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/conversion.rs
@@ -170,6 +170,10 @@ pub(crate) fn tasks_for_aggregate(
         .iter()
         .map(|request| {
             let mut task = queued_task(request);
+            let outcome = aggregate
+                .outcomes
+                .iter()
+                .find(|outcome| outcome.task_id == request.task_id);
             if let Some(event) = aggregate
                 .events
                 .iter()
@@ -177,12 +181,15 @@ pub(crate) fn tasks_for_aggregate(
                 .find(|event| event.task_id == request.task_id)
             {
                 task.state = event.state;
-            } else if let Some(outcome) = aggregate
-                .outcomes
-                .iter()
-                .find(|outcome| outcome.task_id == request.task_id)
-            {
+            } else if let Some(outcome) = outcome {
                 task.state = task_state_for_outcome_status(outcome.status);
+            }
+            if let Some(model) = outcome
+                .and_then(|outcome| outcome.metadata.get("model"))
+                .and_then(Value::as_str)
+                .filter(|model| !model.trim().is_empty())
+            {
+                task.model = Some(model.to_string());
             }
             task
         })

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -1202,8 +1202,9 @@ fn completed_generic_executor_outcome_preserves_runtime_evidence_without_provide
     with_isolated_home(|_| {
         let mut plan = test_plan();
         plan.tasks[0].executor.backend = "opencode".to_string();
-        plan.tasks[0].executor.model = Some("openai/gpt-5.6-terra".to_string());
-        let aggregate = succeeded_aggregate(&plan);
+        plan.tasks[0].executor.model = None;
+        let mut aggregate = succeeded_aggregate(&plan);
+        aggregate.outcomes[0].metadata = json!({ "model": "openai/gpt-5.6-terra" });
 
         let record = record_completed_run(&plan, &aggregate, Some("generic-executor-outcome"))
             .expect("recorded");
@@ -1217,6 +1218,10 @@ fn completed_generic_executor_outcome_preserves_runtime_evidence_without_provide
         assert_eq!(record.metadata["provider_run_ids"], json!([]));
         assert_eq!(runtime.backend, "opencode");
         assert_eq!(runtime.state, ProviderRuntimeState::Succeeded);
+        assert_eq!(
+            record.tasks[0].model.as_deref(),
+            Some("openai/gpt-5.6-terra")
+        );
         assert!(runtime.external_runtime_ids.is_empty());
         assert_eq!(
             runtime.metadata["evidence_source"],


### PR DESCRIPTION
## Summary

- project a concrete terminal outcome model onto the matching lifecycle task
- preserve the declared plan model when terminal metadata does not supply one
- rebuild canonical provider-runtime evidence with the dynamically selected model

Closes #9404.

## Why

Provider rotation can select a model after dispatch, leaving the original plan model null. Detached Lab reconciliation retained the selected model in the terminal outcome but rebuilt lifecycle provider evidence from the plan task, dropping the model and blocking durable publication.

## How to test

1. Run `cargo test -p homeboy-agents completed_generic_executor_outcome_preserves_runtime_evidence_without_provider_run_id --no-fail-fast`.
2. Build an aggregate whose plan task has no model and whose matching terminal outcome records `metadata.model`.
3. Reconcile the aggregate and confirm both `tasks[].model` and `lifecycle.provider_runtime[].metadata.model` contain the terminal model.
4. Remove the outcome model and confirm the declared plan model remains the fallback.

## Verification

- Focused lifecycle regression: 1 passed.
- Both changed files pass direct `rustfmt --check`.

## Compatibility

This fills previously null or stale durable task metadata from authoritative terminal evidence. Existing declared plan models remain the fallback, and no persisted schema or CLI contract changes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Reproduction, implementation, deterministic test, and PR preparation
