### PR TITLE
Keep bench scenario discovery side-effect free

### DIFF
--- a/crates/homeboy-cli/src/commands/bench/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/mod.rs
@@ -131,6 +131,10 @@ fn write_failing_bench_extension(home: &TempDir) {
         &script_path,
         r#"#!/bin/sh
 if [ "$HOMEBOY_BENCH_LIST_ONLY" = "1" ]; then
+  if [ "${HOMEBOY_BENCH_ITERATIONS:-0}" != "0" ]; then
+    printf 'DISCOVERY_MUST_NOT_EXECUTE_WORKLOAD\n' >&2
+    exit 99
+  fi
   cat > "$HOMEBOY_BENCH_RESULTS_FILE" <<JSON
 {
   "component_id": "$HOMEBOY_COMPONENT_ID",

--- a/crates/homeboy-cli/src/commands/bench/tests/scenario_run_tests.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/scenario_run_tests.rs
@@ -198,7 +198,10 @@ fn selected_non_visual_scenario_omits_optional_comparison_artifacts() {
 fn selected_scenario_workload_failure_preserves_runner_error() {
     with_isolated_home(|home| {
         write_failing_bench_extension(home);
-        let component_dir = tempfile::TempDir::new().expect("component dir");
+        let component_dir = tempfile::Builder::new()
+            .prefix("static-site-importer@fix-491-")
+            .tempdir()
+            .expect("component dir");
         write_registered_component(home, "studio", component_dir.path());
 
         let (output, exit_code) = run(

--- a/crates/homeboy-extension/src/bench/run/scenario.rs
+++ b/crates/homeboy-extension/src/bench/run/scenario.rs
@@ -149,7 +149,11 @@ pub(crate) fn discover_bench_scenarios(
         })?;
     }
 
-    let runner_output = build_runner(execution_context, component, args, run_dir, None)?
+    // Discovery has the same zero-iteration contract as `bench list`; some
+    // runners use this independently of HOMEBOY_BENCH_LIST_ONLY.
+    let mut discovery_args = args.clone();
+    discovery_args.iterations = 0;
+    let runner_output = build_runner(execution_context, component, &discovery_args, run_dir, None)?
         .env("HOMEBOY_BENCH_LIST_ONLY", "1")
         .run()?;
 


### PR DESCRIPTION
## Summary
Prevent scenario discovery from running benchmark iterations.

## What changed
- Discovery clones the benchmark arguments with zero iterations before building the extension runner, while tests enforce that list-only discovery cannot enter workload execution.

## How to test
1. Run `cargo test -p homeboy-cli selected_scenario_workload_failure_preserves_runner_error`; expect focused workload/discovery regression passes.

## Compatibility
Normal execution and the existing list-only environment contract remain unchanged.

## Evidence
- Base advanced after verification: verified main at 3ea8cb005f22657aa65a48d7a5a3d060426ecac0; publication observed 8250f34201c84113f89ca86e908dda577780957d. Candidate ancestry was validated against the verified snapshot.
- CI expected: Audit
- CI expected: Lint
- CI expected: Test
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9622
- Verified finalization base: main at 3ea8cb005f22657aa65a48d7a5a3d060426ecac0
- audit: passed (Passed)
- focused-regression: passed (Passed)
- lint: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** OpenCode with openai/gpt-5.6-terra implemented the bounded fix and regression coverage; Homeboy captured focused and broader verification evidence.

## Source relationships
- Closes #9622
