### PR TITLE
fix(lab): bound workspace lease metadata lookup

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -964,8 +964,8 @@ pub(crate) fn materialize_prepared_workspace_update(
         metadata_parent = shell::quote_arg(&format!("{temporary}/.homeboy")),
     );
     let finalize = format!(
-        "grep -qF -- {lease} {live_metadata} && mv {remote} {backup} && if mv {temporary} {remote}; then rm -rf {backup} || true; else if mv {backup} {remote}; then exit 1; else printf '%s\\n' 'prepared workspace promotion failed; original remains at {backup}' >&2; exit 2; fi; fi",
-        lease = shell::quote_arg(&format!("\"workspace_lease\": \"{expected_lease}\"")),
+        "tr -d '[:space:]' < {live_metadata} | grep -qF -- {lease} && mv {remote} {backup} && if mv {temporary} {remote}; then rm -rf {backup} || true; else if mv {backup} {remote}; then exit 1; else printf '%s\\n' 'prepared workspace promotion failed; original remains at {backup}' >&2; exit 2; fi; fi",
+        lease = shell::quote_arg(&format!("\"workspace_lease\":\"{expected_lease}\"")),
         live_metadata = shell::quote_arg(&format!("{remote_path}/{RUNNER_WORKSPACE_METADATA_FILE}")),
         remote = shell::quote_arg(remote_path), temporary = shell::quote_arg(&temporary), backup = shell::quote_arg(&backup),
     );

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -45,6 +45,7 @@ use homeboy_core::engine::shell;
 use homeboy_core::server::{is_transient_ssh_error, CommandOutput};
 
 mod snapshots;
+use snapshots::workspace_snapshot_for_lease;
 #[cfg(test)]
 pub(crate) use snapshots::workspace_snapshot_scan_command;
 pub use snapshots::{list_workspaces, workspace_snapshots};
@@ -431,25 +432,28 @@ pub fn update_workspace(
 ) -> Result<(RunnerWorkspaceUpdateOutput, i32)> {
     let runner = load(runner_id)?;
     let local_path = canonical_workspace_path(&options.path)?;
-    let (snapshots, _) = workspace_snapshots(
-        runner_id,
-        RunnerWorkspaceSnapshotFilters {
-            limit: usize::MAX,
-            ..Default::default()
-        },
-    )?;
-    let snapshot = snapshots
-        .snapshots
-        .into_iter()
-        .find(|entry| entry.workspace_lease.as_deref() == Some(options.lease.as_str()))
-        .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "lease",
-                "workspace update requires a current opaque workspace lease for this runner",
-                Some(options.lease.clone()),
-                None,
-            )
-        })?;
+    let workspace_root = runner.workspace_root.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "workspace_root",
+            "runner workspace update requires workspace_root",
+            Some(runner.id.clone()),
+            None,
+        )
+    })?;
+    validate_absolute_path("workspace_root", workspace_root)?;
+    let snapshot = workspace_snapshot_for_lease(
+        &runner,
+        &format!("{}/_lab_workspaces", workspace_root.trim_end_matches('/')),
+        &options.lease,
+    )?
+    .ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "lease",
+            "workspace update requires a current opaque workspace lease for this runner",
+            Some(options.lease.clone()),
+            None,
+        )
+    })?;
     let state = local_git_state(&local_path);
     if snapshot.local_path != local_path.display().to_string()
         || snapshot.source_remote_url != state.remote_url

