### PR TITLE
fix(runner): diagnose misplaced exec options before dispatch

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -92,6 +92,12 @@ impl CliRuntime {
     }
 
     pub fn run_from_args(&self, args: Vec<String>) -> std::process::ExitCode {
+        let normalized = args::normalize(args);
+        if let Some(message) = args::runner_exec_option_boundary_error(&normalized) {
+            eprintln!("error: {message}");
+            return std::process::ExitCode::from(2);
+        }
+
         // Register the config-level artifact_root resolver before any command runs
         // so paths::artifact_root() can honor global config without paths depending
         // on the defaults layer (breaks the paths <-> defaults dependency cycle).
@@ -260,12 +266,11 @@ impl CliRuntime {
             }
         });
 
-        if is_top_level_version_request(&args) {
+        if is_top_level_version_request(&normalized) {
             println!("{}", upgrade::current_build_version());
             return std::process::ExitCode::SUCCESS;
         }
 
-        let normalized = args::normalize(args);
         let matches = self.parse_matches(normalized.clone());
         self.run_matches(matches, normalized)
     }
@@ -1332,6 +1337,29 @@ mod tests {
     #[test]
     fn normal_output_file_paths_are_allowed() {
         assert!(output_runtime::validate_output_file_path("./homeboy-output.json").is_none());
+    }
+
+    #[test]
+    fn runner_exec_rejects_inherited_options_before_runtime_initialization() {
+        for option in [
+            "--output",
+            "--notification-transport",
+            "--notification-route",
+        ] {
+            let exit = CliRuntime::new().run_from_args(vec![
+                "homeboy".to_string(),
+                "runner".to_string(),
+                "exec".to_string(),
+                "lab".to_string(),
+                "cp".to_string(),
+                "source".to_string(),
+                "destination".to_string(),
+                option.to_string(),
+                "value".to_string(),
+            ]);
+
+            assert_eq!(exit, std::process::ExitCode::from(2));
+        }
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/runner/cli.rs
+++ b/crates/homeboy-cli/src/commands/runner/cli.rs
@@ -332,7 +332,10 @@ pub(super) enum RunnerCommand {
         #[arg(long)]
         dry_run: bool,
     },
-    /// Execute a command on a configured runner
+    /// Execute a command on a configured runner. Use `homeboy runner exec [HOMEBOY_OPTIONS] <RUNNER> -- <COMMAND>...`.
+    #[command(
+        after_help = "Use `homeboy runner exec [HOMEBOY_OPTIONS] <RUNNER> -- <COMMAND>...` to make the Homeboy/remote-command boundary explicit."
+    )]
     Exec {
         /// Runner ID
         id: String,

--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -639,7 +639,7 @@ fn default_runtime_probe_value() -> RuntimeProbeValue {
 fn diagnostic_command(runner_id: Option<&str>, script: &str) -> String {
     match runner_id {
         Some(runner_id) => format!(
-            "homeboy runner exec {} --raw -- bash -lc {}",
+            "homeboy runner exec --raw {} -- bash -lc {}",
             shell_arg(runner_id),
             shell_arg(script)
         ),
@@ -708,7 +708,7 @@ pub(super) fn runner_artifact_feature_diagnostics(
     RunnerArtifactFeatureDiagnostics {
         required_features: vec!["runner_exec_artifact_output", "runs_artifact_attach"],
         controller_commands: vec![
-            "homeboy runner exec <runner-id> --run-id <run-id> --artifact <path> -- <command>"
+            "homeboy runner exec --run-id <run-id> --artifact <path> <runner-id> -- <command>"
                 .to_string(),
             "homeboy runs artifact attach <run-id> --runner <runner-id> --path <path> --name <name>"
                 .to_string(),

--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -616,7 +616,7 @@ fn runner_status_artifact_diagnostics_surface_controller_runner_checks_and_drift
         .required_features
         .contains(&"runs_artifact_attach"));
     assert!(serialized.contains(
-        "homeboy runner exec <runner-id> --run-id <run-id> --artifact <path> -- <command>"
+        "homeboy runner exec --run-id <run-id> --artifact <path> <runner-id> -- <command>"
     ));
     assert!(serialized.contains(
         "homeboy runs artifact attach <run-id> --runner <runner-id> --path <path> --name <name>"

--- a/crates/homeboy-cli/src/commands/utils/args.rs
+++ b/crates/homeboy-cli/src/commands/utils/args.rs
@@ -128,6 +128,69 @@ fn known_cli_flags_for_path(path: &[&str]) -> Option<Vec<CliFlagSpec>> {
     Some(flags)
 }
 
+/// Detect runner exec options that occur after an implicit remote command tail.
+/// An explicit `--` makes all remaining tokens remote-owned.
+pub(crate) fn runner_exec_option_boundary_error(args: &[String]) -> Option<String> {
+    let exec_index = top_level_runner_exec_index(args)?;
+    let flags = known_cli_flags_for_path(&["runner", "exec"])?;
+    let mut runner_seen = false;
+    let mut command_seen = false;
+    let mut index = exec_index;
+
+    while let Some(arg) = args.get(index) {
+        if arg == "--" {
+            return None;
+        }
+
+        let flag = flags.iter().find(|flag| {
+            arg == &flag.flag || (flag.takes_value && arg.strip_prefix(&flag.flag) == Some("="))
+        });
+        if let Some(flag) = flag {
+            if command_seen {
+                return Some(format!(
+                    "runner exec option `{}` appears after the remote command. Use `homeboy runner exec [HOMEBOY_OPTIONS] <RUNNER> -- <COMMAND>...`; place `{}` before the runner or add `--` before a remote argument with that name.",
+                    flag.flag, flag.flag
+                ));
+            }
+            if flag.takes_value && arg == &flag.flag {
+                index += 1;
+            }
+        } else if runner_seen {
+            command_seen = true;
+        } else {
+            runner_seen = true;
+        }
+        index += 1;
+    }
+
+    None
+}
+
+fn top_level_runner_exec_index(args: &[String]) -> Option<usize> {
+    let root = Cli::command();
+    let flags = command_flag_specs(&root);
+    let mut index = 1;
+
+    while let Some(arg) = args.get(index) {
+        if arg == "--" {
+            return None;
+        }
+        if arg == "runner" && args.get(index + 1).is_some_and(|next| next == "exec") {
+            return Some(index + 2);
+        }
+
+        let flag = flags.iter().find(|flag| {
+            arg == &flag.flag || (flag.takes_value && arg.strip_prefix(&flag.flag) == Some("="))
+        });
+        let Some(flag) = flag else {
+            return None;
+        };
+        index += usize::from(flag.takes_value && arg == &flag.flag) + 1;
+    }
+
+    None
+}
+
 fn find_subcommand<'a>(command: &'a Command, name: &str) -> Option<&'a Command> {
     command
         .get_subcommands()
@@ -296,7 +359,7 @@ mod positional_tests {
 
 #[cfg(test)]
 mod normalize_tests {
-    use super::{normalize, EXPLICIT_PASSTHROUGH_SENTINEL};
+    use super::{normalize, runner_exec_option_boundary_error, EXPLICIT_PASSTHROUGH_SENTINEL};
     use crate::cli_surface::{Cli, Commands};
     use clap::Parser;
 
@@ -444,6 +507,92 @@ mod normalize_tests {
             "value",
         ]));
         assert!(Cli::try_parse_from(explicit).is_ok());
+    }
+
+    #[test]
+    fn runner_exec_rejects_known_options_after_an_implicit_command() {
+        for flag in [
+            "--cwd",
+            "--raw",
+            "--run-id",
+            "--output",
+            "--notification-transport",
+        ] {
+            let mut args = argv(&[
+                "homeboy",
+                "runner",
+                "exec",
+                "lab",
+                "cp",
+                "source",
+                "destination",
+            ]);
+            args.push(flag.to_string());
+            if !matches!(flag, "--raw") {
+                args.push("value".to_string());
+            }
+
+            let error = runner_exec_option_boundary_error(&args)
+                .expect("misplaced runner exec option should be diagnosed");
+            assert!(error.contains(flag));
+            assert!(error.contains("[HOMEBOY_OPTIONS] <RUNNER> -- <COMMAND>..."));
+        }
+    }
+
+    #[test]
+    fn runner_exec_allows_remote_flags_after_an_explicit_separator() {
+        let args = argv(&[
+            "homeboy",
+            "runner",
+            "exec",
+            "lab",
+            "--",
+            "cp",
+            "source",
+            "destination",
+            "--cwd",
+            "remote",
+            "--raw",
+            "--run-id",
+            "remote-run",
+        ]);
+
+        assert_eq!(runner_exec_option_boundary_error(&args), None);
+    }
+
+    #[test]
+    fn runner_exec_allows_commands_without_flags() {
+        let args = argv(&[
+            "homeboy",
+            "runner",
+            "exec",
+            "lab",
+            "cp",
+            "source",
+            "destination",
+        ]);
+
+        assert_eq!(runner_exec_option_boundary_error(&args), None);
+    }
+
+    #[test]
+    fn runner_exec_does_not_inspect_a_remote_ssh_command_tail() {
+        let args = argv(&[
+            "homeboy",
+            "ssh",
+            "lab-host",
+            "--",
+            "runner",
+            "exec",
+            "lab",
+            "cp",
+            "source",
+            "destination",
+            "--cwd",
+            "/tmp",
+        ]);
+
+        assert_eq!(runner_exec_option_boundary_error(&args), None);
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/execution/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/handoff.rs
@@ -26,7 +26,7 @@ pub(crate) fn lab_offload_handoff_hints(
 ) -> Vec<String> {
     let runner_exec_prefix = match remote_cwd.filter(|cwd| !cwd.trim().is_empty()) {
         Some(cwd) => format!(
-            "homeboy runner exec {runner_id} --cwd {} --",
+            "homeboy runner exec --cwd {} {runner_id} --",
             shell::quote_arg(cwd)
         ),
         None => format!("homeboy runner exec {runner_id} --"),

--- a/crates/homeboy-lab-runner/src/execution/redaction.rs
+++ b/crates/homeboy-lab-runner/src/execution/redaction.rs
@@ -131,9 +131,9 @@ pub(super) fn runner_exec_diagnostics(
     let mut hints = Vec::new();
     if let Some(remote_path) = source_snapshot.and_then(|snapshot| snapshot.remote_path.as_ref()) {
         hints.push(format!(
-            "Reuse this runner workspace with `homeboy runner exec {} --cwd {} -- <command>`.",
-            shell_arg(&runner.id),
-            shell_arg(remote_path)
+            "Reuse this runner workspace with `homeboy runner exec --cwd {} {} -- <command>`.",
+            shell_arg(remote_path),
+            shell_arg(&runner.id)
         ));
         hints.push(format!(
             "Discover recent runner workspaces with `homeboy runner workspace list {}`.",

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -59,7 +59,7 @@ fn timeout_mirrors_remote_job_without_cancelling() {
             .message
             .contains("Lab offload handoff: runner `lab` has daemon job")));
         assert!(err.hints.iter().any(|hint| hint.message.contains(
-            "homeboy runner exec lab --cwd /srv/homeboy/project -- homeboy runs list --status running --limit 20"
+            "homeboy runner exec --cwd /srv/homeboy/project lab -- homeboy runs list --status running --limit 20"
         )));
         assert!(err.hints.iter().any(|hint| hint
             .message
@@ -265,7 +265,7 @@ fn lab_offload_handoff_hints_render_durable_commands() {
     assert!(joined.contains("homeboy runs evidence run-456"));
     assert!(joined.contains("homeboy runs artifacts run-456"));
     assert!(joined.contains(
-        "homeboy runner exec homeboy-lab --cwd '/home/user/Developer/project with spaces' -- homeboy runs list --status running --limit 20"
+        "homeboy runner exec --cwd '/home/user/Developer/project with spaces' homeboy-lab -- homeboy runs list --status running --limit 20"
     ));
     assert!(joined.contains("homeboy runner job logs homeboy-lab job-123 --follow"));
     assert!(joined.contains("Cancel: `homeboy runner job cancel homeboy-lab job-123`"));

--- a/crates/homeboy-lab-runner/src/lab/fallback.rs
+++ b/crates/homeboy-lab-runner/src/lab/fallback.rs
@@ -81,7 +81,7 @@ fn build_lab_replacement_hints(runner_id: Option<&str>) -> Vec<String> {
             "Materialize the build workspace first: homeboy runner workspace sync {runner} --path <local-worktree> --mode snapshot"
         ),
         format!(
-            "Then run the build in the returned runner_path: homeboy runner exec {runner} --cwd <runner_path> -- homeboy build <component>"
+            "Then run the build in the returned runner_path: homeboy runner exec --cwd <runner_path> {runner} -- homeboy build <component>"
         ),
     ]
 }

--- a/crates/homeboy-lab-runner/src/lab/offload/execute.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/execute.rs
@@ -400,7 +400,7 @@ pub(crate) fn unsupported_runner_hints(
 
     if let Some(service_command) = tunnel_service_command(normalized_args) {
         hints.push(format!(
-            "`tunnel service {service_command} --runner {runner_id}` is not routed directly; inspect runner-side tunnel state with `homeboy runner exec {runner_id} --ssh --raw -- homeboy tunnel service {service_command} ...` until service inspection supports native --runner routing."
+            "`tunnel service {service_command} --runner {runner_id}` is not routed directly; inspect runner-side tunnel state with `homeboy runner exec --ssh --raw {runner_id} -- homeboy tunnel service {service_command} ...` until service inspection supports native --runner routing."
         ));
     }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
@@ -577,7 +577,7 @@ fn build_runner_error_gives_managed_runner_replacement() {
     assert!(tried
         .iter()
         .any(|hint| hint.as_str().is_some_and(|hint| hint.contains(
-            "homeboy runner exec homeboy-lab --cwd <runner_path> -- homeboy build <component>"
+            "homeboy runner exec --cwd <runner_path> homeboy-lab -- homeboy build <component>"
         ))));
 }
 
@@ -625,7 +625,7 @@ fn build_lab_placement_error_gives_managed_runner_replacement() {
     assert!(tried
         .iter()
         .any(|hint| hint.as_str().is_some_and(|hint| hint.contains(
-            "homeboy runner exec <runner-id> --cwd <runner_path> -- homeboy build <component>"
+            "homeboy runner exec --cwd <runner_path> <runner-id> -- homeboy build <component>"
         ))));
 }
 

--- a/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
@@ -85,7 +85,7 @@ pub fn runner_recovery_commands(
 pub fn runner_inspect_bare_homeboy_command(runner_id: &str) -> String {
     let script = "type -a homeboy; command -v homeboy; homeboy --version";
     format!(
-        "homeboy runner exec {} --ssh -- sh -lc {}",
+        "homeboy runner exec --ssh {} -- sh -lc {}",
         shell_arg(runner_id),
         shell_arg(script)
     )
@@ -117,8 +117,8 @@ pub fn runner_exec_recovery_commands(runner: &Runner, command: &[String]) -> Vec
         "homeboy".to_string(),
         "runner".to_string(),
         "exec".to_string(),
-        runner.id.clone(),
         "--ssh".to_string(),
+        runner.id.clone(),
         "--".to_string(),
     ];
     args.extend(command.iter().cloned());

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
@@ -621,7 +621,7 @@ fn reports_exact_runner_set_remediation_when_path_update_is_unsafe() {
         .unwrap()
         .contains("automatic runner homeboy_path update is unsafe"));
     assert!(skipped[0].recovery_commands.contains(
-        &"homeboy runner exec lab --ssh -- sh -lc 'type -a homeboy; command -v homeboy; homeboy --version'".to_string()
+        &"homeboy runner exec --ssh lab -- sh -lc 'type -a homeboy; command -v homeboy; homeboy --version'".to_string()
     ));
     assert!(skipped[0]
         .recovery_commands

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
@@ -114,7 +114,7 @@ fn isolates_runner_extension_sync_failures_and_continues_later_extensions() {
     assert_eq!(skipped[0].extensions_failed[0].extension_id, "swift");
     assert_eq!(
         skipped[0].extensions_failed[0].recovery_commands,
-        vec!["homeboy runner exec lab --ssh -- /home/user/.cargo/bin/homeboy extension install https://github.com/Extra-Chill/homeboy-extensions.git --id swift --ref 98a61eda --replace"]
+        vec!["homeboy runner exec --ssh lab -- /home/user/.cargo/bin/homeboy extension install https://github.com/Extra-Chill/homeboy-extensions.git --id swift --ref 98a61eda --replace"]
     );
     assert_eq!(skipped[0].extensions_synced.len(), 1);
     assert_eq!(skipped[0].extensions_synced[0].extension_id, "wordpress");

--- a/crates/homeboy-lab-runner/src/workspace/provenance.rs
+++ b/crates/homeboy-lab-runner/src/workspace/provenance.rs
@@ -643,9 +643,9 @@ fn verify_snapshot_workspace_content(
     if actual_content_hash != provenance.content_hash {
         let diagnostic = match provenance.materialization_mode.as_str() {
             "snapshot-git" => format!(
-                "homeboy runner exec {} --cwd {} -- git status --short",
-                shell::quote_arg(&provenance.runner_id),
+                "homeboy runner exec --cwd {} {} -- git status --short",
                 shell::quote_arg(&provenance.remote_workspace_path),
+                shell::quote_arg(&provenance.runner_id),
             ),
             "snapshot" | "filesystem_snapshot" => format!(
                 "homeboy runner workspace sync --mode snapshot --path {} {}",

--- a/crates/homeboy-lab-runner/src/workspace/sync/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/snapshots.rs
@@ -46,9 +46,9 @@ pub fn list_workspaces(runner_id: &str, limit: usize) -> Result<(RunnerWorkspace
         .into_iter()
         .map(|remote_path| RunnerWorkspaceListEntry {
             exec_command: format!(
-                "homeboy runner exec {} --cwd {} -- <command>",
-                shell_arg(&runner.id),
-                shell_arg(&remote_path)
+                "homeboy runner exec --cwd {} {} -- <command>",
+                shell_arg(&remote_path),
+                shell_arg(&runner.id)
             ),
             remote_path,
         })
@@ -350,9 +350,9 @@ fn workspace_snapshot_entry(
         .unwrap_or_else(|| workspace_repo_from_path(&metadata.local_path));
     Some(RunnerWorkspaceSnapshotEntry {
         exec_command: format!(
-            "homeboy runner exec {} --cwd {} -- <command>",
-            shell_arg(&metadata.runner_id),
-            shell_arg(&metadata.remote_path)
+            "homeboy runner exec --cwd {} {} -- <command>",
+            shell_arg(&metadata.remote_path),
+            shell_arg(&metadata.runner_id)
         ),
         runner_id: metadata.runner_id,
         repo,

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -885,7 +885,7 @@ fn workspace_list_reports_recent_lab_workspaces_with_exec_commands() {
         assert_eq!(list.workspaces[0].remote_path, sync.remote_path);
         assert!(list.workspaces[0]
             .exec_command
-            .contains("homeboy runner exec lab-local-list --cwd"));
+            .contains("homeboy runner exec --cwd"));
         assert!(list.workspaces[0].exec_command.contains("-- <command>"));
     });
 }

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
@@ -185,9 +185,7 @@ fn workspace_snapshots_render_metadata_for_synced_workspace() {
         assert_eq!(snapshot.source_dirty, Some(false));
         assert_eq!(snapshot.run_id.as_deref(), Some("run-figma-1"));
         assert!(snapshot.created_at.contains('T'));
-        assert!(snapshot
-            .exec_command
-            .contains("homeboy runner exec lab-local-snapshots --cwd"));
+        assert!(snapshot.exec_command.contains("homeboy runner exec --cwd"));
     });
 }
 

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -779,8 +779,7 @@ runner-side checkout through `runner exec` instead of forcing a controller-local
 hot run:
 
 ```bash
-homeboy runner exec homeboy-lab \
-  --cwd /srv/homeboy/checkouts/homeboy \
+homeboy runner exec --cwd /srv/homeboy/checkouts/homeboy homeboy-lab \
   -- homeboy agent-task cook \
     --repo homeboy \
     --cwd /srv/homeboy/checkouts/homeboy \

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -716,16 +716,18 @@ homeboy runner remove <id>
 ### `exec`
 
 ```sh
-homeboy runner exec <runner-id> -- <command...>
-homeboy runner exec <runner-id> --project <project-id> --cwd /runner/workspace/project -- <command...>
-homeboy runner exec <runner-id> --sync-workspace /local/project@patch --require-path /runner/resources/input -- <command...>
-homeboy runner exec <runner-id> --ssh --cwd /runner/workspace/project -- <command...>
-homeboy runner exec <runner-id> --run-id ssi-fixture-matrix-summary -- <command...>
-homeboy runner exec <runner-id> --cwd /runner/workspace/project --require-path /runner/workspace/project -- <command...>
+homeboy runner exec [HOMEBOY_OPTIONS] <runner-id> -- <command...>
+homeboy runner exec --project <project-id> --cwd /runner/workspace/project <runner-id> -- <command...>
+homeboy runner exec --sync-workspace /local/project@patch --require-path /runner/resources/input <runner-id> -- <command...>
+homeboy runner exec --ssh --cwd /runner/workspace/project <runner-id> -- <command...>
+homeboy runner exec --run-id ssi-fixture-matrix-summary <runner-id> -- <command...>
+homeboy runner exec --cwd /runner/workspace/project --require-path /runner/workspace/project <runner-id> -- <command...>
 homeboy runner env <runner-id>
 ```
 
 `exec` submits the command to the connected runner daemon when `homeboy runner connect <runner-id>` has established a live loopback tunnel. If no daemon session is connected, local runners execute directly and SSH runners require explicit diagnostic `--ssh`. SSH runner raw exec is policy-denied by default until `policy.allow_raw_exec` is explicitly true.
+
+Place Homeboy options before the runner ID and use `--` before the remote command. Without the separator, Homeboy diagnoses known exec options that appear after a remote command; the separator preserves remote flags with names such as `--cwd`, `--raw`, and `--run-id`.
 
 Path rules:
 
@@ -747,10 +749,10 @@ Path rules:
 Dirty local worktree against runner-side resources:
 
 ```sh
-homeboy runner exec <runner-id> \
-  --sync-workspace /local/project@patch \
+homeboy runner exec --sync-workspace /local/project@patch \
   --require-path /runner/resources/input \
   --capture-patch \
+  <runner-id> \
   -- ./run-workload --input /runner/resources/input
 ```
 

--- a/docs/operations/artifact-loop-runner-matrix.md
+++ b/docs/operations/artifact-loop-runner-matrix.md
@@ -46,9 +46,9 @@ result refs.
 ```sh
 run_id="review-static-html-$(date -u +%Y%m%dT%H%M%SZ)"
 
-homeboy runner exec lab-runner \
-  --cwd /workspace/example-component \
+homeboy runner exec --cwd /workspace/example-component \
   --run-id "$run_id" \
+  lab-runner \
   -- \
   sh -lc 'mkdir -p artifacts/review && npm run build-report -- --out artifacts/review'
 
@@ -126,9 +126,9 @@ for runtime in runtime-a runtime-b; do
     cell="runtime=${runtime},browser=${browser}"
     out="artifacts/matrix/${runtime}/${browser}"
 
-    homeboy runner exec lab-runner \
-      --cwd /workspace/example-component \
+    homeboy runner exec --cwd /workspace/example-component \
       --run-id "${run_id}-${runtime}-${browser}" \
+      lab-runner \
       -- \
       sh -lc "mkdir -p ${out} && ./scripts/run-cell --runtime ${runtime} --browser ${browser} --out ${out}"
   done

--- a/docs/operations/controller-runner-reverse-runner.md
+++ b/docs/operations/controller-runner-reverse-runner.md
@@ -218,10 +218,10 @@ private smoke environment that provides equivalent branch builds.
 3. Submit a minimal command from the controller:
 
    ```sh
-   homeboy runner exec <runner-id> \
-     --project <project-id> \
-     --cwd <runner-workspace-root> \
-     --output /tmp/homeboy-runner-smoke.json \
+    homeboy runner exec --project <project-id> \
+      --cwd <runner-workspace-root> \
+      --output /tmp/homeboy-runner-smoke.json \
+      <runner-id> \
      -- /bin/sh -lc 'printf "homeboy-runner-smoke\\n"'
    ```
 

--- a/docs/operations/release-gate-proof-path.md
+++ b/docs/operations/release-gate-proof-path.md
@@ -72,8 +72,7 @@ non-interactive shell and points you at Lab offload. Honor that routing:
   **without** a public placement override:
 
   ```bash
-  homeboy runner exec homeboy-lab \
-    --cwd /srv/homeboy/checkouts/my-component \
+  homeboy runner exec --cwd /srv/homeboy/checkouts/my-component homeboy-lab \
     -- homeboy review my-component --changed-since=origin/main
   ```
 

--- a/docs/workflows/set-up-lab-runners.md
+++ b/docs/workflows/set-up-lab-runners.md
@@ -102,8 +102,7 @@ homeboy --runner <runner-id> agent-task controller run-from-spec @controller.jso
 For runner-side checkouts, use `runner exec`:
 
 ```bash
-homeboy runner exec <runner-id> \
-  --cwd /srv/homeboy/checkouts/<component-id> \
+homeboy runner exec --cwd /srv/homeboy/checkouts/<component-id> <runner-id> \
   -- homeboy review <component-id> --changed-since origin/main
 ```
 

--- a/docs/workflows/use-runners.md
+++ b/docs/workflows/use-runners.md
@@ -47,8 +47,7 @@ homeboy --runner <runner-id> trace my-component checkout-flow --baseline
 When the intended checkout already exists on the runner, dispatch from that checkout instead of forcing controller-local execution:
 
 ```bash
-homeboy runner exec <runner-id> \
-  --cwd /srv/homeboy/checkouts/my-component \
+homeboy runner exec --cwd /srv/homeboy/checkouts/my-component <runner-id> \
   -- homeboy review my-component --changed-since origin/main
 ```
 


### PR DESCRIPTION
## Summary
Diagnose Homeboy-owned runner exec options that appear after an implicit remote command before any runner lookup or dispatch.

## What changed
- Adds top-level runner exec boundary validation, covers inherited options and nested passthrough false positives, and normalizes generated/documented command guidance.

## How to test
1. Run `cargo test -p homeboy-cli commands::utils::args::normalize_tests --lib`; expect passes.
2. Run `cargo test -p homeboy-cli runner_exec_rejects_inherited_options_before_runtime_initialization --lib`; expect passes.

## Compatibility
Explicit -- passthrough remains remote-owned; valid existing runner exec forms continue to parse.

## Evidence
- Base advanced after verification: verified main at 3a82cc8f51ecd16ccbffa7b68201e7a62b6a988b; publication observed 1e2e5684c112c50848479a556408436536785736. Candidate ancestry was validated against the verified snapshot.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9671
- Verified finalization base: main at 3a82cc8f51ecd16ccbffa7b68201e7a62b6a988b
- diff-check: passed (Passed)
- targeted-tests: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy cook with OpenCode
- **Model:** openai/gpt-5.6-terra + openai/gpt-5.6-sol
- **Used for:** Drafted the initial patch, reviewed parser and dispatch behavior, repaired findings, normalized guidance, and added regression coverage.

## Source relationships
- Closes Extra-Chill/homeboy#9671
