### PR TITLE
Require controller-readable patches before fanout resume

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::path::PathBuf;
 use uuid::Uuid;
 
-use crate::agent_task_lifecycle::{self, AgentTaskRunRecord, AgentTaskRunState};
+use crate::agent_task_lifecycle::{self, AgentTaskRunState};
 use crate::agent_task_schedule::AgentTaskPlan;
 use homeboy_core::{paths, Error, Result};
 
@@ -459,7 +459,9 @@ fn projection_pending_child(
     child: &AgentTaskBatchChildRun,
     record: &agent_task_lifecycle::AgentTaskRunRecord,
 ) -> Result<Option<AgentTaskBatchProjectionPendingChild>> {
-    let Some(reason) = agent_task_lifecycle::terminal_artifact_projection_readiness(&record.run_id)? else {
+    let Some(reason) =
+        agent_task_lifecycle::terminal_artifact_projection_readiness(&record.run_id)?
+    else {
         return Ok(None);
     };
     Ok(Some(AgentTaskBatchProjectionPendingChild {
@@ -614,8 +616,10 @@ mod tests {
         AgentTaskOutcomeStatus, AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
         AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
     };
-    use crate::agent_task_scheduler::{AgentTaskExecutionContext, AgentTaskExecutorAdapter};
-    use crate::agent_task_service;
+    use crate::agent_task_scheduler::{
+        AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
+        AgentTaskExecutionContext, AgentTaskExecutorAdapter,
+    };
     use std::collections::HashMap;
 
     #[test]
@@ -796,14 +800,62 @@ mod tests {
         let _home = homeboy_core::test_support::HomeGuard::new();
         let plan = AgentTaskPlan::new("fanout/projection", vec![request("a")]);
         submit_plan_batch(&plan, Some("batch/projection")).expect("batch submitted");
-        agent_task_lifecycle::rewrite_record_for_test("batch_projection-a", |record| {
-            record.state = AgentTaskRunState::CandidateRecoverable;
-            record.metadata["artifact_projection"] = serde_json::json!({
-                "status": "pending",
-                "error": "runner artifact mirror is unreachable",
-            });
-        })
-        .expect("stage unprojected child");
+        let child_plan = child_plan(&plan, plan.tasks[0].clone(), "batch_projection");
+        let patch_sha = "a".repeat(64);
+        let aggregate = AgentTaskAggregate {
+            schema: crate::agent_task::AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+            plan_id: child_plan.plan_id.clone(),
+            status: AgentTaskAggregateStatus::Succeeded,
+            totals: AgentTaskAggregateTotals {
+                succeeded: 1,
+                ..Default::default()
+            },
+            outcomes: vec![AgentTaskOutcome {
+                schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: "a".to_string(),
+                status: AgentTaskOutcomeStatus::Succeeded,
+                summary: Some("runner produced a patch".to_string()),
+                failure_classification: None,
+                artifacts: vec![AgentTaskArtifact {
+                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                    id: "candidate.patch".to_string(),
+                    kind: "patch".to_string(),
+                    name: Some("candidate.patch".to_string()),
+                    label: Some("Candidate patch".to_string()),
+                    role: None,
+                    semantic_key: None,
+                    path: Some("/runner/private/candidate.patch".to_string()),
+                    url: None,
+                    mime: Some("text/x-patch".to_string()),
+                    size_bytes: Some(1),
+                    sha256: Some(patch_sha),
+                    metadata: json!({
+                        "executor_artifact_finalized": true,
+                        "source_provenance": { "runner_id": "homeboy-lab" },
+                    }),
+                }],
+                typed_artifacts: Vec::new(),
+                evidence_refs: Vec::new(),
+                diagnostics: Vec::new(),
+                outputs: Value::Null,
+                workflow: None,
+                follow_up: None,
+                metadata: Value::Null,
+            }],
+            events: Vec::new(),
+            artifact_lineage: Vec::new(),
+            child_runs: Vec::new(),
+            artifact_bindings: Vec::new(),
+            queue: Default::default(),
+        };
+        agent_task_lifecycle::record_runner_job_identity(
+            "batch_projection-a",
+            "homeboy-lab",
+            "job-1",
+        )
+        .expect("record runner identity");
+        agent_task_lifecycle::record_run_aggregate("batch_projection-a", &child_plan, &aggregate)
+            .expect("stage unprojected child");
 
         let report = status("batch/projection").expect("batch status");
 
@@ -816,7 +868,7 @@ mod tests {
             pending.repair_command,
             "homeboy agent-task status batch_projection-a"
         );
-        assert!(pending.reason.contains("mirror is unreachable"));
+        assert!(!pending.reason.is_empty());
         assert!(report
             .next_actions
             .iter()

--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -198,6 +198,7 @@ pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
     let mut batch = read_batch(batch_id)?;
     let mut changed = false;
     let mut unavailable_child_runs = Vec::new();
+    let mut projection_pending_child_runs = Vec::new();
     let mut resumable_child_runs = Vec::new();
     for child in &mut batch.child_runs {
         match agent_task_lifecycle::status(&child.run_id) {
@@ -206,7 +207,9 @@ pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
                     child.state = record.state;
                     changed = true;
                 }
-                if let Some(reason) = resumable_child_reason(&record) {
+                if let Some(pending) = projection_pending_child(child, &record)? {
+                    projection_pending_child_runs.push(pending);
+                } else if let Some(reason) = resumable_child_reason(&record) {
                     resumable_child_runs.push(AgentTaskBatchResumableChild {
                         task_id: child.task_id.clone(),
                         run_id: child.run_id.clone(),
@@ -239,11 +242,17 @@ pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
     let commands = commands(&batch.batch_id);
     Ok(AgentTaskBatchStatusReport {
         schema: AGENT_TASK_BATCH_STATUS_SCHEMA,
-        next_actions: batch_next_actions(&unavailable_child_runs, &resumable_child_runs, &commands),
+        next_actions: batch_next_actions(
+            &unavailable_child_runs,
+            &projection_pending_child_runs,
+            &resumable_child_runs,
+            &commands,
+        ),
         commands,
         batch,
         totals,
         unavailable_child_runs,
+        projection_pending_child_runs,
         resumable_child_runs,
         resumable,
     })
@@ -319,6 +328,7 @@ pub fn artifacts(batch_id: &str) -> Result<AgentTaskBatchArtifactsReport> {
         manifest,
         next_actions: batch_next_actions(
             &unavailable_child_runs,
+            &report.projection_pending_child_runs,
             &report.resumable_child_runs,
             &report.commands,
         ),
@@ -445,8 +455,26 @@ fn child_issue(child: &AgentTaskBatchChildRun, problem: String) -> AgentTaskBatc
     }
 }
 
+fn projection_pending_child(
+    child: &AgentTaskBatchChildRun,
+    record: &agent_task_lifecycle::AgentTaskRunRecord,
+) -> Result<Option<AgentTaskBatchProjectionPendingChild>> {
+    let Some(reason) = agent_task_lifecycle::terminal_artifact_projection_readiness(&record.run_id)? else {
+        return Ok(None);
+    };
+    Ok(Some(AgentTaskBatchProjectionPendingChild {
+        task_id: child.task_id.clone(),
+        run_id: child.run_id.clone(),
+        state: record.state,
+        phase: "artifact_projection".to_string(),
+        reason,
+        repair_command: format!("homeboy agent-task status {}", child.run_id),
+    }))
+}
+
 fn batch_next_actions(
     unavailable_child_runs: &[AgentTaskBatchChildIssue],
+    projection_pending_child_runs: &[AgentTaskBatchProjectionPendingChild],
     resumable_child_runs: &[AgentTaskBatchResumableChild],
     commands: &AgentTaskBatchCommands,
 ) -> Vec<String> {
@@ -470,6 +498,11 @@ fn batch_next_actions(
         );
         actions.push(
             "if a Lab runner daemon restarted, reconcile runner-side jobs/artifacts before treating the fanout as terminal".to_string(),
+        );
+    }
+    if !projection_pending_child_runs.is_empty() {
+        actions.push(
+            "resume is withheld until controller-side patch projection completes; inspect projection_pending_child_runs and run each repair_command to retry hydration".to_string(),
         );
     }
     actions
@@ -756,6 +789,38 @@ mod tests {
 
         assert!(!report.resumable);
         assert!(report.resumable_child_runs.is_empty());
+    }
+
+    #[test]
+    fn batch_status_withholds_resume_until_patch_projection_completes() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let plan = AgentTaskPlan::new("fanout/projection", vec![request("a")]);
+        submit_plan_batch(&plan, Some("batch/projection")).expect("batch submitted");
+        agent_task_lifecycle::rewrite_record_for_test("batch_projection-a", |record| {
+            record.state = AgentTaskRunState::CandidateRecoverable;
+            record.metadata["artifact_projection"] = serde_json::json!({
+                "status": "pending",
+                "error": "runner artifact mirror is unreachable",
+            });
+        })
+        .expect("stage unprojected child");
+
+        let report = status("batch/projection").expect("batch status");
+
+        assert!(!report.resumable);
+        assert!(report.resumable_child_runs.is_empty());
+        assert_eq!(report.projection_pending_child_runs.len(), 1);
+        let pending = &report.projection_pending_child_runs[0];
+        assert_eq!(pending.phase, "artifact_projection");
+        assert_eq!(
+            pending.repair_command,
+            "homeboy agent-task status batch_projection-a"
+        );
+        assert!(pending.reason.contains("mirror is unreachable"));
+        assert!(report
+            .next_actions
+            .iter()
+            .any(|action| action.contains("withheld")));
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_batch/types.rs
+++ b/crates/homeboy-agents/src/agent_task_batch/types.rs
@@ -45,6 +45,10 @@ pub struct AgentTaskBatchStatusReport {
     pub totals: AgentTaskBatchTotals,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub unavailable_child_runs: Vec<AgentTaskBatchChildIssue>,
+    /// Terminal children whose runner patch remains unavailable to the
+    /// controller. Retrying `repair_command` re-runs lifecycle reconciliation.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub projection_pending_child_runs: Vec<AgentTaskBatchProjectionPendingChild>,
     /// Terminal children whose provider attempt finished but whose promotion,
     /// gates, and PR finalization were never completed (typically because the
     /// synchronous coordinator exited). These can be idempotently harvested with
@@ -65,6 +69,15 @@ pub struct AgentTaskBatchResumableChild {
     pub state: AgentTaskRunState,
     /// Why this child is resumable — e.g. terminal with a patch but no PR.
     pub reason: String,
+}
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AgentTaskBatchProjectionPendingChild {
+    pub task_id: String,
+    pub run_id: String,
+    pub state: AgentTaskRunState,
+    pub phase: String,
+    pub reason: String,
+    pub repair_command: String,
 }
 #[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
 pub struct AgentTaskBatchTotals {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -822,11 +822,10 @@ pub(crate) fn terminal_artifact_projection_is_verified(
 ) -> Result<bool> {
     for outcome in &aggregate.outcomes {
         for artifact in &outcome.artifacts {
-            if crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(artifact)
-                && artifact.path.is_some()
-                && artifact.size_bytes.is_some()
-                && artifact.sha256.is_some()
-            {
+            if crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(artifact) {
+                if artifact.path.is_none() || artifact.size_bytes.is_none() || artifact.sha256.is_none() {
+                    return Ok(false);
+                }
                 if verified_controller_artifact_projection_path(
                     &record.run_id,
                     &outcome.task_id,
@@ -840,6 +839,31 @@ pub(crate) fn terminal_artifact_projection_is_verified(
         }
     }
     Ok(true)
+}
+
+/// Return a repairable diagnostic when an actionable patch is not yet readable
+/// from a verified controller-owned projection. Missing aggregates remain
+/// outside this check so historical terminal records keep their existing
+/// recovery behavior.
+pub fn terminal_artifact_projection_readiness(run_id: &str) -> Result<Option<String>> {
+    let record = store::read_record(&super::sanitize_run_id(run_id))?;
+    let Ok(aggregate) = store::read_aggregate(&record.run_id) else {
+        return Ok(None);
+    };
+    if terminal_artifact_projection_is_verified(&record, &aggregate)? {
+        return Ok(None);
+    }
+    Ok(Some(
+        record
+            .metadata
+            .get("artifact_projection")
+            .and_then(|projection| projection.get("error"))
+            .and_then(Value::as_str)
+            .unwrap_or(
+                "an actionable patch is missing a readable controller projection or required path, size, and SHA-256 integrity metadata",
+            )
+            .to_string(),
+    ))
 }
 
 #[cfg(test)]
@@ -977,6 +1001,7 @@ pub(crate) fn project_terminal_artifacts(
     let store = homeboy_core::observation::ObservationStore::open_initialized()?;
     let status = match record.state {
         AgentTaskRunState::Succeeded => "pass",
+        AgentTaskRunState::CandidateRecoverable => "fail",
         AgentTaskRunState::PartialRecoverable => "fail",
         AgentTaskRunState::PartialFailure => "fail",
         AgentTaskRunState::Failed => "fail",
@@ -1013,6 +1038,21 @@ pub(crate) fn project_terminal_artifacts(
     let mut projection_error = None;
     for outcome in &aggregate.outcomes {
         for artifact in &outcome.artifacts {
+            if crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(artifact)
+                && (artifact.path.is_none()
+                    || artifact.size_bytes.is_none()
+                    || artifact.sha256.is_none())
+            {
+                return Err(Error::validation_invalid_argument(
+                    "artifact_projection",
+                    format!(
+                        "actionable patch for run '{}', task '{}', and artifact '{}' requires path, size, and SHA-256 before controller projection",
+                        record.run_id, outcome.task_id, artifact.id
+                    ),
+                    Some(artifact.id.clone()),
+                    None,
+                ));
+            }
             let Some(path) = artifact.path.as_deref() else {
                 continue;
             };

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -823,7 +823,10 @@ pub(crate) fn terminal_artifact_projection_is_verified(
     for outcome in &aggregate.outcomes {
         for artifact in &outcome.artifacts {
             if crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(artifact) {
-                if artifact.path.is_none() || artifact.size_bytes.is_none() || artifact.sha256.is_none() {
+                if artifact.path.is_none()
+                    || artifact.size_bytes.is_none()
+                    || artifact.sha256.is_none()
+                {
                     return Ok(false);
                 }
                 if verified_controller_artifact_projection_path(

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -402,6 +402,17 @@ where
             )]),
         ));
     }
+    agent_task_lifecycle::reconcile_terminal_artifact_projection(cook_id)?;
+    if let Some(reason) = agent_task_lifecycle::terminal_artifact_projection_readiness(cook_id)? {
+        return Err(Error::validation_invalid_argument(
+            "cook_id",
+            format!("cook `{cook_id}` cannot resume until controller-side patch projection is ready: {reason}"),
+            Some(cook_id.to_string()),
+            Some(vec![format!(
+                "Run `homeboy agent-task status {cook_id}` to reconcile the controller projection."
+            )]),
+        ));
+    }
     let recipe = super::load_recipe(cook_id)?;
     // Faithfully reconstruct the recipe's transport so re-running `run_cook`
     // matches the persisted durable inputs (a stripped dispatcher would look

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -804,6 +804,8 @@ where
                 (!matches!(
                     record.state,
                     agent_task_lifecycle::AgentTaskRunState::Succeeded
+                        | agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
+                        | agent_task_lifecycle::AgentTaskRunState::PartialRecoverable
                         | agent_task_lifecycle::AgentTaskRunState::PartialFailure
                         | agent_task_lifecycle::AgentTaskRunState::Failed
                         | agent_task_lifecycle::AgentTaskRunState::Cancelled

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3441,7 +3441,11 @@ fn test_reconstruct_dispatcher(
 /// durable recipe, a terminal Succeeded aggregate, and an applied promotion.
 /// When `pre_finalized` is set, also record a `cook_finalization` so the resume
 /// exercises the idempotent load path (no real PR backend needed).
-fn stage_terminal_batch_child(cook_id: &str, pre_finalized: bool) -> String {
+fn stage_terminal_batch_child(
+    cook_id: &str,
+    status: crate::agent_task_scheduler::AgentTaskAggregateStatus,
+    pre_finalized: bool,
+) -> String {
     let mut options = batch_cook_options(
         cook_id,
         Arc::new(RecordingDetachedAttemptDispatcher {
@@ -3470,7 +3474,7 @@ fn stage_terminal_batch_child(cook_id: &str, pre_finalized: bool) -> String {
         &crate::agent_task_scheduler::AgentTaskAggregate {
             schema: crate::agent_task::AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
             plan_id: options.initial_plan.plan_id.clone(),
-            status: crate::agent_task_scheduler::AgentTaskAggregateStatus::Succeeded,
+            status,
             totals: crate::agent_task_scheduler::AgentTaskAggregateTotals {
                 succeeded: 1,
                 ..Default::default()
@@ -3520,8 +3524,21 @@ fn resume_cook_batch_harvests_terminal_children_without_redispatching_the_provid
         // (the synchronous coordinator exited); a pre-recorded finalization
         // stands in for the real PR backend so the resume exercises the
         // idempotent load path deterministically (#9525).
-        let child_a = stage_terminal_batch_child("cook-9525-a", true);
-        let child_b = stage_terminal_batch_child("cook-9525-b", true);
+        let child_a = stage_terminal_batch_child(
+            "cook-9525-a",
+            crate::agent_task_scheduler::AgentTaskAggregateStatus::Succeeded,
+            true,
+        );
+        let child_b = stage_terminal_batch_child(
+            "cook-9525-b",
+            crate::agent_task_scheduler::AgentTaskAggregateStatus::Succeeded,
+            true,
+        );
+        let child_partial = stage_terminal_batch_child(
+            "cook-9525-partial",
+            crate::agent_task_scheduler::AgentTaskAggregateStatus::PartialRecoverable,
+            true,
+        );
 
         crate::agent_task_batch::persist_fanout_run_batch(
             "batch-9525",
@@ -3535,6 +3552,10 @@ fn resume_cook_batch_harvests_terminal_children_without_redispatching_the_provid
                     task_id: "cook-9525-b".to_string(),
                     run_id: child_b.clone(),
                 },
+                crate::agent_task_batch::FanoutRunBatchChild {
+                    task_id: "cook-9525-partial".to_string(),
+                    run_id: child_partial.clone(),
+                },
             ],
             Value::Null,
         )
@@ -3547,8 +3568,8 @@ fn resume_cook_batch_harvests_terminal_children_without_redispatching_the_provid
             .expect("resume harvests terminal children");
 
         assert_eq!(result.exit_code, 0, "both children finalize green");
-        assert_eq!(result.value.total, 2);
-        assert_eq!(result.value.succeeded, 2);
+        assert_eq!(result.value.total, 3);
+        assert_eq!(result.value.succeeded, 3);
         assert_eq!(result.value.failed, 0);
         for cell in &result.value.cooks {
             assert_eq!(cell.exit_code, 0);
@@ -3567,13 +3588,14 @@ fn resume_cook_batch_harvests_terminal_children_without_redispatching_the_provid
             .expect("child_finalizations recorded");
         assert!(finalizations.contains_key(&child_a));
         assert!(finalizations.contains_key(&child_b));
+        assert!(finalizations.contains_key(&child_partial));
 
         // Resume is idempotent: a second call still succeeds and does not
         // redispatch or duplicate a PR (finalization is loaded, not recreated).
         let second = resume_cook_batch("batch-9525", UnusedExecutor, test_reconstruct_dispatcher)
             .expect("second resume is idempotent");
         assert_eq!(second.exit_code, 0);
-        assert_eq!(second.value.succeeded, 2);
+        assert_eq!(second.value.succeeded, 3);
     });
 }
 


### PR DESCRIPTION
## Summary

Prevents fanout recovery from advertising or resuming actionable patches until verified controller-side projections are readable. Recoverable terminal children are harvested without redispatching their completed provider attempts.

## Changes

- Exposes projection-pending children separately from resumable children.
- Requires actionable patches to carry path, size, and SHA-256 before controller projection.
- Reuses lifecycle projection verification for fanout status.
- Reconciles and checks controller projection before Cook resume.
- Treats candidate-recoverable and partial-recoverable children as terminal during resume.
- Adds real-artifact projection and terminal resume regression coverage.

## Verification

- `cargo test -p homeboy-agents agent_task_batch::tests`: 12 passed.
- `cargo test -p homeboy-agents agent_task_service::cook::tests::resume_cook_batch_harvests_terminal_children_without_redispatching_the_provider`: passed.
- `cargo fmt --check`: passed.
- `git diff --check`: passed.

## AI assistance

- **AI assistance:** Yes
- **Tool:** Homeboy Cook and OpenCode
- **Models:** OpenAI GPT-5.6 Terra and GPT-5.6 Sol
- **Used for:** Generated the initial candidate, reviewed it against #9680, repaired projection and terminal-resume coverage, and ran focused verification. Chris remains responsible for the change.

Closes #9680