### PR TITLE
Clarify promotion provider contracts and schema errors

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/apply.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/apply.rs
@@ -799,6 +799,45 @@ pub(crate) fn run_provider_command(
         .get("data")
         .cloned()
         .unwrap_or(response_value);
+    // Check the envelope discriminator before decoding response-specific fields.
+    // This keeps a provider that accidentally returns a different known contract
+    // from being reported as a missing field on this contract.
+    let schema = match response_value.get("schema") {
+        Some(serde_json::Value::String(schema)) => schema,
+        Some(actual) => {
+            return Err(Error::validation_invalid_argument(
+                "promotion_provider.response.schema",
+                format!(
+                    "expected {}, got {}",
+                    AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA, actual
+                ),
+                None,
+                None,
+            ));
+        }
+        None => {
+            return Err(Error::validation_invalid_argument(
+                "promotion_provider.response.schema",
+                format!(
+                    "expected {}, got missing schema",
+                    AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA
+                ),
+                None,
+                None,
+            ));
+        }
+    };
+    if schema != AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA {
+        return Err(Error::validation_invalid_argument(
+            "promotion_provider.response.schema",
+            format!(
+                "expected {}, got {}",
+                AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA, schema
+            ),
+            None,
+            None,
+        ));
+    }
     let response: AgentTaskPromotionApplyResponse = serde_json::from_value(response_value)
         .map_err(|error| {
             Error::validation_invalid_json(
@@ -807,18 +846,6 @@ pub(crate) fn run_provider_command(
                 Some(report.stdout.clone()),
             )
         })?;
-    if !response.schema.is_empty() && response.schema != AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA
-    {
-        return Err(Error::validation_invalid_argument(
-            "promotion_provider.response.schema",
-            format!(
-                "expected {}, got {}",
-                AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA, response.schema
-            ),
-            None,
-            None,
-        ));
-    }
     if response.workspace_path.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
             "promotion_provider.response.workspace_path",

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -1046,3 +1046,53 @@ fn provider_failure_surfaces_bounded_stdout_and_stderr_evidence() {
         "provider-stderr"
     );
 }
+
+#[test]
+fn provider_response_validation_distinguishes_json_schema_and_required_field_errors() {
+    let request = AgentTaskPromotionApplyRequest {
+        schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
+        to_workspace: "target-workspace".to_string(),
+        patch: None,
+        patch_path: "changes.patch".to_string(),
+        changed_files: vec!["src/lib.rs".to_string()],
+        gate_feedback_baseline: None,
+        dry_run: false,
+        trusted_unpushed_candidate_destination: None,
+    };
+    let cases = [
+        ("{", "Invalid JSON"),
+        (
+            r#"{"workspace_path":"/workspace"}"#,
+            "expected homeboy/agent-task-promotion-apply-response/v1, got missing schema",
+        ),
+        (
+            r#"{"schema":"homeboy/agent-task-promotion-apply-request/v1"}"#,
+            "expected homeboy/agent-task-promotion-apply-response/v1, got homeboy/agent-task-promotion-apply-request/v1",
+        ),
+        (
+            r#"{"schema":1}"#,
+            "expected homeboy/agent-task-promotion-apply-response/v1, got 1",
+        ),
+        (
+            r#"{"schema":"homeboy/agent-task-promotion-apply-response/v1"}"#,
+            "missing field `workspace_path`",
+        ),
+    ];
+
+    for (response, expected) in cases {
+        let error = run_provider_command(
+            &CommandInvocation {
+                argv: vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    format!("printf '%s' '{response}'"),
+                ],
+                ..Default::default()
+            },
+            &request,
+        )
+        .expect_err("invalid provider response");
+
+        assert!(error.message.contains(expected), "{}", error.message);
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1117,12 +1117,15 @@ where
                     promotion: None,
                     feedback: None,
                 });
+                let recovery = format!(
+                    "promotion provider response was rejected: {error}. The successful candidate remains durable on run {run_id}; inspect it and generate a corrected apply-provider retry with `homeboy agent-task review {run_id} --to-worktree <handle>`. To replace it with an externally prepared candidate, use `homeboy agent-task adopt {cook_id} --candidate-ref <sha> --ai-model <model>`.",
+                );
                 return Ok(cook_report(
                     cook_id,
                     "policy_failure",
                     attempts,
                     None,
-                    Some(error.to_string()),
+                    Some(recovery),
                     1,
                     Some(&run_id),
                 ));

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -175,12 +175,17 @@ pub struct AgentTaskCookArgs {
     pub goal: Option<String>,
     #[arg(long, value_name = "HANDLE")]
     pub to_worktree: String,
-    #[arg(long, value_name = "COMMAND")]
+    #[arg(
+        long,
+        value_name = "COMMAND",
+        long_help = "Deprecated promotion apply-provider command string. Migrate `--provider-command 'provider --flag value'` to `--provider-argv provider --provider-argv --flag --provider-argv value`; argv preserves exact arguments without shell splitting. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with `workspace_path`."
+    )]
     pub provider_command: Option<String>,
     #[arg(
         long = "provider-argv",
         value_name = "ARG",
