### PR TITLE
fix(agent-task): reconcile terminal lifecycle provider model from aggregate

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -687,6 +687,76 @@ pub(crate) fn record_terminal_artifact_projection(
     store::write_record(record)
 }
 
+/// The authoritative model recorded on an aggregate outcome, if any.
+fn aggregate_selected_model(aggregate: &AgentTaskAggregate, task_id: &str) -> Option<String> {
+    aggregate
+        .outcomes
+        .iter()
+        .find(|outcome| outcome.task_id == task_id)
+        .and_then(|outcome| outcome.metadata.get("model"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(str::to_string)
+}
+
+/// True when a terminal record's durable lifecycle provider model is missing but
+/// the authoritative aggregate outcome recorded a concrete model — the exact
+/// stale-terminal state that blocks `finalize-pr` after the #9404/#9405 repair
+/// (#9411). The nonterminal `status()` path already normalizes this via
+/// `apply_aggregate_to_record`, but a record that went terminal *before* that
+/// repair never gets reprojected on read.
+pub(crate) fn terminal_provider_model_reconciliation_needed(
+    record: &AgentTaskRunRecord,
+    aggregate: &AgentTaskAggregate,
+) -> bool {
+    record.tasks.iter().any(|task| {
+        let durable_missing = task
+            .model
+            .as_deref()
+            .map(str::trim)
+            .is_none_or(str::is_empty);
+        durable_missing && aggregate_selected_model(aggregate, &task.task_id).is_some()
+    })
+}
+
+/// Reproject authoritative aggregate model evidence onto a terminal record when
+/// the durable lifecycle model is stale-null (#9411).
+///
+/// Fills only the previously-null provider model — on the run tasks, provider
+/// handles, and the rebuilt lifecycle projection — and persists. Terminal state,
+/// promotion evidence, gates, totals, and artifact projections are preserved:
+/// `set_run_state` re-asserts the existing terminal state and only the
+/// model-bearing lifecycle projection is rebuilt from the record's own tasks.
+pub(crate) fn reconcile_terminal_provider_model(
+    record: &mut AgentTaskRunRecord,
+    plan: &AgentTaskPlan,
+    aggregate: &AgentTaskAggregate,
+) -> Result<()> {
+    let mut changed = false;
+    for task in &mut record.tasks {
+        if task
+            .model
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|model| !model.is_empty())
+        {
+            continue;
+        }
+        if let Some(model) = aggregate_selected_model(aggregate, &task.task_id) {
+            task.model = Some(model);
+            changed = true;
+        }
+    }
+    if !changed {
+        return Ok(());
+    }
+    persist_provider_handle_models(&mut record.provider_handles, plan);
+    update_lifecycle_from_record(record, plan);
+    record.updated_at = Some(now_timestamp());
+    store::write_record(record)
+}
+
 /// Recover the runner identity for canonical legacy patch artifacts. Diagnostic
 /// artifacts can share an aggregate without participating in promotion.
 fn runner_id_from_artifact_provenance(aggregate: &AgentTaskAggregate) -> Result<String> {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1086,6 +1086,22 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
                     &aggregate,
                 )?;
             }
+            // Reproject authoritative aggregate model evidence onto a terminal
+            // record whose durable lifecycle model is stale-null (#9411). A run
+            // that went terminal before the #9404/#9405 model repair keeps
+            // `provider_runtime[].metadata.model = null`, which blocks
+            // `finalize-pr` even though the aggregate recorded a concrete model.
+            if crate::agent_task_lifecycle::terminal_provider_model_reconciliation_needed(
+                &record, &aggregate,
+            ) {
+                let controller_plan = store::read_controller_plan(&record.run_id)?;
+                let projection_plan = aggregate_projection_plan(&controller_plan, &aggregate);
+                crate::agent_task_lifecycle::reconcile_terminal_provider_model(
+                    &mut record,
+                    &projection_plan,
+                    &aggregate,
+                )?;
+            }
         }
     }
     // Read-side reconciliation only writes the durable continuation signal.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -1522,3 +1522,94 @@ fn post_provider_transport_failure_preserves_the_succeeded_candidate() {
         );
     });
 }
