### PR TITLE
fix(runner): probe admission readiness before refresh-homeboy reports success

### DIFF
--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -17,6 +17,7 @@ use super::connection::{
     active_jobs_before_daemon_replacement, disconnect_with_session, rotate_daemon_generation,
 };
 use super::execution::exec_with_status_snapshot;
+use super::execution::reserve_daemon_admission;
 use super::{
     connect_with_orphan_adoption, exec, load, materialize_runner_extension_with_env, merge,
     normalize_runner_command_env_for_homeboy_path, plan_controller_snapshot_extension,
@@ -33,6 +34,16 @@ const DEFAULT_HOMEBOY_REF: &str = "main";
 const DISCONNECTED_SSH_REFRESH_TIMEOUT: Duration = Duration::from_secs(20 * 60);
 const RECONNECT_VERIFICATION_WINDOW: Duration = Duration::from_secs(3);
 const RECONNECT_VERIFICATION_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+/// A freshly reconnected daemon reports the right identity a beat before its
+/// `/admissions` endpoint will admit against the new lease: the just-rotated
+/// lease heartbeat is momentarily not fresh and the loopback tunnel can drop a
+/// first request with `error sending request`. A refresh that returns success
+/// here strands the immediately following Lab handoff on a retryable failure
+/// the initiating command never recovers (#9466). Probe `/admissions` for
+/// readiness within a bounded window so the reconnect converges onto the exact
+/// lease the next handoff will use before declaring success.
+const ADMISSION_READINESS_WINDOW: Duration = Duration::from_secs(10);
+const ADMISSION_READINESS_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HomeboyBinaryRefreshMode {
@@ -639,6 +650,56 @@ pub fn refresh_homeboy_binary(
                 reconnect_exit_code,
             ));
         }
+        // Identity verification proves the right daemon answered; the reconnect
+        // is not done until that daemon will actually admit a Lab handoff.
+        // Probe `/admissions` for readiness so an immediately following
+        // runner-pinned handoff converges onto this exact lease instead of
+        // hitting a not-fresh lease or a transport drop the initiating command
+        // never recovers (#9466).
+        if let Some(identity_commit) = identity
+            .get("data")
+            .unwrap_or(&identity)
+            .get("git_commit")
+            .and_then(Value::as_str)
+        {
+            if let Err(readiness_error) =
+                probe_reconnected_admission_readiness(&plan.runner_id, identity_commit)
+            {
+                daemon_refreshed = false;
+                if let Err(rollback_error) = rollback_refreshed_daemon(
+                    &plan.runner_id,
+                    previous_homeboy_path.as_deref(),
+                    options.force,
+                ) {
+                    return Err(reconnect_rollback_error(&report, rollback_error));
+                }
+                return Ok((
+                    HomeboyBinaryRefreshOutput {
+                        variant: "refresh_homeboy",
+                        command: "runner.refresh_homeboy",
+                        runner_id: plan.runner_id.clone(),
+                        dry_run: false,
+                        plan: plan.clone(),
+                        identity: Some(identity),
+                        updated_fields: Vec::new(),
+                        daemon_refreshed: false,
+                        interrupted_job_ids,
+                        selected_binary_path: plan.binary_path.clone(),
+                        reconnect_required: true,
+                        followup_commands: plan.followup_commands.clone(),
+                        reconnect_deferred: None,
+                        failure: Some(refresh_reconnect_failure(
+                            &plan,
+                            &exec_output,
+                            &report,
+                            Some(readiness_error.message.as_str()),
+                        )),
+                        bootstrap_provenance: None,
+                    },
+                    1,
+                ));
+            }
+        }
     } else {
         interrupted_job_ids = Vec::new();
     }
