### PR TITLE
fix(review): reject manual release-owned version changes

### DIFF
--- a/crates/contracts/homeboy-component-contract/src/config.rs
+++ b/crates/contracts/homeboy-component-contract/src/config.rs
@@ -237,6 +237,13 @@ pub struct ComponentReleaseConfig {
     /// Disabled by default because configured changelogs are release-generated.
     #[serde(default, skip_serializing_if = "is_false")]
     pub allow_manual_changelog_edits: bool,
+    /// Configured version-target paths that intentionally receive manual
+    /// maintenance outside a Homeboy release.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub manual_version_targets: Vec<String>,
+    /// Extension-declared release lockfiles intentionally maintained manually.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub manual_release_lockfiles: Vec<String>,
     /// Per-ZIP source-to-archive coverage declarations for transformed packages.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub package_coverage: Vec<PackageCoverageConfig>,
@@ -491,5 +498,7 @@ mod tests {
         let value = serde_json::to_value(ComponentReleaseConfig::default()).expect("serialize");
 
         assert!(value.get("allow_manual_changelog_edits").is_none());
+        assert!(value.get("manual_version_targets").is_none());
+        assert!(value.get("manual_release_lockfiles").is_none());
     }
 }

--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -21,7 +21,7 @@ use homeboy::core::plan::PlanStep;
 use homeboy::core::quality::{build_quality_plan, QualityPlanOptions};
 use homeboy_extension::lint::LintCommandOutput;
 use homeboy_extension::test::TestCommandOutput;