+
+#[test]
+fn status_reconciles_terminal_provider_model_from_aggregate_when_durable_is_null() {
+    with_isolated_home(|_| {
+        let mut plan = test_plan();
+        plan.tasks[0].executor.backend = "opencode".to_string();
+        plan.tasks[0].executor.model = None;
+        let mut aggregate = succeeded_aggregate(&plan);
+        // Authoritative: the aggregate outcome recorded the selected model.
+        aggregate.outcomes[0].metadata = json!({ "model": "openai/gpt-5.6-terra" });
+
+        let run_id = "terminal-null-model-9411";
+        let mut record =
+            record_completed_run(&plan, &aggregate, Some(run_id)).expect("terminal record");
+        assert!(record.state.is_terminal());
+
+        // Simulate a record that went terminal BEFORE the #9404/#9405 model
+        // repair: strip the durable model from the task and the lifecycle
+        // provider-runtime projection, then persist that stale terminal state.
+        record.tasks[0].model = None;
+        for runtime in &mut record.lifecycle.provider_runtime {
+            if let Some(object) = runtime.metadata.as_object_mut() {
+                object.insert("model".to_string(), Value::Null);
+                if let Some(executor) = object.get_mut("executor").and_then(Value::as_object_mut) {
+                    executor.insert("model".to_string(), Value::Null);
+                }
+            }
+        }
+        store::write_record(&record).expect("persist stale terminal record");
+
+        // Precondition: durable lifecycle model is null (finalize-pr would reject).
+        let stale = store::read_record(run_id).expect("stale record");
+        assert!(stale.state.is_terminal());
+        assert!(stale
+            .lifecycle
+            .provider_runtime
+            .iter()
+            .all(|runtime| runtime.metadata["model"].is_null()));
+
+        // Read-side reconciliation reprojects the authoritative aggregate model
+        // onto the terminal record and persists it.
+        let reconciled = status(run_id).expect("status reconciles terminal model");
+
+        assert!(reconciled.state.is_terminal(), "terminal state preserved");
+        assert_eq!(
+            reconciled.tasks[0].model.as_deref(),
+            Some("openai/gpt-5.6-terra")
+        );
+        let runtime = reconciled
+            .lifecycle
+            .provider_runtime
+            .first()
+            .expect("provider runtime");
+        assert_eq!(runtime.metadata["model"], "openai/gpt-5.6-terra");
+
+        // Persisted, so finalize-pr's durable read now sees the concrete model.
+        let persisted = store::read_record(run_id).expect("persisted record");
+        assert_eq!(
+            persisted.lifecycle.provider_runtime[0].metadata["model"],
+            "openai/gpt-5.6-terra"
+        );
+    });
+}
+
+#[test]
+fn status_leaves_terminal_record_untouched_when_aggregate_has_no_model() {
+    with_isolated_home(|_| {
+        let mut plan = test_plan();
+        plan.tasks[0].executor.backend = "opencode".to_string();
+        plan.tasks[0].executor.model = None;
+        // Aggregate records no model — nothing authoritative to reproject.
+        let aggregate = succeeded_aggregate(&plan);
+
+        let run_id = "terminal-no-model-9411";
+        let record =
+            record_completed_run(&plan, &aggregate, Some(run_id)).expect("terminal record");
+        assert!(record.state.is_terminal());
+
+        let before = store::read_record(run_id).expect("record before");
+        let reconciled = status(run_id).expect("status");
+
+        // No model to reproject: task model stays absent and the run stays terminal.
+        assert!(reconciled.state.is_terminal());
+        assert!(reconciled.tasks[0]
+            .model
+            .as_deref()
+            .map(str::trim)
+            .is_none_or(str::is_empty));
+        assert_eq!(before.tasks[0].model, reconciled.tasks[0].model);
+    });
+}


### PR DESCRIPTION
## Summary
- A run that went terminal **before** the #9404/#9405 model-normalization repair keeps `lifecycle.provider_runtime[].metadata.model = null` even though its persisted aggregate outcome recorded a concrete selected model.
- `status()` only applied aggregate reconciliation while a run was **nonterminal**, so `agent-task status`/`finalize-pr` kept reading the stale durable lifecycle → publication stayed blocked on `durable provider metadata must record a concrete model before publication` (#9411).

## Root cause
In `lifecycle_ops.rs::status()`, the nonterminal branch runs `apply_aggregate_to_record` (which normalizes the model via `tasks_for_aggregate` — the #9404 fix). The terminal branch only reconciled the *artifact projection*, never the provider model. `resume --full` reprojects it, but `status`/`finalize-pr` don't, so the stale-null terminal record blocks publication.

## Change
- `terminal_provider_model_reconciliation_needed(record, aggregate)` — true when a terminal record's durable task model is null but the aggregate outcome has a concrete model.
- `reconcile_terminal_provider_model(record, plan, aggregate)` — fills **only** the previously-null model onto the run tasks, provider handles (`persist_provider_handle_models`), and the rebuilt lifecycle projection (`update_lifecycle_from_record`), then persists.
- Wired into `status()`'s terminal block, right after the artifact-projection reconciliation.
- **Preserved**: terminal state (`set_run_state` re-asserts the existing state), promotion evidence, gates, totals, and artifact projections — only the model-bearing lifecycle projection is rebuilt from the record's own tasks. Records already carrying a concrete model, or whose aggregate has no model, are untouched.

## Compatibility
Repairs previously-null durable metadata from existing authoritative aggregate evidence. Schemas and correctly-populated terminal records are unchanged.

## Tests (`terminal_and_reconcile`)
- `status_reconciles_terminal_provider_model_from_aggregate_when_durable_is_null` — builds a terminal record, strips the durable model to simulate the pre-#9404 state, then asserts `status` reprojects `openai/gpt-5.6-terra` onto the task + lifecycle and persists it. **Temp-disable proven**: disabling the reconciliation makes this fail with `left: None, right: Some("openai/gpt-5.6-terra")`.
- `status_leaves_terminal_record_untouched_when_aggregate_has_no_model` — no-op safety when there's nothing authoritative to reproject.
- 28/30 `terminal_and_reconcile` tests pass; the 2 failures (`pinned_runtime_recovery_retains_the_existing_lab_proxy_identity`, `long_pre_submission_setup_survives_...`) fail **identically on clean origin/main** (stash-proven) — pre-existing VPS env flakes, unrelated to this change.

_Heavy build/full suite left to CI per repo policy; validated with `cargo check -p homeboy-agents --lib` + scoped tests._