### PR TITLE
Enforce accepted immutable deployment provenance

### DIFF
--- a/crates/homeboy-core/src/project/mod.rs
+++ b/crates/homeboy-core/src/project/mod.rs
@@ -128,6 +128,48 @@ pub struct Project {
     /// that `php -l`/syntax-only checks structurally cannot. See homeboy#5471.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub smoke_check: Option<SmokeCheckConfig>,
+
+    /// Optional fail-closed source-provenance policy for deployments.
+    /// Omission preserves the legacy deployment behavior.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployment_provenance: Option<DeploymentProvenancePolicy>,
+}
+
+/// Project-scoped deployment source policy.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct DeploymentProvenancePolicy {
+    #[serde(default)]
+    pub mode: DeploymentProvenanceMode,
+    /// Forge assertions that bind an accepted commit to review or merge evidence.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub forge_evidence: Vec<DeploymentForgeEvidence>,
+}
+
+/// The source proof required before a project may be deployed.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum DeploymentProvenanceMode {
+    /// Preserve legacy selector behavior.
+    #[default]
+    Any,
+    /// Require a ref resolved to a commit during this deploy's preflight.
+    ImmutableRef,
+    /// Require a release tag resolved to a commit during preflight.
+    Release,
+    /// Require a validated release set, release tag, or matching forge evidence.
+    AcceptedRef,
+}
+
+/// Configured, SHA-bound approval evidence supplied by a forge integration.
+///
+/// The contract is intentionally forge-neutral. Callers may use `forge` and
+/// `reference` for a pull request URL, merge record, or another immutable forge
+/// object; policy evaluation only trusts an exact SHA match.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeploymentForgeEvidence {
+    pub sha: String,
+    pub forge: String,
+    pub reference: String,
 }
 
 impl ConfigEntity for Project {

--- a/crates/homeboy-release/src/deploy/orchestration/mod.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/mod.rs
@@ -41,6 +41,7 @@ pub(super) fn deploy_components(
     base_path: &str,
     release_artifacts: &mut ReleaseArtifactStore,
 ) -> Result<DeployOrchestrationResult> {
+    let mut effective_config = config.clone();
     let loaded = load_project_components(project, &config.component_ids, config.check)?;
     validate_preflighted_component_identities(&loaded.deployable, config)?;
     validate_supported_build_configs(&loaded.deployable)?;
@@ -109,6 +110,13 @@ pub(super) fn deploy_components(
             },
         });
     }
+
+    // This must precede artifact resolution and every source operation below.
+    // Strict project policy failures are therefore unable to trigger a build,
+    // checkout/pull, dependency install, or remote deployment mutation.
+    let deployment_provenance =
+        preflight::guard_deployment_provenance(&project, &components, &mut effective_config)?;
+    let config = &effective_config;
 
     // Remote-path resolution is a pre-mutation guard: it fails closed so a real
     // deploy never writes to an unresolved destination. Read-only modes
@@ -356,6 +364,9 @@ pub(super) fn deploy_components(
         }
         if let Some(prepared_artifact) = config.prepared_artifact.clone() {
             result = result.with_prepared_artifact(prepared_artifact);
+        }
+        if let Some(evidence) = deployment_provenance.get(&component.id) {
+            result = result.with_deployment_provenance(evidence.clone());
         }
 
         // Attach explicit build provenance to every result, regardless of strategy.

--- a/crates/homeboy-release/src/deploy/orchestration/preflight.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/preflight.rs
@@ -1,13 +1,198 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::release::version;
 use homeboy_core::component::Component;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::git;
+use homeboy_core::project::{DeploymentProvenanceMode, Project};
 
 use super::super::execution::{release_artifact_plan, ReleaseArtifactPlan};
 use super::super::generated_artifacts::uncommitted_file_report_excluding_known_generated;
