### PR TITLE
Extract shared durable-stage tamper error constructor

### DIFF
--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -682,6 +682,19 @@ fn durable_stage_header_matches(
         && plan_digest == canonical_digest(&request.durable_agent_task_plan)?)
 }
 
+/// The uniform "missing, tampered, or bound to different run inputs" validation
+/// error every durable Lab stage raises when its persisted state fails to bind
+/// to the current run. `field` is the argument name; `subject` is the stage's
+/// operator-facing noun (e.g. "dispatch receipt", "durable runtime state").
+fn durable_stage_tamper_error(field: &'static str, subject: &str) -> Error {
+    Error::validation_invalid_argument(
+        field,
+        format!("Lab staging {subject} is missing, tampered, or bound to different run inputs"),
+        None,
+        None,
+    )
+}
+
 /// Complete, owner-only output of the one admitted production boundary. Later
 /// stages consume this attachment rather than recomputing or re-syncing it.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -854,7 +867,10 @@ impl DurableLabDispatchReceipt {
                 .as_deref()
                 .is_some_and(|id| id != self.runner_job_id)
         {
-            return Err(Error::validation_invalid_argument("durable_dispatch_receipt", "Lab staging dispatch receipt is missing, tampered, or bound to different run inputs", None, None));
+            return Err(durable_stage_tamper_error(
+                "durable_dispatch_receipt",
+                "dispatch receipt",
+            ));
         }
         Ok(())
     }
@@ -883,7 +899,10 @@ impl DurableLabRuntimeStage {
                 .as_deref()
                 .is_some_and(|id| id != self.runtime_id)
         {
-            return Err(Error::validation_invalid_argument("durable_runtime_stage", "Lab staging durable runtime state is missing, tampered, or bound to different run inputs", None, None));
+            return Err(durable_stage_tamper_error(
+                "durable_runtime_stage",
+                "durable runtime state",
+            ));
         }
         Ok(())
     }
@@ -939,7 +958,10 @@ impl DurableLabHydrationStage {
             || self.dispatch_inputs.get("plan") != Some(&self.plan)
             || checkpoint.hydration_id.as_deref() != Some(self.hydration_id.as_str())
         {
-            return Err(Error::validation_invalid_argument("durable_hydration_stage", "Lab staging durable hydration receipt is missing, tampered, or bound to different run inputs", None, None));
+            return Err(durable_stage_tamper_error(
+                "durable_hydration_stage",
+                "durable hydration receipt",
+            ));
         }
         Ok(())
     }
@@ -988,7 +1010,10 @@ impl DurableLabWorkspaceStage {
                 .and_then(Value::as_str)
                 != Some(self.remote_cwd.as_str())
         {
-            return Err(Error::validation_invalid_argument("durable_workspace_stage", "Lab staging durable workspace state is missing, tampered, or bound to different run inputs", None, None));
+            return Err(durable_stage_tamper_error(
+                "durable_workspace_stage",
+                "durable workspace state",
+            ));
         }
         if let (Some(source), Some(workspace)) =
             (&checkpoint.source_snapshot_id, &checkpoint.workspace_id)


### PR DESCRIPTION
## Summary
Four durable Lab stage `validate` methods (dispatch receipt, runtime, hydration, workspace) each constructed the identical validation error inline:

```rust
Error::validation_invalid_argument("durable_<x>", "Lab staging <subject> is missing, tampered, or bound to different run inputs", None, None)
```

Extract a `durable_stage_tamper_error(field, subject)` helper.

## Scope / risk
- Behavior-preserving: field argument names, error code, and the exact operator-facing messages are byte-identical (the helper reconstructs the same string).
- The terminal receipt keeps its distinct "does not match the authoritative runner job" wording (not folded in).

## Test
- `cargo fmt --check` clean; `cargo check -p homeboy-lab-runner --lib` clean.
- `cargo test -p homeboy-lab-runner --lib lab_staging_controller` — **39 tests pass, 0 failed**.

## Notes
Tech-debt burndown: third bounded, low-risk dedup within the Lab offload path (follows #9737 header dedup and #9757 field-decode dedup). Incrementally shrinking the dual-path duplication with verified, behavior-preserving steps.