### PR TITLE
Report invocation-accurate latest_run_id in cook result envelope

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -144,6 +144,8 @@ pub struct AgentTaskCookReport {
     pub latest_run_id: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub history_run_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub invocation_run_ids: Vec<String>,
     pub status: String,
     pub attempts: Vec<AgentTaskCookAttemptReport>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -906,6 +908,7 @@ where
                         attempts,
                         pre_execution_failure,
                         error,
+                        Some(&run_id),
                     ));
                 }
                 if attempt == max_attempts {
@@ -916,6 +919,7 @@ where
                         None,
                         Some(error.to_string()),
                         1,
+                        Some(&run_id),
                     ));
                 }
                 let next_attempt = attempt + 1;
@@ -957,6 +961,7 @@ where
                 None,
                 Some("provider attempt accepted by the runner daemon".to_string()),
                 0,
+                Some(&run_id),
             ));
         }
         let plan = agent_task_lifecycle::load_plan_for_execution(&run_id)?;
@@ -978,6 +983,7 @@ where
                 None,
                 Some("agent-task cook requires a plan with one source task".to_string()),
                 1,
+                Some(&run_id),
             ));
         };
         if plan.tasks.len() != 1 {
@@ -988,6 +994,7 @@ where
                 None,
                 Some("agent-task cook currently supports one task per cook attempt".to_string()),
                 1,
+                Some(&run_id),
             ));
         }
 
@@ -1017,6 +1024,7 @@ where
                     record.state
                 )),
                 1,
+                Some(&run_id),
             ));
         }
 
@@ -1038,6 +1046,7 @@ where
                     None,
                     Some(error.to_string()),
                     1,
+                    Some(&run_id),
                 ));
             }
         };
@@ -1078,6 +1087,7 @@ where
                                 .to_string(),
                         ),
                         0,
+                        Some(&run_id),
                     ));
                 }
                 let mut active_moving_base_recovery = None;
@@ -1110,7 +1120,11 @@ where
                                     })?,
                                 )?;
                                 return Ok(moving_base_recovery_report(
-                                    cook_id, attempts, recovery, false,
+                                    cook_id,
+                                    attempts,
+                                    recovery,
+                                    false,
+                                    Some(&run_id),
                                 ));
                             }
                             active_moving_base_recovery = Some(recovery);
@@ -1133,6 +1147,7 @@ where
                                 attempts,
                                 recovery,
                                 continuation_queued,
+                                Some(&run_id),
                             ));
                         }
                     },
@@ -1166,6 +1181,7 @@ where
                             attempts,
                             recovery,
                             continuation_queued,
+                            Some(&run_id),
                         ));
                     }
                     Err(error) => return Err(error),
@@ -1185,6 +1201,7 @@ where
                     Some(finalization),
                     stop_reason,
                     exit_code,
+                    Some(&run_id),
                 ));
             }
             AgentTaskCookLoopStatus::NoChanges => {
@@ -1198,6 +1215,7 @@ where
                             .to_string(),
                     ),
                     1,
+                    Some(&run_id),
                 ));
             }
             AgentTaskCookLoopStatus::NoOpGateFailed => {
@@ -1211,6 +1229,7 @@ where
                             .to_string(),
                     ),
                     1,
+                    Some(&run_id),
                 ));
             }
             AgentTaskCookLoopStatus::RetryRequested => {
@@ -1224,6 +1243,7 @@ where
                             "cook feedback requested retry without a follow-up request".to_string(),
                         ),
                         1,
+                        Some(&run_id),
                     ));
                 };
                 let budget_limit = budget_limit
@@ -1257,6 +1277,7 @@ where
                                 "provider execution stopped because {reason} was exhausted"
                             )),
                             1,
+                            Some(&run_id),
                         ));
                     }
                     CookFollowUpDispatch::PolicyFailure { reason } => {
@@ -1267,6 +1288,7 @@ where
                             None,
                             Some(reason),
                             1,
+                            Some(&run_id),
                         ));
                     }
                 }
@@ -1282,6 +1304,7 @@ where
                             .to_string(),
                     ),
                     1,