-use homeboy_release::release::changelog;
+use homeboy_release::release::{changelog, version};
 use homeboy_review::review::{
     self, ReviewArtifactFindings, ReviewCommandOutput, ReviewOutputInput, ReviewService,
     ReviewStage, ReviewStages,
@@ -421,6 +421,11 @@ pub fn run_umbrella(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCo
     if let Some(violation) = &manual_changelog_edit {
         top_hints.push(violation.message.clone());
     }
+    let manual_release_owned_mutations =
+        manual_release_owned_mutations(&component, &source_path, &args, &review_context);
+    for violation in &manual_release_owned_mutations {
+        top_hints.push(violation.message.clone());
+    }
 
     let mut audit_stage = None;
     let mut lint_stage = None;
@@ -527,13 +532,14 @@ pub fn run_umbrella(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCo
             ci_profile: ci_profile_stage,
         },
     );
-    let overall_exit = if manual_changelog_edit.is_some() {
-        output.summary.passed = false;
-        output.summary.status = "failed".to_string();
-        overall_exit.max(1)
-    } else {
-        overall_exit
-    };
+    let overall_exit =
+        if manual_changelog_edit.is_some() || !manual_release_owned_mutations.is_empty() {
+            output.summary.passed = false;
+            output.summary.status = "failed".to_string();
+            overall_exit.max(1)
+        } else {
+            overall_exit
+        };
     attach_review_actionable(&mut output);
 
     print_human_summary(&output);
@@ -554,6 +560,63 @@ fn manual_changelog_edit(
         component.release.allow_manual_changelog_edits,
         None,
     )
+}
+
+fn manual_release_owned_mutations(
+    component: &homeboy::core::component::Component,
+    source_path: &str,
+    args: &ReviewArgs,
+    review_context: &ReviewExecutionContext,
+) -> Vec<version::ReleaseOwnedMutationViolation> {
+    let Some(changed_files) = review_context.precomputed_changed_files() else {
+        return Vec::new();
+    };
+    let baseline = args
+        .changed_since
+        .as_deref()
+        .or(args.changed_only.then_some("HEAD"));
+    let Some(baseline) = baseline else {
+        return Vec::new();
+    };
+
+    let mutations = changed_files
+        .iter()
+        .filter_map(|file| version_mutation_at(source_path, baseline, file, args.changed_only))
+        .collect::<Vec<_>>();
+    version::detect_manual_release_owned_mutations(component, &mutations, None)
+}
+
+fn version_mutation_at(
+    source_path: &str,
+    baseline: &str,
+    file: &str,
+    dirty_worktree: bool,
+) -> Option<version::VersionMutation> {
+    let before = git_file_at(source_path, baseline, file)?;
+    let after = if dirty_worktree {
+        std::fs::read_to_string(Path::new(source_path).join(file)).ok()?
+    } else {
+        git_file_at(source_path, "HEAD", file)?
+    };
+    Some(version::VersionMutation {
+        file: file.to_string(),
+        before,
+        after,
+    })
+}
+
+fn git_file_at(source_path: &str, revision: &str, file: &str) -> Option<String> {
+    let spec = format!("{revision}:{file}");
+    let output = std::process::Command::new("git")
+        .args(["show", &spec])
+        .current_dir(source_path)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8(output.stdout).ok())
+        .flatten()
 }
 
 fn attach_review_actionable(output: &mut ReviewCommandOutput) {

--- a/crates/homeboy-core/src/component/drift.rs
+++ b/crates/homeboy-core/src/component/drift.rs
@@ -48,21 +48,7 @@ use std::path::Path;
 pub fn drift_file_paths(component: &Component) -> Vec<String> {
     let mut extras: BTreeSet<String> = BTreeSet::new();
 
-    if let Some(extensions) = component.extensions.as_ref() {
-        for extension_id in extensions.keys() {
-            let Ok(manifest) = crate::extension_store::load_extension(extension_id) else {
-                continue;
-            };
-            let Some(build) = manifest.build.as_ref() else {
-                continue;
-            };
-            for path in &build.lockfile_paths {
-                if let Some(normalized) = normalize_relative_drift_path(path) {
-                    extras.insert(normalized);
-                }
-            }
-        }
-    }
+    extras.extend(extension_declared_lockfile_paths(component));
 
     for path in &component.extra_drift_files {
         if let Some(normalized) = normalize_relative_drift_path(path) {
@@ -74,6 +60,32 @@ pub fn drift_file_paths(component: &Component) -> Vec<String> {
     out.push("homeboy.json".to_string());
     out.extend(extras);
     out
+}
+
+/// Resolve normalized lockfiles declared by the component's enabled extensions.
+/// This is shared by drift and release ownership policy so extension resolution
+/// remains defined in one owning layer.
+pub fn extension_declared_lockfile_paths(component: &Component) -> Vec<String> {
+    let mut paths = BTreeSet::new();
+    if let Some(extensions) = component.extensions.as_ref() {
+        for extension_id in extensions.keys() {
+            let Ok(manifest) = crate::extension_store::load_extension(extension_id) else {
+                continue;
+            };
+            let Some(build) = manifest.build.as_ref() else {
+                continue;
+            };
+            paths.extend(normalize_extension_lockfile_paths(&build.lockfile_paths));
+        }
+    }
+    paths.into_iter().collect()
+}
+
+fn normalize_extension_lockfile_paths(paths: &[String]) -> BTreeSet<String> {
+    paths
+        .iter()
+        .filter_map(|path| normalize_relative_drift_path(path))
+        .collect()
 }
 
 /// Normalize a drift path into a repo-root-relative POSIX-style string.
@@ -142,6 +154,21 @@ mod tests {
         assert!(normalize_relative_drift_path("/etc/passwd").is_none());
         assert!(normalize_relative_drift_path("../escape").is_none());
         assert!(normalize_relative_drift_path("").is_none());
+    }
+
+    #[test]
+    fn extension_declared_lockfiles_are_normalized_and_deduplicated() {
+        assert_eq!(
+            normalize_extension_lockfile_paths(&[
+                "./package-lock.json".to_string(),
+                "package-lock.json".to_string(),
+                "nested/pnpm-lock.yaml".to_string(),
+                "../escape.lock".to_string(),
+            ])
+            .into_iter()
+            .collect::<Vec<_>>(),
+            vec!["nested/pnpm-lock.yaml", "package-lock.json"]
+        );
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/changelog/guard.rs
+++ b/crates/homeboy-release/src/release/changelog/guard.rs
@@ -39,8 +39,20 @@ pub fn generated_file_mutation_is_authorized(
                 .run_id
                 .as_deref()
                 .is_some_and(|id| !id.trim().is_empty())
-            && provenance.step_id.as_deref() == Some("changelog.finalize")
+            && provenance
+                .step_id
+                .as_deref()
+                .is_some_and(|id| !id.trim().is_empty())
     })
+}
+
+/// Whether durable release provenance identifies the expected producing step.
+pub fn generated_file_mutation_is_authorized_for(
+    provenance: Option<&ChangeArtifactProvenance>,
+    step_id: &str,
+) -> bool {
+    generated_file_mutation_is_authorized(provenance)
+        && provenance.is_some_and(|provenance| provenance.step_id.as_deref() == Some(step_id))
 }
 
 /// Detect whether `changed_files` modifies the configured `changelog_target`.
@@ -89,7 +101,9 @@ pub fn detect_manual_changelog_edit(
     provenance: Option<&ChangeArtifactProvenance>,
 ) -> Option<ChangelogGuardViolation> {
     let violation = detect_changelog_edit(changelog_target, changed_files)?;
-    (!allow_manual_edits && !generated_file_mutation_is_authorized(provenance)).then_some(violation)
+    (!allow_manual_edits
+        && !generated_file_mutation_is_authorized_for(provenance, "changelog.finalize"))
+    .then_some(violation)
 }
 
 /// Build the steering message shown when a changeset hand-edits the changelog.
@@ -270,6 +284,23 @@ mod tests {
         ] {
             assert!(!generated_file_mutation_is_authorized(Some(&provenance)));
         }
+    }
+
+    #[test]
+    fn generated_file_policy_requires_the_expected_producing_step() {
+        let provenance = ChangeArtifactProvenance {
+            source: "release".to_string(),
+            run_id: Some("release.component".to_string()),
+            step_id: Some("version".to_string()),
+            command: None,
+            captured_at: None,
+        };
+
+        assert!(generated_file_mutation_is_authorized(Some(&provenance)));
+        assert!(!generated_file_mutation_is_authorized_for(
+            Some(&provenance),
+            "changelog.finalize"
+        ));
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/changelog/mod.rs
+++ b/crates/homeboy-release/src/release/changelog/mod.rs
@@ -7,7 +7,7 @@ mod settings;
 pub use bulk::{show, ShowOutput};
 pub use guard::{
     detect_changelog_edit, detect_manual_changelog_edit, generated_file_mutation_is_authorized,
-    ChangelogGuardViolation,
+    generated_file_mutation_is_authorized_for, ChangelogGuardViolation,
 };
 pub use io::{
     discover_changelog_relative_path, read_component_snapshots, resolve_changelog_path,

--- a/crates/homeboy-release/src/release/execution_projection.rs
+++ b/crates/homeboy-release/src/release/execution_projection.rs
@@ -73,6 +73,9 @@ fn release_artifacts_from_step(run_id: &str, step: &ReleaseStepResult) -> Vec<Ch
             .into_iter()
             .collect();
     }
+    if step.id == "version" {
+        return version_artifacts_from_step(run_id, step);
+    }
 
     let Some(data) = step.data.as_ref() else {
         return Vec::new();
@@ -117,6 +120,86 @@ fn release_artifacts_from_step(run_id: &str, step: &ReleaseStepResult) -> Vec<Ch
                 approval_scope: None,
                 metadata,
             }
+        })
+        .collect()
+}
+
+fn version_artifacts_from_step(run_id: &str, step: &ReleaseStepResult) -> Vec<ChangeArtifact> {
+    let Some(targets) = step
+        .data
+        .as_ref()
+        .and_then(|data| data.get("targets"))
+        .and_then(serde_json::Value::as_array)
+    else {
+        return Vec::new();
+    };
+    let generated_files = step
+        .data
+        .as_ref()
+        .and_then(|data| data.get("generated_files"))
+        .and_then(serde_json::Value::as_array)
+        .map(|files| {
+            files
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .collect::<std::collections::BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+    let release_lockfiles = step
+        .data
+        .as_ref()
+        .and_then(|data| data.get("release_lockfiles"))
+        .and_then(serde_json::Value::as_array)
+        .map(|files| {
+            files
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .collect::<std::collections::BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+
+    let mut files = targets
+        .iter()
+        .filter_map(|target| target.get("file").and_then(serde_json::Value::as_str))
+        .flat_map(|file| {
+            let mut files = vec![file.to_string()];
+            files.extend(
+                super::planning_worktree::derived_release_lockfiles(file)
+                    .into_iter()
+                    .filter(|lockfile| generated_files.contains(lockfile.as_str())),
+            );
+            files
+        })
+        .chain(
+            release_lockfiles
+                .iter()
+                .filter(|file| generated_files.contains(*file))
+                .map(|file| (*file).to_string()),
+        )
+        .collect::<Vec<_>>();
+    files.sort();
+    files.dedup();
+
+    files
+        .into_iter()
+        .enumerate()
+        .map(|(index, file)| ChangeArtifact {
+            id: format!("{}.artifact.{}", step.id, index + 1),
+            artifact_type: "generated_file".to_string(),
+            provenance: ChangeArtifactProvenance {
+                source: "release".to_string(),
+                run_id: Some(run_id.to_string()),
+                step_id: Some(step.id.clone()),
+                command: None,
+                captured_at: None,
+            },
+            title: Some("Generated release version metadata".to_string()),
+            summary: Some("Homeboy release-generated version or lockfile mutation".to_string()),
+            path: Some(file.clone()),
+            files: vec![file],
+            diff: None,
+            approval_scope: None,
+            metadata: HashMap::new(),
         })
         .collect()
 }
@@ -259,5 +342,47 @@ mod tests {
                 &artifact.provenance
             ))
         );
+    }
+
+    #[test]
+    fn version_step_projects_version_targets_and_derived_lockfiles() {
+        let release = ReleaseRun {
+            component_id: "component".to_string(),
+            enabled: true,
+            result: ReleaseRunResult {
+                steps: vec![ReleaseStepResult {
+                    id: "version".to_string(),
+                    step_type: "version".to_string(),
+                    status: ReleaseStepStatus::Success,
+                    data: Some(serde_json::json!({
+                        "targets": [{"file": "plugin.php"}, {"file": "package.json"}],
+                        "generated_files": ["plugin.php", "package.json", "package-lock.json"]
+                    })),
+                    ..Default::default()
+                }],
+                status: ReleaseStepStatus::Success,
+                warnings: Vec::new(),
+                summary: None,
+                phase_timings: None,
+            },
+        };
+
+        let execution = ExecutionRun::from(&release);
+        let files = execution
+            .artifacts
+            .iter()
+            .flat_map(|artifact| artifact.files.iter().cloned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            files,
+            vec!["package-lock.json", "package.json", "plugin.php"]
+        );
+        assert!(execution.artifacts.iter().all(|artifact| {
+            super::super::changelog::generated_file_mutation_is_authorized_for(
+                Some(&artifact.provenance),
+                "version",
+            )
+        }));
     }
 }

