### PR TITLE
fix(rig): attribute runner_id on resource lifecycle records

### DIFF
--- a/crates/homeboy-rig/src/resource_lifecycle.rs
+++ b/crates/homeboy-rig/src/resource_lifecycle.rs
@@ -134,6 +134,26 @@ mod tests {
     }
 
     #[test]
+    fn propagates_runner_id_to_resource_records() {
+        let resources = RigResourcesSpec {
+            exclusive: vec!["runtime".to_string()],
+            paths: vec!["/tmp/homeboy-rig".to_string()],
+            ports: vec![9981],
+            process_patterns: vec!["homeboy fixture".to_string()],
+        };
+
+        let mut options =
+            RigResourceLifecycleOptions::new("run-1", ResourceLifecycleResourceStatus::Active);
+        options.runner_id = Some("runner-abc".to_string());
+
+        let index = rig_resource_lifecycle_index("fixture-rig", &resources, options);
+
+        for record in &index.resources {
+            assert_eq!(record.runner_id.as_deref(), Some("runner-abc"));
+        }
+    }
+
+    #[test]
     fn applies_declared_cleanup_intent_to_resource_records() {
         let resources = RigResourcesSpec {
             paths: vec!["/tmp/homeboy-rig".to_string()],


### PR DESCRIPTION
## Summary
- Confirmed `runner_id` is already wired through in `record()` (`resource_lifecycle.rs:84`) — `options.runner_id.clone()` populates the field on every `ResourceLifecycleRecord`.
- Added test `propagates_runner_id_to_resource_records` that sets `runner_id = Some("runner-abc")` on `RigResourceLifecycleOptions` and asserts all generated records carry the same value.

## Why
Rig-materialized resource lifecycle records must be attributed to the runner that created them for targeted cleanup. The field was wired but had no test coverage verifying the round-trip.

Ref: tech-debt burndown Wave A.