### PR TITLE
fix(runtime): close remaining run retention gaps

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -462,19 +462,27 @@ fn compare_adoption_gate_failures_to_base(
             )?;
             let command = gate.command.last().cloned().unwrap_or_default();
             let baseline_run_dir = homeboy_core::engine::run_dir::RunDir::create()?;
-            let baseline_runtime = homeboy_core::engine::invocation::InvocationGuard::acquire(
-                &baseline_run_dir,
-                &homeboy_core::engine::invocation::InvocationRequirements::default(),
-            )?;
-            let baseline = run_gate_command_with_timeout(
-                &baseline_path,
-                index + 1,
-                &command,
-                gate.visibility,
-                gate.reveal_policy,
-                &baseline_runtime.context().tmp_dir,
-                std::time::Duration::from_secs(5 * 60),
-            )?;
+            let baseline = match (|| {
+                let baseline_runtime = homeboy_core::engine::invocation::InvocationGuard::acquire(
+                    &baseline_run_dir,
+                    &homeboy_core::engine::invocation::InvocationRequirements::default(),
+                )?;
+                run_gate_command_with_timeout(
+                    &baseline_path,
+                    index + 1,
+                    &command,
+                    gate.visibility,
+                    gate.reveal_policy,
+                    &baseline_runtime.context().tmp_dir,
+                    std::time::Duration::from_secs(5 * 60),
+                )
+            })() {
+                Ok(baseline) => baseline,
+                Err(error) => {
+                    baseline_run_dir.finish(false);
+                    return Err(error);
+                }
+            };
             let candidate_fingerprint = failure_fingerprint(&gate.stdout, &gate.stderr);
             let baseline_fingerprint = failure_fingerprint(&baseline.stdout, &baseline.stderr);
             let matches = baseline.status == AgentTaskGateStatus::Failed
@@ -489,6 +497,7 @@ fn compare_adoption_gate_failures_to_base(
             if matches {
                 gate.accept_inherited_failure();
             }
+            baseline_run_dir.finish(true);
         }
         Ok(all_failures_inherited)
     })();

--- a/crates/homeboy-cli/src/commands/report/bench_coverage.rs
+++ b/crates/homeboy-cli/src/commands/report/bench_coverage.rs
@@ -4,7 +4,9 @@ use serde::Serialize;
 use homeboy::core::component::{self, Component};
 use homeboy::core::engine::execution_context::{self, ResolveOptions};
 use homeboy::core::engine::run_dir::RunDir;
-use homeboy_extension::bench::{run_bench_list_workflow, BenchListWorkflowArgs, BenchScenario};
+use homeboy_extension::bench::{
+    run_bench_list_workflow, BenchListWorkflowArgs, BenchListWorkflowResult, BenchScenario,
+};
 use homeboy_extension::{resolve_extension_for_capability, ExtensionCapability};
 
 use crate::commands::escape_markdown_table_cell;
@@ -148,19 +150,25 @@ fn component_report(
         &run_dir,
     );
 
