### PR TITLE
Fix logical terminal artifact projection

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -654,7 +654,7 @@ pub(crate) fn record_terminal_artifact_projection(
     record: &mut AgentTaskRunRecord,
     aggregate: &AgentTaskAggregate,
 ) -> Result<()> {
-    if record.runner_id().is_none() && aggregate_has_unresolved_actionable_patch(aggregate) {
+    if record.runner_id().is_none() && aggregate_has_runner_backed_actionable_patch(aggregate) {
         match runner_id_from_artifact_provenance(aggregate) {
             Ok(runner_id) => {
                 record
@@ -800,17 +800,17 @@ fn runner_id_from_artifact_provenance(aggregate: &AgentTaskAggregate) -> Result<
     }
 }
 
-fn aggregate_has_unresolved_actionable_patch(aggregate: &AgentTaskAggregate) -> bool {
+fn aggregate_has_runner_backed_actionable_patch(aggregate: &AgentTaskAggregate) -> bool {
     aggregate
         .outcomes
         .iter()
         .flat_map(|outcome| &outcome.artifacts)
         .any(|artifact| {
             crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(artifact)
-                && artifact
-                    .path
-                    .as_deref()
-                    .is_some_and(|path| Path::new(path).is_absolute())
+                && artifact.path.as_deref().is_some_and(|path| {
+                    let path = Path::new(path);
+                    path.is_absolute() && !path.is_file()
+                })
                 && artifact.size_bytes.is_some()
                 && artifact.sha256.is_some()
         })
@@ -1115,11 +1115,15 @@ pub(crate) fn project_terminal_artifacts(
                             format!("agent-task-{:x}", controller_hash.finalize());
                         let mut metadata = metadata;
                         metadata["agent_task"]["projection"] = json!("controller_finalized");
-                        store.record_artifact_with_id(
+                        store.record_verified_artifact_with_id(
                             &record.run_id,
                             &artifact.kind,
                             path,
                             &controller_artifact_id,
+                            artifact
+                                .size_bytes
+                                .and_then(|size| i64::try_from(size).ok()),
+                            artifact.sha256.as_deref(),
                             metadata,
                         )?;
                     }
@@ -1193,11 +1197,13 @@ pub(crate) fn project_terminal_artifacts(
                                     let mut controller_metadata = metadata.clone();
                                     controller_metadata["agent_task"]["projection"] =
                                         json!("runner_mirrored");
-                                    store.record_artifact_with_id(
+                                    store.record_verified_artifact_with_id(
                                         &record.run_id,
                                         &artifact.kind,
                                         &download.output_path,
                                         &controller_artifact_id,
+                                        Some(expected_size as i64),
+                                        Some(expected_sha256),
                                         controller_metadata,
                                     )?;
                                     Ok(())
@@ -1232,11 +1238,15 @@ pub(crate) fn project_terminal_artifacts(
                     }
                 }
             } else {
-                store.record_artifact_with_id(
+                store.record_verified_artifact_with_id(
                     &record.run_id,
                     &artifact.kind,
                     path,
                     &artifact_id,
+                    artifact
+                        .size_bytes
+                        .and_then(|size| i64::try_from(size).ok()),
+                    artifact.sha256.as_deref(),
                     metadata,
                 )?;
             }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -1181,8 +1181,41 @@ fn terminal_executor_artifacts_are_projected_under_logical_ids() {
             sha256: Some(homeboy_core::artifact_metadata::sha256_file(&patch).expect("sha")),
             metadata: json!({ "executor_artifact_finalized": true }),
         });
+        for (id, kind, bytes) in [
+            ("transcript", "transcript", b"transcript bytes".as_slice()),
+            (
+                "agent-result",
+                "agent-result",
+                b"agent result bytes".as_slice(),
+            ),
+        ] {
+            let artifact = root.path().join(id);
+            std::fs::write(&artifact, bytes).expect("write terminal artifact");
+            aggregate.outcomes[0].artifacts.push(AgentTaskArtifact {
+                schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                id: id.to_string(),
+                kind: kind.to_string(),
+                name: None,
+                label: None,
+                role: None,
+                semantic_key: None,
+                path: Some(artifact.display().to_string()),
+                url: None,
+                mime: Some("text/plain".to_string()),
+                size_bytes: Some(bytes.len() as u64),
+                sha256: Some(homeboy_core::artifact_metadata::sha256_file(&artifact).expect("sha")),
+                metadata: json!({ "executor_artifact_finalized": true }),
+            });
+        }
         submit_plan(&plan, Some("projection-parity")).expect("submit");
         record_run_aggregate("projection-parity", &plan, &aggregate).expect("record aggregate");
+        reconcile_terminal_artifact_projection("projection-parity").expect("idempotent projection");
+        let record = status("projection-parity").expect("terminal record");
+        assert_eq!(
+            record.metadata["artifact_projection"]["status"], "complete",
+            "{:#}",
+            record.metadata
+        );
 
         let store = homeboy_core::observation::ObservationStore::open_initialized().expect("store");
         let artifact = homeboy_core::observation::runs_service::resolve_artifact_for_run(
@@ -1210,6 +1243,65 @@ fn terminal_executor_artifacts_are_projected_under_logical_ids() {
         assert_eq!(
             std::fs::read(fetched.output_path).expect("retrieved bytes"),
             b"patch bytes"
+        );
+        for (id, bytes) in [
+            ("transcript", b"transcript bytes".as_slice()),
+            ("agent-result", b"agent result bytes".as_slice()),
+        ] {
+            let artifact = homeboy_core::observation::runs_service::resolve_artifact_for_run(
+                &store,
+                "projection-parity",
+                id,
+            )
+            .expect("resolve logical terminal artifact");
+            assert_eq!(
+                std::fs::read(artifact.path).expect("projected bytes"),
+                bytes
+            );
+        }
+    });
+}
+
+#[test]
+fn terminal_executor_artifact_projection_rejects_mismatched_bytes() {
+    with_isolated_home(|_| {
+        let root = tempfile::tempdir().expect("executor artifact root");
+        let patch = root.path().join("patch.diff");
+        std::fs::write(&patch, "expected patch").expect("write patch");
+        let plan = test_plan();
+        let mut aggregate = succeeded_aggregate(&plan);
+        aggregate.outcomes[0].artifacts.push(AgentTaskArtifact {
+            schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+            id: "patch".to_string(),
+            kind: "patch".to_string(),
+            name: None,
+            label: None,
+            role: None,
+            semantic_key: None,
+            path: Some(patch.display().to_string()),
+            url: None,
+            mime: Some("text/x-patch".to_string()),
+            size_bytes: Some("expected patch".len() as u64),
+            sha256: Some(homeboy_core::artifact_metadata::sha256_file(&patch).expect("sha")),
+            metadata: json!({ "executor_artifact_finalized": true }),
+        });
+        std::fs::write(&patch, "tampered patch").expect("tamper patch");
+        submit_plan(&plan, Some("projection-tampered")).expect("submit");
+        record_run_aggregate("projection-tampered", &plan, &aggregate).expect("record aggregate");
+
+        let record = status("projection-tampered").expect("terminal record");
+        assert_eq!(record.metadata["artifact_projection"]["status"], "pending");
+        assert!(record.metadata["artifact_projection"]["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("does not match")));
+        let store = homeboy_core::observation::ObservationStore::open_initialized().expect("store");
+        assert!(
+            homeboy_core::observation::runs_service::resolve_artifact_for_run(
+                &store,
+                "projection-tampered",
+                "patch",
+            )
+            .is_err()
         );
     });
 }


### PR DESCRIPTION
## Summary
Restore logical artifact lookup for finalized terminal executor outputs.

## What changed
- Project local finalized patch, transcript, and agent-result artifacts under their logical IDs with verified byte metadata.
- Require runner provenance only when an actionable absolute patch is not locally available.

## How to test
1. Run `cargo test -p homeboy-agents terminal_executor_artifacts_are_projected_under_logical_ids -- --test-threads=1`; expect 1 test passes.
2. Run `cargo test -p homeboy-agents terminal_executor_artifact_projection_rejects_mismatched_bytes -- --test-threads=1`; expect 1 test passes.
3. Run `cargo check -p homeboy-agents`; expect passes.

## Compatibility
Preserves runner-backed mirroring while restoring local finalized artifact lookup; no schema changes.

## Evidence
- Base unchanged since verification: main remains at 9c7ce6a0f567fdf945ca5c9aa76db70c3b54066b.
- CI expected: Homeboy pull request CI
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9773
- Verified finalization base: main at 9c7ce6a0f567fdf945ca5c9aa76db70c3b54066b
- cargo-check-homeboy-agents: passed (Passed)
- changed-file-rustfmt: passed (Passed)
- focused-logical-projection: passed (Passed)
- git-diff-check: passed (Passed)
- tampered-byte-rejection: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the projection regression, implemented the fix and deterministic tests, and verified the focused behavior.

## Source relationships
- Closes Extra-Chill/homeboy#9773
- Relates to Extra-Chill/homeboy#9774
