### PR TITLE
Enforce durable changelog provenance

### DIFF
--- a/crates/contracts/homeboy-component-contract/src/config.rs
+++ b/crates/contracts/homeboy-component-contract/src/config.rs
@@ -233,6 +233,10 @@ pub struct GithubHostConfig {
 pub struct ComponentReleaseConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub github_release: Option<ComponentGithubReleaseConfig>,
+    /// Allow contributors to edit `changelog_target` outside Homeboy releases.
+    /// Disabled by default because configured changelogs are release-generated.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub allow_manual_changelog_edits: bool,
     /// Per-ZIP source-to-archive coverage declarations for transformed packages.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub package_coverage: Vec<PackageCoverageConfig>,
@@ -476,4 +480,16 @@ fn is_default_branch(s: &str) -> bool {
 }
 pub(super) fn is_false(value: &bool) -> bool {
     !*value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ComponentReleaseConfig;
+
+    #[test]
+    fn manual_changelog_edit_policy_is_absent_when_defaulted() {
+        let value = serde_json::to_value(ComponentReleaseConfig::default()).expect("serialize");
+
+        assert!(value.get("allow_manual_changelog_edits").is_none());
+    }
 }

--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -414,19 +414,12 @@ pub fn run_umbrella(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCo
 
     let mut top_hints: Vec<String> = Vec::new();
 
-    // Changelog-edit guard (#4876): homeboy regenerates the changelog from
-    // conventional commits at release time, so hand-editing the tracked
-    // changelog in a feature PR is both pointless and a guaranteed multi-PR
-    // merge-conflict surface. Surface a steering hint when the changeset
-    // modifies the component's configured changelog target. Agnostic: keys off
-    // `changelog_target` with no hardcoded filenames, and only runs when we
-    // actually computed a changed-file set (scoped review).
-    if let Some(changed_files) = review_context.precomputed_changed_files() {
-        if let Some(violation) =
-            changelog::detect_changelog_edit(component.changelog_target.as_deref(), changed_files)
-        {
-            top_hints.push(violation.message);
-        }
+    // Changelog-edit guard (#4876): the configured target is release-owned.
+    // Review has no release provenance, so a matching scoped mutation is an
+    // authored edit and must fail rather than remain a non-blocking hint.
+    let manual_changelog_edit = manual_changelog_edit(&component, &review_context);
+    if let Some(violation) = &manual_changelog_edit {
+        top_hints.push(violation.message.clone());
     }
 
     let mut audit_stage = None;
@@ -534,6 +527,13 @@ pub fn run_umbrella(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCo
             ci_profile: ci_profile_stage,
         },
     );
+    let overall_exit = if manual_changelog_edit.is_some() {
+        output.summary.passed = false;
+        output.summary.status = "failed".to_string();
+        overall_exit.max(1)
+    } else {
+        overall_exit
+    };
     attach_review_actionable(&mut output);
 
     print_human_summary(&output);
@@ -541,6 +541,19 @@ pub fn run_umbrella(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCo
     observation::finish_success(review_observation, &output, overall_exit);
 
     Ok((output, overall_exit))
+}
+
+fn manual_changelog_edit(
+    component: &homeboy::core::component::Component,
+    review_context: &ReviewExecutionContext,
+) -> Option<changelog::ChangelogGuardViolation> {
+    let changed_files = review_context.precomputed_changed_files()?;
+    changelog::detect_manual_changelog_edit(
+        component.changelog_target.as_deref(),
+        changed_files,
+        component.release.allow_manual_changelog_edits,
+        None,
+    )
 }
 
 fn attach_review_actionable(output: &mut ReviewCommandOutput) {
@@ -1182,6 +1195,28 @@ mod tests {
             build_audit_args(&args, &review_context).profile,
             "architecture"
         );
+    }
+
+    #[test]
+    fn review_rejects_manual_configured_changelog_edits_only() {
+        let review_context = ReviewExecutionContext {
+            scope: "changed-since".to_string(),
+            changed_file_count: Some(1),
+            precomputed_changed_files: Some(vec!["CHANGELOG.md".to_string()]),
+        };
+        let mut component = homeboy::core::component::Component {
+            changelog_target: Some("CHANGELOG.md".to_string()),
+            ..Default::default()
+        };
+
+        assert!(manual_changelog_edit(&component, &review_context).is_some());
+
+        component.release.allow_manual_changelog_edits = true;
+        assert!(manual_changelog_edit(&component, &review_context).is_none());
+
+        component.release.allow_manual_changelog_edits = false;
+        component.changelog_target = None;
+        assert!(manual_changelog_edit(&component, &review_context).is_none());
     }
 
     fn review_args_fixture() -> ReviewArgs {

--- a/crates/homeboy-release/src/release/changelog/guard.rs
+++ b/crates/homeboy-release/src/release/changelog/guard.rs
@@ -9,12 +9,11 @@
 //! flight against the same branch (#4876).
 //!
 //! This guard detects when a non-release changeset modifies the component's
-//! configured changelog target so callers (`homeboy review`, CI) can steer the
-//! contributor back to conventional commits instead of hand-editing the
-//! changelog. It is intentionally agnostic: it keys off the component's
-//! resolved `changelog_target` and a list of changed paths, with no
-//! hardcoded filenames.
+//! configured changelog target. It also exposes a small provenance policy that
+//! other generated-file guards can reuse: only an identified Homeboy release
+//! run may author generated output.
 
+use homeboy_core::execution::ChangeArtifactProvenance;
 use std::path::{Component as PathComponent, Path, PathBuf};
 
 /// Outcome of checking a changeset against the changelog-edit guard.
@@ -24,6 +23,24 @@ pub struct ChangelogGuardViolation {
     pub path: String,
     /// Human-readable steering message explaining the policy and the fix.
     pub message: String,
+}
+
+/// Whether generated output has durable provenance from Homeboy release.
+///
+/// File guards deliberately do not trust a producer label alone: a release
+/// run and its producing step must also be recorded so the authorization can
+/// be traced after the process exits.
+pub fn generated_file_mutation_is_authorized(
+    provenance: Option<&ChangeArtifactProvenance>,
+) -> bool {
+    provenance.is_some_and(|provenance| {
+        provenance.source == "release"
+            && provenance
+                .run_id
+                .as_deref()
+                .is_some_and(|id| !id.trim().is_empty())
+            && provenance.step_id.as_deref() == Some("changelog.finalize")
+    })
 }
 
 /// Detect whether `changed_files` modifies the configured `changelog_target`.
@@ -58,6 +75,21 @@ pub fn detect_changelog_edit(
         path: matched.clone(),
         message: steering_message(matched),
     })
+}
+
+/// Detect a configured changelog mutation that is not release-generated.
+///
+/// The path discriminator remains the component's configured target. The
+/// provenance policy is intentionally independent of path matching so it can
+/// protect other generated files without broadening this changelog guard.
+pub fn detect_manual_changelog_edit(
+    changelog_target: Option<&str>,
+    changed_files: &[String],
+    allow_manual_edits: bool,
+    provenance: Option<&ChangeArtifactProvenance>,
+) -> Option<ChangelogGuardViolation> {
+    let violation = detect_changelog_edit(changelog_target, changed_files)?;
+    (!allow_manual_edits && !generated_file_mutation_is_authorized(provenance)).then_some(violation)
 }
 
 /// Build the steering message shown when a changeset hand-edits the changelog.
@@ -185,5 +217,69 @@ mod tests {
     #[test]
     fn empty_changeset_is_a_noop() {
         assert!(detect_changelog_edit(Some("docs/changelog.md"), &[]).is_none());
+    }
+
+    #[test]
+    fn manual_changelog_edit_is_rejected_without_release_provenance() {
+        assert!(detect_manual_changelog_edit(
+            Some("docs/changelog.md"),
+            &files(&["docs/changelog.md"]),
+            false,
+            None,
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn release_generated_changelog_edit_is_accepted_with_durable_provenance() {
+        let provenance = ChangeArtifactProvenance {
+            source: "release".to_string(),
+            run_id: Some("release.component".to_string()),
+            step_id: Some("changelog.finalize".to_string()),
+            command: None,
+            captured_at: None,
+        };
+
+        assert!(generated_file_mutation_is_authorized(Some(&provenance)));
+        assert!(detect_manual_changelog_edit(
+            Some("docs/changelog.md"),
+            &files(&["docs/changelog.md"]),
+            false,
+            Some(&provenance),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn generated_file_policy_rejects_incomplete_or_untrusted_provenance() {
+        for provenance in [
+            ChangeArtifactProvenance {
+                source: "manual".to_string(),
+                run_id: Some("release.component".to_string()),
+                step_id: Some("changelog.finalize".to_string()),
+                command: None,
+                captured_at: None,
+            },
+            ChangeArtifactProvenance {
+                source: "release".to_string(),
+                run_id: Some(" ".to_string()),
+                step_id: Some("changelog.finalize".to_string()),
+                command: None,
+                captured_at: None,
+            },
+        ] {
+            assert!(!generated_file_mutation_is_authorized(Some(&provenance)));
+        }
+    }
+
+    #[test]
+    fn manual_edit_policy_allows_an_explicit_component_opt_out() {
+        assert!(detect_manual_changelog_edit(
+            Some("docs/changelog.md"),
+            &files(&["docs/changelog.md"]),
+            true,
+            None,
+        )
+        .is_none());
     }
 }

--- a/crates/homeboy-release/src/release/changelog/mod.rs
+++ b/crates/homeboy-release/src/release/changelog/mod.rs
@@ -5,7 +5,10 @@ mod sections;
 mod settings;
 
 pub use bulk::{show, ShowOutput};
-pub use guard::{detect_changelog_edit, ChangelogGuardViolation};
+pub use guard::{
+    detect_changelog_edit, detect_manual_changelog_edit, generated_file_mutation_is_authorized,
+    ChangelogGuardViolation,
+};
 pub use io::{
     discover_changelog_relative_path, read_component_snapshots, resolve_changelog_path,
     ChangelogSnapshotData, FinalizedReleaseSnapshot, CHANGELOG_CANDIDATES,

--- a/crates/homeboy-release/src/release/execution_projection.rs
+++ b/crates/homeboy-release/src/release/execution_projection.rs
@@ -7,6 +7,7 @@ use homeboy_core::execution::{
 use homeboy_core::plan::PlanSubject;
 
 use super::types::{ReleaseArtifact, ReleaseRun, ReleaseStepResult, ReleaseStepStatus};
+use super::version::ChangelogValidationResult;
 
 impl From<&ReleaseRun> for ExecutionRun {
     fn from(run: &ReleaseRun) -> Self {
@@ -67,6 +68,12 @@ fn release_artifacts_from_run(run_id: &str, steps: &[ReleaseStepResult]) -> Vec<
 }
 
 fn release_artifacts_from_step(run_id: &str, step: &ReleaseStepResult) -> Vec<ChangeArtifact> {
+    if step.id == "changelog.finalize" {
+        return changelog_artifact_from_step(run_id, step)
+            .into_iter()
+            .collect();
+    }
+
     let Some(data) = step.data.as_ref() else {
         return Vec::new();
     };
@@ -112,6 +119,35 @@ fn release_artifacts_from_step(run_id: &str, step: &ReleaseStepResult) -> Vec<Ch
             }
         })
         .collect()
+}
+
+/// Project the release-owned generated file from the changelog lifecycle step.
+/// This makes its origin available after the release process exits through the
+/// durable execution artifact contract, rather than an in-memory guard value.
+fn changelog_artifact_from_step(run_id: &str, step: &ReleaseStepResult) -> Option<ChangeArtifact> {
+    let result = serde_json::from_value::<ChangelogValidationResult>(step.data.clone()?).ok()?;
+    if !result.changelog_changed {
+        return None;
+    }
+
+    Some(ChangeArtifact {
+        id: format!("{}.artifact.1", step.id),
+        artifact_type: "generated_file".to_string(),
+        provenance: ChangeArtifactProvenance {
+            source: "release".to_string(),
+            run_id: Some(run_id.to_string()),
+            step_id: Some(step.id.clone()),
+            command: None,
+            captured_at: None,
+        },
+        title: Some("Generated changelog".to_string()),
+        summary: Some("Homeboy release-generated changelog mutation".to_string()),
+        path: Some(result.changelog_path.clone()),
+        files: vec![result.changelog_path],
+        diff: None,
+        approval_scope: None,
+        metadata: HashMap::new(),
+    })
 }
 
 fn release_artifact_ids(step_id: &str, data: Option<&serde_json::Value>) -> Vec<String> {
@@ -177,5 +213,51 @@ mod tests {
         );
         assert_eq!(execution.artifacts[0].provenance.source, "release");
         assert_eq!(execution.warnings, vec!["signed artifact missing"]);
+    }
+
+    #[test]
+    fn changelog_finalize_projects_durable_generated_file_provenance() {
+        let release = ReleaseRun {
+            component_id: "homeboy".to_string(),
+            enabled: true,
+            result: ReleaseRunResult {
+                steps: vec![ReleaseStepResult {
+                    id: "changelog.finalize".to_string(),
+                    step_type: "changelog.finalize".to_string(),
+                    status: ReleaseStepStatus::Success,
+                    data: Some(serde_json::json!({
+                        "changelog_path": "CHANGELOG.md",
+                        "changelog_finalized": true,
+                        "changelog_changed": true
+                    })),
+                    ..Default::default()
+                }],
+                status: ReleaseStepStatus::Success,
+                warnings: Vec::new(),
+                summary: None,
+                phase_timings: None,
+            },
+        };
+
+        let execution = ExecutionRun::from(&release);
+
+        assert_eq!(execution.artifacts.len(), 1);
+        let artifact = &execution.artifacts[0];
+        assert_eq!(artifact.artifact_type, "generated_file");
+        assert_eq!(artifact.files, vec!["CHANGELOG.md"]);
+        assert_eq!(artifact.provenance.source, "release");
+        assert_eq!(
+            artifact.provenance.run_id.as_deref(),
+            Some("release.homeboy")
+        );
+        assert_eq!(
+            artifact.provenance.step_id.as_deref(),
+            Some("changelog.finalize")
+        );
+        assert!(
+            super::super::changelog::generated_file_mutation_is_authorized(Some(
+                &artifact.provenance
+            ))
+        );
     }
 }

--- a/crates/homeboy-release/src/release/version/types.rs
+++ b/crates/homeboy-release/src/release/version/types.rs
@@ -1,7 +1,7 @@
 //! types — extracted from version.rs.
 
 use homeboy_core::is_zero;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 // VersionTargetInfo and ComponentVersionSnapshot moved DOWN to
 // homeboy-release-contract so core's context status mechanics can hold them in
@@ -33,7 +33,7 @@ pub struct BumpResult {
 }
 
 /// Result of validating and finalizing changelog for a version operation.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChangelogValidationResult {
     pub changelog_path: String,
     pub changelog_finalized: bool,


### PR DESCRIPTION
## Summary

- reject scoped manual changelog edits unless the component explicitly opts out
- project release-generated changelog mutations into durable execution provenance
- make review consume the generated-file provenance contract instead of a non-blocking hint
- preserve default component configuration serialization

## Compatibility

Components that intentionally maintain changelogs manually can set `release.allow_manual_changelog_edits`. Release-generated changelogs now carry durable provenance automatically.

## How to test

1. Run `cargo test -p homeboy-component-contract`.
2. Run `cargo test -p homeboy-release changelog`.
3. Run `cargo test -p homeboy-cli review_rejects_manual_configured_changelog_edits --lib`.
4. Run `cargo fmt --check`.

Closes #9367