### PR TITLE
Make release recovery dry runs non-mutating

### DIFF
--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -1295,6 +1295,129 @@ mod tests {
     }
 
     #[test]
+    fn recover_dry_run_reports_the_recovery_plan_without_mutating_git_or_remote_tags() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let remote = tempfile::tempdir().expect("remote");
+        let dir = temp.path();
+
+        run_in(remote.path(), &["git", "init", "--bare", "-q"]);
+        run_in(dir, &["git", "init", "-q", "--initial-branch", "main"]);
+        run_in(dir, &["git", "config", "user.email", "test@example.com"]);
+        run_in(dir, &["git", "config", "user.name", "Test"]);
+        run_in(dir, &["git", "config", "commit.gpgsign", "false"]);
+        std::fs::write(
+            dir.join("homeboy.json"),
+            r#"{
+                "id": "fixture",
+                "version_targets": [
+                    { "file": "VERSION", "pattern": "^([0-9]+\\.[0-9]+\\.[0-9]+)$" }
+                ]
+            }"#,
+        )
+        .expect("write homeboy config");
+        std::fs::write(dir.join("VERSION"), "1.2.3\n").expect("write version");
+        run_in(dir, &["git", "add", "."]);
+        run_in(dir, &["git", "commit", "-q", "-m", "chore: initial"]);
+        run_in(
+            dir,
+            &[
+                "git",
+                "remote",
+                "add",
+                "origin",
+                &remote.path().to_string_lossy(),
+            ],
+        );
+        run_in(dir, &["git", "push", "-q", "-u", "origin", "main"]);
+
+        std::fs::write(dir.join("VERSION"), "1.2.4\n").expect("stage recovery version change");
+        let head_before =
+            String::from_utf8_lossy(&run_in(dir, &["git", "rev-parse", "HEAD"]).stdout)
+                .trim()
+                .to_string();
+        let status_before =
+            String::from_utf8_lossy(&run_in(dir, &["git", "status", "--porcelain"]).stdout)
+                .to_string();
+        let identity_before =
+            String::from_utf8_lossy(&run_in(dir, &["git", "config", "user.name"]).stdout)
+                .to_string();
+        let local_tags_before =
+            String::from_utf8_lossy(&run_in(dir, &["git", "tag", "--list"]).stdout).to_string();
+        let remote_tags_before = String::from_utf8_lossy(
+            &run_in(
+                remote.path(),
+                &["git", "for-each-ref", "refs/tags", "--format=%(refname)"],
+            )
+            .stdout,
+        )
+        .to_string();
+
+        let (result, exit_code) = run_command(ReleaseCommandInput {
+            component_id: "fixture".to_string(),
+            path_override: Some(dir.to_string_lossy().to_string()),
+            dry_run: true,
+            recover: true,
+            git_identity: Some("Dry Run <dry-run@example.com>".to_string()),
+            ..Default::default()
+        })
+        .expect("recovery dry run should plan without applying");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(result.status, "planned");
+        assert!(result.dry_run);
+        assert_eq!(result.tag.as_deref(), Some("v1.2.4"));
+        assert_eq!(
+            result.release_summary,
+            vec![
+                "would commit version files".to_string(),
+                "would create tag v1.2.4".to_string(),
+                "would push commits and tags".to_string(),
+            ]
+        );
+        let plan = result.plan.expect("recovery plan");
+        assert!(plan.enabled());
+        assert_eq!(
+            plan.plan
+                .steps
+                .iter()
+                .map(|step| step.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["recover.commit", "recover.tag", "recover.push"]
+        );
+        assert!(plan
+            .plan
+            .steps
+            .iter()
+            .all(|step| step.status == PlanStepStatus::Ready));
+        assert_eq!(
+            head_before,
+            String::from_utf8_lossy(&run_in(dir, &["git", "rev-parse", "HEAD"]).stdout).trim()
+        );
+        assert_eq!(
+            status_before,
+            String::from_utf8_lossy(&run_in(dir, &["git", "status", "--porcelain"]).stdout)
+        );
+        assert_eq!(
+            identity_before,
+            String::from_utf8_lossy(&run_in(dir, &["git", "config", "user.name"]).stdout)
+        );
+        assert_eq!(
+            local_tags_before,
+            String::from_utf8_lossy(&run_in(dir, &["git", "tag", "--list"]).stdout)
+        );
+        assert_eq!(
+            remote_tags_before,
+            String::from_utf8_lossy(
+                &run_in(
+                    remote.path(),
+                    &["git", "for-each-ref", "refs/tags", "--format=%(refname)"]
+                )
+                .stdout
+            )
+        );
+    }
+
+    #[test]
     fn release_phase_maps_current_modes() {
         let mut input = ReleaseCommandInput::default();
         assert_eq!(release_execution_plan(&input).phase, ReleasePhase::Publish);

--- a/crates/homeboy-release/src/release/workflow_recover.rs
+++ b/crates/homeboy-release/src/release/workflow_recover.rs
@@ -23,12 +23,6 @@ pub(super) fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommand
         },
     )?;
 
