### PR TITLE
feat(runner): bound homeboy activity latency with a reconcile-free runner view (#9522)

### DIFF
--- a/crates/homeboy-core/src/activity.rs
+++ b/crates/homeboy-core/src/activity.rs
@@ -688,10 +688,16 @@ mod runner_sessions {
     use super::*;
 
     pub(super) fn collect(collector: &mut ActivityCollector) {
-        for report in
-            crate::observation::runs_service::with_runner_evidence(|provider| provider.statuses())
-                .into_iter()
-                .filter(|report| report.connected)
+        // Use the latency-bounded indexed view: activity only needs the
+        // current/recent active-job list, never the full generation reconcile
+        // that `statuses()` performs (one blocking poll per draining
+        // generation). This keeps `homeboy activity` bounded as generation
+        // history grows (#9522).
+        for report in crate::observation::runs_service::with_runner_evidence(|provider| {
+            provider.statuses_indexed()
+        })
+        .into_iter()
+        .filter(|report| report.connected)
         {
             for job in report.active_jobs {
                 collector.insert(item_from_active_runner_job(job));

--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -73,6 +73,19 @@ pub trait RunnerEvidenceProvider: Send + Sync {
     /// Status of all known runners (connected or not).
     fn statuses(&self) -> Vec<RunnerConnectionInfo>;
 
+    /// A latency-bounded, read-only view of each runner's active jobs — no
+    /// generation reconcile, no per-generation network polling.
+    ///
+    /// `statuses()` reconciles the full generation ledger, which issues one
+    /// blocking HTTP call per draining generation and can take minutes on a
+    /// long-lived runner. Callers that only need the current/recent active-job
+    /// view (e.g. `homeboy activity`) use this instead so latency stays bounded
+    /// as generation history grows (#9522). The default falls back to
+    /// `statuses()` for providers that have no cheaper path (tests, no-ops).
+    fn statuses_indexed(&self) -> Vec<RunnerConnectionInfo> {
+        self.statuses()
+    }
+
     /// Raw GET against a runner's daemon API.
     fn daemon_api_get(&self, runner_id: &str, path: &str) -> Result<Value>;
 
@@ -362,6 +375,104 @@ mod tests {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .take();
+    }
+
+    #[test]
+    fn statuses_indexed_defaults_to_statuses_and_honors_override() {
+        // Default: a provider with no cheaper path serves statuses_indexed from
+        // statuses (so `homeboy activity` still works for every provider).
+        struct DefaultProvider;
+        impl RunnerEvidenceProvider for DefaultProvider {
+            fn mirror_connected_runner_run(&self, _: &str) -> Result<Option<RunRecord>> {
+                Ok(None)
+            }
+            fn statuses(&self) -> Vec<RunnerConnectionInfo> {
+                vec![RunnerConnectionInfo {
+                    runner_id: "from-statuses".to_string(),
+                    connected: true,
+                    active_jobs: Vec::new(),
+                    stale_runner_jobs: Vec::new(),
+                }]
+            }
+            fn daemon_api_get(&self, _: &str, _: &str) -> Result<Value> {
+                Ok(Value::Null)
+            }
+            fn runner_artifact_content(&self, _: &str, _: &str, _: &str) -> Result<Value> {
+                Ok(Value::Null)
+            }
+            fn runner_job_cancel(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<(crate::api_jobs::Job, Vec<crate::api_jobs::JobEvent>)> {
+                unreachable!()
+            }
+            fn refresh_mirrored_daemon_evidence(&self, _: &str) -> Result<Option<Vec<RunRecord>>> {
+                Ok(None)
+            }
+            fn mirrored_runner_job_identity(&self, _: &RunRecord) -> Option<(String, String)> {
+                None
+            }
+            fn download_remote_artifact(
+                &self,
+                _: &str,
+                _: Option<PathBuf>,
+            ) -> Result<RemoteArtifactDownloadInfo> {
+                unreachable!()
+            }
+        }
+        let default = DefaultProvider;
+        assert_eq!(default.statuses_indexed().len(), 1);
+        assert_eq!(default.statuses_indexed()[0].runner_id, "from-statuses");
+
+        // Override: a provider with a cheaper indexed path uses it, NOT statuses.
+        // (statuses() here would panic — proving activity never calls it.)
+        struct IndexedProvider;
+        impl RunnerEvidenceProvider for IndexedProvider {
+            fn mirror_connected_runner_run(&self, _: &str) -> Result<Option<RunRecord>> {
+                Ok(None)
+            }
+            fn statuses(&self) -> Vec<RunnerConnectionInfo> {
+                panic!("statuses() must not be called on the indexed activity path");
+            }
+            fn statuses_indexed(&self) -> Vec<RunnerConnectionInfo> {
+                vec![RunnerConnectionInfo {
+                    runner_id: "from-indexed".to_string(),
+                    connected: true,
+                    active_jobs: Vec::new(),
+                    stale_runner_jobs: Vec::new(),
+                }]
+            }
+            fn daemon_api_get(&self, _: &str, _: &str) -> Result<Value> {
+                Ok(Value::Null)
+            }
+            fn runner_artifact_content(&self, _: &str, _: &str, _: &str) -> Result<Value> {
+                Ok(Value::Null)
+            }
+            fn runner_job_cancel(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<(crate::api_jobs::Job, Vec<crate::api_jobs::JobEvent>)> {
+                unreachable!()
+            }
+            fn refresh_mirrored_daemon_evidence(&self, _: &str) -> Result<Option<Vec<RunRecord>>> {
+                Ok(None)
+            }
+            fn mirrored_runner_job_identity(&self, _: &RunRecord) -> Option<(String, String)> {
+                None
+            }
+            fn download_remote_artifact(
+                &self,
+                _: &str,
+                _: Option<PathBuf>,
+            ) -> Result<RemoteArtifactDownloadInfo> {
+                unreachable!()
+            }
+        }
+        let indexed = IndexedProvider;
+        assert_eq!(indexed.statuses_indexed().len(), 1);
+        assert_eq!(indexed.statuses_indexed()[0].runner_id, "from-indexed");
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -26,10 +26,11 @@ use homeboy_core::server::{self, Server, SshClient};
 use super::broker_http;
 use super::session::{
     ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobRecoveryEvidence,
-    RunnerActiveJobSource, RunnerActiveJobState, RunnerChangedRuntimePath, RunnerConnectReport,
-    RunnerDisconnectReport, RunnerFailureKind, RunnerLeaselessRecoveryContract,
-    RunnerLeaselessRecoveryEvidence, RunnerSession, RunnerSessionRole, RunnerSessionState,
-    RunnerStaleDaemonWarning, RunnerStaleRuntimePath, RunnerStatusReport, RunnerTunnelMode,
+    RunnerActiveJobSource, RunnerActiveJobState, RunnerActiveJobsSnapshot,
+    RunnerChangedRuntimePath, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
+    RunnerLeaselessRecoveryContract, RunnerLeaselessRecoveryEvidence, RunnerSession,
+    RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning, RunnerStaleRuntimePath,
+    RunnerStatusReport, RunnerTunnelMode,
 };
 use super::{load, remote_runner_homeboy_path, Runner, RunnerKind};
 use homeboy_core::broker_auth;
@@ -2179,6 +2180,41 @@ pub fn statuses() -> Result<Vec<RunnerStatusReport>> {
         reports.push(status(&runner.id)?);
     }
     Ok(reports)
+}
+
+/// A latency-bounded snapshot of each runner's active jobs — a single `/jobs`
+/// query on the current session, with **no generation reconcile**.
+///
+/// `status()` reconciles the full generation ledger, which issues one blocking
+/// HTTP call per *draining* generation (5s timeout each) and can take minutes
+/// with hundreds of generations. Callers that only need the current active-job
+/// view (e.g. `homeboy activity`) must not pay that cost or scan unbounded
+/// history (#9522). This queries the connected session's `/jobs` endpoint once
+/// per runner — bounded work regardless of how much generation history has
+/// accumulated — and skips the per-generation reconcile entirely. Stale-job
+/// detection is a reconcile concern and is intentionally omitted here.
+pub fn statuses_indexed() -> Result<Vec<RunnerActiveJobsSnapshot>> {
+    let mut snapshots = Vec::new();
+    for runner in super::list()? {
+        let session = read_session_or_live_peer(&runner.id)?;
+        let connected = session_state(session.as_ref()) == RunnerSessionState::Connected;
+        let active_jobs = if connected {
+            match session.as_ref() {
+                Some(session) => runner_jobs(&runner.id, session)
+                    .map(|(active, _stale)| active)
+                    .unwrap_or_default(),
+                None => Vec::new(),
+            }
+        } else {
+            Vec::new()
+        };
+        snapshots.push(RunnerActiveJobsSnapshot {
+            runner_id: runner.id,
+            connected,
+            active_jobs,
+        });
+    }
+    Ok(snapshots)
 }
 
 pub fn disconnect(runner_id: &str) -> Result<RunnerDisconnectReport> {

--- a/crates/homeboy-lab-runner/src/evidence/provider.rs
+++ b/crates/homeboy-lab-runner/src/evidence/provider.rs
@@ -75,6 +75,22 @@ impl RunnerEvidenceProvider for RunnerEvidence {
             .collect()
     }
 
+    fn statuses_indexed(&self) -> Vec<RunnerConnectionInfo> {
+        // Read-only persisted active jobs, no generation reconcile (#9522).
+        // Stale-runner-job detection is a reconcile concern, so the indexed view
+        // reports active jobs only; callers needing stale jobs use `statuses()`.
+        super::super::connection::statuses_indexed()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|snapshot| RunnerConnectionInfo {
+                runner_id: snapshot.runner_id,
+                connected: snapshot.connected,
+                active_jobs: snapshot.active_jobs,
+                stale_runner_jobs: Vec::new(),
+            })
+            .collect()
+    }
+
     fn daemon_api_get(&self, runner_id: &str, path: &str) -> Result<Value> {
         super::super::execution::daemon_api_get(runner_id, path)
     }

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -198,13 +198,14 @@ pub use rolling_generation::{
 pub use runtime_materialization_status::{RunnerBinarySource, RuntimeMaterializationStatus};
 pub use session::{
     LabRunnerHandoff, ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource,
-    RunnerActiveJobState, RunnerAdmissionSummary, RunnerArtifactRef, RunnerAvailability,
-    RunnerChangedRuntimePath, RunnerConnectReport, RunnerDaemonGenerationStatus,
-    RunnerDisconnectReport, RunnerFailureKind, RunnerJob, RunnerLeaselessRecoveryContract,
-    RunnerLeaselessRecoveryEvidence, RunnerLifecycleOwner, RunnerMutationArtifacts,
-    RunnerNamedWorkspaceLease, RunnerRecoveryState, RunnerResult, RunnerSession, RunnerSessionRole,
-    RunnerSessionState, RunnerStaleDaemonWarning, RunnerStaleRuntimePath, RunnerStatusReport,
-    RunnerTunnelMode, RunnerWorkspaceLease, RunnerWorkspaceLeaseSet,
+    RunnerActiveJobState, RunnerActiveJobsSnapshot, RunnerAdmissionSummary, RunnerArtifactRef,
+    RunnerAvailability, RunnerChangedRuntimePath, RunnerConnectReport,
+    RunnerDaemonGenerationStatus, RunnerDisconnectReport, RunnerFailureKind, RunnerJob,
+    RunnerLeaselessRecoveryContract, RunnerLeaselessRecoveryEvidence, RunnerLifecycleOwner,
+    RunnerMutationArtifacts, RunnerNamedWorkspaceLease, RunnerRecoveryState, RunnerResult,
+    RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
+    RunnerStaleRuntimePath, RunnerStatusReport, RunnerTunnelMode, RunnerWorkspaceLease,
+    RunnerWorkspaceLeaseSet,
 };
 pub use tool_registry::{RunnerToolRegistry, RunnerToolSpec};
 pub(crate) use transport::{select_runner_transport, RunnerFileTransfer, RunnerTransport};

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -463,6 +463,16 @@ pub struct RunnerConnectReport {
     pub failure_message: Option<String>,
 }
 
+/// A read-only indexed snapshot of one runner's persisted active jobs, built
+/// without reconciling (polling) the generation ledger. Used by latency-bounded
+/// callers like `homeboy activity` (#9522).
+#[derive(Debug, Clone)]
+pub struct RunnerActiveJobsSnapshot {
+    pub runner_id: String,
+    pub connected: bool,
+    pub active_jobs: Vec<ActiveRunnerJobSummary>,
+}
+
 #[derive(Debug, Clone)]
 pub struct RunnerStatusReport {
     pub runner_id: String,


### PR DESCRIPTION
## Completes the runner-status arc
Final piece of #9478/#9522, after #9609 (admission summary) and #9612 (bounded status ledger).

## Problem
`homeboy activity`'s runner-session collector called the full `statuses()` path, which runs `generation_store::reconcile` per runner — **one blocking HTTP call (5s timeout) per *draining* generation**. On a long-lived runner with hundreds of generations this serializes into minutes; the #9522 report saw `activity` exceed 120s and get terminated.

## Fix
Add a latency-bounded `RunnerEvidenceProvider::statuses_indexed()`: a **single `/jobs` query on the connected session per runner, with no per-generation reconcile**. It backs onto `connection::statuses_indexed()`, which reads the current session and does one bounded active-jobs query instead of walking the generation ledger.

The activity collector now uses `statuses_indexed()` — the only field it consumed was `active_jobs`, so nothing is lost. Stale-runner-job detection is a reconcile concern and stays on `statuses()` for the callers that genuinely need it (`run_lookup`'s mirrored-daemon refresh).

`statuses_indexed()` has a **default impl that delegates to `statuses()`**, so every existing provider (tests, no-ops) keeps working unchanged; only the lab-runner provider supplies the cheaper path.

## Verification
- `cargo check` clean; 12 activity tests + 8 runner_evidence tests pass.
- New test `statuses_indexed_defaults_to_statuses_and_honors_override` proves both: the default delegates to `statuses()`, AND a provider overriding `statuses_indexed()` is used **without ever calling `statuses()`** (its `statuses()` panics to prove the activity path never touches the reconcile).

## Arc complete
With #9609 + #9612 + this, default `runner status` and `homeboy activity` are both **bounded regardless of how much generation history accumulates** — closing #9478/#9522.
