### PR TITLE
fix(agents): project dynamically selected model onto reconciled task (#9404)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/conversion.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/conversion.rs
@@ -184,9 +184,41 @@ pub(crate) fn tasks_for_aggregate(
             {
                 task.state = task_state_for_outcome_status(outcome.status);
             }
+            // Provider rotation can select a concrete model dynamically, so the
+            // plan task carries no model but the authoritative terminal outcome
+            // records the one actually used. Project it onto the reconciled task
+            // (declared plan model remains the fallback) so canonical
+            // `lifecycle.provider_runtime[].metadata.model` is not null and PR
+            // finalization does not reject a run that has a real model (#9404).
+            project_selected_model_onto_task(&mut task, request, aggregate);
             task
         })
         .collect()
+}
+
+/// Fill a reconciled task's model from the authoritative terminal outcome when
+/// the plan task declared none (dynamic rotation selection). Only projects a
+/// non-empty outcome model and never overrides an explicitly declared plan
+/// model, so declared-model behavior and persisted schemas are unchanged.
+fn project_selected_model_onto_task(
+    task: &mut AgentTaskRunTask,
+    request: &crate::agent_task::AgentTaskRequest,
+    aggregate: &AgentTaskAggregate,
+) {
+    if request.executor.model.is_some() {
+        return;
+    }
+    if let Some(model) = aggregate
+        .outcomes
+        .iter()
+        .find(|outcome| outcome.task_id == request.task_id)
+        .and_then(|outcome| outcome.metadata.get("model"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+    {
+        task.model = Some(model.to_string());
+    }
 }
 
 pub(crate) fn task_state_for_outcome_status(status: AgentTaskOutcomeStatus) -> AgentTaskState {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -1448,3 +1448,40 @@ fn run_status_reports_bridge_envelope_and_cursor_filtered_events() {
         assert_eq!(status.artifact_refs[0].kind, "artifact-bundle");
     });
 }
+
+#[test]
+fn tasks_for_aggregate_projects_dynamically_selected_model_when_plan_declares_none() {
+    // #9404: provider rotation can select a concrete model dynamically, so the
+    // plan task has model=None but the authoritative terminal outcome records
+    // the model actually used. The reconciled task must carry that selected
+    // model so canonical provider_runtime metadata is not null and PR
+    // finalization is not spuriously rejected.
+    let plan = test_plan();
+    assert!(
+        plan.tasks[0].executor.model.is_none(),
+        "fixture plan must declare no model to exercise dynamic selection"
+    );
+
+    let mut aggregate = succeeded_aggregate(&plan);
+    aggregate.outcomes[0].metadata = json!({ "model": "openai/gpt-5.6-terra" });
+
+    let tasks = crate::agent_task_lifecycle::conversion::tasks_for_aggregate(&plan, &aggregate);
+
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].model.as_deref(), Some("openai/gpt-5.6-terra"));
+}
+
+#[test]
+fn tasks_for_aggregate_preserves_declared_plan_model_over_outcome_model() {
+    // A declared plan model is authoritative and must never be overridden by a
+    // divergent outcome model; declared-model behavior stays unchanged.
+    let mut plan = test_plan();
+    plan.tasks[0].executor.model = Some("declared/plan-model".to_string());
+
+    let mut aggregate = succeeded_aggregate(&plan);
+    aggregate.outcomes[0].metadata = json!({ "model": "other/outcome-model" });
+
+    let tasks = crate::agent_task_lifecycle::conversion::tasks_for_aggregate(&plan, &aggregate);
+
+    assert_eq!(tasks[0].model.as_deref(), Some("declared/plan-model"));
+}


### PR DESCRIPTION
## Summary

Fixes #9404. A reconciled detached Lab outcome can carry a concrete selected model in `outcome.metadata.model` while the plan task has no model (provider rotation selected it dynamically). `tasks_for_aggregate()` rebuilt each task from the plan only, so canonical `lifecycle.provider_runtime[].metadata.model` became null — and durable PR finalization then rejected publication even though the authoritative terminal outcome and active-provider metadata both recorded the concrete model.

Observed on `homeboy-extensions-2254-playwright-cache-20260721-attempt-1-35b7ef3a`: terminal outcome model `openai/gpt-5.6-terra`; canonical provider runtime model null.

## Fix

`tasks_for_aggregate` now projects a non-empty `outcome.metadata.model` onto the matching reconciled task **when the plan declared no model**, preserving the declared plan model as the authoritative fallback. `provider_runtime[].metadata.model` is built directly from `task.model` (`lifecycle_record_ops.rs`), so the rebuilt canonical evidence now carries the actual selected model.

This only fills previously-null durable metadata from authoritative terminal evidence; persisted schemas and declared-plan-model behavior are unchanged (mirrors the existing `run_provider_handle` model backfill).

## Tests

- `tasks_for_aggregate_projects_dynamically_selected_model_when_plan_declares_none` — plan model None + outcome `metadata.model` set → reconciled task carries the selected model. Proven to catch the bug via temp-disable (fails with null model).
- `tasks_for_aggregate_preserves_declared_plan_model_over_outcome_model` — a declared plan model is never overridden by a divergent outcome model.