+    Ok(finish_component_report(component, &run_dir, list))
+}
+
+fn finish_component_report(
+    component: &Component,
+    run_dir: &RunDir,
+    list: homeboy::core::Result<BenchListWorkflowResult>,
+) -> ComponentBenchCoverage {
     let list = match list {
         Ok(list) => list,
         Err(error) => {
-            return Ok(empty_capability_error(component, error));
+            run_dir.finish(false);
+            return empty_capability_error(component, error);
         }
     };
 
-    Ok(build_component_report(
-        component.id.clone(),
-        true,
-        &list.scenarios,
-        None,
-    ))
+    let report = build_component_report(component.id.clone(), true, &list.scenarios, None);
+    run_dir.finish(true);
+    report
 }
 
 fn empty_capability_error(
@@ -439,5 +447,43 @@ mod tests {
         let markdown = render_markdown(&report);
         assert!(markdown.contains("`audit-self`"));
         assert!(markdown.contains("| `lint` | no | - |"));
+    }
+
+    #[test]
+    fn component_report_disposes_success_and_retains_workflow_errors() {
+        crate::test_support::with_isolated_home(|_| {
+            let component =
+                Component::new("fixture".to_string(), ".".to_string(), String::new(), None);
+            let success_run = RunDir::create().expect("success run");
+            let success_path = success_run.path().to_path_buf();
+            let report = finish_component_report(
+                &component,
+                &success_run,
+                Ok(BenchListWorkflowResult {
+                    component: "fixture".to_string(),
+                    component_id: "fixture".to_string(),
+                    scenarios: vec![scenario("audit-self")],
+                    count: 1,
+                    profiles: Vec::new(),
+                    hints: Vec::new(),
+                    rig_package: None,
+                }),
+            );
+            assert_eq!(report.scenarios.len(), 1);
+            assert!(!success_path.exists());
+
+            let failed_run = RunDir::create().expect("failed run");
+            let failed_path = failed_run.path().to_path_buf();
+            let report = finish_component_report(
+                &component,
+                &failed_run,
+                Err(homeboy::core::Error::internal_io(
+                    "bench list failed".to_string(),
+                    None,
+                )),
+            );
+            assert!(report.error.is_some());
+            assert!(failed_path.exists());
+        });
     }
 }

--- a/crates/homeboy-cli/src/commands/trace.rs
+++ b/crates/homeboy-cli/src/commands/trace.rs
@@ -482,11 +482,13 @@ fn run_outputs(mut args: TraceArgs) -> CmdResult<(TraceCommandOutput, Option<Tra
     let profile = resolved_profile_output_for_args(&args);
     let span_metadata = trace_span_metadata_for_args(&args)?;
     let execution = execute_trace_run(args)?;
+    let workflow_succeeded =
+        execution.workflow.exit_code == 0 && execution.workflow.status == "pass";
 
     let (mut stdout_output, mut artifact_output, exit_code) =
         extension_trace::from_main_workflow_outputs(
-            execution.workflow,
-            execution.rig_state,
+            execution.workflow.clone(),
+            execution.rig_state.clone(),
             summary_only,
         );
     extension_trace::attach_span_summary_metadata(&mut stdout_output, &span_metadata);
@@ -495,6 +497,7 @@ fn run_outputs(mut args: TraceArgs) -> CmdResult<(TraceCommandOutput, Option<Tra
         extension_trace::attach_span_summary_metadata(output, &span_metadata);
         attach_profile_output(output, profile);
     }
+    execution.finish(workflow_succeeded);
     Ok(((stdout_output, artifact_output), exit_code))
 }
 
@@ -584,14 +587,24 @@ fn execute_trace_run_impl(args: TraceArgs) -> homeboy::core::Result<TraceRunExec
         .as_ref()
         .map(|context| rig::snapshot_state(&context.rig_spec));
     let run_dir = RunDir::create()?;
-    run_trace_experiment_setup_for_plan(experiment_plan.as_ref(), &run_dir)?;
-    let experiment_settings = trace_experiment_settings(experiment_plan.as_ref())?;
-    let mut experiment_env = trace_experiment_env(experiment_plan.as_ref())?;
+    retain_trace_error(
+        &run_dir,
+        run_trace_experiment_setup_for_plan(experiment_plan.as_ref(), &run_dir),
+    )?;
+    let experiment_settings = retain_trace_error(
+        &run_dir,
+        trace_experiment_settings(experiment_plan.as_ref()),
+    )?;
+    let mut experiment_env =
+        retain_trace_error(&run_dir, trace_experiment_env(experiment_plan.as_ref()))?;
     experiment_env.extend(args.matrix_env.clone());
