### PR TITLE
fix(runner): stop parsing generic runner-exec stdout as an agent-task run-plan

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/agent_task_lifecycle_event.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/agent_task_lifecycle_event.rs
@@ -114,7 +114,19 @@ pub(crate) fn agent_task_run_plan_lifecycle_event_from_persisted_job_events(
     let Some(stdout) = result.get("stdout").and_then(serde_json::Value::as_str) else {
         return Ok(None);
     };
-    let envelope = parse_offloaded_run_plan_envelope(stdout)?;
+    // Recovery-only: this is reached for every terminal runner-exec result that
+    // carries a `--run-id`, including generic (non-agent-task) execs whose
+    // stdout is arbitrary command output (`pwd`, a fuzz report, empty, ...).
+    // Plain command stdout is not an agent-task run-plan envelope, so a parse
+    // failure here means "no agent-task aggregate to recover", not a hard error.
+    // Only an actual run-plan envelope should produce a lifecycle event
+    // (Extra-Chill/homeboy#9459).
+    let Some(envelope) = parse_offloaded_run_plan_envelope(stdout)
+        .ok()
+        .filter(is_agent_task_run_plan_envelope)
+    else {
+        return Ok(None);
+    };
     let Some(data) = envelope.get("data") else {
         return Ok(None);
     };
@@ -352,5 +364,95 @@ mod tests {
             error.details["context"],
             "hydrate nested Lab terminal agent-task aggregate"
         );
+    }
+
+    fn terminal_result_event(result: serde_json::Value) -> JobEvent {
+        JobEvent {
+            sequence: 1,
+            job_id: uuid::Uuid::nil(),
+            kind: JobEventKind::Result,
+            timestamp_ms: 1,
+            message: None,
+            data: Some(result),
+        }
+    }
+
+    #[test]
+    fn generic_runner_exec_plain_stdout_recovers_no_agent_task_event() {
+        // A generic `runner exec ... --run-id X -- pwd` terminal result carries
+        // arbitrary command stdout and no agent-task workload. The recovery path
+        // must NOT parse plain command output as an agent-task run-plan envelope
+        // (Extra-Chill/homeboy#9459).
+        for stdout in [
+            "/home/runner/workspace\n",
+            "",
+            "line one\nline two\n",
+            "{ not valid json",
+        ] {
+            let events = vec![terminal_result_event(serde_json::json!({
+                "exit_code": 0,
+                "stdout": stdout,
+                "stderr": "",
+            }))];
+
+            let event = agent_task_run_plan_lifecycle_event_from_persisted_job_events(
+                &events,
+                "homeboy-lab",
+                "runner-job-1",
+                "generic-pwd",
+            )
+            .expect("generic runner exec stdout must not error");
+
+            assert!(
+                event.is_none(),
+                "plain stdout `{stdout:?}` must not recover an agent-task lifecycle event"
+            );
+        }
+    }
+
+    #[test]
+    fn generic_runner_exec_nonzero_exit_with_json_stdout_recovers_no_agent_task_event() {
+        // A strict fuzz workload can emit a valid JSON result document to stdout
+        // while intentionally exiting non-zero. That JSON is a command result,
+        // not an agent-task run-plan envelope, so recovery still yields no event
+        // and preserves the runner exit code path (Extra-Chill/homeboy#9459).
+        let events = vec![terminal_result_event(serde_json::json!({
+            "exit_code": 1,
+            "stdout": r#"{"status":"fail","findings":3}"#,
+            "stderr": "",
+        }))];
+
+        let event = agent_task_run_plan_lifecycle_event_from_persisted_job_events(
+            &events,
+            "homeboy-lab",
+            "runner-job-1",
+            "gutenberg-fuzz",
+        )
+        .expect("generic JSON stdout must not error");
+
+        assert!(event.is_none());
+    }
+
+    #[test]
+    fn persisted_run_plan_envelope_in_stdout_still_recovers_event() {
+        // The recovery contract for real agent-task run-plan results is
+        // preserved: an aggregate envelope embedded in stdout still hydrates.
+        let events = vec![terminal_result_event(serde_json::json!({
+            "exit_code": 0,
+            "stdout": r#"{"data":{"schema":"homeboy/agent-task-aggregate/v1","plan_id":"plan-x","status":"succeeded","totals":{"skipped":0,"succeeded":0,"failed":0},"outcomes":[]}}"#,
+            "stderr": "",
+        }))];
+
+        let event = agent_task_run_plan_lifecycle_event_from_persisted_job_events(
+            &events,
+            "homeboy-lab",
+            "runner-job-1",
+            "controller-run",
+        )
+        .expect("run-plan envelope recovery")
+        .expect("agent-task lifecycle event");
+
+        assert_eq!(event.identity.run_id.as_deref(), Some("controller-run"));
+        assert_eq!(event.aggregate.plan_id, "plan-x");
     }
 }


