### PR TITLE
refactor(agents): route validate_runner_job_snapshot through canonical RunnerJobIdentity

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -366,17 +366,28 @@ fn validate_runner_job_snapshot(
     record: &AgentTaskRunRecord,
     snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
 ) -> Result<()> {
-    // Distinguish "controller identity not yet established" from a genuine
-    // identity mismatch. When the controller has never persisted an accepted
-    // runner job id, `runner_job_id()` is `None` and comparing a valid runner
-    // snapshot UUID against an empty string spuriously rejects it as a mismatch
-    // (issue #9240: "runner snapshot job <uuid> does not match controller job "
-    // — the blank trailing value is the missing-identity signal, not a mismatch).
-    // Callers must bind or propagate the accepted Lab job id before validation;
-    // surface the absence as its own diagnostic so it is fixed at the source
-    // instead of being presented as a runner mismatch and classified as a
-    // non-retryable runner error.
-    let Some(expected_job_id) = record.runner_job_id() else {
+    // Build the canonical run/runner/job identity the controller expects, so
+    // this validator names the same tuple as every other handoff-identity site
+    // (`validate_terminal_child_identity`, `accepted_lab_runner_handoff_identity`,
+    // …). This is a snapshot-scoped check: only the `runner_job_id` field is
+    // compared against the daemon snapshot; the run/runner fields are carried
+    // for diagnostics and mismatch descriptions.
+    let expected = homeboy_core::lab_contract::RunnerJobIdentity::new(
+        record.run_id.as_str(),
+        record.runner_id().unwrap_or_default(),
+        record.runner_job_id().unwrap_or_default(),
+    );
+    // Distinguish "controller job identity not yet established" from a genuine
+    // mismatch. When the controller has never persisted an accepted runner job
+    // id, the job field is empty and comparing a valid runner snapshot UUID
+    // against it would spuriously reject it as a mismatch (issue #9240: "runner
+    // snapshot job <uuid> does not match controller job " — the blank trailing
+    // value is the missing-identity signal, not a mismatch). This is scoped to
+    // the runner-job field alone (matching the pre-migration `runner_job_id()`
+    // guard); callers must bind or propagate the accepted Lab job id before
+    // validation, so the absence is surfaced as its own diagnostic instead of
+    // being presented as a runner mismatch and classified non-retryable.
+    if expected.runner_job_id.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
             "runner_job_id",
             format!(
@@ -387,15 +398,15 @@ fn validate_runner_job_snapshot(
             Some(record.run_id.clone()),
             None,
         ));
-    };
-    if expected_job_id == snapshot.job.id.to_string() {
+    }
+    if expected.runner_job_id == snapshot.job.id.to_string() {
         return Ok(());
     }
     Err(Error::validation_invalid_argument(
         "runner_job_id",
         format!(
-            "runner snapshot job {} does not match controller job {expected_job_id}",
-            snapshot.job.id
+            "runner snapshot job {} does not match controller job {}",
+            snapshot.job.id, expected.runner_job_id
         ),
         Some(record.run_id.clone()),
         None,


### PR DESCRIPTION
## Why (data-driven)
Churn analysis of the last ~300 commits on `main`: the commit mix is **495 fix : 295 refactor : 35 feat**, and fix density has *doubled* recently (32% → 65% of commits). The dominant recurring bug cluster is **handoff (×14) / identity (×11) / reconcile (×9)** — all in the `agent_task_lifecycle` handoff-identity machine.

Root cause: a canonical `RunnerJobIdentity` type exists (#9379) with one definition of "same run + runner + job", but **adoption is ~25%** — ~21 sites still hand-roll `run_id`/`runner_job_id` comparisons, each with subtly different edge-case handling. That's why identity bugs land one call site at a time (empty-string compares, missing-id-vs-mismatch confusion).

This PR starts a consolidation campaign: migrate the *true identity-comparison* sites onto the canonical type, one reviewable PR at a time.

## This change
`validate_runner_job_snapshot` was the clearest starting point — its **sibling in the same file** (`validate_terminal_child_identity`) already compares via `RunnerJobIdentity`, but this one still did a bare `expected_job_id == snapshot.job.id.to_string()`. It's also the site where #9240 was patched in place but never migrated.

- Build `expected` via `RunnerJobIdentity::new(run, runner, job)`; compare its `runner_job_id` against the daemon snapshot.
- **Behavior preserved exactly.** The "no accepted runner job identity" (#9240) branch still fires iff the runner-job field is empty — matching the prior `runner_job_id()` `Option` guard. I deliberately did **not** use `is_complete()` here: `runner_job_id()` can be `Some` (via metadata `job_id`) while `runner_id()` is `None`, so a full-tuple completeness check would change *which* branch fires. Scoped to the runner-job field, exactly as before.

## Verification
- `cargo check -p homeboy-agents --lib` clean.
- The existing regression tests that pin both branches stay green:
  - `snapshot_validation_reports_missing_controller_identity_distinctly` (#9240, not-established branch) ✅
  - the `does not match controller job` mismatch tests ✅
  - **40 passed** in `handoff_and_proxy`. The 1 failure (`controller_proxy_is_queued_before_handoff_then_binds_runner_child`) fails **identically on clean origin/main** — a pre-existing env-dependent flake (stash-verified), not from this change.

## Next in the campaign
`accepted_lab_runner_handoff_identity` (controller service), the `lifecycle_ops` accepted-handoff bind, and the remaining true-identity sites. Single-field *lineage filters* (`lineage.run_id == run_id`) are explicitly **not** targets — they're list filters, not identity validation, and routing them through the type would add ceremony without safety.
