### PR TITLE
Persist accepted Lab runner identity before recovery

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -815,6 +815,28 @@ pub fn recorded_runner_job_identity(run_id: &str) -> Result<Option<(String, Stri
         .map(|(runner_id, runner_job_id)| (runner_id.to_string(), runner_job_id.to_string())))
 }
 
+/// Read only a typed, daemon-authoritative accepted Lab handoff. Unlike the
+/// compatibility metadata projection, this cannot be forged by mutating a run
+/// record's `runner_id` or `runner_job_id` fields.
+pub fn accepted_lab_runner_job_identity(
+    run_id: &str,
+) -> Result<Option<homeboy_core::lab_contract::RunnerJobIdentity>> {
+    let record = store::read_record(&sanitize_run_id(run_id))?;
+    let Some(handoff) = record.lab_handoff.as_ref().filter(|handoff| {
+        handoff.validation_error().is_none()
+            && handoff.state == AgentTaskLabHandoffState::Accepted
+            && handoff.authority == AgentTaskLabHandoffAuthority::RunnerDaemon
+    }) else {
+        return Ok(None);
+    };
+    let identity = homeboy_core::lab_contract::RunnerJobIdentity::new(
+        &record.run_id,
+        &handoff.runner_id,
+        handoff.runner_job_id.clone().unwrap_or_default(),
+    );
+    Ok(identity.is_complete().then_some(identity))
+}
+
 /// Metadata `kind` marker for a generic runner-execution run. It distinguishes
 /// an ad hoc `runner exec --run-id` durable run from an agent-task lifecycle
 /// record so ownership collisions are detectable (#8447).
@@ -1397,6 +1419,31 @@ pub struct DetachedLabRunRecord<'a> {
     pub runner_job_id: &'a str,
     pub remote_workspace: &'a str,
     pub remote_command: &'a [String],
+}
+
+/// Atomically persist a daemon-accepted Lab job before a caller can inspect its
+/// snapshot. The typed identity keeps every acceptance path on the canonical
+/// run/runner/job comparison used by reconciliation and terminal projection.
+pub fn bind_accepted_lab_runner_job(
+    identity: &homeboy_core::lab_contract::RunnerJobIdentity,
+    remote_workspace: &str,
+    remote_command: &[String],
+) -> Result<AgentTaskRunRecord> {
+    if !identity.is_complete() {
+        return Err(Error::validation_invalid_argument(
+            "runner_job_identity",
+            "accepted Lab runner job identity requires run id, runner id, and runner job id",
+            Some(identity.describe()),
+            None,
+        ));
+    }
+    record_detached_lab_run(DetachedLabRunRecord {
+        run_id: &identity.run_id,
+        runner_id: &identity.runner_id,
+        runner_job_id: &identity.runner_job_id,
+        remote_workspace,
+        remote_command,
+    })
 }
 
 #[derive(Debug, Clone)]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -543,7 +543,7 @@ impl AgentTaskLabHandoff {
         self.validation_error().is_none()
     }
 
-    fn validation_error(&self) -> Option<&'static str> {
+    pub(crate) fn validation_error(&self) -> Option<&'static str> {
         if self.runner_id.trim().is_empty() {
             return Some("Lab handoff runner_id is blank");
         }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -104,6 +104,80 @@ fn accepted_detached_handoff(run_id: &str) -> AgentTaskRunRecord {
 }
 
 #[test]
