### PR TITLE
Fix detached Lab staging retrieval commands

### DIFF
--- a/crates/homeboy-cli/src/commands/activity.rs
+++ b/crates/homeboy-cli/src/commands/activity.rs
@@ -478,6 +478,8 @@ fn truncate(value: &str, width: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli_surface::Cli;
+    use clap::Parser;
     use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
     use homeboy::test_support::with_isolated_home;
     use serde_json::json;
@@ -498,6 +500,16 @@ mod tests {
             parse_duration("2s").expect("duration"),
             Duration::from_secs(2)
         );
+    }
+
+    #[test]
+    fn controller_job_retrieval_commands_parse() {
+        for command in [
+            ["homeboy", "activity", "show", "controller-job-9678"],
+            ["homeboy", "activity", "watch", "controller-job-9678"],
+        ] {
+            Cli::try_parse_from(command).expect("controller job retrieval command parses");
+        }
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1488,6 +1488,7 @@ pub(crate) fn run_lab_offload_inner(
                 );
             }
         };
+        let controller_job_commands = controller_job_retrieval_commands(&controller_job_id);
         let stdout = serde_json::to_string_pretty(&serde_json::json!({
             "success": true,
             "data": {
@@ -1496,8 +1497,13 @@ pub(crate) fn run_lab_offload_inner(
                 "controller_job_id": controller_job_id,
                 "retrieval_commands": {
                     "status": format!("homeboy agent-task status {run_id}"),
-                    "controller_job": format!("homeboy daemon job {}", controller_job_id),
-                }
+                    "controller_job": controller_job_commands.show,
+                    "controller_job_watch": controller_job_commands.watch,
+                },
+                "next_actions": [
+                    format!("Show controller job: {}", controller_job_commands.show),
+                    format!("Watch controller job: {}", controller_job_commands.watch),
+                ],
             }
         }))
         .unwrap_or_else(|_| {
@@ -1506,7 +1512,10 @@ pub(crate) fn run_lab_offload_inner(
         return Ok(LabOffloadOutcome::InFlight {
             plan,
             stdout: format!("{stdout}\n"),
-            stderr: format!("Lab staging continues in controller job `{controller_job_id}`.\nNext: homeboy agent-task status {run_id}\n"),
+            stderr: format!(
+                "Lab staging continues in controller job `{controller_job_id}`.\nNext: homeboy agent-task status {run_id}\nNext: {}\nNext: {}\n",
+                controller_job_commands.show, controller_job_commands.watch,
+            ),
             exit_code: 0,
             output_file_content: Some(format!("{stdout}\n")),
         });
@@ -1978,6 +1987,18 @@ pub(crate) fn run_lab_offload_inner(
         print_handoff: true,
         detach_after_handoff: request.detach_after_handoff,
     })
+}
+
+pub(crate) struct ControllerJobRetrievalCommands {
+    pub(crate) show: String,
+    pub(crate) watch: String,
+}
+
+pub(crate) fn controller_job_retrieval_commands(job_id: &str) -> ControllerJobRetrievalCommands {
+    ControllerJobRetrievalCommands {
+        show: format!("homeboy activity show {job_id}"),
+        watch: format!("homeboy activity watch {job_id}"),
+    }
 }
 
 /// Keep the generated direct command and the reverse-transport command in

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
@@ -1,6 +1,14 @@
 use super::*;
 
 #[test]
+fn detached_staging_controller_job_commands_use_activity_surface() {
+    let commands = controller_job_retrieval_commands("controller-job-9678");
+
+    assert_eq!(commands.show, "homeboy activity show controller-job-9678");
+    assert_eq!(commands.watch, "homeboy activity watch controller-job-9678");
+}
+
+#[test]
 fn emit_durable_run_id_writes_json_to_output_before_execution() {
     let dir = tempfile::tempdir().expect("temp dir");
     let output_path = dir.path().join("cook-output.json");


### PR DESCRIPTION
## Summary
Emit executable activity show/watch commands for detached controller staging jobs.

## What changed
- Replaced nonexistent daemon job guidance with canonical activity commands and added parsing and output regression coverage.

## How to test
1. Run `homeboy review --placement local homeboy test -- --filter=controller_job`; expect 10 relevant tests pass.

## Compatibility
Adds a watch command while preserving the existing status command and controller\_job field.

## Evidence
- Base advanced after verification: verified main at 2db5816726dd3331bdf56300b9103d803dda06fd; publication observed e43dc93510ef735611e8f5fea7b3a3267ef60b21. Candidate ancestry was validated against the verified snapshot.
- CI expected: cargo test --workspace
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9678
- Verified finalization base: main at 2db5816726dd3331bdf56300b9103d803dda06fd
- targeted: passed (10 relevant tests passed in Homeboy run be1bc1fe-d268-4c20-8972-fd296b0c1022) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Implemented the retrieval command fix and deterministic regression coverage under Chris Huber direction.

## Source relationships
- Closes #9678
