### PR TITLE
Resolve Cook promotion ownership through concrete attempts

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -196,13 +196,17 @@ pub(crate) fn persisted_promotion_for_attempt(
                 None,
             )
         })?;
-    if promotion.source.run_id.as_deref() != Some(run_id) {
-        return Err(Error::validation_invalid_argument(
+    if promotion.source.run_id.as_deref() != Some(record.run_id.as_str()) {
+        let mut error = Error::validation_invalid_argument(
             "latest_promotion.source.run_id",
             "persisted cook promotion does not belong to this attempt",
             Some(run_id.to_string()),
             None,
-        ));
+        );
+        error.details["requested_run_id"] = serde_json::json!(run_id);
+        error.details["resolved_run_id"] = serde_json::json!(record.run_id);
+        error.details["promotion_run_id"] = serde_json::json!(promotion.source.run_id);
+        return Err(error);
     }
     Ok(Some(promotion))
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2473,7 +2473,7 @@ fn adoption_green_candidate_missing_review_form_runs_form_only_follow_up_and_fin
             assert!(output.status.success());
             String::from_utf8(output.stdout).unwrap().trim().to_string()
         };
-        git(&source, &["init"]);
+        git(&source, &["init", "-b", "main"]);
         git(&source, &["config", "user.email", "agent@example.test"]);
         git(&source, &["config", "user.name", "Agent"]);
         std::fs::write(source.join("lib.rs"), "base\n").unwrap();
@@ -2564,9 +2564,27 @@ fn adoption_green_candidate_missing_review_form_runs_form_only_follow_up_and_fin
         let follow_up_promotion = persisted_promotion_for_attempt(follow_up_run_id)
             .unwrap()
             .expect("form-only continuation carries promoted candidate");
+        let alias_promotion = persisted_promotion_for_attempt(cook_id)
+            .unwrap()
+            .expect("Cook alias carries the same promoted candidate");
+        let replayed_alias_promotion = persisted_promotion_for_attempt(cook_id)
+            .unwrap()
+            .expect("Cook alias recovery is idempotent");
         assert_eq!(
             follow_up_promotion.provenance["cook_follow_up"]["kind"],
             "review_form_only"
+        );
+        assert_eq!(
+            alias_promotion.source.run_id,
+            follow_up_promotion.source.run_id
+        );
+        assert_eq!(
+            alias_promotion.patch_artifact.id,
+            follow_up_promotion.patch_artifact.id
+        );
+        assert_eq!(
+            replayed_alias_promotion.source.run_id,
+            follow_up_promotion.source.run_id
         );
         assert_eq!(
             std::fs::read_to_string(target.join("lib.rs")).unwrap(),
@@ -3257,37 +3275,55 @@ fn promotion(run_id: &str) -> AgentTaskPromotionReport {
 }
 
 #[test]
-fn restarted_cook_uses_only_its_exact_persisted_promotion() {
+fn restarted_cook_alias_and_exact_id_reuse_the_same_persisted_promotion() {
     homeboy_core::test_support::with_isolated_home(|_| {
-        let plan = AgentTaskPlan::new("cook-persisted", Vec::new());
-        agent_task_lifecycle::submit_plan(&plan, Some("run-persisted")).unwrap();
+        let cook_id = "cook-persisted";
+        let run_id = "run-persisted";
+        let plan = AgentTaskPlan::new(cook_id, Vec::new());
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).unwrap();
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, run_id).unwrap();
         agent_task_lifecycle::record_promotion(
-            "run-persisted",
-            serde_json::to_value(promotion("run-persisted")).unwrap(),
+            run_id,
+            serde_json::to_value(promotion(run_id)).unwrap(),
         )
         .unwrap();
 
-        let restored = persisted_promotion_for_attempt("run-persisted")
+        let exact = persisted_promotion_for_attempt(run_id)
             .unwrap()
             .expect("durable promotion");
-        assert_eq!(restored.source.run_id.as_deref(), Some("run-persisted"));
-        assert_eq!(restored.patch_artifact.id, "patch");
+        let alias = persisted_promotion_for_attempt(cook_id)
+            .unwrap()
+            .expect("durable promotion through Cook alias");
+        let replayed_exact = persisted_promotion_for_attempt(run_id)
+            .unwrap()
+            .expect("idempotent exact recovery");
+        assert_eq!(exact.source.run_id.as_deref(), Some(run_id));
+        assert_eq!(alias.source.run_id, exact.source.run_id);
+        assert_eq!(alias.patch_artifact.id, exact.patch_artifact.id);
+        assert_eq!(replayed_exact.source.run_id, exact.source.run_id);
     });
 }
 
 #[test]
 fn persisted_promotion_from_another_attempt_is_rejected() {
     homeboy_core::test_support::with_isolated_home(|_| {
-        let plan = AgentTaskPlan::new("cook-persisted", Vec::new());
-        agent_task_lifecycle::submit_plan(&plan, Some("run-persisted")).unwrap();
+        let cook_id = "cook-persisted";
+        let run_id = "run-persisted";
+        let plan = AgentTaskPlan::new(cook_id, Vec::new());
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).unwrap();
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, run_id).unwrap();
         agent_task_lifecycle::record_promotion(
-            "run-persisted",
+            run_id,
             serde_json::to_value(promotion("different-run")).unwrap(),
         )
         .unwrap();
 
-        let error = persisted_promotion_for_attempt("run-persisted").unwrap_err();
+        let error = persisted_promotion_for_attempt(cook_id).unwrap_err();
         assert!(error.message.contains("does not belong to this attempt"));
+        assert_eq!(error.details["requested_run_id"], cook_id);
+        assert_eq!(error.details["resolved_run_id"], run_id);
+        assert_eq!(error.details["promotion_run_id"], "different-run");
+        assert!(persisted_promotion_for_attempt(run_id).is_err());
     });
 }
 


### PR DESCRIPTION
## Summary
Resolve persisted Cook promotion ownership against the concrete lifecycle attempt.

## What changed
- Compare promotion ownership with the resolved immutable attempt ID while retaining requested alias diagnostics.
- Keep exact attempt IDs fail-closed against promotions owned by another attempt.

## How to test
1. Run `cargo test -p homeboy-agents restarted_cook_alias_and_exact_id_reuse_the_same_persisted_promotion -- --test-threads=1`; expect passes.
2. Run `cargo test -p homeboy-agents persisted_promotion_from_another_attempt_is_rejected -- --test-threads=1`; expect passes.
3. Run `cargo test -p homeboy-agents cook_successful_concrete_attempt_publishes_reviewer_body -- --test-threads=1`; expect passes.
4. Run `cargo check -p homeboy-agents`; expect passes.

## Compatibility
Cook aliases gain correct recovery; exact attempt ownership remains strict.

## Evidence
- Base unchanged since verification: main remains at b9ae69677c82c8325f790cafee50e0d702347503.
- CI expected: Homeboy pull request CI
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9749
- Verified finalization base: main at b9ae69677c82c8325f790cafee50e0d702347503
- alias-promotion-recovery: passed (Passed)
- cargo-check: passed (Passed)
- changed-file-rustfmt: passed (Passed)
- concrete-attempt-publication: passed (Passed)
- cross-attempt-rejection: passed (Passed)
- git-diff-check: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Reviewed the provider patch, rebased it onto current main, and verified alias and exact-attempt promotion ownership.

## Source relationships
- Closes Extra-Chill/homeboy#9749
- Relates to Extra-Chill/homeboy#9774
