### PR TITLE
Preserve Git identity for Lab source snapshots

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/tests/workspace_sync.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/workspace_sync.rs
@@ -151,6 +151,45 @@ fn lab_git_workspace_sync_uses_snapshot_for_private_proxied_sources() {
 }
 
 #[test]
+fn lab_source_snapshot_uses_git_workspace_for_committed_git_source() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    std::fs::write(dir.path().join("package.json"), "{}\n").expect("source file");
+    std::process::Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(dir.path())
+        .status()
+        .expect("init git repo");
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(dir.path())
+        .status()
+        .expect("stage source");
+    std::process::Command::new("git")
+        .args([
+            "-c",
+            "user.name=Homeboy Test",
+            "-c",
+            "user.email=test@homeboy.invalid",
+            "commit",
+            "--quiet",
+            "-m",
+            "source",
+        ])
+        .current_dir(dir.path())
+        .status()
+        .expect("commit source");
+
+    let mode = lab_workspace_sync_mode(
+        LabOffloadWorkspaceModePolicy::RunnerResident,
+        &[],
+        dir.path(),
+    )
+    .expect("sync mode");
+
+    assert_eq!(mode, RunnerWorkspaceSyncMode::SnapshotGit);
+}
+
+#[test]
 fn required_git_checkout_sync_keeps_git_for_private_sources() {
     let dir = tempfile::tempdir().expect("temp dir");
     std::process::Command::new("git")

--- a/crates/homeboy-lab-runner/src/lab/workspace_plan.rs
+++ b/crates/homeboy-lab-runner/src/lab/workspace_plan.rs
@@ -48,6 +48,11 @@ pub(super) fn lab_workspace_sync_mode_with_source_policy(
     source_policy: &SourceMaterializationPolicy,
 ) -> Result<RunnerWorkspaceSyncMode> {
     let requested = requested_lab_workspace_sync_mode(policy, args);
+    if requested == RunnerWorkspaceSyncMode::Snapshot
+        && super::super::workspace::git_output(source_path, &["rev-parse", "HEAD"]).is_ok()
+    {
+        return Ok(RunnerWorkspaceSyncMode::SnapshotGit);
+    }
     if requested != RunnerWorkspaceSyncMode::Git {
         return Ok(requested);
     }


### PR DESCRIPTION
## Summary
Materialize committed Git sources with usable repository metadata on Lab.

## What changed
- Snapshot planning upgrades committed Git sources to SnapshotGit while preserving snapshot behavior for non-Git inputs.

## How to test
1. Run `cargo test -p homeboy-lab-runner lab_source_snapshot_uses_git_workspace_for_committed_git_source -- --test-threads=1`; expect committed source selects SnapshotGit.

## Compatibility
Non-Git directory snapshots and private proxied source behavior remain unchanged.

## Evidence
- Base advanced after verification: verified main at 5165dc9ed4ef19a9c1ca1230ab5df7df8bf324c5; publication observed 22376caeb36322da7f4082ebbdb830db0f52f03d. Candidate ancestry was validated against the verified snapshot.
- CI expected: Audit
- CI expected: Lint
- CI expected: Test
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9627
- Verified finalization base: main at 5165dc9ed4ef19a9c1ca1230ab5df7df8bf324c5
- formatting: passed (Passed)
- private-source-policy: passed (Passed)
- snapshot-git-regression: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** OpenCode with openai/gpt-5.6-terra implemented the materialization repair and regression coverage; Homeboy verified and finalized the candidate.

## Source relationships
- Closes #9627
