### PR TITLE
fix(refactor): warn when advertised fixable findings apply zero edits

### DIFF
--- a/crates/homeboy-refactor/src/plan/sources/stages.rs
+++ b/crates/homeboy-refactor/src/plan/sources/stages.rs
@@ -452,13 +452,32 @@ pub(super) fn run_lint_stage(
         (Vec::new(), Vec::new(), Vec::new())
     };
 
-    let (stage_changed_files, fix_results, stage_warnings) = merge_lint_extension_stage(
-        extension_stage,
-        stage_changed_files,
-        fix_results,
-        stage_warnings,
-    );
+    let (stage_changed_files, mut stage_warnings, fix_results) = {
+        let (changed, results, warnings) = merge_lint_extension_stage(
+            extension_stage,
+            stage_changed_files,
+            fix_results,
+            stage_warnings,
+        );
+        (changed, warnings, results)
+    };
     let edit_count = fix_results.len();
+
+    // Reconcile advertised auto-fixable findings against what the fixer pass
+    // actually applied. The lint diagnostic advertises "N findings can be fixed
+    // automatically — run homeboy refactor --from lint --write", but the fixer
+    // pass (phpcbf + custom fixers) may apply zero edits — e.g. PHPCS marks a
+    // finding `fixable` but no registered sniff actually rewrites it, or the
+    // findings are warnings the fixer's severity config suppresses. Previously
+    // this returned a nominal success with edit_count: 0 and no explanation,
+    // sending operators to a command that does nothing (#9618). Surface the
+    // discrepancy as an explicit warning so the no-op is legible instead of
+    // silent.
+    if write {
+        if let Some(warning) = unapplied_fixable_warning(&lint_findings, edit_count) {
+            stage_warnings.push(warning);
+        }
+    }
 
     Ok(PlannedStage {
         source: "lint".to_string(),
@@ -475,6 +494,33 @@ pub(super) fn run_lint_stage(
         },
         fix_results,
     })
+}
+
+/// Reconcile advertised auto-fixable findings against edits the fixer actually
+/// applied. Returns a warning when the lint diagnostic flagged findings as
+/// auto-fixable but the fixer pass applied zero edits (#9618). Returns `None`
+/// when no fixable findings were advertised or at least one edit landed, so a
+/// genuine fix run stays quiet.
+fn unapplied_fixable_warning(
+    lint_findings: &[homeboy_core::finding::HomeboyFinding],
+    edit_count: usize,
+) -> Option<String> {
+    if edit_count > 0 {
+        return None;
+    }
+    let advertised_fixable = lint_findings
+        .iter()
+        .filter(|finding| finding.fix.fixable == Some(true))
+        .count();
+    if advertised_fixable == 0 {
+        return None;
+    }
+    Some(format!(
+        "Lint advertised {advertised_fixable} auto-fixable finding(s) but the fixer pass applied 0 edits. \
+The linter's fixer (e.g. phpcbf + custom fixers) could not automatically rewrite these findings — \
+they may require manual remediation despite being flagged fixable. Re-run `homeboy lint <component>` \
+to see the remaining findings."
+    ))
 }
 
 fn merge_lint_extension_stage(
@@ -827,5 +873,46 @@ mod tests {
         assert_eq!(fix_results.len(), 1);
         assert_eq!(fix_results[0].rule, "phpcbf:WordPress.WhiteSpace");
         assert_eq!(warnings, vec!["tool-native fix warning".to_string()]);
+    }
+
+    fn fixable_finding(file: &str, fixable: bool) -> homeboy_core::finding::HomeboyFinding {
+        homeboy_core::finding::HomeboyFinding::builder("phpcs", "WhiteSpace")
+            .file(file)
+            .fixable(fixable)
+            .build()
+    }
+
+    #[test]
+    fn advertised_fixable_with_zero_edits_warns() {
+        // #9618: lint flags findings auto-fixable but the fixer applies nothing.
+        // The no-op must be surfaced instead of a silent success.
+        let findings = vec![
+            fixable_finding("src/a.php", true),
+            fixable_finding("src/b.php", true),
+        ];
+        let warning = unapplied_fixable_warning(&findings, 0)
+            .expect("advertised-fixable + zero edits must warn");
+        assert!(
+            warning.contains("2 auto-fixable finding(s) but the fixer pass applied 0 edits"),
+            "warning must report the discrepancy: {warning}"
+        );
+    }
+
+    #[test]
+    fn advertised_fixable_with_edits_is_quiet() {
+        // A genuine fix run (at least one edit) must not warn.
+        let findings = vec![fixable_finding("src/a.php", true)];
+        assert!(unapplied_fixable_warning(&findings, 3).is_none());
+    }
+
+    #[test]
+    fn no_fixable_findings_is_quiet() {
+        // Findings exist but none are auto-fixable — zero edits is expected, so
+        // no misleading "fixer applied nothing" warning.
+        let findings = vec![
+            fixable_finding("src/a.php", false),
+            homeboy_core::finding::HomeboyFinding::builder("phpstan", "type error").build(),
+        ];
+        assert!(unapplied_fixable_warning(&findings, 0).is_none());
     }
 }


### PR DESCRIPTION
## Summary
- `homeboy refactor --from lint --write` advertises "N findings can be fixed automatically" from the lint diagnostic, runs the fixer pass (phpcbf + custom fixers), then previously returned a **nominal success with `edit_count: 0` and no explanation** when the fixer applied nothing — sending operators to a no-op command (#9618).
- The engine now reconciles advertised auto-fixable findings against edits actually applied and surfaces an explicit warning when the fixer landed zero edits despite fixable findings.

## Root cause
The lint diagnostic's `AUTO-FIXABLE: N findings` count comes from PHPCS `totals.fixable`, which flags every message a sniff *claims* is fixable. The fixer pass (phpcbf) only rewrites findings whose sniff is actually registered/enabled in the effective ruleset, and severity config can suppress warning-level fixes. The gap between "advertised fixable" and "actually applied" was reported as a silent success, so a release blocked on formatting couldn't tell the prescribed remediation was a no-op.

## Change
`run_lint_stage` (`crates/homeboy-refactor/src/plan/sources/stages.rs`) gains `unapplied_fixable_warning()`:
- Findings flagged `fix.fixable == Some(true)` + `edit_count == 0` → warning explaining the fixer couldn't rewrite them and pointing at `homeboy lint <component>`.
- A genuine fix run (≥1 edit) or a run with no fixable findings stays quiet.

## Ownership note
The reconciliation lives in the engine (homeboy-refactor), which owns the diagnose/fix lifecycle. The underlying phpcbf fixer behavior is owned by the WordPress extension in **homeboy-extensions**; a follow-up there could narrow *which* findings get advertised as fixable. This change makes the engine honest about the outcome regardless of extension.

## Testing
- `cargo test -p homeboy-refactor --lib sources::stages` — 5 passed (3 new: warns on advertised-fixable+zero-edits, quiet on edits applied, quiet when nothing fixable).
- Pre-existing unrelated failures in `plan::generate::*` (module-path mapping, `crate::core::code_audit` vs `homeboy_code_audit`) also fail on clean `origin/main` — not caused by this change.

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Tracing the diagnose/fix lifecycle across homeboy-refactor + the homeboy-extensions WordPress lint runner, identifying the advertised-vs-applied gap, and implementing/​testing the reconciliation.

Closes #9618