### PR TITLE
fix(controller): route pre-cook runtime seal through FIFO admission queue so concurrent cooks queue instead of fail-fast

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -574,9 +574,15 @@ pub fn pinned_runtime_for_mutation(run_id: &str) -> Result<Option<std::path::Pat
 }
 
 /// Seal the currently executing controller into an immutable runtime before a
-/// new cook begins its local routing and admission work.
-pub fn pin_current_controller_runtime() -> Result<std::path::PathBuf> {
-    let runtime = homeboy_core::controller_runtime::pin_current()?;
+/// new cook begins its local routing and admission work.  Participates in the
+/// FIFO admission queue so concurrent seals wait their turn instead of
+/// fast-failing.
+pub fn pin_current_controller_runtime(
+    request_id: &str,
+    cancellation_requested: impl Fn() -> Result<bool>,
+) -> Result<std::path::PathBuf> {
+    let runtime =
+        homeboy_core::controller_runtime::pin_current_queued(request_id, cancellation_requested)?;
     runtime
         .pointer("/originating/pinned_executable")
         .and_then(Value::as_str)

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -2,6 +2,7 @@ use clap::{ArgMatches, Command};
 use std::io::IsTerminal;
 use std::process::Command as ProcessCommand;
 use std::sync::OnceLock;
+use uuid::Uuid;
 
 use crate::cli_surface::{
     command_safety_manifest_from_dynamic, command_surface_from, Cli, CommandSafetyManifest,
@@ -484,7 +485,10 @@ fn delegate_agent_task_cook_to_pinned_runtime(
         }
     }
 
-    let pinned = crate::agents::agent_tasks::lifecycle::pin_current_controller_runtime()?;
+    let pinned = crate::agents::agent_tasks::lifecycle::pin_current_controller_runtime(
+        &format!("seal-{}", Uuid::new_v4()),
+        || Ok(false),
+    )?;
     let status = ProcessCommand::new(&pinned)
         .args(&normalized_args[1..])
         .env(COOK_PINNED_RUNTIME_ENV, &pinned)

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -515,6 +515,38 @@ fn pin_current_unlocked() -> Result<Value> {
     pin_executable(&executable, &identity.display)
 }
 
+/// Pin the currently executing controller while participating in the FIFO
+/// admission queue.  Use this instead of `pin_current()` when concurrent cook
+/// requests must wait their turn rather than fast-fail.
+pub fn pin_current_queued(
+    request_id: &str,
+    cancellation_requested: impl Fn() -> Result<bool>,
+) -> Result<Value> {
+    let root = runtime_root()?;
+    let lock_path = root.join(ADMISSION_LOCK_DIR);
+    let request_id = request_id.trim();
+    if request_id.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "controller_admission",
+            "controller admission request ID is required",
+            None,
+            None,
+        ));
+    }
+    enqueue_admission_request(&lock_path, request_id)?;
+    let lock = match acquire_queued_admission_lock(&lock_path, request_id, &cancellation_requested)
+    {
+        Ok(lock) => lock,
+        Err(error) => {
+            let _ = remove_admission_request(&lock_path, request_id);
+            return Err(error);
+        }
+    };
+    let runtime = pin_current_unlocked()?;
+    drop(lock);
+    Ok(runtime)
+}
+
 fn current_executable() -> Result<PathBuf> {
     #[cfg(any(test, feature = "test-support"))]
     if let Some(executable) = std::env::var_os(TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV) {
@@ -3234,6 +3266,92 @@ mod tests {
             })
             .expect("apply");
             assert!(!tombstone.exists());
+        });
+    }
+
+    #[test]
+    fn concurrent_pin_current_queued_requests_queue_and_succeed_in_fifo_order() {
+        crate::test_support::with_isolated_home(|_| {
+            let first = admit_current_for("existing-owner").expect("hold initial admission");
+
+            let (a_enqueued, a_enqueued_result) = std::sync::mpsc::channel();
+            let (a_release, a_release_result) = std::sync::mpsc::channel();
+            let seal_a =
+                std::thread::spawn(move || match pin_current_queued("seal-a", || Ok(false)) {
+                    Ok(_runtime) => {
+                        let _ = a_enqueued.send(Ok(()));
+                        let _ = a_release_result.recv();
+                    }
+                    Err(error) => {
+                        let _ = a_enqueued.send(Err(error.message));
+                    }
+                });
+
+            let (b_enqueued, b_enqueued_result) = std::sync::mpsc::channel();
+            let b_handle =
+                std::thread::spawn(move || match pin_current_queued("seal-b", || Ok(false)) {
+                    Ok(_runtime) => {
+                        let _ = b_enqueued.send(Ok(()));
+                    }
+                    Err(error) => {
+                        let _ = b_enqueued.send(Err(error.message));
+                    }
+                });
+
+            let waiting_a = (0..40)
+                .map(|_| {
+                    let status = admission_status("seal-a").expect("seal-a status");
+                    if status["state"] == "waiting" {
+                        Some(status)
+                    } else {
+                        std::thread::sleep(Duration::from_millis(25));
+                        None
+                    }
+                })
+                .find_map(|status| status)
+                .expect("seal-a queues behind existing owner");
+            assert_eq!(waiting_a["position"], 2);
+
+            let waiting_b = (0..40)
+                .map(|_| {
+                    let status = admission_status("seal-b").expect("seal-b status");
+                    if status["state"] == "waiting" {
+                        Some(status)
+                    } else {
+                        std::thread::sleep(Duration::from_millis(25));
+                        None
+                    }
+                })
+                .find_map(|status| status)
+                .expect("seal-b queues behind seal-a");
+            assert_eq!(waiting_b["position"], 3);
+
+            drop(first);
+
+            assert_eq!(
+                a_enqueued_result
+                    .recv_timeout(Duration::from_secs(30))
+                    .expect("seal-a resolves"),
+                Ok(())
+            );
+            assert_eq!(
+                admission_status("seal-a").expect("seal-a admitted")["state"],
+                "admitted"
+            );
+            a_release.send(()).expect("release seal-a");
+            seal_a.join().expect("seal-a thread exits");
+
+            assert_eq!(
+                b_enqueued_result
+                    .recv_timeout(Duration::from_secs(30))
+                    .expect("seal-b resolves"),
+                Ok(())
+            );
+            assert_eq!(
+                admission_status("seal-b").expect("seal-b admitted")["state"],
+                "admitted"
+            );
+            b_handle.join().expect("seal-b thread exits");
         });
     }
 }


