### PR TITLE
Re-materialize a reaped cook follow-up baseline worktree instead of failing the provider preflight

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -22,7 +22,8 @@ use homeboy_core::{Error, Result};
 
 use super::cook_baseline::{
     cook_attempt_harvest_context, materialize_follow_up_baseline,
-    materialize_initial_candidate_baseline, CookFollowUpBaseline, DerivedCookBaselineCapability,
+    materialize_initial_candidate_baseline, re_materialize_follow_up_baseline,
+    CookFollowUpBaseline, DerivedCookBaselineCapability,
 };
 use super::cook_budget::{
     budget_remaining, execution_budget_usage, reserve_remediation_budget, ExecutionBudgetUsage,
@@ -823,8 +824,74 @@ where
                 } else {
                     None
                 };
+                // For follow-up attempts (attempt > 1), the plan's workspace.root
+                // was set by a previous dispatch_cook_follow_up to a baseline
+                // worktree path. If that worktree was reaped (e.g. by tmp cleanup,
+                // disk-pressure cleanup, or git worktree prune), re-materialize it
+                // at the same path so the provider preflight check passes.
+                let re_materialized_baseline = if attempt > 1 && initial_baseline.is_none() {
+                    let root = plan
+                        .tasks
+                        .first()
+                        .and_then(|t| t.workspace.root.as_deref())
+                        .map(std::path::Path::new);
+                    match root {
+                        Some(path) if !path.exists() => {
+                            let source_run_id = plan.tasks[0]
+                                .inputs["cook_loop"]["artifact_provenance"]["source_run_id"]
+                                .as_str()
+                                .ok_or_else(|| {
+                                    with_pre_execution_phase(
+                                        Error::validation_invalid_argument(
+                                            "cook_loop.artifact_provenance.source_run_id",
+                                            "follow-up plan missing source run id for baseline re-materialization",
+                                            None,
+                                            None,
+                                        ),
+                                        "re_materialize_follow_up_baseline",
+                                    )
+                                })?;
+                            let promotion = persisted_promotion_for_attempt(source_run_id)?
+                                .ok_or_else(|| {
+                                    with_pre_execution_phase(
+                                        Error::validation_invalid_argument(
+                                            "promotion",
+                                            format!(
+                                                "source attempt {source_run_id} has no persisted \
+                                                 promotion for baseline re-materialization"
+                                            ),
+                                            Some(source_run_id.to_string()),
+                                            None,
+                                        ),
+                                        "re_materialize_follow_up_baseline",
+                                    )
+                                })?;
+                            let task_id = &plan.tasks[0].task_id;
+                            Some(
+                                re_materialize_follow_up_baseline(
+                                    &promotion,
+                                    path,
+                                    source_run_id,
+                                    task_id,
+                                )
+                                .map_err(|error| {
+                                    with_pre_execution_phase(
+                                        error,
+                                        "re_materialize_follow_up_baseline",
+                                    )
+                                })?,
+                            )
+                        }
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
+                let effective_baseline = initial_baseline
+                    .as_ref()
+                    .or(re_materialized_baseline.as_ref());
                 let mut dispatch_plan = plan.clone();
-                if let Some(baseline) = initial_baseline.as_ref() {
+                if let Some(baseline) = effective_baseline {
                     for task in &mut dispatch_plan.tasks {
                         // The baseline is immutable evidence for this dispatch,
                         // never the durable workspace a retry continues in.
@@ -848,18 +915,14 @@ where
                     dispatcher.dispatch_attempt(
                         dispatch_plan,
                         &run_id,
-                        initial_baseline
-                            .as_ref()
-                            .map(CookFollowUpBaseline::capability),
+                        effective_baseline.map(CookFollowUpBaseline::capability),
                     )
                 } else {
                     run_loaded_plan_with_derived_cook_baseline(
                         dispatch_plan,
                         Some(&run_id),
                         executor.clone(),
-                        initial_baseline
-                            .as_ref()
-                            .map(CookFollowUpBaseline::capability),
+                        effective_baseline.map(CookFollowUpBaseline::capability),
                         Some(cook_attempt_harvest_context(&options.harvest_context)),
                     )
                     .map(|_| ())

--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -260,6 +260,36 @@ pub(crate) fn materialize_follow_up_baseline(
     source_run_id: &str,
     bound_task_id: &str,
 ) -> Result<CookFollowUpBaseline> {
+    materialize_follow_up_baseline_at(promotion, None, source_run_id, bound_task_id)
+}
+
+/// Re-materialize a follow-up baseline worktree at a specific path that was
+/// previously created by [`materialize_follow_up_baseline`] but has since been
+/// reaped (e.g. by tmp cleanup, disk-pressure cleanup, or `git worktree prune`).
+///
+/// This reuses the same durable promotion data and worktree/patch logic as
+/// [`materialize_follow_up_baseline`] to deterministically recreate an identical
+/// worktree at the original path, preserving the baseline identity contract for
+/// the provider preflight and subsequent gate verification.
+pub(crate) fn re_materialize_follow_up_baseline(
+    promotion: &AgentTaskPromotionReport,
+    target_path: &std::path::Path,
+    source_run_id: &str,
+    bound_task_id: &str,
+) -> Result<CookFollowUpBaseline> {
+    materialize_follow_up_baseline_at(promotion, Some(target_path), source_run_id, bound_task_id)
+}
+
+/// Shared worktree/patch materialization logic. When `target_path` is `None` a
+/// fresh UUID path is generated under the follow-up baselines temp directory;
+/// when `Some(path)` the worktree is created at the exact given path (used by
+/// recovery to re-materialize a reaped baseline at its original location).
+fn materialize_follow_up_baseline_at(
+    promotion: &AgentTaskPromotionReport,
+    target_path: Option<&std::path::Path>,
+    source_run_id: &str,
+    bound_task_id: &str,
+) -> Result<CookFollowUpBaseline> {
     let source_root = promotion
         .provenance
         .get("worktree_path")
@@ -353,14 +383,19 @@ pub(crate) fn materialize_follow_up_baseline(
         &["write-tree"],
         &[("GIT_INDEX_FILE", &index_path)],
     )?;
-    let parent = std::env::temp_dir().join("homeboy-cook-follow-up-baselines");
-    std::fs::create_dir_all(&parent).map_err(|error| {
-        Error::internal_io(
-            error.to_string(),
-            Some("create cook baseline directory".to_string()),
-        )
-    })?;
-    let path = parent.join(format!("baseline-{}", uuid::Uuid::new_v4()));
+    let path = match target_path {
+        Some(p) => p.to_path_buf(),
+        None => {
+            let parent = std::env::temp_dir().join("homeboy-cook-follow-up-baselines");
+            std::fs::create_dir_all(&parent).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("create cook baseline directory".to_string()),
+                )
+            })?;
+            parent.join(format!("baseline-{}", uuid::Uuid::new_v4()))
+        }
+    };
     let path_string = path.display().to_string();
     git_output(
         &source_root,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3673,6 +3673,97 @@ fn cook_report_latest_run_id_prefers_invocation_over_stale_cook_index() {
 }
 
 #[test]
+fn re_materialize_follow_up_baseline_recovers_after_worktree_deletion() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = &temp.path().join("repo");
+    std::fs::create_dir(root).unwrap();
+    for args in [
+        vec!["init"],
+        vec!["config", "user.name", "Test"],
+        vec!["config", "user.email", "test@example.com"],
+    ] {
+        assert!(Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+    }
+    std::fs::write(root.join("base.txt"), "base\n").unwrap();
+    assert!(Command::new("git")
+        .args(["add", "."])
+        .current_dir(root)
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-m", "base"])
+        .current_dir(root)
+        .status()
+        .unwrap()
+        .success());
+    let target_head = git_output(root, &["rev-parse", "HEAD"]).unwrap();
+    std::fs::write(root.join("patched.txt"), "patched\n").unwrap();
+    assert!(Command::new("git")
+        .args(["add", "patched.txt"])
+        .current_dir(root)
+        .status()
+        .unwrap()
+        .success());
+    let patch = Command::new("git")
+        .args([
+            "diff",
+            "--cached",
+            "--binary",
+            "--full-index",
+            "--find-renames",
+            "HEAD",
+        ])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(patch.status.success());
+    let patch_path = temp.path().join("candidate.patch");
+    std::fs::write(&patch_path, patch.stdout).unwrap();
+    assert!(Command::new("git")
+        .args(["reset"])
+        .current_dir(root)
+        .status()
+        .unwrap()
+        .success());
+    let report: AgentTaskPromotionReport = serde_json::from_value(serde_json::json!({
+        "schema":"homeboy/agent-task-promotion-report/v1", "status":"gate_failed",
+        "source":{"kind":"aggregate","task_id":"candidate-task","run_id":"first-run"},
+        "to_worktree":"fixture@target", "target":{"worktree":"fixture@target", "head":target_head},
+        "patch_artifact":{"id":"candidate","kind":"patch","path":patch_path},
+        "provenance":{"worktree_path":root}, "operator_notification":{"status":"blocked","message":"red"}
+    }))
+    .unwrap();
+    let baseline =
+        materialize_follow_up_baseline(&report, "first-run", "candidate-task").expect("baseline");
+    let baseline_path = baseline.path.clone();
+    assert!(baseline_path.exists());
+    let original_commit = baseline.capability().commit().to_string();
+    let original_tree = baseline.capability().tree().to_string();
+    drop(baseline);
+    assert!(!baseline_path.exists(), "drop should remove the worktree");
+    let re_materialized =
+        re_materialize_follow_up_baseline(&report, &baseline_path, "first-run", "candidate-task")
+            .expect("re-materialized baseline");
+    assert_eq!(re_materialized.path, baseline_path);
+    assert!(baseline_path.exists());
+    assert_eq!(re_materialized.capability().commit(), original_commit);
+    assert_eq!(re_materialized.capability().tree(), original_tree);
+    assert_eq!(
+        std::fs::read_to_string(baseline_path.join("patched.txt")).unwrap(),
+        "patched\n"
+    );
+    assert!(git_output(&baseline_path, &["status", "--porcelain"])
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
 fn cook_report_invocation_run_ids_populated_for_policy_failure() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let fresh_run_id = "agent-task-fresh-abc123".to_string();


### PR DESCRIPTION
## Summary
- Fixes #9685 (sibling of #9663/#9669): the cook follow-up baseline is a git worktree under `TMPDIR/homeboy-cook-follow-up-baselines/baseline-<uuid>`. Between attempts it can be reaped (tmp cleanup, disk-pressure cleanup, `git worktree prune`), so the follow-up/review-form provider preflight failed with `working directory does not exist` → retry budget exhausted → the agent's completed change was stranded (no candidate, no gate, no review-form PR).
- On a follow-up attempt (`attempt > 1`) whose baseline `workspace.root` no longer exists, re-materialize the baseline worktree at the same path from the persisted promotion, reusing the existing materialization/patch logic (factored into `materialize_follow_up_baseline_at`) so baseline identity is preserved.
- Adds `re_materialize_follow_up_baseline` + a shared `materialize_follow_up_baseline_at` helper (no duplicated worktree/patch logic).

## Test
- `cargo fmt --check` clean; `cargo check -p homeboy-agents --lib` clean.
- New test `re_materialize_follow_up_baseline_recovers_after_worktree_deletion`: deletes the baseline worktree after materialization and asserts it is recovered rather than failing.

## Notes
Part of the cook-lifecycle / scratch-hygiene burndown cluster (#9663/#9669/#9664/#9685). Authored via an agent-task cook; the cook completed the full fix (recovery fn + refactor + call-site wiring + test) but died before finalizing (the very lifecycle fragility this cluster addresses), so it was rescued, a missing `use` import was added, verified to compile, and submitted.