### PR TITLE
fix(lab): preserve controller runtime pin across hosts

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -337,6 +337,24 @@ where
     F: FnOnce(&str) -> Result<A>,
     A: RuntimeAdmissionEvidence,
 {
+    submit_plan_with_runtime_admission_on_runner(
+        plan,
+        requested_run_id,
+        execution_runner_id(),
+        admit_runtime,
+    )
+}
+
+pub(crate) fn submit_plan_with_runtime_admission_on_runner<F, A>(
+    plan: &AgentTaskPlan,
+    requested_run_id: Option<&str>,
+    execution_runner_id: Option<String>,
+    admit_runtime: F,
+) -> Result<AgentTaskRunRecord>
+where
+    F: FnOnce(&str) -> Result<A>,
+    A: RuntimeAdmissionEvidence,
+{
     let run_id = requested_run_id
         .map(sanitize_run_id)
         .unwrap_or_else(default_run_id);
@@ -351,7 +369,6 @@ where
         "lifecycle_schema": RUN_LIFECYCLE_RECORD_SCHEMA,
         "note": "submitted tasks are durable; provider run ids are recorded after an executor returns them as generic artifacts or evidence refs"
     });
-    let execution_runner_id = execution_runner_id();
     if let Some(runner_id) = execution_runner_id.as_deref() {
         metadata["runner_id"] = json!(runner_id);
     }
@@ -379,6 +396,7 @@ where
         adoption_run_id: None,
         metadata,
     };
+    let mut preserved_controller_runtime = None;
     if let Ok(existing) = store::read_record(&run_id) {
         if execution_runner_id.as_deref() == existing.runner_id() {
             // A foreground daemon binds its job before launching runner-local
@@ -392,6 +410,10 @@ where
                 handoff.state == AgentTaskLabHandoffState::Accepted
                     && handoff.authority == AgentTaskLabHandoffAuthority::RunnerDaemon
             }) {
+                preserved_controller_runtime = Some(controller_runtime_for_runner_execution(
+                    &existing,
+                    execution_runner_id.as_deref(),
+                )?);
                 record.lab_handoff = existing.lab_handoff;
             }
         }
@@ -415,8 +437,19 @@ where
                     return Ok(cancelled);
                 }
             }
-            record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
-                admission.runtime();
+            if let Some(controller_runtime) = preserved_controller_runtime {
+                // The runner executes the portable plan, but the durable run
+                // remains owned by the controller that admitted the handoff.
+                // Keep their immutable pins distinct across host boundaries.
+                record.metadata
+                    [homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
+                    controller_runtime;
+                record.metadata["runner_execution_runtime"] = admission.runtime();
+            } else {
+                record.metadata
+                    [homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
+                    admission.runtime();
+            }
             store::write_record(&record)?;
         }
         Err(error) => {
@@ -435,6 +468,34 @@ where
         }
     }
     Ok(record)
+}
+
+pub(crate) fn controller_runtime_for_runner_execution(
+    existing: &AgentTaskRunRecord,
+    execution_runner_id: Option<&str>,
+) -> Result<Value> {
+    if execution_runner_id != existing.runner_id()
+        || !existing.lab_handoff.as_ref().is_some_and(|handoff| {
+            handoff.state == AgentTaskLabHandoffState::Accepted
+                && handoff.authority == AgentTaskLabHandoffAuthority::RunnerDaemon
+        })
+    {
+        return Err(Error::internal_unexpected(
+            "runner execution identity was requested for a non-accepted Lab handoff",
+        ));
+    }
+    existing
+        .metadata
+        .get(homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY)
+        .cloned()
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "controller_runtime",
+                "accepted Lab handoff has no controller runtime pin",
+                Some(existing.run_id.clone()),
+                None,
+            )
+        })
 }
 
 pub(crate) fn execution_runner_id() -> Option<String> {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -215,6 +215,114 @@ fn detached_lab_run_plan_uses_one_identity_for_status_logs_artifacts_and_cancell
 }
 
 #[test]
