### PR TITLE
fix(lab): keep gitignored .homeboy out of the synthetic snapshot baseline (#9399)

### DIFF
--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -429,7 +429,12 @@ fn materialize_snapshot_git_baseline(envelope: &RunnerExecutionEnvelope) -> Resu
         lab,
     )
     .map(|_| ())
-    .map_err(Error::internal_unexpected)
+    // Baseline materialization is Homeboy infrastructure setup that runs before
+    // any provider execution. A failure here is a transient/infrastructure
+    // condition, not a provider outcome — classify it retryable so recovery can
+    // re-attempt rather than terminalizing the cook as a provider failure
+    // (#9399).
+    .map_err(|message| Error::internal_unexpected(message).with_retryable(true))
 }
 
 /// Materialize broker-owned command files in the worker's durable data root and

--- a/crates/homeboy-lab-runner/src/workspace/provenance.rs
+++ b/crates/homeboy-lab-runner/src/workspace/provenance.rs
@@ -80,17 +80,7 @@ pub(crate) fn materialize_verified_lab_snapshot_git_baseline(
             "--initial-branch=homeboy-snapshot-baseline",
         ],
     )?;
-    git(
-        materialized_workspace_path,
-        &[
-            "add",
-            "--all",
-            "--",
-            SYNTHETIC_BASELINE_PATHS[0],
-            SYNTHETIC_BASELINE_PATHS[1],
-            SYNTHETIC_BASELINE_PATHS[2],
-        ],
-    )?;
+    stage_synthetic_baseline(materialized_workspace_path)?;
     let tree = git(materialized_workspace_path, &["write-tree"])?;
     let message = synthetic_snapshot_baseline_message(&provenance);
     let commit = git_with_env(
@@ -793,6 +783,52 @@ fn validate_content_manifest(
         }
     }
     Ok(())
