### PR TITLE
refactor(agents): narrow same-file-only action_state helpers to private (dead_code)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_controller_service/action_state.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/action_state.rs
@@ -161,7 +161,7 @@ pub(super) fn fail_controller_action_with_diagnostics(
     Ok(())
 }
 
-pub(super) fn infer_terminal_outcome(
+fn infer_terminal_outcome(
     action: &AgentTaskLoopPolicyActionRecord,
     execution: &Value,
     exit_code: i32,
@@ -230,7 +230,7 @@ fn fan_out_item_count(entity_ids: &[String], execution: &Value) -> usize {
         .unwrap_or(entity_ids.len())
 }
 
-pub(super) fn gate_terminal_status(result: &Value, exit_code: i32) -> AgentTaskLoopTerminalStatus {
+fn gate_terminal_status(result: &Value, exit_code: i32) -> AgentTaskLoopTerminalStatus {
     if exit_code == 0 {
         return match result.get("status").and_then(Value::as_str) {
             Some("warn") => AgentTaskLoopTerminalStatus::NoPublication,
@@ -251,7 +251,7 @@ pub(super) fn gate_terminal_status(result: &Value, exit_code: i32) -> AgentTaskL
     }
 }
 
-pub(super) fn gate_terminal_reason(status: AgentTaskLoopTerminalStatus) -> String {
+fn gate_terminal_reason(status: AgentTaskLoopTerminalStatus) -> String {
     match status {
         AgentTaskLoopTerminalStatus::Passed => "gate bundle passed".to_string(),
         AgentTaskLoopTerminalStatus::NoPublication => {
@@ -264,7 +264,7 @@ pub(super) fn gate_terminal_reason(status: AgentTaskLoopTerminalStatus) -> Strin
     }
 }
 
-pub(super) fn action_entity_id_for_record(
+fn action_entity_id_for_record(
     record: &AgentTaskLoopControllerRecord,
     action_id: &str,
 ) -> Option<String> {
@@ -275,7 +275,7 @@ pub(super) fn action_entity_id_for_record(
         .and_then(|action| action_entity_id(&action.action))
 }
 
-pub(super) fn set_controller_action_status(
+fn set_controller_action_status(
     record: &mut AgentTaskLoopControllerRecord,
     action_id: &str,
     status: AgentTaskLoopActionStatus,


### PR DESCRIPTION
## First cut at dead_code (#9502, 599 findings)
The `dead_code` category is `unreferenced_export` — "Public function X is not referenced **by any other file**." That does **not** mean unused; it usually means **over-broad visibility**: a `pub`/`pub(super)` fn only used within its own file. The correct fix is almost always **narrowing visibility**, not deletion.

## This change
Five `pub(super)` fns in `agent_task_controller_service/action_state.rs`, each **verified called only within action_state.rs** (zero references in sibling module files, zero outside the crate):
- `infer_terminal_outcome`, `gate_terminal_status`, `gate_terminal_reason`, `action_entity_id_for_record`, `set_controller_action_status`

`pub(super)` is over-broad for helpers with no cross-file caller → narrowed to private `fn`. The four `pub(super)` fns that **are** used by sibling files (`claim_`/`complete_`/`fail_controller_action*`) correctly keep `pub(super)`.

**Behavior-preserving:** narrowing a same-file-only fn cannot change name resolution — confirmed by the absence of any `never used` warning (proving they're still reached same-file). Clears 5 findings by tightening encapsulation, not deleting live code.

## Verification
- `cargo check -p homeboy-agents --lib` clean, `agent_task_controller_service` 81 tests passed.

## Method note (for the rest of #9502)
dead_code narrowing must be **per-function with compile verification**, not batch. I attempted a blanket `pub fn → fn` sed on `artifacts.rs` (14 findings) and it broke name resolution — several helpers there are nested inside other fns/impls. Each fix needs individual verification, which is how I'll approach the remaining files.
