### PR TITLE
refactor: consolidate canonical-JSON into homeboy-engine-primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,6 +862,7 @@ name = "homeboy-component-contract"
 version = "0.1.0"
 dependencies = [
  "homeboy-audit-contract",
+ "homeboy-engine-primitives",
  "homeboy-error",
  "homeboy-extension-contract",
  "serde",

--- a/crates/contracts/homeboy-component-contract/Cargo.toml
+++ b/crates/contracts/homeboy-component-contract/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 homeboy-error = { version = "0.1.0", path = "../../homeboy-error" }
+homeboy-engine-primitives = { version = "0.1.0", path = "../../homeboy-engine-primitives" }
 homeboy-audit-contract = { version = "0.1.0", path = "../homeboy-audit-contract" }
 homeboy-extension-contract = { version = "0.1.0", path = "../homeboy-extension-contract" }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/contracts/homeboy-component-contract/src/model.rs
+++ b/crates/contracts/homeboy-component-contract/src/model.rs
@@ -7,6 +7,7 @@ use crate::config::{
     GithubConfig, ScopeConfig, ScopedExtensionConfig, VersionTarget,
 };
 use homeboy_audit_contract::AuditConfig;
+use homeboy_engine_primitives::canonical_json::canonical_json;
 
 /// Lifecycle state of a component.
 ///
@@ -349,7 +350,8 @@ impl Component {
     /// Return a stable serialization suitable for comparing resolved component
     /// configuration across independently loaded snapshots.
     pub fn canonical_identity(&self) -> serde_json::Result<String> {
-        serde_json::to_value(self).and_then(|value| serde_json::to_string(&canonical_json(value)))
+        serde_json::to_value(self)
+            .and_then(|value| serde_json::to_string(&canonical_json(value)))
     }
 
     /// Return a stable identity for comparing a component's *configured*
@@ -531,23 +533,6 @@ impl Component {
                 "Homeboy does not execute component-level build_command.".to_string(),
             ]),
         ))
