### PR TITLE
feat(agent-task): make the review dossier a composable form the AI fills

### DIFF
--- a/crates/homeboy-agents/src/agent_task_cook_loop.rs
+++ b/crates/homeboy-agents/src/agent_task_cook_loop.rs
@@ -9,6 +9,7 @@ use crate::agent_task_gate::{
     AgentTaskGateVisibility,
 };
 use crate::agent_task_promotion::{AgentTaskPromotionReport, AgentTaskPromotionStatus};
+use crate::agent_task_review_dossier::AiFilledReviewForm;
 use homeboy_core::gate::{HomeboyGateResult, HomeboyGateStatus};
 
 pub const AGENT_TASK_COOK_FEEDBACK_REPORT_SCHEMA: &str =
@@ -25,6 +26,18 @@ pub struct AgentTaskCookLoopOptions {
     pub source_run_id: Option<String>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub current_diff: String,
+    /// Whether the AI-authored review form is a required gate for this
+    /// evaluation. Cook finalization enables it (a green change is not "done"
+    /// until a valid form exists); standalone/diagnostic evaluations leave it
+    /// off so they never demand a form the caller isn't producing.
+    #[serde(default)]
+    pub require_review_form: bool,
+    /// The AI-authored review form parsed off the terminal attempt outcome, if
+    /// the agent emitted one. A green cook is not "done" until this is present
+    /// and valid — a missing/invalid form nudges another attempt exactly like a
+    /// red deterministic gate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review_form: Option<AiFilledReviewForm>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
 }
@@ -114,17 +127,41 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
     let should_retry = options.promotion_report.status == AgentTaskPromotionStatus::GateFailed
         && !failed_gates.is_empty()
         && retry_budget_remaining > 0;
-    let follow_up_request = should_retry.then(|| build_follow_up_request(&options, &failed_gates));
+    // Deterministic gates take precedence: a red gate must be fixed before the
+    // review form is even worth requesting. Only once the change itself is green
+    // (and actually produced changes) does the AI-authored form become the last
+    // outstanding "gate".
+    let gates_green_with_changes = failed_gates.is_empty()
+        && options.promotion_report.status != AgentTaskPromotionStatus::NoChangesGateFailed
+        && quality.classification != AgentTaskCookLoopQualityClassification::NoChanges;
+    let review_form_gap = (options.require_review_form && gates_green_with_changes)
+        .then(|| review_form_requirement_gap(&options.review_form));
+
+    let follow_up_request = if should_retry {
+        Some(build_follow_up_request(&options, &failed_gates))
+    } else if let Some(Some(gap)) = &review_form_gap {
+        // Gates are green but the AI form is missing/invalid: nudge another
+        // attempt with actionable feedback, exactly like a red gate — unless the
+        // retry budget is exhausted.
+        (retry_budget_remaining > 0).then(|| build_review_form_follow_up_request(&options, gap))
+    } else {
+        None
+    };
+
     let status = if follow_up_request.is_some() {
         AgentTaskCookLoopStatus::RetryRequested
     } else if options.promotion_report.status == AgentTaskPromotionStatus::NoChangesGateFailed {
         AgentTaskCookLoopStatus::NoOpGateFailed
     } else if quality.classification == AgentTaskCookLoopQualityClassification::NoChanges {
         AgentTaskCookLoopStatus::NoChanges
-    } else if failed_gates.is_empty() {
-        AgentTaskCookLoopStatus::GreenCompleted
-    } else {
+    } else if !failed_gates.is_empty() {
         AgentTaskCookLoopStatus::RetriesExhausted
+    } else if matches!(&review_form_gap, Some(Some(_))) {
+        // Green change, but the agent never produced a valid form and the retry
+        // budget is spent. The cook does not publish a PR without the form.
+        AgentTaskCookLoopStatus::RetriesExhausted
+    } else {
+        AgentTaskCookLoopStatus::GreenCompleted
     };
 
     AgentTaskCookLoopReport {
@@ -306,6 +343,86 @@ fn build_follow_up_request(
     request
 }
 
+/// Returns `Some(feedback)` describing why the AI review form is not yet
+/// acceptable (absent or failing validation), or `None` when the form is valid.
+fn review_form_requirement_gap(form: &Option<AiFilledReviewForm>) -> Option<String> {
+    match form {
+        None => Some(format!(
+            "The change passed deterministic gates but no review form was emitted. {}",
+            AiFilledReviewForm::requirement_feedback()
+        )),
+        Some(form) => form.validate().err().map(|error| error.message),
+    }
+}
+
+/// Build a follow-up attempt request that nudges the agent to emit a valid
+/// review form. Mirrors `build_follow_up_request` but the outstanding work is
+/// authoring the review form, not fixing a red gate.
+fn build_review_form_follow_up_request(
+    options: &AgentTaskCookLoopOptions,
+    gap_feedback: &str,
+) -> AgentTaskRequest {
+    let mut request = options.source_request.clone();
+    let next_attempt = options.attempt.saturating_add(1);
+    request.schema = AGENT_TASK_REQUEST_SCHEMA.to_string();
+    request.task_id = format!("{}-review-form-{}", request.task_id, next_attempt);
+    request.parent_plan_id = request
+        .parent_plan_id
+        .clone()
+        .or_else(|| options.source_run_id.clone());
+    request.instructions = format!(
+        "Continue the Homeboy cook loop from the current candidate worktree state.\n\nThe change is complete and deterministic gates passed, but the reviewer-facing review form is not yet valid, so the pull request cannot be opened.\n\n{gap_feedback}\n\nDo not modify the code. Emit the `review_form` object in your task outputs and finish.",
+    );
+    request.inputs = json!({
+        "cook_loop": {
+            "source_run_id": options.source_run_id,
+            "source_task_id": options.source_request.task_id,
+            "source_patch_task_id": options.promotion_report.source.task_id,
+            "promotion_status": options.promotion_report.status,
+            "attempt": options.attempt,
+            "next_attempt": next_attempt,
+            "max_attempts": options.max_attempts,
+            "retry_budget_remaining_after_dispatch": options.max_attempts.saturating_sub(next_attempt),
+            "to_worktree": options.promotion_report.to_worktree,
+            "changed_files": options.promotion_report.changed_files,
+            "review_form_required": true,
+            "review_form_feedback": gap_feedback,
+            "current_diff": options.current_diff,
+        }
+    });
+    request.source_refs.push(AgentTaskSourceRef {
+        kind: "agent-task-run".to_string(),
+        uri: options
+            .source_run_id
+            .as_ref()
+            .map(|run_id| format!("homeboy://agent-task/run/{run_id}"))
+            .unwrap_or_else(|| {
+                format!(
+                    "homeboy://agent-task/task/{}",
+                    options.source_request.task_id
+                )
+            }),
+        revision: None,
+    });
+    request.workspace.mode = AgentTaskWorkspaceMode::Existing;
+    request.workspace.root = request
+        .workspace
+        .root
+        .clone()
+        .or_else(|| worktree_root_hint(&options.promotion_report));
+    request.metadata = json!({
+        "cook_loop": {
+            "kind": "review-form-feedback",
+            "attempt": next_attempt,
+            "previous_attempt": options.attempt,
+            "max_attempts": options.max_attempts,
+            "source_task_id": options.source_request.task_id,
+            "source_run_id": options.source_run_id,
+        }
+    });
+    request
+}
+
 fn gate_failure(gate: &AgentTaskGateReport) -> AgentTaskCookLoopGateFailure {
     let command = gate
         .failure_evidence
@@ -479,6 +596,8 @@ mod tests {
             max_attempts: 3,
             source_run_id: Some("run-3676".to_string()),
             current_diff: "diff --git a/src/lib.rs b/src/lib.rs".to_string(),
+            require_review_form: false,
+            review_form: None,
             metadata: Value::Null,
         });
 
@@ -516,6 +635,8 @@ mod tests {
             max_attempts: 2,
             source_run_id: Some("run-3676".to_string()),
             current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
             metadata: Value::Null,
         });
 
