### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,12 +426,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,7 +511,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -700,58 +694,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "homeboy"
 version = "0.301.2"
 dependencies = [
  "base64",
  "chrono",
  "clap",
- "core-foundation-sys",
- "ctrlc",
- "glob",
- "glob-match",
- "heck",
  "homeboy-cli",
- "homeboy-cli-contract",
  "homeboy-core",
- "homeboy-engine-primitives",
- "homeboy-error",
  "homeboy-extension",
- "homeboy-finding",
  "homeboy-lab-contract",
- "homeboy-lab-runner",
- "homeboy-output",
- "homeboy-paths",
- "homeboy-process",
  "homeboy-product-identity",
- "homeboy-redaction",
- "keyring",
  "libc",
- "regex",
  "reqwest",
  "rusqlite",
- "security-framework-sys",
- "semver",
- "serde",
  "serde_json",
- "serde_json_path",
- "serde_path_to_error",
- "serde_yml",
- "sha2",
- "shellexpand",
  "tempfile",
- "toml 1.1.2+spec-1.1.0",
  "uuid",
- "zip",
 ]
 
 [[package]]
@@ -760,8 +719,6 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "chrono",
- "fs4",
- "glob",
  "homeboy-agents-contract",
  "homeboy-core",
  "homeboy-error",
@@ -827,27 +784,17 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
- "ctrlc",
  "glob",
- "glob-match",
- "heck",
  "homeboy-agents",
  "homeboy-cli-contract",
  "homeboy-core",
- "homeboy-engine-primitives",
- "homeboy-error",
  "homeboy-extension",
  "homeboy-extension-contract",
- "homeboy-finding",
  "homeboy-fuzz",
  "homeboy-issues",
  "homeboy-lab-contract",
  "homeboy-lab-runner",
- "homeboy-output",
- "homeboy-paths",
- "homeboy-process",
  "homeboy-product-identity",
- "homeboy-redaction",
  "homeboy-refactor",
  "homeboy-refactor-contract",
  "homeboy-release",
@@ -858,19 +805,15 @@ dependencies = [
  "homeboy-tunnel",
  "homeboy-upgrade",
  "libc",
- "regex",
  "reqwest",
- "rusqlite",
  "semver",
  "serde",
  "serde_json",
  "serde_json_path",
  "serde_path_to_error",
- "serde_yml",
  "sha2",
  "shellexpand",
  "tempfile",
- "toml 1.1.2+spec-1.1.0",
  "uuid",
  "zip",
 ]
