### PR TITLE
fix(cli): exempt rig source management from resource-policy admission (#9428)

### DIFF
--- a/crates/homeboy-cli/src/commands/utils/resource_policy.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy.rs
@@ -174,6 +174,7 @@ pub fn hot_command(command: &Commands) -> Option<HotCommand> {
     if is_plan_only_command(command)
         || is_controller_owned_fanout_coordination(command)
         || is_read_only_agent_task(command)
+        || is_local_registry_management(command)
     {
         return None;
     }
@@ -304,6 +305,21 @@ fn is_read_only_agent_task(command: &Commands) -> bool {
                 | agent_task::AgentTaskCommand::Review(_),
         })
     )
+}
+
+/// Local registry/source-state management (`rig install|update|sync|sources`)
+/// is lightweight controller-local bookkeeping, not a resource-intensive
+/// workload. These commands carry a `LocalOnly` Lab contract only to *explain*
+/// their controller-local boundary when an operator requests unsupported Lab
+/// placement. `hot_command` otherwise converts every command with a Lab
+/// contract — including every explanatory `LocalOnly` one — into a
+/// `HotCommand`, which put rig source management behind warm/hot resource-policy
+/// refusal and forced callers to bypass setup with `--skip-install --skip-sync`
+/// (#9428). Resource policy must gate only genuinely resource-intensive
+/// commands (e.g. `rig up`, `rig check`), so exempt these here while their
+/// portability diagnostics stay intact.
+fn is_local_registry_management(command: &Commands) -> bool {
+    matches!(command, Commands::Rig(args) if args.is_runner_source_management_command())
 }
 
 pub fn evaluate(command: HotCommand, resources: &DoctorOutput) -> Option<ResourcePolicyWarning> {
@@ -755,6 +771,59 @@ mod tests {
         ]);
 
         assert!(hot_command(&cli.command).is_none());
+    }
+
+    #[test]
+    fn rig_source_management_commands_bypass_hot_resource_admission() {
+        // Rig registry/source-state management is lightweight controller-local
+        // bookkeeping, not a resource-intensive workload, so it must never be
+        // refused by warm/hot resource policy (#9428).
+        for args in [
+            [
+                "homeboy",
+                "rig",
+                "install",
+                "https://example.invalid/rig.git",
+            ]
+            .as_slice(),
+            ["homeboy", "rig", "update"].as_slice(),
+            ["homeboy", "rig", "update", "--all"].as_slice(),
+            ["homeboy", "rig", "sync", "example-rig"].as_slice(),
+            ["homeboy", "rig", "sources"].as_slice(),
+        ] {
+            let cli = Cli::parse_from(args);
+            assert!(
+                hot_command(&cli.command).is_none(),
+                "rig source management must not be resource-managed: {args:?}"
+            );
+            // The explanatory local-only Lab portability contract is preserved so
+            // an explicit unsupported Lab placement still gets a clear diagnostic.
+            let contract = cli
+                .command
+                .lab_contract()
+                .expect("rig source management keeps a Lab portability contract");
+            assert!(matches!(
+                contract.portability,
+                crate::command_contract::LabCommandPortability::LocalOnly(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn rig_up_and_check_remain_resource_managed() {
+        // Genuinely resource-intensive rig commands keep their resource-policy
+        // classification (#9428).
+        let up = Cli::parse_from(["homeboy", "rig", "up", "example-rig"]);
+        assert!(
+            hot_command(&up.command).is_some(),
+            "rig up remains resource-managed"
+        );
+
+        let check = Cli::parse_from(["homeboy", "rig", "check", "example-rig"]);
+        assert!(
+            hot_command(&check.command).is_some(),
+            "rig check remains resource-managed"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #9428. `rig install`, `rig update`, `rig sync`, and `rig sources` were refused before execution when the controller is warm or hot, forcing callers to bypass setup with `--skip-install --skip-sync` even when the actual matrix workload runs on Lab.

## Root cause

These commands carry a `LocalOnly` Lab portability contract purely to **explain** their controller-local boundary when an operator requests unsupported Lab placement. But `resource_policy::hot_command()` converts *every* command with a Lab contract — including every explanatory `LocalOnly` one — into a `HotCommand`. That conflated two independent properties:

1. Whether a command is portable to Lab.
2. Whether a command requires warm/hot resource admission.

So adding an explanatory local-only portability contract accidentally placed lightweight local registry/source-state management behind resource-policy refusal.

## Fix

`hot_command()` now returns `None` for rig source-management commands via a small `is_local_registry_management` guard (built on the existing `RigArgs::is_runner_source_management_command`, so classification lives in one place). Resource policy therefore gates only genuinely resource-intensive commands. The commands' `LocalOnly` Lab portability contracts and explicit-placement diagnostics are untouched, and `rig up` / `rig check` remain resource-managed.

## Acceptance criteria

- ✅ `rig install`, `rig update`, `rig sync`, `rig sources` are not returned by `resource_policy::hot_command()`.
- ✅ Their local-only Lab portability contracts and explicit-placement diagnostics remain intact (test asserts the contract is still `LocalOnly`).
- ✅ `rig up`, `rig check`, and other genuinely resource-managed commands retain current behavior.
- ✅ Deterministic tests prove source-management commands bypass hot admission while preserving their portability contracts.
- ✅ Generic separation between portability and resource classification rather than per-command diagnostic workarounds.

## Tests (temp-disable proven)

- `rig_source_management_commands_bypass_hot_resource_admission` — install/update/sync/sources return `None` and keep their `LocalOnly` contract; fails without the guard.
- `rig_up_and_check_remain_resource_managed`.
- All 37 resource_policy tests pass.

Verified with `cargo check/test -p homeboy-cli --lib` + `cargo fmt`.