### PR TITLE
Add durable controller daemon jobs

### DIFF
--- a/crates/homeboy-core/src/api_jobs/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/mod.rs
@@ -19,6 +19,9 @@ pub(crate) use runner_job_preparation::with_runner_job_preparation;
 pub use runner_job_preparation::{
     register_runner_job_preparation_provider, RunnerJobPreparationProvider,
 };
+pub(crate) use store::ControllerJobStartOutcome;
+pub(crate) use store::ControllerJobState;
+pub(crate) use store::ControllerJobSubmissionOutcome;
 pub(crate) use store::LocalChildStartDiscriminator;
 pub(crate) use store::LocalRunnerJob;
 pub use store::{JobHandle, JobRunner, JobStore, RecoveredTerminalJob};

--- a/crates/homeboy-core/src/api_jobs/persistence.rs
+++ b/crates/homeboy-core/src/api_jobs/persistence.rs
@@ -180,6 +180,14 @@ pub(super) fn compact_terminal_jobs(
         retained_terminal_bytes -= serialized_len;
     }
     let removed_terminal_jobs = removed_job_ids.len();
+    let removed_controller_jobs = durable
+        .jobs
+        .iter()
+        .filter(|stored| {
+            removed_job_ids.contains(&stored.job.id) && stored.controller_job.is_some()
+        })
+        .map(|stored| (stored.job.id, stored.job.clone()))
+        .collect::<std::collections::HashMap<_, _>>();
     durable
         .jobs
         .retain(|stored| !removed_job_ids.contains(&stored.job.id));
@@ -191,6 +199,23 @@ pub(super) fn compact_terminal_jobs(
             durable.expired_submission_keys.insert(key, submission);
         } else {
             durable.submission_keys.insert(key, submission);
+        }
+    }
+    // Controller keys are permanent once accepted. Their tombstones retain the
+    // canonical fingerprint after terminal-job compaction, preventing a retry
+    // from executing the same logical work a second time.
+    for (key, submission) in std::mem::take(&mut durable.controller_submissions) {
+        if removed_job_ids.contains(&submission.job_id) {
+            let terminal_job = removed_controller_jobs.get(&submission.job_id).cloned();
+            durable.expired_controller_submissions.insert(
+                key,
+                super::store::ControllerJobSubmission {
+                    terminal_job,
+                    ..submission
+                },
+            );
+        } else {
+            durable.controller_submissions.insert(key, submission);
         }
     }
     let evidence = JobStoreCompactionEvidence {

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -583,6 +583,7 @@ impl JobStore {
                 job: job.clone(),
                 events: Vec::new(),
                 admission_idempotency_key: None,
+                controller_job: None,
                 admission_lease: None,
                 remote_runner: Some(StoredRemoteRunnerJob {
                     // Durable broker state intentionally contains only the
@@ -637,6 +638,8 @@ impl JobStore {
                 jobs: inner.jobs.values().cloned().collect(),
                 submission_keys: inner.submission_keys.clone(),
                 expired_submission_keys: inner.expired_submission_keys.clone(),
+                controller_submissions: inner.controller_submissions.clone(),
+                expired_controller_submissions: inner.expired_controller_submissions.clone(),
                 compaction: inner.compaction.clone(),
             };
             if let Err(error) = super::persistence::write_durable_store(&persistence.path, &durable)

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -7,6 +7,7 @@ use std::thread::{self, JoinHandle};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use super::persistence::{
@@ -47,6 +48,8 @@ pub struct JobStore {
     pub(super) next_event_sequence: Arc<AtomicU64>,
     pub(super) persistence: Option<Arc<JobStorePersistence>>,
     pub(super) daemon_lease_id: Option<String>,
+    #[cfg(test)]
+    terminal_write_failures: Arc<AtomicU64>,
 }
 
 #[derive(Debug, Clone)]
@@ -57,11 +60,13 @@ pub(super) struct JobStorePersistence {
     pub(super) terminal_job_retention_bytes: usize,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub(super) struct JobStoreInner {
     pub(super) jobs: HashMap<Uuid, StoredJob>,
     pub(super) submission_keys: HashMap<String, RemoteRunnerSubmission>,
     pub(super) expired_submission_keys: HashMap<String, RemoteRunnerSubmission>,
+    pub(super) controller_submissions: HashMap<String, ControllerJobSubmission>,
+    pub(super) expired_controller_submissions: HashMap<String, ControllerJobSubmission>,
     pub(super) compaction: Option<JobStoreCompactionEvidence>,
 }
 
@@ -74,11 +79,45 @@ pub(super) struct RemoteRunnerSubmission {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ControllerJobState {
+    pub(crate) job_type: String,
+    pub(crate) version: u32,
+    /// Private daemon-store state. It is never copied into `JobEvent` data.
+    pub(crate) request: Value,
+    /// Driver-owned safe projection exposed in the queued event and API logs.
+    pub(crate) public_request: Value,
+    pub(crate) request_digest: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) checkpoint: Option<Value>,
+    #[serde(default)]
+    pub(crate) cancellation_requested: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) cancellation_reason: Option<String>,
+    /// A durable owner marker is written before a daemon dispatches this job.
+    /// Startup replaces an abandoned marker with one recovery claim before it
+    /// invokes the driver's recovery entry point.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) execution_claim_id: Option<String>,
+    #[serde(default)]
+    pub(crate) recovery_attempted: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct ControllerJobSubmission {
+    pub(super) fingerprint: String,
+    pub(super) job_id: Uuid,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) terminal_job: Option<Job>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct StoredJob {
     pub(super) job: Job,
     pub(super) events: Vec<JobEvent>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) admission_idempotency_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) controller_job: Option<ControllerJobState>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) admission_lease: Option<AdmissionLease>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -141,6 +180,10 @@ pub(super) struct DurableJobStore {
     pub(super) submission_keys: HashMap<String, RemoteRunnerSubmission>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub(super) expired_submission_keys: HashMap<String, RemoteRunnerSubmission>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub(super) controller_submissions: HashMap<String, ControllerJobSubmission>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub(super) expired_controller_submissions: HashMap<String, ControllerJobSubmission>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) compaction: Option<JobStoreCompactionEvidence>,
 }
@@ -149,6 +192,17 @@ pub(super) struct DurableJobStore {
 pub struct JobRunner {
     pub job_id: Uuid,
     pub handle: JoinHandle<()>,
+}
+
+/// The durable result of a controller submission lookup or admission.
+pub(crate) enum ControllerJobSubmissionOutcome {
+    Submitted(Uuid),
+    Existing(Job),
+}
+
+pub(crate) enum ControllerJobStartOutcome {
+    Claimed(ControllerJobState),
+    Existing,
 }
 
 #[derive(Debug, Clone)]
@@ -242,6 +296,8 @@ impl JobStore {
                     .collect(),
                 submission_keys: durable.submission_keys,
                 expired_submission_keys: durable.expired_submission_keys,
+                controller_submissions: durable.controller_submissions,
+                expired_controller_submissions: durable.expired_controller_submissions,
                 compaction: durable.compaction,
             })),
             next_event_sequence: Arc::new(AtomicU64::new(next_sequence)),
@@ -252,6 +308,8 @@ impl JobStore {
                 terminal_job_retention_bytes,
             })),
             daemon_lease_id: None,
+            #[cfg(test)]
+            terminal_write_failures: Arc::new(AtomicU64::new(0)),
         };
 
         store.persist()?;
@@ -369,6 +427,8 @@ impl JobStore {
                     .collect(),
                 submission_keys: durable.submission_keys,
                 expired_submission_keys: durable.expired_submission_keys,
+                controller_submissions: durable.controller_submissions,
+                expired_controller_submissions: durable.expired_controller_submissions,
                 compaction: durable.compaction,
             })),
             next_event_sequence: Arc::new(AtomicU64::new(next_sequence)),
@@ -379,6 +439,8 @@ impl JobStore {
                 terminal_job_retention_bytes,
             })),
             daemon_lease_id: None,
+            #[cfg(test)]
+            terminal_write_failures: Arc::new(AtomicU64::new(0)),
         };
         store.persist()?;
         Ok(store)
