### PR TITLE
Run provider-owned readiness against effective settings

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -53,7 +53,8 @@ mod tests;
 
 pub use catalog::*;
 pub use command_runner::{
-    probe_provider_executor_resolves, provider_command_parts, ProviderExecutorResolution,
+    probe_provider_executor_resolves, provider_command_parts, run_provider_readiness_invocation,
+    ProviderExecutorResolution,
 };
 pub(crate) use config_preflight::preflight_plan_provider_config_with_providers;
 pub use resolution::{resolve_provider_for_backend, ProviderResolution};

--- a/crates/homeboy-agents/src/agent_task_provider/catalog.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/catalog.rs
@@ -453,6 +453,28 @@ fn validate_provider_runner_readiness_for_backend_with_diagnostics(
         )
     })?;
 
+    let effective_config =
+        crate::agent_task_config_materialization::materialize_provider_config_refs(Value::Object(
+            defaults::load_config().settings.into_iter().collect(),
+        ))?;
+    super::command_runner::run_provider_readiness_invocation(provider, &effective_config).map_err(
+        |message| {
+            Error::validation_invalid_argument(
+                "backend",
+                format!(
+                    "agent-task backend '{backend}' is registered but configured readiness failed for provider '{}': {message}",
+                    provider.id
+                ),
+                Some(backend.to_string()),
+                provider
+                    .readiness_invocation
+                    .as_ref()
+                    .and_then(|invocation| invocation.display.clone())
+                    .map(|display| vec![format!("Provider readiness invocation: {display}")]),
+            )
+        },
+    )?;
+
     Ok(())
 }
 

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -16,6 +16,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 const EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES: usize = 16 * 1024;
 const REDACTED_VALUE: &str = "[redacted]";
