### PR TITLE
Make detached Lab staging daemon-owned and durable

### DIFF
--- a/crates/contracts/homeboy-cli-contract/src/lib.rs
+++ b/crates/contracts/homeboy-cli-contract/src/lib.rs
@@ -6,11 +6,11 @@
 //! would create a `core -> commands` dependency edge).
 
 use clap::ValueEnum;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// The requested execution location. This is normalized once at the CLI
 /// boundary and is the only placement input used by routing code.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Serialize, Deserialize)]
 #[value(rename_all = "lower")]
 pub enum Placement {
     Auto,

--- a/crates/contracts/homeboy-lab-contract/src/lab/types.rs
+++ b/crates/contracts/homeboy-lab-contract/src/lab/types.rs
@@ -80,13 +80,13 @@ pub struct LabRigWorkloadArguments {
     pub extension_overrides: Vec<String>,
 }
 
-#[derive(Debug, Clone, Copy, serde::Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub enum LabRigWorkloadKind {
     Bench,
     Fuzz,
 }
 
-#[derive(Debug, Clone, Copy, serde::Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub enum LabSecretEnvSource {
     AgentTask,
     Trace,
@@ -157,13 +157,13 @@ pub enum LabCommandPortability {
     LocalOnly(&'static str),
 }
 
-#[derive(Debug, Clone, Copy, serde::Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub enum LabSourcePathMode {
     CwdOrPathFlag,
     RunnerResident,
 }
 
-#[derive(Debug, Clone, Copy, serde::Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub enum LabWorkspaceModePolicy {
     ChangedSinceGitElseSnapshot,
     Git,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -94,13 +94,52 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
         ));
     }
 
