### PR TITLE
Persist Lab observations outside runtime HOME

### DIFF
--- a/crates/homeboy-core/src/paths_tests.rs
+++ b/crates/homeboy-core/src/paths_tests.rs
@@ -6,11 +6,12 @@
 #![cfg(test)]
 
 use crate::paths::{
-    artifact_root, authorize_remote_artifact_path, expand_tilde_path, join_remote_child,
-    join_remote_path, local_path_is_contained, normalize_local_path, resolve_contained_local_path,
-    resolve_optional_base_path, resolve_path_string, runner_session_file, runner_sessions_dir,
-    set_artifact_root_override, set_config_artifact_root_resolver, RemotePathAuthorizationError,
-    RemotePathRootContainment,
+    artifact_root, authorize_remote_artifact_path, expand_tilde_path, homeboy_data,
+    join_remote_child, join_remote_path, local_path_is_contained, normalize_local_path,
+    resolve_contained_local_path, resolve_optional_base_path, resolve_path_string,
+    runner_session_file, runner_sessions_dir, set_artifact_root_override,
+    set_config_artifact_root_resolver, RemotePathAuthorizationError, RemotePathRootContainment,
+    HOMEBOY_DATA_DIR_ENV,
 };
 use crate::test_support::with_isolated_home;
 use std::path::{Path, PathBuf};
@@ -30,6 +31,18 @@ fn artifact_root_defaults_under_homeboy_data() {
             artifact_root().expect("artifact root"),
             home.path().join(".local/share/homeboy/artifacts")
         );
+    });
+}
+
+#[test]
+fn homeboy_data_honors_explicit_durable_directory() {
+    with_isolated_home(|home| {
+        let durable = home.path().join("durable-homeboy-data");
+        std::env::set_var(HOMEBOY_DATA_DIR_ENV, &durable);
+
+        assert_eq!(homeboy_data().expect("homeboy data"), durable);
+
+        std::env::remove_var(HOMEBOY_DATA_DIR_ENV);
     });
 }
 

--- a/crates/homeboy-lab-runner/src/execution/process.rs
+++ b/crates/homeboy-lab-runner/src/execution/process.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -463,10 +463,40 @@ pub(super) fn apply_runner_process_env(
             }
         }
     }
+    preserve_durable_homeboy_data_dir(command, &plan.env);
     command.envs(plan.env.iter()).env(
         homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV,
         serde_json::to_string(&plan.source_snapshot).unwrap_or_default(),
     );
+}
+
+fn preserve_durable_homeboy_data_dir(
+    command: &mut std::process::Command,
+    job_env: &HashMap<String, String>,
+) {
+    let data_dir = durable_homeboy_data_dir_for_job(
+        job_env,
+        std::env::var("HOME").ok().as_deref(),
+        homeboy_core::paths::homeboy_data().ok(),
+    );
+    if let Some(data_dir) = data_dir {
+        command.env(homeboy_core::paths::HOMEBOY_DATA_DIR_ENV, data_dir);
+    }
+}
+
+pub(super) fn durable_homeboy_data_dir_for_job(
+    job_env: &HashMap<String, String>,
+    runner_home: Option<&str>,
+    runner_data_dir: Option<PathBuf>,
+) -> Option<PathBuf> {
+    if job_env.contains_key(homeboy_core::paths::HOMEBOY_DATA_DIR_ENV) {
+        return None;
+    }
+    let job_home = job_env.get("HOME")?;
+    if runner_home == Some(job_home) {
+        return None;
+    }
+    runner_data_dir
 }
 
 fn validate_runner_inherited_secret_env(

--- a/crates/homeboy-lab-runner/src/execution/tests/exec.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/exec.rs
@@ -8,6 +8,39 @@ use homeboy_core::runner_execution_envelope::{
     PATH_MATERIALIZATION_STATUS_MATERIALIZED,
 };
 use serde_json::json;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+#[test]
+fn extension_runtime_home_keeps_homeboy_data_on_the_runner() {
+    let job_env = HashMap::from([("HOME".to_string(), "/job/extension-home".to_string())]);
+    let durable = PathBuf::from("/runner/home/.local/share/homeboy");
+
+    assert_eq!(
+        durable_homeboy_data_dir_for_job(&job_env, Some("/runner/home"), Some(durable.clone())),
+        Some(durable)
+    );
+}
+
+#[test]
+fn explicit_job_data_directory_remains_authoritative() {
+    let job_env = HashMap::from([
+        ("HOME".to_string(), "/job/extension-home".to_string()),
+        (
+            homeboy_core::paths::HOMEBOY_DATA_DIR_ENV.to_string(),
+            "/job/explicit-data".to_string(),
+        ),
+    ]);
+
+    assert_eq!(
+        durable_homeboy_data_dir_for_job(
+            &job_env,
+            Some("/runner/home"),
+            Some(PathBuf::from("/runner/home/.local/share/homeboy"))
+        ),
+        None
+    );
+}
 
 #[test]
 fn daemon_submission_recovers_a_lost_tunnel_before_resending_to_the_same_lease() {

--- a/crates/homeboy-paths/src/lib.rs
+++ b/crates/homeboy-paths/src/lib.rs
@@ -4,6 +4,8 @@ use std::ffi::OsString;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
+pub const HOMEBOY_DATA_DIR_ENV: &str = "HOMEBOY_DATA_DIR";
+
 mod locations;
 mod rigs;
 mod runtime;
@@ -98,6 +100,12 @@ pub fn homeboy_json() -> Result<PathBuf> {
 /// Config/spec files remain under `homeboy()` (`~/.config/homeboy`). This
 /// directory is for machine-local observations such as the SQLite store.
 pub fn homeboy_data() -> Result<PathBuf> {
+    if let Ok(path) = env::var(HOMEBOY_DATA_DIR_ENV) {
+        if !path.trim().is_empty() {
+            return Ok(expand_tilde_path(path));
+        }
+    }
+
     #[cfg(windows)]
     {
         let base = env::var("LOCALAPPDATA")


### PR DESCRIPTION
## Summary

- add an explicit `HOMEBOY_DATA_DIR` override for Homeboy machine-local state
- preserve the runner durable Homeboy data directory when Lab extension isolation replaces `HOME`
- keep explicit job-scoped data-directory overrides authoritative

Lab extension overlays need an isolated configuration HOME, but observation records and default artifacts must outlive the terminal workspace. Previously both were written below the disposable extension runtime HOME, so emitted `homeboy runs show` and `homeboy runs artifacts` commands referred to deleted records.

Closes #9403.

## How to test

1. Run `cargo test -p homeboy-core paths_tests::homeboy_data_honors_explicit_durable_directory`.
2. Run `cargo test -p homeboy-lab-runner extension_runtime_home_keeps_homeboy_data_on_the_runner`.
3. Run `cargo test -p homeboy-lab-runner explicit_job_data_directory_remains_authoritative`.
4. Run `cargo test -p homeboy-paths`.
5. Offload a bench command that requires an extension overlay to a Lab runner.
6. Read its `persisted_run.run_id`, then run `homeboy runner exec <runner> -- homeboy runs show <run-id>` after the Lab workspace reaches terminal cleanup.
7. Confirm the run and its recorded artifacts remain resolvable from the runner durable store.

## Test results

- targeted durable-directory and Lab injection tests pass
- `homeboy-paths`: 7 passed
- `homeboy-lab-runner`: 1,204 passed, 19 unrelated environment-sensitive failures involving local runner registry and promisor git fixtures
- touched files pass `rustfmt --check` and `git diff --check`
