### PR TITLE
fix(agent-task): enforce non-empty used_for at render time and attribute Homeboy in tool disclosure

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -1848,7 +1848,7 @@ fn options() -> AgentTaskPrFinalizationOptions {
             public_contract_evidence: None,
             lifecycle: None,
         },
-        ai_used_for: "Drafted implementation and tests; Chris reviews and owns the change."
+        ai_used_for: "Traced the finalization contract change, implemented it, and confirmed with the recorded gate."
             .to_string(),
         review_dossier: AgentTaskReviewDossier {
             schema: "homeboy/agent-task-review-dossier/v1".to_string(),
@@ -1864,9 +1864,9 @@ fn options() -> AgentTaskPrFinalizationOptions {
             public_contract_evidence: None,
             ai_assistance: crate::agent_task_review_dossier::AgentTaskReviewAiAssistance {
                 used: true,
-                tool: "OpenCode (GPT-5.5)".to_string(),
+                tool: "Homeboy (OpenCode (GPT-5.5))".to_string(),
                 model: "GPT-5.5".to_string(),
-                used_for: "Drafted implementation and tests; Chris reviews and owns the change."
+                used_for: "Traced the finalization contract change, implemented it, and confirmed with the recorded gate."
                     .to_string(),
             },
             source_relationships: Vec::new(),

--- a/crates/homeboy-agents/src/agent_task_review_dossier.rs
+++ b/crates/homeboy-agents/src/agent_task_review_dossier.rs
@@ -266,6 +266,23 @@ fn used_for_is_placeholder(value: &str) -> bool {
     )
 }
 
+/// Compose the deterministic AI-assistance tool disclosure for a generated PR.
+///
+/// The tool string is orchestrator-owned (not AI-authored), which makes it the
+/// honest place to attribute the orchestrator that actually drove the change.
+/// Every PR Homeboy opens names Homeboy as the harness, wrapping the underlying
+/// provider disclosure: `Homeboy (OpenCode / openai/gpt-5.6-terra)`.
+///
+/// If the provider disclosure is already Homeboy-attributed (idempotent) or
+/// empty, it is passed through unchanged.
+pub fn homeboy_tool_disclosure(provider_disclosure: &str) -> String {
+    let provider = provider_disclosure.trim();
+    if provider.is_empty() || provider.starts_with("Homeboy") {
+        return provider.to_string();
+    }
+    format!("Homeboy ({provider})")
+}
+
 pub fn default_profile() -> AgentTaskReviewProfile {
     AgentTaskReviewProfile {
         required_sections: vec![
@@ -498,6 +515,25 @@ impl AgentTaskReviewDossier {
                 "ai_assistance.model",
                 "AI disclosure requires a concrete model identifier",
             );
+        }
+        // `used_for` is the one introspective slot and must never render empty or
+        // as a canned placeholder. This is the render-time boundary EVERY
+        // finalization path crosses (cook's form gate is upstream of the cook
+        // path only), so enforcing it here closes the hole for the manual
+        // `agent-task review`/`pr` path too.
+        if self.ai_assistance.used {
+            if self.ai_assistance.used_for.trim().is_empty() {
+                return invalid(
+                    "ai_assistance.used_for",
+                    "AI disclosure requires a concrete, self-reflective description of how AI was used (the `used_for` field); it cannot be empty",
+                );
+            }
+            if used_for_is_placeholder(&self.ai_assistance.used_for) {
+                return invalid(
+                    "ai_assistance.used_for",
+                    "AI disclosure `used_for` is a placeholder; provide a genuine, self-reflective description of the process the AI took",
+                );
+            }
         }
         Ok(())
     }
@@ -951,7 +987,7 @@ mod tests {
                 used: true,
                 tool: "OpenCode".into(),
                 model: "openai/gpt-5.6-terra".into(),
-                used_for: "Implementation".into(),
+                used_for: "Isolated the failing path, implemented the guard, and verified with the recorded gate before finalizing.".into(),
             },
             source_relationships: vec![AgentTaskReviewIssueRelationship {
                 kind: AgentTaskReviewIssueRelationshipKind::Closes,
@@ -1118,6 +1154,41 @@ mod tests {
         value.source_relationships[0].reference = "https://evil.test/issues/1".into();
         assert!(value.validate(&default_profile()).is_err());
     }
+    #[test]
+    fn dossier_validate_rejects_empty_or_placeholder_used_for_on_every_path() {
+        // Regression for #9649: the manual finalize path rendered an empty
+        // `Used for:` because used_for enforcement only lived in the cook form
+        // gate. The render-time dossier gate must reject it regardless of path.
+        let mut empty = dossier();
+        empty.ai_assistance.used_for = "  ".into();
+        assert!(
+            empty.validate(&default_profile()).is_err(),
+            "empty used_for must fail finalization"
+        );
+
+        let mut placeholder = dossier();
+        placeholder.ai_assistance.used_for =
+            "Drafted implementation and tests; Chris reviews and owns the change.".into();
+        assert!(
+            placeholder.validate(&default_profile()).is_err(),
+            "canned placeholder used_for must fail finalization"
+        );
+    }
+
+    #[test]
+    fn homeboy_tool_disclosure_attributes_the_orchestrator() {
+        assert_eq!(
+            homeboy_tool_disclosure("OpenCode (openai/gpt-5.6-terra)"),
+            "Homeboy (OpenCode (openai/gpt-5.6-terra))"
+        );
+        // Idempotent and empty-safe.
+        assert_eq!(
+            homeboy_tool_disclosure("Homeboy (OpenCode)"),
+            "Homeboy (OpenCode)"
+        );
+        assert_eq!(homeboy_tool_disclosure(""), "");
+    }
+
     #[test]
     fn profile_conflicts_fail_closed() {
         let profile = AgentTaskReviewProfile {

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -703,9 +703,10 @@ fn cook_review_dossier(
         changed_public_contracts: Vec::new(),
         public_contract_evidence: None,
         ai_assistance: AgentTaskReviewAiAssistance {
-            // Deterministic: the orchestrator knows whether/what tool+model ran.
+            // Deterministic: the orchestrator knows whether/what tool+model ran,
+            // and attributes Homeboy as the harness that drove the change.
             used: true,
-            tool: options.ai_tool.clone(),
+            tool: crate::agent_task_review_dossier::homeboy_tool_disclosure(&options.ai_tool),
             model: options
                 .ai_model
                 .clone()

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2341,7 +2341,7 @@ fn historical_orphan_recipe_adoption_uses_recorded_policy_without_provider_repla
         assert_eq!(adoption.state, "completed");
         assert_eq!(adoption.candidate_sha, candidate);
         assert_eq!(adoption.ai_model, "openai/gpt-5.6-sol");
-        assert!(backend.body.contains("- **Tool(s):** test"));
+        assert!(backend.body.contains("- **Tool(s):** Homeboy (test)"));
         assert!(backend.body.contains("- **Model:** openai/gpt-5.6-sol"));
         assert!(backend.committed && backend.pushed && backend.created);
     });

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -226,14 +226,15 @@ pub mod finalization {
 /// Typed reviewer dossier contracts and deterministic rendering.
 pub mod review_dossier {
     pub use super::super::agent_task_review_dossier::{
-        default_profile, enrich_dossier, render_review_dossier, resolve_review_profile,
-        validate_profile, AgentTaskExternalUsageEvidence, AgentTaskExternalUsageStatus,
-        AgentTaskPublicContract, AgentTaskPublicContractEvidence, AgentTaskReviewAdditionalSection,
-        AgentTaskReviewAiAssistance, AgentTaskReviewDossier, AgentTaskReviewEvidence,
-        AgentTaskReviewIssueRelationship, AgentTaskReviewIssueRelationshipKind,
-        AgentTaskReviewOverride, AgentTaskReviewOverrideTarget, AgentTaskReviewProfile,
-        AgentTaskReviewSectionId, AgentTaskReviewTestStep, AiFilledReviewForm,
-        AGENT_TASK_REVIEW_DOSSIER_SCHEMA, AI_REVIEW_FORM_OUTPUT_KEY,
+        default_profile, enrich_dossier, homeboy_tool_disclosure, render_review_dossier,
+        resolve_review_profile, validate_profile, AgentTaskExternalUsageEvidence,
+        AgentTaskExternalUsageStatus, AgentTaskPublicContract, AgentTaskPublicContractEvidence,
+        AgentTaskReviewAdditionalSection, AgentTaskReviewAiAssistance, AgentTaskReviewDossier,
+        AgentTaskReviewEvidence, AgentTaskReviewIssueRelationship,
+        AgentTaskReviewIssueRelationshipKind, AgentTaskReviewOverride,
+        AgentTaskReviewOverrideTarget, AgentTaskReviewProfile, AgentTaskReviewSectionId,
+        AgentTaskReviewTestStep, AiFilledReviewForm, AGENT_TASK_REVIEW_DOSSIER_SCHEMA,
+        AI_REVIEW_FORM_OUTPUT_KEY,
     };
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -15,11 +15,11 @@ use homeboy::agents::agent_tasks::provider::{
     AgentTaskExecutorProvider, AgentTaskProviderCatalog, ExtensionProviderAgentTaskExecutor,
 };
 use homeboy::agents::agent_tasks::review_dossier::{
-    resolve_review_profile, AgentTaskExternalUsageEvidence, AgentTaskExternalUsageStatus,
-    AgentTaskPublicContract, AgentTaskPublicContractEvidence, AgentTaskReviewAiAssistance,
-    AgentTaskReviewDossier, AgentTaskReviewIssueRelationship, AgentTaskReviewIssueRelationshipKind,
-    AgentTaskReviewOverride, AgentTaskReviewOverrideTarget, AgentTaskReviewTestStep,
-    AGENT_TASK_REVIEW_DOSSIER_SCHEMA,
+    homeboy_tool_disclosure, resolve_review_profile, AgentTaskExternalUsageEvidence,
+    AgentTaskExternalUsageStatus, AgentTaskPublicContract, AgentTaskPublicContractEvidence,
+    AgentTaskReviewAiAssistance, AgentTaskReviewDossier, AgentTaskReviewIssueRelationship,
+    AgentTaskReviewIssueRelationshipKind, AgentTaskReviewOverride, AgentTaskReviewOverrideTarget,
+    AgentTaskReviewTestStep, AGENT_TASK_REVIEW_DOSSIER_SCHEMA,
 };
 use homeboy::agents::agent_tasks::service as agent_task_service;
 use homeboy::agents::agent_tasks::{
@@ -459,7 +459,7 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
         public_contract_evidence: evidence.public_contract_evidence.clone(),
         ai_assistance: AgentTaskReviewAiAssistance {
             used: true,
-            tool: evidence.ai_tool.clone(),
+            tool: homeboy_tool_disclosure(&evidence.ai_tool),
             model: evidence
                 .ai_model
                 .clone()


### PR DESCRIPTION
## Summary

Two follow-ups to #9537, both surfaced by **#9649** — which rendered an empty `- **Used for:**` line in its PR body.

## 1. Empty `used_for` (the bug)

#9537 made `used_for` (the one introspective slot) a required, gated field — but the enforcement only lived in the **cook loop's form gate**. The **manual finalize path** (`agent-task review`/`pr`) builds `used_for` straight from the `--ai-used-for` CLI flag, whose canned default #9537 retired to empty, and it never runs the form gate. So that path could render a blank introspection. #9649 came through it.

**Fix:** move the non-empty / non-placeholder `used_for` check into the dossier's render-time `validate()` — the boundary **every** finalization path crosses (cook and manual). An empty or canned `used_for` now fails finalization regardless of path, right next to the existing model-placeholder check.

## 2. Homeboy attribution in the tool disclosure

The AI-assistance `tool` line is deterministic and orchestrator-owned — which makes it the honest place to attribute the harness that actually drove the change. It read just `OpenCode`. New `homeboy_tool_disclosure()` wraps the provider disclosure as `Homeboy (OpenCode / openai/gpt-5.6-terra)` (idempotent, empty-safe), applied at both the cook-synthesis and manual-finalize build sites, so every generated PR names Homeboy.

## Tests
- `dossier_validate_rejects_empty_or_placeholder_used_for_on_every_path` — the exact #9649 regression: empty and canned-placeholder `used_for` both fail `validate()`.
- `homeboy_tool_disclosure_attributes_the_orchestrator` — wraps provider, idempotent, empty-safe.
- Updated finalization + cook fixtures to valid reflections and the Homeboy-wrapped tool string. Dossier (28), finalization (45), cook reviewer-body, and CLI review suites all pass.

_Heavy build/full suite left to CI per repo policy; validated with `cargo check --lib --tests` (both crates) + scoped test runs._