### PR DESCRIPTION
## Root cause

When multiple `homeboy agent-task cook` invocations start concurrently with local placement, only one succeeds; the others die immediately with `controller generation admission is currently owned by pid=X`.

Homeboy has a fully-built FIFO admission queue (`acquire_queued_admission_lock` / `enqueue_admission_request` in `controller_runtime.rs`) that is designed to make concurrent controller requests wait their turn — but the pre-cook controller-seal step bypasses it and uses a non-blocking fast-fail lock.

Call chain:
- `cli_runtime.rs:delegate_agent_task_cook_to_pinned_runtime()` →
- `lifecycle_ops.rs:pin_current_controller_runtime()` →
- `controller_runtime.rs:pin_current()` → `acquire_admission_lock()` (non-blocking `try_lock`) → `admission_busy_error()`

Meanwhile the submit path (`submit_plan` → `admit_current_for_with_cancellation_check`) already uses the correct FIFO path. The seal and submit had two different admission strategies — the seal fast-fails, the submit queues.

## Fix

Added `pin_current_queued(request_id, cancellation_check)` in `controller_runtime.rs` that acquires admission via the same FIFO queue (`acquire_queued_admission_lock` / `enqueue_admission_request`) used by the submit path, then runs `pin_current_unlocked()`. This reuses existing queue infrastructure — no new admission contract or queue was introduced.

Updated `pin_current_controller_runtime()` to accept a `request_id` and `cancellation_check` and route through `pin_current_queued()` instead of `pin_current()`.

Updated `delegate_agent_task_cook_to_pinned_runtime()` in `cli_runtime.rs` to generate a stable `seal-{uuid}` request ID and pass it through.

There is now a single fair admission path for the cook lifecycle: both the pre-cook seal and the submit participate in the same FIFO queue.

## Retained fast-fail callers

`pin_current()` and `acquire_admission_lock` were **retained** — not deleted — because `acquire_admission_lock` is still used by 6 other legitimate single-shot admin operations that must not wait in a FIFO queue:
- `cleanup()` — inventory and reclaim immutable runtime identities
- `activate_installed_generation()` — publish verified installation executable
- `migrate_legacy_pin()` / `migrate_legacy_pin_and_persist()` — legacy pin migration
- `recover_pin()` / `recover_pin_and_persist()` — restore missing/corrupted pins

`pin_current()` itself remains as a non-queued pin primitive for tests that don't need FIFO serialization.

## Concurrency test

Added `concurrent_pin_current_queued_requests_queue_and_succeed_in_fifo_order` in `controller_runtime.rs` test module. The test:
1. Holds an initial admission via `admit_current_for`
2. Spawns two threads calling `pin_current_queued` with different request IDs
3. Verifies both queue at positions 2 and 3 (not fast-fail)
4. Releases the initial owner
5. Verifies both resolve successfully in FIFO order

Follows the existing admission test harness style (`with_isolated_home`, `admission_status` polling, `mpsc` channels).

Refs: #9228, #9474

Burndown #1 of homeboy tech-debt fleet.