### PR TITLE
feat(agents): enforce public contract evidence

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -1770,6 +1770,8 @@ fn options() -> AgentTaskPrFinalizationOptions {
             source_relationship: AgentTaskPrSourceRelationship::default(),
             verification: AgentTaskPrVerification::default(),
             runtime_guardrails: AgentTaskPrRuntimeGuardrails::default(),
+            changed_public_contracts: Vec::new(),
+            public_contract_evidence: None,
             lifecycle: None,
         },
         ai_used_for: "Drafted implementation and tests; Chris reviews and owns the change."
@@ -1784,6 +1786,8 @@ fn options() -> AgentTaskPrFinalizationOptions {
             }],
             compatibility: "No compatibility impact.".to_string(),
             evidence: Vec::new(),
+            changed_public_contracts: Vec::new(),
+            public_contract_evidence: None,
             ai_assistance: crate::agent_task_review_dossier::AgentTaskReviewAiAssistance {
                 used: true,
                 tool: "OpenCode (GPT-5.5)".to_string(),

--- a/crates/homeboy-agents/src/agent_task_finalization/types.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/types.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::*;
+use crate::agent_task_review_dossier::{AgentTaskPublicContract, AgentTaskPublicContractEvidence};
 use homeboy_core::git::GitIdentityProof;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -134,6 +135,10 @@ pub struct AgentTaskPrEvidence {
         skip_serializing_if = "AgentTaskPrRuntimeGuardrails::is_empty"
     )]
     pub runtime_guardrails: AgentTaskPrRuntimeGuardrails,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed_public_contracts: Vec<AgentTaskPublicContract>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_contract_evidence: Option<AgentTaskPublicContractEvidence>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lifecycle: Option<RunLifecycleRecord>,
 }

