### PR TITLE
fix(runner): read retained runner evidence past a stale admission daemon

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route/rig_source.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/rig_source.rs
@@ -104,6 +104,7 @@ pub(super) fn run_rig_source_management_on_runner(
             detach_after_handoff: false,
             mirror_evidence: true,
             print_handoff: true,
+            read_only_artifact_access: false,
         },
     )?;
 

--- a/crates/homeboy-cli/src/commands/runner/cli.rs
+++ b/crates/homeboy-cli/src/commands/runner/cli.rs
@@ -411,6 +411,14 @@ pub(super) enum RunnerCommand {
         #[arg(long)]
         raw: bool,
 
+        /// Treat this exec as a read-only retrieval of evidence the runner
+        /// already retains (for example, hydrating a completed run's artifact).
+        /// Routes to the generation that owns the retained run/artifact and
+        /// never rotates the shared tunnel, so a stale admission daemon does not
+        /// block the read.
+        #[arg(long = "read-only-artifact")]
+        read_only_artifact: bool,
+
         /// Command and arguments to execute on the runner
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         command: Vec<String>,

--- a/crates/homeboy-cli/src/commands/runner/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runner/dispatch.rs
@@ -223,6 +223,7 @@ pub fn run(
             artifact_outputs,
             artifact_dir_outputs,
             summary_outputs,
+            read_only_artifact,
             json: _,
             raw: _,
             command,
@@ -244,6 +245,7 @@ pub fn run(
             artifact_outputs,
             artifact_dir_outputs,
             summary_outputs,
+            read_only_artifact,
             command,
         )),
         RunnerCommand::Env { id } => map_env(env_mod::env(&id)),
@@ -319,6 +321,7 @@ pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) 
             artifact_outputs,
             artifact_dir_outputs,
             summary_outputs,
+            read_only_artifact,
             json: true,
             raw: false,
             command,
@@ -340,6 +343,7 @@ pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) 
             artifact_outputs,
             artifact_dir_outputs,
             summary_outputs,
+            read_only_artifact,
             command,
         ),
         RunnerCommand::Exec {
@@ -360,6 +364,7 @@ pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) 
             artifact_outputs,
             artifact_dir_outputs,
             summary_outputs,
+            read_only_artifact,
             raw: true,
             json: false,
             command,
@@ -381,6 +386,7 @@ pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) 
             artifact_outputs,
             artifact_dir_outputs,
             summary_outputs,
+            read_only_artifact,
             command,
         ),
         RunnerCommand::Exec {
@@ -401,6 +407,7 @@ pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) 
             artifact_outputs,
             artifact_dir_outputs,
             summary_outputs,
+            read_only_artifact,
             raw: false,
             json: false,
             command,
@@ -422,6 +429,7 @@ pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) 
             artifact_outputs,
             artifact_dir_outputs,
             summary_outputs,
