### PR TITLE
Report durable release rollback state

### DIFF
--- a/crates/homeboy-release/src/release/checkout_guard.rs
+++ b/crates/homeboy-release/src/release/checkout_guard.rs
@@ -5,6 +5,13 @@ use homeboy_core::error::{Error, Result};
 use homeboy_core::git;
 
 #[derive(Debug, Clone)]
+pub(super) struct CheckoutRestoreEvidence {
+    pub(super) original_head: String,
+    pub(super) temporary_head: String,
+    pub(super) final_head: String,
+}
+
+#[derive(Debug, Clone)]
 pub(super) struct ReleaseCheckoutGuard {
     path: String,
     original_ref: OriginalRef,
@@ -48,7 +55,8 @@ impl ReleaseCheckoutGuard {
         }))
     }
 
-    pub(super) fn restore_after_failure(&self) -> Result<()> {
+    pub(super) fn restore_after_failure(&self) -> Result<CheckoutRestoreEvidence> {
+        let temporary_head = git_stdout(&self.path, &["rev-parse", "HEAD"])?;
         abort_in_progress_operations(&self.path);
         run_git_checked(&self.path, &["reset", "--hard"])?;
         remove_new_untracked(&self.path, &self.original_untracked)?;
@@ -64,7 +72,12 @@ impl ReleaseCheckoutGuard {
 
         run_git_checked(&self.path, &["reset", "--hard", &self.original_head])?;
         remove_new_untracked(&self.path, &self.original_untracked)?;
-        Ok(())
+        let final_head = git_stdout(&self.path, &["rev-parse", "HEAD"])?;
+        Ok(CheckoutRestoreEvidence {
+            original_head: self.original_head.clone(),
+            temporary_head,
+            final_head,
+        })
     }
 }
 
@@ -212,7 +225,7 @@ mod tests {
         run_git(dir, &["add", "file.txt"]);
         run_git(dir, &["commit", "-q", "-m", "release: v1.0.0"]);
 
-        guard.restore_after_failure().expect("restore");
+        let rollback = guard.restore_after_failure().expect("restore");
 
         assert_eq!(
             git_stdout_for_test(dir, &["branch", "--show-current"]),
@@ -222,6 +235,9 @@ mod tests {
             git_stdout_for_test(dir, &["rev-parse", "HEAD"]),
             original_head
         );
+        assert_eq!(rollback.original_head, original_head);
+        assert_ne!(rollback.temporary_head, rollback.original_head);
+        assert_eq!(rollback.final_head, rollback.original_head);
         assert_eq!(git_stdout_for_test(dir, &["status", "--porcelain=v1"]), "");
         assert!(!dir.join("generated.txt").exists());
         assert_eq!(

--- a/crates/homeboy-release/src/release/deployment.rs
+++ b/crates/homeboy-release/src/release/deployment.rs
@@ -367,6 +367,7 @@ mod tests {
                 warnings: vec![],
                 summary: None,
                 phase_timings: None,
+                rollback: None,
             },
         };
 

--- a/crates/homeboy-release/src/release/execution_projection.rs
+++ b/crates/homeboy-release/src/release/execution_projection.rs
@@ -278,6 +278,7 @@ mod tests {
                 warnings: vec!["signed artifact missing".to_string()],
                 summary: None,
                 phase_timings: None,
+                rollback: None,
             },
         };
 
@@ -319,6 +320,7 @@ mod tests {
                 warnings: Vec::new(),
                 summary: None,
                 phase_timings: None,
+                rollback: None,
             },
         };
 
@@ -364,6 +366,7 @@ mod tests {
                 warnings: Vec::new(),
                 summary: None,
                 phase_timings: None,
+                rollback: None,
             },
         };
 

--- a/crates/homeboy-release/src/release/mod.rs
+++ b/crates/homeboy-release/src/release/mod.rs
@@ -37,8 +37,9 @@ pub use types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseArtifact,
     ReleaseCommandInput, ReleaseCommandResult, ReleaseDeploymentResult, ReleaseDeploymentSummary,
     ReleaseExecutionPlan, ReleaseOptions, ReleasePhase, ReleasePipelineOptions, ReleasePlan,
