### PR TITLE
Restore durable Cook baselines on retry

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2144,6 +2144,7 @@ pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRu
     let source = store::read_record(&resolve_run_id(run_id)?)?;
     let mut plan = load_controller_plan(&source.run_id)?;
     restore_initial_cook_candidate_workspace(&mut plan)?;
+    restore_follow_up_cook_candidate_workspace(&mut plan)?;
     let mut retry = submit_plan(&plan, requested_run_id)?;
     let metadata = retry.ensure_metadata_object();
     if let Some(route) =
@@ -2180,6 +2181,117 @@ pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRu
     metadata.insert("retry_requested_at".to_string(), json!(now_timestamp()));
     store::write_record(&retry)?;
     Ok(retry)
+}
+
+/// Rebuild a gate-failed Cook candidate from its controller-owned promotion
+/// before retrying. A persisted follow-up plan names a temporary checkout, not
+/// authority to reuse whatever happens to exist at that path.
+fn restore_follow_up_cook_candidate_workspace(plan: &mut AgentTaskPlan) -> Result<()> {
+    let candidate_tasks = plan
+        .tasks
+        .iter()
+        .enumerate()
+        .filter(|(_, task)| {
+            task.inputs
+                .pointer("/cook_loop/artifact_provenance/source_run_id")
+                .and_then(Value::as_str)
+                .is_some()
+        })
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    if candidate_tasks.len() > 1 {
+        return Err(Error::validation_invalid_argument(
+            "cook_loop.artifact_provenance",
+            "Cook retry plan has ambiguous prior candidates",
+            None,
+            None,
+        ));
+    }
+    let Some(&index) = candidate_tasks.first() else {
+        return Ok(());
+    };
+    let task = &mut plan.tasks[index];
+    let provenance = task
+        .inputs
+        .pointer("/cook_loop/artifact_provenance")
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cook_loop.artifact_provenance",
+                "Cook retry candidate has no prior artifact evidence",
+                None,
+                None,
+            )
+        })?;
+    let source_run_id = provenance
+        .get("source_run_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cook_loop.artifact_provenance.source_run_id",
+                "Cook retry candidate has no source run evidence",
+                None,
+                None,
+            )
+        })?;
+    let source_task_id = provenance
+        .get("source_task_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cook_loop.artifact_provenance.source_task_id",
+                "Cook retry candidate has no source task evidence",
+                None,
+                None,
+            )
+        })?;
+    let source_sha256 = provenance
+        .get("source_patch_artifact_sha256")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cook_loop.artifact_provenance.source_patch_artifact_sha256",
+                "Cook retry candidate has no patch identity evidence",
+                None,
+                None,
+            )
+        })?;
+    let promotion = crate::agent_task_service::persisted_promotion_for_attempt(source_run_id)?
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cook_loop.artifact_provenance",
+                "Cook retry candidate has no durable prior promotion",
+                Some(source_run_id.to_string()),
+                None,
+            )
+        })?;
+    if promotion.source.task_id != source_task_id
+        || promotion.patch_artifact.sha256.as_deref() != Some(source_sha256)
+    {
+        return Err(Error::validation_invalid_argument(
+            "cook_loop.artifact_provenance",
+            "Cook retry candidate evidence does not match its prior promotion",
+            Some(source_run_id.to_string()),
+            None,
+        ));
+    }
+    let baseline = crate::agent_task_service::materialize_follow_up_baseline(
+        &promotion,
+        source_run_id,
+        &task.task_id,
+    )?;
+    task.workspace.root = Some(baseline.path.display().to_string());
+    task.executor.remap_workspace_root(
+        task.workspace
+            .root
+            .as_deref()
+            .expect("baseline path is assigned"),
+    );
+    task.metadata["verified_cook_baseline"] = baseline.capability().verified_baseline_provenance();
+    baseline.preserve_for_retry();
+    Ok(())
 }
 
 /// Cook's first dirty-candidate baseline is process-local and removed after a

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -15,6 +15,7 @@ use crate::agent_task_scheduler::{
 use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStore, RemoteRunnerJobRequest};
 use homeboy_core::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};
