### PR TITLE
Discover apply-capable managed-worktree promotion providers

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/apply.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/apply.rs
@@ -375,6 +375,7 @@ pub(crate) trait AgentTaskPromotionWorkspaceProvider {
 pub(crate) struct ExternalPromotionWorkspaceProvider {
     invocation: Option<CommandInvocation>,
     provenance: Option<serde_json::Value>,
+    expected_workspace: Option<PathBuf>,
     configured_fallback: Option<ConfiguredPromotionWorkspaceProvider>,
 }
 
@@ -404,6 +405,7 @@ impl ExternalPromotionWorkspaceProvider {
             return Self {
                 invocation: Some(invocation),
                 provenance: None,
+                expected_workspace: None,
                 configured_fallback: None,
             };
         }
@@ -418,6 +420,7 @@ impl ExternalPromotionWorkspaceProvider {
                     ..Default::default()
                 }),
                 provenance: None,
+                expected_workspace: None,
                 configured_fallback: None,
             };
         }
@@ -425,6 +428,7 @@ impl ExternalPromotionWorkspaceProvider {
         Self {
             invocation: None,
             provenance: None,
+            expected_workspace: None,
             configured_fallback: Some(ConfiguredPromotionWorkspaceProvider {
                 config: config.clone(),
                 executable,
@@ -499,15 +503,42 @@ impl ExternalPromotionWorkspaceProvider {
             }));
             std::path::PathBuf::from(workspace)
         };
-        self.invocation = Some(CommandInvocation {
-            argv: vec![
-                executable.display().to_string(),
-                "agent-task".to_string(),
-                "promotion-provider".to_string(),
-                "--workspace".to_string(),
-                workspace.display().to_string(),
-            ],
-            ..Default::default()
+        self.expected_workspace = Some(workspace.clone());
+        let configured_apply = self
+            .provenance
+            .as_ref()
+            .and_then(|provenance| provenance.get("id"))
+            .and_then(serde_json::Value::as_str)
+            .filter(|id| *id != "homeboy")
+            .and_then(|provider_id| {
+                configured_fallback
+                    .config
+                    .worktree_providers
+                    .get(provider_id)
+            })
+            .and_then(|provider| provider.commands.apply.as_ref())
+            .map(|command| {
+                command
+                    .iter()
+                    .map(|argument| argument.replace("{handle}", &request.to_workspace))
+                    .collect::<Vec<_>>()
+            });
+        self.invocation = Some(if let Some(argv) = configured_apply {
+            CommandInvocation {
+                argv,
+                ..Default::default()
+            }
+        } else {
+            CommandInvocation {
+                argv: vec![
+                    executable.display().to_string(),
+                    "agent-task".to_string(),
+                    "promotion-provider".to_string(),
+                    "--workspace".to_string(),
+                    workspace.display().to_string(),
+                ],
+                ..Default::default()
+            }
         });
         Ok(())
     }
@@ -549,7 +580,7 @@ impl AgentTaskPromotionWorkspaceProvider for ExternalPromotionWorkspaceProvider 
                 None,
             )
         })?;
-        run_provider_command(invocation, &request)
+        run_provider_command_for_workspace(invocation, &request, self.expected_workspace.as_deref())
             .map_err(|error| self.with_configured_provider_provenance(error))
     }
 
