### PR TITLE
Keep release attribution out of generated changelogs

### DIFF
--- a/crates/homeboy-release/src/release/executor/github_release/notes.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/notes.rs
@@ -6,6 +6,7 @@ use crate::release::types::ReleaseState;
 use homeboy_core::component::Component;
 use homeboy_core::component::GithubConfig;
 use homeboy_core::error::{Error, Result};
+use homeboy_core::git;
 use homeboy_core::git::release_download::GitHubRepo;
 
 use super::gh_cli::{gh_command, safe_filename};
@@ -20,9 +21,9 @@ use super::gh_cli::{gh_command, safe_filename};
 /// The body is one of:
 /// - GitHub-generated notes with the `**Full Changelog**` footer rewritten to
 ///   point at the component's changelog URL (`source = GeneratedNotes`), or
-/// - the changelog section text from [`ReleaseState::notes`] (or a minimal
-///   `Release <tag>` body) with the same changelog footer appended
-///   (`source = ChangelogFallback`) when generated notes are unavailable.
+/// - component-scoped commit notes, or the changelog section text from
+///   [`ReleaseState::notes`] when enrichment is unavailable, with the same
+///   changelog footer appended (`source = ChangelogFallback`).
 #[derive(Debug, Clone)]
 pub(crate) struct GitHubReleaseBody {
     /// The exact markdown body passed to `gh release create --notes`.
@@ -68,7 +69,13 @@ pub(crate) fn build_github_release_body(
             tag
         );
         return GitHubReleaseBody {
-            body: fallback_release_notes(state, changelog_url, tag),
+            body: component_scoped_release_notes(
+                component,
+                state,
+                changelog_url,
+                tag,
+                notes_start_tag,
+            ),
             generated_notes_ok: false,
             changelog_url: changelog_url.map(str::to_string),
         };
@@ -104,6 +111,78 @@ fn component_release_notes_require_changelog_fallback(component: &Component) -> 
     ReleaseScope::resolve(component, &component.id)
         .map(|scope| !scope.path_prefix.is_empty() || !scope.path_prefixes.is_empty())
         .unwrap_or(false)
+}
+
+/// Enrich the same component-scoped release range used for changelog generation
+/// only at the GitHub presentation boundary. The persisted changelog remains
+/// durable history without forge-specific links or author metadata.
+fn component_scoped_release_notes(
+    component: &Component,
+    state: &ReleaseState,
+    changelog_url: Option<&str>,
+    tag: &str,
+    previous_tag: Option<&str>,
+) -> String {
+    let entries = git::get_component_changes_since_tag(component, previous_tag)
+        .ok()
+        .map(|commits| {
+            commits
+                .into_iter()
+                .filter(|commit| commit.category.to_changelog_entry_type().is_some())
+                .map(|commit| format!("- {}", format_github_release_entry(component, &commit)))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let base = if entries.is_empty() {
+        fallback_release_notes(state, None, tag)
+    } else {
+        format!("## {}\n\n{}", tag, entries.join("\n"))
+    };
+    changelog_url
+        .map(|url| replace_full_changelog_footer(&base, url))
+        .unwrap_or(base)
+}
+
+fn format_github_release_entry(component: &Component, commit: &git::CommitInfo) -> String {
+    let subject = git::strip_conventional_prefix(&commit.subject);
+    let subject = github_reference_links(component, subject);
+    match commit_author(component, &commit.hash) {
+        Some(author) => format!("{} (by {})", subject, author),
+        None => subject,
+    }
+}
+
+fn commit_author(component: &Component, hash: &str) -> Option<String> {
+    let output =
+        git::execute_git_for_release(&component.local_path, &["show", "-s", "--format=%an", hash])
+            .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let author = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!author.is_empty()).then_some(author)
+}
+
+fn github_reference_links(component: &Component, subject: &str) -> String {
+    let remote = component.remote_url.clone().or_else(|| {
+        git::release_download::detect_remote_url(std::path::Path::new(&component.local_path))
+    });
+    let Some(remote) = remote else {
+        return subject.to_string();
+    };
+    let Some(repo) = git::release_download::parse_github_url(&remote) else {
+        return subject.to_string();
+    };
+    let reference = regex::Regex::new(r"#(\d+)").expect("valid GitHub reference regex");
+    reference
+        .replace_all(subject, |captures: &regex::Captures<'_>| {
+            format!(
+                "[#{}](https://{}/{}/{}/pull/{})",
+                &captures[1], repo.host, repo.owner, repo.repo, &captures[1]
+            )
+        })
+        .into_owned()
 }
 
 /// Persist the exact release body to `build/<tag>-release-notes.md` so it is