+use std::process::Command;
 use std::sync::{Arc, Mutex};
 
 enum TestRunnerReconciliation {
@@ -393,6 +394,108 @@ fn retry_stamps_replacement_run_with_current_runtime_not_stale_source() {
             current_identity,
             "retry must not rewrite the source run's runtime provenance"
         );
+    });
+}
+
+#[test]
+fn retry_rebuilds_follow_up_candidate_from_durable_promotion() {
+    with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("temporary repository");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir(&repo).expect("create repository");
+        let git = |args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .expect("run git");
+            assert!(
+                output.status.success(),
+                "git {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        };
+        git(&["init"]);
+        std::fs::write(repo.join("candidate.txt"), "base\n").expect("write base");
+        git(&["add", "candidate.txt"]);
+        git(&[
+            "-c",
+            "user.name=Homeboy Test",
+            "-c",
+            "user.email=homeboy-test@localhost",
+            "commit",
+            "-m",
+            "base",
+        ]);
+        let head = git(&["rev-parse", "HEAD"]);
+        std::fs::write(repo.join("candidate.txt"), "candidate\n").expect("write candidate");
+        let patch = format!("{}\n", git(&["diff", "--binary"]));
+        let patch_path = temp.path().join("candidate.patch");
+        std::fs::write(&patch_path, &patch).expect("write patch artifact");
+        let patch_sha = format!("{:x}", Sha256::digest(patch.as_bytes()));
+
+        let source_run = "cook-follow-up-source";
+        let mut plan = test_plan();
+        plan.tasks[0].inputs = json!({
+            "cook_loop": {
+                "artifact_provenance": {
+                    "source_run_id": source_run,
+                    "source_task_id": "task-a",
+                    "source_patch_artifact_sha256": patch_sha,
+                }
+            }
+        });
+        plan.tasks[0].workspace.root = Some("/stale/follow-up-baseline".to_string());
+        submit_plan(&plan, Some(source_run)).expect("submit source run");
+        record_promotion(
+            source_run,
+            json!({
+                "schema": "homeboy/agent-task-promotion-report/v1",
+                "status": "gate_failed",
+                "source": {"kind": "aggregate", "task_id": "task-a", "run_id": source_run},
+                "to_worktree": "homeboy@test",
+                "target": {"worktree": "homeboy@test", "path": repo, "head": head},
+                "patch_artifact": {
+                    "id": "patch",
+                    "kind": "patch",
+                    "path": patch_path,
+                    "sha256": patch_sha,
+                },
+                "provenance": {
+                    "worktree_path": repo,
+                    "gate_feedback_baseline": {"current_diff": patch},
+                },
+                "operator_notification": {"status": "completed", "message": "complete"},
+            }),
+        )
+        .expect("record durable promotion");
+
+        let replacement = retry(source_run, Some("cook-follow-up-retry")).expect("retry succeeds");
+        let restored = load_plan(&replacement.run_id).expect("load replacement plan");
+        let restored_task = &restored.tasks[0];
+        let restored_root = restored_task
+            .workspace
+            .root
+            .as_deref()
+            .expect("restored root");
+        assert_ne!(restored_root, "/stale/follow-up-baseline");
+        assert_eq!(
+            std::fs::read_to_string(std::path::Path::new(restored_root).join("candidate.txt"))
+                .expect("read restored candidate"),
+            "candidate\n"
+        );
+        assert_eq!(
+            restored_task.metadata["verified_cook_baseline"]["source_run_id"],
+            source_run
+        );
+        assert_eq!(
+            restored_task.metadata["verified_cook_baseline"]["promoted_patch_artifact_sha256"],
+            patch_sha
+        );
+
+        git(&["worktree", "remove", "--force", restored_root]);
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -102,6 +102,13 @@ impl CookFollowUpBaseline {
     pub(crate) fn artifact_provenance(&self) -> Value {
         self.capability.artifact_provenance()
     }
+
+    /// A lifecycle retry persists this controller-materialized checkout for a
+    /// later provider dispatch. Unlike the in-process Cook path, no owner is
+    /// available to remove it when this function returns.
+    pub(crate) fn preserve_for_retry(self) {
+        std::mem::forget(self);
+    }
 }
 
 #[cfg(any(test, feature = "test-support"))]


### PR DESCRIPTION
## Summary
Restore retryable dirty Cook candidates from controller-owned durable promotion evidence instead of stale temporary workspace paths.

## What changed
- Validates the persisted source run, task, and patch digest; materializes a verified follow-up baseline; remaps the retry plan; and preserves that baseline through deferred dispatch.
- Adds lifecycle coverage proving the stale path is replaced and candidate content and provenance survive retry.

## How to test
1. Run `cargo test -p homeboy-agents committed_harvest -- --test-threads=1`; expect 8 matching tests pass.
2. Run `cargo test -p homeboy-agents dirty -- --test-threads=1`; expect 6 matching tests pass.
3. Run `cargo test -p homeboy-agents retry_rebuilds_follow_up_candidate_from_durable_promotion -- --test-threads=1`; expect lifecycle regression passes.
4. Run `cargo check -p homeboy-agents -p homeboy-cli`; expect both crates compile.
5. Run `cargo fmt --check`; expect formatting is clean.
6. Run `git diff --check`; expect diff has no whitespace errors.

## Compatibility
Existing clean and initial-candidate retries remain unchanged; follow-up retries now fail closed on absent or mismatched durable promotion evidence.

## Evidence
- Base unchanged since verification: main remains at d33eb3b8b69d420f09800a2ea410ee83f22be908.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/8375
- Verified finalization base: main at d33eb3b8b69d420f09800a2ea410ee83f22be908
- agents-cli-check: passed (Passed)
- committed-harvest: passed (8 tests) (Passed)
- dirty-workspace: passed (6 tests) (Passed)
- lifecycle-regression: passed (1 test) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** OpenCode with openai/gpt-5.6-terra drafted the implementation; OpenCode with openai/gpt-5.6-sol reviewed it and added the lifecycle regression test.

## Source relationships
- Closes Extra-Chill/homeboy#8375