@@ -595,6 +626,14 @@ impl AgentTaskPromotionWorkspaceProvider for ExternalPromotionWorkspaceProvider 
 pub(crate) fn run_provider_command(
     invocation: &CommandInvocation,
     request: &AgentTaskPromotionApplyRequest,
+) -> Result<AgentTaskPromotionWorkspace> {
+    run_provider_command_for_workspace(invocation, request, None)
+}
+
+fn run_provider_command_for_workspace(
+    invocation: &CommandInvocation,
+    request: &AgentTaskPromotionApplyRequest,
+    expected_workspace: Option<&Path>,
 ) -> Result<AgentTaskPromotionWorkspace> {
     let (program, args) = invocation_program_and_args(invocation).ok_or_else(|| {
         Error::validation_invalid_argument(
@@ -857,6 +896,36 @@ pub(crate) fn run_provider_command(
 
     let workspace_path = PathBuf::from(response.workspace_path);
     validate_provider_workspace_path(&workspace_path)?;
+    if let Some(expected_workspace) = expected_workspace {
+        let actual = std::fs::canonicalize(&workspace_path).map_err(|error| {
+            Error::validation_invalid_argument(
+                "promotion_provider.response.workspace_path",
+                format!("could not canonicalize provider workspace_path: {error}"),
+                None,
+                None,
+            )
+        })?;
+        let expected = std::fs::canonicalize(expected_workspace).map_err(|error| {
+            Error::validation_invalid_argument(
+                "to_worktree",
+                format!("could not canonicalize resolved managed worktree: {error}"),
+                None,
+                None,
+            )
+        })?;
+        if actual != expected {
+            return Err(Error::validation_invalid_argument(
+                "promotion_provider.response.workspace_path",
+                format!(
+                    "promotion provider returned {}, but configured provider resolved {}",
+                    actual.display(),
+                    expected.display()
+                ),
+                None,
+                None,
+            ));
+        }
+    }
 
     let mut command_evidence = response.command_evidence;
     if command_evidence.is_empty() {

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -59,6 +59,154 @@ fn configured_promotion_preflight_rejects_missing_provider_before_dispatch() {
 
 #[cfg(unix)]
 #[test]
+fn configured_apply_provider_discovers_and_promotes_a_nonempty_patch() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("managed-worktree");
+    std::fs::create_dir(&workspace).expect("workspace");
+    git(&workspace, &["init"]);
+    git(&workspace, &["checkout", "-b", "managed"]);
+    git(&workspace, &["config", "user.email", "agent@example.test"]);
+    git(&workspace, &["config", "user.name", "Agent"]);
+    std::fs::create_dir(workspace.join("src")).expect("source directory");
+    std::fs::write(workspace.join("src/lib.rs"), "old\n").expect("source");
+    git(&workspace, &["add", "src/lib.rs"]);
+    git(&workspace, &["commit", "-m", "initial"]);
+    let patch = temp.path().join("promotion.patch");
+    std::fs::write(&patch, VALID_PATCH).expect("patch");
+
+    let resolve = temp.path().join("dmc-shaped-resolve.sh");
+    let apply = temp.path().join("dmc-shaped-apply.sh");
+    std::fs::write(
+        &resolve,
+        format!(
+            "#!/bin/sh\nset -eu\ntest \"$1\" = fixture@managed\nprintf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@managed\",\"path\":\"{}\",\"branch\":\"managed\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n",
+            workspace.display(),
+        ),
+    )
+    .expect("resolve script");
+    std::fs::write(
+        &apply,
+        format!(
+            "#!/bin/sh\nset -eu\ntest \"$1\" = fixture@managed\nrequest=$(cat)\nprintf '%s' \"$request\" | grep -q 'homeboy/agent-task-promotion-apply-request/v1'\ngit -C '{}' apply '{}'\nprintf '%s\\n' '{{\"schema\":\"homeboy/agent-task-promotion-apply-response/v1\",\"workspace_path\":\"{}\",\"command_evidence\":[{{\"command\":[\"dmc-shaped\",\"apply\"],\"exit_code\":0,\"stdout\":\"applied\",\"stderr\":\"\",\"capture\":{{\"stdout\":{{\"limit_bytes\":0,\"seen_bytes\":0,\"retained_bytes\":0,\"truncated\":false}},\"stderr\":{{\"limit_bytes\":0,\"seen_bytes\":0,\"retained_bytes\":0,\"truncated\":false}}}}}}]}}'\n",
+            workspace.display(),
+            patch.display(),
+            workspace.display(),
+        ),
+    )
+    .expect("apply script");
+    for script in [&resolve, &apply] {
+        let mut permissions = std::fs::metadata(script)
+            .expect("script metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(script, permissions).expect("make script executable");
+    }
+
+    let config = config_with_provider(
+        &resolve,
+        Some(vec![apply.display().to_string(), "{handle}".to_string()]),
+    );
+    preflight_configured_workspace_provider_with_config("fixture@managed", &config)
+        .expect("configured provider discovers clean managed target");
+    let mut provider = ExternalPromotionWorkspaceProvider::from_options_with_config_and_environment(
+        &promotion_options("fixture@managed"),
+        &config,
+        Some(PathBuf::from("/unused/homeboy")),
+        None,
+    );
+    let result = provider
+        .apply_patch(AgentTaskPromotionApplyRequest {
+            schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
+            to_workspace: "fixture@managed".to_string(),
+            patch: Some(VALID_PATCH.to_string()),
+            patch_path: patch.display().to_string(),
+            changed_files: vec!["src/lib.rs".to_string()],
+            gate_feedback_baseline: None,
+            dry_run: false,
+            trusted_unpushed_candidate_destination: None,
+        })
+        .expect("configured apply provider promotes patch");
+
+    assert_eq!(
+        result.path.canonicalize().unwrap(),
+        workspace.canonicalize().unwrap()
+    );
+    assert_eq!(
+        std::fs::read_to_string(workspace.join("src/lib.rs")).unwrap(),
+        "new\n"
+    );
+    assert_eq!(
+        result.command_evidence[0].command,
+        vec!["dmc-shaped", "apply"]
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn configured_apply_provider_rejects_a_dirty_destination_before_mutation() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let resolve = temp.path().join("dmc-shaped-resolve.sh");
+    let apply = temp.path().join("dmc-shaped-apply.sh");
+    let marker = temp.path().join("apply-ran");
+    std::fs::write(
+        &resolve,
+        "#!/bin/sh\nprintf '%s\\n' '{\"worktrees\":[{\"handle\":\"fixture@dirty\",\"path\":\"/tmp/not-used\",\"branch\":\"managed\",\"safety\":{\"dirty\":true,\"unpushed\":false,\"primary\":false}}]}'\n",
+    )
+    .expect("resolve script");
+    std::fs::write(&apply, format!("#!/bin/sh\ntouch '{}'\n", marker.display()))
+        .expect("apply script");
+    for script in [&resolve, &apply] {
+        let mut permissions = std::fs::metadata(script)
+            .expect("script metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(script, permissions).expect("make script executable");
+    }
+
+    let config = config_with_provider(&resolve, Some(vec![apply.display().to_string()]));
+    let error = preflight_configured_workspace_provider_with_config("fixture@dirty", &config)
+        .expect_err("dirty provider destination must be rejected");
+    assert!(error.message.contains("dirty"));
+    assert!(
+        !marker.exists(),
+        "apply must not run before safety rejection"
+    );
+}
+
+#[cfg(unix)]
+fn config_with_provider(resolve: &Path, apply: Option<Vec<String>>) -> HomeboyConfig {
+    let mut config = HomeboyConfig::default();
+    config.worktree_providers.insert(
+        "fixture-provider".to_string(),
+        WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: true,
+            commands: WorktreeProviderCommands {
+                resolve: Some(vec![resolve.display().to_string(), "{handle}".to_string()]),
+                apply,
+                ..Default::default()
+            },
+            list_result_mapping: Some(WorktreeProviderListResultMapping {
+                items: "$.worktrees".to_string(),
+                handle: "$.handle".to_string(),
+                path: "$.path".to_string(),
+                branch: "$.branch".to_string(),
+                dirty: "$.safety.dirty".to_string(),
+                unpushed: "$.safety.unpushed".to_string(),
+                primary: "$.safety.primary".to_string(),
+            }),
+        },
+    );
+    config
+}
+
+#[cfg(unix)]
+#[test]
 fn adopted_workspace_wins_over_a_rejecting_configured_provider() {
     use std::os::unix::fs::PermissionsExt;
 

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -308,6 +308,11 @@ pub struct WorktreeProviderCommands {
     /// `resolve`. Exact handle lookups prefer `resolve` when it is configured.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub list: Option<Vec<String>>,
+    /// Promotion apply command. Homeboy sends the typed promotion request on
+    /// stdin and requires the typed apply response on stdout. `{handle}`
+    /// arguments are replaced with the selected managed-worktree handle.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub apply: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cleanup_preview: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -105,7 +105,9 @@ variables.
 
 ### `WorktreeProviderCommands`
 
+- `resolve`
 - `list`
+- `apply` — Typed promotion apply invocation. Homeboy writes `homeboy/agent-task-promotion-apply-request/v1` to stdin and requires `homeboy/agent-task-promotion-apply-response/v1` on stdout. `{handle}` argv values resolve to the selected managed-worktree handle.
 - `cleanup_preview`
 - `cleanup_apply`
 - `artifacts_preview`


### PR DESCRIPTION
## Summary
Let configured managed-worktree providers expose a typed promotion apply command without product-specific Homeboy logic.

## What changed
- Added optional commands.apply argv with exact {handle} substitution.
- Selected configured apply invocations after existing managed-target safety resolution.
- Rejected provider responses whose canonical workspace differs from the resolved target.

## How to test
1. Run `cargo test -p homeboy-agents configured_apply_provider_ -- --test-threads=1`; expect configured apply success and dirty rejection pass.
2. Run `cargo test -p homeboy-agents configured_provider_accepts_only_the_unpushed_immutable_candidate_destination -- --exact --test-threads=1`; expect trusted-unpushed identity contract passes.
3. Run `cargo check -p homeboy-agents -p homeboy-cli`; expect both crates compile.

## Compatibility
Additive optional provider command with unchanged explicit-provider and built-in fallback precedence.

## Evidence
**Declared public contracts**
- `worktree-provider-commands-apply`: Command worktree providers may declare a typed promotion apply argv with {handle} substitution.
- `promotion-workspace-identity`: Configured provider responses must resolve to the same canonical workspace selected during safety preflight.

**Compatibility impact:** The apply field is optional and defaults absent. Existing explicit providers and built-in Homeboy workspace fallback behavior are unchanged.

**External-consumer impact:** Managed-worktree integrations can opt into typed promotion; DMC requires the paired adapter and configuration PRs before enabling the field.

**External usage:** completed; source: DMC-shaped fixture tests, live Homeboy configuration inspection, and paired DMC/wp-coding-agents PRs; limitations: True no-override Cook runtime proof requires #9719, DMC #946, and wp-coding-agents #292 to be merged and installed together.; evidence: https://github.com/Extra-Chill/homeboy/issues/7898

- Base unchanged since verification: fix/9704-promotion-provider-diagnostics remains at 6efb59987da08909d40b2e852a425931790a953a.
- CI expected: GitHub Actions repository checks
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/7898
- Verified finalization base: fix/9704-promotion-provider-diagnostics at 6efb59987da08909d40b2e852a425931790a953a
- cargo-check: passed (homeboy-agents and homeboy-cli) (Passed)
- configured-apply: passed (non-empty patch, command evidence, and canonical managed workspace) (Passed)
- dirty-safety: passed (dirty destination rejected before apply invocation) (Passed)
- trusted-unpushed: passed (only exact path and HEAD attestation accepted) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Implemented generic configured apply-provider discovery, workspace identity validation, docs, and DMC-shaped tests; GPT-5.6 Sol reviewed the cross-repo ownership split, ran focused safety/compile gates, and finalized the preserved candidate.

## Source relationships
- Closes #7898
- Relates to #9704
