### PR TITLE
fix(deploy): ignore execution-resolved build_artifact in release-set drift guard

### DIFF
--- a/crates/contracts/homeboy-component-contract/src/model.rs
+++ b/crates/contracts/homeboy-component-contract/src/model.rs
@@ -352,6 +352,26 @@ impl Component {
         serde_json::to_value(self).and_then(|value| serde_json::to_string(&canonical_json(value)))
     }
 
+    /// Return a stable identity for comparing a component's *configured*
+    /// attachment across independently loaded snapshots — release-set preflight
+    /// vs. deploy execution (#9205).
+    ///
+    /// Excludes `build_artifact`, which is a deterministic, execution-only
+    /// derivation of `local_path` + the configured artifact (deploy planning
+    /// resolves it to an absolute path via `resolve_path_string`, while
+    /// preflight captures the pre-resolution component). Comparing the raw
+    /// serialization therefore reported a clean attachment as "changed after
+    /// release-set preflight" even though no configuration drifted. Real
+    /// attachment/config/path drift still changes every remaining field, so the
+    /// drift guard keeps its fail-closed intent.
+    pub fn canonical_attachment_identity(&self) -> serde_json::Result<String> {
+        let mut value = serde_json::to_value(self)?;
+        if let Some(object) = value.as_object_mut() {
+            object.remove("build_artifact");
+        }
+        serde_json::to_string(&canonical_json(value))
+    }
+
     pub fn new(
         id: String,
         local_path: String,
@@ -550,4 +570,48 @@ where
 {
     let opt = Option::<String>::deserialize(deserializer)?;
     Ok(opt.filter(|s| !s.is_empty()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_attachment_identity_ignores_build_artifact_but_catches_config_drift() {
+        let base = Component::new(
+            "agents-api".to_string(),
+            "/source/agents-api".to_string(),
+            "wp-content/plugins/agents-api".to_string(),
+            Some("dist/plugin.zip".to_string()),
+        );
+
+        // Same attachment, but build_artifact resolved to an absolute path during
+        // execution (the #9205 divergence). Attachment identity must be equal.
+        let mut resolved = base.clone();
+        resolved.build_artifact = Some("/source/agents-api/dist/plugin.zip".to_string());
+        assert_eq!(
+            base.canonical_attachment_identity().expect("base identity"),
+            resolved
+                .canonical_attachment_identity()
+                .expect("resolved identity"),
+            "build_artifact resolution must not change the attachment identity"
+        );
+
+        // The raw canonical_identity still differs (build_artifact is included),
+        // proving the attachment variant is what makes them agree.
+        assert_ne!(
+            base.canonical_identity().expect("base"),
+            resolved.canonical_identity().expect("resolved"),
+            "raw canonical_identity should still reflect the build_artifact difference"
+        );
+
+        // A real config change (different remote_path) still drifts.
+        let mut drifted = base.clone();
+        drifted.remote_path = "wp-content/plugins/changed".to_string();
+        assert_ne!(
+            base.canonical_attachment_identity().expect("base"),
+            drifted.canonical_attachment_identity().expect("drifted"),
+            "real config drift must still change the attachment identity"
+        );
+    }
 }

--- a/crates/homeboy-cli/src/commands/deploy.rs
+++ b/crates/homeboy-cli/src/commands/deploy.rs
@@ -395,7 +395,7 @@ fn apply_release_set(
         .iter()
         .map(|(entry, component)| {
             component
-                .canonical_identity()
+                .canonical_attachment_identity()
                 .map(|identity| (entry.id.clone(), identity))
                 .map_err(|error| homeboy::core::Error::internal_io(
                     format!("Failed to encode release-set component '{}': {error}", entry.id),

--- a/crates/homeboy-release/src/deploy/orchestration/mod.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/mod.rs
@@ -470,7 +470,7 @@ fn validate_preflighted_component_identities(
         let Some(expected_path) = config.preflighted_source_paths.get(&component.id) else {
             continue;
         };
-        let actual_identity = component.canonical_identity().map_err(|error| {
+        let actual_identity = component.canonical_attachment_identity().map_err(|error| {
             Error::internal_io(
                 format!(
                     "Failed to encode effective component '{}': {error}",
@@ -1421,7 +1421,7 @@ mod tests {
         config.preflighted_component_identities = std::collections::BTreeMap::from([(
             "fixture".to_string(),
             preflighted
-                .canonical_identity()
+                .canonical_attachment_identity()
                 .expect("preflight identity"),
         )]);
 
@@ -1452,7 +1452,9 @@ mod tests {
         )]);
         config.preflighted_component_identities = std::collections::BTreeMap::from([(
             "fixture".to_string(),
-            component.canonical_identity().expect("preflight identity"),
+            component
+                .canonical_attachment_identity()
+                .expect("preflight identity"),
         )]);
 
         let mut changed_path = component.clone();
@@ -1465,6 +1467,64 @@ mod tests {
         changed_config.remote_path = "wp-content/plugins/changed".to_string();
         let err = validate_preflighted_component_identities(&[changed_config], &config)
             .expect_err("config drift must fail before dry-run planning");
+        assert!(err.message.contains("changed after release-set preflight"));
+    }
+
+    #[test]
+    fn release_set_preflight_ignores_execution_resolved_build_artifact() {
+        // Regression for #9205: deploy planning resolves `build_artifact` to an
+        // absolute path (`resolve_path_string`) after preflight captured the
+        // pre-resolution component, so the raw serialization reported a clean
+        // attachment as "changed after release-set preflight". The drift guard
+        // must ignore this deterministic, execution-only derivation.
+        let component = artifact_component("agents-api", "/source/agents-api", "dist/plugin.zip");
+        let mut config = base_deploy_config();
+        config.dry_run = true;
+        config.preflighted_source_paths = std::collections::BTreeMap::from([(
+            "agents-api".to_string(),
+            component.local_path.clone(),
+        )]);
+        // Preflight captured the component BEFORE build_artifact resolution.
+        config.preflighted_component_identities = std::collections::BTreeMap::from([(
+            "agents-api".to_string(),
+            component
+                .canonical_attachment_identity()
+                .expect("preflight identity"),
+        )]);
+
+        // Execution loads the same attachment, then resolves build_artifact to an
+        // absolute path — the only field deploy planning mutates post-resolution.
+        let mut executed = component.clone();
+        executed.build_artifact = Some("/source/agents-api/dist/plugin.zip".to_string());
+
+        validate_preflighted_component_identities(&[executed], &config).expect(
+            "a build_artifact resolved only during execution must not count as attachment drift",
+        );
+    }
+
+    #[test]
+    fn release_set_preflight_still_fails_on_real_config_drift_despite_ignoring_build_artifact() {
+        // The build_artifact exclusion must not weaken the guard: a genuine
+        // config change (a different *configured* artifact) still drifts because
+        // it changes other fields, and any non-derived field change is caught.
+        let component = artifact_component("agents-api", "/source/agents-api", "dist/plugin.zip");
+        let mut config = base_deploy_config();
+        config.dry_run = true;
+        config.preflighted_source_paths = std::collections::BTreeMap::from([(
+            "agents-api".to_string(),
+            component.local_path.clone(),
+        )]);
+        config.preflighted_component_identities = std::collections::BTreeMap::from([(
+            "agents-api".to_string(),
+            component
+                .canonical_attachment_identity()
+                .expect("preflight identity"),
+        )]);
+
+        let mut drifted = component;
+        drifted.extract_command = Some("tar xzf {artifact}".to_string());
+        let err = validate_preflighted_component_identities(&[drifted], &config)
+            .expect_err("real config drift must still fail closed");
         assert!(err.message.contains("changed after release-set preflight"));
     }
 


### PR DESCRIPTION
## Summary
- A clean `homeboy deploy <project> --release-set <manifest> --dry-run` failed with `Project attachment for component '<id>' changed after release-set preflight` even though nothing drifted (#9205), blocking release-set deploys entirely.

## Root cause
The guard (`validate_preflighted_component_identities`) compares a component's serialized identity captured at **release-set preflight** (CLI `apply_release_set`) against the identity loaded during **deploy execution** (`load_project_components`). Deploy planning resolves `build_artifact` to an absolute path via `resolve_path_string` — the **only** field it mutates after resolution (planning.rs:814) — while preflight captured the *pre-resolution* component. The two serializations diverged on a deterministic, execution-only value, so any component with a build artifact (Chubes' repro: `agents-api`) always tripped the guard.

#9207 canonicalized JSON map ordering but did **not** address this value divergence — confirmed still failing on `0.297.2+ae438d66a024`.

## Change
- Add `Component::canonical_attachment_identity()` (component contract), which excludes `build_artifact` from the identity, then use it on **both** the preflight capture (deploy CLI) and the execution-time validation.
- `build_artifact` is a pure derivation of `local_path` + the configured artifact — not attachment drift. Every real config/attachment/path change still alters another field, so the guard keeps its fail-closed intent.

## Acceptance criteria
- ✅ Unchanged effective attachments pass preflight + execution identity validation.
- ✅ Real path/config drift after preflight still fails before any lifecycle/build/transfer/remote mutation.
- ✅ Tests cover a managed-worktree attachment whose loaded identity differs only through the execution-resolved `build_artifact`.

## Tests
- `canonical_attachment_identity_ignores_build_artifact_but_catches_config_drift` (contract) — build_artifact resolution yields equal attachment identity; raw `canonical_identity` still differs; a `remote_path` change still drifts.
- `release_set_preflight_ignores_execution_resolved_build_artifact` (release) — the exact #9205 scenario passes. **Temp-disable proven**: reverting validation to `canonical_identity()` makes this fail (build_artifact counted as drift).
- `release_set_preflight_still_fails_on_real_config_drift_despite_ignoring_build_artifact` — a changed `extract_command` still fails closed.
- Existing `release_set_attachment_drift_fails_before_dry_run_materialization` and `release_set_dry_run_accepts_unchanged_managed_worktree_attachment` updated to the attachment identity and still pass.

_Heavy build/full suite left to CI per repo policy; validated with `cargo check` + scoped tests._