+const PROVIDER_READINESS_RESULT_SCHEMA: &str = "homeboy/agent-task-provider-readiness-result/v1";
+const PROVIDER_READINESS_TIMEOUT: Duration = Duration::from_secs(20);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum ProviderCommandEnvError {
@@ -1014,12 +1016,135 @@ pub(crate) fn render_provider_command_display(provider: &AgentTaskExecutorProvid
     String::new()
 }
 
+pub fn run_provider_readiness_invocation(
+    provider: &AgentTaskExecutorProvider,
+    effective_config: &Value,
+) -> Result<(), String> {
+    let Some(invocation) = provider.readiness_invocation.as_ref() else {
+        return Ok(());
+    };
+    let Some((program, args, cwd)) = invocation_command_parts(provider, invocation) else {
+        return Err(format!(
+            "provider '{}' declares an empty readiness invocation",
+            provider.id
+        ));
+    };
+    let input = serde_json::to_vec(&json!({
+        "schema": "homeboy/agent-task-provider-readiness-request/v1",
+        "provider_id": provider.id,
+        "backend": provider.backend,
+        "effective_config": effective_config,
+    }))
+    .map_err(|error| format!("failed to encode provider readiness request: {error}"))?;
+
+    let mut command = Command::new(program);
+    command
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("failed to spawn provider readiness invocation: {error}"))?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(&input)
+            .map_err(|error| format!("failed to write provider readiness request: {error}"))?;
+    }
+
+    let stdout_buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let last_progress = Arc::new(AtomicU64::new(now_unix_ms()));
+    let stdout_reader = child
+        .stdout
+        .take()
+        .map(|stdout| spawn_output_reader(stdout, Arc::clone(&stdout_buffer), last_progress));
+    let started = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if started.elapsed() < PROVIDER_READINESS_TIMEOUT => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                if let Some(reader) = stdout_reader {
+                    let _ = reader.join();
+                }
+                return Err(format!(
+                    "provider '{}' readiness invocation timed out after {} seconds",
+                    provider.id,
+                    PROVIDER_READINESS_TIMEOUT.as_secs()
+                ));
+            }
+            Err(error) => {
+                return Err(format!(
+                    "failed to wait for provider readiness result: {error}"
+                ));
+            }
+        }
+    };
+    if let Some(reader) = stdout_reader {
+        let _ = reader.join();
+    }
+    if !status.success() {
+        return Err(format!(
+            "provider '{}' readiness invocation exited with status {}",
+            provider.id,
+            status.code().unwrap_or(-1)
+        ));
+    }
+    let stdout = stdout_buffer.lock().expect("stdout buffer").clone();
+    let result: Value = serde_json::from_slice(&stdout).map_err(|_| {
+        format!(
+            "provider '{}' readiness invocation returned malformed JSON",
+            provider.id
+        )
+    })?;
+    if result.get("schema").and_then(Value::as_str) != Some(PROVIDER_READINESS_RESULT_SCHEMA) {
+        return Err(format!(
+            "provider '{}' readiness invocation returned an unsupported result schema",
+            provider.id
+        ));
+    }
+    if result.get("ready").and_then(Value::as_bool) != Some(true) {
+        let message = result
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("provider-owned readiness check failed");
+        return Err(format!(
+            "provider '{}' readiness failed: {message}",
+            provider.id
+        ));
+    }
+    Ok(())
+}
+
 fn render_provider_command_template(value: &str, provider: &AgentTaskExecutorProvider) -> String {
     let extension_path = provider.extension_path.as_deref().unwrap_or_default();
     let runtime_path = provider.runtime_path.as_deref().unwrap_or(extension_path);
     value
         .replace("{{extension_path}}", extension_path)
         .replace("{{runtime_path}}", runtime_path)
+}
+
+fn invocation_command_parts(
+    provider: &AgentTaskExecutorProvider,
+    invocation: &CommandInvocation,
+) -> Option<(String, Vec<String>, Option<PathBuf>)> {
+    let mut argv = invocation
+        .argv
+        .iter()
+        .map(|arg| render_provider_command_template(arg, provider));
+    let program = argv.next()?;
+    let cwd = invocation
+        .cwd
+        .as_deref()
+        .map(|cwd| PathBuf::from(render_provider_command_template(cwd, provider)));
+    Some((program, argv.collect(), cwd))
 }
 
 fn render_provider_command_argv(provider: &AgentTaskExecutorProvider) -> Vec<String> {
@@ -1042,21 +1167,13 @@ fn render_provider_invocation_argv(provider: &AgentTaskExecutorProvider) -> Vec<
 pub fn provider_command_parts(
     provider: &AgentTaskExecutorProvider,
 ) -> Option<(String, Vec<String>, Option<PathBuf>)> {
-    let (argv, cwd) = if !provider.invocation.argv.is_empty() {
-        (
-            render_provider_invocation_argv(provider),
-            provider
-                .invocation
-                .cwd
-                .as_deref()
-                .map(|cwd| PathBuf::from(render_provider_command_template(cwd, provider))),
-        )
+    if !provider.invocation.argv.is_empty() {
+        invocation_command_parts(provider, &provider.invocation)
     } else {
-        (render_provider_command_argv(provider), None)
-    };
-    let mut parts = argv.into_iter();
-    let program = parts.next()?;
-    Some((program, parts.collect(), cwd))
+        let mut argv = render_provider_command_argv(provider).into_iter();
+        let program = argv.next()?;
+        Some((program, argv.collect(), None))
+    }
 }
 
 /// Result of probing whether a provider's executor entrypoint actually loads on

--- a/crates/homeboy-agents/src/agent_task_provider/tests/common.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/common.rs
@@ -31,6 +31,7 @@ pub(super) fn request(
         workspace_materialization: None,
         provider_defaults: BTreeMap::new(),
         runner_readiness: Vec::new(),
+        readiness_invocation: None,
         runner_sources: Vec::new(),
         dependency_failure_patterns: Vec::new(),
         config_preflights: Vec::new(),

--- a/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
@@ -220,6 +220,23 @@ fn provider_command_parts_uses_argv() {
 }
 
 #[test]
+fn provider_readiness_invocation_receives_effective_config_and_fails_closed() {
+    let (_, mut provider) = request("configured-readiness", "node ignored.js".to_string());
+    provider.readiness_invocation = Some(CommandInvocation {
+        argv: vec![
+            "node".to_string(),
+            script("let fs=require('fs');let req=JSON.parse(fs.readFileSync(0,'utf8'));process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-provider-readiness-result/v1',ready:req.effective_config.marker==='ready',message:'configured marker is not ready'}));"),
+        ],
+        ..CommandInvocation::default()
+    });
+
+    assert!(run_provider_readiness_invocation(&provider, &json!({ "marker": "ready" })).is_ok());
+    let error = run_provider_readiness_invocation(&provider, &json!({ "marker": "blocked" }))
+        .expect_err("provider-owned readiness failure blocks validation");
+    assert!(error.contains("configured marker is not ready"));
+}
+
+#[test]
 fn opencode_provider_boundary_uses_task_workspace_for_cwd_and_config() {
     let temp = tempfile::tempdir().expect("tempdir");
     let original = temp.path().join("promotion-target");

--- a/crates/homeboy-agents/src/agent_task_provider/types.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/types.rs
@@ -74,6 +74,8 @@ pub struct AgentTaskExecutorProvider {
     pub provider_defaults: BTreeMap<String, Value>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub runner_readiness: Vec<AgentTaskProviderRunnerReadiness>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub readiness_invocation: Option<CommandInvocation>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub runner_sources: Vec<AgentTaskProviderRunnerSource>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/homeboy-lab-runner/src/lab/secrets/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/secrets/tests/mod.rs
@@ -96,6 +96,7 @@ pub(super) fn fixture_provider_with_example_defaults_at(path: &str) -> AgentTask
         workspace_materialization: None,
         provider_defaults,
         runner_readiness: Vec::new(),
+        readiness_invocation: None,
         runner_sources: Vec::new(),
         dependency_failure_patterns: Vec::new(),
         config_preflights: Vec::new(),


### PR DESCRIPTION
## Summary

- Add an optional structured `readiness_invocation` to the generic agent-task provider contract.
- Invoke provider-owned readiness against materialized effective Homeboy settings after static executable validation.
- Fail closed on timeout, nonzero exit, malformed output, unsupported schema, or a negative readiness result.

Closes #9696.

## Tests

- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents agent_task_provider::tests::manifest_tests::provider_readiness_invocation_receives_effective_config_and_fails_closed`
- `cargo fmt --check`
- `git diff --check`

The broad `agent_task_provider::tests` filter passed 85 tests and failed 14 existing parallel tests whose shared temp script fixture collides by body length. The focused new contract test passes independently.

## Follow-up

- Extra-Chill/homeboy-extensions#2352 declares WP Codebox readiness through this generic primitive.
- Controller-profile and explicit command-level config overlays still need to be routed through the same effective-config helper before this leaves draft.

## AI assistance

- **AI assistance:** Yes
- **Tool:** OpenCode
- **Model:** OpenAI GPT-5.6 Sol
- **Used for:** Reproduced the readiness mismatch, implemented the provider contract and bounded invocation, and added focused deterministic coverage. Chris reviewed and owns every line.