### PR TITLE
Reconcile terminal lifecycle provider models

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1078,6 +1078,9 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     }
     if record.state.is_terminal() {
         if let Ok(aggregate) = store::read_aggregate(&record.run_id) {
+            if reconcile_terminal_provider_models(&mut record, &aggregate) {
+                store::write_record(&record)?;
+            }
             if !crate::agent_task_lifecycle::terminal_artifact_projection_is_verified(
                 &record, &aggregate,
             )? {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_record_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_record_ops.rs
@@ -128,6 +128,98 @@ pub(crate) fn update_lifecycle_from_record(record: &mut AgentTaskRunRecord, plan
     };
 }
 
+pub(crate) fn reconcile_terminal_provider_models(
+    record: &mut AgentTaskRunRecord,
+    aggregate: &AgentTaskAggregate,
+) -> bool {
+    let mut changed = false;
+    for outcome in &aggregate.outcomes {
+        let Some(model) = outcome
+            .metadata
+            .get("model")
+            .and_then(Value::as_str)
+            .filter(|model| !model.trim().is_empty())
+        else {
+            continue;
+        };
+
+        if let Some(task) = record
+            .tasks
+            .iter_mut()
+            .find(|task| task.task_id == outcome.task_id)
+        {
+            changed |= replace_model(&mut task.model, model);
+        }
+        for handle in record
+            .provider_handles
+            .iter_mut()
+            .filter(|handle| handle.task_id == outcome.task_id)
+        {
+            changed |= replace_metadata_model(&mut handle.metadata, model);
+        }
+        for runtime in record
+            .lifecycle
+            .provider_runtime
+            .iter_mut()
+            .filter(|runtime| runtime.task_id == outcome.task_id)
+        {
+            changed |= replace_metadata_model(&mut runtime.metadata, model);
+            if let Some(executor) = runtime
+                .metadata
+                .get_mut("executor")
+                .and_then(Value::as_object_mut)
+            {
+                changed |= replace_json_model(executor, model);
+            }
+        }
+        if let Some(executions) = record
+            .metadata
+            .get_mut("provider_executions")
+            .and_then(Value::as_array_mut)
+        {
+            for execution in executions.iter_mut().filter(|execution| {
+                execution["task_id"] == outcome.task_id && execution["state"] == "succeeded"
+            }) {
+                if let Some(metadata) = execution.as_object_mut() {
+                    changed |= replace_json_model(metadata, model);
+                }
+            }
+        }
+    }
+    if changed {
+        let timestamp = now_timestamp();
+        record.updated_at = Some(timestamp.clone());
+        record.lifecycle.updated_at = Some(timestamp);
+    }
+    changed
+}
+
+fn replace_model(current: &mut Option<String>, model: &str) -> bool {
+    if current.as_deref() == Some(model) {
+        return false;
+    }
+    *current = Some(model.to_string());
+    true
+}
+
+fn replace_metadata_model(metadata: &mut Value, model: &str) -> bool {
+    if !metadata.is_object() {
+        *metadata = json!({});
+    }
+    replace_json_model(
+        metadata.as_object_mut().expect("provider metadata object"),
+        model,
+    )
+}
+
+fn replace_json_model(metadata: &mut serde_json::Map<String, Value>, model: &str) -> bool {
+    if metadata.get("model").and_then(Value::as_str) == Some(model) {
+        return false;
+    }
+    metadata.insert("model".to_string(), json!(model));
+    true
+}
+
 fn provider_executions_for_task(
     record: &AgentTaskRunRecord,
     task_id: &str,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -1235,6 +1235,66 @@ fn completed_generic_executor_outcome_preserves_runtime_evidence_without_provide
 }
 
 #[test]
+fn status_repairs_terminal_provider_model_from_aggregate_idempotently() {
+    with_isolated_home(|_| {
+        let mut plan = test_plan();
+        plan.tasks[0].executor.backend = "opencode".to_string();
+        plan.tasks[0].executor.model = None;
+        let mut aggregate = succeeded_aggregate(&plan);
+        aggregate.outcomes[0].metadata = json!({ "model": "openai/gpt-5.6-terra" });
+        record_completed_run(&plan, &aggregate, Some("terminal-model-repair")).expect("recorded");
+
+        let mut stale = store::read_record("terminal-model-repair").expect("record loaded");
+        stale.tasks[0].model = None;
+        stale.lifecycle.provider_runtime[0].metadata["model"] = Value::Null;
+        stale.lifecycle.provider_runtime[0].metadata["executor"]["model"] = Value::Null;
+        stale.metadata["latest_promotion"] = json!({ "status": "applied" });
+        stale.metadata["provider_executions"] = json!([
+            {
+                "task_id": "task-a",
+                "state": "failed",
+                "model": "openai/failed-attempt"
+            },
+            {
+                "task_id": "task-a",
+                "state": "succeeded",
+                "model": null
+            }
+        ]);
+        store::write_record(&stale).expect("stale terminal record stored");
+
+        let repaired = status("terminal-model-repair").expect("status repaired model");
+
+        assert_eq!(repaired.state, AgentTaskRunState::Succeeded);
+        assert_eq!(repaired.metadata["latest_promotion"]["status"], "applied");
+        assert_eq!(
+            repaired.tasks[0].model.as_deref(),
+            Some("openai/gpt-5.6-terra")
+        );
+        assert_eq!(
+            repaired.lifecycle.provider_runtime[0].metadata["model"],
+            "openai/gpt-5.6-terra"
+        );
+        assert_eq!(
+            repaired.lifecycle.provider_runtime[0].metadata["executor"]["model"],
+            "openai/gpt-5.6-terra"
+        );
+        assert_eq!(
+            repaired.metadata["provider_executions"][0]["model"],
+            "openai/failed-attempt"
+        );
+        assert_eq!(
+            repaired.metadata["provider_executions"][1]["model"],
+            "openai/gpt-5.6-terra"
+        );
+
+        let repeated = status("terminal-model-repair").expect("repeat status");
+        assert_eq!(repeated.updated_at, repaired.updated_at);
+        assert_eq!(repeated.lifecycle, repaired.lifecycle);
+    });
+}
+
+#[test]
 fn cancel_keeps_run_state_and_execution_state_paired() {
     with_isolated_home(|_| {
         let plan = test_plan();


### PR DESCRIPTION
## Summary

- reconcile concrete provider models from terminal aggregate outcomes into stale durable task/runtime projections
- persist the selected model on succeeded execution evidence while preserving failed-attempt provenance
- keep the repair idempotent and leave promotion, gate, state, and artifact evidence untouched

Closes #9411.

## How to test

1. Run `cargo test -p homeboy-agents status_repairs_terminal_provider_model_from_aggregate_idempotently`.
2. Confirm the regression passes and repairs a stale terminal runtime model from aggregate evidence.
3. Confirm the test preserves promotion metadata and the failed attempt model, and a repeated `status()` call makes no further lifecycle change.
4. Run `rustfmt --edition 2021 --check crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_record_ops.rs crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs`.
5. Run `git diff --check`.

## Compatibility

This is backwards-compatible for external consumers. It fills stale provider-model fields only from the existing authoritative terminal aggregate, changes no persisted schema, and preserves historical failed-attempt models plus promotion, gate, state, and artifact evidence.

## AI assistance

- **Tool:** OpenCode
- **Model:** `openai/gpt-5.6-sol`
- **Used for:** Root-cause analysis, implementation, and tests
- **Human owner:** Chris reviews and owns the change
