### PR TITLE
refactor(core): extract runner-file HTTP ops from daemon god file

### DIFF
--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -1,4 +1,3 @@
-use base64::Engine;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -15,7 +14,6 @@ use crate::api_jobs::{
     DaemonActiveJobRecoveryEvidence, JobStatus, JobStore, LocalRunnerJob,
     RunnerJobLifecycleMetadata,
 };
-use crate::broker_auth::BrokerScope;
 use crate::build_identity;
 use crate::error::{Error, RemoteCommandFailedDetails, Result, TargetDetails};
 use crate::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnalysisJobRunner};
@@ -37,6 +35,7 @@ mod daemon_lease;
 mod patch_capture;
 mod remote_runner;
 pub mod runner_exec_driver;
+mod runner_files;
 pub mod runner_workspace_root;
 pub use artifact_download::ArtifactDownload;
 pub use broker_config::{render_broker_config, BrokerConfig, BrokerConfigOptions, ServiceIdentity};
@@ -47,6 +46,7 @@ pub use control::{
 };
 use daemon_lease::{daemon_state_identity, freshness_report_from_validation, validate_lease_file};
 use patch_capture::{capture_baseline, capture_patch_report};
+use runner_files::{create_runner_file_directory, download_runner_file, upload_runner_file};
 
 pub const DEFAULT_ADDR: &str = "127.0.0.1:0";
 
