### PR TITLE
Consolidate duplicated allowlist shell_arg in lab-runner

### DIFF
--- a/crates/homeboy-lab-runner/src/execution/redaction.rs
+++ b/crates/homeboy-lab-runner/src/execution/redaction.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::shell_quote::shell_arg;
 use serde_json::Value;
 
 use homeboy_core::api_jobs::{Job, JobArtifactMetadata, JobEvent, JobStatus};
@@ -159,16 +160,6 @@ pub(super) fn runner_exec_diagnostics(
         homeboy_binaries: None,
         hints,
     })
-}
-
-fn shell_arg(value: &str) -> String {
-    if value
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '='))
-    {
-        return value.to_string();
-    }
-    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 pub(super) fn runner_result(

--- a/crates/homeboy-lab-runner/src/git_dependency_materialization.rs
+++ b/crates/homeboy-lab-runner/src/git_dependency_materialization.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use crate::shell_quote::shell_arg;
 use homeboy_core::engine::shell;
 use homeboy_core::error::{Error, Result};
 use homeboy_rig::spec::DependencyCacheSpec;
@@ -801,16 +802,6 @@ fn terminal_dependency_error(
         ),
         Some(hints),
     )
-}
-
-fn shell_arg(value: &str) -> String {
-    if value
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '='))
-    {
-        return value.to_string();
-    }
-    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn run_git(local_path: &Path, args: &[&str]) -> Result<()> {

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -79,6 +79,7 @@ mod runtime_materialization_status;
 pub mod runtime_materializer;
 mod runtime_overlay_freshness;
 mod session;
+mod shell_quote;
 mod source_materialization;
 mod tool_registry;
 mod transport;

--- a/crates/homeboy-lab-runner/src/rig_materialization/rig_source_install.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/rig_source_install.rs
@@ -8,6 +8,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use crate::shell_quote::shell_arg;
 use homeboy_core::{Error, Result};
 
 use super::super::{
@@ -218,16 +219,6 @@ pub(super) fn validate_installed_rig_source(
             "Run `homeboy rig sources list` to inspect installed rig sources.".to_string(),
         ]),
     ))
-}
-
-fn shell_arg(value: &str) -> String {
-    if value
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '='))
-    {
-        return value.to_string();
-    }
-    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 #[cfg(test)]

--- a/crates/homeboy-lab-runner/src/shell_quote.rs
+++ b/crates/homeboy-lab-runner/src/shell_quote.rs
@@ -1,0 +1,46 @@
+//! Crate-internal shell argument quoting used by lab-runner command builders.
+//!
+//! This uses an *allowlist* policy: a value is emitted verbatim only when every
+//! character is in a known-safe set, otherwise it is single-quoted. It is
+//! intentionally distinct from [`homeboy_core::engine::shell::quote_arg`], which
+//! uses a shell-metacharacter *denylist* and therefore quotes a different set of
+//! inputs. Several lab-runner command builders relied on the allowlist behavior;
+//! this consolidates the previously copy-pasted definitions into one place
+//! without changing what gets quoted.
+pub(crate) fn shell_arg(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '='))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_chars_are_not_quoted() {
+        assert_eq!(shell_arg("abc-DEF_1.2/x:y=z"), "abc-DEF_1.2/x:y=z");
+    }
+
+    #[test]
+    fn unsafe_chars_are_single_quoted() {
+        assert_eq!(shell_arg("a b"), "'a b'");
+        assert_eq!(shell_arg("a@b"), "'a@b'");
+    }
+
+    #[test]
+    fn embedded_single_quote_is_escaped() {
+        assert_eq!(shell_arg("a'b"), "'a'\\''b'");
+    }
+
+    #[test]
+    fn empty_value_is_quoted() {
+        // Empty string has no chars, so `all` is vacuously true and it is emitted
+        // verbatim — preserving the historical behavior of these call sites.
+        assert_eq!(shell_arg(""), "");
+    }
+}

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -1814,15 +1814,7 @@ fn has_pending_apply_back_local(path: &Path) -> bool {
     })
 }
 
-pub(crate) fn shell_arg(value: &str) -> String {
-    if value
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '='))
-    {
-        return value.to_string();
-    }
-    format!("'{}'", value.replace('\'', "'\\''"))
-}
+pub(crate) use crate::shell_quote::shell_arg;
 
 fn workspace_lease(
     runner_id: &str,


### PR DESCRIPTION
## Summary
Four **byte-identical** copies of an allowlist-based `shell_arg` shell-quoting helper were copy-pasted across the `homeboy-lab-runner` crate. This extracts them into a single crate-internal `shell_quote` module and repoints the call sites, with no behavior change.

Consolidated (all confirmed byte-identical via hash):
- `git_dependency_materialization.rs`
- `rig_materialization/rig_source_install.rs`
- `workspace/sync/mod.rs` (was already `pub(crate)`; now a `pub(crate) use` re-export so `super::shell_arg` importers keep working)
- `execution/redaction.rs`

## Why not merge with `homeboy_core::engine::shell::quote_arg`
The extracted helper uses an **allowlist** policy (emit verbatim only when every char is in `[alnum] - _ . / : =`, else single-quote). Core's `quote_arg` uses a shell-metacharacter **denylist** and therefore quotes a *different* set of inputs (e.g. `%`, `+`, unicode are quoted by the allowlist but not by the denylist). Merging them would silently change quoting on command-dispatch paths, so they are intentionally kept separate.

Also left untouched (different behavior):
- The two lab-runner `shell_arg` definitions that already delegate to `quote_arg`/`quote_path` (`extension_materialization.rs`, `homeboy_refresh.rs`).
- The two `@`-allowing variants with empty-string guards (`upgrade_runners/commands.rs`, `lab/offload/fallback_commands.rs`).

## Behavior preservation
The extracted body is byte-for-byte the previous logic, including the pre-existing quirk that an empty string is emitted verbatim (vacuous `all`). Added unit tests pin: safe-chars pass through, unsafe chars single-quoted, embedded `'` escaped, empty-string verbatim.

## Verification
- `cargo fmt -p homeboy-lab-runner --check` clean
- `cargo check -p homeboy-lab-runner --lib` compiles (no new warnings; no reference to shell_arg/shell_quote in warnings)
- Test compilation deferred to CI per this VPS's no-heavy-local-build rule

Net diff: -39/+5 across 5 files plus one new ~50-line documented+tested module.