### PR TITLE
Fix durable fanout resume recovery

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
@@ -80,6 +80,24 @@ pub fn start_candidate_adoption_with_rerun_policy(
     active_gate: &str,
     rerun_completed_gates: bool,
 ) -> Result<AgentTaskRunRecord> {
+    start_candidate_adoption_with_policy(
+        run_id,
+        candidate_sha,
+        ai_model,
+        active_gate,
+        rerun_completed_gates,
+        false,
+    )
+}
+
+pub fn start_candidate_adoption_with_policy(
+    run_id: &str,
+    candidate_sha: &str,
+    ai_model: &str,
+    active_gate: &str,
+    rerun_completed_gates: bool,
+    replace_interrupted: bool,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
     let candidate_sha = candidate_sha.to_string();
     let ai_model = ai_model.to_string();
@@ -87,6 +105,7 @@ pub fn start_candidate_adoption_with_rerun_policy(
     let mut conflict = false;
     let record = store::mutate_record(&run_id, |record| {
         let now = now_timestamp();
+        let mut replacement = None;
         if let Some(existing) = record.candidate_adoption.as_mut() {
             if existing.gate_process_group.is_some_and(|pgid| {
                 homeboy_core::process::isolated_process_group_is_running(pgid).unwrap_or(false)
@@ -104,7 +123,9 @@ pub fn start_candidate_adoption_with_rerun_policy(
                 existing.updated_at = now.clone();
                 existing.terminal_error = Some("adoption owner process is not running".to_string());
             }
-            if existing.state == "interrupted"
+            if existing.state == "interrupted" && replace_interrupted {
+                replacement = Some(existing.clone());
+            } else if existing.state == "interrupted"
                 && existing.candidate_sha == candidate_sha
                 && existing.ai_model == ai_model
             {
@@ -127,9 +148,20 @@ pub fn start_candidate_adoption_with_rerun_policy(
                 conflict = true;
                 return false;
             }
-            if existing.state == "verification_running" || existing.state == "interrupted" {
+            if replacement.is_none()
+                && (existing.state == "verification_running" || existing.state == "interrupted")
+            {
                 conflict = true;
                 return false;
+            }
+        }
+        if let Some(replacement) = replacement {
+            let metadata = record.ensure_metadata_object();
+            let replacements = metadata
+                .entry("candidate_adoption_replacements".to_string())
+                .or_insert_with(|| serde_json::json!([]));
+            if let Some(replacements) = replacements.as_array_mut() {
+                replacements.push(serde_json::to_value(replacement).expect("adoption serializes"));
             }
         }
         record.candidate_adoption = Some(AgentTaskCandidateAdoptionAttempt {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2564,8 +2564,44 @@ pub fn record_cook_attempt(
     store::write_cook_index_attempt(cook_id, attempt, run_id, recorded_at)
 }
 
+/// Record the controller-owned boundary that a resumed Cook must advance.
+/// Provider terminal evidence and promotion reports remain separate so a later
+/// failed attempt cannot replace the source candidate's recovery checkpoint.
+pub fn record_cook_recovery_checkpoint(
+    run_id: &str,
+    phase: &str,
+    next_command: &str,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let checkpoint = json!({
+        "schema": "homeboy/agent-task-cook-recovery-checkpoint/v1",
+        "phase": phase,
+        "next_command": next_command,
+    });
+    let record = store::mutate_record(&run_id, |record| {
+        if record.metadata.get("cook_recovery_checkpoint") == Some(&checkpoint) {
+            return false;
+        }
+        record.updated_at = Some(now_timestamp());
+        record
+            .ensure_metadata_object()
+            .insert("cook_recovery_checkpoint".to_string(), checkpoint.clone());
+        true
+    })?;
+    match record {
+        Some(record) => Ok(record),
+        None => store::read_record(&run_id),
+    }
+}
+
 pub fn cook_index(cook_id: &str) -> Result<AgentTaskCookIndex> {
     store::read_cook_index(&sanitize_run_id(cook_id))
+}
+
+/// Read one durable attempt without resolving a cook ID through its latest
+/// index entry. Recovery must inspect historical source attempts directly.
+pub fn exact_record(run_id: &str) -> Result<AgentTaskRunRecord> {
+    store::read_record(&sanitize_run_id(run_id))
 }
 
 fn resolve_run_id(run_id: &str) -> Result<String> {
@@ -2584,6 +2620,14 @@ pub fn record_promotion(run_id: &str, promotion: Value) -> Result<AgentTaskRunRe
         }
         record.updated_at = Some(now_timestamp());
         let metadata = record.ensure_metadata_object();
+        // The first post-apply checkpoint is immutable recovery authority. Later
+        // gate/finalization reports advance `latest_promotion` without obscuring
+        // the exact candidate that may be resumed after a coordinator loss.
+        if promotion.get("status").and_then(Value::as_str) == Some("verification_pending") {
+            metadata
+                .entry("cook_recovery_source_checkpoint".to_string())
+                .or_insert_with(|| promotion.clone());
+        }
         let promotions = metadata
             .entry("promotions".to_string())
             .or_insert_with(|| json!([]));

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -261,6 +261,62 @@ fn candidate_adoption_status_persists_running_stale_resume_and_completion() {
 }
 
 #[test]
+fn interrupted_candidate_adoption_can_be_explicitly_replaced_with_audit_history() {
+    with_isolated_home(|_| {
+        let record = submit_plan(&test_plan(), Some("adoption-replacement")).expect("submit");
+        let original = "a3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1";
+        let replacement = "b3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1";
+        start_candidate_adoption(
+            &record.run_id,
+            original,
+            "openai/gpt-5.6-terra",
+            "cargo test",
+        )
+        .expect("start original adoption");
+        assert!(start_candidate_adoption_with_policy(
+            &record.run_id,
+            replacement,
+            "openai/gpt-5.6-sol",
+            "cargo test",
+            false,
+            true,
+        )
+        .is_err());
+
+        rewrite_record_for_test(&record.run_id, |record| {
+            record
+                .candidate_adoption
+                .as_mut()
+                .expect("original adoption")
+                .owner_pid = u32::MAX;
+        })
+        .unwrap();
+        status(&record.run_id).expect("reconcile stale owner");
+        let replaced = start_candidate_adoption_with_policy(
+            &record.run_id,
+            replacement,
+            "openai/gpt-5.6-sol",
+            "cargo test",
+            false,
+            true,
+        )
+        .expect("explicitly replace interrupted adoption");
+
+        let current = replaced.candidate_adoption.expect("replacement adoption");
+        assert_eq!(current.candidate_sha, replacement);
+        assert_eq!(current.ai_model, "openai/gpt-5.6-sol");
+        assert_eq!(
+            replaced.metadata["candidate_adoption_replacements"][0]["candidate_sha"],
+            original
+        );
+        assert_eq!(
+            replaced.metadata["candidate_adoption_replacements"][0]["state"],
+            "interrupted"
+        );
+    });
+}
+
+#[test]
 fn candidate_adoption_gate_heartbeats_are_durable() {
     with_isolated_home(|_| {
         let record = submit_plan(&test_plan(), Some("adoption-gate-supervision")).expect("submit");

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -135,6 +135,7 @@ pub struct AgentTaskCookServiceOptions {
 #[derive(Debug, Clone, Default)]
 pub struct AgentTaskCandidateAdoptionOptions {
     pub ai_model: Option<String>,
+    pub replace_interrupted: bool,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -314,6 +314,25 @@ where
     E: AgentTaskExecutorAdapter + Clone,
     D: Fn(&Value) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
 {
+    resume_cook_batch_with_finalizer(
+        batch_id,
+        executor,
+        reconstruct_dispatcher,
+        finalize_or_load_cook_pr,
+    )
+}
+
+fn resume_cook_batch_with_finalizer<E, D, F>(
+    batch_id: &str,
+    executor: E,
+    reconstruct_dispatcher: D,
+    mut finalize: F,
+) -> Result<AgentTaskRunResult<AgentTaskCookBatchReport>>
+where
+    E: AgentTaskExecutorAdapter + Clone,
+    D: Fn(&Value) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
+    F: FnMut(&AgentTaskCookServiceOptions, &str, &AgentTaskPromotionReport) -> Result<Value>,
+{
     let batch = crate::agent_task_batch::read_batch_record(batch_id)?;
     if batch.child_runs.is_empty() {
         return Err(Error::validation_invalid_argument(
@@ -331,7 +350,13 @@ where
         // is exactly the durable recipe key. Reconstruct from that recipe so the
         // resumed cook re-runs its own gates and finalization contract.
         let cook_id = child.run_id.clone();
-        let cell = match resume_batch_child(&cook_id, executor.clone(), &reconstruct_dispatcher) {
+        let cell = match resume_batch_child(
+            batch_id,
+            &cook_id,
+            executor.clone(),
+            &reconstruct_dispatcher,
+            &mut finalize,
+        ) {
             Ok(report) => {
                 let exit_code = cook_report_exit_code(&report);
                 AgentTaskCookBatchCellReport {
@@ -382,14 +407,17 @@ where
 /// Reconstruct one batch child's cook from its durable recipe and re-run it.
 /// A missing recipe means the child never reached cook start; surface an
 /// actionable resumability error instead of fabricating a cook.
-fn resume_batch_child<E, D>(
+fn resume_batch_child<E, D, F>(
+    batch_id: &str,
     cook_id: &str,
     executor: E,
     reconstruct_dispatcher: &D,
+    finalize: &mut F,
 ) -> Result<AgentTaskCookReport>
 where
     E: AgentTaskExecutorAdapter + Clone,
     D: Fn(&Value) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
+    F: FnMut(&AgentTaskCookServiceOptions, &str, &AgentTaskPromotionReport) -> Result<Value>,
 {
     if !super::recipe_exists(cook_id)? {
         return Err(Error::validation_invalid_argument(
@@ -403,18 +431,45 @@ where
             )]),
         ));
     }
-    agent_task_lifecycle::reconcile_terminal_artifact_projection(cook_id)?;
-    if let Some(reason) = agent_task_lifecycle::terminal_artifact_projection_readiness(cook_id)? {
-        return Err(Error::validation_invalid_argument(
-            "cook_id",
-            format!("cook `{cook_id}` cannot resume until controller-side patch projection is ready: {reason}"),
-            Some(cook_id.to_string()),
-            Some(vec![format!(
-                "Run `homeboy agent-task status {cook_id}` to reconcile the controller projection."
-            )]),
-        ));
-    }
     let recipe = super::load_recipe(cook_id)?;
+    let mut attempt_run_ids = recipe
+        .attempts
+        .iter()
+        .map(|attempt| attempt.run_id.clone())
+        .collect::<Vec<_>>();
+    if let Ok(index) = agent_task_lifecycle::cook_index(cook_id) {
+        attempt_run_ids.extend(index.attempts.into_iter().map(|attempt| attempt.run_id));
+    }
+    let checkpoint_run_id = attempt_run_ids.into_iter().find(|run_id| {
+        agent_task_lifecycle::exact_record(run_id)
+            .ok()
+            .is_some_and(|record| {
+                record
+                    .metadata
+                    .get("cook_recovery_source_checkpoint")
+                    .is_some()
+                    || record
+                        .metadata
+                        .get("latest_promotion")
+                        .and_then(|promotion| promotion.get("status"))
+                        .and_then(Value::as_str)
+                        == Some("verification_pending")
+            })
+    });
+    if checkpoint_run_id.is_none() {
+        agent_task_lifecycle::reconcile_terminal_artifact_projection(cook_id)?;
+        if let Some(reason) = agent_task_lifecycle::terminal_artifact_projection_readiness(cook_id)?
+        {
+            return Err(Error::validation_invalid_argument(
+                "cook_id",
+                format!("cook `{cook_id}` cannot resume until controller-side patch projection is ready: {reason}"),
+                Some(cook_id.to_string()),
+                Some(vec![format!(
+                    "Run `homeboy agent-task status {cook_id}` to reconcile the controller projection."
+                )]),
+            ));
+        }
+    }
     // Faithfully reconstruct the recipe's transport so re-running `run_cook`
     // matches the persisted durable inputs (a stripped dispatcher would look
     // like a conflicting new cook). A terminal child is not re-dispatched — its
@@ -423,8 +478,36 @@ where
     // (#9525).
     let attempt_dispatcher =
         reconstruct_dispatcher(&recipe.promotion_transport["attempt_dispatch"])?;
-    let options = super::reconstruct_options_with_dispatcher(&recipe, attempt_dispatcher)?;
-    Ok(run_cook(options, executor)?.value)
+    let mut options = super::reconstruct_options_with_dispatcher(&recipe, attempt_dispatcher)?;
+    if let Some(run_id) = checkpoint_run_id {
+        let attempt = recipe
+            .attempts
+            .iter()
+            .find(|attempt| attempt.run_id == run_id)
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "cook_recovery_source_checkpoint",
+                    "checkpointed source attempt is absent from the durable cook recipe",
+                    Some(run_id.clone()),
+                    None,
+                )
+            })?;
+        // An earlier post-apply checkpoint remains the source of truth even if
+        // a later provider attempt failed and became the cook-index latest run.
+        options.initial_run_id = attempt.run_id.clone();
+        options.initial_plan = attempt.plan.clone();
+        agent_task_lifecycle::record_cook_recovery_checkpoint(
+            &attempt.run_id,
+            "verification_pending",
+            &format!("homeboy agent-task fanout resume {batch_id}"),
+        )?;
+    }
+    Ok(
+        run_cook_with_finalizer(options, executor, |options, run_id, promotion| {
+            finalize(options, run_id, promotion)
+        })?
+        .value,
+    )
 }
 
 fn child_finalization_value(cell: &AgentTaskCookBatchCellReport) -> Value {
@@ -692,7 +775,24 @@ where
         .ok()
         .and_then(|record| record.metadata.get("cook_moving_base_recovery").cloned())
         .is_some();
+    let verification_pending_continuation = agent_task_lifecycle::status(&options.initial_run_id)
+        .ok()
+        .is_some_and(|record| {
+            record
+                .metadata
+                .get("cook_recovery_source_checkpoint")
+                .and_then(|checkpoint| checkpoint.get("phase"))
+                .and_then(Value::as_str)
+                == Some("verification_pending")
+                || record
+                    .metadata
+                    .get("latest_promotion")
+                    .and_then(|promotion| promotion.get("status"))
+                    .and_then(Value::as_str)
+                    == Some("verification_pending")
+        });
     if !moving_base_continuation
+        && !verification_pending_continuation
         && options.attempt_dispatcher.is_none()
         && options.provider_command.is_none()
         && options.provider_invocation.is_none()
@@ -743,15 +843,17 @@ where
     // Transport readiness can serialize on a reconnect/runtime-promotion
     // lease. Complete it before entering the provider-attempt loop so that
     // waiting for a shared Lab session never consumes a cook attempt.
-    if let Some(dispatcher) = &options.attempt_dispatcher {
-        if let Err(error) = dispatcher.prepare_for_cook() {
-            agent_task_lifecycle::record_pre_execution_failure(
-                &options.initial_run_id,
-                &options.initial_plan,
-                dispatcher.pre_execution_failure_phase(),
-                &error,
-            )?;
-            return Err(error);
+    if !verification_pending_continuation {
+        if let Some(dispatcher) = &options.attempt_dispatcher {
+            if let Err(error) = dispatcher.prepare_for_cook() {
+                agent_task_lifecycle::record_pre_execution_failure(
+                    &options.initial_run_id,
+                    &options.initial_plan,
+                    dispatcher.pre_execution_failure_phase(),
+                    &error,
+                )?;
+                return Err(error);
+            }
         }
     }
     // The initial attempt is the durable status/activity owner. Pin it rather
@@ -769,8 +871,9 @@ where
         .find(|attempt| attempt.run_id == options.initial_run_id)
         .map(|attempt| attempt.attempt)
         .unwrap_or(1);
-    let resumed_run_id = agent_task_lifecycle::cook_index(&options.cook_id)
-        .ok()
+    let resumed_run_id = (!verification_pending_continuation)
+        .then(|| agent_task_lifecycle::cook_index(&options.cook_id).ok())
+        .flatten()
         .map(|index| index.latest_run_id)
         .filter(|run_id| run_id != &options.initial_run_id)
         .filter(|run_id| {

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -623,7 +623,22 @@ where
             })
         }
     };
-    let next_attempt = attempt + 1;
+    let next_attempt = super::load_recipe(cook_id)?
+        .attempts
+        .iter()
+        .map(|recipe_attempt| recipe_attempt.attempt)
+        .max()
+        .unwrap_or(attempt)
+        .max(attempt)
+        .checked_add(1)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cook_recipe.attempts",
+                "durable cook attempt sequence is exhausted",
+                Some(cook_id.to_string()),
+                None,
+            )
+        })?;
     let next_run_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, next_attempt);
     // This is reviewable lineage, not the process-local baseline capability.
     follow_up_request.inputs["cook_loop"]["artifact_provenance"] = serde_json::json!({

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -38,7 +38,7 @@ use super::cook_promotion::{
     is_moving_base_finalization_error, moving_base_recovery_for_run,
     moving_base_recovery_from_promotion, moving_base_recovery_report, next_moving_base_recovery,
     persisted_promotion_for_attempt, promote_or_load_attempt, recover_moving_base_cook_candidate,
-    refreshed_moving_base_recovery, MovingBaseCookRecovery,
+    refreshed_moving_base_recovery, retryable_provider_discovery_failure, MovingBaseCookRecovery,
 };
 use super::execution::run_loaded_plan_with_derived_cook_baseline;
 use super::AgentTaskRunResult;
@@ -585,7 +585,41 @@ pub(crate) fn dispatch_cook_follow_up<E>(
 where
     E: AgentTaskExecutorAdapter + Clone,
 {
-    let Some(remaining_budget) = budget_remaining(budget_limit, budget_used) else {
+    let recipe = super::load_recipe(cook_id)?;
+    let related_attempts = recipe.attempts.iter().filter(|recipe_attempt| {
+        recipe_attempt.plan.tasks.len() == 1
+            && recipe_attempt.plan.tasks[0].inputs["cook_loop"]["artifact_provenance"]
+                ["source_run_id"]
+                .as_str()
+                == Some(source_run_id)
+    });
+    let replay = related_attempts
+        .clone()
+        .max_by_key(|recipe_attempt| recipe_attempt.attempt)
+        .filter(|recipe_attempt| recipe_attempt.attempt > attempt)
+        .filter(|recipe_attempt| {
+            recipe_attempt.plan.tasks[0].inputs["cook_loop"]["review_form_required"] == true
+                && retryable_provider_discovery_failure(&recipe_attempt.run_id)
+        })
+        .cloned();
+    let mut durable_budget_used = budget_used;
+    for recipe_attempt in related_attempts.clone() {
+        if let Ok(aggregate) = agent_task_lifecycle::read_aggregate(&recipe_attempt.run_id) {
+            durable_budget_used.add(execution_budget_usage(&aggregate));
+        }
+    }
+    if known_same_executor {
+        durable_budget_used.same_provider_retries =
+            durable_budget_used.same_provider_retries.saturating_add(
+                related_attempts
+                    .map(|recipe_attempt| recipe_attempt.attempt)
+                    .collect::<std::collections::BTreeSet<_>>()
+                    .len()
+                    .try_into()
+                    .unwrap_or(u32::MAX),
+            );
+    }
+    let Some(remaining_budget) = budget_remaining(budget_limit, durable_budget_used) else {
         return Ok(CookFollowUpDispatch::BudgetExhausted {
             reason: "max_provider_executions".to_string(),
         });
@@ -615,47 +649,66 @@ where
                 .to_string(),
         });
     };
-    let reservation = match reserve_remediation_budget(&remaining_budget, same_provider) {
-        Ok(reservation) => reservation,
-        Err(reason) => {
-            return Ok(CookFollowUpDispatch::BudgetExhausted {
-                reason: reason.to_string(),
-            })
+    let reservation = if replay.is_some() {
+        ExecutionBudgetUsage::default()
+    } else {
+        match reserve_remediation_budget(&remaining_budget, same_provider) {
+            Ok(reservation) => reservation,
+            Err(reason) => {
+                return Ok(CookFollowUpDispatch::BudgetExhausted {
+                    reason: reason.to_string(),
+                })
+            }
         }
     };
-    let next_attempt = super::load_recipe(cook_id)?
-        .attempts
-        .iter()
-        .map(|recipe_attempt| recipe_attempt.attempt)
-        .max()
-        .unwrap_or(attempt)
-        .max(attempt)
-        .checked_add(1)
-        .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "cook_recipe.attempts",
-                "durable cook attempt sequence is exhausted",
-                Some(cook_id.to_string()),
-                None,
-            )
-        })?;
-    let next_run_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, next_attempt);
     // This is reviewable lineage, not the process-local baseline capability.
     follow_up_request.inputs["cook_loop"]["artifact_provenance"] = serde_json::json!({
         "source_run_id": source_run_id,
         "source_task_id": promotion.source.task_id,
         "source_patch_artifact_sha256": promotion.patch_artifact.sha256,
     });
-    let mut follow_up_plan = AgentTaskPlan::new(
-        format!("{cook_id}-cook-attempt-{next_attempt}"),
-        vec![follow_up_request],
-    );
-    follow_up_plan.options = plan.options.clone();
-    follow_up_plan.options.execution_budget = AgentTaskExecutionBudget::new(1, 0, 0);
-    follow_up_plan.options.retry.max_attempts = 1;
+    let (next_attempt, next_run_id, mut follow_up_plan, replaced_run_id) = match replay {
+        Some(recipe_attempt) => (
+            recipe_attempt.attempt,
+            agent_task_lifecycle::cook_attempt_run_id(cook_id, recipe_attempt.attempt),
+            recipe_attempt.plan.clone(),
+            Some(recipe_attempt.run_id.clone()),
+        ),
+        None => {
+            let next_attempt = recipe
+                .attempts
+                .iter()
+                .map(|recipe_attempt| recipe_attempt.attempt)
+                .max()
+                .unwrap_or(attempt)
+                .max(attempt)
+                .checked_add(1)
+                .ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "cook_recipe.attempts",
+                        "durable cook attempt sequence is exhausted",
+                        Some(cook_id.to_string()),
+                        None,
+                    )
+                })?;
+            let next_run_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, next_attempt);
+            let mut follow_up_plan = AgentTaskPlan::new(
+                format!("{cook_id}-cook-attempt-{next_attempt}"),
+                vec![follow_up_request],
+            );
+            follow_up_plan.options = plan.options.clone();
+            follow_up_plan.options.execution_budget = AgentTaskExecutionBudget::new(1, 0, 0);
+            follow_up_plan.options.retry.max_attempts = 1;
+            (next_attempt, next_run_id, follow_up_plan, None)
+        }
+    };
     let review_form_only =
         follow_up_plan.tasks[0].inputs["cook_loop"]["review_form_required"] == true;
-    super::record_recipe_attempt(cook_id, next_attempt, &next_run_id, &follow_up_plan)?;
+    if let Some(replaced_run_id) = replaced_run_id {
+        super::record_recipe_attempt_replacement(cook_id, &replaced_run_id, &next_run_id)?;
+    } else {
+        super::record_recipe_attempt(cook_id, next_attempt, &next_run_id, &follow_up_plan)?;
+    }
     if attempt_needs_execution(&next_run_id) {
         let baseline = materialize_follow_up_baseline(
             promotion,

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -854,6 +854,23 @@ pub(crate) fn resolve_adoption_target(
         return materialize_adoption_attempt(recipe, run_id);
     }
 
+    // Runner-side lifecycle projection can omit the controller's `cook_id`
+    // metadata. Resolve an explicit attempt through durable recipe membership
+    // before falling back to record metadata, otherwise the actionable exact
+    // run ID emitted for an ambiguous Cook is misread as a recipe directory.
+    if let Some(recipe) = super::load_recipe_for_attempt(cook_or_run_id)? {
+        let attempt = recipe
+            .attempts
+            .iter()
+            .find(|attempt| attempt.run_id == cook_or_run_id)
+            .expect("attempt lookup returns a recipe that declares the run id");
+        if agent_task_lifecycle::run_record_exists(&attempt.run_id)? {
+            return Ok((agent_task_lifecycle::status(&attempt.run_id)?, recipe));
+        }
+        let run_id = attempt.run_id.clone();
+        return materialize_adoption_attempt(recipe, run_id);
+    }
+
     if agent_task_lifecycle::run_record_exists(cook_or_run_id)? {
         let record = agent_task_lifecycle::status(cook_or_run_id)?;
         let cook_id = record
@@ -865,27 +882,12 @@ pub(crate) fn resolve_adoption_target(
         return Ok((record, super::load_recipe(&cook_id)?));
     }
 
-    let recipe = if let Some(recipe) = super::load_recipe_for_attempt(cook_or_run_id)? {
-        recipe
-    } else {
-        return Err(Error::validation_invalid_argument(
-            "run_or_cook_id",
-            "unknown agent-task run or durable cook id",
-            Some(cook_or_run_id.to_string()),
-            None,
-        ));
-    };
-    let attempt = recipe
-        .attempts
-        .iter()
-        .find(|attempt| attempt.run_id == cook_or_run_id)
-        .expect("attempt lookup returns a recipe that declares the run id");
-    if agent_task_lifecycle::run_record_exists(&attempt.run_id)? {
-        return Ok((agent_task_lifecycle::status(&attempt.run_id)?, recipe));
-    }
-
-    let run_id = attempt.run_id.clone();
-    materialize_adoption_attempt(recipe, run_id)
+    Err(Error::validation_invalid_argument(
+        "run_or_cook_id",
+        "unknown agent-task run or durable cook id",
+        Some(cook_or_run_id.to_string()),
+        None,
+    ))
 }
 
 fn materialize_adoption_attempt(

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -840,6 +840,20 @@ pub(crate) fn resolve_adoption_target(
     agent_task_lifecycle::AgentTaskRunRecord,
     super::AgentTaskCookRecipe,
 )> {
+    // A durable Cook id names its immutable recipe, not whichever attempt the
+    // mutable Cook index most recently observed. Resolve recipes before run
+    // records so a later failed attempt cannot steal adoption ownership from
+    // the original equivalent source attempt.
+    if super::recipe_exists(cook_or_run_id)? {
+        let recipe = super::load_recipe(cook_or_run_id)?;
+        let attempt = resolve_cook_adoption_attempt(&recipe)?;
+        if agent_task_lifecycle::run_record_exists(&attempt.run_id)? {
+            return Ok((agent_task_lifecycle::status(&attempt.run_id)?, recipe));
+        }
+        let run_id = attempt.run_id.clone();
+        return materialize_adoption_attempt(recipe, run_id);
+    }
+
     if agent_task_lifecycle::run_record_exists(cook_or_run_id)? {
         let record = agent_task_lifecycle::status(cook_or_run_id)?;
         let cook_id = record
@@ -851,9 +865,7 @@ pub(crate) fn resolve_adoption_target(
         return Ok((record, super::load_recipe(&cook_id)?));
     }
 
-    let recipe = if super::recipe_exists(cook_or_run_id)? {
-        super::load_recipe(cook_or_run_id)?
-    } else if let Some(recipe) = super::load_recipe_for_attempt(cook_or_run_id)? {
+    let recipe = if let Some(recipe) = super::load_recipe_for_attempt(cook_or_run_id)? {
         recipe
     } else {
         return Err(Error::validation_invalid_argument(
@@ -863,19 +875,31 @@ pub(crate) fn resolve_adoption_target(
             None,
         ));
     };
-    let attempt = if recipe.cook_id == cook_or_run_id {
-        resolve_cook_adoption_attempt(&recipe)?
-    } else {
-        recipe
-            .attempts
-            .iter()
-            .find(|attempt| attempt.run_id == cook_or_run_id)
-            .expect("attempt lookup returns a recipe that declares the run id")
-    };
+    let attempt = recipe
+        .attempts
+        .iter()
+        .find(|attempt| attempt.run_id == cook_or_run_id)
+        .expect("attempt lookup returns a recipe that declares the run id");
     if agent_task_lifecycle::run_record_exists(&attempt.run_id)? {
         return Ok((agent_task_lifecycle::status(&attempt.run_id)?, recipe));
     }
 
+    let run_id = attempt.run_id.clone();
+    materialize_adoption_attempt(recipe, run_id)
+}
+
+fn materialize_adoption_attempt(
+    recipe: super::AgentTaskCookRecipe,
+    run_id: String,
+) -> Result<(
+    agent_task_lifecycle::AgentTaskRunRecord,
+    super::AgentTaskCookRecipe,
+)> {
+    let attempt = recipe
+        .attempts
+        .iter()
+        .find(|attempt| attempt.run_id == run_id)
+        .expect("selected adoption attempt remains in its recipe");
     agent_task_lifecycle::submit_plan(&attempt.plan, Some(&attempt.run_id))?;
     agent_task_lifecycle::record_cook_attempt(&recipe.cook_id, attempt.attempt, &attempt.run_id)?;
     let recovery = Error::internal_unexpected(

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -309,12 +309,13 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
     let attempt_dispatcher =
         reconstruct_dispatcher(&recipe.promotion_transport["attempt_dispatch"])?;
     options.attempt_dispatcher = attempt_dispatcher;
-    agent_task_lifecycle::start_candidate_adoption_with_rerun_policy(
+    agent_task_lifecycle::start_candidate_adoption_with_policy(
         &record.run_id,
         &candidate_sha,
         &adoption_ai_model,
         &gate_identity,
         options.gates.rerun_completed_gates,
+        adoption.replace_interrupted,
     )?;
     let gate_run_id = record.run_id.clone();
     let promotion = crate::agent_task_promotion::with_gate_supervision(

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -120,6 +120,51 @@ pub(crate) fn promote_or_load_attempt(
     run_id: &str,
 ) -> Result<AgentTaskPromotionReport> {
     if let Some(promotion) = persisted_promotion_for_attempt(run_id)? {
+        if promotion.status == AgentTaskPromotionStatus::VerificationPending {
+            let target_path = promotion.target.path.as_deref().or_else(|| {
+                promotion.provenance.get("worktree_path").and_then(Value::as_str)
+            }).map(PathBuf::from).or_else(|| {
+                homeboy_core::worktree::resolve_if_present(&promotion.to_worktree)
+                    .ok()
+                    .flatten()
+                    .map(|record| PathBuf::from(record.worktree_path))
+            }).ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "promotion.target.path",
+                    "verification-pending promotion has no durable candidate worktree path or registered worktree handle",
+                    Some(run_id.to_string()),
+                    None,
+                )
+            })?;
+            let (source, source_path) = promotion_source(run_id)?;
+            let resumed = resume_promoted_patch(
+                AgentTaskPromotionOptions {
+                    source,
+                    source_run_id: Some(run_id.to_string()),
+                    source_path,
+                    source_worktree_path: options.source_worktree_path.clone(),
+                    base_ref: Some(options.base.clone()),
+                    task_base_sha: options.task_base_sha.clone(),
+                    candidate_ref: None,
+                    to_worktree: options.to_worktree.clone(),
+                    task_id: None,
+                    artifact_id: None,
+                    dry_run: false,
+                    gates: options.gates.clone(),
+                    provider_command: options.provider_command.clone(),
+                    provider_invocation: options.provider_invocation.clone(),
+                },
+                &target_path,
+                &serde_json::to_value(&promotion)
+                    .map_err(|error| Error::internal_json(error.to_string(), None))?,
+            )?;
+            agent_task_lifecycle::record_promotion(
+                run_id,
+                serde_json::to_value(&resumed)
+                    .map_err(|error| Error::internal_json(error.to_string(), None))?,
+            )?;
+            return Ok(resumed);
+        }
         return Ok(promotion);
     }
     let promotion = promote_attempt(options, run_id)?;

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -223,6 +223,20 @@ pub(crate) fn attempt_needs_execution(run_id: &str) -> bool {
         .unwrap_or(true)
 }
 
+pub(crate) fn retryable_provider_discovery_failure(run_id: &str) -> bool {
+    agent_task_lifecycle::status(run_id)
+        .is_ok_and(|record| record.state == agent_task_lifecycle::AgentTaskRunState::Failed)
+        && agent_task_lifecycle::read_aggregate(run_id).is_ok_and(|aggregate| {
+            !aggregate.outcomes.is_empty()
+                && aggregate.outcomes.iter().all(|outcome| {
+                    outcome
+                        .diagnostics
+                        .iter()
+                        .any(|diagnostic| diagnostic.class == "agent_task.provider_missing")
+                })
+        })
+}
+
 pub(crate) fn is_moving_base_finalization_error(error: &Error) -> bool {
     error.code == homeboy_core::ErrorCode::ValidationInvalidArgument
         && error

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -345,7 +345,14 @@ pub fn record_recipe_attempt(
             None,
         ));
     }
-    if attempt != recipe.attempts.len() as u32 + 1 {
+    let next_attempt = recipe
+        .attempts
+        .iter()
+        .map(|attempt| attempt.attempt)
+        .max()
+        .unwrap_or(0)
+        .saturating_add(1);
+    if attempt != next_attempt {
         return Err(Error::validation_invalid_argument(
             "cook_recipe.attempts",
             "durable cook attempts must be appended in order",
@@ -364,6 +371,57 @@ pub fn record_recipe_attempt(
         .collect();
     recipe.sensitive_mappings.sort();
     recipe.sensitive_mappings.dedup();
+    validate_recipe(&recipe)?;
+    write_recipe(&recipe)?;
+    Ok(recipe)
+}
+
+pub fn record_recipe_attempt_replacement(
+    cook_id: &str,
+    replaced_run_id: &str,
+    replacement_run_id: &str,
+) -> Result<AgentTaskCookRecipe> {
+    let mut recipe = load_recipe(cook_id)?;
+    if let Some(existing) = recipe
+        .attempts
+        .iter()
+        .find(|attempt| attempt.run_id == replacement_run_id)
+    {
+        if recipe
+            .attempts
+            .iter()
+            .any(|attempt| attempt.run_id == replaced_run_id && attempt.attempt == existing.attempt)
+        {
+            return Ok(recipe);
+        }
+        return Err(Error::validation_invalid_argument(
+            "cook_recipe.attempts",
+            "replacement run id is already bound to another durable cook attempt",
+            Some(replacement_run_id.to_string()),
+            None,
+        ));
+    }
+    let replaced = recipe.attempts.last().cloned().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "cook_recipe.attempts",
+            "durable cook recipe has no attempt to replace",
+            Some(cook_id.to_string()),
+            None,
+        )
+    })?;
+    if replaced.run_id != replaced_run_id {
+        return Err(Error::validation_invalid_argument(
+            "cook_recipe.attempts",
+            "only the latest durable cook attempt can receive a replacement run",
+            Some(replaced_run_id.to_string()),
+            None,
+        ));
+    }
+    recipe.attempts.push(AgentTaskCookRecipeAttempt {
+        attempt: replaced.attempt,
+        run_id: replacement_run_id.to_string(),
+        plan: replaced.plan,
+    });
     validate_recipe(&recipe)?;
     write_recipe(&recipe)?;
     Ok(recipe)

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -811,6 +811,86 @@ impl AgentTaskExecutorAdapter for ReviewFormOnlyExecutor {
     }
 }
 
+#[derive(Clone)]
+struct ProviderMissingExecutor;
+
+impl AgentTaskExecutorAdapter for ProviderMissingExecutor {
+    fn execute(
+        &self,
+        request: crate::agent_task::AgentTaskRequest,
+        _context: crate::agent_task_scheduler::AgentTaskExecutionContext,
+    ) -> crate::agent_task::AgentTaskOutcome {
+        crate::agent_task::AgentTaskOutcome {
+            schema: crate::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: request.task_id,
+            status: crate::agent_task::AgentTaskOutcomeStatus::Failed,
+            summary: Some("no extension agent-task provider found".to_string()),
+            failure_classification: Some(
+                crate::agent_task::AgentTaskFailureClassification::CapabilityMissing,
+            ),
+            artifacts: Vec::new(),
+            typed_artifacts: Vec::new(),
+            evidence_refs: Vec::new(),
+            diagnostics: vec![crate::agent_task::AgentTaskDiagnostic {
+                class: "agent_task.provider_missing".to_string(),
+                message: "no extension agent-task provider found".to_string(),
+                data: Value::Null,
+            }],
+            outputs: Value::Null,
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ProviderDiscoveryReplayDispatcher {
+    dispatches: AtomicUsize,
+    provider_missing_before_success: usize,
+}
+
+impl AgentTaskCookAttemptDispatcher for ProviderDiscoveryReplayDispatcher {
+    fn durable_recipe(&self) -> Result<Value> {
+        Ok(serde_json::json!({ "kind": "test-provider-discovery-replay" }))
+    }
+
+    fn dispatch_attempt(
+        &self,
+        plan: AgentTaskPlan,
+        run_id: &str,
+        derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+    ) -> Result<()> {
+        let dispatch = self.dispatches.fetch_add(1, Ordering::SeqCst);
+        let provider_missing = dispatch < self.provider_missing_before_success;
+        let result = if provider_missing {
+            run_loaded_plan_with_derived_cook_baseline(
+                plan,
+                Some(run_id),
+                ProviderMissingExecutor,
+                derived_cook_baseline,
+                None,
+            )?
+        } else {
+            run_loaded_plan_with_derived_cook_baseline(
+                plan,
+                Some(run_id),
+                ReviewFormOnlyExecutor,
+                derived_cook_baseline,
+                None,
+            )?
+        };
+        if provider_missing {
+            assert_eq!(result.exit_code, 1);
+            return Err(Error::internal_unexpected(
+                "fixture runner reported provider discovery failure",
+            ));
+        }
+        assert_eq!(result.exit_code, 0);
+        Ok(())
+    }
+}
+
 #[derive(Debug)]
 struct BatchAttemptDispatcher {
     barrier: Arc<Barrier>,
@@ -2621,6 +2701,138 @@ fn adoption_of_historical_attempt_appends_after_the_latest_recipe_attempt() {
         assert_eq!(recipe.attempts.len(), 3);
         assert_eq!(recipe.attempts[2].attempt, 3);
         assert_eq!(recipe.attempts[2].run_id, result.value.attempts[1].run_id);
+    });
+}
+
+#[test]
+fn adoption_replays_provider_discovery_failure_in_the_same_recipe_attempt() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let dispatcher = Arc::new(ProviderDiscoveryReplayDispatcher {
+            dispatches: AtomicUsize::new(0),
+            provider_missing_before_success: 1,
+        });
+        let fixture = CandidateAdoptionFixture::new(
+            "cook-9575-provider-replay",
+            2,
+            1,
+            true,
+            Some(dispatcher.clone()),
+        );
+        let mut backend = CaptureBackend::default();
+
+        fixture
+            .adopt(
+                |_| Ok(Some(dispatcher.clone())),
+                UnusedExecutor,
+                &mut backend,
+            )
+            .expect_err("runner provider discovery failure interrupts adoption");
+        let failed_recipe = super::super::load_recipe(&fixture.cook_id).unwrap();
+        assert_eq!(failed_recipe.attempts.len(), 2);
+        let failed_run_id = failed_recipe.attempts[1].run_id.clone();
+        assert!(retryable_provider_discovery_failure(&failed_run_id));
+        agent_task_lifecycle::rewrite_record_for_test(&fixture.run_id, |record| {
+            record
+                .candidate_adoption
+                .as_mut()
+                .expect("durable adoption owner")
+                .owner_pid = u32::MAX;
+        })
+        .unwrap();
+        assert_eq!(
+            agent_task_lifecycle::status(&fixture.run_id)
+                .unwrap()
+                .candidate_adoption
+                .unwrap()
+                .state,
+            "interrupted"
+        );
+
+        let result = fixture
+            .adopt(
+                |_| Ok(Some(dispatcher.clone())),
+                UnusedExecutor,
+                &mut backend,
+            )
+            .expect("provider discovery repair replays the durable attempt");
+
+        assert_eq!(result.value.status, "green_no_finalize");
+        assert_eq!(dispatcher.dispatches.load(Ordering::SeqCst), 2);
+        assert_eq!(result.value.attempts[1].attempt, 2);
+        assert_ne!(result.value.attempts[1].run_id, failed_run_id);
+        let replayed_recipe = super::super::load_recipe(&fixture.cook_id).unwrap();
+        assert_eq!(replayed_recipe.attempts.len(), 3);
+        assert_eq!(replayed_recipe.attempts[1].run_id, failed_run_id);
+        assert_eq!(replayed_recipe.attempts[2].attempt, 2);
+        assert_eq!(
+            replayed_recipe.attempts[2].run_id,
+            result.value.attempts[1].run_id
+        );
+        let next_run_id = agent_task_lifecycle::cook_attempt_run_id(&fixture.cook_id, 3);
+        super::super::record_recipe_attempt(
+            &fixture.cook_id,
+            3,
+            &next_run_id,
+            &replayed_recipe.attempts[2].plan,
+        )
+        .expect("replacement entries do not consume the next logical attempt number");
+        let extended_recipe = super::super::load_recipe(&fixture.cook_id).unwrap();
+        assert_eq!(extended_recipe.attempts[3].attempt, 3);
+    });
+}
+
+#[test]
+fn repeated_provider_discovery_failures_exhaust_the_execution_budget() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let dispatcher = Arc::new(ProviderDiscoveryReplayDispatcher {
+            dispatches: AtomicUsize::new(0),
+            provider_missing_before_success: usize::MAX,
+        });
+        let fixture = CandidateAdoptionFixture::new(
+            "cook-9575-provider-replay-budget",
+            2,
+            1,
+            true,
+            Some(dispatcher.clone()),
+        );
+        let mut backend = CaptureBackend::default();
+
+        for expected_dispatches in 1..=2 {
+            fixture
+                .adopt(
+                    |_| Ok(Some(dispatcher.clone())),
+                    UnusedExecutor,
+                    &mut backend,
+                )
+                .expect_err("provider discovery failure interrupts adoption");
+            assert_eq!(
+                dispatcher.dispatches.load(Ordering::SeqCst),
+                expected_dispatches
+            );
+            agent_task_lifecycle::rewrite_record_for_test(&fixture.run_id, |record| {
+                record
+                    .candidate_adoption
+                    .as_mut()
+                    .expect("durable adoption owner")
+                    .owner_pid = u32::MAX;
+            })
+            .unwrap();
+            agent_task_lifecycle::status(&fixture.run_id).unwrap();
+        }
+
+        let exhausted = fixture
+            .adopt(
+                |_| Ok(Some(dispatcher.clone())),
+                UnusedExecutor,
+                &mut backend,
+            )
+            .expect("budget exhaustion is a durable Cook result");
+        assert_eq!(exhausted.value.status, "execution_budget_exhausted");
+        assert_eq!(dispatcher.dispatches.load(Ordering::SeqCst), 2);
+        let recipe = super::super::load_recipe(&fixture.cook_id).unwrap();
+        assert_eq!(recipe.attempts.len(), 3);
+        assert_eq!(recipe.attempts[1].attempt, 2);
+        assert_eq!(recipe.attempts[2].attempt, 2);
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1353,6 +1353,7 @@ impl CandidateAdoptionFixture {
             &self.candidate,
             AgentTaskCandidateAdoptionOptions {
                 ai_model: Some("openai/gpt-5.6-terra".to_string()),
+                replace_interrupted: false,
             },
             dispatcher,
             executor,
@@ -2360,6 +2361,7 @@ fn historical_orphan_recipe_adoption_uses_recorded_policy_without_provider_repla
                 &candidate_for_thread,
                 AgentTaskCandidateAdoptionOptions {
                     ai_model: Some("openai/gpt-5.6-sol".to_string()),
+                    replace_interrupted: false,
                 },
                 |_| Ok(None),
                 ReviewFormOnlyExecutor,
@@ -2530,6 +2532,7 @@ fn adoption_green_candidate_missing_review_form_runs_form_only_follow_up_and_fin
             &candidate,
             AgentTaskCandidateAdoptionOptions {
                 ai_model: Some("openai/gpt-5.6-terra".to_string()),
+                replace_interrupted: false,
             },
             |_| Ok(None),
             ReviewFormOnlyExecutor,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1258,8 +1258,18 @@ impl CandidateAdoptionFixture {
         executor: E,
         backend: &mut CaptureBackend,
     ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
+        self.adopt_run(&self.run_id, dispatcher, executor, backend)
+    }
+
+    fn adopt_run<E: AgentTaskExecutorAdapter + Clone>(
+        &self,
+        run_id: &str,
+        dispatcher: impl FnOnce(&Value) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
+        executor: E,
+        backend: &mut CaptureBackend,
+    ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
         adopt_cook_candidate_with_dispatcher_and_backend(
-            &self.run_id,
+            run_id,
             &self.candidate,
             AgentTaskCandidateAdoptionOptions {
                 ai_model: Some("openai/gpt-5.6-terra".to_string()),
@@ -2581,6 +2591,36 @@ fn adoption_of_attempt_n_appends_n_plus_one_and_resumes_that_attempt() {
         assert_eq!(recipe.attempts.len(), 4);
         assert_eq!(recipe.attempts[3].attempt, 4);
         assert_eq!(recipe.attempts[3].run_id, result.value.attempts[1].run_id);
+    });
+}
+
+#[test]
+fn adoption_of_historical_attempt_appends_after_the_latest_recipe_attempt() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let mut fixture = CandidateAdoptionFixture::new("cook-9575-historical", 3, 1, true, None);
+        let historical_run_id = fixture.run_id.clone();
+        fixture.append_adoptable_attempt(2);
+        let mut backend = CaptureBackend::default();
+
+        let result = fixture
+            .adopt_run(
+                &historical_run_id,
+                |_| Ok(None),
+                ReviewFormOnlyExecutor,
+                &mut backend,
+            )
+            .expect("historical attempt adoption allocates after the durable recipe tail");
+
+        assert_eq!(result.value.status, "green_no_finalize");
+        assert_eq!(result.value.attempts[0].attempt, 1);
+        assert_eq!(result.value.attempts[1].attempt, 3);
+        assert!(result.value.attempts[1]
+            .run_id
+            .starts_with("cook-9575-historical-attempt-3"));
+        let recipe = super::super::load_recipe(&fixture.cook_id).unwrap();
+        assert_eq!(recipe.attempts.len(), 3);
+        assert_eq!(recipe.attempts[2].attempt, 3);
+        assert_eq!(recipe.attempts[2].run_id, result.value.attempts[1].run_id);
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2849,6 +2849,8 @@ fn adoption_by_cook_id_rejects_conflicting_recipe_attempts_with_explicit_choices
         conflicting_plan.plan_id = "conflicting-plan".to_string();
         super::super::record_recipe_attempt(cook_id, 2, second_run_id, &conflicting_plan)
             .expect("persist conflicting second recipe attempt");
+        agent_task_lifecycle::submit_plan(&conflicting_plan, Some(second_run_id))
+            .expect("persist exact conflicting attempt record without Cook metadata");
 
         let error = resolve_adoption_target(cook_id)
             .expect_err("conflicting recipe adoption requires an explicit run id");
@@ -2861,7 +2863,7 @@ fn adoption_by_cook_id_rejects_conflicting_recipe_attempts_with_explicit_choices
             .contains(&format!("homeboy agent-task adopt {first_run_id}")));
 
         let (record, recipe) = resolve_adoption_target(second_run_id)
-            .expect("an exact orphaned attempt run id selects its recipe");
+            .expect("an exact existing attempt run id selects its owning recipe");
         assert_eq!(recipe.cook_id, cook_id);
         assert_eq!(record.run_id, second_run_id);
     });

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -8,9 +8,9 @@ use super::super::cook_adoption::{
 };
 use super::super::cook_baseline::git_output;
 use super::super::cook_promotion::{
-    cook_report, finalize_cook_pr_with_backend, moving_base_recovery_for_run,
-    moving_base_recovery_from_promotion, moving_base_recovery_report, next_moving_base_recovery,
-    persisted_promotion_for_attempt, recover_moving_base_cook_candidate,
+    cook_report, finalize_cook_pr_with_backend, finalize_or_load_cook_pr_with_backend,
+    moving_base_recovery_for_run, moving_base_recovery_from_promotion, moving_base_recovery_report,
+    next_moving_base_recovery, persisted_promotion_for_attempt, recover_moving_base_cook_candidate,
     refreshed_moving_base_recovery, MovingBaseCookRecovery,
 };
 use super::*;
@@ -2823,6 +2823,10 @@ fn adoption_by_cook_id_uses_the_first_of_repeated_equivalent_recipe_attempts() {
             .expect("persist first lifecycle record");
         agent_task_lifecycle::submit_plan(&options.initial_plan, Some(second_run_id))
             .expect("persist second lifecycle record");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, first_run_id)
+            .expect("index first attempt");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 2, second_run_id)
+            .expect("make later failed attempt the mutable index target");
 
         let (record, recipe) = resolve_adoption_target(cook_id)
             .expect("equivalent attempts resolve deterministically");
@@ -2883,6 +2887,7 @@ struct CaptureBackend {
     pushed: bool,
     created: bool,
     hydrate_run_id: Option<String>,
+    hydrate_gate_proof_run_id: Option<String>,
 }
 
 impl AgentTaskPrFinalizationBackend for CaptureBackend {
@@ -2909,7 +2914,7 @@ impl AgentTaskPrFinalizationBackend for CaptureBackend {
         })
     }
     fn hydrate_gate_proof(&mut self, run_id: &str) -> Result<AgentTaskPrDurableGateProof> {
-        if self.hydrate_run_id.is_some() {
+        if self.hydrate_run_id.is_some() || self.hydrate_gate_proof_run_id.is_some() {
             return RealAgentTaskPrFinalizationBackend.hydrate_gate_proof(run_id);
         }
         Ok(AgentTaskPrDurableGateProof {
@@ -3596,6 +3601,221 @@ fn resume_cook_batch_harvests_terminal_children_without_redispatching_the_provid
             .expect("second resume is idempotent");
         assert_eq!(second.exit_code, 0);
         assert_eq!(second.value.succeeded, 3);
+    });
+}
+
+#[test]
+fn fanout_resume_prefers_immutable_verification_checkpoint_over_later_failed_attempt() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let target = temp.path().join("candidate");
+        std::fs::create_dir(&target).unwrap();
+        for args in [
+            vec!["init", "-b", "main"],
+            vec!["config", "user.email", "test@example.com"],
+            vec!["config", "user.name", "Test"],
+        ] {
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(&target)
+                .status()
+                .unwrap()
+                .success());
+        }
+        std::fs::write(target.join("lib.rs"), "old\n").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "."])
+            .current_dir(&target)
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "-m", "base"])
+            .current_dir(&target)
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["remote", "add", "origin", "."])
+            .current_dir(&target)
+            .status()
+            .unwrap()
+            .success());
+        std::fs::write(target.join("lib.rs"), "new\n").unwrap();
+        let patch = format!("{}\n", git_output(&target, &["diff", "--binary"]).unwrap());
+        let patch_path = temp.path().join("candidate.patch");
+        std::fs::write(&patch_path, &patch).unwrap();
+
+        let dispatches = Arc::new(AtomicUsize::new(0));
+        let cook_id = "cook-9703";
+        let mut options = batch_cook_options(
+            cook_id,
+            Arc::new(RecordingDetachedAttemptDispatcher {
+                dispatches: Arc::clone(&dispatches),
+            }),
+        );
+        options.initial_run_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, 1);
+        options.initial_plan.tasks[0].workspace.root = Some(target.display().to_string());
+        options.source_worktree_path = None;
+        options.gates.verify = vec!["true".to_string()];
+        options.no_finalize = false;
+        options.head = Some("fix/8058".to_string());
+        super::super::persist_initial_recipe(&options).unwrap();
+        let run_id = options.initial_run_id.clone();
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&run_id)).unwrap();
+        seed_review_form_aggregate(&run_id, &options.initial_plan);
+        let mut aggregate = agent_task_lifecycle::read_aggregate(&run_id).unwrap();
+        aggregate.outcomes[0]
+            .artifacts
+            .push(crate::agent_task::AgentTaskArtifact {
+                schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                id: "patch".to_string(),
+                kind: "patch".to_string(),
+                name: Some("candidate.patch".to_string()),
+                label: None,
+                role: None,
+                semantic_key: None,
+                path: Some(patch_path.display().to_string()),
+                url: None,
+                mime: Some("text/x-diff".to_string()),
+                size_bytes: Some(patch.len() as u64),
+                sha256: Some(format!("{:x}", sha2::Sha256::digest(patch.as_bytes()))),
+                metadata: Value::Null,
+            });
+        agent_task_lifecycle::record_run_aggregate(&run_id, &options.initial_plan, &aggregate)
+            .unwrap();
+        let candidate = crate::agent_task_promotion::candidate_fingerprint(
+            target.to_str().expect("target path"),
+        )
+        .unwrap();
+        let base_sha = git_output(&target, &["rev-parse", "HEAD"]).unwrap();
+        let mut checkpoint = serde_json::to_value(promotion(&run_id)).unwrap();
+        checkpoint["status"] = serde_json::json!("verification_pending");
+        checkpoint["source"]["task_id"] = serde_json::json!(options.initial_plan.tasks[0].task_id);
+        checkpoint["to_worktree"] = serde_json::json!(options.to_worktree);
+        checkpoint["target"] = serde_json::json!({"worktree": options.to_worktree, "path": target});
+        checkpoint["patch_artifact"]["path"] = serde_json::json!(patch_path);
+        checkpoint["patch_artifact"]["sha256"] =
+            serde_json::json!(format!("{:x}", sha2::Sha256::digest(patch.as_bytes())));
+        checkpoint["provenance"] = serde_json::json!({
+            "worktree_path": target,
+            "candidate": candidate,
+            "resume_inputs": {"base_ref": "main", "task_base_sha": null, "candidate_ref": null}
+        });
+        checkpoint["verified_base"]["sha"] = serde_json::json!(base_sha.trim());
+        agent_task_lifecycle::record_promotion(&run_id, checkpoint.clone()).unwrap();
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, &run_id).unwrap();
+
+        // This is the coordinator's bad later attempt. It becomes the index
+        // latest run, but must not replace the promoted source checkpoint.
+        let failed_run = agent_task_lifecycle::cook_attempt_run_id(cook_id, 2);
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&failed_run)).unwrap();
+        agent_task_lifecycle::record_run_aggregate(
+            &failed_run,
+            &options.initial_plan,
+            &crate::agent_task_scheduler::AgentTaskAggregate {
+                schema: crate::agent_task::AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+                plan_id: options.initial_plan.plan_id.clone(),
+                status: crate::agent_task_scheduler::AgentTaskAggregateStatus::Failed,
+                totals: crate::agent_task_scheduler::AgentTaskAggregateTotals {
+                    failed: 1,
+                    ..Default::default()
+                },
+                outcomes: Vec::new(),
+                events: Vec::new(),
+                artifact_lineage: Vec::new(),
+                child_runs: Vec::new(),
+                artifact_bindings: Vec::new(),
+                queue: Default::default(),
+            },
+        )
+        .unwrap();
+        super::super::record_recipe_attempt(cook_id, 2, &failed_run, &options.initial_plan)
+            .unwrap();
+        agent_task_lifecycle::record_cook_attempt(cook_id, 2, &failed_run).unwrap();
+        crate::agent_task_batch::persist_fanout_run_batch(
+            "batch-9703",
+            "batch-9703",
+            &[crate::agent_task_batch::FanoutRunBatchChild {
+                task_id: cook_id.to_string(),
+                run_id: cook_id.to_string(),
+            }],
+            Value::Null,
+        )
+        .unwrap();
+
+        let mut backend = CaptureBackend {
+            hydrate_gate_proof_run_id: Some(run_id.clone()),
+            ..Default::default()
+        };
+        let first = resume_cook_batch_with_finalizer(
+            "batch-9703",
+            UnusedExecutor,
+            |_| {
+                Ok(Some(Arc::new(RecordingDetachedAttemptDispatcher {
+                    dispatches: Arc::clone(&dispatches),
+                })))
+            },
+            |options, source_run_id, promotion| {
+                finalize_or_load_cook_pr_with_backend(
+                    options,
+                    source_run_id,
+                    promotion,
+                    &mut backend,
+                )
+            },
+        )
+        .unwrap();
+        assert_eq!(first.exit_code, 0, "{:?}", first.value);
+        assert_eq!(
+            first.value.cooks[0]
+                .result
+                .as_ref()
+                .unwrap()
+                .latest_run_id
+                .as_deref(),
+            Some(run_id.as_str())
+        );
+        assert_eq!(dispatches.load(Ordering::SeqCst), 0);
+        assert!(backend.committed);
+        assert!(backend.pushed);
+        assert!(backend.created);
+        let source = agent_task_lifecycle::status(&run_id).unwrap();
+        assert_eq!(
+            source.metadata["cook_recovery_source_checkpoint"],
+            checkpoint
+        );
+        assert_eq!(
+            source.metadata["cook_recovery_checkpoint"]["next_command"],
+            "homeboy agent-task fanout resume batch-9703"
+        );
+
+        backend.committed = false;
+        backend.pushed = false;
+        backend.created = false;
+        let second = resume_cook_batch_with_finalizer(
+            "batch-9703",
+            UnusedExecutor,
+            |_| {
+                Ok(Some(Arc::new(RecordingDetachedAttemptDispatcher {
+                    dispatches: Arc::clone(&dispatches),
+                })))
+            },
+            |options, source_run_id, promotion| {
+                finalize_or_load_cook_pr_with_backend(
+                    options,
+                    source_run_id,
+                    promotion,
+                    &mut backend,
+                )
+            },
+        )
+        .unwrap();
+        assert_eq!(second.exit_code, 0);
+        assert_eq!(dispatches.load(Ordering::SeqCst), 0);
+        assert!(!backend.committed);
+        assert!(!backend.pushed);
+        assert!(!backend.created);
     });
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -257,6 +257,9 @@ pub struct AdoptArgs {
     /// Concrete model that prepared the externally supplied candidate.
     #[arg(long, value_name = "MODEL")]
     pub ai_model: Option<String>,
+    /// Replace a stale interrupted adoption while retaining its lifecycle evidence.
+    #[arg(long)]
+    pub replace_interrupted: bool,
     /// Return the complete cook adoption report, including nested gate evidence.
     #[arg(long)]
     pub full: bool,

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -388,6 +388,7 @@ pub(crate) fn adopt_candidate(args: AdoptArgs) -> CmdResult<Value> {
         &args.candidate_ref,
         agent_task_service::AgentTaskCandidateAdoptionOptions {
             ai_model: args.ai_model.clone(),
+            replace_interrupted: args.replace_interrupted,
         },
         crate::commands::infra::route::reconstruct_cook_attempt_dispatcher,
         ExtensionProviderAgentTaskExecutor::discover(),
@@ -402,6 +403,7 @@ pub(crate) fn adopt_candidate(args: AdoptArgs) -> CmdResult<Value> {
         "source": args.run_or_cook_id,
         "candidate_ref": args.candidate_ref,
         "ai_model": args.ai_model,
+        "replace_interrupted": args.replace_interrupted,
         "controller_owned": true,
     });
     Ok((value, exit_code))


### PR DESCRIPTION
## Summary
Make durable fanout recovery resume the correct logical attempt and explicitly replace stale interrupted candidate adoptions.

## What changed
- Resolve adoption through the owning Cook recipe and allocate retries after its durable tail.
- Replay canonical provider-discovery failures under the same logical attempt while preserving bounded execution budgets.
- Add an explicit `--replace-interrupted` adoption policy that retains superseded lifecycle evidence.

## How to test
1. Run `cargo test -p homeboy-agents interrupted_candidate_adoption_can_be_explicitly_replaced_with_audit_history`; expect passes.
2. Run `cargo check -p homeboy-agents -p homeboy-cli`; expect passes.

## Compatibility
Existing adoption resume behavior remains unchanged unless the explicit replacement flag is supplied; provider execution limits and immutable candidate identity remain enforced.

## Evidence
- Base unchanged since verification: `main` remains at `9c7ce6a0f567fdf945ca5c9aa76db70c3b54066b`.
- CI expected: Homeboy pull request checks
- Durable run execution: Succeeded
- Source issue: https://github.com/Extra-Chill/homeboy/issues/9703
- Candidate failure matched the immutable baseline; no candidate regression detected.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Models:** `openai/gpt-5.6-terra` (original Cook), `openai/gpt-5.6-sol` (recovery implementation, review, and finalization)
- **Used for:** Traced the durable Cook and adoption lifecycle, implemented bounded recovery and explicit interrupted-attempt replacement, and verified the resulting candidate.

## Source relationships
- Closes Extra-Chill/homeboy#9703
