### PR TITLE
fix(runtime): close retained run lifecycle races

### DIFF
--- a/crates/homeboy-cli/src/commands/bench/matrix.rs
+++ b/crates/homeboy-cli/src/commands/bench/matrix.rs
@@ -789,6 +789,7 @@ fn run_component_with_rig_context(
         extension_bench::from_main_workflow_with_rig(workflow, rig_snapshot)
     };
     output.persisted_run = persisted_run;
+    run_dir.finish(exit_code == 0);
     Ok((output, exit_code))
 }
 

--- a/crates/homeboy-cli/src/commands/fuzz/execution.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/execution.rs
@@ -186,9 +186,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         &results_path,
     );
     let campaign_contract = fuzz_campaign_contract(fuzz_config.as_ref(), args.seed.as_deref());
-    if success {
-        run_dir.cleanup();
-    }
+    run_dir.finish(success);
 
     Ok((
         FuzzRunOutput {

--- a/crates/homeboy-cli/src/commands/fuzz/replay.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/replay.rs
@@ -226,8 +226,9 @@ fn run_replay_like(
     }
     let output = runner.run()?;
     let exit_code = if output.success { 0 } else { output.exit_code };
+    let succeeded = output.success;
 
-    Ok((
+    let result = (
         FuzzReplayOutput {
             command: mode.command_name().to_string(),
             status: if output.success { "passed" } else { "failed" }.to_string(),
@@ -264,7 +265,9 @@ fn run_replay_like(
             next_steps: replay_next_steps(false, mode),
         },
         exit_code,
-    ))
+    );
+    run_dir.finish(succeeded);
+    Ok(result)
 }
 
 #[derive(Clone)]

--- a/crates/homeboy-core/src/engine/run_dir.rs
+++ b/crates/homeboy-core/src/engine/run_dir.rs
@@ -26,6 +26,7 @@
 
 use crate::error::{Error, Result};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 
 /// Well-known filenames for step outputs within a run directory.
@@ -72,11 +73,14 @@ pub struct RunDir {
 struct RunDirLifecycle {
     path: PathBuf,
     _pin: super::temp::RuntimeTempPin,
+    disposition: AtomicU8,
 }
 
 impl Drop for RunDirLifecycle {
     fn drop(&mut self) {
-        super::temp::retain_failed_run_dir(&self.path);
+        if self.disposition.load(Ordering::Acquire) == 0 {
+            super::temp::retain_failed_run_dir(&self.path);
+        }
     }
 }
 
@@ -97,7 +101,11 @@ impl RunDir {
         })?;
         Ok(Self {
             path: path.clone(),
-            _lifecycle: Some(Arc::new(RunDirLifecycle { path, _pin: pin })),
+            _lifecycle: Some(Arc::new(RunDirLifecycle {
+                path,
+                _pin: pin,
+                disposition: AtomicU8::new(0),
+            })),
         })
     }
 
@@ -253,8 +261,31 @@ impl RunDir {
 
     /// Clean up the run directory. Called after the pipeline completes.
     pub fn cleanup(&self) {
-        super::temp::mark_run_dir_succeeded(&self.path);
-        let _ = std::fs::remove_dir_all(&self.path);
+        self.finish(true);
+    }
+
+    /// Record an explicit terminal lifecycle outcome.
+    pub fn finish(&self, succeeded: bool) {
+        let Some(lifecycle) = self._lifecycle.as_ref() else {
+            if succeeded {
+                let _ = std::fs::remove_dir_all(&self.path);
+            }
+            return;
+        };
+        let disposition = if succeeded { 1 } else { 2 };
+        if lifecycle
+            .disposition
+            .compare_exchange(0, disposition, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        if succeeded {
+            super::temp::mark_run_dir_succeeded(&self.path);
+            let _ = std::fs::remove_dir_all(&self.path);
+        } else {
+            super::temp::retain_failed_run_dir(&self.path);
+        }
     }
 }
 
@@ -370,6 +401,26 @@ mod tests {
         assert_eq!(output.removed_count, 0);
         assert_eq!(output.rows[0].owner_state.as_deref(), Some("failed"));
         assert!(path.exists());
+        std::env::remove_var("HOMEBOY_RUNTIME_TMPDIR");
+    }
+
+    #[test]
+    fn explicit_failure_retains_and_success_removes() {
+        let _guard = crate::test_support::home_env_guard();
+        let root = tempfile::tempdir().expect("runtime root");
+        std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", root.path());
+
+        let failed = RunDir::create().expect("failed run dir");
+        let failed_path = failed.path().to_path_buf();
+        failed.finish(false);
+        drop(failed);
+        assert!(failed_path.exists());
+
+        let succeeded = RunDir::create().expect("successful run dir");
+        let succeeded_path = succeeded.path().to_path_buf();
+        succeeded.finish(true);
+        drop(succeeded);
+        assert!(!succeeded_path.exists());
         std::env::remove_var("HOMEBOY_RUNTIME_TMPDIR");
     }
 

--- a/crates/homeboy-core/src/engine/temp/implementation.rs
+++ b/crates/homeboy-core/src/engine/temp/implementation.rs
@@ -177,7 +177,12 @@ pub(crate) fn pin_runtime_temp_dir(dir: &Path) -> Result<RuntimeTempPin> {
 }
 
 pub(crate) fn managed_run_temp_dir(prefix: &str) -> Result<(PathBuf, RuntimeTempPin)> {
-    let path = runtime_temp_dir(prefix)?;
+    let root = ensure_runtime_tmp_dir()?;
+    let _lock = acquire_cleanup_lock(&root)?;
+    let path = root.join(unique_name(prefix, ""));
+    fs::create_dir(&path).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(format!("create temp dir {prefix}")))
+    })?;
     let owner = RuntimeRunOwner {
         schema: RUN_OWNER_SCHEMA.to_string(),
         owner_id: uuid::Uuid::new_v4().to_string(),
@@ -218,6 +223,15 @@ pub(crate) fn bind_run_dir_owner(
     run_id: Option<&str>,
     invocation_id: Option<&str>,
 ) -> Result<()> {
+    let root = path.parent().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "runDir",
+            "managed run directory has no runtime root",
+            Some(path.display().to_string()),
+            None,
+        )
+    })?;
+    let _lock = acquire_cleanup_lock(root)?;
     let mut owner = read_run_owner(path)?;
     if let Some(run_id) = run_id {
         owner.run_id = Some(run_id.to_string());
@@ -237,6 +251,12 @@ mod owner_support {
         if !path.exists() {
             return;
         }
+        let Some(root) = path.parent() else {
+            return;
+        };
+        let Ok(_lock) = acquire_cleanup_lock(root) else {
+            return;
+        };
         let Ok(mut owner) = read_run_owner(path) else {
             return;
         };
@@ -275,7 +295,7 @@ mod owner_support {
 
     pub(super) fn write_run_owner(path: &Path, owner: &RuntimeRunOwner) -> Result<()> {
         let owner_path = path.join(RUN_OWNER_FILE);
-        let temporary = path.join(format!("{RUN_OWNER_FILE}.tmp-{}", std::process::id()));
+        let temporary = path.join(format!("{RUN_OWNER_FILE}.tmp-{}", uuid::Uuid::new_v4()));
         let raw = serde_json::to_vec_pretty(owner).map_err(|error| {
             Error::internal_json(
                 error.to_string(),
@@ -400,6 +420,50 @@ mod owner_support {
         }
     }
 
+    pub(super) fn managed_deletion_protection(
+        path: &Path,
+        inspected: &RuntimeRunOwner,
+        age_seconds: u64,
+    ) -> Option<String> {
+        match read_run_owner(path) {
+            Ok(current) => {
+                if current.owner_id != inspected.owner_id
+                    || current.run_id != inspected.run_id
+                    || current.invocation_ids != inspected.invocation_ids
+                    || current.state != inspected.state
+                {
+                    return Some("runtime run ownership changed after inspection".to_string());
+                }
+                if let Some(reason) = inspection_owner_protection(&current) {
+                    return Some(reason);
+                }
+                if current.state == "active" && owner_process_identity_matches(&current) {
+                    return Some(format!(
+                        "runtime run owner PID {} is running",
+                        current.owner_pid
+                    ));
+                }
+            }
+            Err(_)
+                if inspected.state == "corrupt" && age_seconds >= CORRUPT_OWNER_GRACE.as_secs() => {
+            }
+            Err(_) => return Some("runtime run ownership changed after inspection".to_string()),
+        }
+        match runtime_temp_pin_state(path) {
+            RuntimeTempPinState::Active(pid) => {
+                Some(format!("runtime temp pin owner PID {pid} is running"))
+            }
+            RuntimeTempPinState::Malformed(reason)
+                if age_seconds < CORRUPT_OWNER_GRACE.as_secs() =>
+            {
+                Some(format!("{reason}; protected during quarantine grace"))
+            }
+            RuntimeTempPinState::Malformed(_)
+            | RuntimeTempPinState::Dead
+            | RuntimeTempPinState::Absent => None,
+        }
+    }
+
     pub(super) fn runtime_root() -> Result<PathBuf> {
         if let Ok(override_dir) = env::var(runtime_tmpdir_env()) {
             let trimmed = override_dir.trim();
@@ -416,6 +480,10 @@ mod owner_support {
     }
 }
 use owner_support::*;
+
+#[path = "implementation/storage.rs"]
+mod storage;
+use storage::*;
 
 /// Inspected/planned/removed byte totals shared across cleanup output DTOs.
 /// Flattened into the parent structs so the JSON wire format keeps
@@ -553,26 +621,30 @@ pub fn cleanup_runtime_tmp_bounded(
             .cmp(&unique_name_timestamp(&left.file_name().to_string_lossy()))
             .then_with(|| right.file_name().cmp(&left.file_name()))
     });
-    let (cursor_name, mut retained_count, mut retained_bytes) = options
+    let (cursor_phase, cursor_name, mut retained_count, mut retained_bytes) = options
         .cursor
         .and_then(parse_runtime_cursor)
-        .unwrap_or((None, 0, 0));
-    let start = cursor_name
-        .as_deref()
-        .and_then(|cursor| {
-            let cursor_timestamp = unique_name_timestamp(cursor);
-            managed.iter().position(|entry| {
-                let name = entry.file_name().to_string_lossy().to_string();
-                let timestamp = unique_name_timestamp(&name);
-                timestamp < cursor_timestamp
-                    || (timestamp == cursor_timestamp && name.as_str() < cursor)
+        .unwrap_or(("managed", None, 0, 0));
+    let start = if cursor_phase == "unmanaged" {
+        managed.len()
+    } else {
+        cursor_name
+            .as_deref()
+            .and_then(|cursor| {
+                let cursor_timestamp = unique_name_timestamp(cursor);
+                managed.iter().position(|entry| {
+                    let name = entry.file_name().to_string_lossy().to_string();
+                    let timestamp = unique_name_timestamp(&name);
+                    timestamp < cursor_timestamp
+                        || (timestamp == cursor_timestamp && name.as_str() < cursor)
+                })
             })
-        })
-        .unwrap_or(0);
+            .unwrap_or(0)
+    };
     let page_end = start
         .saturating_add(options.limit.max(1))
         .min(managed.len());
-    output.has_more = page_end < managed.len();
+    let managed_has_more = page_end < managed.len();
     let page_last_name = managed
         .get(page_end.saturating_sub(1))
         .map(|entry| entry.file_name().to_string_lossy().to_string());
@@ -733,10 +805,6 @@ pub fn cleanup_runtime_tmp_bounded(
         }
         managed_decisions.push((inspection, eligibility_reason));
     }
-    if output.has_more {
-        output.next_cursor =
-            page_last_name.map(|name| format_runtime_cursor(&name, retained_count, retained_bytes));
-    }
     // Candidate-first ordering lets bounded invocations converge even when the
     // configured inspection limit is smaller than the retained count budget.
     managed_decisions.sort_by(|left, right| {
@@ -769,6 +837,19 @@ pub fn cleanup_runtime_tmp_bounded(
             row.reason = reason;
             output.skipped_count += 1;
         } else if let Some(reason) = eligibility_reason {
+            if options.apply {
+                if let Some(protection) = managed_deletion_protection(
+                    &inspection.path,
+                    &inspection.owner,
+                    inspection.age_seconds,
+                ) {
+                    row.reason = protection.clone();
+                    row.protection_reason = Some(protection);
+                    output.skipped_count += 1;
+                    output.rows.push(row);
+                    continue;
+                }
+            }
             row.action = if options.apply { "removed" } else { "remove" }.to_string();
             row.reason = reason;
             output.planned_count += 1;
@@ -806,11 +887,37 @@ pub fn cleanup_runtime_tmp_bounded(
         output.rows.push(row);
     }
 
-    for entry in unmanaged.into_iter().take(if output.has_more {
+    let unmanaged_len = unmanaged.len();
+    let unmanaged_start = if managed_has_more {
+        0
+    } else if cursor_phase == "unmanaged" {
+        cursor_name
+            .as_deref()
+            .and_then(|cursor| {
+                unmanaged
+                    .iter()
+                    .position(|entry| entry.file_name().to_string_lossy().as_ref() > cursor)
+            })
+            .unwrap_or(unmanaged_len)
+    } else {
+        0
+    };
+    let unmanaged_capacity = if managed_has_more {
         0
     } else {
         options.limit.max(1).saturating_sub(output.rows.len())
-    }) {
+    };
+    let unmanaged_end = unmanaged_start
+        .saturating_add(unmanaged_capacity)
+        .min(unmanaged_len);
+    let unmanaged_last_name = unmanaged
+        .get(unmanaged_end.saturating_sub(1))
+        .map(|entry| entry.file_name().to_string_lossy().to_string());
+    for entry in unmanaged
+        .into_iter()
+        .skip(unmanaged_start)
+        .take(unmanaged_capacity)
+    {
         lock.heartbeat()?;
         output.totals.inspected_count += 1;
         let path = entry.path();
@@ -887,6 +994,20 @@ pub fn cleanup_runtime_tmp_bounded(
         output.rows.push(row);
     }
 
+    if managed_has_more {
+        output.has_more = true;
+        output.next_cursor = page_last_name
+            .map(|name| format_runtime_cursor("managed", &name, retained_count, retained_bytes));
+    } else if unmanaged_end < unmanaged_len {
+        output.has_more = true;
+        output.next_cursor = Some(format_runtime_cursor(
+            "unmanaged",
+            unmanaged_last_name.as_deref().unwrap_or(""),
+            retained_count,
+            retained_bytes,
+        ));
+    }
+
     Ok(output)
 }
 
@@ -901,19 +1022,24 @@ mod cleanup_support {
     }
 
     pub(super) fn format_runtime_cursor(
+        phase: &str,
         name: &str,
         retained_count: usize,
         retained_bytes: u64,
     ) -> String {
-        format!("{name}|{retained_count}|{retained_bytes}")
+        format!("{phase}|{name}|{retained_count}|{retained_bytes}")
     }
 
-    pub(super) fn parse_runtime_cursor(cursor: &str) -> Option<(Option<String>, usize, u64)> {
-        let mut fields = cursor.rsplitn(3, '|');
+    pub(super) fn parse_runtime_cursor(cursor: &str) -> Option<(&str, Option<String>, usize, u64)> {
+        let mut fields = cursor.rsplitn(4, '|');
         let retained_bytes = fields.next()?.parse().ok()?;
         let retained_count = fields.next()?.parse().ok()?;
         let name = fields.next()?.to_string();
-        Some((Some(name), retained_count, retained_bytes))
+        let phase = fields.next().unwrap_or("managed");
+        if !matches!(phase, "managed" | "unmanaged") {
+            return None;
+        }
+        Some((phase, Some(name), retained_count, retained_bytes))
     }
 
     pub(super) fn skip_row(path: PathBuf, name: String, reason: &str) -> RuntimeTempCleanupRow {
@@ -1081,6 +1207,41 @@ mod cleanup_support {
         output.totals.planned_size_bytes += row.size_bytes;
         output.planned_allocated_bytes += row.allocated_bytes;
         if apply {
+            if metadata.is_dir() {
+                match runtime_temp_pin_state(path) {
+                    RuntimeTempPinState::Active(pid) => {
+                        row.action = "skip".to_string();
+                        row.reason = format!("runtime temp pin owner PID {pid} is running");
+                        row.protection_reason = Some(row.reason.clone());
+                        output.planned_count = output.planned_count.saturating_sub(1);
+                        output.totals.planned_size_bytes = output
+                            .totals
+                            .planned_size_bytes
+                            .saturating_sub(row.size_bytes);
+                        output.planned_allocated_bytes = output
+                            .planned_allocated_bytes
+                            .saturating_sub(row.allocated_bytes);
+                        output.skipped_count += 1;
+                        return Ok(());
+                    }
+                    RuntimeTempPinState::Malformed(reason) => {
+                        row.action = "skip".to_string();
+                        row.reason = reason;
+                        row.protection_reason = Some(row.reason.clone());
+                        output.planned_count = output.planned_count.saturating_sub(1);
+                        output.totals.planned_size_bytes = output
+                            .totals
+                            .planned_size_bytes
+                            .saturating_sub(row.size_bytes);
+                        output.planned_allocated_bytes = output
+                            .planned_allocated_bytes
+                            .saturating_sub(row.allocated_bytes);
+                        output.skipped_count += 1;
+                        return Ok(());
+                    }
+                    RuntimeTempPinState::Dead | RuntimeTempPinState::Absent => {}
+                }
+            }
             let available_before = filesystem_available_bytes(path);
             remove_runtime_tmp_entry(path, metadata)?;
             if !path.exists() {
@@ -1108,94 +1269,6 @@ mod cleanup_support {
         let root = fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
         let candidate = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
         candidate.starts_with(root)
-    }
-
-    #[derive(Debug, Clone, Copy)]
-    pub(super) struct StorageMeasure {
-        pub(super) logical_bytes: u64,
-        pub(super) allocated_bytes: u64,
-    }
-
-    pub(super) fn path_storage_measure(path: &Path) -> Result<StorageMeasure> {
-        path_storage_measure_inner(path, &mut HashSet::new())
-    }
-
-    fn path_storage_measure_inner(
-        path: &Path,
-        seen: &mut HashSet<(u64, u64)>,
-    ) -> Result<StorageMeasure> {
-        let metadata = fs::symlink_metadata(path).map_err(|error| {
-            Error::internal_io(error.to_string(), Some(format!("stat {}", path.display())))
-        })?;
-        if file_identity(&metadata).is_some_and(|identity| !seen.insert(identity)) {
-            return Ok(StorageMeasure {
-                logical_bytes: 0,
-                allocated_bytes: 0,
-            });
-        }
-        if !metadata.is_dir() || metadata.file_type().is_symlink() {
-            return Ok(StorageMeasure {
-                logical_bytes: metadata.len(),
-                allocated_bytes: allocated_bytes(&metadata),
-            });
-        }
-        let mut total = StorageMeasure {
-            logical_bytes: 0,
-            allocated_bytes: allocated_bytes(&metadata),
-        };
-        for entry in fs::read_dir(path).map_err(|error| {
-            Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
-        })? {
-            let entry = entry.map_err(|error| {
-                Error::internal_io(
-                    error.to_string(),
-                    Some(format!("read entry {}", path.display())),
-                )
-            })?;
-            let measure = path_storage_measure_inner(&entry.path(), seen)?;
-            total.logical_bytes = total.logical_bytes.saturating_add(measure.logical_bytes);
-            total.allocated_bytes = total
-                .allocated_bytes
-                .saturating_add(measure.allocated_bytes);
-        }
-        Ok(total)
-    }
-
-    #[cfg(unix)]
-    fn file_identity(metadata: &fs::Metadata) -> Option<(u64, u64)> {
-        use std::os::unix::fs::MetadataExt;
-        Some((metadata.dev(), metadata.ino()))
-    }
-
-    #[cfg(not(unix))]
-    fn file_identity(_metadata: &fs::Metadata) -> Option<(u64, u64)> {
-        None
-    }
-
-    #[cfg(unix)]
-    fn allocated_bytes(metadata: &fs::Metadata) -> u64 {
-        use std::os::unix::fs::MetadataExt;
-        metadata.blocks().saturating_mul(512)
-    }
-
-    #[cfg(not(unix))]
-    fn allocated_bytes(metadata: &fs::Metadata) -> u64 {
-        metadata.len()
-    }
-
-    pub(super) fn filesystem_available_bytes(path: &Path) -> Option<u64> {
-        fs4::available_space(path.parent().unwrap_or(path)).ok()
-    }
-
-    pub(super) fn verified_reclaimed_bytes(
-        before: Option<u64>,
-        after: Option<u64>,
-        allocated: u64,
-    ) -> u64 {
-        match (before, after) {
-            (Some(before), Some(after)) => after.saturating_sub(before).min(allocated),
-            _ => 0,
-        }
     }
 
     pub(super) fn remove_runtime_tmp_entry(path: &Path, metadata: &fs::Metadata) -> Result<()> {

--- a/crates/homeboy-core/src/engine/temp/implementation/storage.rs
+++ b/crates/homeboy-core/src/engine/temp/implementation/storage.rs
@@ -1,0 +1,93 @@
+use super::*;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct StorageMeasure {
+    pub(super) logical_bytes: u64,
+    pub(super) allocated_bytes: u64,
+}
+
+pub(super) fn path_storage_measure(path: &Path) -> Result<StorageMeasure> {
+    path_storage_measure_inner(path, &mut HashSet::new())
+}
+
+fn path_storage_measure_inner(
+    path: &Path,
+    seen: &mut HashSet<(u64, u64)>,
+) -> Result<StorageMeasure> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(format!("stat {}", path.display())))
+    })?;
+    if file_identity(&metadata).is_some_and(|identity| !seen.insert(identity)) {
+        return Ok(StorageMeasure {
+            logical_bytes: 0,
+            allocated_bytes: 0,
+        });
+    }
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Ok(StorageMeasure {
+            logical_bytes: metadata.len(),
+            allocated_bytes: allocated_bytes(&metadata),
+        });
+    }
+    let mut total = StorageMeasure {
+        logical_bytes: 0,
+        allocated_bytes: allocated_bytes(&metadata),
+    };
+    for entry in fs::read_dir(path).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+    })? {
+        let entry = entry.map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("read entry {}", path.display())),
+            )
+        })?;
+        let measure = path_storage_measure_inner(&entry.path(), seen)?;
+        total.logical_bytes = total.logical_bytes.saturating_add(measure.logical_bytes);
+        total.allocated_bytes = total
+            .allocated_bytes
+            .saturating_add(measure.allocated_bytes);
+    }
+    Ok(total)
+}
+
+#[cfg(unix)]
+fn file_identity(metadata: &fs::Metadata) -> Option<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt;
+    Some((metadata.dev(), metadata.ino()))
+}
+
+#[cfg(not(unix))]
+fn file_identity(_metadata: &fs::Metadata) -> Option<(u64, u64)> {
+    None
+}
+
+#[cfg(unix)]
+fn allocated_bytes(metadata: &fs::Metadata) -> u64 {
+    use std::os::unix::fs::MetadataExt;
+    if metadata.is_dir() || metadata.nlink() == 1 {
+        metadata.blocks().saturating_mul(512)
+    } else {
+        0
+    }
+}
+
+#[cfg(not(unix))]
+fn allocated_bytes(metadata: &fs::Metadata) -> u64 {
+    metadata.len()
+}
+
+pub(super) fn filesystem_available_bytes(path: &Path) -> Option<u64> {
+    fs4::available_space(path.parent().unwrap_or(path)).ok()
+}
+
+pub(super) fn verified_reclaimed_bytes(
+    before: Option<u64>,
+    after: Option<u64>,
+    allocated: u64,
+) -> u64 {
+    match (before, after) {
+        (Some(before), Some(after)) => after.saturating_sub(before).min(allocated),
+        _ => 0,
+    }
+}

--- a/crates/homeboy-core/src/engine/temp/implementation/tests/retention_tests.rs
+++ b/crates/homeboy-core/src/engine/temp/implementation/tests/retention_tests.rs
@@ -249,3 +249,117 @@ fn concurrent_cleanup_serializes_and_removes_once() {
     assert!(!path.exists());
     env::remove_var(runtime_tmpdir_env());
 }
+
+#[test]
+fn concurrent_shared_run_binding_preserves_every_invocation() {
+    let _guard = home_env_guard();
+    let root = tempfile::tempdir().expect("tempdir");
+    env::set_var(runtime_tmpdir_env(), root.path());
+    let (path, pin) = managed_run_temp_dir("homeboy-run-bind").expect("managed run");
+    let threads = (0..12)
+        .map(|index| {
+            let path = path.clone();
+            std::thread::spawn(move || {
+                bind_run_dir_owner(&path, None, Some(&format!("invocation-{index}")))
+                    .expect("bind invocation");
+            })
+        })
+        .collect::<Vec<_>>();
+    for thread in threads {
+        thread.join().expect("binding thread");
+    }
+
+    let owner = read_run_owner(&path).expect("owner");
+    assert_eq!(owner.invocation_ids.len(), 12);
+    for index in 0..12 {
+        assert!(owner
+            .invocation_ids
+            .contains(&format!("invocation-{index}")));
+    }
+    drop(pin);
+    env::remove_var(runtime_tmpdir_env());
+}
+
+#[test]
+fn deletion_revalidation_blocks_invocation_bound_after_inspection() {
+    let _guard = home_env_guard();
+    let root = tempfile::tempdir().expect("tempdir");
+    env::set_var(runtime_tmpdir_env(), root.path());
+    let run_dir = super::super::super::run_dir::RunDir::create().expect("run dir");
+    let path = run_dir.path().to_path_buf();
+    fs::remove_file(path.join(RUNTIME_TEMP_PIN_FILE)).expect("remove pin");
+    run_dir.finish(false);
+    let inspected = read_run_owner(&path).expect("inspected owner");
+
+    let invocation = super::super::super::invocation::InvocationGuard::acquire(
+        &run_dir,
+        &super::super::super::invocation::InvocationRequirements::default(),
+    )
+    .expect("late invocation binding");
+    let protection = managed_deletion_protection(&path, &inspected, u64::MAX)
+        .expect("ownership change protects deletion");
+
+    assert!(protection.contains("ownership changed") || protection.contains("invocation lease"));
+    assert!(path.exists());
+    drop(invocation);
+    env::remove_var(runtime_tmpdir_env());
+}
+
+#[test]
+fn unmanaged_only_cleanup_pages_with_cursor() {
+    let _guard = home_env_guard();
+    let root = tempfile::tempdir().expect("tempdir");
+    env::set_var(runtime_tmpdir_env(), root.path());
+    for index in 0..3 {
+        let path = runtime_temp_dir(&format!("homeboy-unmanaged-page-{index}"))
+            .expect("unmanaged directory");
+        fs::write(path.join("payload"), b"payload").expect("payload");
+    }
+    let mut cursor = None;
+    let mut names = Vec::new();
+    loop {
+        let mut options = bounded_options(false, Some("homeboy-unmanaged-page"));
+        options.older_than_days = 0;
+        options.limit = 1;
+        options.cursor = cursor.as_deref();
+        let page = cleanup_runtime_tmp_bounded(options).expect("cleanup page");
+        assert_eq!(page.totals.inspected_count, 1);
+        names.push(page.rows[0].name.clone());
+        if !page.has_more {
+            assert!(page.next_cursor.is_none());
+            break;
+        }
+        cursor = page.next_cursor;
+        assert!(cursor.is_some());
+    }
+    names.sort();
+    names.dedup();
+    assert_eq!(names.len(), 3);
+    env::remove_var(runtime_tmpdir_env());
+}
+
+#[cfg(unix)]
+#[test]
+fn external_hardlink_is_not_reported_as_reclaimable_allocation() {
+    let _guard = home_env_guard();
+    let root = tempfile::tempdir().expect("tempdir");
+    env::set_var(runtime_tmpdir_env(), root.path());
+    let path = runtime_temp_dir("homeboy-external-hardlink").expect("runtime dir");
+    let payload = path.join("payload.bin");
+    fs::write(&payload, vec![b'x'; 64 * 1024]).expect("payload");
+    let external = root.path().join("external-link.bin");
+    fs::hard_link(&payload, &external).expect("external hardlink");
+
+    assert_eq!(
+        path_storage_measure(&payload)
+            .expect("payload measure")
+            .allocated_bytes,
+        0
+    );
+    let output =
+        cleanup_runtime_tmp(true, 0, Some("homeboy-external-hardlink"), 10).expect("cleanup");
+    assert_eq!(output.removed_count, 1);
+    assert!(external.exists());
+    assert!(output.verified_reclaimed_bytes <= output.removed_allocated_bytes);
+    env::remove_var(runtime_tmpdir_env());
+}

--- a/crates/homeboy-refactor/src/plan/sources.rs
+++ b/crates/homeboy-refactor/src/plan/sources.rs
@@ -320,7 +320,7 @@ pub fn collect_refactor_sources(
         Vec::new()
     };
 
-    Ok(RefactorSourceRun {
+    let output = RefactorSourceRun {
         component_id: request.component.id,
         source_path: root_str,
         sources,
@@ -337,7 +337,9 @@ pub fn collect_refactor_sources(
         warnings,
         hints,
         guard_block: None,
-    })
+    };
+    run_dir.finish(true);
+    Ok(output)
 }
 
 fn allows_dirty_worktree_write(request: &RefactorSourceRequest) -> bool {

--- a/crates/homeboy-release/src/release/planning_quality.rs
+++ b/crates/homeboy-release/src/release/planning_quality.rs
@@ -147,11 +147,15 @@ pub(super) fn validate_lint_quality(component: &Component) -> LintQualityOutcome
     .and_then(|runner| runner.run())
     {
         Ok(output) => output,
-        Err(e) => return runner_error(e),
+        Err(e) => {
+            release_run_dir.finish(false);
+            return runner_error(e);
+        }
     };
 
     if output.success {
         homeboy_core::log_status!("release", "Lint passed");
+        release_run_dir.finish(true);
         return LintQualityOutcome::Passed { ran: true };
     }
 
@@ -163,6 +167,7 @@ pub(super) fn validate_lint_quality(component: &Component) -> LintQualityOutcome
     // a real lint failure — the linter found nothing to report. The underlying
     // linter is clean, so this must not hard-block the release.
     if findings.is_empty() {
+        release_run_dir.finish(false);
         return LintQualityOutcome::HarnessError {
             message: harness_failure_message("Lint", output.exit_code),
         };
@@ -182,10 +187,12 @@ pub(super) fn validate_lint_quality(component: &Component) -> LintQualityOutcome
                 "Lint has known findings but no new drift (baseline honored)"
             );
             homeboy_core::log_status!("release", "Lint passed");
+            release_run_dir.finish(true);
             return LintQualityOutcome::Passed { ran: true };
         }
     }
 
+    release_run_dir.finish(false);
     LintQualityOutcome::Failed(quality_error(
         "lint",
         code_quality_failure_message("Lint", &output),
@@ -268,6 +275,7 @@ pub(super) fn validate_test_quality(component: &Component) -> Result<bool> {
 
     if output.success {
         homeboy_core::log_status!("release", "Tests passed");
+        test_run_dir.finish(true);
         Ok(true)
     } else {
         let evidence = command_evidence(
@@ -277,6 +285,7 @@ pub(super) fn validate_test_quality(component: &Component) -> Result<bool> {
             &output.stdout,
             &output.stderr,
         );
+        test_run_dir.finish(false);
         Err(quality_error_with_evidence(
             "test",
             code_quality_failure_message("Tests", &output),


### PR DESCRIPTION
## Summary
- give every production `RunDir` caller an explicit semantic success/failure disposition, deleting successful bench/refactor/fuzz/release scratch and retaining failed or interrupted evidence
- serialize managed-directory creation and owner binding with the cleanup lock, use UUID owner temp files, and revalidate owner/lease/pin state immediately before deletion
- page unmanaged entries with phase-aware cursors and accurate `has_more` semantics under `--limit`
- exclude multiply-linked files from physically reclaimable allocation accounting while keeping verified filesystem deltas conservative
- add deterministic lifecycle, late-binding deletion, concurrent shared binding, unmanaged pagination, and external-hardlink tests

## Follow-up Context
PR #9453 merged at `e82781c5` before these blocker corrections landed. This branch is rebased onto current `main` at `e619a837` and contains exactly one correction commit absent from main.

## Verification
- `cargo test -p homeboy-core engine::temp -- --test-threads=1` (20 passed)
- `cargo test -p homeboy-core cleanup -- --test-threads=1` (89 passed; branch-caused cleanup filter failures resolved)
- `cargo test -p homeboy-cli commands::cleanup -- --test-threads=1` (18 passed)
- `cargo test -p homeboy-core engine::run_dir::tests -- --test-threads=1` (12 passed)
- `cargo check -p homeboy-cli -p homeboy-release -p homeboy-refactor` (passed)
- `cargo clippy -p homeboy-core -p homeboy-cli -p homeboy-release -p homeboy-refactor --all-targets` (passed with existing repository warnings)
- `homeboy review audit homeboy --path /var/lib/datamachine/workspace/homeboy@fix-runtime-run-retention-9430 --changed-since origin/main --placement local --profile pr --json-summary` (0 introduced findings)
- `git diff --check origin/main...HEAD` (passed)