### PR TITLE
Scope durable Cook identities to fanout generations

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -900,12 +900,18 @@ fn build_cook_batch_plan(args: &AgentTaskFanoutCookBatchArgs) -> Result<BatchCoo
         .first()
         .map(|cook| cook.cook_id.clone())
         .unwrap_or_else(|| "empty".to_string());
+    let fanout_id = args
+        .fanout_id
+        .clone()
+        .unwrap_or_else(|| format!("cook-batch-{}-{}-{}", args.repo, first, cooks.len()));
+    // Durable cook recipes are keyed by cook_id. Scope each generated child to
+    // its fanout generation so the same issue can run in a later batch.
+    for cook in &mut cooks {
+        cook.cook_id = format!("{fanout_id}-{}", cook.cook_id);
+    }
     Ok(BatchCookFanoutPlan {
         schema: batch_cook_fanout_plan_schema(),
-        fanout_id: args
-            .fanout_id
-            .clone()
-            .unwrap_or_else(|| format!("cook-batch-{}-{}-{}", args.repo, first, cooks.len())),
+        fanout_id,
         cooks,
         metadata: serde_json::json!({
             "source": "agent-task fanout cook-batch",
@@ -1545,7 +1551,7 @@ mod tests {
 
             assert_eq!(plan.fanout_id, "issue-wave");
             assert_eq!(plan.cooks.len(), 2);
-            assert_eq!(plan.cooks[0].cook_id, "issue-6453");
+            assert_eq!(plan.cooks[0].cook_id, "issue-wave-issue-6453");
             assert_eq!(plan.cooks[0].to_worktree, "homeboy@fix-issue-6453-homeboy");
             assert_eq!(
                 plan.cooks[0].head.as_deref(),
@@ -1578,6 +1584,25 @@ mod tests {
                 Some("homeboy@fix-issue-6453-homeboy")
             );
         });
+    }
+
+    #[test]
+    fn cook_batch_scopes_durable_children_to_the_fanout_generation() {
+        let first = build_cook_batch_plan(&cook_batch_args()).expect("first cook batch plan");
+        let mut second_args = cook_batch_args();
+        second_args.fanout_id = Some("issue-wave-v2".to_string());
+        second_args.branch_prefix = "fix-v2".to_string();
+        let second = build_cook_batch_plan(&second_args).expect("second cook batch plan");
+
+        assert_eq!(first.cooks[0].task_url, second.cooks[0].task_url);
+        assert_eq!(
+            first.cooks[0].client_context, second.cooks[0].client_context,
+            "issue identity remains task metadata"
+        );
+        assert_ne!(first.cooks[0].cook_id, second.cooks[0].cook_id);
+        assert_ne!(first.cooks[0].run_id(), second.cooks[0].run_id());
+        assert_ne!(first.cooks[0].to_worktree, second.cooks[0].to_worktree);
+        assert_eq!(second.cooks[0].cook_id, "issue-wave-v2-issue-6453");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Scopes generated Cook child IDs to the fanout generation so later batches over the same issue set no longer collide with historical durable recipes.

## Changes

- Computes the effective fanout ID before constructing the final plan.
- Prefixes generated child Cook IDs with that fanout ID.
- Preserves issue URLs and refs as task metadata.
- Adds focused generation-isolation coverage.

## Current status

This is intentionally a draft. The core identity test passes, but #9681 acceptance remains incomplete:

- Recipe compatibility is still checked after batch/worktree mutation.
- The default fanout identity omits significant execution inputs.
- Parent ID overrides do not normalize legacy/manual child IDs.
- End-to-end exact replay and collision-preflight coverage is missing.

## Verification

- `cargo fmt --check` passed.
- `cargo test -p homeboy-cli cook_batch_scopes_durable_children_to_the_fanout_generation` passed.
- `git diff --check` passed.
- The broad review gate reported three introduced audit findings before rejecting the dirty promoted checkout.

## AI assistance

- **AI assistance:** Yes
- **Tool:** Homeboy Cook and OpenCode
- **Models:** OpenAI GPT-5.6 Terra and GPT-5.6 Sol
- **Used for:** Generated the candidate, reviewed identity and compatibility behavior, ran focused verification, and documented missing acceptance work. Chris remains responsible for the change.

Closes #9681