### PR TITLE
fix(release): package component-owned artifacts

### DIFF
--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -875,6 +875,53 @@ mod tests {
     }
 
     #[test]
+    fn run_package_collects_component_build_artifact_without_extension() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let component_dir = tempfile::tempdir().expect("component tempdir");
+            let component = Component {
+                id: "plugin".to_string(),
+                local_path: component_dir.path().to_string_lossy().to_string(),
+                build_artifact: Some("build/plugin.zip".to_string()),
+                scripts: Some(homeboy_core::component::ComponentScriptsConfig {
+                    build: vec!["mkdir -p build; printf plugin > build/plugin.zip".to_string()],
+                    ..Default::default()
+                }),
+                ..Component::default()
+            };
+            let mut state = ReleaseState {
+                version: Some("1.2.3".to_string()),
+                ..ReleaseState::default()
+            };
+
+            let result = run_package(
+                &[],
+                &mut state,
+                &component,
+                "plugin",
+                &component.local_path,
+                None,
+                component.build_artifact.as_deref(),
+                false,
+            )
+            .expect("component build package step");
+
+            assert_eq!(result.status, ReleaseStepStatus::Success);
+            assert_eq!(state.artifacts.len(), 1);
+            assert_eq!(state.artifacts[0].path, "build/plugin.zip");
+            let durable_path = state.artifacts[0]
+                .durable_path
+                .as_deref()
+                .expect("durable artifact path");
+            assert_eq!(
+                std::fs::read_to_string(durable_path).expect("durable artifact bytes"),
+                "plugin"
+            );
+            github_release::validate_declared_build_artifact(&component, &state, false)
+                .expect("component-owned artifact should satisfy GitHub Release");
+        });
+    }
+
+    #[test]
     fn github_release_rejects_declared_artifact_when_source_and_durable_bytes_are_missing() {
         let component = Component {
             build_artifact: Some("build/plugin.zip".to_string()),

--- a/crates/homeboy-release/src/release/executor/package.rs
+++ b/crates/homeboy-release/src/release/executor/package.rs
@@ -40,17 +40,6 @@ pub(crate) fn run_package(
         .filter(|m| m.actions.iter().any(|a| a.id == "release.package"))
         .collect();
 
-    if package_extensions.is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "release.package",
-            "No extension provides release.package action",
-            None,
-            Some(vec![
-                "Add an extension with a release.package action to the component".to_string(),
-            ]),
-        ));
-    }
-
     let declared_artifact_built =
         build_declared_component_artifact(component, declared_build_artifact)?;
     if declared_artifact_built {
@@ -60,6 +49,29 @@ pub(crate) fn run_package(
             component_id,
             component_local_path,
         )?;
+    }
+
+    if package_extensions.is_empty() {
+        if declared_artifact_built {
+            return Ok(step_success(
+                "package",
+                "package",
+                Some(serde_json::json!({
+                    "action": "scripts.build",
+                    "artifact": declared_build_artifact,
+                })),
+                Vec::new(),
+            ));
+        }
+
+        return Err(Error::validation_invalid_argument(
+            "release.package",
+            "No extension provides release.package action and the component has no scripts.build + build_artifact contract",
+            None,
+            Some(vec![
+                "Add an extension with a release.package action or configure scripts.build and build_artifact on the component".to_string(),
+            ]),
+        ));
     }
 
     let extra_config = package_build_config(skip_build_validation);

--- a/crates/homeboy-release/src/release/plan_steps/release.rs
+++ b/crates/homeboy-release/src/release/plan_steps/release.rs
@@ -9,7 +9,7 @@ use crate::release::types::{ReleaseChangelogPlan, ReleaseOptions};
 use homeboy_core::component::Component;
 use homeboy_core::plan::PlanStep;
 use homeboy_core::Result;
-use homeboy_extension::ExtensionManifest;
+use homeboy_extension::{ExtensionCapability, ExtensionManifest};
 
 /// Build all release steps: core steps (non-configurable) + publish steps (extension-derived).
 #[allow(clippy::too_many_arguments)]
@@ -52,11 +52,17 @@ pub(in crate::release) fn build_release_steps(
     }
 
     let github_release_needed = github_release_needed(component, options);