@@ -537,6 +658,8 @@ mod tests {
             max_attempts: 3,
             source_run_id: None,
             current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
             metadata: Value::Null,
         });
 
@@ -560,6 +683,8 @@ mod tests {
             max_attempts: 1,
             source_run_id: Some("run-inherited".to_string()),
             current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
             metadata: Value::Null,
         });
         assert_eq!(accepted.status, AgentTaskCookLoopStatus::GreenCompleted);
@@ -575,6 +700,8 @@ mod tests {
             max_attempts: 1,
             source_run_id: Some("run-regression".to_string()),
             current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
             metadata: Value::Null,
         });
         assert_eq!(regression.status, AgentTaskCookLoopStatus::RetriesExhausted);
@@ -594,6 +721,8 @@ mod tests {
             max_attempts: 3,
             source_run_id: Some("run-4324".to_string()),
             current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
             metadata: Value::Null,
         });
 
@@ -619,6 +748,8 @@ mod tests {
             max_attempts: 3,
             source_run_id: Some("run-verified-no-op".to_string()),
             current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
             metadata: Value::Null,
         });
         assert_eq!(verified.status, AgentTaskCookLoopStatus::GreenCompleted);
@@ -638,6 +769,8 @@ mod tests {
             max_attempts: 3,
             source_run_id: Some("run-failed-no-op".to_string()),
             current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
             metadata: Value::Null,
         });
         assert_eq!(failed.status, AgentTaskCookLoopStatus::NoOpGateFailed);
@@ -660,6 +793,8 @@ mod tests {
             max_attempts: 3,
             source_run_id: Some("run-4327".to_string()),
             current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
             metadata: Value::Null,
         });
 
@@ -686,6 +821,8 @@ mod tests {
             max_attempts: 3,
             source_run_id: Some("run-3688".to_string()),
             current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
             metadata: Value::Null,
         });
 
@@ -708,6 +845,8 @@ mod tests {
             max_attempts: 3,
             source_run_id: Some("run-3688".to_string()),
             current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
             metadata: Value::Null,
         });
 
@@ -741,6 +880,8 @@ mod tests {
             max_attempts: 3,
             source_run_id: Some("run-3688".to_string()),
             current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
             metadata: Value::Null,
         });
 
