### PR TITLE
Reconcile stale runner generations and timed-out handoffs

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -72,6 +72,16 @@ pub(crate) fn has_expired_pending_runner_submission_intent(
         && record.has_expired_pending_lab_handoff(now)
 }
 
+/// Check whether a controller-owned Lab handoff remains unaccepted after its
+/// durable deadline. Terminalization rechecks this predicate under the handoff
+/// lock before mutating the record.
+pub(crate) fn has_expired_unaccepted_lab_handoff(run_id: &str) -> Result<bool> {
+    Ok(has_expired_pending_runner_submission_intent(
+        &store::read_record(&sanitize_run_id(run_id))?,
+        chrono::Utc::now(),
+    ))
+}
+
 fn has_complete_pending_runner_submission_intent(record: &AgentTaskRunRecord) -> bool {
     if record.state != AgentTaskRunState::Queued || record.runner_job_id().is_some() {
         return false;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -63,7 +63,12 @@ pub(crate) fn has_expired_pending_runner_submission_intent(
     record: &AgentTaskRunRecord,
     now: chrono::DateTime<chrono::Utc>,
 ) -> bool {
-    has_complete_pending_runner_submission_intent(record)
+    record.state == AgentTaskRunState::Queued
+        && record.runner_job_id().is_none()
+        && record.lab_handoff.as_ref().is_some_and(|handoff| {
+            handoff.state == AgentTaskLabHandoffState::Pending
+                && handoff.authority == AgentTaskLabHandoffAuthority::Controller
+        })
         && record.has_expired_pending_lab_handoff(now)
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -224,20 +224,6 @@ pub fn discover_runs_with_options(
     discovery_report(filter, options, records, record_health)
 }
 
-/// Discovery for an operator-requested reconciliation. Unlike ordinary bounded
-/// readers, this refreshes runner-backed records before classifying candidates.
-pub(crate) fn discover_runs_with_reconciliation(
-    filter: AgentTaskDiscoveryFilter,
-) -> Result<AgentTaskDiscoveryReport> {
-    let (records, record_health) = agent_task_lifecycle::list_records_with_health()?;
-    discovery_report(
-        filter,
-        AgentTaskDiscoveryOptions::default(),
-        records,
-        record_health,
-    )
-}
-
 fn discovery_report(
     filter: AgentTaskDiscoveryFilter,
     options: AgentTaskDiscoveryOptions,

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -4,9 +4,7 @@
 use crate::agent_task_lifecycle;
 use homeboy_core::Result;
 
-use super::discovery::{
-    discover_runs_with_reconciliation, AgentTaskDiscoveryFilter, AgentTaskLiveness,
-};
+use super::discovery::{discover_runs, AgentTaskDiscoveryFilter, AgentTaskLiveness};
 
 /// Report returned by [`reconcile_stale_active_runs`]. Lists every active run
 /// that was classified non-active, and for the reconcilable ones records the
@@ -46,7 +44,11 @@ pub struct AgentTaskReconcileRun {
 /// work) are never touched. With `dry_run`, candidates are reported but no
 /// record is mutated so an operator can preview the blast radius first.
 pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileReport> {
-    let report = discover_runs_with_reconciliation(AgentTaskDiscoveryFilter::Active)?;
+    // Read the durable snapshot first so an expired controller handoff remains
+    // visible to this managed recovery command. `status` also converges expiry,
+    // but would otherwise terminalize it before this report can record the
+    // actionable retry outcome.
+    let report = discover_runs(AgentTaskDiscoveryFilter::Active)?;
 
     let mut runs = Vec::new();
     let mut reconciled = 0usize;
@@ -60,6 +62,8 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
             continue;
         }
 
+        let expired_handoff =
+            agent_task_lifecycle::has_expired_unaccepted_lab_handoff(&run.run_id)?;
         if dry_run {
             runs.push(AgentTaskReconcileRun {
                 run_id: run.run_id,
@@ -76,7 +80,12 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
             .stale_reason
             .clone()
             .unwrap_or_else(|| format!("reconciled stale-{} run", liveness.as_str()));
-        match agent_task_lifecycle::cancel_run(&run.run_id, Some(&reason)) {
+        let result = if expired_handoff {
+            agent_task_lifecycle::expire_unaccepted_lab_handoff(&run.run_id).map(|_| ())
+        } else {
+            agent_task_lifecycle::cancel_run(&run.run_id, Some(&reason)).map(|_| ())
+        };
+        match result {
             Ok(_) => {
                 reconciled += 1;
                 runs.push(AgentTaskReconcileRun {

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -944,12 +944,11 @@ fn reconcile_terminalizes_an_unaccepted_controller_handoff_after_its_deadline() 
         let reconciliation = reconcile_stale_active_runs(false).expect("reconciled");
         assert_eq!(reconciliation.reconciled, 1);
         assert_eq!(reconciliation.runs[0].action, "reconciled");
-        assert_eq!(
-            lifecycle_status("controller-handoff-unaccepted")
-                .expect("terminal controller record")
-                .state,
-            AgentTaskRunState::Cancelled
-        );
+        let terminal =
+            lifecycle_status("controller-handoff-unaccepted").expect("terminal controller record");
+        assert_eq!(terminal.state, AgentTaskRunState::Cancelled);
+        assert_eq!(terminal.metadata["provider_executions_consumed"], 0);
+        assert_eq!(terminal.metadata["retryable"], true);
     });
 }
 

--- a/crates/homeboy-cli/src/commands/runner/doctor/repair.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/repair.rs
@@ -54,19 +54,12 @@ pub fn apply(
         format!("homeboy runner disconnect {id}"),
         format!("homeboy runner connect {id}"),
     ];
-    let disconnected = runner::disconnect(id);
-    if let Err(err) = disconnected {
-        report.repairs.push(RunnerRepair {
-            id: "repair.daemon".to_string(),
-            status: RunnerDoctorStatus::Error,
-            message: format!("Could not disconnect stale Lab daemon: {}", err.message),
-            commands,
-        });
-        return;
-    }
-
+    let disconnect_error = runner::disconnect(id).err();
+    // Connect owns lease-safe dead-daemon adoption. A failed disconnect must not
+    // force operators through repeated stop/adopt cycles when its authoritative
+    // probe has already established that the recorded owner is gone.
     match runner::connect(id) {
-        Ok(_) => {
+        Ok((_, 0)) => {
             report.checks.retain(|check| check.id != "daemon.exec");
             let workspace_root = runner_config.workspace_root.as_deref().unwrap_or(".");
             report
@@ -75,8 +68,31 @@ pub fn apply(
             report.repairs.push(RunnerRepair {
                 id: "repair.daemon".to_string(),
                 status: RunnerDoctorStatus::Ok,
-                message: "Reconnected the Lab runner daemon and reran the daemon exec probe"
-                    .to_string(),
+                message: match disconnect_error {
+                    Some(error) => format!(
+                        "Recovered the Lab runner daemon after bounded disconnect failed ({}) and reran the daemon exec probe",
+                        error.message
+                    ),
+                    None => "Reconnected the Lab runner daemon and reran the daemon exec probe"
+                        .to_string(),
+                },
+                commands,
+            });
+        }
+        Ok((connect_report, exit_code)) => {
+            let failure = connect_report
+                .failure_message
+                .unwrap_or_else(|| format!("runner connect exited with code {exit_code}"));
+            report.repairs.push(RunnerRepair {
+                id: "repair.daemon".to_string(),
+                status: RunnerDoctorStatus::Error,
+                message: match disconnect_error {
+                    Some(disconnect_error) => format!(
+                        "Could not recover Lab daemon after bounded disconnect failed ({}): {}",
+                        disconnect_error.message, failure
+                    ),
+                    None => format!("Could not reconnect Lab daemon: {failure}"),
+                },
                 commands,
             });
         }
@@ -84,7 +100,13 @@ pub fn apply(
             report.repairs.push(RunnerRepair {
                 id: "repair.daemon".to_string(),
                 status: RunnerDoctorStatus::Error,
-                message: format!("Could not reconnect Lab daemon: {}", err.message),
+                message: match disconnect_error {
+                    Some(disconnect_error) => format!(
+                        "Could not recover Lab daemon after bounded disconnect failed ({}): {}",
+                        disconnect_error.message, err.message
+                    ),
+                    None => format!("Could not reconnect Lab daemon: {}", err.message),
+                },
                 commands,
             });
         }


### PR DESCRIPTION
## Summary

- terminalize expired controller-owned Lab handoffs even when materialization never persisted a complete replay intent
- reconcile expired handoffs through active-run discovery without consuming provider execution budget
- extend Lab doctor repair with bounded lease-safe reconnect recovery
- preserve upstream generation reconciliation and authoritative daemon protections

## How to test

1. Run `cargo test -p homeboy-agents reconcile_terminalizes_an_unaccepted_controller_handoff_after_its_deadline --lib`.
2. Run `cargo test -p homeboy-cli commands::runner::doctor --lib`.
3. Run `cargo test -p homeboy-lab-runner connection::tests::recovery --lib`.
4. Run `cargo fmt --check`.

Closes #9406