### PR TITLE
Fail closed on stale Lab command binaries

### DIFF
--- a/crates/contracts/homeboy-lab-contract/src/lab/handoff.rs
+++ b/crates/contracts/homeboy-lab-contract/src/lab/handoff.rs
@@ -460,15 +460,21 @@ mod runner_job_identity_tests {
             "persisted_run_id": "persisted-run",
             "handoff_id": "handoff-xyz",
         });
-        assert_ne!(stored, replayed, "raw Value equality would reject this pair");
+        assert_ne!(
+            stored, replayed,
+            "raw Value equality would reject this pair"
+        );
         let stored_identity = RunnerJobIdentity::from_dispatch_value(&stored).expect("stored");
-        let replayed_identity = RunnerJobIdentity::from_dispatch_value(&replayed).expect("replayed");
+        let replayed_identity =
+            RunnerJobIdentity::from_dispatch_value(&replayed).expect("replayed");
         assert!(stored_identity.matches(&replayed_identity));
     }
 
     #[test]
     fn from_dispatch_value_rejects_a_non_identity_object() {
-        assert!(RunnerJobIdentity::from_dispatch_value(&serde_json::json!("not-an-object")).is_none());
+        assert!(
+            RunnerJobIdentity::from_dispatch_value(&serde_json::json!("not-an-object")).is_none()
+        );
         assert!(
             RunnerJobIdentity::from_dispatch_value(&serde_json::json!({ "runner_id": "a" }))
                 .is_none(),

--- a/crates/homeboy-cli/src/commands/runner/cli.rs
+++ b/crates/homeboy-cli/src/commands/runner/cli.rs
@@ -124,6 +124,10 @@ pub(super) enum RunnerCommand {
         #[arg(long)]
         allow_raw_exec: Option<bool>,
 
+        /// Explicitly allow controller-driven Homeboy binary convergence
+        #[arg(long)]
+        allow_homeboy_convergence: Option<bool>,
+
         /// Workspace root allowed by policy. Repeat for multiple roots.
         #[arg(long = "workspace-root")]
         workspace_roots: Vec<String>,
@@ -164,6 +168,10 @@ pub(super) enum RunnerCommand {
         /// Explicitly allow or deny raw runner exec shell commands
         #[arg(long)]
         allow_raw_exec: Option<bool>,
+
+        /// Explicitly allow controller-driven Homeboy binary convergence
+        #[arg(long)]
+        allow_homeboy_convergence: Option<bool>,
     },
     /// Remove a runner configuration
     Remove {

--- a/crates/homeboy-cli/src/commands/runner/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runner/dispatch.rs
@@ -74,6 +74,7 @@ pub fn run(
             projects,
             commands,
             allow_raw_exec,
+            allow_homeboy_convergence,
             workspace_roots,
             artifact_policy,
             peers,
@@ -86,6 +87,7 @@ pub fn run(
                 projects,
                 commands,
                 allow_raw_exec,
+                allow_homeboy_convergence,
                 workspace_roots,
                 artifact_policy,
             ),
@@ -98,6 +100,7 @@ pub fn run(
             projects,
             workspace_roots,
             allow_raw_exec,
+            allow_homeboy_convergence,
         } => map_registry(policy::update(
             &runner_id,
             policy::RunnerPolicyPatch::pair(
@@ -105,6 +108,7 @@ pub fn run(
                 fingerprints,
                 projects,
                 allow_raw_exec,
+                allow_homeboy_convergence,
                 workspace_roots,
             ),
             "runner.pair",

--- a/crates/homeboy-cli/src/commands/runner/policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/policy/mod.rs
@@ -10,6 +10,7 @@ pub(super) struct RunnerPolicyPatch {
     pub(super) allowed_projects: Vec<String>,
     pub(super) allowed_commands: Vec<String>,
     pub(super) allow_raw_exec: Option<bool>,
+    pub(super) allow_homeboy_convergence: Option<bool>,
     pub(super) workspace_roots: Vec<String>,
     pub(super) artifact_policy: Option<String>,
 }
@@ -21,6 +22,7 @@ impl RunnerPolicyPatch {
         projects: Vec<String>,
         commands: Vec<String>,
         allow_raw_exec: Option<bool>,
+        allow_homeboy_convergence: Option<bool>,
         workspace_roots: Vec<String>,
         artifact_policy: Option<String>,
     ) -> Self {
@@ -30,6 +32,7 @@ impl RunnerPolicyPatch {
             allowed_projects: projects,
             allowed_commands: commands,
             allow_raw_exec,
+            allow_homeboy_convergence,
             workspace_roots,
             artifact_policy,
         }
@@ -40,6 +43,7 @@ impl RunnerPolicyPatch {
         fingerprints: Vec<String>,
         projects: Vec<String>,
         allow_raw_exec: Option<bool>,
+        allow_homeboy_convergence: Option<bool>,
         workspace_roots: Vec<String>,
     ) -> Self {
         Self {
@@ -48,6 +52,7 @@ impl RunnerPolicyPatch {
             allowed_projects: projects,
             allowed_commands: Vec::new(),
             allow_raw_exec,
+            allow_homeboy_convergence,
             workspace_roots,
             artifact_policy: None,
         }
@@ -59,6 +64,7 @@ impl RunnerPolicyPatch {
             && self.allowed_projects.is_empty()
             && self.allowed_commands.is_empty()
             && self.allow_raw_exec.is_none()
+            && self.allow_homeboy_convergence.is_none()
             && self.workspace_roots.is_empty()
             && self.artifact_policy.is_none()
     }
@@ -114,6 +120,9 @@ fn apply_patch(policy: &mut RunnerPolicy, patch: RunnerPolicyPatch) {
     extend_unique(&mut policy.workspace_roots, patch.workspace_roots);
     if let Some(allow_raw_exec) = patch.allow_raw_exec {
         policy.allow_raw_exec = Some(allow_raw_exec);
+    }
+    if let Some(allow_homeboy_convergence) = patch.allow_homeboy_convergence {
+        policy.allow_homeboy_convergence = Some(allow_homeboy_convergence);
     }
     if let Some(artifact_policy) = patch.artifact_policy {
         policy.artifact_policy = Some(artifact_policy);

--- a/crates/homeboy-core/src/server/mod.rs
+++ b/crates/homeboy-core/src/server/mod.rs
@@ -104,6 +104,10 @@ pub struct RunnerPolicy {
     pub allowed_commands: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allow_raw_exec: Option<bool>,
+    /// Explicitly permits controller-driven Homeboy binary convergence. This
+    /// is separate from arbitrary command execution and defaults to deny.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_homeboy_convergence: Option<bool>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub workspace_roots: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -148,6 +152,7 @@ impl RunnerPolicy {
             && self.allowed_projects.is_empty()
             && self.allowed_commands.is_empty()
             && self.allow_raw_exec.is_none()
+            && self.allow_homeboy_convergence.is_none()
             && self.workspace_roots.is_empty()
             && self.artifact_policy.is_none()
             && self.snapshot_excludes.is_empty()

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+fn expected_controller_refresh_ref() -> String {
+    homeboy_product_identity::build_identity()
+        .git_commit
+        .unwrap_or_else(|| format!("v{}", homeboy_product_identity::product_version()))
+}
+
 #[test]
 fn command_prefix_tools_are_included_in_capability_contract() {
     let dir = tempfile::tempdir().expect("temp dir");
@@ -392,7 +398,15 @@ fn lab_offload_workspace_verification_metadata_survives_process_env_hydration() 
         .expect("change remote file");
     let error = verify_lab_workspace_from_env(&remote_path.display().to_string(), remote.path())
         .expect_err("changed remote content must fail verification");
-    assert!(error.contains("homeboy-workspace-content-v3+"));
+    assert!(
+        error.contains(
+            crate::workspace_content_hash_algorithm(
+                crate::WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+            )
+            .expect("default content hash algorithm")
+            .as_str()
+        )
+    );
     assert!(error.contains("expected sha256:"));
     assert!(error.contains("got sha256:"));
     assert!(error.contains("homeboy runner workspace sync --mode snapshot"));
@@ -564,8 +578,8 @@ fn lab_runner_homeboy_metadata_names_binary_and_refresh_path() {
         metadata["refresh_commands"],
         serde_json::json!([
             format!(
-                "homeboy runner refresh-homeboy 'homeboy lab' --ref v{} --reconnect",
-                homeboy_product_identity::product_version()
+                "homeboy runner refresh-homeboy 'homeboy lab' --ref {} --reconnect",
+                expected_controller_refresh_ref()
             ),
             "homeboy runner disconnect 'homeboy lab'",
             "homeboy runner connect 'homeboy lab'"
@@ -605,8 +619,8 @@ fn runner_homeboy_version_drift_blocks_offload_with_upgrade_guidance() {
     let tried = err.details["tried"].as_array().expect("tried hints");
     assert!(tried.iter().any(
         |hint| hint.as_str().is_some_and(|hint| hint.contains(&format!(
-            "homeboy runner refresh-homeboy homeboy-lab --ref v{} --reconnect",
-            homeboy_product_identity::product_version()
+            "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
+            expected_controller_refresh_ref()
         )))
     ));
     assert!(tried.iter().any(|hint| hint
@@ -658,8 +672,8 @@ fn same_minor_patch_drift_is_compatible_and_proceeds_with_warning() {
         .expect("compatible patch drift should warn");
     assert!(warning.contains("wire-compatible"));
     assert!(warning.contains(&format!(
-        "homeboy runner refresh-homeboy homeboy-lab --ref v{} --reconnect",
-        homeboy_product_identity::product_version()
+        "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
+        expected_controller_refresh_ref()
     )));
     assert!(warning.contains("require_exact_homeboy_version"));
 }
@@ -764,8 +778,8 @@ fn older_runner_than_controller_points_to_runner_refresh_first() {
     assert_eq!(
         metadata["primary_remediation_command"],
         format!(
-            "homeboy runner refresh-homeboy homeboy-lab --ref v{} --reconnect",
-            homeboy_product_identity::product_version()
+            "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
+            expected_controller_refresh_ref()
         )
     );
 
@@ -775,8 +789,8 @@ fn older_runner_than_controller_points_to_runner_refresh_first() {
         .first()
         .and_then(|hint| hint.as_str())
         .is_some_and(|hint| hint.contains(&format!(
-            "homeboy runner refresh-homeboy homeboy-lab --ref v{} --reconnect",
-            homeboy_product_identity::product_version()
+            "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
+            expected_controller_refresh_ref()
         ))));
 }
 
@@ -1040,8 +1054,8 @@ fn stale_runner_homeboy_error_blocks_offload_with_reconnect_guidance() {
         )));
     assert!(tried.iter().any(
         |hint| hint.as_str().is_some_and(|hint| hint.contains(&format!(
-            "homeboy runner refresh-homeboy 'homeboy lab' --ref v{} --reconnect",
-            homeboy_product_identity::product_version()
+            "homeboy runner refresh-homeboy 'homeboy lab' --ref {} --reconnect",
+            expected_controller_refresh_ref()
         )))
     ));
     assert!(tried.iter().any(|hint| hint

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -105,6 +105,10 @@ pub struct LabStagingRecipe {
     pub schema: String,
     pub run_id: String,
     pub runner_id: String,
+    /// Immutable Homeboy build selected by the controller for this handoff.
+    /// Optional only for recipes persisted by older controllers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_homeboy_build_identity: Option<String>,
     #[serde(default = "default_lab_staging_tunnel_mode")]
     pub tunnel_mode: crate::RunnerTunnelMode,
     pub command: LabStagingCommand,
@@ -182,6 +186,9 @@ impl LabStagingRecipe {
             schema: LAB_STAGING_RECIPE_SCHEMA.to_string(),
             run_id: run_id.into(),
             runner_id: runner_id.into(),
+            required_homeboy_build_identity: Some(
+                homeboy_product_identity::build_identity().display,
+            ),
             tunnel_mode,
             command: command.into(),
             normalized_args: request.normalized_args.to_vec(),
@@ -256,6 +263,131 @@ impl LabStagingRecipe {
             ));
         }
         Ok(())
+    }
+}
+
+/// The four identities that determine whether a handoff can execute safely.
+/// This is persisted with the workspace receipt so recovery evidence names the
+/// requested capability as well as the binary that actually ran the command.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct LabHandoffHomeboyIdentity {
+    requested_build_identity: String,
+    configured_command_build_identity: String,
+    daemon_build_identity: String,
+    /// This is populated only when the command execution itself reports it.
+    /// Session and configured-binary identities are pre-dispatch evidence.
+    executed_command_build_identity: Option<String>,
+}
+
+/// Execution evidence is appended only after runner admission. The current
+/// runtime reports the configured command provenance, not a child-process
+/// measurement, so `executed_command_build_identity` remains null.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct LabHandoffExecutionEvidence {
+    runner_job_id: String,
+    execution_record_id: String,
+    command_build_identity: Option<String>,
+}
+
+fn canonical_homeboy_identity(identity: &str) -> &str {
+    identity
+        .trim()
+        .strip_prefix("homeboy ")
+        .unwrap_or(identity.trim())
+}
+
+fn handoff_build_reference(identity: &str) -> String {
+    let identity = canonical_homeboy_identity(identity);
+    identity
+        .split_once('+')
+        .map(|(_, commit)| commit.trim_end_matches("-dirty").to_string())
+        .filter(|commit| !commit.is_empty())
+        .unwrap_or_else(|| format!("v{}", identity.split('+').next().unwrap_or(identity)))
+}
+
+fn immutable_handoff_recovery_command(runner_id: &str, requested: &str) -> String {
+    let reference = handoff_build_reference(requested);
+    format!(
+        "homeboy runner refresh-homeboy {} --ref {} --reconnect",
+        homeboy_core::engine::shell::quote_arg(runner_id),
+        homeboy_core::engine::shell::quote_arg(&reference),
+    )
+}
+
+fn handoff_identity_error(
+    runner_id: &str,
+    requested: &str,
+    configured: Option<&str>,
+    daemon: Option<&str>,
+) -> Error {
+    let recovery = immutable_handoff_recovery_command(runner_id, requested);
+    let mut error = Error::validation_invalid_argument(
+        "runner",
+        format!(
+            "Lab handoff refused runner `{runner_id}` before workspace materialization because required Homeboy build `{requested}` does not match the selected runner command identity `{}` or active daemon identity `{}`",
+            configured.unwrap_or("unavailable"),
+            daemon.unwrap_or("unavailable"),
+        ),
+        Some(runner_id.to_string()),
+        Some(vec![recovery.clone()]),
+    );
+    error.details["homeboy_handoff_identity"] = json!({
+        "requested_build_identity": requested,
+        "configured_command_build_identity": configured,
+        "daemon_build_identity": daemon,
+        "executed_command_build_identity": serde_json::Value::Null,
+        "recovery_command": recovery,
+    });
+    error
+}
+
+fn handoff_execution_evidence(
+    output: &crate::RunnerExecOutput,
+    runner_job_id: &str,
+) -> Option<LabHandoffExecutionEvidence> {
+    let record = output.execution_record.as_ref()?;
+    handoff_execution_evidence_from_record(record, runner_job_id)
+}
+
+fn handoff_execution_evidence_from_record(
+    record: &homeboy_core::runner_execution_envelope::RunnerExecutionRecord,
+    runner_job_id: &str,
+) -> Option<LabHandoffExecutionEvidence> {
+    if record.job_id.as_deref() != Some(runner_job_id) {
+        return None;
+    }
+    Some(LabHandoffExecutionEvidence {
+        runner_job_id: runner_job_id.to_string(),
+        execution_record_id: record.execution_id.clone(),
+        command_build_identity: record
+            .orchestration_provenance
+            .as_ref()
+            .and_then(|provenance| provenance.runner_command_binary.build_identity.clone()),
+    })
+}
+
+fn automatic_handoff_convergence_allowed(runner: &crate::Runner) -> bool {
+    runner.policy.allow_homeboy_convergence == Some(true)
+}
+
+fn handoff_refresh_options(
+    runner_id: String,
+    mode: crate::HomeboyBinaryRefreshMode,
+    requested: &str,
+) -> crate::HomeboyBinaryRefreshOptions {
+    crate::HomeboyBinaryRefreshOptions {
+        runner_id,
+        mode,
+        source: None,
+        git_ref: Some(handoff_build_reference(requested)),
+        target_dir: None,
+        reconnect: true,
+        force: false,
+        // Automatic recovery must preserve #9088's monotonic upgrade contract.
+        allow_downgrade: false,
+        dry_run: false,
     }
 }
 
@@ -539,6 +671,8 @@ struct DurableLabWorkspaceStage {
     source_snapshot_id: String,
     workspace_id: String,
     remote_cwd: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    homeboy_handoff_identity: Option<LabHandoffHomeboyIdentity>,
     stage: Value,
 }
 
@@ -601,6 +735,9 @@ struct DurableLabDispatchReceipt {
     remote_workspace: String,
     remote_command: Vec<String>,
     workload_identity: String,
+    /// Optional for receipts persisted before handoff execution evidence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    homeboy_handoff_execution_evidence: Option<LabHandoffExecutionEvidence>,
 }
 
 /// Written only after the runner's terminal state has been read and projected
@@ -1318,10 +1455,19 @@ trait LabStagingStageOperations: Send + Sync {
     ) -> Result<Option<LabStagingStageEffect>> {
         Ok(None)
     }
+    /// This must run immediately before the first workspace side effect. It
+    /// returns the pre-dispatch evidence persisted with the workspace receipt.
+    fn validate_handoff_identity(
+        &self,
+        _request: &LabStagingExecutionRequest,
+    ) -> Result<Option<LabHandoffHomeboyIdentity>> {
+        Ok(None)
+    }
     fn materialize_workspace(
         &self,
         request: &LabStagingExecutionRequest,
         checkpoint: &LabStagingCheckpoint,
+        handoff_identity: Option<LabHandoffHomeboyIdentity>,
     ) -> Result<(String, String)>;
     fn materialize_runtime(
         &self,
@@ -1375,6 +1521,85 @@ enum LabStagingStageEffect {
 struct ProductionLabStagingOperations;
 
 impl ProductionLabStagingOperations {
+    /// Validate the immutable handoff binding immediately before the first
+    /// workspace side effect. An explicit convergence policy may refresh an
+    /// idle Direct SSH runner, but recovery never authorizes a downgrade.
+    fn validate_handoff_homeboy_identity(
+        request: &LabStagingExecutionRequest,
+    ) -> Result<Option<LabHandoffHomeboyIdentity>> {
+        let Some(requested) = request.recipe.required_homeboy_build_identity.as_deref() else {
+            // Mixed-version recovery: old recipes had no immutable binding.
+            return Ok(None);
+        };
+        let mut runner = crate::load(&request.recipe.runner_id)?;
+        let mut command =
+            crate::remote_runner_homeboy_path(&runner, "durable Lab handoff")?.to_string();
+        let mut status = Self::status_for_recipe_transport(request)?;
+        let configured = crate::configured_runner_homeboy_build_identity(&runner, &command)?;
+        let daemon = status
+            .session
+            .as_ref()
+            .and_then(|session| session.homeboy_build_identity.clone());
+        let identities_match = |configured: Option<&str>, daemon: Option<&str>| {
+            configured.is_some_and(|identity| {
+                canonical_homeboy_identity(identity) == canonical_homeboy_identity(requested)
+            }) && daemon.is_some_and(|identity| {
+                canonical_homeboy_identity(identity) == canonical_homeboy_identity(requested)
+            })
+        };
+        if !identities_match(configured.as_deref(), daemon.as_deref())
+            && automatic_handoff_convergence_allowed(&runner)
+            && status.active_jobs.is_empty()
+            && status.active_job_state == crate::RunnerActiveJobState::Available
+            && status
+                .session
+                .as_ref()
+                .is_some_and(|session| session.mode == crate::RunnerTunnelMode::DirectSsh)
+        {
+            let mode = if configured.as_deref().is_some_and(|identity| {
+                canonical_homeboy_identity(identity) == canonical_homeboy_identity(requested)
+            }) {
+                crate::HomeboyBinaryRefreshMode::Select {
+                    binary_path: command.to_string(),
+                }
+            } else {
+                crate::HomeboyBinaryRefreshMode::Materialize
+            };
+            let (report, exit_code) = crate::refresh_homeboy_binary(handoff_refresh_options(
+                request.recipe.runner_id.clone(),
+                mode,
+                requested,
+            ))?;
+            if exit_code == 0 && report.daemon_refreshed {
+                status = Self::status_for_recipe_transport(request)?;
+                runner = crate::load(&request.recipe.runner_id)?;
+                command =
+                    crate::remote_runner_homeboy_path(&runner, "durable Lab handoff")?.to_string();
+            }
+        }
+        let daemon = status
+            .session
+            .as_ref()
+            .and_then(|session| session.homeboy_build_identity.clone());
+        let configured = crate::configured_runner_homeboy_build_identity(&runner, &command)?;
+        if !identities_match(configured.as_deref(), daemon.as_deref()) {
+            return Err(handoff_identity_error(
+                &request.recipe.runner_id,
+                requested,
+                configured.as_deref(),
+                daemon.as_deref(),
+            ));
+        }
+        Ok(Some(LabHandoffHomeboyIdentity {
+            requested_build_identity: requested.to_string(),
+            configured_command_build_identity: configured
+                .clone()
+                .expect("checked configured identity"),
+            daemon_build_identity: daemon.expect("checked daemon identity"),
+            executed_command_build_identity: None,
+        }))
+    }
+
     fn durable_workspace(
         request: &LabStagingExecutionRequest,
     ) -> Result<homeboy_agents::agent_task_lifecycle::PrivateRunAttachment<DurableLabWorkspaceStage>>
@@ -1478,6 +1703,7 @@ impl ProductionLabStagingOperations {
             remote_workspace: workspace.payload.remote_cwd,
             remote_command,
             workload_identity: canonical_digest(&hydration.payload.hydration_metadata)?,
+            homeboy_handoff_execution_evidence: None,
         };
         receipt.validate(request, checkpoint)?;
         homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
@@ -1707,10 +1933,18 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
         }
     }
 
+    fn validate_handoff_identity(
+        &self,
+        request: &LabStagingExecutionRequest,
+    ) -> Result<Option<LabHandoffHomeboyIdentity>> {
+        Self::validate_handoff_homeboy_identity(request)
+    }
+
     fn materialize_workspace(
         &self,
         request: &LabStagingExecutionRequest,
         checkpoint: &LabStagingCheckpoint,
+        homeboy_handoff_identity: Option<LabHandoffHomeboyIdentity>,
     ) -> Result<(String, String)> {
         if checkpoint.phase != LabStagingPhase::AcceptedMaterializeWorkspace {
             return Err(Error::internal_unexpected(
@@ -1807,6 +2041,8 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
         let mut projection =
             crate::lab::offload::workspace_stage::durable_workspace_stage_projection(&stage);
         projection["lab_dispatch_metadata"] = lab_metadata;
+        projection["homeboy_handoff_identity"] =
+            serde_json::to_value(&homeboy_handoff_identity).unwrap_or(serde_json::Value::Null);
         let source_snapshot_id = projection
             .pointer("/source_snapshot/workspace_snapshot_identity")
             .and_then(Value::as_str)
@@ -1834,6 +2070,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
             source_snapshot_id: source_snapshot_id.clone(),
             workspace_id: remote_cwd.clone(),
             remote_cwd,
+            homeboy_handoff_identity,
             stage: projection,
         };
         durable.validate(request, checkpoint)?;
@@ -2288,10 +2525,16 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
         );
         // Both daemon and broker submissions are idempotent on the immutable run
         // id. A dropped response is reconciled from active durable-job state.
-        let runner_job_id = match submitted {
-            Ok((output, _)) => output.job_id.ok_or_else(|| {
-                Error::internal_unexpected("durable Lab acceptance returned no runner job identity")
-            })?,
+        let (runner_job_id, handoff_execution_evidence) = match submitted {
+            Ok((output, _)) => {
+                let runner_job_id = output.job_id.clone().ok_or_else(|| {
+                    Error::internal_unexpected(
+                        "durable Lab acceptance returned no runner job identity",
+                    )
+                })?;
+                let evidence = handoff_execution_evidence(&output, &runner_job_id);
+                (runner_job_id, evidence)
+            }
             Err(error) => crate::status(&request.recipe.runner_id)
                 .ok()
                 .and_then(|status| {
@@ -2301,6 +2544,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
                         .find(|job| job.durable_run_id.as_deref() == Some(&request.recipe.run_id))
                         .map(|job| job.job_id)
                 })
+                .map(|runner_job_id| (runner_job_id, None))
                 .ok_or(error)?,
         };
         // Direct-daemon authority can expire while `/exec` is in flight. Reverse
@@ -2345,6 +2589,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
             remote_workspace: workspace.payload.remote_cwd,
             remote_command: command,
             workload_identity: canonical_digest(&hydration.payload.hydration_metadata)?,
+            homeboy_handoff_execution_evidence: handoff_execution_evidence,
         };
         receipt.validate(request, checkpoint)?;
         homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
@@ -2565,9 +2810,11 @@ impl StageExecutionAdapter {
                 Some(effect) => effect,
                 None => match checkpoint.next_action() {
                     LabStagingPhase::AcceptedMaterializeWorkspace => {
+                        let handoff_identity =
+                            self.operations.validate_handoff_identity(request)?;
                         let (source_snapshot_id, workspace_id) = self
                             .operations
-                            .materialize_workspace(request, &checkpoint)?;
+                            .materialize_workspace(request, &checkpoint, handoff_identity)?;
                         LabStagingStageEffect::Workspace(source_snapshot_id, workspace_id)
                     }
                     LabStagingPhase::MaterializeRuntime => LabStagingStageEffect::Runtime(
@@ -3275,6 +3522,7 @@ mod tests {
     #[derive(Default)]
     struct RecordedStageOperations {
         calls: Mutex<Vec<&'static str>>,
+        reject_handoff_identity: Mutex<bool>,
         fail_hydration: Mutex<bool>,
         cancel_during_hydration: Mutex<bool>,
         recovered_runner_job_id: Mutex<Option<String>>,
@@ -3293,6 +3541,13 @@ mod tests {
 
         fn fail_hydration_once(&self) {
             *self.fail_hydration.lock().expect("failure lock") = true;
+        }
+
+        fn reject_handoff_identity_once(&self) {
+            *self
+                .reject_handoff_identity
+                .lock()
+                .expect("handoff identity lock") = true;
         }
 
         fn cancel_during_hydration_once(&self) {
@@ -3360,10 +3615,32 @@ mod tests {
             Ok(recovered)
         }
 
+        fn validate_handoff_identity(
+            &self,
+            _request: &LabStagingExecutionRequest,
+        ) -> Result<Option<LabHandoffHomeboyIdentity>> {
+            self.record("handoff-identity");
+            if std::mem::take(
+                &mut *self
+                    .reject_handoff_identity
+                    .lock()
+                    .expect("handoff identity lock"),
+            ) {
+                return Err(handoff_identity_error(
+                    "lab-1",
+                    "homeboy 1.2.3+required",
+                    Some("homeboy 1.2.2+stale"),
+                    Some("homeboy 1.2.2+stale"),
+                ));
+            }
+            Ok(None)
+        }
+
         fn materialize_workspace(
             &self,
             _request: &LabStagingExecutionRequest,
             _checkpoint: &LabStagingCheckpoint,
+            _handoff_identity: Option<LabHandoffHomeboyIdentity>,
         ) -> Result<(String, String)> {
             self.record("workspace");
             Ok(("snapshot-1".to_string(), "workspace-1".to_string()))
@@ -3482,6 +3759,152 @@ mod tests {
     }
 
     #[test]
+    fn new_handoff_recipe_pins_the_controller_homeboy_build_identity() {
+        let args = vec!["agent-task".to_string(), "run-plan".to_string()];
+        let recipe = LabStagingRecipe::from_request(
+            "attempt-identity",
+            "lab-identity",
+            &recipe_request(Some(recipe_command()), &args, HashMap::new()),
+        )
+        .expect("recipe");
+
+        assert_eq!(
+            recipe.required_homeboy_build_identity.as_deref(),
+            Some(homeboy_product_identity::build_identity().display.as_str())
+        );
+    }
+
+    #[test]
+    fn legacy_handoff_recipe_without_build_identity_remains_readable() {
+        let mut recipe = serde_json::to_value(execution_request().recipe).expect("recipe JSON");
+        recipe
+            .as_object_mut()
+            .expect("recipe object")
+            .remove("required_homeboy_build_identity");
+
+        let recipe: LabStagingRecipe = serde_json::from_value(recipe).expect("legacy recipe");
+        assert_eq!(recipe.required_homeboy_build_identity, None);
+    }
+
+    #[test]
+    fn handoff_identity_keeps_execution_identity_null_before_dispatch() {
+        let identity = LabHandoffHomeboyIdentity {
+            requested_build_identity: "homeboy 1.2.3+required".to_string(),
+            configured_command_build_identity: "homeboy 1.2.3+required".to_string(),
+            daemon_build_identity: "homeboy 1.2.3+required".to_string(),
+            executed_command_build_identity: None,
+        };
+
+        assert_eq!(
+            serde_json::to_value(identity).expect("serialize")["executed_command_build_identity"],
+            serde_json::Value::Null
+        );
+    }
+
+    #[test]
+    fn post_dispatch_execution_evidence_links_the_authoritative_record() {
+        use homeboy_core::runner_execution_envelope::{
+            BinaryProvenance, OrchestrationTargetProvenance, RunnerExecutionRecord,
+        };
+
+        let binary = |owner: &str| BinaryProvenance {
+            owner: owner.to_string(),
+            path: None,
+            version: None,
+            build_identity: Some("homeboy 1.2.3+required".to_string()),
+        };
+        let record = RunnerExecutionRecord::in_flight("execution-1", "lab-1", "daemon")
+            .with_job_id("runner-job-1")
+            .with_orchestration_provenance(Some(OrchestrationTargetProvenance::new(
+                "lab-1",
+                binary("controller"),
+                binary("daemon"),
+                binary("command"),
+            )));
+        let evidence = handoff_execution_evidence_from_record(&record, "runner-job-1")
+            .expect("matching admitted execution record");
+
+        let value = serde_json::to_value(evidence).expect("serialize");
+        assert_eq!(value["execution_record_id"], "execution-1");
+        assert_eq!(value["command_build_identity"], "homeboy 1.2.3+required");
+    }
+
+    #[test]
+    fn automatic_convergence_requires_its_own_explicit_policy() {
+        let mut runner: crate::Runner =
+            serde_json::from_value(json!({ "kind": "local" })).expect("runner");
+        runner.policy.allow_raw_exec = Some(true);
+        assert!(!automatic_handoff_convergence_allowed(&runner));
+
+        runner.policy.allow_homeboy_convergence = Some(true);
+        assert!(automatic_handoff_convergence_allowed(&runner));
+    }
+
+    #[test]
+    fn automatic_handoff_refresh_never_allows_a_downgrade() {
+        let options = handoff_refresh_options(
+            "lab-identity".to_string(),
+            crate::HomeboyBinaryRefreshMode::Materialize,
+            "homeboy 1.2.3+required",
+        );
+
+        assert!(!options.allow_downgrade);
+        assert_eq!(options.git_ref.as_deref(), Some("required"));
+    }
+
+    #[test]
+    fn stale_or_incompatible_runner_identity_fails_closed_with_one_immutable_recovery() {
+        let error = handoff_identity_error(
+            "lab-identity",
+            "homeboy 1.2.3+required",
+            Some("homeboy 1.2.2+stale"),
+            Some("homeboy 1.2.2+stale"),
+        );
+
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(error.message.contains("before workspace materialization"));
+        assert!(!error.message.contains("warning"));
+        let recovery = error.details["tried"]
+            .as_array()
+            .expect("one recovery command");
+        assert_eq!(recovery.len(), 1);
+        assert_eq!(
+            recovery[0],
+            "homeboy runner refresh-homeboy lab-identity --ref required --reconnect"
+        );
+        assert_eq!(
+            error.details["homeboy_handoff_identity"]["configured_command_build_identity"],
+            "homeboy 1.2.2+stale"
+        );
+        assert_eq!(
+            error.details["homeboy_handoff_identity"]["daemon_build_identity"],
+            "homeboy 1.2.2+stale"
+        );
+        assert_eq!(
+            error.details["homeboy_handoff_identity"]["executed_command_build_identity"],
+            serde_json::Value::Null
+        );
+    }
+
+    #[test]
+    fn incompatible_handoff_identity_is_rejected_before_workspace_materialization() {
+        let operations = Arc::new(RecordedStageOperations::default());
+        operations.reject_handoff_identity_once();
+        let adapter = StageExecutionAdapter::new(operations.clone());
+        let error = adapter
+            .execute_with_checkpoint(
+                &execution_request(),
+                LabStagingCheckpoint::initial(&envelope()),
+                &LabStagingCancellationToken::default(),
+                |_| Ok(()),
+            )
+            .expect_err("stale runner identity must reject the staging operation");
+
+        assert!(error.message.contains("before workspace materialization"));
+        assert_eq!(operations.calls(), ["validate", "handoff-identity"]);
+    }
+
+    #[test]
     fn adapter_recovers_after_each_effect_before_completion_without_repeating_side_effects() {
         // Odd persistence calls store intent. Even calls store the completion
         // checkpoint, so crashing on each even call exercises every exact-once
@@ -3522,7 +3945,7 @@ mod tests {
                 operations
                     .calls()
                     .into_iter()
-                    .filter(|call| *call != "validate")
+                    .filter(|call| !matches!(*call, "validate" | "handoff-identity"))
                     .collect::<Vec<_>>(),
                 ["workspace", "runtime", "hydration", "dispatch", "observe"]
             );
@@ -3880,6 +4303,7 @@ mod tests {
             source_snapshot_id: "snapshot-1".to_string(),
             workspace_id: "/runner/workspaces/attempt-1".to_string(),
             remote_cwd: "/runner/workspaces/attempt-1".to_string(),
+            homeboy_handoff_identity: None,
             stage: json!({
                 "remote_cwd": "/runner/workspaces/attempt-1",
                 "source_snapshot": {
@@ -4013,6 +4437,7 @@ mod tests {
             remote_workspace: "/runner/workspace".to_string(),
             remote_command: vec!["homeboy".to_string(), "agent-task".to_string()],
             workload_identity: "sha256:workload".to_string(),
+            homeboy_handoff_execution_evidence: None,
         };
         receipt.validate(&request, &checkpoint).expect("receipt");
         assert!(!serde_json::to_string(&receipt)
@@ -4169,6 +4594,7 @@ mod tests {
             remote_workspace: "/runner/workspace".to_string(),
             remote_command: vec!["homeboy".to_string(), "agent-task".to_string()],
             workload_identity: "sha256:workload".to_string(),
+            homeboy_handoff_execution_evidence: None,
         };
 
         receipt

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -1324,8 +1324,27 @@ mod tests {
             assert_eq!(runner.policy.allowed_projects, vec!["extrachill"]);
             assert_eq!(runner.policy.allowed_commands, vec!["test", "bench"]);
             assert_eq!(runner.policy.allow_raw_exec, Some(false));
+            assert_eq!(runner.policy.allow_homeboy_convergence, None);
             assert_eq!(runner.policy.workspace_roots, vec!["/home/user/Developer"]);
             assert_eq!(runner.policy.artifact_policy.as_deref(), Some("metadata"));
+            assert!(serde_json::to_value(&runner)
+                .expect("serialize legacy policy")
+                .pointer("/policy/allow_homeboy_convergence")
+                .is_none());
+        });
+    }
+
+    #[test]
+    fn runner_registry_persists_explicit_homeboy_convergence_policy() {
+        test_support::with_isolated_home(|_| {
+            create(
+                r#"{"id":"lab-local","kind":"local","policy":{"allow_homeboy_convergence":true}}"#,
+                false,
+            )
+            .expect("create runner");
+
+            let runner = load("lab-local").expect("load runner");
+            assert_eq!(runner.policy.allow_homeboy_convergence, Some(true));
         });
     }
 


### PR DESCRIPTION
## Summary
Bind durable Lab handoffs to an immutable controller build and prevent known stale command binaries from receiving workloads.

## What changed
- Validate configured-command and daemon identities before workspace materialization; explicitly authorize monotonic convergence; persist honest pre-dispatch and post-admission provenance.

## How to test
1. Run `cargo test -p homeboy-lab-runner lab_staging_controller -- --test-threads=1`; expect All 39 durable staging admission, recovery, policy, and provenance tests pass..
2. Run `cargo test -p homeboy-lab-runner capability_metadata -- --test-threads=1`; expect All 31 build identity and recovery-guidance tests pass..

## Compatibility
Optional/defaulted policy and receipt fields preserve persisted data and callers; stricter behavior applies to new handoffs with known incompatible identities.

## Evidence
**Declared public contracts**
- `runner-policy.allow_homeboy_convergence`: New optional explicit authorization for controller-driven Homeboy binary convergence; omitted values fail closed.
- `lab-handoff-build-admission`: New handoffs bind the controller build and reject mismatched configured/daemon identities before workspace materialization.
- `lab-handoff-provenance`: Durable receipts add optional requested/configured/daemon and authoritative execution-record provenance.

**Compatibility impact:** All additions are optional/defaulted; legacy runner policies and persisted staging/dispatch receipts remain readable, while new handoffs fail closed on known build skew.

**External-consumer impact:** CLI runner trust/pair gain an optional flag; existing invocations and serialized fields remain valid.

**External usage:** unavailable_manual_review; source: Repository Lab handoff and runner-policy callers at the verified base; limitations: No real mixed-version SSH runner integration environment was used locally; CI and reviewer verification should exercise that deployment boundary.; evidence: https://github.com/Extra-Chill/homeboy/blob/9773f5550c46047e83c395de606a0322a1ae10d7/crates/homeboy-lab-runner/src/lab_staging_controller.rs

- Base unchanged since verification: main remains at 9773f5550c46047e83c395de606a0322a1ae10d7.
- CI expected: Rust workspace tests
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9626
- Verified finalization base: main at 9773f5550c46047e83c395de606a0322a1ae10d7
- affected-crates-check: passed (homeboy-core, homeboy-lab-runner, and homeboy-cli) (Passed)
- capability-metadata: passed (31 tests) (Passed)
- independent-review: passed (no remaining findings after two remediation passes) (Passed)
- provider-preflight: passed (14 tests) (Passed)
- registry-compatibility: passed (3 tests) (Passed)
- staging-controller: passed (39 tests) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Cooked the initial candidate, performed two focused review/remediation passes, added deterministic compatibility coverage, and verified the rebased result.

## Source relationships
- Closes #9626
