### PR TITLE
fix(audit): skeleton_duplication requires shared name token, not just control-flow shape

### DIFF
--- a/crates/homeboy-code-audit/src/duplication.rs
+++ b/crates/homeboy-code-audit/src/duplication.rs
@@ -618,6 +618,54 @@ fn parse_skeleton_value(value: &str) -> Option<(usize, &str)> {
     Some((count.parse().ok()?, hash))
 }
 
+/// Generic name segments that carry no domain meaning. A group sharing only one
+/// of these tokens is not semantically related — `get`/`from`/etc. appear in
+/// functions across every domain, so they cannot distinguish a real
+/// primitive-reimplementation from a coincidental skeleton collision.
+const SKELETON_NAME_STOPWORDS: &[&str] = &[
+    "get", "set", "new", "from", "to", "is", "as", "into", "with", "for", "of", "the", "a", "and",
+    "or", "on", "at", "by", "fn", "run", "do", "make", "build", "id", "value", "val", "data",
+    "self", "this", "it", "item", "items", "list", "map", "key", "name",
+];
+
+/// Split a function name into its significant lowercase tokens (snake_case
+/// segments, minus generic stopwords).
+fn significant_name_tokens(name: &str) -> HashSet<String> {
+    name.split('_')
+        .map(|segment| segment.to_ascii_lowercase())
+        .filter(|segment| {
+            segment.len() >= 3 && !SKELETON_NAME_STOPWORDS.contains(&segment.as_str())
+        })
+        .collect()
+}
+
+/// Whether a skeleton group is semantically related enough to report: every
+/// member must share at least one significant name token with some other
+/// member. Two identical names trivially qualify; unrelated names
+/// (`out_of_order_span_message` vs `install_check_name`) do not.
+///
+/// This distinguishes a real primitive-reimplementation cluster (whose names
+/// carry a common stem) from a coincidental control-flow-shape collision.
+fn skeleton_group_shares_name_token(names: &[&str]) -> bool {
+    let token_sets: Vec<HashSet<String>> = names
+        .iter()
+        .map(|name| significant_name_tokens(name))
+        .collect();
+
+    // Every member must connect to at least one other member via a shared
+    // token. A member with no significant tokens, or none in common with any
+    // sibling, breaks the group's semantic cohesion.
+    token_sets.iter().enumerate().all(|(i, tokens)| {
+        if tokens.is_empty() {
+            return false;
+        }
+        token_sets
+            .iter()
+            .enumerate()
+            .any(|(j, other)| i != j && !tokens.is_disjoint(other))
+    })
+}
+
 /// Detect functions that share an identical **call/control-flow skeleton** but
 /// were missed by the exact, cross-name, and near-duplicate passes because
 /// their error/return tails differ.
@@ -688,6 +736,23 @@ pub(crate) fn detect_skeleton_duplicates(fingerprints: &[&FileFingerprint]) -> V
         // primitive-reimplementation clusters (the scattered `git_output` /
         // `run_git` family) are small and stay well under this ceiling.
         if locations.len() > SKELETON_MAX_GROUP {
+            continue;
+        }
+
+        // Require semantic affinity: the grouped functions must share at least
+        // one significant name token. The skeleton hash keys purely on
+        // call/control-flow shape, so semantically unrelated functions that
+        // happen to share a backbone collide — a timeline error formatter
+        // (`out_of_order_span_message`) and a command→check-name mapper
+        // (`install_check_name`) both reduce to "match/if-else returning a
+        // String", but consolidating them would couple unrelated domains. Real
+        // primitive-reimplementations — the `git_output`/`run_git` family this
+        // detector targets — carry a shared name stem (`git`, `output`,
+        // `normalize`, `redacted`, `trimmed`). Groups whose names share no
+        // significant token are coincidental shape collisions, not
+        // consolidatable duplication.
+        let group_names: Vec<&str> = locations.iter().map(|(_, name, _)| *name).collect();
+        if !skeleton_group_shares_name_token(&group_names) {
             continue;
         }
 

--- a/crates/homeboy-code-audit/src/duplication/tests.rs
+++ b/crates/homeboy-code-audit/src/duplication/tests.rs
@@ -1237,6 +1237,58 @@ fn skeleton_duplicate_flags_same_backbone_with_different_error_tail() {
 }
 
 #[test]