@@ -792,6 +854,7 @@ impl JobStore {
                 job: job.clone(),
                 events: Vec::new(),
                 admission_idempotency_key: admission_idempotency_key.clone(),
+                controller_job: None,
                 admission_lease: None,
                 remote_runner: None,
                 local_runner,
@@ -870,6 +933,13 @@ impl JobStore {
         Ok(stored.job.clone())
     }
 
+    pub(crate) fn handle(&self, job_id: Uuid) -> JobHandle {
+        JobHandle {
+            store: self.clone(),
+            job_id,
+        }
+    }
+
     pub(crate) fn list(&self) -> Vec<Job> {
         let inner = self.inner.lock().expect("job store mutex poisoned");
         let mut jobs: Vec<Job> = inner
@@ -919,7 +989,305 @@ impl JobStore {
     }
 
     pub fn cancel(&self, job_id: Uuid, reason: impl Into<String>) -> Result<Job> {
+        if self.controller_job_state(job_id).is_ok() {
+            return Err(Error::validation_invalid_argument(
+                "job_id",
+                "controller jobs must be cancelled through POST /controller/jobs/{id}/cancel so the controller driver can stop owned work",
+                Some(job_id.to_string()),
+                Some(vec![format!("POST /controller/jobs/{job_id}/cancel")]),
+            ));
+        }
         self.transition(job_id, JobStatus::Cancelled, reason.into())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_controller_terminal_writes(&self, count: u64) {
+        self.terminal_write_failures.store(count, Ordering::SeqCst);
+    }
+
+    pub(crate) fn controller_job_state(&self, job_id: Uuid) -> Result<ControllerJobState> {
+        let inner = self.inner.lock().expect("job store mutex poisoned");
+        inner
+            .jobs
+            .get(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?
+            .controller_job
+            .clone()
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "job_id",
+                    "job is not a controller job",
+                    Some(job_id.to_string()),
+                    None,
+                )
+            })
+    }
+
+    pub(crate) fn request_controller_cancellation(
+        &self,
+        job_id: Uuid,
+        reason: String,
+    ) -> Result<Job> {
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let stored = inner
+            .jobs
+            .get_mut(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?;
+        let prior = stored.clone();
+        let controller = stored.controller_job.as_mut().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "job_id",
+                "job is not a controller job",
+                Some(job_id.to_string()),
+                None,
+            )
+        })?;
+        if stored.job.status == JobStatus::Cancelled || controller.cancellation_requested {
+            return Ok(stored.job.clone());
+        }
+        if stored.job.status.is_terminal() {
+            return Err(Error::validation_invalid_argument(
+                "status",
+                "cannot cancel a terminal controller job that did not stop by cancellation",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        // Persist the intent before releasing this lock. Dispatchers only observe
+        // cancellation through this durable state, never through a transient flag.
+        controller.cancellation_requested = true;
+        controller.cancellation_reason = Some(reason.clone());
+        let claimless = stored.job.status == JobStatus::Queued
+            && controller.execution_claim_id.is_none()
+            && controller.checkpoint.is_none();
+        let now = timestamp_ms();
+        stored.job.updated_at_ms = now;
+        if claimless {
+            // A response-handoff failure leaves no worker to observe this request.
+            // Terminalize while holding the claim lock so dispatch cannot start it.
+            stored.job.status = JobStatus::Cancelled;
+            stored.job.finished_at_ms = Some(now);
+        }
+        if let Some(persistence) = &self.persistence {
+            let durable = DurableJobStore {
+                jobs: inner.jobs.values().cloned().collect(),
+                submission_keys: inner.submission_keys.clone(),
+                expired_submission_keys: inner.expired_submission_keys.clone(),
+                controller_submissions: inner.controller_submissions.clone(),
+                expired_controller_submissions: inner.expired_controller_submissions.clone(),
+                compaction: inner.compaction.clone(),
+            };
+            if let Err(error) = write_durable_store(&persistence.path, &durable) {
+                *inner.jobs.get_mut(&job_id).expect("controller job exists") = prior;
+                return Err(error);
+            }
+        }
+        drop(inner);
+        if claimless {
+            self.append_status_event(job_id, JobStatus::Cancelled, reason)?;
+            return self.get(job_id);
+        }
+        self.append_event(
+            job_id,
+            JobEventKind::Progress,
+            Some("controller job cancellation requested".to_string()),
+            Some(serde_json::json!({ "phase": "cancellation_requested", "reason": reason })),
+        )?;
+        self.get(job_id)
+    }
+
+    pub(crate) fn controller_cancellation_requested(&self, job_id: Uuid) -> bool {
+        self.inner
+            .lock()
+            .expect("job store mutex poisoned")
+            .jobs
+            .get(&job_id)
+            .and_then(|stored| stored.controller_job.as_ref())
+            .is_some_and(|controller| controller.cancellation_requested)
+    }
+
+    pub(crate) fn record_controller_prepared(&self, job_id: Uuid, prepared: Value) -> Result<()> {
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let controller = inner
+            .jobs
+            .get_mut(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?
+            .controller_job
+            .as_mut()
+            .ok_or_else(|| Error::internal_unexpected("controller worker lost its typed state"))?;
+        controller.checkpoint = Some(prepared);
+        drop(inner);
+        self.persist()
+    }
+
+    pub(crate) fn complete_controller_cancellation(&self, job_id: Uuid) -> Result<Job> {
+        let state = self.controller_job_state(job_id)?;
+        if !state.cancellation_requested {
+            return Err(Error::internal_unexpected(
+                "controller cancellation completed without a recorded request",
+            ));
+        }
+        self.terminalize_controller_job(
+            job_id,
+            JobStatus::Cancelled,
+            JobEventKind::Status,
+            state
+                .cancellation_reason
+                .unwrap_or_else(|| "controller job cancellation completed".to_string()),
+            serde_json::json!({ "status": JobStatus::Cancelled }),
+        )
+    }
+
+    pub(crate) fn fail_controller_cancellation(
+        &self,
+        job_id: Uuid,
+        message: String,
+        data: Value,
+    ) -> Result<Job> {
+        self.terminalize_controller_job(
+            job_id,
+            JobStatus::Failed,
+            JobEventKind::Error,
+            message,
+            serde_json::json!({ "phase": "cancellation_failed", "error": data }),
+        )
+    }
+
+    pub(crate) fn fail_controller_error(
+        &self,
+        job_id: Uuid,
+        message: String,
+        data: Value,
+    ) -> Result<Job> {
+        self.terminalize_controller_job(
+            job_id,
+            JobStatus::Failed,
+            JobEventKind::Error,
+            message,
+            data,
+        )
+    }
+
+    /// Commit controller terminal evidence, status, and the idempotency projection
+    /// in one durable write. Failed writes restore the entire in-memory snapshot.
+    pub(crate) fn complete_controller_success(&self, job_id: Uuid, result: Value) -> Result<Job> {
+        self.terminalize_controller_job(
+            job_id,
+            JobStatus::Succeeded,
+            JobEventKind::Result,
+            "job succeeded".to_string(),
+            result,
+        )
+    }
+
+    fn terminalize_controller_job(
+        &self,
+        job_id: Uuid,
+        status: JobStatus,
+        event_kind: JobEventKind,
+        message: String,
+        data: Value,
+    ) -> Result<Job> {
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let prior = inner.clone();
+        let now = timestamp_ms();
+        let first_sequence = self.next_event_sequence.fetch_add(2, Ordering::SeqCst) + 1;
+        let job = {
+            let stored = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            let controller = stored.controller_job.as_mut().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "job_id",
+                    "job is not a controller job",
+                    Some(job_id.to_string()),
+                    None,
+                )
+            })?;
+            if status == JobStatus::Succeeded && controller.cancellation_requested {
+                return Err(Error::validation_invalid_argument(
+                    "status",
+                    "cannot complete a controller job after durable cancellation was requested",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            validate_transition(stored.job.status, status)?;
+            stored.events.push(JobEvent {
+                sequence: first_sequence,
+                job_id,
+                kind: event_kind,
+                timestamp_ms: now,
+                message: Some(message.clone()),
+                data: Some(data),
+            });
+            stored.events.push(JobEvent {
+                sequence: first_sequence + 1,
+                job_id,
+                kind: JobEventKind::Status,
+                timestamp_ms: now,
+                message: Some(message),
+                data: Some(serde_json::json!({ "status": status })),
+            });
+            apply_event_retention(&mut stored.events, self.event_retention_limit());
+            stored.job.event_count = stored.events.len();
+            stored.job.status = status;
+            stored.job.updated_at_ms = now;
+            stored.job.finished_at_ms = Some(now);
+            controller.execution_claim_id = None;
+            stored.job.clone()
+        };
+        for submission in inner.controller_submissions.values_mut() {
+            if submission.job_id == job_id {
+                submission.terminal_job = Some(job.clone());
+            }
+        }
+        if let Some(persistence) = &self.persistence {
+            #[cfg(test)]
+            if self
+                .terminal_write_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                *inner = prior;
+                return Err(Error::internal_io(
+                    "injected controller terminal persistence failure",
+                    Some(persistence.path.display().to_string()),
+                ));
+            }
+            let mut durable = DurableJobStore {
+                jobs: inner.jobs.values().cloned().collect(),
+                submission_keys: inner.submission_keys.clone(),
+                expired_submission_keys: inner.expired_submission_keys.clone(),
+                controller_submissions: inner.controller_submissions.clone(),
+                expired_controller_submissions: inner.expired_controller_submissions.clone(),
+                compaction: inner.compaction.clone(),
+            };
+            compact_terminal_jobs(
+                &mut durable,
+                persistence.event_retention_limit,
+                persistence.terminal_job_retention_limit,
+                persistence.terminal_job_retention_bytes,
+            );
+            if let Err(error) = write_durable_store(&persistence.path, &durable) {
+                *inner = prior;
+                return Err(error);
+            }
+            inner.jobs = durable
+                .jobs
+                .into_iter()
+                .map(|stored| (stored.job.id, stored))
+                .collect();
+            inner.submission_keys = durable.submission_keys;
+            inner.expired_submission_keys = durable.expired_submission_keys;
+            inner.controller_submissions = durable.controller_submissions;
+            inner.expired_controller_submissions = durable.expired_controller_submissions;
+            inner.compaction = durable.compaction;
+        }
+        Ok(job)
     }
 
     pub(crate) fn append_event(
@@ -969,6 +1337,257 @@ impl JobStore {
         F: FnOnce(JobHandle) -> Result<T> + Send + 'static,
     {
         self.run_background_with_source_snapshot(operation, None, run)
+    }
+
+    /// Persist a controller-owned typed envelope before spawning its driver.
+    /// A key identifies the request permanently, including its terminal result.
+    pub(crate) fn admit_controller_job(
+        &self,
+        operation: String,
+        idempotency_key: String,
+        controller_job: ControllerJobState,
+    ) -> Result<ControllerJobSubmissionOutcome> {
+        let fingerprint = controller_submission_fingerprint(&controller_job);
+        let now = timestamp_ms();
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        if let Some(existing) = inner.controller_submissions.get(&idempotency_key) {
+            if existing.fingerprint != fingerprint {
+                return Err(controller_idempotency_conflict(&idempotency_key));
+            }
+            let job = inner.jobs.get(&existing.job_id).ok_or_else(|| {
+                Error::internal_unexpected("controller submission index points at a missing job")
+            })?;
+            return Ok(ControllerJobSubmissionOutcome::Existing(job.job.clone()));
+        }
+        if inner
+            .expired_controller_submissions
+            .contains_key(&idempotency_key)
+        {
+            let submission = inner
+                .expired_controller_submissions
+                .get(&idempotency_key)
+                .expect("submission exists");
+            if submission.fingerprint != fingerprint {
+                return Err(controller_idempotency_conflict(&idempotency_key));
+            }
+            if let Some(job) = submission.terminal_job.clone() {
+                return Ok(ControllerJobSubmissionOutcome::Existing(job));
+            }
+            return Err(Error::validation_invalid_argument(
+                "idempotency_key",
+                "controller idempotency key belongs to compacted terminal work; choose a new key for a new attempt",
+                Some(idempotency_key),
+                None,
+            ));
+        }
+        let job = Job {
+            id: Uuid::new_v4(),
+            operation,
+            status: JobStatus::Queued,
+            created_at_ms: now,
+            updated_at_ms: now,
+            started_at_ms: None,
+            finished_at_ms: None,
+            event_count: 0,
+            source_snapshot: None,
+            path_materialization_plan: None,
+            stale_reason: None,
+            daemon_lease_id: self.daemon_lease_id.clone(),
+            target_runner_id: None,
+            target_project_id: None,
+            claim_id: None,
+            claimed_by_runner_id: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            artifacts: Vec::new(),
+            runner_job_projection: None,
+        };
+        let job_id = job.id;
+        let initial_event = JobEvent {
+            sequence: self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1,
+            job_id,
+            kind: JobEventKind::Status,
+            timestamp_ms: now,
+            message: Some("job queued".to_string()),
+            data: Some(serde_json::json!({ "controller_job": controller_job.public_request })),
+        };
+        let mut stored = StoredJob {
+            job,
+            events: vec![initial_event],
+            admission_idempotency_key: None,
+            controller_job: Some(controller_job),
+            admission_lease: None,
+            remote_runner: None,
+            local_runner: None,
+            local_child: None,
+        };
+        stored.job.event_count = stored.events.len();
+        inner.jobs.insert(job_id, stored);
+        inner.controller_submissions.insert(
+            idempotency_key.clone(),
+            ControllerJobSubmission {
+                fingerprint,
+                job_id,
+                terminal_job: None,
+            },
+        );
+        // Persist the initial event, job, and submission index as one admission
+        // commit. Roll back memory on failure so retries cannot observe a ghost.
+        if let Some(persistence) = &self.persistence {
+            let durable = DurableJobStore {
+                jobs: inner.jobs.values().cloned().collect(),
+                submission_keys: inner.submission_keys.clone(),
+                expired_submission_keys: inner.expired_submission_keys.clone(),
+                controller_submissions: inner.controller_submissions.clone(),
+                expired_controller_submissions: inner.expired_controller_submissions.clone(),
+                compaction: inner.compaction.clone(),
+            };
+            if let Err(error) = write_durable_store(&persistence.path, &durable) {
+                inner.jobs.remove(&job_id);
+                inner.controller_submissions.remove(&idempotency_key);
+                return Err(error);
+            }
+        }
+        drop(inner);
+        Ok(ControllerJobSubmissionOutcome::Submitted(job_id))
+    }
+
+    /// Claim a controller job before starting a worker. This is intentionally a
+    /// durable transition: a failed HTTP response leaves a queued, claimless job.
+    pub(crate) fn claim_controller_execution(
+        &self,
+        job_id: Uuid,
+        recovery: bool,
+    ) -> Result<ControllerJobState> {
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let stored = inner
+            .jobs
+            .get_mut(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?;
+        let controller = stored.controller_job.as_mut().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "job_id",
+                "job is not a controller job",
+                Some(job_id.to_string()),
+                None,
+            )
+        })?;
+        if stored.job.status.is_terminal() || (!recovery && controller.execution_claim_id.is_some())
+        {
+            return Err(Error::validation_invalid_argument(
+                "job_id",
+                "controller job is already claimed or terminal",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        if recovery && (controller.checkpoint.is_none() || controller.recovery_attempted) {
+            return Err(Error::validation_invalid_argument(
+                "job_id",
+                "controller job has no recoverable checkpoint",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        controller.execution_claim_id = Some(Uuid::new_v4().to_string());
+        controller.recovery_attempted |= recovery;
+        stored.job.status = JobStatus::Running;
+        stored.job.started_at_ms.get_or_insert_with(timestamp_ms);
+        stored.job.updated_at_ms = timestamp_ms();
+        let controller = controller.clone();
+        drop(inner);
+        self.persist()?;
+        Ok(controller)
+    }
+
+    /// Atomically claim queued work for the explicit second phase of controller
+    /// submission. A retry observes the durable current job rather than starting
+    /// another worker.
+    pub(crate) fn start_controller_execution(
+        &self,
+        job_id: Uuid,
+    ) -> Result<ControllerJobStartOutcome> {
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let stored = inner
+            .jobs
+            .get_mut(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?;
+        let prior = stored.clone();
+        let controller = stored.controller_job.as_mut().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "job_id",
+                "job is not a controller job",
+                Some(job_id.to_string()),
+                None,
+            )
+        })?;
+        if stored.job.status != JobStatus::Queued || controller.execution_claim_id.is_some() {
+            return Ok(ControllerJobStartOutcome::Existing);
+        }
+        controller.execution_claim_id = Some(Uuid::new_v4().to_string());
+        stored.job.status = JobStatus::Running;
+        stored.job.started_at_ms.get_or_insert_with(timestamp_ms);
+        stored.job.updated_at_ms = timestamp_ms();
+        let controller = controller.clone();
+        if let Some(persistence) = &self.persistence {
+            let durable = DurableJobStore {
+                jobs: inner.jobs.values().cloned().collect(),
+                submission_keys: inner.submission_keys.clone(),
+                expired_submission_keys: inner.expired_submission_keys.clone(),
+                controller_submissions: inner.controller_submissions.clone(),
+                expired_controller_submissions: inner.expired_controller_submissions.clone(),
+                compaction: inner.compaction.clone(),
+            };
+            if let Err(error) = write_durable_store(&persistence.path, &durable) {
+                *inner.jobs.get_mut(&job_id).expect("controller job exists") = prior;
+                return Err(error);
+            }
+        }
+        Ok(ControllerJobStartOutcome::Claimed(controller))
+    }
+
+    pub(crate) fn active_controller_jobs(&self) -> Vec<(Uuid, ControllerJobState)> {
+        self.inner
+            .lock()
+            .expect("job store mutex poisoned")
+            .jobs
+            .values()
+            .filter(|stored| stored.job.status == JobStatus::Running)
+            .filter_map(|stored| {
+                stored
+                    .controller_job
+                    .clone()
+                    .map(|state| (stored.job.id, state))
+            })
+            .collect()
+    }
+
+    /// A process-local controller driver has no durable execution identity that
+    /// can prove whether it survived daemon loss. Terminalize such work rather
+    /// than replaying it on startup; its durable request and key remain evidence
+    /// for the domain layer to inspect or retry with a new idempotency key.
+    pub(crate) fn reconcile_unresolved_controller_jobs(&self) -> Result<Vec<Uuid>> {
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let now = timestamp_ms();
+        let mut reconciled = Vec::new();
+        for stored in inner.jobs.values_mut() {
+            if stored.controller_job.is_some()
+                && matches!(stored.job.status, JobStatus::Queued | JobStatus::Running)
+            {
+                stored.job.status = JobStatus::Failed;
+                stored.job.updated_at_ms = now;
+                stored.job.finished_at_ms = Some(now);
+                stored.job.stale_reason = Some(
+                    "controller job was unresolved after daemon restart; not replayed".to_string(),
+                );
+                reconciled.push(stored.job.id);
+            }
+        }
+        drop(inner);
+        if !reconciled.is_empty() {
+            self.persist()?;
+        }
+        Ok(reconciled)
     }
 
     pub(crate) fn run_background_with_source_snapshot<T, F>(
@@ -1259,6 +1878,19 @@ impl JobStore {
             if stored.job.status == JobStatus::Cancelled && next_status == JobStatus::Cancelled {
                 return Ok(stored.job.clone());
             }
+            if next_status == JobStatus::Succeeded
+                && stored
+                    .controller_job
+                    .as_ref()
+                    .is_some_and(|controller| controller.cancellation_requested)
+            {
+                return Err(Error::validation_invalid_argument(
+                    "status",
+                    "cannot complete a controller job after durable cancellation was requested",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
             validate_transition(stored.job.status, next_status)?;
 
             let now = timestamp_ms();
@@ -1361,6 +1993,8 @@ impl JobStore {
                 jobs: inner.jobs.values().cloned().collect(),
                 submission_keys: inner.submission_keys.clone(),
                 expired_submission_keys: inner.expired_submission_keys.clone(),
+                controller_submissions: inner.controller_submissions.clone(),
+                expired_controller_submissions: inner.expired_controller_submissions.clone(),
                 compaction: inner.compaction.clone(),
             };
             compact_terminal_jobs(
@@ -1379,6 +2013,8 @@ impl JobStore {
                 .cloned()
                 .map(|stored| (stored.job.id, stored))
                 .collect();
+            inner.controller_submissions = durable.controller_submissions;
+            inner.expired_controller_submissions = durable.expired_controller_submissions;
             inner.compaction = durable.compaction;
         }
         Ok(true)
@@ -1638,6 +2274,8 @@ impl JobStore {
                 jobs: inner.jobs.values().cloned().collect(),
                 submission_keys: inner.submission_keys.clone(),
                 expired_submission_keys: inner.expired_submission_keys.clone(),
+                controller_submissions: inner.controller_submissions.clone(),
+                expired_controller_submissions: inner.expired_controller_submissions.clone(),
                 compaction: inner.compaction.clone(),
             };
             compact_terminal_jobs(
@@ -1656,6 +2294,8 @@ impl JobStore {
                 .cloned()
                 .map(|stored| (stored.job.id, stored))
                 .collect();
+            inner.controller_submissions = durable.controller_submissions;
+            inner.expired_controller_submissions = durable.expired_controller_submissions;
             inner.compaction = durable.compaction;
         }
         Ok(started)
@@ -1736,6 +2376,8 @@ impl JobStore {
             jobs: inner.jobs.values().cloned().collect(),
             submission_keys: inner.submission_keys.clone(),
             expired_submission_keys: inner.expired_submission_keys.clone(),
+            controller_submissions: inner.controller_submissions.clone(),
+            expired_controller_submissions: inner.expired_controller_submissions.clone(),
             compaction: inner.compaction.clone(),
         };
         compact_terminal_jobs(
@@ -1753,9 +2395,28 @@ impl JobStore {
             .collect();
         inner.submission_keys = durable.submission_keys;
         inner.expired_submission_keys = durable.expired_submission_keys;
+        inner.controller_submissions = durable.controller_submissions;
+        inner.expired_controller_submissions = durable.expired_controller_submissions;
         inner.compaction = durable.compaction;
         Ok(())
     }
+}
+
+fn controller_submission_fingerprint(state: &ControllerJobState) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(state.job_type.as_bytes());
+    hasher.update(state.version.to_be_bytes());
+    hasher.update(state.request_digest.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn controller_idempotency_conflict(idempotency_key: &str) -> Error {
+    Error::validation_invalid_argument(
+        "idempotency_key",
+        "controller idempotency key is already bound to a different type, version, or request",
+        Some(idempotency_key.to_string()),
+        None,
+    )
 }
 
 enum DeadLeaseJobDisposition {
@@ -1905,15 +2566,43 @@ fn recovered_terminal_agent_task_result(stored: &StoredJob) -> Option<RecoveredT
 }
 
 impl JobHandle {
-    pub(crate) fn job_id(&self) -> Uuid {
+    pub fn job_id(&self) -> Uuid {
         self.job_id
     }
 
-    pub(crate) fn is_cancelled(&self) -> bool {
+    pub fn is_cancelled(&self) -> bool {
         self.store
             .get(self.job_id)
             .map(|job| job.status == JobStatus::Cancelled)
             .unwrap_or(true)
+            || self.store.controller_cancellation_requested(self.job_id)
+    }
+
+    pub(crate) fn is_terminal(&self) -> bool {
+        self.store
+            .get(self.job_id)
+            .is_ok_and(|job| job.status.is_terminal())
+    }
+
+    pub(crate) fn record_controller_prepared(&self, prepared: Value) -> Result<()> {
+        self.store.record_controller_prepared(self.job_id, prepared)
+    }
+
+    pub(crate) fn complete_controller_cancellation(&self) -> Result<Job> {
+        self.store.complete_controller_cancellation(self.job_id)
+    }
+
+    pub(crate) fn complete_controller_success(&self, result: Value) -> Result<Job> {
+        self.store.complete_controller_success(self.job_id, result)
+    }
+
+    pub(crate) fn fail_controller_cancellation(&self, message: String, data: Value) -> Result<Job> {
+        self.store
+            .fail_controller_cancellation(self.job_id, message, data)
+    }
+
+    pub(crate) fn fail_controller_error(&self, message: String, data: Value) -> Result<Job> {
+        self.store.fail_controller_error(self.job_id, message, data)
     }
 
     pub(crate) fn local_child_reservation_id(&self) -> Result<String> {
@@ -1958,12 +2647,12 @@ impl JobHandle {
         )
     }
 
-    pub(crate) fn progress(&self, data: Value) -> Result<JobEvent> {
+    pub fn progress(&self, data: Value) -> Result<JobEvent> {
         self.store
             .append_event(self.job_id, JobEventKind::Progress, None, Some(data))
     }
 
-    pub(crate) fn result(&self, data: Value) -> Result<JobEvent> {
+    pub fn result(&self, data: Value) -> Result<JobEvent> {
         self.store
             .append_event(self.job_id, JobEventKind::Result, None, Some(data))
     }

--- a/crates/homeboy-core/src/daemon/controller_job_driver.rs
+++ b/crates/homeboy-core/src/daemon/controller_job_driver.rs
@@ -1,0 +1,121 @@
+//! Typed controller-local work registered by domain crates.
+//!
+//! The daemon owns the durable job lifecycle. Drivers only interpret their
+//! versioned request and report progress through the supplied job handle.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use serde_json::Value;
+
+use crate::api_jobs::JobHandle;
+use crate::error::{Error, Result};
+
+/// A driver-owned error projection safe for durable public job state.
+#[derive(Debug, Clone)]
+pub struct ControllerJobPublicError {
+    pub message: String,
+    pub data: Value,
+}
+
+pub trait ControllerJobDriver: Send + Sync {
+    fn job_type(&self) -> &'static str;
+    fn version(&self) -> u32;
+
+    /// Return the safe request projection exposed through public job events.
+    /// The original request remains in Homeboy's private durable store.
+    fn public_request(&self, request: &Value) -> Result<Value>;
+    fn public_progress(&self, progress: &Value) -> Result<Value>;
+    fn public_result(&self, result: &Value) -> Result<Value>;
+    fn public_error(&self, error: &Error) -> ControllerJobPublicError;
+
+    /// Validate that sensitive inputs are durable references rather than inline
+    /// values. Domain drivers define their own reference vocabulary.
+    fn validate_secret_references(&self, request: &Value) -> Result<()>;
+
+    /// Prepare the persisted request inside the daemon worker. Drivers may
+    /// override this to resolve controller-local inputs after durable admission.
+    fn prepare(&self, request: Value) -> Result<Value> {
+        Ok(request)
+    }
+
+    fn execute(&self, prepared: Value, job: ControllerJobHandle) -> Result<Value>;
+
+    /// Resume one daemon-recovered job from the authoritative checkpoint written
+    /// after `prepare`. Implementations must treat this as a new process-local
+    /// invocation of the same idempotent durable operation.
+    fn resume(&self, checkpoint: Value, job: ControllerJobHandle) -> Result<Value> {
+        self.execute(checkpoint, job)
+    }
+
+    /// Called by the daemon when the durable job is cancelled. Implementations
+    /// must stop their owned work before returning.
+    fn cancel(&self, prepared: &Value) -> Result<()>;
+}
+
+/// The only event surface exposed to controller drivers. Every event payload is
+/// projected by the driver before it reaches the durable public job log.
+#[derive(Clone)]
+pub struct ControllerJobHandle {
+    job: JobHandle,
+    driver: Arc<dyn ControllerJobDriver>,
+}
+
+impl ControllerJobHandle {
+    pub(crate) fn new(job: JobHandle, driver: Arc<dyn ControllerJobDriver>) -> Self {
+        Self { job, driver }
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.job.is_cancelled()
+    }
+
+    pub fn progress(&self, private_progress: Value) -> Result<()> {
+        self.job
+            .progress(self.driver.public_progress(&private_progress)?)
+            .map(|_| ())
+    }
+}
+
+fn drivers() -> &'static Mutex<HashMap<(String, u32), Arc<dyn ControllerJobDriver>>> {
+    static DRIVERS: std::sync::OnceLock<
+        Mutex<HashMap<(String, u32), Arc<dyn ControllerJobDriver>>>,
+    > = std::sync::OnceLock::new();
+    DRIVERS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub fn register_controller_job_driver(driver: Arc<dyn ControllerJobDriver>) -> Result<()> {
+    let key = (driver.job_type().to_string(), driver.version());
+    let mut registry = drivers().lock().expect("controller job driver lock");
+    if registry.contains_key(&key) {
+        return Err(Error::validation_invalid_argument(
+            "controller_job_driver",
+            format!(
+                "controller job driver `{}` version {} is already registered",
+                key.0, key.1
+            ),
+            Some(key.0),
+            None,
+        ));
+    }
+    registry.insert(key, driver);
+    Ok(())
+}
+
+pub(crate) fn driver(job_type: &str, version: u32) -> Result<Arc<dyn ControllerJobDriver>> {
+    drivers()
+        .lock()
+        .expect("controller job driver lock")
+        .get(&(job_type.to_string(), version))
+        .cloned()
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "type",
+                format!(
+                    "no controller job driver is registered for `{job_type}` version {version}"
+                ),
+                Some(job_type.to_string()),
+                None,
+            )
+        })
+}

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -6,12 +6,12 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, OnceLock};
+use std::sync::{mpsc, Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant, UNIX_EPOCH};
 use uuid::Uuid;
 
 use crate::api_jobs::{
-    DaemonActiveJobRecoveryEvidence, JobStatus, JobStore, LocalRunnerJob,
+    ControllerJobState, DaemonActiveJobRecoveryEvidence, JobStatus, JobStore, LocalRunnerJob,
     RunnerJobLifecycleMetadata,
 };
 use crate::build_identity;
@@ -31,6 +31,7 @@ mod artifact_download;
 mod broker_config;
 mod completion_tracker;
 mod control;
+pub mod controller_job_driver;
 mod daemon_lease;
 mod patch_capture;
 mod remote_runner;
@@ -56,6 +57,27 @@ pub const DEFAULT_ADDR: &str = "127.0.0.1:0";
 
 static DAEMON_JOB_STORE: OnceLock<JobStore> = OnceLock::new();
 static DAEMON_RUNTIME_SNAPSHOT: OnceLock<DaemonRuntimeSnapshot> = OnceLock::new();
+
+/// Process-local ownership for active controller work. Durable state remains the
+/// authority across restart; this registry prevents this daemon from declaring a
+/// cancellation terminal while its owned execute thread is still live.
+struct ControllerJobRuntime {
+    cancel: mpsc::Sender<()>,
+    supervisor: std::thread::JoinHandle<()>,
+}
+
+fn controller_job_runtimes() -> &'static Mutex<HashMap<Uuid, ControllerJobRuntime>> {
+    static RUNTIMES: OnceLock<Mutex<HashMap<Uuid, ControllerJobRuntime>>> = OnceLock::new();
+    RUNTIMES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) fn controller_job_runtime_count() -> usize {
+    controller_job_runtimes()
+        .lock()
+        .expect("controller runtimes lock")
+        .len()
+}
 
 pub(crate) const DAEMON_LEASE_SCHEMA: &str = "homeboy.daemon.session_lease.v1";
 pub(super) const DAEMON_STARTUP_TOKEN_ENV: &str = "HOMEBOY_DAEMON_STARTUP_TOKEN";
@@ -424,6 +446,15 @@ struct ExecRequest {
     idempotency_key: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct ControllerJobRequest {
+    #[serde(rename = "type")]
+    job_type: String,
+    version: u32,
+    idempotency_key: String,
+    request: serde_json::Value,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub(super) struct FilePathRequest {
     runner_id: String,
@@ -645,19 +676,38 @@ where
     let owner_lock = acquire_daemon_owner_lock()?;
     let listener = TcpListener::bind(addr)
         .map_err(|e| Error::internal_io(e.to_string(), Some(format!("bind daemon to {}", addr))))?;
-    serve_listener_with_analysis_runner_locked(listener, analysis_runner, owner_lock)
+    serve_listener_with_analysis_runner_locked(listener, analysis_runner, owner_lock, None)
 }
 
 #[cfg(any(test, feature = "test-support"))]
 pub fn serve_listener(listener: TcpListener) -> Result<DaemonState> {
     let owner_lock = acquire_daemon_owner_lock()?;
-    serve_listener_with_analysis_runner_locked(listener, UnsupportedAnalysisJobRunner, owner_lock)
+    serve_listener_with_analysis_runner_locked(
+        listener,
+        UnsupportedAnalysisJobRunner,
+        owner_lock,
+        None,
+    )
+}
+
+/// Serve a finite number of connections for isolated TCP tests. Returning from
+/// this function releases the daemon owner lock and joins daemon-owned helpers.
+#[cfg(any(test, feature = "test-support"))]
+pub fn serve_listener_for_requests(listener: TcpListener, requests: usize) -> Result<DaemonState> {
+    let owner_lock = acquire_daemon_owner_lock()?;
+    serve_listener_with_analysis_runner_locked(
+        listener,
+        UnsupportedAnalysisJobRunner,
+        owner_lock,
+        Some(requests),
+    )
 }
 
 fn serve_listener_with_analysis_runner_locked<R>(
     listener: TcpListener,
     analysis_runner: R,
     _owner_lock: DaemonOwnerLock,
+    request_limit: Option<usize>,
 ) -> Result<DaemonState>
 where
     R: AnalysisJobRunner,
@@ -672,28 +722,43 @@ where
     // Expire only reservations that never recorded a child identity.
     job_store.reconcile_expired_local_child_reservations()?;
     job_store.reconcile_expired_admissions()?;
+    recover_controller_jobs(&job_store);
     let _ = daemon_runtime_snapshot();
     let loopback_bind = local_addr.ip().is_loopback();
 
-    spawn_local_child_reservation_reconciler(job_store.clone());
-    spawn_completion_notifier();
+    let (local_shutdown_tx, local_shutdown_rx) = mpsc::channel();
+    let (completion_shutdown_tx, completion_shutdown_rx) = mpsc::channel();
+    let local_child_reconciler =
+        spawn_local_child_reservation_reconciler(job_store.clone(), local_shutdown_rx);
+    let completion_notifier = spawn_completion_notifier(completion_shutdown_rx);
 
+    let mut accepted = 0;
+    let mut serve_result = Ok(());
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
                 let _ =
                     handle_connection(stream, &job_store, analysis_runner.clone(), loopback_bind);
+                accepted += 1;
+                if request_limit.is_some_and(|limit| accepted >= limit) {
+                    break;
+                }
             }
             Err(err) => {
-                return Err(Error::internal_io(
+                serve_result = Err(Error::internal_io(
                     err.to_string(),
                     Some("accept daemon connection".to_string()),
                 ));
+                break;
             }
         }
     }
 
-    Ok(state)
+    let _ = local_shutdown_tx.send(());
+    let _ = completion_shutdown_tx.send(());
+    let _ = local_child_reconciler.join();
+    let _ = completion_notifier.join();
+    serve_result.map(|()| state)
 }
 
 /// Environment variable overriding the completion-notifier poll interval in
@@ -704,14 +769,22 @@ const LOCAL_CHILD_RESERVATION_RECONCILE_INTERVAL_SECS: u64 = 5;
 
 /// Reclaim capacity even when no controller polls the daemon after a failed
 /// handoff. The store owns the fail-closed child-identity check.
-fn spawn_local_child_reservation_reconciler(job_store: JobStore) {
+fn spawn_local_child_reservation_reconciler(
+    job_store: JobStore,
+    shutdown: mpsc::Receiver<()>,
+) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || loop {
         let _ = job_store.reconcile_expired_local_child_reservations();
         let _ = job_store.reconcile_expired_admissions();
-        std::thread::sleep(std::time::Duration::from_secs(
-            LOCAL_CHILD_RESERVATION_RECONCILE_INTERVAL_SECS,
-        ));
-    });
+        if shutdown
+            .recv_timeout(std::time::Duration::from_secs(
+                LOCAL_CHILD_RESERVATION_RECONCILE_INTERVAL_SECS,
+            ))
+            .is_ok()
+        {
+            return;
+        }
+    })
 }
 
 /// Spawn the background thread that watches in-flight runs and fires a local
@@ -720,13 +793,15 @@ fn spawn_local_child_reservation_reconciler(job_store: JobStore) {
 ///
 /// Delivery is route-driven. Route-less completions are considered only when an
 /// explicit operations default transport is configured.
-fn spawn_completion_notifier() {
+fn spawn_completion_notifier(shutdown: mpsc::Receiver<()>) -> std::thread::JoinHandle<()> {
     let interval = std::env::var(COMPLETION_NOTIFY_INTERVAL_ENV)
         .ok()
         .and_then(|value| value.trim().parse::<u64>().ok())
         .filter(|secs| *secs > 0)
         .unwrap_or(COMPLETION_NOTIFY_DEFAULT_INTERVAL_SECS);
-    std::thread::spawn(move || completion_notify_loop(std::time::Duration::from_secs(interval)));
+    std::thread::spawn(move || {
+        completion_notify_loop(std::time::Duration::from_secs(interval), shutdown)
+    })
 }
 
 /// Poll the observation store for in-flight runs and notify on completion.
@@ -734,7 +809,7 @@ fn spawn_completion_notifier() {
 /// Each pass refreshes mirrored runner evidence for currently-running records
 /// (so offloaded runs advance to their terminal state locally), re-reads the
 /// running set, and pings for any run that left it since the previous pass.
-fn completion_notify_loop(interval: std::time::Duration) {
+fn completion_notify_loop(interval: std::time::Duration, shutdown: mpsc::Receiver<()>) {
     use crate::observation::ObservationStore;
 
     let mut tracker = completion_tracker::CompletionTracker::default();
@@ -764,7 +839,9 @@ fn completion_notify_loop(interval: std::time::Duration) {
                 let _ = crate::notify::dispatch(&event);
             }
         }
-        std::thread::sleep(interval);
+        if shutdown.recv_timeout(interval).is_ok() {
+            return;
+        }
     }
 }
 
@@ -896,6 +973,22 @@ where
             Ok(body) => daemon_endpoint_response("jobs.exec", body),
             Err(err) => error_response(400, err),
         },
+        ("POST", "/controller/jobs") => match enqueue_controller_job(body, job_store) {
+            Ok(body) => daemon_endpoint_response("controller.jobs.create", body),
+            Err(err) => error_response(400, err),
+        },
+        ("POST", path) if path.starts_with("/controller/jobs/") && path.ends_with("/start") => {
+            match start_controller_job(path, job_store) {
+                Ok(body) => daemon_endpoint_response("controller.jobs.start", body),
+                Err(err) => error_response(400, err),
+            }
+        }
+        ("POST", path) if path.starts_with("/controller/jobs/") && path.ends_with("/cancel") => {
+            match cancel_controller_job(path, body, job_store) {
+                Ok(body) => daemon_endpoint_response("controller.jobs.cancel", body),
+                Err(err) => error_response(400, err),
+            }
+        }
         ("POST", "/admissions") => match reserve_admission(body, job_store) {
             Ok(body) => daemon_endpoint_response("admissions.reserve", body),
             Err(err) => error_response(400, err),
@@ -950,13 +1043,24 @@ where
             Ok(body) => daemon_endpoint_response("files.download", body),
             Err(err) => remote_runner::auth_or_bad_request(err),
         },
-        ("GET", "/exec") | ("GET", "/admissions") | ("GET", "/jobs/reconcile-terminal") => {
+        ("GET", path) if path.starts_with("/controller/jobs/") && path.ends_with("/cancel") => {
             HttpResponse {
                 status_code: 405,
                 body: json!({ "error": "method_not_allowed" }),
                 artifact: None,
             }
         }
+        ("GET", path) if path.starts_with("/controller/jobs/") && path.ends_with("/start") => {
+            method_not_allowed()
+        }
+        ("GET", "/exec")
+        | ("GET", "/admissions")
+        | ("GET", "/jobs/reconcile-terminal")
+        | ("GET", "/controller/jobs") => HttpResponse {
+            status_code: 405,
+            body: json!({ "error": "method_not_allowed" }),
+            artifact: None,
+        },
         ("GET", "/lifecycle/stop") => method_not_allowed(),
         ("GET", "/files/mkdir") | ("GET", "/files/upload") | ("GET", "/files/download") => {
             method_not_allowed()
@@ -1597,6 +1701,471 @@ fn enqueue_exec_job(
         },
         "request": summary,
     }))
+}
+
+fn enqueue_controller_job(
+    body: Option<serde_json::Value>,
+    job_store: &JobStore,
+) -> Result<serde_json::Value> {
+    let request: ControllerJobRequest = serde_json::from_value(body.unwrap_or_else(|| json!({})))
+        .map_err(|error| {
+        Error::validation_invalid_argument(
+            "body",
+            format!("invalid controller job request body: {error}"),
+            None,
+            None,
+        )
+    })?;
+    if request.job_type.trim().is_empty() || request.idempotency_key.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "type",
+            "controller jobs require a non-empty type and idempotency_key",
+            None,
+            None,
+        ));
+    }
+    // Resolve before durable admission so an unsupported envelope is never left queued.
+    let driver = controller_job_driver::driver(&request.job_type, request.version)?;
+    driver.validate_secret_references(&request.request)?;
+    let public_request = driver.public_request(&request.request)?;
+    let request_digest = hex_digest(&request.request)?;
+    let controller_job = ControllerJobState {
+        job_type: request.job_type.clone(),
+        version: request.version,
+        request: request.request.clone(),
+        public_request,
+        request_digest,
+        checkpoint: None,
+        cancellation_requested: false,
+        cancellation_reason: None,
+        execution_claim_id: None,
+        recovery_attempted: false,
+    };
+    let outcome = job_store.admit_controller_job(
+        format!("controller.{}", request.job_type),
+        request.idempotency_key.clone(),
+        controller_job,
+    )?;
+    let (job, compacted) = match outcome {
+        crate::api_jobs::ControllerJobSubmissionOutcome::Submitted(job_id) => {
+            (job_store.get(job_id)?, false)
+        }
+        crate::api_jobs::ControllerJobSubmissionOutcome::Existing(job) => {
+            let compacted = job_store.get(job.id).is_err();
+            (job, compacted)
+        }
+    };
+    let job_id = job.id;
+    Ok(json!({
+        "command": "api.controller.jobs.create",
+        "job": job,
+        "terminal_tombstone": if compacted { json!({ "status": "terminal", "compacted": true }) } else { serde_json::Value::Null },
+        "poll": if compacted { json!({ "job": serde_json::Value::Null, "events": serde_json::Value::Null }) } else { json!({ "job": format!("/jobs/{job_id}"), "events": format!("/jobs/{job_id}/events") }) },
+        "start": if compacted { serde_json::Value::Null } else { json!({ "method": "POST", "path": format!("/controller/jobs/{job_id}/start") }) },
+    }))
+}
+
+fn start_controller_job(path: &str, job_store: &JobStore) -> Result<serde_json::Value> {
+    let job_id = controller_job_id_from_path(path, "/start")?;
+    let controller = job_store.controller_job_state(job_id)?;
+    if job_store.get(job_id)?.status != JobStatus::Queued {
+        return Ok(json!({
+            "job": job_store.get(job_id)?,
+            "poll": { "job": format!("/jobs/{job_id}"), "events": format!("/jobs/{job_id}/events") },
+        }));
+    }
+    // Resolve the persisted type/version, not caller-controlled input, before
+    // claiming the job so unsupported work remains queued and recoverable.
+    let _driver = controller_job_driver::driver(&controller.job_type, controller.version)?;
+    if let crate::api_jobs::ControllerJobStartOutcome::Claimed(state) =
+        job_store.start_controller_execution(job_id)?
+    {
+        dispatch_claimed_controller_job(job_store.clone(), job_id, state, false);
+    }
+    Ok(json!({
+        "job": job_store.get(job_id)?,
+        "poll": { "job": format!("/jobs/{job_id}"), "events": format!("/jobs/{job_id}/events") },
+    }))
+}
+
+/// Run work which has already been claimed by either explicit start or startup
+/// recovery. The durable claim is the exactly-once execution authority.
+fn dispatch_claimed_controller_job(
+    job_store: JobStore,
+    job_id: Uuid,
+    state: ControllerJobState,
+    recovery: bool,
+) {
+    let Ok(driver) = controller_job_driver::driver(&state.job_type, state.version) else {
+        let _ = job_store.fail_controller_error(
+            job_id,
+            "controller recovery driver is unavailable".to_string(),
+            json!({ "phase": "recovery_driver_missing" }),
+        );
+        return;
+    };
+    // Cancellation is durable first. This channel only wakes the owner quickly;
+    // every gate below re-reads the durable flag before doing work.
+    let (cancel_tx, cancel_rx) = mpsc::channel();
+    // Register ownership before allowing a fast driver to terminalize itself.
+    let (start_tx, start_rx) = mpsc::channel();
+    let supervisor = std::thread::spawn(move || {
+        let _ = start_rx.recv();
+        let job = job_store.handle(job_id);
+        if job.is_cancelled() {
+            persist_controller_cancellation(&job);
+            controller_job_runtimes()
+                .lock()
+                .expect("controller runtimes lock")
+                .remove(&job_id);
+            return;
+        }
+        let prepared = if recovery {
+            state
+                .checkpoint
+                .clone()
+                .expect("claimed recovery has checkpoint")
+        } else {
+            match driver.prepare(state.request.clone()) {
+                Ok(prepared) => {
+                    if job.record_controller_prepared(prepared.clone()).is_err() {
+                        persist_controller_failure(
+                            &job,
+                            "controller checkpoint could not be persisted".to_string(),
+                            json!({ "phase": "checkpoint_persistence" }),
+                        );
+                        controller_job_runtimes()
+                            .lock()
+                            .expect("controller runtimes lock")
+                            .remove(&job_id);
+                        return;
+                    }
+                    if job.is_cancelled() {
+                        match driver.cancel(&prepared) {
+                            Ok(()) => {
+                                persist_controller_cancellation(&job);
+                            }
+                            Err(error) => {
+                                let public = driver.public_error(&error);
+                                persist_controller_cancellation_failure(
+                                    &job,
+                                    public.message,
+                                    public.data,
+                                );
+                            }
+                        }
+                        controller_job_runtimes()
+                            .lock()
+                            .expect("controller runtimes lock")
+                            .remove(&job_id);
+                        return;
+                    }
+                    prepared
+                }
+                Err(error) => {
+                    let public = driver.public_error(&error);
+                    persist_controller_failure(&job, public.message, public.data);
+                    controller_job_runtimes()
+                        .lock()
+                        .expect("controller runtimes lock")
+                        .remove(&job_id);
+                    return;
+                }
+            }
+        };
+        // The checkpoint write and this durable read form the final gate before
+        // any execute/resume side effect can start.
+        if job.is_cancelled() {
+            match driver.cancel(&prepared) {
+                Ok(()) => {
+                    persist_controller_cancellation(&job);
+                }
+                Err(error) => {
+                    let public = driver.public_error(&error);
+                    persist_controller_cancellation_failure(&job, public.message, public.data);
+                }
+            }
+            controller_job_runtimes()
+                .lock()
+                .expect("controller runtimes lock")
+                .remove(&job_id);
+            return;
+        }
+        let execute_driver = Arc::clone(&driver);
+        let driver_job =
+            controller_job_driver::ControllerJobHandle::new(job.clone(), Arc::clone(&driver));
+        let execute_prepared = prepared.clone();
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        let execute = std::thread::spawn(move || {
+            let result = if recovery {
+                execute_driver.resume(execute_prepared, driver_job)
+            } else {
+                execute_driver.execute(execute_prepared, driver_job)
+            };
+            let _ = sender.send(result);
+        });
+        let mut cancellation_failed = false;
+        loop {
+            if !cancellation_failed && (job.is_cancelled() || cancel_rx.try_recv().is_ok()) {
+                match driver.cancel(&prepared) {
+                    Ok(()) => {
+                        // A successful driver cancellation is not proof of stop.
+                        // Join the owned execute thread before terminalizing.
+                        let _ = execute.join();
+                        persist_controller_cancellation(&job);
+                    }
+                    Err(error) => {
+                        let public = driver.public_error(&error);
+                        persist_controller_cancellation_failure(&job, public.message, public.data);
+                        // The driver could not confirm stop. Keep this supervisor
+                        // and execute handle live until completion proves it ended;
+                        // the durable Failed job is explicit uncertainty, never a
+                        // false Cancelled terminal.
+                        cancellation_failed = true;
+                        continue;
+                    }
+                }
+                controller_job_runtimes()
+                    .lock()
+                    .expect("controller runtimes lock")
+                    .remove(&job_id);
+                return;
+            }
+            match receiver.recv_timeout(Duration::from_millis(10)) {
+                Ok(Ok(private)) => match driver.public_result(&private) {
+                    Ok(public) => {
+                        // The driver has already produced this result. Retry only
+                        // this projection, never the driver side effect.
+                        if job.is_cancelled() {
+                            continue;
+                        }
+                        if !persist_controller_success_or_uncertainty(&job, public) {
+                            continue;
+                        }
+                        let _ = execute.join();
+                    }
+                    Err(error) => {
+                        let _ = execute.join();
+                        let public = driver.public_error(&error);
+                        persist_controller_failure(&job, public.message, public.data);
+                    }
+                },
+                Ok(Err(error)) => {
+                    let _ = execute.join();
+                    let public = driver.public_error(&error);
+                    persist_controller_failure(&job, public.message, public.data);
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                    let _ = execute.join();
+                    persist_controller_failure(
+                        &job,
+                        "controller driver execution thread disconnected".to_string(),
+                        json!({ "phase": "driver_disconnected" }),
+                    );
+                }
+            }
+            controller_job_runtimes()
+                .lock()
+                .expect("controller runtimes lock")
+                .remove(&job_id);
+            return;
+        }
+    });
+    controller_job_runtimes()
+        .lock()
+        .expect("controller runtimes lock")
+        .insert(
+            job_id,
+            ControllerJobRuntime {
+                cancel: cancel_tx,
+                supervisor,
+            },
+        );
+    let _ = start_tx.send(());
+}
+
+/// A terminal write failure after the driver returns must never turn into a
+/// checkpoint resume. After bounded retries of the same result, persist a
+/// fail-closed terminal uncertainty and keep ownership until that is durable.
+fn persist_controller_success_or_uncertainty(
+    job: &crate::api_jobs::JobHandle,
+    result: serde_json::Value,
+) -> bool {
+    for _ in 0..3 {
+        if job.complete_controller_success(result.clone()).is_ok() {
+            return true;
+        }
+        if job.is_cancelled() {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    if job.is_cancelled() {
+        return false;
+    }
+    loop {
+        if job
+            .fail_controller_error(
+                "controller result could not be durably terminalized; driver side effect will not be retried"
+                    .to_string(),
+                json!({ "phase": "terminal_persistence_uncertain" }),
+            )
+            .is_ok()
+        {
+            return true;
+        }
+        if job.is_cancelled() {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn persist_controller_cancellation(job: &crate::api_jobs::JobHandle) {
+    while job.complete_controller_cancellation().is_err() && !job.is_terminal() {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn persist_controller_cancellation_failure(
+    job: &crate::api_jobs::JobHandle,
+    message: String,
+    data: serde_json::Value,
+) {
+    while job
+        .fail_controller_cancellation(message.clone(), data.clone())
+        .is_err()
+        && !job.is_terminal()
+    {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn persist_controller_failure(
+    job: &crate::api_jobs::JobHandle,
+    message: String,
+    data: serde_json::Value,
+) {
+    while job
+        .fail_controller_error(message.clone(), data.clone())
+        .is_err()
+        && !job.is_terminal()
+    {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn recover_controller_jobs(job_store: &JobStore) {
+    for (job_id, state) in job_store.active_controller_jobs() {
+        if state.checkpoint.is_none() || state.recovery_attempted {
+            let _ = job_store.fail_controller_error(
+                job_id,
+                "controller job cannot be resumed after daemon restart".to_string(),
+                json!({ "phase": "recovery_unresolved" }),
+            );
+            continue;
+        }
+        let Ok(state) = job_store.claim_controller_execution(job_id, true) else {
+            continue;
+        };
+        dispatch_claimed_controller_job(job_store.clone(), job_id, state, true);
+    }
+}
+
+fn cancel_controller_job(
+    path: &str,
+    body: Option<serde_json::Value>,
+    job_store: &JobStore,
+) -> Result<serde_json::Value> {
+    let job_id = controller_job_id_from_path(path, "/cancel")?;
+    let controller = job_store.controller_job_state(job_id)?;
+    // Resolve the persisted type/version, not a caller-controlled envelope.
+    let _driver = controller_job_driver::driver(&controller.job_type, controller.version)?;
+    let reason = body
+        .as_ref()
+        .and_then(|value| value.get("reason"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|reason| !reason.trim().is_empty())
+        .unwrap_or("controller job cancellation requested")
+        .to_string();
+    let job = job_store.request_controller_cancellation(job_id, reason)?;
+    if let Some(runtime) = controller_job_runtimes()
+        .lock()
+        .expect("controller runtimes lock")
+        .get(&job_id)
+    {
+        let _ = runtime.cancel.send(());
+    }
+    if job.status == JobStatus::Cancelled {
+        return Ok(json!({ "job": job }));
+    }
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let job = job_store.get(job_id)?;
+        match job.status {
+            JobStatus::Cancelled => return Ok(json!({ "job": job })),
+            JobStatus::Failed => {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    "controller job cancellation failed; inspect the durable job events",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            JobStatus::Succeeded => {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    "controller job completed before cancellation could stop it",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            JobStatus::Queued | JobStatus::Running if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            JobStatus::Queued | JobStatus::Running => {
+                let _ = job_store.append_event(
+                    job_id,
+                    crate::api_jobs::JobEventKind::Error,
+                    Some(
+                        "controller job cancellation did not complete before the daemon timeout"
+                            .to_string(),
+                    ),
+                    Some(json!({ "phase": "cancellation_timeout" })),
+                );
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    "controller job cancellation is still pending; inspect the durable job events",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+        }
+    }
+}
+
+fn controller_job_id_from_path(path: &str, suffix: &str) -> Result<Uuid> {
+    let job_id = path
+        .trim_start_matches("/controller/jobs/")
+        .trim_end_matches(suffix)
+        .trim_end_matches('/');
+    Uuid::parse_str(job_id).map_err(|error| {
+        Error::validation_invalid_argument(
+            "job_id",
+            format!("invalid controller job ID: {error}"),
+            Some(job_id.to_string()),
+            None,
+        )
+    })
+}
+
+fn hex_digest(value: &serde_json::Value) -> Result<String> {
+    let encoded =
+        serde_json::to_vec(value).map_err(|error| Error::internal_unexpected(error.to_string()))?;
+    let mut hasher = Sha256::new();
+    hasher.update(encoded);
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 fn exec_request_run_ref_metadata(
@@ -2717,7 +3286,7 @@ where
                         None,
                     ),
                 );
-                return write_http_response(stream, response);
+                return write_http_response(stream, &response);
             }
         }
     };
@@ -2734,7 +3303,7 @@ where
         .transpose();
     let lifecycle_stop = match lifecycle_stop {
         Ok(request) => request,
-        Err(error) => return write_http_response(stream, error_response(400, error)),
+        Err(error) => return write_http_response(stream, &error_response(400, error)),
     };
     let response = route_with_job_store_and_body_and_runner_and_auth(
         method,
@@ -2744,7 +3313,7 @@ where
         analysis_runner,
         broker_auth,
     );
-    write_http_response(stream, response)?;
+    write_http_response(stream, &response)?;
     if let Some(request) = lifecycle_stop {
         // The accepted response reaches the controller before the daemon signals
         // itself. The exact lease and durable-job gate are rechecked under the
@@ -2795,8 +3364,8 @@ fn http_content_length(headers: &str) -> Option<usize> {
     })
 }
 
-fn write_http_response(mut stream: TcpStream, response: HttpResponse) -> std::io::Result<()> {
-    if let Some(artifact) = response.artifact {
+fn write_http_response(mut stream: TcpStream, response: &HttpResponse) -> std::io::Result<()> {
+    if let Some(artifact) = response.artifact.clone() {
         return artifact_download::write_response(stream, response.status_code, artifact);
     }
 
@@ -2826,7 +3395,8 @@ fn write_http_response(mut stream: TcpStream, response: HttpResponse) -> std::io
         status_text,
         body.len(),
         body
-    )
+    )?;
+    stream.flush()
 }
 
 fn terminate_pid(pid: u32) -> Result<()> {

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1,14 +1,1161 @@
 use super::*;
 use crate::api_jobs::{JobEventKind, JobStatus, JobStore};
+use crate::daemon::controller_job_driver::{self, ControllerJobDriver};
+use crate::error::Result;
 use crate::observation::{ArtifactRecord, NewRunRecord, ObservationStore};
 use crate::test_support::HomeGuard;
 use base64::Engine;
+use serde_json::Value;
 #[cfg(unix)]
 use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
 #[cfg(unix)]
 use std::time::{Duration, Instant};
 
 const DAEMON_TEST_RESPONSE_LIMIT_BYTES: u64 = 64 * 1024;
+
+struct BlockingControllerDriver {
+    job_type: &'static str,
+    started: mpsc::Sender<()>,
+    release: Arc<Mutex<mpsc::Receiver<()>>>,
+    cancellation_release: mpsc::Sender<()>,
+    executions: Arc<AtomicUsize>,
+    cancellations: Arc<AtomicUsize>,
+}
+
+impl ControllerJobDriver for BlockingControllerDriver {
+    fn job_type(&self) -> &'static str {
+        self.job_type
+    }
+    fn version(&self) -> u32 {
+        1
+    }
+    fn public_request(&self, _request: &Value) -> Result<Value> {
+        Ok(serde_json::json!({ "schema": "test/v1" }))
+    }
+    fn public_progress(&self, _progress: &Value) -> Result<Value> {
+        Ok(serde_json::json!({ "progress": "safe" }))
+    }
+    fn public_result(&self, _result: &Value) -> Result<Value> {
+        Ok(serde_json::json!({ "result": "safe" }))
+    }
+    fn public_error(
+        &self,
+        _error: &crate::error::Error,
+    ) -> controller_job_driver::ControllerJobPublicError {
+        controller_job_driver::ControllerJobPublicError {
+            message: "test controller failure".to_string(),
+            data: serde_json::json!({ "classification": "test_failure" }),
+        }
+    }
+    fn validate_secret_references(&self, request: &Value) -> Result<()> {
+        if request.get("inline_secret").is_some() {
+            return Err(crate::error::Error::validation_invalid_argument(
+                "request",
+                "test driver accepts secret references, not inline secrets",
+                None,
+                None,
+            ));
+        }
+        Ok(())
+    }
+    fn execute(
+        &self,
+        _request: Value,
+        _job: crate::daemon::controller_job_driver::ControllerJobHandle,
+    ) -> Result<Value> {
+        self.executions.fetch_add(1, Ordering::SeqCst);
+        self.started.send(()).expect("test observes driver start");
+        self.release
+            .lock()
+            .expect("release lock")
+            .recv()
+            .expect("test releases driver");
+        Ok(serde_json::json!({ "completed": true }))
+    }
+    fn cancel(&self, _prepared: &Value) -> Result<()> {
+        self.cancellations.fetch_add(1, Ordering::SeqCst);
+        self.cancellation_release
+            .send(())
+            .expect("cancel releases driver");
+        Ok(())
+    }
+}
+
+struct FailingCancellationControllerDriver {
+    started: mpsc::Sender<()>,
+    release: Arc<Mutex<mpsc::Receiver<()>>>,
+}
+
+struct ImmediateControllerDriver {
+    executions: Arc<AtomicUsize>,
+}
+
+impl ControllerJobDriver for ImmediateControllerDriver {
+    fn job_type(&self) -> &'static str {
+        "test.immediate-compaction"
+    }
+    fn version(&self) -> u32 {
+        1
+    }
+    fn public_request(&self, _request: &Value) -> Result<Value> {
+        Ok(serde_json::json!({}))
+    }
+    fn public_progress(&self, _progress: &Value) -> Result<Value> {
+        Ok(serde_json::json!({}))
+    }
+    fn public_result(&self, _result: &Value) -> Result<Value> {
+        Ok(serde_json::json!({ "result": "safe" }))
+    }
+    fn public_error(
+        &self,
+        _error: &crate::error::Error,
+    ) -> controller_job_driver::ControllerJobPublicError {
+        controller_job_driver::ControllerJobPublicError {
+            message: "safe immediate failure".to_string(),
+            data: serde_json::json!({ "classification": "immediate_failure" }),
+        }
+    }
+    fn validate_secret_references(&self, _request: &Value) -> Result<()> {
+        Ok(())
+    }
+    fn execute(
+        &self,
+        _prepared: Value,
+        _job: crate::daemon::controller_job_driver::ControllerJobHandle,
+    ) -> Result<Value> {
+        self.executions.fetch_add(1, Ordering::SeqCst);
+        Ok(serde_json::json!({}))
+    }
+    fn cancel(&self, _prepared: &Value) -> Result<()> {
+        Ok(())
+    }
+}
+
+struct SecretErrorControllerDriver {
+    started: mpsc::Sender<()>,
+    release: Arc<Mutex<mpsc::Receiver<()>>>,
+}
+
+impl ControllerJobDriver for SecretErrorControllerDriver {
+    fn job_type(&self) -> &'static str {
+        "test.secret-errors"
+    }
+    fn version(&self) -> u32 {
+        1
+    }
+    fn public_request(&self, request: &Value) -> Result<Value> {
+        Ok(serde_json::json!({ "mode": request["mode"] }))
+    }
+    fn public_progress(&self, _progress: &Value) -> Result<Value> {
+        Ok(serde_json::json!({}))
+    }
+    fn public_result(&self, _result: &Value) -> Result<Value> {
+        Ok(serde_json::json!({}))
+    }
+    fn public_error(
+        &self,
+        _error: &crate::error::Error,
+    ) -> controller_job_driver::ControllerJobPublicError {
+        controller_job_driver::ControllerJobPublicError {
+            message: "safe driver failure".to_string(),
+            data: serde_json::json!({ "classification": "safe_driver_failure" }),
+        }
+    }
+    fn validate_secret_references(&self, _request: &Value) -> Result<()> {
+        Ok(())
+    }
+    fn prepare(&self, request: Value) -> Result<Value> {
+        if request["mode"] == "prepare" {
+            return Err(crate::error::Error::internal_unexpected(
+                "secret-marker-controller-error",
+            ));
+        }
+        Ok(request)
+    }
+    fn execute(
+        &self,
+        prepared: Value,
+        _job: crate::daemon::controller_job_driver::ControllerJobHandle,
+    ) -> Result<Value> {
+        if prepared["mode"] == "execute" {
+            return Err(crate::error::Error::internal_unexpected(
+                "secret-marker-controller-error",
+            ));
+        }
+        self.started.send(()).expect("test observes driver start");
+        while self
+            .release
+            .lock()
+            .expect("release lock")
+            .try_recv()
+            .is_err()
+        {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        Ok(serde_json::json!({}))
+    }
+    fn cancel(&self, _prepared: &Value) -> Result<()> {
+        Err(crate::error::Error::internal_unexpected(
+            "secret-marker-controller-error",
+        ))
+    }
+}
+
+impl ControllerJobDriver for FailingCancellationControllerDriver {
+    fn job_type(&self) -> &'static str {
+        "test.cancellation-fails"
+    }
+    fn version(&self) -> u32 {
+        1
+    }
+    fn public_request(&self, _request: &Value) -> Result<Value> {
+        Ok(serde_json::json!({}))
+    }
+    fn public_progress(&self, _progress: &Value) -> Result<Value> {
+        Ok(serde_json::json!({}))
+    }
+    fn public_result(&self, _result: &Value) -> Result<Value> {
+        Ok(serde_json::json!({}))
+    }
+    fn public_error(
+        &self,
+        _error: &crate::error::Error,
+    ) -> controller_job_driver::ControllerJobPublicError {
+        controller_job_driver::ControllerJobPublicError {
+            message: "safe cancellation failure".to_string(),
+            data: serde_json::json!({ "classification": "cancellation_failed" }),
+        }
+    }
+    fn validate_secret_references(&self, _request: &Value) -> Result<()> {
+        Ok(())
+    }
+    fn execute(
+        &self,
+        _prepared: Value,
+        _job: crate::daemon::controller_job_driver::ControllerJobHandle,
+    ) -> Result<Value> {
+        self.started.send(()).expect("test observes driver start");
+        while self
+            .release
+            .lock()
+            .expect("release lock")
+            .try_recv()
+            .is_err()
+        {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        Ok(serde_json::json!({ "completed": true }))
+    }
+    fn cancel(&self, _prepared: &Value) -> Result<()> {
+        Err(crate::error::Error::internal_unexpected(
+            "owned work refused cancellation",
+        ))
+    }
+}
+
+#[test]
+fn controller_jobs_are_durable_idempotent_and_fail_closed_after_restart() {
+    let _home = HomeGuard::new();
+    let path = crate::paths::daemon_jobs_file().expect("jobs path");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store");
+    let (started_tx, started_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let executions = Arc::new(AtomicUsize::new(0));
+    let cancellations = Arc::new(AtomicUsize::new(0));
+    controller_job_driver::register_controller_job_driver(Arc::new(BlockingControllerDriver {
+        job_type: "test.blocking",
+        started: started_tx,
+        release: Arc::new(Mutex::new(release_rx)),
+        cancellation_release: release_tx.clone(),
+        executions: Arc::clone(&executions),
+        cancellations: Arc::clone(&cancellations),
+    }))
+    .expect("register controller driver once");
+    let request = serde_json::json!({
+        "type": "test.blocking", "version": 1, "idempotency_key": "run-9421", "request": { "schema": "test/v1", "private_input": "not-public" }
+    });
+
+    // Admission is phase one: it is durable but cannot execute until start.
+    let submitted = route_with_body("POST", "/controller/jobs", Some(request.clone()), &store);
+    assert_eq!(submitted.status_code, 200);
+    let job_id = uuid::Uuid::parse_str(
+        submitted.body["body"]["job"]["id"]
+            .as_str()
+            .expect("job id"),
+    )
+    .expect("valid job id");
+    assert_eq!(
+        store.get(job_id).expect("queued durable job").status,
+        JobStatus::Queued
+    );
+    assert_eq!(
+        submitted.body["body"]["start"]["path"],
+        format!("/controller/jobs/{job_id}/start")
+    );
+    let started = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{job_id}/start"),
+        None,
+        &store,
+    );
+    assert_eq!(started.status_code, 200);
+    let repeated_start = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{job_id}/start"),
+        None,
+        &store,
+    );
+    assert_eq!(repeated_start.status_code, 200);
+    assert_eq!(repeated_start.body["body"]["job"]["id"], job_id.to_string());
+    started_rx
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .expect("driver started after acceptance");
+    assert_eq!(store.get(job_id).expect("job").status, JobStatus::Running);
+    assert!(!serialized_contains(&submitted.body, "not-public"));
+    assert!(!serialized_contains(
+        &serde_json::to_value(store.events(job_id).expect("events")).expect("events JSON"),
+        "not-public"
+    ));
+
+    // No submitting-client state is retained: replay returns one daemon job and never executes twice.
+    let duplicate = route_with_body("POST", "/controller/jobs", Some(request), &store);
+    assert_eq!(duplicate.body["body"]["job"]["id"], job_id.to_string());
+    assert_eq!(executions.load(Ordering::SeqCst), 1);
+    let conflict = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.blocking", "version": 1, "idempotency_key": "run-9421", "request": { "different": true }
+        })),
+        &store,
+    );
+    assert_eq!(conflict.status_code, 400);
+    let inline_secret = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.blocking", "version": 1, "idempotency_key": "run-9421-secret", "request": { "inline_secret": "never-persist" }
+        })),
+        &store,
+    );
+    assert_eq!(inline_secret.status_code, 400);
+
+    release_tx.send(()).expect("release blocked driver");
+    for _ in 0..50 {
+        if store.get(job_id).expect("first job").status.is_terminal() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    let cancelled = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.blocking", "version": 1, "idempotency_key": "run-9421-cancel", "request": {}
+        })),
+        &store,
+    );
+    let cancelled_id = uuid::Uuid::parse_str(
+        cancelled.body["body"]["job"]["id"]
+            .as_str()
+            .expect("cancel job id"),
+    )
+    .expect("valid id");
+    let started = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{cancelled_id}/start"),
+        None,
+        &store,
+    );
+    assert_eq!(started.status_code, 200);
+    started_rx
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .expect("second driver start");
+    let cancelled = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{cancelled_id}/cancel"),
+        Some(serde_json::json!({ "reason": "caller disappeared" })),
+        &store,
+    );
+    assert_eq!(cancelled.status_code, 200);
+    assert_eq!(cancelled.body["body"]["job"]["status"], "cancelled");
+    assert_eq!(
+        store.get(cancelled_id).expect("cancelled job").status,
+        JobStatus::Cancelled
+    );
+    for _ in 0..50 {
+        if cancellations.load(Ordering::SeqCst) == 1 {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert_eq!(cancellations.load(Ordering::SeqCst), 1);
+    let repeated_cancel = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{cancelled_id}/cancel"),
+        Some(serde_json::json!({ "reason": "retry" })),
+        &store,
+    );
+    assert_eq!(repeated_cancel.status_code, 200);
+    assert_eq!(cancellations.load(Ordering::SeqCst), 1);
+    // The driver's release races its normal completion with cancellation. The
+    // durable terminal cancellation wins and no late result is published.
+    std::thread::sleep(std::time::Duration::from_millis(25));
+    assert_eq!(
+        store.get(cancelled_id).expect("cancelled job").status,
+        JobStatus::Cancelled
+    );
+    assert!(!store
+        .events(cancelled_id)
+        .expect("events")
+        .iter()
+        .any(|event| event.kind == JobEventKind::Result));
+    let terminal_duplicate = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.blocking", "version": 1, "idempotency_key": "run-9421-cancel", "request": {}
+        })),
+        &store,
+    );
+    assert_eq!(
+        terminal_duplicate.body["body"]["job"]["id"],
+        cancelled_id.to_string()
+    );
+    assert_eq!(executions.load(Ordering::SeqCst), 2);
+
+    // Exercise the production startup helper: a persisted checkpoint resumes
+    // exactly once, while work without one is terminalized fail-closed.
+    let resumable = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.blocking", "version": 1, "idempotency_key": "restart-resume", "request": {}
+        })),
+        &store,
+    );
+    let resumable_id = uuid::Uuid::parse_str(
+        resumable.body["body"]["job"]["id"]
+            .as_str()
+            .expect("resumable ID"),
+    )
+    .expect("valid resumable ID");
+    store
+        .claim_controller_execution(resumable_id, false)
+        .expect("durably claim resumable work");
+    store
+        .handle(resumable_id)
+        .record_controller_prepared(serde_json::json!({ "checkpoint": true }))
+        .expect("persist resume checkpoint");
+    let unresolved = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.blocking", "version": 1, "idempotency_key": "restart-unresolved", "request": {}
+        })),
+        &store,
+    );
+    let unresolved_id = uuid::Uuid::parse_str(
+        unresolved.body["body"]["job"]["id"]
+            .as_str()
+            .expect("unresolved ID"),
+    )
+    .expect("valid unresolved ID");
+    let restarted =
+        JobStore::open_without_reconciliation(&path).expect("restart opens durable store");
+    recover_controller_jobs(&restarted);
+    started_rx
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .expect("checkpointed job resumes once");
+    release_tx.send(()).expect("release resumed driver");
+    for _ in 0..100 {
+        if restarted
+            .get(resumable_id)
+            .expect("resumed job")
+            .status
+            .is_terminal()
+        {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    assert_eq!(
+        restarted.get(resumable_id).expect("resumed job").status,
+        JobStatus::Succeeded
+    );
+    assert_eq!(
+        restarted.get(unresolved_id).expect("unstarted job").status,
+        JobStatus::Queued
+    );
+}
+
+#[test]
+fn cancelling_queued_controller_job_before_start_is_terminal_and_blocks_execution() {
+    let _home = HomeGuard::new();
+    let path = crate::paths::daemon_jobs_file().expect("jobs path");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store");
+    let (started_tx, started_rx) = mpsc::channel();
+    let (_release_tx, release_rx) = mpsc::channel();
+    let executions = Arc::new(AtomicUsize::new(0));
+    let cancellations = Arc::new(AtomicUsize::new(0));
+    let (cancellation_release, _cancellation_rx) = mpsc::channel();
+    controller_job_driver::register_controller_job_driver(Arc::new(BlockingControllerDriver {
+        job_type: "test.queued-cancellation",
+        started: started_tx,
+        release: Arc::new(Mutex::new(release_rx)),
+        cancellation_release,
+        executions: Arc::clone(&executions),
+        cancellations: Arc::clone(&cancellations),
+    }))
+    .expect("register controller driver once");
+
+    let submitted = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.queued-cancellation", "version": 1, "idempotency_key": "queued-cancel-9421", "request": {}
+        })),
+        &store,
+    );
+    let job_id = uuid::Uuid::parse_str(
+        submitted.body["body"]["job"]["id"]
+            .as_str()
+            .expect("job id"),
+    )
+    .expect("valid job id");
+    assert_eq!(
+        store.get(job_id).expect("queued job").status,
+        JobStatus::Queued
+    );
+
+    let cancelled = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{job_id}/cancel"),
+        Some(serde_json::json!({ "reason": "response handoff failed" })),
+        &store,
+    );
+    assert_eq!(cancelled.status_code, 200);
+    assert_eq!(cancelled.body["body"]["job"]["status"], "cancelled");
+    assert_eq!(
+        store.get(job_id).expect("cancelled job").status,
+        JobStatus::Cancelled
+    );
+    assert_eq!(executions.load(Ordering::SeqCst), 0);
+    assert_eq!(cancellations.load(Ordering::SeqCst), 0);
+
+    let repeated = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{job_id}/cancel"),
+        Some(serde_json::json!({ "reason": "retry" })),
+        &store,
+    );
+    assert_eq!(repeated.status_code, 200);
+    assert_eq!(repeated.body["body"]["job"]["status"], "cancelled");
+
+    let start = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{job_id}/start"),
+        None,
+        &store,
+    );
+    assert_eq!(start.status_code, 200);
+    assert!(started_rx
+        .recv_timeout(std::time::Duration::from_millis(100))
+        .is_err());
+    assert_eq!(
+        store.get(job_id).expect("terminal job").status,
+        JobStatus::Cancelled
+    );
+    assert_eq!(executions.load(Ordering::SeqCst), 0);
+    assert_eq!(cancellations.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn generic_cancel_rejects_running_controller_work_without_touching_its_driver() {
+    let _home = HomeGuard::new();
+    let path = crate::paths::daemon_jobs_file().expect("jobs path");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store");
+    let (started_tx, started_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let executions = Arc::new(AtomicUsize::new(0));
+    let cancellations = Arc::new(AtomicUsize::new(0));
+    controller_job_driver::register_controller_job_driver(Arc::new(BlockingControllerDriver {
+        job_type: "test.generic-cancel-bypass",
+        started: started_tx,
+        release: Arc::new(Mutex::new(release_rx)),
+        cancellation_release: release_tx,
+        executions: Arc::clone(&executions),
+        cancellations: Arc::clone(&cancellations),
+    }))
+    .expect("register generic cancellation driver");
+    let submitted = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.generic-cancel-bypass", "version": 1, "idempotency_key": "generic-cancel-bypass", "request": {}
+        })),
+        &store,
+    );
+    let job_id = uuid::Uuid::parse_str(
+        submitted.body["body"]["job"]["id"]
+            .as_str()
+            .expect("job id"),
+    )
+    .expect("valid job id");
+    assert_eq!(
+        route_with_body(
+            "POST",
+            &format!("/controller/jobs/{job_id}/start"),
+            None,
+            &store
+        )
+        .status_code,
+        200
+    );
+    started_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("driver started");
+
+    let generic = route_with_body("POST", &format!("/jobs/{job_id}/cancel"), None, &store);
+    assert_eq!(generic.status_code, 404);
+    assert!(serialized_contains(&generic.body, "/controller/jobs/"));
+    assert_eq!(
+        store.get(job_id).expect("running job").status,
+        JobStatus::Running
+    );
+    assert_eq!(cancellations.load(Ordering::SeqCst), 0);
+
+    let cancelled = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{job_id}/cancel"),
+        None,
+        &store,
+    );
+    assert_eq!(cancelled.status_code, 200);
+    assert_eq!(
+        store.get(job_id).expect("cancelled job").status,
+        JobStatus::Cancelled
+    );
+    assert_eq!(executions.load(Ordering::SeqCst), 1);
+    assert_eq!(cancellations.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn controller_terminal_persistence_retries_the_result_without_reexecuting_after_restart() {
+    let _home = HomeGuard::new();
+    let path = crate::paths::daemon_jobs_file().expect("jobs path");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store");
+    let (started_tx, started_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let executions = Arc::new(AtomicUsize::new(0));
+    controller_job_driver::register_controller_job_driver(Arc::new(BlockingControllerDriver {
+        job_type: "test.terminal-persistence-retry",
+        started: started_tx,
+        release: Arc::new(Mutex::new(release_rx)),
+        cancellation_release: release_tx.clone(),
+        executions: Arc::clone(&executions),
+        cancellations: Arc::new(AtomicUsize::new(0)),
+    }))
+    .expect("register terminal persistence driver");
+    let submitted = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.terminal-persistence-retry", "version": 1, "idempotency_key": "terminal-persistence-retry", "request": {}
+        })),
+        &store,
+    );
+    let job_id = uuid::Uuid::parse_str(
+        submitted.body["body"]["job"]["id"]
+            .as_str()
+            .expect("job id"),
+    )
+    .expect("valid job id");
+    assert_eq!(
+        route_with_body(
+            "POST",
+            &format!("/controller/jobs/{job_id}/start"),
+            None,
+            &store
+        )
+        .status_code,
+        200
+    );
+    started_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("driver started");
+    store.fail_next_controller_terminal_writes(1);
+    release_tx.send(()).expect("release driver");
+    for _ in 0..100 {
+        if store.get(job_id).expect("job").status == JobStatus::Succeeded {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    assert_eq!(
+        store.get(job_id).expect("terminal job").status,
+        JobStatus::Succeeded
+    );
+    assert_eq!(executions.load(Ordering::SeqCst), 1);
+    for _ in 0..100 {
+        if controller_job_runtime_count() == 0 {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    assert_eq!(controller_job_runtime_count(), 0);
+
+    let restarted = JobStore::open_without_reconciliation(&path).expect("reopen durable store");
+    recover_controller_jobs(&restarted);
+    assert_eq!(
+        restarted.get(job_id).expect("durable terminal job").status,
+        JobStatus::Succeeded
+    );
+    assert_eq!(executions.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn controller_job_outlives_tcp_client_after_durable_response_handoff() {
+    let _home = HomeGuard::new();
+    let (started_tx, started_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let executions = Arc::new(AtomicUsize::new(0));
+    controller_job_driver::register_controller_job_driver(Arc::new(BlockingControllerDriver {
+        job_type: "test.tcp-client-loss",
+        started: started_tx,
+        release: Arc::new(Mutex::new(release_rx)),
+        cancellation_release: release_tx.clone(),
+        executions: Arc::clone(&executions),
+        cancellations: Arc::new(AtomicUsize::new(0)),
+    }))
+    .expect("register TCP controller driver");
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+    let addr = listener.local_addr().expect("listener address");
+    // Create, explicit start, terminal poll. The bounded server joins its helpers
+    // before returning, so this test cannot retain the daemon owner lock.
+    let (server_result_tx, server_result_rx) = mpsc::channel();
+    let server = std::thread::spawn(move || {
+        let result = serve_listener_for_requests(listener, 3);
+        server_result_tx.send(result).expect("report server result");
+    });
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .expect("HTTP client");
+    let submitted: Value = client
+        .post(format!("http://{addr}/controller/jobs"))
+        .json(&serde_json::json!({
+            "type": "test.tcp-client-loss",
+            "version": 1,
+            "idempotency_key": "tcp-client-loss",
+            "request": { "work": "blocked" }
+        }))
+        .send()
+        .expect("submit durable job")
+        .json()
+        .expect("parse durable job response");
+    let job_id = submitted["data"]["body"]["job"]["id"]
+        .as_str()
+        .expect("durable job ID")
+        .to_string();
+    drop(client);
+
+    assert!(started_rx
+        .recv_timeout(std::time::Duration::from_millis(100))
+        .is_err());
+    assert_eq!(executions.load(Ordering::SeqCst), 0);
+
+    let start_client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .expect("start HTTP client");
+    let started: Value = start_client
+        .post(format!("http://{addr}/controller/jobs/{job_id}/start"))
+        .send()
+        .expect("start durable job")
+        .json()
+        .expect("parse start response");
+    assert_eq!(started["data"]["body"]["job"]["status"], "running");
+    drop(start_client);
+
+    started_rx
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .expect("daemon-owned driver started after client disconnected");
+    assert_eq!(executions.load(Ordering::SeqCst), 1);
+
+    release_tx.send(()).expect("release daemon-owned driver");
+    let terminal: Value = reqwest::blocking::get(format!("http://{addr}/jobs/{job_id}"))
+        .expect("poll terminal job")
+        .json()
+        .expect("parse terminal job");
+    assert_eq!(terminal["data"]["body"]["job"]["status"], "succeeded");
+    assert_eq!(executions.load(Ordering::SeqCst), 1);
+
+    server.join().expect("join bounded daemon server");
+    server_result_rx
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .expect("bounded daemon server completed")
+        .expect("bounded daemon server succeeded");
+}
+
+#[test]
+fn controller_job_created_by_disconnected_tcp_client_stays_queued_and_cancellable() {
+    let _home = HomeGuard::new();
+    let (started_tx, started_rx) = mpsc::channel();
+    let (_release_tx, release_rx) = mpsc::channel();
+    let executions = Arc::new(AtomicUsize::new(0));
+    controller_job_driver::register_controller_job_driver(Arc::new(BlockingControllerDriver {
+        job_type: "test.tcp-create-client-loss",
+        started: started_tx,
+        release: Arc::new(Mutex::new(release_rx)),
+        cancellation_release: mpsc::channel().0,
+        executions: Arc::clone(&executions),
+        cancellations: Arc::new(AtomicUsize::new(0)),
+    }))
+    .expect("register create-loss controller driver");
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+    let addr = listener.local_addr().expect("listener address");
+    let (server_result_tx, server_result_rx) = mpsc::channel();
+    let server = std::thread::spawn(move || {
+        let result = serve_listener_for_requests(listener, 2);
+        server_result_tx.send(result).expect("report server result");
+    });
+    let client = reqwest::blocking::Client::new();
+    let submitted: Value = client
+        .post(format!("http://{addr}/controller/jobs"))
+        .json(&serde_json::json!({
+            "type": "test.tcp-create-client-loss",
+            "version": 1,
+            "idempotency_key": "tcp-create-client-loss",
+            "request": {}
+        }))
+        .send()
+        .expect("create durable job")
+        .json()
+        .expect("parse create response");
+    let job_id = submitted["data"]["body"]["job"]["id"]
+        .as_str()
+        .expect("durable job ID");
+    drop(client);
+    assert!(started_rx
+        .recv_timeout(std::time::Duration::from_millis(100))
+        .is_err());
+    assert_eq!(executions.load(Ordering::SeqCst), 0);
+
+    let cancelled: Value = reqwest::blocking::Client::new()
+        .post(format!("http://{addr}/controller/jobs/{job_id}/cancel"))
+        .json(&serde_json::json!({ "reason": "create client disconnected" }))
+        .send()
+        .expect("cancel queued job")
+        .json()
+        .expect("parse cancellation response");
+    assert_eq!(cancelled["data"]["body"]["job"]["status"], "cancelled");
+    assert_eq!(executions.load(Ordering::SeqCst), 0);
+    server.join().expect("join bounded daemon server");
+    server_result_rx
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .expect("bounded daemon server completed")
+        .expect("bounded daemon server succeeded");
+}
+
+#[test]
+fn controller_job_cancel_failure_is_diagnostic_and_non_cancelled() {
+    let _home = HomeGuard::new();
+    let path = crate::paths::daemon_jobs_file().expect("jobs path");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store");
+    let (started_tx, started_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    controller_job_driver::register_controller_job_driver(Arc::new(
+        FailingCancellationControllerDriver {
+            started: started_tx,
+            release: Arc::new(Mutex::new(release_rx)),
+        },
+    ))
+    .expect("register failing driver once");
+    let submitted = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.cancellation-fails", "version": 1, "idempotency_key": "cancel-fails", "request": {}
+        })),
+        &store,
+    );
+    let job_id = uuid::Uuid::parse_str(
+        submitted.body["body"]["job"]["id"]
+            .as_str()
+            .expect("job id"),
+    )
+    .expect("valid id");
+    let started = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{job_id}/start"),
+        None,
+        &store,
+    );
+    assert_eq!(started.status_code, 200);
+    started_rx
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .expect("driver started");
+
+    let cancelled = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{job_id}/cancel"),
+        None,
+        &store,
+    );
+    assert_eq!(cancelled.status_code, 400);
+    assert_eq!(store.get(job_id).expect("job").status, JobStatus::Failed);
+    assert!(store.events(job_id).expect("events").iter().any(|event| {
+        event
+            .data
+            .as_ref()
+            .and_then(|data| data.get("phase"))
+            .and_then(Value::as_str)
+            == Some("cancellation_failed")
+    }));
+    release_tx.send(()).expect("release driver");
+}
+
+#[test]
+fn controller_job_retry_after_compaction_returns_tombstoned_terminal_projection() {
+    let _home = HomeGuard::new();
+    let path = crate::paths::daemon_jobs_file().expect("jobs path");
+    let store =
+        JobStore::open_without_reconciliation_with_retention(&path, 100, 1).expect("durable store");
+    let executions = Arc::new(AtomicUsize::new(0));
+    controller_job_driver::register_controller_job_driver(Arc::new(ImmediateControllerDriver {
+        executions: Arc::clone(&executions),
+    }))
+    .expect("register compaction driver once");
+    let request = serde_json::json!({
+        "type": "test.immediate-compaction", "version": 1, "idempotency_key": "compacted", "request": {}
+    });
+    let first = route_with_body("POST", "/controller/jobs", Some(request.clone()), &store);
+    let first_id = first.body["body"]["job"]["id"]
+        .as_str()
+        .expect("job ID")
+        .to_string();
+    let first_start = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{first_id}/start"),
+        None,
+        &store,
+    );
+    assert_eq!(first_start.status_code, 200);
+    for _ in 0..100 {
+        if store
+            .get(uuid::Uuid::parse_str(&first_id).expect("valid ID"))
+            .expect("job")
+            .status
+            .is_terminal()
+        {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    let second = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.immediate-compaction", "version": 1, "idempotency_key": "compaction-trigger", "request": {}
+        })),
+        &store,
+    );
+    assert_eq!(second.status_code, 200);
+    let second_id = second.body["body"]["job"]["id"]
+        .as_str()
+        .expect("second ID");
+    let second_start = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{second_id}/start"),
+        None,
+        &store,
+    );
+    assert_eq!(second_start.status_code, 200);
+    for _ in 0..100 {
+        if executions.load(Ordering::SeqCst) == 2
+            && store
+                .get(
+                    uuid::Uuid::parse_str(
+                        second.body["body"]["job"]["id"]
+                            .as_str()
+                            .expect("second ID"),
+                    )
+                    .expect("valid ID"),
+                )
+                .expect("job")
+                .status
+                .is_terminal()
+        {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    assert!(store
+        .get(uuid::Uuid::parse_str(&first_id).expect("valid ID"))
+        .is_err());
+    for _ in 0..100 {
+        if controller_job_runtime_count() == 0 {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    assert_eq!(controller_job_runtime_count(), 0);
+    let executions_before_retry = executions.load(Ordering::SeqCst);
+    let retry = route_with_body("POST", "/controller/jobs", Some(request), &store);
+    assert_eq!(retry.status_code, 200);
+    assert_eq!(retry.body["body"]["job"]["id"], first_id);
+    assert_eq!(retry.body["body"]["job"]["status"], "succeeded");
+    assert_eq!(retry.body["body"]["terminal_tombstone"]["compacted"], true);
+    assert!(retry.body["body"]["poll"]["job"].is_null());
+    assert!(retry.body["body"]["poll"]["events"].is_null());
+    assert_eq!(executions.load(Ordering::SeqCst), executions_before_retry);
+}
+
+#[test]
+fn controller_job_errors_use_driver_safe_public_projection() {
+    let _home = HomeGuard::new();
+    let path = crate::paths::daemon_jobs_file().expect("jobs path");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store");
+    let (started_tx, started_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    controller_job_driver::register_controller_job_driver(Arc::new(SecretErrorControllerDriver {
+        started: started_tx,
+        release: Arc::new(Mutex::new(release_rx)),
+    }))
+    .expect("register secret error driver once");
+    for mode in ["prepare", "execute"] {
+        let submitted = route_with_body(
+            "POST",
+            "/controller/jobs",
+            Some(serde_json::json!({
+                "type": "test.secret-errors", "version": 1, "idempotency_key": format!("secret-{mode}"), "request": { "mode": mode }
+            })),
+            &store,
+        );
+        let job_id = submitted.body["body"]["job"]["id"]
+            .as_str()
+            .expect("job ID");
+        let started = route_with_body(
+            "POST",
+            &format!("/controller/jobs/{job_id}/start"),
+            None,
+            &store,
+        );
+        assert_eq!(started.status_code, 200);
+        for _ in 0..100 {
+            if store
+                .get(uuid::Uuid::parse_str(job_id).expect("valid ID"))
+                .expect("job")
+                .status
+                .is_terminal()
+            {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        let response = route_with_body("GET", &format!("/jobs/{job_id}"), None, &store);
+        let events = route_with_body("GET", &format!("/jobs/{job_id}/events"), None, &store);
+        let serialized_job = serde_json::to_value(
+            store
+                .get(uuid::Uuid::parse_str(job_id).expect("valid ID"))
+                .expect("job"),
+        )
+        .expect("serialize job");
+        assert!(!serialized_contains(
+            &serialized_job,
+            "secret-marker-controller-error"
+        ));
+        assert!(!serialized_contains(
+            &response.body,
+            "secret-marker-controller-error"
+        ));
+        assert!(!serialized_contains(
+            &events.body,
+            "secret-marker-controller-error"
+        ));
+        assert!(serialized_contains(&events.body, "safe_driver_failure"));
+    }
+    let submitted = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.secret-errors", "version": 1, "idempotency_key": "secret-cancel", "request": { "mode": "cancel" }
+        })),
+        &store,
+    );
+    let job_id = submitted.body["body"]["job"]["id"]
+        .as_str()
+        .expect("job ID");
+    let started = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{job_id}/start"),
+        None,
+        &store,
+    );
+    assert_eq!(started.status_code, 200);
+    started_rx
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .expect("driver started");
+    let response = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{job_id}/cancel"),
+        None,
+        &store,
+    );
+    let events = route_with_body("GET", &format!("/jobs/{job_id}/events"), None, &store);
+    assert!(!serialized_contains(
+        &response.body,
+        "secret-marker-controller-error"
+    ));
+    assert!(!serialized_contains(
+        &events.body,
+        "secret-marker-controller-error"
+    ));
+    assert!(serialized_contains(&events.body, "safe_driver_failure"));
+    release_tx.send(()).expect("release driver");
+}
+
+#[test]
+fn controller_job_cancel_rejects_unknown_and_non_controller_jobs() {
+    let _home = HomeGuard::new();
+    let store = JobStore::default();
+    let ordinary = store.create("ordinary.job");
+    let non_controller = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{}/cancel", ordinary.id),
+        None,
+        &store,
+    );
+    assert_eq!(non_controller.status_code, 400);
+    let non_controller_start = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{}/start", ordinary.id),
+        None,
+        &store,
+    );
+    assert_eq!(non_controller_start.status_code, 400);
+    let unknown = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{}/cancel", uuid::Uuid::new_v4()),
+        None,
+        &store,
+    );
+    assert_eq!(unknown.status_code, 400);
+    let unknown_start = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{}/start", uuid::Uuid::new_v4()),
+        None,
+        &store,
+    );
+    assert_eq!(unknown_start.status_code, 400);
+}
 
 fn serialized_contains(value: &serde_json::Value, needle: &str) -> bool {
     serde_json::to_string(value)


### PR DESCRIPTION
## Summary

- add a generic, versioned `ControllerJobDriver` contract to the existing Homeboy daemon
- persist private controller requests, safe public projections, checkpoints, and idempotency indexes in the durable job store
- use an explicit two-phase create/start protocol so callers receive the durable job ID before execution can begin
- supervise execution, cancellation, terminal persistence, and restart recovery under daemon ownership
- retain compacted terminal projections so exact idempotent retries never execute twice

Fixes #9421.

This is the generic prerequisite for #9163. It does not move Lab staging by itself; a follow-up will register the Lab staging-and-dispatch driver on this primitive.

## Lifecycle

1. `POST /controller/jobs` validates the registered type/version, persists the private envelope and safe public projection, and returns a queued job ID.
2. `POST /controller/jobs/{id}/start` atomically claims that job and dispatches it exactly once.
3. Drivers checkpoint through the restricted controller-job handle and project every public request, progress, result, and error value.
4. Controller cancellation is confirmed by the driver and joined before `Cancelled` is published. Generic job cancellation rejects controller jobs.
5. Restart resumes only checkpointed claimed work. Unresolved claimed work fails closed; unstarted queued work remains queued.

## How to test

1. Run `cargo test -p homeboy-core controller_job -- --test-threads=1`.
2. Run `cargo test -p homeboy-core controller_job`.
3. Run `cargo check -p homeboy-core`.
4. Run `cargo fmt --check`.
5. Run `git diff --check origin/main...HEAD`.

Expected: eight controller-job tests pass in serial and parallel, the core crate checks successfully, formatting passes, and the diff check emits no output.

The tests cover real loopback HTTP client loss before start and after daemon handoff, exact idempotency after terminal compaction, checkpointed restart recovery, secret-safe projections, queued/running cancellation races, generic-cancel rejection, and injected terminal persistence failure without driver re-execution.

## Compatibility

- No existing CLI, extension path, or job endpoint is removed.
- New durable-store fields use serde defaults for existing stores.
- Existing non-controller jobs retain their current cancellation and lifecycle behavior.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Source tracing, implementation, adversarial lifecycle review, race hardening, and deterministic test development; Chris reviewed and owns the change.