### PR TITLE
refactor(agents): complete handoff-identity consolidation — 100% RunnerJobIdentity adoption

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1504,9 +1504,23 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
         handoff.state == AgentTaskLabHandoffState::Accepted
             && handoff.authority == AgentTaskLabHandoffAuthority::RunnerDaemon
     }) {
-        if accepted.runner_id == input.runner_id
-            && accepted.runner_job_id.as_deref() == Some(input.runner_job_id)
-        {
+        // Idempotent re-acceptance: the incoming acceptance names the same
+        // run/runner/job as the already-accepted handoff. Route through the
+        // shared `RunnerJobIdentity` so this agrees with every other
+        // handoff-identity site rather than hand-rolling the tuple compare.
+        // Both identities are scoped to this run, so the run id is `record.run_id`
+        // on each side (the compare reduces to runner + job, as before).
+        let accepted_identity = homeboy_core::lab_contract::RunnerJobIdentity::new(
+            record.run_id.as_str(),
+            accepted.runner_id.as_str(),
+            accepted.runner_job_id.as_deref().unwrap_or_default(),
+        );
+        let incoming_identity = homeboy_core::lab_contract::RunnerJobIdentity::new(
+            record.run_id.as_str(),
+            input.runner_id,
+            input.runner_job_id,
+        );
+        if accepted_identity.matches(&incoming_identity) {
             return Ok(record);
         }
         return Err(Error::validation_invalid_argument(


### PR DESCRIPTION
## The finish line for the identity consolidation
Follow-up to #9452. This migrates the **last** hand-rolled full run/runner/job identity comparison in the agents cluster, hitting **100% adoption** of the canonical `RunnerJobIdentity` for the "is this the same job?" question.

## Why this cluster
Churn data: handoff/identity/reconcile is the dominant recurring bug class (~40 fixes in ~300 commits). Root cause was a correct canonical type (`RunnerJobIdentity`, #9379) with partial adoption — every recurring bug was another hand-rolled site with a slightly different edge case. This closes that gap so the class can't keep recurring one-site-at-a-time.

## This change
`record_detached_lab_run`'s re-acceptance idempotency guard was the last full-tuple hand-roll:
```rust
accepted.runner_id == input.runner_id
    && accepted.runner_job_id.as_deref() == Some(input.runner_job_id)
```
Now built as two `RunnerJobIdentity` values (runner + job scoped to `record.run_id` on both sides) compared via `.matches()`. **Behavior-preserving** — both share `record.run_id`, so the compare reduces to the same runner + job check; the mismatch error path is unchanged.

## The full sweep result (the important part)
After this, a repo-wide scan finds **zero** places comparing `runner_id` + `runner_job_id` together outside `RunnerJobIdentity`. All true full-identity sites now route through the canonical type:
- `validate_runner_job_snapshot` (#9452)
- `validate_terminal_child_identity` (#9379)
- `accepted_lab_runner_handoff_identity` (#9379)
- `record_detached_lab_run` acceptance guard (this PR)

## Deliberately NOT migrated (documented non-targets)
- **5 single-field runner-id-only predicates** — terminal-resurrection guard, resume guard, expired-handoff predicate, transport-identity join, reconciliation submission-key match. These have **no job id in scope** and aren't "same job?" questions; forcing them through the three-field type would fabricate empty fields and *reduce* safety.
- **run_id lineage / artifact-reuse filters** — list filters (`lineage.run_id == run_id`, artifact sha/size equality), not identity validation.

Being precise about what *isn't* an identity check is as important as consolidating what is — over-applying the type is how you'd reintroduce the #9240-class confusion from the other direction.

## Verification
- `cargo check -p homeboy-agents --lib` clean.
- `status_and_recovery`: **36 passed**; the 1 failure (`terminal_executor_artifacts_are_projected_under_logical_ids`) is a pre-existing filesystem-artifact env flake — fails identically on clean `origin/main` (stash-verified).
- Acceptance-idempotency paths green.