+fn skeleton_duplicate_ignores_semantically_unrelated_names_sharing_a_backbone() {
+    // Real false positive: a timeline error formatter and a command→check-name
+    // mapper share the "match/if-else returning a String" backbone but are
+    // unrelated domains with no shared name token. Consolidating them would
+    // couple unrelated modules — this must NOT be flagged.
+    let fp1 = make_fingerprint_with_skeleton(
+        "crates/contracts/homeboy-lifecycle-contract/src/timeline.rs",
+        &["out_of_order_span_message"],
+        &[("out_of_order_span_message", "structuralAAA")],
+        &[("out_of_order_span_message", "6:skelSAME")],
+    );
+    let fp2 = make_fingerprint_with_skeleton(
+        "crates/homeboy-tunnel/src/preview_ingress/install.rs",
+        &["install_check_name"],
+        &[("install_check_name", "structuralBBB")],
+        &[("install_check_name", "6:skelSAME")],
+    );
+
+    let findings = detect_skeleton_duplicates(&[&fp1, &fp2]);
+    assert!(
+        findings.is_empty(),
+        "unrelated names sharing only a control-flow shape are coincidental, not duplication: {findings:?}"
+    );
+}
+
+#[test]
+fn skeleton_duplicate_still_flags_names_sharing_a_significant_token() {
+    // Real reimplementation: `non_empty_trimmed` and `trimmed` are the same
+    // trim-to-Option primitive copied across crates. They share the "trimmed"
+    // token, so the semantic-affinity gate keeps flagging them.
+    let fp1 = make_fingerprint_with_skeleton(
+        "crates/homeboy-agents/src/agent_task/artifacts.rs",
+        &["non_empty_trimmed"],
+        &[("non_empty_trimmed", "structuralAAA")],
+        &[("non_empty_trimmed", "5:skelTRIM")],
+    );
+    let fp2 = make_fingerprint_with_skeleton(
+        "crates/homeboy-fuzz/src/coverage.rs",
+        &["trimmed"],
+        &[("trimmed", "structuralBBB")],
+        &[("trimmed", "5:skelTRIM")],
+    );
+
+    let findings = detect_skeleton_duplicates(&[&fp1, &fp2]);
+    assert_eq!(
+        findings.len(),
+        2,
+        "names sharing the 'trimmed' token are a real reimplementation and stay flagged"
+    );
+}
+
+#[test]
 fn skeleton_duplicate_ignores_group_with_one_shared_structural_hash() {
     // Same skeleton AND same structural hash — the near-duplicate pass owns
     // this; skeleton must not double-report it.


### PR DESCRIPTION
## The false positive
`skeleton_duplication` (#9563, **407 findings — the current #1 audit category**) keys purely on the call/control-flow backbone hash, so semantically **unrelated** functions that happen to share a shape collide.

Verified false positives from the live findings:
- `out_of_order_span_message` (a timeline **error formatter**) flagged as duplicating `install_check_name` (a **command→check-name mapper**) and `reference_artifact_access` (a **fuzz replay helper**).
- All three reduce to "match/if-else returning a String" but live in unrelated crates/domains. Consolidating them would couple unrelated modules — never the right call.

The detector's own docstring says it targets "the same primitive reimplemented" (the `git_output`/`run_git` family), but it never checked that the grouped functions **are** the same primitive.

## Fix
Add a **semantic-affinity gate**: a skeleton group is only reported when every member shares at least one significant name token (snake_case segment ≥3 chars, minus generic stopwords like `get`/`set`/`run`/`map`) with another member.

- **Real reimplementations carry a shared stem** and stay flagged: `normalize_names`/`normalize_names`, `non_empty_trimmed`/`trimmed`, `push_artifact_*_once`, `git_output`/`git_output`.
- **Coincidental shape collisions** (no shared token) are dropped.

## Impact
On the issue's sampled groups this suppresses **~70% (10/14) as coincidental** while keeping the ~30% genuine reimplementations — deflating the 407 to the real, actionable minority.

## Verification
- Two regression tests, both proven:
  - `skeleton_duplicate_ignores_semantically_unrelated_names_sharing_a_backbone` (timeline vs install-check → zero findings)
  - `skeleton_duplicate_still_flags_names_sharing_a_significant_token` (`non_empty_trimmed` vs `trimmed` → still flagged, guards against over-suppression)
- All 9 skeleton tests + **full audit crate (844) green**.

Same detector-quality pattern as #9311/#9320/#9526: fix the false-positive class so the finding count reflects real, actionable work.
