### PR TITLE
fix(rig): attribute runner_id on resource lifecycle records

### DIFF
--- a/crates/homeboy-rig/src/resource_lifecycle.rs
+++ b/crates/homeboy-rig/src/resource_lifecycle.rs
@@ -127,10 +127,31 @@ mod tests {
         assert_eq!(index.resources[1].path, "/tmp/homeboy-rig");
         assert_eq!(index.resources[2].path, "tcp://localhost:9981");
         assert_eq!(index.resources[3].path, "process-pattern:homeboy fixture");
+        assert_eq!(index.resources[0].runner_id, None);
         assert_eq!(
             index.resources[0].cleanup_policy,
             ResourceCleanupPolicy::Manual
         );
+    }
+
+    #[test]
+    fn propagates_runner_id_to_resource_records() {
+        let resources = RigResourcesSpec {
+            exclusive: vec!["runtime".to_string()],
+            paths: vec!["/tmp/homeboy-rig".to_string()],
+            ports: vec![9981],
+            process_patterns: vec!["homeboy fixture".to_string()],
+        };
+
+        let mut options =
+            RigResourceLifecycleOptions::new("run-1", ResourceLifecycleResourceStatus::Active);
+        options.runner_id = Some("runner-abc".to_string());
+
+        let index = rig_resource_lifecycle_index("fixture-rig", &resources, options);
+
+        for record in &index.resources {
+            assert_eq!(record.runner_id.as_deref(), Some("runner-abc"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Added test `propagates_runner_id_to_resource_records` asserting that `runner_id` round-trips through rig resource lifecycle record construction
- Added `runner_id` default-to-None assertion in the existing `converts_rig_resource_declarations_to_lifecycle_records` test

## Notes

The `runner_id` field on `ResourceLifecycleRecord` was **already wired** — `record()` at `resource_lifecycle.rs:84` clones `options.runner_id` into every record. However, no test verified this behavior. This PR adds that coverage so future regressions are caught.

Ref: tech-debt burndown Wave A