### PR TITLE
Fix rig source resource-policy classification

### DIFF
--- a/crates/contracts/homeboy-lab-contract/src/lab/types.rs
+++ b/crates/contracts/homeboy-lab-contract/src/lab/types.rs
@@ -110,27 +110,44 @@ pub struct LabCommandContract {
 #[derive(Debug, Clone, Copy, Default, serde::Serialize, PartialEq, Eq)]
 pub struct CommandPortabilityContract {
     lab_command: Option<LabCommandContract>,
+    resource_intensive: bool,
 }
 
 impl CommandPortabilityContract {
     pub const fn none() -> Self {
-        Self { lab_command: None }
+        Self {
+            lab_command: None,
+            resource_intensive: false,
+        }
     }
 
     pub const fn lab(command: LabCommandContract) -> Self {
         Self {
             lab_command: Some(command),
+            resource_intensive: true,
+        }
+    }
+
+    pub const fn lightweight_lab(command: LabCommandContract) -> Self {
+        Self {
+            lab_command: Some(command),
+            resource_intensive: false,
         }
     }
 
     pub const fn lab_optional(command: Option<LabCommandContract>) -> Self {
         Self {
             lab_command: command,
+            resource_intensive: command.is_some(),
         }
     }
 
     pub const fn lab_command(self) -> Option<LabCommandContract> {
         self.lab_command
+    }
+
+    pub const fn is_resource_intensive(self) -> bool {
+        self.resource_intensive
     }
 }
 

--- a/crates/homeboy-cli/src/commands/rig/mod.rs
+++ b/crates/homeboy-cli/src/commands/rig/mod.rs
@@ -107,7 +107,7 @@ impl RigArgs {
             ));
         }
         if self.is_runner_source_management_command() {
-            return CommandPortabilityContract::lab(LabCommandContract::local_only(
+            return CommandPortabilityContract::lightweight_lab(LabCommandContract::local_only(
                 RIG_SOURCE_MANAGEMENT_LAB_LABEL,
                 RIG_SOURCE_MANAGEMENT_LAB_UNSUPPORTED_REASON,
             ));

--- a/crates/homeboy-cli/src/commands/utils/resource_policy.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy.rs
@@ -228,6 +228,10 @@ pub fn hot_command(command: &Commands) -> Option<HotCommand> {
         });
     }
 
+    if !command.portability_contract().is_resource_intensive() {
+        return None;
+    }
+
     let contract = command.lab_contract()?;
 
     match contract.portability {
@@ -722,6 +726,45 @@ mod tests {
         assert_eq!(hot.label, "review lint");
         assert!(hot.lab_offload_supported);
         assert!(hot.lab_offload_unsupported_reason.is_none());
+    }
+
+    #[test]
+    fn rig_source_management_keeps_lab_diagnostics_without_resource_admission() {
+        for args in [
+            ["homeboy", "rig", "install", "./rig-package"].as_slice(),
+            ["homeboy", "rig", "update", "demo-rig"].as_slice(),
+            ["homeboy", "rig", "sync", "demo-rig"].as_slice(),
+            ["homeboy", "rig", "sources"].as_slice(),
+        ] {
+            let cli = Cli::parse_from(args);
+            let portability = cli.command.portability_contract();
+            let contract = portability
+                .lab_command()
+                .expect("rig source management keeps its Lab diagnostic contract");
+
+            assert!(!portability.is_resource_intensive());
+            assert_eq!(
+                contract.portability,
+                LabCommandPortability::LocalOnly(
+                    crate::command_contract::RIG_SOURCE_MANAGEMENT_LAB_UNSUPPORTED_REASON
+                )
+            );
+            assert!(hot_command(&cli.command).is_none());
+        }
+    }
+
+    #[test]
+    fn rig_workloads_remain_resource_managed() {
+        for args in [
+            ["homeboy", "rig", "up", "demo-rig"].as_slice(),
+            ["homeboy", "rig", "check", "demo-rig"].as_slice(),
+            ["homeboy", "rig", "run", "demo-rig", "--profile", "smoke"].as_slice(),
+        ] {
+            let cli = Cli::parse_from(args);
+
+            assert!(cli.command.portability_contract().is_resource_intensive());
+            assert!(hot_command(&cli.command).is_some());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- separate command resource intensity from Lab portability
- keep local-only Lab diagnostics for rig source-management commands
- allow `rig install`, `rig update`, `rig sync`, and `rig sources` on warm controllers
- preserve resource admission for `rig up`, `rig check`, and `rig run`

## Why

The resource-policy classifier inferred workload intensity from the presence of a Lab portability contract. Adding a local-only diagnostic contract therefore accidentally made lightweight rig registry operations hot workloads. This adds an explicit resource-intensity property to the command portability contract instead of special-casing diagnostics.

## How to test

1. Check out this branch from a fresh clone.
2. Run `cargo test -p homeboy-cli resource_policy`.
3. Run `cargo check -p homeboy-cli`.
4. Run `cargo fmt --check`.
5. Confirm the resource-policy suite includes source-management bypass coverage while rig workloads remain managed.

## Compatibility

No CLI flags or serialized public command shapes change. Existing Lab portability diagnostics remain intact; only erroneous controller resource admission is removed for explicitly lightweight commands.

Closes #9428

## AI assistance

- **AI assistance:** Yes
- **Tool:** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Root-cause analysis, implementation, tests, and verification; Chris Huber reviewed and owns the change.