-    let trace_secret_env_status = hydrate_trace_secret_env(
-        &args.secret_env,
-        Some(&ctx.component_id),
-        &mut experiment_env,
+    let trace_secret_env_status = retain_trace_error(
+        &run_dir,
+        hydrate_trace_secret_env(
+            &args.secret_env,
+            Some(&ctx.component_id),
+            &mut experiment_env,
+        ),
     )?;
     let scenario_id = scenario.clone();
     let rig_id = args.rig.clone();
@@ -642,11 +655,15 @@ fn execute_trace_run_impl(args: TraceArgs) -> homeboy::core::Result<TraceRunExec
     let (extra_workloads, trace_dependencies, runner_capabilities, invocation_requirements) =
         trace_workload_inputs(rig_context.as_ref(), ctx.extension_id.as_deref());
     warn_rig_owned_trace_workload_expansion(rig_context.as_ref(), ctx.extension_id.as_deref());
-    let trace_probes =
-        trace_probes_for_args(&args, rig_context.as_ref(), ctx.extension_id.as_deref())?;
-    let public_preview =
-        trace_public_preview_for_args(&args, rig_context.as_ref(), ctx.extension_id.as_deref())?;
-    let attachments = TraceAttachment::parse_all(&args.attachments)?;
+    let trace_probes = retain_trace_error(
+        &run_dir,
+        trace_probes_for_args(&args, rig_context.as_ref(), ctx.extension_id.as_deref()),
+    )?;
+    let public_preview = retain_trace_error(
+        &run_dir,
+        trace_public_preview_for_args(&args, rig_context.as_ref(), ctx.extension_id.as_deref()),
+    )?;
+    let attachments = retain_trace_error(&run_dir, TraceAttachment::parse_all(&args.attachments))?;
     let resolved_settings = ctx.resolved_settings();
     let mut json_settings = experiment_settings;
     json_settings.extend(resolved_settings.json_overrides());
@@ -656,7 +673,7 @@ fn execute_trace_run_impl(args: TraceArgs) -> homeboy::core::Result<TraceRunExec
             .into_iter()
             .map(|(key, value)| (key, serde_json::Value::String(value))),
     );
-    let workflow = match extension_trace::run_trace_workflow(
+    let mut workflow = match extension_trace::run_trace_workflow(
         &ctx.component,
         TraceRunWorkflowArgs {
             component_label: effective_id.clone(),
@@ -704,8 +721,8 @@ fn execute_trace_run_impl(args: TraceArgs) -> homeboy::core::Result<TraceRunExec
             );
             let teardown_result =
                 run_trace_experiment_teardown_for_plan(experiment_plan.as_ref(), &run_dir);
-            artifact_result?;
-            teardown_result?;
+            retain_trace_error(&run_dir, artifact_result)?;
+            retain_trace_error(&run_dir, teardown_result)?;
             workflow
         }
         Err(error) => {
@@ -713,12 +730,17 @@ fn execute_trace_run_impl(args: TraceArgs) -> homeboy::core::Result<TraceRunExec
             if let Some(observation) = observation.as_ref() {
                 persist_trace_workflow_error(observation, &run_dir, &error);
             }
+            run_dir.finish(false);
             return Err(error);
         }
     };
-    if let Some(observation) = observation.as_ref() {
-        persist_trace_workflow_result(observation, &run_dir, &workflow, rig_state.as_ref());
-    }
+    let artifact_observation = observation
+        .as_ref()
+        .map(|observation| {
+            persist_trace_workflow_result(observation, &run_dir, &mut workflow, rig_state.as_ref())
+        })
+        .unwrap_or_default();
+    let evidence_promoted = artifact_observation.evidence_promoted();
 
     let run_id = observation
         .as_ref()
@@ -727,9 +749,22 @@ fn execute_trace_run_impl(args: TraceArgs) -> homeboy::core::Result<TraceRunExec
     Ok(TraceRunExecution {
         workflow,
         run_dir,
+        artifact_path: artifact_observation.trace_results_path,
+        artifact_dir: artifact_observation.artifact_dir_path,
+        evidence_promoted,
         rig_state,
         run_id,
     })