-        conflicts_with = "provider_command"
+        conflicts_with = "provider_command",
+        long_help = "Promotion apply-provider invocation argument. Repeat once per exact argv element: the first is the executable and later values are its arguments; values are never shell-split. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with required `workspace_path`."
     )]
     pub provider_argv: Vec<String>,
     #[command(flatten)]

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -150,6 +150,33 @@ mod tests {
         };
         assert_eq!(args.ai_model.as_deref(), Some("openai/gpt-5.6-sol"));
     }
+
+    #[test]
+    fn promotion_provider_help_documents_argv_contract_for_cook_review_and_promote() {
+        for command in ["cook", "review", "promote"] {
+            let Err(error) = Cli::try_parse_from(["homeboy", "agent-task", command, "--help"])
+            else {
+                panic!("help exits after rendering");
+            };
+            let help = error.to_string();
+
+            assert!(help.contains("promotion apply-provider"), "{help}");
+            assert!(
+                help.contains("Repeat once per exact argv element"),
+                "{help}"
+            );
+            assert!(help.contains("never shell-split"), "{help}");
+            assert!(
+                help.contains("homeboy/agent-task-promotion-apply-request/v1"),
+                "{help}"
+            );
+            assert!(
+                help.contains("homeboy/agent-task-promotion-apply-response/v1"),
+                "{help}"
+            );
+            assert!(help.contains("Migrate `--provider-command"), "{help}");
+        }
+    }
 }
 #[derive(Args, Debug)]
 pub struct ReplayProviderBoundaryArgs {
@@ -176,12 +203,17 @@ pub struct ReviewArgs {
     pub run_id: String,
     #[arg(long, value_name = "HANDLE")]
     pub to_worktree: Option<String>,
-    #[arg(long, value_name = "COMMAND")]
+    #[arg(
+        long,
+        value_name = "COMMAND",
+        long_help = "Deprecated promotion apply-provider command string. Migrate `--provider-command 'provider --flag value'` to `--provider-argv provider --provider-argv --flag --provider-argv value`; argv preserves exact arguments without shell splitting. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with `workspace_path`."
+    )]
     pub provider_command: Option<String>,
     #[arg(
         long = "provider-argv",
         value_name = "ARG",
-        conflicts_with = "provider_command"
+        conflicts_with = "provider_command",
+        long_help = "Promotion apply-provider invocation argument. Repeat once per exact argv element: the first is the executable and later values are its arguments; values are never shell-split. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with required `workspace_path`."
     )]
     pub provider_argv: Vec<String>,
 }
@@ -193,12 +225,17 @@ pub struct PromoteArgs {
     /// Declared base branch resolved immediately before promotion gates run.
     #[arg(long, default_value = "main", value_name = "BRANCH")]
     pub base: String,
-    #[arg(long, value_name = "COMMAND")]
+    #[arg(
+        long,
+        value_name = "COMMAND",
+        long_help = "Deprecated promotion apply-provider command string. Migrate `--provider-command 'provider --flag value'` to `--provider-argv provider --provider-argv --flag --provider-argv value`; argv preserves exact arguments without shell splitting. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with `workspace_path`."
+    )]
     pub provider_command: Option<String>,
     #[arg(
         long = "provider-argv",
         value_name = "ARG",
-        conflicts_with = "provider_command"
+        conflicts_with = "provider_command",
+        long_help = "Promotion apply-provider invocation argument. Repeat once per exact argv element: the first is the executable and later values are its arguments; values are never shell-split. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with required `workspace_path`."
     )]
     pub provider_argv: Vec<String>,
     #[arg(long, value_name = "TASK_ID")]

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -125,7 +125,7 @@ fn review_reports_completed_aggregate_and_promotion_hints() {
 }
 
 #[test]
