### PR TITLE
Reuse changed-scope audit analysis

### DIFF
--- a/crates/homeboy-code-audit/src/descriptor_runtime.rs
+++ b/crates/homeboy-code-audit/src/descriptor_runtime.rs
@@ -8,7 +8,7 @@ use super::detectors::{
     test_topology, test_wiring, thin_command_adapter, unbounded_output_capture, wrapper_inference,
 };
 use super::doc_drift::detect_doc_drift;
-use super::reference::{fingerprint_component_reference_files, fingerprint_reference_paths};
+use super::reference::DeadCodeReferenceAnalysis;
 use super::{
     comment_hygiene, compiler_warnings, dead_code, fingerprint, shadow_modules, structural,
     time_audit_detector, AuditExecutionPlan, AuditTiming, DetectorDescriptor, DetectorRuntime,
@@ -36,8 +36,7 @@ pub(super) struct DetectorRunContext<'a> {
     /// Shared source snapshot for whole-tree detectors. `None` only on the
     /// root-only fast path when no snapshot-backed detector is enabled.
     pub(super) source_snapshot: Option<&'a CodebaseSnapshot>,
-    /// External reference codebases included in dead-code cross-referencing.
-    pub(super) reference_paths: &'a [String],
+    pub(super) dead_code_references: Option<&'a DeadCodeReferenceAnalysis>,
 }
 
 fn run_fingerprint_descriptor(
@@ -167,11 +166,13 @@ fn run_generic_descriptor(
 /// enabled. The dispatch only invokes this runner for an enabled descriptor, so
 /// the walk stays gated exactly as it was when hand-wired in `engine.rs`.
 fn run_dead_code(context: &DetectorRunContext<'_>) -> Vec<Finding> {
-    let ref_fingerprints = fingerprint_reference_paths(context.reference_paths);
-    let component_ref_fingerprints = fingerprint_component_reference_files(context.root);
-    let ref_fp_refs: Vec<&fingerprint::FileFingerprint> = ref_fingerprints
+    let references = context
+        .dead_code_references
+        .expect("dead-code detector receives repository reference analysis when enabled");
+    let ref_fp_refs: Vec<&fingerprint::FileFingerprint> = references
+        .external
         .iter()
-        .chain(component_ref_fingerprints.iter())
+        .chain(references.component.iter())
         .collect();
     dead_code::analyze_dead_code_with_config(
         context.all_fingerprints,
@@ -326,7 +327,7 @@ mod tests {
             all_fingerprints: &[],
             per_file_fingerprints: &[],
             source_snapshot: None,
-            reference_paths: &[],
+            dead_code_references: None,
         };
 
         let plan = AuditExecutionPlan::from_profile_and_filters(AuditProfile::Full, &[], &[]);
@@ -427,7 +428,7 @@ mod tests {
             all_fingerprints: &fingerprints,
             per_file_fingerprints: &fingerprints,
             source_snapshot: None,
-            reference_paths: &[],
+            dead_code_references: None,
         };
         let plan = AuditExecutionPlan::from_profile_and_filters(AuditProfile::Full, &[], &[]);
         let mut timing = AuditTiming::default();

--- a/crates/homeboy-code-audit/src/engine.rs
+++ b/crates/homeboy-code-audit/src/engine.rs
@@ -19,7 +19,7 @@ use super::detectors::{artifact_portability, source_policy};
 use super::entry::audit_config_for;
 use super::execution_plan::AuditExecutionPlan;
 use super::findings;
-use super::reference::build_convention_method_set;
+use super::reference::{build_convention_method_set, DeadCodeReferenceAnalysis};
 use super::types::{
     time_audit_detector, AuditAnalysisContext, AuditSummary, AuditTiming, AuditWithAnalysis,
     CodeAuditResult, ConventionReport, ScopedAuditExecution,
@@ -54,6 +54,7 @@ pub(super) fn audit_internal(
     reference_paths: &[String],
     plan: &AuditExecutionPlan,
     extension_overrides: &[String],
+    dead_code_references: Option<DeadCodeReferenceAnalysis>,
 ) -> Result<AuditWithAnalysis> {
     let root = Path::new(source_path);
     let audit_config = audit_config_for(component_id, root, extension_overrides);
@@ -277,6 +278,10 @@ pub(super) fn audit_internal(
         .map(|(_, subset)| subset.as_slice())
         .unwrap_or(all_fingerprints.as_slice());
 
+    let dead_code_references = dead_code_references.or_else(|| {
+        plan.detector_enabled("dead_code")
+            .then(|| DeadCodeReferenceAnalysis::build(root, reference_paths))
+    });
     let detector_context = DetectorRunContext {
         root,
         component_id,
@@ -284,7 +289,7 @@ pub(super) fn audit_internal(
         all_fingerprints: &all_fingerprints,
         per_file_fingerprints,
         source_snapshot: Some(&source_snapshot),
-        reference_paths,
+        dead_code_references: dead_code_references.as_ref(),
     };
 
     // The duplication family stays hand-sequenced: it runs five timing spans and
@@ -576,6 +581,7 @@ pub(super) fn audit_internal(
             .into_iter()
             .flat_map(|(_, _, fingerprints)| fingerprints)
             .collect(),
+        dead_code_references,
     };
 
     Ok(AuditWithAnalysis {
@@ -644,7 +650,7 @@ fn audit_root_only(
         all_fingerprints: &[],
         per_file_fingerprints: &[],
         source_snapshot: source_snapshot.as_ref(),
-        reference_paths: &[],
+        dead_code_references: None,
     };
 
     run_descriptor_detectors(

--- a/crates/homeboy-code-audit/src/entry.rs
+++ b/crates/homeboy-code-audit/src/entry.rs
@@ -69,6 +69,7 @@ pub fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeA
         &ref_paths,
         &AuditExecutionPlan::full(),
         &[],
+        None,
     )
     .map(|audit| audit.result)
 }
@@ -119,6 +120,7 @@ pub(crate) fn audit_path_with_id_with_plan_and_analysis(
         reference_paths,
         plan,
         extension_overrides,
+        None,
     )
 }
 
@@ -147,6 +149,7 @@ pub fn audit_path_scoped(
         &ref_paths,
         &AuditExecutionPlan::full(),
         &[],
+        None,
     )
     .map(|audit| audit.result)
 }
@@ -159,6 +162,7 @@ pub(crate) fn audit_path_scoped_with_plan_and_analysis(
     plan: &AuditExecutionPlan,
     reference_paths: &[String],
     extension_overrides: &[String],
+    dead_code_references: Option<super::reference::DeadCodeReferenceAnalysis>,
 ) -> Result<AuditWithAnalysis> {
     audit_internal(
         component_id,
@@ -168,6 +172,7 @@ pub(crate) fn audit_path_scoped_with_plan_and_analysis(
         reference_paths,
         plan,
         extension_overrides,
+        dead_code_references,
     )
 }
 

--- a/crates/homeboy-code-audit/src/reference.rs
+++ b/crates/homeboy-code-audit/src/reference.rs
@@ -2,6 +2,7 @@
 //!
 //! Mechanically split out of `mod.rs`; behavior is preserved unchanged.
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use super::{conventions, fingerprint, walker};
@@ -172,4 +173,100 @@ pub(super) fn fingerprint_component_reference_files(
     }
 
     fingerprints
+}
+
+/// Immutable dead-code inputs that can be shared by candidate and reference
+/// projections of a changed-since audit.
+#[derive(Debug, Clone, Default)]
+pub(super) struct DeadCodeReferenceAnalysis {
+    pub(super) external: Vec<fingerprint::FileFingerprint>,
+    pub(super) component: Vec<fingerprint::FileFingerprint>,
+}
+
+impl DeadCodeReferenceAnalysis {
+    pub(super) fn build(root: &Path, reference_paths: &[String]) -> Self {
+        #[cfg(test)]
+        REPOSITORY_REFERENCE_VISITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Self {
+            external: fingerprint_reference_paths(reference_paths),
+            component: fingerprint_component_reference_files(root),
+        }
+    }
+
+    /// Replace only paths changed since the reference with fingerprints from the
+    /// archived reference tree. All other source and external reference facts are
+    /// immutable across the two projections and stay shared.
+    pub(super) fn project_reference(
+        &self,
+        reference_root: &Path,
+        changed_files: &[String],
+    ) -> Self {
+        let changed: std::collections::HashSet<&str> =
+            changed_files.iter().map(String::as_str).collect();
+        let mut component: HashMap<String, fingerprint::FileFingerprint> = self
+            .component
+            .iter()
+            .filter(|fingerprint| !changed.contains(fingerprint.relative_path.as_str()))
+            .map(|fingerprint| (fingerprint.relative_path.clone(), fingerprint.clone()))
+            .collect();
+
+        for path in changed_files {
+            let source = reference_root.join(path);
+            let Ok(content) = std::fs::read_to_string(&source) else {
+                continue;
+            };
+            if let Some(fingerprint) =
+                fingerprint::fingerprint_content(&source, reference_root, &content)
+            {
+                component.insert(fingerprint.relative_path.clone(), fingerprint);
+            }
+        }
+
+        let mut component: Vec<_> = component.into_values().collect();
+        component.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+        Self {
+            external: self.external.clone(),
+            component,
+        }
+    }
+}
+
+#[cfg(test)]
+static REPOSITORY_REFERENCE_VISITS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(test)]
+pub(super) fn repository_reference_visit_count() -> usize {
+    REPOSITORY_REFERENCE_VISITS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+#[cfg(test)]
+pub(super) fn reset_repository_reference_visit_count() {
+    REPOSITORY_REFERENCE_VISITS.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reference_projection_reuses_candidate_repository_visit() {
+        let candidate = tempfile::tempdir().expect("candidate directory");
+        let reference = tempfile::tempdir().expect("reference directory");
+        std::fs::write(candidate.path().join("changed.rs"), "fn current() {}")
+            .expect("candidate source");
+        std::fs::write(reference.path().join("changed.rs"), "fn baseline() {}")
+            .expect("reference source");
+
+        reset_repository_reference_visit_count();
+        let analysis = DeadCodeReferenceAnalysis::build(candidate.path(), &[]);
+        let _reference_projection =
+            analysis.project_reference(reference.path(), &["changed.rs".to_string()]);
+
+        assert_eq!(
+            repository_reference_visit_count(),
+            1,
+            "changed-since reference projection must not repeat the repository-wide dead-code reference walk"
+        );
+    }
 }

--- a/crates/homeboy-code-audit/src/run.rs
+++ b/crates/homeboy-code-audit/src/run.rs
@@ -219,6 +219,7 @@ fn run_audit(args: &AuditRunWorkflowArgs) -> homeboy_error::Result<Option<AuditW
             &plan,
             &args.reference_paths,
             &args.extension_overrides,
+            None,
         )?))
     } else {
         Ok(Some(crate::audit_path_with_id_with_plan_and_analysis(
@@ -320,7 +321,7 @@ fn run_comparison_workflow(
                 .or_else(|| baseline::load_baseline_from_ref(&result.source_path, git_ref))
         };
         let reference = timing.time_phase("reference_baseline", || {
-            audit_reference_result(args, git_ref)
+            audit_reference_result(args, git_ref, analysis)
         })?;
         let baseline = baseline::baseline_with_reference_findings(persisted, &reference);
         return build_comparison_output(result, analysis, baseline, args, timing);
@@ -387,6 +388,7 @@ fn run_comparison_workflow(
 fn audit_reference_result(
     args: &AuditRunWorkflowArgs,
     git_ref: &str,
+    candidate_analysis: &crate::AuditAnalysisContext,
 ) -> homeboy_error::Result<CodeAuditResult> {
     let source = Path::new(&args.source_path);
     let archive = Command::new("git")
@@ -439,6 +441,10 @@ fn audit_reference_result(
 
     let changed = changed_files_for_scope(args, git_ref)?;
     let reference_path = reference_root.path().to_string_lossy();
+    let dead_code_references = candidate_analysis
+        .dead_code_references
+        .as_ref()
+        .map(|references| references.project_reference(reference_root.path(), &changed));
     let mut reference = crate::audit_path_scoped_with_plan_and_analysis(
         &args.component_id,
         &reference_path,
@@ -447,6 +453,7 @@ fn audit_reference_result(
         &audit_plan(args),
         &args.reference_paths,
         &args.extension_overrides,
+        dead_code_references,
     )?
     .result;
     apply_finding_filters(&mut reference, &args.only_kinds, &args.exclude_kinds);

--- a/crates/homeboy-code-audit/src/types.rs
+++ b/crates/homeboy-code-audit/src/types.rs
@@ -21,6 +21,7 @@ pub use homeboy_audit_contract::{
 #[derive(Debug, Clone, Default)]
 pub(crate) struct AuditAnalysisContext {
     pub(crate) fingerprints: Vec<fingerprint::FileFingerprint>,
+    pub(crate) dead_code_references: Option<super::reference::DeadCodeReferenceAnalysis>,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
Reuse repository-wide dead-code reference analysis across changed-scope candidate and baseline audit projections.

## What changed
- Capture immutable external and component dead-code reference fingerprints in the candidate analysis context.
- Project archived fingerprints only for changed paths instead of repeating the repository-wide reference walk.
- Add deterministic instrumentation-backed coverage asserting one repository reference visit.

## How to test
1. Run `cargo test -p homeboy-code-audit`; expect 846 focused code-audit tests pass after rebase.

## Compatibility
Full audits still build their own reference analysis, changed-scope output schemas and finding semantics remain unchanged, and baseline projections replace only paths changed from the selected git reference.

## Evidence
- Base unchanged since verification: main remains at a2fbf8bb86bc01b2fab23e484507a9b3212708f8.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9766
- Verified finalization base: main at a2fbf8bb86bc01b2fab23e484507a9b3212708f8
- homeboy-code-audit: passed (846 tests after rebase) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** The coding agent traced candidate/reference audit execution, isolated repeated dead-code reference fingerprinting, implemented immutable analysis reuse with changed-path projection, and added deterministic visit-count coverage; Chris rebased and reran the focused crate suite before finalization.

## Source relationships
- Closes #9766