+}
+
+fn retain_trace_error<T>(
+    run_dir: &RunDir,
+    result: homeboy::core::Result<T>,
+) -> homeboy::core::Result<T> {
+    if result.is_err() {
+        run_dir.finish(false);
+    }
+    result
 }
 
 fn trace_scenario(args: &TraceArgs) -> homeboy::core::Result<&str> {
@@ -798,9 +833,16 @@ fn run_list(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
             rig_id: args.rig,
         },
         &run_dir,
-    )?;
-
-    Ok(extension_trace::from_list_workflow(effective_id, list))
+    );
+    let output = match list {
+        Ok(list) => extension_trace::from_list_workflow(effective_id, list),
+        Err(error) => {
+            run_dir.finish(false);
+            return Err(error);
+        }
+    };
+    run_dir.finish(true);
+    Ok(output)
 }
 
 struct TraceRigContext {

--- a/crates/homeboy-cli/src/commands/trace/compare_targets.rs
+++ b/crates/homeboy-cli/src/commands/trace/compare_targets.rs
@@ -522,11 +522,7 @@ impl TargetAggregateBuilder {
         if !passed {
             self.failure_count += 1;
         }
-        let artifact_path = execution
-            .run_dir
-            .step_file(homeboy::core::engine::run_dir::files::TRACE_RESULTS)
-            .to_string_lossy()
-            .to_string();
+        let artifact_path = execution.artifact_path();
         let mut seen_span_ids = BTreeSet::new();
         if let Some(results) = execution.workflow.results.as_ref() {
             for (metric, value) in &results.metrics {
@@ -577,6 +573,7 @@ impl TargetAggregateBuilder {
                     .as_ref()
                     .and_then(|results| results.failure.clone())
             });
+        execution.finish(passed);
         self.runs.push(extension_trace::TraceAggregateRunOutput {
             index,
             passed,

--- a/crates/homeboy-cli/src/commands/trace/experiment_tests.rs
+++ b/crates/homeboy-cli/src/commands/trace/experiment_tests.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 
 use crate::commands::utils::args::{BaselineArgs, PositionalComponentArgs, SettingArgs};
 use crate::test_support::with_isolated_home;
@@ -173,23 +174,26 @@ fn trace_experiment_runs_setup_settings_artifacts_and_teardown() {
             fs::read_to_string(component_dir.path().join("teardown.txt")).expect("teardown marker"),
             "teardown"
         );
-        let results = execution.workflow.results.expect("results");
-        assert!(results.artifacts.iter().any(|artifact| {
-            artifact.label == "setup state"
-                && artifact.path == "artifacts/experiments/template/01-experiment-state.txt"
-        }));
+        let run_path = execution.run_dir.path().to_path_buf();
+        let durable_artifact = execution
+            .workflow
+            .results
+            .as_ref()
+            .expect("results")
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.label == "setup state")
+            .expect("setup artifact")
+            .path
+            .clone();
+        assert!(!Path::new(&durable_artifact).starts_with(&run_path));
         assert_eq!(
-            fs::read_to_string(
-                execution
-                    .run_dir
-                    .path()
-                    .join("artifacts/experiments/template/01-experiment-state.txt")
-            )
-            .expect("collected artifact"),
+            fs::read_to_string(&durable_artifact).expect("persisted collected artifact"),
             "setup"
         );
+        let durable_artifact_dir = execution.artifact_dir();
         let settings_json: serde_json::Value = serde_json::from_str(
-            &fs::read_to_string(execution.run_dir.path().join("artifacts/settings.json"))
+            &fs::read_to_string(Path::new(&durable_artifact_dir).join("settings.json"))
                 .expect("settings artifact"),
         )
         .expect("settings json");
@@ -202,6 +206,12 @@ fn trace_experiment_runs_setup_settings_artifacts_and_teardown() {
                     .to_string_lossy()
                     .to_string()
             )
+        );
+        execution.finish(true);
+        assert!(!run_path.exists());
+        assert_eq!(
+            fs::read_to_string(durable_artifact).expect("artifact survives scratch cleanup"),
+            "setup"
         );
     });
 }
@@ -224,5 +234,26 @@ fn trace_experiment_runs_teardown_when_trace_fails() {
             fs::read_to_string(component_dir.path().join("teardown.txt")).expect("teardown marker"),
             "teardown"
         );
