### PR TITLE
fix(refactor): resolve module paths for the extracted code_audit crate

### DIFF
--- a/crates/homeboy-refactor/src/plan/generate/duplicate_fixes.rs
+++ b/crates/homeboy-refactor/src/plan/generate/duplicate_fixes.rs
@@ -20,7 +20,15 @@ pub(crate) fn extract_function_name_from_unreferenced(description: &str) -> Opti
 }
 
 pub(crate) fn module_path_from_file(file_path: &str) -> String {
-    homeboy_core::engine::symbol_graph::module_path_from_file(file_path)
+    let module_path = homeboy_core::engine::symbol_graph::module_path_from_file(file_path);
+    // `src/core/**` is the homeboy-core crate root, so `core` is not part of the
+    // intra-crate module path — a generated `use crate::core::engine::…` would
+    // not resolve. Strip the leading `core::` (or a bare `core`) so the import
+    // the wrapper builds (`use crate::{path}::{fn};`) is `crate::engine::…`.
+    module_path
+        .strip_prefix("core::")
+        .map(str::to_string)
+        .unwrap_or(module_path)
 }
 
 /// Generate a language-appropriate import statement for a duplicate function fix.

--- a/crates/homeboy-refactor/src/plan/generate/near_duplicate_fixes.rs
+++ b/crates/homeboy-refactor/src/plan/generate/near_duplicate_fixes.rs
@@ -274,8 +274,14 @@ fn find_function_range(content: &str, fn_name: &str) -> Option<(usize, usize)> {
     None
 }
 
-/// Convert a file path like "src/core/code_audit/baseline.rs" to a Rust module path
-/// like "homeboy_code_audit::baseline".
+/// Convert a file path like "src/core/code_audit/baseline.rs" to a Rust module
+/// path like "homeboy_code_audit::baseline".
+///
+/// The `code_audit` subsystem was extracted into its own `homeboy-code-audit`
+/// crate, so paths under `core/code_audit/` resolve through the external crate
+/// name (`homeboy_code_audit::`) rather than the in-tree `crate::core::` path —
+/// generating `use crate::core::code_audit::…` would not compile. Everything
+/// else keeps the in-tree `crate::` prefix.
 fn file_to_module_path(file: &str) -> String {
     let mut path = file.strip_prefix("src/").unwrap_or(file);
     // "foo/mod.rs" → "foo"
@@ -285,6 +291,21 @@ fn file_to_module_path(file: &str) -> String {
         // "foo/bar.rs" → "foo/bar"
         path = stripped;
     }
+
+    // Paths inside the extracted code_audit crate resolve through its external
+    // crate name. `core/code_audit` and `core/code_audit/baseline` both map onto
+    // `homeboy_code_audit[::baseline]`.
+    if let Some(rest) = path
+        .strip_prefix("core/code_audit")
+        .filter(|rest| rest.is_empty() || rest.starts_with('/'))
+    {
+        let suffix = rest.trim_start_matches('/');
+        if suffix.is_empty() {
+            return "homeboy_code_audit".to_string();
+        }
+        return format!("homeboy_code_audit::{}", suffix.replace('/', "::"));
+    }
+
     format!("crate::{}", path.replace('/', "::"))
 }
 


### PR DESCRIPTION
## Summary
The near-duplicate and duplicate-import fixers generate Rust `use` statements from a file's module path. Two mappings were stale after crate extractions, so the generated imports would not compile. Both were already covered by unit tests that **fail on `main`** — this makes them pass.

## Fixes
- **`code_audit` → external crate:** `file_to_module_path` (near_duplicate_fixes) emitted `crate::core::code_audit::…`, but `code_audit` was extracted into the `homeboy-code-audit` crate. Files under `core/code_audit/` now map to `homeboy_code_audit::…`.
- **`core` crate root:** `src/core/**` is the `homeboy-core` crate root, so `core` is not part of the intra-crate module path. The duplicate-import wrapper `module_path_from_file` kept the leading `core::`, producing `use crate::core::engine::…` instead of `crate::engine::…`. Fixed by stripping the leading `core::` in the refactor-side wrapper, leaving the shared `symbol_graph::module_path_from_file` (which other callers rely on with `core::` intact) unchanged.

## Testing
- `cargo test -p homeboy-refactor --lib file_to_module_path` — 2 passed (were failing on main).
- `cargo test -p homeboy-refactor --lib test_generate_duplicate_import` — 3 passed (rust variant was failing on main).

## Not addressed here (separate latent failures on main)
While verifying, I confirmed these also fail on clean `origin/main`, from unrelated root causes — worth separate issues:
- `module_surface::tests::build_uses_snapshot_content_for_module_surfaces` — the surface index `get()` returns `None` for a tempdir fixture file (walker/fingerprint resolution, not module-path mapping).
- `extension_source::tests::{extension_refactor_source_dispatch_uses_generic_source_result, extension_refactor_source_nonzero_exit_reports_real_failure}` — run external processes; fail in a sandboxed env.

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Diagnosing stale module-path mappings surfaced by failing unit tests after the code_audit crate extraction.