-    }
-}
-
-fn canonical_json(value: serde_json::Value) -> serde_json::Value {
-    match value {
-        serde_json::Value::Array(values) => {
-            serde_json::Value::Array(values.into_iter().map(canonical_json).collect())
-        }
-        serde_json::Value::Object(values) => serde_json::Value::Object(
-            values
-                .into_iter()
-                .map(|(key, value)| (key, canonical_json(value)))
-                .collect::<std::collections::BTreeMap<_, _>>()
-                .into_iter()
-                .collect(),
-        ),
-        value => value,
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/private_attachment.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/private_attachment.rs
@@ -4,8 +4,8 @@ use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use homeboy_core::engine::canonical_json::canonical_json_bytes;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Value;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
@@ -62,30 +62,8 @@ fn attachment_path(run_id: &str, kind: &str) -> Result<PathBuf> {
 
 /// Version 1 digests recursively canonicalized JSON: object keys are sorted and
 /// all persistence serializes that same canonical envelope.
-fn canonical_json<T: Serialize>(value: &T) -> Result<Value> {
-    let value = serde_json::to_value(value)
-        .map_err(|_| Error::internal_json("serialize private run attachment", None))?;
-    Ok(canonicalize(value))
-}
-
-fn canonicalize(value: Value) -> Value {
-    match value {
-        Value::Array(values) => Value::Array(values.into_iter().map(canonicalize).collect()),
-        Value::Object(values) => {
-            let mut keys: Vec<_> = values.into_iter().collect();
-            keys.sort_unstable_by(|left, right| left.0.cmp(&right.0));
-            Value::Object(
-                keys.into_iter()
-                    .map(|(key, value)| (key, canonicalize(value)))
-                    .collect(),
-            )
-        }
-        value => value,
-    }
-}
-
 fn canonical_bytes<T: Serialize>(payload: &T) -> Result<Vec<u8>> {
-    serde_json::to_vec(&canonical_json(payload)?)
+    canonical_json_bytes(payload)
         .map_err(|_| Error::internal_json("serialize private run attachment", None))
 }
 

--- a/crates/homeboy-core/src/engine/mod.rs
+++ b/crates/homeboy-core/src/engine/mod.rs
@@ -6,8 +6,8 @@
 // crate. Re-exported here so existing `crate::engine::{shell,command,...}`
 // call sites keep working unchanged.
 pub use homeboy_engine_primitives::{
-    baseline, codebase_scan, command, detail_output, edit_op, edit_op_apply, identifier, language,
-    output_parse, shell, template, text, validation,
+    baseline, canonical_json, codebase_scan, command, detail_output, edit_op, edit_op_apply,
+    identifier, language, output_parse, shell, template, text, validation,
 };
 // local_files was `pub(crate)` in-tree; preserve that visibility across the
 // crate boundary rather than widening it via the `pub use` above.

--- a/crates/homeboy-engine-primitives/src/canonical_json.rs
+++ b/crates/homeboy-engine-primitives/src/canonical_json.rs
@@ -1,0 +1,116 @@
+//! Canonical JSON: a single, order-independent serialization contract.
+//!
+//! Multiple subsystems compute stable digests over JSON payloads (Lab staging
+//! recipe digests, private run-attachment digests, component/deploy evidence
+//! digests). Each independently reimplemented "recursively sort object keys"
+//! canonicalization under a different name (#9759). Divergence between those
+//! copies would silently change digests, so the algorithm is consolidated here
+//! as the one canonicalization contract all consumers share.
+//!
+//! The contract: object keys are sorted recursively; arrays preserve order but
+//! their elements are canonicalized; scalars pass through unchanged. This is
+//! byte-for-byte identical to the previous per-crate copies.
+
+use serde::Serialize;
+use serde_json::Value;
+
+/// Recursively canonicalize a JSON value: object keys are sorted (ascending,
+/// by key string), array order is preserved, scalars pass through. Applied
+/// before serialization so `serde_json::to_vec` produces a stable, order-
+/// independent byte string suitable for hashing.
+pub fn canonical_json(value: Value) -> Value {
+    match value {
+        Value::Array(values) => Value::Array(values.into_iter().map(canonical_json).collect()),
+        Value::Object(values) => {
+            let mut fields: Vec<_> = values.into_iter().collect();
+            fields.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+            Value::Object(
+                fields
+                    .into_iter()
+                    .map(|(key, value)| (key, canonical_json(value)))
+                    .collect(),
+            )
+        }
+        value => value,
+    }
+}
+
+/// Serialize any `Serialize` value to its canonical JSON byte string.
+///
+/// Equivalent to `serde_json::to_vec(&canonical_json(serde_json::to_value(v)?))`.
+/// Consumers hash the returned bytes to produce a stable digest.
+pub fn canonical_json_bytes<T: Serialize>(value: &T) -> serde_json::Result<Vec<u8>> {
+    let value = serde_json::to_value(value)?;
+    serde_json::to_vec(&canonical_json(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{canonical_json, canonical_json_bytes};
+    use serde_json::json;
+
+    #[test]
+    fn object_keys_are_sorted_recursively() {
+        let input = json!({
+            "b": 1,
+            "a": { "z": true, "y": false },
+            "c": [ { "n": 2, "m": 1 } ]
+        });
+        let canonical = canonical_json(input);
+        let bytes = serde_json::to_vec(&canonical).unwrap();
+        let rendered = String::from_utf8(bytes).unwrap();
+        assert_eq!(
+            rendered,
+            r#"{"a":{"y":false,"z":true},"b":1,"c":[{"m":1,"n":2}]}"#
+        );
+    }
+
+    #[test]
+    fn output_is_order_independent() {
+        // Two objects that differ only in key insertion order must canonicalize
+        // to identical bytes — the property every digest consumer relies on.
+        let a = json!({ "one": 1, "two": { "b": 2, "a": 1 }, "three": [3, 2, 1] });
+        let b = json!({ "three": [3, 2, 1], "two": { "a": 1, "b": 2 }, "one": 1 });
+        assert_eq!(
+            canonical_json(a.clone()),
+            canonical_json(b.clone()),
+            "reordered keys must canonicalize identically"
+        );
+        assert_eq!(
+            canonical_json_bytes(&a).unwrap(),
+            canonical_json_bytes(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn array_order_is_preserved() {
+        // Arrays are ordered data — canonicalization must NOT reorder elements,
+        // only canonicalize each element.
+        let input = json!([3, 1, 2, { "b": 1, "a": 2 }]);
+        let canonical = canonical_json(input);
+        let rendered = serde_json::to_string(&canonical).unwrap();
+        assert_eq!(rendered, r#"[3,1,2,{"a":2,"b":1}]"#);
+    }
+
+    #[test]
+    fn scalars_pass_through() {
+        for value in [json!(1), json!("s"), json!(true), json!(null), json!(1.5)] {
+            assert_eq!(canonical_json(value.clone()), value);
+        }
+    }
+
+    #[test]
+    fn canonical_json_bytes_matches_manual_pipeline() {
+        // The helper must be byte-identical to the historical inline pipeline
+        // consumers used: to_value -> canonicalize -> to_vec.
+        #[derive(serde::Serialize)]
+        struct Payload {
+            zebra: u8,
+            alpha: u8,
+        }
+        let payload = Payload { zebra: 9, alpha: 1 };
+        let manual =
+            serde_json::to_vec(&canonical_json(serde_json::to_value(&payload).unwrap())).unwrap();
+        assert_eq!(canonical_json_bytes(&payload).unwrap(), manual);
+    }
+}

--- a/crates/homeboy-engine-primitives/src/lib.rs
+++ b/crates/homeboy-engine-primitives/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod artifact_ref_scheme;
 pub mod baseline;
+pub mod canonical_json;
 pub mod codebase_scan;
 pub mod command;
 pub mod detail_output;

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -15,6 +15,7 @@ use serde_json::{json, Value};
 use homeboy_core::daemon::controller_job_driver::{
     self, ControllerJobDriver, ControllerJobHandle, ControllerJobPublicError,
 };
+use homeboy_core::engine::canonical_json::canonical_json_bytes;
 use homeboy_core::lab_contract::{
     LabRigWorkloadKind, LabRoutingPolicy, LabRunnerWorkloadCapability, LabSecretEnvSource,
     LabSourcePathMode, LabWorkspaceModePolicy,
@@ -623,33 +624,8 @@ pub struct LabStagingRecipeRef {
     pub canonical_plan_digest: String,
 }
 
-fn canonicalize_json(value: Value) -> Value {
-    match value {
-        Value::Array(values) => Value::Array(values.into_iter().map(canonicalize_json).collect()),
-        Value::Object(values) => {
-            let mut fields: Vec<_> = values.into_iter().collect();
-            fields.sort_unstable_by(|left, right| left.0.cmp(&right.0));
-            Value::Object(
-                fields
-                    .into_iter()
-                    .map(|(key, value)| (key, canonicalize_json(value)))
-                    .collect(),
-            )
-        }
-        value => value,
-    }
-}
-
 fn canonical_digest<T: Serialize>(value: &T) -> Result<String> {
-    let bytes = serde_json::to_vec(&canonicalize_json(serde_json::to_value(value).map_err(
-        |error| {
-            Error::internal_json(
-                error.to_string(),
-                Some("serialize durable Lab workspace state".to_string()),
-            )
-        },
-    )?))
-    .map_err(|error| {
+    let bytes = canonical_json_bytes(value).map_err(|error| {
         Error::internal_json(
             error.to_string(),
             Some("serialize canonical durable Lab workspace state".to_string()),

--- a/crates/homeboy-release/src/deploy/preparation.rs
+++ b/crates/homeboy-release/src/deploy/preparation.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 
 use homeboy_core::component::Component;
+use homeboy_core::engine::canonical_json::canonical_json;
 use homeboy_core::error::{Error, Result};
 
 use super::execution::{
@@ -112,23 +113,6 @@ impl ComponentPayloadPreparationRequest {
     #[allow(dead_code)]
     pub fn evidence_digest(&self) -> String {
         digest_json(&self.evidence())
-    }
-}
-
-fn canonical_json(value: serde_json::Value) -> serde_json::Value {
-    match value {
-        serde_json::Value::Array(values) => {
-            serde_json::Value::Array(values.into_iter().map(canonical_json).collect())
-        }
-        serde_json::Value::Object(values) => serde_json::Value::Object(
-            values
-                .into_iter()
-                .map(|(key, value)| (key, canonical_json(value)))
-                .collect::<std::collections::BTreeMap<_, _>>()
-                .into_iter()
-                .collect(),
-        ),
-        value => value,
     }
 }
 


### PR DESCRIPTION
## Summary
- The same recursive canonical-JSON algorithm was copy-pasted across **four crates under three names** (`canonicalize_json`, `canonicalize`, `canonical_json`). All feed sha256 digests, so silent divergence between copies would change digests — a correctness hazard, not just duplication (#9759).
- Consolidated into a single `canonical_json` module in `homeboy-engine-primitives` (the low-level leaf-utility crate depending only on `homeboy-error` + serde) and replaced all four copies.

## Consolidation
New `homeboy_engine_primitives::canonical_json`:
- `canonical_json(Value) -> Value` — recursively sorts object keys, preserves array order, passes scalars through.
- `canonical_json_bytes<T: Serialize>` — `to_value` → canonicalize → `to_vec`.

Replaced copies:
- `crates/contracts/homeboy-component-contract/src/model.rs` — direct engine-primitives dep (stays below core).
- `crates/homeboy-lab-runner/src/lab_staging_controller.rs`, `crates/homeboy-release/src/deploy/preparation.rs`, `crates/homeboy-agents/src/agent_task_lifecycle/private_attachment.rs` — reach the helper via the existing `homeboy_core::engine` re-export (no new dependency edges).

## Digests unchanged
The two prior techniques (`collect::<BTreeMap>` vs `sort_unstable_by`) both yield ascending-key ordering, so the canonical byte output is identical. Each consumer's digest/canonicalization tests still pass.

## Testing
- `cargo test -p homeboy-engine-primitives --lib canonical_json` — 5 new tests (order-independence, array-order preservation, byte-parity with the historical pipeline).
- `cargo test -p homeboy-agents --lib private_attachment` — 6 passed (incl. unordered-map canonicalization + tamper/digest-binding).
- `cargo test -p homeboy-lab-runner --lib lab_staging` — 39 passed.
- `cargo test -p homeboy-release --lib deploy::preparation` — 16 passed.
- `cargo check -p homeboy-core -p homeboy-agents -p homeboy-release -p homeboy-lab-runner --lib` — clean.

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Dependency-graph analysis to pick the host crate, consolidation, and behavior-parity verification.

Closes #9759