### PR TITLE
refactor(core): route git status --porcelain emptiness check onto status_porcelain helper

### DIFF
--- a/crates/homeboy-core/src/git/operations.rs
+++ b/crates/homeboy-core/src/git/operations.rs
@@ -6,7 +6,7 @@ use crate::error::{Error, Result};
 use crate::output::BulkResult;
 
 use super::operation_output::{run_bulk_ids, GitOutput};
-use super::primitives::{is_git_repo, run_git};
+use super::primitives::is_git_repo;
 use super::{execute_git, resolve_target};
 
 #[derive(Debug, Clone, Serialize)]
@@ -42,13 +42,9 @@ pub fn get_repo_snapshot(path: &str) -> Result<RepoSnapshot> {
         "git branch",
     )?;
 
-    let clean = run_git(
-        Path::new(path),
-        &["status", "--porcelain=v1"],
-        "git status --porcelain",
-    )
-    .map(|output| output.is_empty())
-    .unwrap_or(false);
+    let clean = super::status_porcelain(Path::new(path))
+        .map(|output| output.is_empty())
+        .unwrap_or(false);
 
     let (ahead, behind) = crate::engine::command::run_in_optional(
         path,


### PR DESCRIPTION
## The genuine bypass
`operations.rs` computed a clean-tree check by hand-rolling the raw arg-vector:
```rust
run_git(path, &["status", "--porcelain=v1"], ...).map(|o| o.is_empty()).unwrap_or(false)
```
— a genuine `command_wrapper_bypass` (#9498) of the canonical `homeboy_core::git::status_porcelain`.

**Behavior-preserving:** both return untrimmed porcelain text on success (`run_git` does NOT trim its success stdout; `status_porcelain` is `from_utf8_lossy` with no trim), so `.is_empty()` is byte-identical — clean tree → empty → `clean=true`; dirty tree → same non-empty text → `clean=false`. Dropped the now-unused `run_git` import.

## Deliberately NOT migrated
These are legitimately different, and #9526's detector fix now correctly exempts the sibling-wrapper ones:
- `cleanup.rs::git_root`, `operations_commit.rs` status — `Result`-returning with custom errors / needing raw `Output` bytes for line-parsing.
- `controller_runtime.rs::source_provenance` — uses `output_allow_empty` (returns `Some("")` vs `head_sha`'s `None` on empty — a deliberate contract difference).

Being precise about which sites are true equivalents vs deliberately-different variants is the point — the remaining command_wrapper findings are mostly the latter, which the detector fix (#9526) now handles.

## Verification
- `git::` 200 passed, `cargo check -p homeboy-core --lib` clean, no new warnings.
