### PR TITLE
Hydrate finalize-pr recovery from durable Cook evidence

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -31,13 +31,35 @@ pub fn finalize_pr(
     finalize_pr_with_backend(options, &mut RealAgentTaskPrFinalizationBackend)
 }
 
+/// Validate a finalization dossier and its durable candidate without mutation.
+pub fn preflight_pr(
+    options: AgentTaskPrFinalizationOptions,
+) -> Result<AgentTaskPrFinalizationReport> {
+    preflight_pr_with_backend(options, &mut RealAgentTaskPrFinalizationBackend)
+}
+
 fn validate_real_candidate_fingerprint(options: &AgentTaskPrFinalizationOptions) -> Result<()> {
     backend::validate_real_candidate_fingerprint(options)
 }
 
 pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
+    options: AgentTaskPrFinalizationOptions,
+    backend: &mut B,
+) -> Result<AgentTaskPrFinalizationReport> {
+    finalize_pr_with_backend_mode(options, backend, true)
+}
+
+pub fn preflight_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
+    options: AgentTaskPrFinalizationOptions,
+    backend: &mut B,
+) -> Result<AgentTaskPrFinalizationReport> {
+    finalize_pr_with_backend_mode(options, backend, false)
+}
+
+fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
     mut options: AgentTaskPrFinalizationOptions,
     backend: &mut B,
+    publish: bool,
 ) -> Result<AgentTaskPrFinalizationReport> {
     let mut durable_changed_files = Vec::new();
     if !options.manual_finalization {
@@ -178,6 +200,22 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     }
     // An identity mismatch must not create a commit, push, or PR mutation.
     let git_identity = backend.validate_publication_identity(&options.path)?;
+    if !publish {
+        return Ok(report(
+            &options,
+            intent,
+            &head,
+            "validated",
+            "none",
+            None,
+            None,
+            changed_files,
+            Some(proof),
+            false,
+            false,
+            Some(git_identity),
+        ));
+    }
     if commit_required {
         backend.commit_all(&options.path, &options.commit_message)?;
     }

--- a/crates/homeboy-agents/src/agent_task_review_dossier.rs
+++ b/crates/homeboy-agents/src/agent_task_review_dossier.rs
@@ -928,7 +928,7 @@ fn builtin_section_name(id: &str) -> bool {
 fn issue_pattern() -> Regex {
     Regex::new(r"^(?:#\d+|[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#\d+|https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/issues/\d+)$").expect("valid issue regex")
 }
-fn validate_issue_reference(value: &str) -> Result<()> {
+pub fn validate_issue_reference(value: &str) -> Result<()> {
     if issue_pattern().is_match(value) {
         Ok(())
     } else {

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -13,9 +13,9 @@ use serde_json::Value;
 use std::path::PathBuf;
 
 use crate::agent_task_finalization::{
-    finalize_pr_with_backend, AgentTaskPrEvidence, AgentTaskPrFinalizationBackend,
-    AgentTaskPrFinalizationOptions, AgentTaskPrRuntimeGuardrails, AgentTaskPrSourceRelationship,
-    AgentTaskPrVerification, RealAgentTaskPrFinalizationBackend,
+    finalize_pr_with_backend, preflight_pr_with_backend, AgentTaskPrEvidence,
+    AgentTaskPrFinalizationBackend, AgentTaskPrFinalizationOptions, AgentTaskPrRuntimeGuardrails,
+    AgentTaskPrSourceRelationship, AgentTaskPrVerification, RealAgentTaskPrFinalizationBackend,
 };
 use crate::agent_task_lifecycle;
 use crate::agent_task_promotion::{
@@ -24,7 +24,7 @@ use crate::agent_task_promotion::{
 };
 use crate::agent_task_review_dossier::{
     resolve_review_profile, AgentTaskReviewAiAssistance, AgentTaskReviewDossier,
-    AgentTaskReviewEvidence, AgentTaskReviewTestStep,
+    AgentTaskReviewEvidence, AgentTaskReviewOverride, AgentTaskReviewTestStep,
 };
 use homeboy_core::{config, Error, Result};
 
@@ -581,6 +581,22 @@ pub(crate) fn finalize_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
             None,
         ));
     }
+    crate::agent_task_lifecycle::record_promotion(
+        successful_run_id,
+        serde_json::to_value(promotion).unwrap_or(Value::Null),
+    )?;
+    let finalization =
+        cook_finalization_options(options, successful_run_id, promotion, Vec::new())?;
+    finalize_pr_with_backend(finalization, backend)
+        .map(|report| serde_json::to_value(report).unwrap_or(Value::Null))
+}
+
+fn cook_finalization_options(
+    options: &AgentTaskCookServiceOptions,
+    successful_run_id: &str,
+    promotion: &AgentTaskPromotionReport,
+    overrides: Vec<AgentTaskReviewOverride>,
+) -> Result<AgentTaskPrFinalizationOptions> {
     let path = promotion
         .provenance
         .get("worktree_path")
@@ -615,54 +631,143 @@ pub(crate) fn finalize_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
                 None,
             )
         })?;
