### PR TITLE
Fix upgrade runner fleet convergence

### DIFF
--- a/crates/homeboy-cli/src/commands/upgrade.rs
+++ b/crates/homeboy-cli/src/commands/upgrade.rs
@@ -32,9 +32,13 @@ pub struct UpgradeArgs {
     #[arg(long)]
     pub no_restart_services: bool,
 
-    /// Upgrade only the named configured runner. Repeat to target multiple runners.
-    #[arg(long = "upgrade-runner", value_name = "RUNNER_ID")]
+    /// Select the configured runner to converge with the controller. Repeat to target multiple runners.
+    #[arg(long = "upgrade-runner", value_name = "RUNNER_ID", conflicts_with = "skip_runners")]
     pub runners: Vec<String>,
+
+    /// Refresh selected runners without promoting the controller.
+    #[arg(long, requires = "runners")]
+    pub runner_only: bool,
 
     /// Override install method detection (homebrew|cargo|source|binary)
     #[arg(long)]
@@ -79,6 +83,7 @@ pub fn run(args: UpgradeArgs, _global: &GlobalArgs) -> CmdResult<Value> {
         args.skip_extensions,
         args.skip_runners,
         args.no_restart_services,
+        args.runner_only,
         &args.runners,
         args.source_path.as_deref(),
     )?;
@@ -90,7 +95,7 @@ pub fn run(args: UpgradeArgs, _global: &GlobalArgs) -> CmdResult<Value> {
     // the JSON payload (only ever rediscovered via `homeboy self status`).
     warn_degraded_runners(&result);
 
-    Ok((json, upgrade_exit_code(&result, !args.runners.is_empty())))
+    Ok((json, upgrade_exit_code(&result, args.runner_only)))
 }
 
 /// Configured runners that the upgrade left version-degraded (PATH/version drift
@@ -155,7 +160,9 @@ fn warn_degraded_runners(result: &upgrade::UpgradeResult) {
 }
 
 fn upgrade_exit_code(result: &upgrade::UpgradeResult, targeted_runner_upgrade: bool) -> i32 {
-    if targeted_runner_upgrade && result.runners_skipped.iter().any(|runner| !runner.success) {
+    if result.partial
+        || (targeted_runner_upgrade && result.runners_skipped.iter().any(|runner| !runner.success))
+    {
         return 1;
     }
 
@@ -188,11 +195,21 @@ mod tests {
             extensions_skipped: Vec::new(),
             extensions_failed: Vec::new(),
             stale_daemon: None,
+            daemon_previous_version: None,
+            daemon_new_version: None,
             exit_code: 0,
             detail: "extension sync failed".to_string(),
         });
 
         assert_eq!(upgrade_exit_code(&result, true), 1);
+    }
+
+    #[test]
+    fn partial_convergence_returns_non_zero_status() {
+        let mut result = base_upgrade_result();
+        result.partial = true;
+
+        assert_eq!(upgrade_exit_code(&result, false), 1);
     }
 
     #[test]
@@ -214,6 +231,8 @@ mod tests {
             extensions_skipped: Vec::new(),
             extensions_failed: Vec::new(),
             stale_daemon: None,
+            daemon_previous_version: None,
+            daemon_new_version: None,
             exit_code: 1,
             detail: "runner unavailable".to_string(),
         });
@@ -244,6 +263,8 @@ mod tests {
             extensions_skipped: Vec::new(),
             extensions_failed: Vec::new(),
             stale_daemon: None,
+            daemon_previous_version: None,
+            daemon_new_version: None,
             exit_code: 0,
             detail: "runner remains degraded".to_string(),
         });
@@ -274,6 +295,8 @@ mod tests {
             extensions_skipped: Vec::new(),
             extensions_failed: Vec::new(),
             stale_daemon: None,
+            daemon_previous_version: None,
+            daemon_new_version: None,
             exit_code: 0,
             detail: "upgraded".to_string(),
         });