@@ -421,7 +421,7 @@ struct ExecRequest {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-struct FilePathRequest {
+pub(super) struct FilePathRequest {
     runner_id: String,
     path: String,
     #[serde(default)]
@@ -429,7 +429,7 @@ struct FilePathRequest {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-struct FileUploadRequest {
+pub(super) struct FileUploadRequest {
     runner_id: String,
     path: String,
     #[serde(default)]
@@ -1589,199 +1589,6 @@ fn daemon_freshness_report(job_store: &JobStore) -> Result<DaemonFreshnessReport
         .filter(|job| matches!(job.status, JobStatus::Queued | JobStatus::Running))
         .count();
     Ok(freshness_report_from_validation(&validation, active_jobs))
-}
-
-fn create_runner_file_directory(
-    body: Option<serde_json::Value>,
-    broker_auth: &remote_runner::BrokerAuthContext,
-) -> Result<serde_json::Value> {
-    let request: FilePathRequest = serde_json::from_value(body.unwrap_or_else(|| json!({})))
-        .map_err(|err| {
-            Error::internal_json(
-                err.to_string(),
-                Some("parse file mkdir request".to_string()),
-            )
-        })?;
-    broker_auth.authorize(BrokerScope::Submit, Some(&request.runner_id))?;
-    let path = resolve_runner_workspace_path(
-        &request.runner_id,
-        &request.path,
-        request.workspace_root.as_deref(),
-    )?;
-    fs::create_dir_all(&path).map_err(|err| {
-        Error::internal_io(err.to_string(), Some(format!("create {}", path.display())))
-    })?;
-    Ok(json!({
-        "runner_id": request.runner_id,
-        "path": path.display().to_string(),
-    }))
-}
-
-fn upload_runner_file(
-    body: Option<serde_json::Value>,
-    broker_auth: &remote_runner::BrokerAuthContext,
-) -> Result<serde_json::Value> {
-    let request: FileUploadRequest = serde_json::from_value(body.unwrap_or_else(|| json!({})))
-        .map_err(|err| {
-            Error::internal_json(
-                err.to_string(),
-                Some("parse file upload request".to_string()),
-            )
-        })?;
-    broker_auth.authorize(BrokerScope::Submit, Some(&request.runner_id))?;
-    let path = resolve_runner_workspace_path(
-        &request.runner_id,
-        &request.path,
-        request.workspace_root.as_deref(),
-    )?;
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|err| {
-            Error::internal_io(
-                err.to_string(),
-                Some(format!("create {}", parent.display())),
-            )
-        })?;
-    }
-    let content = base64::engine::general_purpose::STANDARD
-        .decode(&request.content_base64)
-        .map_err(|err| {
-            Error::validation_invalid_argument(
-                "content_base64",
-                format!("runner file upload content is not valid base64: {err}"),
-                None,
-                None,
-            )
-        })?;
-    fs::write(&path, &content).map_err(|err| {
-        Error::internal_io(err.to_string(), Some(format!("write {}", path.display())))
-    })?;
-    Ok(json!({
-        "runner_id": request.runner_id,
-        "path": path.display().to_string(),
-        "size_bytes": content.len(),
-    }))
-}
-
-fn download_runner_file(
-    body: Option<serde_json::Value>,
-    broker_auth: &remote_runner::BrokerAuthContext,
-) -> Result<serde_json::Value> {
-    let request: FilePathRequest = serde_json::from_value(body.unwrap_or_else(|| json!({})))
-        .map_err(|err| {
-            Error::internal_json(
-                err.to_string(),
-                Some("parse file download request".to_string()),
-            )
-        })?;
-    broker_auth.authorize(BrokerScope::Submit, Some(&request.runner_id))?;
-    let path = resolve_runner_workspace_path(
-        &request.runner_id,
-        &request.path,
-        request.workspace_root.as_deref(),
-    )?;
-    let content = fs::read(&path).map_err(|err| {
-        Error::internal_io(err.to_string(), Some(format!("read {}", path.display())))
-    })?;
-    Ok(json!({
-        "runner_id": request.runner_id,
-        "path": path.display().to_string(),
-        "size_bytes": content.len(),
-        "content_base64": base64::engine::general_purpose::STANDARD.encode(content),
-    }))
-}
-
-fn resolve_runner_workspace_path(
-    runner_id: &str,
-    requested_path: &str,
-    request_workspace_root: Option<&str>,
-) -> Result<PathBuf> {
-    let resolved_root;
-    let workspace_root = match request_workspace_root.filter(|root| !root.trim().is_empty()) {
-        Some(root) => root,
-        None => {
-            resolved_root = runner_workspace_root::runner_workspace_root(runner_id);
-            resolved_root.as_deref().ok_or_else(|| {
-                Error::validation_invalid_argument(
-                    "workspace_root",
-                    format!("runner `{runner_id}` file API requires workspace_root"),
-                    Some(runner_id.to_string()),
-                    Some(vec![
-                        "Configure the runner workspace_root before using daemon file transfer."
-                            .to_string(),
-                    ]),
-                )
-            })?
-        }
-    };
-    let root = fs::canonicalize(workspace_root).map_err(|err| {
-        Error::internal_io(
-            err.to_string(),
-            Some(format!(
-                "canonicalize runner workspace_root {workspace_root}"
-            )),
-        )
-    })?;
-    let requested = Path::new(requested_path);
-    let candidate = if requested.is_absolute() {
-        requested.to_path_buf()
-    } else {
-        root.join(requested)
-    };
-    let normalized = canonicalize_existing_prefix(&normalize_path(&candidate));
-    if !normalized.starts_with(&root) {
-        return Err(Error::validation_invalid_argument(
-            "path",
-            "runner file path must stay inside the runner workspace_root",
-            Some(requested_path.to_string()),
-            Some(vec![format!(
-                "Runner `{runner_id}` workspace_root is {}.",
-                root.display()
-            )]),
-        ));
-    }
-    Ok(normalized)
-}
-
-fn normalize_path(path: &Path) -> PathBuf {
-    use std::path::Component;
-
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            _ => normalized.push(component.as_os_str()),
-        }
-    }
-    normalized
-}
-
-fn canonicalize_existing_prefix(path: &Path) -> PathBuf {
-    if let Ok(canonical) = fs::canonicalize(path) {
-        return canonical;
-    }
-
-    let mut missing = Vec::new();
-    let mut current = path;
-    loop {
-        if let Ok(canonical) = fs::canonicalize(current) {
-            let mut resolved = canonical;
-            for component in missing.iter().rev() {
-                resolved.push(component);
-            }
-            return resolved;
-        }
-        let Some(file_name) = current.file_name() else {
-            return path.to_path_buf();
-        };
-        missing.push(file_name.to_os_string());
-        let Some(parent) = current.parent() else {
-            return path.to_path_buf();
-        };
-        current = parent;
-    }
 }
 
 pub(super) fn daemon_endpoint_response(endpoint: &str, body: serde_json::Value) -> HttpResponse {
@@ -3384,5 +3191,5 @@ fn terminate_pid(pid: u32) -> Result<()> {
 }
 
 #[cfg(test)]
-#[path = "../../../tests/core/daemon_test.rs"]
+#[path = "../../../../tests/core/daemon_test.rs"]
 mod daemon_test;

--- a/crates/homeboy-core/src/daemon/runner_files.rs
+++ b/crates/homeboy-core/src/daemon/runner_files.rs
@@ -1,0 +1,208 @@
+//! Runner-file HTTP operations for the daemon: create workspace file
+//! directories, upload/download runner files, and resolve/normalize workspace
+//! paths safely within the runner root. Extracted from the `daemon` god file.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use base64::Engine;
+use serde_json::json;
+
+use super::remote_runner;
+use super::runner_workspace_root;
+use super::{FilePathRequest, FileUploadRequest};
+use crate::broker_auth::BrokerScope;
+use crate::error::{Error, Result};
+
+pub(super) fn create_runner_file_directory(
+    body: Option<serde_json::Value>,
+    broker_auth: &remote_runner::BrokerAuthContext,
+) -> Result<serde_json::Value> {
+    let request: FilePathRequest = serde_json::from_value(body.unwrap_or_else(|| json!({})))
+        .map_err(|err| {
+            Error::internal_json(
+                err.to_string(),
+                Some("parse file mkdir request".to_string()),
+            )
+        })?;
+    broker_auth.authorize(BrokerScope::Submit, Some(&request.runner_id))?;
+    let path = resolve_runner_workspace_path(
+        &request.runner_id,
+        &request.path,
+        request.workspace_root.as_deref(),
+    )?;
+    fs::create_dir_all(&path).map_err(|err| {
+        Error::internal_io(err.to_string(), Some(format!("create {}", path.display())))
+    })?;
+    Ok(json!({
+        "runner_id": request.runner_id,
+        "path": path.display().to_string(),
+    }))
+}
+
+pub(super) fn upload_runner_file(
+    body: Option<serde_json::Value>,
+    broker_auth: &remote_runner::BrokerAuthContext,
+) -> Result<serde_json::Value> {
+    let request: FileUploadRequest = serde_json::from_value(body.unwrap_or_else(|| json!({})))
+        .map_err(|err| {
+            Error::internal_json(
+                err.to_string(),
+                Some("parse file upload request".to_string()),
+            )
+        })?;
+    broker_auth.authorize(BrokerScope::Submit, Some(&request.runner_id))?;
+    let path = resolve_runner_workspace_path(
+        &request.runner_id,
+        &request.path,
+        request.workspace_root.as_deref(),
+    )?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!("create {}", parent.display())),
+            )
+        })?;
+    }
+    let content = base64::engine::general_purpose::STANDARD
+        .decode(&request.content_base64)
+        .map_err(|err| {
+            Error::validation_invalid_argument(
+                "content_base64",
+                format!("runner file upload content is not valid base64: {err}"),
+                None,
+                None,
+            )
+        })?;
+    fs::write(&path, &content).map_err(|err| {
+        Error::internal_io(err.to_string(), Some(format!("write {}", path.display())))
+    })?;
+    Ok(json!({
+        "runner_id": request.runner_id,
+        "path": path.display().to_string(),
+        "size_bytes": content.len(),
+    }))
+}
+
+pub(super) fn download_runner_file(
+    body: Option<serde_json::Value>,
+    broker_auth: &remote_runner::BrokerAuthContext,
+) -> Result<serde_json::Value> {
+    let request: FilePathRequest = serde_json::from_value(body.unwrap_or_else(|| json!({})))
+        .map_err(|err| {
+            Error::internal_json(
+                err.to_string(),
+                Some("parse file download request".to_string()),
+            )
+        })?;
+    broker_auth.authorize(BrokerScope::Submit, Some(&request.runner_id))?;
+    let path = resolve_runner_workspace_path(
+        &request.runner_id,
+        &request.path,
+        request.workspace_root.as_deref(),
+    )?;
+    let content = fs::read(&path).map_err(|err| {
+        Error::internal_io(err.to_string(), Some(format!("read {}", path.display())))
+    })?;
+    Ok(json!({
+        "runner_id": request.runner_id,
+        "path": path.display().to_string(),
+        "size_bytes": content.len(),
+        "content_base64": base64::engine::general_purpose::STANDARD.encode(content),
+    }))
+}
+
+fn resolve_runner_workspace_path(
+    runner_id: &str,
+    requested_path: &str,
+    request_workspace_root: Option<&str>,
+) -> Result<PathBuf> {
+    let resolved_root;
+    let workspace_root = match request_workspace_root.filter(|root| !root.trim().is_empty()) {
+        Some(root) => root,
+        None => {
+            resolved_root = runner_workspace_root::runner_workspace_root(runner_id);
+            resolved_root.as_deref().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "workspace_root",
+                    format!("runner `{runner_id}` file API requires workspace_root"),
+                    Some(runner_id.to_string()),
+                    Some(vec![
+                        "Configure the runner workspace_root before using daemon file transfer."
+                            .to_string(),
+                    ]),
+                )
+            })?
+        }
+    };
+    let root = fs::canonicalize(workspace_root).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!(
+                "canonicalize runner workspace_root {workspace_root}"
+            )),
+        )
+    })?;
+    let requested = Path::new(requested_path);
+    let candidate = if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        root.join(requested)
+    };
+    let normalized = canonicalize_existing_prefix(&normalize_path(&candidate));
+    if !normalized.starts_with(&root) {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "runner file path must stay inside the runner workspace_root",
+            Some(requested_path.to_string()),
+            Some(vec![format!(
+                "Runner `{runner_id}` workspace_root is {}.",
+                root.display()
+            )]),
+        ));
+    }
+    Ok(normalized)
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    use std::path::Component;
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn canonicalize_existing_prefix(path: &Path) -> PathBuf {
+    if let Ok(canonical) = fs::canonicalize(path) {
+        return canonical;
+    }
+
+    let mut missing = Vec::new();
+    let mut current = path;
+    loop {
+        if let Ok(canonical) = fs::canonicalize(current) {
+            let mut resolved = canonical;
+            for component in missing.iter().rev() {
+                resolved.push(component);
+            }
+            return resolved;
+        }
+        let Some(file_name) = current.file_name() else {
+            return path.to_path_buf();
+        };
+        missing.push(file_name.to_os_string());
+        let Some(parent) = current.parent() else {
+            return path.to_path_buf();
+        };
+        current = parent;
+    }
+}


