### PR TITLE
fix(fuzz): dispatch campaign children with concrete workload, not parent profile

### DIFF
--- a/crates/homeboy-cli/src/commands/fuzz/planning.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/planning.rs
@@ -15,7 +15,7 @@ use super::execution::fuzz_runner_contract;
 use super::execution::run_run;
 use super::types::{
     FuzzCampaignDispatchRecordOutput, FuzzCampaignRunOutput, FuzzPlanArgs, FuzzPlanOutput,
-    FuzzPlanStrategy,
+    FuzzPlanStrategy, FuzzRunArgs,
 };
 use super::types_extra::{
     FuzzCampaignPlanEntryOutput, FuzzCampaignPlanIsolationOutput, FuzzCampaignPlanOutput,
@@ -190,9 +190,7 @@ pub(super) fn run_campaign(
             continue;
         }
 
-        let mut run_args = args.run.clone();
-        run_args.workload_id = Some(entry.workload_id.clone());
-        run_args.run_id = Some(entry.run_id.clone());
+        let run_args = campaign_child_run_args(&args.run, &entry.workload_id, &entry.run_id);
         let (run_output, entry_exit) = run_run(run_args)?;
         if entry_exit != 0 && exit_code == 0 {
             exit_code = entry_exit;
@@ -520,6 +518,27 @@ fn campaign_entry_metadata(
         );
     }
     metadata
+}
+
+/// Build the child `fuzz run` args for one expanded campaign entry.
+///
+/// The campaign already resolved the parent multi-workload `--profile` into
+/// concrete entries, so each child dispatches with its own `--workload` and no
+/// `--profile`: the single-workload `fuzz run` primitive rejects a profile that
+/// resolves to more than one workload, and `--profile`/`--workload` cannot be
+/// combined (#9778). All other shared campaign policy — gates, tracker refs,
+/// isolation, destructive permission, seed, artifacts — is inherited unchanged
+/// from the parent run args.
+pub(super) fn campaign_child_run_args(
+    parent: &FuzzRunArgs,
+    workload_id: &str,
+    run_id: &str,
+) -> FuzzRunArgs {
+    let mut run_args = parent.clone();
+    run_args.profile = None;
+    run_args.workload_id = Some(workload_id.to_string());
+    run_args.run_id = Some(run_id.to_string());
+    run_args
 }
 
 fn campaign_run_command(

--- a/crates/homeboy-cli/src/commands/fuzz/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/mod.rs
@@ -10,8 +10,8 @@ use super::execution::{
     run_fuzz_artifact_postprocess, FuzzRunEvidenceInput,
 };
 use super::planning::{
-    build_campaign_plan, load_or_default_isolation_proof, plan_inventory_selection, run_campaign,
-    run_plan,
+    build_campaign_plan, campaign_child_run_args, load_or_default_isolation_proof,
+    plan_inventory_selection, run_campaign, run_plan,
 };
 use super::replay::{run_minimize, run_replay};
 use super::report::{

--- a/crates/homeboy-cli/src/commands/fuzz/tests/planning_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/planning_tests.rs
@@ -413,6 +413,65 @@ fn fuzz_campaign_plan_emits_deterministic_run_entries_from_manifest_and_cli_work
 }
 
 #[test]
+fn campaign_child_run_args_drops_parent_profile_and_pins_concrete_workload() {
+    // #9778: a multi-workload parent profile is expanded into concrete entries,
+    // so each child dispatch must carry its own --workload and drop the parent
+    // --profile. Forwarding the profile makes the single-workload `fuzz run`
+    // primitive reject the entry (profile resolves to multiple workloads, and
+    // --profile/--workload cannot be combined). Shared policy must survive.
+    let mut parent = planner_args().run;
+    parent.profile = Some("full-surface".to_string());
+    parent.workload_id = None;
+    parent.run_id = Some("parent-run".to_string());
+    parent.allow_destructive = true;
+    parent.isolation = FuzzIsolationArg::Isolated;
+    parent.gate_profile = FuzzGateProfileArg::Evidence;
+    parent.tracker_refs = vec![homeboy::core::evidence_manifest::TrackerRef {
+        kind: "github_issue".to_string(),
+        id: "Extra-Chill/homeboy#9778".to_string(),
+        url: None,
+        title: None,
+        state: None,
+    }];
+
+    let child = campaign_child_run_args(&parent, "db-fuzz", "campaign-1-db-fuzz");
+
+    // Parent multi-workload profile is dropped; the concrete workload is pinned.
+    assert_eq!(child.profile, None);
+    assert_eq!(child.workload_id.as_deref(), Some("db-fuzz"));
+    assert_eq!(child.run_id.as_deref(), Some("campaign-1-db-fuzz"));
+
+    // The child now resolves to exactly one workload with no profile conflict,
+    // matching the `fuzz run` primitive's contract.
+    assert_eq!(
+        resolve_profile_workload_id(None, child.rig_profile(), child.workload_id.as_deref())
+            .expect("child resolves without profile/workload conflict"),
+        Some("db-fuzz".to_string())
+    );
+
+    // Shared campaign policy is preserved on the child.
+    assert!(child.allow_destructive);
+    assert_eq!(child.isolation, FuzzIsolationArg::Isolated);
+    assert_eq!(child.gate_profile, FuzzGateProfileArg::Evidence);
+    assert_eq!(child.tracker_refs, parent.tracker_refs);
+}
+
+#[test]
+fn direct_run_with_multi_workload_profile_and_workload_is_still_rejected() {
+    // The acceptance guard: `fuzz run --profile <multi> --workload <id>` (i.e.
+    // a profile combined with an explicit workload) must remain rejected. Only
+    // the campaign expansion path is allowed to resolve profiles into workloads.
+    let error = resolve_profile_workload_id(None, Some("full-surface"), Some("db-fuzz"))
+        .expect_err("profile + explicit workload must be rejected");
+    assert!(
+        error
+            .to_string()
+            .contains("--profile and --workload cannot be combined"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
 fn generic_lab_profile_expands_safe_destructive_evidence_defaults() {
     let cli = FuzzCli::try_parse_from([
         "fuzz",


### PR DESCRIPTION
## Summary
- `fuzz run-campaign --profile <multi-workload> --execute` expanded the profile into per-workload entries, but each child dispatch still cloned the parent `--profile`. The single-workload `fuzz run` primitive then rejected every entry — the profile resolves to multiple workloads and `--profile`/`--workload` cannot be combined — so a fully-planned campaign failed before any workload ran (#9778).

## Root cause
`run_campaign`'s execute loop built each child from `args.run.clone()`, which retained `profile: Some("full-surface")`, then set `workload_id`. That gives the child both a multi-workload profile *and* a workload — rejected at `resolve_profile_workload_id`. (The planned display/lab commands were already correct; only the actual dispatch args leaked the profile.)

## Change
- New `campaign_child_run_args(parent, workload_id, run_id)` clears `--profile` and pins the resolved `--workload` for each entry. Shared campaign policy (gates, tracker refs, isolation, destructive permission, seed, artifacts) is inherited unchanged.

## Acceptance criteria
- [x] `run-campaign --execute` dispatches each entry with its concrete `--workload` and no parent `--profile`.
- [x] Shared campaign policy continues to reach child runs (asserted: destructive, isolation, gate profile, tracker refs).
- [x] Deterministic coverage proves a multi-workload profile resolves each workload without a profile/workload conflict.
- [x] Direct `fuzz run --profile <multi> --workload <id>` remains rejected.

## Testing
- `cargo test -p homeboy-cli --lib fuzz::tests::planning_tests` — 35 passed (2 new: child-args drops profile + pins workload; direct profile+workload still rejected).
- `cargo test -p homeboy-cli --lib commands::fuzz -- --test-threads=1` — 136 passed. (A parallel run shows one unrelated flake, `fuzz_run_cli_preserves_action_model_and_exploration_policy_in_execution_request`, from shared process-global state across fuzz tests — passes in isolation and single-threaded; tracked separately by the process-global-state isolation work.)

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Tracing the campaign expand/dispatch path, isolating the profile leak in the execute loop, and regression coverage.

Closes #9778