+}
+
+/// Stage the synthetic snapshot baseline, keeping Homeboy-owned runner metadata
+/// (`.homeboy/runner-workspace.json`, `.homeboy/lab-at-files/**`) out of the
+/// committed tree.
+///
+/// When the repository itself gitignores `.homeboy`, the metadata is already
+/// excluded by gitignore — and `git add --all -- . :(exclude).homeboy/...`
+/// fails, because the explicit `.` pathspec makes Git treat the ignored
+/// `.homeboy` directory as an explicit add target and reject it ("The following
+/// paths are ignored by one of your .gitignore files: .homeboy"). That blocked
+/// committed-harvest baseline materialization on any repo that ignores
+/// `.homeboy` (#9399). In that case, stage with a bare `git add --all`, which
+/// respects `.gitignore` silently. Otherwise use the explicit exclude pathspecs
+/// so the metadata is kept out of a repo that does not ignore `.homeboy`.
+fn stage_synthetic_baseline(workspace: &Path) -> std::result::Result<(), String> {
+    if homeboy_metadata_is_gitignored(workspace) {
+        git(workspace, &["add", "--all"])?;
+    } else {
+        git(
+            workspace,
+            &[
+                "add",
+                "--all",
+                "--",
+                SYNTHETIC_BASELINE_PATHS[0],
+                SYNTHETIC_BASELINE_PATHS[1],
+                SYNTHETIC_BASELINE_PATHS[2],
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+/// Whether the repository's own ignore rules already exclude the `.homeboy`
+/// runner-metadata directory, so `git add --all` will never stage it.
+fn homeboy_metadata_is_gitignored(workspace: &Path) -> bool {
+    // `git check-ignore` exits 0 when the path is ignored, 1 when it is not, and
+    // >1 on error. Treat only a clean "ignored" (0) as gitignored so a
+    // check-ignore failure falls back to the explicit-exclude path.
+    Command::new("git")
+        .args(["check-ignore", "-q", ".homeboy"])
+        .current_dir(workspace)
+        .status()
+        .map(|status| status.code() == Some(0))
+        .unwrap_or(false)
 }
 
 fn git(cwd: &Path, args: &[&str]) -> std::result::Result<String, String> {
@@ -1933,5 +1969,69 @@ mod tests {
         .expect_err("changed snapshot workspace must fail");
         assert!(error.contains("runner workspace sync --mode snapshot"));
         assert!(!error.contains("git status --short"));
+    }
+
+    #[test]
+    fn synthetic_baseline_succeeds_when_the_repository_gitignores_homeboy_metadata() {
+        // A repository that ignores `.homeboy` must remain Cook-able on Lab: the
+        // committed-harvest baseline previously died with "The following paths
+        // are ignored by one of your .gitignore files: .homeboy" because the
+        // explicit `.` add pathspec made Git treat the ignored metadata
+        // directory as an explicit add target (#9399).
+        let workspace = tempfile::tempdir().expect("runner workspace");
+        std::fs::write(workspace.path().join(".gitignore"), ".homeboy/\n")
+            .expect("repository ignores .homeboy");
+        std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("snapshot source");
+        std::fs::create_dir_all(workspace.path().join(".homeboy/lab-at-files"))
+            .expect("runner metadata directory");
+        std::fs::write(
+            workspace.path().join(".homeboy/runner-workspace.json"),
+            "runner-owned metadata\n",
+        )
+        .expect("runner metadata");
+        std::fs::write(
+            workspace.path().join(".homeboy/lab-at-files/handoff.json"),
+            "lab @file materialization\n",
+        )
+        .expect("lab at-file metadata");
+
+        let snapshot = snapshot(workspace.path());
+        let lab = lab(workspace.path(), &snapshot);
+        let baseline = materialize_verified_lab_snapshot_git_baseline(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot,
+            lab,
+        )
+        .expect("synthetic baseline succeeds despite gitignored .homeboy");
+
+        let tree = git(workspace.path(), &["ls-tree", "-r", "--name-only", "HEAD"])
+            .expect("list baseline tree");
+        // Real, non-ignored source is present; ignored Homeboy metadata is not.
+        assert!(
+            tree.contains("file.txt"),
+            "real source is committed: {tree}"
+        );
+        assert!(
+            !tree.contains(".homeboy"),
+            "ignored Homeboy metadata is absent from the baseline tree: {tree}"
+        );
+
+        // A real, non-ignored provider change is still detectable against the
+        // baseline.
+        std::fs::write(
+            workspace.path().join("provider-edit.txt"),
+            "provider edit\n",
+        )
+        .expect("provider edit");
+        stage_synthetic_baseline(workspace.path()).expect("stage provider delta");
+        let patch = git(
+            workspace.path(),
+            &["diff", "--cached", "--binary", "--full-index", &baseline],
+        )
+        .expect("provider delta");
+        assert!(patch.contains("provider-edit.txt"));
+        assert!(!patch.contains("runner-workspace.json"));
+        assert!(!patch.contains("handoff.json"));
     }
 }


### PR DESCRIPTION
## Summary

Closes #9399. A Lab Cook (`cook-ssi-673`) failed **before provider execution** while materializing its verified snapshot Git baseline, on any repository that gitignores `.homeboy`:

```
git add --all -- . :(exclude).homeboy/runner-workspace.json :(exclude).homeboy/lab-at-files/** failed:
The following paths are ignored by one of your .gitignore files: .homeboy
```

## Root cause

The synthetic baseline stages with `git add --all -- . :(exclude).homeboy/runner-workspace.json :(exclude).homeboy/lab-at-files/**`. The explicit `.` pathspec makes Git treat the ignored `.homeboy` runner-metadata directory as an **explicit add target** and reject it. The two `:(exclude)` entries only cover specific files, so the ignored parent directory still triggers the fatal error (exit 1) — blocking committed-harvest baseline materialization on any repo that ignores `.homeboy`.

## Fix

- New `stage_synthetic_baseline` helper: when the repository already gitignores `.homeboy` (`git check-ignore -q .homeboy`), stage with a bare `git add --all` — `.gitignore` silently excludes the metadata, and there is no explicit `.` pathspec to error on. Repos that do **not** ignore `.homeboy` keep the explicit `.`-plus-`:(exclude)` behavior, so `.homeboy/runner-workspace.json` and `.homeboy/lab-at-files/**` stay out of candidate diffs either way.
- Classify a baseline-materialization failure as **retryable infrastructure** (`.with_retryable(true)`) in the reverse worker, rather than terminalizing the cook as a provider failure — this is Homeboy setup that runs before any provider executes.

## Acceptance criteria

1. ✅ Fixture repository ignores `.homeboy`.
2. ✅ Lab materialization writes Homeboy runner metadata under `.homeboy`.
3. ✅ Committed-change harvest baseline succeeds (test asserts `materialize_verified_lab_snapshot_git_baseline` returns Ok).
4. ✅ Homeboy metadata is absent from harvested patches and commits (test asserts `.homeboy` not in the baseline tree; `runner-workspace.json`/`handoff.json` not in the delta).
5. ✅ Real non-ignored source changes remain detectable (test asserts `provider-edit.txt` appears in the delta).

## Tests

`synthetic_baseline_succeeds_when_the_repository_gitignores_homeboy_metadata` — **temp-disable proven**: with the gitignore branch disabled it fails with the exact production error string. The other 18 provenance baseline tests still pass (the non-ignoring path is unchanged).

## Notes

- `filesystem_snapshot_dispatches_providers_and_harvests_only_changed_candidates` fails identically on clean `origin/main` (full-scheduler-dispatch environment flake) — pre-existing, unrelated; this PR adds zero new failures.
- Verified with `cargo check/test -p homeboy-lab-runner --lib` + `cargo fmt`; heavy suites left to CI per repo policy.