-    // Configure git identity for recovery commits/tags
-    if let Some(ref identity_str) = input.git_identity {
-        let identity = git::parse_git_identity(Some(identity_str));
-        git::configure_identity(&component.local_path, &identity)?;
-    }
-
     let release_scope = ReleaseScope::resolve(&component, &input.component_id)?;
     let version_info = crate::release::version::read_component_version(&component)?;
     let current_version = &version_info.version;
@@ -186,6 +180,27 @@ pub(super) fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommand
             ));
         }
 
+        if input.dry_run {
+            let actions = vec![format!("would retag {} to HEAD", tag_name)];
+            return Ok((
+                recovery_dry_run_result(
+                    input,
+                    current_version,
+                    &tag_name,
+                    false,
+                    true,
+                    true,
+                    actions,
+                ),
+                0,
+            ));
+        }
+
+        if let Some(ref identity_str) = input.git_identity {
+            let identity = git::parse_git_identity(Some(identity_str));
+            git::configure_identity(&component.local_path, &identity)?;
+        }
+
         // Safe to move: delete the stale tag (local + remote) and re-create at HEAD.
         homeboy_core::log_status!(
             "recover",
@@ -284,6 +299,41 @@ pub(super) fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommand
 
     let uncommitted = git::get_uncommitted_changes(&component.local_path)?;
 
+    if input.dry_run {
+        let mut actions = Vec::new();
+        if uncommitted.has_changes {
+            actions.push("would commit version files".to_string());
+        }
+        if !tag_exists_local {
+            actions.push(format!("would create tag {}", tag_name));
+        }
+        if !tag_exists_remote {
+            actions.push("would push commits and tags".to_string());
+        }
+
+        return Ok((
+            recovery_dry_run_result(
+                input,
+                current_version,
+                &tag_name,
+                uncommitted.has_changes,
+                !tag_exists_local,
+                !tag_exists_remote,
+                actions,
+            ),
+            0,
+        ));
+    }
+
+    // Recovery dry-runs must not update repository config. Apply the requested
+    // identity only immediately before a recovery can create a commit or tag.
+    if uncommitted.has_changes || !tag_exists_local {
+        if let Some(ref identity_str) = input.git_identity {
+            let identity = git::parse_git_identity(Some(identity_str));
+            git::configure_identity(&component.local_path, &identity)?;
+        }
+    }
+
     let mut actions = Vec::new();
 
     if uncommitted.has_changes {
@@ -380,6 +430,40 @@ pub(super) fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommand
         },
         0,
     ))
+}
+
+fn recovery_dry_run_result(
+    input: &ReleaseCommandInput,
+    version: &str,
+    tag_name: &str,
+    commit_needed: bool,
+    tag_needed: bool,
+    push_needed: bool,
+    actions: Vec<String>,
+) -> ReleaseCommandResult {
+    ReleaseCommandResult {
+        component_id: input.component_id.clone(),
+        status: "planned".to_string(),
+        phase: release_execution_plan(input).phase,
+        bump_type: "recover".to_string(),
+        dry_run: true,
+        releasable_commits: 0,
+        new_version: None,
+        tag: Some(tag_name.to_string()),
+        skipped_reason: None,
+        plan: Some(recovery_release_plan(
+            &input.component_id,
+            version,
+            tag_name,
+            commit_needed,
+            tag_needed,
+            push_needed,
+            &actions,
+        )),
+        run: None,
+        deployment: None,
+        release_summary: actions,
+    }
 }
 
 /// Reconcile the release branch with an advanced remote during `--recover`


### PR DESCRIPTION
## Summary
- route recovery dry runs through a non-mutating planning path
- report `dry_run: true` with exact commit, tag, and push recovery steps
- defer Git identity configuration until an applied mutation is required

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-release recover_dry_run_reports_the_recovery_plan_without_mutating_git_or_remote_tags --lib`
- `cargo test -p homeboy-release recovery_release_plan --lib`

Closes #9491

## AI assistance
Substantive implementation was drafted with OpenCode using OpenAI GPT-5.6 Sol. Chris reviewed the complete diff and post-rebase verification results.