### PR TITLE
Fix Cook remediation executor classification

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -496,7 +496,22 @@ where
     let same_provider = (known_same_executor
         || follow_up_request.inputs["cook_loop"]["review_form_required"] == true)
         .then_some(true)
-        .or_else(|| terminal_executor_matches(aggregate, &follow_up_request.executor));
+        .or_else(|| {
+            let durable_provider_executions = agent_task_lifecycle::status(source_run_id)
+                .ok()
+                .and_then(|record| record.metadata.get("provider_executions").cloned())
+                .filter(|executions| {
+                    executions
+                        .as_array()
+                        .is_some_and(|executions| !executions.is_empty())
+                });
+            terminal_executor_matches(
+                aggregate,
+                plan,
+                durable_provider_executions.as_ref(),
+                &follow_up_request.executor,
+            )
+        });
     let Some(same_provider) = same_provider else {
         return Ok(CookFollowUpDispatch::PolicyFailure {
             reason: "cannot classify Cook remediation without terminal executor identity"

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -150,10 +150,12 @@ pub(crate) fn record_pre_execution_failure(
 
 pub(crate) fn terminal_executor_matches(
     aggregate: &crate::agent_task_scheduler::AgentTaskAggregate,
+    plan: &AgentTaskPlan,
+    durable_provider_executions: Option<&Value>,
     follow_up: &AgentTaskExecutor,
 ) -> Option<bool> {
     let outcome = aggregate.outcomes.last()?;
-    let terminal = terminal_executor_identity(outcome)?;
+    let terminal = terminal_executor_identity(outcome, plan, durable_provider_executions)?;
     Some(
         terminal.backend == follow_up.backend
             && terminal.selector == follow_up.selector
@@ -181,26 +183,130 @@ pub(crate) struct TerminalExecutorIdentity {
 
 pub(crate) fn terminal_executor_identity(
     outcome: &crate::agent_task::AgentTaskOutcome,
+    plan: &AgentTaskPlan,
+    durable_provider_executions: Option<&Value>,
 ) -> Option<TerminalExecutorIdentity> {
-    if let Some(attempt) =
-        provider_rotation_attempts(outcome).and_then(|attempts| attempts.last().cloned())
+    // Rotation evidence is the only persisted source with all three executor
+    // fields after a provider swap. A durable execution ledger, when present,
+    // must corroborate its backend/model rather than silently selecting the
+    // initial plan executor.
+    if outcome
+        .metadata
+        .pointer("/provider_rotation/attempts")
+        .is_some()
     {
-        return Some(TerminalExecutorIdentity {
+        let attempt = provider_rotation_attempts(outcome)?.last()?.clone();
+        let terminal = TerminalExecutorIdentity {
             backend: attempt.backend,
             selector: attempt.selector,
             model: attempt.model,
-        });
+        };
+        if durable_provider_executions.is_some() {
+            let durable = terminal_provider_execution(outcome, durable_provider_executions)?;
+            return (durable.backend == terminal.backend && durable.model == terminal.model)
+                .then_some(terminal);
+        }
+        return Some(terminal);
     }
-    let executor = outcome.metadata.get("executor")?;
-    Some(TerminalExecutorIdentity {
-        backend: executor.get("backend")?.as_str()?.to_string(),
-        selector: executor
-            .get("selector")
-            .and_then(Value::as_str)
-            .map(str::to_string),
-        model: executor
-            .get("model")
-            .and_then(Value::as_str)
-            .map(str::to_string),
-    })
+
+    // Preserve the normalized outcome identity used before durable execution
+    // evidence was introduced. When both sources exist they must agree.
+    if let Some(executor) = outcome.metadata.get("executor") {
+        let terminal = TerminalExecutorIdentity {
+            backend: executor.get("backend")?.as_str()?.to_string(),
+            selector: executor
+                .get("selector")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            model: executor
+                .get("model")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        };
+        if durable_provider_executions.is_some() {
+            let durable = terminal_provider_execution(outcome, durable_provider_executions)?;
+            return (durable.backend == terminal.backend && durable.model == terminal.model)
+                .then_some(terminal);
+        }
+        return Some(terminal);
+    }
+
+    // Without rotation, the source task is authoritative for the selector only
+    // if the durable terminal execution proves it remained the executor.
+    let task = plan
+        .tasks
+        .iter()
+        .find(|task| task.task_id == outcome.task_id)?;
+    let durable = terminal_provider_execution(outcome, durable_provider_executions)?;
+    (durable.backend == task.executor.backend && durable.model.as_deref() == task.executor.model())
+        .then_some(TerminalExecutorIdentity {
+            backend: task.executor.backend.clone(),
+            selector: task.executor.selector.clone(),
+            model: task.executor.model().map(str::to_string),
+        })
+}
+
+struct DurableTerminalExecution {
+    backend: String,
+    model: Option<String>,
+}
+
+fn terminal_provider_execution(
+    outcome: &crate::agent_task::AgentTaskOutcome,
+    durable_provider_executions: Option<&Value>,
+) -> Option<DurableTerminalExecution> {
+    let executions = durable_provider_executions?.as_array()?;
+    let terminal_attempt = executions
+        .iter()
+        .filter(|execution| {
+            execution["task_id"] == outcome.task_id
+                && matches!(
+                    execution["state"].as_str(),
+                    Some(
+                        "succeeded"
+                            | "failed"
+                            | "cancelled"
+                            | "timed_out"
+                            | "candidate_recoverable"
+                    )
+                )
+        })
+        .filter_map(|execution| {
+            execution["attempt"]
+                .as_u64()
+                .map(|attempt| (attempt, execution))
+        })
+        .max_by_key(|(attempt, _)| *attempt)?
+        .0;
+    let identities: Vec<_> = executions
+        .iter()
+        .filter(|execution| {
+            execution["task_id"] == outcome.task_id
+                && execution["attempt"].as_u64() == Some(terminal_attempt)
+                && matches!(
+                    execution["state"].as_str(),
+                    Some(
+                        "succeeded"
+                            | "failed"
+                            | "cancelled"
+                            | "timed_out"
+                            | "candidate_recoverable"
+                    )
+                )
+        })
+        .map(|execution| {
+            Some(DurableTerminalExecution {
+                backend: execution["backend"].as_str()?.to_string(),
+                model: execution["model"].as_str().map(str::to_string),
+            })
+        })
+        .collect::<Option<Vec<_>>>()?;
+    let terminal = identities.first()?;
+    identities
+        .iter()
+        .all(|identity| identity.backend == terminal.backend && identity.model == terminal.model)
+        .then(|| DurableTerminalExecution {
+            backend: terminal.backend.clone(),
+            model: terminal.model.clone(),
+        })
 }

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -11,6 +11,7 @@ use crate::agent_task_lifecycle;
 use crate::agent_task_lifecycle::{status as lifecycle_status, AgentTaskRunState};
 use crate::agent_task_schedule::AgentTaskPlan;
 use crate::agent_task_scheduler::{
+    AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
     AgentTaskExecutionContext, AgentTaskExecutorAdapter, AgentTaskProviderRotationEntry,
     AgentTaskProviderRotationPolicy, AgentTaskScheduler, AgentTaskState,
 };
@@ -52,6 +53,145 @@ fn cook_usage_reads_scheduler_rotation_metadata_and_decrements_budget() {
     assert_eq!(usage.provider_rotations, 1);
     assert_eq!(remaining.max_provider_executions, 1);
     assert_eq!(remaining.max_provider_rotations, 0);
+}
+
+#[test]
+fn terminal_executor_uses_durable_execution_when_outcome_executor_is_absent() {
+    let mut plan = test_plan();
+    plan.tasks[0].executor.model = Some("openai/gpt-5.6-terra".to_string());
+    let aggregate = aggregate_with_outcome(serde_json::json!({}));
+    let follow_up = plan.tasks[0].executor.clone();
+    let durable = serde_json::json!([{
+        "task_id": "service-task",
+        "attempt": 1,
+        "backend": "test",
+        "model": "openai/gpt-5.6-terra",
+        "state": "succeeded"
+    }]);
+
+    assert_eq!(
+        terminal_executor_matches(&aggregate, &plan, Some(&durable), &follow_up),
+        Some(true)
+    );
+}
+
+#[test]
+fn terminal_executor_preserves_normalized_outcome_identity() {
+    let mut plan = test_plan();
+    plan.tasks[0].executor.model = Some("normalized-model".to_string());
+    let aggregate = aggregate_with_outcome(serde_json::json!({
+        "executor": {
+            "backend": "test",
+            "selector": "service",
+            "model": "normalized-model"
+        }
+    }));
+
+    assert_eq!(
+        terminal_executor_matches(&aggregate, &plan, None, &plan.tasks[0].executor),
+        Some(true)
+    );
+
+    let conflicting = serde_json::json!([{
+        "task_id": "service-task",
+        "attempt": 1,
+        "backend": "other",
+        "model": "normalized-model",
+        "state": "succeeded"
+    }]);
+    assert_eq!(
+        terminal_executor_matches(
+            &aggregate,
+            &plan,
+            Some(&conflicting),
+            &plan.tasks[0].executor
+        ),
+        None
+    );
+}
+
+#[test]
+fn terminal_executor_uses_rotated_terminal_identity_not_initial_plan() {
+    let mut plan = test_plan();
+    plan.tasks[0].executor.model = Some("initial-model".to_string());
+    let aggregate = aggregate_with_outcome(serde_json::json!({
+        "provider_rotation": {
+            "attempts": [{
+                "attempt": 1,
+                "rotation_index": 0,
+                "backend": "rotated",
+                "selector": "terminal-selector",
+                "model": "terminal-model",
+                "status": "succeeded",
+                "summary": null
+            }]
+        }
+    }));
+    let durable = serde_json::json!([{
+        "task_id": "service-task",
+        "attempt": 1,
+        "backend": "rotated",
+        "model": "terminal-model",
+        "state": "succeeded"
+    }]);
+    let mut follow_up = plan.tasks[0].executor.clone();
+    follow_up.backend = "rotated".to_string();
+    follow_up.selector = Some("terminal-selector".to_string());
+    follow_up.model = Some("terminal-model".to_string());
+
+    assert_eq!(
+        terminal_executor_matches(&aggregate, &plan, Some(&durable), &follow_up),
+        Some(true)
+    );
+    assert_eq!(
+        terminal_executor_matches(&aggregate, &plan, Some(&durable), &plan.tasks[0].executor),
+        Some(false)
+    );
+}
+
+#[test]
+fn terminal_executor_rejects_conflicting_or_unavailable_authority() {
+    let mut plan = test_plan();
+    plan.tasks[0].executor.model = Some("initial-model".to_string());
+    let aggregate = aggregate_with_outcome(serde_json::json!({
+        "provider_rotation": {
+            "attempts": [{
+                "attempt": 1,
+                "rotation_index": 0,
+                "backend": "rotated",
+                "selector": "terminal-selector",
+                "model": "terminal-model",
+                "status": "succeeded",
+                "summary": null
+            }]
+        }
+    }));
+    let conflicting = serde_json::json!([{
+        "task_id": "service-task",
+        "attempt": 1,
+        "backend": "other",
+        "model": "terminal-model",
+        "state": "succeeded"
+    }]);
+
+    assert_eq!(
+        terminal_executor_matches(
+            &aggregate,
+            &plan,
+            Some(&conflicting),
+            &plan.tasks[0].executor
+        ),
+        None
+    );
+    assert_eq!(
+        terminal_executor_matches(
+            &aggregate_with_outcome(serde_json::json!({})),
+            &plan,
+            None,
+            &plan.tasks[0].executor,
+        ),
+        None
+    );
 }
 
 #[test]
@@ -1166,6 +1306,38 @@ fn test_plan() -> AgentTaskPlan {
             metadata: Value::Null,
         }],
     )
+}
+
+fn aggregate_with_outcome(metadata: Value) -> AgentTaskAggregate {
+    AgentTaskAggregate {
+        schema: crate::agent_task::AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+        plan_id: "service-plan".to_string(),
+        status: AgentTaskAggregateStatus::Succeeded,
+        totals: AgentTaskAggregateTotals {
+            succeeded: 1,
+            ..Default::default()
+        },
+        outcomes: vec![AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: "service-task".to_string(),
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: None,
+            failure_classification: None,
+            artifacts: Vec::new(),
+            typed_artifacts: Vec::new(),
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            outputs: Value::Null,
+            workflow: None,
+            follow_up: None,
+            metadata,
+        }],
+        events: Vec::new(),
+        artifact_lineage: Vec::new(),
+        child_runs: Vec::new(),
+        artifact_bindings: Vec::new(),
+        queue: Default::default(),
+    }
 }
 
 fn discovery_plan() -> AgentTaskPlan {


### PR DESCRIPTION
## Summary

- recover terminal executor identity from the durable provider-execution ledger when normalized outcomes omit `metadata.executor`
- preserve normalized outcome and provider-rotation identity paths, corroborating durable backend/model evidence when both exist
- fail closed for missing, malformed, conflicting, or ambiguous terminal identity evidence
- cover durable fallback, normalized compatibility, provider rotation, and conflict handling

Closes #9659.
Related to #9652.

## Verification

- `cargo check -p homeboy-agents`
- four exact `terminal_executor_*` regression tests
- scoped `rustfmt --check` for all changed files
- `git diff --check origin/main...HEAD`

The broader `agent_task_service::` run progressed through all Cook execution, adoption, and finalization tests before the five-minute cap. Two unrelated fixed-ID/shared-runtime tests failed and also fail when run alone: `retry_attempts_are_appended_idempotently_before_scheduling` encounters an existing durable recipe, and `discovery_active_classifies_liveness_and_source` observes the active local runtime instead of a stale fixture.

## AI assistance

Homeboy Cook with `openai/gpt-5.6-terra` drafted the initial repair. OpenCode with `openai/gpt-5.6-sol` reviewed the candidate, restored compatibility with normalized outcome identity, added corroboration coverage, rebased it onto current `main`, and ran verification. Chris Huber remains responsible for the submitted changes.