### PR TITLE
feat(audit): detect lossy policy projections

### DIFF
--- a/crates/contracts/homeboy-audit-contract/src/finding.rs
+++ b/crates/contracts/homeboy-audit-contract/src/finding.rs
@@ -205,7 +205,8 @@ pub fn finding_confidence(finding: &AuditFinding) -> FindingConfidence {
             | AuditFinding::LayerOwnershipViolation
             | AuditFinding::DeprecationAge
             | AuditFinding::DeadGuard
-            | AuditFinding::MutatingResourceAccess => FindingConfidence::Graph,
+            | AuditFinding::MutatingResourceAccess
+            | AuditFinding::LossyPolicyProjection => FindingConfidence::Graph,
 
             // Convention, naming, body-shape, and similarity findings require judgment.
             _ => FindingConfidence::Heuristic,

--- a/crates/contracts/homeboy-audit-contract/src/finding_kind.rs
+++ b/crates/contracts/homeboy-audit-contract/src/finding_kind.rs
@@ -212,6 +212,9 @@ pub enum AuditFinding {
     /// formatting); orchestration density beyond the configured threshold is a
     /// boundary violation.
     ThinCommandAdapterViolation,
+    /// Policy-bearing state is dropped by an aggregate projection and a
+    /// downstream decision reimplements the authoritative policy seam.
+    LossyPolicyProjection,
 }
 
 impl AuditFinding {
@@ -288,6 +291,7 @@ impl AuditFinding {
             "command_status_contract_violation",
             "command_status_fixture_missing",
             "thin_command_adapter_violation",
+            "lossy_policy_projection",
         ]
     }
 }

--- a/crates/contracts/homeboy-audit-contract/src/fingerprint.rs
+++ b/crates/contracts/homeboy-audit-contract/src/fingerprint.rs
@@ -6,6 +6,11 @@
 //! `FingerprintOutput` envelope. Pure serde types with no dependencies. The
 //! `code_audit` engine consumes these; `extension::fingerprint` re-exports them
 //! and owns the script-runner that produces them.
