### PR TITLE
Recover Lab reviews through controller snapshots

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -132,7 +132,8 @@ pub fn sync_workspace(
                 WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
             )?;
             let git_backed_snapshot = git_output(&local_path, &["rev-parse", "HEAD"]).is_ok();
-            let synthetic_checkout = if options.mode == RunnerWorkspaceSyncMode::SnapshotGit
+            let (synthetic_checkout, fallback_reason) = if options.mode
+                == RunnerWorkspaceSyncMode::SnapshotGit
                 && git_backed_snapshot
             {
                 match materialize_git_snapshot_from_controller_bundle(
@@ -143,11 +144,26 @@ pub fn sync_workspace(
                 ) {
                     Ok(provenance) => {
                         materialization_plan.controller_git_bundle = provenance;
-                        None
+                        (None, None)
                     }
-                    Err(error) => {
+                    Err(_) => {
                         rollback_materialized_workspace(&runner, workspace_root, &remote_path);
-                        return Err(error);
+                        if let Err(snapshot_error) =
+                            materialize_snapshot(&runner, &local_path, &remote_path, &excludes)
+                        {
+                            rollback_materialized_workspace(&runner, workspace_root, &remote_path);
+                            return Err(snapshot_error);
+                        }
+                        materialization_plan.snapshot_transfer =
+                            Some(super::types::SnapshotTransferStats {
+                                reused: ByteFileCounts::default(),
+                                transferred: stats.clone(),
+                                final_size: stats.clone(),
+                            });
+                        (
+                            None,
+                            Some("snapshot_git_checkout_and_controller_bundle_failed".to_string()),
+                        )
                     }
                 }
             } else if options.mode == RunnerWorkspaceSyncMode::SnapshotGit {
@@ -158,7 +174,7 @@ pub fn sync_workspace(
                     &excludes,
                     &snapshot,
                 ) {
-                    Ok(identity) => Some(identity),
+                    Ok(identity) => (Some(identity), None),
                     Err(error) => {
                         rollback_materialized_workspace(&runner, workspace_root, &remote_path);
                         return Err(error);
@@ -200,25 +216,25 @@ pub fn sync_workspace(
                         }
                     }
                 });
-                None
+                (None, None)
             };
-            if options.mode == RunnerWorkspaceSyncMode::SnapshotGit && git_backed_snapshot {
+            if fallback_reason.is_some() || options.mode == RunnerWorkspaceSyncMode::Snapshot {
+                materialization_plan.actual_materialization_mode =
+                    Some("filesystem_snapshot".to_string());
+            } else if options.mode == RunnerWorkspaceSyncMode::SnapshotGit && git_backed_snapshot {
                 // Snapshot-git deliberately retains Git metadata for callers
                 // that need a checkout baseline.
                 materialization_plan.actual_materialization_mode =
                     Some(RunnerWorkspaceSyncMode::SnapshotGit.label().to_string());
-            } else if options.mode == RunnerWorkspaceSyncMode::Snapshot {
-                // Plain snapshot mode is a readable filesystem transfer. It
-                // must not require a Git object closure from partial clones.
-                materialization_plan.actual_materialization_mode =
-                    Some("filesystem_snapshot".to_string());
             }
+            materialization_plan.fallback_reason = fallback_reason;
             let metadata = workspace_metadata(
                 &runner.id,
                 &local_path,
                 &remote_path,
                 options.mode,
                 materialization_plan.actual_materialization_mode.as_deref(),
+                materialization_plan.fallback_reason.as_deref(),
                 &snapshot,
                 &excludes,
                 Some(content_manifest),
@@ -362,6 +378,7 @@ pub fn sync_workspace(
                 &local_path,
                 &remote_path,
                 RunnerWorkspaceSyncMode::Git,
+                None,
                 None,
                 &git.head,
                 &excludes,
@@ -517,6 +534,7 @@ pub fn update_workspace(
         &snapshot.remote_path,
         RunnerWorkspaceSyncMode::Snapshot,
         Some("prepared_workspace_delta"),
+        None,
         &resulting_snapshot_identity,
         &excludes,
         Some(manifest),
@@ -1002,6 +1020,7 @@ fn workspace_metadata(
     remote_path: &str,
     sync_mode: RunnerWorkspaceSyncMode,
     actual_materialization_mode: Option<&str>,
+    fallback_reason: Option<&str>,
     snapshot_identity: &str,
     snapshot_excludes: &[String],
     content_manifest: Option<super::snapshot::WorkspaceContentManifest>,
@@ -1019,6 +1038,7 @@ fn workspace_metadata(
         remote_path: remote_path.to_string(),
         sync_mode: sync_mode.label().to_string(),
         actual_materialization_mode: actual_materialization_mode.map(str::to_string),
+        fallback_reason: fallback_reason.map(str::to_string),
         snapshot_identity: snapshot_identity.to_string(),
         workspace_lease: Some(new_workspace_lease()),
         workspace_generation: 0,

--- a/crates/homeboy-lab-runner/src/workspace/sync/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/snapshots.rs
@@ -440,6 +440,7 @@ fn workspace_snapshot_entry(
         remote_path: metadata.remote_path,
         sync_mode: metadata.sync_mode,
         actual_materialization_mode: metadata.actual_materialization_mode,
+        fallback_reason: metadata.fallback_reason,
         snapshot_identity: metadata.snapshot_identity,
         workspace_lease: metadata.workspace_lease,
         workspace_generation: metadata.workspace_generation,

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -263,6 +263,114 @@ fn snapshot_git_reports_checkout_provenance_for_committed_harvest() {
 }
 
 #[test]
+fn snapshot_git_falls_back_to_filesystem_snapshot_when_git_closure_is_unavailable() {
+    let _path_guard = PATH_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("PATH lock");
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let source = tempfile::tempdir().expect("source workspace");
+        let runner_root = tempfile::tempdir().expect("runner root");
+        fs::create_dir_all(source.path().join("components/demo")).expect("component root");
+        fs::write(
+            source.path().join("components/demo/component.txt"),
+            "component\n",
+        )
+        .expect("component file");
+        fs::write(source.path().join("dirty.txt"), "committed\n").expect("source file");
+        git(source.path(), &["init", "-b", "main"]);
+        git(source.path(), &["config", "user.email", "test@example.com"]);
+        git(source.path(), &["config", "user.name", "Test User"]);
+        git(source.path(), &["add", "."]);
+        git(source.path(), &["commit", "-m", "source"]);
+        git(
+            source.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "file:///definitely-not-a-runner-accessible-repository",
+            ],
+        );
+        fs::write(source.path().join("dirty.txt"), "dirty\n").expect("dirty change");
+
+        crate::create(
+            &format!(
+                r#"{{"id":"lab-snapshot-git-fallback","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+        let shim_root = tempfile::tempdir().expect("git shim root");
+        let shim = shim_root.path().join("git");
+        fs::write(
+            &shim,
+            "#!/bin/sh\nfor arg in \"$@\"; do [ \"$arg\" = \"rev-list\" ] && { echo 'missing promisor object' >&2; exit 91; }; done\nexec /usr/bin/git \"$@\"\n",
+        )
+        .expect("write git shim");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&shim, fs::Permissions::from_mode(0o755))
+                .expect("make git shim executable");
+        }
+        let original_path = std::env::var_os("PATH").expect("PATH");
+        let mut paths = vec![shim_root.path().to_path_buf()];
+        paths.extend(std::env::split_paths(&original_path));
+        std::env::set_var("PATH", std::env::join_paths(paths).expect("PATH value"));
+        let result = sync_workspace(
+            "lab-snapshot-git-fallback",
+            RunnerWorkspaceSyncOptions {
+                path: source.path().display().to_string(),
+                mode: RunnerWorkspaceSyncMode::SnapshotGit,
+                ..Default::default()
+            },
+        );
+        std::env::set_var("PATH", original_path);
+
+        let (synced, exit_code) = result.expect("filesystem fallback");
+        assert_eq!(exit_code, 0);
+        assert_eq!(
+            synced
+                .materialization_plan
+                .actual_materialization_mode
+                .as_deref(),
+            Some("filesystem_snapshot")
+        );
+        assert!(synced.materialization_plan.controller_git_bundle.is_none());
+        assert_eq!(
+            synced.materialization_plan.fallback_reason.as_deref(),
+            Some("snapshot_git_checkout_and_controller_bundle_failed")
+        );
+        let remote = Path::new(&synced.remote_path);
+        assert_eq!(
+            fs::read_to_string(remote.join("dirty.txt")).unwrap(),
+            "dirty\n"
+        );
+        assert!(!remote.join(".git").exists());
+        let component = std::process::Command::new("sh")
+            .args(["-c", "test -f components/demo/component.txt && pwd"])
+            .current_dir(remote)
+            .output()
+            .expect("execute from remote component workspace");
+        assert!(component.status.success());
+        let metadata: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(remote.join(".homeboy/runner-workspace.json")).expect("metadata"),
+        )
+        .expect("parse metadata");
+        assert_eq!(
+            metadata["actual_materialization_mode"],
+            "filesystem_snapshot"
+        );
+        assert_eq!(
+            metadata["fallback_reason"],
+            "snapshot_git_checkout_and_controller_bundle_failed"
+        );
+    });
+}
+
+#[test]
 fn snapshot_command_failure_keeps_exit_status_and_silent_transport_cause() {
     let error =
         super::super::util::run_shell_command("exit 23", "materialize SSH workspace snapshot")

--- a/crates/homeboy-lab-runner/src/workspace/types.rs
+++ b/crates/homeboy-lab-runner/src/workspace/types.rs
@@ -105,6 +105,8 @@ pub struct RunnerWorkspaceMaterializationContract {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub actual_materialization_mode: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub snapshot_transfer: Option<SnapshotTransferStats>,
 }
 
@@ -227,6 +229,7 @@ impl RunnerWorkspaceMaterializationContract {
             output_paths: RunnerWorkspaceOutputPaths::for_remote_path(&workspace_root, remote_path),
             controller_git_bundle: None,
             actual_materialization_mode: None,
+            fallback_reason: None,
             snapshot_transfer: None,
         }
     }
@@ -420,6 +423,8 @@ pub struct RunnerWorkspaceSnapshotEntry {
     pub sync_mode: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub actual_materialization_mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_reason: Option<String>,
     pub snapshot_identity: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_lease: Option<String>,
@@ -462,6 +467,8 @@ pub(super) struct RunnerWorkspaceMetadata {
     pub sync_mode: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub actual_materialization_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fallback_reason: Option<String>,
     pub snapshot_identity: String,
     /// Opaque, single-generation capability for a prepared workspace. Older
     /// metadata intentionally has no lease and is ineligible for mutation.


### PR DESCRIPTION
## Summary

- fall back from failed `snapshot-git` checkout/controller Git-bundle materialization to the existing controller filesystem snapshot transport
- preserve dirty worktree content while reporting the actual `filesystem_snapshot` mode and a stable, non-sensitive fallback reason
- persist fallback provenance in runner workspace metadata and snapshot listings
- add deterministic coverage for missing Git closure, dirty-file preservation, rollback/retry behavior, and provenance

Closes #9755.

## Root cause

`SnapshotGit` already tried runner checkout and then controller Git-bundle materialization, but returned the bundle error when a partial/promisor checkout could not enumerate its object closure. Plain controller filesystem snapshot transfer already worked for the same source; the automatic path never invoked it.

Current `main` already includes terminal runner-result projection and reconciliation. Existing disappeared-job and timeout tests pass, so this PR does not add a duplicate terminalization mechanism.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner workspace::tests::snapshot` (58 passed)
- `cargo test -p homeboy-lab-runner lab_source_snapshot_uses_git_workspace_for_committed_git_source`
- `cargo test -p homeboy-lab-runner accepted_job_that_disappears_persists_a_terminal_controller_failure`
- `cargo test -p homeboy-lab-runner timeout_mirrors_remote_job_without_cancelling`
- Real `homeboy-lab` proof against dirty partial/promisor `/Users/chubes/Developer/wp-build@main`: reproduced inaccessible GHE plus missing object `c8cccc5989906925e8eb178438fe9e6f3866f210`, then succeeded with 509 files / 11,942,764 bytes, `source_dirty: true`, `actual_materialization_mode: filesystem_snapshot`, and `fallback_reason: snapshot_git_checkout_and_controller_bundle_failed`.
- Nested component execution succeeded from the resulting remote `plugins/host/wp-build` directory in runner job `bea63fa0-3008-4e54-8c18-ceae5f48eec8`. Reproduce evidence with `homeboy runs show runner-exec-generic-homeboy-lab-bea63fa0-3008-4e54-8c18-ceae5f48eec8`.

`cargo test --workspace` reached the unrelated `reverse_cook_queue_acceptance` test and failed before workspace materialization because its reverse-runner fixture had no active daemon identity. The focused workspace, routing, and terminalization suites above pass.

## AI assistance

OpenCode using `openai/gpt-5.6-sol` drafted the implementation and tests and assisted with review and verification. Chris Huber reviewed the resulting code and evidence.