### PR TITLE
fix(lab): make reverse staging controller-owned

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -703,12 +703,20 @@ where
         }
         agent_task_lifecycle::record_cook_attempt(&cook_id, attempt, &run_id)?;
         let record = agent_task_lifecycle::status(&run_id)?;
-        if record.state == agent_task_lifecycle::AgentTaskRunState::Running
-            && record.runner_job_id().is_some()
+        let controller_owned_staging = record
+            .metadata
+            .get("lab_staging_controller_job_id")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|job_id| !job_id.is_empty());
+        if matches!(
+            record.state,
+            agent_task_lifecycle::AgentTaskRunState::Queued
+                | agent_task_lifecycle::AgentTaskRunState::Running
+        ) && (record.runner_job_id().is_some() || controller_owned_staging)
         {
-            // A detached runner handoff has durably accepted the provider
-            // child. Its daemon owns timeout and provider rotation; this
-            // controller returns without attempting to read a future aggregate.
+            // Detached staging or runner handoff has a durable owner. It owns
+            // timeout and provider rotation, so Cook must not read a future
+            // aggregate before that owner has produced it.
             attempts.push(AgentTaskCookAttemptReport {
                 attempt,
                 run_id: run_id.clone(),

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -1144,11 +1144,19 @@ fn handle_reverse_broker_request(
         return ok(json!({ "content_base64": encoded }));
     }
     if request.method == "GET" {
-        if let Some(job_id) = request.path.strip_prefix("/jobs/") {
-            let job = store
-                .get(uuid::Uuid::parse_str(job_id).expect("broker job id"))
-                .expect("broker job");
-            return ok(json!({ "job": job }));
+        if let Some(job_path) = request.path.strip_prefix("/jobs/") {
+            let (job_id, action) = job_path.split_once('/').unwrap_or((job_path, ""));
+            let job_id = uuid::Uuid::parse_str(job_id).expect("broker job id");
+            return match action {
+                "" => ok(json!({ "job": store.get(job_id).expect("broker job") })),
+                "events" => ok(json!({
+                    "events": store.events(job_id).expect("broker job events")
+                })),
+                _ => json!({
+                    "success": false,
+                    "error": { "message": "unknown reverse broker fixture read path" }
+                }),
+            };
         }
     }
     if let Some(job_id) = request.path.strip_prefix("/runner/jobs/") {

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -18,6 +18,10 @@ use super::super::{Runner, RunnerJob};
 #[allow(unused_imports)]
 use super::*;
 
+pub(crate) fn reverse_broker_submission_key(runner_id: &str, run_id: &str) -> String {
+    format!("agent-task:v1:{runner_id}:{run_id}")
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn exec_via_reverse_broker(
     runner: &Runner,
@@ -93,7 +97,7 @@ pub(super) fn exec_via_reverse_broker(
             let mut metadata = runner_exec_request_metadata(run_id.as_deref(), "reverse_broker");
             if let Some(run_id) = run_id.as_deref() {
                 metadata["submission_key"] =
-                    serde_json::json!(format!("agent-task:v1:{}:{run_id}", runner.id));
+                    serde_json::json!(reverse_broker_submission_key(&runner.id, run_id));
             }
             metadata
         }),

--- a/crates/homeboy-lab-runner/src/execution/daemon_api.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon_api.rs
@@ -52,6 +52,10 @@ pub fn canonical_daemon_body<'a>(data: &'a Value, context: &str) -> Result<&'a V
         .ok_or_else(|| Error::internal_unexpected(format!("{context} missing canonical data.body")))
 }
 
+fn reverse_broker_daemon_data(body: Value) -> Value {
+    json!({ "body": body })
+}
+
 pub(super) fn daemon_transport_error(
     kind: DaemonHttpErrorKind,
     path: &str,
@@ -152,7 +156,7 @@ pub(super) fn daemon_api_request(runner_id: &str, path: &str, method: &str) -> R
             ));
         };
         let broker_token = homeboy_core::broker_auth::broker_submit_token_for_runner(runner_id)?;
-        return match method {
+        let body = match method {
             "GET" => broker_http::get_json(
                 &client,
                 broker_url,
@@ -169,7 +173,12 @@ pub(super) fn daemon_api_request(runner_id: &str, path: &str, method: &str) -> R
                 broker_token.as_deref(),
             ),
             _ => Err(unsupported_daemon_api_method(method)),
-        };
+        }?;
+        // Broker helpers validate and extract their canonical `data.body`, while
+        // daemon API consumers intentionally parse the daemon `data` object.
+        // Restore that shared shape so direct and reverse transports are
+        // interchangeable for status, logs, artifacts, and cancellation.
+        return Ok(reverse_broker_daemon_data(body));
     }
     Err(Error::validation_invalid_argument(
         "runner",
@@ -260,6 +269,13 @@ mod tests {
                 b
             );
         });
+    }
+
+    #[test]
+    fn reverse_broker_body_normalizes_to_daemon_data_contract() {
+        let data = reverse_broker_daemon_data(json!({ "job": { "id": "job-1" } }));
+        let body = canonical_daemon_body(&data, "reverse broker job").expect("canonical body");
+        assert_eq!(body["job"]["id"], "job-1");
     }
 }
 

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -54,6 +54,7 @@ pub(crate) use homeboy_lab_runner_contract::is_internal_control_env;
 
 mod artifact_promotion;
 mod broker;