+fn accepted_lab_runner_execution_preserves_controller_runtime_pin_across_host_identity_divergence()
+{
+    with_isolated_home(|_| {
+        let run_id = "cross-host-controller-pin";
+        let controller_runtime = json!({
+            "schema": "homeboy/controller-runtime-pin/v2",
+            "originating": {
+                "build_identity": "homeboy 0.300.0+398952a1501d",
+                "pinned_executable": "/Users/chubes/.local/share/homeboy/controller-runtimes/macos/homeboy",
+                "sha256": "macos-controller-sha256"
+            }
+        });
+        let runner_runtime = json!({
+            "schema": "homeboy/controller-runtime-pin/v2",
+            "originating": {
+                "build_identity": "homeboy 0.300.0+398952a1501d",
+                "pinned_executable": "/home/chubes/.local/share/homeboy/controller-runtimes/linux/homeboy",
+                "sha256": "linux-runner-sha256"
+            }
+        });
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+        ];
+
+        let record = submit_plan_with_runtime_admission(&test_plan(), Some(run_id), |_| {
+            Ok(controller_runtime.clone())
+        })
+        .expect("controller submits the durable run");
+        record_detached_lab_run(DetachedLabRunRecord {
+            run_id,
+            runner_id: "linux-lab",
+            runner_job_id: "runner-job-9574",
+            remote_workspace: "/home/chubes/homeboy",
+            remote_command: &command,
+        })
+        .expect("runner acceptance is recorded");
+
+        submit_plan_with_runtime_admission_on_runner(
+            &test_plan(),
+            Some(run_id),
+            Some("linux-lab".to_string()),
+            |_| Ok(runner_runtime.clone()),
+        )
+        .expect("runner records its execution identity without replacing the controller pin");
+        let mirrored = status(&record.run_id).expect("runner-updated controller record");
+        let preserved = mirrored.metadata
+            [homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
+            .clone();
+
+        assert_eq!(preserved, controller_runtime);
+        assert_eq!(
+            mirrored.metadata["runner_execution_runtime"],
+            runner_runtime
+        );
+        assert_ne!(
+            preserved["originating"]["pinned_executable"],
+            runner_runtime["originating"]["pinned_executable"]
+        );
+        assert_ne!(
+            preserved["originating"]["sha256"],
+            runner_runtime["originating"]["sha256"]
+        );
+    });
+}
+
+#[test]
+fn accepted_lab_runner_execution_rejects_missing_controller_runtime_pin() {
+    with_isolated_home(|_| {
+        let run_id = "missing-cross-host-controller-pin";
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+        ];
+        submit_plan(&test_plan(), Some(run_id)).expect("controller submits the durable run");
+        record_detached_lab_run(DetachedLabRunRecord {
+            run_id,
+            runner_id: "linux-lab",
+            runner_job_id: "runner-job-9574",
+            remote_workspace: "/home/chubes/homeboy",
+            remote_command: &command,
+        })
+        .expect("runner acceptance is recorded");
+        rewrite_record_for_test(run_id, |record| {
+            record
+                .metadata
+                .as_object_mut()
+                .expect("metadata object")
+                .remove(homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY);
+        })
+        .expect("remove controller runtime pin");
+
+        let error = submit_plan_with_runtime_admission_on_runner(
+            &test_plan(),
+            Some(run_id),
+            Some("linux-lab".to_string()),
+            |_| Ok(json!({ "runner": "runtime" })),
+        )
+        .expect_err("accepted handoff without its controller pin fails closed");
+
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert!(error.message.contains("no controller runtime pin"));
+    });
+}
+
+#[test]
 fn cancelling_queued_runner_proxy_projects_to_accepted_daemon_job() {
     with_isolated_home(|_| {
         let run_id = "agent-task-queued-runner-proxy";


### PR DESCRIPTION
## Summary
- Preserve the controller-host `controller_runtime` pin when an accepted Lab runner recreates a portable agent-task run.
- Store the runner-local immutable runtime separately as `runner_execution_runtime` execution evidence.
- Fail closed when an accepted handoff has no controller runtime pin.

## Root Cause
Runner-local `agent-task run-plan` re-entered lifecycle submission and replaced the pre-existing controller pin with its Linux executable path and hash. A macOS controller could then neither validate nor recover the substituted Linux binary.

## Test Evidence
- `cargo test -p homeboy-agents accepted_lab_runner_execution --lib`
  - Models divergent macOS controller and Linux runner paths/hashes without platform-specific execution.
  - Verifies the durable controller pin remains unchanged, runner identity is separate evidence, and missing pins fail closed.
- `cargo fmt --check`
- `git diff --check`

Closes #9574

## AI Assistance
AI assistance: Yes.
Tool: OpenAI GPT-5.6 Terra via OpenCode.
Used for: diagnosis, implementation, and focused test development; changes and test results were reviewed in the worktree.