### PR TITLE
Fix Lab controller Git fallback classification

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -578,7 +578,13 @@ fn compatible_incremental_snapshot(
 }
 
 fn is_runner_git_auth_or_network_failure(error: &Error) -> bool {
-    let message = error.message.to_ascii_lowercase();
+    let details = error.details.to_string();
+    let evidence = std::iter::once(error.message.as_str())
+        .chain(error.hints.iter().map(|hint| hint.message.as_str()))
+        .chain(std::iter::once(details.as_str()))
+        .map(str::to_ascii_lowercase)
+        .collect::<Vec<_>>()
+        .join("\n");
     [
         "authentication failed",
         "permission denied",
@@ -592,7 +598,7 @@ fn is_runner_git_auth_or_network_failure(error: &Error) -> bool {
         "proxy",
     ]
     .iter()
-    .any(|needle| message.contains(needle))
+    .any(|needle| evidence.contains(needle))
 }
 
 pub(crate) fn workspace_materialization_plan(
@@ -1678,8 +1684,10 @@ fn local_git_state(local_path: &Path) -> LocalGitState {
 #[cfg(test)]
 mod tests {
     use super::{
-        retry_idempotent_ssh_operation, runner_workspace_disk_is_critical, RunnerWorkspaceDiskProbe,
+        is_runner_git_auth_or_network_failure, retry_idempotent_ssh_operation,
+        runner_workspace_disk_is_critical, RunnerWorkspaceDiskProbe,
     };
+    use homeboy_core::error::{Error, ErrorCode};
     use homeboy_core::server::CommandOutput;
 
     fn command_output(success: bool, exit_code: i32, stderr: &str) -> CommandOutput {
@@ -1691,6 +1699,46 @@ mod tests {
             timed_out: false,
             child_resource: None,
         }
+    }
+
+    #[test]
+    fn runner_git_network_failure_in_hint_activates_controller_fallback() {
+        let error = Error::validation_invalid_argument(
+            "changed_since",
+            "runner dispatch could not make the requested --changed-since base reachable in the runner workspace before dispatch",
+            None,
+            Some(vec![
+                "Remote git error: ssh: Could not resolve hostname git.example.test: Temporary failure in name resolution\nfatal: Could not read from remote repository."
+                    .to_string(),
+            ]),
+        );
+
+        assert!(is_runner_git_auth_or_network_failure(&error));
+    }
+
+    #[test]
+    fn runner_git_network_failure_in_structured_details_activates_controller_fallback() {
+        let error = Error::new(
+            ErrorCode::RunnerLabTransportFailure,
+            "runner Git materialization failed",
+            serde_json::json!({
+                "stderr": "fatal: unable to access source: Failed to connect to git.example.test",
+            }),
+        );
+
+        assert!(is_runner_git_auth_or_network_failure(&error));
+    }
+
+    #[test]
+    fn runner_git_non_transport_failure_does_not_activate_controller_fallback() {
+        let error = Error::validation_invalid_argument(
+            "changed_since",
+            "runner dispatch could not make the requested --changed-since base reachable in the runner workspace before dispatch",
+            None,
+            Some(vec!["Remote git error: fatal: invalid object name 'missing-ref'".to_string()]),
+        );
+
+        assert!(!is_runner_git_auth_or_network_failure(&error));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- classify runner Git authentication and network failures from the complete Homeboy error envelope
- include top-level messages, structured details, and hints when deciding whether to activate controller-routed Git bundle materialization
- preserve fail-closed behavior for non-transport Git failures

Closes #9722.

## Live evidence

The configured `homeboy-lab` runner passed `runner doctor --scope lab-offload`, but direct Enterprise HTTPS and Git SSH probes were unreachable:

- `runner-exec-generic-homeboy-lab-1d67f535-be49-4444-9b5f-9d9290000036`
- `runner-exec-generic-homeboy-lab-dad8c46b-41ee-47fe-b7de-c6ab681a16ed`

Before this patch, `materialize_git()` placed the remote stderr in a hint while fallback classification examined only the generic top-level message, so Homeboy never invoked its controller bundle fallback.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner runner_git_` (3 passed)
- `cargo test -p homeboy-lab-runner --lib` (1,272 passed, 23 existing failures, 6 ignored)

The full crate suite is not green on current `main`. Existing failures include local-runner policy drift, version expectation drift, and shared fixture isolation. The existing `changed_since_retry_route_materializes_private_unavailable_origin_from_bundle` scenario currently fails before runner dispatch because its controller fixture references a commit-graph object absent from the object database; it does not reach this classifier.

## AI assistance

- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Use:** Root-cause analysis, implementation, regression tests, and verification. Chris remains responsible for every line.