-use super::super::types::{compare_deployed_versions, ComponentStatus, DeployConfig};
+use super::super::types::{
+    compare_deployed_versions, ComponentStatus, DeployConfig, DeploymentProvenanceEvidence,
+};
+
+/// Enforce an opt-in project source-provenance policy before any source sync,
+/// checkout, dependency install, build, or remote deployment work begins.
+///
+/// The selected source is resolved once here and retained in `config`, so later
+/// materialization cannot silently follow a moved branch or tag. `--force`
+/// never weakens an active policy.
+pub(super) fn guard_deployment_provenance(
+    project: &Project,
+    components: &[Component],
+    config: &mut DeployConfig,
+) -> Result<BTreeMap<String, DeploymentProvenanceEvidence>> {
+    let Some(policy) = project.deployment_provenance.as_ref() else {
+        return Ok(BTreeMap::new());
+    };
+    if policy.mode == DeploymentProvenanceMode::Any {
+        return Ok(BTreeMap::new());
+    }
+    if config.force {
+        return Err(Error::validation_invalid_argument(
+            "force",
+            "--force cannot bypass this project's deployment provenance policy",
+            Some(project.id.clone()),
+            Some(vec![
+                "Remove --force and deploy a preflighted immutable source identity".to_string(),
+            ]),
+        ));
+    }
+    if config.head {
+        return Err(provenance_policy_error(project, "refuses --head"));
+    }
+
+    let mut evidence = BTreeMap::new();
+    for component in components
+        .iter()
+        .filter(|component| !component.is_file_component())
+    {
+        let release_set = config.requested_refs.contains_key(&component.id)
+            && config.preflighted_source_paths.contains_key(&component.id)
+            && config
+                .preflighted_component_identities
+                .contains_key(&component.id);
+        let requested_ref = config.requested_ref_for(&component.id).map(str::to_string);
+        let (requested_ref, resolved_sha, is_release_tag) = match requested_ref {
+            Some(requested_ref) => {
+                let resolved_sha = resolve_policy_ref(component, &requested_ref, config)?;
+                let is_release_tag = !release_set && is_release_tag(component, &requested_ref)?;
+                (requested_ref, resolved_sha, is_release_tag)
+            }
+            None => {
+                let tag = crate::release::latest_component_tag(component)?.ok_or_else(|| {
+                    provenance_policy_error(
+                        project,
+                        &format!("requires a release tag for '{}'", component.id),
+                    )
+                })?;
+                let resolved_sha = resolve_policy_ref(component, &tag, config)?;
+                config
+                    .requested_refs
+                    .insert(component.id.clone(), tag.clone());
+                (tag, resolved_sha, true)
+            }
+        };
+
+        let proof = match policy.mode {
+            DeploymentProvenanceMode::ImmutableRef => DeploymentProvenanceEvidence {
+                policy: "immutable-ref".to_string(),
+                kind: "immutable_ref".to_string(),
+                resolved_sha,
+                requested_ref: Some(requested_ref),
+                forge: None,
+                reference: None,
+            },
+            DeploymentProvenanceMode::Release if is_release_tag => DeploymentProvenanceEvidence {
+                policy: "release".to_string(),
+                kind: "release_tag".to_string(),
+                resolved_sha,
+                requested_ref: Some(requested_ref),
+                forge: None,
+                reference: None,
+            },
+            DeploymentProvenanceMode::AcceptedRef if release_set => DeploymentProvenanceEvidence {
+                policy: "accepted-ref".to_string(),
+                kind: "release_set".to_string(),
+                resolved_sha,
+                requested_ref: Some(requested_ref),
+                forge: None,
+                reference: None,
+            },
+            DeploymentProvenanceMode::AcceptedRef if is_release_tag => {
+                DeploymentProvenanceEvidence {
+                    policy: "accepted-ref".to_string(),
+                    kind: "release_tag".to_string(),
+                    resolved_sha,
+                    requested_ref: Some(requested_ref),
+                    forge: None,
+                    reference: None,
+                }
+            }
+            DeploymentProvenanceMode::AcceptedRef => {
+                let forge = policy
+                    .forge_evidence
+                    .iter()
+                    .find(|entry| entry.sha.eq_ignore_ascii_case(&resolved_sha))
+                    .ok_or_else(|| {
+                        provenance_policy_error(
+                            project,
+                            &format!("cannot verify accepted source for '{}'", component.id),
+                        )
+                    })?;
+                DeploymentProvenanceEvidence {
+                    policy: "accepted-ref".to_string(),
+                    kind: "forge".to_string(),
+                    resolved_sha,
+                    requested_ref: Some(requested_ref),
+                    forge: Some(forge.forge.clone()),
+                    reference: Some(forge.reference.clone()),
+                }
+            }
+            DeploymentProvenanceMode::Release => {
+                return Err(provenance_policy_error(
+                    project,
+                    &format!("requires a release tag for '{}'", component.id),
+                ));
+            }
+            DeploymentProvenanceMode::Any => unreachable!("any policy returns before preflight"),
+        };
+        evidence.insert(component.id.clone(), proof);
+    }
+    Ok(evidence)
+}
+
+fn resolve_policy_ref(
+    component: &Component,
+    requested_ref: &str,
+    config: &mut DeployConfig,
+) -> Result<String> {
+    let resolved_sha = match config.resolved_ref_for(&component.id) {
+        Some(sha) if is_full_git_sha(sha) => sha.to_string(),
+        Some(_) => {
+            return Err(Error::validation_invalid_argument(
+                "deployment_provenance",
+                format!(
+                    "Preflighted source for '{}' is not a full Git SHA",
+                    component.id
+                ),
+                None,
+                None,
+            ));
+        }
+        None => crate::deploy::preflight_exact_ref(component, requested_ref)?,
+    };
+    config
+        .resolved_refs
+        .insert(component.id.clone(), resolved_sha.clone());
+    Ok(resolved_sha)
+}
+
+fn is_release_tag(component: &Component, requested_ref: &str) -> Result<bool> {
+    Ok(crate::release::latest_component_tag(component)?.as_deref() == Some(requested_ref))
+}
+
+fn is_full_git_sha(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn provenance_policy_error(project: &Project, reason: &str) -> Error {
+    Error::validation_invalid_argument(
+        "deployment_provenance",
+        format!(
+            "Project '{}' deployment provenance policy {}",
+            project.id, reason
+        ),
+        Some(project.id.clone()),
+        Some(vec![
+            "Use a release tag, a validated --release-set, or a SHA with configured forge evidence"
+                .to_string(),
+            "The selected ref must resolve to an immutable commit before build or remote mutation"
+                .to_string(),
+        ]),
+    )
+}
 
 /// Return the components whose payload depends on local source or a local artifact.
 /// Downloaded release assets are immutable remote inputs and intentionally bypass
@@ -411,11 +596,14 @@ mod tests {
     use std::process::Command;
 
     use super::{
-        guard_head_matches_invocation_checkout, guard_local_build_downgrades,
-        guard_local_build_source_freshness, local_build_components,
+        guard_deployment_provenance, guard_head_matches_invocation_checkout,
+        guard_local_build_downgrades, guard_local_build_source_freshness, local_build_components,
     };
     use crate::deploy::DeployConfig;
     use homeboy_core::component::Component;
+    use homeboy_core::project::{
+        DeploymentForgeEvidence, DeploymentProvenanceMode, DeploymentProvenancePolicy, Project,
+    };
 
     fn config() -> DeployConfig {
         DeployConfig {
@@ -451,6 +639,111 @@ mod tests {
             local_path: path.to_string_lossy().to_string(),
             ..Component::default()
         }
+    }
+
+    fn accepted_ref_project() -> Project {
+        Project {
+            id: "production".to_string(),
+            deployment_provenance: Some(DeploymentProvenancePolicy {
+                mode: DeploymentProvenanceMode::AcceptedRef,
+                forge_evidence: vec![],
+            }),
+            ..Project::default()
+        }
+    }
+
+    #[test]
+    fn deployment_provenance_policy_fails_before_mutable_selectors_can_run() {
+        let component = component(Path::new("/unread-source"));
+        let project = accepted_ref_project();
+        let mut config = config();
+        config.head = true;
+        let error = guard_deployment_provenance(&project, &[component], &mut config)
+            .expect_err("HEAD must fail before source work");
+        assert_eq!(error.details["field"], "deployment_provenance");
+    }
+
+    #[test]
+    fn accepted_ref_policy_accepts_validated_release_set_and_refuses_force() {
+        let component = component(Path::new("/unread-source"));
+        let project = accepted_ref_project();
+        let mut config = config();
+        config
+            .requested_refs
+            .insert("example".to_string(), "v1.2.3".to_string());
+        config
+            .resolved_refs
+            .insert("example".to_string(), "a".repeat(40));
+        config
+            .preflighted_source_paths
+            .insert("example".to_string(), "/unread-source".to_string());
+        config
+            .preflighted_component_identities
+            .insert("example".to_string(), "identity".to_string());
+        let evidence = guard_deployment_provenance(&project, &[component.clone()], &mut config)
+            .expect("validated release set is accepted evidence");
+        assert_eq!(evidence["example"].kind, "release_set");
+
+        config.force = true;
+        let error = guard_deployment_provenance(&project, &[component], &mut config)
+            .expect_err("force must not bypass active policy");
+        assert_eq!(error.details["field"], "force");
+    }
+
+    #[test]
+    fn accepted_ref_policy_accepts_release_tag_and_sha_bound_forge_evidence() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        init_repo_with_commit(temp.path());
+        git(temp.path(), &["tag", "v1.2.3"]);
+        let component = component(temp.path());
+        let project = accepted_ref_project();
+
+        let mut tagged = config();
+        let evidence = guard_deployment_provenance(&project, &[component.clone()], &mut tagged)
+            .expect("latest release tag is accepted");
+        assert_eq!(evidence["example"].kind, "release_tag");
+
+        let sha = homeboy_core::git::run_git(temp.path(), &["rev-parse", "HEAD"], "read SHA")
+            .expect("SHA")
+            .trim()
+            .to_string();
+        let mut project = accepted_ref_project();
+        project
+            .deployment_provenance
+            .as_mut()
+            .expect("policy")
+            .forge_evidence = vec![DeploymentForgeEvidence {
+            sha: sha.clone(),
+            forge: "github".to_string(),
+            reference: "https://github.com/acme/example/pull/42".to_string(),
+        }];
+        let mut direct = config();
+        direct.requested_ref = Some(sha);
+        let evidence = guard_deployment_provenance(&project, &[component], &mut direct)
+            .expect("forge evidence for exact SHA is accepted");
+        assert_eq!(evidence["example"].kind, "forge");
+        assert_eq!(evidence["example"].forge.as_deref(), Some("github"));
+    }
+
+    #[test]
+    fn accepted_ref_policy_refuses_unverifiable_ref() {
+        let component = component(Path::new("/unread-source"));
+        let mut config = config();
+        config.requested_ref = Some("unverifiable".to_string());
+        assert!(
+            guard_deployment_provenance(&accepted_ref_project(), &[component], &mut config)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn omitted_deployment_provenance_policy_preserves_force_compatibility() {
+        let component = component(Path::new("/unread-source"));
+        let mut config = config();
+        config.head = true;
+        config.force = true;
+        guard_deployment_provenance(&Project::default(), &[component], &mut config)
+            .expect("projects without a policy retain legacy force semantics");
     }
 
     fn git(path: &Path, args: &[&str]) {

--- a/crates/homeboy-release/src/deploy/types.rs
+++ b/crates/homeboy-release/src/deploy/types.rs
@@ -368,6 +368,20 @@ pub struct BuildProvenance {
     pub artifact_identity: Option<ArtifactIdentity>,
 }
 
+/// The proof that satisfied a project deployment provenance policy.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeploymentProvenanceEvidence {
+    pub policy: String,
+    pub kind: String,
+    pub resolved_sha: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub forge: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference: Option<String>,
+}
+
 // DeployReason and ComponentStatus moved DOWN to homeboy-release-contract so
 // core's fleet/project/context status mechanics can reference them without a
 // cycle. Re-exported here so the deploy/release code keeps its paths.
@@ -460,6 +474,9 @@ pub struct ComponentDeployResult {
     /// Identity of an upstream-prepared artifact, when used.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prepared_artifact: Option<PreparedDeployArtifact>,
+    /// Project policy proof that authorized this component's source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployment_provenance: Option<DeploymentProvenanceEvidence>,
 }
 
 impl ComponentDeployResult {
@@ -494,6 +511,7 @@ impl ComponentDeployResult {
             resolution_mode: None,
             build_provenance: None,
             prepared_artifact: None,
+            deployment_provenance: None,
         }
     }
 
@@ -609,6 +627,14 @@ impl ComponentDeployResult {
         self
     }
 
+    pub(super) fn with_deployment_provenance(
+        mut self,
+        evidence: DeploymentProvenanceEvidence,
+    ) -> Self {
+        self.deployment_provenance = Some(evidence);
+        self
+    }
+
     pub(super) fn with_source_identity(mut self, component: &Component, head_deploy: bool) -> Self {
         let path = Path::new(&component.local_path);
         self.local_path = Some(component.local_path.clone());
@@ -676,8 +702,8 @@ fn detect_linked_worktree(path: &Path) -> Option<bool> {
 mod tests {
     use super::{
         compare_deployed_versions, parse_bulk_component_ids, ComponentDeployResult,
-        ComponentStatus, DeployConfig, DeployResult, PreparedDeployArtifact, ReleaseState,
-        ReleaseStateStatus,
+        ComponentStatus, DeployConfig, DeployResult, DeploymentProvenanceEvidence,
+        PreparedDeployArtifact, ReleaseState, ReleaseStateStatus,
     };
     use homeboy_core::component::{Component, ScopedExtensionConfig};
     use homeboy_core::project::Project;
@@ -974,6 +1000,26 @@ mod tests {
         assert_eq!(
             evidence["git_head"],
             "0123456789abcdef0123456789abcdef01234567"
+        );
+    }
+
+    #[test]
+    fn deployment_provenance_evidence_is_persisted_in_serialized_deploy_result() {
+        let result = deploy_result().with_deployment_provenance(DeploymentProvenanceEvidence {
+            policy: "accepted-ref".to_string(),
+            kind: "forge".to_string(),
+            resolved_sha: "0123456789abcdef0123456789abcdef01234567".to_string(),
+            requested_ref: Some("0123456789abcdef0123456789abcdef01234567".to_string()),
+            forge: Some("github".to_string()),
+            reference: Some("https://github.com/acme/example/pull/42".to_string()),
+        });
+
+        let evidence = serde_json::to_value(result).expect("serialize deploy result");
+        assert_eq!(evidence["deployment_provenance"]["policy"], "accepted-ref");
+        assert_eq!(evidence["deployment_provenance"]["kind"], "forge");
+        assert_eq!(
+            evidence["deployment_provenance"]["reference"],
+            "https://github.com/acme/example/pull/42"
         );
     }
 

--- a/docs/reference/schemas/project-schema.md
+++ b/docs/reference/schemas/project-schema.md
@@ -35,7 +35,15 @@ matter when the workflow needs environment context.
   "changelog_next_section_label": "string",
   "changelog_next_section_aliases": [],
   "cli_path": "string",
-  "extensions": {}
+  "extensions": {},
+  "deployment_provenance": {
+    "mode": "accepted-ref",
+    "forge_evidence": [{
+      "sha": "0123456789abcdef0123456789abcdef01234567",
+      "forge": "github",
+      "reference": "https://github.com/acme/component/pull/42"
+    }]
+  }
 }
 ```
 
@@ -86,6 +94,10 @@ matter when the workflow needs environment context.
 - **`extensions`** (object): Extension-specific settings for this project
   - Keys are extension IDs
   - Values are flat extension setting objects; `version` is reserved for extension version constraints
+- **`deployment_provenance`** (object): Optional fail-closed deployment source policy. Omit it to preserve legacy deploy behavior.
+  - **`mode`**: `any` (default), `immutable-ref`, `release`, or `accepted-ref`.
+  - **`forge_evidence`**: Optional SHA-bound forge records (`sha`, `forge`, `reference`). `accepted-ref` accepts a validated release set, a resolved release tag, or an exact SHA matching one of these records.
+  - Policies other than `any` reject `--head` and unverifiable refs before source checkout, dependency installation, build, or remote deployment. `--force` cannot bypass them. The resolved policy evidence is included in every deploy result.
 
 ## Example
 


### PR DESCRIPTION
## Summary

- add generic `any`, `immutable-ref`, `release`, and `accepted-ref` project deployment policies
- require strict policies to resolve accepted provenance before build or remote mutation
- accept validated release sets, resolved release tags, and exact-SHA forge evidence
- persist deployment provenance in deploy results and prevent `--force` bypass

## Compatibility

Existing projects remain unchanged because the default policy is `any`. Strict behavior is opt-in through project configuration.

## How to test

1. Run `cargo test -p homeboy-core --lib project::`.
2. Run `cargo test -p homeboy-release deployment_provenance`.
3. Run `cargo fmt --check`.

Closes #9368