+        let run_path = execution.run_dir.path().to_path_buf();
+        execution.finish(false);
+        assert!(run_path.exists());
+    });
+}
+
+#[test]
+fn trace_success_retains_scratch_when_postprocessing_fails() {
+    with_isolated_home(|home| {
+        write_trace_experiment_extension(home, false);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        write_trace_experiment_rig(home, component_dir.path());
+
+        let mut args = trace_args_for_rig("studio-rig", "product-workflow");
+        args.experiment = Some("template".to_string());
+        let execution = execute_trace_run(args).expect("trace experiment should run");
+        assert_eq!(execution.workflow.exit_code, 0);
+
+        let run_path = execution.run_dir.path().to_path_buf();
+        execution.finish(false);
+        assert!(run_path.exists());
     });
 }

--- a/crates/homeboy-cli/src/commands/trace/matrix.rs
+++ b/crates/homeboy-cli/src/commands/trace/matrix.rs
@@ -214,22 +214,17 @@ pub(super) fn run_scenario_matrix(args: TraceArgs) -> CmdResult<TraceCommandOutp
                         execution.workflow.exit_code == 0 && execution.workflow.status == "pass";
                     let stdout_output = extension_trace::from_main_workflow(
                         execution.workflow.clone(),
-                        execution.rig_state,
+                        execution.rig_state.clone(),
                         false,
                     )
                     .0;
