### PR TITLE
fix(runner): create the generic run for diagnostic-SSH exec so declared evidence attaches

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -865,6 +865,52 @@ pub fn record_runner_exec_job_identity(
     Ok(record)
 }
 
+/// Create (or validate ownership of) a generic runner-exec run that has no
+/// daemon runner job — the diagnostic-SSH transport executes synchronously and
+/// never accepts a durable runner job, but a caller-supplied `--run-id` with
+/// declared `--artifact`/`--artifact-dir`/`--summary` still needs a persisted
+/// run to attach that evidence to. Mirrors [`record_runner_exec_job_identity`]'s
+/// on-demand creation and fail-closed ownership check, minus the job binding
+/// (Extra-Chill/homeboy#9485, restoring #8447 for the SSH path).
+pub fn ensure_generic_runner_exec_run(
+    run_id: &str,
+    runner_id: &str,
+    remote_workspace: &str,
+    remote_command: &[String],
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let mut record = match store::read_record(&run_id) {
+        Ok(record) => match record_run_kind(&record) {
+            Some(RUNNER_EXEC_RUN_KIND) => record,
+            other => {
+                return Err(Error::validation_invalid_argument(
+                    "run_id",
+                    format!(
+                        "run '{run_id}' already exists as {} and cannot be reused as a generic runner-exec run",
+                        other
+                            .map(|kind| format!("an agent-task run (kind '{kind}')"))
+                            .unwrap_or_else(|| "an agent-task run".to_string())
+                    ),
+                    Some(run_id.clone()),
+                    Some(vec![
+                        "Pass a distinct --run-id for ad hoc runner exec evidence.".to_string(),
+                    ]),
+                ));
+            }
+        },
+        Err(error) if error.code == ErrorCode::ValidationInvalidArgument => submit_plan(
+            &runner_exec_plan(&run_id, runner_id, remote_workspace, remote_command),
+            Some(&run_id),
+        )?,
+        Err(error) => return Err(error),
+    };
+    let metadata = record.ensure_metadata_object();
+    metadata.insert("kind".to_string(), json!(RUNNER_EXEC_RUN_KIND));
+    metadata.insert("runner_id".to_string(), json!(runner_id));
+    store::write_record(&record)?;
+    Ok(record)
+}
+
 fn runner_exec_plan(
     run_id: &str,
     runner_id: &str,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -338,6 +338,100 @@ fn runner_exec_run_id_creates_generic_run_on_demand() {
 }
 
 #[test]
+fn diagnostic_ssh_run_id_creates_generic_run_without_a_runner_job() {
+    // #9485: the diagnostic-SSH transport executes synchronously and never
+    // accepts a durable runner job, but `runner exec --ssh --run-id <new-id>`
+    // with declared `--artifact`/`--summary` still needs a persisted run to
+    // attach evidence to. A new ad hoc ID must create a generic runner-exec run
+    // on demand even with no runner job, restoring #8447 for the SSH path.
+    with_isolated_home(|_| {
+        let command = vec!["node".to_string(), "fuzz.mjs".to_string()];
+
+        // (1) A new valid ad hoc ID creates a generic run with no runner_job_id.
+        let created = ensure_generic_runner_exec_run(
+            "fisiostetic-image-specificity-v4",
+            "homeboy-lab",
+            "/runner/workspace/dirty",
+            &command,
+        )
+        .expect("new ad hoc ssh run id creates a generic runner-exec run");
+        assert_eq!(created.metadata["kind"], RUNNER_EXEC_RUN_KIND);
+        assert_eq!(created.metadata["runner_id"], "homeboy-lab");
+        assert!(
+            created.metadata.get("runner_job_id").is_none(),
+            "diagnostic-SSH run has no accepted runner job"
+        );
+
+        // The run is a real durable record — declared artifacts can attach.
+        let loaded = status("fisiostetic-image-specificity-v4").expect("generic run persisted");
+        assert_eq!(loaded.metadata["kind"], RUNNER_EXEC_RUN_KIND);
+
+        // (2) Re-running the same ad hoc ID is idempotent (reuses the run).
+        let reused = ensure_generic_runner_exec_run(
+            "fisiostetic-image-specificity-v4",
+            "homeboy-lab",
+            "/runner/workspace/dirty",
+            &command,
+        )
+        .expect("existing generic ssh run id is reused");
+        assert_eq!(reused.metadata["kind"], RUNNER_EXEC_RUN_KIND);
+
+        // (3) An ID owned by an agent-task run fails closed with a typed
+        //     ownership diagnostic before any runner mutation.
+        submit_plan(&test_plan(), Some("agent-task-owned-9485")).expect("agent-task run submitted");
+        let collision = ensure_generic_runner_exec_run(
+            "agent-task-owned-9485",
+            "homeboy-lab",
+            "/runner/workspace/dirty",
+            &command,
+        )
+        .expect_err("reusing an agent-task id as a generic runner-exec run must fail closed");
+        assert_eq!(collision.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(collision.details["field"], "run_id");
+        assert!(collision
+            .message
+            .contains("already exists as an agent-task run"));
+        assert!(collision.details["tried"]
+            .as_array()
+            .is_some_and(|tried| tried.iter().any(|hint| hint
+                .as_str()
+                .is_some_and(|hint| hint.contains("distinct --run-id")))));
+    });
+}
+
+#[test]
+fn generic_runner_exec_run_supports_artifact_attachment() {
+    // The end-to-end contract #9485 restores: once the generic run exists, the
+    // declared evidence attaches to it (previously `run record not found`).
+    with_isolated_home(|_| {
+        use homeboy_core::observation::ObservationStore;
+
+        ensure_generic_runner_exec_run(
+            "adhoc-evidence-9485",
+            "homeboy-lab",
+            "/runner/workspace",
+            &["node".to_string(), "fuzz.mjs".to_string()],
+        )
+        .expect("generic run created");
+
+        let store = ObservationStore::open_initialized().expect("store");
+        let temp = tempfile::tempdir().expect("tempdir");
+        let summary = temp.path().join("summary.json");
+        std::fs::write(&summary, r#"{"status":"fail","findings":3}"#).expect("write summary");
+
+        let artifact = store
+            .record_artifact_with_metadata(
+                "adhoc-evidence-9485",
+                "summary",
+                &summary,
+                serde_json::json!({ "promoted_by": "runner.exec" }),
+            )
+            .expect("declared summary attaches to the generic run");
+        assert_eq!(artifact.run_id, "adhoc-evidence-9485");
+    });
+}
+
+#[test]
 fn status_expires_an_unaccepted_handoff_but_late_runner_acceptance_wins() {
     with_isolated_home(|_| {
         let _runner = RunnerContinuationTestGuard::install(Box::new(IntentReplayProvider {

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -846,6 +846,22 @@ pub(crate) fn exec_with_status_snapshot(
 
     if should_force_diagnostic_ssh(&runner, &options) {
         run_capability_preflight(&runner)?;
+        // The diagnostic-SSH transport executes synchronously and never accepts
+        // a durable runner job, so — unlike the daemon path — it must create the
+        // generic runner-exec run itself. Without this, a caller-supplied
+        // `--run-id` with declared `--artifact`/`--summary` fails artifact
+        // promotion with `run record not found` even though the run was never
+        // created (Extra-Chill/homeboy#9485, restoring #8447 for SSH).
+        if options.run_id_owns_generic_exec {
+            if let Some(run_id) = options.run_id.as_deref() {
+                homeboy_agents::agent_task_lifecycle::ensure_generic_runner_exec_run(
+                    run_id,
+                    &runner.id,
+                    &cwd,
+                    &options.command,
+                )?;
+            }
+        }
         return exec_diagnostic_ssh(
             &runner,
             cwd,


### PR DESCRIPTION
## Summary

`runner exec --ssh --run-id <new-id>` with declared `--artifact`/`--artifact-dir`/`--summary` failed **before its evidence could attach**:

```
Invalid argument run_id: run record not found: fisiostetic-image-specificity-v4
```

A closed loop: declared evidence requires a `--run-id`, but the command could not create the run id it required — regressing the #8447 contract for the SSH path. The workload's failure log was left only in the ephemeral runner workspace.

## Root cause

The **daemon** transport creates the generic runner-exec run on demand via `record_runner_exec_job_identity` (lifecycle_ops). The **diagnostic-SSH** transport (`exec_diagnostic_ssh`) executes synchronously and never accepts a durable runner job, so it returned without creating *any* run. The CLI then promoted the declared artifacts, which hit `record_artifact`'s run-existence guard (`store/artifacts.rs`: `if get_run(run_id).is_none()`) and failed with `run record not found`.

## Fix

- **`ensure_generic_runner_exec_run`** (homeboy-agents `lifecycle_ops`) — a job-less sibling of `record_runner_exec_job_identity`: creates the generic runner-exec run on demand (via `submit_plan`) when the id is new, reuses it when it already exists as a generic runner-exec run, and **fails closed with a typed ownership diagnostic** when the id already belongs to an agent-task run.
- The diagnostic-SSH branch in `execution/mod.rs` now calls it when `run_id_owns_generic_exec` is set and a `--run-id` is present — mirroring what the daemon path does 30 lines away, in the same layer and dependency direction (lab-runner → agents; agents still depends only on the lab-runner *contract*).

A new ad hoc id now creates the run, executes, and attaches its declared artifacts/summary; existing generic ids remain reusable; ownership collisions fail with a copy-pasteable remediation.

## Acceptance criteria
- [x] A new ad hoc run id works with `--ssh` (this fix) and connected-daemon transports (already worked).
- [x] `--artifact`, `--artifact-dir`, and `--summary` attach to the newly created run.
- [x] Existing compatible generic run ids remain reusable.
- [x] Ownership collisions fail with a typed diagnostic (`run_id` field + `--run-id` remediation).
- [x] The diagnostic includes a copy-pasteable remediation only when caller action is required.

## Tests (homeboy-agents `submit_and_persist`)
- `diagnostic_ssh_run_id_creates_generic_run_without_a_runner_job` — new ad hoc id creates a generic run with no `runner_job_id`, is reusable, and collides-closed on an agent-task id. **Temp-disable-proven**: breaking the on-demand creation reproduces the failure.
- `generic_runner_exec_run_supports_artifact_attachment` — the end-to-end contract: once the generic run exists, a declared summary attaches (previously `run record not found`).
- Full `submit_and_persist` suite: 29 passing.

Related: #8447, #9495 (the durable-finalization follow-up), #9524.

Closes #9485