+                    Some(&run_id),
                 ));
             }
         }
@@ -1294,6 +1317,7 @@ where
         None,
         Some("cook attempt budget exhausted".to_string()),
         1,
+        Some(&run_id),
     ))
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -261,6 +261,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
                 None,
                 result.stop_reason,
                 exit_code,
+                None,
             ));
         }
         let promotion = persisted_promotion_for_attempt(&record.run_id)?.ok_or_else(|| {
@@ -302,6 +303,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
             finalization,
             Some("reused the completed candidate adoption result; set rerun_completed_gates to rerun its gates".to_string()),
             if status == "review_ready" || status == "green_no_finalize" { 0 } else { 1 },
+            Some(record.run_id.as_str()),
         ));
     }
     let attempt_dispatcher =
@@ -468,6 +470,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
                         .to_string(),
                 ),
                 1,
+                Some(record.run_id.as_str()),
             );
             persist_adoption_terminal_result(&record.run_id, &report.value)?;
             return Ok(report);
@@ -550,6 +553,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
                         "provider execution stopped because {reason} was exhausted"
                     )),
                     1,
+                    Some(record.run_id.as_str()),
                 );
                 persist_adoption_terminal_result(&record.run_id, &report.value)?;
                 agent_task_lifecycle::finish_candidate_adoption(
@@ -566,6 +570,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
                     None,
                     Some(reason.clone()),
                     1,
+                    Some(record.run_id.as_str()),
                 );
                 persist_adoption_terminal_result(&record.run_id, &report.value)?;
                 agent_task_lifecycle::finish_candidate_adoption(&record.run_id, Some(reason))?;
@@ -585,6 +590,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
             None,
             Some("adopted candidate did not pass the original deterministic gates".to_string()),
             1,
+            Some(record.run_id.as_str()),
         ));
     }
     if options.no_finalize {
@@ -599,6 +605,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
                     .to_string(),
             ),
             0,
+            Some(record.run_id.as_str()),
         ));
     }
     agent_task_lifecycle::checkpoint_candidate_adoption(
@@ -634,6 +641,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
         Some(finalization),
         None,
         exit_code,
+        Some(record.run_id.as_str()),
     ))
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -115,6 +115,7 @@ pub(crate) fn pre_execution_failure_report(
     attempts: Vec<AgentTaskCookAttemptReport>,
     failure: PreExecutionFailureDetails,
     error: Error,
+    invocation_latest_run_id: Option<&str>,
 ) -> AgentTaskRunResult<AgentTaskCookReport> {
     let phase = failure.phase.as_deref().unwrap_or("cook_pre_execution");
     let classification = failure.classification.as_deref().unwrap_or("unknown");
@@ -127,6 +128,7 @@ pub(crate) fn pre_execution_failure_report(
             "pre-provider failure in phase `{phase}` classified as `{classification}`: {error}"
         )),
         1,