@@ -749,6 +890,131 @@ mod tests {
 
         assert!(agent_context.contains("./hidden-heldout-check"));
         assert!(agent_context.contains("secret fixture mismatch"));
+    }
+
+    fn valid_review_form() -> AiFilledReviewForm {
+        AiFilledReviewForm {
+            summary: "Fix the reload crash.".to_string(),
+            what_changed: vec!["Guard the null render path.".to_string()],
+            compatibility: "Internal only; no compatibility impact.".to_string(),
+            used_for: "Reproduced the crash, isolated the null path, added a guard, and verified with a focused gate before finalizing.".to_string(),
+        }
+    }
+
+    #[test]
+    fn green_change_without_review_form_requests_another_attempt() {
+        let report = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report(
+                AgentTaskPromotionStatus::Applied,
+                vec![green_gate()],
+            ),
+            attempt: 1,
+            max_attempts: 3,
+            source_run_id: Some("run-form-1".to_string()),
+            current_diff: String::new(),
+            require_review_form: true,
+            review_form: None,
+            metadata: Value::Null,
+        });
+
+        assert_eq!(report.status, AgentTaskCookLoopStatus::RetryRequested);
+        let request = report
+            .follow_up_request
+            .expect("missing form must nudge a follow-up attempt");
+        assert!(request.task_id.contains("review-form"));
+        assert_eq!(request.inputs["cook_loop"]["review_form_required"], true);
+        assert!(request.instructions.contains("review_form"));
+    }
+
+    #[test]
+    fn green_change_with_valid_review_form_completes() {
+        let report = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report(
+                AgentTaskPromotionStatus::Applied,
+                vec![green_gate()],
+            ),
+            attempt: 1,
+            max_attempts: 3,
+            source_run_id: Some("run-form-2".to_string()),
+            current_diff: String::new(),
+            require_review_form: true,
+            review_form: Some(valid_review_form()),
+            metadata: Value::Null,
+        });
+
+        assert_eq!(report.status, AgentTaskCookLoopStatus::GreenCompleted);
+        assert!(report.follow_up_request.is_none());
+    }
+
+    #[test]
+    fn green_change_with_invalid_review_form_requests_another_attempt_with_feedback() {
+        let mut form = valid_review_form();
+        form.used_for = form.summary.clone(); // not a distinct reflection
+        let report = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report(
+                AgentTaskPromotionStatus::Applied,
+                vec![green_gate()],
+            ),
+            attempt: 1,
+            max_attempts: 3,
+            source_run_id: Some("run-form-3".to_string()),
+            current_diff: String::new(),
+            require_review_form: true,
+            review_form: Some(form),
+            metadata: Value::Null,
+        });
+
+        assert_eq!(report.status, AgentTaskCookLoopStatus::RetryRequested);
+        let request = report.follow_up_request.expect("invalid form nudges retry");
+        assert!(request.inputs["cook_loop"]["review_form_feedback"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("distinct from summary"));
+    }
+
+    #[test]
+    fn missing_review_form_with_exhausted_budget_does_not_complete() {
+        let report = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report(
+                AgentTaskPromotionStatus::Applied,
+                vec![green_gate()],
+            ),
+            attempt: 3,
+            max_attempts: 3,
+            source_run_id: Some("run-form-4".to_string()),
+            current_diff: String::new(),
+            require_review_form: true,
+            review_form: None,
+            metadata: Value::Null,
+        });
+
+        assert_eq!(report.status, AgentTaskCookLoopStatus::RetriesExhausted);
+        assert!(report.follow_up_request.is_none());
+    }
+
+    #[test]
+    fn review_form_not_required_completes_green_without_a_form() {
+        let report = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report(
+                AgentTaskPromotionStatus::Applied,
+                vec![green_gate()],
+            ),
+            attempt: 1,
+            max_attempts: 3,
+            source_run_id: Some("run-form-5".to_string()),
+            current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
+            metadata: Value::Null,
+        });
+
+        assert_eq!(report.status, AgentTaskCookLoopStatus::GreenCompleted);
+        assert!(report.follow_up_request.is_none());
     }
 
     fn source_request() -> AgentTaskRequest {

--- a/crates/homeboy-agents/src/agent_task_review_dossier.rs
+++ b/crates/homeboy-agents/src/agent_task_review_dossier.rs
@@ -137,6 +137,135 @@ pub struct AgentTaskReviewOverride {
     pub provenance: String,
 }
 
+/// Schema key the agent emits its review form under inside `AgentTaskOutcome.outputs`.
+pub const AI_REVIEW_FORM_OUTPUT_KEY: &str = "review_form";
+
+/// The single AI-authored "form" — every non-deterministic slot of the review
+/// dossier. The orchestrator owns everything else (AI-assistance tool/model,
+/// evidence, gate labels, how-to-test, source relationships, the section
+/// skeleton). The agent fills this once and returns it via
+/// `AgentTaskOutcome.outputs["review_form"]`; it is the only reviewer-facing
+/// prose the model authors.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AiFilledReviewForm {
+    /// What is changing in this PR and why.
+    pub summary: String,
+    /// Bullet points of the concrete changes.
+    #[serde(default)]
+    pub what_changed: Vec<String>,
+    /// Compatibility / impact assessment.
+    pub compatibility: String,
+    /// Self-reflective, concise description of the *process* the AI took —
+    /// deliberately distinct from `summary` (which describes *what* changed).
+    pub used_for: String,
+}
+
+impl AiFilledReviewForm {
+    /// Parse the form the agent emitted under `outputs["review_form"]`.
+    ///
+    /// Returns `Ok(None)` when the key is absent (the agent did not emit a
+    /// form at all — the loop treats that like a red gate and nudges a retry).
+    /// A present-but-malformed value is a hard parse error so a garbage form
+    /// is never silently rendered.
+    pub fn from_outcome_outputs(outputs: &serde_json::Value) -> Result<Option<Self>> {
+        let Some(value) = outputs.get(AI_REVIEW_FORM_OUTPUT_KEY) else {
+            return Ok(None);
+        };
+        if value.is_null() {
+            return Ok(None);
+        }
+        let form: Self = serde_json::from_value(value.clone()).map_err(|error| {
+            Error::validation_invalid_argument(
+                "review_form",
+                format!("agent-emitted review_form is malformed: {error}"),
+                None,
+                None,
+            )
+        })?;
+        Ok(Some(form))
+    }
+
+    /// Reviewer-facing feedback describing exactly what a valid form requires.
+    /// Surfaced to the agent when the form is missing or incomplete so the
+    /// nudge loop can converge.
+    pub fn requirement_feedback() -> &'static str {
+        "Emit a `review_form` object in your task outputs with: `summary` (what is changing and why), \
+`what_changed` (a non-empty list of concrete change bullets), `compatibility` (impact/compatibility \
+assessment), and `used_for` (a concise, self-reflective description of the process you took — distinct \
+from the summary of what changed). `used_for` must be a genuine reflection, not a restatement of the summary."
+    }
+
+    /// Validate that the agent filled every required slot with real content.
+    /// `Err` carries actionable, agent-facing feedback for the nudge loop.
+    pub fn validate(&self) -> Result<()> {
+        if self.summary.trim().is_empty() {
+            return Err(review_form_gap("review_form.summary", "summary is empty"));
+        }
+        if self
+            .what_changed
+            .iter()
+            .all(|entry| entry.trim().is_empty())
+        {
+            return Err(review_form_gap(
+                "review_form.what_changed",
+                "what_changed has no non-empty entries",
+            ));
+        }
+        if self.compatibility.trim().is_empty() {
+            return Err(review_form_gap(
+                "review_form.compatibility",
+                "compatibility is empty",
+            ));
+        }
+        if self.used_for.trim().is_empty() {
+            return Err(review_form_gap("review_form.used_for", "used_for is empty"));
+        }
+        if used_for_is_placeholder(&self.used_for) {
+            return Err(review_form_gap(
+                "review_form.used_for",
+                "used_for is a placeholder, not a genuine process reflection",
+            ));
+        }
+        // A used_for that merely restates the summary is not a reflection.
+        if self
+            .used_for
+            .trim()
+            .eq_ignore_ascii_case(self.summary.trim())
+        {
+            return Err(review_form_gap(
+                "review_form.used_for",
+                "used_for must be distinct from summary (it describes the process, not the change)",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn review_form_gap(field: &str, problem: &str) -> Error {
+    Error::validation_invalid_argument(
+        field,
+        format!("{problem}. {}", AiFilledReviewForm::requirement_feedback()),
+        None,
+        None,
+    )
+}
+
+/// Canned/placeholder `used_for` values that must not pass as a genuine
+/// reflection — including the legacy CLI default this refactor retires.
+fn used_for_is_placeholder(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    matches!(
+        normalized.as_str(),
+        "" | "n/a"
+            | "na"
+            | "none"
+            | "ai-assisted"
+            | "ai assisted"
+            | "implementation"
+            | "drafted implementation and tests; chris reviews and owns the change."
+    )
+}
+
 pub fn default_profile() -> AgentTaskReviewProfile {
     AgentTaskReviewProfile {
         required_sections: vec![
@@ -363,6 +492,23 @@ impl AgentTaskReviewDossier {
     }
 }
 
+/// Reviewer-facing evidence label for a deterministic gate.
+///
+/// Gate `name` is a positional id (`gate-1`, `gate-2`) that is meaningless to a
+/// reviewer. The gate `summary` carries the concrete, reveal-policy-safe
+/// description instead — for a passing command gate it is
+/// `"deterministic gate passed: <command>"`, and for a private/withheld gate it
+/// is already redacted by policy. Prefer that; only fall back to the positional
+/// id when no summary was recorded.
+fn gate_evidence_summary(gate: &HomeboyGateResult) -> String {
+    let summary = gate.summary.trim();
+    if summary.is_empty() {
+        format!("{}: {:?}", gate.name, gate.status)
+    } else {
+        format!("{summary} ({:?})", gate.status)
+    }
+}
+
 pub fn enrich_dossier(
     dossier: &mut AgentTaskReviewDossier,
     source_refs: &[String],
@@ -373,7 +519,7 @@ pub fn enrich_dossier(
 ) {
     for gate in gates {
         dossier.evidence.push(AgentTaskReviewEvidence {
-            summary: format!("{}: {:?}", gate.name, gate.status),
+            summary: gate_evidence_summary(gate),
             url: None,
         });
     }
@@ -781,6 +927,119 @@ mod tests {
             overrides: Vec::new(),
         }
     }
+
+    fn valid_form() -> AiFilledReviewForm {
+        AiFilledReviewForm {
+            summary: "Fix the widget so it renders on reload.".into(),
+            what_changed: vec!["Guard the null path in render().".into()],
+            compatibility: "No compatibility impact; internal only.".into(),
+            used_for: "I traced the null deref to the reload path, added a guard, and verified with a focused test before finalizing.".into(),
+        }
+    }
+
+    #[test]
+    fn valid_review_form_passes_validation() {
+        assert!(valid_form().validate().is_ok());
+    }
+
+    #[test]
+    fn review_form_rejects_empty_required_fields() {
+        for mutate in [
+            (|f: &mut AiFilledReviewForm| f.summary.clear()) as fn(&mut AiFilledReviewForm),
+            |f| f.what_changed.clear(),
+            |f| f.compatibility.clear(),
+            |f| f.used_for.clear(),
+        ] {
+            let mut form = valid_form();
+            mutate(&mut form);
+            assert!(
+                form.validate().is_err(),
+                "expected validation failure for cleared required field"
+            );
+        }
+    }
+
+    #[test]
+    fn review_form_rejects_placeholder_used_for() {
+        let mut form = valid_form();
+        form.used_for =
+            "Drafted implementation and tests; Chris reviews and owns the change.".into();
+        let error = form
+            .validate()
+            .expect_err("legacy canned default must be rejected");
+        assert!(error.message.contains("placeholder"));
+    }
+
+    #[test]
+    fn review_form_rejects_used_for_equal_to_summary() {
+        let mut form = valid_form();
+        form.used_for = form.summary.clone();
+        let error = form
+            .validate()
+            .expect_err("used_for restating summary is not a process reflection");
+        assert!(error.message.contains("distinct from summary"));
+    }
+
+    #[test]
+    fn review_form_parses_from_outcome_outputs() {
+        let outputs = serde_json::json!({ "review_form": valid_form() });
+        let parsed = AiFilledReviewForm::from_outcome_outputs(&outputs)
+            .expect("parse")
+            .expect("present");
+        assert_eq!(parsed, valid_form());
+    }
+
+    #[test]
+    fn absent_review_form_parses_as_none() {
+        assert!(
+            AiFilledReviewForm::from_outcome_outputs(&serde_json::json!({}))
+                .expect("parse")
+                .is_none()
+        );
+        assert!(AiFilledReviewForm::from_outcome_outputs(
+            &serde_json::json!({ "review_form": null })
+        )
+        .expect("parse")
+        .is_none());
+    }
+
+    #[test]
+    fn malformed_review_form_is_a_hard_error() {
+        let outputs = serde_json::json!({ "review_form": { "summary": 42 } });
+        assert!(AiFilledReviewForm::from_outcome_outputs(&outputs).is_err());
+    }
+
+    #[test]
+    fn gate_evidence_summary_uses_command_bearing_summary_not_positional_id() {
+        let gate = HomeboyGateResult::new(
+            "gate-1",
+            "gate-1",
+            homeboy_core::gate::HomeboyGateKind::Command,
+            homeboy_core::gate::HomeboyGateStatus::Passed,
+        )
+        .summary("deterministic gate passed: cargo test widget");
+        let label = gate_evidence_summary(&gate);
+        assert!(
+            label.contains("cargo test widget"),
+            "expected the command in the label, got: {label}"
+        );
+        assert!(
+            !label.starts_with("gate-1"),
+            "must not lead with the positional id"
+        );
+    }
+
+    #[test]
+    fn gate_evidence_summary_falls_back_to_id_when_summary_absent() {
+        let gate = HomeboyGateResult::new(
+            "gate-2",
+            "gate-2",
+            homeboy_core::gate::HomeboyGateKind::Command,
+            homeboy_core::gate::HomeboyGateStatus::Passed,
+        );
+        assert_eq!(gate_evidence_summary(&gate), "gate-2: Passed");
+    }
+
     #[test]
     fn renderer_is_deterministic_and_safe() {
         let body = render_review_dossier(&dossier(), &default_profile());

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -53,6 +53,21 @@ pub(crate) fn gate_feedback_current_diff(promotion: &AgentTaskPromotionReport) -
         .to_string()
 }
 
+/// Parse the AI-authored review form off the terminal attempt outcome.
+///
+/// The agent emits it under `outputs["review_form"]`; the terminal outcome is
+/// the last one recorded in the aggregate. Returns `Ok(None)` when the agent
+/// emitted no form (the loop treats absence as a gap and nudges a retry). A
+/// present-but-malformed form is a hard error so garbage is never rendered.
+fn review_form_from_aggregate(
+    aggregate: &crate::agent_task_schedule::AgentTaskAggregate,
+) -> Result<Option<crate::agent_task_review_dossier::AiFilledReviewForm>> {
+    let Some(outcome) = aggregate.outcomes.last() else {
+        return Ok(None);
+    };
+    crate::agent_task_review_dossier::AiFilledReviewForm::from_outcome_outputs(&outcome.outputs)
+}
+
 /// Executes one provider attempt while cook retains ownership of promotion,
 /// gates, retries, and finalization.
 pub trait AgentTaskCookAttemptDispatcher: Send + Sync + std::fmt::Debug {
@@ -635,6 +650,7 @@ where
             }
         };
 
+        let review_form = review_form_from_aggregate(&aggregate)?;
         let feedback = evaluate_cook_loop(AgentTaskCookLoopOptions {
             source_request,
             promotion_report: promotion.clone(),
@@ -642,6 +658,8 @@ where
             max_attempts,
             source_run_id: Some(run_id.clone()),
             current_diff: gate_feedback_current_diff(&promotion),
+            require_review_form: true,
+            review_form,
             metadata: Value::Null,
         });
         let feedback_status = feedback.status;

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -42,6 +42,26 @@ use super::cook_promotion::{
 };
 use super::AgentTaskRunResult;
 
+/// Read the AI-authored review form off an adopted candidate's terminal
+/// outcome. The candidate was produced by an earlier cook attempt, so any form
+/// the original agent emitted is recorded on its aggregate. Absent/invalid here
+/// re-triggers the review-form gate exactly as it would for a fresh cook.
+fn adopted_review_form(
+    run_id: &str,
+) -> Result<Option<crate::agent_task_review_dossier::AiFilledReviewForm>> {
+    let aggregate = agent_task_lifecycle::read_aggregate(run_id)?;
+    aggregate
+        .outcomes
+        .last()
+        .map(|outcome| {
+            crate::agent_task_review_dossier::AiFilledReviewForm::from_outcome_outputs(
+                &outcome.outputs,
+            )
+        })
+        .transpose()
+        .map(Option::flatten)
+}
+
 /// Adopt an externally prepared immutable commit into a durable cook. The
 /// source recipe remains authoritative for repository, base, gates, and
 /// finalization policy; adoption only replaces provider artifact harvesting.
@@ -171,6 +191,8 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
             max_attempts: options.max_attempts,
             source_run_id: Some(record.run_id.clone()),
             current_diff: String::new(),
+            require_review_form: true,
+            review_form: adopted_review_form(&record.run_id)?,
             metadata: serde_json::json!({"adopted_candidate_ref": candidate_ref}),
         });
         let finalization = record.metadata.get("cook_finalization").cloned();
@@ -325,6 +347,8 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
         max_attempts: options.max_attempts,
         source_run_id: Some(record.run_id.clone()),
         current_diff: gate_feedback_current_diff(&promotion),
+        require_review_form: true,
+        review_form: adopted_review_form(&record.run_id)?,
         metadata: serde_json::json!({"adopted_candidate_ref": candidate_ref}),
     });
     let attempt = AgentTaskCookAttemptReport {

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -594,7 +594,7 @@ pub(crate) fn finalize_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
                     .map(|record| record.lifecycle),
             },
             ai_used_for: options.ai_used_for.clone(),
-            review_dossier: cook_review_dossier(options, promotion)?,
+            review_dossier: cook_review_dossier(options, promotion, successful_run_id)?,
             review_profile: resolve_review_profile(&path)?,
             manual_finalization: false,
             protected_branches: options.protected_branches.clone(),
@@ -607,6 +607,7 @@ pub(crate) fn finalize_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
 fn cook_review_dossier(
     options: &AgentTaskCookServiceOptions,
     promotion: &AgentTaskPromotionReport,
+    successful_run_id: &str,
 ) -> Result<AgentTaskReviewDossier> {
     let changed_files = promotion.changed_files.join(", ");
     let changed_file_count = promotion.changed_files.len();
@@ -656,28 +657,28 @@ fn cook_review_dossier(
         })
         .collect::<Result<Vec<_>>>()?;
 
+    // The AI-authored form is the sole source of the non-deterministic prose
+    // (summary / what changed / compatibility / used_for). Finalization is only
+    // reached after the cook loop's form gate accepted a valid form, so its
+    // absence here is a hard invariant violation, not a soft fallback. Read it
+    // after the deterministic gate-evidence validations so those failure modes
+    // still surface first.
+    let form = review_form_for_finalization(successful_run_id)?;
     Ok(AgentTaskReviewDossier {
         schema: "homeboy/agent-task-review-dossier/v1".to_string(),
-        summary: options.title.clone(),
-        what_changed: vec![
-            format!("Task objective: {task_summary}"),
-            format!(
-                "Verified candidate changed {changed_file_count} file(s): {changed_files}."
-            ),
-            format!(
-                "Cook completed {gate_count} deterministic verification gate(s) before finalization."
-            ),
-            if adoption {
-                "Candidate adoption provenance: an immutable candidate was adopted through the recorded Cook workflow and passed the recorded gates.".to_string()
-            } else {
-                "Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.".to_string()
-            },
-        ],
+        // Non-deterministic prose: authored by the AI form.
+        summary: form.summary.clone(),
+        what_changed: form.what_changed.clone(),
         how_to_test,
-        compatibility: format!(
-            "Compatibility impact is unknown from durable task and promotion evidence. The candidate is bounded to {changed_file_count} changed file(s): {changed_files}; review externally consumed interfaces in this scope."
-        ),
+        compatibility: form.compatibility.clone(),
+        // Deterministic evidence: orchestrator-owned. The task objective, scope,
+        // gate count, and adoption provenance are factual records, not prose the
+        // AI restates.
         evidence: vec![
+            AgentTaskReviewEvidence {
+                summary: format!("Task objective: {task_summary}"),
+                url: None,
+            },
             AgentTaskReviewEvidence {
                 summary: format!(
                     "Verified candidate scope: {changed_file_count} changed file(s): {changed_files}."
@@ -690,21 +691,67 @@ fn cook_review_dossier(
                 ),
                 url: None,
             },
+            AgentTaskReviewEvidence {
+                summary: if adoption {
+                    "Candidate adoption provenance: an immutable candidate was adopted through the recorded Cook workflow and passed the recorded gates.".to_string()
+                } else {
+                    "Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.".to_string()
+                },
+                url: None,
+            },
         ],
         changed_public_contracts: Vec::new(),
         public_contract_evidence: None,
         ai_assistance: AgentTaskReviewAiAssistance {
+            // Deterministic: the orchestrator knows whether/what tool+model ran.
             used: true,
             tool: options.ai_tool.clone(),
             model: options
                 .ai_model
                 .clone()
                 .unwrap_or_else(|| "not recorded".to_string()),
-            used_for: options.ai_used_for.clone(),
+            // Non-deterministic: the AI's self-reflective process description.
+            used_for: form.used_for.clone(),
         },
         source_relationships: Vec::new(),
         overrides: Vec::new(),
     })
+}
+
+/// Load and validate the AI-authored review form for a finalizing run.
+///
+/// The cook loop's review-form gate guarantees a valid form before finalization
+/// is reached; this re-reads it from the terminal outcome as the single source
+/// of the reviewer-facing prose. Its absence/invalidity here is an invariant
+/// violation (the gate would have looped), surfaced as a hard error rather than
+/// silently falling back to machine-templated prose.
+fn review_form_for_finalization(
+    run_id: &str,
+) -> Result<crate::agent_task_review_dossier::AiFilledReviewForm> {
+    let aggregate = crate::agent_task_lifecycle::read_aggregate(run_id)?;
+    let form = aggregate
+        .outcomes
+        .last()
+        .map(|outcome| {
+            crate::agent_task_review_dossier::AiFilledReviewForm::from_outcome_outputs(
+                &outcome.outputs,
+            )
+        })
+        .transpose()?
+        .flatten()
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "review_form",
+                format!(
+                    "cook finalization requires an AI-authored review form on run {run_id}; none was recorded. {}",
+                    crate::agent_task_review_dossier::AiFilledReviewForm::requirement_feedback()
+                ),
+                None,
+                None,
+            )
+        })?;
+    form.validate()?;
+    Ok(form)
 }
 
 pub(crate) fn cook_report(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -31,6 +31,67 @@ use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Barrier, Condvar};
 