-    let package_step_needed =
-        package_step_needed(extensions, &publish_targets, options, github_release_needed);
+    let package_step_needed = package_step_needed(
+        component,
+        extensions,
+        &publish_targets,
+        options,
+        github_release_needed,
+    );
 
     let package_preflight_step_id = add_package_preflight_step(
         &mut steps,
+        component,
         extensions,
         &publish_targets,
         options,
@@ -375,13 +381,20 @@ fn build_head_release_steps(
 
 fn add_package_preflight_step(
     steps: &mut Vec<PlanStep>,
+    component: &Component,
     extensions: &[ExtensionManifest],
     publish_targets: &[String],
     options: &ReleaseOptions,
     github_release_needed: bool,
     needs: &str,
 ) -> Option<String> {
-    if !package_step_needed(extensions, publish_targets, options, github_release_needed) {
+    if !package_step_needed(
+        component,
+        extensions,
+        publish_targets,
+        options,
+        github_release_needed,
+    ) {
         return None;
     }
 
@@ -401,12 +414,13 @@ fn github_release_needed(component: &Component, options: &ReleaseOptions) -> boo
 }
 
 fn package_step_needed(
+    component: &Component,
     extensions: &[ExtensionManifest],
     publish_targets: &[String],
     options: &ReleaseOptions,
     github_release_needed: bool,
 ) -> bool {
-    has_package_capability(extensions)
+    (has_package_capability(extensions) || has_component_package_contract(component))
         && ((!publish_targets.is_empty() && !options.pipeline.skip_publish)
             || github_release_needed)
 }
@@ -417,9 +431,17 @@ fn head_package_step_needed(
     publish_targets: &[String],
     options: &ReleaseOptions,
 ) -> bool {
-    has_package_capability(extensions)
+    (has_package_capability(extensions) || has_component_package_contract(component))
         && ((!publish_targets.is_empty() && !options.pipeline.skip_publish)
             || github_release_needed(component, options))
+}
+
+fn has_component_package_contract(component: &Component) -> bool {
+    component
+        .build_artifact
+        .as_deref()
+        .is_some_and(|path| !path.trim().is_empty())
+        && component.has_script(ExtensionCapability::Build)
 }
 
 fn add_release_extension_diagnostics(

--- a/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
+++ b/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
@@ -6,7 +6,7 @@ use crate::release::types::{
     ReleaseBumpPolicyOptions, ReleaseChangelogPlan, ReleaseOptions, ReleasePipelineOptions,
     ReleaseSemverRecommendation,
 };
-use homeboy_core::component::{Component, ScopedExtensionConfig};
+use homeboy_core::component::{Component, ComponentScriptsConfig, ScopedExtensionConfig};
 use homeboy_core::plan::PlanStepStatus;
 use homeboy_extension::ExtensionManifest;
 
@@ -617,6 +617,79 @@ fn head_skip_publish_with_package_provider_still_packages_before_github_release(
     let steps = build_release_steps(
         &component,
         &[extension],
+        "1.0.1",
+        "1.0.1",
+        &fixture_changelog_plan(),
+        &options,
+        &release_scope,
+        &mut warnings,
+        &mut hints,
+    )
+    .expect("steps");
+
+    let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
+    assert_eq!(ids, vec!["package", "github.release"]);
+    assert_eq!(steps[1].needs, vec!["package"]);
+}
+
+#[test]
+fn component_build_artifact_packages_before_github_release_without_extension() {
+    let mut component = github_fixture_component();
+    component.build_artifact = Some("build/fixture.zip".to_string());
+    component.scripts = Some(ComponentScriptsConfig {
+        build: vec!["build-fixture".to_string()],
+        ..Default::default()
+    });
+    let mut warnings = Vec::new();
+    let mut hints = Vec::new();
+    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
+    let options = ReleaseOptions {
+        bump_type: "patch".to_string(),
+        ..Default::default()
+    };
+
+    let steps = build_release_steps(
+        &component,
+        &[],
+        "1.0.0",
+        "1.0.1",
+        &fixture_changelog_plan(),
+        &options,
+        &release_scope,
+        &mut warnings,
+        &mut hints,
+    )
+    .expect("steps");
+
+    let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
+    assert!(step_index(&ids, "preflight.package") < step_index(&ids, "package"));
+    assert!(step_index(&ids, "package") < step_index(&ids, "github.release"));
+    assert_eq!(steps[step_index(&ids, "git.tag")].needs, vec!["package"]);
+}
+
+#[test]
+fn head_component_build_artifact_packages_before_github_release_without_extension() {
+    let mut component = github_fixture_component();
+    component.build_artifact = Some("build/fixture.zip".to_string());
+    component.scripts = Some(ComponentScriptsConfig {
+        build: vec!["build-fixture".to_string()],
+        ..Default::default()
+    });
+    let mut warnings = Vec::new();
+    let mut hints = Vec::new();
+    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
+    let options = ReleaseOptions {
+        bump_type: "head".to_string(),
+        pipeline: ReleasePipelineOptions {
+            head: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let steps = build_release_steps(
+        &component,
+        &[],
         "1.0.1",
         "1.0.1",
         &fixture_changelog_plan(),


### PR DESCRIPTION
## Summary

- treat `scripts.build + build_artifact` as a package capability in normal and tagged-HEAD release plans
- build and durably collect a component-owned artifact without requiring an extension `release.package` provider
- retain fail-closed behavior when neither packaging contract exists

Closes #9582.

## Verification

- `cargo test -p homeboy-release component_build_artifact -- --nocapture` (3 passed)
- built the patched `homeboy` binary and successfully ran the exact recovery command for `site-generation-agents-v0.1.3`
- durable recovery manifest contains the expected ZIP at `/Users/chubes/.local/share/homeboy/artifacts/release-packages/site-generation-agents/site-generation-agents-v0_1_3/`
- full `homeboy-release` crate run: 613 passed; five unrelated baseline/environment-sensitive tests failed (`default_release_guard_rejects_commits_after_component_prefixed_tag`, `default_tagged_release_guard_still_blocks_unreleased_head`, `test_directory_artifact_normalizes_group_write_and_setgid`, `version_step_uses_planned_bump_input`, `release_plan_runs_package_preflight_before_mutating_release_steps`)

## AI assistance

- **AI assistance:** Yes
- **Tool:** OpenCode with `openai/gpt-5.6-sol`
- **Used for:** diagnosis, implementation, tests, and live recovery verification