### PR TITLE
Fire run-completion from the Lab runner directly with exactly-once delivery

### DIFF
--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -893,6 +893,12 @@ fn completion_notify_loop(interval: std::time::Duration, shutdown: mpsc::Receive
             }
             let running_after = list_running_run_ids(&store);
             for completed_id in tracker.observe(running_after) {
+                let already_delivered = store
+                    .is_notification_delivered(&completed_id)
+                    .unwrap_or(false);
+                if already_delivered {
+                    continue;
+                }
                 let run = store.get_run(&completed_id).ok().flatten();
                 let status = run
                     .as_ref()
@@ -901,6 +907,12 @@ fn completion_notify_loop(interval: std::time::Duration, shutdown: mpsc::Receive
                 let route = run.as_ref().and_then(|run| {
                     crate::notification_route::NotificationRoute::from_metadata(&run.metadata_json)
                 });
+                let won_race = store
+                    .mark_notification_delivered(&completed_id, "controller")
+                    .unwrap_or(false);
+                if !won_race {
+                    continue;
+                }
                 let event = crate::notify::NotifyEvent::run_completed_with_route(
                     &completed_id,
                     status,

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -347,6 +347,66 @@ impl ObservationStore {
         collect_rows(rows, "collect recent run records")
     }
 
+    /// Atomically mark a run's notification as delivered.
+    ///
+    /// Sets `notification_delivered` in the run's `metadata_json` **only if**
+    /// it is not already present. Returns `Ok(true)` if the marker was newly
+    /// set (this caller won the exactly-once race) or `Ok(false)` if the run
+    /// was already marked (another caller dispatched first).
+    ///
+    /// This is the single coordination point that prevents duplicate
+    /// notifications when both the runner-direct path and the controller
+    /// backstop observe a terminal run.
+    pub fn mark_notification_delivered(&self, run_id: &str, delivered_by: &str) -> Result<bool> {
+        validate_required("run_id", run_id)?;
+        let marker = serde_json::json!({
+            "at": chrono::Utc::now().to_rfc3339(),
+            "by": delivered_by,
+        });
+        let marker_str = serde_json::to_string(&marker).map_err(|e| {
+            Error::internal_json(
+                e.to_string(),
+                Some("serialize notification marker".to_string()),
+            )
+        })?;
+        let rows = execute_with_retry("mark notification delivered", || {
+            self.connection.execute(
+                r#"
+                UPDATE runs
+                SET metadata_json = json_set(
+                    COALESCE(metadata_json, '{}'),
+                    '$.notification_delivered',
+                    json(?1)
+                )
+                WHERE id = ?2
+                  AND json_extract(COALESCE(metadata_json, '{}'), '$.notification_delivered') IS NULL
+                "#,
+                params![marker_str, run_id],
+            )
+        })?;
+        Ok(rows > 0)
+    }
+
+    /// Check whether a run's notification has already been delivered.
+    pub fn is_notification_delivered(&self, run_id: &str) -> Result<bool> {
+        validate_required("run_id", run_id)?;
+        let result: bool = self
+            .connection
+            .query_row(
+                r#"
+                SELECT json_extract(COALESCE(metadata_json, '{}'), '$.notification_delivered') IS NOT NULL
+                FROM runs
+                WHERE id = ?1
+                "#,
+                [run_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(sqlite_error("check notification delivered"))?
+            .unwrap_or(false);
+        Ok(result)
+    }
+
     pub fn import_run(&self, run: &RunRecord) -> Result<()> {
         validate_required("run.id", &run.id)?;
         let metadata_json = serialize_metadata(&run.metadata_json)?;

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -297,6 +297,13 @@ pub(super) fn exec_via_reverse_broker(
         run_id.as_deref(),
         mirror_run_id.as_deref(),
     )?;
+    fire_runner_direct_notification(
+        run_id.as_deref(),
+        &job,
+        lab_runner_workload
+            .as_ref()
+            .and_then(|workload| workload.notification_route.as_ref()),
+    );
     let artifacts = job.artifacts.clone();
     let mutation_artifacts = mutation_artifacts_from_job(&job, &result);
 

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -341,6 +341,13 @@ pub(super) fn exec_via_daemon(
             },
         )?;
     }
+    fire_runner_direct_notification(
+        run_id.as_deref(),
+        &job,
+        lab_runner_workload
+            .as_ref()
+            .and_then(|workload| workload.notification_route.as_ref()),
+    );
     let artifacts = job.artifacts.clone();
     if let Some(session) = accepted_session.as_ref() {
         super::super::generation_store::record_job_artifacts(

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -1265,3 +1265,36 @@ fn should_force_diagnostic_ssh(runner: &Runner, options: &RunnerExecOptions) -> 
     select_runner_transport(runner, None, options.allow_diagnostic_ssh)
         == RunnerTransport::DiagnosticSsh
 }
+
+/// Fire a run-completion notification directly from the runner, bypassing the
+/// controller poll loop.  The exactly-once delivered marker in `metadata_json`
+/// ensures the controller backstop does not duplicate the notification.
+///
+/// Best-effort: notification dispatch and marker persistence are non-fatal.
+pub(super) fn fire_runner_direct_notification(
+    run_id: Option<&str>,
+    job: &Job,
+    notification_route: Option<&homeboy_core::notification_route::NotificationRoute>,
+) {
+    let Some(run_id) = run_id else {
+        return;
+    };
+    let Some(route) = notification_route else {
+        return;
+    };
+    let status = job.status.daemon_status_label();
+    let store = match homeboy_core::observation::ObservationStore::open_initialized() {
+        Ok(store) => store,
+        Err(_) => return,
+    };
+    let already_delivered = store.is_notification_delivered(run_id).unwrap_or(true);
+    if already_delivered {
+        return;
+    }
+    let event =
+        homeboy_core::notify::NotifyEvent::run_completed_with_route(run_id, status, Some(route));
+    let outcome = homeboy_core::notify::dispatch(&event);
+    if outcome.delivered {
+        let _ = store.mark_notification_delivered(run_id, "runner-direct");
+    }
+}

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -1062,3 +1062,113 @@ mod write_retry {
         assert!(err.message.contains("insert run record"));
     }
 }
+
+mod notification_delivery_marker_tests {
+    use super::*;
+
+    #[test]
+    fn mark_notification_delivered_sets_marker_and_returns_true() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("init store");
+            let run = store
+                .start_run(sample_run("test", "homeboy"))
+                .expect("start run");
+
+            assert!(!store.is_notification_delivered(&run.id).unwrap());
+            let won = store
+                .mark_notification_delivered(&run.id, "runner-direct")
+                .unwrap();
+
+            assert!(won);
+            assert!(store.is_notification_delivered(&run.id).unwrap());
+        });
+    }
+
+    #[test]
+    fn mark_notification_delivered_idempotent_second_call_returns_false() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("init store");
+            let run = store
+                .start_run(sample_run("test", "homeboy"))
+                .expect("start run");
+
+            let first = store
+                .mark_notification_delivered(&run.id, "runner-direct")
+                .unwrap();
+            let second = store
+                .mark_notification_delivered(&run.id, "controller")
+                .unwrap();
+
+            assert!(first);
+            assert!(!second);
+            assert!(store.is_notification_delivered(&run.id).unwrap());
+        });
+    }
+
+    #[test]
+    fn is_notification_delivered_returns_false_for_missing_run() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("init store");
+
+            assert!(!store.is_notification_delivered("nonexistent-run").unwrap());
+        });
+    }
+
+    #[test]
+    fn notification_delivered_marker_preserves_existing_metadata() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("init store");
+            let run = store
+                .start_run(sample_run("test", "homeboy"))
+                .expect("start run");
+
+            store
+                .mark_notification_delivered(&run.id, "runner-direct")
+                .unwrap();
+
+            let fetched = store
+                .get_run(&run.id)
+                .expect("get run")
+                .expect("run exists");
+            assert_eq!(fetched.metadata_json["scenario"], "fixture");
+            assert_eq!(
+                fetched.metadata_json["notification_delivered"]["by"],
+                "runner-direct"
+            );
+            assert!(fetched.metadata_json["notification_delivered"]["at"]
+                .as_str()
+                .is_some());
+        });
+    }
+
+    #[test]
+    fn runner_and_controller_race_only_one_wins() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("init store");
+            let run = store
+                .start_run(sample_run("test", "homeboy"))
+                .expect("start run");
+
+            let runner_won = store
+                .mark_notification_delivered(&run.id, "runner-direct")
+                .unwrap();
+            let controller_won = store
+                .mark_notification_delivered(&run.id, "controller")
+                .unwrap();
+
+            assert!(runner_won);
+            assert!(!controller_won);
+            let marker = &store
+                .get_run(&run.id)
+                .expect("get run")
+                .expect("run exists")
+                .metadata_json["notification_delivered"];
+            assert_eq!(marker["by"], "runner-direct");
+        });
+    }
+}