--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -124,8 +124,17 @@ pub(crate) fn run_version(
         None,
         state.changelog_validation.as_ref(),
     )?;
-    let data = serde_json::to_value(&result)
+    let mut data = serde_json::to_value(&result)
         .map_err(|e| Error::internal_json(e.to_string(), Some("version output".to_string())))?;
+    // Persist the exact release-generated file set so durable artifacts never
+    // authorize a merely possible derived lockfile mutation.
+    let generated_files = homeboy_core::git::get_uncommitted_changes(&component.local_path)?;
+    data["generated_files"] = serde_json::json!(generated_files
+        .staged
+        .into_iter()
+        .chain(generated_files.unstaged)
+        .collect::<std::collections::BTreeSet<_>>());
+    data["release_lockfiles"] = serde_json::json!(version::release_owned_lockfiles(component));
 
     if let Some(mismatches) = collect_version_target_mismatches(component, &result.new_version) {
         let error_msg = format!(

--- a/crates/homeboy-release/src/release/planning_worktree.rs
+++ b/crates/homeboy-release/src/release/planning_worktree.rs
@@ -173,7 +173,7 @@ pub(super) fn get_release_allowed_files(
     allowed
 }
 
-fn derived_release_lockfiles(version_target: &str) -> Vec<String> {
+pub(super) fn derived_release_lockfiles(version_target: &str) -> Vec<String> {
     let path = std::path::Path::new(version_target);
     let parent = path
         .parent()

--- a/crates/homeboy-release/src/release/version.rs
+++ b/crates/homeboy-release/src/release/version.rs
@@ -1,4 +1,5 @@
 mod default_pattern_for_file;
+mod guard;
 mod types;
 
 pub(crate) use default_pattern_for_file::{
@@ -10,6 +11,10 @@ use default_pattern_for_file::{
 };
 pub use default_pattern_for_file::{
     default_pattern_for_file, read_component_version, read_version,
+};
+pub use guard::{
+    detect_manual_release_owned_mutations, release_owned_lockfiles, ReleaseOwnedMutationViolation,
+    VersionMutation,
 };
 #[cfg(test)]
 use types::DEFAULT_SINCE_PLACEHOLDER;

--- a/crates/homeboy-release/src/release/version/guard.rs
+++ b/crates/homeboy-release/src/release/version/guard.rs
@@ -1,0 +1,294 @@
+use std::collections::BTreeSet;
+
+use homeboy_core::component::{Component, VersionTarget};
+use homeboy_core::execution::ChangeArtifactProvenance;
+
+use crate::release::changelog::generated_file_mutation_is_authorized_for;
+
+use super::{parse_versions, resolve_target_pattern};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionMutation {
+    pub file: String,
+    pub before: String,
+    pub after: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseOwnedMutationViolation {
+    pub file: String,
+    pub message: String,
+}
+
+/// Reject version-field and release-derived lockfile mutations that were not
+/// produced by the release version step. Target matching remains entirely
+/// configuration-driven: a target's configured regex identifies its version
+/// field, regardless of whether it is a PHP header, JSON manifest, or text file.
+pub fn detect_manual_release_owned_mutations(
+    component: &Component,
+    mutations: &[VersionMutation],
+    provenance: Option<&ChangeArtifactProvenance>,
+) -> Vec<ReleaseOwnedMutationViolation> {
+    if generated_file_mutation_is_authorized_for(provenance, "version") {
+        return Vec::new();
+    }
+
+    let targets = component.version_targets.as_deref().unwrap_or_default();
+    let derived_lockfiles = derived_lockfiles(targets);
+    let declared_lockfiles =
+        homeboy_core::component::drift::extension_declared_lockfile_paths(component)
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+    mutations
+        .iter()
+        .filter_map(|mutation| {
+            let file = normalize_path(&mutation.file)?;
+            let target = targets
+                .iter()
+                .find(|target| normalize_path(&target.file).as_deref() == Some(&file));
+            let manually_maintained = component
+                .release
+                .manual_version_targets
+                .iter()
+                .filter_map(|path| normalize_path(path))
+                .any(|path| path == file);
+
+            if derived_lockfiles.contains(&file) || declared_lockfiles.contains(&file) {
+                let lockfile_manually_maintained = targets.iter().any(|target| {
+                    component
+                        .release
+                        .manual_version_targets
+                        .iter()
+                        .any(|configured| {
+                            normalize_path(configured) == normalize_path(&target.file)
+                        })
+                        && crate::release::planning_worktree::derived_release_lockfiles(
+                            &target.file,
+                        )
+                        .iter()
+                        .filter_map(|path| normalize_path(path))
+                        .any(|path| path == file)
+                });
+                let declared_lockfile_manually_maintained =
+                    manual_release_lockfile_is_allowed(component, &file);
+                return (!lockfile_manually_maintained && !declared_lockfile_manually_maintained)
+                    .then(|| {
+                        violation(
+                            &file,
+                            if declared_lockfiles.contains(&file) {
+                                "extension-declared release lockfile"
+                            } else {
+                                "release-derived lockfile"
+                            },
+                        )
+                    });
+            }
+
+            let target = target?;
+            let pattern = resolve_target_pattern(target).ok()?;
+            let before = parse_versions(&mutation.before, &pattern)?;
+            let after = parse_versions(&mutation.after, &pattern)?;
+            (before != after && !manually_maintained)
+                .then(|| violation(&file, "configured version field"))
+        })
+        .collect()
+}
+
+fn manual_release_lockfile_is_allowed(component: &Component, file: &str) -> bool {
+    component
+        .release
+        .manual_release_lockfiles
+        .iter()
+        .filter_map(|path| normalize_path(path))
+        .any(|path| path == file)
+}
+
+pub fn derived_lockfiles(targets: &[VersionTarget]) -> BTreeSet<String> {
+    targets
+        .iter()
+        .flat_map(|target| {
+            crate::release::planning_worktree::derived_release_lockfiles(&target.file)
+        })
+        .filter_map(|path| normalize_path(&path))
+        .collect()
+}
+
+pub fn release_owned_lockfiles(component: &Component) -> BTreeSet<String> {
+    let mut lockfiles = derived_lockfiles(component.version_targets.as_deref().unwrap_or_default());
+    lockfiles.extend(homeboy_core::component::drift::extension_declared_lockfile_paths(component));
+    lockfiles
+}
+
+fn normalize_path(path: &str) -> Option<String> {
+    let path = std::path::Path::new(path);
+    if path.is_absolute() {
+        return None;
+    }
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(part) => parts.push(part.to_string_lossy().to_string()),
+            std::path::Component::CurDir => {}
+            _ => return None,
+        }
+    }
+    (!parts.is_empty()).then(|| parts.join("/"))
+}
+
+fn violation(file: &str, kind: &str) -> ReleaseOwnedMutationViolation {
+    ReleaseOwnedMutationViolation {
+        file: file.to_string(),
+        message: format!(
+            "{file} changed a {kind}. Release-owned mutations require durable Homeboy release provenance from the `version` step; configure `release.manual_version_targets` only for intentional manual maintenance."
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn component(file: &str, pattern: &str) -> Component {
+        Component {
+            version_targets: Some(vec![VersionTarget {
+                file: file.to_string(),
+                pattern: Some(pattern.to_string()),
+                artifact_path: None,
+            }]),
+            ..Default::default()
+        }
+    }
+
+    fn mutation(file: &str, before: &str, after: &str) -> VersionMutation {
+        VersionMutation {
+            file: file.to_string(),
+            before: before.to_string(),
+            after: after.to_string(),
+        }
+    }
+
+    #[test]
+    fn rejects_direct_php_and_package_version_bumps() {
+        let php = component("plugin.php", r"Version:\s*([0-9.]+)");
+        let package = component("package.json", r#""version"\s*:\s*"([0-9.]+)""#);
+
+        assert_eq!(
+            detect_manual_release_owned_mutations(
+                &php,
+                &[mutation(
+                    "plugin.php",
+                    "/*\n * Version: 1.0.0\n */",
+                    "/*\n * Version: 1.0.1\n */"
+                )],
+                None
+            )
+            .len(),
+            1
+        );
+        assert_eq!(
+            detect_manual_release_owned_mutations(
+                &package,
+                &[mutation(
+                    "package.json",
+                    r#"{"version":"1.0.0"}"#,
+                    r#"{"version":"1.0.1"}"#
+                )],
+                None
+            )
+            .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn ignores_manifest_edits_when_the_configured_version_is_unchanged() {
+        let component = component("package.json", r#""version"\s*:\s*"([0-9.]+)""#);
+        let violations = detect_manual_release_owned_mutations(
+            &component,
+            &[mutation(
+                "package.json",
+                r#"{"version":"1.0.0","description":"before"}"#,
+                r#"{"version":"1.0.0","description":"after"}"#,
+            )],
+            None,
+        );
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn accepts_only_durable_version_step_provenance() {
+        let component = component("VERSION", r"([0-9.]+)");
+        let mutation = mutation("VERSION", "1.0.0", "1.0.1");
+        let authorized = ChangeArtifactProvenance {
+            source: "release".to_string(),
+            run_id: Some("release.component".to_string()),
+            step_id: Some("version".to_string()),
+            command: None,
+            captured_at: None,
+        };
+        let malformed = ChangeArtifactProvenance {
+            source: "release".to_string(),
+            run_id: Some(" ".to_string()),
+            step_id: Some("version".to_string()),
+            command: None,
+            captured_at: None,
+        };
+
+        assert!(detect_manual_release_owned_mutations(
+            &component,
+            &[mutation.clone()],
+            Some(&authorized)
+        )
+        .is_empty());
+        assert_eq!(
+            detect_manual_release_owned_mutations(&component, &[mutation], Some(&malformed)).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn protects_derived_lockfiles_and_allows_a_target_scoped_opt_out() {
+        let mut component = component("Cargo.toml", r#"version\s*=\s*"([0-9.]+)""#);
+        assert_eq!(
+            detect_manual_release_owned_mutations(
+                &component,
+                &[mutation("Cargo.lock", "old", "new")],
+                None
+            )
+            .len(),
+            1
+        );
+
+        component
+            .release
+            .manual_version_targets
+            .push("Cargo.toml".to_string());
+        assert!(detect_manual_release_owned_mutations(
+            &component,
+            &[
+                mutation("Cargo.toml", r#"version = "1.0.0""#, r#"version = "1.0.1""#),
+                mutation("Cargo.lock", "old", "new")
+            ],
+            None
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn declared_lockfile_opt_out_is_exact_path_scoped() {
+        let mut component = Component::default();
+        component
+            .release
+            .manual_release_lockfiles
+            .push("./nested/package-lock.json".to_string());
+
+        assert!(manual_release_lockfile_is_allowed(
+            &component,
+            "nested/package-lock.json"
+        ));
+        assert!(!manual_release_lockfile_is_allowed(
+            &component,
+            "package-lock.json"
+        ));
+    }
+}


### PR DESCRIPTION
Closes #9451

## Summary

- detect manual mutations to configured release-owned version targets
- include derived lockfiles and extension-declared `build.lockfile_paths` in release ownership
- persist release and version provenance for review
- provide exact-path opt-outs for intentionally manual version targets and release lockfiles

## How to test

1. Run `cargo test -p homeboy-release release::version::guard --lib`.
2. Run `cargo test -p homeboy-core component::drift --lib`.
3. Run `cargo test -p homeboy-release release::execution_projection --lib`.
4. Run `git diff --check origin/main...HEAD`.

## Compatibility

The guard applies only to configured release-owned targets. Repositories with intentionally manual paths can declare them through `release.manual_version_targets` or `release.manual_release_lockfiles`.