### PR TITLE
feat(rig): register local command artifacts

### DIFF
--- a/crates/homeboy-cli/src/commands/rig/mod.rs
+++ b/crates/homeboy-cli/src/commands/rig/mod.rs
@@ -12,10 +12,11 @@ use homeboy::rig;
 use homeboy::runner::runners;
 
 use self::output::{
-    RigAppOutput, RigCheckOutput, RigDownOutput, RigInstallOutput, RigInstalledStackSummary,
-    RigInstalledSummary, RigListOutput, RigMaterializeOutput, RigReleaseLockOutput,
-    RigRepairOutput, RigRunOutput, RigShowOutput, RigSourceSummary, RigStatusOutput, RigSummary,
-    RigSyncOutput, RigUpOutput, RigUpPlanOutput, RigUpPlanStep, RigUpdateOutput,
+    RigAppOutput, RigArtifactRegisterOutput, RigCheckOutput, RigDownOutput, RigInstallOutput,
+    RigInstalledStackSummary, RigInstalledSummary, RigListOutput, RigMaterializeOutput,
+    RigReleaseLockOutput, RigRepairOutput, RigRunOutput, RigShowOutput, RigSourceSummary,
+    RigStatusOutput, RigSummary, RigSyncOutput, RigUpOutput, RigUpPlanOutput, RigUpPlanStep,
+    RigUpdateOutput,
 };
 use super::bench::RigRunBenchOptions;
 use super::utils::args::SettingArgs;
@@ -256,6 +257,24 @@ enum RigCommand {
         #[command(subcommand)]
         command: RigAppCommand,
     },
