### PR TITLE
refactor(agents): consolidate provider-model resolution behind AgentTaskOutcome::selected_model

### DIFF
--- a/crates/homeboy-agents/src/agent_task/outcome.rs
+++ b/crates/homeboy-agents/src/agent_task/outcome.rs
@@ -66,6 +66,27 @@ impl Default for AgentTaskOutcome {
     }
 }
 
+impl AgentTaskOutcome {
+    /// The concrete provider model this outcome recorded, if any.
+    ///
+    /// This is the single authoritative reader for "what model did this run
+    /// actually execute under" — the value lives in `metadata.model` and every
+    /// lifecycle reconciliation path (aggregate → task, provider handle
+    /// backfill, terminal-record repair) needs it. Previously each site
+    /// re-implemented `metadata.get("model") → as_str → trim → non-empty` with
+    /// subtly different handling (one path forgot the trim), which is why the
+    /// same "reconcile the terminal provider model" fix landed three times
+    /// (#9405/#9415/#9423). Centralizing the read here gives one definition:
+    /// present, non-blank after trimming, or `None`.
+    pub fn selected_model(&self) -> Option<&str> {
+        self.metadata
+            .get("model")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+    }
+}
+
 #[cfg(test)]
 impl AgentTaskOutcome {
     pub(crate) fn redacted(&self) -> Self {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/conversion.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/conversion.rs
@@ -184,11 +184,7 @@ pub(crate) fn tasks_for_aggregate(
             } else if let Some(outcome) = outcome {
                 task.state = task_state_for_outcome_status(outcome.status);
             }
-            if let Some(model) = outcome
-                .and_then(|outcome| outcome.metadata.get("model"))
-                .and_then(Value::as_str)
-                .filter(|model| !model.trim().is_empty())
-            {
+            if let Some(model) = outcome.and_then(|outcome| outcome.selected_model()) {
                 task.model = Some(model.to_string());
             }
             task
@@ -490,7 +486,7 @@ pub(crate) fn run_provider_handle(
 ) -> AgentTaskRunProviderHandle {
     let mut metadata = handle.metadata;
     if metadata.get("model").and_then(Value::as_str).is_none() {
-        if let Some(model) = outcome.metadata.get("model").and_then(Value::as_str) {
+        if let Some(model) = outcome.selected_model() {
             if !metadata.is_object() {
                 metadata = json!({});
             }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -688,15 +688,17 @@ pub(crate) fn record_terminal_artifact_projection(
 }
 
 /// The authoritative model recorded on an aggregate outcome, if any.
+///
+/// Locates the outcome for `task_id` and reads its concrete model through the
+/// canonical [`AgentTaskOutcome::selected_model`] reader, so aggregate → task
+/// model reconciliation uses the same present/non-blank definition as every
+/// other model-resolution site.
 fn aggregate_selected_model(aggregate: &AgentTaskAggregate, task_id: &str) -> Option<String> {
     aggregate
         .outcomes
         .iter()
         .find(|outcome| outcome.task_id == task_id)
-        .and_then(|outcome| outcome.metadata.get("model"))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|model| !model.is_empty())
+        .and_then(|outcome| outcome.selected_model())
         .map(str::to_string)
 }
 


### PR DESCRIPTION
## Why (same missing-abstraction pattern as the identity cluster)
Churn analysis flagged **reconcile** as a top recurring fix class. Drilling in, the sharpest sub-cluster is provider-model reconciliation: the **same "reconcile the terminal provider model" fix landed three separate times, in three different files**:
- #9405 (`conversion.rs`) — preserve reconciled provider model
- #9415 (`lifecycle_record_ops.rs`) — reconcile terminal provider models
- #9423 (`failure_recording.rs`) — reconcile terminal lifecycle provider model from aggregate

Root cause: "what concrete model did this run execute under?" was hand-rolled at **four** sites as `outcome.metadata.get("model") → as_str → trim → non-empty`, each slightly different — and `run_provider_handle` **forgot the trim entirely** (a latent bug). No single reader = the fix has to be re-applied everywhere it was missed, one file at a time.

## Change
Add `AgentTaskOutcome::selected_model()` as the one authoritative reader (present, non-blank after trimming, else `None`) and route every site through it:
- `conversion.rs` `tasks_for_aggregate` model projection
- `conversion.rs` `run_provider_handle` backfill
- `failure_recording.rs` `aggregate_selected_model`

Now there's exactly one definition of "the model this outcome recorded," so aggregate→task, provider-handle backfill, and terminal-record repair all agree by construction.

## Behavior note (called out honestly)
`run_provider_handle` previously did **not** trim before backfilling, so a whitespace-only metadata model could be persisted. Routing it through `selected_model()` now trims it — a strictly-better normalization, consistent with every other reader. All other sites already trimmed, so their behavior is byte-identical.

## Deliberately left alone
The `task.model` blank-check in `terminal_provider_model_reconciliation_needed` / `reconcile_terminal_provider_model` is a **2-site, same-file** pair — not the cross-file duplication that caused the recurring bug. Extracting it would be over-abstraction.

## Verification
- `cargo check -p homeboy-agents --lib` clean, no new warnings.
- `terminal_and_reconcile`: **29 passed**, including every model-reconciliation test (`status_repairs_terminal_provider_model_from_aggregate_idempotently`, `status_reconciles_terminal_provider_model_from_aggregate_when_durable_is_null`, `status_leaves_terminal_record_untouched_when_aggregate_has_no_model`).
- The 2 failures (`pinned_runtime_recovery_retains_the_existing_lab_proxy_identity`, `long_pre_submission_setup_survives_reconciliation`) are pre-existing env flakes — fail identically on clean `origin/main` (stash-verified).