+    // Staging is controller-local work, not a runner child. Its terminal
+    // confirmation is required before this parent can become Cancelled.
+    let controller_cancelled = if let Some(controller_job_id) = record
+        .metadata
+        .get("lab_staging_controller_job_id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|id| !id.trim().is_empty())
+    {
+        // The controller owns every child admitted during staging, including the
+        // final runner job. Never bypass it merely because that child identity
+        // was already projected onto the parent.
+        let controller_job = homeboy_core::daemon::LocalControllerJobClient::connect()?
+            .cancel_and_wait(
+                controller_job_id,
+                reason.unwrap_or("agent-task cancellation requested"),
+            )?;
+        let metadata = record.ensure_metadata_object();
+        metadata.insert(
+            "controller_job_cancellation".to_string(),
+            json!({
+                "controller_job_id": controller_job.id,
+                "status": controller_job.status,
+                "confirmed": true,
+            }),
+        );
+        store::write_record(&record)?;
+        // The controller cancellation projects owned child state. Re-read once
+        // after its terminal confirmation before finalizing this parent.
+        record = store::read_record(&record.run_id)?;
+        if record.state.is_terminal() {
+            return Ok(record);
+        }
+        true
+    } else {
+        false
+    };
+
     // Classify how live cancellation can be performed for this run BEFORE we
     // mutate the durable record, so we can record either a real termination or
     // deterministic operator recovery instructions (acceptance: never force
     // manual process spelunking; always surface pids + safe commands).
     // A runner-backed proxy can have an accepted daemon job while it is still
     // queued before the provider starts. Project cancellation to that job too.
-    let cancellation = if record.state == AgentTaskRunState::Running
+    let cancellation = if controller_cancelled {
+        LiveCancellationOutcome::NotRunning
+    } else if record.state == AgentTaskRunState::Running
         || (record.state == AgentTaskRunState::Queued
             && record.runner_id().is_some()
             && record.runner_job_id().is_some())

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -804,6 +804,17 @@ pub fn record_runner_job_identity(
     Ok(record)
 }
 
+/// Read the accepted runner binding without triggering status reconciliation.
+/// Controller-owned cancellation uses this durable parent projection to close
+/// the window between child acceptance and its next controller checkpoint.
+pub fn recorded_runner_job_identity(run_id: &str) -> Result<Option<(String, String)>> {
+    let record = store::read_record(&sanitize_run_id(run_id))?;
+    Ok(record
+        .runner_id()
+        .zip(record.runner_job_id())
+        .map(|(runner_id, runner_job_id)| (runner_id.to_string(), runner_job_id.to_string())))
+}
+
 /// Metadata `kind` marker for a generic runner-execution run. It distinguishes
 /// an ad hoc `runner exec --run-id` durable run from an agent-task lifecycle
 /// record so ownership collisions are detectable (#8447).

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1437,6 +1437,57 @@ pub fn record_lab_offload_phase_executions(
     Ok(record)
 }
 
+/// Bind the controller-owned staging job separately from the eventual runner job.
+pub fn record_lab_staging_controller_job(
+    run_id: &str,
+    runner_id: &str,
+    controller_job_id: &str,
+) -> Result<AgentTaskRunRecord> {
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    if record.state.is_terminal() {
+        return Ok(record);
+    }
+    record.updated_at = Some(now_timestamp());
+    let started_at = record.updated_at.clone().unwrap_or_else(now_timestamp);
+    let metadata = record.ensure_metadata_object();
+    record_lab_offload_phase_metadata(metadata, "materializing", &started_at);
+    metadata.insert(
+        "lab_staging_controller_job_id".to_string(),
+        json!(controller_job_id),
+    );
+    metadata.insert(
+        "lab_staging_controller_runner_id".to_string(),
+        json!(runner_id),
+    );
+    metadata.insert("materialization_owner".to_string(), json!("controller_job"));
+    store::write_record(&record)?;
+    Ok(record)
+}
+
+/// Preserve the controller-stage terminal context on the durable parent after
+/// its generic controller job has failed.
+pub fn record_lab_staging_controller_failure(
+    run_id: &str,
+    phase: &str,
+    controller_job_id: &str,
+) -> Result<AgentTaskRunRecord> {
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let metadata = record.ensure_metadata_object();
+    metadata.insert(
+        "lab_staging_controller_failure".to_string(),
+        json!({
+            "phase": phase,
+            "controller_job_id": controller_job_id,
+            "classification": "lab_staging",
+            "retry_command": format!("homeboy agent-task retry {run_id}"),
+            "cleanup_status": "controller-owned cleanup pending terminal confirmation",
+        }),
+    );
+    record.updated_at = Some(now_timestamp());
+    store::write_record(&record)?;
+    Ok(record)
+}
+
 fn record_lab_offload_phase_metadata(
     metadata: &mut serde_json::Map<String, Value>,
     phase: &str,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
@@ -43,6 +43,7 @@ mod lifecycle_ops;
 mod lifecycle_record_ops;
 mod lifecycle_runner_projection;
 mod lifecycle_transport_proxy;
+mod private_attachment;
 mod records;
 pub mod runner_continuation;
 
@@ -57,6 +58,7 @@ pub use lifecycle_ops::*;
 pub use lifecycle_record_ops::cook_attempt_run_id;
 pub use lifecycle_runner_projection::*;
 pub use lifecycle_transport_proxy::*;
+pub use private_attachment::*;
 pub use records::*;
 #[cfg(any(test, feature = "test-support"))]
 pub use runner_continuation::{

--- a/crates/homeboy-agents/src/agent_task_lifecycle/private_attachment.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/private_attachment.rs
@@ -1,0 +1,275 @@
+//! Owner-only immutable payloads associated with an authoritative agent-task run.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use super::{sanitize_run_id, store, Error, Result};
+
+pub const PRIVATE_RUN_ATTACHMENT_SCHEMA: &str = "homeboy/agent-task-private-attachment/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct PrivateRunAttachment<T> {
+    pub schema: String,
+    pub run_id: String,
+    pub kind: String,
+    pub payload_digest: String,
+    pub payload: T,
+}
+
+fn validated_kind(kind: &str) -> Result<&str> {
+    if kind.is_empty()
+        || !kind
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    {
+        return Err(Error::validation_invalid_argument(
+            "kind",
+            "private attachment kind must use lowercase ASCII letters, digits, and hyphens",
+            None,
+            None,
+        ));
+    }
+    Ok(kind)
+}
+
+fn validated_run_id(run_id: &str) -> Result<String> {
+    let sanitized = sanitize_run_id(run_id);
+    if run_id.is_empty() || sanitized != run_id || Path::new(run_id).components().count() != 1 {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "private attachment run id must be one safe path component",
+            None,
+            None,
+        ));
+    }
+    Ok(sanitized)
+}
+
+fn attachment_path(run_id: &str, kind: &str) -> Result<PathBuf> {
+    let run_id = validated_run_id(run_id)?;
+    validated_kind(kind)?;
+    Ok(store::run_dir(&run_id)?
+        .join("private")
+        .join(format!("{kind}.json")))
+}
+
+/// Version 1 digests recursively canonicalized JSON: object keys are sorted and
+/// all persistence serializes that same canonical envelope.
+fn canonical_json<T: Serialize>(value: &T) -> Result<Value> {
+    let value = serde_json::to_value(value)
+        .map_err(|_| Error::internal_json("serialize private run attachment", None))?;
+    Ok(canonicalize(value))
+}
+
+fn canonicalize(value: Value) -> Value {
+    match value {
+        Value::Array(values) => Value::Array(values.into_iter().map(canonicalize).collect()),
+        Value::Object(values) => {
+            let mut keys: Vec<_> = values.into_iter().collect();
+            keys.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+            Value::Object(
+                keys.into_iter()
+                    .map(|(key, value)| (key, canonicalize(value)))
+                    .collect(),
+            )
+        }
+        value => value,
+    }
+}
+
+fn canonical_bytes<T: Serialize>(payload: &T) -> Result<Vec<u8>> {
+    serde_json::to_vec(&canonical_json(payload)?)
+        .map_err(|_| Error::internal_json("serialize private run attachment", None))
+}
+
+fn digest<T: Serialize>(payload: &T) -> Result<String> {
+    let bytes = canonical_bytes(payload)?;
+    Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
+}
+
+fn validate<T: Serialize>(
+    attachment: &PrivateRunAttachment<T>,
+    run_id: &str,
+    kind: &str,
+) -> Result<()> {
+    if attachment.schema != PRIVATE_RUN_ATTACHMENT_SCHEMA
+        || attachment.run_id != validated_run_id(run_id)?
+        || attachment.kind != kind
+        || attachment.payload_digest != digest(&attachment.payload)?
+    {
+        return Err(Error::validation_invalid_argument(
+            "private_attachment",
+            "private run attachment schema, binding, or payload digest is invalid",
+            None,
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn io_error(operation: &'static str) -> impl FnOnce(std::io::Error) -> Error {
+    move |_| Error::internal_io(operation, None)
+}
+
+fn ensure_private_directory(run_id: &str) -> Result<PathBuf> {
+    let run_dir = store::run_dir(run_id)?;
+    ensure_real_owner_directory(&run_dir, "private attachment run directory")?;
+    let private_dir = run_dir.join("private");
+    ensure_real_owner_directory(&private_dir, "private attachment directory")?;
+    Ok(private_dir)
+}
+
+fn ensure_real_owner_directory(path: &Path, operation: &'static str) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                return Err(Error::validation_invalid_argument(
+                    "private_attachment",
+                    "private attachment storage directory is unsafe",
+                    None,
+                    None,
+                ));
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => match fs::create_dir(path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let metadata = fs::symlink_metadata(path).map_err(io_error(operation))?;
+                if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                    return Err(Error::validation_invalid_argument(
+                        "private_attachment",
+                        "private attachment storage directory is unsafe",
+                        None,
+                        None,
+                    ));
+                }
+            }
+            Err(error) => return Err(io_error(operation)(error)),
+        },
+        Err(error) => return Err(io_error(operation)(error)),
+    }
+    #[cfg(unix)]
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700)).map_err(io_error(operation))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+fn write_temp_file(directory: &Path, bytes: &[u8]) -> Result<PathBuf> {
+    for _ in 0..16 {
+        let path = directory.join(format!(".attachment-{}.tmp", Uuid::new_v4()));
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        match options.open(&path) {
+            Ok(mut file) => {
+                if let Err(error) = file.write_all(bytes).and_then(|_| file.sync_all()) {
+                    let _ = fs::remove_file(&path);
+                    return Err(io_error("write private attachment temporary file")(error));
+                }
+                return Ok(path);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(io_error("create private attachment temporary file")(error)),
+        }
+    }
+    Err(Error::internal_io(
+        "create private attachment temporary file",
+        None,
+    ))
+}
+
+fn sync_directory(directory: &Path) -> Result<()> {
+    File::open(directory)
+        .and_then(|directory| directory.sync_all())
+        .map_err(io_error("sync private attachment directory"))
+}
+
+fn persist_no_replace(path: &Path, bytes: &[u8]) -> Result<bool> {
+    let directory = path.parent().expect("attachment has parent");
+    let temporary = write_temp_file(directory, bytes)?;
+    let installed = match fs::hard_link(&temporary, path) {
+        Ok(()) => {
+            sync_directory(directory)?;
+            true
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => false,
+        Err(error) => {
+            let _ = fs::remove_file(&temporary);
+            return Err(io_error("install private attachment")(error));
+        }
+    };
+    let _ = fs::remove_file(&temporary);
+    if installed {
+        sync_directory(directory)?;
+    }
+    Ok(installed)
+}
+
+/// Persist an immutable owner-only attachment. Exact replays are idempotent;
+/// a changed payload conflicts rather than replacing the original recipe.
+pub fn persist_private_run_attachment<T: Serialize + DeserializeOwned + Clone + PartialEq>(
+    run_id: &str,
+    kind: &str,
+    payload: &T,
+) -> Result<PrivateRunAttachment<T>> {
+    let run_id = validated_run_id(run_id)?;
+    // Prove the authoritative lifecycle exists before creating side data.
+    store::read_record(&run_id)?;
+    let path = attachment_path(&run_id, kind)?;
+    let attachment = PrivateRunAttachment {
+        schema: PRIVATE_RUN_ATTACHMENT_SCHEMA.to_string(),
+        run_id: run_id.clone(),
+        kind: kind.to_string(),
+        payload_digest: digest(payload)?,
+        payload: payload.clone(),
+    };
+    ensure_private_directory(&run_id)?;
+    let bytes = canonical_bytes(&attachment)?;
+    if persist_no_replace(&path, &bytes)? {
+        return Ok(attachment);
+    }
+    let existing = load_private_run_attachment(&attachment.run_id, kind)?;
+    if existing.payload_digest == attachment.payload_digest {
+        return Ok(existing);
+    }
+    Err(Error::validation_invalid_argument(
+        "private_attachment",
+        "private run attachment already exists with a different immutable payload",
+        None,
+        None,
+    ))
+}
+
+pub fn load_private_run_attachment<T: Serialize + DeserializeOwned>(
+    run_id: &str,
+    kind: &str,
+) -> Result<PrivateRunAttachment<T>> {
+    let run_id = validated_run_id(run_id)?;
+    store::read_record(&run_id)?;
+    let path = attachment_path(&run_id, kind)?;
+    ensure_private_directory(&run_id)?;
+    let metadata = fs::symlink_metadata(&path).map_err(io_error("inspect private attachment"))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(Error::validation_invalid_argument(
+            "private_attachment",
+            "private attachment storage file is unsafe",
+            None,
+            None,
+        ));
+    }
+    let contents = fs::read_to_string(&path).map_err(io_error("read private attachment"))?;
+    let attachment: PrivateRunAttachment<T> = serde_json::from_str(&contents)
+        .map_err(|_| Error::internal_json("parse private attachment", None))?;
+    validate(&attachment, &run_id, kind)?;
+    Ok(attachment)
+}

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
@@ -380,6 +380,7 @@ pub(super) fn succeeded_aggregate(plan: &AgentTaskPlan) -> AgentTaskAggregate {
 }
 
 mod handoff_and_proxy;
+mod private_attachment;
 mod status_and_recovery;
 mod submit_and_persist;
 mod terminal_and_reconcile;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/private_attachment.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/private_attachment.rs
@@ -1,0 +1,178 @@
+use super::*;
+use crate::agent_task_lifecycle::{load_private_run_attachment, persist_private_run_attachment};
+use serde_json::{json, Value};
+
+fn submit_attachment_run(run_id: &str) {
+    submit_plan(&test_plan(), Some(run_id)).expect("submit attachment run");
+}
+
+fn attachment_path(run_id: &str, kind: &str) -> std::path::PathBuf {
+    homeboy_core::paths::homeboy_data()
+        .expect("data root")
+        .join("agent-task-runs")
+        .join(run_id)
+        .join("private")
+        .join(format!("{kind}.json"))
+}
+
+#[test]
+fn private_attachments_require_an_authoritative_safe_run_and_kind() {
+    with_isolated_home(|_| {
+        let payload = json!({"value": "secret-marker"});
+        for (run_id, kind) in [
+            ("unknown", "recipe"),
+            ("bad/../run", "recipe"),
+            ("unknown", "../recipe"),
+        ] {
+            let error = persist_private_run_attachment(run_id, kind, &payload)
+                .expect_err("reject unsafe attachment");
+            assert!(!error.message.contains("secret-marker"));
+            assert!(!error.message.contains("/Users/"));
+        }
+    });
+}
+
+#[test]
+fn private_attachment_is_idempotent_and_conflicts_without_leaking_payload() {
+    with_isolated_home(|_| {
+        submit_attachment_run("attachment-replay");
+        let payload = json!({"nested": {"value": "first-secret-marker"}});
+        let first = persist_private_run_attachment("attachment-replay", "recipe", &payload)
+            .expect("persist");
+        assert_eq!(
+            persist_private_run_attachment("attachment-replay", "recipe", &payload)
+                .expect("replay"),
+            first
+        );
+        let error = persist_private_run_attachment(
+            "attachment-replay",
+            "recipe",
+            &json!({"value": "second-secret-marker"}),
+        )
+        .expect_err("conflict");
+        assert!(!error.message.contains("first-secret-marker"));
+        assert!(!error.message.contains("second-secret-marker"));
+    });
+}
+
+#[test]
+fn private_attachment_canonicalizes_unordered_maps() {
+    with_isolated_home(|_| {
+        submit_attachment_run("attachment-canonical");
+        let first = json!({"z": [{"b": 2, "a": 1}], "a": {"d": 4, "c": 3}});
+        let reordered = json!({"a": {"c": 3, "d": 4}, "z": [{"a": 1, "b": 2}]});
+        let persisted = persist_private_run_attachment("attachment-canonical", "recipe", &first)
+            .expect("persist");
+        let replay = persist_private_run_attachment("attachment-canonical", "recipe", &reordered)
+            .expect("canonical replay");
+        assert_eq!(persisted.payload_digest, replay.payload_digest);
+    });
+}
+
+#[test]
+fn private_attachment_rejects_tampered_envelope_bindings_and_digest() {
+    with_isolated_home(|_| {
+        submit_attachment_run("attachment-tamper");
+        for (kind, field, value) in [
+            ("schema", "schema", json!("wrong")),
+            ("run", "run_id", json!("other")),
+            ("kind", "kind", json!("other")),
+            ("digest", "payload_digest", json!("sha256:wrong")),
+        ] {
+            persist_private_run_attachment("attachment-tamper", kind, &json!({"value": 1}))
+                .expect("persist");
+            let path = attachment_path("attachment-tamper", kind);
+            let mut tampered: Value =
+                serde_json::from_slice(&std::fs::read(&path).expect("read attachment"))
+                    .expect("parse attachment");
+            tampered[field] = value;
+            std::fs::write(&path, serde_json::to_vec(&tampered).expect("encode tamper"))
+                .expect("tamper attachment");
+            assert!(
+                load_private_run_attachment::<Value>("attachment-tamper", kind).is_err(),
+                "{field} tamper rejected"
+            );
+        }
+    });
+}
+
+#[test]
+fn concurrent_conflicting_private_attachment_writers_commit_once() {
+    with_isolated_home(|_| {
+        submit_attachment_run("attachment-concurrent");
+        let threads: Vec<_> = [json!({"winner": "one"}), json!({"winner": "two"})]
+            .into_iter()
+            .map(|payload| {
+                std::thread::spawn(move || {
+                    persist_private_run_attachment("attachment-concurrent", "recipe", &payload)
+                })
+            })
+            .collect();
+        let results: Vec<_> = threads
+            .into_iter()
+            .map(|thread| thread.join().expect("writer thread"))
+            .collect();
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        let stored = load_private_run_attachment::<Value>("attachment-concurrent", "recipe")
+            .expect("load winner");
+        assert!(
+            stored.payload == json!({"winner":"one"}) || stored.payload == json!({"winner":"two"})
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn private_attachment_has_owner_permissions_and_rejects_symlink_directories() {
+    use std::os::unix::fs::{symlink, PermissionsExt};
+
+    with_isolated_home(|_| {
+        submit_attachment_run("attachment-permissions");
+        persist_private_run_attachment("attachment-permissions", "recipe", &json!({"value": 1}))
+            .expect("persist");
+        let path = attachment_path("attachment-permissions", "recipe");
+        assert_eq!(
+            std::fs::metadata(&path)
+                .expect("file metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        assert_eq!(
+            std::fs::metadata(path.parent().expect("private dir"))
+                .expect("dir metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        let run_dir = path
+            .parent()
+            .expect("private dir")
+            .parent()
+            .expect("run dir");
+        assert_eq!(
+            std::fs::metadata(run_dir)
+                .expect("run metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+
+        submit_attachment_run("attachment-symlink");
+        let unsafe_private = attachment_path("attachment-symlink", "recipe")
+            .parent()
+            .expect("private path")
+            .to_path_buf();
+        let target = tempfile::tempdir().expect("symlink target");
+        symlink(target.path(), &unsafe_private).expect("create unsafe symlink");
+        assert!(persist_private_run_attachment(
+            "attachment-symlink",
+            "recipe",
+            &json!({"value": 1})
+        )
+        .is_err());
+    });
+}

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -164,6 +164,7 @@ impl CliRuntime {
         // Lab owns its durable staging/dispatch controller-job interpretation;
         // core only owns the generic daemon lifecycle.
         crate::runner::register_lab_staging_controller_driver();
+        crate::runner::enable_production_lab_staging();
         // Register the runner workspace-root provider so the daemon file API can
         // resolve a runner's configured workspace_root without core depending on
         // the runner config registry.

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -161,6 +161,9 @@ impl CliRuntime {
         // can prepare and run a runner job as a local child without core
         // depending on runner process-execution behavior.
         crate::runner::register_runner_daemon_exec_driver();
+        // Lab owns its durable staging/dispatch controller-job interpretation;
+        // core only owns the generic daemon lifecycle.
+        crate::runner::register_lab_staging_controller_driver();
         // Register the runner workspace-root provider so the daemon file API can
         // resolve a runner's configured workspace_root without core depending on
         // the runner config registry.

--- a/crates/homeboy-core/src/daemon/controller_job_driver.rs
+++ b/crates/homeboy-core/src/daemon/controller_job_driver.rs
@@ -70,6 +70,12 @@ impl ControllerJobHandle {
         self.job.is_cancelled()
     }
 
+    /// Durable identity for domain projections which need to link their parent
+    /// record to this generic controller job.
+    pub fn job_id(&self) -> String {
+        self.job.job_id().to_string()
+    }
+
     pub fn progress(&self, private_progress: Value) -> Result<()> {
         self.job
             .progress(self.driver.public_progress(&private_progress)?)

--- a/crates/homeboy-core/src/daemon/controller_job_driver.rs
+++ b/crates/homeboy-core/src/daemon/controller_job_driver.rs
@@ -75,6 +75,12 @@ impl ControllerJobHandle {
             .progress(self.driver.public_progress(&private_progress)?)
             .map(|_| ())
     }
+
+    /// Replace the durable recovery checkpoint after an idempotent phase has
+    /// completed. The daemon resumes from this value after process recovery.
+    pub fn checkpoint(&self, private_checkpoint: Value) -> Result<()> {
+        self.job.record_controller_prepared(private_checkpoint)
+    }
 }
 
 fn drivers() -> &'static Mutex<HashMap<(String, u32), Arc<dyn ControllerJobDriver>>> {

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -55,6 +55,76 @@ use runner_files::{create_runner_file_directory, download_runner_file, upload_ru
 
 pub const DEFAULT_ADDR: &str = "127.0.0.1:0";
 
+/// Generic client for controller-local daemon jobs. Domain crates use this
+/// rather than carrying daemon HTTP or controller-job semantics themselves.
+pub struct LocalControllerJobClient {
+    endpoint: String,
+    client: reqwest::blocking::Client,
+}
+
+impl LocalControllerJobClient {
+    pub fn connect() -> Result<Self> {
+        let daemon = ensure_running(DEFAULT_ADDR)?;
+        let client = reqwest::blocking::Client::builder()
+            .no_proxy()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .map_err(|error| {
+                Error::internal_unexpected(format!("build local controller-job client: {error}"))
+            })?;
+        Ok(Self {
+            endpoint: format!("http://{}", daemon.address),
+            client,
+        })
+    }
+
+    /// Requests cancellation and returns only after the daemon confirms the
+    /// owned controller work reached `Cancelled`.
+    pub fn cancel_and_wait(&self, job_id: &str, reason: &str) -> Result<crate::api_jobs::Job> {
+        let response = self
+            .client
+            .post(format!("{}/controller/jobs/{job_id}/cancel", self.endpoint))
+            .json(&json!({ "reason": reason }))
+            .send()
+            .map_err(|error| {
+                Error::internal_unexpected(format!(
+                    "cancel local controller job `{job_id}`: {error}"
+                ))
+            })?;
+        let status = response.status();
+        let value: serde_json::Value = response.json().map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse local controller-job cancellation response".to_string()),
+            )
+        })?;
+        if !status.is_success()
+            || value.get("success").and_then(serde_json::Value::as_bool) != Some(true)
+        {
+            return Err(Error::internal_unexpected(format!(
+                "local controller job `{job_id}` cancellation was not confirmed: {value}"
+            )));
+        }
+        let job: crate::api_jobs::Job =
+            serde_json::from_value(value.pointer("/data/job").cloned().ok_or_else(|| {
+                Error::internal_unexpected("local controller-job cancellation response has no job")
+            })?)
+            .map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("parse local controller job".to_string()),
+                )
+            })?;
+        if job.status != JobStatus::Cancelled {
+            return Err(Error::internal_unexpected(format!(
+                "local controller job `{job_id}` remains {} after cancellation",
+                job.status.daemon_status_label()
+            )));
+        }
+        Ok(job)
+    }
+}
+
 static DAEMON_JOB_STORE: OnceLock<JobStore> = OnceLock::new();
 static DAEMON_RUNTIME_SNAPSHOT: OnceLock<DaemonRuntimeSnapshot> = OnceLock::new();
 
@@ -1182,6 +1252,9 @@ fn reserve_admission(
         "job": reservation.job,
         "daemon_lease_id": daemon_lease.lease_id,
         "idempotent_resubmission": !reservation.created,
+        // A strict controller must receive an explicit server acknowledgement;
+        // a token-shaped legacy response alone is not sufficient authority.
+        "admission_lease_protocol": 1,
         "admission_token": reservation.token,
         "lease": {
             "expires_at_ms": reservation.expires_at_ms,
@@ -2383,6 +2456,8 @@ mod tests {
                 .as_str()
                 .expect("admission identity")
                 .to_string();
+            assert_eq!(reservation["admission_lease_protocol"], 1);
+            assert!(reservation["admission_token"].as_str().is_some());
 
             let accepted = enqueue_exec_job(
                 Some(json!({

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -1886,7 +1886,23 @@ fn dispatch_claimed_controller_job(
         let _ = start_rx.recv();
         let job = job_store.handle(job_id);
         if job.is_cancelled() {
-            persist_controller_cancellation(&job);
+            if recovery {
+                let checkpoint = state
+                    .checkpoint
+                    .as_ref()
+                    .expect("claimed recovery has checkpoint");
+                match driver.cancel(checkpoint) {
+                    Ok(()) => persist_controller_cancellation(&job),
+                    Err(error) => {
+                        let public = driver.public_error(&error);
+                        persist_controller_cancellation_failure(&job, public.message, public.data);
+                    }
+                }
+            } else {
+                // A fresh job cancelled before prepare has admitted no driver
+                // side effect, so durable cancellation is already sufficient.
+                persist_controller_cancellation(&job);
+            }
             controller_job_runtimes()
                 .lock()
                 .expect("controller runtimes lock")

--- a/crates/homeboy-core/src/lab_offload.rs
+++ b/crates/homeboy-core/src/lab_offload.rs
@@ -21,7 +21,7 @@ use crate::lab_contract::{
 use crate::plan::HomeboyPlan;
 
 /// Per-job overrides carried into a Lab offload.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct LabJobOverrides {
     pub env: HashMap<String, String>,
     pub secret_env_names: Vec<String>,
@@ -29,7 +29,7 @@ pub struct LabJobOverrides {
 }
 
 /// A resolved Lab command with its required extensions/capabilities/workload.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct LabOffloadCommand {
     pub command: LabCommandContract,
     pub required_extensions: Vec<String>,

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::mpsc::{self, Sender};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use reqwest::blocking::Client;
@@ -242,10 +243,7 @@ pub(super) fn exec_via_daemon(
 
     let deadline = Instant::now() + runner_exec_wait_timeout();
     let mut daemon_endpoint = local_url.to_string();
-    while !matches!(
-        job.status,
-        JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
-    ) {
+    while !job.status.is_terminal() {
         if Instant::now() >= deadline {
             let events = fetch_daemon_events(&client, &daemon_endpoint, &job.id.to_string())
                 .map(|events| redact_runner_job_events(&events, &env, &secret_env_names))
@@ -292,7 +290,7 @@ pub(super) fn exec_via_daemon(
         Err(err) => {
             return Err(lab_terminal_result_transport_error(
                 runner, &cwd, &command, &job, err,
-            ));
+            ))
         }
     };
     append_agent_task_lifecycle_workload_event(
@@ -437,6 +435,82 @@ pub(super) fn exec_via_daemon(
     ))
 }
 
+/// Selects whether an admission may interoperate with legacy daemon responses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DaemonAdmissionPolicy {
+    LegacyCompatible,
+    DurableLeaseRequired,
+}
+
+#[derive(Debug, Default)]
+struct AdmissionRenewalHealth {
+    lease_expires_at_ms: Option<u64>,
+    failure: Option<String>,
+}
+
+/// Token-free proof material a durable dispatcher may retain or serialize.
+/// The admission token remains exclusively inside the RAII reservation.
+#[derive(Clone, serde::Serialize)]
+pub(crate) struct DaemonAdmissionReservationAuthority {
+    daemon_lease_id: String,
+    reservation_job_id: String,
+    token_present: bool,
+    lease_expires_at_ms: u64,
+    #[serde(skip)]
+    renewal_health: Arc<Mutex<AdmissionRenewalHealth>>,
+}
+
+impl std::fmt::Debug for DaemonAdmissionReservationAuthority {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("DaemonAdmissionReservationAuthority")
+            .field("daemon_lease_id", &self.daemon_lease_id)
+            .field("reservation_job_id", &self.reservation_job_id)
+            .field("token_present", &self.token_present)
+            .field("lease_expires_at_ms", &self.lease_expires_at_ms)
+            .finish()
+    }
+}
+
+impl DaemonAdmissionReservationAuthority {
+    pub(crate) fn daemon_lease_id(&self) -> &str {
+        &self.daemon_lease_id
+    }
+
+    pub(crate) fn reservation_job_id(&self) -> &str {
+        &self.reservation_job_id
+    }
+
+    /// Proves that the daemon, rather than local Drop cleanup, still owns the
+    /// lease expiry/cancellation contract before the dispatcher submits `/exec`.
+    pub(crate) fn prove_server_owned_expiry_or_cancellation_authority(&self) -> Result<()> {
+        if !self.token_present || self.lease_expires_at_ms == 0 {
+            return Err(Error::internal_unexpected(
+                "strict daemon admission has no server-owned lease authority",
+            ));
+        }
+        let health = self
+            .renewal_health
+            .lock()
+            .expect("admission renewal health lock");
+        if let Some(failure) = &health.failure {
+            return Err(Error::internal_unexpected(format!(
+                "strict daemon admission renewal failed before dispatch: {failure}"
+            )));
+        }
+        if health
+            .lease_expires_at_ms
+            .unwrap_or(self.lease_expires_at_ms)
+            == 0
+        {
+            return Err(Error::internal_unexpected(
+                "strict daemon admission has no renewable server lease expiry",
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// Keeps an admitted Lab offload visible in daemon active-job accounting until
 /// its staged execution reaches a terminal or detached handoff outcome.
 pub(crate) struct DaemonAdmissionReservation {
@@ -445,12 +519,16 @@ pub(crate) struct DaemonAdmissionReservation {
     token: Option<String>,
     renewer_stop: Option<Sender<()>>,
     renewer: Option<std::thread::JoinHandle<()>>,
-    pub(crate) daemon_lease_id: String,
+    authority: DaemonAdmissionReservationAuthority,
 }
 
 impl DaemonAdmissionReservation {
     pub(crate) fn job_id(&self) -> &str {
-        &self.job_id
+        self.authority.reservation_job_id()
+    }
+
+    pub(crate) fn authority(&self) -> DaemonAdmissionReservationAuthority {
+        self.authority.clone()
     }
 }
 
@@ -489,6 +567,7 @@ pub(crate) fn reserve_daemon_admission(
     command: &str,
     expected_daemon_lease_id: &str,
     idempotency_key: Option<&str>,
+    policy: DaemonAdmissionPolicy,
 ) -> Result<DaemonAdmissionReservation> {
     let client = Client::builder()
         .no_proxy()
@@ -557,12 +636,39 @@ pub(crate) fn reserve_daemon_admission(
         .and_then(Value::as_str)
         .filter(|token| !token.is_empty())
         .map(str::to_string);
+    let lease_protocol_confirmed =
+        body.get("admission_lease_protocol").and_then(Value::as_u64) == Some(1);
+    let lease_expires_at_ms = body.pointer("/lease/expires_at_ms").and_then(Value::as_u64);
+    let renewable = body.pointer("/lease/renewable").and_then(Value::as_bool) == Some(true);
+    if policy == DaemonAdmissionPolicy::DurableLeaseRequired
+        && !strict_admission_response_is_complete(
+            lease_protocol_confirmed,
+            token.as_deref(),
+            renewable,
+            lease_expires_at_ms,
+        )
+    {
+        return Err(strict_admission_rejection(
+            &client,
+            runner_id,
+            local_url,
+            &job.id.to_string(),
+            token.as_deref(),
+            lease_protocol_confirmed,
+        ));
+    }
+    let renewal_health = Arc::new(Mutex::new(AdmissionRenewalHealth {
+        lease_expires_at_ms,
+        failure: None,
+    }));
+    let token_present = token.is_some();
     let (renewer_stop, renewer) = match token.as_deref() {
         Some(token) => {
             let (stop, renewer) = spawn_admission_renewer(
                 local_url.to_string(),
                 job.id.to_string(),
                 token.to_string(),
+                renewal_health.clone(),
             );
             (Some(stop), Some(renewer))
         }
@@ -576,8 +682,72 @@ pub(crate) fn reserve_daemon_admission(
         token,
         renewer_stop,
         renewer,
-        daemon_lease_id: daemon_lease_id.to_string(),
+        authority: DaemonAdmissionReservationAuthority {
+            daemon_lease_id: daemon_lease_id.to_string(),
+            reservation_job_id: job.id.to_string(),
+            token_present,
+            lease_expires_at_ms: lease_expires_at_ms.unwrap_or_default(),
+            renewal_health,
+        },
     })
+}
+
+fn strict_admission_response_is_complete(
+    lease_protocol_confirmed: bool,
+    token: Option<&str>,
+    renewable: bool,
+    lease_expires_at_ms: Option<u64>,
+) -> bool {
+    lease_protocol_confirmed
+        && token.is_some_and(|token| !token.trim().is_empty())
+        && renewable
+        && lease_expires_at_ms.is_some_and(|expires_at_ms| expires_at_ms > 0)
+}
+
+fn strict_admission_rejection(
+    client: &Client,
+    runner_id: &str,
+    local_url: &str,
+    job_id: &str,
+    token: Option<&str>,
+    lease_protocol_confirmed: bool,
+) -> Error {
+    let release = daemon_post_json_text(
+        client,
+        local_url,
+        &format!("/admissions/{job_id}/release"),
+        &token
+            .map(|token| json!({ "admission_token": token }))
+            .unwrap_or_else(|| json!({})),
+        DaemonPostOptions::default(),
+    );
+    let released = release
+        .ok()
+        .and_then(|response| serde_json::from_str::<DaemonEnvelope>(&response.body).ok())
+        .and_then(|envelope| envelope.data)
+        .and_then(|data| {
+            canonical_daemon_body(&data, "daemon admission release response")
+                .ok()
+                .cloned()
+        })
+        .and_then(|body| serde_json::from_value::<Job>(body["job"].clone()).ok())
+        .is_some_and(|job| job.status.is_terminal());
+    let cleanup = if released {
+        "the legacy reservation was released and reconciled"
+    } else {
+        "the reservation could not be proven released; reconcile the daemon admission before retrying"
+    };
+    let protocol = if lease_protocol_confirmed {
+        "the daemon lease response omitted required token or expiry authority"
+    } else {
+        "the daemon did not confirm admission lease protocol v1"
+    };
+    Error::validation_invalid_argument(
+        "daemon_admission",
+        format!("runner `{runner_id}` rejected durable dispatch: {protocol}; {cleanup}"),
+        Some(job_id.to_string()),
+        None,
+    )
 }
 
 /// Renew at half the daemon's bounded lease interval while staging keeps the
@@ -586,6 +756,7 @@ fn spawn_admission_renewer(
     local_url: String,
     job_id: String,
     token: String,
+    health: Arc<Mutex<AdmissionRenewalHealth>>,
 ) -> (Sender<()>, std::thread::JoinHandle<()>) {
     let (stop, shutdown) = mpsc::channel();
     let renewer = std::thread::spawn(move || {
@@ -595,18 +766,118 @@ fn spawn_admission_renewer(
                 .timeout(Duration::from_secs(10))
                 .build()
             else {
-                continue;
+                health
+                    .lock()
+                    .expect("admission renewal health lock")
+                    .failure = Some("build daemon renewal client".to_string());
+                return;
             };
-            let _ = daemon_post_json_text(
+            let response = daemon_post_json_text(
                 &client,
                 &local_url,
                 &format!("/admissions/{job_id}/renew"),
                 &json!({ "admission_token": token }),
                 DaemonPostOptions::default(),
             );
+            let expires_at_ms = response
+                .ok()
+                .and_then(|response| serde_json::from_str::<DaemonEnvelope>(&response.body).ok())
+                .and_then(|envelope| envelope.data)
+                .and_then(|data| {
+                    canonical_daemon_body(&data, "daemon admission renewal response")
+                        .ok()
+                        .cloned()
+                })
+                .and_then(|body| body.pointer("/lease/expires_at_ms").and_then(Value::as_u64));
+            match expires_at_ms {
+                Some(expires_at_ms) if expires_at_ms > 0 => {
+                    health
+                        .lock()
+                        .expect("admission renewal health lock")
+                        .lease_expires_at_ms = Some(expires_at_ms);
+                }
+                _ => {
+                    health
+                        .lock()
+                        .expect("admission renewal health lock")
+                        .failure =
+                        Some("daemon did not confirm admission lease renewal".to_string());
+                    return;
+                }
+            }
         }
     });
     (stop, renewer)
+}
+
+#[cfg(test)]
+mod admission_tests {
+    use super::*;
+
+    #[test]
+    fn strict_admission_requires_protocol_token_and_server_expiry() {
+        assert!(strict_admission_response_is_complete(
+            true,
+            Some("opaque-token"),
+            true,
+            Some(42),
+        ));
+        assert!(!strict_admission_response_is_complete(
+            true,
+            None,
+            true,
+            Some(42)
+        ));
+        assert!(!strict_admission_response_is_complete(
+            false,
+            Some("opaque-token"),
+            true,
+            Some(42),
+        ));
+        assert!(!strict_admission_response_is_complete(
+            true,
+            Some("opaque-token"),
+            false,
+            Some(42),
+        ));
+    }
+
+    #[test]
+    fn authority_excludes_token_from_debug_and_serialization() {
+        let authority = DaemonAdmissionReservationAuthority {
+            daemon_lease_id: "lease-a".to_string(),
+            reservation_job_id: "job-a".to_string(),
+            token_present: true,
+            lease_expires_at_ms: 42,
+            renewal_health: Arc::new(Mutex::new(AdmissionRenewalHealth::default())),
+        };
+        let debug = format!("{authority:?}");
+        let serialized = serde_json::to_string(&authority).expect("serialize authority");
+        assert!(!debug.contains("opaque-token"));
+        assert!(!serialized.contains("token\":\""));
+        assert!(authority
+            .prove_server_owned_expiry_or_cancellation_authority()
+            .is_ok());
+    }
+
+    #[test]
+    fn renewal_failure_blocks_strict_dispatch_authority() {
+        let authority = DaemonAdmissionReservationAuthority {
+            daemon_lease_id: "lease-a".to_string(),
+            reservation_job_id: "job-a".to_string(),
+            token_present: true,
+            lease_expires_at_ms: 42,
+            renewal_health: Arc::new(Mutex::new(AdmissionRenewalHealth {
+                lease_expires_at_ms: Some(42),
+                failure: Some("daemon rejected renewal".to_string()),
+            })),
+        };
+        let error = authority
+            .prove_server_owned_expiry_or_cancellation_authority()
+            .expect_err("renewal failure must be observable before dispatch");
+        assert!(error.message.contains("renewal failed"));
+        assert!(!error.message.contains("opaque-token"));
+    }
 }
 
 /// Recover only a connection that failed before the daemon could answer. A
@@ -873,6 +1144,60 @@ pub(super) fn fetch_daemon_job_resilient(
 ) -> Result<Job> {
     fetch_daemon_job_resilient_with_endpoint_reload(client, local_url, job_id, || Ok(None))
         .map(|(job, _)| job)
+}
+
+/// Authoritative terminal state for a known daemon job. This observer never
+/// submits work, making it safe for foreground waiting and controller resume.
+pub(crate) struct DaemonTerminalObservation {
+    pub(crate) job: Job,
+    pub(crate) events: Vec<JobEvent>,
+}
+
+pub(crate) fn observe_daemon_job_until_terminal(
+    runner_id: &str,
+    runner_job_id: &str,
+    accepted_daemon_identity: Option<&str>,
+) -> Result<DaemonTerminalObservation> {
+    let client = Client::builder()
+        .no_proxy()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|error| {
+            Error::internal_unexpected(format!("build daemon observer client: {error}"))
+        })?;
+    let status = super::super::status(runner_id)?;
+    let session = status.session.filter(|_| status.connected).ok_or_else(|| {
+        Error::internal_unexpected(format!(
+            "runner `{runner_id}` has no connected daemon session for observation"
+        ))
+    })?;
+    let mut endpoint = session.local_url.clone().ok_or_else(|| {
+        Error::internal_unexpected(format!(
+            "runner `{runner_id}` has no direct daemon endpoint for observation"
+        ))
+    })?;
+    let job = loop {
+        let (job, refreshed_endpoint) = fetch_daemon_job_resilient_with_endpoint_reload(
+            &client,
+            &endpoint,
+            runner_job_id,
+            || refreshed_daemon_endpoint(runner_id, accepted_daemon_identity),
+        )?;
+        endpoint = refreshed_endpoint;
+        if job.status.is_terminal() {
+            break job;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    };
+    let events = fetch_daemon_events(&client, &endpoint, runner_job_id)?;
+    super::super::generation_store::record_job_artifacts(
+        runner_id,
+        &session,
+        runner_job_id,
+        job.artifacts.iter().map(|artifact| artifact.id.clone()),
+    )?;
+    super::super::generation_store::reconcile(runner_id, Some(&session))?;
+    Ok(DaemonTerminalObservation { job, events })
 }
 
 pub(super) fn fetch_daemon_job_resilient_with_endpoint_reload<Reload>(

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -878,6 +878,40 @@ mod admission_tests {
         assert!(error.message.contains("renewal failed"));
         assert!(!error.message.contains("opaque-token"));
     }
+
+    #[test]
+    fn renewal_failure_during_exec_is_visible_after_acceptance() {
+        let renewal_health = Arc::new(Mutex::new(AdmissionRenewalHealth {
+            lease_expires_at_ms: Some(42),
+            failure: None,
+        }));
+        let authority = DaemonAdmissionReservationAuthority {
+            daemon_lease_id: "lease-a".to_string(),
+            reservation_job_id: "job-a".to_string(),
+            token_present: true,
+            lease_expires_at_ms: 42,
+            renewal_health: Arc::clone(&renewal_health),
+        };
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let renewer_barrier = Arc::clone(&barrier);
+        let renewer = std::thread::spawn(move || {
+            renewer_barrier.wait();
+            renewal_health.lock().expect("renewal health lock").failure =
+                Some("daemon rejected renewal during exec".to_string());
+            renewer_barrier.wait();
+        });
+
+        authority
+            .prove_server_owned_expiry_or_cancellation_authority()
+            .expect("authority before exec");
+        barrier.wait();
+        barrier.wait();
+        renewer.join().expect("renewer");
+        let error = authority
+            .prove_server_owned_expiry_or_cancellation_authority()
+            .expect_err("post-acceptance authority must observe renewal failure");
+        assert!(error.message.contains("renewal failed"));
+    }
 }
 
 /// Recover only a connection that failed before the daemon could answer. A

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -91,7 +91,10 @@ use secrets::*;
 
 // Crate-internal surface consumed by sibling `runner` modules (evidence, worker,
 // lab_env, lab/offload) and re-exported by the parent `runner` module.
-pub(crate) use daemon::{reserve_daemon_admission, result_event_data, DaemonAdmissionReservation};
+pub(crate) use daemon::{
+    observe_daemon_job_until_terminal, reserve_daemon_admission, result_event_data,
+    DaemonAdmissionPolicy, DaemonAdmissionReservation, DaemonAdmissionReservationAuthority,
+};
 pub use daemon_api::{canonical_daemon_body, daemon_api_get};
 pub(crate) use failure::{
     append_failure_context_error_summary, runner_exec_failure_context_from_output,

--- a/crates/homeboy-lab-runner/src/git_dependency_materialization.rs
+++ b/crates/homeboy-lab-runner/src/git_dependency_materialization.rs
@@ -112,7 +112,7 @@ pub(crate) struct RunnerDependencyCacheKeyFile {
     pub sha256: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub(crate) struct RunnerDependencyCacheSaveRequest {
     pub remote_path: String,
     pub cache_path: String,

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -17,7 +17,7 @@ use super::connection::{
     active_jobs_before_daemon_replacement, disconnect_with_session, rotate_daemon_generation,
 };
 use super::execution::exec_with_status_snapshot;
-use super::execution::reserve_daemon_admission;
+use super::execution::{reserve_daemon_admission, DaemonAdmissionPolicy};
 use super::{
     connect_with_orphan_adoption, exec, load, materialize_runner_extension_with_env, merge,
     normalize_runner_command_env_for_homeboy_path, plan_controller_snapshot_extension,
@@ -907,6 +907,7 @@ fn probe_reconnected_admission_readiness(runner_id: &str, identity_commit: &str)
                 &format!("runner.refresh_homeboy readiness probe ({identity_commit})"),
                 expected_lease_id,
                 None,
+                DaemonAdmissionPolicy::LegacyCompatible,
             )
             .map(|reservation| {
                 // Drop releases the reservation immediately; readiness is the

--- a/crates/homeboy-lab-runner/src/lab.rs
+++ b/crates/homeboy-lab-runner/src/lab.rs
@@ -27,9 +27,9 @@ mod agent_task_bridge;
 mod args_util;
 mod evidence;
 mod fallback;
-mod offload;
+pub(crate) mod offload;
 mod provider_preflight;
-pub(super) mod secrets;
+pub(crate) mod secrets;
 mod trace_fetch_refs;
 mod workspace_plan;
 

--- a/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
@@ -86,6 +86,27 @@ pub(crate) fn hydrate_lab_workspace_dependencies(
     local_path: &str,
     remote_path: &str,
 ) -> Result<LabWorkspaceHydrationOutput> {
+    hydrate_lab_workspace_dependencies_for_run(runner_id, local_path, remote_path, None)
+}
+
+const HYDRATION_RUN_SEGMENT: &str = "-lab-hydration-";
+
+pub(crate) fn hydration_execution_run_id(parent_run_id: &str, index: usize) -> String {
+    format!("{parent_run_id}{HYDRATION_RUN_SEGMENT}{index}")
+}
+
+pub(crate) fn is_hydration_execution_run_id(parent_run_id: &str, candidate: &str) -> bool {
+    candidate
+        .strip_prefix(parent_run_id)
+        .is_some_and(|suffix| suffix.starts_with(HYDRATION_RUN_SEGMENT))
+}
+
+fn hydrate_lab_workspace_dependencies_for_run(
+    runner_id: &str,
+    local_path: &str,
+    remote_path: &str,
+    parent_run_id: Option<&str>,
+) -> Result<LabWorkspaceHydrationOutput> {
     let plan = deps::dependency_install_plan(std::path::Path::new(local_path))?;
     if plan.is_empty() {
         return Ok(LabWorkspaceHydrationOutput::skipped_no_provider(
@@ -94,18 +115,20 @@ pub(crate) fn hydrate_lab_workspace_dependencies(
     }
 
     let mut steps = Vec::new();
-    for plan_step in plan {
+    for (index, plan_step) in plan.into_iter().enumerate() {
         let command = runner_hydration_command(&plan_step.invocation)?;
         let started = std::time::Instant::now();
+        let mut options = RunnerExecOptions::raw_command(command.clone())
+            .with_cwd(remote_path)
+            .without_evidence_mirror();
+        options.run_id = parent_run_id.map(|run_id| hydration_execution_run_id(run_id, index));
         let (output, exit_code) = exec(
             runner_id,
             // The install command is provider-built shell argv, not a
             // Homeboy-routed command, so dispatch it raw exactly as produced.
             // Hydration is a workspace-setup sub-step of the agent-task offload,
             // so do not mirror it as a standalone controller-side run record.
-            RunnerExecOptions::raw_command(command.clone())
-                .with_cwd(remote_path)
-                .without_evidence_mirror(),
+            options,
         )?;
         let step = LabWorkspaceHydrationStep {
             provider_id: plan_step.provider_id.clone(),
@@ -271,12 +294,13 @@ pub(crate) fn hydrate_for_lab_workspace_exec_with_lifecycle(
     plan: HomeboyPlan,
     agent_task_run_id: Option<&str>,
 ) -> Result<RecordedLabDependencyHydration> {
-    let hydration = hydrate_for_lab_workspace_exec(
+    let hydration = hydrate_for_lab_workspace_exec_internal(
         skip_deps_hydration,
         runner_id,
         local_path,
         remote_path,
         plan,
+        agent_task_run_id,
     )?;
     let execution_ids = match &hydration.record {
         LabWorkspaceHydrationRecord::Applied(output) => output
@@ -312,13 +336,32 @@ pub(crate) fn hydrate_for_lab_workspace_exec(
     remote_path: &str,
     plan: HomeboyPlan,
 ) -> Result<LabOffloadDependencyHydration> {
+    hydrate_for_lab_workspace_exec_internal(
+        skip_deps_hydration,
+        runner_id,
+        local_path,
+        remote_path,
+        plan,
+        None,
+    )
+}
+
+fn hydrate_for_lab_workspace_exec_internal(
+    skip_deps_hydration: bool,
+    runner_id: &str,
+    local_path: &str,
+    remote_path: &str,
+    plan: HomeboyPlan,
+    agent_task_run_id: Option<&str>,
+) -> Result<LabOffloadDependencyHydration> {
     let record = if skip_deps_hydration {
         LabWorkspaceHydrationRecord::NotApplied { reason: "opt_out" }
     } else {
-        LabWorkspaceHydrationRecord::Applied(hydrate_lab_workspace_dependencies(
+        LabWorkspaceHydrationRecord::Applied(hydrate_lab_workspace_dependencies_for_run(
             runner_id,
             local_path,
             remote_path,
+            agent_task_run_id,
         )?)
     };
 
@@ -364,6 +407,15 @@ pub(crate) fn dependency_hydration_metadata(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn hydration_execution_ids_are_parent_scoped_and_discoverable() {
+        let child = hydration_execution_run_id("attempt-1", 2);
+        assert_eq!(child, "attempt-1-lab-hydration-2");
+        assert!(is_hydration_execution_run_id("attempt-1", &child));
+        assert!(!is_hydration_execution_run_id("attempt-2", &child));
+        assert!(!is_hydration_execution_run_id("attempt-1", "attempt-1"));
+    }
 
     /// Holds a temp bin dir containing a fake executable. The runner exec path
     /// uses a curated `PATH` (`local_runner_command_path`), not the process

--- a/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
@@ -101,6 +101,21 @@ pub(crate) fn is_hydration_execution_run_id(parent_run_id: &str, candidate: &str
         .is_some_and(|suffix| suffix.starts_with(HYDRATION_RUN_SEGMENT))
 }
 
+fn hydration_runner_exec_options(
+    command: Vec<String>,
+    remote_path: &str,
+    parent_run_id: Option<&str>,
+    index: usize,
+) -> RunnerExecOptions {
+    let mut options = RunnerExecOptions::raw_command(command)
+        .with_cwd(remote_path)
+        .without_evidence_mirror();
+    options.run_id = parent_run_id.map(|run_id| hydration_execution_run_id(run_id, index));
+    // Hydration children are generic runner executions, not agent-task handoffs.
+    options.run_id_owns_generic_exec = options.run_id.is_some();
+    options
+}
+
 fn hydrate_lab_workspace_dependencies_for_run(
     runner_id: &str,
     local_path: &str,
@@ -118,10 +133,8 @@ fn hydrate_lab_workspace_dependencies_for_run(
     for (index, plan_step) in plan.into_iter().enumerate() {
         let command = runner_hydration_command(&plan_step.invocation)?;
         let started = std::time::Instant::now();
-        let mut options = RunnerExecOptions::raw_command(command.clone())
-            .with_cwd(remote_path)
-            .without_evidence_mirror();
-        options.run_id = parent_run_id.map(|run_id| hydration_execution_run_id(run_id, index));
+        let options =
+            hydration_runner_exec_options(command.clone(), remote_path, parent_run_id, index);
         let (output, exit_code) = exec(
             runner_id,
             // The install command is provider-built shell argv, not a
@@ -415,6 +428,28 @@ mod tests {
         assert!(is_hydration_execution_run_id("attempt-1", &child));
         assert!(!is_hydration_execution_run_id("attempt-2", &child));
         assert!(!is_hydration_execution_run_id("attempt-1", "attempt-1"));
+    }
+
+    #[test]
+    fn hydration_execution_ids_own_generic_runner_exec_lifecycles() {
+        let options = hydration_runner_exec_options(
+            vec!["fixture-tool".to_string(), "install".to_string()],
+            "/runner/workspace",
+            Some("attempt-1"),
+            2,
+        );
+
+        assert_eq!(options.run_id.as_deref(), Some("attempt-1-lab-hydration-2"));
+        assert!(options.run_id_owns_generic_exec);
+        assert!(
+            !hydration_runner_exec_options(
+                vec!["fixture-tool".to_string()],
+                "/runner/workspace",
+                None,
+                0,
+            )
+            .run_id_owns_generic_exec
+        );
     }
 
     /// Holds a temp bin dir containing a fake executable. The runner exec path

--- a/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
@@ -242,7 +242,7 @@ pub(crate) fn hydration_failure_error(
 /// Hydration outcome as recorded by the offload orchestrator. `NotApplied`
 /// captures why hydration was skipped (explicit opt-out); `Applied` carries the
 /// per-provider results.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub(crate) enum LabWorkspaceHydrationRecord {
     NotApplied { reason: &'static str },
     Applied(LabWorkspaceHydrationOutput),
@@ -253,6 +253,50 @@ pub(crate) enum LabWorkspaceHydrationRecord {
 pub(crate) struct LabOffloadDependencyHydration {
     pub(crate) plan: HomeboyPlan,
     pub(crate) record: LabWorkspaceHydrationRecord,
+}
+
+/// Hydration plus the runner execution identities durably recorded against an
+/// agent-task attempt. Both synchronous offload and controller staging use this
+/// boundary so recovery observes the same lifecycle authority.
+pub(crate) struct RecordedLabDependencyHydration {
+    pub(crate) hydration: LabOffloadDependencyHydration,
+    pub(crate) execution_ids: Vec<String>,
+}
+
+pub(crate) fn hydrate_for_lab_workspace_exec_with_lifecycle(
+    skip_deps_hydration: bool,
+    runner_id: &str,
+    local_path: &str,
+    remote_path: &str,
+    plan: HomeboyPlan,
+    agent_task_run_id: Option<&str>,
+) -> Result<RecordedLabDependencyHydration> {
+    let hydration = hydrate_for_lab_workspace_exec(
+        skip_deps_hydration,
+        runner_id,
+        local_path,
+        remote_path,
+        plan,
+    )?;
+    let execution_ids = match &hydration.record {
+        LabWorkspaceHydrationRecord::Applied(output) => output
+            .steps
+            .iter()
+            .filter_map(|step| step.job_id.clone())
+            .collect(),
+        LabWorkspaceHydrationRecord::NotApplied { .. } => Vec::new(),
+    };
+    if let Some(run_id) = agent_task_run_id {
+        agent_task_lifecycle::record_lab_offload_phase_executions(
+            run_id,
+            "hydrating",
+            execution_ids.clone(),
+        )?;
+    }
+    Ok(RecordedLabDependencyHydration {
+        hydration,
+        execution_ids,
+    })
 }
 
 /// Decide whether to hydrate and, when applicable, run hydration for a
@@ -410,6 +454,28 @@ mod tests {
         assert_eq!(output.status, "skipped_no_provider");
         assert!(output.is_empty());
         assert_eq!(output.schema, HYDRATION_SCHEMA);
+    }
+
+    #[test]
+    fn explicit_skip_is_a_completed_no_op_without_runner_access() {
+        let hydration = hydrate_for_lab_workspace_exec(
+            true,
+            "unreachable-runner",
+            "/missing/controller-workspace",
+            "/missing/runner-workspace",
+            HomeboyPlan::for_description(homeboy_core::plan::PlanKind::LabOffload, "hydration"),
+        )
+        .expect("skip does not detect or execute dependencies");
+
+        assert!(matches!(
+            hydration.record,
+            LabWorkspaceHydrationRecord::NotApplied { reason: "opt_out" }
+        ));
+        assert!(hydration.plan.steps.is_empty());
+        assert_eq!(
+            dependency_hydration_metadata(&hydration.record)["status"],
+            "not_applied"
+        );
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1463,8 +1463,24 @@ pub(crate) fn run_lab_offload_inner(
                 &mut messages,
             );
         }
-        let controller_job_id =
-            crate::lab_staging_controller::submit_detached_staging(run_id, runner_id, &request)?;
+        let controller_job_id = match crate::lab_staging_controller::submit_detached_staging(
+            run_id, runner_id, &request,
+        ) {
+            Ok(controller_job_id) => controller_job_id,
+            Err(error) => {
+                if let Some(durable_plan) = request.durable_agent_task_plan.as_ref() {
+                    let _ = agent_task_lifecycle::record_pre_execution_failure(
+                        run_id,
+                        durable_plan,
+                        "lab_staging_submission",
+                        &error,
+                    );
+                }
+                return Err(
+                    error.with_hint(format!("Retry: homeboy agent-task retry {run_id} --run"))
+                );
+            }
+        };
         let stdout = serde_json::to_string_pretty(&serde_json::json!({
             "success": true,
             "data": {

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1468,13 +1468,18 @@ pub(crate) fn run_lab_offload_inner(
         ) {
             Ok(controller_job_id) => controller_job_id,
             Err(error) => {
-                if let Some(durable_plan) = request.durable_agent_task_plan.as_ref() {
-                    let _ = agent_task_lifecycle::record_pre_execution_failure(
-                        run_id,
-                        durable_plan,
-                        "lab_staging_submission",
-                        &error,
-                    );
+                // A retryable transport failure can follow durable acceptance.
+                // Keep the parent nonterminal so replay can reconcile the same
+                // controller idempotency key instead of contradicting live work.
+                if error.retryable != Some(true) {
+                    if let Some(durable_plan) = request.durable_agent_task_plan.as_ref() {
+                        let _ = agent_task_lifecycle::record_pre_execution_failure(
+                            run_id,
+                            durable_plan,
+                            "lab_staging_submission",
+                            &error,
+                        );
+                    }
                 }
                 return Err(
                     error.with_hint(format!("Retry: homeboy agent-task retry {run_id} --run"))

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -85,6 +85,158 @@ pub(crate) fn ensure_remote_lab_artifact_dir(runner_id: &str, output_file: &str)
     Ok(())
 }
 
+/// Serializable result of the runner-private runtime preparation boundary.
+/// It is shared by synchronous offload and durable staging so the two paths
+/// publish identical rig, extension, and agent-runtime state.
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct LabRuntimeMaterializationOutput {
+    pub(crate) remote_cwd: String,
+    pub(crate) plan: HomeboyPlan,
+    pub(crate) synced_rigs: Vec<rig_materialization::LabOffloadRigSync>,
+    pub(crate) rig_registry_root: Option<String>,
+    pub(crate) extension_overlays: serde_json::Value,
+    pub(crate) extension_runtime_root: String,
+    pub(crate) extension_runtime_home: Option<String>,
+    pub(crate) runtime_generation:
+        Option<crate::runtime_materializer::ResolvedAgentRuntimeGeneration>,
+    pub(crate) runtime_env: Vec<(String, String)>,
+    pub(crate) runtime_evidence: Option<crate::runtime_materializer::AgentRuntimeExecutionEvidence>,
+    pub(crate) remapped_args: Vec<String>,
+    pub(crate) command: Vec<String>,
+    pub(crate) remote_command: Vec<String>,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn materialize_lab_runtime<F>(
+    runner: &Runner,
+    homeboy_path: &str,
+    remote_cwd: &str,
+    changed_args: &[String],
+    synced_local_path: &str,
+    source_snapshot: &SourceSnapshot,
+    workspace_snapshot_identity: &str,
+    workspace_remaps: &[(String, String)],
+    runner_required_extensions: &[String],
+    agent_task_run_id: Option<&str>,
+    mut plan: HomeboyPlan,
+    mut remapped_args: Vec<String>,
+    mut command: Vec<String>,
+    mut remote_command: Vec<String>,
+    mut check_cancelled: F,
+) -> Result<LabRuntimeMaterializationOutput>
+where
+    F: FnMut() -> Result<()>,
+{
+    check_cancelled()?;
+    ensure_remote_lab_artifact_dir(runner.id.as_str(), &remote_lab_artifact_dir(remote_cwd))?;
+    check_cancelled()?;
+
+    let candidate_rig_registry_root = remote_lab_rig_registry_root(remote_cwd);
+    let synced_rigs = rig_materialization::sync_lab_offload_rigs(
+        runner.id.as_str(),
+        homeboy_path,
+        remote_cwd,
+        &candidate_rig_registry_root,
+        changed_args,
+        rig_materialization::LabOffloadPrimaryRigSource {
+            local_path: synced_local_path,
+            remote_path: remote_cwd,
+            source_snapshot,
+            workspace_snapshot_identity,
+        },
+    )?;
+    check_cancelled()?;
+    if !synced_rigs.is_empty() {
+        plan = with_step(
+            plan,
+            PlanStep::ready("lab.sync_rigs", "lab.sync_rigs")
+                .inputs(
+                    PlanValues::new()
+                        .json("count", synced_rigs.len())
+                        .string("source_snapshot_remote_path", remote_cwd)
+                        .string("registry_root", &candidate_rig_registry_root)
+                        .json("rigs", &synced_rigs),
+                )
+                .build(),
+        );
+    }
+    let rig_registry_root = (!synced_rigs.is_empty()).then_some(candidate_rig_registry_root);
+
+    let extension_runtime_root =
+        format!("{}/extension-runtime", remote_lab_artifact_dir(remote_cwd));
+    let extension_overlays = crate::materialize_lab_job_extension_overlays(
+        runner,
+        &extension_runtime_root,
+        runner_required_extensions,
+    )?;
+    check_cancelled()?;
+    let extension_runtime_home =
+        (!extension_overlays.is_empty()).then(|| format!("{extension_runtime_root}/home"));
+
+    let mut runtime_operations = RunnerRuntimeMaterializerOperations::new(runner.clone());
+    let resolved_runtime = resolve_lab_agent_runtime(
+        &mut runtime_operations,
+        runner,
+        &remapped_args,
+        workspace_remaps,
+        agent_task_run_id.unwrap_or("lab-offload"),
+    )?;
+    check_cancelled()?;
+    let runtime_generation = resolved_runtime
+        .as_ref()
+        .map(|resolved| resolved.generation.clone());
+    let runtime_env = resolved_runtime
+        .as_ref()
+        .map(|resolved| resolved.env.clone())
+        .unwrap_or_default();
+    if let Some(resolved) = resolved_runtime {
+        let prior_args = remapped_args.clone();
+        remapped_args = resolved.args;
+        rewrite_dispatched_runtime_args(
+            &prior_args,
+            &remapped_args,
+            &mut command,
+            &mut remote_command,
+        );
+        plan = with_step(
+            plan,
+            PlanStep::ready(
+                "lab.materialize_agent_runtime",
+                "lab.materialize_agent_runtime",
+            )
+            .inputs(PlanValues::new().json("generation", &runtime_generation))
+            .build(),
+        );
+    }
+    let runtime_evidence = runtime_generation
+        .as_ref()
+        .map(|generation| {
+            runtime_execution_evidence(generation, &remapped_args, runner.id.as_str())
+        })
+        .transpose()?;
+
+    Ok(LabRuntimeMaterializationOutput {
+        remote_cwd: remote_cwd.to_string(),
+        plan,
+        synced_rigs,
+        rig_registry_root,
+        extension_overlays: serde_json::to_value(extension_overlays).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize Lab extension overlays".to_string()),
+            )
+        })?,
+        extension_runtime_root,
+        extension_runtime_home,
+        runtime_generation,
+        runtime_env,
+        runtime_evidence,
+        remapped_args,
+        command,
+        remote_command,
+    })
+}
+
 pub(crate) fn args_contain_output_file(args: &[String]) -> bool {
     let mut passthrough = false;
     args.iter().any(|arg| {
@@ -1288,10 +1440,58 @@ pub(crate) fn run_lab_offload_inner(
     }
 
     let capability_preflight: Option<RunnerCapabilityPreflight> = capability_plan.map(Into::into);
+    // Detached direct-daemon agent-task work is controller-owned from this point.
+    // It must never fall through to caller-side workspace staging after admission.
+    if request.detach_after_handoff
+        && request.durable_agent_task_plan.is_some()
+        && selection.mode != super::super::super::RunnerTunnelMode::Reverse
+        && capability_preflight.is_some()
+    {
+        let run_id = pre_acceptance_run_id.as_deref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+            "run_id",
+            "detached Lab offload requires a durable agent-task attempt before controller staging",
+            None,
+            None,
+        )
+        })?;
+        if request.local_output_file.is_some() {
+            emit_durable_run_id_before_execution(
+                run_id,
+                runner_id,
+                request.local_output_file,
+                &mut messages,
+            );
+        }
+        let controller_job_id =
+            crate::lab_staging_controller::submit_detached_staging(run_id, runner_id, &request)?;
+        let stdout = serde_json::to_string_pretty(&serde_json::json!({
+            "success": true,
+            "data": {
+                "status": "materializing",
+                "durable_run_id": run_id,
+                "controller_job_id": controller_job_id,
+                "retrieval_commands": {
+                    "status": format!("homeboy agent-task status {run_id}"),
+                    "controller_job": format!("homeboy daemon job {}", controller_job_id),
+                }
+            }
+        }))
+        .unwrap_or_else(|_| {
+            format!("Lab staging controller job {controller_job_id} accepted for {run_id}")
+        });
+        return Ok(LabOffloadOutcome::InFlight {
+            plan,
+            stdout: format!("{stdout}\n"),
+            stderr: format!("Lab staging continues in controller job `{controller_job_id}`.\nNext: homeboy agent-task status {run_id}\n"),
+            exit_code: 0,
+            output_file_content: Some(format!("{stdout}\n")),
+        });
+    }
     let workspace_sync_timer = overhead.phase(LabOffloadPhase::WorkspaceSync);
     let workspace_stage = match prepare_lab_offload_workspace_stage(
         &request,
-        &contract,
+        crate::lab::offload::workspace_stage::LabWorkspaceStageCommand::from(&contract),
         plan,
         runner_id,
         &source_path,
@@ -1368,53 +1568,6 @@ pub(crate) fn run_lab_offload_inner(
         cleanup_policy,
     );
 
-    ensure_remote_lab_artifact_dir(runner_id, &remote_lab_artifact_dir(&remote_cwd))?;
-
-    let candidate_rig_registry_root = remote_lab_rig_registry_root(&remote_cwd);
-    let synced_rigs = rig_materialization::sync_lab_offload_rigs(
-        runner_id,
-        homeboy_path,
-        &remote_cwd,
-        &candidate_rig_registry_root,
-        &changed_since_preflight.args,
-        rig_materialization::LabOffloadPrimaryRigSource {
-            local_path: &synced.local_path,
-            remote_path: &remote_cwd,
-            source_snapshot: &source_snapshot,
-            workspace_snapshot_identity: &synced.snapshot_identity,
-        },
-    )?;
-    if !synced_rigs.is_empty() {
-        plan = with_step(
-            plan,
-            PlanStep::ready("lab.sync_rigs", "lab.sync_rigs")
-                .inputs(
-                    PlanValues::new()
-                        .json("count", synced_rigs.len())
-                        .string("source_snapshot_remote_path", &remote_cwd)
-                        .string("registry_root", &candidate_rig_registry_root)
-                        .json("rigs", &synced_rigs),
-                )
-                .build(),
-        );
-    }
-    let rig_registry_root = (!synced_rigs.is_empty()).then_some(candidate_rig_registry_root);
-
-    // Materialize after establishing the owner so a partial extension sync or
-    // any later pre-dispatch failure reaps the complete job-private runtime.
-    let extension_runtime_root =
-        format!("{}/extension-runtime", remote_lab_artifact_dir(&remote_cwd));
-    let extension_overlays = crate::materialize_lab_job_extension_overlays(
-        &runner,
-        &extension_runtime_root,
-        &runner_required_extensions,
-    )?;
-    let extension_runtime_home =
-        (!extension_overlays.is_empty()).then(|| format!("{extension_runtime_root}/home"));
-
-    // Runtime sources have now been synchronized to the runner, but no daemon
-    // admission exists yet. Materialization can therefore fail atomically
-    // without creating a reserved or submitted job.
     let workspace_remaps = workspace_mapping
         .iter()
         .map(|entry| {
@@ -1424,48 +1577,34 @@ pub(crate) fn run_lab_offload_inner(
             )
         })
         .collect::<Vec<_>>();
-    let mut runtime_operations = RunnerRuntimeMaterializerOperations::new(runner.clone());
-    let resolved_runtime = resolve_lab_agent_runtime(
-        &mut runtime_operations,
+    let runtime = materialize_lab_runtime(
         &runner,
-        &remapped_args,
+        homeboy_path,
+        &remote_cwd,
+        &changed_since_preflight.args,
+        &synced.local_path,
+        &source_snapshot,
+        &synced.snapshot_identity,
         &workspace_remaps,
-        agent_task_run_id.as_deref().unwrap_or("lab-offload"),
+        &runner_required_extensions,
+        agent_task_run_id.as_deref(),
+        plan,
+        remapped_args,
+        command,
+        remote_command,
+        || Ok(()),
     )?;
-    let runtime_generation = resolved_runtime
-        .as_ref()
-        .map(|resolved| resolved.generation.clone());
-    let runtime_env = resolved_runtime
-        .as_ref()
-        .map(|resolved| resolved.env.clone())
-        .unwrap_or_default();
-    if let Some(resolved) = resolved_runtime {
-        let prior_args = remapped_args.clone();
-        remapped_args = resolved.args;
-        // The policy is conventionally encoded as
-        // `--resolved-provider-policy=<json>`, not as bare JSON. Replace every
-        // changed argument so both direct and reverse daemon transports execute
-        // the runner-local generation rather than the controller declaration.
-        rewrite_dispatched_runtime_args(
-            &prior_args,
-            &remapped_args,
-            &mut command,
-            &mut remote_command,
-        );
-        plan = with_step(
-            plan,
-            PlanStep::ready(
-                "lab.materialize_agent_runtime",
-                "lab.materialize_agent_runtime",
-            )
-            .inputs(PlanValues::new().json("generation", &runtime_generation))
-            .build(),
-        );
-    }
-    let runtime_evidence = runtime_generation
-        .as_ref()
-        .map(|generation| runtime_execution_evidence(generation, &remapped_args, runner_id))
-        .transpose()?;
+    plan = runtime.plan;
+    let synced_rigs = runtime.synced_rigs;
+    let rig_registry_root = runtime.rig_registry_root;
+    let extension_overlays = runtime.extension_overlays;
+    let extension_runtime_home = runtime.extension_runtime_home;
+    let runtime_generation = runtime.runtime_generation;
+    let runtime_env = runtime.runtime_env;
+    let runtime_evidence = runtime.runtime_evidence;
+    remapped_args = runtime.remapped_args;
+    command = runtime.command;
+    remote_command = runtime.remote_command;
     if let Some(run_id) = agent_task_run_id.as_deref() {
         agent_task_lifecycle::record_lab_offload_phase(
             run_id,
@@ -1478,28 +1617,17 @@ pub(crate) fn run_lab_offload_inner(
         )?;
     }
 
-    let dependency_hydration = hydrate_for_lab_workspace_exec(
+    let recorded_dependency_hydration = hydrate_for_lab_workspace_exec_with_lifecycle(
         request.skip_deps_hydration,
         runner_id,
         &synced.local_path,
         &remote_cwd,
         plan,
+        agent_task_run_id.as_deref(),
     )?;
+    let dependency_hydration = recorded_dependency_hydration.hydration;
     plan = dependency_hydration.plan;
     if let Some(run_id) = agent_task_run_id.as_deref() {
-        let execution_ids = match &dependency_hydration.record {
-            LabWorkspaceHydrationRecord::Applied(output) => output
-                .steps
-                .iter()
-                .filter_map(|step| step.job_id.clone())
-                .collect(),
-            LabWorkspaceHydrationRecord::NotApplied { .. } => Vec::new(),
-        };
-        agent_task_lifecycle::record_lab_offload_phase_executions(
-            run_id,
-            "hydrating",
-            execution_ids,
-        )?;
         agent_task_lifecycle::record_lab_offload_phase(
             run_id,
             runner_id,
@@ -1696,6 +1824,7 @@ pub(crate) fn run_lab_offload_inner(
             &redact_argv_shell_display(&command_prefix.argv),
             expected_daemon_lease_id,
             agent_task_run_id.as_deref(),
+            DaemonAdmissionPolicy::LegacyCompatible,
         )
     })
     .transpose()?;
@@ -1707,7 +1836,9 @@ pub(crate) fn run_lab_offload_inner(
                 .or_else(|| runner_homeboy.get("active_daemon_build_identity")),
         },
         "admission": {
-            "daemon_lease_id": admission.as_ref().map(|reservation| &reservation.daemon_lease_id),
+            "daemon_lease_id": admission
+                .as_ref()
+                .map(|reservation| reservation.authority().daemon_lease_id().to_string()),
             "reservation_job_id": admission.as_ref().map(|reservation| reservation.job_id()),
             "authority": admission.is_none().then_some("reverse_broker"),
         },
@@ -1731,7 +1862,9 @@ pub(crate) fn run_lab_offload_inner(
             },
             "executed": {
                 "argv": &remote_command,
-                "daemon_lease_id": admission.as_ref().map(|reservation| &reservation.daemon_lease_id),
+                "daemon_lease_id": admission
+                    .as_ref()
+                    .map(|reservation| reservation.authority().daemon_lease_id().to_string()),
                 "reservation_job_id": admission.as_ref().map(|reservation| reservation.job_id()),
                 "authority": admission.is_none().then_some("reverse_broker"),
             },

--- a/crates/homeboy-lab-runner/src/lab/offload/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/mod.rs
@@ -27,7 +27,7 @@ mod path_materialization;
 mod resident;
 mod telemetry;
 mod types;
-mod workspace_stage;
+pub(crate) mod workspace_stage;
 
 #[cfg(test)]
 mod tests;
@@ -62,7 +62,7 @@ use super::super::daemon_health::runner_daemon_health_failure;
 use super::super::execution::{
     append_failure_context_error_summary, lab_offload_handoff_hints, reserve_daemon_admission,
     runner_exec_failure_context_from_output, runner_exec_failure_context_remediation_hint,
-    DaemonAdmissionReservation, DaemonJobHandoffState,
+    DaemonAdmissionPolicy, DaemonAdmissionReservation, DaemonJobHandoffState,
 };
 use super::super::lab_apply::{
     apply_lab_offload_patch, apply_lab_promotion_patch, PromotionPatchIntent,

--- a/crates/homeboy-lab-runner/src/lab/offload/path_materialization.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/path_materialization.rs
@@ -15,7 +15,7 @@ pub(crate) struct PathMaterializationPlanner {
 impl PathMaterializationPlanner {
     pub(crate) fn plan(
         args: &[String],
-        contract: &LabOffloadCommand,
+        workload: Option<&homeboy_core::lab_contract::LabRigWorkloadArguments>,
         source_path: &Path,
         allow_dirty_lab_workspace: bool,
     ) -> Result<Self> {
@@ -39,7 +39,7 @@ impl PathMaterializationPlanner {
         )?);
         extra_workspaces.extend(rig_declared_path_input_extra_workspaces(
             &args,
-            contract.workload.as_ref(),
+            workload,
             source_path,
         )?);
         extra_workspaces.extend(runtime_refresh_source_extra_workspaces(
@@ -162,8 +162,9 @@ mod tests {
             extension_overrides: Vec::new(),
         });
 
-        let planner = PathMaterializationPlanner::plan(&args, &contract, &primary, false)
-            .expect("materialization plan");
+        let planner =
+            PathMaterializationPlanner::plan(&args, contract.workload.as_ref(), &primary, false)
+                .expect("materialization plan");
         let paths = planner
             .extra_workspaces
             .iter()

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -8,6 +8,48 @@ use homeboy_core::runner_execution_envelope::{
 };
 use homeboy_rig;
 
+/// Owned command facts consumed while materializing a workspace. This keeps the
+/// durable controller path bounded by the request lifetime rather than forcing
+/// persisted strings into a static command contract.
+pub(crate) struct LabWorkspaceStageCommand {
+    pub(crate) workspace_mode_policy: LabOffloadWorkspaceModePolicy,
+    pub(crate) requires_extension_parity: bool,
+    pub(crate) workload: Option<homeboy_core::lab_contract::LabRigWorkloadArguments>,
+    pub(crate) required_extensions: Vec<String>,
+    pub(crate) secret_env_sources: Vec<homeboy_core::lab_contract::LabSecretEnvSource>,
+}
+
+impl From<&LabOffloadCommand> for LabWorkspaceStageCommand {
+    fn from(command: &LabOffloadCommand) -> Self {
+        Self {
+            workspace_mode_policy: command.workspace_mode_policy,
+            requires_extension_parity: command.routing_policy.requires_extension_parity,
+            workload: command.workload.clone(),
+            required_extensions: command.required_extensions.clone(),
+            secret_env_sources: command.secret_env_sources.to_vec(),
+        }
+    }
+}
+
+impl From<&crate::lab_staging_controller::LabStagingCommand> for LabWorkspaceStageCommand {
+    fn from(command: &crate::lab_staging_controller::LabStagingCommand) -> Self {
+        Self {
+            workspace_mode_policy: command.workspace_mode_policy,
+            requires_extension_parity: command.routing_policy.requires_extension_parity,
+            workload: command.workload.as_ref().map(|workload| {
+                homeboy_core::lab_contract::LabRigWorkloadArguments {
+                    kind: workload.kind,
+                    rig_ids: workload.rig_ids.clone(),
+                    component: workload.component.clone(),
+                    extension_overrides: workload.extension_overrides.clone(),
+                }
+            }),
+            required_extensions: command.required_extensions.clone(),
+            secret_env_sources: command.secret_env_sources.clone(),
+        }
+    }
+}
+
 pub(crate) struct LabOffloadWorkspaceStage {
     pub(crate) plan: HomeboyPlan,
     pub(crate) sync_mode: RunnerWorkspaceSyncMode,
@@ -33,10 +75,63 @@ pub(crate) struct LabOffloadWorkspaceStage {
     pub(crate) runtime_overlay_metadata: serde_json::Value,
 }
 
+/// The subset of workspace-stage output consumed by runtime publication. It is
+/// fully deserializable so durable recovery never re-runs workspace sync.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct DurableLabRuntimeWorkspaceInput {
+    pub(crate) synced_local_path: String,
+    pub(crate) workspace_snapshot_identity: String,
+    pub(crate) source_snapshot: SourceSnapshot,
+    pub(crate) workspace_remaps: Vec<(String, String)>,
+}
+
+/// Owner-only durable representation of all workspace-stage outputs consumed by
+/// the remaining Lab stages. Keep this projection data-only: it is persisted
+/// before a controller checkpoint can advance and must never contain secret
+/// values (the staging recipe carries secret names only).
+pub(crate) fn durable_workspace_stage_projection(
+    stage: &LabOffloadWorkspaceStage,
+) -> serde_json::Value {
+    serde_json::json!({
+        "remote_cwd": stage.remote_cwd,
+        "sync_mode": stage.sync_mode,
+        "sync": stage.synced,
+        "changed_since": {
+            "args": stage.changed_since_preflight.args,
+            "requested_ref": stage.changed_since_preflight.requested_ref,
+            "resolved_base": stage.changed_since_preflight.resolved_base,
+            "git_fetch_refs": stage.changed_since_preflight.git_fetch_refs,
+        },
+        "workspace_mapping": stage.workspace_mapping,
+        "path_materialization_plan": stage.path_materialization_plan,
+        "source_snapshot": stage.source_snapshot,
+        "remapped_args": stage.remapped_args,
+        "agent_task_run_id": stage.agent_task_run_id,
+        "runner_required_extensions": stage.runner_required_extensions,
+        "accepted_extension_settings": stage.accepted_extension_settings,
+        "command": stage.command,
+        "remote_command": stage.remote_command,
+        "remote_output_file": stage.remote_output_file,
+        "rig_component_path_overrides": stage.rig_component_path_overrides,
+        "dependency_cache_saves": stage.dependency_cache_saves,
+        "runtime_overlay_env": stage.runtime_overlay_env,
+        "runtime_overlay_metadata": stage.runtime_overlay_metadata,
+        "plan": stage.plan,
+        "runtime_input": DurableLabRuntimeWorkspaceInput {
+            synced_local_path: stage.synced.local_path.clone(),
+            workspace_snapshot_identity: stage.synced.snapshot_identity.clone(),
+            source_snapshot: stage.source_snapshot.clone(),
+            workspace_remaps: stage.workspace_mapping.iter().map(|entry| (
+                entry.local_path().to_string(), entry.remote_path().to_string()
+            )).collect(),
+        },
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn prepare_lab_offload_workspace_stage(
     request: &LabOffloadRequest<'_>,
-    contract: &LabOffloadCommand,
+    contract: LabWorkspaceStageCommand,
     plan: HomeboyPlan,
     runner_id: &str,
     source_path: &Path,
@@ -60,7 +155,7 @@ pub(crate) fn prepare_lab_offload_workspace_stage(
 
     prepare_lab_offload_workspace_stage_inner(
         request,
-        contract,
+        &contract,
         plan,
         runner_id,
         source_path,
@@ -76,7 +171,7 @@ pub(crate) fn prepare_lab_offload_workspace_stage(
 #[allow(clippy::too_many_arguments)]
 fn prepare_lab_offload_workspace_stage_inner(
     request: &LabOffloadRequest<'_>,
-    contract: &LabOffloadCommand,
+    contract: &LabWorkspaceStageCommand,
     mut plan: HomeboyPlan,
     runner_id: &str,
     source_path: &Path,
@@ -128,7 +223,7 @@ fn prepare_lab_offload_workspace_stage_inner(
     )?;
     let materialization_planner = PathMaterializationPlanner::plan(
         &offload_args,
-        contract,
+        contract.workload.as_ref(),
         source_path,
         request.allow_dirty_lab_workspace,
     )?;
@@ -324,7 +419,7 @@ fn prepare_lab_offload_workspace_stage_inner(
     source_snapshot.synthetic_checkout_tree =
         synced.current_workspace.synthetic_checkout_tree.clone();
     validate_lab_source_snapshot_handoff(source_path, &synced, &source_snapshot)?;
-    if contract.routing_policy.requires_extension_parity {
+    if contract.requires_extension_parity {
         plan = with_step(
             plan,
             PlanStep::ready("lab.extension_parity", "lab.extension_parity").build(),
@@ -513,7 +608,7 @@ pub(crate) fn path_remaps_from_materialization_plan(
 }
 
 fn preflight_agent_task_secret_env_before_workspace_stage(
-    contract: &LabOffloadCommand,
+    contract: &LabWorkspaceStageCommand,
     runner_id: &str,
     runner: &crate::Runner,
     args: &[String],
@@ -606,7 +701,7 @@ pub(crate) fn validate_lab_source_snapshot_handoff(
 }
 
 fn lab_path_materialization_mode(
-    contract: &LabOffloadCommand,
+    contract: &LabWorkspaceStageCommand,
     sync_mode: RunnerWorkspaceSyncMode,
 ) -> String {
     if matches!(
@@ -1931,7 +2026,10 @@ mod tests {
         let plan = workspace_path_materialization_plan(
             &workspace_mapping,
             PATH_MATERIALIZATION_OWNER_LAB_PROVIDER_CONFIG,
-            lab_path_materialization_mode(&contract, RunnerWorkspaceSyncMode::Git),
+            lab_path_materialization_mode(
+                &LabWorkspaceStageCommand::from(&contract),
+                RunnerWorkspaceSyncMode::Git,
+            ),
         );
 
         assert_eq!(plan.entries.len(), 1);
@@ -1999,7 +2097,10 @@ mod tests {
         let plan = workspace_path_materialization_plan(
             &workspace_mapping,
             PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
-            lab_path_materialization_mode(&contract, RunnerWorkspaceSyncMode::Git),
+            lab_path_materialization_mode(
+                &LabWorkspaceStageCommand::from(&contract),
+                RunnerWorkspaceSyncMode::Git,
+            ),
         );
 
         assert_eq!(plan.entries[0].materialization_mode, "git");
@@ -2022,7 +2123,10 @@ mod tests {
         ];
 
         let err = preflight_agent_task_secret_env_before_workspace_stage(
-            &contract, "lab", &runner, &args,
+            &LabWorkspaceStageCommand::from(&contract),
+            "lab",
+            &runner,
+            &args,
         )
         .expect_err("missing controller-forwarded secret should fail before workspace sync");
 
@@ -2179,7 +2283,7 @@ mod tests {
             let runner_workspace_root = runner_root.path().display().to_string();
             let stage = prepare_lab_offload_workspace_stage(
                 &request,
-                &contract,
+                LabWorkspaceStageCommand::from(&contract),
                 crate::lab_plan::base_lab_plan(Some(&contract)),
                 "lab-controller-bundle-stage",
                 source.path(),
@@ -2331,7 +2435,7 @@ mod tests {
             let runner_workspace_root = runner_root.path().display().to_string();
             let stage = prepare_lab_offload_workspace_stage(
                 &request,
-                &contract,
+                LabWorkspaceStageCommand::from(&contract),
                 crate::lab_plan::base_lab_plan(Some(&contract)),
                 "lab-managed-worktree-stage",
                 &source,

--- a/crates/homeboy-lab-runner/src/lab/secrets.rs
+++ b/crates/homeboy-lab-runner/src/lab/secrets.rs
@@ -33,16 +33,16 @@ const PLAN_PROVIDER_PROVENANCE: &str = "plan:provider";
 const LAB_SECRET_ENV_HANDOFF_SCHEMA: &str = "homeboy/lab-secret-env-handoff/v1";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct LabSecretEnvHandoffPlan {
-    pub(super) env_delta: HashMap<String, String>,
-    pub(super) diagnostics: serde_json::Value,
-    pub(super) entries: Vec<SecretEnvHandoffEntry>,
-    pub(super) secret_env_plan: SecretEnvPlan,
-    pub(super) secret_env_names: Vec<String>,
-    pub(super) runner_deferred_secret_env: Vec<String>,
+pub(crate) struct LabSecretEnvHandoffPlan {
+    pub(crate) env_delta: HashMap<String, String>,
+    pub(crate) diagnostics: serde_json::Value,
+    pub(crate) entries: Vec<SecretEnvHandoffEntry>,
+    pub(crate) secret_env_plan: SecretEnvPlan,
+    pub(crate) secret_env_names: Vec<String>,
+    pub(crate) runner_deferred_secret_env: Vec<String>,
 }
 
-pub(super) fn build_lab_secret_env_handoff_plan(
+pub(crate) fn build_lab_secret_env_handoff_plan(
     secret_env_sources: &[LabSecretEnvSource],
     args: &[String],
     mut env_delta: HashMap<String, String>,

--- a/crates/homeboy-lab-runner/src/lab_plan.rs
+++ b/crates/homeboy-lab-runner/src/lab_plan.rs
@@ -2,7 +2,7 @@ use homeboy_core::plan::{HomeboyPlan, PlanKind, PlanStep};
 
 use super::LabOffloadCommand;
 
-pub(super) fn base_lab_plan(command: Option<&LabOffloadCommand>) -> HomeboyPlan {
+pub(crate) fn base_lab_plan(command: Option<&LabOffloadCommand>) -> HomeboyPlan {
     let description = command
         .map(|contract| contract.hot_label)
         .unwrap_or("command");

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -1313,11 +1313,13 @@ trait LabStagingStageOperations: Send + Sync {
         request: &LabStagingExecutionRequest,
         checkpoint: &LabStagingCheckpoint,
         runner_job_id: &str,
+        cancellation: &LabStagingCancellationToken,
     ) -> Result<()>;
     fn recover_admitted_runner_job(
         &self,
         request: &LabStagingExecutionRequest,
     ) -> Result<Option<String>>;
+    fn cancel_active_staging_jobs(&self, request: &LabStagingExecutionRequest) -> Result<usize>;
     fn prove_no_runner_admission(&self, request: &LabStagingExecutionRequest) -> Result<()>;
     fn cancel_and_reconcile_runner_job(
         &self,
@@ -2120,6 +2122,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
         request: &LabStagingExecutionRequest,
         checkpoint: &LabStagingCheckpoint,
         runner_job_id: &str,
+        cancellation: &LabStagingCancellationToken,
     ) -> Result<()> {
         let dispatch = homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
             DurableLabDispatchReceipt,
@@ -2146,6 +2149,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
         ) {
             return receipt.payload.validate(request, checkpoint);
         }
+        Self::check_cancelled(cancellation)?;
         let observed = crate::execution::observe_daemon_job_until_terminal(
             &request.recipe.runner_id,
             runner_job_id,
@@ -2193,6 +2197,45 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
             ));
         }
         Ok(Some(runner_job_id))
+    }
+    fn cancel_active_staging_jobs(&self, request: &LabStagingExecutionRequest) -> Result<usize> {
+        let active_jobs = crate::status(&request.recipe.runner_id)?
+            .active_runner_jobs
+            .into_iter()
+            .filter_map(|job| {
+                job.durable_run_id.clone().and_then(|run_id| {
+                    (run_id == request.recipe.run_id
+                        || crate::lab::offload::is_hydration_execution_run_id(
+                            &request.recipe.run_id,
+                            &run_id,
+                        ))
+                    .then_some((job.job_id, run_id))
+                })
+            })
+            .collect::<Vec<_>>();
+        for (job_id, durable_run_id) in &active_jobs {
+            if durable_run_id == &request.recipe.run_id {
+                self.cancel_and_reconcile_runner_job(request, job_id)?;
+                continue;
+            }
+            crate::execution::runner_job_cancel_projection(
+                &request.recipe.runner_id,
+                job_id,
+                durable_run_id,
+            )?;
+            let observed = crate::execution::observe_daemon_job_until_terminal(
+                &request.recipe.runner_id,
+                job_id,
+                None,
+            )?;
+            if observed.job.status != homeboy_core::api_jobs::JobStatus::Cancelled {
+                return Err(Error::internal_unexpected(format!(
+                    "Lab staging child cancellation for runner job `{job_id}` was not authoritative: observed `{}`",
+                    observed.job.status.daemon_status_label(),
+                )));
+            }
+        }
+        Ok(active_jobs.len())
     }
     fn prove_no_runner_admission(&self, request: &LabStagingExecutionRequest) -> Result<()> {
         let status = crate::status(&request.recipe.runner_id)?;
@@ -2322,8 +2365,23 @@ impl StageExecutionAdapter {
                                     "Lab staging observation has no final runner job identity",
                                 )
                             })?;
-                        self.operations
-                            .observe_runner(request, &checkpoint, runner_job_id)?;
+                        loop {
+                            if cancellation.is_cancelled() {
+                                return Err(Self::cancellation_error());
+                            }
+                            match self.operations.observe_runner(
+                                request,
+                                &checkpoint,
+                                runner_job_id,
+                                cancellation,
+                            ) {
+                                Ok(()) => break,
+                                Err(error) if error.retryable == Some(true) => {
+                                    std::thread::sleep(Duration::from_millis(200));
+                                }
+                                Err(error) => return Err(error),
+                            }
+                        }
                         LabStagingStageEffect::Observe
                     }
                     LabStagingPhase::Completed => return Ok(checkpoint),
@@ -2407,7 +2465,13 @@ impl LabStagingExecutionAdapter for StageExecutionAdapter {
             Some(job_id) => self
                 .operations
                 .cancel_and_reconcile_runner_job(request, &job_id),
-            None => self.operations.prove_no_runner_admission(request),
+            None => {
+                if self.operations.cancel_active_staging_jobs(request)? > 0 {
+                    Ok(())
+                } else {
+                    self.operations.prove_no_runner_admission(request)
+                }
+            }
         }
     }
 }
@@ -2517,11 +2581,9 @@ impl LabStagingDispatchDriver {
         let token = cancellations()
             .lock()
             .expect("Lab staging cancellation lock")
-            .get(&run_id)
-            .cloned()
-            .ok_or_else(|| {
-                Error::internal_unexpected("Lab staging execution has no cancellation ownership")
-            })?;
+            .entry(run_id.clone())
+            .or_default()
+            .clone();
         let _cleanup = CancellationGuard(run_id);
         let result = if resume {
             adapter.resume(&request, checkpoint, token, job.clone())
@@ -2649,11 +2711,9 @@ impl ControllerJobDriver for LabStagingDispatchDriver {
         let token = cancellations()
             .lock()
             .expect("Lab staging cancellation lock")
-            .get(&checkpoint.run_id)
-            .cloned()
-            .ok_or_else(|| {
-                Error::internal_unexpected("Lab staging cancellation has no owned execution token")
-            })?;
+            .entry(checkpoint.run_id.clone())
+            .or_default()
+            .clone();
         let adapter = require_production_adapter()?;
         token.cancel();
         adapter.cancel(&request, &checkpoint)
@@ -2958,6 +3018,8 @@ mod tests {
         fail_hydration: Mutex<bool>,
         cancel_during_hydration: Mutex<bool>,
         recovered_runner_job_id: Mutex<Option<String>>,
+        active_staging_jobs: AtomicUsize,
+        fail_observation: Mutex<bool>,
     }
 
     impl RecordedStageOperations {
@@ -2985,6 +3047,14 @@ mod tests {
                 .recovered_runner_job_id
                 .lock()
                 .expect("runner job lock") = Some(runner_job_id.to_string());
+        }
+
+        fn set_active_staging_jobs(&self, count: usize) {
+            self.active_staging_jobs.store(count, Ordering::SeqCst);
+        }
+
+        fn fail_observation_once(&self) {
+            *self.fail_observation.lock().expect("observation lock") = true;
         }
     }
 
@@ -3087,9 +3157,15 @@ mod tests {
             _request: &LabStagingExecutionRequest,
             _checkpoint: &LabStagingCheckpoint,
             runner_job_id: &str,
+            _cancellation: &LabStagingCancellationToken,
         ) -> Result<()> {
             assert_eq!(runner_job_id, "runner-job-1");
             self.record("observe");
+            if std::mem::take(&mut *self.fail_observation.lock().expect("observation lock")) {
+                let mut error = Error::internal_unexpected("simulated daemon observation outage");
+                error.retryable = Some(true);
+                return Err(error);
+            }
             Ok(())
         }
 
@@ -3108,6 +3184,14 @@ mod tests {
                 .lock()
                 .expect("runner job lock")
                 .clone())
+        }
+
+        fn cancel_active_staging_jobs(
+            &self,
+            _request: &LabStagingExecutionRequest,
+        ) -> Result<usize> {
+            self.record("cancel-active-staging-jobs");
+            Ok(self.active_staging_jobs.swap(0, Ordering::SeqCst))
         }
 
         fn cancel_and_reconcile_runner_job(
@@ -3229,6 +3313,7 @@ mod tests {
             [
                 "validate",
                 "recover-runner-job",
+                "cancel-active-staging-jobs",
                 "prove-no-admission",
                 "validate",
                 "cancel-runner-job"
@@ -3256,6 +3341,29 @@ mod tests {
         assert_eq!(
             operations.calls(),
             ["validate", "recover-runner-job", "cancel-runner-job"]
+        );
+    }
+
+    #[test]
+    fn adapter_cancellation_stops_active_hydration_children() {
+        let operations = Arc::new(RecordedStageOperations::default());
+        operations.set_active_staging_jobs(1);
+        let adapter = StageExecutionAdapter::new(operations.clone());
+
+        adapter
+            .cancel(
+                &execution_request(),
+                &LabStagingCheckpoint::initial(&envelope()),
+            )
+            .expect("cancel active hydration child");
+
+        assert_eq!(
+            operations.calls(),
+            [
+                "validate",
+                "recover-runner-job",
+                "cancel-active-staging-jobs"
+            ]
         );
     }
 
@@ -3292,6 +3400,32 @@ mod tests {
             assert!(persisted[0].stage_intent.is_some());
             assert_eq!(operations.calls(), ["validate", "hydration"]);
         }
+    }
+
+    #[test]
+    fn retryable_observation_outage_keeps_the_original_child_recoverable() {
+        let operations = Arc::new(RecordedStageOperations::default());
+        operations.fail_observation_once();
+        let adapter = StageExecutionAdapter::new(operations.clone());
+        let mut checkpoint = LabStagingCheckpoint::initial(&envelope());
+        checkpoint.phase = LabStagingPhase::ObserveRunner;
+        checkpoint.source_snapshot_id = Some("snapshot-1".to_string());
+        checkpoint.workspace_id = Some("workspace-1".to_string());
+        checkpoint.runtime_id = Some("runtime-1".to_string());
+        checkpoint.hydration_id = Some("hydration-1".to_string());
+        checkpoint.final_runner_job_id = Some("runner-job-1".to_string());
+
+        let completed = adapter
+            .execute_with_checkpoint(
+                &execution_request(),
+                checkpoint,
+                &LabStagingCancellationToken::default(),
+                |_| Ok(()),
+            )
+            .expect("retry observation");
+
+        assert_eq!(completed.phase, LabStagingPhase::Completed);
+        assert_eq!(operations.calls(), ["validate", "observe", "observe"]);
     }
 
     #[test]
@@ -3371,11 +3505,10 @@ mod tests {
             checkpoint.runtime_id = Some("runtime-1".to_string());
             checkpoint.hydration_id = Some("hydration-1".to_string());
             checkpoint.final_runner_job_id = Some("runner-job-1".to_string());
-            let token = LabStagingCancellationToken::default();
             cancellations()
                 .lock()
                 .expect("lock")
-                .insert(checkpoint.run_id.clone(), token.clone());
+                .remove(&checkpoint.run_id);
             let cancelled = Arc::new(AtomicUsize::new(0));
             install_production_execution_adapter(Arc::new(CancellationAdapter(Arc::clone(
                 &cancelled,
@@ -3385,7 +3518,12 @@ mod tests {
                 .cancel(&serde_json::to_value(&checkpoint).expect("serialize"))
                 .expect("cancel");
 
-            assert!(token.is_cancelled());
+            assert!(cancellations()
+                .lock()
+                .expect("lock")
+                .get(&checkpoint.run_id)
+                .expect("recreated cancellation token")
+                .is_cancelled());
             assert_eq!(cancelled.load(Ordering::SeqCst), 1);
             *adapter_slot().lock().expect("adapter lock") = None;
             cancellations()

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -1,0 +1,3627 @@
+//! Durable controller-job contract for Lab staging and final dispatch.
+//!
+//! Routing deliberately does not submit this job yet. Phase 2 will construct an
+//! envelope after the agent-task attempt exists and before workspace staging.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use homeboy_core::daemon::controller_job_driver::{
+    self, ControllerJobDriver, ControllerJobHandle, ControllerJobPublicError,
+};
+use homeboy_core::lab_contract::{
+    LabRigWorkloadKind, LabRoutingPolicy, LabRunnerWorkloadCapability, LabSecretEnvSource,
+    LabSourcePathMode, LabWorkspaceModePolicy,
+};
+use homeboy_core::{Error, Result};
+use sha2::{Digest, Sha256};
+
+use crate::{LabOffloadCommand, LabOffloadRequest};
+
+pub const LAB_STAGING_DISPATCH_JOB_TYPE: &str = "lab.staging-dispatch";
+pub const LAB_STAGING_DISPATCH_VERSION: u32 = 1;
+pub const LAB_STAGING_DISPATCH_SCHEMA: &str = "homeboy/lab-staging-dispatch/v1";
+pub const LAB_STAGING_CHECKPOINT_SCHEMA: &str = "homeboy/lab-staging-dispatch-checkpoint/v1";
+pub const LAB_STAGING_RECIPE_SCHEMA: &str = "homeboy/lab-staging-recipe/v1";
+pub const LAB_STAGING_RECIPE_ATTACHMENT_KIND: &str = "lab-staging-recipe";
+const DURABLE_LAB_WORKSPACE_STAGE_ATTACHMENT_KIND: &str = "durable-lab-workspace-stage";
+const DURABLE_LAB_RUNTIME_STAGE_ATTACHMENT_KIND: &str = "durable-lab-runtime-stage";
+const DURABLE_LAB_HYDRATION_STAGE_ATTACHMENT_KIND: &str = "durable-lab-hydration-stage";
+const DURABLE_LAB_DISPATCH_RECEIPT_ATTACHMENT_KIND: &str = "durable-lab-dispatch-receipt";
+const DURABLE_LAB_TERMINAL_RECEIPT_ATTACHMENT_KIND: &str = "durable-lab-terminal-receipt";
+const CONTROLLER_SUBMISSION_ATTEMPTS: usize = 3;
+
+/// Serializable, owned counterpart to the static Lab command contract.
+/// This is the persisted, owned command representation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LabStagingCommand {
+    pub hot_label: String,
+    pub portable: bool,
+    pub source_path_mode: LabSourcePathMode,
+    pub workspace_mode_policy: LabWorkspaceModePolicy,
+    pub capture_mutation_patch: bool,
+    pub mutation_flag: Option<String>,
+    pub extra_required_capabilities: Vec<String>,
+    pub secret_env_sources: Vec<LabSecretEnvSource>,
+    pub routing_policy: LabRoutingPolicy,
+    pub required_extensions: Vec<String>,
+    pub required_capabilities: Vec<LabRunnerWorkloadCapability>,
+    pub workload: Option<LabStagingWorkload>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LabStagingWorkload {
+    pub kind: LabRigWorkloadKind,
+    pub rig_ids: Vec<String>,
+    pub component: Option<String>,
+    pub extension_overrides: Vec<String>,
+}
+
+impl From<&LabOffloadCommand> for LabStagingCommand {
+    fn from(command: &LabOffloadCommand) -> Self {
+        Self {
+            hot_label: command.command.hot_label.to_string(),
+            portable: command.command.is_portable(),
+            source_path_mode: command.command.source_path_mode,
+            workspace_mode_policy: command.command.workspace_mode_policy,
+            capture_mutation_patch: command.command.capture_mutation_patch,
+            mutation_flag: command.command.mutation_flag.map(str::to_string),
+            extra_required_capabilities: command
+                .command
+                .extra_required_capabilities
+                .iter()
+                .map(|value| (*value).to_string())
+                .collect(),
+            secret_env_sources: command.command.secret_env_sources.to_vec(),
+            routing_policy: command.command.routing_policy,
+            required_extensions: command.required_extensions.clone(),
+            required_capabilities: command.required_capabilities.clone(),
+            workload: command
+                .workload
+                .as_ref()
+                .map(|workload| LabStagingWorkload {
+                    kind: workload.kind,
+                    rig_ids: workload.rig_ids.clone(),
+                    component: workload.component.clone(),
+                    extension_overrides: workload.extension_overrides.clone(),
+                }),
+        }
+    }
+}
+
+/// Immutable pre-staging input stored privately against an agent-task attempt.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LabStagingRecipe {
+    pub schema: String,
+    pub run_id: String,
+    pub runner_id: String,
+    pub command: LabStagingCommand,
+    pub normalized_args: Vec<String>,
+    pub placement: homeboy_cli_contract::Placement,
+    pub allow_local_fallback: bool,
+    pub allow_dirty_lab_workspace: bool,
+    pub skip_deps_hydration: bool,
+    pub capture_patch: bool,
+    pub mutation_flag: Option<String>,
+    pub detach_after_handoff: bool,
+    pub output_file_requested: bool,
+    /// The initiating CLI emitted the durable run id before controller-job
+    /// creation when a local output was requested.
+    pub local_output_run_id_emitted: bool,
+    pub read_only_polling: bool,
+    pub require_controller_git_bundle: bool,
+    pub reuse_compatible_snapshot: bool,
+    pub source_path: Option<PathBuf>,
+    pub verified_cook_baseline: Option<Value>,
+    /// Public override values only. Declared secret names are removed before
+    /// this recipe reaches the private attachment store.
+    pub job_override_env: HashMap<String, String>,
+    pub secret_env_names: Vec<String>,
+    pub workspace_root: Option<String>,
+}
+
+impl LabStagingRecipe {
+    pub fn from_request(
+        run_id: impl Into<String>,
+        runner_id: impl Into<String>,
+        request: &LabOffloadRequest<'_>,
+    ) -> Result<Self> {
+        Self::from_request_with_output_obligation(run_id, runner_id, request, false)
+    }
+
+    fn from_request_with_output_obligation(
+        run_id: impl Into<String>,
+        runner_id: impl Into<String>,
+        request: &LabOffloadRequest<'_>,
+        local_output_run_id_emitted: bool,
+    ) -> Result<Self> {
+        let command = request.command.as_ref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "command",
+                "Lab staging requires a resolved agent-task Lab command",
+                None,
+                None,
+            )
+        })?;
+        let secret_env_names = request.job_overrides.secret_env_names.clone();
+        if secret_env_names
+            .iter()
+            .any(|name| request.job_overrides.env.contains_key(name))
+        {
+            return Err(Error::validation_invalid_argument(
+                "secret_env_names",
+                "Lab staging declared secret identities cannot carry inline values",
+                None,
+                None,
+            ));
+        }
+        let mut job_override_env = request.job_overrides.env.clone();
+        for name in &secret_env_names {
+            job_override_env.remove(name);
+        }
+        let recipe = Self {
+            schema: LAB_STAGING_RECIPE_SCHEMA.to_string(),
+            run_id: run_id.into(),
+            runner_id: runner_id.into(),
+            command: command.into(),
+            normalized_args: request.normalized_args.to_vec(),
+            placement: request.placement,
+            allow_local_fallback: request.allow_local_fallback,
+            allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
+            skip_deps_hydration: request.skip_deps_hydration,
+            capture_patch: request.capture_patch,
+            mutation_flag: request.mutation_flag.map(str::to_string),
+            detach_after_handoff: request.detach_after_handoff,
+            output_file_requested: request.output_file_requested,
+            local_output_run_id_emitted: !request.output_file_requested
+                || local_output_run_id_emitted,
+            read_only_polling: request.read_only_polling,
+            require_controller_git_bundle: request.require_controller_git_bundle,
+            reuse_compatible_snapshot: request.reuse_compatible_snapshot,
+            source_path: request.source_path.map(PathBuf::from),
+            verified_cook_baseline: request.verified_cook_baseline.cloned(),
+            job_override_env,
+            secret_env_names,
+            workspace_root: request.job_overrides.workspace_root.clone(),
+        };
+        recipe.validate()?;
+        Ok(recipe)
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.schema != LAB_STAGING_RECIPE_SCHEMA
+            || self.run_id.trim().is_empty()
+            || self.runner_id.trim().is_empty()
+            || !self.command.portable
+            || !self.command.hot_label.starts_with("agent-task")
+            || self.normalized_args.first().map(String::as_str) != Some("agent-task")
+        {
+            return Err(Error::validation_invalid_argument(
+                "lab_staging_recipe",
+                "Lab staging requires its v1 schema, bound run and runner identities, and an agent-task command shape",
+                None,
+                None,
+            ));
+        }
+        if self.output_file_requested && !self.local_output_run_id_emitted {
+            return Err(Error::validation_invalid_argument(
+                "local_output_run_id_emitted",
+                "Lab staging requires the initiating CLI to emit the durable run id before controller-job creation when local output was requested",
+                None,
+                None,
+            ));
+        }
+        let mut names = self.secret_env_names.clone();
+        names.sort();
+        names.dedup();
+        if names != self.secret_env_names
+            || names.iter().any(|name| {
+                name.is_empty()
+                    || !name.bytes().all(|byte| {
+                        byte == b'_' || byte.is_ascii_uppercase() || byte.is_ascii_digit()
+                    })
+            })
+            || names
+                .iter()
+                .any(|name| self.job_override_env.contains_key(name))
+        {
+            return Err(Error::validation_invalid_argument(
+                "secret_env_names",
+                "Lab staging secret identities must be unique environment names and cannot carry inline values",
+                None,
+                None,
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Owned replay inputs plus the separately loaded durable plan.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LabStagingRequest {
+    pub recipe: LabStagingRecipe,
+    pub durable_agent_task_plan: homeboy_agents::agent_task_scheduler::AgentTaskPlan,
+}
+
+/// Future staging adapters consume this owned request directly. The current
+/// offload runtime remains untouched until it has an owned request boundary.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LabStagingExecutionRequest {
+    pub recipe: LabStagingRecipe,
+    pub durable_agent_task_plan: homeboy_agents::agent_task_scheduler::AgentTaskPlan,
+}
+
+impl From<LabStagingRequest> for LabStagingExecutionRequest {
+    fn from(value: LabStagingRequest) -> Self {
+        Self {
+            recipe: value.recipe,
+            durable_agent_task_plan: value.durable_agent_task_plan,
+        }
+    }
+}
+
+pub fn persist_lab_staging_recipe(
+    run_id: &str,
+    runner_id: &str,
+    request: &LabOffloadRequest<'_>,
+) -> Result<LabStagingRecipe> {
+    persist_lab_staging_recipe_with_output_obligation(run_id, runner_id, request, false)
+}
+
+fn persist_lab_staging_recipe_with_output_obligation(
+    run_id: &str,
+    runner_id: &str,
+    request: &LabOffloadRequest<'_>,
+    local_output_run_id_emitted: bool,
+) -> Result<LabStagingRecipe> {
+    let recipe = LabStagingRecipe::from_request_with_output_obligation(
+        run_id,
+        runner_id,
+        request,
+        local_output_run_id_emitted,
+    )?;
+    homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
+        run_id,
+        LAB_STAGING_RECIPE_ATTACHMENT_KIND,
+        &recipe,
+    )
+    .map(|attachment| attachment.payload)
+}
+
+/// Controller-owned admission for a detached direct-daemon agent-task attempt.
+/// No workspace side effect occurs before this returns an accepted controller job.
+pub(crate) fn submit_detached_staging(
+    run_id: &str,
+    runner_id: &str,
+    request: &LabOffloadRequest<'_>,
+) -> Result<String> {
+    if !routing_ready() {
+        return Err(Error::validation_invalid_argument(
+            "lab_staging_adapter",
+            "detached Lab offload requires a ready durable staging adapter",
+            None,
+            None,
+        ));
+    }
+    let recipe = persist_lab_staging_recipe_with_output_obligation(
+        run_id,
+        runner_id,
+        request,
+        request.local_output_file.is_some(),
+    )?;
+    let attachment = homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
+        LabStagingRecipe,
+    >(run_id, LAB_STAGING_RECIPE_ATTACHMENT_KIND)?;
+    let plan = homeboy_agents::agent_task_lifecycle::load_controller_plan(run_id)?;
+    let envelope = LabStagingDispatchEnvelope::new(
+        run_id,
+        runner_id,
+        LabStagingInputRef::AgentTaskAttempt {
+            run_id: run_id.to_string(),
+            recipe: LabStagingRecipeRef::from_authority(attachment.payload_digest, &plan)?,
+        },
+    );
+    envelope.validate()?;
+    if recipe.run_id != run_id || recipe.runner_id != runner_id {
+        return Err(Error::internal_unexpected(
+            "persisted Lab staging recipe changed its attempt identity",
+        ));
+    }
+
+    let daemon = homeboy_core::daemon::ensure_running(homeboy_core::daemon::DEFAULT_ADDR)?;
+    let endpoint = format!("http://{}", daemon.address);
+    let client = Client::builder()
+        .no_proxy()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|error| {
+            Error::internal_unexpected(format!("build controller daemon client: {error}"))
+        })?;
+    let create = post_controller_job_with_retries(
+        &client,
+        format!("{endpoint}/controller/jobs"),
+        Some(json!({
+            "job_type": LAB_STAGING_DISPATCH_JOB_TYPE,
+            "version": LAB_STAGING_DISPATCH_VERSION,
+            "request": envelope,
+            "idempotency_key": run_id,
+        })),
+        "create durable Lab staging controller job",
+    )?;
+    let job = create;
+    validate_controller_job(&job)?;
+    let job_id = job.id.to_string();
+    homeboy_agents::agent_task_lifecycle::record_lab_staging_controller_job(
+        run_id, runner_id, &job_id,
+    )?;
+
+    let started = post_controller_job_with_retries(
+        &client,
+        format!("{endpoint}/controller/jobs/{job_id}/start"),
+        None,
+        &format!("start durable Lab staging controller job `{job_id}`"),
+    )?;
+    validate_controller_job(&started)?;
+    if started.id != job.id {
+        return Err(Error::internal_unexpected(format!(
+            "controller start returned job `{}` instead of requested job `{}`",
+            started.id, job.id
+        )));
+    }
+    Ok(job_id)
+}
+
+/// A response can be lost after the daemon accepted the request. Create uses
+/// the durable run ID as its idempotency key; replaying start targets that same
+/// job ID. Both operations can therefore be retried without admitting another
+/// controller execution.
+fn post_controller_job_with_retries(
+    client: &Client,
+    url: String,
+    body: Option<Value>,
+    operation: &str,
+) -> Result<homeboy_core::api_jobs::Job> {
+    let mut last_failure = None;
+    for attempt in 1..=CONTROLLER_SUBMISSION_ATTEMPTS {
+        let request = client.post(&url);
+        let request = if let Some(body) = &body {
+            request.json(body)
+        } else {
+            request
+        };
+        match request.send() {
+            Ok(response) => {
+                let status = response.status();
+                match response.json::<Value>() {
+                    Ok(value) => match controller_job_from_response(&value, status.as_u16()) {
+                        Ok(job) => return Ok(job),
+                        Err(error) => return Err(error),
+                    },
+                    Err(error) => {
+                        last_failure = Some(format!("response parse failed after send: {error}"));
+                    }
+                }
+            }
+            Err(error) => last_failure = Some(format!("connection or timeout after send: {error}")),
+        }
+        if attempt < CONTROLLER_SUBMISSION_ATTEMPTS {
+            std::thread::sleep(Duration::from_millis(50 * attempt as u64));
+        }
+    }
+    Err(Error::internal_unexpected(format!(
+        "{operation} did not receive a valid response after {CONTROLLER_SUBMISSION_ATTEMPTS} idempotent attempts; reconcile controller jobs for this run before retrying: {}",
+        last_failure.unwrap_or_else(|| "unknown transport failure".to_string())
+    )))
+}
+
+fn controller_job_from_response(value: &Value, status: u16) -> Result<homeboy_core::api_jobs::Job> {
+    if status >= 400 || value.get("success").and_then(Value::as_bool) != Some(true) {
+        return Err(Error::internal_unexpected(format!(
+            "controller daemon rejected Lab staging job: {value}"
+        )));
+    }
+    serde_json::from_value(
+        value
+            .pointer("/data/job")
+            .cloned()
+            .ok_or_else(|| Error::internal_unexpected("controller daemon response has no job"))?,
+    )
+    .map_err(|error| {
+        Error::internal_json(error.to_string(), Some("parse controller job".to_string()))
+    })
+}
+
+fn validate_controller_job(job: &homeboy_core::api_jobs::Job) -> Result<()> {
+    if job.operation != format!("controller.{LAB_STAGING_DISPATCH_JOB_TYPE}")
+        || !matches!(
+            job.status,
+            homeboy_core::api_jobs::JobStatus::Queued | homeboy_core::api_jobs::JobStatus::Running
+        )
+    {
+        return Err(Error::internal_unexpected(
+            "controller daemon returned an invalid Lab staging job identity or state",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LabStagingRecipeRef {
+    pub attachment_digest: String,
+    pub durable_plan_id: String,
+    pub canonical_plan_digest: String,
+}
+
+fn canonical_plan_digest(
+    plan: &homeboy_agents::agent_task_scheduler::AgentTaskPlan,
+) -> Result<String> {
+    fn canonicalize(value: Value) -> Value {
+        match value {
+            Value::Array(values) => Value::Array(values.into_iter().map(canonicalize).collect()),
+            Value::Object(values) => {
+                let mut fields: Vec<_> = values.into_iter().collect();
+                fields.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+                Value::Object(
+                    fields
+                        .into_iter()
+                        .map(|(key, value)| (key, canonicalize(value)))
+                        .collect(),
+                )
+            }
+            value => value,
+        }
+    }
+    let bytes = serde_json::to_vec(&canonicalize(serde_json::to_value(plan).map_err(
+        |error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize durable Lab staging plan".to_string()),
+            )
+        },
+    )?))
+    .map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize canonical durable Lab staging plan".to_string()),
+        )
+    })?;
+    Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
+}
+
+fn canonical_digest<T: Serialize>(value: &T) -> Result<String> {
+    fn canonicalize(value: Value) -> Value {
+        match value {
+            Value::Array(values) => Value::Array(values.into_iter().map(canonicalize).collect()),
+            Value::Object(values) => {
+                let mut fields: Vec<_> = values.into_iter().collect();
+                fields.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+                Value::Object(
+                    fields
+                        .into_iter()
+                        .map(|(key, value)| (key, canonicalize(value)))
+                        .collect(),
+                )
+            }
+            value => value,
+        }
+    }
+    let bytes = serde_json::to_vec(&canonicalize(serde_json::to_value(value).map_err(
+        |error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize durable Lab workspace state".to_string()),
+            )
+        },
+    )?))
+    .map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize canonical durable Lab workspace state".to_string()),
+        )
+    })?;
+    Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
+}
+
+/// Complete, owner-only output of the one admitted production boundary. Later
+/// stages consume this attachment rather than recomputing or re-syncing it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct DurableLabWorkspaceStage {
+    schema: String,
+    run_id: String,
+    runner_id: String,
+    recipe_digest: String,
+    plan_digest: String,
+    source_snapshot_id: String,
+    workspace_id: String,
+    remote_cwd: String,
+    stage: Value,
+}
+
+/// Owner-only receipt for all runtime side effects. The workspace attachment
+/// supplies inputs; this attachment is the immutable recovery authority once
+/// rig, extension, and runtime publication have completed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct DurableLabRuntimeStage {
+    schema: String,
+    run_id: String,
+    runner_id: String,
+    recipe_digest: String,
+    plan_digest: String,
+    workspace_id: String,
+    runtime_id: String,
+    output: Value,
+}
+
+/// Immutable receipt for the dependency boundary. `dispatch_inputs` is the
+/// complete post-hydration handoff: later stages consume it rather than loading
+/// mutable runner state or replaying hydration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct DurableLabHydrationStage {
+    schema: String,
+    run_id: String,
+    runner_id: String,
+    recipe_digest: String,
+    plan_digest: String,
+    workspace_id: String,
+    runtime_id: String,
+    hydration_id: String,
+    plan: Value,
+    hydration_record: Value,
+    hydration_metadata: Value,
+    execution_ids: Vec<String>,
+    dispatch_inputs: Value,
+}
+
+/// Immutable private proof of the accepted child. Secrets and admission tokens
+/// stay process-local; recovery retains only stable identities and digests.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct DurableLabDispatchReceipt {
+    schema: String,
+    run_id: String,
+    runner_id: String,
+    recipe_digest: String,
+    workspace_attachment_digest: String,
+    runtime_attachment_digest: String,
+    hydration_attachment_digest: String,
+    daemon_lease_id: String,
+    reservation_job_id: String,
+    runner_job_id: String,
+    remote_workspace: String,
+    remote_command: Vec<String>,
+    workload_identity: String,
+}
+
+/// Written only after the runner's terminal state has been read and projected
+/// into the controller lifecycle. It is intentionally identity/status-only.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct DurableLabTerminalReceipt {
+    schema: String,
+    run_id: String,
+    runner_id: String,
+    runner_job_id: String,
+    status: String,
+}
+
+impl DurableLabTerminalReceipt {
+    fn validate(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+    ) -> Result<()> {
+        if self.schema != "homeboy/durable-lab-terminal-receipt/v1"
+            || self.run_id != request.recipe.run_id
+            || self.runner_id != request.recipe.runner_id
+            || checkpoint.final_runner_job_id.as_deref() != Some(self.runner_job_id.as_str())
+            || !matches!(self.status.as_str(), "succeeded" | "failed" | "cancelled")
+        {
+            return Err(Error::validation_invalid_argument("durable_terminal_receipt", "Lab staging terminal receipt is missing, tampered, or does not match the authoritative runner job", None, None));
+        }
+        Ok(())
+    }
+}
+
+impl DurableLabDispatchReceipt {
+    fn validate(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+    ) -> Result<()> {
+        if self.schema != "homeboy/durable-lab-dispatch-receipt/v1"
+            || self.run_id != request.recipe.run_id
+            || self.runner_id != request.recipe.runner_id
+            || self.recipe_digest != canonical_digest(&request.recipe)?
+            || self.workspace_attachment_digest.is_empty()
+            || self.runtime_attachment_digest.is_empty()
+            || self.hydration_attachment_digest.is_empty()
+            || self.daemon_lease_id.is_empty()
+            || self.reservation_job_id.is_empty()
+            || self.runner_job_id.is_empty()
+            || self.remote_workspace.is_empty()
+            || self.remote_command.is_empty()
+            || self.workload_identity.is_empty()
+            || checkpoint
+                .final_runner_job_id
+                .as_deref()
+                .is_some_and(|id| id != self.runner_job_id)
+        {
+            return Err(Error::validation_invalid_argument("durable_dispatch_receipt", "Lab staging dispatch receipt is missing, tampered, or bound to different run inputs", None, None));
+        }
+        Ok(())
+    }
+}
+
+impl DurableLabRuntimeStage {
+    fn validate(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+    ) -> Result<()> {
+        if self.schema != "homeboy/durable-lab-runtime-stage/v1"
+            || self.run_id != request.recipe.run_id
+            || self.runner_id != request.recipe.runner_id
+            || self.recipe_digest != canonical_digest(&request.recipe)?
+            || self.plan_digest != canonical_plan_digest(&request.durable_agent_task_plan)?
+            || self.output.get("remote_cwd").and_then(Value::as_str)
+                != Some(self.workspace_id.as_str())
+            || self.runtime_id.trim().is_empty()
+            || checkpoint.workspace_id.as_deref() != Some(self.workspace_id.as_str())
+            || checkpoint
+                .runtime_id
+                .as_deref()
+                .is_some_and(|id| id != self.runtime_id)
+        {
+            return Err(Error::validation_invalid_argument("durable_runtime_stage", "Lab staging durable runtime state is missing, tampered, or bound to different run inputs", None, None));
+        }
+        Ok(())
+    }
+}
+
+impl DurableLabHydrationStage {
+    fn validate(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+        workspace: &DurableLabWorkspaceStage,
+        runtime: &DurableLabRuntimeStage,
+    ) -> Result<()> {
+        let step_execution_ids = self
+            .hydration_metadata
+            .get("steps")
+            .and_then(Value::as_array)
+            .map(|steps| {
+                steps
+                    .iter()
+                    .filter_map(|step| step.get("job_id").and_then(Value::as_str))
+                    .filter(|id| !id.trim().is_empty())
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        if self.schema != "homeboy/durable-lab-hydration-stage/v1"
+            || self.run_id != request.recipe.run_id
+            || self.runner_id != request.recipe.runner_id
+            || self.recipe_digest != canonical_digest(&request.recipe)?
+            || self.plan_digest != canonical_plan_digest(&request.durable_agent_task_plan)?
+            || self.workspace_id != workspace.workspace_id
+            || self.runtime_id != runtime.runtime_id
+            || self.hydration_id != canonical_digest(&self.hydration_record)?
+            || self
+                .hydration_metadata
+                .get("schema")
+                .and_then(Value::as_str)
+                != Some(crate::lab::offload::HYDRATION_SCHEMA)
+            || !matches!(
+                self.hydration_metadata
+                    .get("status")
+                    .and_then(Value::as_str),
+                Some("hydrated") | Some("skipped_no_provider") | Some("not_applied")
+            )
+            || self.hydration_metadata != hydration_metadata_from_record(&self.hydration_record)
+            || self.execution_ids != step_execution_ids
+            || self.dispatch_inputs.get("workspace_stage") != Some(&workspace.stage)
+            || self.dispatch_inputs.get("runtime_output") != Some(&runtime.output)
+            || self.dispatch_inputs.get("plan") != Some(&self.plan)
+            || checkpoint.hydration_id.as_deref() != Some(self.hydration_id.as_str())
+        {
+            return Err(Error::validation_invalid_argument("durable_hydration_stage", "Lab staging durable hydration receipt is missing, tampered, or bound to different run inputs", None, None));
+        }
+        Ok(())
+    }
+}
+
+fn hydration_metadata_from_record(record: &Value) -> Value {
+    match record {
+        Value::Object(value) if value.len() == 1 => match value.iter().next() {
+            Some((kind, Value::Object(payload))) if kind == "NotApplied" => json!({
+                "schema": crate::lab::offload::HYDRATION_SCHEMA,
+                "status": "not_applied",
+                "reason": payload.get("reason").cloned().unwrap_or(Value::Null),
+            }),
+            Some((kind, payload)) if kind == "Applied" => payload.clone(),
+            _ => Value::Null,
+        },
+        _ => Value::Null,
+    }
+}
+
+impl DurableLabWorkspaceStage {
+    fn validate(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+    ) -> Result<()> {
+        if self.schema != "homeboy/durable-lab-workspace-stage/v1"
+            || self.run_id != request.recipe.run_id
+            || self.runner_id != request.recipe.runner_id
+            || self.recipe_digest != canonical_digest(&request.recipe)?
+            || self.plan_digest != canonical_plan_digest(&request.durable_agent_task_plan)?
+            || self.remote_cwd.trim().is_empty()
+            || self.source_snapshot_id.trim().is_empty()
+            || self.workspace_id != self.remote_cwd
+            || self
+                .stage
+                .pointer("/source_snapshot/workspace_snapshot_identity")
+                .and_then(Value::as_str)
+                != Some(self.source_snapshot_id.as_str())
+            || self
+                .stage
+                .pointer("/source_snapshot/remote_path")
+                .and_then(Value::as_str)
+                != Some(self.remote_cwd.as_str())
+        {
+            return Err(Error::validation_invalid_argument("durable_workspace_stage", "Lab staging durable workspace state is missing, tampered, or bound to different run inputs", None, None));
+        }
+        if let (Some(source), Some(workspace)) =
+            (&checkpoint.source_snapshot_id, &checkpoint.workspace_id)
+        {
+            if source != &self.source_snapshot_id || workspace != &self.workspace_id {
+                return Err(Error::validation_invalid_argument(
+                    "checkpoint",
+                    "Lab staging checkpoint does not match its durable workspace state",
+                    None,
+                    None,
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl LabStagingRecipeRef {
+    pub fn from_authority(
+        attachment_digest: String,
+        plan: &homeboy_agents::agent_task_scheduler::AgentTaskPlan,
+    ) -> Result<Self> {
+        Ok(Self {
+            attachment_digest,
+            durable_plan_id: plan.plan_id.clone(),
+            canonical_plan_digest: canonical_plan_digest(plan)?,
+        })
+    }
+
+    fn validate(&self) -> Result<()> {
+        if !self.attachment_digest.starts_with("sha256:")
+            || self.durable_plan_id.trim().is_empty()
+            || !self.canonical_plan_digest.starts_with("sha256:")
+        {
+            return Err(Error::validation_invalid_argument(
+                "recipe_ref",
+                "Lab staging recipe reference requires attachment, plan id, and canonical plan digests",
+                None,
+                None,
+            ));
+        }
+        Ok(())
+    }
+}
+
+pub fn load_lab_staging_recipe(run_id: &str) -> Result<LabStagingRequest> {
+    let attachment = homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
+        LabStagingRecipe,
+    >(run_id, LAB_STAGING_RECIPE_ATTACHMENT_KIND)?;
+    let recipe = attachment.payload;
+    recipe.validate()?;
+    if recipe.run_id != run_id {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "Lab staging recipe run identity does not match its requested attempt",
+            None,
+            None,
+        ));
+    }
+    let record = homeboy_agents::agent_task_lifecycle::status(run_id)?;
+    if record.run_id != recipe.run_id {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "Lab staging recipe must bind to the closed agent-task attempt identity",
+            None,
+            None,
+        ));
+    }
+    let durable_agent_task_plan =
+        homeboy_agents::agent_task_lifecycle::load_controller_plan(run_id)?;
+    if durable_agent_task_plan.plan_id != record.plan_id {
+        return Err(Error::validation_invalid_argument(
+            "plan_id",
+            "Lab staging recipe durable plan does not match its agent-task attempt",
+            None,
+            None,
+        ));
+    }
+    Ok(LabStagingRequest {
+        recipe,
+        durable_agent_task_plan,
+    })
+}
+
+fn load_validated_staging_request(
+    run_id: &str,
+    runner_id: &str,
+    recipe_ref: &LabStagingRecipeRef,
+) -> Result<LabStagingExecutionRequest> {
+    recipe_ref.validate()?;
+    let attachment = homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
+        LabStagingRecipe,
+    >(run_id, LAB_STAGING_RECIPE_ATTACHMENT_KIND)?;
+    let staging = load_lab_staging_recipe(run_id)?;
+    if attachment.payload_digest != recipe_ref.attachment_digest
+        || staging.recipe.runner_id != runner_id
+        || staging.durable_agent_task_plan.plan_id != recipe_ref.durable_plan_id
+        || canonical_plan_digest(&staging.durable_agent_task_plan)?
+            != recipe_ref.canonical_plan_digest
+    {
+        return Err(Error::validation_invalid_argument(
+            "recipe_ref",
+            "Lab staging recovery binding does not match the authoritative recipe attachment, runner, or controller plan",
+            None,
+            None,
+        ));
+    }
+    Ok(staging.into())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum LabStagingInputRef {
+    /// Resolution reads the controller-owned agent-task attempt record and plan.
+    /// It deliberately cannot name a URI, file, or raw replay payload.
+    AgentTaskAttempt {
+        run_id: String,
+        recipe: LabStagingRecipeRef,
+    },
+}
+
+impl LabStagingInputRef {
+    fn run_id(&self) -> &str {
+        match self {
+            Self::AgentTaskAttempt { run_id, .. } => run_id,
+        }
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.run_id().trim().is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "input.run_id",
+                "Lab staging input requires a non-empty durable agent-task attempt id",
+                None,
+                None,
+            ));
+        }
+        match self {
+            Self::AgentTaskAttempt { recipe, .. } => recipe.validate()?,
+        }
+        Ok(())
+    }
+}
+
+/// Immutable recipe for one agent-task attempt's Lab staging and dispatch.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LabStagingDispatchEnvelope {
+    pub schema: String,
+    pub run_id: String,
+    pub runner_id: String,
+    pub input: LabStagingInputRef,
+}
+
+impl LabStagingDispatchEnvelope {
+    pub fn new(
+        run_id: impl Into<String>,
+        runner_id: impl Into<String>,
+        input: LabStagingInputRef,
+    ) -> Self {
+        Self {
+            schema: LAB_STAGING_DISPATCH_SCHEMA.to_string(),
+            run_id: run_id.into(),
+            runner_id: runner_id.into(),
+            input,
+        }
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.schema != LAB_STAGING_DISPATCH_SCHEMA
+            || self.run_id.trim().is_empty()
+            || self.runner_id.trim().is_empty()
+        {
+            return Err(Error::validation_invalid_argument(
+                "lab_staging_dispatch",
+                "Lab staging dispatch requires its v1 schema, run_id, runner_id, and durable input reference",
+                None,
+                None,
+            ));
+        }
+        self.input.validate()?;
+        if self.input.run_id() != self.run_id {
+            return Err(Error::validation_invalid_argument(
+                "input.run_id",
+                "Lab staging input attempt id must match the immutable envelope run_id",
+                Some(self.input.run_id().to_string()),
+                None,
+            ));
+        }
+        Ok(())
+    }
+
+    fn public_projection(&self) -> Value {
+        json!({
+            "schema": LAB_STAGING_DISPATCH_SCHEMA,
+            "run_id": self.run_id,
+            "runner_id": self.runner_id,
+            "state": "accepted",
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub enum LabStagingPhase {
+    AcceptedMaterializeWorkspace,
+    MaterializeRuntime,
+    HydrateDependencies,
+    DispatchRunner,
+    ObserveRunner,
+    Completed,
+}
+
+/// An operation is durably declared before its remote effect. Its fixed name is
+/// also the idempotency/reconciliation key used after a controller restart.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct LabStagingStageIntent {
+    pub stage: LabStagingPhase,
+    pub operation_id: String,
+}
+
+/// Private recovery state. Identities are references rather than output blobs.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LabStagingCheckpoint {
+    pub schema: String,
+    pub run_id: String,
+    pub runner_id: String,
+    pub input: LabStagingInputRef,
+    pub phase: LabStagingPhase,
+    pub source_snapshot_id: Option<String>,
+    pub workspace_id: Option<String>,
+    pub runtime_id: Option<String>,
+    pub hydration_id: Option<String>,
+    pub final_runner_job_id: Option<String>,
+    pub stage_intent: Option<LabStagingStageIntent>,
+}
+
+impl LabStagingCheckpoint {
+    fn initial(envelope: &LabStagingDispatchEnvelope) -> Self {
+        Self {
+            schema: LAB_STAGING_CHECKPOINT_SCHEMA.to_string(),
+            run_id: envelope.run_id.clone(),
+            runner_id: envelope.runner_id.clone(),
+            input: envelope.input.clone(),
+            phase: LabStagingPhase::AcceptedMaterializeWorkspace,
+            source_snapshot_id: None,
+            workspace_id: None,
+            runtime_id: None,
+            hydration_id: None,
+            final_runner_job_id: None,
+            stage_intent: None,
+        }
+    }
+
+    fn public_projection(&self) -> Value {
+        json!({
+            "run_id": self.run_id,
+            "runner_id": self.runner_id,
+            "phase": match self.phase {
+                LabStagingPhase::AcceptedMaterializeWorkspace => "accepted_materialize_workspace",
+                LabStagingPhase::MaterializeRuntime => "materialize_runtime",
+                LabStagingPhase::HydrateDependencies => "hydrate_dependencies",
+                LabStagingPhase::DispatchRunner => "dispatch_runner",
+                LabStagingPhase::ObserveRunner => "observe_runner",
+                LabStagingPhase::Completed => "completed",
+            },
+            "final_runner_job_id": self.final_runner_job_id,
+        })
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.schema != LAB_STAGING_CHECKPOINT_SCHEMA
+            || self.run_id.trim().is_empty()
+            || self.runner_id.trim().is_empty()
+        {
+            return Err(Error::validation_invalid_argument(
+                "checkpoint",
+                "Lab staging checkpoint requires its v1 schema and immutable run/runner ids",
+                None,
+                None,
+            ));
+        }
+        self.input.validate()?;
+        if self.input.run_id() != self.run_id {
+            return Err(Error::validation_invalid_argument(
+                "checkpoint.input.run_id",
+                "Lab staging checkpoint input attempt id must match run_id",
+                Some(self.input.run_id().to_string()),
+                None,
+            ));
+        }
+        let non_empty = |name: &str, value: &Option<String>| -> Result<()> {
+            if value
+                .as_deref()
+                .is_some_and(|value| value.trim().is_empty())
+            {
+                return Err(Error::validation_invalid_argument(
+                    format!("checkpoint.{name}"),
+                    "Lab staging identity values must be non-empty when present",
+                    None,
+                    None,
+                ));
+            }
+            Ok(())
+        };
+        for (name, value) in [
+            ("source_snapshot_id", &self.source_snapshot_id),
+            ("workspace_id", &self.workspace_id),
+            ("runtime_id", &self.runtime_id),
+            ("hydration_id", &self.hydration_id),
+            ("final_runner_job_id", &self.final_runner_job_id),
+        ] {
+            non_empty(name, value)?;
+        }
+        if let Some(intent) = &self.stage_intent {
+            let expected = self.operation_id_for_phase();
+            if self.phase == LabStagingPhase::Completed
+                || intent.stage != self.phase
+                || intent.operation_id != expected
+            {
+                return Err(Error::validation_invalid_argument(
+                    "checkpoint.stage_intent",
+                    format!("Lab staging intent must bind the current incomplete stage to its immutable operation id (intent={:?}:{}, phase={:?}, expected={expected})", intent.stage, intent.operation_id, self.phase),
+                    None,
+                    None,
+                ));
+            }
+        }
+        let has = |value: &Option<String>| value.is_some();
+        let required = match self.phase {
+            LabStagingPhase::AcceptedMaterializeWorkspace => 0,
+            LabStagingPhase::MaterializeRuntime => 2,
+            LabStagingPhase::HydrateDependencies => 3,
+            LabStagingPhase::DispatchRunner => 4,
+            LabStagingPhase::ObserveRunner | LabStagingPhase::Completed => 5,
+        };
+        let identities = [
+            &self.source_snapshot_id,
+            &self.workspace_id,
+            &self.runtime_id,
+            &self.hydration_id,
+            &self.final_runner_job_id,
+        ];
+        if identities[..required].iter().any(|value| !has(value))
+            || identities[required..].iter().any(|value| has(value))
+        {
+            return Err(Error::validation_invalid_argument(
+                "checkpoint.phase",
+                "Lab staging checkpoint fields must exactly represent completed side effects before its next action",
+                None,
+                None,
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_identity_matches(&self, prior: &Self) -> Result<()> {
+        if self.run_id != prior.run_id
+            || self.runner_id != prior.runner_id
+            || self.input != prior.input
+        {
+            return Err(Error::validation_invalid_argument(
+                "checkpoint",
+                "Lab staging execution cannot change immutable run, runner, or input identity",
+                Some(self.run_id.clone()),
+                None,
+            ));
+        }
+        Ok(())
+    }
+
+    fn validated_transition(prior: &Self, next: Self) -> Result<Self> {
+        next.validate()?;
+        next.validate_identity_matches(prior)?;
+        let rank = |phase: &LabStagingPhase| match phase {
+            LabStagingPhase::AcceptedMaterializeWorkspace => 0,
+            LabStagingPhase::MaterializeRuntime => 1,
+            LabStagingPhase::HydrateDependencies => 2,
+            LabStagingPhase::DispatchRunner => 3,
+            LabStagingPhase::ObserveRunner => 4,
+            LabStagingPhase::Completed => 5,
+        };
+        if rank(&next.phase) < rank(&prior.phase) {
+            return Err(Error::validation_invalid_argument(
+                "checkpoint.phase",
+                "Lab staging checkpoint transition cannot regress",
+                None,
+                None,
+            ));
+        }
+        for (name, before, after) in [
+            (
+                "source_snapshot_id",
+                &prior.source_snapshot_id,
+                &next.source_snapshot_id,
+            ),
+            ("workspace_id", &prior.workspace_id, &next.workspace_id),
+            ("runtime_id", &prior.runtime_id, &next.runtime_id),
+            ("hydration_id", &prior.hydration_id, &next.hydration_id),
+            (
+                "final_runner_job_id",
+                &prior.final_runner_job_id,
+                &next.final_runner_job_id,
+            ),
+        ] {
+            if before.is_some() && before != after {
+                return Err(Error::validation_invalid_argument(format!("checkpoint.{name}"), "Lab staging checkpoint transition cannot remove or change an authoritative identity", None, None));
+            }
+        }
+        Ok(next)
+    }
+
+    /// The sole side effect that may run when resuming this checkpoint.
+    fn next_action(&self) -> LabStagingPhase {
+        self.phase.clone()
+    }
+
+    fn operation_id_for_phase(&self) -> String {
+        let stage = match self.phase {
+            LabStagingPhase::AcceptedMaterializeWorkspace => "workspace",
+            LabStagingPhase::MaterializeRuntime => "runtime",
+            LabStagingPhase::HydrateDependencies => "hydration",
+            LabStagingPhase::DispatchRunner => "dispatch",
+            LabStagingPhase::ObserveRunner => "observe",
+            LabStagingPhase::Completed => "completed",
+        };
+        format!("{}:{stage}", self.run_id)
+    }
+
+    fn intent_for_current_action(&self) -> LabStagingStageIntent {
+        LabStagingStageIntent {
+            stage: self.phase.clone(),
+            operation_id: self.operation_id_for_phase(),
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct LabStagingCancellationToken(Arc<std::sync::atomic::AtomicBool>);
+
+impl LabStagingCancellationToken {
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    fn cancel(&self) {
+        self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+/// Lab's narrow execution seam. Its production implementation will call the
+/// existing offload stages; the durable driver owns only lifecycle mechanics.
+pub(crate) trait LabStagingExecutionAdapter: Send + Sync {
+    fn execute(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: LabStagingCheckpoint,
+        cancellation: LabStagingCancellationToken,
+        job: ControllerJobHandle,
+    ) -> Result<LabStagingCheckpoint>;
+    fn resume(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: LabStagingCheckpoint,
+        cancellation: LabStagingCancellationToken,
+        job: ControllerJobHandle,
+    ) -> Result<LabStagingCheckpoint> {
+        self.execute(request, checkpoint, cancellation, job)
+    }
+    /// Must prove all owned work, including a final runner job when present,
+    /// has stopped before returning successfully.
+    fn cancel(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+    ) -> Result<()>;
+}
+
+/// Side-effect boundary for durable Lab staging. The production implementation
+/// will delegate each operation to the corresponding synchronous Lab stage;
+/// keeping this narrow makes recovery execute only the incomplete operation.
+trait LabStagingStageOperations: Send + Sync {
+    fn validate_recorded_identities(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+    ) -> Result<()>;
+    /// Reconcile an effect after its intent was persisted but before its
+    /// receipt/checkpoint was durably recorded. `None` proves no completion;
+    /// callers may then execute the one declared operation.
+    fn recover_stage(
+        &self,
+        _request: &LabStagingExecutionRequest,
+        _checkpoint: &LabStagingCheckpoint,
+        _intent: &LabStagingStageIntent,
+    ) -> Result<Option<LabStagingStageEffect>> {
+        Ok(None)
+    }
+    fn materialize_workspace(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+    ) -> Result<(String, String)>;
+    fn materialize_runtime(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+        cancellation: &LabStagingCancellationToken,
+    ) -> Result<String>;
+    fn hydrate_dependencies(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+        cancellation: &LabStagingCancellationToken,
+    ) -> Result<String>;
+    fn dispatch_runner(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+        cancellation: &LabStagingCancellationToken,
+    ) -> Result<String>;
+    fn observe_runner(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+        runner_job_id: &str,
+    ) -> Result<()>;
+    fn prove_no_runner_admission(&self, request: &LabStagingExecutionRequest) -> Result<()>;
+    fn cancel_and_reconcile_runner_job(
+        &self,
+        request: &LabStagingExecutionRequest,
+        runner_job_id: &str,
+    ) -> Result<()>;
+}
+
+#[derive(Debug)]
+enum LabStagingStageEffect {
+    Workspace(String, String),
+    Runtime(String),
+    Hydration(String),
+    Dispatch(String),
+    Observe,
+}
+
+/// Production implementation deliberately exposes only the first durable
+/// boundary. Registering it makes workspace recovery testable, not routable:
+/// every later remote effect remains unavailable until it has equivalent
+/// durable input/output ownership.
+struct ProductionLabStagingOperations;
+
+impl ProductionLabStagingOperations {
+    fn durable_workspace(
+        request: &LabStagingExecutionRequest,
+    ) -> Result<homeboy_agents::agent_task_lifecycle::PrivateRunAttachment<DurableLabWorkspaceStage>>
+    {
+        homeboy_agents::agent_task_lifecycle::load_private_run_attachment(
+            &request.recipe.run_id,
+            DURABLE_LAB_WORKSPACE_STAGE_ATTACHMENT_KIND,
+        )
+    }
+
+    fn unavailable(stage: &str) -> Error {
+        Error::internal_unexpected(format!(
+            "Lab staging {stage} is unavailable: durable runtime, hydration, and dispatch boundaries are not implemented"
+        ))
+    }
+
+    fn durable_runtime(
+        request: &LabStagingExecutionRequest,
+    ) -> Result<homeboy_agents::agent_task_lifecycle::PrivateRunAttachment<DurableLabRuntimeStage>>
+    {
+        homeboy_agents::agent_task_lifecycle::load_private_run_attachment(
+            &request.recipe.run_id,
+            DURABLE_LAB_RUNTIME_STAGE_ATTACHMENT_KIND,
+        )
+    }
+
+    fn durable_hydration(
+        request: &LabStagingExecutionRequest,
+    ) -> Result<homeboy_agents::agent_task_lifecycle::PrivateRunAttachment<DurableLabHydrationStage>>
+    {
+        homeboy_agents::agent_task_lifecycle::load_private_run_attachment(
+            &request.recipe.run_id,
+            DURABLE_LAB_HYDRATION_STAGE_ATTACHMENT_KIND,
+        )
+    }
+
+    fn cancellation_error() -> Error {
+        Error::internal_unexpected("Lab staging was cancelled during runtime materialization")
+    }
+
+    fn check_cancelled(cancellation: &LabStagingCancellationToken) -> Result<()> {
+        (!cancellation.is_cancelled())
+            .then_some(())
+            .ok_or_else(Self::cancellation_error)
+    }
+
+    fn ambiguous_intent(stage: &str) -> Error {
+        Error::validation_invalid_argument(
+            "checkpoint.stage_intent",
+            format!("Lab staging {stage} intent has no authoritative completion receipt; recovery is ambiguous and fails closed"),
+            None,
+            None,
+        )
+    }
+}
+
+impl LabStagingStageOperations for ProductionLabStagingOperations {
+    fn validate_recorded_identities(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+    ) -> Result<()> {
+        if checkpoint.phase == LabStagingPhase::AcceptedMaterializeWorkspace {
+            return Ok(());
+        }
+        // A recorded workspace is authoritative. A missing or tampered durable
+        // attachment is a recovery failure, never permission to sync again.
+        Self::durable_workspace(request)?
+            .payload
+            .validate(request, checkpoint)?;
+        if checkpoint.runtime_id.is_some() {
+            Self::durable_runtime(request)?
+                .payload
+                .validate(request, checkpoint)?;
+        }
+        if checkpoint.hydration_id.is_some() {
+            let workspace = Self::durable_workspace(request)?.payload;
+            let runtime = Self::durable_runtime(request)?.payload;
+            Self::durable_hydration(request)?
+                .payload
+                .validate(request, checkpoint, &workspace, &runtime)?;
+        }
+        if checkpoint.final_runner_job_id.is_some() {
+            homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
+                DurableLabDispatchReceipt,
+            >(
+                &request.recipe.run_id,
+                DURABLE_LAB_DISPATCH_RECEIPT_ATTACHMENT_KIND,
+            )?
+            .payload
+            .validate(request, checkpoint)?;
+        }
+        if checkpoint.phase == LabStagingPhase::Completed {
+            homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
+                DurableLabTerminalReceipt,
+            >(
+                &request.recipe.run_id,
+                DURABLE_LAB_TERMINAL_RECEIPT_ATTACHMENT_KIND,
+            )?
+            .payload
+            .validate(request, checkpoint)?;
+        }
+        Ok(())
+    }
+
+    fn recover_stage(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+        intent: &LabStagingStageIntent,
+    ) -> Result<Option<LabStagingStageEffect>> {
+        if intent.stage != checkpoint.phase
+            || intent.operation_id != checkpoint.operation_id_for_phase()
+        {
+            return Err(Error::validation_invalid_argument(
+                "checkpoint.stage_intent",
+                "Lab staging recovery intent does not match the incomplete operation",
+                None,
+                None,
+            ));
+        }
+        match checkpoint.phase {
+            LabStagingPhase::AcceptedMaterializeWorkspace => {
+                let workspace = Self::durable_workspace(request)
+                    .map_err(|_| Self::ambiguous_intent("workspace"))?;
+                let mut completed = checkpoint.clone();
+                completed.phase = LabStagingPhase::MaterializeRuntime;
+                completed.stage_intent = None;
+                completed.source_snapshot_id = Some(workspace.payload.source_snapshot_id.clone());
+                completed.workspace_id = Some(workspace.payload.workspace_id.clone());
+                workspace.payload.validate(request, &completed)?;
+                Ok(Some(LabStagingStageEffect::Workspace(
+                    workspace.payload.source_snapshot_id,
+                    workspace.payload.workspace_id,
+                )))
+            }
+            LabStagingPhase::MaterializeRuntime => {
+                let runtime = Self::durable_runtime(request)
+                    .map_err(|_| Self::ambiguous_intent("runtime"))?;
+                let mut completed = checkpoint.clone();
+                completed.phase = LabStagingPhase::HydrateDependencies;
+                completed.stage_intent = None;
+                completed.runtime_id = Some(runtime.payload.runtime_id.clone());
+                runtime.payload.validate(request, &completed)?;
+                Ok(Some(LabStagingStageEffect::Runtime(
+                    runtime.payload.runtime_id,
+                )))
+            }
+            LabStagingPhase::HydrateDependencies => {
+                let hydration = Self::durable_hydration(request)
+                    .map_err(|_| Self::ambiguous_intent("hydration"))?;
+                let workspace = Self::durable_workspace(request)?.payload;
+                let runtime = Self::durable_runtime(request)?.payload;
+                let mut completed = checkpoint.clone();
+                completed.phase = LabStagingPhase::DispatchRunner;
+                completed.stage_intent = None;
+                completed.hydration_id = Some(hydration.payload.hydration_id.clone());
+                hydration
+                    .payload
+                    .validate(request, &completed, &workspace, &runtime)?;
+                Ok(Some(LabStagingStageEffect::Hydration(
+                    hydration.payload.hydration_id,
+                )))
+            }
+            LabStagingPhase::DispatchRunner => {
+                let dispatch = homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
+                    DurableLabDispatchReceipt,
+                >(
+                    &request.recipe.run_id,
+                    DURABLE_LAB_DISPATCH_RECEIPT_ATTACHMENT_KIND,
+                )
+                .map_err(|_| Self::ambiguous_intent("dispatch"))?;
+                let mut completed = checkpoint.clone();
+                completed.phase = LabStagingPhase::ObserveRunner;
+                completed.stage_intent = None;
+                completed.final_runner_job_id = Some(dispatch.payload.runner_job_id.clone());
+                dispatch.payload.validate(request, &completed)?;
+                Ok(Some(LabStagingStageEffect::Dispatch(
+                    dispatch.payload.runner_job_id,
+                )))
+            }
+            LabStagingPhase::ObserveRunner => {
+                let terminal = homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
+                    DurableLabTerminalReceipt,
+                >(
+                    &request.recipe.run_id,
+                    DURABLE_LAB_TERMINAL_RECEIPT_ATTACHMENT_KIND,
+                )
+                .map_err(|_| Self::ambiguous_intent("observe"))?;
+                let mut completed = checkpoint.clone();
+                completed.phase = LabStagingPhase::Completed;
+                completed.stage_intent = None;
+                terminal.payload.validate(request, &completed)?;
+                Ok(Some(LabStagingStageEffect::Observe))
+            }
+            LabStagingPhase::Completed => Ok(Some(LabStagingStageEffect::Observe)),
+        }
+    }
+
+    fn materialize_workspace(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+    ) -> Result<(String, String)> {
+        if checkpoint.phase != LabStagingPhase::AcceptedMaterializeWorkspace {
+            return Err(Error::internal_unexpected(
+                "Lab staging refused to re-materialize a recorded workspace",
+            ));
+        }
+        if Self::durable_workspace(request).is_ok() {
+            return Err(Error::validation_invalid_argument("durable_workspace_stage", "Lab staging already has a durable workspace attachment but no completed checkpoint", None, None));
+        }
+        let source_path = request.recipe.source_path.as_deref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "source_path",
+                "Durable Lab workspace staging requires the recorded source path",
+                None,
+                None,
+            )
+        })?;
+        if request.recipe.command.workspace_mode_policy == LabWorkspaceModePolicy::RunnerResident {
+            return Err(Error::validation_invalid_argument(
+                "workspace_mode_policy",
+                "Runner-resident Lab commands are not implemented by durable workspace staging",
+                None,
+                None,
+            ));
+        }
+        let offload_request = LabOffloadRequest {
+            command: None,
+            normalized_args: &request.recipe.normalized_args,
+            explicit_runner: Some(&request.recipe.runner_id),
+            placement: request.recipe.placement,
+            allow_local_fallback: request.recipe.allow_local_fallback,
+            allow_dirty_lab_workspace: request.recipe.allow_dirty_lab_workspace,
+            skip_deps_hydration: request.recipe.skip_deps_hydration,
+            capture_patch: request.recipe.capture_patch,
+            mutation_flag: request.recipe.mutation_flag.as_deref(),
+            detach_after_handoff: request.recipe.detach_after_handoff,
+            output_file_requested: request.recipe.output_file_requested,
+            read_only_polling: request.recipe.read_only_polling,
+            local_output_file: None,
+            durable_agent_task_plan: Some(&request.durable_agent_task_plan),
+            source_path: Some(source_path),
+            verified_cook_baseline: request.recipe.verified_cook_baseline.as_ref(),
+            require_controller_git_bundle: request.recipe.require_controller_git_bundle,
+            reuse_compatible_snapshot: request.recipe.reuse_compatible_snapshot,
+            job_overrides: homeboy_core::lab_offload::LabJobOverrides {
+                env: request.recipe.job_override_env.clone(),
+                secret_env_names: request.recipe.secret_env_names.clone(),
+                workspace_root: request.recipe.workspace_root.clone(),
+            },
+        };
+        let workspace_root = offload_request.job_overrides.workspace_root.as_deref();
+        let stage = crate::lab::offload::workspace_stage::prepare_lab_offload_workspace_stage(
+            &offload_request,
+            crate::lab::offload::workspace_stage::LabWorkspaceStageCommand::from(
+                &request.recipe.command,
+            ),
+            crate::lab_plan::base_lab_plan(None),
+            &request.recipe.runner_id,
+            source_path,
+            &["homeboy".to_string()],
+            workspace_root,
+            Some(request.recipe.run_id.clone()),
+            &request.recipe.normalized_args,
+            Some(&request.recipe.run_id),
+        )?;
+        let projection =
+            crate::lab::offload::workspace_stage::durable_workspace_stage_projection(&stage);
+        let source_snapshot_id = projection
+            .pointer("/source_snapshot/workspace_snapshot_identity")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| {
+                Error::internal_unexpected(
+                    "materialized Lab workspace did not report a source snapshot identity",
+                )
+            })?
+            .to_string();
+        let remote_cwd = projection
+            .get("remote_cwd")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| {
+                Error::internal_unexpected("materialized Lab workspace did not report a remote cwd")
+            })?
+            .to_string();
+        let durable = DurableLabWorkspaceStage {
+            schema: "homeboy/durable-lab-workspace-stage/v1".to_string(),
+            run_id: request.recipe.run_id.clone(),
+            runner_id: request.recipe.runner_id.clone(),
+            recipe_digest: canonical_digest(&request.recipe)?,
+            plan_digest: canonical_plan_digest(&request.durable_agent_task_plan)?,
+            source_snapshot_id: source_snapshot_id.clone(),
+            workspace_id: remote_cwd.clone(),
+            remote_cwd,
+            stage: projection,
+        };
+        durable.validate(request, checkpoint)?;
+        // This must succeed before the driver records a completed checkpoint.
+        homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
+            &request.recipe.run_id,
+            DURABLE_LAB_WORKSPACE_STAGE_ATTACHMENT_KIND,
+            &durable,
+        )?;
+        Ok((source_snapshot_id, durable.workspace_id))
+    }
+
+    fn materialize_runtime(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+        cancellation: &LabStagingCancellationToken,
+    ) -> Result<String> {
+        if checkpoint.phase != LabStagingPhase::MaterializeRuntime {
+            return Err(Error::internal_unexpected(
+                "Lab staging refused to re-materialize a recorded runtime",
+            ));
+        }
+        if Self::durable_runtime(request).is_ok() {
+            return Err(Error::validation_invalid_argument(
+                "durable_runtime_stage",
+                "Lab staging already has a durable runtime attachment but no completed checkpoint",
+                None,
+                None,
+            ));
+        }
+        let workspace = Self::durable_workspace(request)?.payload;
+        workspace.validate(request, checkpoint)?;
+        Self::check_cancelled(cancellation)?;
+        let field = |name: &str| {
+            workspace.stage.get(name).cloned().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "durable_workspace_stage",
+                    format!("Lab staging workspace state has no {name}"),
+                    None,
+                    None,
+                )
+            })
+        };
+        let runtime_input: crate::lab::offload::DurableLabRuntimeWorkspaceInput =
+            serde_json::from_value(field("runtime_input")?).map_err(|_| {
+                Error::validation_invalid_argument(
+                    "durable_workspace_stage",
+                    "Lab staging runtime workspace input is invalid",
+                    None,
+                    None,
+                )
+            })?;
+        let changed_args: Vec<String> = serde_json::from_value(
+            workspace
+                .stage
+                .pointer("/changed_since/args")
+                .cloned()
+                .ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "durable_workspace_stage",
+                        "Lab staging workspace state has no changed arguments",
+                        None,
+                        None,
+                    )
+                })?,
+        )
+        .map_err(|_| {
+            Error::validation_invalid_argument(
+                "durable_workspace_stage",
+                "Lab staging changed arguments are invalid",
+                None,
+                None,
+            )
+        })?;
+        let required_extensions: Vec<String> =
+            serde_json::from_value(field("runner_required_extensions")?).map_err(|_| {
+                Error::validation_invalid_argument(
+                    "durable_workspace_stage",
+                    "Lab staging required extensions are invalid",
+                    None,
+                    None,
+                )
+            })?;
+        let remapped_args: Vec<String> =
+            serde_json::from_value(field("remapped_args")?).map_err(|_| {
+                Error::validation_invalid_argument(
+                    "durable_workspace_stage",
+                    "Lab staging remapped arguments are invalid",
+                    None,
+                    None,
+                )
+            })?;
+        let command: Vec<String> = serde_json::from_value(field("command")?).map_err(|_| {
+            Error::validation_invalid_argument(
+                "durable_workspace_stage",
+                "Lab staging command is invalid",
+                None,
+                None,
+            )
+        })?;
+        let remote_command: Vec<String> = serde_json::from_value(field("remote_command")?)
+            .map_err(|_| {
+                Error::validation_invalid_argument(
+                    "durable_workspace_stage",
+                    "Lab staging remote command is invalid",
+                    None,
+                    None,
+                )
+            })?;
+        let agent_task_run_id: Option<String> = serde_json::from_value(field("agent_task_run_id")?)
+            .map_err(|_| {
+                Error::validation_invalid_argument(
+                    "durable_workspace_stage",
+                    "Lab staging agent-task identity is invalid",
+                    None,
+                    None,
+                )
+            })?;
+        let plan: homeboy_core::plan::HomeboyPlan = serde_json::from_value(field("plan")?)
+            .map_err(|_| {
+                Error::validation_invalid_argument(
+                    "durable_workspace_stage",
+                    "Lab staging plan is invalid",
+                    None,
+                    None,
+                )
+            })?;
+        let runner = crate::load(&request.recipe.runner_id)?;
+        let homeboy_path =
+            crate::remote_runner_homeboy_path(&runner, "durable Lab runtime materialization")?;
+        Self::check_cancelled(cancellation)?;
+        let output = crate::lab::offload::materialize_lab_runtime(
+            &runner,
+            homeboy_path,
+            &workspace.remote_cwd,
+            &changed_args,
+            &runtime_input.synced_local_path,
+            &runtime_input.source_snapshot,
+            &runtime_input.workspace_snapshot_identity,
+            &runtime_input.workspace_remaps,
+            &required_extensions,
+            agent_task_run_id.as_deref(),
+            plan,
+            remapped_args,
+            command,
+            remote_command,
+            || Self::check_cancelled(cancellation),
+        )?;
+        Self::check_cancelled(cancellation)?;
+        let runtime_id = output
+            .runtime_generation
+            .as_ref()
+            .map(|generation| generation.generation_identity.clone())
+            .unwrap_or_else(|| format!("runtime:workspace:{}", workspace.workspace_id));
+        let durable = DurableLabRuntimeStage {
+            schema: "homeboy/durable-lab-runtime-stage/v1".to_string(),
+            run_id: request.recipe.run_id.clone(),
+            runner_id: request.recipe.runner_id.clone(),
+            recipe_digest: canonical_digest(&request.recipe)?,
+            plan_digest: canonical_plan_digest(&request.durable_agent_task_plan)?,
+            workspace_id: workspace.workspace_id,
+            runtime_id: runtime_id.clone(),
+            output: serde_json::to_value(&output).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("serialize durable Lab runtime state".to_string()),
+                )
+            })?,
+        };
+        durable.validate(request, checkpoint)?;
+        homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
+            &request.recipe.run_id,
+            DURABLE_LAB_RUNTIME_STAGE_ATTACHMENT_KIND,
+            &durable,
+        )?;
+        Ok(runtime_id)
+    }
+    fn hydrate_dependencies(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+        cancellation: &LabStagingCancellationToken,
+    ) -> Result<String> {
+        if checkpoint.phase != LabStagingPhase::HydrateDependencies {
+            return Err(Error::internal_unexpected(
+                "Lab staging refused to re-hydrate a recorded workspace",
+            ));
+        }
+        if Self::durable_hydration(request).is_ok() {
+            return Err(Error::validation_invalid_argument(
+                "durable_hydration_stage",
+                "Lab staging already has a durable hydration attachment but no completed checkpoint",
+                None,
+                None,
+            ));
+        }
+        let workspace = Self::durable_workspace(request)?.payload;
+        let runtime = Self::durable_runtime(request)?.payload;
+        workspace.validate(request, checkpoint)?;
+        runtime.validate(request, checkpoint)?;
+        let local_path = workspace
+            .stage
+            .pointer("/runtime_input/synced_local_path")
+            .and_then(Value::as_str)
+            .filter(|path| !path.trim().is_empty())
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "durable_workspace_stage",
+                    "Lab staging hydration requires the recorded local workspace path",
+                    None,
+                    None,
+                )
+            })?;
+        let plan: homeboy_core::plan::HomeboyPlan =
+            serde_json::from_value(runtime.output.get("plan").cloned().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "durable_runtime_stage",
+                    "Lab staging hydration requires the recorded runtime plan",
+                    None,
+                    None,
+                )
+            })?)
+            .map_err(|_| {
+                Error::validation_invalid_argument(
+                    "durable_runtime_stage",
+                    "Lab staging recorded runtime plan is invalid",
+                    None,
+                    None,
+                )
+            })?;
+        Self::check_cancelled(cancellation)?;
+        let recorded = crate::lab::offload::hydrate_for_lab_workspace_exec_with_lifecycle(
+            request.recipe.skip_deps_hydration,
+            &request.recipe.runner_id,
+            local_path,
+            &workspace.remote_cwd,
+            plan,
+            Some(&request.recipe.run_id),
+        )?;
+        Self::check_cancelled(cancellation)?;
+        let plan = serde_json::to_value(&recorded.hydration.plan).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize durable Lab hydration plan".to_string()),
+            )
+        })?;
+        let hydration_record =
+            serde_json::to_value(&recorded.hydration.record).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("serialize durable Lab hydration record".to_string()),
+                )
+            })?;
+        let hydration_metadata =
+            crate::lab::offload::dependency_hydration_metadata(&recorded.hydration.record);
+        let hydration_id = canonical_digest(&hydration_record)?;
+        let durable = DurableLabHydrationStage {
+            schema: "homeboy/durable-lab-hydration-stage/v1".to_string(),
+            run_id: request.recipe.run_id.clone(),
+            runner_id: request.recipe.runner_id.clone(),
+            recipe_digest: canonical_digest(&request.recipe)?,
+            plan_digest: canonical_plan_digest(&request.durable_agent_task_plan)?,
+            workspace_id: workspace.workspace_id.clone(),
+            runtime_id: runtime.runtime_id.clone(),
+            hydration_id: hydration_id.clone(),
+            plan: plan.clone(),
+            hydration_record,
+            hydration_metadata,
+            execution_ids: recorded.execution_ids,
+            dispatch_inputs: json!({
+                "workspace_stage": workspace.stage,
+                "runtime_output": runtime.output,
+                "plan": plan,
+            }),
+        };
+        // The immutable receipt must exist before the checkpoint advances.
+        homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
+            &request.recipe.run_id,
+            DURABLE_LAB_HYDRATION_STAGE_ATTACHMENT_KIND,
+            &durable,
+        )?;
+        Ok(hydration_id)
+    }
+    fn dispatch_runner(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+        cancellation: &LabStagingCancellationToken,
+    ) -> Result<String> {
+        if checkpoint.phase != LabStagingPhase::DispatchRunner {
+            return Err(Error::internal_unexpected(
+                "Lab staging refused to re-dispatch a recorded runner job",
+            ));
+        }
+        let workspace = Self::durable_workspace(request)?;
+        let runtime = Self::durable_runtime(request)?;
+        let hydration = Self::durable_hydration(request)?;
+        workspace.payload.validate(request, checkpoint)?;
+        runtime.payload.validate(request, checkpoint)?;
+        hydration
+            .payload
+            .validate(request, checkpoint, &workspace.payload, &runtime.payload)?;
+        let command: Vec<String> =
+            serde_json::from_value(runtime.payload.output.get("command").cloned().ok_or_else(
+                || Error::internal_unexpected("durable runtime has no final command"),
+            )?)
+            .map_err(|_| {
+                Error::validation_invalid_argument(
+                    "durable_runtime_stage",
+                    "Lab staging final command is invalid",
+                    None,
+                    None,
+                )
+            })?;
+        let source_snapshot = serde_json::from_value(
+            workspace
+                .payload
+                .stage
+                .get("source_snapshot")
+                .cloned()
+                .ok_or_else(|| {
+                    Error::internal_unexpected("durable workspace has no source snapshot")
+                })?,
+        )
+        .map_err(|_| {
+            Error::validation_invalid_argument(
+                "durable_workspace_stage",
+                "Lab staging source snapshot is invalid",
+                None,
+                None,
+            )
+        })?;
+        let runtime_env: Vec<(String, String)> = serde_json::from_value(
+            runtime
+                .payload
+                .output
+                .get("runtime_env")
+                .cloned()
+                .unwrap_or_else(|| json!([])),
+        )
+        .map_err(|_| {
+            Error::validation_invalid_argument(
+                "durable_runtime_stage",
+                "Lab staging runtime environment is invalid",
+                None,
+                None,
+            )
+        })?;
+        let mut public_env = request.recipe.job_override_env.clone();
+        public_env.extend(runtime_env);
+        let secret_handoff = crate::lab::secrets::build_lab_secret_env_handoff_plan(
+            &request.recipe.command.secret_env_sources,
+            &request.recipe.normalized_args,
+            public_env,
+        )?;
+        let mut env = secret_handoff.env_delta.clone();
+        env.insert(
+            "HOMEBOY_RUNNER_PLACEMENT_RESOLVED".to_string(),
+            "1".to_string(),
+        );
+        env.insert(
+            homeboy_core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV.to_string(),
+            request.recipe.runner_id.clone(),
+        );
+        let runner_status = crate::status_for_admission(&request.recipe.runner_id)?;
+        let session = runner_status.session.as_ref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "runner",
+                "durable Lab dispatch requires an admitted direct daemon session",
+                Some(request.recipe.runner_id.clone()),
+                None,
+            )
+        })?;
+        if session.mode != crate::RunnerTunnelMode::DirectSsh {
+            return Err(Error::validation_invalid_argument(
+                "runner",
+                "durable Lab dispatch requires direct daemon admission",
+                Some(request.recipe.runner_id.clone()),
+                None,
+            ));
+        }
+        let local_url = session.local_url.as_deref().ok_or_else(|| {
+            Error::internal_unexpected("durable Lab dispatch has no daemon endpoint")
+        })?;
+        let lease_id = session.remote_daemon_lease_id.as_deref().ok_or_else(|| {
+            Error::internal_unexpected("durable Lab dispatch has no daemon lease")
+        })?;
+        Self::check_cancelled(cancellation)?;
+        let admission = crate::execution::reserve_daemon_admission(
+            &request.recipe.runner_id,
+            local_url,
+            "lab.staging-dispatch",
+            lease_id,
+            Some(&request.recipe.run_id),
+            crate::execution::DaemonAdmissionPolicy::DurableLeaseRequired,
+        )?;
+        Self::check_cancelled(cancellation)?;
+        let authority = admission.authority();
+        authority.prove_server_owned_expiry_or_cancellation_authority()?;
+        Self::check_cancelled(cancellation)?;
+        let submitted = crate::exec_with_status_snapshot(
+            &request.recipe.runner_id,
+            crate::RunnerExecOptions {
+                cwd: Some(workspace.payload.remote_cwd.clone()),
+                command: command.clone(),
+                env,
+                secret_env_names: secret_handoff.secret_env_names.clone(),
+                secret_env_plan: Some(secret_handoff.secret_env_plan),
+                capture_patch: request.recipe.capture_patch,
+                source_snapshot: Some(source_snapshot),
+                required_extensions: request.recipe.command.required_extensions.clone(),
+                run_id: Some(request.recipe.run_id.clone()),
+                detach_after_handoff: true,
+                mirror_evidence: true,
+                ..Default::default()
+            },
+            Some(runner_status),
+        );
+        // `/exec` is idempotent on the immutable run id. A dropped response is
+        // reconciled from the daemon's active durable-job projection instead of
+        // submitting a second child.
+        let runner_job_id = match submitted {
+            Ok((output, _)) => output.job_id.ok_or_else(|| {
+                Error::internal_unexpected(
+                    "durable Lab daemon acceptance returned no runner job identity",
+                )
+            })?,
+            Err(error) => crate::status(&request.recipe.runner_id)
+                .ok()
+                .and_then(|status| {
+                    status
+                        .active_runner_jobs
+                        .into_iter()
+                        .find(|job| job.durable_run_id.as_deref() == Some(&request.recipe.run_id))
+                        .map(|job| job.job_id)
+                })
+                .ok_or(error)?,
+        };
+        // The renewer may fail while `/exec` is in flight. Acceptance is then
+        // known, but dispatch authority is not: stop and reconcile this exact
+        // child before failing the controller stage closed.
+        if let Err(error) = authority.prove_server_owned_expiry_or_cancellation_authority() {
+            self.cancel_and_reconcile_runner_job(request, &runner_job_id)?;
+            return Err(error);
+        }
+        if cancellation.is_cancelled() {
+            self.cancel_and_reconcile_runner_job(request, &runner_job_id)?;
+            return Err(Self::cancellation_error());
+        }
+        // Lifecycle is bound before the receipt and controller checkpoint expose
+        // the accepted job to recovery.
+        homeboy_agents::agent_task_lifecycle::record_detached_lab_run(
+            homeboy_agents::agent_task_lifecycle::DetachedLabRunRecord {
+                run_id: &request.recipe.run_id,
+                runner_id: &request.recipe.runner_id,
+                runner_job_id: &runner_job_id,
+                remote_workspace: &workspace.payload.remote_cwd,
+                remote_command: &command,
+            },
+        )?;
+        let receipt = DurableLabDispatchReceipt {
+            schema: "homeboy/durable-lab-dispatch-receipt/v1".to_string(),
+            run_id: request.recipe.run_id.clone(),
+            runner_id: request.recipe.runner_id.clone(),
+            recipe_digest: canonical_digest(&request.recipe)?,
+            workspace_attachment_digest: workspace.payload_digest,
+            runtime_attachment_digest: runtime.payload_digest,
+            hydration_attachment_digest: hydration.payload_digest,
+            daemon_lease_id: authority.daemon_lease_id().to_string(),
+            reservation_job_id: authority.reservation_job_id().to_string(),
+            runner_job_id: runner_job_id.clone(),
+            remote_workspace: workspace.payload.remote_cwd,
+            remote_command: command,
+            workload_identity: canonical_digest(&hydration.payload.hydration_metadata)?,
+        };
+        receipt.validate(request, checkpoint)?;
+        homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
+            &request.recipe.run_id,
+            DURABLE_LAB_DISPATCH_RECEIPT_ATTACHMENT_KIND,
+            &receipt,
+        )?;
+        Ok(runner_job_id)
+    }
+    fn observe_runner(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+        runner_job_id: &str,
+    ) -> Result<()> {
+        let dispatch = homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
+            DurableLabDispatchReceipt,
+        >(
+            &request.recipe.run_id,
+            DURABLE_LAB_DISPATCH_RECEIPT_ATTACHMENT_KIND,
+        )?;
+        dispatch.payload.validate(request, checkpoint)?;
+        if dispatch.payload.runner_job_id != runner_job_id {
+            return Err(Error::validation_invalid_argument(
+                "runner_job_id",
+                "Lab staging observer job identity does not match its dispatch receipt",
+                None,
+                None,
+            ));
+        }
+        // A completed receipt makes recovery idempotent and prevents a resumed
+        // controller from polling or submitting a replacement child.
+        if let Ok(receipt) = homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
+            DurableLabTerminalReceipt,
+        >(
+            &request.recipe.run_id,
+            DURABLE_LAB_TERMINAL_RECEIPT_ATTACHMENT_KIND,
+        ) {
+            return receipt.payload.validate(request, checkpoint);
+        }
+        let observed = crate::execution::observe_daemon_job_until_terminal(
+            &request.recipe.runner_id,
+            runner_job_id,
+            None,
+        )?;
+        homeboy_agents::agent_task_lifecycle::project_terminal_runner_result(
+            &request.recipe.run_id,
+            &homeboy_core::api_jobs::RunnerJobLogSnapshot {
+                job: observed.job.clone(),
+                events: observed.events,
+            },
+        )?;
+        let receipt = DurableLabTerminalReceipt {
+            schema: "homeboy/durable-lab-terminal-receipt/v1".to_string(),
+            run_id: request.recipe.run_id.clone(),
+            runner_id: request.recipe.runner_id.clone(),
+            runner_job_id: runner_job_id.to_string(),
+            status: observed.job.status.daemon_status_label().to_string(),
+        };
+        receipt.validate(request, checkpoint)?;
+        homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
+            &request.recipe.run_id,
+            DURABLE_LAB_TERMINAL_RECEIPT_ATTACHMENT_KIND,
+            &receipt,
+        )?;
+        Ok(())
+    }
+    fn prove_no_runner_admission(&self, request: &LabStagingExecutionRequest) -> Result<()> {
+        let status = crate::status(&request.recipe.runner_id)?;
+        if status
+            .active_runner_jobs
+            .into_iter()
+            .any(|job| job.durable_run_id.as_deref() == Some(&request.recipe.run_id))
+        {
+            return Err(Error::internal_unexpected("Lab staging cancellation cannot prove the strict runner admission is absent or released"));
+        }
+        Ok(())
+    }
+    fn cancel_and_reconcile_runner_job(
+        &self,
+        request: &LabStagingExecutionRequest,
+        runner_job_id: &str,
+    ) -> Result<()> {
+        let (job, _) = crate::execution::runner_job_cancel_projection(
+            &request.recipe.runner_id,
+            runner_job_id,
+            &request.recipe.run_id,
+        )?;
+        let observed = crate::execution::observe_daemon_job_until_terminal(
+            &request.recipe.runner_id,
+            runner_job_id,
+            None,
+        )?;
+        if observed.job.status != homeboy_core::api_jobs::JobStatus::Cancelled {
+            return Err(Error::internal_unexpected(format!(
+                "Lab staging cancellation for runner job `{runner_job_id}` was not authoritative: observed `{}`",
+                observed.job.status.daemon_status_label(),
+            )));
+        }
+        homeboy_agents::agent_task_lifecycle::project_terminal_runner_result(
+            &request.recipe.run_id,
+            &homeboy_core::api_jobs::RunnerJobLogSnapshot {
+                job: observed.job,
+                events: observed.events,
+            },
+        )?;
+        // `cancel-projection` may return an already terminal cancellation. Keep
+        // the result consumed so future API changes cannot silently skip it.
+        if !job.status.is_terminal() {
+            return Err(Error::internal_unexpected(
+                "runner cancellation response was not terminal",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Executes the durable phase machine. It owns lifecycle mechanics only: the
+/// supplied operations own materialization and runner transport.
+struct StageExecutionAdapter {
+    operations: Arc<dyn LabStagingStageOperations>,
+}
+
+impl StageExecutionAdapter {
+    fn new(operations: Arc<dyn LabStagingStageOperations>) -> Self {
+        Self { operations }
+    }
+
+    fn cancellation_error() -> Error {
+        Error::internal_unexpected("Lab staging was cancelled before the next durable stage")
+    }
+
+    fn execute_with_checkpoint<F>(
+        &self,
+        request: &LabStagingExecutionRequest,
+        mut checkpoint: LabStagingCheckpoint,
+        cancellation: &LabStagingCancellationToken,
+        mut persist: F,
+    ) -> Result<LabStagingCheckpoint>
+    where
+        F: FnMut(&LabStagingCheckpoint) -> Result<()>,
+    {
+        self.operations
+            .validate_recorded_identities(request, &checkpoint)?;
+        loop {
+            if cancellation.is_cancelled() {
+                return Err(Self::cancellation_error());
+            }
+            if checkpoint.phase == LabStagingPhase::Completed {
+                return Ok(checkpoint);
+            }
+            let prior = checkpoint.clone();
+            let recovering = checkpoint.stage_intent.is_some();
+            let intent = checkpoint
+                .stage_intent
+                .clone()
+                .unwrap_or_else(|| checkpoint.intent_for_current_action());
+            if !recovering {
+                checkpoint.stage_intent = Some(intent.clone());
+                checkpoint = LabStagingCheckpoint::validated_transition(&prior, checkpoint)?;
+                // Intent must survive a crash before the effect can begin.
+                persist(&checkpoint)?;
+            }
+            let recovered = recovering
+                .then(|| self.operations.recover_stage(request, &checkpoint, &intent))
+                .transpose()?
+                .flatten();
+            let effect = match recovered {
+                Some(effect) => effect,
+                None => match checkpoint.next_action() {
+                    LabStagingPhase::AcceptedMaterializeWorkspace => {
+                        let (source_snapshot_id, workspace_id) = self
+                            .operations
+                            .materialize_workspace(request, &checkpoint)?;
+                        LabStagingStageEffect::Workspace(source_snapshot_id, workspace_id)
+                    }
+                    LabStagingPhase::MaterializeRuntime => LabStagingStageEffect::Runtime(
+                        self.operations
+                            .materialize_runtime(request, &checkpoint, cancellation)?,
+                    ),
+                    LabStagingPhase::HydrateDependencies => LabStagingStageEffect::Hydration(
+                        self.operations
+                            .hydrate_dependencies(request, &checkpoint, cancellation)?,
+                    ),
+                    LabStagingPhase::DispatchRunner => LabStagingStageEffect::Dispatch(
+                        self.operations
+                            .dispatch_runner(request, &checkpoint, cancellation)?,
+                    ),
+                    LabStagingPhase::ObserveRunner => {
+                        let runner_job_id =
+                            checkpoint.final_runner_job_id.as_deref().ok_or_else(|| {
+                                Error::internal_unexpected(
+                                    "Lab staging observation has no final runner job identity",
+                                )
+                            })?;
+                        self.operations
+                            .observe_runner(request, &checkpoint, runner_job_id)?;
+                        LabStagingStageEffect::Observe
+                    }
+                    LabStagingPhase::Completed => return Ok(checkpoint),
+                },
+            };
+            checkpoint = match effect {
+                LabStagingStageEffect::Workspace(source_snapshot_id, workspace_id) => {
+                    LabStagingCheckpoint {
+                        phase: LabStagingPhase::MaterializeRuntime,
+                        source_snapshot_id: Some(source_snapshot_id),
+                        workspace_id: Some(workspace_id),
+                        stage_intent: None,
+                        ..checkpoint
+                    }
+                }
+                LabStagingStageEffect::Runtime(runtime_id) => LabStagingCheckpoint {
+                    phase: LabStagingPhase::HydrateDependencies,
+                    runtime_id: Some(runtime_id),
+                    stage_intent: None,
+                    ..checkpoint
+                },
+                LabStagingStageEffect::Hydration(hydration_id) => LabStagingCheckpoint {
+                    phase: LabStagingPhase::DispatchRunner,
+                    hydration_id: Some(hydration_id),
+                    stage_intent: None,
+                    ..checkpoint
+                },
+                LabStagingStageEffect::Dispatch(runner_job_id) => LabStagingCheckpoint {
+                    phase: LabStagingPhase::ObserveRunner,
+                    final_runner_job_id: Some(runner_job_id),
+                    stage_intent: None,
+                    ..checkpoint
+                },
+                LabStagingStageEffect::Observe => LabStagingCheckpoint {
+                    phase: LabStagingPhase::Completed,
+                    stage_intent: None,
+                    ..checkpoint
+                },
+            };
+            if cancellation.is_cancelled() {
+                return Err(Self::cancellation_error());
+            }
+            checkpoint = LabStagingCheckpoint::validated_transition(&prior, checkpoint)?;
+            // Persist before beginning another effect, so recovery cannot repeat
+            // an already admitted remote operation.
+            persist(&checkpoint)?;
+        }
+    }
+}
+
+impl LabStagingExecutionAdapter for StageExecutionAdapter {
+    fn execute(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: LabStagingCheckpoint,
+        cancellation: LabStagingCancellationToken,
+        job: ControllerJobHandle,
+    ) -> Result<LabStagingCheckpoint> {
+        self.execute_with_checkpoint(request, checkpoint, &cancellation, |checkpoint| {
+            job.checkpoint(serde_json::to_value(checkpoint).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("serialize Lab staging checkpoint".to_string()),
+                )
+            })?)
+        })
+    }
+
+    fn cancel(
+        &self,
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+    ) -> Result<()> {
+        self.operations
+            .validate_recorded_identities(request, checkpoint)?;
+        match checkpoint.final_runner_job_id.as_deref() {
+            Some(job_id) => self
+                .operations
+                .cancel_and_reconcile_runner_job(request, job_id),
+            None => self.operations.prove_no_runner_admission(request),
+        }
+    }
+}
+
+fn adapter_slot() -> &'static Mutex<Option<Arc<dyn LabStagingExecutionAdapter>>> {
+    static ADAPTER: OnceLock<Mutex<Option<Arc<dyn LabStagingExecutionAdapter>>>> = OnceLock::new();
+    ADAPTER.get_or_init(|| Mutex::new(None))
+}
+
+/// Phase 2 installs the adapter which delegates to existing Lab offload stages.
+/// Registration alone never makes controller-job submission/recovery safe.
+pub(crate) fn install_production_execution_adapter(adapter: Arc<dyn LabStagingExecutionAdapter>) {
+    *adapter_slot().lock().expect("Lab staging adapter lock") = Some(adapter);
+}
+
+pub(crate) fn require_production_adapter() -> Result<Arc<dyn LabStagingExecutionAdapter>> {
+    adapter_slot()
+        .lock()
+        .expect("Lab staging adapter lock")
+        .clone()
+        .ok_or_else(|| {
+            Error::internal_unexpected(
+                "Lab staging controller is registered but its production execution adapter is unavailable",
+            )
+        })
+}
+
+/// Registration makes the durable driver available to its owner. Traffic stays
+/// disabled until every subsequent stage has a production implementation.
+pub(crate) fn routing_ready() -> bool {
+    adapter_slot()
+        .lock()
+        .expect("Lab staging adapter lock")
+        .is_some()
+}
+
+fn cancellations() -> &'static Mutex<HashMap<String, LabStagingCancellationToken>> {
+    static CANCELLATIONS: OnceLock<Mutex<HashMap<String, LabStagingCancellationToken>>> =
+        OnceLock::new();
+    CANCELLATIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+struct CancellationGuard(String);
+
+impl Drop for CancellationGuard {
+    fn drop(&mut self) {
+        cancellations()
+            .lock()
+            .expect("Lab staging cancellation lock")
+            .remove(&self.0);
+    }
+}
+
+pub struct LabStagingDispatchDriver;
+
+impl LabStagingDispatchDriver {
+    fn envelope(value: &Value) -> Result<LabStagingDispatchEnvelope> {
+        let envelope: LabStagingDispatchEnvelope =
+            serde_json::from_value(value.clone()).map_err(|error| {
+                Error::validation_invalid_argument(
+                    "request",
+                    format!("invalid Lab staging dispatch envelope: {error}"),
+                    None,
+                    None,
+                )
+            })?;
+        envelope.validate()?;
+        Ok(envelope)
+    }
+
+    fn checkpoint(value: Value) -> Result<LabStagingCheckpoint> {
+        let checkpoint: LabStagingCheckpoint = serde_json::from_value(value).map_err(|error| {
+            Error::validation_invalid_argument(
+                "checkpoint",
+                format!("invalid Lab staging checkpoint: {error}"),
+                None,
+                None,
+            )
+        })?;
+        checkpoint.validate()?;
+        Ok(checkpoint)
+    }
+
+    fn execute_checkpoint(
+        &self,
+        checkpoint: LabStagingCheckpoint,
+        job: ControllerJobHandle,
+        resume: bool,
+    ) -> Result<Value> {
+        checkpoint.validate()?;
+        let adapter = require_production_adapter()?;
+        let request = match &checkpoint.input {
+            LabStagingInputRef::AgentTaskAttempt { recipe, .. } => {
+                load_validated_staging_request(&checkpoint.run_id, &checkpoint.runner_id, recipe)?
+            }
+        };
+        let expected_identity = checkpoint.clone();
+        let run_id = checkpoint.run_id.clone();
+        let token = cancellations()
+            .lock()
+            .expect("Lab staging cancellation lock")
+            .get(&run_id)
+            .cloned()
+            .ok_or_else(|| {
+                Error::internal_unexpected("Lab staging execution has no cancellation ownership")
+            })?;
+        let _cleanup = CancellationGuard(run_id);
+        let result = if resume {
+            adapter.resume(&request, checkpoint, token, job.clone())
+        } else {
+            adapter.execute(&request, checkpoint, token, job.clone())
+        };
+        let checkpoint = result.map_err(|error| {
+            if !job.is_cancelled() {
+                if homeboy_agents::agent_task_lifecycle::record_pre_execution_failure(
+                    &request.recipe.run_id,
+                    &request.durable_agent_task_plan,
+                    "lab_staging_controller",
+                    &error,
+                )
+                .is_ok()
+                {
+                    let _ =
+                        homeboy_agents::agent_task_lifecycle::record_lab_staging_controller_failure(
+                            &request.recipe.run_id,
+                            &format!("{:?}", expected_identity.phase),
+                            &job.job_id(),
+                        );
+                }
+            }
+            error
+        })?;
+        checkpoint.validate()?;
+        let checkpoint =
+            LabStagingCheckpoint::validated_transition(&expected_identity, checkpoint)?;
+        job.checkpoint(serde_json::to_value(&checkpoint).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize Lab staging checkpoint".to_string()),
+            )
+        })?)?;
+        Ok(serde_json::to_value(checkpoint).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize Lab staging result".to_string()),
+            )
+        })?)
+    }
+}
+
+impl ControllerJobDriver for LabStagingDispatchDriver {
+    fn job_type(&self) -> &'static str {
+        LAB_STAGING_DISPATCH_JOB_TYPE
+    }
+    fn version(&self) -> u32 {
+        LAB_STAGING_DISPATCH_VERSION
+    }
+    fn public_request(&self, request: &Value) -> Result<Value> {
+        Ok(Self::envelope(request)?.public_projection())
+    }
+    fn public_progress(&self, progress: &Value) -> Result<Value> {
+        let checkpoint = Self::checkpoint(progress.clone())?;
+        Ok(checkpoint.public_projection())
+    }
+    fn public_result(&self, result: &Value) -> Result<Value> {
+        let checkpoint = Self::checkpoint(result.clone())?;
+        Ok(checkpoint.public_projection())
+    }
+    fn public_error(&self, error: &Error) -> ControllerJobPublicError {
+        ControllerJobPublicError {
+            message: "Lab staging and dispatch failed".to_string(),
+            data: json!({ "classification": "lab_staging", "code": format!("{:?}", error.code) }),
+        }
+    }
+    fn validate_secret_references(&self, request: &Value) -> Result<()> {
+        Self::envelope(request).map(|_| ())
+    }
+    fn prepare(&self, request: Value) -> Result<Value> {
+        let envelope = Self::envelope(&request)?;
+        // Cancellation ownership is durable before prepare can race with a
+        // caller cancelling a queued controller job.
+        cancellations()
+            .lock()
+            .expect("Lab staging cancellation lock")
+            .entry(envelope.run_id.clone())
+            .or_default();
+        // Resolve only durable, owner-controlled input before the daemon can
+        // accept the job. Stage execution remains intentionally uninstalled.
+        let recipe = match &envelope.input {
+            LabStagingInputRef::AgentTaskAttempt { recipe, .. } => recipe,
+        };
+        if let Err(error) =
+            load_validated_staging_request(&envelope.run_id, &envelope.runner_id, recipe)
+        {
+            // Prepare runs before any Lab side effect. Project malformed recipe,
+            // durable-plan, and readiness failures onto the parent attempt so
+            // callers receive terminal retry guidance rather than a stranded
+            // controller job with an otherwise queued parent.
+            if let Ok(plan) =
+                homeboy_agents::agent_task_lifecycle::load_controller_plan(&envelope.run_id)
+            {
+                let _ = homeboy_agents::agent_task_lifecycle::record_pre_execution_failure(
+                    &envelope.run_id,
+                    &plan,
+                    "lab_staging_prepare",
+                    &error,
+                );
+            }
+            return Err(error);
+        }
+        serde_json::to_value(LabStagingCheckpoint::initial(&envelope)).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize Lab staging checkpoint".to_string()),
+            )
+        })
+    }
+    fn execute(&self, prepared: Value, job: ControllerJobHandle) -> Result<Value> {
+        self.execute_checkpoint(Self::checkpoint(prepared)?, job, false)
+    }
+    fn resume(&self, checkpoint: Value, job: ControllerJobHandle) -> Result<Value> {
+        self.execute_checkpoint(Self::checkpoint(checkpoint)?, job, true)
+    }
+    fn cancel(&self, prepared: &Value) -> Result<()> {
+        let checkpoint = Self::checkpoint(prepared.clone())?;
+        let request = match &checkpoint.input {
+            LabStagingInputRef::AgentTaskAttempt { recipe, .. } => {
+                load_validated_staging_request(&checkpoint.run_id, &checkpoint.runner_id, recipe)?
+            }
+        };
+        let token = cancellations()
+            .lock()
+            .expect("Lab staging cancellation lock")
+            .get(&checkpoint.run_id)
+            .cloned()
+            .ok_or_else(|| {
+                Error::internal_unexpected("Lab staging cancellation has no owned execution token")
+            })?;
+        let adapter = require_production_adapter()?;
+        token.cancel();
+        adapter.cancel(&request, &checkpoint)
+    }
+}
+
+/// Registers the Lab driver once for daemon and CLI processes.
+pub fn register() {
+    static REGISTERED: OnceLock<()> = OnceLock::new();
+    // Driver registration is intentionally independent of traffic enablement.
+    // The production adapter stays uninstalled until the offload gate is
+    // explicitly approved in a later change.
+    REGISTERED.get_or_init(|| {
+        controller_job_driver::register_controller_job_driver(Arc::new(LabStagingDispatchDriver))
+            .expect("register Lab staging controller driver");
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use homeboy_core::lab_contract::LabCommandContract;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn recipe_command() -> LabOffloadCommand {
+        LabOffloadCommand {
+            command: LabCommandContract::portable("agent-task run-plan", None, false, &[]),
+            required_extensions: vec!["agent-runtime".to_string()],
+            required_capabilities: vec![LabRunnerWorkloadCapability {
+                name: "agent-task".to_string(),
+                required: true,
+            }],
+            workload: None,
+        }
+    }
+
+    fn recipe_request<'a>(
+        command: Option<LabOffloadCommand>,
+        args: &'a [String],
+        env: HashMap<String, String>,
+    ) -> LabOffloadRequest<'a> {
+        LabOffloadRequest {
+            command,
+            normalized_args: args,
+            explicit_runner: None,
+            placement: homeboy_cli_contract::Placement::Lab,
+            allow_local_fallback: false,
+            allow_dirty_lab_workspace: false,
+            skip_deps_hydration: false,
+            capture_patch: false,
+            mutation_flag: None,
+            detach_after_handoff: true,
+            output_file_requested: false,
+            read_only_polling: false,
+            local_output_file: None,
+            durable_agent_task_plan: None,
+            source_path: Some(std::path::Path::new("/work/source")),
+            verified_cook_baseline: None,
+            require_controller_git_bundle: true,
+            reuse_compatible_snapshot: true,
+            job_overrides: homeboy_core::lab_offload::LabJobOverrides {
+                env,
+                secret_env_names: vec!["AGENT_TOKEN".to_string()],
+                workspace_root: Some("/runner/workspaces".to_string()),
+            },
+        }
+    }
+
+    fn submit_recipe_run(run_id: &str) {
+        homeboy_agents::agent_task_lifecycle::submit_plan(
+            &homeboy_agents::agent_task_scheduler::AgentTaskPlan::new("recipe-plan", Vec::new()),
+            Some(run_id),
+        )
+        .expect("submit durable attempt");
+    }
+
+    fn envelope() -> LabStagingDispatchEnvelope {
+        LabStagingDispatchEnvelope::new(
+            "attempt-1",
+            "lab-1",
+            LabStagingInputRef::AgentTaskAttempt {
+                run_id: "attempt-1".to_string(),
+                recipe: recipe_ref(),
+            },
+        )
+    }
+
+    fn recipe_ref() -> LabStagingRecipeRef {
+        LabStagingRecipeRef {
+            attachment_digest: "sha256:attachment".to_string(),
+            durable_plan_id: "recipe-plan".to_string(),
+            canonical_plan_digest: "sha256:plan".to_string(),
+        }
+    }
+
+    fn global_state_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn envelope_and_checkpoint_round_trip_without_secret_projection() {
+        let envelope = envelope();
+        let encoded = serde_json::to_value(&envelope).expect("serialize");
+        assert_eq!(
+            LabStagingDispatchDriver::envelope(&encoded).expect("parse"),
+            envelope
+        );
+        let public = envelope.public_projection();
+        assert!(public.get("input").is_none());
+        assert_eq!(
+            LabStagingCheckpoint::initial(&envelope).phase,
+            LabStagingPhase::AcceptedMaterializeWorkspace
+        );
+    }
+
+    #[test]
+    fn registration_is_idempotent_for_cli_and_daemon_initialization() {
+        register();
+        register();
+    }
+
+    #[test]
+    fn progress_and_result_projections_are_safe() {
+        let mut checkpoint = LabStagingCheckpoint::initial(&envelope());
+        checkpoint.phase = LabStagingPhase::Completed;
+        checkpoint.source_snapshot_id = Some("snapshot-1".to_string());
+        checkpoint.workspace_id = Some("workspace-1".to_string());
+        checkpoint.runtime_id = Some("runtime-1".to_string());
+        checkpoint.hydration_id = Some("hydration-1".to_string());
+        checkpoint.final_runner_job_id = Some("runner-job-1".to_string());
+        let value = serde_json::to_value(checkpoint).expect("serialize");
+        let public = LabStagingDispatchDriver
+            .public_result(&value)
+            .expect("project");
+        assert_eq!(public["phase"], "completed");
+        assert!(public.get("input").is_none());
+    }
+
+    #[test]
+    fn completed_checkpoint_is_the_resume_recipe() {
+        let mut checkpoint = LabStagingCheckpoint::initial(&envelope());
+        checkpoint.phase = LabStagingPhase::MaterializeRuntime;
+        checkpoint.source_snapshot_id = Some("snapshot-1".to_string());
+        checkpoint.workspace_id = Some("workspace-1".to_string());
+
+        let recovered = LabStagingDispatchDriver::checkpoint(
+            serde_json::to_value(&checkpoint).expect("serialize checkpoint"),
+        )
+        .expect("recover checkpoint");
+
+        assert_eq!(recovered, checkpoint);
+        assert_eq!(recovered.phase, LabStagingPhase::MaterializeRuntime);
+        assert_eq!(recovered.workspace_id.as_deref(), Some("workspace-1"));
+    }
+
+    #[derive(Default)]
+    struct RecordedStageOperations {
+        calls: Mutex<Vec<&'static str>>,
+        fail_hydration: Mutex<bool>,
+        cancel_during_hydration: Mutex<bool>,
+    }
+
+    impl RecordedStageOperations {
+        fn calls(&self) -> Vec<&'static str> {
+            self.calls.lock().expect("calls lock").clone()
+        }
+
+        fn record(&self, name: &'static str) {
+            self.calls.lock().expect("calls lock").push(name);
+        }
+
+        fn fail_hydration_once(&self) {
+            *self.fail_hydration.lock().expect("failure lock") = true;
+        }
+
+        fn cancel_during_hydration_once(&self) {
+            *self
+                .cancel_during_hydration
+                .lock()
+                .expect("cancellation lock") = true;
+        }
+    }
+
+    impl LabStagingStageOperations for RecordedStageOperations {
+        fn validate_recorded_identities(
+            &self,
+            _request: &LabStagingExecutionRequest,
+            _checkpoint: &LabStagingCheckpoint,
+        ) -> Result<()> {
+            self.record("validate");
+            Ok(())
+        }
+
+        fn recover_stage(
+            &self,
+            _request: &LabStagingExecutionRequest,
+            checkpoint: &LabStagingCheckpoint,
+            intent: &LabStagingStageIntent,
+        ) -> Result<Option<LabStagingStageEffect>> {
+            assert_eq!(intent.operation_id, checkpoint.operation_id_for_phase());
+            let calls = self.calls();
+            let recovered = match checkpoint.phase {
+                LabStagingPhase::AcceptedMaterializeWorkspace if calls.contains(&"workspace") => {
+                    Some(LabStagingStageEffect::Workspace(
+                        "snapshot-1".to_string(),
+                        "workspace-1".to_string(),
+                    ))
+                }
+                LabStagingPhase::MaterializeRuntime if calls.contains(&"runtime") => {
+                    Some(LabStagingStageEffect::Runtime("runtime-1".to_string()))
+                }
+                LabStagingPhase::HydrateDependencies if calls.contains(&"hydration") => {
+                    Some(LabStagingStageEffect::Hydration("hydration-1".to_string()))
+                }
+                LabStagingPhase::DispatchRunner if calls.contains(&"dispatch") => {
+                    Some(LabStagingStageEffect::Dispatch("runner-job-1".to_string()))
+                }
+                LabStagingPhase::ObserveRunner if calls.contains(&"observe") => {
+                    Some(LabStagingStageEffect::Observe)
+                }
+                _ => None,
+            };
+            Ok(recovered)
+        }
+
+        fn materialize_workspace(
+            &self,
+            _request: &LabStagingExecutionRequest,
+            _checkpoint: &LabStagingCheckpoint,
+        ) -> Result<(String, String)> {
+            self.record("workspace");
+            Ok(("snapshot-1".to_string(), "workspace-1".to_string()))
+        }
+
+        fn materialize_runtime(
+            &self,
+            _request: &LabStagingExecutionRequest,
+            _checkpoint: &LabStagingCheckpoint,
+            _cancellation: &LabStagingCancellationToken,
+        ) -> Result<String> {
+            self.record("runtime");
+            Ok("runtime-1".to_string())
+        }
+
+        fn hydrate_dependencies(
+            &self,
+            _request: &LabStagingExecutionRequest,
+            _checkpoint: &LabStagingCheckpoint,
+            cancellation: &LabStagingCancellationToken,
+        ) -> Result<String> {
+            self.record("hydration");
+            if std::mem::take(&mut *self.fail_hydration.lock().expect("failure lock")) {
+                return Err(Error::internal_unexpected(
+                    "simulated partial hydration failure",
+                ));
+            }
+            if std::mem::take(
+                &mut *self
+                    .cancel_during_hydration
+                    .lock()
+                    .expect("cancellation lock"),
+            ) {
+                cancellation.cancel();
+            }
+            Ok("hydration-1".to_string())
+        }
+
+        fn dispatch_runner(
+            &self,
+            _request: &LabStagingExecutionRequest,
+            _checkpoint: &LabStagingCheckpoint,
+            _cancellation: &LabStagingCancellationToken,
+        ) -> Result<String> {
+            self.record("dispatch");
+            Ok("runner-job-1".to_string())
+        }
+
+        fn observe_runner(
+            &self,
+            _request: &LabStagingExecutionRequest,
+            _checkpoint: &LabStagingCheckpoint,
+            runner_job_id: &str,
+        ) -> Result<()> {
+            assert_eq!(runner_job_id, "runner-job-1");
+            self.record("observe");
+            Ok(())
+        }
+
+        fn prove_no_runner_admission(&self, _request: &LabStagingExecutionRequest) -> Result<()> {
+            self.record("prove-no-admission");
+            Ok(())
+        }
+
+        fn cancel_and_reconcile_runner_job(
+            &self,
+            _request: &LabStagingExecutionRequest,
+            runner_job_id: &str,
+        ) -> Result<()> {
+            assert_eq!(runner_job_id, "runner-job-1");
+            self.record("cancel-runner-job");
+            Ok(())
+        }
+    }
+
+    fn execution_request() -> LabStagingExecutionRequest {
+        let args = vec!["agent-task".to_string(), "run-plan".to_string()];
+        LabStagingExecutionRequest {
+            recipe: LabStagingRecipe::from_request(
+                "attempt-1",
+                "lab-1",
+                &recipe_request(Some(recipe_command()), &args, HashMap::new()),
+            )
+            .expect("recipe"),
+            durable_agent_task_plan: homeboy_agents::agent_task_scheduler::AgentTaskPlan::new(
+                "recipe-plan",
+                Vec::new(),
+            ),
+        }
+    }
+
+    #[test]
+    fn adapter_recovers_after_each_effect_before_completion_without_repeating_side_effects() {
+        // Odd persistence calls store intent. Even calls store the completion
+        // checkpoint, so crashing on each even call exercises every exact-once
+        // window after an injected side effect.
+        for crash_after in [2, 4, 6, 8, 10] {
+            let operations = Arc::new(RecordedStageOperations::default());
+            let adapter = StageExecutionAdapter::new(operations.clone());
+            let request = execution_request();
+            let token = LabStagingCancellationToken::default();
+            let mut persisted = Vec::new();
+            let interrupted = adapter.execute_with_checkpoint(
+                &request,
+                LabStagingCheckpoint::initial(&envelope()),
+                &token,
+                |checkpoint| {
+                    if persisted.len() + 1 == crash_after {
+                        Err(Error::internal_unexpected("simulated controller crash"))
+                    } else {
+                        persisted.push(checkpoint.clone());
+                        Ok(())
+                    }
+                },
+            );
+            assert!(
+                interrupted.is_err(),
+                "crash point {crash_after} must interrupt"
+            );
+            let checkpoint = persisted.last().expect("checkpoint before crash").clone();
+            let completed = adapter
+                .execute_with_checkpoint(&request, checkpoint, &token, |checkpoint| {
+                    persisted.push(checkpoint.clone());
+                    Ok(())
+                })
+                .unwrap_or_else(|error| panic!("resume after crash {crash_after}: {error:?}"));
+
+            assert_eq!(completed.phase, LabStagingPhase::Completed);
+            assert_eq!(
+                operations
+                    .calls()
+                    .into_iter()
+                    .filter(|call| *call != "validate")
+                    .collect::<Vec<_>>(),
+                ["workspace", "runtime", "hydration", "dispatch", "observe"]
+            );
+            assert_eq!(
+                persisted
+                    .iter()
+                    .map(|checkpoint| checkpoint.phase.clone())
+                    .collect::<Vec<_>>(),
+                [
+                    LabStagingPhase::AcceptedMaterializeWorkspace,
+                    LabStagingPhase::MaterializeRuntime,
+                    LabStagingPhase::MaterializeRuntime,
+                    LabStagingPhase::HydrateDependencies,
+                    LabStagingPhase::HydrateDependencies,
+                    LabStagingPhase::DispatchRunner,
+                    LabStagingPhase::DispatchRunner,
+                    LabStagingPhase::ObserveRunner,
+                    LabStagingPhase::ObserveRunner,
+                    LabStagingPhase::Completed,
+                ]
+            );
+        }
+    }
+
+    #[test]
+    fn adapter_cancellation_proves_no_admission_before_dispatch_and_reconciles_after_acceptance() {
+        let operations = Arc::new(RecordedStageOperations::default());
+        let adapter = StageExecutionAdapter::new(operations.clone());
+        let request = execution_request();
+        let initial = LabStagingCheckpoint::initial(&envelope());
+        adapter
+            .cancel(&request, &initial)
+            .expect("pre-dispatch cancellation");
+
+        let mut accepted = initial;
+        accepted.phase = LabStagingPhase::ObserveRunner;
+        accepted.source_snapshot_id = Some("snapshot-1".to_string());
+        accepted.workspace_id = Some("workspace-1".to_string());
+        accepted.runtime_id = Some("runtime-1".to_string());
+        accepted.hydration_id = Some("hydration-1".to_string());
+        accepted.final_runner_job_id = Some("runner-job-1".to_string());
+        adapter
+            .cancel(&request, &accepted)
+            .expect("post-acceptance cancellation");
+
+        assert_eq!(
+            operations.calls(),
+            [
+                "validate",
+                "prove-no-admission",
+                "validate",
+                "cancel-runner-job"
+            ]
+        );
+    }
+
+    #[test]
+    fn partial_or_cancelled_hydration_does_not_advance_the_checkpoint() {
+        for cancelled in [false, true] {
+            let operations = Arc::new(RecordedStageOperations::default());
+            if cancelled {
+                operations.cancel_during_hydration_once();
+            } else {
+                operations.fail_hydration_once();
+            }
+            let adapter = StageExecutionAdapter::new(operations.clone());
+            let request = execution_request();
+            let mut checkpoint = LabStagingCheckpoint::initial(&envelope());
+            checkpoint.phase = LabStagingPhase::HydrateDependencies;
+            checkpoint.source_snapshot_id = Some("snapshot-1".to_string());
+            checkpoint.workspace_id = Some("workspace-1".to_string());
+            checkpoint.runtime_id = Some("runtime-1".to_string());
+            let mut persisted = Vec::new();
+            assert!(adapter
+                .execute_with_checkpoint(
+                    &request,
+                    checkpoint,
+                    &LabStagingCancellationToken::default(),
+                    |next| {
+                        persisted.push(next.clone());
+                        Ok(())
+                    },
+                )
+                .is_err());
+            assert_eq!(persisted.len(), 1);
+            assert_eq!(persisted[0].phase, LabStagingPhase::HydrateDependencies);
+            assert!(persisted[0].stage_intent.is_some());
+            assert_eq!(operations.calls(), ["validate", "hydration"]);
+        }
+    }
+
+    #[test]
+    fn production_recovery_fails_closed_for_an_intent_without_a_receipt() {
+        let request = execution_request();
+        let mut checkpoint = LabStagingCheckpoint::initial(&envelope());
+        let intent = checkpoint.intent_for_current_action();
+        checkpoint.stage_intent = Some(intent.clone());
+        let error = ProductionLabStagingOperations
+            .recover_stage(&request, &checkpoint, &intent)
+            .expect_err("an intent with no workspace receipt is ambiguous");
+        assert_eq!(
+            error.code,
+            homeboy_core::ErrorCode::ValidationInvalidArgument
+        );
+    }
+
+    struct CancellationAdapter(Arc<AtomicUsize>);
+
+    impl LabStagingExecutionAdapter for CancellationAdapter {
+        fn execute(
+            &self,
+            _request: &LabStagingExecutionRequest,
+            checkpoint: LabStagingCheckpoint,
+            _cancellation: LabStagingCancellationToken,
+            _job: ControllerJobHandle,
+        ) -> Result<LabStagingCheckpoint> {
+            Ok(checkpoint)
+        }
+
+        fn cancel(
+            &self,
+            _request: &LabStagingExecutionRequest,
+            checkpoint: &LabStagingCheckpoint,
+        ) -> Result<()> {
+            assert_eq!(
+                checkpoint.final_runner_job_id.as_deref(),
+                Some("runner-job-1")
+            );
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn cancellation_signals_the_owned_token_before_adapter_confirmation() {
+        let _serial = global_state_lock().lock().expect("lock");
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let run_id = "cancel-authority";
+            submit_recipe_run(run_id);
+            let args = vec!["agent-task".to_string(), "run-plan".to_string()];
+            persist_lab_staging_recipe(
+                run_id,
+                "lab-1",
+                &recipe_request(Some(recipe_command()), &args, HashMap::new()),
+            )
+            .expect("persist");
+            let attachment = homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
+                LabStagingRecipe,
+            >(run_id, LAB_STAGING_RECIPE_ATTACHMENT_KIND)
+            .expect("attachment");
+            let plan =
+                homeboy_agents::agent_task_lifecycle::load_controller_plan(run_id).expect("plan");
+            let envelope = LabStagingDispatchEnvelope::new(
+                run_id,
+                "lab-1",
+                LabStagingInputRef::AgentTaskAttempt {
+                    run_id: run_id.to_string(),
+                    recipe: LabStagingRecipeRef::from_authority(attachment.payload_digest, &plan)
+                        .expect("ref"),
+                },
+            );
+            let mut checkpoint = LabStagingCheckpoint::initial(&envelope);
+            checkpoint.phase = LabStagingPhase::Completed;
+            checkpoint.source_snapshot_id = Some("snapshot-1".to_string());
+            checkpoint.workspace_id = Some("workspace-1".to_string());
+            checkpoint.runtime_id = Some("runtime-1".to_string());
+            checkpoint.hydration_id = Some("hydration-1".to_string());
+            checkpoint.final_runner_job_id = Some("runner-job-1".to_string());
+            let token = LabStagingCancellationToken::default();
+            cancellations()
+                .lock()
+                .expect("lock")
+                .insert(checkpoint.run_id.clone(), token.clone());
+            let cancelled = Arc::new(AtomicUsize::new(0));
+            install_production_execution_adapter(Arc::new(CancellationAdapter(Arc::clone(
+                &cancelled,
+            ))));
+
+            LabStagingDispatchDriver
+                .cancel(&serde_json::to_value(&checkpoint).expect("serialize"))
+                .expect("cancel");
+
+            assert!(token.is_cancelled());
+            assert_eq!(cancelled.load(Ordering::SeqCst), 1);
+            *adapter_slot().lock().expect("adapter lock") = None;
+            cancellations()
+                .lock()
+                .expect("lock")
+                .remove(&checkpoint.run_id);
+        });
+    }
+
+    #[test]
+    fn unsupported_raw_input_reference_is_rejected() {
+        let value = json!({
+            "schema": LAB_STAGING_DISPATCH_SCHEMA,
+            "run_id": "attempt-1",
+            "runner_id": "lab-1",
+            "input": { "type": "uri", "locator": "file:///private/input.json" },
+        });
+        assert!(LabStagingDispatchDriver::envelope(&value).is_err());
+    }
+
+    #[test]
+    fn malformed_or_inconsistent_checkpoint_is_rejected_before_projection() {
+        let mut checkpoint = LabStagingCheckpoint::initial(&envelope());
+        checkpoint.phase = LabStagingPhase::Completed;
+        checkpoint.source_snapshot_id = Some("snapshot-1".to_string());
+        checkpoint.workspace_id = Some("workspace-1".to_string());
+        checkpoint.runtime_id = Some("runtime-1".to_string());
+        // A dispatching phase cannot omit completed hydration/final handoff.
+        assert!(LabStagingDispatchDriver::checkpoint(
+            serde_json::to_value(&checkpoint).expect("serialize"),
+        )
+        .is_err());
+
+        checkpoint.phase = LabStagingPhase::AcceptedMaterializeWorkspace;
+        checkpoint.workspace_id = Some("workspace-1".to_string());
+        assert!(LabStagingDispatchDriver::checkpoint(
+            serde_json::to_value(&checkpoint).expect("serialize"),
+        )
+        .is_err());
+
+        let mut inconsistent = LabStagingCheckpoint::initial(&envelope());
+        inconsistent.input = LabStagingInputRef::AgentTaskAttempt {
+            run_id: "another-attempt".to_string(),
+            recipe: recipe_ref(),
+        };
+        assert!(LabStagingDispatchDriver::checkpoint(
+            serde_json::to_value(&inconsistent).expect("serialize"),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn production_adapter_readiness_fails_closed_when_uninstalled() {
+        let _serial = global_state_lock().lock().expect("lock");
+        *adapter_slot().lock().expect("lock") = None;
+        assert!(require_production_adapter().is_err());
+    }
+
+    fn durable_workspace_state(request: &LabStagingExecutionRequest) -> DurableLabWorkspaceStage {
+        DurableLabWorkspaceStage {
+            schema: "homeboy/durable-lab-workspace-stage/v1".to_string(),
+            run_id: request.recipe.run_id.clone(),
+            runner_id: request.recipe.runner_id.clone(),
+            recipe_digest: canonical_digest(&request.recipe).expect("recipe digest"),
+            plan_digest: canonical_plan_digest(&request.durable_agent_task_plan)
+                .expect("plan digest"),
+            source_snapshot_id: "snapshot-1".to_string(),
+            workspace_id: "/runner/workspaces/attempt-1".to_string(),
+            remote_cwd: "/runner/workspaces/attempt-1".to_string(),
+            stage: json!({
+                "remote_cwd": "/runner/workspaces/attempt-1",
+                "source_snapshot": {
+                    "workspace_snapshot_identity": "snapshot-1",
+                    "remote_path": "/runner/workspaces/attempt-1",
+                },
+                "command": ["homeboy", "agent-task", "run-plan"],
+                "remapped_args": ["agent-task", "run-plan"],
+            }),
+        }
+    }
+
+    #[test]
+    fn durable_workspace_state_reuses_exact_recording_and_fails_closed_on_tamper_or_recipe_change()
+    {
+        let request = execution_request();
+        let mut checkpoint = LabStagingCheckpoint::initial(&envelope());
+        checkpoint.phase = LabStagingPhase::MaterializeRuntime;
+        checkpoint.source_snapshot_id = Some("snapshot-1".to_string());
+        checkpoint.workspace_id = Some("/runner/workspaces/attempt-1".to_string());
+        let durable = durable_workspace_state(&request);
+
+        durable
+            .validate(&request, &checkpoint)
+            .expect("valid resume");
+        assert!(!serde_json::to_string(&durable)
+            .expect("serialize")
+            .contains("private-marker"));
+
+        let mut tampered = durable.clone();
+        tampered.stage["source_snapshot"]["remote_path"] = json!("/other");
+        assert!(tampered.validate(&request, &checkpoint).is_err());
+
+        let mut changed = request.clone();
+        changed.recipe.normalized_args.push("--changed".to_string());
+        assert!(durable.validate(&changed, &checkpoint).is_err());
+    }
+
+    #[test]
+    fn durable_hydration_receipt_binds_results_and_dispatch_inputs_without_secrets() {
+        let request = execution_request();
+        let mut checkpoint = LabStagingCheckpoint::initial(&envelope());
+        checkpoint.phase = LabStagingPhase::DispatchRunner;
+        checkpoint.source_snapshot_id = Some("snapshot-1".to_string());
+        checkpoint.workspace_id = Some("/runner/workspaces/attempt-1".to_string());
+        checkpoint.runtime_id = Some("runtime-1".to_string());
+        let workspace = durable_workspace_state(&request);
+        let plan = serde_json::to_value(homeboy_core::plan::HomeboyPlan::for_description(
+            homeboy_core::plan::PlanKind::LabOffload,
+            "hydration",
+        ))
+        .expect("plan");
+        let runtime = DurableLabRuntimeStage {
+            schema: "homeboy/durable-lab-runtime-stage/v1".to_string(),
+            run_id: request.recipe.run_id.clone(),
+            runner_id: request.recipe.runner_id.clone(),
+            recipe_digest: canonical_digest(&request.recipe).expect("recipe digest"),
+            plan_digest: canonical_plan_digest(&request.durable_agent_task_plan)
+                .expect("plan digest"),
+            workspace_id: workspace.workspace_id.clone(),
+            runtime_id: "runtime-1".to_string(),
+            output: json!({ "remote_cwd": workspace.workspace_id, "plan": plan }),
+        };
+        let hydration_record = json!({ "Applied": {
+            "schema": crate::lab::offload::HYDRATION_SCHEMA,
+            "status": "hydrated",
+            "workspace": workspace.workspace_id,
+            "steps": [{ "job_id": "hydration-job-1" }]
+        }});
+        let hydration_id = canonical_digest(&hydration_record).expect("hydration digest");
+        checkpoint.hydration_id = Some(hydration_id.clone());
+        let receipt = DurableLabHydrationStage {
+            schema: "homeboy/durable-lab-hydration-stage/v1".to_string(),
+            run_id: request.recipe.run_id.clone(),
+            runner_id: request.recipe.runner_id.clone(),
+            recipe_digest: canonical_digest(&request.recipe).expect("recipe digest"),
+            plan_digest: canonical_plan_digest(&request.durable_agent_task_plan)
+                .expect("plan digest"),
+            workspace_id: workspace.workspace_id.clone(),
+            runtime_id: runtime.runtime_id.clone(),
+            hydration_id,
+            plan: runtime.output["plan"].clone(),
+            hydration_record: hydration_record.clone(),
+            hydration_metadata: hydration_metadata_from_record(&hydration_record),
+            execution_ids: vec!["hydration-job-1".to_string()],
+            dispatch_inputs: json!({
+                "workspace_stage": workspace.stage,
+                "runtime_output": runtime.output,
+                "plan": runtime.output["plan"],
+            }),
+        };
+        receipt
+            .validate(&request, &checkpoint, &workspace, &runtime)
+            .expect("bound receipt");
+        assert!(!serde_json::to_string(&receipt)
+            .expect("serialize")
+            .contains("private-marker"));
+
+        let mut tampered = receipt.clone();
+        tampered.execution_ids.clear();
+        assert!(tampered
+            .validate(&request, &checkpoint, &workspace, &runtime)
+            .is_err());
+        let mut different_runner = request.clone();
+        different_runner.recipe.runner_id = "other-runner".to_string();
+        assert!(receipt
+            .validate(&different_runner, &checkpoint, &workspace, &runtime)
+            .is_err());
+    }
+
+    #[test]
+    fn dispatch_receipt_fails_closed_on_tamper_and_never_serializes_secret_values() {
+        let request = execution_request();
+        let mut checkpoint = LabStagingCheckpoint::initial(&envelope());
+        checkpoint.phase = LabStagingPhase::ObserveRunner;
+        checkpoint.source_snapshot_id = Some("snapshot-1".to_string());
+        checkpoint.workspace_id = Some("workspace-1".to_string());
+        checkpoint.runtime_id = Some("runtime-1".to_string());
+        checkpoint.hydration_id = Some("hydration-1".to_string());
+        checkpoint.final_runner_job_id = Some("runner-job-1".to_string());
+        let receipt = DurableLabDispatchReceipt {
+            schema: "homeboy/durable-lab-dispatch-receipt/v1".to_string(),
+            run_id: request.recipe.run_id.clone(),
+            runner_id: request.recipe.runner_id.clone(),
+            recipe_digest: canonical_digest(&request.recipe).expect("digest"),
+            workspace_attachment_digest: "sha256:workspace".to_string(),
+            runtime_attachment_digest: "sha256:runtime".to_string(),
+            hydration_attachment_digest: "sha256:hydration".to_string(),
+            daemon_lease_id: "lease-1".to_string(),
+            reservation_job_id: "reservation-1".to_string(),
+            runner_job_id: "runner-job-1".to_string(),
+            remote_workspace: "/runner/workspace".to_string(),
+            remote_command: vec!["homeboy".to_string(), "agent-task".to_string()],
+            workload_identity: "sha256:workload".to_string(),
+        };
+        receipt.validate(&request, &checkpoint).expect("receipt");
+        assert!(!serde_json::to_string(&receipt)
+            .expect("serialize")
+            .contains("private-marker"));
+        let mut tampered = receipt;
+        tampered.runner_job_id = "other-job".to_string();
+        assert!(tampered.validate(&request, &checkpoint).is_err());
+    }
+
+    #[test]
+    fn registration_keeps_lab_routing_disabled_without_submission_hook() {
+        let _serial = global_state_lock().lock().expect("lock");
+        *adapter_slot().lock().expect("adapter lock") = None;
+        register();
+        assert!(!routing_ready());
+    }
+
+    #[test]
+    fn cancellation_guard_removes_token_after_adapter_error() {
+        let _serial = global_state_lock().lock().expect("lock");
+        let run_id = "adapter-error".to_string();
+        let token = LabStagingCancellationToken::default();
+        cancellations()
+            .lock()
+            .expect("lock")
+            .insert(run_id.clone(), token);
+        let result: Result<()> = {
+            let _cleanup = CancellationGuard(run_id.clone());
+            Err(Error::internal_unexpected("adapter failed"))
+        };
+        assert!(result.is_err());
+        assert!(!cancellations().lock().expect("lock").contains_key(&run_id));
+    }
+
+    #[test]
+    fn recipe_round_trips_without_secret_values_and_reconstructs_borrowed_request() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let run_id = "recipe-round-trip";
+            submit_recipe_run(run_id);
+            let args = vec!["agent-task".to_string(), "run-plan".to_string()];
+            let request = recipe_request(
+                Some(recipe_command()),
+                &args,
+                HashMap::from([("PUBLIC_FLAG".to_string(), "enabled".to_string())]),
+            );
+            let recipe = persist_lab_staging_recipe(run_id, "lab-1", &request).expect("persist");
+            let loaded = load_lab_staging_recipe(run_id).expect("load");
+            assert_eq!(loaded.recipe, recipe);
+            let execution: LabStagingExecutionRequest = loaded.into();
+            assert_eq!(execution.recipe.normalized_args, args);
+            assert_eq!(execution.recipe.runner_id, "lab-1");
+            assert_eq!(
+                execution.recipe.source_path,
+                Some(PathBuf::from("/work/source"))
+            );
+            assert_eq!(execution.recipe.job_override_env["PUBLIC_FLAG"], "enabled");
+            assert!(!execution
+                .recipe
+                .job_override_env
+                .contains_key("AGENT_TOKEN"));
+            assert_eq!(execution.recipe.secret_env_names, vec!["AGENT_TOKEN"]);
+            let bytes = std::fs::read(
+                homeboy_core::paths::homeboy_data()
+                    .expect("data root")
+                    .join("agent-task-runs")
+                    .join(run_id)
+                    .join("private/lab-staging-recipe.json"),
+            )
+            .expect("attachment bytes");
+            assert!(!String::from_utf8_lossy(&bytes).contains("private-marker"));
+            let public = LabStagingDispatchEnvelope::new(
+                run_id,
+                "lab-1",
+                LabStagingInputRef::AgentTaskAttempt {
+                    run_id: run_id.to_string(),
+                    recipe: recipe_ref(),
+                },
+            )
+            .public_projection();
+            assert!(!public.to_string().contains("private-marker"));
+        });
+    }
+
+    #[test]
+    fn recipe_rejects_inline_secrets_and_non_agent_task_or_mismatched_identity() {
+        let args = vec!["agent-task".to_string(), "run-plan".to_string()];
+        let inline = recipe_request(
+            Some(recipe_command()),
+            &args,
+            HashMap::from([("AGENT_TOKEN".to_string(), "private-marker".to_string())]),
+        );
+        let error =
+            LabStagingRecipe::from_request("run", "lab", &inline).expect_err("secret rejected");
+        assert!(!error.message.contains("private-marker"));
+
+        let wrong_args = vec!["review".to_string()];
+        let wrong_shape = recipe_request(Some(recipe_command()), &wrong_args, HashMap::new());
+        assert!(LabStagingRecipe::from_request("run", "lab", &wrong_shape).is_err());
+
+        let mut recipe = LabStagingRecipe::from_request(
+            "run",
+            "lab",
+            &recipe_request(Some(recipe_command()), &args, HashMap::new()),
+        )
+        .expect("recipe");
+        recipe.schema = "unsupported".to_string();
+        assert!(recipe.validate().is_err());
+        recipe.schema = LAB_STAGING_RECIPE_SCHEMA.to_string();
+        recipe.secret_env_names = vec!["AGENT_TOKEN".to_string(), "AGENT_TOKEN".to_string()];
+        assert!(recipe.validate().is_err());
+    }
+
+    #[test]
+    fn prepare_recipe_lookup_failure_terminalizes_the_parent_with_retry_metadata() {
+        let _serial = global_state_lock().lock().expect("lock");
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let run_id = "prepare-plan-lookup-failure";
+            submit_recipe_run(run_id);
+            let args = vec!["agent-task".to_string(), "run-plan".to_string()];
+            persist_lab_staging_recipe(
+                run_id,
+                "lab-1",
+                &recipe_request(Some(recipe_command()), &args, HashMap::new()),
+            )
+            .expect("persist recipe");
+            let attachment = homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
+                LabStagingRecipe,
+            >(run_id, LAB_STAGING_RECIPE_ATTACHMENT_KIND)
+            .expect("recipe attachment");
+            let plan = homeboy_agents::agent_task_lifecycle::load_controller_plan(run_id)
+                .expect("durable plan");
+            std::fs::remove_file(
+                homeboy_core::paths::homeboy_data()
+                    .expect("data root")
+                    .join("agent-task-runs")
+                    .join(run_id)
+                    .join("private/lab-staging-recipe.json"),
+            )
+            .expect("remove recipe to force real authoritative lookup failure");
+            let envelope = LabStagingDispatchEnvelope::new(
+                run_id,
+                "lab-1",
+                LabStagingInputRef::AgentTaskAttempt {
+                    run_id: run_id.to_string(),
+                    recipe: LabStagingRecipeRef::from_authority(attachment.payload_digest, &plan)
+                        .expect("recipe reference"),
+                },
+            );
+
+            LabStagingDispatchDriver
+                .prepare(serde_json::to_value(envelope).expect("serialize envelope"))
+                .expect_err("missing recipe must fail before staging");
+
+            let record = homeboy_agents::agent_task_lifecycle::status(run_id).expect("parent");
+            assert!(matches!(
+                record.state,
+                homeboy_agents::agent_task_lifecycle::AgentTaskRunState::Failed
+            ));
+            assert_eq!(
+                record.metadata["pre_execution_failure"]["phase"],
+                "lab_staging_prepare"
+            );
+            assert_eq!(
+                record.metadata["pre_execution_failure"]["provider_executions_consumed"],
+                0
+            );
+            assert!(!routing_ready());
+        });
+    }
+
+    #[test]
+    fn secret_bearing_recipe_never_reaches_public_or_durable_projection_surfaces() {
+        let _serial = global_state_lock().lock().expect("lock");
+        homeboy_core::test_support::with_isolated_home(|_| {
+            const MARKER: &str = "staging-secret-marker";
+            let run_id = "secret-projection";
+            submit_recipe_run(run_id);
+            let args = vec!["agent-task".to_string(), "run-plan".to_string()];
+            let request = recipe_request(
+                Some(recipe_command()),
+                &args,
+                HashMap::from([("PUBLIC_FLAG".to_string(), "enabled".to_string())]),
+            );
+            let recipe = persist_lab_staging_recipe(run_id, "lab-1", &request).expect("persist");
+            let plan = homeboy_agents::agent_task_lifecycle::load_controller_plan(run_id)
+                .expect("durable plan");
+            let attachment = homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
+                LabStagingRecipe,
+            >(run_id, LAB_STAGING_RECIPE_ATTACHMENT_KIND)
+            .expect("recipe attachment");
+            let envelope = LabStagingDispatchEnvelope::new(
+                run_id,
+                "lab-1",
+                LabStagingInputRef::AgentTaskAttempt {
+                    run_id: run_id.to_string(),
+                    recipe: LabStagingRecipeRef::from_authority(attachment.payload_digest, &plan)
+                        .expect("recipe reference"),
+                },
+            );
+            let checkpoint = LabStagingCheckpoint::initial(&envelope);
+            let public_request = LabStagingDispatchDriver
+                .public_request(&serde_json::to_value(&envelope).expect("request"))
+                .expect("public request");
+            let public_checkpoint = LabStagingDispatchDriver
+                .public_progress(&serde_json::to_value(&checkpoint).expect("checkpoint"))
+                .expect("public checkpoint");
+            let record = homeboy_agents::agent_task_lifecycle::status(run_id).expect("record");
+            let recipe_bytes = std::fs::read(
+                homeboy_core::paths::homeboy_data()
+                    .expect("data root")
+                    .join("agent-task-runs")
+                    .join(run_id)
+                    .join("private/lab-staging-recipe.json"),
+            )
+            .expect("recipe bytes");
+
+            for surface in [
+                serde_json::to_string(&recipe).expect("recipe"),
+                public_request.to_string(),
+                public_checkpoint.to_string(),
+                serde_json::to_string(&record).expect("record"),
+                String::from_utf8_lossy(&recipe_bytes).into_owned(),
+                LabStagingDispatchDriver
+                    .public_error(&Error::internal_unexpected("staging failed"))
+                    .data
+                    .to_string(),
+            ] {
+                assert!(!surface.contains(MARKER), "secret leaked to {surface}");
+            }
+            assert_eq!(recipe.secret_env_names, ["AGENT_TOKEN"]);
+            assert!(!routing_ready());
+        });
+    }
+
+    #[test]
+    fn recipe_load_requires_existing_attempt_plan_and_immutable_attachment() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            assert!(load_lab_staging_recipe("missing-attempt").is_err());
+            let run_id = "recipe-conflict";
+            submit_recipe_run(run_id);
+            let args = vec!["agent-task".to_string(), "run-plan".to_string()];
+            let request = recipe_request(Some(recipe_command()), &args, HashMap::new());
+            persist_lab_staging_recipe(run_id, "lab-1", &request).expect("persist");
+            assert!(persist_lab_staging_recipe(run_id, "lab-2", &request).is_err());
+            let record = homeboy_agents::agent_task_lifecycle::status(run_id).expect("record");
+            std::fs::remove_file(record.plan_path).expect("remove durable plan");
+            assert!(load_lab_staging_recipe(run_id).is_err());
+        });
+    }
+}

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -1,7 +1,7 @@
 //! Durable controller-job contract for Lab staging and final dispatch.
 //!
-//! Routing deliberately does not submit this job yet. Phase 2 will construct an
-//! envelope after the agent-task attempt exists and before workspace staging.
+//! Detached direct-daemon routing constructs this job after the agent-task
+//! attempt exists and before workspace staging begins.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -1335,10 +1335,8 @@ enum LabStagingStageEffect {
     Observe,
 }
 
-/// Production implementation deliberately exposes only the first durable
-/// boundary. Registering it makes workspace recovery testable, not routable:
-/// every later remote effect remains unavailable until it has equivalent
-/// durable input/output ownership.
+/// Production implementation of the durable staging boundaries. Each remote
+/// effect persists an immutable receipt before the next phase can begin.
 struct ProductionLabStagingOperations;
 
 impl ProductionLabStagingOperations {
@@ -1350,12 +1348,6 @@ impl ProductionLabStagingOperations {
             &request.recipe.run_id,
             DURABLE_LAB_WORKSPACE_STAGE_ATTACHMENT_KIND,
         )
-    }
-
-    fn unavailable(stage: &str) -> Error {
-        Error::internal_unexpected(format!(
-            "Lab staging {stage} is unavailable: durable runtime, hydration, and dispatch boundaries are not implemented"
-        ))
     }
 
     fn durable_runtime(
@@ -2425,8 +2417,7 @@ fn adapter_slot() -> &'static Mutex<Option<Arc<dyn LabStagingExecutionAdapter>>>
     ADAPTER.get_or_init(|| Mutex::new(None))
 }
 
-/// Phase 2 installs the adapter which delegates to existing Lab offload stages.
-/// Registration alone never makes controller-job submission/recovery safe.
+/// Install an execution adapter after its owner has registered the driver.
 pub(crate) fn install_production_execution_adapter(adapter: Arc<dyn LabStagingExecutionAdapter>) {
     *adapter_slot().lock().expect("Lab staging adapter lock") = Some(adapter);
 }
@@ -2450,6 +2441,15 @@ pub(crate) fn routing_ready() -> bool {
         .lock()
         .expect("Lab staging adapter lock")
         .is_some()
+}
+
+/// Enable the production staging implementation after generic driver
+/// registration. Keeping this explicit prevents partial embedders from routing
+/// detached work before they initialize the Lab runtime.
+pub fn enable_production_routing() {
+    install_production_execution_adapter(Arc::new(StageExecutionAdapter::new(Arc::new(
+        ProductionLabStagingOperations,
+    ))));
 }
 
 fn cancellations() -> &'static Mutex<HashMap<String, LabStagingCancellationToken>> {
@@ -3605,6 +3605,16 @@ mod tests {
         *adapter_slot().lock().expect("adapter lock") = None;
         register();
         assert!(!routing_ready());
+    }
+
+    #[test]
+    fn production_enablement_installs_the_staging_adapter() {
+        let _serial = global_state_lock().lock().expect("lock");
+        *adapter_slot().lock().expect("adapter lock") = None;
+        register();
+        enable_production_routing();
+        assert!(routing_ready());
+        *adapter_slot().lock().expect("adapter lock") = None;
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -431,7 +431,7 @@ fn controller_job_from_response(value: &Value, status: u16) -> Result<homeboy_co
     }
     serde_json::from_value(
         value
-            .pointer("/data/job")
+            .pointer("/data/body/job")
             .cloned()
             .ok_or_else(|| Error::internal_unexpected("controller daemon response has no job"))?,
     )
@@ -1314,6 +1314,10 @@ trait LabStagingStageOperations: Send + Sync {
         checkpoint: &LabStagingCheckpoint,
         runner_job_id: &str,
     ) -> Result<()>;
+    fn recover_admitted_runner_job(
+        &self,
+        request: &LabStagingExecutionRequest,
+    ) -> Result<Option<String>>;
     fn prove_no_runner_admission(&self, request: &LabStagingExecutionRequest) -> Result<()>;
     fn cancel_and_reconcile_runner_job(
         &self,
@@ -2177,6 +2181,27 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
         )?;
         Ok(())
     }
+    fn recover_admitted_runner_job(
+        &self,
+        request: &LabStagingExecutionRequest,
+    ) -> Result<Option<String>> {
+        let Some((runner_id, runner_job_id)) =
+            homeboy_agents::agent_task_lifecycle::recorded_runner_job_identity(
+                &request.recipe.run_id,
+            )?
+        else {
+            return Ok(None);
+        };
+        if runner_id != request.recipe.runner_id {
+            return Err(Error::validation_invalid_argument(
+                "runner_id",
+                "accepted Lab runner binding does not match its staging recipe",
+                Some(runner_id),
+                None,
+            ));
+        }
+        Ok(Some(runner_job_id))
+    }
     fn prove_no_runner_admission(&self, request: &LabStagingExecutionRequest) -> Result<()> {
         let status = crate::status(&request.recipe.runner_id)?;
         if status
@@ -2382,10 +2407,14 @@ impl LabStagingExecutionAdapter for StageExecutionAdapter {
     ) -> Result<()> {
         self.operations
             .validate_recorded_identities(request, checkpoint)?;
-        match checkpoint.final_runner_job_id.as_deref() {
+        let runner_job_id = match checkpoint.final_runner_job_id.clone() {
+            Some(job_id) => Some(job_id),
+            None => self.operations.recover_admitted_runner_job(request)?,
+        };
+        match runner_job_id {
             Some(job_id) => self
                 .operations
-                .cancel_and_reconcile_runner_job(request, job_id),
+                .cancel_and_reconcile_runner_job(request, &job_id),
             None => self.operations.prove_no_runner_admission(request),
         }
     }
@@ -2647,6 +2676,8 @@ pub fn register() {
 mod tests {
     use super::*;
     use homeboy_core::lab_contract::LabCommandContract;
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn recipe_command() -> LabOffloadCommand {
@@ -2747,6 +2778,146 @@ mod tests {
         register();
     }
 
+    fn read_http_request(stream: &mut TcpStream) -> String {
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .expect("read timeout");
+        let mut request = Vec::new();
+        let mut content_length = None;
+        loop {
+            let mut chunk = [0_u8; 4096];
+            let count = stream.read(&mut chunk).expect("read request");
+            if count == 0 {
+                break;
+            }
+            request.extend_from_slice(&chunk[..count]);
+            if content_length.is_none() {
+                if let Some(header_end) = request.windows(4).position(|part| part == b"\r\n\r\n") {
+                    let headers = String::from_utf8_lossy(&request[..header_end]);
+                    content_length = Some(
+                        headers
+                            .lines()
+                            .find_map(|line| {
+                                line.strip_prefix("content-length: ")
+                                    .or_else(|| line.strip_prefix("Content-Length: "))
+                            })
+                            .map(|value| value.parse::<usize>().expect("content length"))
+                            .unwrap_or(0),
+                    );
+                }
+            }
+            if let (Some(header_end), Some(content_length)) = (
+                request.windows(4).position(|part| part == b"\r\n\r\n"),
+                content_length,
+            ) {
+                if request.len() >= header_end + 4 + content_length {
+                    break;
+                }
+            }
+        }
+        String::from_utf8(request).expect("UTF-8 request")
+    }
+
+    fn controller_job(
+        id: uuid::Uuid,
+        status: homeboy_core::api_jobs::JobStatus,
+    ) -> homeboy_core::api_jobs::Job {
+        homeboy_core::api_jobs::Job {
+            id,
+            operation: format!("controller.{LAB_STAGING_DISPATCH_JOB_TYPE}"),
+            status,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            started_at_ms: None,
+            finished_at_ms: None,
+            event_count: 0,
+            source_snapshot: None,
+            path_materialization_plan: None,
+            stale_reason: None,
+            daemon_lease_id: None,
+            target_runner_id: None,
+            target_project_id: None,
+            claim_id: None,
+            claimed_by_runner_id: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            artifacts: Vec::new(),
+            runner_job_projection: None,
+        }
+    }
+
+    #[test]
+    fn controller_submission_recovers_create_and_start_after_accepted_response_loss() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let endpoint = format!("http://{}", listener.local_addr().expect("address"));
+        let job_id = uuid::Uuid::new_v4();
+        let server = std::thread::spawn(move || {
+            let mut requests = Vec::new();
+            for index in 0..4 {
+                let (mut stream, _) = listener.accept().expect("accept request");
+                requests.push(read_http_request(&mut stream));
+                if index == 0 || index == 2 {
+                    continue;
+                }
+                let status = if index == 1 {
+                    homeboy_core::api_jobs::JobStatus::Queued
+                } else {
+                    homeboy_core::api_jobs::JobStatus::Running
+                };
+                let body = json!({
+                    "success": true,
+                    "data": { "body": { "job": controller_job(job_id, status) } },
+                })
+                .to_string();
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                )
+                .expect("write response");
+            }
+            requests
+        });
+        let client = Client::builder()
+            .no_proxy()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .expect("client");
+        let create_body = json!({
+            "job_type": LAB_STAGING_DISPATCH_JOB_TYPE,
+            "version": LAB_STAGING_DISPATCH_VERSION,
+            "request": envelope(),
+            "idempotency_key": "attempt-1",
+        });
+
+        let created = post_controller_job_with_retries(
+            &client,
+            format!("{endpoint}/controller/jobs"),
+            Some(create_body),
+            "create test controller job",
+        )
+        .expect("recover create response");
+        let started = post_controller_job_with_retries(
+            &client,
+            format!("{endpoint}/controller/jobs/{job_id}/start"),
+            None,
+            "start test controller job",
+        )
+        .expect("recover start response");
+        let requests = server.join().expect("server");
+
+        assert_eq!(created.id, job_id);
+        assert_eq!(created.status, homeboy_core::api_jobs::JobStatus::Queued);
+        assert_eq!(started.id, job_id);
+        assert_eq!(started.status, homeboy_core::api_jobs::JobStatus::Running);
+        assert_eq!(requests.len(), 4);
+        assert_eq!(requests[0], requests[1]);
+        assert_eq!(requests[2], requests[3]);
+        assert!(requests[0].starts_with("POST /controller/jobs HTTP/1.1"));
+        assert!(requests[2].starts_with(&format!("POST /controller/jobs/{job_id}/start HTTP/1.1")));
+    }
+
     #[test]
     fn progress_and_result_projections_are_safe() {
         let mut checkpoint = LabStagingCheckpoint::initial(&envelope());
@@ -2786,6 +2957,7 @@ mod tests {
         calls: Mutex<Vec<&'static str>>,
         fail_hydration: Mutex<bool>,
         cancel_during_hydration: Mutex<bool>,
+        recovered_runner_job_id: Mutex<Option<String>>,
     }
 
     impl RecordedStageOperations {
@@ -2806,6 +2978,13 @@ mod tests {
                 .cancel_during_hydration
                 .lock()
                 .expect("cancellation lock") = true;
+        }
+
+        fn recover_runner_job(&self, runner_job_id: &str) {
+            *self
+                .recovered_runner_job_id
+                .lock()
+                .expect("runner job lock") = Some(runner_job_id.to_string());
         }
     }
 
@@ -2917,6 +3096,18 @@ mod tests {
         fn prove_no_runner_admission(&self, _request: &LabStagingExecutionRequest) -> Result<()> {
             self.record("prove-no-admission");
             Ok(())
+        }
+
+        fn recover_admitted_runner_job(
+            &self,
+            _request: &LabStagingExecutionRequest,
+        ) -> Result<Option<String>> {
+            self.record("recover-runner-job");
+            Ok(self
+                .recovered_runner_job_id
+                .lock()
+                .expect("runner job lock")
+                .clone())
         }
 
         fn cancel_and_reconcile_runner_job(
@@ -3037,10 +3228,34 @@ mod tests {
             operations.calls(),
             [
                 "validate",
+                "recover-runner-job",
                 "prove-no-admission",
                 "validate",
                 "cancel-runner-job"
             ]
+        );
+    }
+
+    #[test]
+    fn adapter_cancellation_recovers_child_accepted_before_checkpoint_binding() {
+        let operations = Arc::new(RecordedStageOperations::default());
+        operations.recover_runner_job("runner-job-1");
+        let adapter = StageExecutionAdapter::new(operations.clone());
+        let request = execution_request();
+        let mut dispatching = LabStagingCheckpoint::initial(&envelope());
+        dispatching.phase = LabStagingPhase::DispatchRunner;
+        dispatching.source_snapshot_id = Some("snapshot-1".to_string());
+        dispatching.workspace_id = Some("workspace-1".to_string());
+        dispatching.runtime_id = Some("runtime-1".to_string());
+        dispatching.hydration_id = Some("hydration-1".to_string());
+
+        adapter
+            .cancel(&request, &dispatching)
+            .expect("cancel accepted child before checkpoint binding");
+
+        assert_eq!(
+            operations.calls(),
+            ["validate", "recover-runner-job", "cancel-runner-job"]
         );
     }
 

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -418,9 +418,10 @@ fn post_controller_job_with_retries(
         }
     }
     Err(Error::internal_unexpected(format!(
-        "{operation} did not receive a valid response after {CONTROLLER_SUBMISSION_ATTEMPTS} idempotent attempts; reconcile controller jobs for this run before retrying: {}",
+        "{operation} did not receive a valid response after {CONTROLLER_SUBMISSION_ATTEMPTS} idempotent attempts; the durable request may have been accepted, so retry this same run identity to reconcile it: {}",
         last_failure.unwrap_or_else(|| "unknown transport failure".to_string())
-    )))
+    ))
+    .with_retryable(true))
 }
 
 fn controller_job_from_response(value: &Value, status: u16) -> Result<homeboy_core::api_jobs::Job> {
@@ -2468,6 +2469,12 @@ impl LabStagingExecutionAdapter for StageExecutionAdapter {
             None => {
                 if self.operations.cancel_active_staging_jobs(request)? > 0 {
                     Ok(())
+                } else if checkpoint.phase == LabStagingPhase::DispatchRunner
+                    && checkpoint.stage_intent.is_some()
+                {
+                    Err(Error::internal_unexpected(
+                        "Lab staging cancellation cannot prove that an in-flight dispatch was not accepted; keep the lifecycle uncertain until its immutable run identity is reconciled",
+                    ))
                 } else {
                     self.operations.prove_no_runner_admission(request)
                 }
@@ -2979,6 +2986,36 @@ mod tests {
     }
 
     #[test]
+    fn controller_submission_exhaustion_reports_uncertain_retryable_acceptance() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let endpoint = format!("http://{}", listener.local_addr().expect("address"));
+        let server = std::thread::spawn(move || {
+            for _ in 0..CONTROLLER_SUBMISSION_ATTEMPTS {
+                let (mut stream, _) = listener.accept().expect("accept request");
+                let _ = read_http_request(&mut stream);
+            }
+        });
+        let client = Client::builder()
+            .no_proxy()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .expect("client");
+
+        let error = post_controller_job_with_retries(
+            &client,
+            format!("{endpoint}/controller/jobs"),
+            Some(json!({ "idempotency_key": "attempt-1" })),
+            "create test controller job",
+        )
+        .expect_err("all accepted responses are lost");
+        server.join().expect("server");
+
+        assert_eq!(error.retryable, Some(true));
+        assert!(error.message.contains("may have been accepted"));
+        assert!(error.message.contains("same run identity"));
+    }
+
+    #[test]
     fn progress_and_result_projections_are_safe() {
         let mut checkpoint = LabStagingCheckpoint::initial(&envelope());
         checkpoint.phase = LabStagingPhase::Completed;
@@ -3341,6 +3378,34 @@ mod tests {
         assert_eq!(
             operations.calls(),
             ["validate", "recover-runner-job", "cancel-runner-job"]
+        );
+    }
+
+    #[test]
+    fn adapter_cancellation_fails_uncertain_for_unreconciled_dispatch_intent() {
+        let operations = Arc::new(RecordedStageOperations::default());
+        let adapter = StageExecutionAdapter::new(operations.clone());
+        let request = execution_request();
+        let mut dispatching = LabStagingCheckpoint::initial(&envelope());
+        dispatching.phase = LabStagingPhase::DispatchRunner;
+        dispatching.source_snapshot_id = Some("snapshot-1".to_string());
+        dispatching.workspace_id = Some("workspace-1".to_string());
+        dispatching.runtime_id = Some("runtime-1".to_string());
+        dispatching.hydration_id = Some("hydration-1".to_string());
+        dispatching.stage_intent = Some(dispatching.intent_for_current_action());
+
+        let error = adapter
+            .cancel(&request, &dispatching)
+            .expect_err("an in-flight dispatch without a child identity is uncertain");
+
+        assert!(error.message.contains("cannot prove"));
+        assert_eq!(
+            operations.calls(),
+            [
+                "validate",
+                "recover-runner-job",
+                "cancel-active-staging-jobs"
+            ]
         );
     }
 

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -173,6 +173,7 @@ pub use lab::{
 pub(crate) use lab_env::build_lab_offload_env;
 pub use lab_offload_provider::register as register_runner_lab_offload_provider;
 pub use lab_selection::prepare_explicit_lab_runner_for_offload;
+pub use lab_staging_controller::enable_production_routing as enable_production_lab_staging;
 pub use lab_staging_controller::register as register_lab_staging_controller_driver;
 pub use lab_staging_controller::{
     load_lab_staging_recipe, persist_lab_staging_recipe, LabStagingRecipe, LabStagingRecipeRef,

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -43,6 +43,7 @@ mod execution;
 mod execution_bundle;
 mod extension_materialization;
 mod generation_store;
+pub mod lab_staging_controller;
 pub fn runner_generation_inventory(runner_id: &str) -> Result<Vec<RunnerDaemonGenerationStatus>> {
     let report = connection::status(runner_id)?;
     generation_store::status_projection(runner_id, report.session.as_ref())
@@ -57,7 +58,7 @@ mod lab_capabilities;
 mod lab_command;
 mod lab_env;
 mod lab_offload_provider;
-mod lab_plan;
+pub(crate) mod lab_plan;
 mod lab_selection;
 mod lab_workspace_provenance_provider;
 mod lab_workspaces;
@@ -172,6 +173,11 @@ pub use lab::{
 pub(crate) use lab_env::build_lab_offload_env;
 pub use lab_offload_provider::register as register_runner_lab_offload_provider;
 pub use lab_selection::prepare_explicit_lab_runner_for_offload;
+pub use lab_staging_controller::register as register_lab_staging_controller_driver;
+pub use lab_staging_controller::{
+    load_lab_staging_recipe, persist_lab_staging_recipe, LabStagingRecipe, LabStagingRecipeRef,
+    LabStagingRequest,
+};
 pub use lab_workspace_provenance_provider::register as register_lab_workspace_provenance_provider;
 pub use offload_changed_since::{
     lab_offload_changed_since_ref, preflight_lab_offload_changed_since,

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -34,7 +34,7 @@ pub(super) struct RigComponentDependency {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-pub(super) struct LabOffloadRigSync {
+pub(crate) struct LabOffloadRigSync {
     pub rig_id: String,
     pub source: String,
     pub source_kind: LabOffloadRigSyncSource,

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -446,10 +446,12 @@ fn controller_jobs_are_durable_idempotent_and_fail_closed_after_restart() {
     store
         .claim_controller_execution(resumable_id, false)
         .expect("durably claim resumable work");
-    store
-        .handle(resumable_id)
-        .record_controller_prepared(serde_json::json!({ "checkpoint": true }))
-        .expect("persist resume checkpoint");
+    crate::daemon::controller_job_driver::ControllerJobHandle::new(
+        store.handle(resumable_id),
+        controller_job_driver::driver("test.blocking", 1).expect("registered driver"),
+    )
+    .checkpoint(serde_json::json!({ "checkpoint": true }))
+    .expect("persist resume checkpoint through driver handle");
     let unresolved = route_with_body(
         "POST",
         "/controller/jobs",

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -24,6 +24,63 @@ struct BlockingControllerDriver {
     cancellations: Arc<AtomicUsize>,
 }
 
+struct RecoveryCancellationControllerDriver {
+    cancelled_checkpoint: mpsc::Sender<Value>,
+    release_cancel: Arc<Mutex<mpsc::Receiver<()>>>,
+    executions: Arc<AtomicUsize>,
+}
+
+impl ControllerJobDriver for RecoveryCancellationControllerDriver {
+    fn job_type(&self) -> &'static str {
+        "test.recovery-cancellation"
+    }
+    fn version(&self) -> u32 {
+        1
+    }
+    fn public_request(&self, _request: &Value) -> Result<Value> {
+        Ok(serde_json::json!({}))
+    }
+    fn public_progress(&self, _progress: &Value) -> Result<Value> {
+        Ok(serde_json::json!({}))
+    }
+    fn public_result(&self, _result: &Value) -> Result<Value> {
+        Ok(serde_json::json!({}))
+    }
+    fn public_error(
+        &self,
+        _error: &crate::error::Error,
+    ) -> controller_job_driver::ControllerJobPublicError {
+        controller_job_driver::ControllerJobPublicError {
+            message: "recovery cancellation failed".to_string(),
+            data: serde_json::json!({ "classification": "recovery_cancellation_failed" }),
+        }
+    }
+    fn validate_secret_references(&self, _request: &Value) -> Result<()> {
+        Ok(())
+    }
+    fn execute(
+        &self,
+        _prepared: Value,
+        _job: crate::daemon::controller_job_driver::ControllerJobHandle,
+    ) -> Result<Value> {
+        self.executions.fetch_add(1, Ordering::SeqCst);
+        Err(crate::error::Error::internal_unexpected(
+            "cancelled recovery resumed execution",
+        ))
+    }
+    fn cancel(&self, prepared: &Value) -> Result<()> {
+        self.cancelled_checkpoint
+            .send(prepared.clone())
+            .expect("test observes recovered checkpoint cancellation");
+        self.release_cancel
+            .lock()
+            .expect("cancel release lock")
+            .recv()
+            .expect("test releases recovered cancellation");
+        Ok(())
+    }
+}
+
 impl ControllerJobDriver for BlockingControllerDriver {
     fn job_type(&self) -> &'static str {
         self.job_type
@@ -492,6 +549,89 @@ fn controller_jobs_are_durable_idempotent_and_fail_closed_after_restart() {
         restarted.get(unresolved_id).expect("unstarted job").status,
         JobStatus::Queued
     );
+}
+
+#[test]
+fn recovered_cancellation_calls_driver_with_checkpoint_before_terminalizing() {
+    let _home = HomeGuard::new();
+    let path = crate::paths::daemon_jobs_file().expect("jobs path");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store");
+    let (cancelled_checkpoint_tx, cancelled_checkpoint_rx) = mpsc::channel();
+    let (release_cancel_tx, release_cancel_rx) = mpsc::channel();
+    let executions = Arc::new(AtomicUsize::new(0));
+    controller_job_driver::register_controller_job_driver(Arc::new(
+        RecoveryCancellationControllerDriver {
+            cancelled_checkpoint: cancelled_checkpoint_tx,
+            release_cancel: Arc::new(Mutex::new(release_cancel_rx)),
+            executions: Arc::clone(&executions),
+        },
+    ))
+    .expect("register recovery cancellation driver once");
+
+    let submitted = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.recovery-cancellation",
+            "version": 1,
+            "idempotency_key": "restart-cancellation-9163",
+            "request": {}
+        })),
+        &store,
+    );
+    let job_id = uuid::Uuid::parse_str(
+        submitted.body["body"]["job"]["id"]
+            .as_str()
+            .expect("job id"),
+    )
+    .expect("valid job id");
+    store
+        .claim_controller_execution(job_id, false)
+        .expect("durably claim abandoned work");
+    let checkpoint = serde_json::json!({ "recovery": "checkpoint-9163" });
+    crate::daemon::controller_job_driver::ControllerJobHandle::new(
+        store.handle(job_id),
+        controller_job_driver::driver("test.recovery-cancellation", 1).expect("registered driver"),
+    )
+    .checkpoint(checkpoint.clone())
+    .expect("persist recovery checkpoint");
+    store
+        .request_controller_cancellation(job_id, "daemon crashed".to_string())
+        .expect("persist cancellation intent");
+
+    let restarted = JobStore::open_without_reconciliation(&path).expect("reopen durable store");
+    recover_controller_jobs(&restarted);
+    assert_eq!(
+        cancelled_checkpoint_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("driver cancellation receives checkpoint"),
+        checkpoint
+    );
+    assert_eq!(
+        restarted.get(job_id).expect("recovering job").status,
+        JobStatus::Running
+    );
+    assert_eq!(executions.load(Ordering::SeqCst), 0);
+
+    release_cancel_tx
+        .send(())
+        .expect("release recovered cancellation");
+    for _ in 0..100 {
+        if restarted
+            .get(job_id)
+            .expect("recovered job")
+            .status
+            .is_terminal()
+        {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    assert_eq!(
+        restarted.get(job_id).expect("cancelled job").status,
+        JobStatus::Cancelled
+    );
+    assert_eq!(executions.load(Ordering::SeqCst), 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- transfer detached direct-daemon Lab ownership to a durable controller job before workspace materialization
- checkpoint workspace, runtime, dependency hydration, runner dispatch, and terminal observation with immutable private receipts
- reconcile response loss, daemon restart, cancellation, strict renewable admission, and accepted runner-child ownership without duplicate effects
- keep ambiguous unreceipted effects fail-closed and preserve explicit uncertainty when acceptance cannot be disproved
- register production routing explicitly while preserving existing foreground and reverse-broker paths

## Verification

- `cargo test -p homeboy-lab-runner lab_staging_controller::tests -- --test-threads=1` (29 passed)
- `cargo test -p homeboy-core recovered_cancellation_calls_driver_with_checkpoint_before_terminalizing -- --test-threads=1`
- `cargo test -p homeboy-core controller_job -- --test-threads=1` (8 passed)
- `cargo test -p homeboy-lab-runner hydration_execution_ids_own_generic_runner_exec_lifecycles -- --test-threads=1`
- `cargo check -p homeboy-cli -p homeboy-lab-runner -p homeboy-agents`
- touched files pass `rustfmt --check` and `git diff --check`

Repository-wide `cargo fmt --all -- --check` currently reports a pre-existing formatting diff in `crates/contracts/homeboy-lab-contract/src/lab/handoff.rs`, outside this PR.

## Follow-up

Reverse detached staging remains caller-owned before broker acceptance and is tracked separately in #9541.

Closes #9163