### PR TITLE
Bind terminal Lab jobs before snapshot validation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
@@ -267,6 +267,14 @@ pub(crate) fn bind_pending_lab_handoff_snapshot(
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
+    if record.state.is_terminal() {
+        // The runner can finish and mirror its aggregate before the controller
+        // projects the daemon snapshot. Preserve that terminal outcome while
+        // attaching the authoritative job identity needed for validation.
+        *record =
+            record_runner_job_identity(&record.run_id, &runner_id, &snapshot.job.id.to_string())?;
+        return Ok(());
+    }
     *record = record_detached_lab_run(DetachedLabRunRecord {
         run_id: &record.run_id,
         runner_id: &runner_id,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -877,6 +877,44 @@ fn foreground_terminal_projection_binds_a_pending_handoff_before_validation() {
 }
 
 #[test]
+fn terminal_aggregate_binds_runner_job_before_snapshot_validation() {
+    with_isolated_home(|_| {
+        let run_id = "cook-terminal-aggregate-preacceptance-bind";
+        let plan = test_plan();
+        let record = record_lab_offload_phase(
+            run_id,
+            "homeboy-lab",
+            "lab_handoff_preacceptance",
+            Some("/runner/workspace/homeboy"),
+            None,
+            None,
+            Some(&plan),
+        )
+        .expect("persist planned controller execution");
+        let aggregate = succeeded_aggregate(&plan);
+        store::write_aggregate(run_id, &aggregate).expect("aggregate written");
+        let terminal = status(run_id).expect("aggregate terminalizes the run");
+        assert_eq!(terminal.state, AgentTaskRunState::Succeeded);
+        assert!(terminal.runner_job_id().is_none());
+
+        let mut snapshot = terminal_child_snapshot(&aggregate);
+        let accepted_job_id = snapshot.job.id.to_string();
+        let identity = &mut snapshot.events[0].data.as_mut().expect("event data")["identity"];
+        identity["run_id"] = json!(run_id);
+        identity["persisted_run_id"] = json!(run_id);
+
+        let projected = project_terminal_runner_result(&record.run_id, &snapshot)
+            .expect("terminal run binds the daemon job before validation");
+        assert!(!projected, "the matching aggregate was already projected");
+
+        let bound = status(run_id).expect("bound terminal run");
+        assert_eq!(bound.state, AgentTaskRunState::Succeeded);
+        assert_eq!(bound.runner_id(), Some("homeboy-lab"));
+        assert_eq!(bound.runner_job_id(), Some(accepted_job_id.as_str()));
+    });
+}
+
+#[test]
 fn snapshot_validation_reports_missing_controller_identity_distinctly() {
     // Issue #9240: when the controller has never established an accepted runner
     // job identity and no pending handoff can bind one, snapshot validation must


### PR DESCRIPTION
## Summary

- bind the authoritative daemon job identity onto an already-terminal agent-task record before snapshot validation
- preserve the mirrored terminal outcome instead of routing through detached-run acceptance, which intentionally refuses terminal resurrection
- add lifecycle regression coverage for a runner aggregate that terminalizes before its daemon snapshot is projected

## Root cause

The provider completed and mirrored its aggregate before the controller projected the daemon snapshot. `bind_pending_lab_handoff_snapshot()` delegated to `record_detached_lab_run()`, which correctly returned the terminal record unchanged, leaving `runner_job_id` empty. Snapshot validation then rejected the authoritative daemon job as unbound.

## Verification

- `cargo test -p homeboy-agents terminal_aggregate_binds_runner_job_before_snapshot_validation`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::handoff_and_proxy` (42 passed)
- `rustfmt --edition 2021 --check crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs`
- `git diff --check`

Repository-wide `cargo fmt --all -- --check` still reports pre-existing formatting drift in `crates/contracts/homeboy-lab-contract/src/lab/handoff.rs`; the changed files pass `rustfmt --check`.

Closes #9571

## AI assistance

- **AI assistance:** Yes
- **Tool:** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Runtime evidence analysis, implementation, deterministic regression coverage, and verification.