### PR TITLE
refactor(core): route genuine git-toplevel/short-HEAD bypasses onto canonical helpers

### DIFF
--- a/crates/homeboy-core/src/component/inventory/path_diagnostics.rs
+++ b/crates/homeboy-core/src/component/inventory/path_diagnostics.rs
@@ -1,6 +1,6 @@
 use crate::component::Component;
 use crate::engine::shell::quote_path;
-use crate::git::{output_optional, run_git_output};
+use crate::git::output_optional;
 use crate::transient_workspace_policy::TransientWorkspacePolicy;
 use std::path::{Path, PathBuf};
 
@@ -78,7 +78,7 @@ pub(super) fn local_path_diagnostic_for(
             .and_then(|path| output_optional(path, &["rev-parse", "--abbrev-ref", "HEAD"])),
         head: git_root_path
             .as_ref()
-            .and_then(|path| output_optional(path, &["rev-parse", "--short", "HEAD"])),
+            .and_then(|path| crate::git::head_sha_short(path)),
         remote_url: git_root_path
             .as_ref()
             .and_then(|path| output_optional(path, &["config", "--get", "remote.origin.url"])),
@@ -118,16 +118,10 @@ pub(super) fn detect_git_root(path: &Path) -> Option<PathBuf> {
         return Some(path.to_path_buf());
     }
 
-    let output = run_git_output(path, &["rev-parse", "--show-toplevel"], "git rev-parse").ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if raw.is_empty() {
-        None
-    } else {
-        Some(PathBuf::from(raw))
-    }
+    // Fall back to `rev-parse --show-toplevel` via the canonical `repo_root`
+    // helper (trimmed, non-empty toplevel as a `PathBuf`) instead of assembling
+    // the raw arg-vector. The `.git`-exists fast path above is preserved.
+    crate::git::repo_root(path)
 }
 
 fn shell_quote_for_hint(value: &str) -> String {

--- a/crates/homeboy-core/src/component/resolution.rs
+++ b/crates/homeboy-core/src/component/resolution.rs
@@ -2,7 +2,7 @@ use crate::component::{
     discover_from_portable, inventory, load, try_discover_from_portable, Component,
 };
 use crate::error::{Error, Result};
-use crate::git::{run_git, run_git_output};
+use crate::git::run_git;
 use homeboy_extension_contract::ExtensionCapability;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -504,17 +504,13 @@ fn path_strictly_contains(parent: &Path, child: &Path) -> bool {
 }
 
 /// Find the git root directory for a given path.
+///
+/// Delegates to the canonical [`crate::git::repo_root`] helper — which runs
+/// `rev-parse --show-toplevel` and returns the trimmed, non-empty toplevel as a
+/// `PathBuf` on success — rather than assembling the raw arg-vector here. The
+/// observable contract (best-effort `Option<PathBuf>`) is unchanged.
 pub fn detect_git_root(dir: &Path) -> Option<PathBuf> {
-    let output = run_git_output(dir, &["rev-parse", "--show-toplevel"], "git root").ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if !path.is_empty() {
-        return Some(PathBuf::from(path));
-    }
-    None
+    crate::git::repo_root(dir)
 }
 
 /// Resolve a Component from an optional ID, with CWD auto-discovery fallback.


### PR DESCRIPTION
## Companion to #9526
#9526 fixes the detector false-positive (Result-returning sibling wrappers wrongly flagged). **This PR fixes the genuine bypasses** — sites that already return the same best-effort `Option` contract as the canonical `homeboy_core::git` helpers, but assemble the raw arg-vector instead of calling them.

## Sites migrated (all behavior-preserving)
- **`component/resolution.rs::detect_git_root`** — raw `rev-parse --show-toplevel` + success/trim/non-empty → delegates to `git::repo_root` (identical semantics, 8 callers untouched).
- **`component/inventory/path_diagnostics.rs` head field** — raw `rev-parse --short HEAD` via `output_optional` → `git::head_sha_short`.
- **`component/inventory/path_diagnostics.rs::detect_git_root`** — raw `rev-parse --show-toplevel` tail → `git::repo_root` (the `.git`-exists fast path is preserved).

Each is exactly equivalent: `repo_root` is `toplevel().map(PathBuf::from)` where `toplevel` = `output_optional(&["rev-parse","--show-toplevel"])` = success + trim + non-empty — precisely what the hand-rolled versions did. `head_sha_short` = `output_optional(&["rev-parse","--short","HEAD"])`, identical to the inlined call. Dropped the now-unused `run_git_output` imports.

## Deliberately left alone
The `rev-parse --abbrev-ref HEAD`, `@{u}`, and `config --get remote.origin.url` reads in `path_diagnostics` — no matching helper exists, and (correctly) the detector doesn't flag them.

## Verification
- `component::resolution` 36 passed, `git::` 200 passed, `cargo check -p homeboy-core --lib` clean with no new warnings.
