### PR TITLE
Run refresh ancestry checks on runners

### DIFF
--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -430,6 +430,9 @@ pub fn refresh_homeboy_binary(
                     identity,
                     options.allow_downgrade,
                     &promotion_authorities,
+                    |older, newer| {
+                        runner_commits_are_ancestral(&plan, older, newer, disconnected_ssh)
+                    },
                 )?;
                 Ok((
                     promote_verified_runner_binary(&plan.runner_id, homeboy_path)?,
@@ -455,6 +458,7 @@ pub fn refresh_homeboy_binary(
                 &identity,
                 options.allow_downgrade,
                 &promotion_authorities,
+                |older, newer| runner_commits_are_ancestral(&plan, older, newer, disconnected_ssh),
             )?;
             let updated_fields =
                 promote_verified_runner_binary(&plan.runner_id, &plan.binary_path)?;
@@ -1163,12 +1167,16 @@ fn refresh_promotion_authorities(runner_id: &str) -> Result<RefreshPromotionAuth
     })
 }
 
-fn validate_refresh_promotion(
+fn validate_refresh_promotion<IsAncestor>(
     plan: &HomeboyBinaryRefreshPlan,
     candidate: &Value,
     allow_downgrade: bool,
     authorities: &RefreshPromotionAuthorities,
-) -> Result<Option<HomeboyBinaryRefreshRollback>> {
+    mut is_ancestor: IsAncestor,
+) -> Result<Option<HomeboyBinaryRefreshRollback>>
+where
+    IsAncestor: FnMut(&str, &str) -> Result<bool>,
+{
     let candidate_commit = identity_commit(candidate).ok_or_else(|| {
         Error::validation_invalid_argument(
             "identity",
@@ -1191,7 +1199,7 @@ fn validate_refresh_promotion(
         let Some(authority) = authority.filter(|authority| *authority != candidate_commit) else {
             continue;
         };
-        match commits_are_ancestral(plan, &candidate_commit, authority) {
+        match is_ancestor(&candidate_commit, authority) {
             Ok(true) => previous.push(format!("{name}:{authority}")),
             Ok(false) => {}
             Err(_) if allow_downgrade => unproven.push(format!("{name}:{authority}")),
@@ -1238,10 +1246,11 @@ fn identity_commit(identity: &Value) -> Option<String> {
         .map(str::to_string)
 }
 
-fn commits_are_ancestral(
+fn runner_commits_are_ancestral(
     plan: &HomeboyBinaryRefreshPlan,
     older: &str,
     newer: &str,
+    disconnected_ssh: bool,
 ) -> Result<bool> {
     let repository = plan.target_dir.as_deref().ok_or_else(|| {
         Error::validation_invalid_argument(
@@ -1251,22 +1260,46 @@ fn commits_are_ancestral(
             None,
         )
     })?;
-    let status = Command::new("git")
-        .args([
-            "-C",
-            repository,
-            "merge-base",
-            "--is-ancestor",
-            older,
-            newer,
-        ])
-        .status()
-        .map_err(|error| {
-            Error::internal_io(error.to_string(), Some("run git merge-base".to_string()))
-        })?;
-    match status.code() {
-        Some(0) => Ok(true),
-        Some(1) => Ok(false),
+    let (_, exit_code) = exec(
+        &plan.runner_id,
+        refresh_ancestry_execution_options(repository, older, newer, disconnected_ssh),
+    )?;
+    classify_refresh_ancestry_exit(plan, exit_code)
+}
+
+fn refresh_ancestry_execution_options(
+    repository: &str,
+    older: &str,
+    newer: &str,
+    disconnected_ssh: bool,
+) -> RunnerExecOptions {
+    let command = vec![
+        "git".to_string(),
+        "-C".to_string(),
+        repository.to_string(),
+        "merge-base".to_string(),
+        "--is-ancestor".to_string(),
+        older.to_string(),
+        newer.to_string(),
+    ];
+    let options = if disconnected_ssh {
+        RunnerExecOptions::diagnostic_raw_command(command)
+            .with_diagnostic_ssh_timeout(DISCONNECTED_SSH_REFRESH_TIMEOUT)
+    } else {
+        RunnerExecOptions::raw_command(command)
+    };
+    options.with_capability_preflight(RunnerCapabilityPreflight {
+        command: "runner.refresh-homeboy".to_string(),
+        required_commands: vec!["git".to_string()],
+        timeout: disconnected_ssh.then_some(DISCONNECTED_SSH_REFRESH_TIMEOUT),
+        ..Default::default()
+    })
+}
+
+fn classify_refresh_ancestry_exit(plan: &HomeboyBinaryRefreshPlan, exit_code: i32) -> Result<bool> {
+    match exit_code {
+        0 => Ok(true),
+        1 => Ok(false),
         _ => Err(Error::validation_invalid_argument(
             "allow_downgrade",
             "authoritative source repository cannot compare selected Homeboy commits",

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -7,6 +7,15 @@ use crate::{
 use crate::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};
 use homeboy_core::test_support;
 
+fn fixture_commits_are_ancestral(repository: &Path, older: &str, newer: &str) -> Result<bool> {
+    let status = Command::new("git")
+        .args(["merge-base", "--is-ancestor", older, newer])
+        .current_dir(repository)
+        .status()
+        .expect("compare fixture commits");
+    Ok(status.success())
+}
+
 #[test]
 fn routine_reconnect_refuses_to_interrupt_an_admitted_lab_offload() {
     let admission = active_admission("0b77251a-b6a7-42a6-91a3-e49ff5f57c16");
@@ -410,10 +419,16 @@ fn promotion_policy_blocks_tag_downgrade_without_mutating_selection_and_records_
             .map(str::to_string),
         configured_selected: None,
     };
-    let denied = validate_refresh_promotion(&plan, &candidate, false, &authorities)
+    let denied =
+        validate_refresh_promotion(&plan, &candidate, false, &authorities, |older, newer| {
+            fixture_commits_are_ancestral(fixture.path(), older, newer)
+        })
         .expect_err("post-tag active daemon must block implicit rollback");
     assert_eq!(denied.details["field"], "allow_downgrade");
-    let rollback = validate_refresh_promotion(&plan, &candidate, true, &authorities)
+    let rollback =
+        validate_refresh_promotion(&plan, &candidate, true, &authorities, |older, newer| {
+            fixture_commits_are_ancestral(fixture.path(), older, newer)
+        })
         .expect("explicit rollback is allowed")
         .expect("rollback evidence");
     assert_eq!(rollback.requested.as_deref(), Some("v1.0.0"));
@@ -501,11 +516,15 @@ fn old_materializes_first_new_selects_first_uses_fresh_promotion_authorities() {
         active_daemon: None,
         configured_selected: None,
     };
-    assert!(
-        validate_refresh_promotion(&plan, &candidate, false, &stale_authorities)
-            .expect("stale snapshot would allow selection")
-            .is_none()
-    );
+    assert!(validate_refresh_promotion(
+        &plan,
+        &candidate,
+        false,
+        &stale_authorities,
+        |older, newer| fixture_commits_are_ancestral(fixture.path(), older, newer),
+    )
+    .expect("stale snapshot would allow selection")
+    .is_none());
 
     // Selection must use the authority reread after obtaining its lease.
     let fresh_authorities = RefreshPromotionAuthorities {
@@ -513,7 +532,14 @@ fn old_materializes_first_new_selects_first_uses_fresh_promotion_authorities() {
         active_daemon: None,
         configured_selected: Some(new),
     };
-    assert!(validate_refresh_promotion(&plan, &candidate, false, &fresh_authorities).is_err());
+    assert!(validate_refresh_promotion(
+        &plan,
+        &candidate,
+        false,
+        &fresh_authorities,
+        |older, newer| fixture_commits_are_ancestral(fixture.path(), older, newer),
+    )
+    .is_err());
 }
 
 #[test]
@@ -595,6 +621,7 @@ fn rollback_evidence_excludes_unrelated_authorities() {
             active_daemon: None,
             configured_selected: None,
         },
+        |older, newer| fixture_commits_are_ancestral(fixture.path(), older, newer),
     )
     .expect("unrelated authority is not a rollback");
     assert!(evidence.is_none());
@@ -1258,6 +1285,69 @@ fn connected_refresh_keeps_daemon_execution_options() {
 
     assert!(!options.allow_diagnostic_ssh);
     assert_eq!(options.diagnostic_ssh_timeout, None);
+}
+
+#[test]
+fn refresh_ancestry_probe_executes_in_the_runner_repository() {
+    let connected = refresh_ancestry_execution_options(
+        "/runner/homeboy",
+        "candidate-sha",
+        "authority-sha",
+        false,
+    );
+    assert_eq!(
+        connected.command,
+        vec![
+            "git",
+            "-C",
+            "/runner/homeboy",
+            "merge-base",
+            "--is-ancestor",
+            "candidate-sha",
+            "authority-sha",
+        ]
+    );
+    assert!(!connected.allow_diagnostic_ssh);
+    assert_eq!(
+        connected
+            .capability_preflight
+            .expect("connected preflight")
+            .required_commands,
+        vec!["git"]
+    );
+
+    let disconnected = refresh_ancestry_execution_options(
+        "/runner/homeboy",
+        "candidate-sha",
+        "authority-sha",
+        true,
+    );
+    assert!(disconnected.allow_diagnostic_ssh);
+    assert_eq!(
+        disconnected.diagnostic_ssh_timeout,
+        Some(DISCONNECTED_SSH_REFRESH_TIMEOUT)
+    );
+}
+
+#[test]
+fn refresh_ancestry_exit_status_requires_authoritative_git_result() {
+    let plan = HomeboyBinaryRefreshPlan {
+        runner_id: "lab".to_string(),
+        mode: "materialize".to_string(),
+        source: None,
+        git_ref: Some("candidate".to_string()),
+        target_dir: Some("/runner/homeboy".to_string()),
+        binary_path: "/runner/homeboy/target/release/homeboy".to_string(),
+        script: String::new(),
+        reconnect: false,
+        followup_commands: Vec::new(),
+    };
+
+    assert!(classify_refresh_ancestry_exit(&plan, 0).unwrap());
+    assert!(!classify_refresh_ancestry_exit(&plan, 1).unwrap());
+    let error = classify_refresh_ancestry_exit(&plan, 128)
+        .expect_err("git comparison errors are not ancestry evidence");
+    assert_eq!(error.details["field"], "allow_downgrade");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- execute refresh anti-downgrade ancestry checks in the runner-side authoritative checkout
- preserve exact rollback rejection while supporting connected daemon and bounded disconnected SSH transport
- inject ancestry evaluation into promotion policy for deterministic direction and race coverage

Closes #9776.

## Verification

- `cargo test -p homeboy-lab-runner homeboy_refresh -- --test-threads=1`
- `cargo check -p homeboy-lab-runner`
- `git diff --check`
- `homeboy runner refresh-homeboy homeboy-lab --ref a827c597e9fd --reconnect`
  - selected `homeboy 0.306.1+a827c597e9fd`
  - updated `homeboy_path`
  - reconnected the runner without `--allow-downgrade`
  - materialization job: `runner-exec-generic-homeboy-lab-50c09423-d140-4052-bea1-34dbeaebd85c`

## AI Assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode was used to investigate the runner/controller path mismatch, implement the repair and deterministic tests, and execute verification. Chris Huber reviewed and remains responsible for the change.