+/// Seed a terminal aggregate whose last outcome carries a valid AI-authored
+/// review form under `outputs["review_form"]`, so cook finalization (which now
+/// sources reviewer prose from the form) can proceed.
+/// A valid AI-authored review form, for tests whose cook flow reaches
+/// finalization (which now sources reviewer prose from the form).
+fn test_review_form() -> crate::agent_task_review_dossier::AiFilledReviewForm {
+    crate::agent_task_review_dossier::AiFilledReviewForm {
+        summary: "Close the issue by guarding the reload path.".to_string(),
+        what_changed: vec!["Add a null guard in the render path.".to_string()],
+        compatibility: "Internal-only change; no compatibility impact.".to_string(),
+        used_for: "Reproduced the failure, isolated the reload path, added a guard, and verified with the recorded deterministic gate before finalizing.".to_string(),
+    }
+}
+
+/// The `outputs` object carrying a valid review form under `review_form`.
+fn test_review_form_outputs() -> Value {
+    serde_json::json!({ "review_form": test_review_form() })
+}
+
+fn seed_review_form_aggregate(run_id: &str, plan: &AgentTaskPlan) {
+    use crate::agent_task::{AgentTaskOutcome, AgentTaskOutcomeStatus};
+    use crate::agent_task_scheduler::{
+        AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
+    };
+    let form = test_review_form();
+    agent_task_lifecycle::record_run_aggregate(
+        run_id,
+        plan,
+        &AgentTaskAggregate {
+            schema: crate::agent_task::AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+            plan_id: plan.plan_id.clone(),
+            status: AgentTaskAggregateStatus::Succeeded,
+            totals: AgentTaskAggregateTotals {
+                succeeded: 1,
+                ..Default::default()
+            },
+            outcomes: vec![AgentTaskOutcome {
+                schema: crate::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: "provider".to_string(),
+                status: AgentTaskOutcomeStatus::Succeeded,
+                summary: Some("provider dispatched once".to_string()),
+                failure_classification: None,
+                artifacts: Vec::new(),
+                typed_artifacts: Vec::new(),
+                evidence_refs: Vec::new(),
+                diagnostics: Vec::new(),
+                outputs: serde_json::json!({ "review_form": form }),
+                workflow: None,
+                follow_up: None,
+                metadata: Value::Null,
+            }],
+            events: Vec::new(),
+            artifact_lineage: Vec::new(),
+            child_runs: Vec::new(),
+            artifact_bindings: Vec::new(),
+            queue: Default::default(),
+        },
+    )
+    .unwrap();
+}
+
 #[test]
 fn cook_service_retry_uses_the_same_passed_context_after_ambient_mutation() {
     let _env_lock = homeboy_core::test_support::env_lock();
@@ -211,7 +272,7 @@ fn moving_base_continuation_finalizes_without_a_second_provider_dispatch() {
                     typed_artifacts: Vec::new(),
                     evidence_refs: Vec::new(),
                     diagnostics: Vec::new(),
-                    outputs: Value::Null,
+                    outputs: test_review_form_outputs(),
                     workflow: None,
                     follow_up: None,
                     metadata: Value::Null,
@@ -460,7 +521,7 @@ fn moving_base_recovery_rebases_real_authenticated_candidate_and_refuses_diverge
                     typed_artifacts: Vec::new(),
                     evidence_refs: Vec::new(),
                     diagnostics: Vec::new(),
-                    outputs: Value::Null,
+                    outputs: test_review_form_outputs(),
                     workflow: None,
                     follow_up: None,
                     metadata: Value::Null,
@@ -2350,6 +2411,7 @@ fn cook_successful_concrete_attempt_publishes_reviewer_body() {
             attempt_dispatcher: None,
             harvest_context: crate::agent_task_scheduler::HarvestExecutionContext::default(),
         };
+        seed_review_form_aggregate(run_id, &plan);
         let mut backend = CaptureBackend::default();
         finalize_cook_pr_with_backend(&options, run_id, &promotion(run_id), &mut backend).unwrap();
         for section in [
@@ -2361,10 +2423,13 @@ fn cook_successful_concrete_attempt_publishes_reviewer_body() {
                 "## AI assistance",
                 "openai/gpt-5.6-terra",
                 "Verified finalization base: main at verified-base",
-                "Verified candidate changed 1 file(s): src/lib.rs.",
-                "Cook completed 1 deterministic verification gate(s) before finalization.",
+                // AI-authored prose (from the seeded review form).
+                "Close the issue by guarding the reload path.",
+                "Add a null guard in the render path.",
+                "Internal-only change; no compatibility impact.",
+                "Reproduced the failure, isolated the reload path",
+                // Deterministic evidence (orchestrator-owned).
                 "1. Run `cargo test --locked agent_task_promotion --lib`; expect passes as recorded by Cook's deterministic gate.",
-                "Compatibility impact is unknown from durable task and promotion evidence.",
                 "Verified candidate scope: 1 changed file(s): src/lib.rs.",
                 "Cook deterministic verification: 1 gate(s) completed green.",
             ] {

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -232,7 +232,8 @@ pub mod review_dossier {
         AgentTaskReviewAiAssistance, AgentTaskReviewDossier, AgentTaskReviewEvidence,
         AgentTaskReviewIssueRelationship, AgentTaskReviewIssueRelationshipKind,
         AgentTaskReviewOverride, AgentTaskReviewOverrideTarget, AgentTaskReviewProfile,
-        AgentTaskReviewSectionId, AgentTaskReviewTestStep, AGENT_TASK_REVIEW_DOSSIER_SCHEMA,
+        AgentTaskReviewSectionId, AgentTaskReviewTestStep, AiFilledReviewForm,
+        AGENT_TASK_REVIEW_DOSSIER_SCHEMA, AI_REVIEW_FORM_OUTPUT_KEY,
     };
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -122,11 +122,12 @@ pub struct AgentTaskCookArgs {
     pub protected_branches: Vec<String>,
     #[arg(long, default_value = "AI-assisted", value_name = "TEXT")]
     pub ai_tool: String,
-    #[arg(
-        long,
-        default_value = "Drafted implementation and tests; Chris reviews and owns the change.",
-        value_name = "TEXT"
-    )]
+    /// Legacy AI-usage disclosure. The reviewer-facing "Used for" text is now
+    /// authored by the agent's `review_form.used_for` (a self-reflective process
+    /// description) and validated by the cook loop's review-form gate; this flag
+    /// no longer feeds the PR body. Retained only for recipe back-compatibility
+    /// and defaults empty (no canned platitude).
+    #[arg(long, default_value = "", value_name = "TEXT")]
     pub ai_used_for: String,
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -246,11 +246,7 @@ pub struct FinalizePrArgs {
     pub changed_files: Vec<String>,
     #[arg(long = "protected-branch", default_values_t = review::default_protected_branches(), value_name = "BRANCH")]
     pub protected_branches: Vec<String>,
-    #[arg(
-        long,
-        default_value = "Drafted implementation and tests; Chris reviews and owns the change.",
-        value_name = "TEXT"
-    )]
+    #[arg(long, default_value = "", value_name = "TEXT")]
     pub ai_used_for: String,
     #[arg(long, value_name = "TEXT")]
     pub summary: Option<String>,

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1245,8 +1245,12 @@ pub(super) fn resolve_ai_tool_disclosure(
         .unwrap_or_else(|| ai_tool.to_string())
 }
 
+/// Legacy AI-usage disclosure default. The reviewer-facing "Used for" text is
+/// now authored by the agent's `review_form.used_for` and enforced by the cook
+/// loop's review-form gate, so this no longer feeds the PR body. Defaults empty
+/// (no canned platitude); retained only for recipe back-compatibility.
 fn default_ai_used_for() -> String {
-    "Drafted implementation and tests; Chris reviews and owns the change.".to_string()
+    String::new()
 }
 
 fn batch_commands(batch_id: &str) -> Value {

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -664,6 +664,8 @@ pub(crate) fn gate_feedback(args: GateFeedbackArgs) -> CmdResult<Value> {
         max_attempts: args.max_attempts.max(1),
         source_run_id: args.source_run_id,
         current_diff,
+        require_review_form: false,
+        review_form: None,
         metadata: Value::Null,
     });
 


### PR DESCRIPTION
## Summary

The generated PR body is now a **deterministic template with two clean halves** — an orchestrator-owned deterministic set and a single AI-authored *form* for every non-deterministic slot. This replaces the previous state where cook machine-templated the whole dossier and the model authored nothing.

**The split**
- **AI-authored form** (`review_form`): `summary`, `what_changed`, `compatibility`, `used_for`.
- **Orchestrator-deterministic**: `ai_assistance.{used,tool,model}`, `evidence`, gate labels, `how_to_test` (gate-derived), `source_relationships`, the section skeleton + order.

## The problem

In the cook path the agent filled out **nothing** in the dossier: `cook_review_dossier` machine-synthesized `summary` from the cook title, templated `what_changed`/`compatibility`, and sourced `used_for` from a canned CLI-flag default (`"Drafted implementation and tests; Chris reviews and owns the change."`). The "AI assistance → Used for" line was a static platitude, not a reflection. Gate evidence rendered the positional id (`gate-1: Passed`) instead of the command that ran.

## The design — the form is a gate

The agent emits a `review_form` object under its task `outputs`. Enforcement reuses the existing **gate-feedback nudge loop**: in `evaluate_cook_loop`, once deterministic gates are green, a missing or invalid form is treated exactly like a red gate — it builds a follow-up attempt request with actionable feedback (`RetryRequested`) so the agent keeps going until the form is valid. Budget exhausted with no valid form → `RetriesExhausted` (no PR). This is opt-in via `require_review_form` so the standalone `agent-task review` evaluator is unaffected.

`used_for` must be a genuine, **distinct-from-summary** process reflection; empty, placeholder, or summary-restating values are rejected (the legacy canned default is explicitly rejected and retired from the CLI/fanout defaults).

Finalization (`cook_review_dossier`) now sources reviewer prose from the form (read after the deterministic gate-evidence validations so those failure modes still surface first). Its absence at finalize is a hard invariant violation, since the loop gate would have looped.

## Gate label de-ambiguation

`enrich_dossier` now labels each gate with its reveal-policy-safe `summary` (which carries the command, e.g. `deterministic gate passed: cargo test foo`) instead of the positional `gate-N` id, falling back to the id only when no summary was recorded.

## Tests
- `AiFilledReviewForm`: validation (rejects empty/placeholder/summary-equal `used_for`), `from_outcome_outputs` (absent → None, present → parsed, malformed → hard error).
- `gate_evidence_summary`: renders the command; falls back to id when summary absent.
- `evaluate_cook_loop` form gate: green + no form → RetryRequested with feedback; green + valid form → GreenCompleted; invalid form → RetryRequested with distinct-from-summary feedback; budget exhausted → RetriesExhausted; `require_review_form: false` → GreenCompleted regardless.
- Updated cook flow tests broken by strict finalization to seed `review_form` aggregates and assert the AI-authored body.

Pre-existing, unrelated: `historical_orphan_recipe_adoption`, `adoption_rejects_aggregate_free`, `cook_claims_its_durable_attempt`, `retry_attempts_are_appended`, and `moving_base_recovery_rebases_real` fail **identically on clean `origin/main`** on this environment (real-git-remote / isolated-home / recipe-conflict VPS flakes) — stash-verified, not touched by this change.

_Heavy build/full suite left to CI per repo policy; validated with `cargo check --lib --tests` (both crates) + scoped test runs._