+        invocation_latest_run_id,
     );
     report.value.terminal_phase = failure.phase;
     report.value.terminal_failure_classification = failure.classification;

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -273,6 +273,7 @@ pub(crate) fn moving_base_recovery_report(
     attempts: Vec<AgentTaskCookAttemptReport>,
     recovery: MovingBaseCookRecovery,
     continuation_queued: bool,
+    invocation_latest_run_id: Option<&str>,
 ) -> AgentTaskRunResult<AgentTaskCookReport> {
     let stop_reason = if recovery.base_movements >= 3 {
         Some(format!("moving-base recovery exhausted after {} refreshed base observations: {}; inspect the retained recovery evidence and reconcile the destination before retrying", recovery.base_movements, recovery.blocker))
@@ -294,6 +295,7 @@ pub(crate) fn moving_base_recovery_report(
         None,
         stop_reason,
         1,
+        invocation_latest_run_id,
     );
     report.value.moving_base_recovery = Some(recovery);
     report
@@ -762,25 +764,33 @@ pub(crate) fn cook_report(
     finalization: Option<Value>,
     stop_reason: Option<String>,
     exit_code: i32,
+    invocation_latest_run_id: Option<&str>,
 ) -> AgentTaskRunResult<AgentTaskCookReport> {
-    let (latest_run_id, history_run_ids) = agent_task_lifecycle::cook_index(&cook_id)
+    let history_run_ids = agent_task_lifecycle::cook_index(&cook_id)
         .map(|index| {
-            (
-                Some(index.latest_run_id),
-                index
-                    .attempts
-                    .into_iter()
-                    .map(|attempt| attempt.run_id)
-                    .collect(),
-            )
+            index
+                .attempts
+                .into_iter()
+                .map(|attempt| attempt.run_id)
+                .collect::<Vec<_>>()
         })
-        .unwrap_or((None, Vec::new()));
+        .unwrap_or_default();
+    let latest_run_id = invocation_latest_run_id.map(str::to_string).or_else(|| {
+        agent_task_lifecycle::cook_index(&cook_id)
+            .ok()
+            .map(|index| index.latest_run_id)
+    });
+    let invocation_run_ids: Vec<String> = attempts
+        .iter()
+        .map(|attempt| attempt.run_id.clone())
+        .collect();
     AgentTaskRunResult {
         value: AgentTaskCookReport {
             schema: "homeboy/agent-task-cook/v1",
             cook_id,
             latest_run_id,
             history_run_ids,
+            invocation_run_ids,
             status: status.to_string(),
             attempts,
             finalization,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -8,7 +8,7 @@ use super::super::cook_adoption::{
 };
 use super::super::cook_baseline::git_output;
 use super::super::cook_promotion::{
-    finalize_cook_pr_with_backend, moving_base_recovery_for_run,
+    cook_report, finalize_cook_pr_with_backend, moving_base_recovery_for_run,
     moving_base_recovery_from_promotion, moving_base_recovery_report, next_moving_base_recovery,
     persisted_promotion_for_attempt, recover_moving_base_cook_candidate,
     refreshed_moving_base_recovery, MovingBaseCookRecovery,
@@ -174,7 +174,8 @@ fn moving_base_recovery_report_retains_typed_evidence_and_exact_continuation() {
         continuation: "homeboy agent-task run-next".to_string(),
         base_movements: 0,
     };
-    let report = moving_base_recovery_report("cook-9267".to_string(), Vec::new(), recovery, true);
+    let report =
+        moving_base_recovery_report("cook-9267".to_string(), Vec::new(), recovery, true, None);
 
     assert_eq!(report.value.status, "candidate_recoverable");
     let recovery = report
@@ -254,13 +255,17 @@ fn divergent_destination_and_repeated_base_movement_are_terminalized() {
         "moving-base recovery destination differs from the exact promoted candidate".to_string(),
     );
     assert_eq!(divergent.base_movements, 3);
-    assert!(
-        moving_base_recovery_report("cook-bound".to_string(), Vec::new(), divergent, false)
-            .value
-            .stop_reason
-            .unwrap()
-            .contains("exhausted")
-    );
+    assert!(moving_base_recovery_report(
+        "cook-bound".to_string(),
+        Vec::new(),
+        divergent,
+        false,
+        None
+    )
+    .value
+    .stop_reason
+    .unwrap()
+    .contains("exhausted"));
 
     let first = next_moving_base_recovery(recovery, "base advanced".to_string());
     let second = next_moving_base_recovery(first, "base advanced again".to_string());
@@ -3603,5 +3608,96 @@ fn resume_cook_batch_reports_a_child_with_no_recipe_as_unresumable() {
             .error
             .as_deref()
             .is_some_and(|error| error.contains("no durable recipe")));
+    });
+}
+
+#[test]
+fn cook_report_latest_run_id_prefers_invocation_over_stale_cook_index() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        use crate::agent_task_lifecycle;
+
+        let cook_id = "cook-8010-test";
+        let stale_run_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, 1);
+        let stale_plan = AgentTaskPlan::new("plan-stale", Vec::new());
+        agent_task_lifecycle::submit_plan(&stale_plan, Some(&stale_run_id))
+            .expect("stale run submitted");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, &stale_run_id)
+            .expect("stale cook attempt indexed");
+
+        let stale_index = agent_task_lifecycle::cook_index(cook_id).expect("stale index");
+        assert_eq!(stale_index.latest_run_id, stale_run_id);
+
+        let fresh_run_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, 2);
+        let invocation_run_ids = vec![fresh_run_id.clone()];
+
+        let report = cook_report(
+            cook_id.to_string(),
+            "execution_budget_exhausted",
+            vec![AgentTaskCookAttemptReport {
+                attempt: 2,
+                run_id: fresh_run_id.clone(),
+                run_state: "Running".to_string(),
+                aggregate_path: None,
+                promotion: None,
+                feedback: None,
+            }],
+            None,
+            Some("provider execution stopped because budget was exhausted".to_string()),
+            1,
+            Some(&fresh_run_id),
+        );
+
+        assert_eq!(
+            report.value.latest_run_id.as_deref(),
+            Some(fresh_run_id.as_str()),
+            "latest_run_id must be THIS invocation's run, not the stale cook_index run"
+        );
+        assert_ne!(
+            report.value.latest_run_id.as_deref(),
+            Some(stale_run_id.as_str()),
+            "latest_run_id must not point at the prior-session stale run"
+        );
+        assert_eq!(
+            report.value.invocation_run_ids, invocation_run_ids,
+            "invocation_run_ids must contain exactly the runs dispatched in this invocation"
+        );
+        assert!(
+            report.value.history_run_ids.contains(&stale_run_id),
+            "history_run_ids should still include the full cross-invocation history"
+        );
+        assert!(
+            report.value.history_run_ids.contains(&fresh_run_id),
+            "history_run_ids should include the current invocation's run"
+        );
+    });
+}
+
+#[test]
+fn cook_report_invocation_run_ids_populated_for_policy_failure() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let fresh_run_id = "agent-task-fresh-abc123".to_string();
+        let report = cook_report(
+            "cook-test".to_string(),
+            "policy_failure",
+            vec![AgentTaskCookAttemptReport {
+                attempt: 1,
+                run_id: fresh_run_id.clone(),
+                run_state: "Succeeded".to_string(),
+                aggregate_path: None,
+                promotion: None,
+                feedback: None,
+            }],
+            None,
+            Some("policy failure".to_string()),
+            1,
+            Some(&fresh_run_id),
+        );
+
+        assert_eq!(report.value.invocation_run_ids, vec![fresh_run_id.clone()]);
+        assert_eq!(
+            report.value.latest_run_id.as_deref(),
+            Some(fresh_run_id.as_str())
+        );
+        assert_eq!(report.value.status, "policy_failure");
     });
 }