--- a/crates/homeboy-release/src/release/executor/github_release/tests/notes_tests.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/tests/notes_tests.rs
@@ -41,11 +41,40 @@ fn fallback_release_notes_falls_back_to_minimal_body_when_empty() {
 #[test]
 fn component_scoped_release_body_uses_changelog_fallback() {
     let temp = git_repo();
+    let root = temp.path();
     let component_dir = temp.path().join("packages/wordpress");
     std::fs::create_dir_all(&component_dir).expect("create component dir");
+    std::fs::write(root.join("README.md"), "initial").expect("write initial file");
+    super::run_git(root, &["add", "README.md"]);
+    super::run_git(root, &["commit", "-q", "-m", "chore: initial"]);
+    super::run_git(root, &["tag", "wordpress-v1.2.2"]);
+    std::fs::write(component_dir.join("release.md"), "release").expect("write release file");
+    super::run_git(root, &["add", "packages/wordpress/release.md"]);
+    super::run_git(
+        root,
+        &[
+            "commit",
+            "-q",
+            "-m",
+            "fix: bound homeboy activity latency with a reconcile-free runner view (#9522)",
+        ],
+    );
+    std::fs::write(component_dir.join("workspace.md"), "workspace").expect("write workspace file");
+    super::run_git(root, &["add", "packages/wordpress/workspace.md"]);
+    super::run_git(
+        root,
+        &[
+            "commit",
+            "-q",
+            "-m",
+            "fix: preserve the prepared workspace on retryable admission failure (#9469)",
+        ],
+    );
+    super::run_git(root, &["tag", "wordpress-v1.2.3"]);
     let component = homeboy_core::component::Component {
         id: "wordpress".to_string(),
         local_path: component_dir.to_string_lossy().to_string(),
+        remote_url: Some("https://github.com/example-org/studio-web.git".to_string()),
         ..Default::default()
     };
     let state = ReleaseState {
@@ -64,7 +93,13 @@ fn component_scoped_release_body_uses_changelog_fallback() {
 
     assert!(!body.generated_notes_ok);
     assert_eq!(body.source_label(), "changelog-fallback");
-    assert!(body.body.contains("- Fix scoped release notes"));
+    assert!(body.body.contains(
+        "- bound homeboy activity latency with a reconcile-free runner view ([#9522](https://github.com/example-org/studio-web/pull/9522)) (by Homeboy Test)"
+    ));
+    assert!(body.body.contains(
+        "- preserve the prepared workspace on retryable admission failure ([#9469](https://github.com/example-org/studio-web/pull/9469)) (by Homeboy Test)"
+    ));
+    assert!(!body.body.contains("- Fix scoped release notes"));
     assert!(body.body.contains("packages/wordpress/CHANGELOG.md"));
 }
 

--- a/crates/homeboy-release/src/release/planning_changelog.rs
+++ b/crates/homeboy-release/src/release/planning_changelog.rs
@@ -91,7 +91,7 @@ pub(super) fn generate_changelog_entries(
         .filter(|c| c.category.to_changelog_entry_type().is_some())
         .collect();
 
-    let entries = group_commits_for_changelog(component, &releasable);
+    let entries = group_commits_for_changelog(&releasable);
     let count: usize = entries.values().map(|v| v.len()).sum();
 
     homeboy_core::log_status!(
@@ -172,9 +172,8 @@ pub(super) fn ensure_changelog_initialized(component: &Component) -> Result<()> 
     Ok(())
 }
 
-/// Group component-scoped commits into reviewer-facing changelog sections.
+/// Group component-scoped commits into durable product-history changelog sections.
 fn group_commits_for_changelog(
-    component: &Component,
     commits: &[git::CommitInfo],
 ) -> std::collections::HashMap<String, Vec<String>> {
     let mut entries_by_type: std::collections::HashMap<String, Vec<String>> =
@@ -182,7 +181,7 @@ fn group_commits_for_changelog(
 
     for commit in commits {
         if let Some(entry_type) = commit.category.to_changelog_entry_type() {
-            let message = format_changelog_entry(component, commit);
+            let message = format_changelog_entry(commit);
             entries_by_type
                 .entry(entry_type.to_string())
                 .or_default()
@@ -202,7 +201,7 @@ fn group_commits_for_changelog(
                         | git::CommitCategory::Release
                 )
             })
-            .map(|c| format_changelog_entry(component, c))
+            .map(format_changelog_entry)
             .unwrap_or_else(|| "Internal improvements".to_string());
 
         entries_by_type.insert("changed".to_string(), vec![fallback]);
@@ -211,49 +210,45 @@ fn group_commits_for_changelog(
     entries_by_type
 }
 
-/// Render the authoritative component change set for reviewer-facing release
-/// notes. Commit subjects retain their GitHub references as clickable links and
-/// are attributed to the commit author. A mixed commit is emitted once because
-/// the scoped git path query returns each matching commit only once.
-fn format_changelog_entry(component: &Component, commit: &git::CommitInfo) -> String {
-    let subject = git::strip_conventional_prefix(&commit.subject);
-    let subject = github_reference_links(component, &subject);
-    match commit_author(component, &commit.hash) {
-        Some(author) => format!("{} (by {})", subject, author),
-        None => subject,
-    }
+fn format_changelog_entry(commit: &git::CommitInfo) -> String {
+    strip_trailing_reference_groups(git::strip_conventional_prefix(&commit.subject))
 }
 
-fn commit_author(component: &Component, hash: &str) -> Option<String> {
-    let output =
-        git::execute_git_for_release(&component.local_path, &["show", "-s", "--format=%an", hash])
-            .ok()?;
-    if !output.status.success() {
-        return None;
+/// Remove only terminal groups containing GitHub-style numeric references.
+/// Inline `#` characters remain product-history text rather than metadata.
+fn strip_trailing_reference_groups(subject: &str) -> String {
+    let mut subject = subject.trim_end();
+    loop {
+        let Some((open, close)) = subject.chars().last().and_then(|close| match close {
+            ')' => Some(('(', ')')),
+            ']' => Some(('[', ']')),
+            _ => None,
+        }) else {
+            break;
+        };
+        let Some(start) = subject.rfind(open) else {
+            break;
+        };
+        let group = &subject[start + open.len_utf8()..subject.len() - close.len_utf8()];
+        if !is_reference_group(group) {
+            break;
+        }
+        subject = subject[..start].trim_end();
     }
-    let author = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    (!author.is_empty()).then_some(author)
+    subject.to_string()
 }
 
-fn github_reference_links(component: &Component, subject: &str) -> String {
-    let remote = component.remote_url.clone().or_else(|| {
-        git::release_download::detect_remote_url(std::path::Path::new(&component.local_path))
-    });
-    let Some(remote) = remote else {
-        return subject.to_string();
-    };
-    let Some(repo) = git::release_download::parse_github_url(&remote) else {
-        return subject.to_string();
-    };
-    let reference = regex::Regex::new(r"#(\d+)").expect("valid GitHub reference regex");
-    reference
-        .replace_all(subject, |captures: &regex::Captures<'_>| {
-            format!(
-                "[#{}](https://{}/{}/{}/pull/{})",
-                &captures[1], repo.host, repo.owner, repo.repo, &captures[1]
-            )
+fn is_reference_group(group: &str) -> bool {
+    let references: Vec<&str> = group
+        .split(|character: char| character.is_whitespace() || matches!(character, ',' | '&'))
+        .filter(|part| !part.is_empty())
+        .collect();
+    !references.is_empty()
+        && references.iter().all(|reference| {
+            reference.strip_prefix('#').is_some_and(|number| {
+                !number.is_empty() && number.chars().all(|character| character.is_ascii_digit())
+            })
         })
-        .into_owned()
 }
 
 #[cfg(test)]
@@ -432,7 +427,7 @@ mod tests {
             dir,
             "feature.txt",
             "feature",
-            "feat: add release planner (#2478)",
+            "feat: bound homeboy activity latency with a reconcile-free runner view (#9522) (#9523)",
         );
         let component = component_with_changelog_target(&temp, Some("CHANGELOG.md"));
         let release_scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
@@ -447,7 +442,7 @@ mod tests {
 
         assert_eq!(
             entries["added"],
-            vec!["add release planner (#2478) (by Homeboy Test)"]
+            vec!["bound homeboy activity latency with a reconcile-free runner view"]
         );
     }
 
@@ -464,8 +459,7 @@ mod tests {
             ),
         ];
 
-        let component = Component::default();
-        let entries = group_commits_for_changelog(&component, &commits);
+        let entries = group_commits_for_changelog(&commits);
         let added = &entries["added"];
         let fixed = &entries["fixed"];
 
@@ -477,32 +471,51 @@ mod tests {
     }
 
     #[test]
-    fn group_commits_for_changelog_strips_pr_references() {
+    fn group_commits_for_changelog_strips_all_trailing_reference_groups() {
         let commits = vec![
             commit(
-                "feat: agent-first scoping — Phase 1 schema (#738)",
+                "feat: agent-first scoping — Phase 1 schema (#738) (#739, #740)",
                 CommitCategory::Feature,
             ),
             commit(
                 "fix: rename $class param — fixes bootstrap crash (#711)",
                 CommitCategory::Fix,
             ),
+            commit(
+                "fix: preserve the prepared workspace on retryable admission failure (#9469)",
+                CommitCategory::Fix,
+            ),
         ];
 
-        let component = Component::default();
-        let entries = group_commits_for_changelog(&component, &commits);
+        let entries = group_commits_for_changelog(&commits);
         let added = &entries["added"];
         let fixed = &entries["fixed"];
 
-        assert_eq!(added[0], "agent-first scoping — Phase 1 schema (#738)");
+        assert_eq!(added[0], "agent-first scoping — Phase 1 schema");
+        assert_eq!(fixed[0], "rename $class param — fixes bootstrap crash");
         assert_eq!(
-            fixed[0],
-            "rename $class param — fixes bootstrap crash (#711)"
+            fixed[1],
+            "preserve the prepared workspace on retryable admission failure"
         );
     }
 
     #[test]
-    fn blocks_engine_shaped_changes_exclude_siblings_and_preserve_attribution() {
+    fn changelog_keeps_inline_hash_characters_and_non_reference_groups() {
+        let commits = vec![commit(
+            "fix: preserve #![feature] syntax (#9522) (reviewed)",
+            CommitCategory::Fix,
+        )];
+
+        let entries = group_commits_for_changelog(&commits);
+
+        assert_eq!(
+            entries["fixed"],
+            vec!["preserve #![feature] syntax (#9522) (reviewed)"]
+        );
+    }
+
+    #[test]
+    fn blocks_engine_shaped_changes_exclude_siblings_and_emit_mixed_changes_once() {
         let temp = git_repo();
         let dir = temp.path();
         commit_file(dir, "README.md", "initial", "chore: initial");
@@ -559,7 +572,7 @@ mod tests {
         };
         let scope = ReleaseScope::resolve(&component, &component.id).unwrap();
         let (_, commits) = scope.commits_since_latest_tag().unwrap();
-        let entries = group_commits_for_changelog(&component, &commits);
+        let entries = group_commits_for_changelog(&commits);
         let fixed = &entries["fixed"];
 
         assert_eq!(
@@ -568,11 +581,7 @@ mod tests {
             "mixed commits are emitted once per component release"
         );
         assert!(fixed.iter().all(|entry| !entry.contains("figma-only")));
-        assert!(fixed.iter().any(|entry| {
-            entry.contains("php-only change")
-                && entry.contains("PHP Author")
-                && entry.contains("https://github.com/Automattic/blocks-engine/pull/942")
-        }));
+        assert!(fixed.iter().any(|entry| entry == "php-only change"));
         assert_eq!(
             fixed
                 .iter()


### PR DESCRIPTION
## Summary
Restore clean generated changelogs while retaining author and linked-PR attribution in component GitHub Release notes.

## What changed
- Stripped terminal numeric PR/issue reference groups from persisted changelog entries without removing ordinary inline hash text.
- Moved commit-author and GitHub-reference enrichment to component GitHub Release body construction.
- Used the already validated notes\_start\_tag when rebuilding the authoritative scoped commit range.

## How to test
1. Run `cargo test -q -p homeboy-release planning_changelog`; expect All 12 changelog planning tests pass, including multiple trailing references and inline hash preservation..
2. Run `cargo test -q -p homeboy-release executor::github_release`; expect All 35 GitHub Release tests pass, including attributed linked component notes..

## Compatibility
No CLI or schema changes. Persisted changelogs return to their pre-#9440 format; component GitHub Release notes preserve #9440 attribution behavior.

## Evidence
- Base unchanged since verification: main remains at 3ea8cb005f22657aa65a48d7a5a3d060426ecac0.
- CI expected: Homeboy CI
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9644
- Reviewer-resolvable evidence from source\_refs\[1\]: https://github.com/Extra-Chill/homeboy/pull/9440
- Verified finalization base: main at 3ea8cb005f22657aa65a48d7a5a3d060426ecac0
- formatting: passed (Passed)
- github-release: passed (35 tests) (Passed)
- planning-changelog: passed (12 tests) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** 

## Source relationships
- Closes #9644
- Relates to #9440