+fn accepted_runner_identity_binds_before_snapshot_validation_and_survives_caller_loss() {
+    with_isolated_home(|_| {
+        let run_id = "cook-9567-pre-provider-race";
+        let plan = test_plan();
+        record_lab_offload_phase(
+            run_id,
+            "homeboy-lab",
+            "provider_dispatch",
+            Some("/runner/workspace/homeboy"),
+            None,
+            None,
+            Some(&plan),
+        )
+        .expect("persist pending handoff before daemon acceptance");
+        let identity = homeboy_core::lab_contract::RunnerJobIdentity::new(
+            run_id,
+            "homeboy-lab",
+            "00000000-0000-0000-0000-000000009567",
+        );
+
+        // Daemon admission persists the typed accepted identity before a
+        // foreground caller can observe a snapshot or disappear.
+        let accepted = bind_accepted_lab_runner_job(&identity, "/runner/workspace/homeboy", &[])
+            .expect("bind accepted daemon job");
+        let replay = bind_accepted_lab_runner_job(&identity, "/runner/workspace/homeboy", &[])
+            .expect("repeated acceptance is idempotent");
+        assert_eq!(accepted, replay);
+
+        let foreign = bind_accepted_lab_runner_job(
+            &homeboy_core::lab_contract::RunnerJobIdentity::new(
+                run_id,
+                "homeboy-lab",
+                "00000000-0000-0000-0000-000000009568",
+            ),
+            "/runner/workspace/homeboy",
+            &[],
+        )
+        .expect_err("a foreign daemon job cannot replace accepted identity");
+        assert_eq!(foreign.code, ErrorCode::ValidationInvalidArgument);
+
+        // Reloading models controller/caller loss after daemon acceptance. A
+        // status reconciliation validates the accepted job directly and never
+        // needs to replay the provider command.
+        let mut recovered = status(run_id).expect("reload accepted handoff");
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
+        snapshot.job.id = uuid::Uuid::parse_str(&identity.runner_job_id).expect("valid job id");
+        snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
+        snapshot.events.clear();
+        reconcile_runner_job_snapshot(&mut recovered, &snapshot)
+            .expect("accepted identity validates recovered runner snapshot");
+        assert_eq!(
+            recovered.runner_job_id(),
+            Some(identity.runner_job_id.as_str())
+        );
+        assert_eq!(recovered.state, AgentTaskRunState::Running);
+    });
+}
+
+#[test]
+fn accepted_runner_identity_rejects_mutable_metadata_without_typed_handoff() {
+    with_isolated_home(|_| {
+        let run_id = "cook-9567-metadata-is-not-acceptance";
+        let mut record = submit_plan(&test_plan(), Some(run_id)).expect("persist run");
+        record.metadata["runner_id"] = json!("homeboy-lab");
+        record.metadata["runner_job_id"] = json!("foreign-job");
+        store::write_record(&record).expect("persist mutable metadata");
+
+        assert!(accepted_lab_runner_job_identity(run_id)
+            .expect("read typed handoff")
+            .is_none());
+    });
+}
+
+#[test]
 fn submit_plan_persists_queued_status() {
     with_isolated_home(|_| {
         let plan = test_plan();

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -168,14 +168,14 @@ pub(super) fn exec_via_reverse_broker(
         // validate a runner snapshot; metadata-only binding leaves the typed
         // handoff pending and loses that identity at preacceptance (#9240).
         if !run_id_owns_generic_exec {
-            homeboy_agents::agent_task_lifecycle::record_detached_lab_run(
-                homeboy_agents::agent_task_lifecycle::DetachedLabRunRecord {
+            homeboy_agents::agent_task_lifecycle::bind_accepted_lab_runner_job(
+                &homeboy_core::lab_contract::RunnerJobIdentity::new(
                     run_id,
-                    runner_id: &runner.id,
-                    runner_job_id: &job.id.to_string(),
-                    remote_workspace: &cwd,
-                    remote_command: &command,
-                },
+                    &runner.id,
+                    job.id.to_string(),
+                ),
+                &cwd,
+                &command,
             )?;
         } else {
             homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -199,14 +199,14 @@ pub(super) fn exec_via_daemon(
             // the controller record. Metadata-only binding leaves the typed
             // handoff pending and can expose a valid snapshot to validation with
             // no accepted controller job identity (#9240).
-            homeboy_agents::agent_task_lifecycle::record_detached_lab_run(
-                homeboy_agents::agent_task_lifecycle::DetachedLabRunRecord {
+            homeboy_agents::agent_task_lifecycle::bind_accepted_lab_runner_job(
+                &homeboy_core::lab_contract::RunnerJobIdentity::new(
                     run_id,
-                    runner_id: &runner.id,
-                    runner_job_id: &job.id.to_string(),
-                    remote_workspace: &cwd,
-                    remote_command: &command,
-                },
+                    &runner.id,
+                    job.id.to_string(),
+                ),
+                &cwd,
+                &command,
             )?;
         } else {
             homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -647,6 +647,14 @@ fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
             run.metadata_json["lab"]["remote_job"]["id"].as_str(),
             Some(job_id)
         );
+        let controller_record = homeboy_agents::agent_task_lifecycle::status(stable_run_id)
+            .expect("accepted reverse-broker handoff remains durable");
+        assert!(controller_record.lab_handoff.is_some_and(|handoff| {
+            handoff.state
+                == homeboy_agents::agent_task_lifecycle::AgentTaskLabHandoffState::Accepted
+                && handoff.runner_id == "lab"
+                && handoff.runner_job_id.as_deref() == Some(job_id)
+        }));
     });
 }
 
@@ -720,6 +728,11 @@ fn direct_daemon_detached_handoff_returns_while_the_workload_remains_running() {
             .expect("controller record remains observable after accepted handoff");
         assert_eq!(controller_record.runner_id(), Some("lab"));
         assert_eq!(controller_record.runner_job_id(), Some(job_id.as_str()));
+        assert!(controller_record.lab_handoff.is_some_and(|handoff| {
+            handoff.state
+                == homeboy_agents::agent_task_lifecycle::AgentTaskLabHandoffState::Accepted
+                && handoff.runner_job_id.as_deref() == Some(job_id.as_str())
+        }));
         wait_for_path(&started, "blocked workload start");
         let client = Client::builder().no_proxy().build().expect("daemon client");
         let job = fetch_daemon_job(&client, &daemon_url, &job_id).expect("running daemon job");

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -598,8 +598,10 @@ struct DurableLabDispatchReceipt {
     workspace_attachment_digest: String,
     runtime_attachment_digest: String,
     hydration_attachment_digest: String,
-    daemon_lease_id: String,
-    reservation_job_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    daemon_lease_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    reservation_job_id: Option<String>,
     runner_job_id: String,
     remote_workspace: String,
     remote_command: Vec<String>,
@@ -649,8 +651,6 @@ impl DurableLabDispatchReceipt {
             || self.workspace_attachment_digest.is_empty()
             || self.runtime_attachment_digest.is_empty()
             || self.hydration_attachment_digest.is_empty()
-            || self.daemon_lease_id.is_empty()
-            || self.reservation_job_id.is_empty()
             || self.runner_job_id.is_empty()
             || self.remote_workspace.is_empty()
             || self.remote_command.is_empty()
@@ -1373,6 +1373,81 @@ impl ProductionLabStagingOperations {
         )
     }
 
+    /// The lifecycle's accepted identity is authoritative once daemon admission
+    /// has completed. A controller crash can occur after that atomic bind but
+    /// before this staging receipt is written; rebuild the receipt from the
+    /// immutable stage attachments instead of submitting the provider again.
+    fn recover_dispatch_receipt(
+        request: &LabStagingExecutionRequest,
+        checkpoint: &LabStagingCheckpoint,
+    ) -> Result<Option<DurableLabDispatchReceipt>> {
+        if let Ok(receipt) = homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
+            DurableLabDispatchReceipt,
+        >(
+            &request.recipe.run_id,
+            DURABLE_LAB_DISPATCH_RECEIPT_ATTACHMENT_KIND,
+        ) {
+            receipt.payload.validate(request, checkpoint)?;
+            return Ok(Some(receipt.payload));
+        }
+        let Some(identity) =
+            homeboy_agents::agent_task_lifecycle::accepted_lab_runner_job_identity(
+                &request.recipe.run_id,
+            )?
+        else {
+            return Ok(None);
+        };
+        if identity.run_id != request.recipe.run_id
+            || identity.runner_id != request.recipe.runner_id
+        {
+            return Err(Error::validation_invalid_argument(
+                "runner_job_identity",
+                "accepted Lab runner identity does not match its staging recipe",
+                Some(identity.describe()),
+                None,
+            ));
+        }
+        let workspace = Self::durable_workspace(request)?;
+        let runtime = Self::durable_runtime(request)?;
+        let hydration = Self::durable_hydration(request)?;
+        let remote_command =
+            serde_json::from_value(runtime.payload.output.get("command").cloned().ok_or_else(
+                || Error::internal_unexpected("durable runtime has no final command"),
+            )?)
+            .map_err(|_| {
+                Error::validation_invalid_argument(
+                    "durable_runtime_stage",
+                    "Lab staging final command is invalid",
+                    None,
+                    None,
+                )
+            })?;
+        let receipt = DurableLabDispatchReceipt {
+            schema: "homeboy/durable-lab-dispatch-receipt/v1".to_string(),
+            run_id: request.recipe.run_id.clone(),
+            runner_id: request.recipe.runner_id.clone(),
+            recipe_digest: canonical_digest(&request.recipe)?,
+            workspace_attachment_digest: workspace.payload_digest,
+            runtime_attachment_digest: runtime.payload_digest,
+            hydration_attachment_digest: hydration.payload_digest,
+            // Lease and reservation evidence authorize submission only. The
+            // accepted lifecycle identity is the recovery authority.
+            daemon_lease_id: None,
+            reservation_job_id: None,
+            runner_job_id: identity.runner_job_id,
+            remote_workspace: workspace.payload.remote_cwd,
+            remote_command,
+            workload_identity: canonical_digest(&hydration.payload.hydration_metadata)?,
+        };
+        receipt.validate(request, checkpoint)?;
+        homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
+            &request.recipe.run_id,
+            DURABLE_LAB_DISPATCH_RECEIPT_ATTACHMENT_KIND,
+            &receipt,
+        )?;
+        Ok(Some(receipt))
+    }
+
     fn cancellation_error() -> Error {
         Error::internal_unexpected("Lab staging was cancelled during runtime materialization")
     }
@@ -1420,14 +1495,8 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
                 .validate(request, checkpoint, &workspace, &runtime)?;
         }
         if checkpoint.final_runner_job_id.is_some() {
-            homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
-                DurableLabDispatchReceipt,
-            >(
-                &request.recipe.run_id,
-                DURABLE_LAB_DISPATCH_RECEIPT_ATTACHMENT_KIND,
-            )?
-            .payload
-            .validate(request, checkpoint)?;
+            Self::recover_dispatch_receipt(request, checkpoint)?
+                .ok_or_else(|| Self::ambiguous_intent("dispatch"))?;
         }
         if checkpoint.phase == LabStagingPhase::Completed {
             homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
@@ -1502,20 +1571,15 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
                 )))
             }
             LabStagingPhase::DispatchRunner => {
-                let dispatch = homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
-                    DurableLabDispatchReceipt,
-                >(
-                    &request.recipe.run_id,
-                    DURABLE_LAB_DISPATCH_RECEIPT_ATTACHMENT_KIND,
-                )
-                .map_err(|_| Self::ambiguous_intent("dispatch"))?;
+                let dispatch = Self::recover_dispatch_receipt(request, checkpoint)?
+                    .ok_or_else(|| Self::ambiguous_intent("dispatch"))?;
                 let mut completed = checkpoint.clone();
                 completed.phase = LabStagingPhase::ObserveRunner;
                 completed.stage_intent = None;
-                completed.final_runner_job_id = Some(dispatch.payload.runner_job_id.clone());
-                dispatch.payload.validate(request, &completed)?;
+                completed.final_runner_job_id = Some(dispatch.runner_job_id.clone());
+                dispatch.validate(request, &completed)?;
                 Ok(Some(LabStagingStageEffect::Dispatch(
-                    dispatch.payload.runner_job_id,
+                    dispatch.runner_job_id,
                 )))
             }
             LabStagingPhase::ObserveRunner => {
@@ -2086,14 +2150,14 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
         }
         // Lifecycle is bound before the receipt and controller checkpoint expose
         // the accepted job to recovery.
-        homeboy_agents::agent_task_lifecycle::record_detached_lab_run(
-            homeboy_agents::agent_task_lifecycle::DetachedLabRunRecord {
-                run_id: &request.recipe.run_id,
-                runner_id: &request.recipe.runner_id,
-                runner_job_id: &runner_job_id,
-                remote_workspace: &workspace.payload.remote_cwd,
-                remote_command: &command,
-            },
+        homeboy_agents::agent_task_lifecycle::bind_accepted_lab_runner_job(
+            &homeboy_core::lab_contract::RunnerJobIdentity::new(
+                &request.recipe.run_id,
+                &request.recipe.runner_id,
+                &runner_job_id,
+            ),
+            &workspace.payload.remote_cwd,
+            &command,
         )?;
         let receipt = DurableLabDispatchReceipt {
             schema: "homeboy/durable-lab-dispatch-receipt/v1".to_string(),
@@ -2103,8 +2167,8 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
             workspace_attachment_digest: workspace.payload_digest,
             runtime_attachment_digest: runtime.payload_digest,
             hydration_attachment_digest: hydration.payload_digest,
-            daemon_lease_id: authority.daemon_lease_id().to_string(),
-            reservation_job_id: authority.reservation_job_id().to_string(),
+            daemon_lease_id: Some(authority.daemon_lease_id().to_string()),
+            reservation_job_id: Some(authority.reservation_job_id().to_string()),
             runner_job_id: runner_job_id.clone(),
             remote_workspace: workspace.payload.remote_cwd,
             remote_command: command,
@@ -3786,8 +3850,8 @@ mod tests {
             workspace_attachment_digest: "sha256:workspace".to_string(),
             runtime_attachment_digest: "sha256:runtime".to_string(),
             hydration_attachment_digest: "sha256:hydration".to_string(),
-            daemon_lease_id: "lease-1".to_string(),
-            reservation_job_id: "reservation-1".to_string(),
+            daemon_lease_id: Some("lease-1".to_string()),
+            reservation_job_id: Some("reservation-1".to_string()),
             runner_job_id: "runner-job-1".to_string(),
             remote_workspace: "/runner/workspace".to_string(),
             remote_command: vec!["homeboy".to_string(), "agent-task".to_string()],
@@ -3800,6 +3864,122 @@ mod tests {
         let mut tampered = receipt;
         tampered.runner_job_id = "other-job".to_string();
         assert!(tampered.validate(&request, &checkpoint).is_err());
+    }
+
+    #[test]
+    fn production_dispatch_recovery_rebuilds_receipt_after_accepted_bind_before_receipt() {
+        let _serial = global_state_lock().lock().expect("lock");
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let request = execution_request();
+            submit_recipe_run(&request.recipe.run_id);
+            homeboy_agents::agent_task_lifecycle::record_lab_offload_phase(
+                &request.recipe.run_id,
+                &request.recipe.runner_id,
+                "dispatching",
+                Some("/runner/workspaces/attempt-1"),
+                None,
+                None,
+                Some(&request.durable_agent_task_plan),
+            )
+            .expect("record staging handoff");
+
+            let workspace = durable_workspace_state(&request);
+            let mut checkpoint = LabStagingCheckpoint::initial(&envelope());
+            checkpoint.phase = LabStagingPhase::DispatchRunner;
+            checkpoint.source_snapshot_id = Some(workspace.source_snapshot_id.clone());
+            checkpoint.workspace_id = Some(workspace.workspace_id.clone());
+            checkpoint.runtime_id = Some("runtime-1".to_string());
+
+            let runtime = DurableLabRuntimeStage {
+                schema: "homeboy/durable-lab-runtime-stage/v1".to_string(),
+                run_id: request.recipe.run_id.clone(),
+                runner_id: request.recipe.runner_id.clone(),
+                recipe_digest: canonical_digest(&request.recipe).expect("recipe digest"),
+                plan_digest: canonical_plan_digest(&request.durable_agent_task_plan)
+                    .expect("plan digest"),
+                workspace_id: workspace.workspace_id.clone(),
+                runtime_id: "runtime-1".to_string(),
+                output: json!({
+                    "remote_cwd": workspace.workspace_id,
+                    "command": ["homeboy", "agent-task", "run-plan"],
+                }),
+            };
+            let hydration_record = json!({ "NotApplied": { "reason": "fixture" } });
+            let hydration = DurableLabHydrationStage {
+                schema: "homeboy/durable-lab-hydration-stage/v1".to_string(),
+                run_id: request.recipe.run_id.clone(),
+                runner_id: request.recipe.runner_id.clone(),
+                recipe_digest: canonical_digest(&request.recipe).expect("recipe digest"),
+                plan_digest: canonical_plan_digest(&request.durable_agent_task_plan)
+                    .expect("plan digest"),
+                workspace_id: workspace.workspace_id.clone(),
+                runtime_id: runtime.runtime_id.clone(),
+                hydration_id: canonical_digest(&hydration_record).expect("hydration digest"),
+                plan: Value::Null,
+                hydration_record: hydration_record.clone(),
+                hydration_metadata: hydration_metadata_from_record(&hydration_record),
+                execution_ids: Vec::new(),
+                dispatch_inputs: json!({
+                    "workspace_stage": workspace.stage,
+                    "runtime_output": runtime.output,
+                    "plan": null,
+                }),
+            };
+            checkpoint.hydration_id = Some(hydration.hydration_id.clone());
+            homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
+                &request.recipe.run_id,
+                DURABLE_LAB_WORKSPACE_STAGE_ATTACHMENT_KIND,
+                &workspace,
+            )
+            .expect("persist workspace receipt");
+            homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
+                &request.recipe.run_id,
+                DURABLE_LAB_RUNTIME_STAGE_ATTACHMENT_KIND,
+                &runtime,
+            )
+            .expect("persist runtime receipt");
+            homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
+                &request.recipe.run_id,
+                DURABLE_LAB_HYDRATION_STAGE_ATTACHMENT_KIND,
+                &hydration,
+            )
+            .expect("persist hydration receipt");
+
+            homeboy_agents::agent_task_lifecycle::bind_accepted_lab_runner_job(
+                &homeboy_core::lab_contract::RunnerJobIdentity::new(
+                    &request.recipe.run_id,
+                    &request.recipe.runner_id,
+                    "runner-job-accepted",
+                ),
+                "/runner/workspaces/attempt-1",
+                &[
+                    "homeboy".to_string(),
+                    "agent-task".to_string(),
+                    "run-plan".to_string(),
+                ],
+            )
+            .expect("bind accepted job before receipt");
+
+            let intent = checkpoint.intent_for_current_action();
+            let recovered = ProductionLabStagingOperations
+                .recover_stage(&request, &checkpoint, &intent)
+                .expect("recover accepted dispatch")
+                .expect("recovered dispatch effect");
+            assert!(matches!(
+                recovered,
+                LabStagingStageEffect::Dispatch(ref job_id) if job_id == "runner-job-accepted"
+            ));
+            let receipt = homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
+                DurableLabDispatchReceipt,
+            >(
+                &request.recipe.run_id,
+                DURABLE_LAB_DISPATCH_RECEIPT_ATTACHMENT_KIND,
+            )
+            .expect("reconstructed dispatch receipt");
+            assert_eq!(receipt.payload.runner_job_id, "runner-job-accepted");
+            assert!(receipt.payload.daemon_lease_id.is_none());
+            assert!(receipt.payload.reservation_job_id.is_none());
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- bind every accepted direct-daemon, reverse-broker, and staged Lab job through the canonical typed runner identity before snapshot observation
- recover a missing staging dispatch receipt from the accepted lifecycle identity and immutable stage attachments without replaying provider dispatch
- reject metadata-only and foreign runner identities as recovery authority

## Root cause

Daemon admission could succeed before the controller persisted its staging dispatch receipt. If the caller disappeared in that window, recovery saw a valid runner snapshot but no durable accepted identity/receipt pair and failed before provider execution. The accepted lifecycle handoff now becomes authoritative at admission, and staging can deterministically rebuild the receipt from that identity.

This complements #9572, which handles the later case where a mirrored aggregate terminalizes before snapshot projection.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p homeboy-agents accepted_runner_identity_binds_before_snapshot_validation_and_survives_caller_loss`
- `cargo test -p homeboy-agents accepted_runner_identity_rejects_mutable_metadata_without_typed_handoff`
- `cargo test -p homeboy-lab-runner production_dispatch_recovery_rebuilds_receipt_after_accepted_bind_before_receipt`
- `cargo test -p homeboy-lab-runner foreground_portable -- --nocapture` (2 passed)

Closes #9567

## AI assistance

- **AI assistance:** Yes
- **Tool:** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause analysis, implementation, regression coverage, verification, and final review.