--- a/crates/homeboy-agents/src/agent_task_review_dossier.rs
+++ b/crates/homeboy-agents/src/agent_task_review_dossier.rs
@@ -53,6 +53,36 @@ pub struct AgentTaskReviewEvidence {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPublicContract {
+    pub id: String,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskExternalUsageStatus {
+    Completed,
+    UnavailableManualReview,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskExternalUsageEvidence {
+    pub status: AgentTaskExternalUsageStatus,
+    pub source: String,
+    pub limitations: String,
+    pub url: String,
+}
+
+/// Reviewer-facing evidence required when this change declares a public contract.
+/// The contract itself remains generic; callers supply their own ecosystem meaning.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPublicContractEvidence {
+    pub compatibility_impact: String,
+    pub external_consumer_impact: String,
+    pub external_usage: AgentTaskExternalUsageEvidence,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskReviewDossier {
     #[serde(default = "dossier_schema")]
     pub schema: String,
@@ -62,6 +92,10 @@ pub struct AgentTaskReviewDossier {
     pub compatibility: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub evidence: Vec<AgentTaskReviewEvidence>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed_public_contracts: Vec<AgentTaskPublicContract>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_contract_evidence: Option<AgentTaskPublicContractEvidence>,
     pub ai_assistance: AgentTaskReviewAiAssistance,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub source_relationships: Vec<AgentTaskReviewIssueRelationship>,
@@ -149,6 +183,15 @@ pub fn validate_profile(profile: &AgentTaskReviewProfile) -> Result<()> {
         return invalid(
             "review_profile",
             "required and hidden sections cannot conflict",
+        );
+    }
+    if profile
+        .hidden_sections
+        .contains(&AgentTaskReviewSectionId::HowToTest)
+    {
+        return invalid(
+            "review_profile",
+            "How to test cannot be hidden from generated PRs",
         );
     }
     let mut additional = std::collections::BTreeSet::new();
@@ -244,6 +287,54 @@ impl AgentTaskReviewDossier {
                 validate_reviewer_url(url)?;
             }
         }
+        for contract in &self.changed_public_contracts {
+            scalar("changed_public_contracts.id", &contract.id)?;
+            scalar("changed_public_contracts.summary", &contract.summary)?;
+            if contract.id.trim().is_empty() || contract.summary.trim().is_empty() {
+                return invalid(
+                    "changed_public_contracts",
+                    "each declared public contract needs an identifier and summary",
+                );
+            }
+        }
+        match (&self.changed_public_contracts[..], &self.public_contract_evidence) {
+            ([], Some(_)) => {
+                return invalid(
+                    "public_contract_evidence",
+                    "public-contract evidence requires a declared changed public contract",
+                )
+            }
+            (contracts, None) if !contracts.is_empty() => {
+                return invalid(
+                    "public_contract_evidence",
+                    "declared public contracts require compatibility, external-consumer, and external-usage evidence",
+                )
+            }
+            (_, Some(evidence)) => {
+                scalar(
+                    "public_contract_evidence.compatibility_impact",
+                    &evidence.compatibility_impact,
+                )?;
+                scalar(
+                    "public_contract_evidence.external_consumer_impact",
+                    &evidence.external_consumer_impact,
+                )?;
+                scalar("public_contract_evidence.external_usage.source", &evidence.external_usage.source)?;
+                scalar("public_contract_evidence.external_usage.limitations", &evidence.external_usage.limitations)?;
+                validate_reviewer_url(&evidence.external_usage.url)?;
+                if evidence.compatibility_impact.trim().is_empty()
+                    || evidence.external_consumer_impact.trim().is_empty()
+                    || evidence.external_usage.source.trim().is_empty()
+                    || evidence.external_usage.limitations.trim().is_empty()
+                {
+                    return invalid(
+                        "public_contract_evidence",
+                        "public-contract evidence requires non-empty compatibility impact, external-consumer impact, usage source, and usage limitations",
+                    );
+                }
+            }
+            _ => {}
+        }
         for relationship in &self.source_relationships {
             validate_issue_reference(&relationship.reference)?;
         }
@@ -254,7 +345,7 @@ impl AgentTaskReviewDossier {
         {
             return invalid("what_changed", "what changed is required");
         }
-        if required(profile, AgentTaskReviewSectionId::HowToTest) && self.how_to_test.is_empty() {
+        if self.how_to_test.is_empty() {
             return invalid("how_to_test", "How to test requires --test-step COMMAND=>EXPECTED, a recorded targeted command, or a manual reviewer instruction");
         }
         if required(profile, AgentTaskReviewSectionId::Compatibility)
@@ -341,6 +432,7 @@ pub fn render_review_dossier(
             ))
         }
         AgentTaskReviewSectionId::Compatibility if !dossier.compatibility.is_empty() => Some(("Compatibility", prose(&dossier.compatibility))),
+        AgentTaskReviewSectionId::Evidence if !dossier.changed_public_contracts.is_empty() => Some(("Evidence", format!("{}{}", render_public_contract_evidence(dossier), render_evidence(&dossier.evidence)))),
         AgentTaskReviewSectionId::Evidence if !dossier.evidence.is_empty() => Some(("Evidence", dossier.evidence.iter().map(|item| match &item.url { Some(url) => format!("- {}: {url}", prose(&item.summary)), None => format!("- {}", prose(&item.summary)) }).collect::<Vec<_>>().join("\n"))),
         AgentTaskReviewSectionId::AiAssistance => Some(("AI assistance", format!("- **AI assistance:** {}\n- **Tool(s):** {}\n- **Model:** {}\n- **Used for:** {}", if dossier.ai_assistance.used { "Yes" } else { "No" }, prose(&dossier.ai_assistance.tool), prose(&dossier.ai_assistance.model), prose(&dossier.ai_assistance.used_for)))),
         AgentTaskReviewSectionId::SourceRelationships if !dossier.source_relationships.is_empty() => Some(("Source relationships", dossier.source_relationships.iter().map(|item| format!("- {} {}", match item.kind { AgentTaskReviewIssueRelationshipKind::Closes => "Closes", AgentTaskReviewIssueRelationshipKind::RelatesTo => "Relates to" }, relationship_reference(&item.reference))).collect::<Vec<_>>().join("\n"))), _ => None };
@@ -358,6 +450,40 @@ pub fn render_review_dossier(
         }
     }
     sections.join("\n\n") + "\n"
+}
+fn render_public_contract_evidence(dossier: &AgentTaskReviewDossier) -> String {
+    let contracts = dossier
+        .changed_public_contracts
+        .iter()
+        .map(|contract| format!("- `{}`: {}", code(&contract.id), prose(&contract.summary)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let evidence = dossier
+        .public_contract_evidence
+        .as_ref()
+        .expect("validated before rendering");
+    let status = match &evidence.external_usage.status {
+        AgentTaskExternalUsageStatus::Completed => "completed",
+        AgentTaskExternalUsageStatus::UnavailableManualReview => "unavailable_manual_review",
+    };
+    format!(
+        "**Declared public contracts**\n{contracts}\n\n**Compatibility impact:** {}\n\n**External-consumer impact:** {}\n\n**External usage:** {status}; source: {}; limitations: {}; evidence: {}\n\n",
+        prose(&evidence.compatibility_impact),
+        prose(&evidence.external_consumer_impact),
+        prose(&evidence.external_usage.source),
+        prose(&evidence.external_usage.limitations),
+        evidence.external_usage.url,
+    )
+}
+fn render_evidence(evidence: &[AgentTaskReviewEvidence]) -> String {
+    evidence
+        .iter()
+        .map(|item| match &item.url {
+            Some(url) => format!("- {}: {url}", prose(&item.summary)),
+            None => format!("- {}", prose(&item.summary)),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn ordered_sections(profile: &AgentTaskReviewProfile) -> Vec<AgentTaskReviewSectionId> {
@@ -640,6 +766,8 @@ mod tests {
             }],
             compatibility: "No compatibility impact".into(),
             evidence: Vec::new(),
+            changed_public_contracts: Vec::new(),
+            public_contract_evidence: None,
             ai_assistance: AgentTaskReviewAiAssistance {
                 used: true,
                 tool: "OpenCode".into(),
@@ -715,6 +843,104 @@ mod tests {
             url: Some("https://localhost/a".into()),
         });
         assert!(value.validate(&default_profile()).is_err());
+    }
+
+    fn public_contract_evidence() -> AgentTaskPublicContractEvidence {
+        AgentTaskPublicContractEvidence {
+            compatibility_impact: "Existing callers retain their supported behavior.".into(),
+            external_consumer_impact: "External consumers must review the declared change.".into(),
+            external_usage: AgentTaskExternalUsageEvidence {
+                status: AgentTaskExternalUsageStatus::Completed,
+                source: "Repository-wide usage search".into(),
+                limitations: "Search only covers the indexed source repositories.".into(),
+                url: "https://github.com/example/project/issues/1".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn declared_public_contract_requires_complete_reviewer_evidence() {
+        let mut value = dossier();
+        value
+            .changed_public_contracts
+            .push(AgentTaskPublicContract {
+                id: "api.widget.render".into(),
+                summary: "Changes the rendered result.".into(),
+            });
+        assert!(value.validate(&default_profile()).is_err());
+
+        value.public_contract_evidence = Some(public_contract_evidence());
+        value
+            .validate(&default_profile())
+            .expect("complete evidence");
+        assert!(
+            render_review_dossier(&value, &default_profile()).contains("unavailable_manual_review")
+                == false
+        );
+    }
+
+    #[test]
+    fn public_contract_evidence_rejects_malformed_or_local_only_proof() {
+        let mut value = dossier();
+        value
+            .changed_public_contracts
+            .push(AgentTaskPublicContract {
+                id: "api.widget.render".into(),
+                summary: "Changes the rendered result.".into(),
+            });
+        let mut evidence = public_contract_evidence();
+        evidence.external_usage.source.clear();
+        value.public_contract_evidence = Some(evidence);
+        assert!(value.validate(&default_profile()).is_err());
+
+        let mut evidence = public_contract_evidence();
+        evidence.external_usage.url = "https://localhost/evidence".into();
+        value.public_contract_evidence = Some(evidence);
+        assert!(value.validate(&default_profile()).is_err());
+    }
+
+    #[test]
+    fn unavailable_manual_review_is_accepted_with_durable_evidence() {
+        let mut value = dossier();
+        value
+            .changed_public_contracts
+            .push(AgentTaskPublicContract {
+                id: "api.widget.render".into(),
+                summary: "Changes the rendered result.".into(),
+            });
+        let mut evidence = public_contract_evidence();
+        evidence.external_usage.status = AgentTaskExternalUsageStatus::UnavailableManualReview;
+        value.public_contract_evidence = Some(evidence);
+        value
+            .validate(&default_profile())
+            .expect("manual review outcome");
+        assert!(
+            render_review_dossier(&value, &default_profile()).contains("unavailable_manual_review")
+        );
+    }
+
+    #[test]
+    fn internal_only_changes_do_not_require_public_contract_evidence() {
+        dossier()
+            .validate(&default_profile())
+            .expect("internal-only change");
+    }
+
+    #[test]
+    fn test_instructions_are_required_even_when_profile_does_not_require_them() {
+        let mut value = dossier();
+        value.how_to_test.clear();
+        let profile = AgentTaskReviewProfile {
+            required_sections: vec![AgentTaskReviewSectionId::Summary],
+            ..Default::default()
+        };
+        assert!(value.validate(&profile).is_err());
+
+        let hidden = AgentTaskReviewProfile {
+            hidden_sections: vec![AgentTaskReviewSectionId::HowToTest],
+            ..Default::default()
+        };
+        assert!(validate_profile(&hidden).is_err());
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -587,6 +587,8 @@ pub(crate) fn finalize_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
                     manual_reviewer_check: None,
                 },
                 runtime_guardrails: AgentTaskPrRuntimeGuardrails::default(),
+                changed_public_contracts: Vec::new(),
+                public_contract_evidence: None,
                 lifecycle: crate::agent_task_lifecycle::status(successful_run_id)
                     .ok()
                     .map(|record| record.lifecycle),
@@ -689,6 +691,8 @@ fn cook_review_dossier(
                 url: None,
             },
         ],
+        changed_public_contracts: Vec::new(),
+        public_contract_evidence: None,
         ai_assistance: AgentTaskReviewAiAssistance {
             used: true,
             tool: options.ai_tool.clone(),

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -227,11 +227,12 @@ pub mod finalization {
 pub mod review_dossier {
     pub use super::super::agent_task_review_dossier::{
         default_profile, enrich_dossier, render_review_dossier, resolve_review_profile,
-        validate_profile, AgentTaskReviewAdditionalSection, AgentTaskReviewAiAssistance,
-        AgentTaskReviewDossier, AgentTaskReviewEvidence, AgentTaskReviewIssueRelationship,
-        AgentTaskReviewIssueRelationshipKind, AgentTaskReviewOverride,
-        AgentTaskReviewOverrideTarget, AgentTaskReviewProfile, AgentTaskReviewSectionId,
-        AgentTaskReviewTestStep, AGENT_TASK_REVIEW_DOSSIER_SCHEMA,
+        validate_profile, AgentTaskExternalUsageEvidence, AgentTaskExternalUsageStatus,
+        AgentTaskPublicContract, AgentTaskPublicContractEvidence, AgentTaskReviewAdditionalSection,
+        AgentTaskReviewAiAssistance, AgentTaskReviewDossier, AgentTaskReviewEvidence,
+        AgentTaskReviewIssueRelationship, AgentTaskReviewIssueRelationshipKind,
+        AgentTaskReviewOverride, AgentTaskReviewOverrideTarget, AgentTaskReviewProfile,
+        AgentTaskReviewSectionId, AgentTaskReviewTestStep, AGENT_TASK_REVIEW_DOSSIER_SCHEMA,
     };
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -15,8 +15,9 @@ use homeboy::agents::agent_tasks::provider::{
     AgentTaskExecutorProvider, AgentTaskProviderCatalog, ExtensionProviderAgentTaskExecutor,
 };
 use homeboy::agents::agent_tasks::review_dossier::{
-    resolve_review_profile, AgentTaskReviewAiAssistance, AgentTaskReviewDossier,
-    AgentTaskReviewIssueRelationship, AgentTaskReviewIssueRelationshipKind,
+    resolve_review_profile, AgentTaskExternalUsageEvidence, AgentTaskExternalUsageStatus,
+    AgentTaskPublicContract, AgentTaskPublicContractEvidence, AgentTaskReviewAiAssistance,
+    AgentTaskReviewDossier, AgentTaskReviewIssueRelationship, AgentTaskReviewIssueRelationshipKind,
     AgentTaskReviewOverride, AgentTaskReviewOverrideTarget, AgentTaskReviewTestStep,
     AGENT_TASK_REVIEW_DOSSIER_SCHEMA,
 };
@@ -104,11 +105,47 @@ pub struct FinalizePrEvidenceArgs {
     /// Nearby predicate/contract preserved by the runtime fix. Repeatable.
     #[arg(long = "nearby-contract-preserved", value_name = "TEXT")]
     pub nearby_contracts_preserved: Vec<String>,
+
+    /// Declared changed public contract as ID=>SUMMARY. Repeatable.
+    #[arg(long = "changed-public-contract", value_name = "ID=>SUMMARY")]
+    pub changed_public_contracts: Vec<String>,
+
+    /// Compatibility impact for declared public contracts.
+    #[arg(long, value_name = "TEXT")]
+    pub compatibility_impact: Option<String>,
+
+    /// External-consumer impact for declared public contracts.
+    #[arg(long, value_name = "TEXT")]
+    pub external_consumer_impact: Option<String>,
+
+    /// External usage evidence status: completed or unavailable_manual_review.
+    #[arg(long, value_name = "STATUS")]
+    pub external_usage_status: Option<String>,
+
+    /// Source used for external usage evidence.
+    #[arg(long, value_name = "TEXT")]
+    pub external_usage_source: Option<String>,
+
+    /// Limitations of the external usage evidence or manual review.
+    #[arg(long, value_name = "TEXT")]
+    pub external_usage_limitations: Option<String>,
+
+    /// Reviewer-resolvable HTTPS URL for external usage evidence.
+    #[arg(long, value_name = "URL")]
+    pub external_usage_url: Option<String>,
 }
 
-impl From<FinalizePrEvidenceArgs> for AgentTaskPrEvidence {
-    fn from(args: FinalizePrEvidenceArgs) -> Self {
-        Self {
+impl TryFrom<FinalizePrEvidenceArgs> for AgentTaskPrEvidence {
+    type Error = homeboy::core::Error;
+
+    fn try_from(args: FinalizePrEvidenceArgs) -> homeboy::core::Result<Self> {
+        let changed_public_contracts = args
+            .changed_public_contracts
+            .iter()
+            .map(|raw| parse_public_contract(raw))
+            .collect::<homeboy::core::Result<Vec<_>>>()?;
+        let public_contract_evidence = public_contract_evidence(&args)?;
+        Ok(Self {
             source_refs: args.source_refs,
             artifact_refs: args.artifact_refs,
             attempt_summary: args.attempt_summary,
@@ -132,8 +169,10 @@ impl From<FinalizePrEvidenceArgs> for AgentTaskPrEvidence {
                 evidence_discriminators: args.evidence_discriminators,
                 nearby_contracts_preserved: args.nearby_contracts_preserved,
             },
+            changed_public_contracts,
+            public_contract_evidence,
             lifecycle: None,
-        }
+        })
     }
 }
 
@@ -371,7 +410,7 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
         .cloned()
         .map(HomeboyGateResult::from)
         .collect();
-    let evidence: AgentTaskPrEvidence = args.evidence.into();
+    let evidence: AgentTaskPrEvidence = args.evidence.try_into()?;
     let how_to_test = if args.test_steps.is_empty() {
         let legacy_steps: Vec<AgentTaskReviewTestStep> = evidence
             .verification
@@ -415,6 +454,8 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
                 .to_string()
         }),
         evidence: Vec::new(),
+        changed_public_contracts: evidence.changed_public_contracts.clone(),
+        public_contract_evidence: evidence.public_contract_evidence.clone(),
         ai_assistance: AgentTaskReviewAiAssistance {
             used: true,
             tool: evidence.ai_tool.clone(),
@@ -475,6 +516,61 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
     value["handoff"] = finalization_handoff(&report.status, report.pr_url.as_deref());
 
     Ok((value, exit_code))
+}
+
+fn parse_public_contract(raw: &str) -> homeboy::core::Result<AgentTaskPublicContract> {
+    let (id, summary) = raw.split_once("=>").ok_or_else(|| {
+        homeboy::core::Error::validation_invalid_argument(
+            "changed-public-contract",
+            "expected ID=>SUMMARY",
+            None,
+            None,
+        )
+    })?;
+    Ok(AgentTaskPublicContract {
+        id: id.trim().to_string(),
+        summary: summary.trim().to_string(),
+    })
+}
+
+fn public_contract_evidence(
+    args: &FinalizePrEvidenceArgs,
+) -> homeboy::core::Result<Option<AgentTaskPublicContractEvidence>> {
+    let supplied = [
+        args.compatibility_impact.as_ref(),
+        args.external_consumer_impact.as_ref(),
+        args.external_usage_status.as_ref(),
+        args.external_usage_source.as_ref(),
+        args.external_usage_limitations.as_ref(),
+        args.external_usage_url.as_ref(),
+    ]
+    .iter()
+    .any(Option::is_some);
+    if !supplied {
+        return Ok(None);
+    }
+    let status = match args.external_usage_status.as_deref() {
+        Some("completed") => AgentTaskExternalUsageStatus::Completed,
+        Some("unavailable_manual_review") => AgentTaskExternalUsageStatus::UnavailableManualReview,
+        _ => {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "external-usage-status",
+                "must be completed or unavailable_manual_review",
+                None,
+                None,
+            ))
+        }
+    };
+    Ok(Some(AgentTaskPublicContractEvidence {
+        compatibility_impact: args.compatibility_impact.clone().unwrap_or_default(),
+        external_consumer_impact: args.external_consumer_impact.clone().unwrap_or_default(),
+        external_usage: AgentTaskExternalUsageEvidence {
+            status,
+            source: args.external_usage_source.clone().unwrap_or_default(),
+            limitations: args.external_usage_limitations.clone().unwrap_or_default(),
+            url: args.external_usage_url.clone().unwrap_or_default(),
+        },
+    }))
 }
 
 fn parse_test_step(raw: &str) -> homeboy::core::Result<AgentTaskReviewTestStep> {


### PR DESCRIPTION
Closes #9450

## Summary

- declare changed public contracts and required compatibility evidence in review dossiers
- require numbered, stranger-runnable test steps for generated pull requests
- project compatibility, consumer impact, and external-usage evidence through `finalize-pr`
- reject local-only evidence references while leaving internal-only changes unaffected

## How to test

1. Run `cargo test -p homeboy-agents agent_task_review_dossier --lib`.
2. Run `cargo test -p homeboy-cli typed_test_steps_and_overrides_have_explicit_grammar --lib`.
3. Run `git diff --check origin/main...HEAD`.

## Compatibility

This adds generic review-dossier and finalization fields. Existing internal-only workflows remain valid and do not need public-contract evidence unless they declare changed public contracts.