### PR TITLE
fix(agents): validate the declared base before mutating the target worktree (#9400)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -577,6 +577,31 @@ pub(super) fn promote_with_provider_and_checkpoint(
     let normalized_patch = normalize_promotion_patch(&patch, &options.to_worktree)?;
     let changed_files = normalized_patch.changed_files.clone();
 
+    // Validate the declared remote base BEFORE mutating the target worktree.
+    // Promotion must be atomic around base validation: a nonexistent declared
+    // base (e.g. `--base trunk` on a repo whose base is `main`) has to fail with
+    // no patch applied and no durable post-apply state recorded, so the same
+    // artifact/target can be retried with a corrected base (#9400).
+    let pre_apply_verified_base = if !options.dry_run {
+        match resolve_promotion_target_path(&options.to_worktree)? {
+            Some(target_path) => capture_declared_base(&target_path, options.base_ref.as_deref())?,
+            // No pre-apply Homeboy-managed target path resolves (e.g. a
+            // provider-owned destination); fall back to validating against the
+            // applied worktree below, preserving prior behavior for that path.
+            None => None,
+        }
+    } else {
+        None
+    };
+    // A declared base with no resolvable pre-apply target path still needs
+    // validation after apply; an empty/absent base has nothing to verify.
+    let base_verified_before_apply = pre_apply_verified_base.is_some()
+        || options
+            .base_ref
+            .as_deref()
+            .map(str::trim)
+            .is_none_or(str::is_empty);
+
     let mut command_evidence = Vec::new();
     let mut applied_worktree_path = None;
     {
@@ -631,7 +656,13 @@ pub(super) fn promote_with_provider_and_checkpoint(
         None
     };
     let verified_base = if let Some(worktree_path) = applied_worktree_path.as_deref() {
-        let verified_base = capture_declared_base(worktree_path, options.base_ref.as_deref())?;
+        // Reuse the base verified before apply; only re-capture when a
+        // provider-owned destination had no resolvable pre-apply target path.
+        let verified_base = if base_verified_before_apply {
+            pre_apply_verified_base
+        } else {
+            capture_declared_base(worktree_path, options.base_ref.as_deref())?
+        };
         (
             run_promotion_gates(&options, provider, worktree_path)?,
             verified_base,
@@ -1237,6 +1268,23 @@ fn promotion_source(
             .as_ref()
             .map(|path| path.display().to_string()),
     }
+}
+
+/// Resolve the Homeboy-managed target worktree path before the patch is
+/// applied, so the declared base can be validated against it without mutating
+/// the working tree (#9400). Returns `None` for a non-Homeboy destination
+/// (provider-owned), where the pre-apply path is not known and validation falls
+/// back to the applied worktree.
+fn resolve_promotion_target_path(to_worktree: &str) -> Result<Option<PathBuf>> {
+    let Some(record) = homeboy_core::worktree::resolve_workspace_ref_if_present(to_worktree)?
+    else {
+        return Ok(None);
+    };
+    if record.state() != &homeboy_core::worktree::TaskWorktreeState::Active {
+        return Ok(None);
+    }
+    let path = PathBuf::from(record.path());
+    Ok(path.is_dir().then_some(path))
 }
 
 fn capture_declared_base(

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -822,3 +822,131 @@ fn provider_command_response_supplies_workspace_and_evidence() {
         request
     );
 }
+
+#[test]
+fn promotion_validates_declared_base_before_mutating_the_target_worktree() {
+    // #9400: a nonexistent declared base must fail with no patch applied and no
+    // durable post-apply state recorded, so the same artifact/target can be
+    // retried with a corrected base.
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let worktree_path = temp.path().join("managed-target");
+        std::fs::create_dir(&worktree_path).expect("create target");
+        git(&worktree_path, &["init"]);
+        git(
+            &worktree_path,
+            &["config", "user.email", "test@example.com"],
+        );
+        git(&worktree_path, &["config", "user.name", "Test"]);
+        std::fs::create_dir_all(worktree_path.join("src")).expect("source dir");
+        std::fs::write(worktree_path.join("src/lib.rs"), "old\n").expect("base source");
+        git(&worktree_path, &["add", "."]);
+        git(&worktree_path, &["commit", "-m", "base"]);
+        git(&worktree_path, &["branch", "-M", "main"]);
+        let remote = temp.path().join("origin.git");
+        assert!(Command::new("git")
+            .args(["init", "--bare", remote.to_str().expect("remote path")])
+            .status()
+            .expect("create remote")
+            .success());
+        git(
+            &worktree_path,
+            &[
+                "remote",
+                "add",
+                "origin",
+                remote.to_str().expect("remote path"),
+            ],
+        );
+        git(&worktree_path, &["push", "-u", "origin", "main"]);
+
+        // Register the target as a Homeboy-managed worktree so promotion can
+        // resolve its path before applying (the pre-apply base validation gate).
+        worktree::adopt(WorktreeAdoptOptions {
+            handle: "repo@base-9400".to_string(),
+            path: worktree_path.display().to_string(),
+            kind: None,
+            provenance: None,
+        })
+        .expect("adopt target worktree");
+
+        let (source_path, source) = write_patch_source(&temp);
+        let options = |base: &str| AgentTaskPromotionOptions {
+            source: source.clone(),
+            source_run_id: Some("cook-9400".to_string()),
+            source_path: Some(source_path.clone()),
+            source_worktree_path: None,
+            base_ref: Some(base.to_string()),
+            task_base_sha: None,
+            candidate_ref: None,
+            to_worktree: "repo@base-9400".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["true".to_string()],
+                private_verify: Vec::new(),
+                private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+                ..Default::default()
+            },
+            provider_command: None,
+            provider_invocation: None,
+        };
+
+        let mut provider = FakePromotionWorkspaceProvider {
+            workspace_path: Some(worktree_path.clone()),
+            apply_to_git: true,
+            ..Default::default()
+        };
+        let mut checkpoints = Vec::new();
+        let error =
+            promote_with_provider_and_checkpoint(options("trunk"), &mut provider, &mut |report| {
+                checkpoints.push(report.clone());
+                Ok(())
+            })
+            .expect_err("nonexistent declared base must fail before apply");
+        assert!(
+            error
+                .message
+                .contains("declared base `trunk` was not found"),
+            "unexpected error: {}",
+            error.message
+        );
+        // Criterion 1 + 2: no patch applied, no durable post-apply checkpoint.
+        assert!(
+            provider.apply_calls.is_empty(),
+            "the target worktree must not be mutated"
+        );
+        assert!(
+            checkpoints.is_empty(),
+            "no post-apply state may be recorded"
+        );
+        assert_eq!(
+            Command::new("git")
+                .args(["status", "--porcelain"])
+                .current_dir(&worktree_path)
+                .output()
+                .expect("git status")
+                .stdout,
+            b"",
+            "the working tree must be clean"
+        );
+
+        // Criterion 3: retrying the same artifact/target with a valid base
+        // succeeds.
+        let mut provider = FakePromotionWorkspaceProvider {
+            workspace_path: Some(worktree_path.clone()),
+            apply_to_git: true,
+            ..Default::default()
+        };
+        let report =
+            promote_with_provider_and_checkpoint(options("main"), &mut provider, &mut |_| Ok(()))
+                .expect("valid base promotes cleanly");
+        assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
+        assert_eq!(provider.apply_calls.len(), 1);
+        assert_eq!(
+            report.verified_base.as_ref().map(|base| base.base.as_str()),
+            Some("main")
+        );
+    });
+}


