### PR TITLE
refactor(agents): narrow same-scope-only artifact helpers to private (dead_code)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_artifacts.rs
+++ b/crates/homeboy-agents/src/agent_task_artifacts.rs
@@ -16,7 +16,7 @@ pub(crate) fn reviewer_facing_artifact(artifact: &AgentTaskArtifact) -> AgentTas
     artifact
 }
 
-pub(crate) fn reviewer_facing_artifacts(artifacts: &[AgentTaskArtifact]) -> Vec<AgentTaskArtifact> {
+fn reviewer_facing_artifacts(artifacts: &[AgentTaskArtifact]) -> Vec<AgentTaskArtifact> {
     artifacts.iter().map(reviewer_facing_artifact).collect()
 }
 
@@ -41,7 +41,7 @@ pub fn reviewer_facing_aggregate(aggregate: &AgentTaskAggregate) -> AgentTaskAgg
     aggregate
 }
 
-pub(crate) fn reviewer_facing_typed_artifact(
+fn reviewer_facing_typed_artifact(
     typed_artifact: &AgentTaskTypedArtifact,
 ) -> AgentTaskTypedArtifact {
     let mut typed_artifact = typed_artifact.clone();
@@ -52,7 +52,7 @@ pub(crate) fn reviewer_facing_typed_artifact(
     typed_artifact
 }
 
-pub(crate) fn reviewer_facing_binding(
+fn reviewer_facing_binding(
     mut binding: AgentTaskArtifactRunBinding,
 ) -> AgentTaskArtifactRunBinding {
     binding.path = reviewer_facing_path(binding.path.as_deref());

--- a/crates/homeboy-agents/src/agent_task_controller_service/artifacts.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/artifacts.rs
@@ -310,7 +310,7 @@ mod hydration {
         ids
     }
 
-    pub fn append_artifact_dependency_ids(ids: &mut Vec<String>, value: Option<&Value>) {
+    fn append_artifact_dependency_ids(ids: &mut Vec<String>, value: Option<&Value>) {
         let Some(values) = value.and_then(Value::as_array) else {
             return;
         };
@@ -323,7 +323,7 @@ mod hydration {
         }));
     }
 
-    pub fn append_string_array(ids: &mut Vec<String>, value: Option<&Value>) {
+    fn append_string_array(ids: &mut Vec<String>, value: Option<&Value>) {
         let Some(values) = value.and_then(Value::as_array) else {
             return;
         };
@@ -353,7 +353,7 @@ mod hydration {
         None
     }
 
-    pub fn artifact_from_outputs(outputs: &Value, artifact_id: &str) -> Option<Value> {
+    fn artifact_from_outputs(outputs: &Value, artifact_id: &str) -> Option<Value> {
         outputs
             .get("artifacts")
             .and_then(|artifacts| artifacts.get(artifact_id))
@@ -365,7 +365,7 @@ mod hydration {
             .cloned()
     }
 
-    pub fn artifact_from_history_payload(payload: &Value, artifact_id: &str) -> Option<Value> {
+    fn artifact_from_history_payload(payload: &Value, artifact_id: &str) -> Option<Value> {
         let result = payload.get("execution")?.get("result")?;
         if let Some(artifact) = artifact_from_outputs(result, artifact_id) {
             return Some(artifact);
@@ -1000,7 +1000,7 @@ mod evidence_index {
         })
     }
 
-    pub fn artifact_ref_from_artifact(artifact: &AgentTaskArtifact) -> AgentTaskLoopArtifactRef {
+    fn artifact_ref_from_artifact(artifact: &AgentTaskArtifact) -> AgentTaskLoopArtifactRef {
         AgentTaskLoopArtifactRef {
             uri: artifact
                 .url
@@ -1014,7 +1014,7 @@ mod evidence_index {
         }
     }
 
-    pub fn artifact_ref_from_evidence_ref(
+    fn artifact_ref_from_evidence_ref(
         evidence_ref: &AgentTaskEvidenceRef,
     ) -> AgentTaskLoopArtifactRef {
         AgentTaskLoopArtifactRef {
@@ -1026,7 +1026,7 @@ mod evidence_index {
         }
     }
 
-    pub fn artifact_ref_from_typed_artifact(
+    fn artifact_ref_from_typed_artifact(
         task_id: &str,
         typed_artifact: &AgentTaskTypedArtifact,
     ) -> AgentTaskLoopArtifactRef {


### PR DESCRIPTION
## dead_code #9502, batch 2
Ten `unreferenced_export` findings across two files. Each is a `pub`/`pub(crate)`/`pub fn` whose only callers live in its own file (or its own **nested in-file module**). Verified per-function that none is referenced from any other file → narrowed to private. **Encapsulation tightening, not deletion.**

- **`agent_task_artifacts.rs`** (`pub(crate) → fn`, same-file callers): `reviewer_facing_artifacts`, `reviewer_facing_binding`, `reviewer_facing_typed_artifact`
- **`agent_task_controller_service/artifacts.rs`** (`pub fn → fn`; each called only within its own nested module `hydration {}` or `evidence_index {}`): `append_artifact_dependency_ids`, `append_string_array`, `artifact_from_history_payload`, `artifact_from_outputs`, `artifact_ref_from_artifact`, `artifact_ref_from_evidence_ref`, `artifact_ref_from_typed_artifact`

## Method (the lesson from #9531)
Done **per-function with compile verification** — not a blanket sed. `artifacts.rs` helpers live inside nested modules (`hydration`, `evidence_index`), so I checked each function's call-sites against its module boundary before narrowing: functions used only within their nested module go all the way to private `fn`. A blanket `pub fn → fn` sed broke name resolution on a prior attempt (reverted); this batch verifies each.

Confirmed no `never used` warning appears for any narrowed fn (still reached same-scope), so this is pure visibility tightening.

## Verification
- `cargo check -p homeboy-agents --lib` clean; `agent_task_controller_service::artifacts` + `agent_task_artifacts` tests pass.