@@ -805,6 +866,109 @@ fn verify_refreshed_daemon_status(
 fn build_identity_commit(identity: &str) -> Option<&str> {
     let (_, commit) = identity.strip_prefix("homeboy ")?.split_once('+')?;
     Some(commit.strip_suffix("-dirty").unwrap_or(commit))
+}
+
+/// Prove the reconnected daemon will admit a Lab handoff before the refresh
+/// reports success. Identity verification confirms the right daemon answered,
+/// but the just-rotated lease can still be momentarily not fresh and the new
+/// loopback tunnel can drop the first admission request — exactly the two
+/// failures an immediately following handoff hit in #9466. This reserves and
+/// immediately releases an admission against the reconnected session's own
+/// lease, so success guarantees the next handoff converges onto the same
+/// endpoint.
+fn probe_reconnected_admission_readiness(runner_id: &str, identity_commit: &str) -> Result<()> {
+    let session = super::connection::status_for_admission(runner_id)?
+        .session
+        .filter(|session| session.mode == super::RunnerTunnelMode::DirectSsh);
+    let Some(session) = session else {
+        // A reverse-broker session admits through the broker, not a direct
+        // loopback `/admissions` endpoint, so there is no local readiness probe
+        // to run. Identity verification already gated this reconnect.
+        return Ok(());
+    };
+    let (Some(local_url), Some(expected_lease_id)) = (
+        session.local_url.as_deref(),
+        session
+            .remote_daemon_lease_id
+            .as_deref()
+            .filter(|lease| !lease.is_empty()),
+    ) else {
+        // No direct endpoint or proven lease means the next handoff resolves
+        // its own coordinates; there is nothing this probe can assert here.
+        return Ok(());
+    };
+    probe_admission_readiness_until_ready(
+        expected_lease_id,
+        Instant::now() + ADMISSION_READINESS_WINDOW,
+        || {
+            reserve_daemon_admission(
+                runner_id,
+                local_url,
+                &format!("runner.refresh_homeboy readiness probe ({identity_commit})"),
+                expected_lease_id,
+                None,
+            )
+            .map(|reservation| {
+                // Drop releases the reservation immediately; readiness is the
+                // only signal we need.
+                drop(reservation);
+            })
+        },
+        || std::thread::sleep(ADMISSION_READINESS_RETRY_INTERVAL),
+    )
+}
+
+/// Retry the admission readiness probe through the transient post-reconnect
+/// window (stale-but-settling lease and dropped first requests) while failing
+/// immediately on an authoritative lease mismatch — that means a different
+/// daemon owns the endpoint and no amount of waiting will converge it.
+fn probe_admission_readiness_until_ready<Reserve, Wait>(
+    expected_lease_id: &str,
+    deadline: Instant,
+    mut reserve: Reserve,
+    mut wait: Wait,
+) -> Result<()>
+where
+    Reserve: FnMut() -> Result<()>,
+    Wait: FnMut(),
+{
+    loop {
+        match reserve() {
+            Ok(()) => return Ok(()),
+            Err(error) if admission_readiness_failure_is_authoritative(&error) => {
+                return Err(error);
+            }
+            Err(error) => {
+                if Instant::now() >= deadline {
+                    return Err(admission_readiness_timeout_error(expected_lease_id, error));
+                }
+                wait();
+            }
+        }
+    }
+}
+
+/// A reservation that bound against a *different* lease proves another daemon
+/// owns the endpoint (identity mismatch), so retrying cannot help. Every other
+/// failure — a not-fresh lease heartbeat or a transport drop — is the transient
+/// post-reconnect window this probe exists to absorb.
+fn admission_readiness_failure_is_authoritative(error: &Error) -> bool {
+    error.details.get("field").and_then(Value::as_str) == Some("expected_daemon_lease_id")
+}
+
+fn admission_readiness_timeout_error(expected_lease_id: &str, source: Error) -> Error {
+    Error::validation_invalid_argument(
+        "reconnect",
+        format!(
+            "refreshed daemon did not become ready to admit Lab handoffs against lease `{expected_lease_id}` within {}s: {}",
+            ADMISSION_READINESS_WINDOW.as_secs(),
+            source.message
+        ),
+        Some(expected_lease_id.to_string()),
+        Some(vec![
+            "re-run `homeboy runner refresh-homeboy <runner> --reconnect` to reconcile the daemon session".to_string(),
+        ]),
+    )
 }
 
 fn refresh_execution_options(

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/mod.rs
@@ -2,6 +2,7 @@
 
 mod part_a;
 mod part_b;
+mod part_c;
 
 use super::*;
 use crate::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_c.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_c.rs
@@ -1,0 +1,146 @@
+#![cfg(test)]
+
+use std::cell::RefCell;
+use std::time::{Duration, Instant};
+
+use super::*;
+use homeboy_core::error::Error;
+
+fn not_fresh_error() -> Error {
+    // Shape mirrors `reserve_daemon_admission` when the daemon refuses the
+    // reservation because its just-rotated lease heartbeat is not yet fresh.
+    Error::validation_invalid_argument(
+        "runner",
+        "runner `homeboy-lab` refused Lab admission reservation: daemon lease is not fresh",
+        Some("homeboy-lab".to_string()),
+        None,
+    )
+}
+
+fn transport_drop_error() -> Error {
+    // Shape mirrors a dropped first request against the new loopback tunnel.
+    let mut error = Error::internal_unexpected(
+        "query runner daemon: error sending request for url (http://127.0.0.1:52163/admissions)",
+    );
+    error.retryable = Some(true);
+    error
+}
+
+fn lease_mismatch_error() -> Error {
+    // Shape mirrors `reserve_daemon_admission` when the endpoint admitted
+    // against a different lease than the one we expected — a different daemon
+    // owns it, so retrying cannot converge.
+    Error::validation_invalid_argument(
+        "expected_daemon_lease_id",
+        "runner `homeboy-lab` admitted against daemon lease `other`, expected `lease-new`",
+        Some("lease-new".to_string()),
+        None,
+    )
+}
+
+/// #9466: a freshly reconnected daemon momentarily refuses admission (lease not
+/// fresh) and can drop the first request. The readiness probe must retry
+/// through that window and converge, so the refresh only reports success once
+/// the daemon will actually admit the next Lab handoff.
+#[test]
+fn admission_readiness_retries_through_the_transient_reconnect_window() {
+    let attempts = RefCell::new(0);
+    let result = probe_admission_readiness_until_ready(
+        "lease-new",
+        Instant::now() + Duration::from_secs(30),
+        || {
+            let mut count = attempts.borrow_mut();
+            *count += 1;
+            match *count {
+                1 => Err(not_fresh_error()),
+                2 => Err(transport_drop_error()),
+                _ => Ok(()),
+            }
+        },
+        || {},
+    );
+
+    assert!(
+        result.is_ok(),
+        "probe must converge after the lease settles: {result:?}"
+    );
+    assert_eq!(
+        *attempts.borrow(),
+        3,
+        "probe must retry the not-fresh lease and the transport drop before succeeding"
+    );
+}
+
+/// An authoritative lease mismatch means a different daemon owns the admission
+/// endpoint; no amount of waiting will converge it, so the probe must fail
+/// immediately without burning the readiness window.
+#[test]
+fn admission_readiness_fails_immediately_on_an_authoritative_lease_mismatch() {
+    let attempts = RefCell::new(0);
+    let result = probe_admission_readiness_until_ready(
+        "lease-new",
+        Instant::now() + Duration::from_secs(30),
+        || {
+            *attempts.borrow_mut() += 1;
+            Err(lease_mismatch_error())
+        },
+        || panic!("an authoritative mismatch must not wait and retry"),
+    );
+
+    let error = result.expect_err("lease mismatch is authoritative");
+    assert_eq!(error.details["field"], "expected_daemon_lease_id");
+    assert_eq!(
+        *attempts.borrow(),
+        1,
+        "authoritative mismatch must not retry"
+    );
+}
+
+/// When the daemon never becomes ready within the window, the probe surfaces a
+/// single canonical recovery action so the operator has exactly one next step.
+#[test]
+fn admission_readiness_timeout_surfaces_one_canonical_recovery_action() {
+    let result = probe_admission_readiness_until_ready(
+        "lease-new",
+        Instant::now(),
+        || Err(not_fresh_error()),
+        || panic!("an already-expired deadline must not wait"),
+    );
+
+    let error = result.expect_err("an unready daemon must fail the refresh");
+    assert_eq!(error.details["field"], "reconnect");
+    assert!(
+        error.message.contains("did not become ready to admit"),
+        "timeout must explain the readiness failure: {}",
+        error.message
+    );
+    let tried = error.details["tried"]
+        .as_array()
+        .expect("timeout error carries a recovery action");
+    assert_eq!(tried.len(), 1, "exactly one canonical recovery action");
+    assert!(
+        tried[0]
+            .as_str()
+            .expect("recovery action string")
+            .contains("refresh-homeboy"),
+        "recovery action points at the refresh command: {tried:?}"
+    );
+    // The underlying transient error is preserved for diagnosis.
+    assert!(error.message.contains("daemon lease is not fresh"));
+}
+
+/// The retry classifier treats only an authoritative lease mismatch as fatal;
+/// both #9466 transient shapes (not-fresh lease and transport drop) are
+/// retryable so the reconnect can converge.
+#[test]
+fn only_lease_mismatch_is_treated_as_authoritative() {
+    assert!(admission_readiness_failure_is_authoritative(
+        &lease_mismatch_error()
+    ));
+    assert!(!admission_readiness_failure_is_authoritative(
+        &not_fresh_error()
+    ));
+    assert!(!admission_readiness_failure_is_authoritative(
+        &transport_drop_error()
+    ));
+}


### PR DESCRIPTION
## Summary

`refresh-homeboy --reconnect` returned `success: true` after only verifying that the reconnected daemon reported the right **identity**. It never proved the daemon would actually **admit a Lab handoff**. The just-rotated lease can be momentarily not fresh and the new loopback tunnel can drop the first request, so an immediately following runner-pinned handoff hit two failures the initiating command never recovered (#9466):

```text
runner `homeboy-lab` refused Lab admission reservation: daemon lease is not fresh
query runner daemon: error sending request for url (http://127.0.0.1:52163/admissions)
```

## Fix

After identity verification succeeds on a reconnecting refresh, probe `/admissions` for readiness before declaring success:

- Reserve and **immediately release** an admission against the reconnected session's own `local_url` + `remote_daemon_lease_id`. This exercises the exact `/admissions` + `heartbeat_lease()` path the next handoff uses, so success guarantees convergence onto the same lease/session.
- **Retry** through the transient post-reconnect window (not-fresh lease heartbeat and dropped first requests) within a bounded 10s budget.
- **Fail immediately** only on an authoritative lease mismatch (`field == "expected_daemon_lease_id"`) — a different daemon owns the endpoint and retrying cannot converge.
- On timeout, roll back the refreshed daemon and surface **one canonical recovery action**.
- Reverse-broker sessions (no direct loopback endpoint) are skipped — they admit through the broker; identity verification already gated them.

## Acceptance criteria

- [x] Refresh waits for `/admissions` readiness before returning success.
- [x] The returned lease/session is the same one used by the next runner-pinned handoff (probes the session's own lease coordinates).
- [x] Stale lease and transient admission transport failures trigger bounded self-recovery before acceptance.
- [x] Failure output provides one canonical recovery action only when automatic recovery is exhausted.
- [x] Deterministic coverage reproduces refresh followed immediately by admission reservation.

## Tests

New `homeboy_refresh/tests/part_c.rs` (4 tests), each proven to catch the regression via temp-disable of the retry classifier:

- `admission_readiness_retries_through_the_transient_reconnect_window` — not-fresh + transport-drop then converges.
- `admission_readiness_fails_immediately_on_an_authoritative_lease_mismatch` — no retry, no wait.
- `admission_readiness_timeout_surfaces_one_canonical_recovery_action` — exactly one `tried` recovery action, underlying transient error preserved.
- `only_lease_mismatch_is_treated_as_authoritative` — classifier boundary.

`cargo check -p homeboy-lab-runner --lib` clean. Full `homeboy_refresh::tests` module green except one pre-existing environment flake (`materialize_failure_preserves_compiler_diagnostics_and_active_binary`, verified failing identically on clean `origin/main` — it shells out to a build this VPS can't run, and is untouched by this `reconnect: true`-only change).

Fixes #9466