### PR TITLE
Filter internal refs from reviewer finalization evidence

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -851,6 +851,80 @@ fn durable_finalization_requires_successful_provider_run_and_hydrates_model() {
 }
 
 #[test]
+fn finalization_keeps_internal_durable_refs_for_operators_but_not_reviewers() {
+    let internal_ref = "homeboy://agent-task/run/run-9568/artifacts#task=cook&artifact=patch";
+    let reviewer_ref = "https://github.com/Extra-Chill/homeboy/issues/9568";
+
+    let mut durable_options = options();
+    durable_options.manual_finalization = false;
+    durable_options.changed_files = vec!["src/lib.rs".to_string()];
+    durable_options.evidence.source_refs = vec![reviewer_ref.to_string()];
+    durable_options.evidence.artifact_refs = vec![internal_ref.to_string()];
+    durable_options.review_dossier.evidence.push(
+        crate::agent_task_review_dossier::AgentTaskReviewEvidence {
+            summary: "Hydrated durable artifact".to_string(),
+            url: Some(internal_ref.to_string()),
+        },
+    );
+    let mut durable_gate_proof = successful_gate_proof();
+    durable_gate_proof.promotion.changed_files = vec!["src/lib.rs".to_string()];
+    let mut durable_backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        lifecycle: Some(successful_lifecycle("openai/gpt-5.6-terra")),
+        gate_proof: Some(durable_gate_proof),
+        ..Default::default()
+    };
+    let durable_report = finalize_pr_with_backend(durable_options, &mut durable_backend)
+        .expect("durable finalization succeeds");
+
+    let mut manual_options = options();
+    manual_options.evidence.source_refs = vec![reviewer_ref.to_string()];
+    manual_options.evidence.artifact_refs.clear();
+    manual_options.review_dossier.evidence.push(
+        crate::agent_task_review_dossier::AgentTaskReviewEvidence {
+            summary: "Hydrated source-run artifact".to_string(),
+            url: Some(internal_ref.to_string()),
+        },
+    );
+    let mut manual_backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        ..Default::default()
+    };
+    let manual_report = finalize_pr_with_backend(manual_options, &mut manual_backend)
+        .expect("manual finalization succeeds");
+
+    assert!(durable_report
+        .evidence
+        .artifact_refs
+        .contains(&internal_ref.to_string()));
+    assert!(durable_report
+        .publication_intent
+        .artifact_refs
+        .contains(&internal_ref.to_string()));
+    assert!(manual_report.evidence.artifact_refs.is_empty());
+    assert!(manual_report.publication_intent.artifact_refs.is_empty());
+
+    for (report, body) in [
+        (&durable_report, &durable_backend.last_body),
+        (&manual_report, &manual_backend.last_body),
+    ] {
+        assert!(report
+            .review_dossier
+            .evidence
+            .iter()
+            .any(|evidence| evidence.url.as_deref() == Some(reviewer_ref)));
+        assert!(!report.review_dossier.evidence.iter().any(|evidence| {
+            evidence
+                .url
+                .as_deref()
+                .is_some_and(|url| url.starts_with("homeboy://"))
+        }));
+        assert!(body.contains(reviewer_ref));
+        assert!(!body.contains(internal_ref));
+    }
+}
+
+#[test]
 fn durable_finalization_accepts_only_authenticated_pre_provider_candidate_adoption_recovery() {
     let recovery_lifecycle = RunLifecycleRecord {
         execution: RunExecutionLifecycle {

--- a/crates/homeboy-agents/src/agent_task_review_dossier.rs
+++ b/crates/homeboy-agents/src/agent_task_review_dossier.rs
@@ -410,10 +410,14 @@ impl AgentTaskReviewDossier {
                 );
             }
         }
-        for evidence in &self.evidence {
+        for (index, evidence) in self.evidence.iter().enumerate() {
             scalar("evidence.summary", &evidence.summary)?;
             if let Some(url) = &evidence.url {
-                validate_reviewer_url(url)?;
+                validate_reviewer_url(
+                    &format!("evidence[{index}].url"),
+                    url,
+                    &format!("review dossier evidence summary `{}`", evidence.summary),
+                )?;
             }
         }
         for contract in &self.changed_public_contracts {
@@ -450,7 +454,14 @@ impl AgentTaskReviewDossier {
                 )?;
                 scalar("public_contract_evidence.external_usage.source", &evidence.external_usage.source)?;
                 scalar("public_contract_evidence.external_usage.limitations", &evidence.external_usage.limitations)?;
-                validate_reviewer_url(&evidence.external_usage.url)?;
+                validate_reviewer_url(
+                    "public_contract_evidence.external_usage.url",
+                    &evidence.external_usage.url,
+                    &format!(
+                        "public-contract external usage source `{}`",
+                        evidence.external_usage.source
+                    ),
+                )?;
                 if evidence.compatibility_impact.trim().is_empty()
                     || evidence.external_consumer_impact.trim().is_empty()
                     || evidence.external_usage.source.trim().is_empty()
@@ -517,6 +528,11 @@ pub fn enrich_dossier(
     ci_expected: &[String],
     lifecycle: Option<&homeboy_core::run_lifecycle_record::RunLifecycleRecord>,
 ) {
+    // Durable/operator evidence can be hydrated before finalization. Keep it in
+    // the run report, but do not carry operator-only URLs into the reviewer form.
+    dossier
+        .evidence
+        .retain(|evidence| !evidence.url.as_deref().is_some_and(operator_only_reference));
     for gate in gates {
         dossier.evidence.push(AgentTaskReviewEvidence {
             summary: gate_evidence_summary(gate),
@@ -535,10 +551,20 @@ pub fn enrich_dossier(
             url: None,
         });
     }
-    for reference in source_refs.iter().chain(artifact_refs) {
+    for (provenance, reference) in source_refs
+        .iter()
+        .enumerate()
+        .map(|(index, reference)| (format!("source_refs[{index}]"), reference))
+        .chain(
+            artifact_refs
+                .iter()
+                .enumerate()
+                .map(|(index, reference)| (format!("artifact_refs[{index}]"), reference)),
+        )
+    {
         if is_reviewer_url(reference) {
             dossier.evidence.push(AgentTaskReviewEvidence {
-                summary: "Reviewer-resolvable source evidence".to_string(),
+                summary: format!("Reviewer-resolvable evidence from {provenance}"),
                 url: Some(reference.clone()),
             });
         }
@@ -879,15 +905,22 @@ fn validate_issue_reference(value: &str) -> Result<()> {
 fn is_reviewer_url(value: &str) -> bool {
     value.starts_with("https://") && !operator_only_reference(value)
 }
-fn validate_reviewer_url(value: &str) -> Result<()> {
-    let url = reqwest::Url::parse(value).map_err(|_| {
-        Error::validation_invalid_argument("evidence.url", "evidence URL is invalid", None, None)
-    })?;
+fn validate_reviewer_url(field: &str, value: &str, provenance: &str) -> Result<()> {
+    let url = match reqwest::Url::parse(value) {
+        Ok(url) => url,
+        Err(_) => return invalid_reviewer_url(field, value, provenance, "is invalid"),
+    };
     let host = url.host_str().unwrap_or_default();
-    if operator_only_reference(value) || host.is_empty() {
-        return invalid("evidence.url", "evidence URL must be a public HTTPS URL");
+    if url.scheme() != "https" || operator_only_reference(value) || host.is_empty() {
+        return invalid_reviewer_url(field, value, provenance, "must be a public HTTPS URL");
     }
     Ok(())
+}
+fn invalid_reviewer_url(field: &str, value: &str, provenance: &str, problem: &str) -> Result<()> {
+    invalid(
+        field,
+        &format!("reviewer evidence URL `{value}` from {provenance} {problem}"),
+    )
 }
 fn invalid(field: &str, message: &str) -> Result<()> {
     Err(Error::validation_invalid_argument(
@@ -1102,6 +1135,50 @@ mod tests {
             url: Some("https://localhost/a".into()),
         });
         assert!(value.validate(&default_profile()).is_err());
+    }
+
+    #[test]
+    fn reviewer_url_diagnostic_identifies_the_url_and_its_provenance() {
+        let mut value = dossier();
+        value.evidence.push(AgentTaskReviewEvidence {
+            summary: "durable artifact retained for operators".into(),
+            url: Some("homeboy://agent-task/run/run-9568/artifacts".into()),
+        });
+
+        let error = value
+            .validate(&default_profile())
+            .expect_err("internal URL is not reviewer-resolvable");
+
+        assert!(error
+            .message
+            .contains("homeboy://agent-task/run/run-9568/artifacts"));
+        assert!(error
+            .message
+            .contains("durable artifact retained for operators"));
+    }
+
+    #[test]
+    fn public_contract_url_diagnostic_identifies_the_url_and_source() {
+        let mut value = dossier();
+        value
+            .changed_public_contracts
+            .push(AgentTaskPublicContract {
+                id: "api.widget.render".into(),
+                summary: "Changes the rendered result.".into(),
+            });
+        let mut evidence = public_contract_evidence();
+        evidence.external_usage.source = "Internal durable artifact".into();
+        evidence.external_usage.url = "homeboy://agent-task/run/run-9568/artifacts".into();
+        value.public_contract_evidence = Some(evidence);
+
+        let error = value
+            .validate(&default_profile())
+            .expect_err("internal public-contract URL is not reviewer-resolvable");
+
+        assert!(error
+            .message
+            .contains("homeboy://agent-task/run/run-9568/artifacts"));
+        assert!(error.message.contains("Internal durable artifact"));
     }
 
     fn public_contract_evidence() -> AgentTaskPublicContractEvidence {


### PR DESCRIPTION
## Summary

- remove operator-only URLs already hydrated into a reviewer dossier while retaining them in durable/operator finalization evidence
- add indexed URL provenance to reviewer-evidence validation diagnostics and require public HTTPS URLs
- cover durable and manual finalization with internal run refs plus explicit public source evidence

## Root cause

New source and artifact refs were filtered before entering the reviewer dossier, but evidence already hydrated into the dossier was validated unchanged. A durable `homeboy://` artifact URL therefore reached reviewer validation and blocked finalization even when the caller supplied only public HTTPS evidence.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p homeboy-agents --lib agent_task_finalization::tests` (36 passed)
- `cargo test -p homeboy-agents --lib agent_task_review_dossier::tests` (26 passed)
- independent candidate re-review: no findings, PR-ready

The original broad cook gate also selected an unrelated integration test whose pinned test binary emitted harness output during `self identity`; all intended library finalization tests passed.

Closes #9568

## AI assistance

- **AI assistance:** Yes
- **Tool:** OpenAI GPT-5.6 Terra and GPT-5.6 Sol via Homeboy/OpenCode
- **Used for:** Candidate generation, root-cause correction, deterministic coverage, verification, and independent review.