+pub(crate) use broker::reverse_broker_submission_key;
 mod daemon;
 mod daemon_api;
 mod extension_parity;
@@ -93,7 +94,7 @@ use secrets::*;
 // lab_env, lab/offload) and re-exported by the parent `runner` module.
 pub(crate) use daemon::{
     observe_daemon_job_until_terminal, reserve_daemon_admission, result_event_data,
-    DaemonAdmissionPolicy, DaemonAdmissionReservation, DaemonAdmissionReservationAuthority,
+    DaemonAdmissionPolicy, DaemonAdmissionReservation,
 };
 pub use daemon_api::{canonical_daemon_body, daemon_api_get};
 pub(crate) use failure::{

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1440,11 +1440,10 @@ pub(crate) fn run_lab_offload_inner(
     }
 
     let capability_preflight: Option<RunnerCapabilityPreflight> = capability_plan.map(Into::into);
-    // Detached direct-daemon agent-task work is controller-owned from this point.
+    // Detached agent-task work is controller-owned from this point.
     // It must never fall through to caller-side workspace staging after admission.
     if request.detach_after_handoff
         && request.durable_agent_task_plan.is_some()
-        && selection.mode != super::super::super::RunnerTunnelMode::Reverse
         && capability_preflight.is_some()
     {
         let run_id = pre_acceptance_run_id.as_deref().ok_or_else(|| {
@@ -1464,7 +1463,10 @@ pub(crate) fn run_lab_offload_inner(
             );
         }
         let controller_job_id = match crate::lab_staging_controller::submit_detached_staging(
-            run_id, runner_id, &request,
+            run_id,
+            runner_id,
+            selection.mode.clone(),
+            &request,
         ) {
             Ok(controller_job_id) => controller_job_id,
             Err(error) => {

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -1,7 +1,7 @@
 //! Durable controller-job contract for Lab staging and final dispatch.
 //!
-//! Detached direct-daemon routing constructs this job after the agent-task
-//! attempt exists and before workspace staging begins.
+//! Detached Lab routing constructs this job after the agent-task attempt exists
+//! and before workspace staging begins.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -19,6 +19,7 @@ use homeboy_core::lab_contract::{
     LabRigWorkloadKind, LabRoutingPolicy, LabRunnerWorkloadCapability, LabSecretEnvSource,
     LabSourcePathMode, LabWorkspaceModePolicy,
 };
+use homeboy_core::runner_execution_envelope::PathMaterializationPlan;
 use homeboy_core::{Error, Result};
 use sha2::{Digest, Sha256};
 
@@ -104,6 +105,8 @@ pub struct LabStagingRecipe {
     pub schema: String,
     pub run_id: String,
     pub runner_id: String,
+    #[serde(default = "default_lab_staging_tunnel_mode")]
+    pub tunnel_mode: crate::RunnerTunnelMode,
     pub command: LabStagingCommand,
     pub normalized_args: Vec<String>,
     pub placement: homeboy_cli_contract::Placement,
@@ -135,12 +138,19 @@ impl LabStagingRecipe {
         runner_id: impl Into<String>,
         request: &LabOffloadRequest<'_>,
     ) -> Result<Self> {
-        Self::from_request_with_output_obligation(run_id, runner_id, request, false)
+        Self::from_request_with_transport(
+            run_id,
+            runner_id,
+            crate::RunnerTunnelMode::DirectSsh,
+            request,
+            false,
+        )
     }
 
-    fn from_request_with_output_obligation(
+    fn from_request_with_transport(
         run_id: impl Into<String>,
         runner_id: impl Into<String>,
+        tunnel_mode: crate::RunnerTunnelMode,
         request: &LabOffloadRequest<'_>,
         local_output_run_id_emitted: bool,
     ) -> Result<Self> {
@@ -172,6 +182,7 @@ impl LabStagingRecipe {
             schema: LAB_STAGING_RECIPE_SCHEMA.to_string(),
             run_id: run_id.into(),
             runner_id: runner_id.into(),
+            tunnel_mode,
             command: command.into(),
             normalized_args: request.normalized_args.to_vec(),
             placement: request.placement,
@@ -198,12 +209,15 @@ impl LabStagingRecipe {
     }
 
     fn validate(&self) -> Result<()> {
+        // Canonical argv may contain the executable and global options before
+        // the resolved subcommand token.
+        let normalized_agent_task = self.normalized_args.iter().any(|arg| arg == "agent-task");
         if self.schema != LAB_STAGING_RECIPE_SCHEMA
             || self.run_id.trim().is_empty()
             || self.runner_id.trim().is_empty()
             || !self.command.portable
             || !self.command.hot_label.starts_with("agent-task")
-            || self.normalized_args.first().map(String::as_str) != Some("agent-task")
+            || !normalized_agent_task
         {
             return Err(Error::validation_invalid_argument(
                 "lab_staging_recipe",
@@ -245,6 +259,10 @@ impl LabStagingRecipe {
     }
 }
 
+fn default_lab_staging_tunnel_mode() -> crate::RunnerTunnelMode {
+    crate::RunnerTunnelMode::DirectSsh
+}
+
 /// Owned replay inputs plus the separately loaded durable plan.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LabStagingRequest {
@@ -274,18 +292,26 @@ pub fn persist_lab_staging_recipe(
     runner_id: &str,
     request: &LabOffloadRequest<'_>,
 ) -> Result<LabStagingRecipe> {
-    persist_lab_staging_recipe_with_output_obligation(run_id, runner_id, request, false)
+    persist_lab_staging_recipe_for_transport(
+        run_id,
+        runner_id,
+        crate::RunnerTunnelMode::DirectSsh,
+        request,
+        false,
+    )
 }
 
-fn persist_lab_staging_recipe_with_output_obligation(
+fn persist_lab_staging_recipe_for_transport(
     run_id: &str,
     runner_id: &str,
+    tunnel_mode: crate::RunnerTunnelMode,
     request: &LabOffloadRequest<'_>,
     local_output_run_id_emitted: bool,
 ) -> Result<LabStagingRecipe> {
-    let recipe = LabStagingRecipe::from_request_with_output_obligation(
+    let recipe = LabStagingRecipe::from_request_with_transport(
         run_id,
         runner_id,
+        tunnel_mode,
         request,
         local_output_run_id_emitted,
     )?;
@@ -297,11 +323,12 @@ fn persist_lab_staging_recipe_with_output_obligation(
     .map(|attachment| attachment.payload)
 }
 
-/// Controller-owned admission for a detached direct-daemon agent-task attempt.
+/// Controller-owned admission for a detached agent-task attempt.
 /// No workspace side effect occurs before this returns an accepted controller job.
 pub(crate) fn submit_detached_staging(
     run_id: &str,
     runner_id: &str,
+    tunnel_mode: crate::RunnerTunnelMode,
     request: &LabOffloadRequest<'_>,
 ) -> Result<String> {
     if !routing_ready() {
@@ -312,9 +339,10 @@ pub(crate) fn submit_detached_staging(
             None,
         ));
     }
-    let recipe = persist_lab_staging_recipe_with_output_obligation(
+    let recipe = persist_lab_staging_recipe_for_transport(
         run_id,
         runner_id,
+        tunnel_mode,
         request,
         request.local_output_file.is_some(),
     )?;
@@ -350,7 +378,7 @@ pub(crate) fn submit_detached_staging(
         &client,
         format!("{endpoint}/controller/jobs"),
         Some(json!({
-            "job_type": LAB_STAGING_DISPATCH_JOB_TYPE,
+            "type": LAB_STAGING_DISPATCH_JOB_TYPE,
             "version": LAB_STAGING_DISPATCH_VERSION,
             "request": envelope,
             "idempotency_key": run_id,
@@ -602,6 +630,8 @@ struct DurableLabDispatchReceipt {
     daemon_lease_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     reservation_job_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    reverse_submission_key: Option<String>,
     runner_job_id: String,
     remote_workspace: String,
     remote_command: Vec<String>,
@@ -644,6 +674,43 @@ impl DurableLabDispatchReceipt {
         request: &LabStagingExecutionRequest,
         checkpoint: &LabStagingCheckpoint,
     ) -> Result<()> {
+        let authority_valid = match request.recipe.tunnel_mode {
+            crate::RunnerTunnelMode::DirectSsh => {
+                let live_admission = self
+                    .daemon_lease_id
+                    .as_deref()
+                    .is_some_and(|value| !value.is_empty())
+                    && self
+                        .reservation_job_id
+                        .as_deref()
+                        .is_some_and(|value| !value.is_empty());
+                let recovered_admission =
+                    if self.daemon_lease_id.is_none() && self.reservation_job_id.is_none() {
+                        homeboy_agents::agent_task_lifecycle::accepted_lab_runner_job_identity(
+                            &request.recipe.run_id,
+                        )?
+                        .is_some_and(|identity| {
+                            identity.run_id == request.recipe.run_id
+                                && identity.runner_id == request.recipe.runner_id
+                                && identity.runner_job_id == self.runner_job_id
+                        })
+                    } else {
+                        false
+                    };
+                (live_admission || recovered_admission) && self.reverse_submission_key.is_none()
+            }
+            crate::RunnerTunnelMode::Reverse => {
+                self.daemon_lease_id.is_none()
+                    && self.reservation_job_id.is_none()
+                    && self.reverse_submission_key.as_deref().is_some_and(|value| {
+                        value
+                            == crate::execution::reverse_broker_submission_key(
+                                &request.recipe.runner_id,
+                                &request.recipe.run_id,
+                            )
+                    })
+            }
+        };
         if self.schema != "homeboy/durable-lab-dispatch-receipt/v1"
             || self.run_id != request.recipe.run_id
             || self.runner_id != request.recipe.runner_id
@@ -651,6 +718,7 @@ impl DurableLabDispatchReceipt {
             || self.workspace_attachment_digest.is_empty()
             || self.runtime_attachment_digest.is_empty()
             || self.hydration_attachment_digest.is_empty()
+            || !authority_valid
             || self.runner_job_id.is_empty()
             || self.remote_workspace.is_empty()
             || self.remote_command.is_empty()
@@ -1434,6 +1502,14 @@ impl ProductionLabStagingOperations {
             // accepted lifecycle identity is the recovery authority.
             daemon_lease_id: None,
             reservation_job_id: None,
+            reverse_submission_key: (request.recipe.tunnel_mode
+                == crate::RunnerTunnelMode::Reverse)
+                .then(|| {
+                    crate::execution::reverse_broker_submission_key(
+                        &request.recipe.runner_id,
+                        &request.recipe.run_id,
+                    )
+                }),
             runner_job_id: identity.runner_job_id,
             remote_workspace: workspace.payload.remote_cwd,
             remote_command,
@@ -1458,6 +1534,72 @@ impl ProductionLabStagingOperations {
             .ok_or_else(Self::cancellation_error)
     }
 
+    fn status_for_recipe_transport(
+        request: &LabStagingExecutionRequest,
+    ) -> Result<crate::RunnerStatusReport> {
+        let status = crate::status_for_admission(&request.recipe.runner_id)?;
+        let session = status.session.as_ref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "runner",
+                "durable Lab staging requires an accepted runner session",
+                Some(request.recipe.runner_id.clone()),
+                None,
+            )
+        })?;
+        if session.mode != request.recipe.tunnel_mode {
+            return Err(Error::validation_invalid_argument(
+                "runner",
+                format!(
+                    "durable Lab staging recipe requires `{}` transport, but the current session is `{}`",
+                    request.recipe.tunnel_mode.metadata_value(),
+                    session.mode.metadata_value(),
+                ),
+                Some(request.recipe.runner_id.clone()),
+                None,
+            ));
+        }
+        if session.mode == crate::RunnerTunnelMode::Reverse && session.broker_url.is_none() {
+            return Err(Error::validation_invalid_argument(
+                "runner",
+                "durable reverse Lab staging requires its accepted broker endpoint",
+                Some(request.recipe.runner_id.clone()),
+                None,
+            ));
+        }
+        Ok(status)
+    }
+
+    fn observe_runner_job_until_terminal(
+        request: &LabStagingExecutionRequest,
+        runner_job_id: &str,
+        cancellation: Option<&LabStagingCancellationToken>,
+    ) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot> {
+        if request.recipe.tunnel_mode == crate::RunnerTunnelMode::DirectSsh {
+            let observed = crate::execution::observe_daemon_job_until_terminal(
+                &request.recipe.runner_id,
+                runner_job_id,
+                None,
+            )?;
+            return Ok(homeboy_core::api_jobs::RunnerJobLogSnapshot {
+                job: observed.job,
+                events: observed.events,
+            });
+        }
+        loop {
+            if cancellation.is_some_and(LabStagingCancellationToken::is_cancelled) {
+                return Err(Self::cancellation_error());
+            }
+            match crate::runner_job_log_snapshot(&request.recipe.runner_id, runner_job_id) {
+                Ok(snapshot) if snapshot.job.status.is_terminal() => return Ok(snapshot),
+                Ok(_) => std::thread::sleep(Duration::from_millis(200)),
+                Err(mut error) => {
+                    error.retryable = error.retryable.or(Some(true));
+                    return Err(error);
+                }
+            }
+        }
+    }
+
     fn ambiguous_intent(stage: &str) -> Error {
         Error::validation_invalid_argument(
             "checkpoint.stage_intent",
@@ -1474,6 +1616,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
         request: &LabStagingExecutionRequest,
         checkpoint: &LabStagingCheckpoint,
     ) -> Result<()> {
+        Self::status_for_recipe_transport(request)?;
         if checkpoint.phase == LabStagingPhase::AcceptedMaterializeWorkspace {
             return Ok(());
         }
@@ -1669,8 +1812,37 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
             &request.recipe.normalized_args,
             Some(&request.recipe.run_id),
         )?;
-        let projection =
+        let workspace_mapping =
+            serde_json::to_value(&stage.workspace_mapping).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("serialize durable Lab workspace mapping".to_string()),
+                )
+            })?;
+        let mut lab_metadata = crate::lab_offload_metadata_with_workspace_mapping(
+            &stage.plan,
+            "durable_controller",
+            Some(&request.recipe.runner_id),
+            Some(request.recipe.tunnel_mode.metadata_value()),
+            "offloaded",
+            Some(&stage.remote_cwd),
+            None,
+            Some(&workspace_mapping),
+        );
+        crate::lab::offload::attach_lab_workspace_metadata(
+            &mut lab_metadata,
+            crate::lab::offload::LabWorkspaceMetadataInputs {
+                source_snapshot: &stage.source_snapshot,
+                legacy_path_materialization_plan: &stage.path_materialization_plan,
+                primary_synced_workspace: &stage.synced,
+            },
+        )?;
+        lab_metadata["workspace_cleanliness"] = json!({
+            "allow_dirty_lab_workspace": request.recipe.allow_dirty_lab_workspace,
+        });
+        let mut projection =
             crate::lab::offload::workspace_stage::durable_workspace_stage_projection(&stage);
+        projection["lab_dispatch_metadata"] = lab_metadata;
         let source_snapshot_id = projection
             .pointer("/source_snapshot/workspace_snapshot_identity")
             .and_then(Value::as_str)
@@ -2031,6 +2203,33 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
                 None,
             )
         })?;
+        let path_materialization_plan: PathMaterializationPlan = serde_json::from_value(
+            workspace
+                .payload
+                .stage
+                .get("path_materialization_plan")
+                .cloned()
+                .ok_or_else(|| {
+                    Error::internal_unexpected("durable workspace has no path materialization plan")
+                })?,
+        )
+        .map_err(|_| {
+            Error::validation_invalid_argument(
+                "durable_workspace_stage",
+                "Lab staging path materialization plan is invalid",
+                None,
+                None,
+            )
+        })?;
+        let mut lab_metadata = workspace
+            .payload
+            .stage
+            .get("lab_dispatch_metadata")
+            .cloned()
+            .ok_or_else(|| {
+                Error::internal_unexpected("durable workspace has no Lab dispatch metadata")
+            })?;
+        lab_metadata["dependency_hydration"] = hydration.payload.hydration_metadata.clone();
         let runtime_env: Vec<(String, String)> = serde_json::from_value(
             runtime
                 .payload
@@ -2049,6 +2248,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
         })?;
         let mut public_env = request.recipe.job_override_env.clone();
         public_env.extend(runtime_env);
+        public_env.extend(crate::lab_env::build_lab_offload_env(&lab_metadata));
         let secret_handoff = crate::lab::secrets::build_lab_secret_env_handoff_plan(
             &request.recipe.command.secret_env_sources,
             &request.recipe.normalized_args,
@@ -2063,41 +2263,45 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
             homeboy_core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV.to_string(),
             request.recipe.runner_id.clone(),
         );
-        let runner_status = crate::status_for_admission(&request.recipe.runner_id)?;
+        let runner_status = Self::status_for_recipe_transport(request)?;
         let session = runner_status.session.as_ref().ok_or_else(|| {
             Error::validation_invalid_argument(
                 "runner",
-                "durable Lab dispatch requires an admitted direct daemon session",
+                "durable Lab dispatch requires its accepted runner session",
                 Some(request.recipe.runner_id.clone()),
                 None,
             )
         })?;
-        if session.mode != crate::RunnerTunnelMode::DirectSsh {
-            return Err(Error::validation_invalid_argument(
-                "runner",
-                "durable Lab dispatch requires direct daemon admission",
-                Some(request.recipe.runner_id.clone()),
+        Self::check_cancelled(cancellation)?;
+        let (admission, daemon_authority, reverse_submission_key) = match session.mode {
+            crate::RunnerTunnelMode::DirectSsh => {
+                let local_url = session.local_url.as_deref().ok_or_else(|| {
+                    Error::internal_unexpected("durable Lab dispatch has no daemon endpoint")
+                })?;
+                let lease_id = session.remote_daemon_lease_id.as_deref().ok_or_else(|| {
+                    Error::internal_unexpected("durable Lab dispatch has no daemon lease")
+                })?;
+                let admission = crate::execution::reserve_daemon_admission(
+                    &request.recipe.runner_id,
+                    local_url,
+                    "lab.staging-dispatch",
+                    lease_id,
+                    Some(&request.recipe.run_id),
+                    crate::execution::DaemonAdmissionPolicy::DurableLeaseRequired,
+                )?;
+                let authority = admission.authority();
+                authority.prove_server_owned_expiry_or_cancellation_authority()?;
+                (Some(admission), Some(authority), None)
+            }
+            crate::RunnerTunnelMode::Reverse => (
                 None,
-            ));
-        }
-        let local_url = session.local_url.as_deref().ok_or_else(|| {
-            Error::internal_unexpected("durable Lab dispatch has no daemon endpoint")
-        })?;
-        let lease_id = session.remote_daemon_lease_id.as_deref().ok_or_else(|| {
-            Error::internal_unexpected("durable Lab dispatch has no daemon lease")
-        })?;
-        Self::check_cancelled(cancellation)?;
-        let admission = crate::execution::reserve_daemon_admission(
-            &request.recipe.runner_id,
-            local_url,
-            "lab.staging-dispatch",
-            lease_id,
-            Some(&request.recipe.run_id),
-            crate::execution::DaemonAdmissionPolicy::DurableLeaseRequired,
-        )?;
-        Self::check_cancelled(cancellation)?;
-        let authority = admission.authority();
-        authority.prove_server_owned_expiry_or_cancellation_authority()?;
+                None,
+                Some(crate::execution::reverse_broker_submission_key(
+                    &request.recipe.runner_id,
+                    &request.recipe.run_id,
+                )),
+            ),
+        };
         Self::check_cancelled(cancellation)?;
         let submitted = crate::exec_with_status_snapshot(
             &request.recipe.runner_id,
@@ -2109,6 +2313,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
                 secret_env_plan: Some(secret_handoff.secret_env_plan),
                 capture_patch: request.recipe.capture_patch,
                 source_snapshot: Some(source_snapshot),
+                path_materialization_plan: Some(path_materialization_plan),
                 required_extensions: request.recipe.command.required_extensions.clone(),
                 run_id: Some(request.recipe.run_id.clone()),
                 detach_after_handoff: true,
@@ -2117,14 +2322,11 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
             },
             Some(runner_status),
         );
-        // `/exec` is idempotent on the immutable run id. A dropped response is
-        // reconciled from the daemon's active durable-job projection instead of
-        // submitting a second child.
+        // Both daemon and broker submissions are idempotent on the immutable run
+        // id. A dropped response is reconciled from active durable-job state.
         let runner_job_id = match submitted {
             Ok((output, _)) => output.job_id.ok_or_else(|| {
-                Error::internal_unexpected(
-                    "durable Lab daemon acceptance returned no runner job identity",
-                )
+                Error::internal_unexpected("durable Lab acceptance returned no runner job identity")
             })?,
             Err(error) => crate::status(&request.recipe.runner_id)
                 .ok()
@@ -2137,12 +2339,13 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
                 })
                 .ok_or(error)?,
         };
-        // The renewer may fail while `/exec` is in flight. Acceptance is then
-        // known, but dispatch authority is not: stop and reconcile this exact
-        // child before failing the controller stage closed.
-        if let Err(error) = authority.prove_server_owned_expiry_or_cancellation_authority() {
-            self.cancel_and_reconcile_runner_job(request, &runner_job_id)?;
-            return Err(error);
+        // Direct-daemon authority can expire while `/exec` is in flight. Reverse
+        // authority is the broker's durable submission-key record itself.
+        if let Some(authority) = daemon_authority.as_ref() {
+            if let Err(error) = authority.prove_server_owned_expiry_or_cancellation_authority() {
+                self.cancel_and_reconcile_runner_job(request, &runner_job_id)?;
+                return Err(error);
+            }
         }
         if cancellation.is_cancelled() {
             self.cancel_and_reconcile_runner_job(request, &runner_job_id)?;
@@ -2167,8 +2370,13 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
             workspace_attachment_digest: workspace.payload_digest,
             runtime_attachment_digest: runtime.payload_digest,
             hydration_attachment_digest: hydration.payload_digest,
-            daemon_lease_id: Some(authority.daemon_lease_id().to_string()),
-            reservation_job_id: Some(authority.reservation_job_id().to_string()),
+            daemon_lease_id: daemon_authority
+                .as_ref()
+                .map(|authority| authority.daemon_lease_id().to_string()),
+            reservation_job_id: daemon_authority
+                .as_ref()
+                .map(|authority| authority.reservation_job_id().to_string()),
+            reverse_submission_key,
             runner_job_id: runner_job_id.clone(),
             remote_workspace: workspace.payload.remote_cwd,
             remote_command: command,
@@ -2180,6 +2388,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
             DURABLE_LAB_DISPATCH_RECEIPT_ATTACHMENT_KIND,
             &receipt,
         )?;
+        drop(admission);
         Ok(runner_job_id)
     }
     fn observe_runner(
@@ -2215,17 +2424,11 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
             return receipt.payload.validate(request, checkpoint);
         }
         Self::check_cancelled(cancellation)?;
-        let observed = crate::execution::observe_daemon_job_until_terminal(
-            &request.recipe.runner_id,
-            runner_job_id,
-            None,
-        )?;
+        let observed =
+            Self::observe_runner_job_until_terminal(request, runner_job_id, Some(cancellation))?;
         homeboy_agents::agent_task_lifecycle::project_terminal_runner_result(
             &request.recipe.run_id,
-            &homeboy_core::api_jobs::RunnerJobLogSnapshot {
-                job: observed.job.clone(),
-                events: observed.events,
-            },
+            &observed,
         )?;
         let receipt = DurableLabTerminalReceipt {
             schema: "homeboy/durable-lab-terminal-receipt/v1".to_string(),
@@ -2288,11 +2491,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
                 job_id,
                 durable_run_id,
             )?;
-            let observed = crate::execution::observe_daemon_job_until_terminal(
-                &request.recipe.runner_id,
-                job_id,
-                None,
-            )?;
+            let observed = Self::observe_runner_job_until_terminal(request, job_id, None)?;
             if observed.job.status != homeboy_core::api_jobs::JobStatus::Cancelled {
                 return Err(Error::internal_unexpected(format!(
                     "Lab staging child cancellation for runner job `{job_id}` was not authoritative: observed `{}`",
@@ -2323,11 +2522,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
             runner_job_id,
             &request.recipe.run_id,
         )?;
-        let observed = crate::execution::observe_daemon_job_until_terminal(
-            &request.recipe.runner_id,
-            runner_job_id,
-            None,
-        )?;
+        let observed = Self::observe_runner_job_until_terminal(request, runner_job_id, None)?;
         if observed.job.status != homeboy_core::api_jobs::JobStatus::Cancelled {
             return Err(Error::internal_unexpected(format!(
                 "Lab staging cancellation for runner job `{runner_job_id}` was not authoritative: observed `{}`",
@@ -3016,7 +3211,7 @@ mod tests {
             .build()
             .expect("client");
         let create_body = json!({
-            "job_type": LAB_STAGING_DISPATCH_JOB_TYPE,
+            "type": LAB_STAGING_DISPATCH_JOB_TYPE,
             "version": LAB_STAGING_DISPATCH_VERSION,
             "request": envelope(),
             "idempotency_key": "attempt-1",
@@ -3852,6 +4047,7 @@ mod tests {
             hydration_attachment_digest: "sha256:hydration".to_string(),
             daemon_lease_id: Some("lease-1".to_string()),
             reservation_job_id: Some("reservation-1".to_string()),
+            reverse_submission_key: None,
             runner_job_id: "runner-job-1".to_string(),
             remote_workspace: "/runner/workspace".to_string(),
             remote_command: vec!["homeboy".to_string(), "agent-task".to_string()],
@@ -3979,7 +4175,46 @@ mod tests {
             assert_eq!(receipt.payload.runner_job_id, "runner-job-accepted");
             assert!(receipt.payload.daemon_lease_id.is_none());
             assert!(receipt.payload.reservation_job_id.is_none());
+            assert!(receipt.payload.reverse_submission_key.is_none());
         });
+    }
+
+    #[test]
+    fn reverse_dispatch_receipt_requires_the_bound_broker_submission_key() {
+        let mut request = execution_request();
+        request.recipe.tunnel_mode = crate::RunnerTunnelMode::Reverse;
+        let mut checkpoint = LabStagingCheckpoint::initial(&envelope());
+        checkpoint.phase = LabStagingPhase::ObserveRunner;
+        checkpoint.source_snapshot_id = Some("snapshot-1".to_string());
+        checkpoint.workspace_id = Some("workspace-1".to_string());
+        checkpoint.runtime_id = Some("runtime-1".to_string());
+        checkpoint.hydration_id = Some("hydration-1".to_string());
+        checkpoint.final_runner_job_id = Some("runner-job-1".to_string());
+        let mut receipt = DurableLabDispatchReceipt {
+            schema: "homeboy/durable-lab-dispatch-receipt/v1".to_string(),
+            run_id: request.recipe.run_id.clone(),
+            runner_id: request.recipe.runner_id.clone(),
+            recipe_digest: canonical_digest(&request.recipe).expect("digest"),
+            workspace_attachment_digest: "sha256:workspace".to_string(),
+            runtime_attachment_digest: "sha256:runtime".to_string(),
+            hydration_attachment_digest: "sha256:hydration".to_string(),
+            daemon_lease_id: None,
+            reservation_job_id: None,
+            reverse_submission_key: Some(crate::execution::reverse_broker_submission_key(
+                &request.recipe.runner_id,
+                &request.recipe.run_id,
+            )),
+            runner_job_id: "runner-job-1".to_string(),
+            remote_workspace: "/runner/workspace".to_string(),
+            remote_command: vec!["homeboy".to_string(), "agent-task".to_string()],
+            workload_identity: "sha256:workload".to_string(),
+        };
+
+        receipt
+            .validate(&request, &checkpoint)
+            .expect("reverse receipt");
+        receipt.reverse_submission_key = Some("wrong-key".to_string());
+        assert!(receipt.validate(&request, &checkpoint).is_err());
     }
 
     #[test]

--- a/tests/reverse_cook_queue_acceptance.rs
+++ b/tests/reverse_cook_queue_acceptance.rs
@@ -1,4 +1,5 @@
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 use homeboy::core::api_jobs::{JobEventKind, JobStatus};
 use homeboy_core::test_support::{HermeticTestContext, ReverseBrokerFixture, TestBinary};
@@ -14,6 +15,32 @@ fn output(command: &mut Command) -> std::process::Output {
     output
 }
 
+fn wait_until<T>(timeout: Duration, mut inspect: impl FnMut() -> Option<T>) -> T {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(value) = inspect() {
+            return value;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for fixture state"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn json_field<'a>(value: &'a serde_json::Value, field: &str) -> Option<&'a serde_json::Value> {
+    match value {
+        serde_json::Value::Object(entries) => entries
+            .get(field)
+            .or_else(|| entries.values().find_map(|value| json_field(value, field))),
+        serde_json::Value::Array(entries) => {
+            entries.iter().find_map(|value| json_field(value, field))
+        }
+        _ => None,
+    }
+}
+
 #[cfg(unix)]
 #[test]
 fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
@@ -27,6 +54,10 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
     std::env::set_var("HOMEBOY_ARTIFACT_ROOT", context.artifact_dir());
     std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", context.runtime_dir());
     std::env::set_var("TMPDIR", context.temp_dir());
+    std::env::set_var(
+        homeboy_core::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV,
+        "0000000000000000000000000000000000000000000000000000000000000000",
+    );
     let broker = ReverseBrokerFixture::start("lab");
     let (_checkout_guard, checkout) =
         homeboy_core::test_support::shared_committed_git_repo_fixture("cook-source");
@@ -58,6 +89,37 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
         context.root().display(),
         std::env::var("PATH").expect("PATH")
     );
+    let daemon_stderr_path = context.root().join("daemon.stderr");
+    let mut daemon = context
+        .command(TestBinary::HomeboyFixture)
+        .env("PATH", &path)
+        .env("HOMEBOY_CONTROLLER_ID", "fixture-controller")
+        .args(["daemon", "serve", "--addr", "127.0.0.1:0"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(
+            std::fs::File::create(&daemon_stderr_path).expect("create daemon stderr"),
+        ))
+        .spawn()
+        .expect("start controller daemon fixture");
+    let daemon_status = wait_until(Duration::from_secs(10), || {
+        let output = context
+            .command(TestBinary::HomeboyFixture)
+            .args(["daemon", "status"])
+            .output()
+            .ok()?;
+        let status: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+        (output.status.success() && json_field(&status, "running")?.as_bool()? == true)
+            .then_some(status)
+    });
+    let daemon_lease_id = json_field(&daemon_status, "lease_id")
+        .and_then(serde_json::Value::as_str)
+        .expect("daemon lease id");
+    let daemon_address = json_field(&daemon_status, "address")
+        .and_then(serde_json::Value::as_str)
+        .expect("daemon address");
+    let daemon_pid = json_field(&daemon_status, "pid")
+        .and_then(serde_json::Value::as_u64)
+        .expect("daemon pid");
 
     output(context.command(TestBinary::HomeboyFixture).args([
         "server",
@@ -98,6 +160,9 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
             "role": "controller",
             "controller_id": "fixture-controller",
             "broker_url": broker.url(),
+            "remote_daemon_address": daemon_address,
+            "remote_daemon_pid": daemon_pid,
+            "remote_daemon_lease_id": daemon_lease_id,
             "homeboy_version": env!("CARGO_PKG_VERSION"),
             "homeboy_build_identity": null,
             "connected_at": "2026-01-01T00:00:00Z",
@@ -135,14 +200,55 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
             "1",
             "--no-finalize",
         ]);
-    let cook = output(&mut cook_command);
-    let accepted: serde_json::Value = serde_json::from_slice(&cook.stdout).expect("cook JSON");
-    assert_eq!(
-        accepted["status"], "in_flight",
-        "expected accepted queue lifecycle: {accepted}"
+    let cook_stdout_path = context.root().join("cook.stdout");
+    let cook_stderr_path = context.root().join("cook.stderr");
+    let cook_status = cook_command
+        .stdout(Stdio::from(
+            std::fs::File::create(&cook_stdout_path).expect("create Cook stdout"),
+        ))
+        .stderr(Stdio::from(
+            std::fs::File::create(&cook_stderr_path).expect("create Cook stderr"),
+        ))
+        .status()
+        .expect("run Cook fixture command");
+    let cook_stdout = std::fs::read(&cook_stdout_path).expect("read Cook stdout");
+    let cook_stderr = std::fs::read(&cook_stderr_path).expect("read Cook stderr");
+    assert!(
+        cook_status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&cook_stdout),
+        String::from_utf8_lossy(&cook_stderr),
+    );
+    let accepted: serde_json::Value = serde_json::from_slice(&cook_stdout).expect("cook JSON");
+    assert!(
+        accepted["status"] == "in_flight"
+            || accepted.pointer("/data/status") == Some(&serde_json::json!("materializing")),
+        "expected accepted durable staging lifecycle: {accepted}"
     );
 
-    let queued = broker.jobs();
+    // The submitting CLI is gone before the reverse worker exists. The local
+    // controller daemon must finish staging and durably enqueue the final job.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let queued = loop {
+        let jobs = broker.jobs();
+        if !jobs.is_empty() {
+            break jobs;
+        }
+        if Instant::now() >= deadline {
+            let run_id = accepted["latest_run_id"].as_str().unwrap_or("unknown");
+            let status = context
+                .command(TestBinary::HomeboyFixture)
+                .args(["agent-task", "status", run_id])
+                .output()
+                .expect("inspect stalled controller parent");
+            panic!(
+                "controller did not enqueue reverse job\nstatus stdout={}\nstatus stderr={}",
+                String::from_utf8_lossy(&status.stdout),
+                String::from_utf8_lossy(&status.stderr),
+            );
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    };
     assert_eq!(queued.len(), 1, "detached Cook submits one durable job");
     assert_eq!(queued[0].status, JobStatus::Queued);
 
@@ -201,4 +307,44 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
         })
         .expect("duplicate worker wake");
     assert_eq!(duplicate_code, 0);
+    // The controller must project the broker result after the worker exits.
+    // `daemon serve` is intentionally un-tokenized, so terminate the test-owned
+    // foreground child only after that durable parent lifecycle is terminal.
+    let run_id = accepted["latest_run_id"].as_str().expect("accepted run id");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let terminal = loop {
+        let status = context
+            .command(TestBinary::HomeboyFixture)
+            .args(["agent-task", "status", run_id])
+            .output()
+            .expect("read terminal parent status");
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&status.stdout).expect("parse terminal parent status");
+        if matches!(
+            parsed
+                .pointer("/data/state")
+                .and_then(serde_json::Value::as_str),
+            Some("succeeded" | "failed" | "cancelled")
+        ) {
+            break parsed;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "controller did not project terminal broker result\nstatus={}\ndaemon stderr={}",
+                parsed,
+                std::fs::read_to_string(&daemon_stderr_path)
+                    .unwrap_or_else(|error| format!("<unavailable: {error}>")),
+            );
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    };
+    assert_eq!(
+        terminal
+            .pointer("/data/state")
+            .and_then(serde_json::Value::as_str),
+        Some("succeeded"),
+        "controller terminal projection: {terminal}"
+    );
+    daemon.kill().expect("stop test-owned controller daemon");
+    daemon.wait().expect("controller daemon fixture exits");
 }


### PR DESCRIPTION
Closes #9541

## Summary
- route detached reverse Lab selections through durable controller-owned staging before workspace, runtime, and hydration work
- bind dispatch receipts to direct daemon admission or the canonical reverse broker submission key while preserving lifecycle-backed crash recovery
- normalize reverse broker responses to the daemon API contract and extend the reverse fixture with canonical job and event routes
- add an end-to-end caller-loss proof covering terminal projection and idempotent duplicate wakes

## Verification
- `cargo test -p homeboy-lab-runner lab_staging_controller::tests`
- `cargo test -p homeboy --test reverse_cook_queue_acceptance`
- `cargo test -p homeboy-agents cook_returns_after_accepted_detached_attempt_without_waiting_for_daemon_completion`
- `rustfmt --check --edition 2021 crates/homeboy-lab-runner/src/lab_staging_controller.rs`
- `git diff --check origin/main...HEAD`