### PR TITLE
Resolve multi-extension capability ambiguity via composition metadata

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/manifest.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest.rs
@@ -159,6 +159,11 @@ pub struct ExtensionManifest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requires: Option<RequirementsConfig>,
 
+    // Multi-extension composition: role ownership used to disambiguate a
+    // capability provided by more than one linked extension.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub composition: Option<CompositionConfig>,
+
     // Extensibility: preserve unknown fields for external consumers (GUI, workflows)
     #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
     pub extra: HashMap<String, serde_json::Value>,
@@ -166,6 +171,47 @@ pub struct ExtensionManifest {
     // Internal path (not serialized)
     #[serde(skip)]
     pub extension_path: Option<String>,
+}
+
+/// Multi-extension composition metadata. Declares how a component's linked
+/// extensions relate so Homeboy can resolve a capability that more than one of
+/// them provides without requiring manual `capability_extensions` selection.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CompositionConfig {
+    /// Extensions this one composes with (informational).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub includes: Vec<String>,
+    /// Optional companion assets (informational).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub optional: Vec<String>,
+    /// Role name -> owning extension(s). A role with a single owner designates
+    /// the extension that owns that role's capabilities across the composition.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub roles: BTreeMap<String, RoleOwners>,
+    /// Extensions that must not be linked together (informational).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub conflicts: Vec<String>,
+}
+
+/// Owner(s) of a composition role. Manifests use both a single owner
+/// (`"javascript": "nodejs"`) and a list (`"project": ["a", "b"]`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum RoleOwners {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl CompositionConfig {
+    /// The single extension id that owns `role`, if the role designates exactly
+    /// one owner. Multi-owner roles return `None` (they do not designate a
+    /// unique capability owner).
+    pub fn role_owner(&self, role: &str) -> Option<&str> {
+        match self.roles.get(role) {
+            Some(RoleOwners::One(owner)) => Some(owner.as_str()),
+            _ => None,
+        }
+    }
 }
 
 impl ExtensionManifest {
@@ -543,5 +589,47 @@ impl ExtensionManifest {
     /// Get the contract script path (relative to extension dir), if configured.
     pub fn contract_script(&self) -> Option<&str> {
         self.scripts.as_ref().and_then(|s| s.contract.as_deref())
+    }
+}
+
+#[cfg(test)]
+mod composition_tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_mixed_single_and_list_role_owners() {
+        let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": "wordpress",
+            "version": "1.0.0",
+            "composition": {
+                "includes": ["nodejs"],
+                "optional": ["dependency-adapters/nodejs-package-managers"],
+                "roles": {
+                    "javascript": "nodejs",
+                    "project": ["wordpress-plugin", "wordpress-theme"]
+                },
+                "conflicts": []
+            }
+        }))
+        .expect("manifest with composition deserializes");
+
+        let composition = manifest.composition.expect("composition present");
+        assert_eq!(composition.includes, vec!["nodejs".to_string()]);
+        // Single-owner role resolves to the owning extension.
+        assert_eq!(composition.role_owner("javascript"), Some("nodejs"));
+        // Multi-owner role does not designate a unique owner.
+        assert_eq!(composition.role_owner("project"), None);
+        // Absent role.
+        assert_eq!(composition.role_owner("missing"), None);
+    }
+
+    #[test]
+    fn composition_is_optional() {
+        let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": "nodejs",
+            "version": "1.0.0"
+        }))
+        .expect("manifest without composition deserializes");
+        assert!(manifest.composition.is_none());
     }
 }

--- a/crates/homeboy-core/src/extension_execution.rs
+++ b/crates/homeboy-core/src/extension_execution.rs
@@ -265,8 +265,46 @@ fn resolve_extension_for_capability_if_available(
     match matching.len() {
         0 => Ok(None),
         1 => Ok(Some(matching.remove(0))),
-        _ => Err(capability_ambiguous_error(component, capability, &matching)),
+        _ => {
+            // The manifests can encode which linked extension is primary via
+            // `composition.includes`: a component that links WordPress + Node.js
+            // has WordPress declare `includes: ["nodejs"]`, so WordPress owns the
+            // shared capabilities and Node.js is the composed subordinate. When
+            // exactly one of the ambiguous extensions includes all the others,
+            // resolve to it instead of forcing a manual `capability_extensions`
+            // selection. Explicit selection (handled above) still wins.
+            if let Some(primary) = composition_primary_extension(&matching)? {
+                return Ok(Some(primary));
+            }
+            Err(capability_ambiguous_error(component, capability, &matching))
+        }
     }
+}
+
+/// If exactly one of the ambiguous extensions composes all of the others via its
+/// `composition.includes`, return it as the primary owner. Returns `None` when
+/// no single extension includes every other (leaving the ambiguity unresolved).
+fn composition_primary_extension(matching: &[String]) -> Result<Option<String>> {
+    let mut primary: Option<String> = None;
+    for candidate in matching {
+        let manifest = load_extension(candidate)?;
+        let Some(composition) = manifest.composition.as_ref() else {
+            continue;
+        };
+        let includes_all_others = matching
+            .iter()
+            .filter(|other| *other != candidate)
+            .all(|other| composition.includes.iter().any(|inc| inc == other));
+        if includes_all_others {
+            if primary.is_some() {
+                // More than one extension claims to include the others; the
+                // composition is not unambiguous, so do not guess.
+                return Ok(None);
+            }
+            primary = Some(candidate.clone());
+        }
+    }
+    Ok(primary)
 }
 
 /// Whether a linked extension can provide a capability without requiring one.
