### PR TITLE
Harvest committed changes from durable source when attempt scratch workspace is reaped

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -72,13 +72,19 @@ impl HarvestExecutionContext {
         &self,
     ) -> Result<homeboy_core::source_snapshot::SourceSnapshot, HarvestError> {
         self.source_snapshot.clone().ok_or_else(|| {
-            snapshot_harvest_error("is missing source snapshot transport metadata".to_string())
+            snapshot_harvest_error(
+                Path::new("<snapshot>"),
+                "is missing source snapshot transport metadata".to_string(),
+            )
         })
     }
 
     fn lab_offload(&self) -> Result<serde_json::Value, HarvestError> {
         self.lab_offload.clone().ok_or_else(|| {
-            snapshot_harvest_error("is missing Lab dispatch transport metadata".to_string())
+            snapshot_harvest_error(
+                Path::new("<snapshot>"),
+                "is missing Lab dispatch transport metadata".to_string(),
+            )
         })
     }
 }
@@ -194,18 +200,20 @@ pub(super) fn prepare_committed_harvest(
                     is_repository,
                 )
             })
-            .map_err(snapshot_harvest_error)?;
+            .map_err(|msg| snapshot_harvest_error(root, msg))?;
         if is_repository {
             // git-root verification is folded into verify_lab_workspace above via
             // require_git_root = is_repository.
         } else {
             if provenance.materialization_mode == "git" {
                 return Err(snapshot_harvest_error(
+                    root,
                     "verified Git materialization is missing root Git metadata".to_string(),
                 ));
             }
             if root.join(".git").exists() {
                 return Err(snapshot_harvest_error(
+                    root,
                     "snapshot workspace unexpectedly contains root .git metadata".to_string(),
                 ));
             }
@@ -213,10 +221,13 @@ pub(super) fn prepare_committed_harvest(
                 provenance.materialization_mode.as_str(),
                 "snapshot" | "filesystem_snapshot" | "snapshot-git"
             ) {
-                return Err(snapshot_harvest_error(format!(
-                    "unsupported snapshot materialization mode `{}`",
-                    provenance.materialization_mode
-                )));
+                return Err(snapshot_harvest_error(
+                    root,
+                    format!(
+                        "unsupported snapshot materialization mode `{}`",
+                        provenance.materialization_mode
+                    ),
+                ));
             }
         }
         let mut source_provenance = serde_json::json!({
@@ -254,12 +265,14 @@ pub(super) fn prepare_committed_harvest(
         })
         .map_err(|message| HarvestError::Git {
             command: "materialize verified Lab snapshot Git baseline".to_string(),
+            cwd: root.to_path_buf(),
             message,
         })?;
     }
     let git_root = git_output(root, &["rev-parse", "--show-toplevel"])?;
     let canonical_root = root.canonicalize().map_err(|error| HarvestError::Git {
         command: "canonicalize workspace root".to_string(),
+        cwd: root.to_path_buf(),
         message: error.to_string(),
     })?;
     let canonical_git_root =
