### PR TITLE
fix(lab): preserve the prepared workspace on retryable admission failure (#9469)

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1584,7 +1584,7 @@ pub(crate) fn run_lab_offload_inner(
     let mut workspace_resource_lifecycle = synced.resource_lifecycle.clone();
     workspace_resource_lifecycle.cleanup_policy =
         homeboy_core::resource_lifecycle_index::ResourceCleanupPolicy::DeleteOnTerminal;
-    let materialized_workspace = MaterializedWorkspace::new(
+    let mut materialized_workspace = MaterializedWorkspace::new(
         runner_id.to_string(),
         remote_cwd.clone(),
         Some(remote_lab_artifact_dir(&remote_cwd)),
@@ -1835,22 +1835,50 @@ pub(crate) fn run_lab_offload_inner(
     // Reserve only after every local/pre-dispatch preparation, including runtime
     // publication, succeeded. The reservation's Drop implementation releases
     // the lease if the subsequent provider preflight rejects the handoff.
-    let admission = direct_daemon_admission_coordinates(
+    //
+    // A *retryable* pre-acceptance admission failure (a stale lease or a
+    // transient `/admissions` transport error) means the workload never
+    // started, yet all the expensive preparation — rig install/sync, workspace
+    // and package snapshots/uploads, path translation — is already staged on the
+    // remote workspace. Reaping it here (the DeleteAlways default) forces a
+    // retry to repeat the entire prep sequence with new identities (#9469).
+    // Preserve the prepared workspace so a retry can resume against the current
+    // healthy daemon instead; a genuine terminal outcome still reaps as before.
+    let admission = match direct_daemon_admission_coordinates(
         runner_id,
         &selection.mode,
         runner_status.session.as_ref(),
-    )?
-    .map(|(local_url, expected_daemon_lease_id)| {
-        reserve_daemon_admission(
-            runner_id,
-            local_url,
-            &redact_argv_shell_display(&command_prefix.argv),
-            expected_daemon_lease_id,
-            agent_task_run_id.as_deref(),
-            DaemonAdmissionPolicy::LegacyCompatible,
-        )
-    })
-    .transpose()?;
+    )
+    .and_then(|coordinates| {
+        coordinates
+            .map(|(local_url, expected_daemon_lease_id)| {
+                reserve_daemon_admission(
+                    runner_id,
+                    local_url,
+                    &redact_argv_shell_display(&command_prefix.argv),
+                    expected_daemon_lease_id,
+                    agent_task_run_id.as_deref(),
+                    DaemonAdmissionPolicy::LegacyCompatible,
+                )
+            })
+            .transpose()
+    }) {
+        Ok(admission) => admission,
+        Err(error) => {
+            if error.retryable == Some(true) {
+                materialized_workspace.preserve();
+                if let Some(run_id) = agent_task_run_id.as_deref() {
+                    eprintln!(
+                        "Lab offload: retryable admission failure for run `{run_id}` on runner \
+                         `{runner_id}`; preserving prepared workspace `{remote_cwd}` for resume \
+                         (rig install/sync and snapshots are reusable). Retry to resume from \
+                         admission."
+                    );
+                }
+            }
+            return Err(error);
+        }
+    };
     lab_metadata["execution_bundle"] = serde_json::json!({
         "schema": crate::execution_bundle::LAB_EXECUTION_BUNDLE_SCHEMA,
         "binary": {

--- a/crates/homeboy-lab-runner/src/workspace/tests/reap.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/reap.rs
@@ -165,6 +165,37 @@ fn materialized_workspace_preserve_disarms_reap_even_on_success() {
 }
 
 #[test]
+fn delete_always_workspace_preserved_on_retryable_admission_failure_is_not_reaped() {
+    // #9469: the Lab offload workspace uses DeleteAlways so genuine terminal
+    // outcomes always release the admitted rig/extension snapshots. But a
+    // retryable pre-acceptance admission failure calls preserve() on it so the
+    // already-staged rig install/sync + snapshots survive for a retry to resume
+    // — even under DeleteAlways. Proves preserve() disarms the reap the offload
+    // path would otherwise perform.
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        let remote_path = sync_local_workspace("lab-local-mat-retry", runner_root.path());
+
+        {
+            let mut handle = MaterializedWorkspace::new(
+                "lab-local-mat-retry".to_string(),
+                remote_path.clone(),
+                None,
+                WorkspaceCleanupPolicy::DeleteAlways,
+            );
+            // A retryable admission failure preserves the prepared workspace.
+            handle.preserve();
+        } // drop must NOT reap despite DeleteAlways
+
+        assert!(
+            Path::new(&remote_path).exists(),
+            "a retryable admission failure must preserve the prepared workspace for resume, \
+             even under DeleteAlways"
+        );
+    });
+}
+
+#[test]
 fn materialized_workspace_preserve_always_policy_never_reaps() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let runner_root = tempfile::tempdir().expect("runner root tempdir");


### PR DESCRIPTION
## Problem
A runner-pinned bench completes all expensive controller preparation — rig install, rig sync, component/package workspace snapshots + uploads, path translation — before reserving daemon admission. When admission then fails with a **retryable** stale-lease or transient `/admissions` transport error, the workload never started, yet the run-scoped workspace (which owns the admitted rig/extension snapshots) is created with `DeleteAlways` and gets **reaped on the early-return drop**.

Result (#9469): a retry repeats the entire preparation sequence with new identities, and the failed attempt even reports reaping the run-scoped SSI workspace though the bench never started.

## Fix
Distinguish a **retryable pre-acceptance admission failure** from a genuine terminal outcome. On a retryable admission error, call `materialized_workspace.preserve()` before propagating, so the already-staged snapshots survive for a retry to resume against the current healthy daemon. A non-retryable failure or any real terminal result still reaps as before (`DeleteAlways` unchanged for those paths). The preserved path logs which run to resume.

## Scope (honest)
This is the **cleanup-policy half** of #9469 — "distinguish successful completion from pre-acceptance failure" — and directly fixes the premature-reaping bug that was the concrete symptom. The remaining acceptance criteria build on top of this preservation and are separate follow-ups:
- content-addressed reusable snapshot identities
- bounded recovery window for retained snapshots
- automatic admission retry against the current healthy daemon
- manual resume by run/checkpoint id (skip rig install/sync/uploads)

Keeping this PR to the preservation seam makes it reviewable and immediately fixes the reported waste; resume-by-id builds on preserved snapshots existing in the first place.

## Verification
- `cargo check` clean; 8 reap tests pass, including a new `delete_always_workspace_preserved_on_retryable_admission_failure_is_not_reaped` that proves `preserve()` disarms the `DeleteAlways` reap — the exact combination the offload path now relies on.