-    ReleaseProjectDeployResult, ReleaseRun, ReleaseRunResult, ReleaseRunSummary,
-    ReleaseSemverCommit, ReleaseSemverRecommendation, ReleaseStepResult, ReleaseStepStatus,
+    ReleaseProjectDeployResult, ReleaseRollbackEvidence, ReleaseRun, ReleaseRunResult,
+    ReleaseRunSummary, ReleaseSemverCommit, ReleaseSemverRecommendation, ReleaseStepResult,
+    ReleaseStepStatus,
 };
 pub use utils::{extract_latest_notes, parse_release_artifacts};
 pub use workflow::{run_batch, run_command, SKIPPED_RELEASE_EXIT_CODE};

--- a/crates/homeboy-release/src/release/orchestrator.rs
+++ b/crates/homeboy-release/src/release/orchestrator.rs
@@ -13,7 +13,8 @@ use super::execution_plan::{
 use super::pipeline_summary::{build_summary, derive_overall_status};
 use super::planner::plan;
 use super::types::{
-    ReleaseOptions, ReleasePlan, ReleaseRun, ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus,
+    ReleaseOptions, ReleasePlan, ReleaseRollbackEvidence, ReleaseRun, ReleaseRunResult,
+    ReleaseStepResult, ReleaseStepStatus,
 };
 
 /// Execute a release end-to-end.
@@ -63,8 +64,8 @@ fn run_with_plan_inner(
     })?;
 
     if initial_stop {
-        let run = finalize(component_id, results, timer.into_report());
-        restore_checkout_after_failed_run(checkout_guard, &run)?;
+        let mut run = finalize(component_id, results, timer.into_report());
+        restore_checkout_after_failed_run(checkout_guard, &mut run)?;
         return Ok((initial_plan, run));
     }
 
@@ -86,8 +87,8 @@ fn run_with_plan_inner(
         )
     })?;
 
-    let run = finalize(component_id, results, timer.into_report());
-    restore_checkout_after_failed_run(checkout_guard, &run)?;
+    let mut run = finalize(component_id, results, timer.into_report());
+    restore_checkout_after_failed_run(checkout_guard, &mut run)?;
 
     Ok((release_plan, run))
 }
@@ -111,20 +112,32 @@ fn finalize(
             warnings: Vec::new(),
             summary: Some(summary),
             phase_timings: Some(phase_timings),
+            rollback: None,
         },
     }
 }
 
 fn restore_checkout_after_failed_run(
     checkout_guard: Option<&super::checkout_guard::ReleaseCheckoutGuard>,
-    run: &ReleaseRun,
+    run: &mut ReleaseRun,
 ) -> Result<()> {
     if matches!(run.result.status, ReleaseStepStatus::Success) {
         return Ok(());
     }
 
     if let Some(checkout_guard) = checkout_guard {
-        checkout_guard.restore_after_failure()?;
+        let evidence = checkout_guard.restore_after_failure()?;
+        run.result.rollback = Some(ReleaseRollbackEvidence {
+            original_head: evidence.original_head,
+            temporary_head: evidence.temporary_head,
+            final_head: evidence.final_head,
+        });
+        if let Some(summary) = &mut run.result.summary {
+            summary.next_actions.push(
+                "Inspect remote branch and tag state before retrying: git ls-remote --heads --tags origin"
+                    .to_string(),
+            );
+        }
     }
 
     Ok(())

--- a/crates/homeboy-release/src/release/types.rs
+++ b/crates/homeboy-release/src/release/types.rs
@@ -172,6 +172,18 @@ pub struct ReleaseRunResult {
     pub summary: Option<ReleaseRunSummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub phase_timings: Option<PhaseTimingReport>,
+    /// Recorded only after a failed release has restored the checkout. This
+    /// makes the result describe the durable exit state rather than mutations
+    /// attempted before rollback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rollback: Option<ReleaseRollbackEvidence>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReleaseRollbackEvidence {
+    pub original_head: String,
+    pub temporary_head: String,
+    pub final_head: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -447,6 +447,7 @@ fn run_dry_run_preflights(
                 warnings: Vec::new(),
                 summary: None,
                 phase_timings: None,
+                rollback: None,
             },
         }));
     }
@@ -604,6 +605,16 @@ fn release_summary_from_run(run: &ReleaseRun) -> Vec<String> {
     summary.push(git_commit_summary_line(run));
     summary.push(git_tag_summary_line(run));
     summary.push(github_release_summary_line(run));
+    if let Some(rollback) = &run.result.rollback {
+        summary.push(format!(
+            "Rollback evidence: original HEAD {}; temporary HEAD {}; final HEAD {}",
+            rollback.original_head, rollback.temporary_head, rollback.final_head
+        ));
+        summary.push(
+            "Inspect remote branch and tag state before retrying: git ls-remote --heads --tags origin"
+                .to_string(),
+        );
+    }
     summary
 }
 