### PR DESCRIPTION
## Summary

`homeboy runner exec <runner> --run-id X -- <command>` on a **connected daemon** failed before returning remote output:

```
internal.json_error
context: parse offloaded agent-task run-plan output
error: expected value at line 1 column 1
```

The same command succeeded through `--ssh` (diagnostic transport) and via `runner doctor` probes — the daemon was connected, idle, and healthy. The defect also lost the typed terminal result for valid runner-exec jobs (including workloads that intentionally exit non-zero to report strict findings).

## Root cause

Every terminal runner-exec result that carries a `--run-id` is projected through the agent-task terminal recovery path (`project_terminal_runner_result` → `terminal_runner_lifecycle_event` → `agent_task_run_plan_lifecycle_event_from_persisted_job_events`). That recovery function is *recovery-only for agent-task run-plans*, but it runs for **generic** execs too. After finding no agent-task workload on the result, it fell through to:

```rust
let envelope = parse_offloaded_run_plan_envelope(stdout)?; // <- hard error on non-JSON stdout
```

feeding the command's **plain stdout** (`pwd` output, a fuzz JSON report, empty, etc.) to the run-plan envelope parser, whose `?` propagated `internal.json_error` and failed the whole controller exec.

## Fix

Make the persisted-events recovery treat a non-run-plan stdout as *"no agent-task event to recover"* rather than a fatal error. Only an actual agent-task run-plan envelope now hydrates a lifecycle event; anything else returns `Ok(None)` and falls through to the ordinary runner-job snapshot projection — preserving the remote exit code and the `--raw`/`--json` output contracts. The recovery contract for genuine run-plan results is unchanged (one-line-plus guard, no behavior change for agent-task dispatch).

## Acceptance criteria
- [x] Generic `runner exec` succeeds through a connected daemon.
- [x] Plain-text command output does not enter (fail) agent-task run-plan parsing.
- [x] `--raw` and `--json` preserve their documented output contracts (projection change only; envelope/exit-code path untouched).
- [x] Regression test exercises `pwd`/empty/non-JSON stdout, plus a **non-zero-exit JSON** result, through the daemon runner-exec recovery path.

## Tests
- `generic_runner_exec_plain_stdout_recovers_no_agent_task_event` — `pwd` output, empty, multiline, and malformed JSON stdout all recover `Ok(None)` (no error). **Temp-disable-proven**: reverting the guard reproduces the exact `parse offloaded agent-task run-plan output` failure.
- `generic_runner_exec_nonzero_exit_with_json_stdout_recovers_no_agent_task_event` — a strict workload emitting valid JSON while exiting non-zero still recovers no agent-task event.
- `persisted_run_plan_envelope_in_stdout_still_recovers_event` — the real run-plan recovery contract is preserved.

Pre-existing, unrelated: 2 `terminal_and_reconcile` tests (`pinned_runtime_recovery_...`, `long_pre_submission_setup_...`) fail identically on clean `origin/main` on this VPS (dirty-build runtime-pin mismatch / shared state) — stash-verified, not touched here.

Note: a follow-up issue (referenced in #9459) covers the durable run remaining `running` and declared artifacts not attaching after such a terminal job — out of scope for this parse fix.

Closes #9459