### PR TITLE
fix(runtime): finish remaining run directory callers

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -941,6 +941,24 @@ fn valid_sha256(value: &str) -> bool {
 mod declared_base_tests {
     use super::*;
 
+    #[test]
+    fn promotion_gate_run_dir_disposes_success_and_failure_explicitly() {
+        let _guard = homeboy_core::test_support::home_env_guard();
+        let root = tempfile::tempdir().expect("runtime root");
+        std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", root.path());
+
+        let success = homeboy_core::engine::run_dir::RunDir::create().expect("success run");
+        let success_path = success.path().to_path_buf();
+        finish_promotion_gate_run_dir(&success, true);
+        assert!(!success_path.exists());
+
+        let failure = homeboy_core::engine::run_dir::RunDir::create().expect("failure run");
+        let failure_path = failure.path().to_path_buf();
+        finish_promotion_gate_run_dir(&failure, false);
+        assert!(failure_path.exists());
+        std::env::remove_var("HOMEBOY_RUNTIME_TMPDIR");
+    }
+
     fn git(path: &Path, args: &[&str]) {
         assert!(Command::new("git")
             .args(args)
@@ -1200,14 +1218,24 @@ fn run_promotion_gate(
         &format!("gate-{index}"),
         1,
     )?;
-    let runtime_tmpdir = match homeboy_core::engine::run_dir::RunDir::create().and_then(|run_dir| {
-        homeboy_core::engine::invocation::InvocationGuard::acquire(
-            &run_dir,
-            &homeboy_core::engine::invocation::InvocationRequirements::default(),
-        )
-    }) {
+    let run_dir = match homeboy_core::engine::run_dir::RunDir::create() {
+        Ok(run_dir) => run_dir,
+        Err(error) => {
+            crate::controller_scratch::release_attempt(
+                &allocation,
+                "verification_runtime_setup_failed",
+                serde_json::json!({ "error": error.message }),
+            )?;
+            return Err(error);
+        }
+    };
+    let runtime_tmpdir = match homeboy_core::engine::invocation::InvocationGuard::acquire(
+        &run_dir,
+        &homeboy_core::engine::invocation::InvocationRequirements::default(),
+    ) {
         Ok(runtime_tmpdir) => runtime_tmpdir,
         Err(error) => {
+            finish_promotion_gate_run_dir(&run_dir, false);
             crate::controller_scratch::release_attempt(
                 &allocation,
                 "verification_runtime_setup_failed",
@@ -1251,7 +1279,15 @@ fn run_promotion_gate(
         Err(_) => "verification_execution_failed",
     };
     crate::controller_scratch::release_attempt(&allocation, reason, evidence)?;
+    finish_promotion_gate_run_dir(
+        &run_dir,
+        matches!(&result, Ok(report) if report.status == AgentTaskGateStatus::Succeeded),
+    );
     result
+}
+
+fn finish_promotion_gate_run_dir(run_dir: &homeboy_core::engine::run_dir::RunDir, success: bool) {
+    run_dir.finish(success);
 }
 
 fn promotion_source(

--- a/crates/homeboy-extension/src/build/mod.rs
+++ b/crates/homeboy-extension/src/build/mod.rs
@@ -561,7 +561,7 @@ fn execute_build_component(
         Vec::new()
     };
 
-    Ok((
+    let result = (
         BuildOutput {
             command: "build.run".to_string(),
             component_id: comp.id.clone(),
@@ -574,7 +574,13 @@ fn execute_build_component(
             success,
         },
         runner_output.exit_code,
-    ))
+    );
+    finish_build_run_dir(&run_dir, success);
+    Ok(result)
+}
+
+fn finish_build_run_dir(run_dir: &RunDir, success: bool) {
+    run_dir.finish(success);
 }
 
 fn build_timeout() -> Duration {
@@ -850,6 +856,24 @@ mod tests {
             build_timeout_from(Some("invalid")),
             Duration::from_secs(30 * 60)
         );
+    }
+
+    #[test]
+    fn build_run_dir_disposes_success_and_failure_explicitly() {
+        let _guard = homeboy_core::test_support::home_env_guard();
+        let root = tempfile::tempdir().expect("runtime root");
+        std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", root.path());
+
+        let success = RunDir::create().expect("success run");
+        let success_path = success.path().to_path_buf();
+        finish_build_run_dir(&success, true);
+        assert!(!success_path.exists());
+
+        let failure = RunDir::create().expect("failure run");
+        let failure_path = failure.path().to_path_buf();
+        finish_build_run_dir(&failure, false);
+        assert!(failure_path.exists());
+        std::env::remove_var("HOMEBOY_RUNTIME_TMPDIR");
     }
 
     #[test]

--- a/crates/homeboy-extension/src/lint/run/tests/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/tests/workflow.rs
@@ -1,4 +1,6 @@
-use super::super::workflow::{run_main_lint_workflow, run_self_check_lint_workflow};
+use super::super::workflow::{
+    finish_scoped_lint_run_dir, run_main_lint_workflow, run_self_check_lint_workflow,
+};
 use super::{component, lint_args};
 use homeboy_core::component::{Component, ComponentScriptsConfig};
 use homeboy_core::engine::run_dir::RunDir;
@@ -76,4 +78,22 @@ fn lint_config_deserializes_changed_file_routes() {
     assert_eq!(config.changed_file_routes[0].step, "phpcs,phpstan");
     assert_eq!(config.changed_file_routes[1].globs, vec!["assets/**/*.css"]);
     assert_eq!(config.changed_file_routes[1].step, "stylelint");
+}
+
+#[test]
+fn scoped_lint_run_dir_disposes_success_and_failure_explicitly() {
+    let _guard = homeboy_core::test_support::home_env_guard();
+    let root = tempfile::tempdir().expect("runtime root");
+    std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", root.path());
+
+    let success = RunDir::create().expect("success run");
+    let success_path = success.path().to_path_buf();
+    finish_scoped_lint_run_dir(Some(&success), true);
+    assert!(!success_path.exists());
+
+    let failure = RunDir::create().expect("failure run");
+    let failure_path = failure.path().to_path_buf();
+    finish_scoped_lint_run_dir(Some(&failure), false);
+    assert!(failure_path.exists());
+    std::env::remove_var("HOMEBOY_RUNTIME_TMPDIR");
 }

--- a/crates/homeboy-extension/src/lint/run/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/workflow.rs
@@ -242,13 +242,8 @@ fn run_scoped_lint_runs(
     )?;
 
     for (index, run) in runs.iter().enumerate() {
-        let scoped_run_dir;
-        let active_run_dir = if index == 0 {
-            run_dir
-        } else {
-            scoped_run_dir = RunDir::create()?;
-            &scoped_run_dir
-        };
+        let scoped_run_dir = (index > 0).then(RunDir::create).transpose()?;
+        let active_run_dir = scoped_run_dir.as_ref().unwrap_or(run_dir);
 
         let runner = build_lint_runner(
             component,
@@ -297,6 +292,7 @@ fn run_scoped_lint_runs(
                 exit_code = output.exit_code;
             }
         }
+        finish_scoped_lint_run_dir(scoped_run_dir.as_ref(), output.success);
     }
 
     Ok(extension::RunnerOutput {
@@ -308,6 +304,12 @@ fn run_scoped_lint_runs(
         child_resource: None,
         extension_phase_timings,
     })
+}
+
+pub(super) fn finish_scoped_lint_run_dir(run_dir: Option<&RunDir>, success: bool) {
+    if let Some(run_dir) = run_dir {
+        run_dir.finish(success);
+    }
 }
 
 pub fn run_self_check_lint_workflow(


### PR DESCRIPTION
## Summary
- explicitly dispose extension build run directories after artifact processing, removing successful scratch and retaining failed builds
- explicitly dispose each secondary scoped lint run after its output artifacts and progress evidence are recorded
- retain the promotion gate run directory and invocation guard through the gate outcome and controller-scratch release, then dispose it from the semantic gate result
- add direct success-removal and failure-retention tests for all three production paths

## Follow-up Context
PR #9461 merged at `495af52c` before these final caller-disposition corrections were committed. This branch is rebased onto current `main` and contains exactly one correction commit absent from main.

## Verification
- `cargo test -p homeboy-extension build::tests -- --test-threads=1` (9 passed)
- `cargo test -p homeboy-extension lint::run::tests::workflow -- --test-threads=1` (4 passed)
- `cargo test -p homeboy-agents agent_task_promotion::promote::declared_base_tests -- --test-threads=1` (2 passed)
- direct disposition filter (3 passed across extension and agents)
- `cargo check -p homeboy-extension -p homeboy-agents` (passed with existing repository warnings)
- `homeboy review audit homeboy --path /var/lib/datamachine/workspace/homeboy@fix-runtime-run-retention-9430 --changed-since origin/main --placement local --profile pr --json-summary` (0 introduced findings)
- production `RunDir::create()` caller grep audited; the three outstanding normal-return paths now reach explicit `finish(success)` calls after their semantic outcome boundary
- `git diff --check origin/main...HEAD` (passed)

Local clippy was unavailable because the task-specific Rust toolchain does not have the clippy cargo subcommand installed; CI remains authoritative for lint.