### PR TITLE
Translate Lab paths in recovered agent-task plans

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -144,6 +144,14 @@ pub fn route_after_parse(
                 .map(|handoff| handoff.args.as_slice())
         })
         .unwrap_or(normalized_args);
+    // A controller-owned `run` becomes a portable `run-plan`. Route according
+    // to that materialized command so Lab stages its workspace and rewrites the
+    // structured plan instead of taking the original runner-resident path.
+    let lab_command = if run_handoff.is_some() {
+        lab_offload_command_for_materialized_args(normalized_args)?
+    } else {
+        lab_command
+    };
     let cook_plan = if lab_command.is_some() && inferred_runner_id.is_some() {
         materialize_agent_task_cook_plan(cli)?
     } else {
@@ -1627,6 +1635,20 @@ fn lab_offload_command(
     Ok(Some(lab_routing::lab_offload_command_from_route_contract(
         route_contract,
     )))
+}
+
+fn lab_offload_command_for_materialized_args(
+    args: &[String],
+) -> homeboy::core::Result<Option<runners::LabOffloadCommand>> {
+    let cli = Cli::try_parse_from(args).map_err(|error| {
+        Error::validation_invalid_argument(
+            "agent-task run",
+            format!("build materialized Lab run-plan: {error}"),
+            None,
+            None,
+        )
+    })?;
+    lab_offload_command(&cli.command)
 }
 
 fn destructive_fuzz_requires_lab(command: &Commands) -> bool {

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -1012,6 +1012,17 @@ fn controller_owned_run_materializes_plan_for_lab_execution() {
         let handoff = materialize_agent_task_run_handoff(&cli, &args)
             .expect("materialize run handoff")
             .expect("controller-owned handoff");
+        let routed_contract = lab_offload_command_for_materialized_args(&handoff.args)
+            .expect("resolve materialized route contract")
+            .expect("materialized run-plan remains Lab portable");
+        assert_eq!(
+            routed_contract.source_path_mode,
+            homeboy::core::lab_contract::LabSourcePathMode::CwdOrPathFlag
+        );
+        assert_eq!(
+            routed_contract.workspace_mode_policy,
+            homeboy::core::lab_contract::LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot
+        );
         let remote_cli = Cli::try_parse_from(&handoff.args).expect("portable run-plan argv");
         let Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
             command: crate::commands::agent_task::AgentTaskCommand::RunPlan(remote),

--- a/crates/homeboy-lab-runner/src/lab_args/tests.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/tests.rs
@@ -1538,6 +1538,145 @@ mod materialize_specs_tests {
     use super::*;
 
     #[test]
+    fn materialize_run_plan_translates_executable_paths_before_remote_dispatch() {
+        let controller_workspace = "/controller/worktree";
+        let runner_workspace = "/runner/worktree";
+        let mappings = vec![
+            LabPathRemap {
+                local: controller_workspace.to_string(),
+                remote: runner_workspace.to_string(),
+            },
+            LabPathRemap {
+                local: "/controller/source".to_string(),
+                remote: "/runner/source".to_string(),
+            },
+            LabPathRemap {
+                local: "/controller/provider-plugin".to_string(),
+                remote: "/runner/provider-plugin".to_string(),
+            },
+            LabPathRemap {
+                local: "/controller/runtime-overlay".to_string(),
+                remote: "/runner/runtime-overlay".to_string(),
+            },
+            LabPathRemap {
+                local: "/controller/runtime-source".to_string(),
+                remote: "/runner/runtime-source".to_string(),
+            },
+        ];
+        let plan = serde_json::json!({
+            "schema": "homeboy/agent-task-plan/v1",
+            "plan_id": "durable-recovery",
+            "metadata": { "workspace_root": controller_workspace },
+            "tasks": [{
+                "task_id": "task-1",
+                "workspace": {
+                    "root": controller_workspace,
+                    "materialization": {
+                        "root": controller_workspace,
+                        "source_checkout": "/controller/source"
+                    }
+                },
+                "executor": {
+                    "backend": "opencode",
+                    "config": {
+                        "workspace_root": controller_workspace,
+                        "provider_plugin_paths": ["/controller/provider-plugin/plugin.json"],
+                        "runtime_overlays": [{
+                            "source": "/controller/runtime-overlay",
+                            "materialized_path": "/controller/runtime-overlay/materialized"
+                        }]
+                    }
+                },
+                "metadata": {
+                    "workspace": {
+                        "root": controller_workspace,
+                        "source_checkout": "/controller/source"
+                    },
+                    "resolved_runtime_identity": {
+                        "provider": {
+                            "extension_path": "/controller/provider-plugin",
+                            "runtime_path": "/controller/runtime-overlay/runtime",
+                            "runner_sources": [{ "path": "/controller/runtime-source" }]
+                        },
+                        "materialization_plan": {
+                            "runtime_path": "/controller/runtime-overlay/runtime",
+                            "selected_identity": {
+                                "source_path": "/controller/runtime-source"
+                            },
+                            "runtime_sources": [{
+                                "locator": {
+                                    "kind": "local_path",
+                                    "path": "/controller/runtime-source"
+                                },
+                                "destination_path": "runtime/source"
+                            }]
+                        }
+                    }
+                }
+            }]
+        })
+        .to_string();
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+            "--plan".to_string(),
+            plan,
+        ];
+        let mut staged = None;
+
+        let out = materialize_agent_task_specs_in_args(
+            &args,
+            &mappings,
+            Path::new(controller_workspace),
+            |spec| {
+                staged = Some(spec.spec.to_string());
+                Ok(Some((
+                    "@/runner/staged/agent-task-plan.json".to_string(),
+                    (),
+                )))
+            },
+        )
+        .expect("materialize recovered run plan");
+        let staged = staged.expect("staged plan");
+        let value: serde_json::Value = serde_json::from_str(&staged).expect("staged plan JSON");
+
+        assert_eq!(out.argv[4], "@/runner/staged/agent-task-plan.json");
+        assert_eq!(value["metadata"]["workspace_root"], runner_workspace);
+        assert_eq!(value["tasks"][0]["workspace"]["root"], runner_workspace);
+        assert_eq!(
+            value["tasks"][0]["workspace"]["materialization"]["source_checkout"],
+            "/runner/source"
+        );
+        assert_eq!(
+            value["tasks"][0]["executor"]["config"]["provider_plugin_paths"][0],
+            "/runner/provider-plugin/plugin.json"
+        );
+        assert_eq!(
+            value["tasks"][0]["executor"]["config"]["runtime_overlays"][0]["source"],
+            "/runner/runtime-overlay"
+        );
+        assert_eq!(
+            value["tasks"][0]["metadata"]["resolved_runtime_identity"]["materialization_plan"]
+                ["runtime_sources"][0]["locator"]["path"],
+            "/runner/runtime-source"
+        );
+        assert_eq!(
+            value["tasks"][0]["metadata"]["resolved_runtime_identity"]["materialization_plan"]
+                ["runtime_sources"][0]["destination_path"],
+            "runtime/source"
+        );
+        assert_eq!(
+            value["tasks"][0]["metadata"]["workspace_source_provenance"]["controller_root"],
+            controller_workspace
+        );
+        assert!(!staged.contains("/controller/provider-plugin"));
+        assert!(!staged.contains("/controller/runtime-overlay"));
+        assert!(!staged.contains("/controller/runtime-source"));
+        assert_eq!(staged.matches(controller_workspace).count(), 1);
+    }
+
+    #[test]
     fn materialize_agent_task_specs_syncs_inline_and_file_plan_json() {
         let temp = tempfile::tempdir().expect("tempdir");
         let plan = serde_json::json!({


### PR DESCRIPTION
## Summary

- route a controller-owned `agent-task run` according to its materialized portable `run-plan` command
- stage and rewrite executable paths embedded inside serialized agent-task plans
- cover workspace, source checkout, provider plugin, runtime overlay, and runtime source paths
- preserve fail-closed preflight for genuinely untranslated arbitrary argv

## Why

Durable recovery transformed `agent-task run` into `run-plan`, but routing retained the original runner-resident contract. The serialized plan consequently skipped structured plan materialization, reached remote argv preflight with controller paths, and was rejected before provider execution.

## How to test

1. Check out this branch from a fresh clone.
2. Run `cargo test -p homeboy-cli controller_owned_run_materializes_plan_for_lab_execution`.
3. Run `cargo test -p homeboy-lab-runner materialize_run_plan_translates_executable_paths_before_remote_dispatch`.
4. Run `cargo check -p homeboy-cli -p homeboy-lab-runner`.
5. Confirm the staged plan retains controller provenance only as metadata and contains runner paths for executable locations.

## Compatibility

No CLI surface changes. Durable runner recovery now uses the already-declared portable `run-plan` contract and existing structured path materialization pipeline.

Closes #9429

## AI assistance

- **AI assistance:** Yes
- **Tool:** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Reproduction analysis, implementation, regression coverage, and verification; Chris Huber reviewed and owns the change.