@@ -631,6 +642,11 @@ fn git_commit_summary_line(run: &ReleaseRun) -> String {
     };
     if step_data_bool(step, "skipped") {
         "No release commit created".to_string()
+    } else if let Some(rollback) = &run.result.rollback {
+        format!(
+            "Release commit rolled back: {} (checkout restored to {})",
+            rollback.temporary_head, rollback.final_head
+        )
     } else {
         "Release commit created".to_string()
     }
@@ -645,6 +661,16 @@ fn git_tag_summary_line(run: &ReleaseRun) -> String {
         .as_ref()
         .and_then(|data| data.get("tag"))
         .and_then(|value| value.as_str());
+    if run.result.rollback.is_some() {
+        return tag
+            .map(|tag| {
+                format!(
+                    "Tag {} may have been created before rollback; inspect local and remote state",
+                    tag
+                )
+            })
+            .unwrap_or_else(|| "Tag state requires inspection after rollback".to_string());
+    }
     if step_data_bool(step, "skipped") {
         tag.map(|tag| format!("Tag already exists: {}", tag))
             .unwrap_or_else(|| "No tag created".to_string())
@@ -854,7 +880,9 @@ pub fn run_batch(
 mod tests {
     use super::*;
     use crate::release::types::ReleasePhase;
-    use crate::release::{ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus};
+    use crate::release::{
+        ReleaseRollbackEvidence, ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus,
+    };
     use homeboy_core::plan::{PlanStep, PlanStepStatus, PlanValues};
 
     #[test]
@@ -1087,6 +1115,7 @@ mod tests {
                 warnings: vec![],
                 summary: None,
                 phase_timings: None,
+                rollback: None,
             },
         };
 
@@ -1110,6 +1139,7 @@ mod tests {
                 warnings: vec![],
                 summary: None,
                 phase_timings: None,
+                rollback: None,
             },
         };
 
@@ -1184,6 +1214,7 @@ mod tests {
                 warnings: vec![],
                 summary: None,
                 phase_timings: None,
+                rollback: None,
             },
         };
 
@@ -1193,6 +1224,45 @@ mod tests {
         assert!(summary.contains(&"Release commit created".to_string()));
         assert!(summary.contains(&"Tag created: v1.2.3".to_string()));
         assert!(summary.contains(&"No GitHub Release created".to_string()));
+    }
+
+    #[test]
+    fn release_summary_reports_rolled_back_commit_as_non_durable() {
+        let run = ReleaseRun {
+            component_id: "demo".to_string(),
+            enabled: true,
+            result: ReleaseRunResult {
+                steps: vec![ReleaseStepResult {
+                    id: "git.commit".to_string(),
+                    step_type: "git.commit".to_string(),
+                    status: ReleaseStepStatus::Success,
+                    ..Default::default()
+                }],
+                status: ReleaseStepStatus::PartialSuccess,
+                warnings: vec![],
+                summary: None,
+                phase_timings: None,
+                rollback: Some(ReleaseRollbackEvidence {
+                    original_head: "original".to_string(),
+                    temporary_head: "release-commit".to_string(),
+                    final_head: "original".to_string(),
+                }),
+            },
+        };
+
+        let summary = release_summary_from_run(&run);
+
+        assert!(summary.contains(
+            &"Release commit rolled back: release-commit (checkout restored to original)"
+                .to_string()
+        ));
+        assert!(summary.iter().any(|line| line.contains(
+            "original HEAD original; temporary HEAD release-commit; final HEAD original"
+        )));
+        assert!(summary
+            .iter()
+            .any(|line| line.contains("git ls-remote --heads --tags origin")));
+        assert!(!summary.contains(&"Release commit created".to_string()));
     }
 
     #[test]
@@ -1226,6 +1296,7 @@ mod tests {
                 warnings: vec![],
                 summary: None,
                 phase_timings: None,
+                rollback: None,
             },
         };
 


### PR DESCRIPTION
## Summary
- capture original, temporary, and final HEAD evidence after failed-release rollback
- distinguish rolled-back commits from durable release commits in summaries
- surface uncertain tag and remote state with an inspection next action

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-release package_failure_restores_release_commit_and_generated_files`
- `cargo test -p homeboy-release release_summary_reports_rolled_back_commit_as_non_durable`

Closes #9642

## AI assistance
Substantive implementation was drafted with OpenCode using OpenAI GPT-5.6 Sol. Chris reviewed the complete diff and post-rebase verification results.