### PR DESCRIPTION
## Summary
The Lab runner already carries the opaque `NotificationRoute` through its execution stack (`broker.rs`, `daemon.rs`) but never delivered notifications itself — a Lab-offloaded cook waited for the controller to mirror evidence back and for the controller's completion poll loop (5s) to notice and fire. Extra hop + poll latency.

- Fire `notify::dispatch(run_completed_with_route(...))` directly from the runner on terminal state using the route it already holds, so a Lab cook reports straight to its configured transport without the controller round-trip.
- A durable **delivered-marker** on the run record coordinates **exactly-once** delivery: the controller completion loop skips runs the runner already notified and remains the backstop for local cooks and runners that don't deliver directly.

## Layering
Core stays fully generic: it operates only on the **opaque `NotificationRoute`** and knows nothing about any specific transport (discord) or launcher (kimaki). Route *injection* and any launcher/thread-specific resolution live outside core — in the launcher and/or the domain-specific extension — not here.

## Test
- `cargo fmt --check` clean; `cargo check` clean for `homeboy-core` and `homeboy-lab-runner`.
- `tests/core/observation/store_test.rs` covers route persistence + the exactly-once delivered-marker (runner delivers → controller skips; no route or unmarked → controller backstop).

## Notes
Part of the async-orchestration / report-back epic (#8282). This is the generic half of report-back; the origin-thread route resolution belongs in the launcher / `homeboy-extensions/discord` (which is allowed to be kimaki-aware), not in core.