### PR TITLE
fix(audit): command_wrapper_bypass exempts sibling thin wrappers with different return contracts

### DIFF
--- a/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs
+++ b/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs
@@ -80,6 +80,35 @@ const EXEC_SINK_TOKENS: &[&str] = &[
     "process", "invoke",
 ];
 
+/// Whether a body is a *direct delegation* — the exec call is the body's tail
+/// expression rather than a result captured by a `let`-binding to drive further
+/// logic.
+///
+/// A canonical thin wrapper returns the command call directly:
+/// `run(p, &[..])` or `run(p, &[..]).map(trim)`. A short function that merely
+/// *contains* a raw command captures it (`let x = git_output(p, &[..])?;`) to
+/// do more work, and is a genuine bypass. The distinguishing signal is whether
+/// the first meaningful statement/expression binds the value: a leading `let`
+/// (before the arg-vector) means "capture and use", i.e. not a pure delegation.
+fn is_direct_delegation(body: &str) -> bool {
+    // Position of the arg-vector within the body; everything before it is the
+    // call prefix (`run(p, ` etc.). If a `let` binding opens before the
+    // arg-vector, the command result is being captured rather than returned.
+    let Some(argv_at) = argvec_regex().find(body).map(|m| m.start()) else {
+        return false;
+    };
+    let prefix = &body[..argv_at];
+    !prefix_has_binding_keyword(prefix)
+}
+
+/// Whether a body prefix contains a statement-level binding keyword (`let`) as a
+/// whole word — signalling the command result is captured, not returned.
+fn prefix_has_binding_keyword(prefix: &str) -> bool {
+    static LET_RE: std::sync::LazyLock<Regex> =
+        std::sync::LazyLock::new(|| Regex::new(r"\blet\b").expect("valid let regex"));
+    LET_RE.is_match(prefix)
+}
+
 /// Whether a wrapper body passes its arg-vector to an exec sink.
 fn wraps_exec_sink(body: &str) -> bool {
     static CALL_RE: std::sync::LazyLock<Regex> =
@@ -110,6 +139,18 @@ struct WrapperDef {
 fn detect_command_wrapper_bypass(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
     // argvec-key -> canonical wrapper.
     let mut wrappers: HashMap<Vec<String>, WrapperDef> = HashMap::new();
+    // `(file, argv_offset)` of EVERY canonical thin wrapper's own delegation —
+    // including sibling wrappers that wrap an arg-vector already claimed by
+    // another wrapper. A file may define several thin wrappers around the same
+    // command with different return contracts (e.g. an Option-returning
+    // `head_sha` and a Result-returning `get_head_commit`); each is a canonical
+    // definition, not a raw bypass of the other. The flagging pass skips these
+    // offsets so a legitimate sibling wrapper is never reported (advising
+    // callers to "call the other instead" would silently change error
+    // handling). Only the first wrapper per arg-vector wins the `wrappers` map
+    // (the attribution target), but ALL of them are recorded here.
+    let mut wrapper_argv_sites: std::collections::HashSet<(String, usize)> =
+        std::collections::HashSet::new();
 
     for fp in fingerprints {
         if is_test_path(&fp.relative_path) {
@@ -129,6 +170,18 @@ fn detect_command_wrapper_bypass(fingerprints: &[&FileFingerprint]) -> Vec<Findi
             if !wraps_exec_sink(&body) {
                 continue;
             }
+            // A canonical wrapper *directly returns* its delegation: the body is
+            // the exec call as the tail expression (optionally post-processed
+            // with `.map(...)`/`.trim()`), not a `let`-binding that captures the
+            // result to do further work. `fn f() { run(&[...]) }` and
+            // `fn f() { run(&[...]).map(trim) }` are wrappers;
+            // `fn f() { let x = run(&[...])?; use(x); }` is a function that
+            // happens to call the command — a genuine bypass. This is the signal
+            // that separates a sibling wrapper (skip) from an ordinary short
+            // caller (flag).
+            if !is_direct_delegation(&body) {
+                continue;
+            }
             let m = matches[0];
             let elems = argvec_elements(
                 argvec_regex()
@@ -140,10 +193,12 @@ fn detect_command_wrapper_bypass(fingerprints: &[&FileFingerprint]) -> Vec<Findi
             if elems.len() < MIN_ARGV_LEN {
                 continue;
             }
+            let argv_offset = body_offset + m.start();
+            wrapper_argv_sites.insert((fp.relative_path.clone(), argv_offset));
             wrappers.entry(elems).or_insert(WrapperDef {
                 name: name.clone(),
                 file: fp.relative_path.clone(),
-                argv_offset: body_offset + m.start(),
+                argv_offset,
                 is_public,
             });
         }
@@ -167,6 +222,15 @@ fn detect_command_wrapper_bypass(fingerprints: &[&FileFingerprint]) -> Vec<Findi
             inline_test_regions(&fp.content, fp.language.inline_test_region_markers());
         for m in argvec_regex().find_iter(&fp.content) {
             if offset_in_test_region(m.start(), &test_regions) {
+                continue;
+            }
+            // A canonical thin wrapper's own delegation is never a bypass — not
+            // of the wrapper it happens to duplicate the arg-vector of, and not
+            // of itself. This covers sibling wrappers with different return
+            // contracts (Option vs Result) around the same command. Non-wrapper
+            // code (functions doing real work) is not in this set, so genuine
+            // raw bypasses are still flagged.
+            if wrapper_argv_sites.contains(&(fp.relative_path.clone(), m.start())) {
                 continue;
             }
             let inner = argvec_regex()

--- a/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass/tests.rs
+++ b/crates/homeboy-code-audit/src/detectors/command_wrapper_bypass/tests.rs
@@ -29,6 +29,53 @@ fn flags_raw_argvector_that_bypasses_a_thin_wrapper() {
 }
 
 #[test]
+fn does_not_flag_a_sibling_thin_wrapper_with_a_different_return_contract() {
+    // `head_sha` returns Option (best-effort read); `get_head_commit` is a
+    // separate canonical thin wrapper around the SAME arg-vector that returns
+    // Result (error-propagating, for callers that must not silently swallow a
+    // failed rev-parse). Both are legitimate sibling helpers — callers pick the
+    // contract they need. `get_head_commit` is NOT a raw bypass of `head_sha`;
+    // flagging it as one and telling callers to "call head_sha instead" would
+    // downgrade error handling. A thin wrapper delegating an arg-vector is a
+    // canonical definition, not drift.
+    let option_helper = fp(
+        "src/git/primitives_query.rs",
+        "pub fn head_sha(git_root: &Path) -> Option<String> {\n    output_optional(git_root, &[\"rev-parse\", \"HEAD\"])\n}\n",
+    );
+    let result_helper = fp(
+        "src/git/operations_tags.rs",
+        "pub fn get_head_commit(path: &str) -> Result<String> {\n    run_in(path, \"git\", &[\"rev-parse\", \"HEAD\"], \"get HEAD commit\")\n}\n",
+    );
+    let findings = detect_command_wrapper_bypass(&[&option_helper, &result_helper]);
+    assert!(
+        findings.is_empty(),
+        "a sibling thin wrapper around the same arg-vector is a canonical helper, not a bypass; got: {findings:?}"
+    );
+}
+
+#[test]
+fn still_flags_a_raw_call_in_a_non_wrapper_function_even_beside_sibling_wrappers() {
+    // Guard against over-suppression: the sibling-wrapper skip must be scoped to
+    // genuine thin wrappers. A raw arg-vector inside a function that does real
+    // work (not a one-call delegation) is still a bypass.
+    let helper = fp(
+        "src/git/primitives_query.rs",
+        "pub fn head_sha(git_root: &Path) -> Option<String> {\n    output_optional(git_root, &[\"rev-parse\", \"HEAD\"])\n}\n",
+    );
+    let user = fp(
+        "src/finalization/backend.rs",
+        "fn go(path: &str) {\n    let before = do_setup(path);\n    let head = git_output(path, &[\"rev-parse\", \"HEAD\"])?;\n    finalize(before, head);\n}\n",
+    );
+    let findings = detect_command_wrapper_bypass(&[&helper, &user]);
+    assert_eq!(
+        findings.len(),
+        1,
+        "raw call in a working function is still a bypass"
+    );
+    assert_eq!(findings[0].file, "src/finalization/backend.rs");
+}
+
+#[test]
 fn does_not_flag_the_wrapper_definition_itself() {
     let helper = fp(
         "src/git/primitives_query.rs",


### PR DESCRIPTION
## The false positive
`command_wrapper_bypass` (issue #9498, 52 findings) matches raw calls to a canonical helper purely by **byte-identical arg-vector**, ignoring the return contract. So a legitimate **sibling thin wrapper** around the same command gets flagged as bypassing whichever was registered first.

Concrete case in the current findings:
- `head_sha(git_root) -> Option<String>` wraps `&["rev-parse", "HEAD"]` (best-effort read)
- `get_head_commit(path) -> Result<String>` wraps the *same* `&["rev-parse", "HEAD"]` (error-propagating)

The detector flags `get_head_commit` as "duplicates helper `head_sha`" and advises "call `head_sha` instead." **That advice is wrong** — `get_head_commit` exists precisely so its **12+ callers** can propagate errors instead of silently swallowing a failed `rev-parse`. Two sibling wrappers with different contracts are both canonical; neither bypasses the other. Same story for `get_git_root` (Result) vs `toplevel`/`repo_root` (Option).

## Fix
1. Record the arg-vector offset of **every** canonical thin wrapper (not just the first per arg-vector), and skip those offsets in the flagging pass.
2. Tighten the wrapper definition to a **direct delegation** — the exec call must be the body's tail expression (optionally `.map`/`.trim`), not a result captured by a `let`-binding.

That second point is the key discriminator, and it's what keeps the fix from over-suppressing:
- `fn f() { run(p, &[..]) }` / `fn f() { run(p, &[..]).map(trim) }` → **sibling wrapper, skip**
- `fn f() { let x = git_output(p, &[..])?; use(x); }` → **short function that merely contains a raw command, still flagged**

## Verification
- Two new regression tests, both proven:
  - `does_not_flag_a_sibling_thin_wrapper_with_a_different_return_contract` (head_sha vs get_head_commit → zero findings)
  - `still_flags_a_raw_call_in_a_non_wrapper_function_even_beside_sibling_wrappers` (let-binding in a working function → still flagged — guards against over-suppression)
- All 12 `command_wrapper_bypass` tests + **full audit crate (827 tests) green**.

## Effect
Deflates the `command_wrapper_bypass` count (#9498) by removing the Result-wrapper false positives, leaving the genuine raw-bypass sites — which I'll then fix in a follow-up (routing the true already-Option sites like `detect_git_root` onto `repo_root`/`toplevel`). Same detector-quality-then-cook pattern as #9311/#9320/#9329.