-    crate::agent_task_lifecycle::record_promotion(
-        successful_run_id,
-        serde_json::to_value(promotion).unwrap_or(Value::Null),
-    )?;
-    let report = finalize_pr_with_backend(
-        AgentTaskPrFinalizationOptions {
-            path: path.clone(),
-            run_id: successful_run_id.to_string(),
-            base: options.base.clone(),
-            verified_base_sha: Some(verified_base.sha.clone()),
-            head: options.head.clone(),
-            title: options.title.clone(),
-            commit_message: options.commit_message.clone(),
-            gate_results: Vec::new(),
-            normalized_gate_results: promotion.gate_results.clone(),
-            changed_files: promotion.changed_files.clone(),
-            evidence: AgentTaskPrEvidence {
-                source_refs,
-                artifact_refs,
-                attempt_summary: format!(
-                    "{} deterministic cook gate attempt(s) completed green",
-                    promotion.deterministic_gates.len()
-                ),
-                ai_tool: options.ai_tool.clone(),
-                ai_model: options.ai_model.clone(),
-                source_relationship: AgentTaskPrSourceRelationship::default(),
-                verification: AgentTaskPrVerification {
-                    targeted_checks_run: options.gates.verify.clone(),
-                    targeted_checks_unavailable: None,
-                    ci_expected: vec!["Homeboy CI after push".to_string()],
-                    manual_reviewer_check: None,
-                },
-                runtime_guardrails: AgentTaskPrRuntimeGuardrails::default(),
-                changed_public_contracts: Vec::new(),
-                public_contract_evidence: None,
-                lifecycle: crate::agent_task_lifecycle::status(successful_run_id)
-                    .ok()
-                    .map(|record| record.lifecycle),
+    let mut review_dossier = cook_review_dossier(options, promotion, successful_run_id)?;
+    review_dossier.overrides = overrides;
+    Ok(AgentTaskPrFinalizationOptions {
+        path: path.clone(),
+        run_id: successful_run_id.to_string(),
+        base: options.base.clone(),
+        verified_base_sha: Some(verified_base.sha.clone()),
+        head: options.head.clone(),
+        title: options.title.clone(),
+        commit_message: options.commit_message.clone(),
+        gate_results: Vec::new(),
+        normalized_gate_results: promotion.gate_results.clone(),
+        changed_files: promotion.changed_files.clone(),
+        evidence: AgentTaskPrEvidence {
+            source_refs,
+            artifact_refs,
+            attempt_summary: format!(
+                "{} deterministic cook gate attempt(s) completed green",
+                promotion.deterministic_gates.len()
+            ),
+            ai_tool: options.ai_tool.clone(),
+            ai_model: options.ai_model.clone(),
+            source_relationship: AgentTaskPrSourceRelationship::default(),
+            verification: AgentTaskPrVerification {
+                targeted_checks_run: options.gates.verify.clone(),
+                targeted_checks_unavailable: None,
+                ci_expected: vec!["Homeboy CI after push".to_string()],
+                manual_reviewer_check: None,
             },
-            ai_used_for: options.ai_used_for.clone(),
-            review_dossier: cook_review_dossier(options, promotion, successful_run_id)?,
-            review_profile: resolve_review_profile(&path)?,
-            manual_finalization: false,
-            protected_branches: options.protected_branches.clone(),
+            runtime_guardrails: AgentTaskPrRuntimeGuardrails::default(),
+            changed_public_contracts: Vec::new(),
+            public_contract_evidence: None,
+            lifecycle: crate::agent_task_lifecycle::status(successful_run_id)
+                .ok()
+                .map(|record| record.lifecycle),
         },
-        backend,
-    )?;
-    Ok(serde_json::to_value(report).unwrap_or(Value::Null))
+        ai_used_for: options.ai_used_for.clone(),
+        review_dossier,
+        review_profile: resolve_review_profile(&path)?,
+        manual_finalization: false,
+        protected_branches: options.protected_branches.clone(),
+    })
+}
+
+/// Recover publication from the durable Cook recipe and applied promotion.
+pub fn recover_cook_pr(
+    run_or_cook_id: &str,
+    overrides: Vec<AgentTaskReviewOverride>,
+    preflight: bool,
+) -> Result<Value> {
+    recover_cook_pr_with_backend(
+        run_or_cook_id,
+        overrides,
+        preflight,
+        &mut RealAgentTaskPrFinalizationBackend,
+    )
+}
+
+pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
+    run_or_cook_id: &str,
+    overrides: Vec<AgentTaskReviewOverride>,
+    preflight: bool,
+    backend: &mut B,
+) -> Result<Value> {
+    let recipe = if super::cook_recipe::recipe_exists(run_or_cook_id)? {
+        super::cook_recipe::load_recipe(run_or_cook_id)?
+    } else {
+        super::cook_recipe::load_recipe_for_attempt(run_or_cook_id)?.ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "run_or_cook_id",
+                "no durable Cook recipe contains this run or cook id",
+                Some(run_or_cook_id.to_string()),
+                None,
+            )
+        })?
+    };
+    let run_id = if recipe
+        .attempts
+        .iter()
+        .any(|attempt| attempt.run_id == run_or_cook_id)
+    {
+        run_or_cook_id.to_string()
+    } else {
+        let mut applied_run_id = None;
+        for attempt in recipe.attempts.iter().rev() {
+            if persisted_promotion_for_attempt(&attempt.run_id)?
+                .is_some_and(|promotion| promotion.status == AgentTaskPromotionStatus::Applied)
+            {
+                applied_run_id = Some(attempt.run_id.clone());
+                break;
+            }
+        }
+        applied_run_id.ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "run_or_cook_id",
+                "durable Cook recipe has no attempt with an applied promotion",
+                Some(run_or_cook_id.to_string()),
+                None,
+            )
+        })?
+    };
+    let promotion = persisted_promotion_for_attempt(&run_id)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "latest_promotion",
+            "recovery requires the attempt's persisted applied promotion",
+            Some(run_id.clone()),
+            None,
+        )
+    })?;
+    if promotion.status != AgentTaskPromotionStatus::Applied {
+        return Err(Error::validation_invalid_argument(
+            "latest_promotion.status",
+            "recovery requires an applied promotion with green gates",
+            Some(run_id),
+            None,
+        ));
+    }
+    if !preflight {
+        if let Some(finalization) = agent_task_lifecycle::status(&run_id)?
+            .metadata
+            .get("cook_finalization")
+        {
+            return Ok(finalization.clone());
+        }
+    }
+    let options = super::cook_recipe::reconstruct_adoption_options(&recipe)?;
+    let finalization = cook_finalization_options(&options, &run_id, &promotion, overrides)?;
+    let report = if preflight {
+        preflight_pr_with_backend(finalization, backend)?
+    } else {
+        finalize_pr_with_backend(finalization, backend)?
+    };
+    let value = serde_json::to_value(report).unwrap_or(Value::Null);
+    if !preflight {
+        agent_task_lifecycle::record_cook_finalization(&run_id, value.clone())?;
+    }
+    Ok(value)
 }
 
 fn cook_review_dossier(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -10,9 +10,10 @@ use super::super::cook_baseline::git_output;
 use super::super::cook_promotion::{
     cook_report, finalize_cook_pr_with_backend, finalize_or_load_cook_pr_with_backend,
     moving_base_recovery_for_run, moving_base_recovery_from_promotion, moving_base_recovery_report,
-    next_moving_base_recovery, persisted_promotion_for_attempt, recover_moving_base_cook_candidate,
-    refreshed_moving_base_recovery, MovingBaseCookRecovery,
+    next_moving_base_recovery, persisted_promotion_for_attempt, recover_cook_pr_with_backend,
+    recover_moving_base_cook_candidate, refreshed_moving_base_recovery, MovingBaseCookRecovery,
 };
+use super::super::cook_recipe::persist_initial_recipe;
 use super::*;
 use crate::agent_task::{
     AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
@@ -3369,6 +3370,58 @@ fn cook_successful_concrete_attempt_publishes_reviewer_body() {
             );
         }
         assert!(backend.committed && backend.pushed && backend.created);
+    });
+}
+
+#[test]
+fn recovery_hydrates_durable_cook_evidence_and_can_preflight_without_mutation() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-9750";
+        let run_id = "cook-9750-attempt-1";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = run_id.to_string();
+        options.head = Some("fix/8058".to_string());
+        options.gates = VerifyGateOptions {
+            verify: vec!["cargo test --locked agent_task_promotion --lib".to_string()],
+            ..Default::default()
+        };
+        persist_initial_recipe(&options).unwrap();
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id)).unwrap();
+        seed_review_form_aggregate(run_id, &options.initial_plan);
+        agent_task_lifecycle::record_promotion(
+            run_id,
+            serde_json::to_value(promotion(run_id)).unwrap(),
+        )
+        .unwrap();
+
+        let mut preflight_backend = CaptureBackend::default();
+        let preflight =
+            recover_cook_pr_with_backend(cook_id, Vec::new(), true, &mut preflight_backend)
+                .unwrap();
+        assert_eq!(preflight["status"], "validated");
+        assert!(!preflight_backend.committed);
+        assert!(!preflight_backend.pushed);
+        assert!(!preflight_backend.created);
+
+        let mut publish_backend = CaptureBackend::default();
+        let report = recover_cook_pr_with_backend(
+            run_id,
+            vec![crate::agent_task_review_dossier::AgentTaskReviewOverride {
+                target: crate::agent_task_review_dossier::AgentTaskReviewOverrideTarget::Summary,
+                value: "Recovered from durable Cook evidence.".to_string(),
+                provenance: "reviewed issue #9750".to_string(),
+            }],
+            false,
+            &mut publish_backend,
+        )
+        .unwrap();
+        assert_eq!(report["status"], "review_ready");
+        assert_eq!(report["run_id"], run_id);
+        assert_eq!(report["changed_files"], serde_json::json!(["src/lib.rs"]));
+        assert!(publish_backend.committed && publish_backend.pushed && publish_backend.created);
+        assert!(publish_backend
+            .body
+            .contains("Recovered from durable Cook evidence."));
     });
 }
 

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -212,8 +212,9 @@ pub mod dispatch_service {
 /// PR finalization contracts and backends.
 pub mod finalization {
     pub use super::super::agent_task_finalization::{
-        finalize_pr, finalize_pr_with_backend, validate_publication_intent, AgentTaskGateResult,
-        AgentTaskPrEvidence, AgentTaskPrFinalizationBackend, AgentTaskPrFinalizationOptions,
+        finalize_pr, finalize_pr_with_backend, preflight_pr, preflight_pr_with_backend,
+        validate_publication_intent, AgentTaskGateResult, AgentTaskPrEvidence,
+        AgentTaskPrFinalizationBackend, AgentTaskPrFinalizationOptions,
         AgentTaskPrFinalizationOutcome, AgentTaskPrFinalizationReport, AgentTaskPrRef,
         AgentTaskPrRuntimeGuardrails, AgentTaskPrSourceRelationship, AgentTaskPrVerification,
         AgentTaskPublicationIntent, AgentTaskPublicationProof, AgentTaskPublicationTarget,
@@ -227,14 +228,14 @@ pub mod finalization {
 pub mod review_dossier {
     pub use super::super::agent_task_review_dossier::{
         default_profile, enrich_dossier, homeboy_tool_disclosure, render_review_dossier,
-        resolve_review_profile, validate_profile, AgentTaskExternalUsageEvidence,
-        AgentTaskExternalUsageStatus, AgentTaskPublicContract, AgentTaskPublicContractEvidence,
-        AgentTaskReviewAdditionalSection, AgentTaskReviewAiAssistance, AgentTaskReviewDossier,
-        AgentTaskReviewEvidence, AgentTaskReviewIssueRelationship,
-        AgentTaskReviewIssueRelationshipKind, AgentTaskReviewOverride,
-        AgentTaskReviewOverrideTarget, AgentTaskReviewProfile, AgentTaskReviewSectionId,
-        AgentTaskReviewTestStep, AiFilledReviewForm, AGENT_TASK_REVIEW_DOSSIER_SCHEMA,
-        AI_REVIEW_FORM_OUTPUT_KEY,
+        resolve_review_profile, validate_issue_reference, validate_profile,
+        AgentTaskExternalUsageEvidence, AgentTaskExternalUsageStatus, AgentTaskPublicContract,
+        AgentTaskPublicContractEvidence, AgentTaskReviewAdditionalSection,
+        AgentTaskReviewAiAssistance, AgentTaskReviewDossier, AgentTaskReviewEvidence,
+        AgentTaskReviewIssueRelationship, AgentTaskReviewIssueRelationshipKind,
+        AgentTaskReviewOverride, AgentTaskReviewOverrideTarget, AgentTaskReviewProfile,
+        AgentTaskReviewSectionId, AgentTaskReviewTestStep, AiFilledReviewForm,
+        AGENT_TASK_REVIEW_DOSSIER_SCHEMA, AI_REVIEW_FORM_OUTPUT_KEY,
     };
 }
 
@@ -385,10 +386,10 @@ pub mod service {
         evidence_ref_task_id, hydrate_evidence_ref, hydrate_evidence_summary, logs,
         normalize_plan_workspaces, offloaded_status_remediation, persist_initial_recipe,
         persist_provider_boundary_replay_evidence, promotion_source, read_plan,
-        reconcile_terminal_artifact_projection, resume, resume_cook_batch, retry, run_cook,
-        run_cook_batch, run_loaded_plan, run_next, run_next_with_cook_dispatcher, run_status,
-        run_submitted, run_submitted_with_timeout, source_worktree_path, status, submit_plan_spec,
-        validate_initial_recipe_compatibility, AgentTaskCandidateAdoptionOptions,
+        reconcile_terminal_artifact_projection, recover_cook_pr, resume, resume_cook_batch, retry,
+        run_cook, run_cook_batch, run_loaded_plan, run_next, run_next_with_cook_dispatcher,
+        run_status, run_submitted, run_submitted_with_timeout, source_worktree_path, status,
+        submit_plan_spec, validate_initial_recipe_compatibility, AgentTaskCandidateAdoptionOptions,
         AgentTaskCookAttemptReport, AgentTaskCookBatchCellReport, AgentTaskCookBatchOptions,
         AgentTaskCookBatchReport, AgentTaskCookReport, AgentTaskCookServiceOptions,
         AgentTaskDiscoveryCommands, AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter,

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -266,10 +266,17 @@ pub struct AdoptArgs {
 }
 #[derive(Args, Debug)]
 pub struct FinalizePrArgs {
-    #[arg(long, value_name = "ID")]
-    pub run_id: String,
-    #[arg(long, value_name = "PATH")]
-    pub path: String,
+    /// Hydrate finalization from a durable Cook recipe and its applied promotion.
+    #[arg(
+        long,
+        value_name = "RUN_OR_COOK_ID",
+        conflicts_with = "manual_finalization"
+    )]
+    pub recover: Option<String>,
+    #[arg(long, value_name = "ID", required_unless_present = "recover")]
+    pub run_id: Option<String>,
+    #[arg(long, value_name = "PATH", required_unless_present = "recover")]
+    pub path: Option<String>,
     #[arg(long, default_value = "main", value_name = "BRANCH")]
     pub base: String,
     /// Immutable base commit SHA recorded before the declared verification gates ran.
@@ -277,10 +284,10 @@ pub struct FinalizePrArgs {
     pub verified_base_sha: Option<String>,
     #[arg(long, value_name = "BRANCH")]
     pub head: Option<String>,
-    #[arg(long, value_name = "TEXT")]
-    pub title: String,
-    #[arg(long, value_name = "TEXT")]
-    pub commit_message: String,
+    #[arg(long, value_name = "TEXT", required_unless_present = "recover")]
+    pub title: Option<String>,
+    #[arg(long, value_name = "TEXT", required_unless_present = "recover")]
+    pub commit_message: Option<String>,
     #[command(flatten)]
     pub evidence: review::FinalizePrEvidenceArgs,
     #[arg(long = "gate-result", value_name = "NAME=STATUS[:DETAIL]")]
@@ -295,16 +302,22 @@ pub struct FinalizePrArgs {
     pub summary: Option<String>,
     #[arg(long = "what-changed", value_name = "TEXT")]
     pub what_changed: Vec<String>,
-    #[arg(long = "test-step", value_name = "TEXT")]
+    /// Reviewer test step. Strict shape: COMMAND=>EXPECTED.
+    #[arg(long = "test-step", value_name = "COMMAND=>EXPECTED")]
     pub test_steps: Vec<String>,
     #[arg(long, value_name = "TEXT")]
     pub compatibility: Option<String>,
-    #[arg(long = "closes", value_name = "REF")]
+    /// Closing issue reference: #NUMBER, OWNER/REPO#NUMBER, or a github.com issue URL.
+    #[arg(long = "closes", value_name = "ISSUE_REF")]
     pub closes: Vec<String>,
-    #[arg(long = "relates-to", value_name = "REF")]
+    /// Related issue reference: #NUMBER, OWNER/REPO#NUMBER, or a github.com issue URL.
+    #[arg(long = "relates-to", value_name = "ISSUE_REF")]
     pub relates_to: Vec<String>,
     #[arg(long = "review-override", value_name = "TARGET=VALUE@PROVENANCE")]
     pub review_overrides: Vec<String>,
+    /// Validate the complete hydrated dossier and candidate without publishing.
+    #[arg(long)]
+    pub preflight: bool,
     #[arg(long)]
     pub manual_finalization: bool,
 }

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -15,11 +15,12 @@ use homeboy::agents::agent_tasks::provider::{
     AgentTaskExecutorProvider, AgentTaskProviderCatalog, ExtensionProviderAgentTaskExecutor,
 };
 use homeboy::agents::agent_tasks::review_dossier::{
-    homeboy_tool_disclosure, resolve_review_profile, AgentTaskExternalUsageEvidence,
-    AgentTaskExternalUsageStatus, AgentTaskPublicContract, AgentTaskPublicContractEvidence,
-    AgentTaskReviewAiAssistance, AgentTaskReviewDossier, AgentTaskReviewIssueRelationship,
-    AgentTaskReviewIssueRelationshipKind, AgentTaskReviewOverride, AgentTaskReviewOverrideTarget,
-    AgentTaskReviewTestStep, AGENT_TASK_REVIEW_DOSSIER_SCHEMA,
+    homeboy_tool_disclosure, resolve_review_profile, validate_issue_reference,
+    AgentTaskExternalUsageEvidence, AgentTaskExternalUsageStatus, AgentTaskPublicContract,
+    AgentTaskPublicContractEvidence, AgentTaskReviewAiAssistance, AgentTaskReviewDossier,
+    AgentTaskReviewIssueRelationship, AgentTaskReviewIssueRelationshipKind,
+    AgentTaskReviewOverride, AgentTaskReviewOverrideTarget, AgentTaskReviewTestStep,
+    AGENT_TASK_REVIEW_DOSSIER_SCHEMA,
 };
 use homeboy::agents::agent_tasks::service as agent_task_service;
 use homeboy::agents::agent_tasks::{
@@ -106,7 +107,7 @@ pub struct FinalizePrEvidenceArgs {
     #[arg(long = "nearby-contract-preserved", value_name = "TEXT")]
     pub nearby_contracts_preserved: Vec<String>,
 
-    /// Declared changed public contract as ID=>SUMMARY. Repeatable.
+    /// Declared changed public contract as ID=>SUMMARY. Requires the complete compatibility/external-usage evidence bundle below.
     #[arg(long = "changed-public-contract", value_name = "ID=>SUMMARY")]
     pub changed_public_contracts: Vec<String>,
 
@@ -410,6 +411,28 @@ pub(crate) fn adopt_candidate(args: AdoptArgs) -> CmdResult<Value> {
 }
 
 pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
+    validate_finalize_inputs(&args)?;
+    if let Some(run_or_cook_id) = args.recover.as_deref() {
+        let overrides = args
+            .review_overrides
+            .iter()
+            .map(|raw| parse_override(raw))
+            .collect::<homeboy::core::Result<Vec<_>>>()?;
+        let value = agent_task_service::recover_cook_pr(run_or_cook_id, overrides, args.preflight)?;
+        let success = value
+            .get("status")
+            .and_then(Value::as_str)
+            .is_some_and(|status| matches!(status, "review_ready" | "validated"));
+        return Ok((value, i32::from(!success)));
+    }
+    let run_id = args
+        .run_id
+        .expect("clap requires --run-id without --recover");
+    let path = args.path.expect("clap requires --path without --recover");
+    let title = args.title.expect("clap requires --title without --recover");
+    let commit_message = args
+        .commit_message
+        .expect("clap requires --commit-message without --recover");
     let gate_results = parse_gate_results(&args.gate_results)?;
     let normalized_gate_results: Vec<HomeboyGateResult> = gate_results
         .iter()
@@ -448,7 +471,7 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
     };
     let mut review_dossier = AgentTaskReviewDossier {
         schema: AGENT_TASK_REVIEW_DOSSIER_SCHEMA.to_string(),
-        summary: args.summary.clone().unwrap_or_else(|| args.title.clone()),
+        summary: args.summary.clone().unwrap_or_else(|| title.clone()),
         what_changed: if args.what_changed.is_empty() {
             vec![evidence.attempt_summary.clone()]
         } else {
@@ -493,15 +516,15 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
             .collect::<homeboy::core::Result<Vec<_>>>()?,
     };
     review_dossier.apply_overrides()?;
-    let review_profile = resolve_review_profile(&args.path)?;
-    let report = finalize_pr(AgentTaskPrFinalizationOptions {
-        path: args.path,
-        run_id: args.run_id,
+    let review_profile = resolve_review_profile(&path)?;
+    let options = AgentTaskPrFinalizationOptions {
+        path,
+        run_id,
         base: args.base,
         verified_base_sha: args.verified_base_sha,
         head: args.head,
-        title: args.title,
-        commit_message: args.commit_message,
+        title,
+        commit_message,
         gate_results,
         normalized_gate_results,
         changed_files: args.changed_files,
@@ -511,8 +534,13 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
         review_profile,
         manual_finalization: args.manual_finalization,
         protected_branches: args.protected_branches,
-    })?;
-    let exit_code = if report.status == "review_ready" {
+    };
+    let report = if args.preflight {
+        homeboy::agents::agent_tasks::finalization::preflight_pr(options)?
+    } else {
+        finalize_pr(options)?
+    };
+    let exit_code = if matches!(report.status.as_str(), "review_ready" | "validated") {
         0
     } else {
         1
@@ -524,6 +552,58 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
     Ok((value, exit_code))
 }
 
+fn validate_finalize_inputs(args: &FinalizePrArgs) -> homeboy::core::Result<()> {
+    let mut errors = Vec::new();
+    for raw in &args.gate_results {
+        if let Err(error) = parse_gate_results(std::slice::from_ref(raw)) {
+            errors.push(error);
+        }
+    }
+    for raw in &args.evidence.changed_public_contracts {
+        if let Err(error) = parse_public_contract(raw) {
+            errors.push(error);
+        }
+    }
+    if let Err(error) = public_contract_evidence(&args.evidence) {
+        errors.push(error);
+    }
+    for raw in &args.test_steps {
+        if let Err(error) = parse_test_step(raw) {
+            errors.push(error);
+        }
+    }
+    for raw in &args.review_overrides {
+        if let Err(error) = parse_override(raw) {
+            errors.push(error);
+        }
+    }
+    for reference in args.closes.iter().chain(&args.relates_to) {
+        if let Err(error) = validate_issue_reference(reference) {
+            errors.push(error);
+        }
+    }
+    if errors.is_empty() {
+        return Ok(());
+    }
+    let diagnostics: Vec<Value> = errors
+        .iter()
+        .map(|error| {
+            serde_json::json!({
+            "code": format!("{:?}", error.code),
+                "message": error.message,
+                "details": error.details,
+            })
+        })
+        .collect();
+    let mut error = errors.remove(0);
+    error.message = format!(
+        "finalize-pr input validation failed with {} independent error(s)",
+        diagnostics.len()
+    );
+    error.details = serde_json::json!({ "diagnostics": diagnostics });
+    Err(error)
+}
+
 fn parse_public_contract(raw: &str) -> homeboy::core::Result<AgentTaskPublicContract> {
     let (id, summary) = raw.split_once("=>").ok_or_else(|| {
         homeboy::core::Error::validation_invalid_argument(
@@ -533,9 +613,19 @@ fn parse_public_contract(raw: &str) -> homeboy::core::Result<AgentTaskPublicCont
             None,
         )
     })?;
+    let id = id.trim();
+    let summary = summary.trim();
+    if id.is_empty() || summary.is_empty() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "changed-public-contract",
+            "contract identifier and summary must be non-empty",
+            None,
+            None,
+        ));
+    }
     Ok(AgentTaskPublicContract {
-        id: id.trim().to_string(),
-        summary: summary.trim().to_string(),
+        id: id.to_string(),
+        summary: summary.to_string(),
     })
 }
 
@@ -588,9 +678,19 @@ fn parse_test_step(raw: &str) -> homeboy::core::Result<AgentTaskReviewTestStep> 
             None,
         )
     })?;
+    let command = command.trim();
+    let expected = expected.trim();
+    if command.is_empty() || expected.is_empty() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "test-step",
+            "command and expected result must be non-empty",
+            None,
+            None,
+        ));
+    }
     Ok(AgentTaskReviewTestStep {
-        command: command.trim().to_string(),
-        expected: expected.trim().to_string(),
+        command: command.to_string(),
+        expected: expected.to_string(),
     })
 }
 