@@ -903,7 +846,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -933,7 +876,6 @@ dependencies = [
  "chrono",
  "clap",
  "core-foundation-sys",
- "ctrlc",
  "fs4",
  "glob",
  "glob-match",
@@ -962,9 +904,7 @@ dependencies = [
  "homeboy-product-identity",
  "homeboy-redaction",
  "homeboy-refactor-contract",
- "homeboy-release",
  "homeboy-release-contract",
- "homeboy-rig-contract",
  "homeboy-run-lifecycle-contract",
  "homeboy-source-snapshot-contract",
  "keyring",
@@ -977,12 +917,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_path",
- "serde_path_to_error",
  "serde_yml",
  "sha2",
  "shellexpand",
  "tempfile",
- "toml 1.1.2+spec-1.1.0",
  "uuid",
  "windows-sys 0.61.2",
  "zip",
@@ -999,7 +937,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -1206,7 +1144,6 @@ dependencies = [
  "homeboy-code-audit",
  "homeboy-core",
  "homeboy-engine-primitives",
- "homeboy-error",
  "homeboy-extension",
  "homeboy-refactor-contract",
  "regex",
@@ -1214,7 +1151,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "toml 0.8.23",
 ]
 
 [[package]]
@@ -1222,7 +1158,6 @@ name = "homeboy-refactor-contract"
 version = "0.1.0"
 dependencies = [
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1233,7 +1168,6 @@ dependencies = [
  "glob",
  "glob-match",
  "homeboy-core",
- "homeboy-error",
  "homeboy-extension",
  "homeboy-product-identity",
  "homeboy-release-contract",
@@ -1243,7 +1177,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "toml 1.1.2+spec-1.1.0",
  "uuid",
  "zip",
 ]
@@ -1253,7 +1186,6 @@ name = "homeboy-release-contract"
 version = "0.1.0"
 dependencies = [
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1263,7 +1195,6 @@ dependencies = [
  "chrono",
  "homeboy-code-audit",
  "homeboy-core",
- "homeboy-error",
  "homeboy-extension",
  "homeboy-finding",
  "serde",
@@ -1276,7 +1207,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "homeboy-core",
- "homeboy-error",
  "homeboy-extension",
  "homeboy-lab-runner-contract",
  "homeboy-lifecycle-contract",
@@ -1288,8 +1218,6 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "tempfile",
- "toml 0.8.23",
- "which",
 ]
 
 [[package]]
@@ -1297,7 +1225,6 @@ name = "homeboy-rig-contract"
 version = "0.1.0"
 dependencies = [
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1313,7 +1240,6 @@ name = "homeboy-source-snapshot-contract"
 version = "0.1.0"
 dependencies = [
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1321,7 +1247,6 @@ name = "homeboy-stack"
 version = "0.1.0"
 dependencies = [
  "homeboy-core",
- "homeboy-error",
  "serde",
  "serde_json",
  "tempfile",
@@ -1359,7 +1284,6 @@ name = "homeboy-upgrade"
 version = "0.1.0"
 dependencies = [
  "homeboy-core",
- "homeboy-error",
  "homeboy-extension",
  "homeboy-product-identity",
  "libc",
@@ -1369,9 +1293,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "toml 1.1.2+spec-1.1.0",
- "which",
- "zip",
+ "toml",
 ]
 
 [[package]]
@@ -1741,12 +1663,6 @@ dependencies = [
  "anyhow",
  "version_check",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2195,19 +2111,6 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2215,7 +2118,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -2414,15 +2317,6 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -2607,7 +2501,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -2714,38 +2608,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "winnow",
 ]
 
 [[package]]
@@ -2758,33 +2631,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -3087,18 +2940,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "6.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
-dependencies = [
- "either",
- "home",
- "rustix 0.38.44",
- "winsafe",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3335,24 +3176,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ publish = false
 [package.metadata.dist]
 dist = true
 
+[package.metadata.cargo-machete]
+ignored = ["homeboy-lab-contract"] # Required as a direct edge by release preflight.
+
 [lib]
 name = "homeboy"
 path = "src/lib.rs"
@@ -41,54 +44,27 @@ name = "bench-audit-self"
 path = "src/bin/bench-audit-self.rs"
 
 [dependencies]
-# Private workspace crates shipped only in the Homeboy binary.
-homeboy-cli-contract = { path = "crates/contracts/homeboy-cli-contract" }
-homeboy-error = { path = "crates/homeboy-error" }
-homeboy-finding = { path = "crates/homeboy-finding" }
-homeboy-output = { path = "crates/homeboy-output" }
-homeboy-paths = { path = "crates/homeboy-paths" }
-homeboy-process = { path = "crates/homeboy-process" }
 homeboy-product-identity = { path = "crates/homeboy-product-identity" }
-homeboy-engine-primitives = { path = "crates/homeboy-engine-primitives" }
 homeboy-cli = { path = "crates/homeboy-cli" }
 homeboy-core = { path = "crates/homeboy-core" }
-homeboy-lab-runner = { path = "crates/homeboy-lab-runner" }
 homeboy-lab-contract = { path = "crates/contracts/homeboy-lab-contract" }
-homeboy-redaction = { path = "crates/homeboy-redaction" }
 
 # Core library dependencies
 base64 = "0.22"
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_path_to_error = "0.1"
-serde_yml = "0.0.12"
-heck = "0.5"
 uuid = { version = "1.11", features = ["v4", "v5", "serde"] }
-shellexpand = "3.1"
-regex = "1.11"
-glob-match = "0.2"
-glob = "0.3"
-zip = "0.6"
-keyring = { version = "3.6", features = ["apple-native"] }
-core-foundation-sys = "0.8"
-security-framework-sys = "2.17"
 # default-features disabled to drop reqwest's `default-tls` (native-tls/openssl),
 # which pulled a second, redundant TLS stack alongside the rustls-tls we actually use.
 # Kept features cover current usage (blocking JSON client, socks proxy, http2, charset,
 # system proxy).
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls", "socks", "http2", "charset", "system-proxy"] }
 chrono = "0.4"
-ctrlc = "3.4"
-semver = "1.0"
 libc = "0.2"
 rusqlite = { version = "0.32", features = ["bundled"] }
-serde_json_path = "0.7"
 tempfile = "3.14"
 
 # CLI dependencies
 clap = { version = "4.5", features = ["derive", "string"] }
-toml = "1.0.3"
-sha2 = "0.10.9"
 
 [dev-dependencies]
 # Enable homeboy-core's shared hermetic test fixtures for this crate's test build

--- a/crates/contracts/homeboy-refactor-contract/Cargo.toml
+++ b/crates/contracts/homeboy-refactor-contract/Cargo.toml
@@ -14,4 +14,3 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"

--- a/crates/contracts/homeboy-release-contract/Cargo.toml
+++ b/crates/contracts/homeboy-release-contract/Cargo.toml
@@ -12,4 +12,3 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"

--- a/crates/contracts/homeboy-rig-contract/Cargo.toml
+++ b/crates/contracts/homeboy-rig-contract/Cargo.toml
@@ -12,4 +12,3 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"

--- a/crates/contracts/homeboy-source-snapshot-contract/Cargo.toml
+++ b/crates/contracts/homeboy-source-snapshot-contract/Cargo.toml
@@ -14,4 +14,3 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"

--- a/crates/homeboy-agents/Cargo.toml
+++ b/crates/homeboy-agents/Cargo.toml
@@ -25,9 +25,7 @@ uuid = { version = "1.11", features = ["v4", "v5", "serde"] }
 sha2 = "0.10.9"
 base64 = "0.22"
 regex = "1.11"
-glob = "0.3"
 libc = "0.2"
-fs4 = "0.13"
 shellexpand = "3.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls", "socks", "http2", "charset", "system-proxy"] }
 tempfile = "3.14"

--- a/crates/homeboy-cli/Cargo.toml
+++ b/crates/homeboy-cli/Cargo.toml
@@ -31,37 +31,23 @@ homeboy-issues = { version = "0.1.0", path = "../homeboy-issues" }
 homeboy-triage = { version = "0.1.0", path = "../homeboy-triage" }
 homeboy-tunnel = { version = "0.1.0", path = "../homeboy-tunnel" }
 homeboy-cli-contract = { version = "0.1.0", path = "../contracts/homeboy-cli-contract" }
-homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
-homeboy-finding = { version = "0.1.0", path = "../homeboy-finding" }
-homeboy-output = { version = "0.1.0", path = "../homeboy-output" }
-homeboy-paths = { version = "0.1.0", path = "../homeboy-paths" }
-homeboy-process = { version = "0.1.0", path = "../homeboy-process" }
 homeboy-product-identity = { version = "0.1.0", path = "../homeboy-product-identity" }
-homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 homeboy-lab-contract = { version = "0.1.0", path = "../contracts/homeboy-lab-contract" }
-homeboy-redaction = { version = "0.1.0", path = "../homeboy-redaction" }
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_path_to_error = "0.1"
-serde_yml = "0.0.12"
-heck = "0.5"
 uuid = { version = "1.11", features = ["v4", "v5", "serde"] }
 shellexpand = "3.1"
-regex = "1.11"
-glob-match = "0.2"
 glob = "0.3"
 zip = "0.6"
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls", "socks", "http2", "charset", "system-proxy"] }
 chrono = "0.4"
-ctrlc = "3.4"
 semver = "1.0"
 libc = "0.2"
-rusqlite = { version = "0.32", features = ["bundled"] }
 serde_json_path = "0.7"
 tempfile = "3.14"
 clap = { version = "4.5", features = ["derive", "string"] }
-toml = "1.0.3"
 sha2 = "0.10.9"
 
 [dev-dependencies]

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -8,6 +8,9 @@ description = "Core engine for homeboy: build/deploy/test/triage orchestration, 
 repository = "https://github.com/Extra-Chill/homeboy"
 publish = false
 
+[package.metadata.cargo-machete]
+ignored = ["homeboy-extension"] # Imported by an out-of-tree included test fixture.
+
 [lib]
 name = "homeboy_core"
 path = "src/lib.rs"
@@ -41,7 +44,6 @@ homeboy-refactor-contract = { version = "0.1.0", path = "../contracts/homeboy-re
 homeboy-code-audit = { version = "0.1.0", path = "../homeboy-code-audit" }
 homeboy-extension-contract = { version = "0.1.0", path = "../contracts/homeboy-extension-contract" }
 homeboy-lifecycle-contract = { version = "0.1.0", path = "../contracts/homeboy-lifecycle-contract" }
-homeboy-rig-contract = { version = "0.1.0", path = "../contracts/homeboy-rig-contract" }
 homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 homeboy-lab-contract = { version = "0.1.0", path = "../contracts/homeboy-lab-contract" }
 homeboy-lab-runner-contract = { version = "0.1.0", path = "../contracts/homeboy-lab-runner-contract" }
@@ -50,7 +52,6 @@ homeboy-redaction = { version = "0.1.0", path = "../homeboy-redaction" }
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_path_to_error = "0.1"
 serde_yml = "0.0.12"
 heck = "0.5"
 uuid = { version = "1.11", features = ["v4", "v5", "serde"] }
@@ -64,7 +65,6 @@ core-foundation-sys = "0.8"
 security-framework-sys = "2.17"
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls", "socks", "http2", "charset", "system-proxy"] }
 chrono = "0.4"
-ctrlc = "3.4"
 fs4 = "0.13"
 semver = "1.0"
 libc = "0.2"
@@ -72,7 +72,6 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 serde_json_path = "0.7"
 tempfile = "3.14"
 clap = { version = "4.5", features = ["derive", "string"] }
-toml = "1.0.3"
 sha2 = "0.10.9"
 
 [target.'cfg(windows)'.dependencies]
@@ -80,5 +79,4 @@ windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage
 
 [dev-dependencies]
 homeboy-code-audit = { version = "0.1.0", path = "../homeboy-code-audit", features = ["test-support"] }
-homeboy-release = { version = "0.1.0", path = "../homeboy-release" }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }

--- a/crates/homeboy-refactor/Cargo.toml
+++ b/crates/homeboy-refactor/Cargo.toml
@@ -17,13 +17,11 @@ homeboy-code-audit = { version = "0.1.0", path = "../homeboy-code-audit" }
 homeboy-refactor-contract = { version = "0.1.0", path = "../contracts/homeboy-refactor-contract" }
 homeboy-audit-contract = { version = "0.1.0", path = "../contracts/homeboy-audit-contract" }
 homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
-homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 regex = "1.11"
 glob = "0.3"
 glob-match = "0.2"
-toml = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls"] }
 tempfile = "3.14"
 

--- a/crates/homeboy-release/Cargo.toml
+++ b/crates/homeboy-release/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/lib.rs"
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }
 homeboy-release-contract = { version = "0.1.0", path = "../contracts/homeboy-release-contract" }
-homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 regex = "1.11"
@@ -22,7 +21,6 @@ zip = "0.6"
 chrono = "0.4"
 semver = "1.0"
 tempfile = "3.14"
-toml = "1.0.3"
 sha2 = "0.10.9"
 glob = "0.3"
 glob-match = "0.2"

--- a/crates/homeboy-review/Cargo.toml
+++ b/crates/homeboy-review/Cargo.toml
@@ -15,7 +15,6 @@ homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }
 homeboy-code-audit = { version = "0.1.0", path = "../homeboy-code-audit" }
 homeboy-finding = { version = "0.1.0", path = "../homeboy-finding" }
-homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"

--- a/crates/homeboy-rig/Cargo.toml
+++ b/crates/homeboy-rig/Cargo.toml
@@ -18,12 +18,9 @@ homeboy-rig-contract = { version = "0.1.0", path = "../contracts/homeboy-rig-con
 homeboy-lab-runner-contract = { version = "0.1.0", path = "../contracts/homeboy-lab-runner-contract" }
 homeboy-lifecycle-contract = { version = "0.1.0", path = "../contracts/homeboy-lifecycle-contract" }
 homeboy-product-identity = { version = "0.1.0", path = "../homeboy-product-identity" }
-homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-toml = "0.8"
 chrono = "0.4"
-which = "6.0"
 shellexpand = "3.1"
 libc = "0.2"
 tempfile = "3.14"

--- a/crates/homeboy-stack/Cargo.toml
+++ b/crates/homeboy-stack/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/lib.rs"
 
 [dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
-homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/homeboy-upgrade/Cargo.toml
+++ b/crates/homeboy-upgrade/Cargo.toml
@@ -14,15 +14,12 @@ path = "src/lib.rs"
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }
 homeboy-product-identity = { version = "0.1.0", path = "../homeboy-product-identity" }
-homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 semver = "1.0"
 regex = "1.11"
 toml = "1.0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls", "socks", "http2", "charset", "system-proxy"] }
-zip = "0.6"
-which = "6.0"
 libc = "0.2"
 tempfile = "3.14"
 


### PR DESCRIPTION
## Summary
- remove 63 unused direct dependency declarations left by workspace extraction
- prune 12 packages from the resolved graph, including the duplicate TOML 0.8 and `which` stacks
- document the intentional root Lab contract and test-only extension dependency edges for future `cargo-machete` audits

## Verification
- `cargo check --workspace --all-targets`
- `cargo machete --with-metadata`
- `cargo test -p homeboy --test release_workflow_test`
- `cargo test --workspace` progressed through the root integration suite and into the 931-test agents crate before being manually interrupted; CI should complete the full suite