-                    write_json_artifact(&output_path, &stdout_output)?;
-                    let artifact_path = execution
-                        .run_dir
-                        .step_file(homeboy::core::engine::run_dir::files::TRACE_RESULTS)
-                        .to_string_lossy()
-                        .to_string();
-                    let artifact_dir = execution
-                        .run_dir
-                        .path()
-                        .join("artifacts")
-                        .to_string_lossy()
-                        .to_string();
+                    if let Err(error) = write_json_artifact(&output_path, &stdout_output) {
+                        execution.finish(false);
+                        return Err(error);
+                    }
+                    let artifact_path = execution.artifact_path();
+                    let artifact_dir = execution.artifact_dir();
+                    execution.finish(passed);
                     (
                         passed,
                         execution.workflow.status,

--- a/crates/homeboy-cli/src/commands/trace/observation_lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/trace/observation_lifecycle.rs
@@ -158,9 +158,9 @@ pub(crate) fn finish_lab_dispatch_observation(
 pub(super) fn persist_trace_workflow_result(
     observation: &ActiveTraceObservation,
     run_dir: &RunDir,
-    workflow: &extension_trace::TraceRunWorkflowResult,
+    workflow: &mut extension_trace::TraceRunWorkflowResult,
     rig_state: Option<&rig::RigStateSnapshot>,
-) {
+) -> observations::TraceArtifactObservationResult {
     let run_status = trace_run_status(workflow);
     let baseline_status = baseline_status(workflow);
     let results = workflow.results.as_ref();
@@ -221,6 +221,9 @@ pub(super) fn persist_trace_workflow_result(
         run_dir,
         results,
     );
+    if let Some(results) = workflow.results.as_mut() {
+        artifact_observation.rewrite_declared_artifact_paths(results);
+    }
     let finish_status =
         if run_status == RunStatus::Pass && artifact_observation.has_declared_artifact_failures() {
             RunStatus::Fail
@@ -236,6 +239,7 @@ pub(super) fn persist_trace_workflow_result(
             Some(&artifact_observation),
         )),
     );
+    artifact_observation
 }
 
 pub(super) fn persist_trace_workflow_error(

--- a/crates/homeboy-cli/src/commands/trace/observations.rs
+++ b/crates/homeboy-cli/src/commands/trace/observations.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use homeboy::core::engine::run_dir::RunDir;
@@ -10,11 +11,29 @@ use extension_trace::resolve_declared_trace_artifact_path;
 pub(super) struct TraceArtifactObservationResult {
     pub missing_declared_artifacts: usize,
     pub invalid_declared_artifacts: usize,
+    pub persistence_failures: usize,
+    pub trace_results_path: Option<String>,
+    pub artifact_dir_path: Option<String>,
+    pub declared_artifact_paths: BTreeMap<String, String>,
 }
 
 impl TraceArtifactObservationResult {
     pub fn has_declared_artifact_failures(&self) -> bool {
         self.missing_declared_artifacts > 0 || self.invalid_declared_artifacts > 0
+    }
+
+    pub fn evidence_promoted(&self) -> bool {
+        self.trace_results_path.is_some()
+            && !self.has_declared_artifact_failures()
+            && self.persistence_failures == 0
+    }
+
+    pub fn rewrite_declared_artifact_paths(&self, results: &mut extension_trace::TraceResults) {
+        for artifact in &mut results.artifacts {
+            if let Some(path) = self.declared_artifact_paths.get(&artifact.path) {
+                artifact.path = path.clone();
+            }
+        }
     }
 }
 
@@ -27,15 +46,17 @@ pub(super) fn record_trace_artifacts(
     let mut observation_result = TraceArtifactObservationResult::default();
     let trace_results_path =
         run_dir.step_file(homeboy::core::engine::run_dir::files::TRACE_RESULTS);
-    record_artifact_if_file(store, run_id, "trace-results", &trace_results_path);
+    observation_result.trace_results_path =
+        record_artifact_if_file(store, run_id, "trace-results", &trace_results_path);
+    if trace_results_path.is_file() && observation_result.trace_results_path.is_none() {
+        observation_result.persistence_failures += 1;
+    }
     let artifact_dir = run_dir.path().join("artifacts");
-    let mut recorded_declared_directory = false;
     if let Some(results) = results {
         for artifact in &results.artifacts {
             if let Some(resolved) =
                 declared_trace_artifact_candidate(artifact, run_dir, &artifact_dir)
             {
-                let is_declared_directory = resolved.is_dir();
                 record_declared_artifact(
                     store,
                     run_id,
@@ -44,7 +65,6 @@ pub(super) fn record_trace_artifacts(
                     &resolved,
                     &mut observation_result,
                 );
-                recorded_declared_directory |= is_declared_directory;
             } else {
                 record_unresolved_declared_artifact(
                     store,
@@ -56,8 +76,11 @@ pub(super) fn record_trace_artifacts(
             }
         }
     }
-    if !recorded_declared_directory {
-        record_artifact_dir_if_non_empty(store, run_id, "trace-artifacts", &artifact_dir);
+    let artifact_dir_exists = artifact_dir.is_dir();
+    observation_result.artifact_dir_path =
+        record_artifact_dir(store, run_id, "trace-artifacts", &artifact_dir);
+    if artifact_dir_exists && observation_result.artifact_dir_path.is_none() {
+        observation_result.persistence_failures += 1;
     }
     observation_result
 }
@@ -84,26 +107,34 @@ fn declared_trace_artifact_candidate(
     Some(run_dir.path().join(relative))
 }
 
-fn record_artifact_if_file(store: &ObservationStore, run_id: &str, kind: &str, path: &Path) {
-    if path.is_file() {
-        let _ = store.record_artifact(run_id, kind, path);
-    }
-}
-
-fn record_artifact_dir_if_non_empty(
+fn record_artifact_if_file(
     store: &ObservationStore,
     run_id: &str,
     kind: &str,
     path: &Path,
-) {
-    if path.is_dir()
-        && std::fs::read_dir(path)
+) -> Option<String> {
+    if path.is_file() {
+        return store
+            .record_artifact(run_id, kind, path)
             .ok()
-            .and_then(|mut entries| entries.next())
-            .is_some()
-    {
-        let _ = store.record_directory_artifact(run_id, kind, path);
+            .map(|artifact| artifact.path);
     }
+    None
+}
+
+fn record_artifact_dir(
+    store: &ObservationStore,
+    run_id: &str,
+    kind: &str,
+    path: &Path,
+) -> Option<String> {
+    if path.is_dir() {
+        return store
+            .record_directory_artifact(run_id, kind, path)
+            .ok()
+            .map(|artifact| artifact.path);
+    }
+    None
 }
 
 fn record_declared_artifact(
@@ -174,21 +205,29 @@ fn record_declared_artifact(
         return;
     };
 
-    if let Err(error) = record_result {
-        result.invalid_declared_artifacts += 1;
-        record_declared_artifact_finding(
-            store,
-            run_id,
-            "trace.artifact.record_failed",
-            "error",
-            format!(
-                "trace result declared artifact '{}' at '{}' could not be persisted: {}",
-                artifact.label, artifact.path, error.message
-            ),
-            artifact,
-            run_root,
-            resolved,
-        );
+    match record_result {
+        Ok(record) => {
+            result
+                .declared_artifact_paths
+                .insert(artifact.path.clone(), record.path);
+        }
+        Err(error) => {
+            result.invalid_declared_artifacts += 1;
+            result.persistence_failures += 1;
+            record_declared_artifact_finding(
+                store,
+                run_id,
+                "trace.artifact.record_failed",
+                "error",
+                format!(
+                    "trace result declared artifact '{}' at '{}' could not be persisted: {}",
+                    artifact.label, artifact.path, error.message
+                ),
+                artifact,
+                run_root,
+                resolved,
+            );
+        }
     }
 }
 
@@ -319,6 +358,11 @@ mod tests {
                 )
                 .expect("run");
             let run_dir = RunDir::create().expect("run dir");
+            std::fs::write(
+                run_dir.step_file(homeboy::core::engine::run_dir::files::TRACE_RESULTS),
+                "{}",
+            )
+            .expect("trace results");
             let browser_dir = run_dir
                 .path()
                 .join("artifacts/provider-artifacts/runtime-abc/files/browser");
@@ -327,13 +371,14 @@ mod tests {
                 .expect("write network");
             std::fs::write(browser_dir.join("console.jsonl"), "{\"text\":\"ok\"}\n")
                 .expect("write console");
-            let results = sample_results(vec![TraceArtifact {
+            let mut results = sample_results(vec![TraceArtifact {
                 label: "Provider browser probe".to_string(),
                 path: "artifacts/provider-artifacts/runtime-abc/files/browser".to_string(),
                 kind: None,
             }]);
 
             let outcome = record_trace_artifacts(&store, &run.id, &run_dir, Some(&results));
+            outcome.rewrite_declared_artifact_paths(&mut results);
             let artifacts = store.list_artifacts(&run.id).expect("artifacts");
             let declared_artifact = artifacts
                 .iter()
@@ -343,7 +388,12 @@ mod tests {
                 .expect("declared trace artifact");
 
             assert!(!outcome.has_declared_artifact_failures());
+            assert!(outcome.evidence_promoted());
             let persisted = PathBuf::from(&declared_artifact.path);
+            assert_eq!(results.artifacts[0].path, declared_artifact.path);
+            let scratch_path = run_dir.path().to_path_buf();
+            run_dir.finish(true);
+            assert!(!scratch_path.exists());
             assert_eq!(
                 std::fs::read_to_string(persisted.join("network.jsonl")).expect("network"),
                 "{\"url\":\"/\"}\n"
@@ -352,7 +402,6 @@ mod tests {
                 std::fs::read_to_string(persisted.join("console.jsonl")).expect("console"),
                 "{\"text\":\"ok\"}\n"
             );
-            run_dir.cleanup();
         });
     }
 
@@ -394,7 +443,9 @@ mod tests {
                 missing_finding.metadata_json["declared_artifact"]["path"],
                 "artifacts/provider-artifacts/runtime-missing/files/browser/network.jsonl"
             );
-            run_dir.cleanup();
+            let scratch_path = run_dir.path().to_path_buf();
+            run_dir.finish(false);
+            assert!(scratch_path.exists());
         });
     }
 }

--- a/crates/homeboy-cli/src/commands/trace/repeat.rs
+++ b/crates/homeboy-cli/src/commands/trace/repeat.rs
@@ -57,11 +57,7 @@ pub(super) fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
                 if !passed {
                     failure_count += 1;
                 }
-                let artifact_path = execution
-                    .run_dir
-                    .step_file(homeboy::core::engine::run_dir::files::TRACE_RESULTS)
-                    .to_string_lossy()
-                    .to_string();
+                let artifact_path = execution.artifact_path();
                 let mut seen_span_ids = BTreeSet::new();
                 if let Some(results) = execution.workflow.results.as_ref() {
                     for (metric, value) in &results.metrics {
@@ -100,6 +96,7 @@ pub(super) fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
                         *span_failures.entry(span_id.clone()).or_default() += 1;
                     }
                 }
+                execution.finish(passed);
                 runs.push(extension_trace::TraceAggregateRunOutput {
                     index,
                     passed,

--- a/crates/homeboy-cli/src/commands/trace/run_service.rs
+++ b/crates/homeboy-cli/src/commands/trace/run_service.rs
@@ -19,12 +19,40 @@ pub(super) struct TraceRunService;
 pub(super) struct TraceRunExecution {
     pub(super) workflow: extension_trace::TraceRunWorkflowResult,
     pub(super) run_dir: RunDir,
+    pub(super) artifact_path: Option<String>,
+    pub(super) artifact_dir: Option<String>,
+    pub(super) evidence_promoted: bool,
     pub(super) rig_state: Option<rig::RigStateSnapshot>,
     /// Observation run id of the child trace run, when an observation store was
     /// available. Surfaced so compare orchestration can link child run records
     /// into the first-class compare pair artifact instead of forcing downstream
     /// reporting to rediscover run ids from artifact directories.
     pub(super) run_id: Option<String>,
+}
+
+impl TraceRunExecution {
+    pub(super) fn artifact_path(&self) -> String {
+        self.artifact_path.clone().unwrap_or_else(|| {
+            self.run_dir
+                .step_file(homeboy::core::engine::run_dir::files::TRACE_RESULTS)
+                .to_string_lossy()
+                .to_string()
+        })
+    }
+
+    pub(super) fn artifact_dir(&self) -> String {
+        self.artifact_dir.clone().unwrap_or_else(|| {
+            self.run_dir
+                .path()
+                .join("artifacts")
+                .to_string_lossy()
+                .to_string()
+        })
+    }
+
+    pub(super) fn finish(&self, success: bool) {
+        self.run_dir.finish(success && self.evidence_promoted);
+    }
 }
 
 impl TraceRunService {


### PR DESCRIPTION
## Summary
- explicitly dispose candidate-adoption baseline gate and bench-coverage run directories after their semantic evidence is copied
- explicitly finalize trace list and normal/repeat/matrix/compare executions, retaining failed or post-processing-error scratch
- promote trace results, declared artifacts, and complete artifact directories through the existing observation store before successful cleanup
- rewrite returned artifact references to durable persisted paths so no output points into deleted runtime scratch
- add path-level success, semantic failure, post-processing failure, and artifact-survival coverage

## RunDir Audit
Audited every production `RunDir::create()` caller. The previously safe build, scoped-lint, promotion, release, refactor, fuzz, bench, observe, and observed-workflow paths retain their explicit terminal handling. This change closes the remaining implicit successful drops in candidate adoption, bench coverage, trace list, and every `TraceRunExecution` consumer.

## Verification
- `cargo test -p homeboy-cli commands::trace -- --test-threads=1` (75 passed)
- `cargo test -p homeboy-cli commands::report::bench_coverage::tests -- --test-threads=1` (3 passed)
- trace artifact persistence tests (2 passed)
- `cargo check -p homeboy-cli -p homeboy-agents` (passed with existing warnings)
- `homeboy review audit homeboy --path /var/lib/datamachine/workspace/homeboy@fix-9518-run-dir-retention-gaps --changed-since origin/main --placement local --profile pr --json-summary` (0 introduced findings)
- `git diff --check origin/main...HEAD` (passed)

Closes #9518