### PR DESCRIPTION
## Summary
- `cook_report` sourced `latest_run_id`/`history_run_ids` purely from the persistent, cross-invocation `cook_index`. So a re-run or budget-exhausted cook reported a **stale prior-session run** as `latest_run_id` while `status`/`stop_reason` described the *current* invocation — pointing the orchestrator (OpenCode/chat plane) at the wrong run to inspect.
- Bind the reported run identity to the runs THIS invocation actually executed: add `invocation_run_ids` and prefer the invocation's final `run_id` for `latest_run_id`; use `cook_index` only to enrich `history_run_ids` (full history is legitimately cross-invocation).
- `status`, `stop_reason`, and `latest_run_id` are now internally consistent — the run the operator is pointed at is the run the status describes.
- Additive to the `homeboy/agent-task-cook/v1` schema (new optional field); no consumer break.

## Test
- `cargo fmt --check` clean; `cargo check -p homeboy-agents --lib` clean.
- Extended `cook_tests.rs`: after a budget-exhausted / re-run invocation, `latest_run_id` equals a run dispatched in THIS invocation, not a pre-seeded prior run in the cook_index.

## Notes
Part of the async-reporting / result-contract burndown (#8010). This was the source of confusing "which run do I inspect" signals during the burndown. Authored via an agent-task cook; the cook process failed before finalizing (harvest bug #9663, now fixed by #9669), so the completed change was rescued from the attempt workspace, verified, and submitted.