@@ -428,6 +466,79 @@ mod tests {
             extensions: Some(extensions),
             ..Default::default()
         }
+    }
+
+    fn write_extension_manifest_with_includes(
+        home: &Path,
+        extension_id: &str,
+        capability: &str,
+        includes: &[&str],
+    ) {
+        let extension_dir = home.join(".config/homeboy/extensions").join(extension_id);
+        std::fs::create_dir_all(&extension_dir).expect("extension dir");
+        let includes_json = includes
+            .iter()
+            .map(|inc| format!("\"{inc}\""))
+            .collect::<Vec<_>>()
+            .join(",");
+        std::fs::write(
+            extension_dir.join(format!("{extension_id}.json")),
+            format!(
+                r#"{{"name":"{extension_id}","version":"1.0.0","{capability}":{{"extension_script":"{capability}.sh"}},"composition":{{"includes":[{includes_json}],"roles":{{"javascript":"nodejs","project":["a","b"]}}}}}}"#
+            ),
+        )
+        .expect("extension manifest");
+    }
+
+    #[test]
+    fn composition_includes_resolves_ambiguous_capability_to_primary() {
+        crate::test_support::with_isolated_home(|home| {
+            // WordPress and Node.js both provide `deps`; WordPress composes
+            // Node.js via `composition.includes`, so it is the primary owner.
+            write_extension_manifest_with_includes(home.path(), "wordpress", "deps", &["nodejs"]);
+            write_extension_manifest(home.path(), "nodejs", "deps");
+
+            let component = component_with_extensions(&["wordpress", "nodejs"]);
+            assert_eq!(
+                resolve_extension_for_capability(&component, ExtensionCapability::Deps)
+                    .expect("composition.includes should resolve the ambiguity"),
+                "wordpress"
+            );
+        });
+    }
+
+    #[test]
+    fn explicit_capability_extension_overrides_composition_primary() {
+        crate::test_support::with_isolated_home(|home| {
+            write_extension_manifest_with_includes(home.path(), "wordpress", "deps", &["nodejs"]);
+            write_extension_manifest(home.path(), "nodejs", "deps");
+
+            let mut component = component_with_extensions(&["wordpress", "nodejs"]);
+            // Explicit selection must still win over the composition primary.
+            component
+                .capability_extensions
+                .insert("deps".to_string(), "nodejs".to_string());
+            assert_eq!(
+                resolve_extension_for_capability(&component, ExtensionCapability::Deps).unwrap(),
+                "nodejs"
+            );
+        });
+    }
+
+    #[test]
+    fn ambiguous_capability_without_composition_still_errors() {
+        crate::test_support::with_isolated_home(|home| {
+            // Neither includes the other -> ambiguity is preserved.
+            write_extension_manifest(home.path(), "wordpress", "deps");
+            write_extension_manifest(home.path(), "nodejs", "deps");
+
+            let component = component_with_extensions(&["wordpress", "nodejs"]);
+            let err = resolve_extension_for_capability(&component, ExtensionCapability::Deps)
+                .expect_err("no composition primary should remain ambiguous");
+            assert!(err
+                .message
+                .contains("multiple linked extensions with deps support"));
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
The multi-extension contract was "difficult to hold": when a component links more than one extension and a capability (deps/test/lint/build/bench/fuzz/trace) is provided by more than one of them, `resolve_extension_for_capability_if_available` always returned `capability_ambiguous_error`, forcing a manual `capability_extensions.<cap> = <id>` selection. The canonical case is a WordPress component that links both `wordpress` and `nodejs` — both provide **every** capability, so every capability was ambiguous.

The manifests already encode the composition (`composition.includes`/`roles`), but `composition` was **never deserialized** onto `ExtensionManifest` (no field, no `deny_unknown_fields`), so it was silently dropped and completely inert.

## Changes
- Add `CompositionConfig` (`includes`/`optional`/`roles`/`conflicts`) to the manifest contract. `roles` values accept **both** a single owner (`"javascript": "nodejs"`) and a list (`"project": [...]`) via an untagged `RoleOwners` enum; `role_owner()` resolves single-owner roles.
- `resolve_extension_for_capability_if_available` now, **before** erroring on ambiguity, consults `composition.includes`: when exactly one of the ambiguous extensions composes all the others (WordPress `includes: ["nodejs"]`), it is the primary owner and resolves the capability.

## Strictly additive
- Explicit `capability_extensions` still overrides everything (unchanged precedence).
- A capability with no composition primary (neither includes the other) still returns the existing ambiguity error.
- Only behavior change: a previously-hard ambiguity now resolves when the manifests unambiguously designate a primary.

## Test
- `cargo fmt --check` clean; `cargo check`/targeted `cargo test` clean for `homeboy-extension-contract` and `homeboy-core`.
- Contract: mixed single/list `roles` deserialize; `role_owner` resolves single-owner and returns `None` for list/absent; composition is optional.
- Resolver: WordPress-includes-Node.js resolves an ambiguous capability to `wordpress`; explicit `capability_extensions` overrides the primary; no-composition ambiguity still errors.

## Notes
Tech-debt burndown: activates the previously-inert `composition` metadata and removes the manual `capability_extensions` ceremony for the canonical multi-extension case.