@@ -624,10 +724,18 @@ fn parse_override(raw: &str) -> homeboy::core::Result<AgentTaskReviewOverride> {
             ))
         }
     };
+    if value.trim().is_empty() || provenance.trim().is_empty() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "review-override",
+            "override value and provenance must be non-empty",
+            None,
+            None,
+        ));
+    }
     Ok(AgentTaskReviewOverride {
         target,
-        value: value.to_string(),
-        provenance: provenance.to_string(),
+        value: value.trim().to_string(),
+        provenance: provenance.trim().to_string(),
     })
 }
 
@@ -980,14 +1088,8 @@ fn review_next_actions(
     actions
 }
 
-fn promotion_handoff(report: &AgentTaskPromotionReport, to_worktree: &str) -> Value {
+fn promotion_handoff(report: &AgentTaskPromotionReport, _to_worktree: &str) -> Value {
     let patch_promoted = report.status.patch_promoted();
-    let finalize_path = report
-        .provenance
-        .get("worktree_path")
-        .and_then(Value::as_str)
-        .unwrap_or(to_worktree);
-    let verified_base = report.verified_base.as_ref();
     let mut next_actions = Vec::new();
     if report.status.gate_failed() {
         next_actions.push(
@@ -1011,9 +1113,8 @@ fn promotion_handoff(report: &AgentTaskPromotionReport, to_worktree: &str) -> Va
             "pr_opened": false
         },
         "boundary": report.status.handoff_boundary(),
-        "finalize_command": verified_base.map(|verified_base| format!(
-            "homeboy agent-task finalize-pr --run-id <run-id> --path {finalize_path} --base {} --verified-base-sha {} --title <title> --commit-message <message>",
-            verified_base.base, verified_base.sha
+        "finalize_command": report.source.run_id.as_ref().map(|run_id| format!(
+            "homeboy agent-task finalize-pr --recover {run_id}"
         )),
         "next_actions": next_actions
     })
@@ -1249,6 +1350,8 @@ mod tests {
         assert_eq!(step.command, "cargo test dossier");
         assert_eq!(step.expected, "all tests pass");
         assert!(parse_test_step("cargo test dossier").is_err());
+        assert!(parse_test_step("=>all tests pass").is_err());
+        assert!(parse_test_step("cargo test dossier=>").is_err());
 
         let override_ = parse_override("summary=Reviewed summary@operator").expect("override");
         assert!(matches!(
@@ -1257,6 +1360,9 @@ mod tests {
         ));
         assert_eq!(override_.provenance, "operator");
         assert!(parse_override("evidence=nope@operator").is_err());
+        assert!(parse_override("summary=@operator").is_err());
+        assert!(parse_override("summary=Reviewed summary@").is_err());
+        assert!(parse_public_contract("cli.finalize-pr=>").is_err());
     }
 
     #[test]
@@ -1342,16 +1448,10 @@ mod tests {
         assert_eq!(handoff["states"]["patch_promoted"], true);
         assert_eq!(handoff["states"]["pr_opened"], false);
         assert_eq!(handoff["boundary"], "patch_promoted_no_pr");
-        assert!(handoff["finalize_command"]
-            .as_str()
-            .expect("finalize command")
-            .contains("--path /Users/user/Developer/homeboy@fix-runtime"));
-        assert!(handoff["finalize_command"]
-            .as_str()
-            .expect("finalize command")
-            .contains(
-                "--base release --verified-base-sha 0123456789012345678901234567890123456789"
-            ));
+        assert_eq!(
+            handoff["finalize_command"],
+            "homeboy agent-task finalize-pr --recover agent-task-run-1"
+        );
     }
 
     #[test]

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -106,7 +106,7 @@ an exhausted run records which budget stopped further execution.
 | `review <run-id>` | Build a durable aggregate review envelope from run state, logs, artifacts, and promotion hints. |
 | `promote <source>` | Promote a completed generic patch artifact into a managed worktree. |
 | `adopt <run-or-cook-id> --candidate-ref <sha>` | Adopt an immutable commit candidate through the recorded cook gates and finalization policy. |
-| `finalize-pr` | Finalize a green cook run into a review-ready pull request. |
+| `finalize-pr` | Finalize a green run, or recover publication from a durable Cook record. |
 | `gate-feedback` | Convert deterministic gate results into a cook retry or stop decision. |
 
 `adopt` accepts only immutable commits from the recorded cook source workspace.
@@ -129,6 +129,36 @@ structured contracts:
 
 Extensions and lab runners should delegate PR creation/update and proof assembly
 to this command instead of recreating GitHub publication logic locally.
+
+Recovery hydrates the run, worktree, base snapshot, candidate, changed files,
+gates, source references, model/tool disclosure, and accepted review form from
+the durable Cook recipe and applied promotion. It fails closed when either
+record is absent, malformed, belongs to another attempt, or no longer matches
+the candidate. `--preflight` performs the same hydration and complete validation
+without commit, push, or pull-request mutation:
+
+```bash
+homeboy agent-task finalize-pr --recover cook-9750 --preflight
+homeboy agent-task finalize-pr --recover cook-9750 \
+  --review-override 'compatibility=No public compatibility impact.@reviewed issue #9750'
+```
+
+Strict repeated-value shapes are `--gate-result NAME=STATUS[:DETAIL]`,
+`--test-step COMMAND=>EXPECTED`, `--changed-public-contract ID=>SUMMARY`, and
+`--review-override TARGET=VALUE@PROVENANCE`. Issue references accept `#NUMBER`,
+`OWNER/REPO#NUMBER`, or an HTTPS `github.com/OWNER/REPO/issues/NUMBER` URL.
+Declaring a changed public contract requires one complete evidence bundle:
+
+```bash
+homeboy agent-task finalize-pr ... \
+  --changed-public-contract 'cli.finalize-pr=>Adds durable recovery input' \
+  --compatibility-impact 'Additive CLI input; existing manual mode remains supported.' \
+  --external-consumer-impact 'External runtimes may replace reconstructed commands.' \
+  --external-usage-status completed \
+  --external-usage-source 'repository call-site search and CLI integration tests' \
+  --external-usage-limitations 'No consumers outside indexed repositories were inspected.' \
+  --external-usage-url 'https://github.com/Extra-Chill/homeboy/issues/9750'
+```
 
 #### Review Dossier Migration
 


### PR DESCRIPTION
## Summary
Add a durable-evidence recovery path and self-describing input grammar for finalize-pr.

## What changed
- Hydrate finalization inputs from persisted Cook promotion evidence and support non-mutating preflight.
- Expose strict CLI value grammars and aggregate independent dossier validation failures.

## How to test
1. Run `cargo test -p homeboy-agents recovery_hydrates_durable_cook_evidence_and_can_preflight_without_mutation -- --test-threads=1`; expect passes.
2. Run `cargo test -p homeboy-cli typed_test_steps_and_overrides_have_explicit_grammar -- --test-threads=1`; expect passes.
3. Run `cargo check -p homeboy-agents -p homeboy-cli`; expect passes.

## Compatibility
Adds recovery and preflight behavior while preserving explicit finalization inputs and existing durable evidence validation.

## Evidence
- Base unchanged since verification: main remains at b9ae69677c82c8325f790cafee50e0d702347503.
- CI expected: Homeboy pull request CI
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9750
- Verified finalization base: main at b9ae69677c82c8325f790cafee50e0d702347503
- cargo-check: passed (Passed)
- changed-file-rustfmt: passed (Passed)
- durable-recovery: passed (Passed)
- git-diff-check: passed (Passed)
- strict-cli-grammar: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Reviewed and rebased the provider patch, resolved its upstream integration conflict, and verified recovery and CLI grammar behavior.

## Source relationships
- Closes Extra-Chill/homeboy#9750
- Relates to Extra-Chill/homeboy#9774