--- a/crates/homeboy-lab-runner/src/workspace/sync/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/snapshots.rs
@@ -272,10 +272,7 @@ fn workspace_snapshots_ssh(
 )> {
     let (_server, mut client) = ssh_client_for_runner(runner)?;
     client.env.extend(runner.env.clone());
-    // Enumerate paths separately from their metadata. A root can hold many
-    // large manifests; projecting all of them through one SSH stdout capture
-    // corrupts the entire scan when that capture reaches its bound.
-    let command = workspace_snapshot_paths_command(root);
+    let command = workspace_snapshot_scan_command(root);
     let output = client.execute(&command);
     if !output.success {
         return Err(Error::internal_unexpected(format!(
@@ -285,19 +282,14 @@ fn workspace_snapshots_ssh(
     }
     let mut snapshots = Vec::new();
     let mut skipped_invalid_metadata = Vec::new();
-    for path in output
-        .stdout
-        .lines()
-        .map(str::trim)
-        .filter(|path| !path.is_empty())
-    {
-        let output = client.execute(&workspace_snapshot_metadata_command(path));
-        if !output.success || output.stdout.trim().is_empty() {
+    for line in output.stdout.lines() {
+        let parts = line.splitn(2, '\t').collect::<Vec<_>>();
+        if parts.len() != 2 {
             continue;
         }
         let decoded = base64::engine::general_purpose::STANDARD
-            .decode(output.stdout.trim())
-            .map_err(|error| invalid_workspace_metadata(path, error));
+            .decode(parts[1])
+            .map_err(|error| invalid_workspace_metadata(parts[0], error));
         let Ok(decoded) = decoded else {
             skipped_invalid_metadata.push(decoded.expect_err("base64 decode failed"));
             continue;
@@ -305,7 +297,7 @@ fn workspace_snapshots_ssh(
         let metadata: RunnerWorkspaceMetadata = match serde_json::from_slice(&decoded) {
             Ok(metadata) => metadata,
             Err(error) => {
-                skipped_invalid_metadata.push(invalid_workspace_metadata(path, error));
+                skipped_invalid_metadata.push(invalid_workspace_metadata(parts[0], error));
                 continue;
             }
         };
@@ -412,21 +404,6 @@ pub(crate) fn workspace_snapshot_scan_command(root: &str) -> String {
         "root={root}; meta_rel={meta}; if [ -d \"$root\" ]; then for dir in \"$root\"/*; do [ -d \"$dir\" ] || continue; meta=\"$dir/$meta_rel\"; [ -f \"$meta\" ] || continue; encoded=$(base64 < \"$meta\" 2>/dev/null) || continue; encoded=$(printf '%s' \"$encoded\" | tr -d '\\n'); printf \"%s\\t%s\\n\" \"$dir\" \"$encoded\"; done; [ -d \"$root\" ] || {{ printf '%s\\n' \"runner workspace snapshot root disappeared during scan: $root\" >&2; exit 1; }}; fi",
         root = shell::quote_arg(root),
         meta = shell::quote_arg(WORKSPACE_METADATA_FILE),
-    )
-}
-
-fn workspace_snapshot_paths_command(root: &str) -> String {
-    format!(
-        "root={root}; meta_rel={meta}; if [ -d \"$root\" ]; then for dir in \"$root\"/*; do [ -f \"$dir/$meta_rel\" ] && printf '%s\\n' \"$dir\"; done; [ -d \"$root\" ] || {{ printf '%s\\n' \"runner workspace snapshot root disappeared during scan: $root\" >&2; exit 1; }}; fi",
-        root = shell::quote_arg(root),
-        meta = shell::quote_arg(WORKSPACE_METADATA_FILE),
-    )
-}
-
-fn workspace_snapshot_metadata_command(path: &str) -> String {
-    format!(
-        "meta={}; [ -f \"$meta\" ] && base64 < \"$meta\" 2>/dev/null | tr -d '\\n'",
-        shell::quote_arg(&format!("{path}/{WORKSPACE_METADATA_FILE}")),
     )
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/sync/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/snapshots.rs
@@ -272,7 +272,10 @@ fn workspace_snapshots_ssh(
 )> {
     let (_server, mut client) = ssh_client_for_runner(runner)?;
     client.env.extend(runner.env.clone());
-    let command = workspace_snapshot_scan_command(root);
+    // Enumerate paths separately from their metadata. A root can hold many
+    // large manifests; projecting all of them through one SSH stdout capture
+    // corrupts the entire scan when that capture reaches its bound.
+    let command = workspace_snapshot_paths_command(root);
     let output = client.execute(&command);
     if !output.success {
         return Err(Error::internal_unexpected(format!(
@@ -282,18 +285,27 @@ fn workspace_snapshots_ssh(
     }
     let mut snapshots = Vec::new();
     let mut skipped_invalid_metadata = Vec::new();
-    for line in output.stdout.lines() {
-        let parts = line.splitn(2, '\t').collect::<Vec<_>>();
-        if parts.len() != 2 {
+    for path in output
+        .stdout
+        .lines()
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+    {
+        let output = client.execute(&workspace_snapshot_metadata_command(path));
+        if !output.success || output.stdout.trim().is_empty() {
             continue;
         }
         let decoded = base64::engine::general_purpose::STANDARD
-            .decode(parts[1])
-            .map_err(|err| Error::internal_json(err.to_string(), None))?;
+            .decode(output.stdout.trim())
+            .map_err(|error| invalid_workspace_metadata(path, error));
+        let Ok(decoded) = decoded else {
+            skipped_invalid_metadata.push(decoded.expect_err("base64 decode failed"));
+            continue;
+        };
         let metadata: RunnerWorkspaceMetadata = match serde_json::from_slice(&decoded) {
             Ok(metadata) => metadata,
             Err(error) => {
-                skipped_invalid_metadata.push(invalid_workspace_metadata(parts[0], error));
+                skipped_invalid_metadata.push(invalid_workspace_metadata(path, error));
                 continue;
             }
         };
@@ -304,9 +316,74 @@ fn workspace_snapshots_ssh(
     Ok((snapshots, skipped_invalid_metadata))
 }
 
+pub(super) fn workspace_snapshot_for_lease(
+    runner: &super::super::super::Runner,
+    root: &str,
+    lease: &str,
+) -> Result<Option<RunnerWorkspaceSnapshotEntry>> {
+    match runner.kind {
+        RunnerKind::Local => workspace_snapshot_for_lease_local(Path::new(root), lease),
+        RunnerKind::Ssh => workspace_snapshot_for_lease_ssh(runner, root, lease),
+    }
+}
+
+fn workspace_snapshot_for_lease_local(
+    root: &Path,
+    lease: &str,
+) -> Result<Option<RunnerWorkspaceSnapshotEntry>> {
+    if !root.is_dir() {
+        return Ok(None);
+    }
+    for entry in fs::read_dir(root).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some("read runner workspace root".to_string()),
+        )
+    })? {
+        let Ok(entry) = entry else { continue };
+        if !entry.file_type().map(|kind| kind.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(entry.path().join(WORKSPACE_METADATA_FILE)) else {
+            continue;
+        };
+        let Ok(metadata) = serde_json::from_str::<RunnerWorkspaceMetadata>(&content) else {
+            continue;
+        };
+        if metadata.workspace_lease.as_deref() == Some(lease) {
+            return Ok(workspace_snapshot_entry(metadata));
+        }
+    }
+    Ok(None)
+}
+
+fn workspace_snapshot_for_lease_ssh(
+    runner: &super::super::super::Runner,
+    root: &str,
+    lease: &str,
+) -> Result<Option<RunnerWorkspaceSnapshotEntry>> {
+    let (_server, mut client) = ssh_client_for_runner(runner)?;
+    client.env.extend(runner.env.clone());
+    let output = client.execute(&workspace_snapshot_lease_command(root, lease));
+    if !output.success || output.stdout.trim().is_empty() {
+        return Ok(None);
+    }
+    let decoded = match base64::engine::general_purpose::STANDARD.decode(output.stdout.trim()) {
+        Ok(decoded) => decoded,
+        Err(_) => return Ok(None),
+    };
+    let metadata = match serde_json::from_slice::<RunnerWorkspaceMetadata>(&decoded) {
+        Ok(metadata) => metadata,
+        Err(_) => return Ok(None),
+    };
+    Ok((metadata.workspace_lease.as_deref() == Some(lease))
+        .then(|| workspace_snapshot_entry(metadata))
+        .flatten())
+}
+
 fn invalid_workspace_metadata(
     source: &str,
-    error: serde_json::Error,
+    error: impl std::fmt::Display,
 ) -> RunnerWorkspaceSnapshotInvalidMetadata {
     const MAX_PARSE_ERROR_BYTES: usize = 512;
 
@@ -332,9 +409,35 @@ pub(crate) fn workspace_snapshot_scan_command(root: &str) -> String {
     // disappeared child as an error even though the snapshot root remains
     // valid, so read each candidate defensively and verify the root afterwards.
     format!(
-        "root={root}; meta_rel={meta}; if [ -d \"$root\" ]; then for dir in \"$root\"/*; do [ -d \"$dir\" ] || continue; meta=\"$dir/$meta_rel\"; [ -f \"$meta\" ] || continue; encoded=$(base64 < \"$meta\" 2>/dev/null) || continue; printf \"%s\\t%s\\n\" \"$dir\" \"$encoded\"; done; [ -d \"$root\" ] || {{ printf '%s\\n' \"runner workspace snapshot root disappeared during scan: $root\" >&2; exit 1; }}; fi",
+        "root={root}; meta_rel={meta}; if [ -d \"$root\" ]; then for dir in \"$root\"/*; do [ -d \"$dir\" ] || continue; meta=\"$dir/$meta_rel\"; [ -f \"$meta\" ] || continue; encoded=$(base64 < \"$meta\" 2>/dev/null) || continue; encoded=$(printf '%s' \"$encoded\" | tr -d '\\n'); printf \"%s\\t%s\\n\" \"$dir\" \"$encoded\"; done; [ -d \"$root\" ] || {{ printf '%s\\n' \"runner workspace snapshot root disappeared during scan: $root\" >&2; exit 1; }}; fi",
         root = shell::quote_arg(root),
         meta = shell::quote_arg(WORKSPACE_METADATA_FILE),
+    )
+}
+
+fn workspace_snapshot_paths_command(root: &str) -> String {
+    format!(
+        "root={root}; meta_rel={meta}; if [ -d \"$root\" ]; then for dir in \"$root\"/*; do [ -f \"$dir/$meta_rel\" ] && printf '%s\\n' \"$dir\"; done; [ -d \"$root\" ] || {{ printf '%s\\n' \"runner workspace snapshot root disappeared during scan: $root\" >&2; exit 1; }}; fi",
+        root = shell::quote_arg(root),
+        meta = shell::quote_arg(WORKSPACE_METADATA_FILE),
+    )
+}
+
+fn workspace_snapshot_metadata_command(path: &str) -> String {
+    format!(
+        "meta={}; [ -f \"$meta\" ] && base64 < \"$meta\" 2>/dev/null | tr -d '\\n'",
+        shell::quote_arg(&format!("{path}/{WORKSPACE_METADATA_FILE}")),
+    )
+}
+
+fn workspace_snapshot_lease_command(root: &str, lease: &str) -> String {
+    let lease = serde_json::to_string(lease).expect("serialize workspace lease");
+    let needle = format!("\"workspace_lease\":{lease}");
+    format!(
+        "root={root}; meta_rel={meta}; needle={needle}; if [ -d \"$root\" ]; then for dir in \"$root\"/*; do meta=\"$dir/$meta_rel\"; [ -f \"$meta\" ] || continue; tr -d '[:space:]' < \"$meta\" | grep -Fq -- \"$needle\" || continue; base64 < \"$meta\" 2>/dev/null | tr -d '\\n'; exit 0; done; fi",
+        root = shell::quote_arg(root),
+        meta = shell::quote_arg(WORKSPACE_METADATA_FILE),
+        needle = shell::quote_arg(&needle),
     )
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
@@ -233,6 +233,54 @@ fn stale_truncated_metadata_does_not_block_current_workspace_sync() {
 }
 
 #[test]
+fn ssh_snapshot_listing_preserves_entries_and_isolates_invalid_metadata() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root");
+        create_ssh_runner("lab-ssh-snapshots", runner_root.path());
+        let source = tempfile::tempdir().expect("source");
+        fs::write(source.path().join("file.txt"), "source\n").expect("source");
+        let (synced, _) = sync_workspace(
+            "lab-ssh-snapshots",
+            sync_options(
+                source.path().display().to_string(),
+                Some("ssh-run".to_string()),
+            ),
+        )
+        .expect("sync");
+        let invalid = runner_root
+            .path()
+            .join("_lab_workspaces/invalid/.homeboy/runner-workspace.json");
+        fs::create_dir_all(invalid.parent().expect("invalid parent")).expect("invalid workspace");
+        fs::write(&invalid, "{\"workspace_lease\":").expect("invalid metadata");
+
+        let (output, _) = workspace_snapshots(
+            "lab-ssh-snapshots",
+            RunnerWorkspaceSnapshotFilters {
+                run_id: Some("ssh-run".to_string()),
+                limit: 10,
+                ..Default::default()
+            },
+        )
+        .expect("SSH snapshot listing");
+
+        assert_eq!(output.variant, "workspace_snapshots");
+        assert_eq!(output.snapshots.len(), 1);
+        assert_eq!(output.snapshots[0].remote_path, synced.remote_path);
+        assert_eq!(output.skipped_invalid_metadata.len(), 1);
+        assert_eq!(
+            output.skipped_invalid_metadata[0].source,
+            invalid
+                .parent()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .display()
+                .to_string()
+        );
+    });
+}
+
+#[test]
 fn workspace_snapshots_filters_by_repo_ref_commit_and_run() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
@@ -661,6 +709,22 @@ fn create_local_runner(id: &str, workspace_root: &std::path::Path) {
         false,
     )
     .expect("create runner");
+}
+
+fn create_ssh_runner(id: &str, workspace_root: &std::path::Path) {
+    homeboy_core::server::create(
+        &format!(r#"{{"id":"{id}","host":"localhost","user":"test"}}"#),
+        false,
+    )
+    .expect("create localhost server");
+    crate::create(
+        &format!(
+            r#"{{"id":"{id}","kind":"ssh","server_id":"{id}","workspace_root":"{}"}}"#,
+            workspace_root.display()
+        ),
+        false,
+    )
+    .expect("create SSH runner");
 }
 
 fn sync_options(path: String, run_id: Option<String>) -> RunnerWorkspaceSyncOptions {

--- a/crates/homeboy-lab-runner/src/workspace/tests/update.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/update.rs
@@ -81,6 +81,81 @@ fn prepared_workspace_update_applies_delta_retains_assets_and_rotates_lease() {
 }
 
 #[test]
+fn ssh_prepared_workspace_update_resolves_fresh_lease_without_projecting_large_root() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root");
+        create_ssh_runner("prepared-update-ssh", runner_root.path());
+        let source = tempfile::tempdir().expect("source");
+        fs::write(source.path().join("file.txt"), "before\n").expect("source");
+        let (synced, _) =
+            sync_workspace("prepared-update-ssh", sync_options(source.path())).expect("sync");
+        let lease = synced.prepared_workspace_lease.expect("lease");
+
+        let root = runner_root.path().join("_lab_workspaces");
+        let metadata_path = Path::new(&synced.remote_path).join(".homeboy/runner-workspace.json");
+        let metadata = fs::read_to_string(&metadata_path).expect("metadata");
+        let metadata_value: serde_json::Value =
+            serde_json::from_str(&metadata).expect("valid metadata");
+        fs::write(
+            &metadata_path,
+            serde_json::to_string(&metadata_value).expect("compact metadata"),
+        )
+        .expect("write compact metadata");
+        for index in 0..24 {
+            let path = root.join(format!("stale-large-{index:02}/.homeboy"));
+            fs::create_dir_all(&path).expect("stale workspace");
+            let oversized = metadata.replacen(
+                "\n}",
+                &format!(
+                    ",\n  \"ignored_large_manifest_{index}\": \"{}\"\n}}",
+                    "x".repeat(256 * 1024)
+                ),
+                1,
+            );
+            fs::write(path.join("runner-workspace.json"), oversized).expect("stale metadata");
+        }
+
+        fs::write(source.path().join("file.txt"), "after\n").expect("update source");
+        let (updated, _) = update_workspace(
+            "prepared-update-ssh",
+            RunnerWorkspaceUpdateOptions {
+                path: source.path().display().to_string(),
+                lease,
+            },
+        )
+        .expect("fresh lease update despite oversized aggregate metadata");
+
+        assert_eq!(
+            fs::read_to_string(Path::new(&updated.remote_path).join("file.txt")).unwrap(),
+            "after\n"
+        );
+    });
+}
+
+#[test]
+fn prepared_workspace_update_rejects_relative_runner_root() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        crate::create(
+            r#"{"id":"relative-update","kind":"local","workspace_root":"relative"}"#,
+            false,
+        )
+        .expect("create runner");
+        let source = tempfile::tempdir().expect("source");
+
+        let error = update_workspace(
+            "relative-update",
+            RunnerWorkspaceUpdateOptions {
+                path: source.path().display().to_string(),
+                lease: "workspace:unused".to_string(),
+            },
+        )
+        .expect_err("relative workspace root must be rejected");
+
+        assert!(error.message.contains("absolute path"));
+    });
+}
+
+#[test]
 fn duplicate_snapshot_identities_target_their_own_opaque_workspace_lease() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let runner_root = tempfile::tempdir().expect("runner root");
@@ -314,6 +389,22 @@ fn create_local_runner(id: &str, workspace_root: &Path) {
         false,
     )
     .expect("create runner");
+}
+
+fn create_ssh_runner(id: &str, workspace_root: &Path) {
+    homeboy_core::server::create(
+        &format!(r#"{{"id":"{id}","host":"localhost","user":"test"}}"#),
+        false,
+    )
+    .expect("create localhost server");
+    crate::create(
+        &format!(
+            r#"{{"id":"{id}","kind":"ssh","server_id":"{id}","workspace_root":"{}"}}"#,
+            workspace_root.display()
+        ),
+        false,
+    )
+    .expect("create SSH runner");
 }
 
 fn sync_options(path: &Path) -> RunnerWorkspaceSyncOptions {


### PR DESCRIPTION
## Summary
Resolve prepared workspace leases without projecting every large metadata manifest through one bounded SSH response.

## What changed
- Read SSH snapshot metadata independently so malformed or oversized entries remain isolated; use a targeted lease lookup for updates; preserve absolute-root validation and whitespace-independent metadata ownership checks.

## How to test
1. Run `cargo test -p homeboy-lab-runner workspace::tests::snapshots`; expect 14 tests pass.
2. Run `cargo test -p homeboy-lab-runner workspace::tests::update`; expect 9 tests pass.
3. Run `cargo fmt -p homeboy-lab-runner -- --check`; expect formatting passes.
4. Run `real homeboy-lab prepared workspace update`; expect previously rejected lease resolves, assets remain retained, and lease rotates.

## Compatibility
Preserves runner workspace output schemas, local and SSH update semantics, malformed-metadata isolation, absolute workspace-root validation, and opaque lease compare-and-swap behavior.

## Evidence
- Base unchanged since verification: main remains at 9773f5550c46047e83c395de606a0322a1ae10d7.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9730
- Verified finalization base: main at 9773f5550c46047e83c395de606a0322a1ae10d7
- focused-snapshots: passed (14 tests) (Passed)
- focused-update: passed (9 tests) (Passed)
- real-lab-update: passed (lease resolved, assets retained, lease rotated) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** OpenCode with openai/gpt-5.6-terra drafted the initial patch; OpenCode with openai/gpt-5.6-sol independently reviewed, corrected compatibility gaps, added tests, and verified the real Lab workflow.

## Source relationships
- Closes #9730