+    /// Register local command-step evidence with the enclosing rig run.
+    Artifact {
+        #[command(subcommand)]
+        command: RigArtifactCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum RigArtifactCommand {
+    /// Register an existing local file or directory with the current rig run.
+    Register {
+        /// Stable artifact kind used by run artifact readers.
+        #[arg(long)]
+        kind: String,
+        /// Existing local file or directory to retain.
+        #[arg(long)]
+        path: std::path::PathBuf,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -388,6 +407,19 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Update { rig_id, all } => update(rig_id.as_deref(), all),
         RigCommand::Sources { command } => sources::run(command),
         RigCommand::App { command } => app(command),
+        RigCommand::Artifact { command } => artifact(command),
+    }
+}
+
+fn artifact(command: RigArtifactCommand) -> CmdResult<RigCommandOutput> {
+    match command {
+        RigArtifactCommand::Register { kind, path } => Ok((
+            RigCommandOutput::ArtifactRegister(RigArtifactRegisterOutput {
+                command: "rig.artifact.register",
+                registration: rig::register_current_run_artifact(&kind, path)?,
+            }),
+            0,
+        )),
     }
 }
 
@@ -1068,6 +1100,29 @@ mod tests {
             panic!("expected rig sources command");
         };
         assert!(command.is_none());
+    }
+
+    #[test]
+    fn parses_local_artifact_registration() {
+        let cli = TestCli::try_parse_from([
+            "homeboy",
+            "artifact",
+            "register",
+            "--kind",
+            "wp_codebox_bundle",
+            "--path",
+            "/tmp/wp-codebox-bundle",
+        ])
+        .expect("rig artifact registration should parse");
+
+        let RigCommand::Artifact {
+            command: RigArtifactCommand::Register { kind, path },
+        } = cli.rig.command
+        else {
+            panic!("expected rig artifact register command");
+        };
+        assert_eq!(kind, "wp_codebox_bundle");
+        assert_eq!(path, std::path::Path::new("/tmp/wp-codebox-bundle"));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/rig/output.rs
+++ b/crates/homeboy-cli/src/commands/rig/output.rs
@@ -27,8 +27,16 @@ pub enum RigCommandOutput {
     Update(RigUpdateOutput),
     Sources(RigSourcesOutput),
     App(RigAppOutput),
+    ArtifactRegister(RigArtifactRegisterOutput),
     ReleaseLock(RigReleaseLockOutput),
     Run(RigRunOutput),
+}
+
+#[derive(Serialize)]
+pub struct RigArtifactRegisterOutput {
+    pub command: &'static str,
+    #[serde(flatten)]
+    pub registration: rig::LocalArtifactRegistration,
 }
 
 #[derive(Serialize)]

--- a/crates/homeboy-rig/src/artifact_index.rs
+++ b/crates/homeboy-rig/src/artifact_index.rs
@@ -18,6 +18,8 @@ pub struct RigRunArtifactIndex {
     pub evidence_commands: RunEvidenceCommands,
     pub export_command: String,
     pub retrieval_commands: Vec<String>,
+    #[serde(default)]
+    pub registered_artifact_refs: Vec<RigRunArtifactRef>,
     pub key_report_refs: Vec<RigRunArtifactRef>,
     pub failed_step_refs: Vec<RigRunFailedStepRef>,
 }
@@ -121,6 +123,17 @@ fn build(
         .filter(|artifact| artifact_is_key_report_ref(artifact))
         .map(artifact_ref)
         .collect::<Vec<_>>();
+    let registered_artifact_refs = artifacts
+        .iter()
+        .filter(|artifact| {
+            artifact
+                .metadata_json
+                .get("source")
+                .and_then(serde_json::Value::as_str)
+                == Some("rig_command_registration")
+        })
+        .map(artifact_ref)
+        .collect::<Vec<_>>();
     RigRunArtifactIndex {
         run_id: run_id.to_string(),
         rig_id: rig_id.to_string(),
@@ -134,6 +147,7 @@ fn build(
         },
         export_command: export_command.clone(),
         retrieval_commands: vec![artifacts_command, evidence_command, export_command],
+        registered_artifact_refs,
         key_report_refs,
         failed_step_refs,
     }

--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -28,6 +28,7 @@ pub mod install;
 mod json_config;
 pub mod lease;
 pub mod lint;
+pub mod local_artifact;
 pub mod pipeline;
 pub mod provider;
 pub mod resource_lifecycle;
@@ -62,6 +63,9 @@ pub use lease::{
     acquire_active_run_lease, acquire_active_run_lease_with_settings, active_run_leases,
     release_active_run_lease, ActiveRigRunLease, ReleaseLeaseOutcome, RigRunLease,
     RIG_LEASE_TTL_ENV,
+};
+pub use local_artifact::{
+    register_current_run_artifact, LocalArtifactRegistration, RIG_ARTIFACT_MANIFEST_ENV,
 };
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
 pub use resource_lifecycle::{

--- a/crates/homeboy-rig/src/local_artifact.rs
+++ b/crates/homeboy-rig/src/local_artifact.rs
@@ -1,0 +1,553 @@
+//! Local artifact registration for command steps inside an observed rig run.
+
+use std::cell::RefCell;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Component, Path};
+use std::process::Command;
+
+use homeboy_core::error::{Error, Result};
+use serde::{Deserialize, Serialize};
+
+pub const RIG_ARTIFACT_MANIFEST_ENV: &str = "HOMEBOY_RIG_ARTIFACT_MANIFEST";
+const MANIFEST_SCHEMA: &str = "homeboy/rig-command-artifacts/v1";
+const MAX_REGISTRATIONS: usize = 128;
+const MAX_KIND_LEN: usize = 64;
+const MAX_PATH_LEN: usize = 4096;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LocalArtifactRegistration {
+    pub run_id: String,
+    pub kind: String,
+    pub artifact_type: String,
+    pub path: String,
+    pub duplicate: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct RegisteredLocalArtifact {
+    pub kind: String,
+    pub artifact_type: String,
+    pub path: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RegistrationManifest {
+    schema: String,
+    run_id: String,
+    artifacts: Vec<RegisteredLocalArtifact>,
+}
+
+#[derive(Clone)]
+struct RegistrationContext {
+    run_id: String,
+    manifest_path: String,
+}
+
+thread_local! {
+    static REGISTRATION_CONTEXT: RefCell<Option<RegistrationContext>> = const { RefCell::new(None) };
+}
+
+pub(crate) fn with_registration_context<T>(
+    run_id: &str,
+    manifest_path: &Path,
+    operation: impl FnOnce() -> T,
+) -> T {
+    REGISTRATION_CONTEXT.with(|slot| {
+        let previous = slot.replace(Some(RegistrationContext {
+            run_id: run_id.to_string(),
+            manifest_path: manifest_path.display().to_string(),
+        }));
+        let _guard = RegistrationContextGuard { slot, previous };
+        operation()
+    })
+}
+
+struct RegistrationContextGuard<'a> {
+    slot: &'a RefCell<Option<RegistrationContext>>,
+    previous: Option<RegistrationContext>,
+}
+
+impl Drop for RegistrationContextGuard<'_> {
+    fn drop(&mut self) {
+        self.slot.replace(self.previous.take());
+    }
+}
+
+pub(crate) fn inherit_registration_context(command: &mut Command) {
+    REGISTRATION_CONTEXT.with(|slot| {
+        if let Some(context) = slot.borrow().as_ref() {
+            command.env(
+                homeboy_core::observation::ACTIVE_RUN_ID_ENV,
+                &context.run_id,
+            );
+            command.env(RIG_ARTIFACT_MANIFEST_ENV, &context.manifest_path);
+        }
+    });
+}
+
+pub fn register_current_run_artifact(
+    kind: &str,
+    path: impl AsRef<Path>,
+) -> Result<LocalArtifactRegistration> {
+    validate_kind(kind)?;
+    let run_id = required_env(homeboy_core::observation::ACTIVE_RUN_ID_ENV)?;
+    let manifest_path = required_env(RIG_ARTIFACT_MANIFEST_ENV)?;
+    let manifest_path = Path::new(&manifest_path);
+    if !manifest_path.is_absolute() || !manifest_path.is_file() {
+        return Err(Error::validation_invalid_argument(
+            "artifact_manifest",
+            "rig artifact registration manifest must be an existing absolute file",
+            Some(manifest_path.display().to_string()),
+            None,
+        ));
+    }
+
+    let (canonical_path, artifact_type) = safe_artifact_path(path.as_ref())?;
+    let path_string = canonical_path.display().to_string();
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(manifest_path)
+        .map_err(|error| manifest_io_error(manifest_path, error))?;
+    lock_manifest(&file)?;
+    let result = update_manifest(&mut file, &run_id, kind, &artifact_type, &path_string);
+    unlock_manifest(&file);
+    let duplicate = result?;
+
+    Ok(LocalArtifactRegistration {
+        run_id,
+        kind: kind.to_string(),
+        artifact_type,
+        path: path_string,
+        duplicate,
+    })
+}
+
+pub(crate) fn read_registrations(
+    run_id: &str,
+    manifest_path: &Path,
+) -> Result<Vec<RegisteredLocalArtifact>> {
+    let mut file =
+        File::open(manifest_path).map_err(|error| manifest_io_error(manifest_path, error))?;
+    let manifest = read_manifest(&mut file, run_id)?;
+    let mut validated = Vec::with_capacity(manifest.artifacts.len());
+    for artifact in manifest.artifacts {
+        validate_kind(&artifact.kind)?;
+        let (canonical, artifact_type) = safe_artifact_path(Path::new(&artifact.path))?;
+        if canonical.display().to_string() != artifact.path
+            || artifact_type != artifact.artifact_type
+        {
+            return Err(Error::validation_invalid_argument(
+                "artifact_manifest",
+                "rig artifact registration entry does not match its canonical path and type",
+                Some(artifact.path),
+                None,
+            ));
+        }
+        if validated.iter().any(|existing: &RegisteredLocalArtifact| {
+            existing.kind == artifact.kind && existing.path == artifact.path
+        }) {
+            continue;
+        }
+        validated.push(artifact);
+    }
+    Ok(validated)
+}
+
+fn update_manifest(
+    file: &mut File,
+    run_id: &str,
+    kind: &str,
+    artifact_type: &str,
+    path: &str,
+) -> Result<bool> {
+    let mut manifest = read_manifest(file, run_id)?;
+    if manifest
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.kind == kind && artifact.path == path)
+    {
+        return Ok(true);
+    }
+    if manifest.artifacts.len() >= MAX_REGISTRATIONS {
+        return Err(Error::validation_invalid_argument(
+            "artifact_manifest",
+            format!("rig command steps may register at most {MAX_REGISTRATIONS} artifacts"),
+            Some(manifest.artifacts.len().to_string()),
+            None,
+        ));
+    }
+    manifest.artifacts.push(RegisteredLocalArtifact {
+        kind: kind.to_string(),
+        artifact_type: artifact_type.to_string(),
+        path: path.to_string(),
+    });
+    file.seek(SeekFrom::Start(0)).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("seek rig artifact manifest".to_string()),
+        )
+    })?;
+    file.set_len(0).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("truncate rig artifact manifest".to_string()),
+        )
+    })?;
+    serde_json::to_writer(&mut *file, &manifest).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize rig artifact manifest".to_string()),
+        )
+    })?;
+    file.write_all(b"\n").map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("write rig artifact manifest".to_string()),
+        )
+    })?;
+    file.sync_data().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("sync rig artifact manifest".to_string()),
+        )
+    })?;
+    Ok(false)
+}
+
+fn read_manifest(file: &mut File, run_id: &str) -> Result<RegistrationManifest> {
+    file.seek(SeekFrom::Start(0)).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("seek rig artifact manifest".to_string()),
+        )
+    })?;
+    let mut raw = String::new();
+    file.read_to_string(&mut raw).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("read rig artifact manifest".to_string()),
+        )
+    })?;
+    if raw.trim().is_empty() {
+        return Ok(RegistrationManifest {
+            schema: MANIFEST_SCHEMA.to_string(),
+            run_id: run_id.to_string(),
+            artifacts: Vec::new(),
+        });
+    }
+    let manifest: RegistrationManifest = serde_json::from_str(&raw).map_err(|error| {
+        Error::validation_invalid_argument(
+            "artifact_manifest",
+            format!("invalid rig artifact registration manifest: {error}"),
+            None,
+            None,
+        )
+    })?;
+    if manifest.schema != MANIFEST_SCHEMA || manifest.run_id != run_id {
+        return Err(Error::validation_invalid_argument(
+            "artifact_manifest",
+            "rig artifact registration manifest does not match the active run",
+            Some(manifest.run_id),
+            None,
+        ));
+    }
+    if manifest.artifacts.len() > MAX_REGISTRATIONS {
+        return Err(Error::validation_invalid_argument(
+            "artifact_manifest",
+            "rig artifact registration manifest exceeds its entry limit",
+            Some(manifest.artifacts.len().to_string()),
+            None,
+        ));
+    }
+    Ok(manifest)
+}
+
+fn validate_kind(kind: &str) -> Result<()> {
+    let valid = !kind.is_empty()
+        && kind.len() <= MAX_KIND_LEN
+        && kind.bytes().enumerate().all(|(index, byte)| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || (index > 0 && matches!(byte, b'_' | b'-' | b'.'))
+        });
+    if valid {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "kind",
+        "artifact kind must be 1-64 lowercase ASCII letters, digits, dots, dashes, or underscores and start with a letter or digit",
+        Some(kind.to_string()),
+        None,
+    ))
+}
+
+fn safe_artifact_path(path: &Path) -> Result<(std::path::PathBuf, String)> {
+    let raw = path.as_os_str().to_string_lossy();
+    if raw.is_empty()
+        || raw.len() > MAX_PATH_LEN
+        || path.components().any(|part| part == Component::ParentDir)
+    {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "artifact path must be non-empty, bounded, and must not contain parent directory components",
+            Some(raw.to_string()),
+            None,
+        ));
+    }
+    let link_metadata = fs::symlink_metadata(path).map_err(|error| {
+        Error::validation_invalid_argument(
+            "path",
+            format!("artifact path is missing or unreadable: {error}"),
+            Some(raw.to_string()),
+            None,
+        )
+    })?;
+    if link_metadata.file_type().is_symlink() {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "artifact path must not be a symbolic link",
+            Some(raw.to_string()),
+            None,
+        ));
+    }
+    let artifact_type = if link_metadata.is_file() {
+        "file"
+    } else if link_metadata.is_dir() {
+        "directory"
+    } else {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "artifact path must be a regular file or directory",
+            Some(raw.to_string()),
+            None,
+        ));
+    };
+    let canonical = fs::canonicalize(path).map_err(|error| {
+        Error::validation_invalid_argument(
+            "path",
+            format!("artifact path could not be canonicalized: {error}"),
+            Some(raw.to_string()),
+            None,
+        )
+    })?;
+    if artifact_type == "directory" {
+        validate_directory_entries(&canonical)?;
+    }
+    Ok((canonical, artifact_type.to_string()))
+}
+
+fn validate_directory_entries(root: &Path) -> Result<()> {
+    let mut pending = vec![root.to_path_buf()];
+    let mut seen = 0usize;
+    while let Some(directory) = pending.pop() {
+        let entries = fs::read_dir(&directory).map_err(|error| {
+            Error::validation_invalid_argument(
+                "path",
+                format!("artifact directory is unreadable: {error}"),
+                Some(directory.display().to_string()),
+                None,
+            )
+        })?;
+        for entry in entries {
+            let entry = entry.map_err(|error| {
+                Error::validation_invalid_argument(
+                    "path",
+                    format!("artifact directory entry is unreadable: {error}"),
+                    Some(directory.display().to_string()),
+                    None,
+                )
+            })?;
+            seen += 1;
+            if seen > 10_000 {
+                return Err(Error::validation_invalid_argument(
+                    "path",
+                    "artifact directory may contain at most 10000 entries",
+                    Some(root.display().to_string()),
+                    None,
+                ));
+            }
+            let metadata = fs::symlink_metadata(entry.path()).map_err(|error| {
+                Error::validation_invalid_argument(
+                    "path",
+                    format!("artifact directory entry is unreadable: {error}"),
+                    Some(entry.path().display().to_string()),
+                    None,
+                )
+            })?;
+            if metadata.file_type().is_symlink() || (!metadata.is_file() && !metadata.is_dir()) {
+                return Err(Error::validation_invalid_argument(
+                    "path",
+                    "artifact directories may contain only regular files and directories",
+                    Some(entry.path().display().to_string()),
+                    None,
+                ));
+            }
+            if metadata.is_dir() {
+                pending.push(entry.path());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn required_env(name: &str) -> Result<String> {
+    std::env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "run_context",
+                "local artifact registration is only available inside an observed rig command step",
+                None,
+                Some(vec![format!("Missing inherited {name} context.")]),
+            )
+        })
+}
+
+fn manifest_io_error(path: &Path, error: std::io::Error) -> Error {
+    Error::internal_io(
+        error.to_string(),
+        Some(format!("access rig artifact manifest {}", path.display())),
+    )
+}
+
+#[cfg(unix)]
+fn lock_manifest(file: &File) -> Result<()> {
+    use std::os::fd::AsRawFd;
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } == 0 {
+        Ok(())
+    } else {
+        Err(Error::internal_io(
+            std::io::Error::last_os_error().to_string(),
+            Some("lock rig artifact manifest".to_string()),
+        ))
+    }
+}
+
+#[cfg(not(unix))]
+fn lock_manifest(_file: &File) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn unlock_manifest(file: &File) {
+    use std::os::fd::AsRawFd;
+    let _ = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+}
+
+#[cfg(not(unix))]
+fn unlock_manifest(_file: &File) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        run_id: Option<String>,
+        manifest: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(run_id: Option<&str>, manifest: Option<&Path>) -> Self {
+            let guard = Self {
+                run_id: std::env::var(homeboy_core::observation::ACTIVE_RUN_ID_ENV).ok(),
+                manifest: std::env::var(RIG_ARTIFACT_MANIFEST_ENV).ok(),
+            };
+            match run_id {
+                Some(run_id) => {
+                    std::env::set_var(homeboy_core::observation::ACTIVE_RUN_ID_ENV, run_id)
+                }
+                None => std::env::remove_var(homeboy_core::observation::ACTIVE_RUN_ID_ENV),
+            }
+            match manifest {
+                Some(path) => std::env::set_var(RIG_ARTIFACT_MANIFEST_ENV, path),
+                None => std::env::remove_var(RIG_ARTIFACT_MANIFEST_ENV),
+            }
+            guard
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.run_id {
+                Some(value) => {
+                    std::env::set_var(homeboy_core::observation::ACTIVE_RUN_ID_ENV, value)
+                }
+                None => std::env::remove_var(homeboy_core::observation::ACTIVE_RUN_ID_ENV),
+            }
+            match &self.manifest {
+                Some(value) => std::env::set_var(RIG_ARTIFACT_MANIFEST_ENV, value),
+                None => std::env::remove_var(RIG_ARTIFACT_MANIFEST_ENV),
+            }
+        }
+    }
+
+    #[test]
+    fn registers_files_and_directories_and_deduplicates_entries() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("temp dir");
+        let manifest = tempfile::NamedTempFile::new().expect("manifest");
+        let file = temp.path().join("result.json");
+        let directory = temp.path().join("bundle");
+        fs::write(&file, "{}").expect("file artifact");
+        fs::create_dir(&directory).expect("directory artifact");
+        fs::write(directory.join("failure.json"), "{}").expect("bundle content");
+        let _env = EnvGuard::set(Some("rig-run-1"), Some(manifest.path()));
+
+        let first =
+            register_current_run_artifact("wp_codebox_result", &file).expect("file registration");
+        let duplicate = register_current_run_artifact("wp_codebox_result", &file)
+            .expect("duplicate registration");
+        let bundle = register_current_run_artifact("wp_codebox_bundle", &directory)
+            .expect("directory registration");
+        let registrations = read_registrations("rig-run-1", manifest.path()).expect("manifest");
+
+        assert_eq!(first.artifact_type, "file");
+        assert!(!first.duplicate);
+        assert!(duplicate.duplicate);
+        assert_eq!(bundle.artifact_type, "directory");
+        assert_eq!(registrations.len(), 2);
+        assert_eq!(registrations[0].kind, "wp_codebox_result");
+        assert_eq!(registrations[1].kind, "wp_codebox_bundle");
+    }
+
+    #[test]
+    fn rejects_missing_unsafe_and_unstable_artifacts() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let missing = temp.path().join("missing.json");
+        let unsafe_path = temp.path().join("child").join("..").join("missing.json");
+
+        assert!(safe_artifact_path(&missing).is_err());
+        assert!(safe_artifact_path(&unsafe_path).is_err());
+        assert!(validate_kind("WP Codebox Bundle").is_err());
+        assert!(validate_kind("wp_codebox_bundle").is_ok());
+
+        #[cfg(unix)]
+        {
+            let directory = temp.path().join("bundle");
+            fs::create_dir(&directory).expect("bundle");
+            std::os::unix::fs::symlink("/etc/passwd", directory.join("unsafe-link"))
+                .expect("symlink");
+            assert!(safe_artifact_path(&directory).is_err());
+        }
+    }
+
+    #[test]
+    fn rejects_registration_without_an_enclosing_run() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("temp dir");
+        let artifact = temp.path().join("result.json");
+        fs::write(&artifact, "{}").expect("artifact");
+        let _env = EnvGuard::set(None, None);
+
+        let error = register_current_run_artifact("result", artifact)
+            .expect_err("registration requires run context");
+
+        assert!(error.to_string().contains("observed rig command step"));
+    }
+}