-fn cook_returns_durable_id_when_promotion_provider_is_missing() {
+fn cook_preserves_successful_candidate_when_provider_response_has_wrong_schema() {
     with_temp_home(|| {
         let (value, exit_code) = run_cook_with_executor(
             AgentTaskCookArgs {
@@ -162,7 +162,12 @@ fn cook_returns_durable_id_when_promotion_provider_is_missing() {
                 goal: Some("cook fixture".to_string()),
                 to_worktree: "homeboy@fix-agent-task-runner-cook".to_string(),
                 provider_command: None,
-                provider_argv: Vec::new(),
+                provider_argv: vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "printf '%s' '{\"schema\":\"homeboy/agent-task-promotion-apply-request/v1\"}'"
+                        .to_string(),
+                ],
                 gates: VerifyGateArgs {
                     verify: vec!["cargo test --lib".to_string()],
                     private_verify: Vec::new(),
@@ -177,7 +182,7 @@ fn cook_returns_durable_id_when_promotion_provider_is_missing() {
                 },
                 max_attempts: 2,
                 no_finalize: false,
-                full: false,
+                full: true,
                 base: "main".to_string(),
                 head: None,
                 title: None,
@@ -198,15 +203,27 @@ fn cook_returns_durable_id_when_promotion_provider_is_missing() {
             "cook-missing-provider-attempt-1-controller"
         );
         assert_eq!(
-            value["history_run_ids"].as_array().expect("history").len(),
-            1
+            value["history_run_ids"].as_array().map(Vec::len),
+            Some(1),
+            "{value:#}"
         );
         assert_eq!(value["status"], "policy_failure");
         assert_eq!(value["attempts"][0]["run_id"], value["latest_run_id"]);
         assert!(value["stop_reason"]
             .as_str()
             .expect("stop reason")
-            .contains("no worktree providers are configured"));
+            .contains("expected homeboy/agent-task-promotion-apply-response/v1, got homeboy/agent-task-promotion-apply-request/v1"));
+        assert!(value["stop_reason"]
+            .as_str()
+            .expect("stop reason")
+            .contains("homeboy agent-task review cook-missing-provider-attempt-1-controller --to-worktree <handle>"));
+        assert!(value["stop_reason"]
+            .as_str()
+            .expect("stop reason")
+            .contains("homeboy agent-task adopt cook-missing-provider --candidate-ref <sha> --ai-model <model>"));
+        let lifecycle = lifecycle_status("cook-missing-provider-attempt-1-controller")
+            .expect("successful candidate remains in durable lifecycle");
+        assert_eq!(lifecycle.state, AgentTaskRunState::Succeeded);
     });
 }
 


### PR DESCRIPTION
## Summary
Make promotion-provider invocation and response contracts self-describing and preserve actionable candidate recovery.

## What changed
- Documented canonical repeatable argv semantics and request/response schemas across Cook, review, and promote.
- Validated response schema before deserializing required response fields.
- Preserved successful candidates with precise review/adopt recovery guidance after invalid provider responses.

## How to test
1. Run `schema response validation`; expect passes malformed, missing schema, wrong schema, and missing workspace\_path distinctions.
2. Run `CLI argument and help tests`; expect pass for Cook, review, and promote.
3. Run `Cook wrong-schema recovery test`; expect candidate remains durable with review and adopt guidance.
4. Run `cargo check`; expect passes for homeboy-agents and homeboy-cli.
5. Run `broad promotion suite baseline comparison`; expect same six unrelated failures on clean origin/main and branch.

## Compatibility
No valid provider contract changes; deprecated string invocation remains available with migration guidance.

## Evidence
**Declared public contracts**
- `promotion-provider-cli`: Cook, review, and promote now document promotion apply-provider argv and schema contracts.
- `promotion-provider-response`: Responses validate the schema discriminator before schema-specific required fields.

**Compatibility impact:** Structured argv behavior is unchanged; the deprecated command string remains accepted. Invalid responses now produce a more precise schema error and preserve candidate recovery guidance.

**External-consumer impact:** Promotion-provider integrations returning the documented response schema are unaffected; integrations returning another schema receive the intended contract mismatch.

**External usage:** completed; source: Issue #9704 reproduction and repository call-site review; limitations: Evidence covers repository callers and the recorded failing OpenCode integration; no external private consumers were available for direct execution.; evidence: https://github.com/Extra-Chill/homeboy/issues/9704

- Base unchanged since verification: main remains at e6b1331484aed1816906bf2da6d7205e7248334a.
- CI expected: GitHub Actions repository checks
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9704
- Verified finalization base: main at e6b1331484aed1816906bf2da6d7205e7248334a
- cargo-check: passed (homeboy-agents and homeboy-cli) (Passed)
- cli-help-contract: passed (cook, review, and promote help assertions) (Passed)
- cook-candidate-recovery: passed (wrong-schema candidate remains durable with review and adopt guidance) (Passed)
- schema-response-validation: passed (malformed, missing schema, wrong schema, and missing workspace\_path distinctions) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Implemented schema-first promotion response validation, durable recovery guidance, CLI help, and deterministic tests; GPT-5.6 Sol reviewed, rebased, baseline-compared, and finalized the candidate.

## Source relationships
- Closes #9704
- Relates to #7898
- Relates to #9575