@@ -267,11 +280,13 @@ pub(super) fn prepare_committed_harvest(
             .canonicalize()
             .map_err(|error| HarvestError::Git {
                 command: "canonicalize Git top-level".to_string(),
+                cwd: root.to_path_buf(),
                 message: error.to_string(),
             })?;
     if canonical_root != canonical_git_root {
         return Err(HarvestError::Git {
             command: "verify Git top-level ownership".to_string(),
+            cwd: root.to_path_buf(),
             message: "Git top-level does not exactly match the managed workspace root".to_string(),
         });
     }
@@ -334,6 +349,7 @@ fn verified_initial_cook_candidate_baseline(
     }
     let index = tempfile::NamedTempFile::new().map_err(|error| HarvestError::Git {
         command: "create initial Cook candidate verification index".to_string(),
+        cwd: root.to_path_buf(),
         message: error.to_string(),
     })?;
     let index_path = index.path().display().to_string();
@@ -408,6 +424,7 @@ fn verified_preexisting_cook_baseline(
 fn workspace_patch_for_tree(root: &Path, expected_tree: &str) -> Result<String, HarvestError> {
     let index = tempfile::NamedTempFile::new().map_err(|error| HarvestError::Git {
         command: "create Cook baseline Git index".to_string(),
+        cwd: root.to_path_buf(),
         message: error.to_string(),
     })?;
     let index_path = index.path().display().to_string();
@@ -419,6 +436,7 @@ fn workspace_patch_for_tree(root: &Path, expected_tree: &str) -> Result<String, 
             .output()
             .map_err(|error| HarvestError::Git {
                 command: args.join(" "),
+                cwd: root.to_path_buf(),
                 message: error.to_string(),
             })?;
         if output.status.success() {
@@ -488,9 +506,10 @@ fn verified_gate_feedback_baseline(
     Ok(CandidateBaseline { patch })
 }
 
-fn snapshot_harvest_error(message: String) -> HarvestError {
+fn snapshot_harvest_error(cwd: &Path, message: String) -> HarvestError {
     HarvestError::Git {
         command: "verify Lab snapshot harvest provenance".to_string(),
+        cwd: cwd.to_path_buf(),
         message,
     }
 }
@@ -502,12 +521,13 @@ fn validate_derived_cook_baseline(
     context: &HarvestExecutionContext,
 ) -> Result<(), HarvestError> {
     let canonical_root = root.canonicalize().map_err(|error| {
-        snapshot_harvest_error(format!("canonicalize derived baseline root: {error}"))
+        snapshot_harvest_error(root, format!("canonicalize derived baseline root: {error}"))
     })?;
     if canonical_root != capability.canonical_path()
         || request.task_id != capability.bound_task_id()
     {
         return Err(snapshot_harvest_error(
+            root,
             "derived baseline capability does not bind this workspace and task".to_string(),
         ));
     }
@@ -519,19 +539,22 @@ fn validate_derived_cook_baseline(
     let tree = git_output(root, &["rev-parse", "HEAD^{tree}"])?;
     if head != capability.commit() || tree != capability.tree() {
         return Err(snapshot_harvest_error(
+            root,
             "derived baseline HEAD/tree does not match its internal contract".to_string(),
         ));
     }
     if let Some(parent_snapshot) = capability.parent_snapshot() {
         let ambient = serde_json::to_value(context.source_snapshot()?)
-            .map_err(|error| snapshot_harvest_error(error.to_string()))?;
+            .map_err(|error| snapshot_harvest_error(root, error.to_string()))?;
         if parent_snapshot != &ambient {
             return Err(snapshot_harvest_error(
+                root,
                 "derived baseline parent snapshot does not match ambient snapshot".to_string(),
             ));
         }
     } else if context.source_snapshot.is_some() {
         return Err(snapshot_harvest_error(
+            root,
             "derived baseline is missing its Lab parent snapshot".to_string(),
         ));
     }
@@ -636,10 +659,12 @@ fn apply_gate_feedback_baseline(
 ) -> Result<(), HarvestError> {
     let patch = tempfile::NamedTempFile::new().map_err(|error| HarvestError::Git {
         command: "create gate-feedback baseline patch".to_string(),
+        cwd: root.to_path_buf(),
         message: error.to_string(),
     })?;
     std::fs::write(patch.path(), &baseline.patch).map_err(|error| HarvestError::Git {
         command: "write gate-feedback baseline patch".to_string(),
+        cwd: root.to_path_buf(),
         message: error.to_string(),
     })?;
     let patch_path = patch.path().display().to_string();

--- a/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
@@ -201,22 +201,51 @@ fn harvest_committed_patch_with_metadata(
     let Some(attempt_root) = running.request.workspace.root.as_deref().map(Path::new) else {
         return Ok(());
     };
-    let mut root = attempt_root;
+
+    // Resolve the harvest root resiliently: prefer the attempt scratch workspace,
+    // but fall back to the durable source workspace when the attempt directory has
+    // been reaped (e.g. multi-attempt cook lifecycle). A missing or non-repo cwd
+    // is not fatal — it just means the attempt scratch is unavailable.
+    let attempt_is_repo = git_is_repository(attempt_root)?;
+    let mut root = if attempt_is_repo {
+        attempt_root
+    } else if let Some(source_root) = running
+        .source_workspace_root
+        .as_deref()
+        .map(Path::new)
+        .filter(|source_root| source_root != &attempt_root)
+    {
+        if git_is_repository(source_root)? {
+            source_root
+        } else {
+            return Ok(());
+        }
+    } else {
+        return Ok(());
+    };
+
     let mut head = git_output(root, &["rev-parse", "HEAD"])?;
     if head == base {
-        if let Some(source_root) = running
-            .source_workspace_root
-            .as_deref()
-            .map(Path::new)
-            .filter(|source_root| source_root != &attempt_root)
-        {
-            let source_head = git_output(source_root, &["rev-parse", "HEAD"])?;
-            if source_head != base {
-                // The scheduler owns this bounded Git-derived patch. It is not
-                // a provider-declared runtime file, even though its source
-                // checkout differs from the isolated execution checkout.
-                root = source_root;
-                head = source_head;
+        // When the attempt root was valid but had no new commits, check the
+        // durable source workspace for commits beyond base.
+        if root == attempt_root {
+            if let Some(source_root) = running
+                .source_workspace_root
+                .as_deref()
+                .map(Path::new)
+                .filter(|source_root| source_root != &attempt_root)
+            {
+                if git_is_repository(source_root)? {
+                    let source_head = git_output(source_root, &["rev-parse", "HEAD"])?;
+                    if source_head != base {
+                        root = source_root;
+                        head = source_head;
+                    } else {
+                        return Ok(());
+                    }
+                } else {
+                    return Ok(());
+                }
             } else {
                 return Ok(());
             }
@@ -405,20 +434,33 @@ fn git_is_ancestor(cwd: &Path, base: &str, head: &str) -> Result<bool, HarvestEr
         .output()
         .map_err(|error| HarvestError::Git {
             command: format!("git merge-base --is-ancestor {base} {head}"),
+            cwd: cwd.to_path_buf(),
             message: error.to_string(),
         })?;
     Ok(output.status.success())
 }
 
 pub(super) fn git_is_repository(cwd: &Path) -> Result<bool, HarvestError> {
-    let output = Command::new("git")
+    let output = match Command::new("git")
         .args(["rev-parse", "--is-inside-work-tree"])
         .current_dir(cwd)
         .output()
-        .map_err(|error| HarvestError::Git {
-            command: "git rev-parse --is-inside-work-tree".to_string(),
-            message: error.to_string(),
-        })?;
+    {
+        Ok(output) => output,
+        Err(error) => {
+            // A missing or inaccessible cwd (e.g. reaped scratch workspace)
+            // is not a git repository. Return false so callers can fall back
+            // instead of propagating ENOENT as a hard harvest failure.
+            if error.kind() == std::io::ErrorKind::NotFound {
+                return Ok(false);
+            }
+            return Err(HarvestError::Git {
+                command: "git rev-parse --is-inside-work-tree".to_string(),
+                cwd: cwd.to_path_buf(),
+                message: error.to_string(),
+            });
+        }
+    };
     Ok(output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "true")
 }
 
@@ -469,11 +511,13 @@ fn git_output_raw_with_env(
         .output()
         .map_err(|error| HarvestError::Git {
             command: format!("git {}", args.join(" ")),
+            cwd: cwd.to_path_buf(),
             message: error.to_string(),
         })?;
     if !output.status.success() {
         return Err(HarvestError::Git {
             command: format!("git {}", args.join(" ")),
+            cwd: cwd.to_path_buf(),
             message: String::from_utf8_lossy(&output.stderr).trim().to_string(),
         });
     }
@@ -482,13 +526,32 @@ fn git_output_raw_with_env(
 
 #[derive(Debug)]
 pub(crate) enum HarvestError {
-    DirtyWorkspace { status: String },
-    UnrelatedHead { base: String, head: String },
-    Git { command: String, message: String },
-    ArtifactDirectory { path: PathBuf, message: String },
-    ArtifactWrite { path: PathBuf, message: String },
-    Adoption { message: String },
-    CandidateBaselineMismatch { message: String },
+    DirtyWorkspace {
+        status: String,
+    },
+    UnrelatedHead {
+        base: String,
+        head: String,
+    },
+    Git {
+        command: String,
+        cwd: PathBuf,
+        message: String,
+    },
+    ArtifactDirectory {
+        path: PathBuf,
+        message: String,
+    },
+    ArtifactWrite {
+        path: PathBuf,
+        message: String,
+    },
+    Adoption {
+        message: String,
+    },
+    CandidateBaselineMismatch {
+        message: String,
+    },
 }
 
 pub(super) fn committed_harvest_preflight_outcome(task_id: String) -> AgentTaskOutcome {
@@ -530,10 +593,14 @@ pub(super) fn committed_harvest_failure(
                 .to_string(),
             serde_json::json!({ "base": base, "head": head }),
         ),
-        HarvestError::Git { command, message } => (
+        HarvestError::Git {
+            command,
+            cwd,
+            message,
+        } => (
             "agent_task.committed_harvest_git_failed",
             format!("committed-change harvest failed while running {command}: {message}"),
-            serde_json::json!({ "command": command, "stderr": message }),
+            serde_json::json!({ "command": command, "cwd": cwd.display().to_string(), "stderr": message }),
         ),
         HarvestError::ArtifactDirectory { path, message } => (
             "agent_task.committed_harvest_artifact_failed",
@@ -869,6 +936,7 @@ mod committed_harvest_tests {
         let error = harvest_committed_patch_with_metadata(&mut outcome, &running, |_, _| {
             Err(HarvestError::Git {
                 command: "git log injected metadata failure".to_string(),
+                cwd: PathBuf::from("/test/workspace"),
                 message: "injected failure".to_string(),
             })
         })
@@ -1129,5 +1197,120 @@ mod committed_harvest_tests {
         );
         assert!(preflight.source_provenance.is_none());
         std::env::remove_var(homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV);
+    }
+
+    #[test]
+    fn committed_harvest_falls_back_to_source_when_attempt_scratch_is_reaped() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        // Create the durable source workspace with a committed change past base.
+        let source = temp.path().join("source-workspace");
+        std::fs::create_dir(&source).expect("source workspace dir");
+        git(&source, &["init", "--quiet", "-b", "main"]);
+        git(&source, &["config", "user.email", "test@example.com"]);
+        git(&source, &["config", "user.name", "Homeboy Test"]);
+        std::fs::write(source.join("file.txt"), "base\n").expect("base file");
+        git(&source, &["add", "file.txt"]);
+        git(&source, &["commit", "--quiet", "-m", "base"]);
+        let base = git(&source, &["rev-parse", "HEAD"]);
+        std::fs::write(source.join("file.txt"), "agent change\n").expect("agent edit");
+        git(&source, &["commit", "--quiet", "-am", "agent change"]);
+
+        // Simulate a reaped attempt scratch workspace (path does not exist).
+        let reaped_scratch = temp.path().join("nonexistent-scratch-workspace");
+        assert!(!reaped_scratch.exists());
+
+        let request = AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "reaped-task".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "test".to_string(),
+                selector: None,
+                runtime_selection: None,
+                required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
+                model: None,
+                config: serde_json::Value::Null,
+            },
+            instructions: String::new(),
+            inputs: serde_json::Value::Null,
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace {
+                // The attempt scratch workspace root points at a reaped path.
+                root: Some(reaped_scratch.display().to_string()),
+                ..Default::default()
+            },
+            component_contracts: Vec::new(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            artifact_declarations: Vec::new(),
+            metadata: serde_json::Value::Null,
+        };
+        let running = RunningTask {
+            task_id: "reaped-task".to_string(),
+            request,
+            workspace_key: None,
+            executor_key: "test".to_string(),
+            model_key: None,
+            resource_units: 1,
+            exclusive_resource_keys: Vec::new(),
+            attempt: 3,
+            started_at: Instant::now(),
+            timeout_ms: None,
+            execution_deadline_unix_ms: None,
+            timeout_cancel_requested: false,
+            rotation_index: 0,
+            rotation_attempts: Vec::new(),
+            candidate_artifacts: Vec::new(),
+            retry_attempts: Vec::new(),
+            // The durable source workspace is the real, persistent checkout.
+            source_workspace_root: Some(source.display().to_string()),
+            _attempt_workspace: None,
+            run_id: Some("reaped-harvest-test".to_string()),
+            artifact_nonce: "test-artifact".to_string(),
+            task_base_sha: Some(base),
+            source_provenance: None,
+            scratch: crate::controller_scratch::ControllerScratchAllocation {
+                path: temp.path().join("controller-scratch"),
+                lease_id: "test-lease-1".to_string(),
+                index_path: temp.path().join("resources.json"),
+            },
+            adoption: None,
+            join_handle: None,
+        };
+        std::fs::create_dir_all(&running.scratch.path).expect("scratch dir");
+
+        let mut outcome = committed_harvest_preflight_outcome("reaped-task".to_string());
+        outcome.status = AgentTaskOutcomeStatus::Succeeded;
+
+        // The harvest must fall back to the durable source and produce the patch.
+        harvest_committed_patch_with_metadata(&mut outcome, &running, |cwd, range| {
+            committed_change_metadata_for_range(cwd, range)
+        })
+        .expect("harvest falls back to source workspace");
+
+        assert!(
+            !outcome.artifacts.is_empty(),
+            "a committed patch artifact must be produced"
+        );
+        let patch_artifact = &outcome.artifacts[0];
+        assert_eq!(patch_artifact.kind, "patch");
+        let patch_path = patch_artifact.path.as_ref().expect("patch path");
+        let patch = std::fs::read_to_string(patch_path).expect("read patch");
+        assert!(
+            patch.contains("agent change"),
+            "patch must contain the agent's change: {patch}"
+        );
+        assert!(
+            !outcome
+                .diagnostics
+                .iter()
+                .any(|d| d.class == "agent_task.committed_harvest_git_failed"),
+            "no harvest git failure diagnostic expected"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #9663: the committed-change harvest ran `git` in the attempt scratch workspace before any fallback, so a reaped scratch dir caused `git rev-parse` to ENOENT and the harvest aborted — silently discarding a successful agent's committed change (no candidate, no PR, no deterministic review-form comment).
- Harvest root-selection is now resilient: use the attempt workspace only if it exists and is a git work tree; otherwise fall back to `source_workspace_root` (the durable checkout); otherwise no-op instead of hard-failing.
- `git_is_repository` treats a missing cwd as not-a-repo (`Ok(false)`) rather than erroring.
- `HarvestError::Git` now carries the `cwd` and surfaces it in the `committed_harvest_git_failed` diagnostic (previously root-causing this required manual scratch-dir archaeology).
- Adds a test simulating a reaped attempt scratch workspace with a valid durable source that has a commit past base → harvest falls back to source and produces the committed patch artifact instead of failing.

## Test
- `cargo fmt --check` clean.
- `cargo check -p homeboy-agents --lib` clean.
- New unit test for the reaped-scratch fallback path.

## Notes
Part of the cook-lifecycle / scratch-workspace-hygiene burndown cluster (see also #9664 scratch cleanup gap). Authored via a homeboy agent-task cook; the cook process died before finalizing, so the completed change was rescued, verified, and submitted manually.