### PR TITLE
refactor(core): replace audit-evasion string splits with sourced literals

### DIFF
--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -412,8 +412,11 @@ pub struct InstallMethodsConfig {
     pub binary: InstallMethodConfig,
 }
 
+/// Known ecosystem key used as a secondary install-method discriminant in
+/// extension-provided defaults. Pending externalization into the defaults asset;
+/// allowed by `core-agnostic-source` audit allowlist (tech-debt burndown Wave A, #18).
 pub fn secondary_install_method_key() -> String {
-    ["car", "go"].concat()
+    "cargo".to_string() // audit-allow-cargo-secondary-key
 }
 
 impl Serialize for InstallMethodsConfig {

--- a/crates/homeboy-core/src/defaults/builtins.rs
+++ b/crates/homeboy-core/src/defaults/builtins.rs
@@ -33,7 +33,9 @@ fn load_extension_provided_defaults() -> ExtensionProvidedDefaults {
 }
 
 fn load_external_extension_provided_defaults() -> Option<ExtensionProvidedDefaults> {
-    let path = std::env::var(["HOMEBOY", "EXTENSION_DEFAULTS_PATH"].join("_")).ok()?;
+    let path =
+        std::env::var(crate::product_identity::PRODUCT_IDENTITY.env_var("EXTENSION_DEFAULTS_PATH"))
+            .ok()?;
     let content = fs::read_to_string(path).ok()?;
 
     Some(parse_extension_provided_defaults(&content))
@@ -170,7 +172,7 @@ mod tests {
 
         // No PHP `Test.php` convention baked into core; generic JS/TS/Rust
         // suffixes remain.
-        assert!(!suffixes.contains(&["Test.", "p", "hp"].concat()));
+        assert!(!suffixes.contains(&"Test.php".to_string()));
         assert!(suffixes.contains(&".test.js".to_string()));
         assert!(suffixes.contains(&".spec.tsx".to_string()));
         assert!(suffixes.contains(&"_test.rs".to_string()));

--- a/homeboy.json
+++ b/homeboy.json
@@ -146,6 +146,9 @@
           "crates/homeboy-core/src/release/executor/lockfile_guard.rs",
           "crates/homeboy-core/src/extension/bench/baseline.rs"
         ],
+        "allow_line_contains": [
+          "audit-allow-cargo-secondary-key"
+        ],
         "id": "core-agnostic-source",
         "ignore_after_line_equals": [
           "#[cfg(test)]"


### PR DESCRIPTION
## Summary

- **builtins.rs:36**: Replaced `["HOMEBOY","EXTENSION_DEFAULTS_PATH"].join("_")` with `PRODUCT_IDENTITY.env_var("EXTENSION_DEFAULTS_PATH")` — the canonical Homeboy-owned env var accessor. Same result, honest coupling.
- **defaults.rs:415**: Replaced `["car","go"].concat()` with the plain literal `"cargo"`. This is a known ecosystem key pending externalization into the extension-provided defaults asset. Added to the `core-agnostic-source` allowlist with a doc comment and inline marker (`audit-allow-cargo-secondary-key`).
- **builtins.rs:173**: Un-split `["Test.","p","hp"].concat()` to `"Test.php"`. Test code lives after `#[cfg(test)]` which is already in the detector's `ignore_after_line_equals`, so no allowlist entry needed.

## Audit result

All source_policy detector unit tests pass (14/14), confirming the allowlist mechanism works correctly with the new `audit-allow-cargo-secondary-key` marker. The builtins test suite (5/5) and defaults test suite (14/14) also pass.

`homeboy review audit` could not be run in this environment (requires remote runner), but the unit-test coverage of the allowlist path is complete — specifically `core_boundary_skips_explicit_path_and_line_allowlists` exercises the exact code path our new allowlist entry triggers.

---

Tech-debt burndown Wave A, finding #18.