### PR TITLE
Lock direct runner identity comparison contract

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
@@ -868,13 +868,15 @@ fn matching_full_build_identities_have_no_drift_under_strict_mode() {
 }
 
 #[test]
-fn direct_runner_admission_accepts_matching_configured_build_identity() {
+fn direct_runner_admission_compares_daemon_with_configured_runner_identity() {
     let identity = "homeboy 0.295.0+b03d659866d1";
     let mut status = status_with_runner_version("homeboy-lab", "0.295.0");
     let session = status.session.as_mut().expect("runner session");
     session.mode = RunnerTunnelMode::DirectSsh;
     session.homeboy_build_identity = Some(identity.to_string());
 
+    // Direct SSH admission compares the daemon with the runner-side executable
+    // that will execute jobs, never with the controller's target-specific binary.
     assert!(
         !lab_runner_homeboy_has_blocking_drift_against_configured_identity(
             &status,


### PR DESCRIPTION
## Summary
Lock the existing direct-SSH admission contract to runner-side configured identity.

## What changed
- Renamed and documented the regression test to make explicit that controller target-specific binary identity is not part of direct runner admission.

## How to test
1. Run `homeboy review --placement local homeboy test -- --filter=direct_runner_admission_compares_daemon_with_configured_runner_identity`; expect 1 contract test passes.

## Compatibility
Test-only change; no runtime contract changes.

## Evidence
- Base advanced after verification: verified main at 2db5816726dd3331bdf56300b9103d803dda06fd; publication observed e43dc93510ef735611e8f5fea7b3a3267ef60b21. Candidate ancestry was validated against the verified snapshot.
- CI expected: cargo test --workspace
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9679
- Verified finalization base: main at 2db5816726dd3331bdf56300b9103d803dda06fd
- targeted: passed (direct runner configured-identity contract passed in Homeboy run 0cb39ed9-ca1c-4881-b25d-0245fc567da9) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Verified the existing runner identity behavior and strengthened deterministic coverage under Chris Huber direction.

## Source relationships
- Closes #9679