### PR DESCRIPTION
## Summary

Closes #9400. `agent-task promote` was not atomic around declared-base validation. For run `cook-intelligence-889`, `--base trunk` (the repo's actual base is `main`) failed — **but the patch had already been applied** and durable post-apply state recorded. Retrying with `--base main` then failed:

```
Invalid argument promotion: promotion resume base or candidate input does not match the durable post-apply promotion
```

The candidate was applied but its lifecycle could not be resumed with the corrected base.

## Root cause

In the main promote path the ordering was: `apply_patch` (mutates the worktree) → `checkpoint` (persists durable post-apply state) → `capture_declared_base` (validates the base). So a nonexistent declared base failed *after* mutation + checkpoint.

## Fix

For a Homeboy-managed target worktree, resolve its path (`resolve_promotion_target_path`) and `capture_declared_base` **before** the apply block. A nonexistent base now fails with:

1. no patch applied,
2. no durable post-apply checkpoint recorded,

so the same artifact/target can be retried with a corrected base. The base verified before apply is reused for the report; the post-apply capture only re-runs as a fallback for a provider-owned destination with no resolvable pre-apply path (behavior preserved for that path — validated by the existing `promotion_checkpoints_applied_target_before_gate_transport_failure` test).

## Acceptance criteria

1. ✅ A nonexistent declared base fails without changing the target worktree.
2. ✅ No durable post-apply state is recorded for that pre-mutation failure.
3. ✅ Retrying the same artifact and target with a valid base succeeds.

## Tests (temp-disable proven)

`promotion_validates_declared_base_before_mutating_the_target_worktree` — adopts a real Homeboy worktree (origin/main pushed), promotes with `--base trunk`, asserts the error, empty `apply_calls`, no checkpoint, and a clean working tree; then retries with `--base main` and asserts `Applied` with `verified_base == main`. With the pre-apply gate disabled it fails at "the target worktree must not be mutated".

## Notes

- The broader `agent_task_promotion` test suite has a set of pre-existing environment flakes on this VPS (real git + gate execution; the failing set shifts run-to-run and reproduces identically on clean `origin/main` in isolation, e.g. `promote_reports_no_changes_for_empty_patch_metadata`: `VerifiedNoChanges` vs `NoChanges`). Those paths never reach the base-validation gate; this PR adds one passing test and breaks none.
- Verified with `cargo check/test -p homeboy-agents --lib` + `cargo fmt`.