### PR TITLE
fix(lab): exclude serialized run-plan JSON from remote argv path preflight (#9429)

### DIFF
--- a/crates/homeboy-lab-runner/src/command_path.rs
+++ b/crates/homeboy-lab-runner/src/command_path.rs
@@ -85,11 +85,7 @@ pub fn preflight_remote_argv_path_translation(
         return Ok(());
     }
 
-    let leaked: Vec<String> = command
-        .iter()
-        .filter(|arg| arg_embeds_untranslated_local_path(arg, local_root, remote_cwd))
-        .cloned()
-        .collect();
+    let leaked: Vec<String> = leaked_argv_paths(command, local_root, remote_cwd);
     if leaked.is_empty() {
         return Ok(());
     }
@@ -539,6 +535,40 @@ fn is_path_bearing_flag(flag: &str) -> bool {
 /// True when `arg` embeds the controller-local source root but has not been
 /// translated to the remote workspace path. Arguments that already point at the
 /// remote workspace (or do not reference the local root at all) are accepted.
+/// The value of `agent-task run-plan --plan <json>` is a serialized
+/// `homeboy/agent-task-plan/v1` document, not a raw executable path argument.
+/// Its structured fields (workspace roots, provider plugin paths, runtime
+/// overlay sources, materialization paths) still carry controller-local
+/// provenance because the runner re-materializes and remaps them from the plan
+/// on its own side before execution. Scanning that opaque JSON as if it were a
+/// path-bearing argv argument falsely rejected the supported durable recovery
+/// `agent-task run <run-id> --runner <id>` before provider execution (#9429).
+///
+/// Skip the `--plan` value (both `--plan <json>` and `--plan=<json>` forms)
+/// while still checking every other argument, so a genuinely untranslated raw
+/// path argument continues to fail closed.
+fn leaked_argv_paths(command: &[String], local_root: &str, remote_cwd: &str) -> Vec<String> {
+    let mut leaked = Vec::new();
+    let mut skip_next_plan_value = false;
+    for arg in command {
+        if skip_next_plan_value {
+            skip_next_plan_value = false;
+            continue;
+        }
+        if arg == "--plan" {
+            skip_next_plan_value = true;
+            continue;
+        }
+        if arg.starts_with("--plan=") {
+            continue;
+        }
+        if arg_embeds_untranslated_local_path(arg, local_root, remote_cwd) {
+            leaked.push(arg.clone());
+        }
+    }
+    leaked
+}
+
 fn arg_embeds_untranslated_local_path(arg: &str, local_root: &str, remote_cwd: &str) -> bool {
     if !arg.contains(local_root) {
         return false;
@@ -977,5 +1007,93 @@ mod tests {
             &mappings,
         )
         .expect("remote mapped paths and non-path settings should pass");
+    }
+
+    #[test]
+    fn preflight_allows_controller_paths_inside_the_serialized_plan_argument() {
+        // A durable `agent-task run <id> --runner <id>` recovery hands the runner
+        // a serialized `run-plan --plan <json>` whose structured fields still
+        // carry controller-local provenance paths (workspace roots, plugin paths,
+        // overlay sources). The runner re-materializes and remaps those from the
+        // plan itself, so the opaque JSON must NOT be rejected as an untranslated
+        // argv path (#9429).
+        let controller = tempfile::tempdir().expect("controller");
+        let source = controller.path().join("homeboy");
+        fs::create_dir_all(&source).expect("source");
+        let local_root = source.display().to_string();
+        let plan_json = serde_json::json!({
+            "schema": "homeboy/agent-task-plan/v1",
+            "tasks": [{
+                "workspace": { "root": local_root, "source_checkout": local_root },
+                "executor": { "config": { "workspace_root": local_root } },
+                "provider_plugin_paths": [format!("{local_root}/plugin")],
+                "runtime": { "overlay": { "source": format!("{local_root}/overlay") } },
+            }]
+        })
+        .to_string();
+
+        for command in [
+            vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "run-plan".to_string(),
+                "--plan".to_string(),
+                plan_json.clone(),
+                "--record-run-id".to_string(),
+                "run-9429".to_string(),
+            ],
+            vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "run-plan".to_string(),
+                format!("--plan={plan_json}"),
+                "--record-run-id".to_string(),
+                "run-9429".to_string(),
+            ],
+        ] {
+            preflight_remote_argv_path_translation(
+                "Lab offload",
+                "homeboy-lab",
+                &command,
+                &source,
+                "/home/chubes/Developer",
+            )
+            .expect("serialized plan provenance paths must not fail argv preflight");
+        }
+    }
+
+    #[test]
+    fn preflight_still_rejects_a_raw_untranslated_path_alongside_a_plan_argument() {
+        // Excluding the `--plan` JSON must not disable fail-closed protection for
+        // a genuinely untranslated raw path argument in the same argv (#9429).
+        let controller = tempfile::tempdir().expect("controller");
+        let source = controller.path().join("homeboy");
+        fs::create_dir_all(&source).expect("source");
+        let local_root = source.display().to_string();
+        let plan_json = serde_json::json!({
+            "schema": "homeboy/agent-task-plan/v1",
+            "tasks": [{ "workspace": { "root": local_root } }],
+        })
+        .to_string();
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+            "--plan".to_string(),
+            plan_json,
+            "--artifact-root".to_string(),
+            format!("{local_root}/artifacts"),
+        ];
+
+        let err = preflight_remote_argv_path_translation(
+            "Lab offload",
+            "homeboy-lab",
+            &command,
+            &source,
+            "/home/chubes/Developer",
+        )
+        .expect_err("a raw untranslated path argument must still fail closed");
+        assert!(err.message.contains("remote argv argument"));
+        assert!(err.details.to_string().contains("artifacts"));
     }
 }


