### PR TITLE
fix(agent-task): stage Lab retry handoffs

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -131,6 +131,10 @@ pub fn route_after_parse(
     } else {
         None
     };
+    stage_retry_lab_handoff_before_preacceptance(
+        retry_handoff.as_ref(),
+        inferred_runner_id.as_deref(),
+    )?;
     let normalized_args = run_handoff
         .as_ref()
         .map(|handoff| handoff.args.as_slice())
@@ -728,6 +732,21 @@ fn stage_controller_lab_handoff_before_preacceptance(
         remote_command,
         durable_plan: Some(plan),
     })?;
+    Ok(())
+}
+
+fn stage_retry_lab_handoff_before_preacceptance(
+    handoff: Option<&AgentTaskRetryHandoff>,
+    runner_id: Option<&str>,
+) -> homeboy::core::Result<()> {
+    if let (Some(handoff), Some(runner_id)) = (handoff, runner_id) {
+        stage_controller_lab_handoff_before_preacceptance(
+            &handoff.run_id,
+            runner_id,
+            &handoff.args,
+            &handoff.plan,
+        )?;
+    }
     Ok(())
 }
 

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -944,6 +944,19 @@ fn detached_retry_materializes_failed_plan_and_persists_bounded_preacceptance_fa
         let replacement = agent_task_lifecycle::status(&handoff.run_id).expect("replacement");
         assert_eq!(replacement.metadata["retry_of"], "failed-run");
 
+        stage_retry_lab_handoff_before_preacceptance(Some(&handoff), Some("homeboy-lab"))
+            .expect("stage replacement handoff before Lab preacceptance");
+        let replacement = agent_task_lifecycle::status(&handoff.run_id)
+            .expect("staged replacement remains inspectable");
+        let staged_handoff = replacement
+            .lab_handoff
+            .expect("replacement has pending controller handoff");
+        assert_eq!(staged_handoff.runner_id, "homeboy-lab");
+        let staged_handoff =
+            serde_json::to_value(staged_handoff).expect("serialize staged retry handoff");
+        assert_eq!(staged_handoff["state"], "pending");
+        assert_eq!(staged_handoff["authority"], "controller");
+
         let error = persist_retry_handoff_preacceptance_failure(
             &handoff,
             Error::internal_unexpected("runner preflight rejected the handoff"),


### PR DESCRIPTION
## Summary
- stage controller-owned Lab handoff authorization before `agent-task retry --run` enters Lab preacceptance
- reuse the existing Cook handoff-staging contract rather than weakening terminal snapshot validation
- cover replacement-run pending authority and runner identity before a preacceptance failure

## Root cause
The generic `agent-task retry --run` route materialized a replacement `run-plan` but did not call `record_lab_offload_planned()` before daemon dispatch. A provider could finish successfully, then terminal snapshot projection rejected its runner job because the controller record had no accepted identity to bind. The wrapper then recorded a synthetic preacceptance failure, emitted no candidate artifacts, and reaped the run workspace.

Observed on aligned controller/daemon/job build `6e83d8f3b431`:
- run `agent-task-47a01543-ada0-4b14-b091-ef45761f518c`
- provider execution `cook-wp-build:1` succeeded
- terminal snapshot job `1797f142-28c8-45ab-ad94-5688feca1c5b` was rejected because no accepted runner job identity existed
- zero patch/report artifacts survived and no target branch was pushed

Closes #9377

## How to test
1. Run `cargo test -p homeboy-cli detached_retry_materializes_failed_plan_and_persists_bounded_preacceptance_failure --lib`.
2. Run `cargo fmt -p homeboy-cli --check`.
3. Run `git diff --check origin/main...HEAD`.
4. Retry a failed controller-owned task with `homeboy agent-task retry <run-id> --run --runner <runner-id>` and verify its replacement record has a pending controller-authority Lab handoff before daemon acceptance.
5. Let the provider complete and verify terminal snapshot projection binds the accepted daemon job instead of reporting a missing `runner_job_id`.

## Verification
- Focused retry-route test: passed
- `homeboy-cli` formatting: passed
- Diff check: passed
- Workspace-wide formatting was also attempted before the final rebase; unrelated formatting drift in an untouched contract file prevented that broader command from being used as evidence.

## Backwards compatibility
This changes the durable lifecycle timing for external callers of `agent-task retry --run` through Lab: replacement runs now expose a pending controller-authority handoff before daemon acceptance, matching the existing Cook attempt path. CLI arguments and output schemas are unchanged. Terminal snapshot validation remains fail-closed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Runtime diagnosis, durable-run evidence analysis, implementation, focused regression coverage, and PR preparation.