### PR TITLE
fix(agent-task): persist fanout run-plan batch record for status resolution

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -121,6 +121,79 @@ where
     Ok(record)
 }
 
+/// One child of a fanout run-plan batch: the durable run id the coordinator
+/// dispatches and the task/cook id it was compiled from.
+#[derive(Debug, Clone)]
+pub struct FanoutRunBatchChild {
+    pub task_id: String,
+    pub run_id: String,
+}
+
+/// Persist the durable batch record for an `agent-task fanout run-plan`
+/// invocation before child admission.
+///
+/// `fanout run-plan` executes cooks directly on the controller (unlike
+/// `fanout submit`, which queues them), but it previously never wrote the
+/// `agent-task-batches/<fanout_id>.json` record that `fanout status`/`artifacts`
+/// read. A named, Lab-routed run-plan therefore admitted its children and then
+/// failed `fanout status <id>` with `No such file or directory` (#9397).
+///
+/// Writing the record here, keyed by `fanout_id` with each child's durable run
+/// id, lets `status` resolve every child live (including detached Lab runs and
+/// retries) and survives controller exit / partial admission. Children start in
+/// `Running` because run-plan dispatches immediately; `status` reconciles the
+/// live per-child state on read.
+pub fn persist_fanout_run_batch(
+    fanout_id: &str,
+    plan_id: &str,
+    children: &[FanoutRunBatchChild],
+    metadata: Value,
+) -> Result<AgentTaskBatchRecord> {
+    if children.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "cooks",
+            "agent-task fanout run-plan requires at least one cook",
+            Some(fanout_id.to_string()),
+            None,
+        ));
+    }
+    let batch_id = sanitize_id(fanout_id);
+    let mut seen = HashSet::new();
+    for child in children {
+        if !seen.insert(child.run_id.clone()) {
+            return Err(Error::validation_invalid_argument(
+                "cook_id",
+                format!(
+                    "agent-task fanout run-plan child run id '{}' is duplicated",
+                    child.run_id
+                ),
+                Some(fanout_id.to_string()),
+                None,
+            ));
+        }
+    }
+    let record = AgentTaskBatchRecord {
+        schema: AGENT_TASK_BATCH_SCHEMA.to_string(),
+        batch_id,
+        plan_id: plan_id.to_string(),
+        state: AgentTaskBatchState::Running,
+        submitted_at: now_timestamp(),
+        updated_at: None,
+        task_count: children.len(),
+        child_runs: children
+            .iter()
+            .map(|child| AgentTaskBatchChildRun {
+                task_id: child.task_id.clone(),
+                run_id: child.run_id.clone(),
+                state: AgentTaskRunState::Running,
+            })
+            .collect(),
+        metadata,
+    };
+    write_batch(&record)?;
+    Ok(record)
+}
+
 pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
     let mut batch = read_batch(batch_id)?;
     let mut changed = false;