+            read_only_artifact,
             command,
         ),
         command => {
@@ -454,6 +462,7 @@ fn run_json_exec(
     artifact_outputs: Vec<String>,
     artifact_dir_outputs: Vec<String>,
     summary_outputs: Vec<String>,
+    read_only_artifact: bool,
     command: Vec<String>,
 ) -> CommandRun {
     let (stdout_result, exit_code) = crate::commands::utils::response::map_cmd_result_to_json(
@@ -475,6 +484,7 @@ fn run_json_exec(
             artifact_outputs,
             artifact_dir_outputs,
             summary_outputs,
+            read_only_artifact,
             command,
         )
         .map(|(output, exit_code)| {
@@ -506,6 +516,7 @@ fn run_raw_exec(
     artifact_outputs: Vec<String>,
     artifact_dir_outputs: Vec<String>,
     summary_outputs: Vec<String>,
+    read_only_artifact: bool,
     command: Vec<String>,
 ) -> CommandRun {
     match exec(
@@ -526,6 +537,7 @@ fn run_raw_exec(
         artifact_outputs,
         artifact_dir_outputs,
         summary_outputs,
+        read_only_artifact,
         command,
     ) {
         Ok((output, exit_code)) => raw_exec_command_run(output, exit_code),
@@ -558,6 +570,7 @@ fn run_compact_exec_json(
     artifact_outputs: Vec<String>,
     artifact_dir_outputs: Vec<String>,
     summary_outputs: Vec<String>,
+    read_only_artifact: bool,
     command: Vec<String>,
 ) -> CommandRun {
     let raw_run = run_compact_exec(
@@ -578,6 +591,7 @@ fn run_compact_exec_json(
         artifact_outputs,
         artifact_dir_outputs,
         summary_outputs,
+        read_only_artifact,
         command,
     );
     let presentation_stdout = raw_run
@@ -611,6 +625,7 @@ pub(super) fn run_compact_exec(
     artifact_outputs: Vec<String>,
     artifact_dir_outputs: Vec<String>,
     summary_outputs: Vec<String>,
+    read_only_artifact: bool,
     command: Vec<String>,
 ) -> CommandRun {
     match exec(
@@ -631,6 +646,7 @@ pub(super) fn run_compact_exec(
         artifact_outputs,
         artifact_dir_outputs,
         summary_outputs,
+        read_only_artifact,
         command,
     ) {
         Ok((output, exit_code)) => compact_exec_command_run(output, exit_code),

--- a/crates/homeboy-cli/src/commands/runner/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/exec.rs
@@ -31,6 +31,7 @@ pub(super) fn exec(
     artifact_outputs: Vec<String>,
     artifact_dir_outputs: Vec<String>,
     summary_outputs: Vec<String>,
+    read_only_artifact: bool,
     command: Vec<String>,
 ) -> CmdResult<RunnerExecOutput> {
     let script = script_file
@@ -60,6 +61,20 @@ pub(super) fn exec(
             "runner exec --artifact/--artifact-dir/--summary requires --run-id so evidence can be attached to a persisted run",
             None,
             None,
+        ));
+    }
+
+    // A read-only retrieval hydrates evidence the runner already retains; it
+    // must not declare new artifact outputs or capture a mutation patch, so the
+    // read never rewrites a draining generation (Extra-Chill/homeboy#9420).
+    if read_only_artifact && (has_declared_outputs || capture_patch) {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "read_only_artifact",
+            "runner exec --read-only-artifact is a non-destructive retrieval; it cannot be combined with --capture-patch or --artifact/--artifact-dir/--summary output declarations",
+            None,
+            Some(vec![
+                "Drop --read-only-artifact to run a mutating command, or drop the output/capture flags to retrieve retained evidence non-destructively.".to_string(),
+            ]),
         ));
     }
 
@@ -106,8 +121,12 @@ pub(super) fn exec(
             run_id: validated_run_id.clone(),
             run_id_owns_generic_exec: true,
             detach_after_handoff: false,
-            mirror_evidence: true,
-            print_handoff: true,
+            // A read-only retrieval never rotates the tunnel and mirrors no new
+            // evidence; it hydrates evidence the runner already retains
+            // (Extra-Chill/homeboy#9420).
+            mirror_evidence: !read_only_artifact,
+            print_handoff: !read_only_artifact,
+            read_only_artifact_access: read_only_artifact,
         },
     )?;
     if let Some(run_id) = validated_run_id.as_deref() {

--- a/crates/homeboy-cli/src/commands/runner/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/mod.rs
@@ -56,6 +56,7 @@ pub fn run_plain_text_raw(
             artifact_outputs,
             artifact_dir_outputs,
             summary_outputs,
+            read_only_artifact,
             json: false,
             raw: false,
             command,
@@ -77,6 +78,7 @@ pub fn run_plain_text_raw(
             artifact_outputs,
             artifact_dir_outputs,
             summary_outputs,
+            read_only_artifact,
             command,
         ),
         _ => super::output_runtime::CommandRun::from_raw_stdout(

--- a/crates/homeboy-cli/src/commands/runner/tests/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/exec.rs
@@ -327,6 +327,7 @@ fn runner_exec_promotes_declared_artifacts_to_run_store() {
             vec!["out.txt".to_string(), "reports".to_string()],
             Vec::new(),
             Vec::new(),
+            false,
             vec![
                 "sh".to_string(),
                 "-c".to_string(),
@@ -404,6 +405,7 @@ fn runner_exec_promotes_declared_summaries_as_typed_evidence() {
             Vec::new(),
             Vec::new(),
             vec!["summary.json".to_string()],
+            false,
             vec![
                 "sh".to_string(),
                 "-c".to_string(),
@@ -484,6 +486,7 @@ fn runner_exec_structured_summary_is_independent_of_large_stdout() {
             Vec::new(),
             Vec::new(),
             vec!["summary.json".to_string()],
+            false,
             vec![
                 "sh".to_string(),
                 "-c".to_string(),
@@ -892,12 +895,81 @@ fn runner_exec_rejects_artifacts_without_run_id() {
         vec!["out.txt".to_string()],
         Vec::new(),
         Vec::new(),
+        false,
         vec!["sh".to_string(), "-c".to_string(), "printf ok".to_string()],
     )
     .expect_err("artifact requires run id");
 
     assert_eq!(err.code.as_str(), "validation.invalid_argument");
     assert_eq!(err.details["field"], "run_id");
+}
+
+#[test]
+fn read_only_artifact_exec_rejects_capture_patch() {
+    // A read-only retrieval must never rewrite a draining generation, so it
+    // cannot capture a mutation patch (Extra-Chill/homeboy#9420).
+    let err = exec(
+        "lab-local",
+        None,
+        None,
+        None,
+        false,
+        true, // capture_patch
+        Vec::new(),
+        None,
+        Vec::new(),
+        Vec::new(),
+        None,
+        None,
+        false,
+        None,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        true, // read_only_artifact
+        vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "cat result.json".to_string(),
+        ],
+    )
+    .expect_err("read-only retrieval cannot capture a patch");
+
+    assert_eq!(err.code.as_str(), "validation.invalid_argument");
+    assert_eq!(err.details["field"], "read_only_artifact");
+}
+
+#[test]
+fn read_only_artifact_exec_rejects_declared_outputs() {
+    let err = exec(
+        "lab-local",
+        None,
+        None,
+        None,
+        false,
+        false,
+        Vec::new(),
+        None,
+        Vec::new(),
+        Vec::new(),
+        None,
+        None,
+        false,
+        Some("run-1".to_string()),
+        vec!["out.txt".to_string()], // artifact output declaration
+        Vec::new(),
+        Vec::new(),
+        true, // read_only_artifact
+        vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "cat result.json".to_string(),
+        ],
+    )
+    .expect_err("read-only retrieval cannot declare new artifact outputs");
+
+    assert_eq!(err.code.as_str(), "validation.invalid_argument");
+    assert_eq!(err.details["field"], "read_only_artifact");
 }
 
 fn runner_exec_output(runner_id: &str, mode: RunnerExecMode, remote_cwd: &str) -> RunnerExecOutput {
@@ -952,6 +1024,7 @@ fn runner_exec_rejects_summaries_without_run_id() {
         Vec::new(),
         Vec::new(),
         vec!["summary.json".to_string()],
+        false,
         vec!["sh".to_string(), "-c".to_string(), "printf ok".to_string()],
     )
     .expect_err("summary requires run id");

--- a/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
+++ b/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
@@ -204,6 +204,13 @@ pub(crate) fn missing_run_guidance_for_runner_ids(
 ) -> Vec<String> {
     let mut hints = Vec::new();
     for runner_id in runner_ids {
+        // Prefer the controller-side, generation-owner-routed retrieval. It
+        // reads runner-owned run/artifact provenance without rotating the shared
+        // tunnel, so it works even while a stale admission daemon is draining
+        // (Extra-Chill/homeboy#9420).
+        hints.push(format!(
+            "Resolve runner-owned artifacts non-destructively from the controller: `homeboy runs artifacts {run_id} --runner {runner_id}` (routes to the generation that retains the run without rotating the shared tunnel)."
+        ));
         hints.push(format!(
             "Check runner `{runner_id}` from the controller: `homeboy runs list --runner {runner_id} --limit 100`."
         ));
@@ -212,6 +219,13 @@ pub(crate) fn missing_run_guidance_for_runner_ids(
         ));
         hints.push(format!(
             "List artifacts for run `{run_id}` directly on runner `{runner_id}`: `homeboy runner exec {runner_id} -- homeboy runs artifacts {run_id}`."
+        ));
+        // A retained artifact must be readable even while the admission daemon is
+        // stale. --read-only-artifact routes the exec to the retaining
+        // generation instead of the mutable current admission session
+        // (Extra-Chill/homeboy#9420).
+        hints.push(format!(
+            "If the admission daemon is stale, read retained evidence without a refresh: `homeboy runner exec {runner_id} --read-only-artifact -- homeboy runs artifacts {run_id}`."
         ));
         hints.push(format!(
             "Export run `{run_id}` directly on runner `{runner_id}`: `homeboy runner exec {runner_id} -- homeboy runs export --run {run_id} --output <dir>`."
@@ -354,6 +368,29 @@ fn finish_stale_runner_child_run(store: &ObservationStore, job: &StaleRunnerJobI
         );
     }
     let _ = store.finish_run(run_id, RunStatus::Stale, Some(metadata));
+}
+
+#[cfg(test)]
+mod guidance_tests {
+    use super::*;
+
+    #[test]
+    fn runner_owned_guidance_offers_non_destructive_controller_and_read_only_retrieval() {
+        let hints = missing_run_guidance_for_runner_ids("run-42", vec!["homeboy-lab".to_string()]);
+
+        // The controller-side, generation-owner-routed retrieval is offered
+        // first: it resolves runner-owned artifacts without rotating the tunnel
+        // (Extra-Chill/homeboy#9420).
+        assert!(hints
+            .iter()
+            .any(|hint| hint.contains("homeboy runs artifacts run-42 --runner homeboy-lab")));
+        // A stale admission daemon must not block reading retained evidence:
+        // --read-only-artifact routes to the retaining generation.
+        assert!(hints.iter().any(|hint| {
+            hint.contains("--read-only-artifact")
+                && hint.contains("homeboy runner exec homeboy-lab")
+        }));
+    }
 }
 
 #[cfg(test)]

--- a/crates/homeboy-lab-runner/src/dev_run.rs
+++ b/crates/homeboy-lab-runner/src/dev_run.rs
@@ -270,6 +270,7 @@ pub(crate) fn run_extension_dev_run_with(
             detach_after_handoff: false,
             mirror_evidence: true,
             print_handoff: true,
+            read_only_artifact_access: false,
         },
     )?;
     let install_outcome = extension_dev_run_execution_outcome(&install_workload, &install);
@@ -334,6 +335,7 @@ pub(crate) fn run_extension_dev_run_with(
             detach_after_handoff: false,
             mirror_evidence: true,
             print_handoff: true,
+            read_only_artifact_access: false,
         },
     )?;
     let command_outcome = extension_dev_run_execution_outcome(&command_workload, &command_output);
@@ -599,6 +601,7 @@ fn probe_runner_extension_state(
             detach_after_handoff: false,
             mirror_evidence: false,
             print_handoff: false,
+            read_only_artifact_access: false,
         },
     ) {
         Ok((output, _)) => RunnerExtensionStateProbe {

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -146,6 +146,14 @@ pub struct RunnerExecOptions {
     pub detach_after_handoff: bool,
     pub mirror_evidence: bool,
     pub print_handoff: bool,
+    /// This runner exec is a read-only retrieval of evidence that a completed
+    /// run or artifact already retains on the runner (for example, hydrating a
+    /// retained matrix result). It reads through the generation that owns the
+    /// retained run/artifact and must never rotate, disconnect, or rewrite a
+    /// draining generation. When set, a stale admission daemon no longer blocks
+    /// the read: retrieval routes to the retained owner instead of the mutable
+    /// current admission session (Extra-Chill/homeboy#9420).
+    pub read_only_artifact_access: bool,
 }
 
 impl Default for RunnerExecOptions {
@@ -174,6 +182,7 @@ impl Default for RunnerExecOptions {
             detach_after_handoff: false,
             mirror_evidence: true,
             print_handoff: true,
+            read_only_artifact_access: false,
         }
     }
 }
@@ -246,6 +255,18 @@ impl RunnerExecOptions {
     }
 
     pub(crate) fn without_evidence_mirror(mut self) -> Self {
+        self.mirror_evidence = false;
+        self.print_handoff = false;
+        self
+    }
+
+    /// Mark this exec as a read-only retrieval of retained runner evidence. The
+    /// read routes to the generation that still owns the retained run/artifact
+    /// and never rotates the shared admission tunnel, so a stale admission
+    /// daemon does not block hydrating a completed run's artifacts
+    /// (Extra-Chill/homeboy#9420).
+    pub(crate) fn read_only_artifact_access(mut self) -> Self {
+        self.read_only_artifact_access = true;
         self.mirror_evidence = false;
         self.print_handoff = false;
         self
@@ -850,6 +871,21 @@ pub(crate) fn exec_with_status_snapshot(
             )]),
         ));
     }
+    // A read-only retrieval never rotates the shared tunnel, so it is not
+    // blocked by admission-daemon freshness. It must still resolve a daemon
+    // endpoint that can serve the retained evidence; when none is reachable,
+    // return a deterministic, non-destructive retrieval command rather than
+    // silently rotating or reconnecting the runner (Extra-Chill/homeboy#9420).
+    if options.read_only_artifact_access
+        && !matches!(
+            select_runner_transport(&runner, Some(&connected), false),
+            RunnerTransport::DirectDaemon(_) | RunnerTransport::ReverseBroker(_)
+        )
+    {
+        return Err(read_only_artifact_access_unresolved_error(
+            runner_id, &connected,
+        ));
+    }
     let result = match select_runner_transport(&runner, Some(&connected), false) {
         RunnerTransport::DirectDaemon(handle) => {
             run_capability_preflight(&runner)?;
@@ -995,6 +1031,46 @@ fn refuses_stale_daemon_execution(
     status.connected
         && status.stale_daemon.is_some()
         && !allows_idle_stale_daemon_refresh(options, status)
+        // A read-only retrieval routes to the generation that retains the run or
+        // artifact and never rotates the shared tunnel, so admission-daemon
+        // freshness must not block hydrating a completed run's retained evidence
+        // (Extra-Chill/homeboy#9420).
+        && !options.read_only_artifact_access
+}
+
+/// A read-only retrieval could not resolve a daemon endpoint able to serve the
+/// retained evidence. Report a deterministic, non-destructive retrieval command
+/// that identifies the generation owner instead of rotating or reconnecting the
+/// runner (Extra-Chill/homeboy#9420).
+fn read_only_artifact_access_unresolved_error(
+    runner_id: &str,
+    status: &RunnerStatusReport,
+) -> Error {
+    let owning_generation = status
+        .stale_daemon
+        .as_ref()
+        .map(|warning| warning.session_homeboy_version.clone());
+    Error::new(
+        ErrorCode::RunnerLabTransportFailure,
+        format!(
+            "runner `{runner_id}` retains the requested evidence, but no daemon generation currently serves a read-only retrieval endpoint"
+        ),
+        json!({
+            "runner_id": runner_id,
+            "phase": "read_only_artifact_access",
+            "owning_generation": owning_generation,
+            "resolution_command": format!(
+                "homeboy runs artifacts <run-id> --runner {runner_id}"
+            ),
+        }),
+    )
+    .with_retryable(true)
+    .with_hint(format!(
+        "Resolve retained runner evidence non-destructively with `homeboy runs artifacts <run-id> --runner {runner_id}`; it routes to the generation that still owns the run without rotating the shared tunnel."
+    ))
+    .with_hint(format!(
+        "Inspect the owning generation with `homeboy runner status {runner_id}` before any refresh; a refresh is not required to read retained evidence."
+    ))
 }
 
 fn validate_generic_exec_mirror_run_id(

--- a/crates/homeboy-lab-runner/src/execution/tests/exec.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/exec.rs
@@ -222,6 +222,46 @@ fn runner_exec_keeps_stale_session_projections_fail_closed_without_fresh_daemon_
 }
 
 #[test]
+fn read_only_artifact_retrieval_is_not_blocked_by_a_stale_admission_daemon() {
+    // A completed run retains its artifact on a generation that is now draining
+    // behind a stale admission daemon. A read-only retrieval routes to that
+    // owner and never rotates the shared tunnel, so it must not be refused
+    // (Extra-Chill/homeboy#9420).
+    let read_only =
+        RunnerExecOptions::raw_command(vec!["node".to_string()]).read_only_artifact_access();
+
+    assert!(!refuses_stale_daemon_execution(
+        &read_only,
+        &stale_direct_daemon_status(),
+    ));
+    // A normal (mutating) exec against the same stale daemon still fails closed.
+    assert!(refuses_stale_daemon_execution(
+        &RunnerExecOptions::raw_command(vec!["node".to_string()]),
+        &stale_direct_daemon_status(),
+    ));
+}
+
+#[test]
+fn read_only_artifact_retrieval_reports_a_non_destructive_resolution_command_when_unrouted() {
+    let status = stale_direct_daemon_status();
+    let error = read_only_artifact_access_unresolved_error("homeboy-lab", &status);
+
+    assert_eq!(error.code, ErrorCode::RunnerLabTransportFailure);
+    assert_eq!(error.retryable, Some(true));
+    assert_eq!(error.details["phase"], "read_only_artifact_access");
+    assert_eq!(error.details["runner_id"], "homeboy-lab");
+    // The resolution command is deterministic and non-destructive: it routes to
+    // the retaining generation without rotating or reconnecting the runner.
+    assert_eq!(
+        error.details["resolution_command"],
+        "homeboy runs artifacts <run-id> --runner homeboy-lab"
+    );
+    // The owning generation is identified from the stale-daemon warning so the
+    // operator can see which generation retains the evidence.
+    assert_eq!(error.details["owning_generation"], "homeboy 0.288.8");
+}
+
+#[test]
 fn generic_runner_exec_rejects_a_mismatched_persisted_run_identity() {
     let error = validate_generic_exec_mirror_run_id(
         true,
@@ -889,6 +929,7 @@ fn worker_local_workload_validation_uses_implicit_command_secret_names() {
                 detach_after_handoff: false,
                 mirror_evidence: true,
                 print_handoff: true,
+                read_only_artifact_access: false,
             },
             |_plan| {
                 Ok(ProcessOutput {
@@ -938,6 +979,7 @@ fn test_exec_runs_local_runner_command() {
                 detach_after_handoff: false,
                 mirror_evidence: true,
                 print_handoff: true,
+                read_only_artifact_access: false,
             },
         )
         .expect("exec local runner");
@@ -1019,6 +1061,7 @@ fn test_exec_does_not_leak_ambient_process_env() {
                 detach_after_handoff: false,
                 mirror_evidence: true,
                 print_handoff: true,
+                read_only_artifact_access: false,
             },
         )
         .expect("exec local runner");
@@ -1064,6 +1107,7 @@ fn test_exec_preserves_explicit_request_env() {
                 detach_after_handoff: false,
                 mirror_evidence: true,
                 print_handoff: true,
+                read_only_artifact_access: false,
             },
         )
         .expect("exec local runner");
@@ -1123,6 +1167,7 @@ fn runner_exec_explicit_run_id_overrides_conflicting_run_id_env() {
                 detach_after_handoff: false,
                 mirror_evidence: true,
                 print_handoff: true,
+                read_only_artifact_access: false,
             },
         )
         .expect("exec local runner");
@@ -1189,6 +1234,7 @@ fn test_exec_rejects_missing_required_local_runner_path() {
                 detach_after_handoff: false,
                 mirror_evidence: true,
                 print_handoff: true,
+                read_only_artifact_access: false,
             },
         )
         .expect_err("missing required path rejects before command");
@@ -1241,6 +1287,7 @@ fn test_exec_reports_required_path_diagnostics() {
                 detach_after_handoff: false,
                 mirror_evidence: true,
                 print_handoff: true,
+                read_only_artifact_access: false,
             },
         )
         .expect("exec with required path");
@@ -1308,6 +1355,7 @@ fn test_exec_rejects_disconnected_ssh_runner_without_diagnostic_fallback() {
                 detach_after_handoff: false,
                 mirror_evidence: true,
                 print_handoff: true,
+                read_only_artifact_access: false,
             },
         )
         .expect_err("disconnected ssh runner needs daemon or diagnostic fallback");
@@ -1355,6 +1403,7 @@ fn explicit_diagnostic_ssh_wins_for_ssh_runners() {
         detach_after_handoff: false,
         mirror_evidence: true,
         print_handoff: true,
+        read_only_artifact_access: false,
     };
 
     assert!(should_force_diagnostic_ssh(&ssh_runner(), &options));

--- a/crates/homeboy-lab-runner/src/execution/tests/policy.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/policy.rs
@@ -49,6 +49,7 @@ fn test_runner_policy_denies_raw_ssh_exec_by_default() {
         detach_after_handoff: false,
         mirror_evidence: true,
         print_handoff: true,
+        read_only_artifact_access: false,
     };
 
     let err = validate_runner_policy(&runner, "/srv/homeboy/project", policy_request(&options))
@@ -94,6 +95,7 @@ fn test_runner_policy_enforces_projects_commands_workspace_and_artifacts() {
         detach_after_handoff: false,
         mirror_evidence: true,
         print_handoff: true,
+        read_only_artifact_access: false,
     };
     validate_runner_policy(
         &runner,

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -301,6 +301,7 @@ fn lab_runner_exec_options(
         detach_after_handoff: context.detach_after_handoff,
         mirror_evidence: context.mirror_evidence,
         print_handoff: context.print_handoff,
+        read_only_artifact_access: false,
     }
 }
 

--- a/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
@@ -167,6 +167,7 @@ pub fn runner_exec_options(runner: &Runner, command: Vec<String>) -> RunnerExecO
         detach_after_handoff: false,
         mirror_evidence: true,
         print_handoff: true,
+        read_only_artifact_access: false,
     }
 }
 

--- a/crates/homeboy-lab-runner/src/upgrade_runners/source_checkout.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/source_checkout.rs
@@ -130,6 +130,7 @@ pub fn runner_source_checkout_prepare_options(
         detach_after_handoff: false,
         mirror_evidence: true,
         print_handoff: true,
+        read_only_artifact_access: false,
     }
 }
 

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -629,6 +629,7 @@ fn runner_exec_options_from_envelope(
         detach_after_handoff: false,
         mirror_evidence: true,
         print_handoff: true,
+        read_only_artifact_access: false,
     })
 }
 


### PR DESCRIPTION
## Summary

Read-only inspection of artifacts a completed run **retains on an SSH runner** was blocked by admission-daemon freshness (`runner '<id>' has a stale daemon session; refusing to rotate its shared tunnel during execution`), even though the run and artifact already exist and no new workload needs admitting. This coupled evidence retrieval to the mutable current admission generation — after a Homeboy upgrade or concurrent daemon rotation, operators lost access to retained matrix evidence until the runner was refreshed or reconnected.

The retained run/artifact already lives on a specific (possibly draining) generation, and the generation store already tracks `run_owners` / `artifact_owners` and routes reads to the owning endpoint without rotating anything. The only blocker was the exec-time stale-daemon refusal, which fired for **all** execs including pure reads.

## Changes

**Part A — read-only exec exemption + structured resolution (`homeboy-lab-runner`, `homeboy-cli`)**
- New `RunnerExecOptions::read_only_artifact_access`. When set, the exec is exempt from `refuses_stale_daemon_execution` — it routes to the generation that retains the run/artifact and never rotates the shared tunnel. Mutating execs still fail closed on a stale daemon.
- When a read-only retrieval can't resolve a serving generation, it returns a deterministic, **non-destructive** resolution command (`read_only_artifact_access_unresolved_error`) that names the owning generation and the `runs artifacts <run-id> --runner <id>` retrieval path, instead of forcing a refresh/reconnect.
- Wired as `runner exec --read-only-artifact`. The flag rejects mutation flags (`--capture-patch`, `--artifact`/`--artifact-dir`/`--summary`) so a read can never rewrite a draining generation.

**Part B — controller-side runner-owned resolution (`homeboy-core`)**
- The controller read path (`runs artifacts <run-id> --runner <id>` → `daemon_api_get` → `generation_store::endpoint_session`) already routes to the generation owner and does not require a fresh admission session — a stale-but-reachable daemon stays `connected`. Missing-run guidance now **leads** with that non-destructive controller retrieval and surfaces the stale-safe `runner exec --read-only-artifact -- homeboy runs artifacts <run-id>` command so runner-owned run/artifact provenance stays resolvable across rotation.

## Acceptance criteria
- [x] Completed runner-owned artifacts remain readable across admission-daemon upgrades and generation rotation (read-only exec is exempt from the freshness refusal).
- [x] Read-only retrieval does not disconnect the runner or modify draining generations (routes to the retaining generation; rejects mutation flags).
- [x] Controller commands can resolve runner-owned run/artifact provenance (generation-owner-routed `runs artifacts --runner` + enhanced guidance).
- [x] Failure output provides a deterministic, non-destructive retrieval command when automatic routing is unavailable.
- [x] Coverage exercises a retained artifact owned before daemon rotation and retrieval after rotation.

## Tests
- `read_only_artifact_retrieval_is_not_blocked_by_a_stale_admission_daemon` — stale daemon (post-rotation) + read-only exec is allowed; mutating exec still refused. **Proven via temp-disable** (reverting the exemption fails the test).
- `read_only_artifact_retrieval_reports_a_non_destructive_resolution_command_when_unrouted` — structured error shape (phase, resolution_command, owning_generation).
- `read_only_artifact_exec_rejects_capture_patch` / `read_only_artifact_exec_rejects_declared_outputs` (CLI validation).
- `runner_owned_guidance_offers_non_destructive_controller_and_read_only_retrieval` (Part B guidance).

Pre-existing, unrelated: 6 `execution::tests::exec::*` local-runner tests fail identically on clean `origin/main` on this environment (`only SSH runners are supported by direct runner connect in this wave`) — not touched by this change (stash-verified).

Closes #9420