### PR TITLE
fix(runtime): bound retained run directories

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -349,6 +349,47 @@ fn retained_storage_report(
         });
     }
 
+    let runtime_tmp =
+        engine::temp::cleanup_runtime_tmp_bounded(engine::temp::RuntimeTempCleanupOptions {
+            apply: false,
+            older_than_days: retention.runtime_tmp_days,
+            prefix: None,
+            limit: usize::MAX,
+            run_max_bytes: retention.runtime_run_max_bytes,
+            run_max_count: retention.runtime_run_max_count,
+        })?;
+    for row in runtime_tmp
+        .rows
+        .into_iter()
+        .filter(|row| row.owner_id.is_some())
+    {
+        let liveness = if row
+            .protection_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("is running"))
+        {
+            "active"
+        } else if row.owner_state.as_deref() == Some("active") {
+            "stale"
+        } else {
+            "terminal"
+        };
+        records.push(RetainedStorageRecord {
+            category: "runtime_tmp".to_string(),
+            reason: row.reason,
+            owner: row.owner_id.unwrap_or_else(|| "unknown".to_string()),
+            run_id: None,
+            liveness: liveness.to_string(),
+            age: row
+                .age_seconds
+                .map(age_bucket)
+                .unwrap_or_else(|| "unknown".to_string()),
+            age_seconds: row.age_seconds,
+            size_bytes: row.size_bytes,
+            reference: row.path,
+        });
+    }
+
     let database_path = homeboy::core::observation::store::database_path()?;
     let metadata = std::fs::metadata(&database_path).ok();
     let sqlite = RetainedStorageSqlite {
@@ -423,6 +464,7 @@ fn build_retained_storage_report(
         largest_examples: examples,
         continuation,
         safe_next_commands: vec![
+            "homeboy cleanup --include runtime-tmp".to_string(),
             "homeboy cleanup --include controller-scratch".to_string(),
             "homeboy cleanup --include controller-runtimes".to_string(),
             "homeboy cleanup --include shared-cargo-targets".to_string(),
@@ -483,6 +525,8 @@ pub struct CleanupRetentionManifest {
     pub schema: &'static str,
     pub terminal_run_days: i64,
     pub runtime_tmp_days: u64,
+    pub runtime_run_max_bytes: u64,
+    pub runtime_run_max_count: usize,
     pub shared_store_days: u64,
     pub shared_store_max_bytes: u64,
     pub shared_store_lease_seconds: u64,
@@ -720,12 +764,15 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
     }
 
     if selected.includes(CleanupCategoryArg::RuntimeTmp) {
-        let output = engine::temp::cleanup_runtime_tmp(
-            apply,
-            configured.runtime_tmp_days,
-            None,
-            usize::try_from(limit).unwrap_or(usize::MAX),
-        )?;
+        let output =
+            engine::temp::cleanup_runtime_tmp_bounded(engine::temp::RuntimeTempCleanupOptions {
+                apply,
+                older_than_days: configured.runtime_tmp_days,
+                prefix: None,
+                limit: usize::try_from(limit).unwrap_or(usize::MAX),
+                run_max_bytes: configured.runtime_run_max_bytes,
+                run_max_count: configured.runtime_run_max_count,
+            })?;
         categories.push(category_from_output(
             RUNTIME_TMP_METADATA,
             apply,
@@ -844,6 +891,8 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
             schema: "homeboy/retention-manifest/v1",
             terminal_run_days,
             runtime_tmp_days: configured.runtime_tmp_days,
+            runtime_run_max_bytes: configured.runtime_run_max_bytes,
+            runtime_run_max_count: configured.runtime_run_max_count,
             shared_store_days: configured.shared_store_days,
             shared_store_max_bytes: configured.shared_store_max_bytes,
             shared_store_lease_seconds: configured.shared_store_lease_seconds,

--- a/crates/homeboy-cli/src/commands/self_cmd.rs
+++ b/crates/homeboy-cli/src/commands/self_cmd.rs
@@ -54,6 +54,12 @@ pub struct SelfCleanupRuntimeTmpArgs {
     /// Maximum temp entries to inspect in one invocation.
     #[arg(long, default_value_t = 1000)]
     pub limit: usize,
+    /// Maximum aggregate bytes retained for failed runtime run evidence.
+    #[arg(long, default_value_t = 1024 * 1024 * 1024)]
+    pub run_max_bytes: u64,
+    /// Maximum failed runtime run directories retained.
+    #[arg(long, default_value_t = 100)]
+    pub run_max_count: usize,
 }
 
 pub fn run(args: SelfArgs, _global: &GlobalArgs) -> CmdResult<Value> {
@@ -111,11 +117,15 @@ pub fn run(args: SelfArgs, _global: &GlobalArgs) -> CmdResult<Value> {
             Ok((json, exit_code))
         }
         SelfCommand::CleanupRuntimeTmp(args) => {
-            let output = engine::temp::cleanup_runtime_tmp(
-                args.apply,
-                args.older_than_days,
-                args.prefix.as_deref(),
-                args.limit,
+            let output = engine::temp::cleanup_runtime_tmp_bounded(
+                engine::temp::RuntimeTempCleanupOptions {
+                    apply: args.apply,
+                    older_than_days: args.older_than_days,
+                    prefix: args.prefix.as_deref(),
+                    limit: args.limit,
+                    run_max_bytes: args.run_max_bytes,
+                    run_max_count: args.run_max_count,
+                },
             )?;
             let json = serde_json::to_value(output)
                 .map_err(|e| homeboy::core::Error::internal_json(e.to_string(), None))?;

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -174,6 +174,10 @@ pub struct RetentionConfig {
     pub terminal_run_days: i64,
     #[serde(default = "default_runtime_tmp_retention_days")]
     pub runtime_tmp_days: u64,
+    #[serde(default = "default_runtime_run_max_bytes")]
+    pub runtime_run_max_bytes: u64,
+    #[serde(default = "default_runtime_run_max_count")]
+    pub runtime_run_max_count: usize,
     #[serde(default = "default_controller_runtime_retention_days")]
     pub controller_runtime_days: u64,
     #[serde(default = "default_controller_runtime_max_bytes")]
@@ -193,6 +197,8 @@ impl Default for RetentionConfig {
         Self {
             terminal_run_days: default_terminal_run_retention_days(),
             runtime_tmp_days: default_runtime_tmp_retention_days(),
+            runtime_run_max_bytes: default_runtime_run_max_bytes(),
+            runtime_run_max_count: default_runtime_run_max_count(),
             controller_runtime_days: default_controller_runtime_retention_days(),
             controller_runtime_max_bytes: default_controller_runtime_max_bytes(),
             limit: default_retention_limit(),
@@ -209,6 +215,14 @@ fn default_terminal_run_retention_days() -> i64 {
 
 fn default_runtime_tmp_retention_days() -> u64 {
     7
+}
+
+fn default_runtime_run_max_bytes() -> u64 {
+    1024 * 1024 * 1024
+}
+
+fn default_runtime_run_max_count() -> usize {
+    100
 }
 
 fn default_controller_runtime_retention_days() -> u64 {

--- a/crates/homeboy-core/src/engine/run_dir.rs
+++ b/crates/homeboy-core/src/engine/run_dir.rs
@@ -26,6 +26,7 @@
 
 use crate::error::{Error, Result};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// Well-known filenames for step outputs within a run directory.
 pub mod files {
@@ -64,6 +65,19 @@ pub fn run_dir_env() -> String {
 #[derive(Debug, Clone)]
 pub struct RunDir {
     path: PathBuf,
+    _lifecycle: Option<Arc<RunDirLifecycle>>,
+}
+
+#[derive(Debug)]
+struct RunDirLifecycle {
+    path: PathBuf,
+    _pin: super::temp::RuntimeTempPin,
+}
+
+impl Drop for RunDirLifecycle {
+    fn drop(&mut self) {
+        super::temp::retain_failed_run_dir(&self.path);
+    }
 }
 
 impl RunDir {
@@ -73,7 +87,7 @@ impl RunDir {
     /// drops or explicitly cleans it up — homeboy's temp pruner handles
     /// orphans from killed processes.
     pub fn create() -> Result<Self> {
-        let path = super::temp::runtime_temp_dir(
+        let (path, pin) = super::temp::managed_run_temp_dir(
             crate::product_identity::PRODUCT_IDENTITY.run_dir_prefix,
         )?;
         // Create annotations subdirectory
@@ -81,7 +95,10 @@ impl RunDir {
         std::fs::create_dir_all(&annotations).map_err(|e| {
             Error::internal_io(e.to_string(), Some("create annotations dir".to_string()))
         })?;
-        Ok(Self { path })
+        Ok(Self {
+            path: path.clone(),
+            _lifecycle: Some(Arc::new(RunDirLifecycle { path, _pin: pin })),
+        })
     }
 
     /// Wrap an existing directory as a run dir.
@@ -92,7 +109,10 @@ impl RunDir {
                 Some("open run dir".to_string()),
             ));
         }
-        Ok(Self { path })
+        Ok(Self {
+            path,
+            _lifecycle: None,
+        })
     }
 
     /// The root path of this run directory.
@@ -223,6 +243,7 @@ impl RunDir {
 
     /// Clean up the run directory. Called after the pipeline completes.
     pub fn cleanup(&self) {
+        super::temp::mark_run_dir_succeeded(&self.path);
         let _ = std::fs::remove_dir_all(&self.path);
     }
 }
@@ -310,6 +331,35 @@ mod tests {
         let path = run_dir.path().to_path_buf();
         run_dir.cleanup();
         assert!(!path.exists());
+    }
+
+    #[test]
+    fn drop_retains_failed_run_under_bounded_policy() {
+        let _guard = crate::test_support::home_env_guard();
+        let root = tempfile::tempdir().expect("runtime root");
+        std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", root.path());
+        let run_dir = RunDir::create().expect("run dir");
+        let path = run_dir.path().to_path_buf();
+        std::fs::write(run_dir.step_file(files::TEST_FAILURES), b"failure evidence")
+            .expect("failure evidence");
+
+        drop(run_dir);
+        let output = super::super::temp::cleanup_runtime_tmp_bounded(
+            super::super::temp::RuntimeTempCleanupOptions {
+                apply: true,
+                older_than_days: 7,
+                prefix: Some("homeboy-run"),
+                limit: 10,
+                run_max_bytes: 1024 * 1024,
+                run_max_count: 10,
+            },
+        )
+        .expect("cleanup inventory");
+
+        assert_eq!(output.removed_count, 0);
+        assert_eq!(output.rows[0].owner_state.as_deref(), Some("failed"));
+        assert!(path.exists());
+        std::env::remove_var("HOMEBOY_RUNTIME_TMPDIR");
     }
 
     #[test]

--- a/crates/homeboy-core/src/engine/temp.rs
+++ b/crates/homeboy-core/src/engine/temp.rs
@@ -1,6 +1,6 @@
 use crate::error::{Error, Result};
 use crate::paths;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
@@ -8,11 +8,60 @@ use std::time::{Duration, SystemTime};
 
 const RUNTIME_TEMP_PIN_FILE: &str = ".homeboy-runtime-temp-pin-v1";
 const RUNTIME_TEMP_PIN_SCHEMA_LINE: &str = "schema=homeboy-runtime-temp-pin-v1";
+const RUN_OWNER_FILE: &str = ".homeboy-run-owner-v1.json";
+const RUN_OWNER_SCHEMA: &str = "homeboy/runtime-run-owner/v1";
+const CLEANUP_LOCK_DIR: &str = ".cleanup.lock";
+const CLEANUP_LOCK_STALE_AFTER: Duration = Duration::from_secs(300);
+const CLEANUP_LOCK_ATTEMPTS: usize = 100;
+const CLEANUP_LOCK_SLEEP: Duration = Duration::from_millis(20);
 
 /// A process-owned pin which prevents runtime-temp cleanup from removing its directory.
 #[derive(Debug)]
 pub(crate) struct RuntimeTempPin {
     path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct RuntimeRunOwner {
+    schema: String,
+    owner_id: String,
+    owner_pid: u32,
+    state: String,
+    created_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    completed_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RuntimeTempCleanupOptions<'a> {
+    pub apply: bool,
+    pub older_than_days: u64,
+    pub prefix: Option<&'a str>,
+    pub limit: usize,
+    pub run_max_bytes: u64,
+    pub run_max_count: usize,
+}
+
+#[derive(Debug)]
+struct ManagedRunInspection {
+    path: PathBuf,
+    name: String,
+    owner: RuntimeRunOwner,
+    age_seconds: u64,
+    size_bytes: u64,
+    protection_reason: Option<String>,
+}
+
+struct RuntimeTempCleanupLock {
+    path: PathBuf,
+}
+
+impl Drop for RuntimeTempCleanupLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir(&self.path);
+    }
 }
 
 impl Drop for RuntimeTempPin {
@@ -66,6 +115,105 @@ pub(crate) fn pin_runtime_temp_dir(dir: &Path) -> Result<RuntimeTempPin> {
     }
 
     Ok(RuntimeTempPin { path })
+}
+
+pub(crate) fn managed_run_temp_dir(prefix: &str) -> Result<(PathBuf, RuntimeTempPin)> {
+    let path = runtime_temp_dir(prefix)?;
+    let owner = RuntimeRunOwner {
+        schema: RUN_OWNER_SCHEMA.to_string(),
+        owner_id: uuid::Uuid::new_v4().to_string(),
+        owner_pid: std::process::id(),
+        state: "active".to_string(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        completed_at: None,
+        reason: None,
+    };
+    if let Err(error) = write_run_owner(&path, &owner) {
+        let _ = fs::remove_dir_all(&path);
+        return Err(error);
+    }
+    match pin_runtime_temp_dir(&path) {
+        Ok(pin) => Ok((path, pin)),
+        Err(error) => {
+            let _ = fs::remove_dir_all(&path);
+            Err(error)
+        }
+    }
+}
+
+pub(crate) fn mark_run_dir_succeeded(path: &Path) {
+    update_run_owner(path, "succeeded", "successful teardown");
+}
+
+pub(crate) fn retain_failed_run_dir(path: &Path) {
+    update_run_owner(path, "failed", "owner exited before successful teardown");
+}
+
+fn update_run_owner(path: &Path, state: &str, reason: &str) {
+    if !path.exists() {
+        return;
+    }
+    let Ok(mut owner) = read_run_owner(path) else {
+        return;
+    };
+    if owner.state == "active" {
+        owner.state = state.to_string();
+        owner.completed_at = Some(chrono::Utc::now().to_rfc3339());
+        owner.reason = Some(reason.to_string());
+        let _ = write_run_owner(path, &owner);
+    }
+}
+
+fn read_run_owner(path: &Path) -> Result<RuntimeRunOwner> {
+    let owner_path = path.join(RUN_OWNER_FILE);
+    let raw = fs::read_to_string(&owner_path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("read runtime run owner {}", owner_path.display())),
+        )
+    })?;
+    let owner: RuntimeRunOwner = serde_json::from_str(&raw).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some(format!("parse runtime run owner {}", owner_path.display())),
+        )
+    })?;
+    if owner.schema != RUN_OWNER_SCHEMA || owner.owner_id.is_empty() || owner.owner_pid == 0 {
+        return Err(Error::validation_invalid_argument(
+            "runtime_run_owner",
+            "runtime run owner record has an unrecognized contract",
+            Some(owner_path.display().to_string()),
+            None,
+        ));
+    }
+    Ok(owner)
+}
+
+fn write_run_owner(path: &Path, owner: &RuntimeRunOwner) -> Result<()> {
+    let owner_path = path.join(RUN_OWNER_FILE);
+    let temporary = path.join(format!("{RUN_OWNER_FILE}.tmp-{}", std::process::id()));
+    let raw = serde_json::to_vec_pretty(owner).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize runtime run owner".to_string()),
+        )
+    })?;
+    fs::write(&temporary, raw).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("write runtime run owner {}", temporary.display())),
+        )
+    })?;
+    fs::rename(&temporary, &owner_path).map_err(|error| {
+        let _ = fs::remove_file(&temporary);
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "replace runtime run owner {}",
+                owner_path.display()
+            )),
+        )
+    })
 }
 
 enum RuntimeTempPinState {
@@ -166,6 +314,8 @@ pub struct RuntimeTempCleanupOutput {
     pub dry_run: bool,
     pub runtime_tmp_root: String,
     pub older_than_days: u64,
+    pub run_max_bytes: u64,
+    pub run_max_count: usize,
     pub prefix: Option<String>,
     #[serde(flatten)]
     pub totals: CleanupSizeTotals,
@@ -182,6 +332,16 @@ pub struct RuntimeTempCleanupRow {
     pub action: String,
     pub reason: String,
     pub size_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner_pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub age_seconds: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protection_reason: Option<String>,
 }
 
 pub fn cleanup_runtime_tmp(
@@ -190,13 +350,29 @@ pub fn cleanup_runtime_tmp(
     prefix: Option<&str>,
     limit: usize,
 ) -> Result<RuntimeTempCleanupOutput> {
+    cleanup_runtime_tmp_bounded(RuntimeTempCleanupOptions {
+        apply,
+        older_than_days,
+        prefix,
+        limit,
+        run_max_bytes: u64::MAX,
+        run_max_count: usize::MAX,
+    })
+}
+
+pub fn cleanup_runtime_tmp_bounded(
+    options: RuntimeTempCleanupOptions<'_>,
+) -> Result<RuntimeTempCleanupOutput> {
     let root = runtime_root()?;
+    let _lock = acquire_cleanup_lock(&root)?;
     let mut output = RuntimeTempCleanupOutput {
         command: "self.cleanup-runtime-tmp",
-        dry_run: !apply,
+        dry_run: !options.apply,
         runtime_tmp_root: root.display().to_string(),
-        older_than_days,
-        prefix: prefix.map(str::to_string),
+        older_than_days: options.older_than_days,
+        run_max_bytes: options.run_max_bytes,
+        run_max_count: options.run_max_count,
+        prefix: options.prefix.map(str::to_string),
         totals: CleanupSizeTotals {
             inspected_count: 0,
             planned_size_bytes: 0,
@@ -212,8 +388,11 @@ pub fn cleanup_runtime_tmp(
         return Ok(output);
     }
 
-    let cutoff = SystemTime::now()
-        .checked_sub(Duration::from_secs(older_than_days.saturating_mul(86_400)))
+    let now = SystemTime::now();
+    let cutoff = now
+        .checked_sub(Duration::from_secs(
+            options.older_than_days.saturating_mul(86_400),
+        ))
         .unwrap_or(SystemTime::UNIX_EPOCH);
 
     let mut entries = fs::read_dir(&root)
@@ -222,7 +401,193 @@ pub fn cleanup_runtime_tmp(
         .map_err(|e| Error::internal_io(e.to_string(), Some("read runtime tmp entry".into())))?;
     entries.sort_by_key(|entry| entry.file_name());
 
-    for entry in entries.into_iter().take(limit.max(1)) {
+    let mut managed = Vec::new();
+    let mut unmanaged = Vec::new();
+    for entry in entries {
+        if entry.file_name() == CLEANUP_LOCK_DIR {
+            continue;
+        }
+        if entry.path().join(RUN_OWNER_FILE).is_file() {
+            managed.push(entry);
+        } else {
+            unmanaged.push(entry);
+        }
+    }
+
+    let mut managed_inspections = Vec::new();
+    for entry in managed {
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        if options
+            .prefix
+            .is_some_and(|prefix| !name.starts_with(prefix))
+        {
+            output.skipped_count += 1;
+            output
+                .rows
+                .push(skip_row(path, name, "entry does not match prefix"));
+            continue;
+        }
+        let metadata = fs::symlink_metadata(&path).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("read runtime tmp {}", path.display())),
+            )
+        })?;
+        if metadata.file_type().is_symlink()
+            || !metadata.is_dir()
+            || !path_is_within_root(&path, &root)
+        {
+            output.skipped_count += 1;
+            output.rows.push(skip_row(
+                path,
+                name,
+                "managed run path is not a safe directory",
+            ));
+            continue;
+        }
+        let owner = match read_run_owner(&path) {
+            Ok(owner) => owner,
+            Err(error) => {
+                output.skipped_count += 1;
+                output.rows.push(skip_row(
+                    path,
+                    name,
+                    &format!("owner metadata is protected: {}", error.message),
+                ));
+                continue;
+            }
+        };
+        let age_seconds = owner
+            .completed_at
+            .as_deref()
+            .unwrap_or(&owner.created_at)
+            .parse::<chrono::DateTime<chrono::Utc>>()
+            .ok()
+            .map(|time| {
+                chrono::Utc::now()
+                    .signed_duration_since(time)
+                    .num_seconds()
+                    .max(0) as u64
+            })
+            .unwrap_or(0);
+        let protection_reason = match runtime_temp_pin_state(&path) {
+            RuntimeTempPinState::Active(pid) => {
+                Some(format!("runtime temp pin owner PID {pid} is running"))
+            }
+            RuntimeTempPinState::Malformed(reason) => Some(reason),
+            RuntimeTempPinState::Dead | RuntimeTempPinState::Absent
+                if owner.state == "active" && crate::process::pid_is_running(owner.owner_pid) =>
+            {
+                Some(format!(
+                    "runtime run owner PID {} is running",
+                    owner.owner_pid
+                ))
+            }
+            RuntimeTempPinState::Dead | RuntimeTempPinState::Absent => None,
+        };
+        managed_inspections.push(ManagedRunInspection {
+            path: path.clone(),
+            name,
+            owner,
+            age_seconds,
+            size_bytes: path_size_bytes(&path, &metadata)?,
+            protection_reason,
+        });
+    }
+
+    managed_inspections.sort_by(|left, right| {
+        left.age_seconds
+            .cmp(&right.age_seconds)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    let mut retained_count = 0usize;
+    let mut retained_bytes = 0u64;
+    let mut managed_decisions = Vec::new();
+    for inspection in managed_inspections {
+        let age_expired = inspection.age_seconds >= options.older_than_days.saturating_mul(86_400);
+        let exceeds_count = retained_count >= options.run_max_count;
+        let exceeds_bytes =
+            retained_bytes.saturating_add(inspection.size_bytes) > options.run_max_bytes;
+        let eligible =
+            inspection.owner.state == "succeeded" || age_expired || exceeds_count || exceeds_bytes;
+        let eligibility_reason = if inspection.protection_reason.is_some() || !eligible {
+            None
+        } else if inspection.owner.state == "succeeded" {
+            Some("successful run teardown is complete".to_string())
+        } else if age_expired {
+            Some("failed or interrupted run exceeded age retention".to_string())
+        } else if exceeds_count {
+            Some("failed or interrupted run exceeded count retention".to_string())
+        } else {
+            Some("failed or interrupted run exceeded byte retention".to_string())
+        };
+        if inspection.protection_reason.is_none() && eligibility_reason.is_none() {
+            retained_count += 1;
+            retained_bytes = retained_bytes.saturating_add(inspection.size_bytes);
+        }
+        managed_decisions.push((inspection, eligibility_reason));
+    }
+    // Candidate-first ordering lets bounded invocations converge even when the
+    // configured inspection limit is smaller than the retained count budget.
+    managed_decisions.sort_by(|left, right| {
+        right
+            .1
+            .is_some()
+            .cmp(&left.1.is_some())
+            .then_with(|| right.0.age_seconds.cmp(&left.0.age_seconds))
+            .then_with(|| left.0.path.cmp(&right.0.path))
+    });
+    for (inspection, eligibility_reason) in managed_decisions.into_iter().take(options.limit.max(1))
+    {
+        output.totals.inspected_count += 1;
+        let mut row = RuntimeTempCleanupRow {
+            path: inspection.path.display().to_string(),
+            name: inspection.name,
+            action: "skip".to_string(),
+            reason: String::new(),
+            size_bytes: inspection.size_bytes,
+            owner_id: Some(inspection.owner.owner_id.clone()),
+            owner_pid: Some(inspection.owner.owner_pid),
+            owner_state: Some(inspection.owner.state.clone()),
+            age_seconds: Some(inspection.age_seconds),
+            protection_reason: inspection.protection_reason.clone(),
+        };
+        if let Some(reason) = inspection.protection_reason {
+            row.reason = reason;
+            output.skipped_count += 1;
+        } else if let Some(reason) = eligibility_reason {
+            row.action = if options.apply { "removed" } else { "remove" }.to_string();
+            row.reason = reason;
+            output.planned_count += 1;
+            output.totals.planned_size_bytes += inspection.size_bytes;
+            if options.apply {
+                remove_runtime_tmp_entry(
+                    &inspection.path,
+                    &fs::symlink_metadata(&inspection.path).map_err(|error| {
+                        Error::internal_io(
+                            error.to_string(),
+                            Some(format!("restat {}", inspection.path.display())),
+                        )
+                    })?,
+                )?;
+                if !inspection.path.exists() {
+                    output.removed_count += 1;
+                    output.totals.removed_size_bytes += inspection.size_bytes;
+                }
+            }
+        } else {
+            row.reason = "failed run evidence is within bounded retention".to_string();
+            row.protection_reason = Some(row.reason.clone());
+            output.skipped_count += 1;
+        }
+        output.rows.push(row);
+    }
+
+    for entry in unmanaged
+        .into_iter()
+        .take(options.limit.max(1).saturating_sub(output.rows.len()))
+    {
         output.totals.inspected_count += 1;
         let path = entry.path();
         let name = entry.file_name().to_string_lossy().to_string();
@@ -232,6 +597,11 @@ pub fn cleanup_runtime_tmp(
             action: "skip".to_string(),
             reason: String::new(),
             size_bytes: 0,
+            owner_id: None,
+            owner_pid: None,
+            owner_state: None,
+            age_seconds: None,
+            protection_reason: None,
         };
 
         let metadata = fs::symlink_metadata(&path).map_err(|e| {
@@ -241,7 +611,10 @@ pub fn cleanup_runtime_tmp(
             )
         })?;
 
-        if prefix.is_some_and(|prefix| !name.starts_with(prefix)) {
+        if options
+            .prefix
+            .is_some_and(|prefix| !name.starts_with(prefix))
+        {
             row.reason = "entry does not match prefix".to_string();
             output.skipped_count += 1;
         } else if metadata.file_type().is_symlink() {
@@ -265,7 +638,7 @@ pub fn cleanup_runtime_tmp(
                         &path,
                         &metadata,
                         cutoff,
-                        apply,
+                        options.apply,
                         &mut row,
                         &mut output,
                     )?;
@@ -275,13 +648,72 @@ pub fn cleanup_runtime_tmp(
             row.reason = "entry is newer than retention cutoff".to_string();
             output.skipped_count += 1;
         } else {
-            cleanup_runtime_tmp_entry(&path, &metadata, cutoff, apply, &mut row, &mut output)?;
+            cleanup_runtime_tmp_entry(
+                &path,
+                &metadata,
+                cutoff,
+                options.apply,
+                &mut row,
+                &mut output,
+            )?;
         }
 
         output.rows.push(row);
     }
 
     Ok(output)
+}
+
+fn skip_row(path: PathBuf, name: String, reason: &str) -> RuntimeTempCleanupRow {
+    RuntimeTempCleanupRow {
+        path: path.display().to_string(),
+        name,
+        action: "skip".to_string(),
+        reason: reason.to_string(),
+        size_bytes: 0,
+        owner_id: None,
+        owner_pid: None,
+        owner_state: None,
+        age_seconds: None,
+        protection_reason: Some(reason.to_string()),
+    }
+}
+
+fn acquire_cleanup_lock(root: &Path) -> Result<RuntimeTempCleanupLock> {
+    fs::create_dir_all(root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("create {}", root.display())),
+        )
+    })?;
+    let path = root.join(CLEANUP_LOCK_DIR);
+    for _ in 0..CLEANUP_LOCK_ATTEMPTS {
+        match fs::create_dir(&path) {
+            Ok(()) => return Ok(RuntimeTempCleanupLock { path }),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let stale = fs::metadata(&path)
+                    .ok()
+                    .and_then(|metadata| metadata.modified().ok())
+                    .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+                    .is_some_and(|age| age > CLEANUP_LOCK_STALE_AFTER);
+                if stale {
+                    let _ = fs::remove_dir(&path);
+                } else {
+                    std::thread::sleep(CLEANUP_LOCK_SLEEP);
+                }
+            }
+            Err(error) => {
+                return Err(Error::internal_io(
+                    error.to_string(),
+                    Some(format!("acquire runtime cleanup lock {}", path.display())),
+                ));
+            }
+        }
+    }
+    Err(Error::internal_unexpected(format!(
+        "timed out acquiring runtime cleanup lock {}",
+        path.display()
+    )))
 }
 
 fn cleanup_runtime_tmp_entry(
@@ -402,6 +834,25 @@ mod tests {
     use super::*;
     use crate::test_support::{home_env_guard, with_isolated_home};
 
+    fn failed_run(prefix: &str, payload_bytes: usize) -> PathBuf {
+        let (path, pin) = managed_run_temp_dir(prefix).expect("managed run dir");
+        fs::write(path.join("evidence.bin"), vec![b'x'; payload_bytes]).expect("write evidence");
+        retain_failed_run_dir(&path);
+        drop(pin);
+        path
+    }
+
+    fn bounded_options<'a>(apply: bool, prefix: Option<&'a str>) -> RuntimeTempCleanupOptions<'a> {
+        RuntimeTempCleanupOptions {
+            apply,
+            older_than_days: 7,
+            prefix,
+            limit: 100,
+            run_max_bytes: 1024 * 1024 * 1024,
+            run_max_count: 100,
+        }
+    }
+
     #[test]
     fn runtime_temp_dir_honors_override() {
         let _guard = home_env_guard();
@@ -487,6 +938,160 @@ mod tests {
             .contains("after verifying no active owner"));
         assert!(directory.exists());
 
+        env::remove_var(runtime_tmpdir_env());
+    }
+
+    #[test]
+    fn failed_run_evidence_is_retained_with_owner_diagnostics() {
+        let _guard = home_env_guard();
+        let root = tempfile::tempdir().expect("tempdir");
+        env::set_var(runtime_tmpdir_env(), root.path());
+        let path = failed_run("homeboy-run-retained", 32);
+
+        let output = cleanup_runtime_tmp_bounded(bounded_options(true, Some("homeboy-run")))
+            .expect("cleanup");
+
+        assert_eq!(output.removed_count, 0);
+        assert_eq!(output.skipped_count, 1);
+        assert_eq!(output.rows[0].owner_state.as_deref(), Some("failed"));
+        assert!(output.rows[0].owner_id.is_some());
+        assert!(output.rows[0].owner_pid.is_some());
+        assert!(output.rows[0].age_seconds.is_some());
+        assert_eq!(
+            output.rows[0].protection_reason.as_deref(),
+            Some("failed run evidence is within bounded retention")
+        );
+        assert!(path.exists());
+        env::remove_var(runtime_tmpdir_env());
+    }
+
+    #[test]
+    fn active_run_and_artifact_promotion_are_protected_until_release() {
+        let _guard = home_env_guard();
+        let root = tempfile::tempdir().expect("tempdir");
+        env::set_var(runtime_tmpdir_env(), root.path());
+        let (path, pin) = managed_run_temp_dir("homeboy-run-promotion").expect("managed run");
+        fs::write(path.join("artifact.json"), b"promote me").expect("artifact");
+        let mut options = bounded_options(true, Some("homeboy-run"));
+        options.older_than_days = 0;
+        options.run_max_bytes = 0;
+        options.run_max_count = 0;
+
+        let protected = cleanup_runtime_tmp_bounded(options).expect("protected cleanup");
+        assert_eq!(protected.removed_count, 0);
+        assert!(protected.rows[0]
+            .protection_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("owner PID")));
+        assert_eq!(
+            fs::read(path.join("artifact.json")).expect("artifact remains"),
+            b"promote me"
+        );
+
+        mark_run_dir_succeeded(&path);
+        drop(pin);
+        let removed = cleanup_runtime_tmp_bounded(options).expect("released cleanup");
+        assert_eq!(removed.removed_count, 1);
+        assert!(!path.exists());
+        env::remove_var(runtime_tmpdir_env());
+    }
+
+    #[test]
+    fn stale_crashed_run_becomes_eligible() {
+        let _guard = home_env_guard();
+        let root = tempfile::tempdir().expect("tempdir");
+        env::set_var(runtime_tmpdir_env(), root.path());
+        let (path, pin) = managed_run_temp_dir("homeboy-run-crashed").expect("managed run");
+        let mut owner = read_run_owner(&path).expect("owner");
+        owner.owner_pid = u32::MAX;
+        owner.created_at = "2000-01-01T00:00:00Z".to_string();
+        write_run_owner(&path, &owner).expect("stale owner");
+        drop(pin);
+        fs::write(
+            path.join(RUNTIME_TEMP_PIN_FILE),
+            format!("{RUNTIME_TEMP_PIN_SCHEMA_LINE}\nowner_pid={}\n", u32::MAX),
+        )
+        .expect("dead pin");
+
+        let output = cleanup_runtime_tmp_bounded(bounded_options(true, Some("homeboy-run")))
+            .expect("cleanup stale run");
+        assert_eq!(output.removed_count, 1);
+        assert!(!path.exists());
+        env::remove_var(runtime_tmpdir_env());
+    }
+
+    #[test]
+    fn failed_runs_converge_under_count_and_byte_bounds() {
+        let _guard = home_env_guard();
+        let root = tempfile::tempdir().expect("tempdir");
+        env::set_var(runtime_tmpdir_env(), root.path());
+        let first = failed_run("homeboy-run-bound", 32);
+        std::thread::sleep(Duration::from_millis(5));
+        let second = failed_run("homeboy-run-bound", 64);
+        let mut count_options = bounded_options(true, Some("homeboy-run-bound"));
+        count_options.run_max_count = 1;
+        count_options.limit = 1;
+
+        let count_output = cleanup_runtime_tmp_bounded(count_options).expect("count cleanup");
+        assert_eq!(count_output.removed_count, 1);
+        assert!(first.exists() ^ second.exists());
+
+        let mut byte_options = bounded_options(true, Some("homeboy-run-bound"));
+        byte_options.run_max_bytes = 0;
+        let byte_output = cleanup_runtime_tmp_bounded(byte_options).expect("byte cleanup");
+        assert_eq!(byte_output.removed_count, 1);
+        assert!(!first.exists() && !second.exists());
+        env::remove_var(runtime_tmpdir_env());
+    }
+
+    #[test]
+    fn apply_reports_verified_bytes_and_is_idempotent() {
+        let _guard = home_env_guard();
+        let root = tempfile::tempdir().expect("tempdir");
+        env::set_var(runtime_tmpdir_env(), root.path());
+        let path = failed_run("homeboy-run-accounting", 257);
+        let metadata = fs::symlink_metadata(&path).expect("metadata");
+        let expected = path_size_bytes(&path, &metadata).expect("size");
+        let mut options = bounded_options(true, Some("homeboy-run-accounting"));
+        options.older_than_days = 0;
+
+        let applied = cleanup_runtime_tmp_bounded(options).expect("apply");
+        assert_eq!(applied.removed_count, 1);
+        assert_eq!(applied.totals.removed_size_bytes, expected);
+        assert!(!path.exists());
+
+        let repeated = cleanup_runtime_tmp_bounded(options).expect("repeat apply");
+        assert_eq!(repeated.removed_count, 0);
+        assert_eq!(repeated.totals.removed_size_bytes, 0);
+        env::remove_var(runtime_tmpdir_env());
+    }
+
+    #[test]
+    fn concurrent_cleanup_serializes_and_removes_once() {
+        let _guard = home_env_guard();
+        let root = tempfile::tempdir().expect("tempdir");
+        env::set_var(runtime_tmpdir_env(), root.path());
+        let path = failed_run("homeboy-run-concurrent", 128);
+        let mut options = bounded_options(true, Some("homeboy-run-concurrent"));
+        options.older_than_days = 0;
+
+        let first =
+            std::thread::spawn(move || cleanup_runtime_tmp_bounded(options).expect("first"));
+        let second =
+            std::thread::spawn(move || cleanup_runtime_tmp_bounded(options).expect("second"));
+        let outputs = [
+            first.join().expect("first join"),
+            second.join().expect("second join"),
+        ];
+
+        assert_eq!(
+            outputs
+                .iter()
+                .map(|output| output.removed_count)
+                .sum::<usize>(),
+            1
+        );
+        assert!(!path.exists());
         env::remove_var(runtime_tmpdir_env());
     }
 }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -61,6 +61,8 @@ variables.
 
 - `terminal_run_days` — Age threshold before terminal persisted-run artifacts are eligible for cleanup (default: 30). Active and unknown run states remain protected.
 - `runtime_tmp_days` — Age threshold for Homeboy runtime temporary entries (default: 7).
+- `runtime_run_max_bytes` — Maximum aggregate failed runtime-run evidence retained (default: 1 GiB).
+- `runtime_run_max_count` — Maximum failed runtime-run directories retained (default: 100).
 - `limit` — Maximum persisted-run artifact records inspected per aggregate cleanup invocation (default: 1000).
 
 ### `TriageConfig`


### PR DESCRIPTION
## Summary
- give controller-owned runtime run directories durable owner/state metadata and live pins so active runs and artifact promotion remain protected
- remove successful scratch at teardown while retaining failed/interrupted evidence under configurable 7-day, 1 GiB, and 100-directory defaults
- extend runtime-temp and retained-storage diagnostics with owner state, age, bytes, protection reasons, candidate/removal counts, and verified reclaimed bytes
- serialize cleanup apply, recover stale crashed owners, and order bounded candidates so repeated limited invocations converge

## Verification
- `cargo test -p homeboy-core engine::temp::tests -- --test-threads=1` (11 passed)
- `cargo test -p homeboy-core engine::run_dir::tests -- --test-threads=1` (11 passed)
- `cargo test -p homeboy-cli commands::cleanup -- --test-threads=1` (18 passed)
- rustfmt check passed for all changed Rust files
- clippy completed for `homeboy-core` and `homeboy-cli`; repository pre-existing warnings remain, with none in the new runtime retention code
- `homeboy review ... --changed-since origin/main`: lint passed, test stage passed; audit reported one informational `high_item_count` threshold in the expanded owner module plus baseline-known structural findings

Fixes #9430