### PR DESCRIPTION
## Summary
Begins decomposing `daemon.rs` — the **3388-line** top god file (`god_file` finding). Extracts the cohesive runner-file HTTP operation cluster into a submodule.

## What moved
`create_runner_file_directory`, `upload_runner_file`, `download_runner_file`, and the workspace-path safety helpers `resolve_runner_workspace_path` / `normalize_path` / `canonicalize_existing_prefix` → `daemon/runner_files.rs`.

## Clean seam
- All six functions are file-private (called only by the daemon's route handlers).
- The three entry points (`create`/`upload`/`download_runner_file`) are `pub(super)` for the route handlers; the request structs (`FilePathRequest`, `FileUploadRequest`) are `pub(super)`.
- The generic `daemon_endpoint_response` helper that sat adjacent stayed in `mod.rs` (it's not runner-file-specific) — boundary trimmed to exclude it.

## Mechanics
- Converted `daemon.rs` → `daemon/{mod.rs, runner_files.rs}` (`git mv`, 94% rename, history preserved). The module path `daemon` is unchanged so `mod.rs`'s `crate::` paths stay valid; fixed the `#[path = "…/tests/core/daemon_test.rs"]` attribute (now one directory deeper).
- `daemon/mod.rs`: **3388 → 3197 lines**; `runner_files.rs`: 208.

## Verification
- `cargo check -p homeboy-core --lib` clean (no new warnings).
- Runner-file route tests pass; behavior preserved.

### Pre-existing flakiness (not introduced here)
The daemon suite has 3 order-dependent flaky tests (`daemon_operation_lock_recovers_after_owner_exits_without_drop`, `remote_runner_broker_redacts_secret_env_from_public_surfaces`, `legacy_child_recovery_exact_evidence_is_idempotent_and_conflicts_fail_closed`) that fail identically on clean `main` — **130 passed / 3 failed on both this branch and `main`** (verified by stash). They fail in isolation too (shared-state/lock ordering). Unrelated to this move.

## Note
A first cut on the largest remaining god file. The stop-orchestration cluster (~380 lines) and the HTTP routing/admission cluster are further candidate seams for follow-ups.
