### PR TITLE
Honor release scope exclusions in component notes

### DIFF
--- a/crates/homeboy-core/src/git/commits.rs
+++ b/crates/homeboy-core/src/git/commits.rs
@@ -579,6 +579,17 @@ pub fn get_commits_since_tag_for_paths(
     tag: Option<&str>,
     path_prefixes: &[&str],
 ) -> Result<Vec<CommitInfo>> {
+    get_commits_since_tag_for_scope(path, tag, path_prefixes, &[])
+}
+
+/// Get commits in a release scope while honoring both included and excluded
+/// repository-relative paths.
+pub fn get_commits_since_tag_for_scope(
+    path: &str,
+    tag: Option<&str>,
+    path_prefixes: &[&str],
+    excluded_prefixes: &[&str],
+) -> Result<Vec<CommitInfo>> {
     let range = tag
         .map(|t| format!("{}..HEAD", t))
         .unwrap_or_else(|| "HEAD".to_string());
@@ -592,11 +603,14 @@ pub fn get_commits_since_tag_for_paths(
     ];
 
     // Add path filters for monorepo scoping: `git log <range> -- <path>...`
-    if !path_prefixes.is_empty() {
+    if !path_prefixes.is_empty() || !excluded_prefixes.is_empty() {
         args.push("--".to_string());
     }
     for prefix in path_prefixes {
         args.push(prefix.to_string());
+    }
+    for prefix in excluded_prefixes {
+        args.push(format!(":(exclude){prefix}"));
     }
 
     let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
@@ -623,6 +637,11 @@ pub fn get_component_changes_since_tag(
         .iter()
         .filter_map(|path| normalize_component_change_path(path))
         .collect();
+    let mut excluded_prefixes: Vec<String> = scope
+        .exclude
+        .iter()
+        .filter_map(|path| normalize_component_change_path(path))
+        .collect();
 
     if prefixes.is_empty() {
         if let Some(prefix) = component_prefix.clone() {
@@ -634,17 +653,25 @@ pub fn get_component_changes_since_tag(
 
     if let Some(component_prefix) = component_prefix {
         let component_prefix = component_prefix.trim_end_matches('/');
-        for prefix in &mut prefixes {
-            if prefix != component_prefix && !prefix.starts_with(&format!("{component_prefix}/")) {
-                *prefix = format!("{component_prefix}/{prefix}");
-            }
-        }
+        prefix_component_paths(&mut prefixes, component_prefix);
+        prefix_component_paths(&mut excluded_prefixes, component_prefix);
     }
 
     prefixes.sort();
     prefixes.dedup();
+    excluded_prefixes.sort();
+    excluded_prefixes.dedup();
     let prefixes: Vec<&str> = prefixes.iter().map(String::as_str).collect();
-    get_commits_since_tag_for_paths(&git_root, tag, &prefixes)
+    let excluded_prefixes: Vec<&str> = excluded_prefixes.iter().map(String::as_str).collect();
+    get_commits_since_tag_for_scope(&git_root, tag, &prefixes, &excluded_prefixes)
+}
+
+fn prefix_component_paths(paths: &mut [String], component_prefix: &str) {
+    for path in paths {
+        if path != component_prefix && !path.starts_with(&format!("{component_prefix}/")) {
+            *path = format!("{component_prefix}/{path}");
+        }
+    }
 }
 
 fn normalize_component_change_path(path: &str) -> Option<String> {

--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -29,8 +29,8 @@ pub use commits::extract_version_from_tag;
 pub use commits::{
     categorize_commits, find_version_commit, find_version_release_commit, get_commits_in_range,
     get_commits_since_tag, get_commits_since_tag_for_path, get_commits_since_tag_for_paths,
-    get_component_changes_since_tag, get_last_n_commits, get_latest_tag,
-    get_latest_tag_any_with_prefix, get_latest_tag_with_prefix,
+    get_commits_since_tag_for_scope, get_component_changes_since_tag, get_last_n_commits,
+    get_latest_tag, get_latest_tag_any_with_prefix, get_latest_tag_with_prefix,
     get_previous_tag_before_any_with_prefix, get_previous_tag_before_with_prefix,
     recommended_bump_from_commits, strip_conventional_prefix, CommitCategory, CommitCounts,
     CommitInfo, MonorepoContext, SemverBump,

--- a/crates/homeboy-release/src/release/planning_changelog.rs
+++ b/crates/homeboy-release/src/release/planning_changelog.rs
@@ -264,7 +264,7 @@ mod tests {
     };
     use crate::release::scope::ReleaseScope;
     use crate::release::types::ReleaseOptions;
-    use homeboy_core::component::Component;
+    use homeboy_core::component::{CommandScopeConfig, Component, ScopeConfig};
     use homeboy_core::git::{CommitCategory, CommitInfo};
 
     fn commit(subject: &str, category: CommitCategory) -> CommitInfo {
@@ -510,7 +510,7 @@ mod tests {
         run_git(dir, &["config", "user.name", "PHP Author"]);
         commit_file(
             dir,
-            "figma-transformer/src/index.ts",
+            "php-transformer/tools/visual-parity/figma.ts",
             "figma",
             "feat: figma-only change (#912)",
         );
@@ -521,13 +521,17 @@ mod tests {
             "fix: php-only change (#942)",
         );
         std::fs::write(dir.join("php-transformer/src/index.php"), "mixed").unwrap();
-        std::fs::write(dir.join("figma-transformer/src/index.ts"), "mixed").unwrap();
+        std::fs::write(
+            dir.join("php-transformer/tools/visual-parity/figma.ts"),
+            "mixed",
+        )
+        .unwrap();
         run_git(
             dir,
             &[
                 "add",
                 "php-transformer/src/index.php",
-                "figma-transformer/src/index.ts",
+                "php-transformer/tools/visual-parity/figma.ts",
             ],
         );
         run_git(
@@ -544,6 +548,13 @@ mod tests {
             id: "php-transformer".to_string(),
             local_path: dir.join("php-transformer").to_string_lossy().to_string(),
             remote_url: Some("https://github.com/Automattic/blocks-engine.git".to_string()),
+            scopes: Some(ScopeConfig {
+                release: Some(CommandScopeConfig {
+                    include: vec![],
+                    exclude: vec!["tools/visual-parity/**".to_string()],
+                }),
+                ..Default::default()
+            }),
             ..Default::default()
         };
         let scope = ReleaseScope::resolve(&component, &component.id).unwrap();


### PR DESCRIPTION
## Summary
Honor existing release-scope exclusions when collecting component commits so semantically sibling work inside a component tree does not leak into its notes.

## What changed
- Added exclude pathspec support to scoped commit collection.
- Applied component-relative release exclusions alongside include paths.
- Changed the blocks-engine-shaped regression to place Figma-intent work under php-transformer/tools/visual-parity.

## How to test
1. Run `cargo test -q -p homeboy-release blocks_engine_shaped_changes_exclude_siblings_and_preserve_attribution`; expect Nested excluded work is absent while relevant attributed changes remain..
2. Run `cargo test -q -p homeboy-release planning_changelog`; expect All planning changelog tests pass..
3. Run `cargo test -q -p homeboy-core git::commits`; expect All core git commit tests pass..

## Compatibility
No schema or CLI change. Existing scopes.release.exclude declarations now affect release commit collection as intended.

## Evidence
- Base unchanged since verification: main remains at 571b0a721d84ce858dc021f84e46617b18202a9b.
- CI expected: Homeboy CI
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/9442
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/pull/9440
- Verified finalization base: main at 571b0a721d84ce858dc021f84e46617b18202a9b
- core-git-commits: Passed
- formatting: Passed
- nested-scope-regression: Passed
- planning-changelog: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Drafted implementation and tests; Chris reviews and owns the change.

## Source relationships
- Closes #9442
- Relates to #9440
