### PR TITLE
Start Lab handoff lease at runner submission

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1780,15 +1780,6 @@ fn record_lab_offload_proxy(
     if record.state.is_terminal() {
         return Ok(record);
     }
-    if record.lab_handoff.is_none() {
-        let now = chrono::Utc::now();
-        record.lab_handoff = Some(AgentTaskLabHandoff::pending(
-            runner_id,
-            now.to_rfc3339(),
-            (now + chrono::Duration::seconds(lab_handoff_acceptance_timeout_seconds()))
-                .to_rfc3339(),
-        ));
-    }
     let metadata = record.ensure_metadata_object();
     metadata.insert("kind".to_string(), json!("lab_offload_controller_proxy"));
     // This record is the controller's durable projection of a runner handoff.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -731,7 +731,7 @@ fn accepted_handoff_does_not_terminalize_unconfirmed_generation_absence() {
 }
 
 #[test]
-fn preacceptance_snapshot_binds_the_accepted_daemon_job_before_validation() {
+fn preacceptance_snapshot_binds_planned_runner_job_before_validation() {
     with_isolated_home(|_| {
         let run_id = "cook-preacceptance-snapshot";
         let plan = test_plan();
@@ -744,12 +744,9 @@ fn preacceptance_snapshot_binds_the_accepted_daemon_job_before_validation() {
             None,
             Some(&plan),
         )
-        .expect("persist pending controller handoff");
-        assert_eq!(
-            record.lab_handoff.as_ref().expect("pending handoff").state,
-            AgentTaskLabHandoffState::Pending,
-            "the controller must establish typed acceptance authority before a staging snapshot can arrive"
-        );
+        .expect("persist planned controller execution");
+        assert!(record.lab_handoff.is_none());
+        assert_eq!(record.metadata["runner_id"], "homeboy-lab");
         let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
         snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
         snapshot.job.target_runner_id = Some("homeboy-lab".to_string());
@@ -787,7 +784,7 @@ fn preacceptance_snapshot_binds_a_pre_claim_job_without_a_target_runner() {
             None,
             Some(&plan),
         )
-        .expect("persist pending controller handoff");
+        .expect("persist planned controller execution");
         let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
         snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
         snapshot.job.target_runner_id = None;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -340,6 +340,12 @@ fn runner_exec_run_id_creates_generic_run_on_demand() {
 #[test]
 fn status_expires_an_unaccepted_handoff_but_late_runner_acceptance_wins() {
     with_isolated_home(|_| {
+        let _runner = RunnerContinuationTestGuard::install(Box::new(IntentReplayProvider {
+            store: JobStore::default(),
+            submitted: Arc::new(Mutex::new(Vec::new())),
+            lookups: Arc::new(Mutex::new(Vec::new())),
+            fail_after_accept_once: Arc::new(Mutex::new(false)),
+        }));
         let command = vec![
             "homeboy".to_string(),
             "agent-task".to_string(),
@@ -353,6 +359,11 @@ fn status_expires_an_unaccepted_handoff_but_late_runner_acceptance_wins() {
             durable_plan: None,
         })
         .expect("controller proxy recorded before handoff");
+        record_lab_offload_submission_request(
+            "expired-handoff-late-acceptance",
+            &replay_request("expired-handoff-late-acceptance", &command),
+        )
+        .expect("persist complete pending submission request");
         rewrite_record_for_test("expired-handoff-late-acceptance", |record| {
             record
                 .lab_handoff

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -95,7 +95,7 @@ fn lab_cook_child_invocation_consumes_controller_runner_placement() {
 }
 
 #[test]
-fn cook_dispatch_stages_pending_handoff_before_lab_preacceptance() {
+fn cook_dispatch_stages_runner_identity_without_starting_handoff_lease() {
     crate::test_support::with_isolated_home(|_| {
         let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
             "cook-preacceptance-order",
@@ -128,11 +128,12 @@ fn cook_dispatch_stages_pending_handoff_before_lab_preacceptance() {
         assert!(!error.message.is_empty());
         let record = agent_task_lifecycle::status("cook-preacceptance-order")
             .expect("controller record remains inspectable after preacceptance failure");
-        let handoff = record.lab_handoff.expect("pending controller handoff");
-        assert_eq!(handoff.runner_id, "missing-homeboy-lab");
-        let handoff = serde_json::to_value(handoff).expect("serialize typed handoff");
-        assert_eq!(handoff["state"], "pending");
-        assert_eq!(handoff["authority"], "controller");
+        assert!(record.lab_handoff.is_none());
+        assert_eq!(record.metadata["runner_id"], "missing-homeboy-lab");
+        assert_eq!(
+            record.metadata["runner_execution_record"]["status"],
+            "planned"
+        );
         assert_eq!(
             record.metadata["pre_execution_failure"]["phase"],
             "lab_handoff_preacceptance"


### PR DESCRIPTION
## Summary

- keep preacceptance planning controller-owned without creating a typed handoff lease
- retain durable planned runner identity for snapshot binding
- start expiry semantics only after a complete submission request exists
- update stale tests that conflated planning with submission

Fixes #9534.

## Root cause

#9345 reintroduced `AgentTaskLabHandoff::pending(...)` in `record_lab_offload_proxy()` after #9274 had moved lease creation to `record_lab_offload_submission_request()`. #9374 then called that proxy before Lab validation and workspace materialization. Large source snapshots therefore expired the two-minute handoff lease before submission began.

## Verification

- `cargo test -p homeboy-agents controller_proxy_is_queued_before_handoff_then_binds_runner_child`
- `cargo test -p homeboy-agents long_pre_submission_setup_survives_reconciliation_and_terminal_phase_writes_are_noops`
- `cargo test -p homeboy-agents preacceptance_snapshot_binds_planned_runner_job_before_validation`
- `cargo test -p homeboy-agents preacceptance_snapshot_binds_a_pre_claim_job_without_a_target_runner`
- `cargo test -p homeboy-agents status_expires_an_unaccepted_handoff_but_late_runner_acceptance_wins`
- `cargo test -p homeboy-agents preacceptance_snapshot_binds_replacement_job_from_planned_execution_record`
- `cargo test -p homeboy-cli cook_dispatch_stages_runner_identity_without_starting_handoff_lease`
- changed-file `rustfmt --check` and `git diff --check`

Repository-wide `cargo fmt --all -- --check` remains blocked by pre-existing formatting drift in untouched `crates/contracts/homeboy-lab-contract/src/lab/handoff.rs`. A broad lifecycle run also reproduced an unrelated existing artifact projection failure in `terminal_executor_artifacts_are_projected_under_logical_ids`; focused tests for this change pass.

## AI assistance

- **AI assistance:** Yes
- **Tool:** OpenAI GPT-5.6 Sol via OpenCode/Kimaki
- **Used for:** Diagnosis, implementation, tests, and PR drafting. Chris reviews and owns the change.