### PR TITLE
Keep runner exec raw output pipeable

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runner/dispatch.rs
@@ -227,7 +227,7 @@ pub fn run(
             summary_outputs,
             read_only_artifact,
             json: _,
-            raw: _,
+            raw,
             command,
         } => map_execution(exec(
             &id,
@@ -248,6 +248,7 @@ pub fn run(
             artifact_dir_outputs,
             summary_outputs,
             read_only_artifact,
+            raw,
             command,
         )),
         RunnerCommand::Env { id } => map_env(env_mod::env(&id)),
@@ -487,6 +488,7 @@ fn run_json_exec(
             artifact_dir_outputs,
             summary_outputs,
             read_only_artifact,
+            false,
             command,
         )
         .map(|(output, exit_code)| {
@@ -540,6 +542,7 @@ fn run_raw_exec(
         artifact_dir_outputs,
         summary_outputs,
         read_only_artifact,
+        true,
         command,
     ) {
         Ok((output, exit_code)) => raw_exec_command_run(output, exit_code),
@@ -649,6 +652,7 @@ pub(super) fn run_compact_exec(
         artifact_dir_outputs,
         summary_outputs,
         read_only_artifact,
+        false,
         command,
     ) {
         Ok((output, exit_code)) => compact_exec_command_run(output, exit_code),

--- a/crates/homeboy-cli/src/commands/runner/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/exec.rs
@@ -32,6 +32,7 @@ pub(super) fn exec(
     artifact_dir_outputs: Vec<String>,
     summary_outputs: Vec<String>,
     read_only_artifact: bool,
+    raw: bool,
     command: Vec<String>,
 ) -> CmdResult<RunnerExecOutput> {
     let script = script_file
@@ -125,7 +126,7 @@ pub(super) fn exec(
             // evidence; it hydrates evidence the runner already retains
             // (Extra-Chill/homeboy#9420).
             mirror_evidence: !read_only_artifact,
-            print_handoff: !read_only_artifact,
+            print_handoff: should_print_handoff(raw, read_only_artifact),
             read_only_artifact_access: read_only_artifact,
         },
     )?;
@@ -158,6 +159,10 @@ pub(super) fn exec(
         output.promoted_outputs.extend(promoted_summaries);
     }
     Ok((output, exit_code))
+}
+
+pub(super) fn should_print_handoff(raw: bool, read_only_artifact: bool) -> bool {
+    !raw && !read_only_artifact
 }
 
 pub(super) fn exec_workspace_context(

--- a/crates/homeboy-cli/src/commands/runner/tests/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/exec.rs
@@ -4,7 +4,7 @@ use super::super::dispatch::{
 use super::super::exec::{
     exec, exec_workspace_context, prepare_runner_exec_command, prepare_runner_exec_env,
     prepare_runner_exec_secret_env_plan, read_bounded, read_runner_exec_script,
-    validate_runner_exec_public_env, RUNNER_EXEC_SCRIPT_LIMIT_BYTES,
+    should_print_handoff, validate_runner_exec_public_env, RUNNER_EXEC_SCRIPT_LIMIT_BYTES,
 };
 
 use homeboy::core::observation::{NewRunRecord, ObservationStore};
@@ -59,6 +59,13 @@ fn raw_exec_command_run_keeps_structured_output_and_presentation_streams() {
     assert_eq!(value["stdout"], "hello\n");
     assert_eq!(value["stderr"], "warn\n");
     assert_eq!(value["job_id"], "job-123");
+}
+
+#[test]
+fn raw_exec_suppresses_handoff_output() {
+    assert!(!should_print_handoff(true, false));
+    assert!(!should_print_handoff(false, true));
+    assert!(should_print_handoff(false, false));
 }
 
 #[test]
@@ -328,6 +335,7 @@ fn runner_exec_promotes_declared_artifacts_to_run_store() {
             Vec::new(),
             Vec::new(),
             false,
+            false,
             vec![
                 "sh".to_string(),
                 "-c".to_string(),
@@ -405,6 +413,7 @@ fn runner_exec_promotes_declared_summaries_as_typed_evidence() {
             Vec::new(),
             Vec::new(),
             vec!["summary.json".to_string()],
+            false,
             false,
             vec![
                 "sh".to_string(),
@@ -486,6 +495,7 @@ fn runner_exec_structured_summary_is_independent_of_large_stdout() {
             Vec::new(),
             Vec::new(),
             vec!["summary.json".to_string()],
+            false,
             false,
             vec![
                 "sh".to_string(),
@@ -896,6 +906,7 @@ fn runner_exec_rejects_artifacts_without_run_id() {
         Vec::new(),
         Vec::new(),
         false,
+        false,
         vec!["sh".to_string(), "-c".to_string(), "printf ok".to_string()],
     )
     .expect_err("artifact requires run id");
@@ -927,6 +938,7 @@ fn read_only_artifact_exec_rejects_capture_patch() {
         Vec::new(),
         Vec::new(),
         true, // read_only_artifact
+        false,
         vec![
             "sh".to_string(),
             "-c".to_string(),
@@ -960,6 +972,7 @@ fn read_only_artifact_exec_rejects_declared_outputs() {
         Vec::new(),
         Vec::new(),
         true, // read_only_artifact
+        false,
         vec![
             "sh".to_string(),
             "-c".to_string(),
@@ -1024,6 +1037,7 @@ fn runner_exec_rejects_summaries_without_run_id() {
         Vec::new(),
         Vec::new(),
         vec!["summary.json".to_string()],
+        false,
         false,
         vec!["sh".to_string(), "-c".to_string(), "printf ok".to_string()],
     )


### PR DESCRIPTION
## Summary
Suppress orchestration prose from runner exec raw mode.

## What changed
- The raw flag now reaches runner execution options and disables Lab handoff presentation while retaining existing stream and exit-code handling.

## How to test
1. Run `cargo test -p homeboy-cli raw_exec_ -- --test-threads=1`; expect raw stream and handoff suppression tests pass.

## Compatibility
Structured output, compact output, evidence retention, and non-raw handoff presentation remain unchanged.

## Evidence
- Base advanced after verification: verified main at 5165dc9ed4ef19a9c1ca1230ab5df7df8bf324c5; publication observed 22376caeb36322da7f4082ebbdb830db0f52f03d. Candidate ancestry was validated against the verified snapshot.
- CI expected: Audit
- CI expected: Lint
- CI expected: Test
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9631
- Verified finalization base: main at 5165dc9ed4ef19a9c1ca1230ab5df7df8bf324c5
- formatting: passed (Passed)
- raw-output-regression: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** OpenCode with openai/gpt-5.6-terra implemented the raw presentation repair and tests; Homeboy recovered the timed-out candidate, verified it, and finalized the PR.

## Source relationships
- Closes #9631