@@ -628,6 +701,73 @@ mod tests {
         let error = submit_plan_batch(&plan, Some("workflow")).expect_err("workflow rejected");
 
         assert!(error.message.contains("independent tasks"));
+    }
+
+    #[test]
+    fn fanout_run_plan_persists_batch_record_readable_by_status() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let children = vec![
+            FanoutRunBatchChild {
+                task_id: "audit".to_string(),
+                run_id: "cook-audit".to_string(),
+            },
+            FanoutRunBatchChild {
+                task_id: "rules".to_string(),
+                run_id: "cook-rules".to_string(),
+            },
+        ];
+
+        let record = persist_fanout_run_batch(
+            "rules-memory-gaps-20260721",
+            "rules-memory-gaps-20260721",
+            &children,
+            json!({ "source": "fanout-run-plan" }),
+        )
+        .expect("batch record persisted");
+
+        assert_eq!(record.batch_id, "rules-memory-gaps-20260721");
+        assert_eq!(record.task_count, 2);
+        assert_eq!(record.state, AgentTaskBatchState::Running);
+
+        // The exact failure from #9397: `fanout status <id>` could not read the
+        // batch file because run-plan never wrote it. It is now readable.
+        let persisted = read_batch("rules-memory-gaps-20260721").expect("batch record readable");
+        assert_eq!(persisted.child_runs.len(), 2);
+        assert_eq!(persisted.child_runs[0].run_id, "cook-audit");
+        assert_eq!(persisted.child_runs[1].run_id, "cook-rules");
+        assert!(persisted
+            .child_runs
+            .iter()
+            .all(|child| child.state == AgentTaskRunState::Running));
+    }
+
+    #[test]
+    fn fanout_run_plan_rejects_duplicate_child_run_ids() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let children = vec![
+            FanoutRunBatchChild {
+                task_id: "a".to_string(),
+                run_id: "cook-dup".to_string(),
+            },
+            FanoutRunBatchChild {
+                task_id: "b".to_string(),
+                run_id: "cook-dup".to_string(),
+            },
+        ];
+
+        let error = persist_fanout_run_batch("dup-batch", "dup-batch", &children, Value::Null)
+            .expect_err("duplicate child run ids rejected");
+
+        assert!(error.message.contains("duplicated"));
+    }
+
+    #[test]
+    fn fanout_run_plan_rejects_empty_cooks() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let error = persist_fanout_run_batch("empty-batch", "empty-batch", &[], Value::Null)
+            .expect_err("empty cooks rejected");
+
+        assert!(error.message.contains("at least one cook"));
     }
 
     fn request(task_id: &str) -> AgentTaskRequest {

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -185,11 +185,11 @@ pub mod cook_loop {
 /// Durable batch/fanout lifecycle records built from independent child runs.
 pub mod batch {
     pub use super::super::agent_task_batch::{
-        artifacts, status, submit_plan_batch, AgentTaskBatchArtifactsReport,
-        AgentTaskBatchChildArtifacts, AgentTaskBatchChildRun, AgentTaskBatchCommands,
-        AgentTaskBatchRecord, AgentTaskBatchState, AgentTaskBatchStatusReport,
-        AgentTaskBatchTotals, AGENT_TASK_BATCH_ARTIFACTS_SCHEMA, AGENT_TASK_BATCH_SCHEMA,
-        AGENT_TASK_BATCH_STATUS_SCHEMA,
+        artifacts, persist_fanout_run_batch, status, submit_plan_batch,
+        AgentTaskBatchArtifactsReport, AgentTaskBatchChildArtifacts, AgentTaskBatchChildRun,
+        AgentTaskBatchCommands, AgentTaskBatchRecord, AgentTaskBatchState,
+        AgentTaskBatchStatusReport, AgentTaskBatchTotals, FanoutRunBatchChild,
+        AGENT_TASK_BATCH_ARTIFACTS_SCHEMA, AGENT_TASK_BATCH_SCHEMA, AGENT_TASK_BATCH_STATUS_SCHEMA,
     };
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -140,10 +140,37 @@ pub(crate) fn run_batch_cook_fanout_with_attempt_dispatcher(
     run_batch_cook_fanout_plan_with_attempt_dispatcher(plan, attempt_dispatcher)
 }
 
+/// Persist the durable batch record before dispatching children so
+/// `fanout status <fanout_id>` can resolve every child run (#9397). Without
+/// this, run-plan admitted children but never wrote
+/// `agent-task-batches/<fanout_id>.json`, so status failed with
+/// `No such file or directory`.
+fn persist_fanout_run_batch_record(plan: &BatchCookFanoutPlan) -> Result<()> {
+    let children = plan
+        .cooks
+        .iter()
+        .map(|cook| batch::FanoutRunBatchChild {
+            task_id: cook.cook_id.clone(),
+            run_id: cook.run_id(),
+        })
+        .collect::<Vec<_>>();
+    batch::persist_fanout_run_batch(
+        &plan.fanout_id,
+        &plan.fanout_id,
+        &children,
+        serde_json::json!({
+            "source": "fanout-run-plan",
+            "durable_child_runs": true,
+        }),
+    )?;
+    Ok(())
+}
+
 fn run_batch_cook_fanout_plan_with_attempt_dispatcher(
     plan: BatchCookFanoutPlan,
     attempt_dispatcher: &CookAttemptDispatcherFactory,
 ) -> CmdResult<Value> {
+    persist_fanout_run_batch_record(&plan)?;
     let result = agent_task_service::run_cook_batch(
         agent_task_service::AgentTaskCookBatchOptions {
             batch_id: plan.fanout_id.clone(),
@@ -171,6 +198,7 @@ fn run_batch_cook_fanout_plan_with_executor<E>(
 where
     E: homeboy::agents::agent_tasks::scheduler::AgentTaskExecutorAdapter + Clone + Send,
 {
+    persist_fanout_run_batch_record(&plan)?;
     let result = agent_task_service::run_cook_batch(
         agent_task_service::AgentTaskCookBatchOptions {
             batch_id: plan.fanout_id.clone(),
@@ -248,6 +276,10 @@ fn batch_cook_result(
             "status": report.status,
             "summary": { "total": report.total, "succeeded": report.succeeded, "failed": report.failed },
             "cooks": cooks,
+            "commands": {
+                "status": format!("homeboy agent-task fanout status {}", plan.fanout_id),
+                "artifacts": format!("homeboy agent-task fanout artifacts {}", plan.fanout_id),
+            },
         }),
         result.exit_code,
     )


### PR DESCRIPTION
## Summary
- `agent-task fanout run-plan` admitted its child cooks and returned durable run IDs but **never wrote the `agent-task-batches/<fanout_id>.json` record** that `fanout status`/`artifacts` read.
- A named, Lab-routed run-plan therefore failed `fanout status <id>` with `IO error: ~/.local/share/homeboy/agent-task-batches/<id>.json: No such file or directory` (#9397). Only the `fanout submit` path persisted the batch boundary.

## Root cause
`run_batch_cook_fanout_plan{,_with_attempt_dispatcher,_with_executor}` (homeboy-cli fanout.rs) call `agent_task_service::run_cook_batch` — which runs cooks and manages per-cook lifecycle records but never writes the batch record. `fanout status` reads that record via `read_batch`, so it had nothing to resolve. `fanout submit` (via `batch::submit_plan_batch`) writes it; `run-plan` skipped it.

## Change
- New `batch::persist_fanout_run_batch(fanout_id, plan_id, children, metadata)` in `agent_task_batch.rs`: writes the durable `AgentTaskBatchRecord` keyed by `fanout_id`, with each child's durable run id (`cook-<cook_id>`), **before** dispatch — mirroring `submit_plan_batch`'s persist-before-admission ordering. Rejects empty/duplicate children.
- Children start `Running` (run-plan executes immediately, unlike queued submit); `fanout status` reconciles live per-child state on read, so detached Lab runs, retries, and failures all resolve.
- Both run-plan entry points (executor + attempt-dispatcher) persist before `run_cook_batch`.
- Run-plan result now includes the exact working `fanout status`/`artifacts` commands (acceptance criterion).

## Acceptance criteria mapping
- ✅ run-plan persists one durable batch record before child admission
- ✅ `fanout status <id>` resolves every child (live reconciliation via existing `status`)
- ✅ record survives controller exit / partial admission (written before dispatch)
- ✅ run-plan output includes the exact working status command

## Tests (`agent_task_batch::tests`)
- `fanout_run_plan_persists_batch_record_readable_by_status` — reproduces the #9397 scenario (fanout id `rules-memory-gaps-20260721`), asserts `read_batch` resolves the record with the right child run IDs. **Temp-disable proven**: skipping the write makes this test fail with the exact missing-file symptom.
- `fanout_run_plan_rejects_duplicate_child_run_ids`, `fanout_run_plan_rejects_empty_cooks`.
- Full `agent_task_batch::` suite (10 tests) green.

_Heavy build/full suite left to CI per repo policy; validated with `cargo check -p homeboy-agents -p homeboy-cli --lib` + scoped `agent_task_batch::` tests._