### PR TITLE
test(core): handle reverse-broker file transfer in the fixture (#9408)

### DIFF
--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -1111,6 +1111,38 @@ fn handle_reverse_broker_request(
             .expect("claim broker job");
         return ok(json!({ "claim": claim }));
     }
+    // Reverse-runner file transfer (`RunnerFileChannel::BrokerHttp`) posts
+    // `/files/{mkdir,upload,download}` for the same host the fixture runs on, so
+    // the fixture performs the real filesystem operation. Without these the
+    // detached Lab cook's Homeboy-owned artifact-directory creation fails with
+    // "unknown reverse broker fixture path" (#9408).
+    if request.method == "POST" && request.path == "/files/mkdir" {
+        let path = request.body["path"].as_str().expect("broker mkdir path");
+        std::fs::create_dir_all(path).expect("broker fixture mkdir");
+        return ok(json!({ "created": true }));
+    }
+    if request.method == "POST" && request.path == "/files/upload" {
+        use base64::Engine;
+        let path = request.body["path"].as_str().expect("broker upload path");
+        let encoded = request.body["content_base64"]
+            .as_str()
+            .expect("broker upload content_base64");
+        let content = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .expect("decode broker upload");
+        if let Some(parent) = Path::new(path).parent() {
+            std::fs::create_dir_all(parent).expect("broker fixture upload parent");
+        }
+        std::fs::write(path, content).expect("broker fixture upload write");
+        return ok(json!({ "uploaded": true }));
+    }
+    if request.method == "POST" && request.path == "/files/download" {
+        use base64::Engine;
+        let path = request.body["path"].as_str().expect("broker download path");
+        let content = std::fs::read(path).expect("broker fixture download read");
+        let encoded = base64::engine::general_purpose::STANDARD.encode(content);
+        return ok(json!({ "content_base64": encoded }));
+    }
     if request.method == "GET" {
         if let Some(job_id) = request.path.strip_prefix("/jobs/") {
             let job = store


### PR DESCRIPTION
## Summary

Closes #9408. The `reverse_cook_queue_acceptance` integration test (`detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once`) fails on `main`.

## Root cause

A detached Lab cook creates its Homeboy-owned artifact directory (`_lab_workspaces/...`) through the reverse-runner file-transfer channel (`RunnerFileChannel::BrokerHttp`), which POSTs `/files/mkdir` to the broker. The `ReverseBrokerFixture` only routed `/runner/sessions`, `/runner/jobs`, `/runner/jobs/claim`, `/jobs/*`, and the `events/heartbeat/finish` actions — so `/files/mkdir` fell through to the catch-all:

```
mkdir failed: broker request failed: {"message":"unknown reverse broker fixture path"}
```

That failed the cook (`run_state: Failed`, `status: retries_exhausted`) before it could reach the `in_flight` acceptance the test asserts, so `assert_eq!(accepted["status"], "in_flight")` panicked.

Routing file transfer over the broker is correct by design for a reverse-connected runner (there is no direct SSH to it) — the fixture simply never implemented the `/files/*` endpoints.

## Fix

Teach `ReverseBrokerFixture` to handle `/files/{mkdir,upload,download}` by performing the real local filesystem operation (the fixture "runner" shares the host), matching the client's `file_path_body` / `file_upload_body` request shapes and the `content_base64` download response. This exercises the genuine reverse-broker file-transfer path rather than masking it.

## Verification

- `cargo check -p homeboy-core --lib --features test-support` (the `test_support` module is feature-gated) and `cargo fmt` — clean.
- The integration test itself spawns full binary builds and runs ~260s; per this repo's build policy it is left to CI to run.