--- a/crates/homeboy-rig/src/pipeline/command_step.rs
+++ b/crates/homeboy-rig/src/pipeline/command_step.rs
@@ -38,6 +38,7 @@ pub(crate) fn run_command_step(
     for (k, v) in settings_env(settings) {
         command.env(k, v);
     }
+    crate::local_artifact::inherit_registration_context(&mut command);
 
     let status = command.status().map_err(|e| {
         Error::rig_pipeline_failed(

--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -157,7 +157,7 @@ pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
     let _lease = acquire_active_run_lease(rig, "up")?;
     let observer = RigRunObserver::start(rig, "up");
 
-    let mut result = (|| {
+    let execute = || {
         let outcome = run_pipeline(rig, "up", true)?;
 
         if outcome.is_success() {
@@ -181,7 +181,11 @@ pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
             pipeline: outcome,
             artifact_index: None,
         })
-    })();
+    };
+    let mut result = match observer.as_ref() {
+        Some(observer) => observer.with_command_context(execute),
+        None => execute(),
+    };
 
     let artifact_index = RigRunObserver::finish(
         observer.as_ref(),
@@ -210,7 +214,7 @@ pub fn run_check_with_settings(
 ) -> Result<CheckReport> {
     let observer = RigRunObserver::start(rig, "check");
 
-    let mut result = (|| {
+    let execute = || {
         let requirements = evaluate_requirements(rig);
         let package_lint = run_package_lint(rig)?;
         let check_outcome = run_pipeline_with_settings(rig, "check", false, settings)?;
@@ -229,7 +233,11 @@ pub fn run_check_with_settings(
             pipeline: outcome,
             artifact_index: None,
         })
-    })();
+    };
+    let mut result = match observer.as_ref() {
+        Some(observer) => observer.with_command_context(execute),
+        None => execute(),
+    };
 
     let artifact_index = RigRunObserver::finish(
         observer.as_ref(),
@@ -907,11 +915,13 @@ struct RigRunObserver {
     store: ObservationStore,
     run_id: String,
     command: String,
+    artifact_manifest: tempfile::NamedTempFile,
 }
 
 impl RigRunObserver {
     fn start(rig: &RigSpec, command: &str) -> Option<Self> {
         let store = ObservationStore::open_initialized().ok()?;
+        let artifact_manifest = tempfile::NamedTempFile::new().ok()?;
         let cwd = std::env::current_dir().ok();
         let run = store
             .start_run(
@@ -929,7 +939,16 @@ impl RigRunObserver {
             store,
             run_id: run.id,
             command: command.to_string(),
+            artifact_manifest,
         })
+    }
+
+    fn with_command_context<T>(&self, operation: impl FnOnce() -> T) -> T {
+        crate::local_artifact::with_registration_context(
+            &self.run_id,
+            self.artifact_manifest.path(),
+            operation,
+        )
     }
 
     fn finish<T>(
@@ -948,6 +967,7 @@ impl RigRunObserver {
         let state = RigState::load(&rig.id).ok();
         let metadata =
             rig_observation_metadata(rig, &observer.command, state, pipeline, error.as_deref());
+        observer.record_registered_artifacts();
         let _ = observer
             .store
             .finish_run(&observer.run_id, status, Some(metadata));
@@ -959,6 +979,37 @@ impl RigRunObserver {
             status.as_str(),
             pipeline,
         )
+    }
+
+    fn record_registered_artifacts(&self) {
+        let Ok(artifacts) =
+            crate::local_artifact::read_registrations(&self.run_id, self.artifact_manifest.path())
+        else {
+            return;
+        };
+        for (registration_index, artifact) in artifacts.into_iter().enumerate() {
+            let metadata = serde_json::json!({
+                "source": "rig_command_registration",
+                "source_path": artifact.path,
+                "source_type": artifact.artifact_type,
+                "registration_index": registration_index,
+            });
+            if artifact.artifact_type == "directory" {
+                let _ = self.store.record_directory_artifact_with_metadata(
+                    &self.run_id,
+                    &artifact.kind,
+                    &artifact.path,
+                    metadata,
+                );
+            } else {
+                let _ = self.store.record_artifact_with_metadata(
+                    &self.run_id,
+                    &artifact.kind,
+                    &artifact.path,
+                    metadata,
+                );
+            }
+        }
     }
 
     fn record_resource_lifecycle_index(

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -189,6 +189,88 @@ fn test_run_check_persists_failing_observation() {
 }
 
 #[test]
+fn test_successful_nested_command_retains_registered_file() {
+    with_isolated_home(|home| {
+        let _xdg = XdgDataHomeGuard::unset();
+        let artifact = home.path().join("wp-codebox-result.json");
+        let script = home.path().join("register-success.sh");
+        write_registration_script(&script, &artifact, "file", 0);
+        let mut rig = observation_spec("observed-command-artifact-success");
+        rig.pipeline.insert(
+            "check".to_string(),
+            vec![command_step(format!(
+                "sh {} {}",
+                script.display(),
+                artifact.display()
+            ))],
+        );
+
+        let report = run_check(&rig).expect("check report");
+        assert!(report.success);
+        let run_id = report.run_id.as_deref().expect("run id");
+        let store = ObservationStore::open_initialized().expect("store");
+        let artifacts = store.list_artifacts(run_id).expect("artifacts");
+        let result = artifacts
+            .iter()
+            .find(|artifact| artifact.kind == "wp_codebox_result")
+            .expect("registered result");
+
+        assert_eq!(result.artifact_type, "file");
+        assert_eq!(result.metadata_json["source"], "rig_command_registration");
+        assert_eq!(std::fs::read_to_string(&result.path).unwrap(), "{}");
+        assert!(report
+            .artifact_index
+            .as_ref()
+            .unwrap()
+            .registered_artifact_refs
+            .iter()
+            .any(|artifact| artifact.id == result.id));
+    });
+}
+
+#[test]
+fn test_failed_nested_wp_codebox_command_retains_registered_bundle() {
+    with_isolated_home(|home| {
+        let _xdg = XdgDataHomeGuard::unset();
+        let bundle = home.path().join("wp-codebox-failed-bundle");
+        let script = home.path().join("register-failure.sh");
+        write_registration_script(&script, &bundle, "directory", 23);
+        let mut rig = observation_spec("observed-command-artifact-failure");
+        rig.pipeline.insert(
+            "check".to_string(),
+            vec![command_step(format!(
+                "sh {} {}",
+                script.display(),
+                bundle.display()
+            ))],
+        );
+
+        let report = run_check(&rig).expect("failed check report");
+        assert!(!report.success);
+        let run_id = report.run_id.as_deref().expect("run id");
+        let store = ObservationStore::open_initialized().expect("store");
+        let artifacts = store.list_artifacts(run_id).expect("artifacts");
+        let retained = artifacts
+            .iter()
+            .find(|artifact| artifact.kind == "wp_codebox_bundle")
+            .expect("failed bundle retained");
+
+        assert_eq!(retained.artifact_type, "directory");
+        assert!(std::path::Path::new(&retained.path)
+            .join("failure.json")
+            .is_file());
+        assert_eq!(retained.metadata_json["registration_index"], 0);
+        assert!(report
+            .artifact_index
+            .as_ref()
+            .unwrap()
+            .registered_artifact_refs
+            .iter()
+            .any(|artifact| artifact.id == retained.id));
+    });
+}
+
+#[test]
 fn test_run_up_persists_step_order_source_and_component_snapshot() {
     with_isolated_home(|home| {
         let _xdg = XdgDataHomeGuard::unset();
@@ -317,6 +399,47 @@ fn test_observation_store_failure_does_not_fail_rig_check() {
             Some("pass")
         );
     });
+}
+
+fn command_step(cmd: String) -> PipelineStep {
+    PipelineStep::Command {
+        step_id: None,
+        depends_on: Vec::new(),
+        cmd,
+        cwd: None,
+        env: HashMap::new(),
+        requires_capabilities: Vec::new(),
+        requires_providers: Vec::new(),
+        provides_capabilities: Vec::new(),
+        provides_providers: Vec::new(),
+        label: Some("nested WP Codebox run".to_string()),
+    }
+}
+
+fn write_registration_script(
+    script: &std::path::Path,
+    artifact: &std::path::Path,
+    artifact_type: &str,
+    exit_code: i32,
+) {
+    let create = if artifact_type == "directory" {
+        "mkdir -p \"$1\"\nprintf '{}' > \"$1/failure.json\"\n"
+    } else {
+        "printf '{}' > \"$1\"\n"
+    };
+    let kind = if artifact_type == "directory" {
+        "wp_codebox_bundle"
+    } else {
+        "wp_codebox_result"
+    };
+    std::fs::write(
+        script,
+        format!(
+            "#!/bin/sh\n{create}printf '{{\"schema\":\"homeboy/rig-command-artifacts/v1\",\"run_id\":\"%s\",\"artifacts\":[{{\"kind\":\"{kind}\",\"artifact_type\":\"{artifact_type}\",\"path\":\"{}\"}}]}}\\n' \"$HOMEBOY_ACTIVE_RUN_ID\" > \"$HOMEBOY_RIG_ARTIFACT_MANIFEST\"\nexit {exit_code}\n",
+            artifact.display(),
+        ),
+    )
+    .expect("registration script");
 }
 
 fn git(repo: &std::path::Path, args: &[&str]) {

--- a/tests/rig_local_artifact_registration.rs
+++ b/tests/rig_local_artifact_registration.rs
@@ -1,0 +1,135 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::Command;
+
+use homeboy::rig::{PipelineStep, RigSpec};
+
+#[test]
+fn failed_nested_cli_registration_is_visible_to_runs_artifacts() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let home = temp.path().join("home");
+    std::fs::create_dir(&home).expect("home dir");
+    let bundle = temp.path().join("wp-codebox-failed-bundle");
+    let binary = homeboy_bin();
+    let mut rig = rig_spec("nested-cli-artifact-failure");
+    rig.pipeline.insert(
+        "check".to_string(),
+        vec![command_step(format!(
+            "mkdir -p {bundle}; printf '{{}}' > {bundle}/failure.json; {binary} rig artifact register --kind wp_codebox_bundle --path {bundle} >/dev/null; exit 23",
+            bundle = bundle.display(),
+            binary = binary.display(),
+        ))],
+    );
+    let rig_path = temp.path().join("rig.json");
+    std::fs::write(
+        &rig_path,
+        serde_json::to_vec_pretty(&rig).expect("serialize rig"),
+    )
+    .expect("write rig");
+
+    let check = Command::new(&binary)
+        .args(["--placement", "local", "rig", "check"])
+        .arg(&rig_path)
+        .env("HOME", &home)
+        .env_remove("XDG_DATA_HOME")
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("rig check");
+    assert_eq!(
+        check.status.code(),
+        Some(1),
+        "rig check stderr: {}",
+        String::from_utf8_lossy(&check.stderr)
+    );
+    let check_json: serde_json::Value =
+        serde_json::from_slice(&check.stdout).expect("rig check JSON");
+    let run_id = check_json["data"]["payload"]["run_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("run id missing from {check_json}"));
+    assert!(
+        check_json["data"]["payload"]["artifact_index"]["registered_artifact_refs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|artifact| artifact["kind"] == "wp_codebox_bundle")
+    );
+
+    let output = Command::new(&binary)
+        .args(["runs", "artifacts", run_id])
+        .env("HOME", &home)
+        .env_remove("XDG_DATA_HOME")
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("runs artifacts");
+    assert!(output.status.success());
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("runs artifacts JSON");
+    let artifacts = stdout["data"]["payload"]["artifacts"]
+        .as_array()
+        .expect("artifact rows");
+    let retained = artifacts
+        .iter()
+        .find(|artifact| artifact["kind"] == "wp_codebox_bundle")
+        .expect("registered bundle row");
+
+    assert_eq!(retained["type"], "directory");
+    assert!(std::path::Path::new(retained["path"].as_str().unwrap())
+        .join("failure.json")
+        .is_file());
+    assert_eq!(
+        artifacts
+            .iter()
+            .filter(|artifact| artifact["kind"] == "wp_codebox_bundle")
+            .count(),
+        1
+    );
+}
+
+fn rig_spec(id: &str) -> RigSpec {
+    RigSpec {
+        id: id.to_string(),
+        description: "nested CLI artifact fixture".to_string(),
+        components: HashMap::new(),
+        services: HashMap::new(),
+        symlinks: Vec::new(),
+        shared_paths: Vec::new(),
+        resources: Default::default(),
+        lifecycle: Default::default(),
+        requirements: Default::default(),
+        pipeline: HashMap::new(),
+        bench: None,
+        fuzz: None,
+        trace: Default::default(),
+        bench_workloads: HashMap::new(),
+        trace_workloads: HashMap::new(),
+        fuzz_workloads: Default::default(),
+        trace_workload_defaults: HashMap::new(),
+        trace_phase_templates: HashMap::new(),
+        trace_variants: HashMap::new(),
+        trace_profiles: HashMap::new(),
+        trace_experiments: HashMap::new(),
+        trace_guardrails: Vec::new(),
+        bench_profiles: HashMap::new(),
+        fuzz_profiles: HashMap::new(),
+        app_launcher: None,
+    }
+}
+
+fn command_step(cmd: String) -> PipelineStep {
+    PipelineStep::Command {
+        step_id: None,
+        depends_on: Vec::new(),
+        cmd,
+        cwd: None,
+        env: HashMap::new(),
+        requires_capabilities: Vec::new(),
+        requires_providers: Vec::new(),
+        provides_capabilities: Vec::new(),
+        provides_providers: Vec::new(),
+        label: Some("nested WP Codebox command".to_string()),
+    }
+}
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}


### PR DESCRIPTION
## Summary
- add `homeboy rig artifact register --kind <kind> --path <path>` for local rig command steps
- retain registered files and directories through the existing observation artifact store on both successful and failed commands
- expose registered artifact references in the rig artifact index and `homeboy runs artifacts`

## Safety Contract
- registration is available only inside an active rig command context through a private, command-scoped manifest
- kinds are bounded and restricted to stable lowercase identifiers
- paths must exist, canonicalize to regular files/directories, and reject traversal, symlinks, nested special files, oversized paths, and oversized directory trees
- manifests are schema-versioned, locked, bounded to 128 entries, deduplicated by kind and canonical path, and revalidated before ingestion
- stored metadata records source path, source type, and deterministic registration order
- no new storage substrate or public observation-store internals are introduced

## Evidence
- unit coverage exercises files, directories, duplicates, missing context, unsafe paths, manifest bounds, and validation
- observer coverage proves registered artifacts persist before finalization on success and nonzero exits
- CLI parser coverage proves the registration command contract
- the integration test runs a nested Homeboy CLI command that registers a WP Codebox-style failure bundle, exits 23, and verifies a separate `homeboy runs artifacts <run-id>` lookup returns it exactly once

## Tests
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets`
- `cargo test -p homeboy-rig local_artifact::tests`
- `cargo test -p homeboy-rig runner_observation_test`
- `cargo test -p homeboy-cli commands::rig::tests::parses_local_artifact_registration`
- `cargo test --test rig_local_artifact_registration`
- `git diff --check`

`cargo test --workspace` remains blocked by the unrelated promotion-gate baseline failure tracked in #9701. `cargo fmt --all -- --check` reports only pre-existing formatting drift in `crates/contracts/homeboy-lab-contract/src/lab/handoff.rs`; feature files were formatted and unrelated drift was not included.

Fixes #9579