+//!
+//! Semantic-fact producers must omit facts located in inline test regions.
+//! Core intentionally does not infer language-specific inline-test syntax. It
+//! separately ignores every fact from files whose paths are recognized as test
+//! paths.
 
 /// A hook reference extracted from source code (do_action / apply_filters).
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
@@ -58,7 +63,7 @@ pub struct DeadCodeMarker {
 ///
 /// Language extensions own syntax recognition; core only groups these generic
 /// facts to detect repeated inline construction where a canonical seam exists.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct AggregateLiteral {
     /// Aggregate type name, e.g. a struct/class/interface-backed record.
     pub type_name: String,
@@ -71,7 +76,7 @@ pub struct AggregateLiteral {
 }
 
 /// Extension-reported canonical construction seam for an aggregate type.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct AggregateConstructionSeam {
     /// Aggregate type name this seam constructs.
     pub type_name: String,
@@ -172,24 +177,31 @@ pub struct FingerprintOutput {
     #[serde(default)]
     pub convention_tags: Vec<String>,
     /// Direct aggregate literal construction sites reported by an extension.
+    /// Producers omit sites in inline test regions.
     #[serde(default)]
     pub aggregate_literals: Vec<AggregateLiteral>,
-    /// Canonical construction seams reported by an extension.
+    /// Canonical construction seams reported by an extension. Producers omit
+    /// seams in inline test regions.
     #[serde(default)]
     pub aggregate_construction_seams: Vec<AggregateConstructionSeam>,
-    /// Resolved aggregate definitions used by policy-flow analysis.
+    /// Resolved aggregate definitions used by policy-flow analysis. Producers
+    /// omit definitions in inline test regions.
     #[serde(default)]
     pub aggregate_definitions: Vec<crate::policy_flow::AggregateDefinitionFact>,
-    /// Resolved field reads and writes used by policy-flow analysis.
+    /// Resolved field reads and writes used by policy-flow analysis. Producers
+    /// omit accesses in inline test regions.
     #[serde(default)]
     pub field_accesses: Vec<crate::policy_flow::FieldAccessFact>,
-    /// Resolved aggregate-to-aggregate projection edges.
+    /// Resolved aggregate-to-aggregate projection edges. Producers omit edges
+    /// in inline test regions.
     #[serde(default)]
     pub aggregate_projections: Vec<crate::policy_flow::AggregateProjectionFact>,
-    /// Typed downstream decision branches.
+    /// Typed downstream decision branches. Producers omit branches in inline
+    /// test regions.
     #[serde(default)]
     pub decision_branches: Vec<crate::policy_flow::DecisionBranchFact>,
     /// Resolved calls used to prove delegation to authoritative policy seams.
+    /// Producers omit calls in inline test regions.
     #[serde(default)]
     pub method_calls: Vec<crate::policy_flow::MethodCallFact>,
 }

--- a/crates/contracts/homeboy-audit-contract/src/fingerprint.rs
+++ b/crates/contracts/homeboy-audit-contract/src/fingerprint.rs
@@ -2,7 +2,7 @@
 //!
 //! The typed data an extension's fingerprint script emits about a source file —
 //! hook references, unused/ignored parameters, call sites, dead-code markers,
-//! aggregate literals, and construction seams — plus the top-level
+//! aggregate literals, construction seams, and policy-flow facts — plus the top-level
 //! `FingerprintOutput` envelope. Pure serde types with no dependencies. The
 //! `code_audit` engine consumes these; `extension::fingerprint` re-exports them
 //! and owns the script-runner that produces them.
@@ -177,4 +177,19 @@ pub struct FingerprintOutput {
     /// Canonical construction seams reported by an extension.
     #[serde(default)]
     pub aggregate_construction_seams: Vec<AggregateConstructionSeam>,
+    /// Resolved aggregate definitions used by policy-flow analysis.
+    #[serde(default)]
+    pub aggregate_definitions: Vec<crate::policy_flow::AggregateDefinitionFact>,
+    /// Resolved field reads and writes used by policy-flow analysis.
+    #[serde(default)]
+    pub field_accesses: Vec<crate::policy_flow::FieldAccessFact>,
+    /// Resolved aggregate-to-aggregate projection edges.
+    #[serde(default)]
+    pub aggregate_projections: Vec<crate::policy_flow::AggregateProjectionFact>,
+    /// Typed downstream decision branches.
+    #[serde(default)]
+    pub decision_branches: Vec<crate::policy_flow::DecisionBranchFact>,
+    /// Resolved calls used to prove delegation to authoritative policy seams.
+    #[serde(default)]
+    pub method_calls: Vec<crate::policy_flow::MethodCallFact>,
 }

--- a/crates/contracts/homeboy-audit-contract/src/lib.rs
+++ b/crates/contracts/homeboy-audit-contract/src/lib.rs
@@ -6,7 +6,13 @@ pub use finding::{finding_confidence, Finding, FindingConfidence, Severity};
 pub use finding_kind::AuditFinding;
 pub mod fingerprint;
 pub mod phase_timing;
+pub mod policy_flow;
 pub use phase_timing::ExtensionPhaseTiming;
+pub use policy_flow::{
+    AggregateDefinitionFact, AggregateFieldFact, AggregateProjectionFact, DecisionBranchFact,
+    FactLocation, FieldAccessFact, FieldAccessKind, MethodCallFact, PolicyDecisionSink,
+    PolicyFlowConfig, PolicyFlowRule, ProjectionFieldFact,
+};
 pub mod result;
 pub mod test_mapping;
 pub use fingerprint::{
@@ -146,6 +152,9 @@ pub struct AuditConfig {
     /// adapters over core services.
     #[serde(default, skip_serializing_if = "ThinCommandAdapterConfig::is_empty")]
     pub thin_command_adapter: ThinCommandAdapterConfig,
+    /// Project- or extension-owned declarations for generic policy-flow analysis.
+    #[serde(default, skip_serializing_if = "PolicyFlowConfig::is_empty")]
+    pub policy_flow: PolicyFlowConfig,
 }
 
 impl AuditConfig {
@@ -172,6 +181,7 @@ impl AuditConfig {
             && self.test_wiring.is_empty()
             && self.detector_profile.is_empty()
             && self.thin_command_adapter.is_empty()
+            && self.policy_flow.is_empty()
     }
 
     pub fn merge(&mut self, other: &AuditConfig) {
@@ -210,6 +220,7 @@ impl AuditConfig {
         self.artifact_portability.merge(&other.artifact_portability);
         self.detector_profile.merge(&other.detector_profile);
         self.thin_command_adapter.merge(&other.thin_command_adapter);
+        self.policy_flow.merge(&other.policy_flow);
         for rule in &other.source_policies {
             if !self
                 .source_policies

--- a/crates/contracts/homeboy-audit-contract/src/policy_flow.rs
+++ b/crates/contracts/homeboy-audit-contract/src/policy_flow.rs
@@ -1,0 +1,295 @@
+//! Language-neutral policy-flow facts and detector declarations.
+
+use serde::{Deserialize, Serialize};
+
+/// A source location within the file that emitted the containing fact.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FactLocation {
+    /// One-based source line, or zero when unavailable.
+    #[serde(default)]
+    pub line: usize,
+    /// One-based source column, or zero when unavailable.
+    #[serde(default)]
+    pub column: usize,
+}
+
+/// A field declared by an aggregate.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AggregateFieldFact {
+    pub name: String,
+    /// Canonical field type identity when the extension can resolve it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_id: Option<String>,
+}
+
+/// A resolved aggregate definition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AggregateDefinitionFact {
+    /// Canonical, module-qualified aggregate identity.
+    pub type_id: String,
+    #[serde(default)]
+    pub fields: Vec<AggregateFieldFact>,
+    #[serde(default)]
+    pub location: FactLocation,
+}
+
+/// Whether a field access reads or writes the field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FieldAccessKind {
+    Read,
+    Write,
+}
+
+/// A resolved field read or write within a callable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldAccessFact {
+    pub owner_type_id: String,
+    pub field: String,
+    /// Canonical, module-qualified enclosing function or method identity.
+    pub callable_id: String,
+    pub access: FieldAccessKind,
+    #[serde(default)]
+    pub location: FactLocation,
+}
+
+/// One field copied by an aggregate projection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectionFieldFact {
+    pub source_field: String,
+    pub target_field: String,
+}
+
+/// A transformation from one resolved aggregate type into another.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AggregateProjectionFact {
+    pub source_type_id: String,
+    pub target_type_id: String,
+    /// Canonical identity of the function or method performing the projection.
+    pub callable_id: String,
+    #[serde(default)]
+    pub field_mappings: Vec<ProjectionFieldFact>,
+    #[serde(default)]
+    pub location: FactLocation,
+}
+
+/// A typed match/branch discriminant used by a decision-bearing callable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DecisionBranchFact {
+    pub callable_id: String,
+    /// Canonical type identity of the value being classified.
+    pub domain_type_id: String,
+    /// Stable extension-rendered discriminant identity, not source text.
+    pub discriminant_id: String,
+    #[serde(default)]
+    pub location: FactLocation,
+}
+
+/// A resolved method/function call.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MethodCallFact {
+    pub caller_id: String,
+    pub target_method_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub receiver_type_id: Option<String>,
+    /// Whether the call result directly governs the caller's decision.
+    #[serde(default)]
+    pub result_used_as_decision: bool,
+    /// Canonical decision-domain type governed by the result, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decision_domain_type_id: Option<String>,
+    #[serde(default)]
+    pub location: FactLocation,
+}
+
+/// A downstream decision seam governed by one policy owner.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicyDecisionSink {
+    pub carrier_type_id: String,
+    pub callable_id: String,
+    pub domain_type_id: String,
+}
+
+/// Project- or extension-owned semantic declaration for one policy flow.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicyFlowRule {
+    pub id: String,
+    pub source_type_id: String,
+    #[serde(default)]
+    pub policy_fields: Vec<String>,
+    pub authoritative_method_id: String,
+    #[serde(default)]
+    pub decision_sinks: Vec<PolicyDecisionSink>,
+    #[serde(default = "default_convention")]
+    pub convention: String,
+    #[serde(
+        default = "default_severity",
+        deserialize_with = "deserialize_severity"
+    )]
+    pub severity: String,
+}
+
+fn default_convention() -> String {
+    "policy_flow".to_string()
+}
+
+fn default_severity() -> String {
+    "warning".to_string()
+}
+
+fn deserialize_severity<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    match value.as_str() {
+        "warning" | "info" => Ok(value),
+        _ => Err(serde::de::Error::custom(
+            "policy-flow severity must be `warning` or `info`",
+        )),
+    }
+}
+
+/// Declarations for the generic policy-flow detector.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicyFlowConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<PolicyFlowRule>,
+}
+
+impl PolicyFlowConfig {
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    pub(crate) fn merge(&mut self, other: &Self) {
+        for rule in &other.rules {
+            if !self.rules.iter().any(|existing| existing.id == rule.id) {
+                self.rules.push(rule.clone());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AuditConfig, FingerprintOutput};
+
+    #[test]
+    fn fingerprint_output_accepts_policy_flow_facts() {
+        let output: FingerprintOutput = serde_json::from_value(serde_json::json!({
+            "aggregate_definitions": [{
+                "type_id": "domain::Policy",
+                "fields": [{"name": "threshold", "type_id": "domain::Threshold"}],
+                "location": {"line": 4, "column": 2}
+            }],
+            "field_accesses": [{
+                "owner_type_id": "domain::Policy",
+                "field": "threshold",
+                "callable_id": "domain::Policy::allows",
+                "access": "read",
+                "location": {"line": 8, "column": 3}
+            }],
+            "aggregate_projections": [{
+                "source_type_id": "domain::Policy",
+                "target_type_id": "domain::Carrier",
+                "callable_id": "domain::project",
+                "field_mappings": [{"source_field": "id", "target_field": "id"}],
+                "location": {"line": 12, "column": 1}
+            }],
+            "decision_branches": [{
+                "callable_id": "domain::decide",
+                "domain_type_id": "domain::Severity",
+                "discriminant_id": "severity",
+                "location": {"line": 20, "column": 1}
+            }],
+            "method_calls": [{
+                "caller_id": "domain::decide",
+                "target_method_id": "domain::Policy::allows",
+                "receiver_type_id": "domain::Policy",
+                "result_used_as_decision": true,
+                "decision_domain_type_id": "domain::Severity",
+                "location": {"line": 21, "column": 1}
+            }]
+        }))
+        .expect("policy-flow facts deserialize");
+
+        assert_eq!(output.aggregate_definitions[0].location.line, 4);
+        assert_eq!(output.field_accesses[0].access, FieldAccessKind::Read);
+        assert_eq!(output.aggregate_projections[0].field_mappings.len(), 1);
+        assert_eq!(
+            output.decision_branches[0].domain_type_id,
+            "domain::Severity"
+        );
+        assert_eq!(
+            output.method_calls[0].target_method_id,
+            "domain::Policy::allows"
+        );
+        assert!(output.method_calls[0].result_used_as_decision);
+        assert_eq!(
+            output.method_calls[0].decision_domain_type_id.as_deref(),
+            Some("domain::Severity")
+        );
+    }
+
+    #[test]
+    fn older_fingerprint_output_defaults_policy_flow_facts() {
+        let output: FingerprintOutput = serde_json::from_str("{}").unwrap();
+
+        assert!(output.aggregate_definitions.is_empty());
+        assert!(output.field_accesses.is_empty());
+        assert!(output.aggregate_projections.is_empty());
+        assert!(output.decision_branches.is_empty());
+        assert!(output.method_calls.is_empty());
+    }
+
+    #[test]
+    fn declaration_defaults_and_merge_are_stable() {
+        let first: PolicyFlowConfig = serde_json::from_value(serde_json::json!({
+            "rules": [{
+                "id": "policy",
+                "source_type_id": "domain::Policy",
+                "policy_fields": ["threshold"],
+                "authoritative_method_id": "domain::Policy::allows",
+                "decision_sinks": []
+            }]
+        }))
+        .unwrap();
+        assert_eq!(first.rules[0].convention, "policy_flow");
+        assert_eq!(first.rules[0].severity, "warning");
+
+        let mut merged = first.clone();
+        merged.merge(&PolicyFlowConfig {
+            rules: vec![first.rules[0].clone()],
+        });
+        assert_eq!(merged.rules.len(), 1);
+
+        let mut audit = AuditConfig {
+            policy_flow: first,
+            ..Default::default()
+        };
+        assert!(!audit.is_empty());
+        audit.merge(&AuditConfig {
+            policy_flow: merged,
+            ..Default::default()
+        });
+        assert_eq!(audit.policy_flow.rules.len(), 1);
+    }
+
+    #[test]
+    fn declaration_rejects_unknown_severity() {
+        let result = serde_json::from_value::<PolicyFlowConfig>(serde_json::json!({
+            "rules": [{
+                "id": "policy",
+                "source_type_id": "domain::Policy",
+                "policy_fields": ["threshold"],
+                "authoritative_method_id": "domain::Policy::allows",
+                "decision_sinks": [],
+                "severity": "warn"
+            }]
+        }));
+
+        assert!(result.is_err());
+    }
+}

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -114,10 +114,11 @@ impl CliRuntime {
         homeboy_extension::component_script::register_component_script_runner();
         homeboy_extension::build::register_component_build_runner();
         homeboy_extension::lifecycle::register_component_install_runner();
-        // Register the fingerprint-script provider so code_audit can fall back to
-        // extension fingerprint scripts (for files the core grammar engine can't
-        // handle) without depending on the extension script runner.
+        // Register extension-backed audit providers so code_audit can load
+        // grammars and run fallback fingerprint scripts without depending on the
+        // extension registry or script runner.
         homeboy_extension::audit_fingerprint_script_provider::register();
+        homeboy_extension::audit_grammar_source_provider::register();
         // Register the audit recorded-artifact provider so the artifact-portability
         // detector can read past runs' artifacts from the observation store without
         // code_audit depending on observation — the last seam before audit becomes
@@ -1258,6 +1259,59 @@ mod tests {
             .expect("extension command docs");
     }
 
+    #[cfg(unix)]
+    fn write_audit_extension(home: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let extension_dir = home.join(".config/homeboy/extensions/sample-audit");
+        let scripts_dir = extension_dir.join("scripts");
+        std::fs::create_dir_all(&scripts_dir).expect("audit extension scripts dir");
+        std::fs::write(
+            extension_dir.join("sample-audit.json"),
+            serde_json::json!({
+                "name": "Sample Audit",
+                "version": "0.0.0",
+                "provides": {
+                    "file_extensions": ["sample"],
+                    "capabilities": ["fingerprint"]
+                },
+                "scripts": { "fingerprint": "scripts/fingerprint.sh" }
+            })
+            .to_string(),
+        )
+        .expect("audit extension manifest");
+        std::fs::write(
+            extension_dir.join("grammar.json"),
+            serde_json::json!({
+                "language": { "id": "sample", "extensions": ["sample"] },
+                "comments": { "line": ["//"], "block": [], "doc": [] },
+                "strings": { "quotes": ["\""], "escape": "\\", "multiline": [] },
+                "patterns": {
+                    "function": {
+                        "regex": "fn\\s+(\\w+)\\s*\\(([^)]*)\\)",
+                        "captures": { "name": 1, "params": 2 },
+                        "context": "any",
+                        "skip_comments": true,
+                        "skip_strings": true
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("audit extension grammar");
+        let script = scripts_dir.join("fingerprint.sh");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\nprintf '%s\\n' '{\"aggregate_literals\":[{\"type_name\":\"Policy\",\"fields\":[\"allow\"],\"line\":1}]}'\n",
+        )
+        .expect("audit fingerprint script");
+        let mut permissions = std::fs::metadata(&script)
+            .expect("audit fingerprint script metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(script, permissions).expect("executable audit fingerprint script");
+    }
+
     #[test]
     fn output_format_names_are_rejected_as_global_output_paths() {
         let err = output_runtime::validate_output_file_path("json")
@@ -1305,6 +1359,33 @@ mod tests {
             startup_fast_path(&args(&["homeboy", "sample-cli", "--help"])),
             None
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cli_startup_registers_both_extension_audit_providers() {
+        crate::test_support::with_isolated_home(|home| {
+            write_audit_extension(home.path());
+
+            let exit = CliRuntime::new()
+                .run_from_args(vec!["homeboy".to_string(), "--version".to_string()]);
+
+            assert_eq!(exit, std::process::ExitCode::SUCCESS);
+            let grammar = crate::core::code_audit::core_fingerprint::load_grammar_for_ext("sample")
+                .expect("CLI startup should make the extension grammar provider reachable");
+            assert_eq!(grammar.language.id, "sample");
+
+            let source = home.path().join("policy.sample");
+            let fingerprint = crate::core::code_audit::fingerprint::fingerprint_content(
+                &source,
+                home.path(),
+                "fn decide() {}",
+            )
+            .expect("CLI startup should make both audit providers reachable");
+            assert_eq!(fingerprint.methods, vec!["decide"]);
+            assert_eq!(fingerprint.aggregate_literals.len(), 1);
+            assert_eq!(fingerprint.aggregate_literals[0].type_name, "Policy");
+        });
     }
 
     #[test]

--- a/crates/homeboy-code-audit/src/baseline.rs
+++ b/crates/homeboy-code-audit/src/baseline.rs
@@ -1108,4 +1108,30 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(Path::new(&result_initial.source_path));
     }
+
+    #[test]
+    fn policy_flow_baseline_identity_is_stable_and_seam_specific() {
+        let convention = "policy_flow/rule/domain%3A%3APolicy/domain%3A%3ACarrier/domain%3A%3Aproject/domain%3A%3Adecide/domain%3A%3ASeverity";
+        let first = make_finding_with_kind(
+            convention,
+            "src/project.rs",
+            "Policy source at src/policy.rs:3, projection at src/project.rs:8, sink at src/decide.rs:21",
+            AuditFinding::LossyPolicyProjection,
+        );
+        let moved = make_finding_with_kind(
+            convention,
+            "src/project.rs",
+            "Policy source at src/policy.rs:30, projection at src/project.rs:80, sink at src/decide.rs:210",
+            AuditFinding::LossyPolicyProjection,
+        );
+
+        assert_eq!(
+            finding_baseline_fingerprint(&first),
+            finding_baseline_fingerprint(&moved)
+        );
+        assert_eq!(
+            finding_baseline_fingerprint(&first),
+            format!("{convention}::src/project.rs::LossyPolicyProjection")
+        );
+    }
 }

--- a/crates/homeboy-code-audit/src/core_fingerprint/mod.rs
+++ b/crates/homeboy-code-audit/src/core_fingerprint/mod.rs
@@ -276,6 +276,11 @@ pub fn fingerprint_from_grammar(
         trait_impl_methods,
         aggregate_literals,
         aggregate_construction_seams,
+        aggregate_definitions: Vec::new(),
+        field_accesses: Vec::new(),
+        aggregate_projections: Vec::new(),
+        decision_branches: Vec::new(),
+        method_calls: Vec::new(),
     })
 }
 

--- a/crates/homeboy-code-audit/src/core_fingerprint/mod.rs
+++ b/crates/homeboy-code-audit/src/core_fingerprint/mod.rs
@@ -1485,4 +1485,4 @@ fn count_call_args(text: &str) -> Option<usize> {
 // ============================================================================
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/crates/homeboy-code-audit/src/core_fingerprint/tests.rs
+++ b/crates/homeboy-code-audit/src/core_fingerprint/tests.rs
@@ -918,7 +918,7 @@ mod tests {
 
 /// Rust grammar extended with the construction-seam + aggregate-literal policy
 /// the reference Rust fingerprint script encodes.
-fn rust_aggregate_grammar() -> Grammar {
+pub(crate) fn rust_aggregate_grammar() -> Grammar {
     let mut grammar = rust_grammar();
     grammar.fingerprint.aggregate_seams = Some(AggregateSeamConfig {
         method_names: vec![

--- a/crates/homeboy-code-audit/src/descriptor_runtime.rs
+++ b/crates/homeboy-code-audit/src/descriptor_runtime.rs
@@ -2,10 +2,10 @@ use super::detectors::layer_ownership::run as run_layer_ownership;
 use super::detectors::{
     aggregate_construction, command_status_contracts, command_wrapper_bypass, config_key_usage,
     constant_bypass, dead_guard, deprecation_age, enum_dispatch_contracts, facade_passthrough,
-    global_env_guard, mutating_resource_access, parallel_runner_setup, public_registry_exposure,
-    redirect_validation, remote_execution_preflight, repeated_literal_shape, requested_detectors,
-    shared_scaffolding, source_policy, test_coverage, test_topology, test_wiring,
-    thin_command_adapter, unbounded_output_capture, wrapper_inference,
+    global_env_guard, mutating_resource_access, parallel_runner_setup, policy_flow,
+    public_registry_exposure, redirect_validation, remote_execution_preflight,
+    repeated_literal_shape, requested_detectors, shared_scaffolding, source_policy, test_coverage,
+    test_topology, test_wiring, thin_command_adapter, unbounded_output_capture, wrapper_inference,
 };
 use super::doc_drift::detect_doc_drift;
 use super::reference::{fingerprint_component_reference_files, fingerprint_reference_paths};
@@ -65,6 +65,9 @@ fn run_fingerprint_descriptor(
         }
         FingerprintDetectorRunner::AggregateConstruction => {
             aggregate_construction::run(context.all_fingerprints)
+        }
+        FingerprintDetectorRunner::PolicyFlow => {
+            policy_flow::run(context.all_fingerprints, &context.audit_config.policy_flow)
         }
     }
 }
@@ -264,6 +267,10 @@ pub(super) fn run_descriptor_detectors(
 mod tests {
     use super::*;
     use crate::AuditProfile;
+    use homeboy_audit_contract::{
+        AggregateDefinitionFact, AggregateFieldFact, AggregateProjectionFact, DecisionBranchFact,
+        FactLocation, PolicyDecisionSink, PolicyFlowConfig, PolicyFlowRule, ProjectionFieldFact,
+    };
 
     /// Only the three hand-sequenced families remain `Manual`; every other
     /// detector is dispatched through the data-driven runtime. This guards
@@ -346,6 +353,100 @@ mod tests {
                 .any(|span| span.id == "detector.structural" && span.status == "ok"),
             "dispatch should record the structural timing span"
         );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn policy_flow_runs_via_data_driven_dispatch() {
+        let dir = std::env::temp_dir().join(format!(
+            "homeboy_policy_flow_descriptor_dispatch_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let source = fingerprint::FileFingerprint {
+            relative_path: "src/policy.ext".to_string(),
+            aggregate_definitions: vec![AggregateDefinitionFact {
+                type_id: "domain::Policy".to_string(),
+                fields: vec![AggregateFieldFact {
+                    name: "threshold".to_string(),
+                    type_id: None,
+                }],
+                location: FactLocation { line: 1, column: 1 },
+            }],
+            ..Default::default()
+        };
+        let projection = fingerprint::FileFingerprint {
+            relative_path: "src/project.ext".to_string(),
+            aggregate_projections: vec![AggregateProjectionFact {
+                source_type_id: "domain::Policy".to_string(),
+                target_type_id: "domain::Carrier".to_string(),
+                callable_id: "domain::project".to_string(),
+                field_mappings: vec![ProjectionFieldFact {
+                    source_field: "id".to_string(),
+                    target_field: "id".to_string(),
+                }],
+                location: FactLocation { line: 4, column: 1 },
+            }],
+            ..Default::default()
+        };
+        let decision = fingerprint::FileFingerprint {
+            relative_path: "src/decide.ext".to_string(),
+            decision_branches: vec![DecisionBranchFact {
+                callable_id: "domain::decide".to_string(),
+                domain_type_id: "domain::Severity".to_string(),
+                discriminant_id: "severity".to_string(),
+                location: FactLocation { line: 7, column: 1 },
+            }],
+            ..Default::default()
+        };
+        let fingerprints = [&source, &projection, &decision];
+        let audit_config = AuditConfig {
+            policy_flow: PolicyFlowConfig {
+                rules: vec![PolicyFlowRule {
+                    id: "policy".to_string(),
+                    source_type_id: "domain::Policy".to_string(),
+                    policy_fields: vec!["threshold".to_string()],
+                    authoritative_method_id: "domain::Policy::allows".to_string(),
+                    decision_sinks: vec![PolicyDecisionSink {
+                        carrier_type_id: "domain::Carrier".to_string(),
+                        callable_id: "domain::decide".to_string(),
+                        domain_type_id: "domain::Severity".to_string(),
+                    }],
+                    convention: "policy_flow".to_string(),
+                    severity: "warning".to_string(),
+                }],
+            },
+            ..Default::default()
+        };
+        let context = DetectorRunContext {
+            root: &dir,
+            component_id: "fixture-component",
+            audit_config: &audit_config,
+            all_fingerprints: &fingerprints,
+            per_file_fingerprints: &fingerprints,
+            source_snapshot: None,
+            reference_paths: &[],
+        };
+        let plan = AuditExecutionPlan::from_profile_and_filters(AuditProfile::Full, &[], &[]);
+        let mut timing = AuditTiming::default();
+        let mut findings = Vec::new();
+
+        run_descriptor_detectors(
+            &plan,
+            &mut timing,
+            &mut findings,
+            &context,
+            Some(&["policy_flow"]),
+        );
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, crate::AuditFinding::LossyPolicyProjection);
+        assert!(timing
+            .spans
+            .iter()
+            .any(|span| span.id == "detector.policy_flow" && span.status == "ok"));
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/homeboy-code-audit/src/detectors/mod.rs
+++ b/crates/homeboy-code-audit/src/detectors/mod.rs
@@ -12,6 +12,7 @@ pub(super) mod global_env_guard;
 pub(super) mod layer_ownership;
 pub(super) mod mutating_resource_access;
 pub(super) mod parallel_runner_setup;
+pub(super) mod policy_flow;
 pub(super) mod public_registry_exposure;
 pub(super) mod redirect_validation;
 pub(super) mod remote_execution_preflight;

--- a/crates/homeboy-code-audit/src/detectors/policy_flow.rs
+++ b/crates/homeboy-code-audit/src/detectors/policy_flow.rs
@@ -1,0 +1,470 @@
+//! Lossy policy projection and divergent decision detector.
+//!
+//! Extensions resolve syntax into language-neutral facts. Core only correlates
+//! exact canonical identities declared by project or extension policy.
+
+use homeboy_audit_contract::{
+    AggregateDefinitionFact, AggregateProjectionFact, DecisionBranchFact, MethodCallFact,
+    PolicyFlowConfig, PolicyFlowRule,
+};
+
+use super::conventions::AuditFinding;
+use super::findings::{Finding, Severity};
+use super::fingerprint::FileFingerprint;
+
+struct Located<'a, T> {
+    file: &'a str,
+    fact: &'a T,
+}
+
+pub(crate) fn run(fingerprints: &[&FileFingerprint], config: &PolicyFlowConfig) -> Vec<Finding> {
+    let mut definitions = Vec::new();
+    let mut projections = Vec::new();
+    let mut decisions = Vec::new();
+    let mut calls = Vec::new();
+
+    for fingerprint in fingerprints {
+        if super::walker::is_test_path(&fingerprint.relative_path) {
+            continue;
+        }
+        definitions.extend(
+            fingerprint
+                .aggregate_definitions
+                .iter()
+                .map(|fact| Located {
+                    file: fingerprint.relative_path.as_str(),
+                    fact,
+                }),
+        );
+        projections.extend(
+            fingerprint
+                .aggregate_projections
+                .iter()
+                .map(|fact| Located {
+                    file: fingerprint.relative_path.as_str(),
+                    fact,
+                }),
+        );
+        decisions.extend(fingerprint.decision_branches.iter().map(|fact| Located {
+            file: fingerprint.relative_path.as_str(),
+            fact,
+        }));
+        calls.extend(fingerprint.method_calls.iter().map(|fact| Located {
+            file: fingerprint.relative_path.as_str(),
+            fact,
+        }));
+    }
+
+    definitions.sort_by(|left, right| {
+        left.fact
+            .type_id
+            .cmp(&right.fact.type_id)
+            .then(left.file.cmp(right.file))
+            .then(left.fact.location.line.cmp(&right.fact.location.line))
+            .then(left.fact.location.column.cmp(&right.fact.location.column))
+    });
+    projections.sort_by(|left, right| {
+        left.fact
+            .source_type_id
+            .cmp(&right.fact.source_type_id)
+            .then(left.fact.target_type_id.cmp(&right.fact.target_type_id))
+            .then(left.fact.callable_id.cmp(&right.fact.callable_id))
+            .then(left.file.cmp(right.file))
+            .then(left.fact.location.line.cmp(&right.fact.location.line))
+            .then(left.fact.location.column.cmp(&right.fact.location.column))
+    });
+    decisions.sort_by(|left, right| {
+        left.fact
+            .callable_id
+            .cmp(&right.fact.callable_id)
+            .then(left.fact.domain_type_id.cmp(&right.fact.domain_type_id))
+            .then(left.file.cmp(right.file))
+            .then(left.fact.location.line.cmp(&right.fact.location.line))
+            .then(left.fact.location.column.cmp(&right.fact.location.column))
+    });
+    calls.sort_by(|left, right| {
+        left.fact
+            .caller_id
+            .cmp(&right.fact.caller_id)
+            .then(left.fact.target_method_id.cmp(&right.fact.target_method_id))
+            .then(left.file.cmp(right.file))
+            .then(left.fact.location.line.cmp(&right.fact.location.line))
+            .then(left.fact.location.column.cmp(&right.fact.location.column))
+    });
+
+    let mut findings = Vec::new();
+    for rule in &config.rules {
+        findings.extend(find_rule_findings(
+            rule,
+            &definitions,
+            &projections,
+            &decisions,
+            &calls,
+        ));
+    }
+    findings.sort_by(|left, right| {
+        left.file
+            .cmp(&right.file)
+            .then(left.convention.cmp(&right.convention))
+            .then(left.description.cmp(&right.description))
+    });
+    findings.dedup_by(|left, right| {
+        left.file == right.file && left.convention == right.convention && left.kind == right.kind
+    });
+    findings
+}
+
+fn find_rule_findings(
+    rule: &PolicyFlowRule,
+    definitions: &[Located<'_, AggregateDefinitionFact>],
+    projections: &[Located<'_, AggregateProjectionFact>],
+    decisions: &[Located<'_, DecisionBranchFact>],
+    calls: &[Located<'_, MethodCallFact>],
+) -> Vec<Finding> {
+    if rule.id.is_empty()
+        || rule.source_type_id.is_empty()
+        || rule.authoritative_method_id.is_empty()
+        || rule.policy_fields.is_empty()
+    {
+        return Vec::new();
+    }
+
+    let Some(source) = definitions.iter().find(|item| {
+        item.fact.type_id == rule.source_type_id
+            && rule.policy_fields.iter().all(|policy_field| {
+                item.fact
+                    .fields
+                    .iter()
+                    .any(|field| field.name == *policy_field)
+            })
+    }) else {
+        return Vec::new();
+    };
+
+    let mut findings = Vec::new();
+    for projection in projections
+        .iter()
+        .filter(|item| item.fact.source_type_id == rule.source_type_id)
+    {
+        if projection.fact.field_mappings.is_empty() {
+            continue;
+        }
+        let omitted = rule
+            .policy_fields
+            .iter()
+            .filter(|policy_field| {
+                !projection
+                    .fact
+                    .field_mappings
+                    .iter()
+                    .any(|mapping| mapping.source_field == **policy_field)
+            })
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        if omitted.is_empty() {
+            continue;
+        }
+
+        for sink in rule
+            .decision_sinks
+            .iter()
+            .filter(|sink| sink.carrier_type_id == projection.fact.target_type_id)
+        {
+            let Some(decision) = decisions.iter().find(|item| {
+                item.fact.callable_id == sink.callable_id
+                    && item.fact.domain_type_id == sink.domain_type_id
+            }) else {
+                continue;
+            };
+            if calls.iter().any(|item| {
+                item.fact.caller_id == sink.callable_id
+                    && item.fact.target_method_id == rule.authoritative_method_id
+                    && item.fact.result_used_as_decision
+                    && item.fact.decision_domain_type_id.as_deref()
+                        == Some(sink.domain_type_id.as_str())
+                    && item
+                        .fact
+                        .receiver_type_id
+                        .as_deref()
+                        .is_none_or(|receiver| receiver == rule.source_type_id)
+            }) {
+                continue;
+            }
+
+            findings.push(Finding {
+                convention: stable_convention(
+                    rule,
+                    projection.fact,
+                    &sink.callable_id,
+                    &sink.domain_type_id,
+                ),
+                severity: parse_severity(&rule.severity),
+                file: projection.file.to_string(),
+                description: format!(
+                    "Lossy policy projection `{}` -> `{}` at {} in `{}` omits policy field(s) [{}] owned by `{}` at {}; downstream decision `{}` branches on `{}` at {} instead of calling authoritative method `{}`.",
+                    projection.fact.source_type_id,
+                    projection.fact.target_type_id,
+                    display_location(projection.file, &projection.fact.location),
+                    projection.fact.callable_id,
+                    omitted.join(", "),
+                    rule.source_type_id,
+                    display_location(source.file, &source.fact.location),
+                    sink.callable_id,
+                    decision.fact.domain_type_id,
+                    display_location(decision.file, &decision.fact.location),
+                    rule.authoritative_method_id,
+                ),
+                suggestion: format!(
+                    "Preserve [{}] in the decision carrier or delegate `{}` to `{}`.",
+                    omitted.join(", "),
+                    sink.callable_id,
+                    rule.authoritative_method_id
+                ),
+                kind: AuditFinding::LossyPolicyProjection,
+            });
+        }
+    }
+    findings
+}
+
+fn display_location(file: &str, location: &homeboy_audit_contract::FactLocation) -> String {
+    match (location.line, location.column) {
+        (0, _) => file.to_string(),
+        (line, 0) => format!("{file}:{line}"),
+        (line, column) => format!("{file}:{line}:{column}"),
+    }
+}
+
+fn stable_convention(
+    rule: &PolicyFlowRule,
+    projection: &AggregateProjectionFact,
+    sink_callable: &str,
+    domain_type: &str,
+) -> String {
+    format!(
+        "{}/{}/{}/{}/{}/{}/{}",
+        rule.convention,
+        encode_segment(&rule.id),
+        encode_segment(&projection.source_type_id),
+        encode_segment(&projection.target_type_id),
+        encode_segment(&projection.callable_id),
+        encode_segment(sink_callable),
+        encode_segment(domain_type),
+    )
+}
+
+fn encode_segment(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}
+
+fn parse_severity(value: &str) -> Severity {
+    match value {
+        "info" => Severity::Info,
+        _ => Severity::Warning,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use homeboy_audit_contract::{
+        AggregateDefinitionFact, AggregateProjectionFact, DecisionBranchFact, FieldAccessFact,
+        MethodCallFact, PolicyFlowConfig,
+    };
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct Fixture {
+        config: PolicyFlowConfig,
+        files: Vec<FixtureFile>,
+    }
+
+    #[derive(Deserialize)]
+    struct FixtureFile {
+        path: String,
+        #[serde(default)]
+        aggregate_definitions: Vec<AggregateDefinitionFact>,
+        #[serde(default)]
+        field_accesses: Vec<FieldAccessFact>,
+        #[serde(default)]
+        aggregate_projections: Vec<AggregateProjectionFact>,
+        #[serde(default)]
+        decision_branches: Vec<DecisionBranchFact>,
+        #[serde(default)]
+        method_calls: Vec<MethodCallFact>,
+    }
+
+    fn fixture(contents: &str) -> (PolicyFlowConfig, Vec<FileFingerprint>) {
+        let fixture: Fixture = serde_json::from_str(contents).expect("valid policy-flow fixture");
+        let files = fixture
+            .files
+            .into_iter()
+            .map(|file| FileFingerprint {
+                relative_path: file.path,
+                aggregate_definitions: file.aggregate_definitions,
+                field_accesses: file.field_accesses,
+                aggregate_projections: file.aggregate_projections,
+                decision_branches: file.decision_branches,
+                method_calls: file.method_calls,
+                ..Default::default()
+            })
+            .collect();
+        (fixture.config, files)
+    }
+
+    #[test]
+    fn reports_serialized_lossy_projection_and_divergent_decision() {
+        let (config, files) = fixture(include_str!(
+            "../../../../tests/fixtures/audit_policy_flow/lossy_projection.json"
+        ));
+        let refs = files.iter().collect::<Vec<_>>();
+
+        let findings = run(&refs, &config);
+
+        assert_eq!(findings.len(), 1, "expected one finding: {findings:?}");
+        let finding = &findings[0];
+        assert_eq!(finding.kind, AuditFinding::LossyPolicyProjection);
+        assert_eq!(finding.file, "src/project.ext");
+        for evidence in [
+            "domain::SourcePolicy",
+            "domain::DecisionCarrier",
+            "src/policy.ext:3:1",
+            "src/project.ext:8:5",
+            "src/decide.ext:21:5",
+            "threshold",
+            "domain::SourcePolicy::should_engage",
+        ] {
+            assert!(
+                finding.description.contains(evidence),
+                "missing evidence {evidence}: {}",
+                finding.description
+            );
+        }
+        assert_eq!(
+            finding.convention,
+            "policy_flow/engagement/domain%3A%3ASourcePolicy/domain%3A%3ADecisionCarrier/domain%3A%3Aproject/domain%3A%3Adecide/domain%3A%3ASeverity"
+        );
+    }
+
+    #[test]
+    fn authoritative_delegation_is_clean() {
+        let (config, files) = fixture(include_str!(
+            "../../../../tests/fixtures/audit_policy_flow/clean_delegation.json"
+        ));
+        let refs = files.iter().collect::<Vec<_>>();
+
+        assert!(run(&refs, &config).is_empty());
+    }
+
+    #[test]
+    fn discarded_authoritative_call_does_not_hide_divergence() {
+        let (config, mut files) = fixture(include_str!(
+            "../../../../tests/fixtures/audit_policy_flow/clean_delegation.json"
+        ));
+        files[2].method_calls[0].result_used_as_decision = false;
+        let refs = files.iter().collect::<Vec<_>>();
+
+        assert_eq!(run(&refs, &config).len(), 1);
+    }
+
+    #[test]
+    fn distinct_decision_domains_have_distinct_findings() {
+        let (mut config, mut files) = fixture(include_str!(
+            "../../../../tests/fixtures/audit_policy_flow/lossy_projection.json"
+        ));
+        config.rules[0]
+            .decision_sinks
+            .push(homeboy_audit_contract::PolicyDecisionSink {
+                carrier_type_id: "domain::DecisionCarrier".to_string(),
+                callable_id: "domain::decide".to_string(),
+                domain_type_id: "domain::Pressure".to_string(),
+            });
+        files[2].decision_branches.push(DecisionBranchFact {
+            callable_id: "domain::decide".to_string(),
+            domain_type_id: "domain::Pressure".to_string(),
+            discriminant_id: "pressure".to_string(),
+            location: homeboy_audit_contract::FactLocation {
+                line: 25,
+                column: 5,
+            },
+        });
+        let refs = files.iter().collect::<Vec<_>>();
+
+        let findings = run(&refs, &config);
+        assert_eq!(findings.len(), 2);
+        assert_ne!(findings[0].convention, findings[1].convention);
+    }
+
+    #[test]
+    fn delegation_only_suppresses_its_resolved_decision_domain() {
+        let (mut config, mut files) = fixture(include_str!(
+            "../../../../tests/fixtures/audit_policy_flow/clean_delegation.json"
+        ));
+        config.rules[0]
+            .decision_sinks
+            .push(homeboy_audit_contract::PolicyDecisionSink {
+                carrier_type_id: "domain::DecisionCarrier".to_string(),
+                callable_id: "domain::decide".to_string(),
+                domain_type_id: "domain::Pressure".to_string(),
+            });
+        files[2].decision_branches.push(DecisionBranchFact {
+            callable_id: "domain::decide".to_string(),
+            domain_type_id: "domain::Pressure".to_string(),
+            discriminant_id: "pressure".to_string(),
+            location: homeboy_audit_contract::FactLocation {
+                line: 25,
+                column: 5,
+            },
+        });
+        let refs = files.iter().collect::<Vec<_>>();
+
+        let findings = run(&refs, &config);
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].description.contains("domain::Pressure"));
+    }
+
+    #[test]
+    fn ordinary_dto_projection_is_clean() {
+        let (config, files) = fixture(include_str!(
+            "../../../../tests/fixtures/audit_policy_flow/ordinary_dto.json"
+        ));
+        let refs = files.iter().collect::<Vec<_>>();
+
+        assert!(run(&refs, &config).is_empty());
+    }
+
+    #[test]
+    fn preserving_policy_field_is_clean() {
+        let (config, mut files) = fixture(include_str!(
+            "../../../../tests/fixtures/audit_policy_flow/lossy_projection.json"
+        ));
+        files[1].aggregate_projections[0].field_mappings.push(
+            homeboy_audit_contract::ProjectionFieldFact {
+                source_field: "threshold".to_string(),
+                target_field: "threshold".to_string(),
+            },
+        );
+        let refs = files.iter().collect::<Vec<_>>();
+
+        assert!(run(&refs, &config).is_empty());
+    }
+
+    #[test]
+    fn missing_projection_fact_disables_the_finding() {
+        let (config, mut files) = fixture(include_str!(
+            "../../../../tests/fixtures/audit_policy_flow/lossy_projection.json"
+        ));
+        files[1].aggregate_projections.clear();
+        let refs = files.iter().collect::<Vec<_>>();
+
+        assert!(run(&refs, &config).is_empty());
+    }
+}

--- a/crates/homeboy-code-audit/src/detectors/policy_flow.rs
+++ b/crates/homeboy-code-audit/src/detectors/policy_flow.rs
@@ -182,11 +182,7 @@ fn find_rule_findings(
                     && item.fact.result_used_as_decision
                     && item.fact.decision_domain_type_id.as_deref()
                         == Some(sink.domain_type_id.as_str())
-                    && item
-                        .fact
-                        .receiver_type_id
-                        .as_deref()
-                        .is_none_or(|receiver| receiver == rule.source_type_id)
+                    && item.fact.receiver_type_id.as_deref() == Some(rule.source_type_id.as_str())
             }) {
                 continue;
             }
@@ -376,6 +372,28 @@ mod tests {
     }
 
     #[test]
+    fn unresolved_receiver_does_not_prove_authoritative_delegation() {
+        let (config, mut files) = fixture(include_str!(
+            "../../../../tests/fixtures/audit_policy_flow/clean_delegation.json"
+        ));
+        files[2].method_calls[0].receiver_type_id = None;
+        let refs = files.iter().collect::<Vec<_>>();
+
+        assert_eq!(run(&refs, &config).len(), 1);
+    }
+
+    #[test]
+    fn wrong_receiver_does_not_prove_authoritative_delegation() {
+        let (config, mut files) = fixture(include_str!(
+            "../../../../tests/fixtures/audit_policy_flow/clean_delegation.json"
+        ));
+        files[2].method_calls[0].receiver_type_id = Some("domain::OtherPolicy".to_string());
+        let refs = files.iter().collect::<Vec<_>>();
+
+        assert_eq!(run(&refs, &config).len(), 1);
+    }
+
+    #[test]
     fn distinct_decision_domains_have_distinct_findings() {
         let (mut config, mut files) = fixture(include_str!(
             "../../../../tests/fixtures/audit_policy_flow/lossy_projection.json"
@@ -463,6 +481,19 @@ mod tests {
             "../../../../tests/fixtures/audit_policy_flow/lossy_projection.json"
         ));
         files[1].aggregate_projections.clear();
+        let refs = files.iter().collect::<Vec<_>>();
+
+        assert!(run(&refs, &config).is_empty());
+    }
+
+    #[test]
+    fn facts_from_test_paths_are_ignored() {
+        let (config, mut files) = fixture(include_str!(
+            "../../../../tests/fixtures/audit_policy_flow/lossy_projection.json"
+        ));
+        for file in &mut files {
+            file.relative_path = format!("tests/{}", file.relative_path);
+        }
         let refs = files.iter().collect::<Vec<_>>();
 
         assert!(run(&refs, &config).is_empty());

--- a/crates/homeboy-code-audit/src/execution_plan.rs
+++ b/crates/homeboy-code-audit/src/execution_plan.rs
@@ -112,6 +112,7 @@ pub(crate) enum FingerprintDetectorRunner {
     CommandWrapperBypass,
     SharedScaffolding,
     AggregateConstruction,
+    PolicyFlow,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -488,6 +489,15 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         log_summary: "direct literals bypass construction seams",
     },
     DetectorDescriptor {
+        id: "policy_flow",
+        findings: &[AuditFinding::LossyPolicyProjection],
+        access: DetectorAccess::Discovery,
+        runtime: DetectorRuntime::Fingerprint(FingerprintDetectorRunner::PolicyFlow),
+        timing_id: "detector.policy_flow",
+        log_label: "Policy flow",
+        log_summary: "lossy policy projections with divergent decisions",
+    },
+    DetectorDescriptor {
         id: "public_registry_exposure",
         findings: &[AuditFinding::PublicRegistryExposure],
         access: DetectorAccess::Discovery,
@@ -740,6 +750,27 @@ mod tests {
 
         assert!(plan.detector_enabled("comment_hygiene"));
         assert!(!plan.detector_enabled("dead_code"));
+    }
+
+    #[test]
+    fn policy_flow_uses_normal_fingerprint_execution() {
+        let descriptor = AuditExecutionPlan::descriptors()
+            .iter()
+            .find(|descriptor| descriptor.id == "policy_flow")
+            .expect("policy-flow descriptor");
+        assert_eq!(
+            descriptor.runtime,
+            DetectorRuntime::Fingerprint(FingerprintDetectorRunner::PolicyFlow)
+        );
+        assert_eq!(descriptor.timing_id, "detector.policy_flow");
+
+        let only = AuditExecutionPlan::from_filters(&[AuditFinding::LossyPolicyProjection], &[]);
+        assert!(only.detector_enabled("policy_flow"));
+        assert!(!only.detector_enabled("aggregate_construction"));
+
+        let excluded =
+            AuditExecutionPlan::from_filters(&[], &[AuditFinding::LossyPolicyProjection]);
+        assert!(!excluded.detector_enabled("policy_flow"));
     }
 
     #[test]

--- a/crates/homeboy-code-audit/src/fingerprint.rs
+++ b/crates/homeboy-code-audit/src/fingerprint.rs
@@ -106,6 +106,11 @@ pub struct FileFingerprint {
     pub aggregate_literals: Vec<homeboy_audit_contract::AggregateLiteral>,
     /// Extension-reported canonical construction seams for aggregate types.
     pub aggregate_construction_seams: Vec<homeboy_audit_contract::AggregateConstructionSeam>,
+    pub aggregate_definitions: Vec<homeboy_audit_contract::AggregateDefinitionFact>,
+    pub field_accesses: Vec<homeboy_audit_contract::FieldAccessFact>,
+    pub aggregate_projections: Vec<homeboy_audit_contract::AggregateProjectionFact>,
+    pub decision_branches: Vec<homeboy_audit_contract::DecisionBranchFact>,
+    pub method_calls: Vec<homeboy_audit_contract::MethodCallFact>,
 }
 
 /// Extract a structural fingerprint from a source file on disk.
@@ -203,6 +208,11 @@ pub(crate) fn fingerprint_extension_content(
         trait_impl_methods: Vec::new(), // Extension scripts don't track this
         aggregate_literals: output.aggregate_literals,
         aggregate_construction_seams: output.aggregate_construction_seams,
+        aggregate_definitions: output.aggregate_definitions,
+        field_accesses: output.field_accesses,
+        aggregate_projections: output.aggregate_projections,
+        decision_branches: output.decision_branches,
+        method_calls: output.method_calls,
     })
 }
 

--- a/crates/homeboy-code-audit/src/fingerprint.rs
+++ b/crates/homeboy-code-audit/src/fingerprint.rs
@@ -125,9 +125,10 @@ pub fn fingerprint_file(path: &Path, root: &Path) -> Option<FileFingerprint> {
 
 /// Extract a structural fingerprint from already-loaded file content.
 ///
-/// Tries the grammar-driven core engine first (no subprocess, faster, testable).
-/// Falls back to the extension fingerprint script if no grammar is available
-/// or the core engine can't handle the file.
+/// Tries the grammar-driven core engine first. When it succeeds, language-owned
+/// semantic facts from the extension script are composed into the grammar
+/// fingerprint. Falls back to the extension fingerprint wholesale if no
+/// grammar is available or the core engine can't handle the file.
 ///
 /// This is the content-taking primitive used by [`FingerprintIndex::from_snapshot`]
 /// to avoid re-reading every file from disk after a [`CodebaseSnapshot`] has
@@ -141,11 +142,15 @@ pub fn fingerprint_content(path: &Path, root: &Path, content: &str) -> Option<Fi
         .to_string_lossy()
         .to_string();
 
-    // Try core grammar engine first
+    // Prefer grammar-owned structural facts, while still allowing extensions to
+    // contribute semantic facts that generic grammar parsing cannot resolve.
     if let Some(grammar) = super::core_fingerprint::load_grammar_for_ext(ext) {
-        if let Some(fp) =
+        if let Some(mut fp) =
             super::core_fingerprint::fingerprint_from_grammar(content, &grammar, &relative_path)
         {
+            if let Some(extension_fp) = fingerprint_via_extension(ext, content, &relative_path) {
+                fp.compose_semantic_facts(extension_fp);
+            }
             return Some(fp);
         }
     }
@@ -171,9 +176,23 @@ pub(crate) fn fingerprint_extension_content(
     let output =
         super::fingerprint_script_provider::fingerprint_via_script(ext, relative_path, content)?;
 
+    Some(fingerprint_from_extension_output(
+        ext,
+        relative_path,
+        content,
+        output,
+    ))
+}
+
+fn fingerprint_from_extension_output(
+    ext: &str,
+    relative_path: &str,
+    content: &str,
+    output: homeboy_audit_contract::FingerprintOutput,
+) -> FileFingerprint {
     let language = Language::from_extension(ext);
 
-    Some(FileFingerprint {
+    FileFingerprint {
         relative_path: relative_path.to_string(),
         language,
         methods: output.methods,
@@ -213,7 +232,38 @@ pub(crate) fn fingerprint_extension_content(
         aggregate_projections: output.aggregate_projections,
         decision_branches: output.decision_branches,
         method_calls: output.method_calls,
-    })
+    }
+}
+
+impl FileFingerprint {
+    /// Compose facts whose syntax and type resolution remain extension-owned.
+    /// Grammar facts stay first so composition is stable across runs.
+    fn compose_semantic_facts(&mut self, extension: Self) {
+        append_facts(&mut self.aggregate_literals, extension.aggregate_literals);
+        append_facts(
+            &mut self.aggregate_construction_seams,
+            extension.aggregate_construction_seams,
+        );
+        append_facts(
+            &mut self.aggregate_definitions,
+            extension.aggregate_definitions,
+        );
+        append_facts(&mut self.field_accesses, extension.field_accesses);
+        append_facts(
+            &mut self.aggregate_projections,
+            extension.aggregate_projections,
+        );
+        append_facts(&mut self.decision_branches, extension.decision_branches);
+        append_facts(&mut self.method_calls, extension.method_calls);
+    }
+}
+
+fn append_facts<T: PartialEq>(target: &mut Vec<T>, extension: Vec<T>) {
+    for fact in extension {
+        if !target.contains(&fact) {
+            target.push(fact);
+        }
+    }
 }
 
 pub(crate) fn normalize_convention_tags(tags: Vec<String>) -> Vec<String> {
@@ -292,7 +342,24 @@ impl FingerprintIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fingerprint_script_provider::FingerprintScriptProvider;
+    use homeboy_audit_contract::FingerprintOutput;
     use homeboy_engine_primitives::codebase_scan::ScanConfig;
+
+    struct FakeSemanticProvider {
+        output: FingerprintOutput,
+    }
+
+    impl FingerprintScriptProvider for FakeSemanticProvider {
+        fn fingerprint(
+            &self,
+            _file_extension: &str,
+            _relative_path: &str,
+            _content: &str,
+        ) -> Option<FingerprintOutput> {
+            Some(self.output.clone())
+        }
+    }
 
     /// Sort a slice of strings into an owned Vec for set-equivalence asserts.
     /// Used because some fingerprint vector fields come from HashMap iteration
@@ -370,6 +437,89 @@ mod tests {
             "content"
         )
         .is_none());
+    }
+
+    #[test]
+    fn grammar_fingerprint_composes_provider_semantic_facts() {
+        let grammar = super::super::core_fingerprint::tests::rust_aggregate_grammar();
+        let content = r#"pub struct GrammarOwned { left: usize, right: usize }
+impl GrammarOwned {
+    pub fn new(left: usize, right: usize) -> Self { Self { left, right } }
+}
+pub fn build_other() -> Other { Other { x: 1, y: 2 } }
+"#;
+        let mut fingerprint = super::super::core_fingerprint::fingerprint_from_grammar(
+            content,
+            &grammar,
+            "src/policy.rs",
+        )
+        .expect("grammar fingerprint");
+        let provider = FakeSemanticProvider {
+            output: serde_json::from_value(serde_json::json!({
+                "aggregate_literals": [
+                    {"type_name": "Other", "fields": ["x", "y"], "line": 5},
+                    {"type_name": "ScriptOnly", "fields": ["a", "b"], "line": 9}
+                ],
+                "aggregate_construction_seams": [
+                    {"type_name": "GrammarOwned", "method": "new", "line": 3},
+                    {"type_name": "ScriptOnly", "method": "create", "line": 3}
+                ],
+                "aggregate_definitions": [{
+                    "type_id": "domain::Policy",
+                    "fields": [{"name": "threshold"}],
+                    "location": {"line": 1, "column": 1}
+                }],
+                "field_accesses": [{
+                    "owner_type_id": "domain::Policy",
+                    "field": "threshold",
+                    "callable_id": "domain::Policy::allows",
+                    "access": "read"
+                }],
+                "aggregate_projections": [{
+                    "source_type_id": "domain::Policy",
+                    "target_type_id": "domain::Carrier",
+                    "callable_id": "domain::project"
+                }],
+                "decision_branches": [{
+                    "callable_id": "domain::decide",
+                    "domain_type_id": "domain::Severity",
+                    "discriminant_id": "severity"
+                }],
+                "method_calls": [{
+                    "caller_id": "domain::decide",
+                    "target_method_id": "domain::Policy::allows",
+                    "receiver_type_id": "domain::Policy",
+                    "result_used_as_decision": true,
+                    "decision_domain_type_id": "domain::Severity"
+                }]
+            }))
+            .expect("fake extension output"),
+        };
+        let output = provider
+            .fingerprint("rs", "src/policy.rs", content)
+            .expect("provider output");
+        let extension = fingerprint_from_extension_output("rs", "src/policy.rs", content, output);
+
+        fingerprint.compose_semantic_facts(extension);
+
+        assert!(fingerprint.methods.contains(&"new".to_string()));
+        assert_eq!(fingerprint.aggregate_construction_seams.len(), 2);
+        assert_eq!(
+            fingerprint.aggregate_construction_seams[0].type_name,
+            "GrammarOwned"
+        );
+        assert_eq!(
+            fingerprint.aggregate_construction_seams[1].type_name,
+            "ScriptOnly"
+        );
+        assert_eq!(fingerprint.aggregate_literals.len(), 2);
+        assert_eq!(fingerprint.aggregate_literals[0].type_name, "Other");
+        assert_eq!(fingerprint.aggregate_literals[1].type_name, "ScriptOnly");
+        assert_eq!(fingerprint.aggregate_definitions.len(), 1);
+        assert_eq!(fingerprint.field_accesses.len(), 1);
+        assert_eq!(fingerprint.aggregate_projections.len(), 1);
+        assert_eq!(fingerprint.decision_branches.len(), 1);
+        assert_eq!(fingerprint.method_calls.len(), 1);
     }
 
     #[test]

--- a/crates/homeboy-code-audit/src/shadow_modules.rs
+++ b/crates/homeboy-code-audit/src/shadow_modules.rs
@@ -280,6 +280,11 @@ mod tests {
             trait_impl_methods: vec![],
             aggregate_literals: vec![],
             aggregate_construction_seams: vec![],
+            aggregate_definitions: vec![],
+            field_accesses: vec![],
+            aggregate_projections: vec![],
+            decision_branches: vec![],
+            method_calls: vec![],
         }
     }
 

--- a/crates/homeboy-extension/src/fingerprint.rs
+++ b/crates/homeboy-extension/src/fingerprint.rs
@@ -9,6 +9,10 @@ pub use homeboy_audit_contract::fingerprint::{
     AggregateConstructionSeam, AggregateLiteral, CallSite, DeadCodeMarker, FingerprintOutput,
     HookRef, UnusedParam,
 };
+pub use homeboy_audit_contract::policy_flow::{
+    AggregateDefinitionFact, AggregateFieldFact, AggregateProjectionFact, DecisionBranchFact,
+    FactLocation, FieldAccessFact, FieldAccessKind, MethodCallFact, ProjectionFieldFact,
+};
 
 /// Run a extension's fingerprint script on file content.
 ///

--- a/crates/homeboy-extension/src/lib.rs
+++ b/crates/homeboy-extension/src/lib.rs
@@ -69,8 +69,10 @@ pub use execution::{
     ExtensionStepFilter,
 };
 pub use fingerprint::{
-    run_fingerprint_script, AggregateConstructionSeam, AggregateLiteral, CallSite, DeadCodeMarker,
-    FingerprintOutput, HookRef, UnusedParam,
+    run_fingerprint_script, AggregateConstructionSeam, AggregateDefinitionFact, AggregateFieldFact,
+    AggregateLiteral, AggregateProjectionFact, CallSite, DeadCodeMarker, DecisionBranchFact,
+    FactLocation, FieldAccessFact, FieldAccessKind, FingerprintOutput, HookRef, MethodCallFact,
+    ProjectionFieldFact, UnusedParam,
 };
 pub use homeboy_core::extension_invocation_context::ResolvedExtensionInvocationContext;
 pub use homeboy_core::extension_scope::ExtensionScope;

--- a/docs/audit/policy-flow.md
+++ b/docs/audit/policy-flow.md
@@ -1,0 +1,154 @@
+# Policy-flow detector
+
+The policy-flow detector reports an aggregate transformation that drops declared
+policy state before downstream code independently branches over the same typed
+decision domain. It consumes resolved, language-neutral facts from fingerprint
+extensions; Homeboy core does not parse source syntax or recognize product names.
+
+## Finding conditions
+
+The detector emits `lossy_policy_projection` only when one configured rule has
+all of these facts:
+
+- A resolved source aggregate declares every configured `policy_fields` entry.
+- A projection maps at least one source field into the configured decision carrier.
+- The projection omits at least one configured policy field.
+- The configured decision callable has a branch fact with the configured domain type.
+- The decision callable has no authoritative call whose result governs that same
+  resolved decision domain.
+
+Missing or ambiguous identities produce no finding. Test-path facts are ignored.
+Preserving all policy fields or delegating to the authoritative method is clean.
+An ordinary DTO projection is clean unless a declaration explicitly connects its
+source, carrier, callable, and decision domain.
+
+## Policy declarations
+
+Project/component configuration declares policy semantics under `audit.policy_flow`:
+
+```json
+{
+  "audit": {
+    "policy_flow": {
+      "rules": [
+        {
+          "id": "engagement-policy",
+          "source_type_id": "domain::SourcePolicy",
+          "policy_fields": ["threshold"],
+          "authoritative_method_id": "domain::SourcePolicy::should_engage",
+          "decision_sinks": [
+            {
+              "carrier_type_id": "domain::DecisionCarrier",
+              "callable_id": "domain::decide",
+              "domain_type_id": "domain::Severity"
+            }
+          ],
+          "convention": "policy_flow",
+          "severity": "warning"
+        }
+      ]
+    }
+  }
+}
+```
+
+An extension supplies the same typed declaration under
+`audit.detector_rules.policy_flow`. Linked extension and component declarations
+merge by rule `id`; the first declaration for an ID wins. Use globally unique IDs.
+`convention` defaults to `policy_flow`, and `severity` accepts `warning` or `info`
+and defaults to `warning`.
+
+## Fingerprint producer contract
+
+For each source file, the extension fingerprint script may add these arrays to
+its existing `FingerprintOutput` JSON object:
+
+```json
+{
+  "aggregate_definitions": [
+    {
+      "type_id": "domain::SourcePolicy",
+      "fields": [
+        {"name": "threshold", "type_id": "domain::Threshold"}
+      ],
+      "location": {"line": 3, "column": 1}
+    }
+  ],
+  "field_accesses": [
+    {
+      "owner_type_id": "domain::SourcePolicy",
+      "field": "threshold",
+      "callable_id": "domain::SourcePolicy::should_engage",
+      "access": "read",
+      "location": {"line": 5, "column": 9}
+    }
+  ],
+  "aggregate_projections": [
+    {
+      "source_type_id": "domain::SourcePolicy",
+      "target_type_id": "domain::DecisionCarrier",
+      "callable_id": "domain::project",
+      "field_mappings": [
+        {"source_field": "label", "target_field": "label"}
+      ],
+      "location": {"line": 8, "column": 5}
+    }
+  ],
+  "decision_branches": [
+    {
+      "callable_id": "domain::decide",
+      "domain_type_id": "domain::Severity",
+      "discriminant_id": "severity",
+      "location": {"line": 21, "column": 5}
+    }
+  ],
+  "method_calls": [
+    {
+      "caller_id": "domain::decide",
+      "target_method_id": "domain::SourcePolicy::should_engage",
+      "receiver_type_id": "domain::SourcePolicy",
+      "result_used_as_decision": true,
+      "decision_domain_type_id": "domain::Severity",
+      "location": {"line": 22, "column": 9}
+    }
+  ]
+}
+```
+
+All arrays and all `location` fields are optional and default empty. `line` and
+`column` are one-based; zero means unavailable. `type_id`, `callable_id`,
+`caller_id`, and `target_method_id` must be deterministic canonical identities
+qualified enough to distinguish symbols in different modules. `discriminant_id`
+is a stable resolved identity chosen by the extension, not raw source text.
+`receiver_type_id` and aggregate-field `type_id` are optional when unresolved.
+`access` is `read` or `write`. `result_used_as_decision` is true only when the
+call result directly governs the caller's decision, such as a returned call or
+controlling condition; it defaults to false. A decision-governing call also sets
+`decision_domain_type_id`; delegation suppresses only the matching configured
+domain.
+
+`field_accesses` is part of the shared fact vocabulary for consumers that need
+read/write evidence. This detector treats configured `policy_fields` as the
+authoritative semantic declaration rather than requiring the authoritative method
+to read each field directly, because that method may delegate internally.
+
+The file path is not repeated in each fact. Homeboy associates facts with the
+`file_path` supplied to the fingerprint script. Producers should sort each fact
+array and nested `fields`/`field_mappings` deterministically by canonical identity
+and source location.
+
+Complete positive and negative serialized examples live in
+`tests/fixtures/audit_policy_flow/`.
+
+## Evidence and baselines
+
+The finding is anchored to the projection file and names source, projection, and
+decision locations, omitted fields, and the authoritative method. Findings sort
+deterministically. Their baseline identity uses the configured convention, rule
+ID, canonical source and carrier types, projection callable, decision callable,
+decision domain, projection file, and finding kind. Source line movement does not churn
+the baseline, while two declared seams in one file remain distinct.
+
+The detector runs through the normal full audit execution plan and supports
+`--only lossy_policy_projection`, exclusions, changed-scope reconciliation, and
+standard audit baselines.

--- a/docs/commands/audit-rules.md
+++ b/docs/commands/audit-rules.md
@@ -36,6 +36,21 @@ Use one of:
 
 These findings participate in baseline comparisons like any other audit finding.
 
+## Policy flow
+
+`audit.policy_flow.rules` declares authoritative policy owners and typed decision
+sinks for the language-neutral lossy-projection detector. Extensions can provide
+the same declarations under `audit.detector_rules.policy_flow`; extension
+fingerprint scripts provide resolved aggregate, projection, decision, and call
+facts. See [Policy-flow detector](../audit/policy-flow.md) for the declaration and
+producer schemas.
+
+Finding output:
+
+- `kind`: `lossy_policy_projection`
+- `convention`: stable seam identity prefixed by the configured convention
+- severity: configured `warning` or `info`
+
 ## Thin Command Adapters
 
 `audit.thin_command_adapter` enforces the command/core boundary:

--- a/docs/reference/schemas/extension-manifest-schema.md
+++ b/docs/reference/schemas/extension-manifest-schema.md
@@ -43,7 +43,7 @@ Extension identity is path-derived: Homeboy derives the extension `id` from the 
 - **`id`** (string): Optional compatibility field for external consumers; Homeboy derives the authoritative extension ID from the directory name.
 - **`provides`** (object): File extensions and capabilities this extension handles
 - **`scripts`** (object): Scripts that implement extension capabilities (fingerprint, refactor)
-- **`audit`** (object): Docs audit config — ignore patterns, feature detection, test mapping
+- **`audit`** (object): Audit capability config, including docs, test mapping, and typed detector rules
 - **`deploy`** (object): Deploy lifecycle — verifications, overrides, version patterns
 - **`executable`** (object): Standalone tool runtime and inputs
 - **`platform`** (object): Platform behavior definitions (database, deployment, version patterns)
@@ -420,6 +420,11 @@ Configuration for documentation-reference analysis, feature detection, and struc
       "method_prefix": "test_",
       "inline_tests": true,
       "critical_patterns": ["src/core/"]
+    },
+    "detector_rules": {
+      "policy_flow": {
+        "rules": []
+      }
     }
   }
 }
@@ -433,6 +438,7 @@ Configuration for documentation-reference analysis, feature detection, and struc
 - **`doc_targets`** (object): Maps feature labels to documentation file paths and headings
 - **`feature_context`** (object): Context extraction rules per feature pattern (doc comments, block fields)
 - **`test_mapping`** (object): Test coverage mapping convention
+- **`detector_rules`** (object): Typed extension-owned detector declarations merged into project audit config. See [Policy-flow detector](../../audit/policy-flow.md) for `policy_flow`.
 
 ### Test Mapping Fields
 

--- a/tests/fixtures/audit_policy_flow/clean_delegation.json
+++ b/tests/fixtures/audit_policy_flow/clean_delegation.json
@@ -1,0 +1,64 @@
+{
+  "config": {
+    "rules": [
+      {
+        "id": "engagement",
+        "source_type_id": "domain::SourcePolicy",
+        "policy_fields": ["threshold"],
+        "authoritative_method_id": "domain::SourcePolicy::should_engage",
+        "decision_sinks": [
+          {
+            "carrier_type_id": "domain::DecisionCarrier",
+            "callable_id": "domain::decide",
+            "domain_type_id": "domain::Severity"
+          }
+        ]
+      }
+    ]
+  },
+  "files": [
+    {
+      "path": "src/policy.ext",
+      "aggregate_definitions": [
+        {
+          "type_id": "domain::SourcePolicy",
+          "fields": [{"name": "threshold", "type_id": "domain::Threshold"}],
+          "location": {"line": 3, "column": 1}
+        }
+      ]
+    },
+    {
+      "path": "src/project.ext",
+      "aggregate_projections": [
+        {
+          "source_type_id": "domain::SourcePolicy",
+          "target_type_id": "domain::DecisionCarrier",
+          "callable_id": "domain::project",
+          "field_mappings": [{"source_field": "label", "target_field": "label"}],
+          "location": {"line": 8, "column": 5}
+        }
+      ]
+    },
+    {
+      "path": "src/decide.ext",
+      "decision_branches": [
+        {
+          "callable_id": "domain::decide",
+          "domain_type_id": "domain::Severity",
+          "discriminant_id": "severity",
+          "location": {"line": 21, "column": 5}
+        }
+      ],
+      "method_calls": [
+        {
+          "caller_id": "domain::decide",
+          "target_method_id": "domain::SourcePolicy::should_engage",
+          "receiver_type_id": "domain::SourcePolicy",
+          "result_used_as_decision": true,
+          "decision_domain_type_id": "domain::Severity",
+          "location": {"line": 22, "column": 9}
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/audit_policy_flow/lossy_projection.json
+++ b/tests/fixtures/audit_policy_flow/lossy_projection.json
@@ -1,0 +1,73 @@
+{
+  "config": {
+    "rules": [
+      {
+        "id": "engagement",
+        "source_type_id": "domain::SourcePolicy",
+        "policy_fields": ["threshold"],
+        "authoritative_method_id": "domain::SourcePolicy::should_engage",
+        "decision_sinks": [
+          {
+            "carrier_type_id": "domain::DecisionCarrier",
+            "callable_id": "domain::decide",
+            "domain_type_id": "domain::Severity"
+          }
+        ]
+      }
+    ]
+  },
+  "files": [
+    {
+      "path": "src/policy.ext",
+      "aggregate_definitions": [
+        {
+          "type_id": "domain::SourcePolicy",
+          "fields": [
+            {"name": "threshold", "type_id": "domain::Threshold"},
+            {"name": "label", "type_id": "text::String"}
+          ],
+          "location": {"line": 3, "column": 1}
+        }
+      ],
+      "field_accesses": [
+        {
+          "owner_type_id": "domain::SourcePolicy",
+          "field": "threshold",
+          "callable_id": "domain::SourcePolicy::should_engage",
+          "access": "read",
+          "location": {"line": 5, "column": 9}
+        }
+      ]
+    },
+    {
+      "path": "src/project.ext",
+      "aggregate_definitions": [
+        {
+          "type_id": "domain::DecisionCarrier",
+          "fields": [{"name": "label", "type_id": "text::String"}],
+          "location": {"line": 1, "column": 1}
+        }
+      ],
+      "aggregate_projections": [
+        {
+          "source_type_id": "domain::SourcePolicy",
+          "target_type_id": "domain::DecisionCarrier",
+          "callable_id": "domain::project",
+          "field_mappings": [{"source_field": "label", "target_field": "label"}],
+          "location": {"line": 8, "column": 5}
+        }
+      ]
+    },
+    {
+      "path": "src/decide.ext",
+      "decision_branches": [
+        {
+          "callable_id": "domain::decide",
+          "domain_type_id": "domain::Severity",
+          "discriminant_id": "severity",
+          "location": {"line": 21, "column": 5}
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/audit_policy_flow/ordinary_dto.json
+++ b/tests/fixtures/audit_policy_flow/ordinary_dto.json
@@ -1,0 +1,40 @@
+{
+  "config": {
+    "rules": [
+      {
+        "id": "engagement",
+        "source_type_id": "domain::SourcePolicy",
+        "policy_fields": ["threshold"],
+        "authoritative_method_id": "domain::SourcePolicy::should_engage",
+        "decision_sinks": [
+          {
+            "carrier_type_id": "domain::DecisionCarrier",
+            "callable_id": "domain::decide",
+            "domain_type_id": "domain::Severity"
+          }
+        ]
+      }
+    ]
+  },
+  "files": [
+    {
+      "path": "src/dto.ext",
+      "aggregate_definitions": [
+        {
+          "type_id": "transport::Record",
+          "fields": [{"name": "id", "type_id": "scalar::Id"}],
+          "location": {"line": 1, "column": 1}
+        }
+      ],
+      "aggregate_projections": [
+        {
+          "source_type_id": "transport::Record",
+          "target_type_id": "transport::RecordDto",
+          "callable_id": "transport::to_dto",
+          "field_mappings": [{"source_field": "id", "target_field": "id"}],
+          "location": {"line": 7, "column": 5}
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add language-neutral policy-flow fingerprint facts and detector declarations
- report lossy aggregate projections followed by divergent typed decisions
- compose extension semantic facts with grammar fingerprints and register both providers at CLI startup
- document configuration, evidence, baselines, and producer responsibilities

## Verification
- `cargo test -p homeboy-code-audit`: 842 passed, 1 ignored
- focused CLI startup provider test passed
- package-scoped formatting and diff checks passed
- real Rust extension positive: run `86699f5b-6af7-496b-8aaf-25fc7689e986` emitted one `lossy_policy_projection`
- real authoritative delegation negative: run `dfe38392-3eab-4c24-9e63-ee289fa6ffd9` emitted no findings

## Dependency
- Rust fact producer: https://github.com/Extra-Chill/homeboy-extensions/pull/2340

Closes #9443