### PR DESCRIPTION
## Summary

Closes #9429. Durable recovery `agent-task run <run-id> --runner homeboy-lab` reached the runner daemon, then Lab dispatch refused it before any provider ran:

```
Lab offload refused to dispatch to runner `homeboy-lab`: 1 remote argv argument(s) still reference the controller-local source path `/Users/chubes/Developer/homeboy` instead of the remote workspace `/home/chubes/Developer`
```

## Root cause

The untranslated argument was the serialized `homeboy/agent-task-plan/v1` JSON passed to `agent-task run-plan --plan`. Its structured fields — `workspace.root`/`source_checkout`, `provider_plugin_paths`, runtime overlay `source`, `workspace_root`, materialization paths — still carry controller-local provenance because **the runner re-materializes and remaps them from the plan on its own side** before execution.

`preflight_remote_argv_path_translation` scanned that opaque JSON as if it were a raw path-bearing argv argument and failed closed, blocking the supported durable recovery path.

## Fix

Skip the `--plan` value (both `--plan <json>` and `--plan=<json>` forms) in the argv path-translation preflight — it is structured data the runner materializes, not a raw executable path argument. Every other argument is still scanned, so a genuinely untranslated raw path argument continues to fail closed. The companion `preflight_remote_path_bearing_surfaces` never inspected `--plan` (it is not a path-bearing flag), so no change is needed there.

Per the maintainer's chosen direction: exclude the plan JSON from the remote path preflight (the issue's "controller-only metadata ... excluded from remote path preflight" option), rather than pre-translating the plan on the controller before the remote path is known.

## Acceptance criteria

- ✅ Controller-only provenance paths inside the plan do not trigger false remote-argv rejection.
- ✅ A queued controller proxy with no runner job can be resumed via `agent-task run <run-id> --runner <id>` (the dispatch is no longer refused).
- ✅ Existing fail-closed behavior remains for genuinely untranslated arbitrary command arguments (test: a raw `--artifact-root` controller path alongside a plan still fails).
- Provider runtime/plugin/overlay/workspace paths continue to resolve on the runner via its existing plan materialization/remapping (unchanged; this fix only stops the preflight from pre-empting it).

## Tests (temp-disable proven)

- `preflight_allows_controller_paths_inside_the_serialized_plan_argument` — a serialized plan carrying multiple controller-local paths (both `--plan <json>` and `--plan=<json>`) passes preflight; with the skip disabled it fails with the exact production error.
- `preflight_still_rejects_a_raw_untranslated_path_alongside_a_plan_argument` — proves fail-closed protection is preserved.

All 14 command_path tests pass. Verified with `cargo check/test -p homeboy-lab-runner --lib` + `cargo fmt`.