@@ -291,6 +314,7 @@ mod tests {
             new_build_identity: None,
             source_revision: None,
             upgraded: true,
+            partial: false,
             message: "Upgraded to 0.228.7".to_string(),
             restart_required: false,
             extensions_updated: Vec::new(),

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -40,9 +40,8 @@ const REMOTE_LEASELESS_RECOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 const REMOTE_LEASELESS_RECOVERY_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
 #[path = "connection_daemon.rs"]
 mod connection_daemon;
-use connection_daemon::{
-    connect_remote_daemon, daemon_http_freshness, daemon_http_version, versions_match,
-};
+pub(crate) use connection_daemon::versions_match;
+use connection_daemon::{connect_remote_daemon, daemon_http_freshness, daemon_http_version};
 use connection_daemon::{daemon_http_identity, normalize_homeboy_version_owned};
 use connection_daemon::{daemon_http_runtime_loaded_paths, daemon_http_runtime_stale_paths};
 

--- a/crates/homeboy-lab-runner/src/connection_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection_daemon.rs
@@ -186,7 +186,7 @@ fn open_daemon_tunnel(
     ))
 }
 
-pub(super) fn versions_match(left: &str, right: &str) -> bool {
+pub(crate) fn versions_match(left: &str, right: &str) -> bool {
     normalize_homeboy_version(left) == normalize_homeboy_version(right)
 }
 

--- a/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
@@ -39,16 +39,17 @@ pub fn runner_upgrade_command(
     command
 }
 
-pub fn reconnect_runner_daemon(runner_id: &str) -> Result<String> {
+pub fn reconnect_runner_daemon(runner_id: &str) -> Result<(String, Option<String>)> {
     runner::disconnect(runner_id)?;
     let (report, exit_code) = runner::connect(runner_id)?;
     if exit_code == 0 && report.connected {
-        return Ok(format!(
-            "connected runner daemon restarted after upgrade; session reports {}",
-            report
-                .homeboy_version
-                .as_deref()
-                .unwrap_or("the upgraded version")
+        let homeboy_version = report.homeboy_version;
+        return Ok((
+            format!(
+                "connected runner daemon restarted after upgrade; session reports {}",
+                homeboy_version.as_deref().unwrap_or("the upgraded version")
+            ),
+            homeboy_version,
         ));
     }
 

--- a/crates/homeboy-lab-runner/src/upgrade_runners/failure.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/failure.rs
@@ -38,6 +38,8 @@ pub fn runner_upgrade_failure_entry(
         extensions_skipped: Vec::new(),
         extensions_failed: Vec::new(),
         stale_daemon: None,
+        daemon_previous_version: None,
+        daemon_new_version: None,
         exit_code,
         detail,
     }

--- a/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
@@ -226,7 +226,7 @@ pub fn upgrade_runners_with_executor_source_materializer_path_updater_and_reconn
     extension_updates: &[ExtensionUpgradeEntry],
     exec: impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
     status: impl Fn(&str) -> Result<RunnerStatusReport>,
-    reconnect_stale_daemon: impl FnMut(&str) -> Result<String>,
+    reconnect_stale_daemon: impl FnMut(&str) -> Result<(String, Option<String>)>,
     materialize_source_path: impl FnMut(&Runner, &Path) -> Result<String>,
     update_homeboy_path: impl FnMut(&str, &str) -> Result<()>,
 ) -> (Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>) {
@@ -254,7 +254,7 @@ fn upgrade_runners_with_executor_source_materializer_path_updater_and_reconnecto
     extension_updates: &[ExtensionUpgradeEntry],
     mut exec: impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
     status: impl Fn(&str) -> Result<RunnerStatusReport>,
-    mut reconnect_stale_daemon: impl FnMut(&str) -> Result<String>,
+    mut reconnect_stale_daemon: impl FnMut(&str) -> Result<(String, Option<String>)>,
     mut materialize_source_path: impl FnMut(&Runner, &Path) -> Result<String>,
     mut update_homeboy_path: impl FnMut(&str, &str) -> Result<()>,
     expected_controller_identity: Option<&str>,
@@ -301,7 +301,7 @@ pub fn upgrade_runner_with_executor(
     extension_updates: &[ExtensionUpgradeEntry],
     exec: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
     status: &impl Fn(&str) -> Result<RunnerStatusReport>,
-    reconnect_stale_daemon: &mut impl FnMut(&str) -> Result<String>,
+    reconnect_stale_daemon: &mut impl FnMut(&str) -> Result<(String, Option<String>)>,
     materialize_source_path: &mut impl FnMut(&Runner, &Path) -> Result<String>,
     update_homeboy_path: &mut impl FnMut(&str, &str) -> Result<()>,
     expected_controller_identity: Option<&str>,
@@ -610,11 +610,33 @@ pub fn upgrade_runner_with_executor(
     );
     let mut stale_daemon_repair_detail = None;
     let mut stale_daemon = runner_stale_daemon(runner, status);
+    let mut daemon_previous_version = None;
+    let mut daemon_new_version = None;
     if stale_daemon.is_some() && path_drift.is_none() {
+        let daemon_before = stale_daemon
+            .as_ref()
+            .map(|daemon| daemon.session_homeboy_version.clone())
+            .unwrap_or_else(|| "unknown".to_string());
+        daemon_previous_version = Some(daemon_before.clone());
         match reconnect_stale_daemon(&runner.id) {
-            Ok(detail) => {
-                stale_daemon = None;
-                stale_daemon_repair_detail = Some(detail);
+            Ok((detail, observed_version)) => {
+                daemon_new_version = observed_version.clone();
+                let daemon_after = observed_version.as_deref().unwrap_or("unknown");
+                if matches!(
+                    (observed_version.as_deref(), new_version.as_deref()),
+                    (Some(observed), Some(expected))
+                        if crate::connection::versions_match(observed, expected)
+                ) {
+                    stale_daemon = None;
+                    stale_daemon_repair_detail = Some(format!(
+                        "runner daemon identity: {daemon_before} -> {daemon_after}; {detail}"
+                    ));
+                } else {
+                    stale_daemon_repair_detail = Some(format!(
+                        "runner daemon reconnect did not converge: expected {}, observed {daemon_after}; {detail}",
+                        new_version.as_deref().unwrap_or("the configured runner version")
+                    ));
+                }
             }
             Err(err) => {
                 stale_daemon_repair_detail = Some(format!(
@@ -661,6 +683,8 @@ pub fn upgrade_runner_with_executor(
         extensions_skipped,
         extensions_failed,
         stale_daemon,
+        daemon_previous_version,
+        daemon_new_version,
         exit_code,
         detail,
     }

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
@@ -538,7 +538,7 @@ fn rejects_packaged_runner_with_same_version_but_different_controller_identity()
             Ok((exec_output(runner_id, options.command, &stdout, "", 0), 0))
         },
         &runner_status,
-        &mut |_| Ok("reconnected".to_string()),
+        &mut |_| Ok(("reconnected".to_string(), None)),
         &mut |_, _| Ok("unused".to_string()),
         &mut |_, _| Ok(()),
         Some("controller-build"),
@@ -654,10 +654,11 @@ fn restarts_stale_connected_daemon_after_runner_upgrade() {
             stale_runner_status,
             |runner_id| {
                 reconnects.push(runner_id.to_string());
-                Ok(
+                Ok((
                     "connected runner daemon restarted after upgrade; session reports 0.228.5"
                         .to_string(),
-                )
+                    Some("0.228.5".to_string()),
+                ))
             },
             |_runner, _path| unreachable!("source materialization not used"),
             |_runner_id, _homeboy_path| unreachable!("homeboy_path update not used"),
@@ -667,7 +668,49 @@ fn restarts_stale_connected_daemon_after_runner_upgrade() {
     assert_eq!(updated.len(), 1);
     assert_eq!(reconnects, vec!["lab".to_string()]);
     assert_eq!(updated[0].stale_daemon, None);
+    assert_eq!(
+        updated[0].daemon_previous_version.as_deref(),
+        Some("0.228.4")
+    );
+    assert_eq!(updated[0].daemon_new_version.as_deref(), Some("0.228.5"));
     assert!(updated[0]
         .detail
         .contains("connected runner daemon restarted after upgrade"));
+    assert!(updated[0]
+        .detail
+        .contains("runner daemon identity: 0.228.4 -> 0.228.5"));
+}
+
+#[test]
+fn fails_when_reconnected_daemon_still_reports_the_old_version() {
+    let _local_version = pin_local_version_for_fixtures();
+    let runner = ssh_runner("lab", None);
+
+    let (updated, skipped) =
+        upgrade_runners_with_executor_source_materializer_path_updater_and_reconnector(
+            &[runner],
+            false,
+            None,
+            None,
+            &[],
+            |runner_id, options| {
+                let stdout = match options.command.as_slice() {
+                    [_, flag] if flag == "--version" => "homeboy 0.228.5\n",
+                    _ => "{\"success\":true}\n",
+                };
+                Ok((exec_output(runner_id, options.command, stdout, "", 0), 0))
+            },
+            stale_runner_status,
+            |_| Ok(("reconnected".to_string(), Some("0.228.4".to_string()))),
+            |_runner, _path| unreachable!("source materialization not used"),
+            |_runner_id, _homeboy_path| unreachable!("homeboy_path update not used"),
+        );
+
+    assert!(updated.is_empty());
+    assert_eq!(skipped.len(), 1);
+    assert!(!skipped[0].success);
+    assert_eq!(skipped[0].daemon_new_version.as_deref(), Some("0.228.4"));
+    assert!(skipped[0]
+        .detail
+        .contains("runner daemon reconnect did not converge: expected 0.228.5, observed 0.228.4"));
 }

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -144,10 +144,11 @@ pub fn run_upgrade_with_method(
     skip_extensions: bool,
     skip_runners: bool,
     skip_services: bool,
+    runner_only: bool,
     runner_targets: &[String],
     source_path: Option<&Path>,
 ) -> Result<UpgradeResult> {
-    if !runner_targets.is_empty() {
+    if runner_only {
         return run_targeted_runner_upgrade(force, method_override, runner_targets, source_path);
     }
 
@@ -256,6 +257,11 @@ pub fn run_upgrade_with_method(
                     )
                 })?
             };
+            let partial = runner_convergence_failed(
+                &runners_updated,
+                &runners_skipped,
+                Some(previous_version.as_str()),
+            );
             return Ok(UpgradeResult {
                 command: "upgrade".to_string(),
                 install_method,
@@ -265,7 +271,13 @@ pub fn run_upgrade_with_method(
                 new_build_identity: None,
                 source_revision: None,
                 upgraded: false,
-                message: "Already at latest version".to_string(),
+                partial,
+                message: if partial {
+                    "PARTIAL: controller is already current, but configured runners did not converge"
+                        .to_string()
+                } else {
+                    "Already at latest version; configured runners converged".to_string()
+                },
                 restart_required: false,
                 extensions_unrefreshed: warn_unrefreshed_symlinked_extensions(&extensions_updated),
                 extensions_updated,
@@ -341,24 +353,18 @@ pub fn run_upgrade_with_method(
         new_build_identity: new_build_identity.clone(),
         source_revision,
         upgraded: success,
-        message: if success {
-            if let Some(identity) = &new_build_identity {
-                format!(
-                    "Upgraded to {} ({})",
-                    new_version.as_deref().unwrap_or("latest"),
-                    identity
-                )
-            } else {
-                format!("Upgraded to {}", new_version.as_deref().unwrap_or("latest"))
-            }
-        } else if let Some(version) = &new_version {
-            format!(
-                "Upgrade command completed but active binary is still {}",
-                version
-            )
-        } else {
-            "Upgrade command completed but active binary version could not be verified".to_string()
-        },
+        partial: runner_convergence_failed(
+            &runners_updated,
+            &runners_skipped,
+            new_version.as_deref(),
+        ),
+        message: upgrade_message(
+            success,
+            new_version.as_deref(),
+            new_build_identity.as_deref(),
+            &runners_updated,
+            &runners_skipped,
+        ),
         // Source replacement updates the on-disk executable, but this command
         // exits immediately afterwards. Re-execing only `--version` skips the
         // normal completion path and provides no lifecycle benefit.
@@ -388,6 +394,7 @@ fn source_upgrade_noop_result(
         new_build_identity: None,
         source_revision: None,
         upgraded: false,
+        partial: false,
         message: decision.no_op_message(),
         restart_required: false,
         extensions_updated: Vec::new(),
@@ -458,16 +465,23 @@ fn run_targeted_runner_upgrade(
         command: "upgrade".to_string(),
         install_method,
         previous_version: previous_version.clone(),
-        new_version: Some(previous_version),
+        new_version: Some(previous_version.clone()),
         previous_build_identity: Some(previous_build_identity.clone()),
         new_build_identity: Some(previous_build_identity),
         source_revision: None,
         upgraded: false,
-        message: if source_checkout.is_some() {
-            "Selected runners refreshed from the initiating controller source identity".to_string()
-        } else {
-            "Selected runners refreshed without promoting the initiating controller".to_string()
-        },
+        partial: runner_convergence_failed(
+            &runners_updated,
+            &runners_skipped,
+            Some(previous_version.as_str()),
+        ),
+        message: targeted_runner_message(
+            source_checkout.is_some(),
+            &previous_version,
+            runner_targets,
+            &runners_updated,
+            &runners_skipped,
+        ),
         restart_required: false,
         extensions_updated: Vec::new(),
         extensions_skipped: Vec::new(),
@@ -477,6 +491,70 @@ fn run_targeted_runner_upgrade(
         services_restarted: Vec::new(),
         services_pending_restart: Vec::new(),
     })
+}
+
+fn runner_convergence_failed(
+    updated: &[RunnerUpgradeEntry],
+    skipped: &[RunnerUpgradeEntry],
+    controller_version: Option<&str>,
+) -> bool {
+    updated.iter().chain(skipped).any(|runner| {
+        !runner.success
+            || controller_version
+                .is_some_and(|version| runner.new_version.as_deref() != Some(version))
+    })
+}
+
+fn upgrade_message(
+    success: bool,
+    new_version: Option<&str>,
+    new_build_identity: Option<&str>,
+    updated: &[RunnerUpgradeEntry],
+    skipped: &[RunnerUpgradeEntry],
+) -> String {
+    let controller = new_version.unwrap_or("unverified");
+    let identity = new_build_identity
+        .map(|identity| format!(" ({identity})"))
+        .unwrap_or_default();
+    if runner_convergence_failed(updated, skipped, new_version) {
+        return format!(
+            "PARTIAL: controller upgraded to {controller}{identity}, but {} selected configured runner(s) did not converge",
+            updated.len() + skipped.len()
+        );
+    }
+    if success {
+        format!("Controller upgraded to {controller}{identity}; configured runners converged")
+    } else if new_version.is_some() {
+        format!("Upgrade command completed but active controller is still {controller}")
+    } else {
+        "Upgrade command completed but active controller version could not be verified".to_string()
+    }
+}
+
+fn targeted_runner_message(
+    source_checkout: bool,
+    controller_version: &str,
+    runner_targets: &[String],
+    updated: &[RunnerUpgradeEntry],
+    skipped: &[RunnerUpgradeEntry],
+) -> String {
+    let next = format!(
+        "homeboy upgrade --force{}",
+        runner_targets
+            .iter()
+            .map(|runner| format!(" --upgrade-runner {runner}"))
+            .collect::<String>()
+    );
+    let prefix = if source_checkout {
+        "TARGETED RUNNER SCOPE: selected runners refreshed from the initiating controller source identity"
+    } else {
+        "TARGETED RUNNER SCOPE: selected runners refreshed without promoting the initiating controller"
+    };
+    if runner_convergence_failed(updated, skipped, Some(controller_version)) {
+        format!("PARTIAL: {prefix}; controller remains {controller_version}. Next convergence command: {next}")
+    } else {
+        format!("{prefix}; controller remains {controller_version}. To promote controller and reconverge: {next}")
+    }
 }
 
 /// Read extension provenance without refreshing local extension sources. Entries
@@ -1705,5 +1783,88 @@ mod symlinked_extension_tests {
         // not produce warnings (and must not panic on the missing directory).
         let _guard = SudoUserGuard::set(Some("definitely-not-a-real-user-xyz"));
         assert!(detect_unrefreshed_symlinked_extensions(&[]).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod convergence_tests {
+    use super::*;
+
+    fn runner(previous: &str, current: &str, upgraded: bool) -> RunnerUpgradeEntry {
+        RunnerUpgradeEntry {
+            runner_id: "lab".to_string(),
+            homeboy_path: "/opt/homeboy/homeboy".to_string(),
+            success: true,
+            upgraded,
+            previous_version: Some(previous.to_string()),
+            new_version: Some(current.to_string()),
+            bare_homeboy_version: None,
+            path_drift: None,
+            recovery_commands: Vec::new(),
+            extensions_synced: Vec::new(),
+            extensions_skipped: Vec::new(),
+            extensions_failed: Vec::new(),
+            stale_daemon: None,
+            daemon_previous_version: None,
+            daemon_new_version: None,
+            exit_code: 0,
+            detail: String::new(),
+        }
+    }
+
+    #[test]
+    fn successful_but_stale_child_is_partial_controller_convergence() {
+        let runner = runner("0.301.2", "0.301.2", false);
+
+        assert!(runner_convergence_failed(
+            &[runner.clone()],
+            &[],
+            Some("0.304.0")
+        ));
+        assert!(upgrade_message(true, Some("0.304.0"), None, &[runner], &[])
+            .starts_with("PARTIAL: controller upgraded to 0.304.0"));
+    }
+
+    #[test]
+    fn failed_child_is_partial_even_when_controller_is_already_current() {
+        let mut runner = runner("0.304.0", "0.304.0", false);
+        runner.success = false;
+
+        assert!(runner_convergence_failed(&[], &[runner], None));
+    }
+
+    #[test]
+    fn targeted_runner_only_scope_names_exact_convergence_command() {
+        let message = targeted_runner_message(
+            false,
+            "0.301.2",
+            &["lab".to_string()],
+            &[runner("0.301.2", "0.301.2", false)],
+            &[],
+        );
+
+        assert!(message.starts_with("TARGETED RUNNER SCOPE"));
+        assert!(message.contains("controller remains 0.301.2"));
+        assert!(message.contains("homeboy upgrade --force --upgrade-runner lab"));
+    }
+
+    #[test]
+    fn targeted_runner_only_scope_is_partial_when_runner_remains_stale() {
+        let message = targeted_runner_message(
+            false,
+            "0.301.2",
+            &["lab".to_string()],
+            &[runner("0.299.0", "0.299.0", false)],
+            &[],
+        );
+
+        assert!(message.starts_with("PARTIAL: TARGETED RUNNER SCOPE"));
+    }
+
+    #[test]
+    fn changed_runner_is_partial_when_final_version_still_misses_controller() {
+        let runner = runner("0.299.0", "0.300.0", true);
+
+        assert!(runner_convergence_failed(&[runner], &[], Some("0.301.2")));
     }
 }

--- a/crates/homeboy-upgrade/src/upgrade/types.rs
+++ b/crates/homeboy-upgrade/src/upgrade/types.rs
@@ -68,31 +68,36 @@ pub struct UpgradeResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_revision: Option<String>,
     pub upgraded: bool,
+    /// True when a requested controller/runner fleet upgrade could not fully
+    /// converge. Omitted for successful responses so existing consumers keep
+    /// their current payload shape; accepted when reading persisted responses.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub partial: bool,
     pub message: String,
     pub restart_required: bool,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extensions_updated: Vec<ExtensionUpgradeEntry>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extensions_skipped: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub runners_updated: Vec<RunnerUpgradeEntry>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub runners_skipped: Vec<RunnerUpgradeEntry>,
     /// Symlinked extension clones owned by the invoking (sudo) user that this
     /// upgrade could not refresh because it ran under a different `$HOME`.
     /// Each entry carries the exact recovery command to bring the clone current.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extensions_unrefreshed: Vec<UnrefreshedExtensionWarning>,
     /// Long-running, binary-resident services (declared in config) that were
     /// successfully restarted to pick up the newly-swapped binary. Distinct
     /// from `restart_required`, which only describes the CLI process itself.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub services_restarted: Vec<ServiceRestartEntry>,
     /// Declared resident services that still hold the old binary and need a
     /// restart: either because a restart attempt failed, or because the
     /// upgrade was run with `--no-restart-services`. Each entry carries the
     /// exact recovery command so the operator can restart it manually.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub services_pending_restart: Vec<ServiceRestartEntry>,
 }
 
@@ -174,6 +179,10 @@ pub struct RunnerUpgradeEntry {
     pub extensions_failed: Vec<RunnerExtensionSyncEntry>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stale_daemon: Option<RunnerDaemonDriftEntry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub daemon_previous_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub daemon_new_version: Option<String>,
     pub exit_code: i32,
     pub detail: String,
 }
@@ -194,6 +203,23 @@ pub struct RunnerDaemonDriftEntry {
     pub session_homeboy_version: String,
     pub current_homeboy_version: String,
     pub recovery_commands: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upgrade_response_without_new_fields_remains_deserializable() {
+        let result: UpgradeResult = serde_json::from_str(
+            r#"{"command":"upgrade","install_method":"binary","previous_version":"0.301.2","new_version":"0.304.0","upgraded":true,"message":"ok","restart_required":false}"#,
+        )
+        .expect("pre-convergence response remains readable");
+
+        assert!(!result.partial);
+        assert!(result.runners_updated.is_empty());
+        assert!(result.services_pending_restart.is_empty());
+    }
 }
 
 #[derive(Deserialize)]

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -26,8 +26,9 @@ Runner sync uses this contract:
 - `--force`: Force upgrade even if already at the latest version.
 - `--no-restart`: Skip automatic restart after upgrade. Useful for scripted environments.
 - `--skip-extensions`: Skip automatic extension updates.
-- `--skip-runners`: Skip automatic configured runner upgrades.
-- `--upgrade-runner`: Upgrade only the named configured runner. Repeat to target multiple runners. Runner-only mode leaves the controller unchanged; source-built controllers pin the initiating source identity, while packaged controllers retain their configured runner upgrade method.
+- `--skip-runners`: Upgrade the controller only; cannot be combined with `--upgrade-runner`.
+- `--upgrade-runner`: Select configured runners to converge with the controller upgrade. Repeat to target multiple runners.
+- `--runner-only`: With `--upgrade-runner`, preserve the controller and refresh only the selected runners. The response explicitly reports this partial scope and the exact controller-plus-runner convergence command.
 - `--method`: Override install method detection (`homebrew|cargo|source|binary`).
 
 ## Installation Method Detection
@@ -104,6 +105,7 @@ homeboy upgrade --skip-runners
 - `previous_version`: Version before upgrade
 - `new_version`: Version after upgrade (may be null)
 - `upgraded`: Boolean indicating if upgrade was performed
+- `partial`: Present and true when a selected runner did not converge with the controller
 - `message`: Human-readable status message
 - `restart_required`: Boolean indicating if a restart is needed (true only for source installs)
 - `extensions_updated`: Extension upgrade entries when installed extensions were checked


### PR DESCRIPTION
## Summary
Require one upgrade invocation to converge selected runner binaries and connected daemons before reporting success.

## What changed
- Added explicit runner-only scope, partial fleet outcomes, final-version aggregation, structured daemon identities, and post-reconnect version verification.

## How to test
1. Run `cargo test -p homeboy-upgrade -- --test-threads=1`; expect 117 tests pass.
2. Run `cargo test -p homeboy-lab-runner upgrade_runners -- --test-threads=1`; expect 30 tests pass.
3. Run `cargo test -p homeboy-cli upgrade -- --test-threads=1`; expect 5 tests pass.
4. Run `cargo check -p homeboy-upgrade -p homeboy-lab-runner -p homeboy-cli`; expect packages compile.

## Compatibility
Optional/defaulted response fields preserve existing serialized response readers.

## Evidence
**Declared public contracts**
- `upgrade-json`: Adds optional partial and daemon before/after identity fields while preserving old response deserialization.
- `upgrade-cli`: \--upgrade-runner selects convergence targets; --runner-only explicitly preserves the controller.

**Compatibility impact:** New response fields are optional/defaulted; old persisted responses remain deserializable. Existing controller-only behavior remains available through --skip-runners.

**External-consumer impact:** CLI and JSON consumers may optionally handle partial and daemon identity fields; existing fields remain present.

**External usage:** unavailable_manual_review; source: Repository-local RunnerUpgradeEntry contract and compatibility test; limitations: No live mixed-version SSH runner was available locally.; evidence: https://github.com/Extra-Chill/homeboy/blob/9773f5550c46047e83c395de606a0322a1ae10d7/crates/homeboy-upgrade/src/upgrade/types.rs

- Base unchanged since verification: main remains at 9773f5550c46047e83c395de606a0322a1ae10d7.
- CI expected: CI
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9467
- Verified finalization base: main at 9773f5550c46047e83c395de606a0322a1ae10d7
- cli-upgrade-tests: passed (5-tests) (Passed)
- package-check: passed (Passed)
- runner-upgrade-tests: passed (30-tests) (Passed)
- upgrade-tests: passed (117-tests) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Drafted the initial implementation, reviewed acceptance gaps, corrected convergence aggregation and daemon identity verification, and added regression coverage.

## Source relationships
- Closes #9467
