### PR TITLE
Extract shared durable-stage identity header check in lab_staging_controller

### DIFF
--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -526,6 +526,30 @@ fn canonical_digest<T: Serialize>(value: &T) -> Result<String> {
     Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
 }
 
+/// Shared identity header carried by every durable Lab stage
+/// (schema + run/runner identity + recipe/plan digests). The per-stage
+/// `validate` methods all bind their state to the same request identity; this
+/// centralizes that check so each `validate` only asserts its own extra fields.
+///
+/// Returns `Ok(true)` when the header matches the request, `Ok(false)` on any
+/// mismatch (schema, run id, runner id, recipe digest, or plan digest), and
+/// propagates a digest-computation error.
+fn durable_stage_header_matches(
+    schema: &str,
+    expected_schema: &str,
+    run_id: &str,
+    runner_id: &str,
+    recipe_digest: &str,
+    plan_digest: &str,
+    request: &LabStagingExecutionRequest,
+) -> Result<bool> {
+    Ok(schema == expected_schema
+        && run_id == request.recipe.run_id
+        && runner_id == request.recipe.runner_id
+        && recipe_digest == canonical_digest(&request.recipe)?
+        && plan_digest == canonical_digest(&request.durable_agent_task_plan)?)
+}
+
 /// Complete, owner-only output of the one admitted production boundary. Later
 /// stages consume this attachment rather than recomputing or re-syncing it.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -705,13 +729,16 @@ impl DurableLabRuntimeStage {
         request: &LabStagingExecutionRequest,
         checkpoint: &LabStagingCheckpoint,
     ) -> Result<()> {
-        if self.schema != "homeboy/durable-lab-runtime-stage/v1"
-            || self.run_id != request.recipe.run_id
-            || self.runner_id != request.recipe.runner_id
-            || self.recipe_digest != canonical_digest(&request.recipe)?
-            || self.plan_digest != canonical_digest(&request.durable_agent_task_plan)?
-            || self.output.get("remote_cwd").and_then(Value::as_str)
-                != Some(self.workspace_id.as_str())
+        if !durable_stage_header_matches(
+            &self.schema,
+            "homeboy/durable-lab-runtime-stage/v1",
+            &self.run_id,
+            &self.runner_id,
+            &self.recipe_digest,
+            &self.plan_digest,
+            request,
+        )? || self.output.get("remote_cwd").and_then(Value::as_str)
+            != Some(self.workspace_id.as_str())
             || self.runtime_id.trim().is_empty()
             || checkpoint.workspace_id.as_deref() != Some(self.workspace_id.as_str())
             || checkpoint
@@ -746,12 +773,15 @@ impl DurableLabHydrationStage {
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
-        if self.schema != "homeboy/durable-lab-hydration-stage/v1"
-            || self.run_id != request.recipe.run_id
-            || self.runner_id != request.recipe.runner_id
-            || self.recipe_digest != canonical_digest(&request.recipe)?
-            || self.plan_digest != canonical_digest(&request.durable_agent_task_plan)?
-            || self.workspace_id != workspace.workspace_id
+        if !durable_stage_header_matches(
+            &self.schema,
+            "homeboy/durable-lab-hydration-stage/v1",
+            &self.run_id,
+            &self.runner_id,
+            &self.recipe_digest,
+            &self.plan_digest,
+            request,
+        )? || self.workspace_id != workspace.workspace_id
             || self.runtime_id != runtime.runtime_id
             || self.hydration_id != canonical_digest(&self.hydration_record)?
             || self
@@ -799,12 +829,15 @@ impl DurableLabWorkspaceStage {
         request: &LabStagingExecutionRequest,
         checkpoint: &LabStagingCheckpoint,
     ) -> Result<()> {
-        if self.schema != "homeboy/durable-lab-workspace-stage/v1"
-            || self.run_id != request.recipe.run_id
-            || self.runner_id != request.recipe.runner_id
-            || self.recipe_digest != canonical_digest(&request.recipe)?
-            || self.plan_digest != canonical_digest(&request.durable_agent_task_plan)?
-            || self.remote_cwd.trim().is_empty()
+        if !durable_stage_header_matches(
+            &self.schema,
+            "homeboy/durable-lab-workspace-stage/v1",
+            &self.run_id,
+            &self.runner_id,
+            &self.recipe_digest,
+            &self.plan_digest,
+            request,
+        )? || self.remote_cwd.trim().is_empty()
             || self.source_snapshot_id.trim().is_empty()
             || self.workspace_id != self.remote_cwd
             || self


### PR DESCRIPTION
## Summary
The durable Lab staging stages (`DurableLabRuntimeStage`, `DurableLabHydrationStage`, `DurableLabWorkspaceStage`) each opened their `validate` with the identical 5-field identity header check binding the stage to the execution request:

```rust
self.schema != "<schema>"
    || self.run_id != request.recipe.run_id
    || self.runner_id != request.recipe.runner_id
    || self.recipe_digest != canonical_digest(&request.recipe)?
    || self.plan_digest != canonical_digest(&request.durable_agent_task_plan)?
```

Extract it into one `durable_stage_header_matches(...)` helper so each `validate` only asserts its own extra fields.

## Scope / risk
- Behavior-preserving: the helper returns the same boolean the inlined disjunction computed (`!header_matches` == the original `schema != … || …`).
- The dispatch receipt (which shares only the first 4 fields, no `plan_digest`) is intentionally left as-is.
- No struct/serialization/checkpoint format change — pure validation dedup.

## Test
- `cargo fmt --check` clean; `cargo check -p homeboy-lab-runner --lib` clean.
- `cargo test -p homeboy-lab-runner --lib lab_staging_controller` — **31 tests pass, 0 failed** (unchanged).

## Notes
Tech-debt burndown: first bounded, low-risk dedup within the Lab offload dual-path (#1). Larger structural unification (inline `inner.rs` vs durable controller) remains a separate, careful effort.