### PR TITLE
Fix explicit stale live lease adoption

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -634,7 +634,7 @@ fn connect_with_orphan_adoption_and_live_lease(
         homeboy,
         live_lease_expectation,
         &daemon,
-        &configured_build_identity,
+        &expected_identity,
     ) {
         return Ok(session_write_failure_report(
             runner_id,

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -579,6 +579,19 @@ pub(super) fn remote_daemon_connect_action_for_runner(
     // proves no active or unresolved work. The stop itself remains lease-bound
     // through Homeboy's daemon lifecycle command.
     if !status.fresh {
+        if live_lease_expectation
+            == Some((
+                daemon.lease_id.as_deref().expect("checked above"),
+                daemon.pid.expect("checked above"),
+            ))
+            && daemon
+                .build_identity
+                .as_deref()
+                .is_some_and(|identity| !identity.trim().is_empty())
+            && status.endpoint_probe_error.is_none()
+        {
+            return Ok(RemoteDaemonConnectAction::Reattach);
+        }
         if status.active_jobs == 0
             && status.work_evidence.is_authoritatively_idle()
             && status.endpoint_probe_error.is_none()

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -134,6 +134,37 @@ fn explicit_live_lease_adoption_requires_the_exact_current_lease_and_pid() {
 }
 
 #[test]
+fn explicit_live_lease_adoption_accepts_an_exact_reachable_stale_daemon() {
+    let session = direct_ssh_session("lease-recorded");
+    let mut status = remote_daemon_status_for_test(false, true, 1, "lease-live", 4646);
+    status.daemon.as_mut().expect("daemon").build_identity = Some("homeboy test+live".to_string());
+
+    assert_eq!(
+        remote_daemon::remote_daemon_connect_action_for_runner(
+            Some(&session),
+            &status,
+            "homeboy test+configured",
+            "runner-a",
+            Some(("lease-live", 4646)),
+        )
+        .expect("exact operator adoption reattaches without replacing the live daemon"),
+        RemoteDaemonConnectAction::Reattach,
+    );
+
+    for expectation in [Some(("lease-other", 4646)), Some(("lease-live", 9999))] {
+        assert!(remote_daemon::remote_daemon_connect_action_for_runner(
+            Some(&session),
+            &status,
+            "homeboy test+configured",
+            "runner-a",
+            expectation,
+        )
+        .expect_err("changed stale lease or PID must fail closed")
+        .contains("--adopt-live-lease lease-live --expected-live-pid 4646"));
+    }
+}
+
+#[test]
 fn stale_active_mismatched_daemon_never_reattaches_or_adopts() {
     let session = direct_ssh_session("lease-recorded");
     let mut status = remote_daemon_status_for_test(false, true, 1, "lease-live", 4646);


### PR DESCRIPTION
Fixes #9414

## Summary
- honor an exact explicit live lease and PID when the stale persisted lease differs but the daemon endpoint is reachable
- require and verify the selected live daemon build identity during adoption
- retain fail-closed behavior for lease, PID, and identity drift

## How to test
1. Run `cargo test -p homeboy-lab-runner explicit_live_lease_adoption --lib -- --test-threads=1`.
2. Run `cargo test -p homeboy-lab-runner live_lease --lib -- --test-threads=1`.
3. Run `cargo clippy -p homeboy-lab-runner --lib`.
4. Confirm `cargo fmt --check` and `git diff --check` pass.

## Compatibility
No command-line or extension contract changes. Explicit adoption now performs the recovery already advertised by `runner connect`; implicit reconnect behavior remains fail-closed.