### PR TITLE
Bind publication identity proof to the pushed commit

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -199,9 +199,17 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
     if !options.manual_finalization {
         backend.validate_candidate(&options)?;
     }
-    // An identity mismatch must not create a commit, push, or PR mutation.
-    let git_identity = backend.validate_publication_identity(&options.path)?;
+    // Validate intent before commit mutation, then bind evidence to immutable HEAD before push.
+    let prospective_identity = if commit_required {
+        Some(backend.validate_publication_identity(&options.path)?)
+    } else {
+        None
+    };
     if !publish {
+        let git_identity = match prospective_identity {
+            Some(git_identity) => git_identity,
+            None => backend.validate_committed_publication_identity(&options.path, None)?,
+        };
         return Ok(report(
             &options,
             intent,
@@ -223,8 +231,18 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
     if commit_required {
         backend.commit_all(&options.path, &options.commit_message)?;
     }
+    let git_identity = backend
+        .validate_committed_publication_identity(&options.path, prospective_identity.as_ref())?;
+    let commit_sha = git_identity.commit_sha.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "git_identity",
+            "committed Git identity proof must be bound to a commit SHA before publication",
+            None,
+            None,
+        )
+    })?;
     let git_tracking = if push_required {
-        Some(backend.push_branch(&options.path, &head)?)
+        Some(backend.push_branch(&options.path, commit_sha, &head)?)
     } else {
         None
     };

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -562,9 +562,10 @@ mod remote_base_tests {
     #[test]
     fn pushed_branch_without_upstream_tracks_verified_remote_head() {
         let (repo, _origin) = publication_repo();
+        let commit_sha = git_output(repo.path().to_str().unwrap(), &["rev-parse", "HEAD"]).unwrap();
 
         let tracking = RealAgentTaskPrFinalizationBackend
-            .push_branch(repo.path().to_str().unwrap(), "feature")
+            .push_branch(repo.path().to_str().unwrap(), &commit_sha, "feature")
             .expect("branch published");
 
         assert_eq!(
@@ -587,13 +588,14 @@ mod remote_base_tests {
     #[test]
     fn pushed_branch_replaces_stale_base_upstream_after_verification() {
         let (repo, _origin) = publication_repo();
+        let commit_sha = git_output(repo.path().to_str().unwrap(), &["rev-parse", "HEAD"]).unwrap();
         git(
             repo.path(),
             &["branch", "--set-upstream-to", "origin/main", "feature"],
         );
 
         RealAgentTaskPrFinalizationBackend
-            .push_branch(repo.path().to_str().unwrap(), "feature")
+            .push_branch(repo.path().to_str().unwrap(), &commit_sha, "feature")
             .expect("branch published");
 
         assert_eq!(
@@ -623,9 +625,10 @@ mod remote_base_tests {
             &["config", "branch.feature.merge"],
         )
         .unwrap();
+        let commit_sha = git_output(repo.path().to_str().unwrap(), &["rev-parse", "HEAD"]).unwrap();
 
         RealAgentTaskPrFinalizationBackend
-            .push_branch(repo.path().to_str().unwrap(), "feature")
+            .push_branch(repo.path().to_str().unwrap(), &commit_sha, "feature")
             .expect("branch published");
 
         assert_eq!(
@@ -657,10 +660,11 @@ mod remote_base_tests {
     #[test]
     fn failed_push_does_not_mutate_branch_tracking() {
         let (repo, origin) = publication_repo();
+        let commit_sha = git_output(repo.path().to_str().unwrap(), &["rev-parse", "HEAD"]).unwrap();
         drop(origin);
 
         let error = RealAgentTaskPrFinalizationBackend
-            .push_branch(repo.path().to_str().unwrap(), "feature")
+            .push_branch(repo.path().to_str().unwrap(), &commit_sha, "feature")
             .expect_err("push fails");
 
         assert!(error.message.contains("git push failed"));

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -276,6 +276,14 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
         homeboy_core::git::validate_publication_identity(path)
     }
 
+    fn validate_committed_publication_identity(
+        &mut self,
+        path: &str,
+        expected: Option<&homeboy_core::git::GitIdentityProof>,
+    ) -> Result<homeboy_core::git::GitIdentityProof> {
+        homeboy_core::git::validate_committed_publication_identity(path, expected)
+    }
+
     fn commit_all(&mut self, path: &str, message: &str) -> Result<()> {
         let output = commit_at(None, Some(message), CommitOptions::default(), Some(path))?;
         if !output.success {
@@ -287,12 +295,16 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
         Ok(())
     }
 
-    fn push_branch(&mut self, path: &str, head: &str) -> Result<AgentTaskPublicationGitTracking> {
-        let local_sha = git_output(path, &["rev-parse", "HEAD"])?;
+    fn push_branch(
+        &mut self,
+        path: &str,
+        commit_sha: &str,
+        head: &str,
+    ) -> Result<AgentTaskPublicationGitTracking> {
         let output = push_at(
             None,
             PushOptions {
-                refspec: Some(format!("HEAD:refs/heads/{}", head)),
+                refspec: Some(format!("{commit_sha}:refs/heads/{head}")),
                 ..Default::default()
             },
             Some(path),
@@ -306,9 +318,9 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
         let verified_remote_sha = remote_branch_head(path, head)?.ok_or_else(|| {
             Error::git_command_failed(format!("pushed origin head `{head}` could not be verified"))
         })?;
-        if verified_remote_sha != local_sha {
+        if verified_remote_sha != commit_sha {
             return Err(Error::git_command_failed(format!(
-                "pushed origin head `{head}` resolved to `{verified_remote_sha}` instead of `{local_sha}`"
+                "pushed origin head `{head}` resolved to `{verified_remote_sha}` instead of `{commit_sha}`"
             )));
         }
 

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -32,6 +32,7 @@ struct MockBackend {
     create_error: bool,
     push_error: bool,
     identity_error: bool,
+    committed_identity_error: bool,
     hydrate_error: bool,
     hydrate_run_id: Option<String>,
     lifecycle: Option<RunLifecycleRecord>,
@@ -44,6 +45,7 @@ struct MockBackend {
     changed_files_calls: u8,
     commit_calls: u8,
     push_calls: u8,
+    pushed_commit_sha: Option<String>,
     updated: bool,
     last_body: String,
 }
@@ -169,8 +171,40 @@ impl AgentTaskPrFinalizationBackend for MockBackend {
             host: "git.example.test".to_string(),
             name: "Homeboy Bot".to_string(),
             email: "bot@example.test".to_string(),
+            committer_name: "Homeboy Bot".to_string(),
+            committer_email: "bot@example.test".to_string(),
+            commit_sha: None,
             scope: "repository_local".to_string(),
         })
+    }
+
+    fn validate_committed_publication_identity(
+        &mut self,
+        _path: &str,
+        expected: Option<&homeboy_core::git::GitIdentityProof>,
+    ) -> Result<homeboy_core::git::GitIdentityProof> {
+        if self.committed_identity_error {
+            return Err(Error::validation_invalid_argument(
+                "git_identity",
+                "committed Git identity differs from the identity validated before commit",
+                None,
+                None,
+            ));
+        }
+        let mut proof = expected
+            .cloned()
+            .unwrap_or(homeboy_core::git::GitIdentityProof {
+                host: "git.example.test".to_string(),
+                name: "Homeboy Bot".to_string(),
+                email: "bot@example.test".to_string(),
+                committer_name: "Homeboy Bot".to_string(),
+                committer_email: "bot@example.test".to_string(),
+                commit_sha: None,
+                scope: "commit_host_policy".to_string(),
+            });
+        proof.commit_sha = Some("candidate-sha".to_string());
+        proof.scope = "commit_host_policy".to_string();
+        Ok(proof)
     }
 
     fn commit_all(&mut self, _path: &str, _message: &str) -> Result<()> {
@@ -179,12 +213,18 @@ impl AgentTaskPrFinalizationBackend for MockBackend {
         Ok(())
     }
 
-    fn push_branch(&mut self, _path: &str, head: &str) -> Result<AgentTaskPublicationGitTracking> {
+    fn push_branch(
+        &mut self,
+        _path: &str,
+        commit_sha: &str,
+        head: &str,
+    ) -> Result<AgentTaskPublicationGitTracking> {
         if self.push_error {
             return Err(Error::git_command_failed("git push failed"));
         }
         self.pushed = true;
         self.push_calls += 1;
+        self.pushed_commit_sha = Some(commit_sha.to_string());
         Ok(AgentTaskPublicationGitTracking {
             local_branch: head.to_string(),
             remote: "origin".to_string(),
@@ -257,6 +297,7 @@ fn creates_new_pr_after_green_gates() {
     assert_eq!(backend.changed_files_calls, 0);
     assert_eq!(backend.commit_calls, 1);
     assert_eq!(backend.push_calls, 1);
+    assert_eq!(backend.pushed_commit_sha.as_deref(), Some("candidate-sha"));
     assert!(backend.last_body.contains("## AI assistance"));
     assert!(backend.last_body.contains("## Summary"));
     assert!(backend.last_body.contains("## How to test"));
@@ -323,6 +364,14 @@ fn creates_new_pr_after_green_gates() {
             .map(|tracking| tracking.upstream_ref.as_str()),
         Some("refs/remotes/origin/fix/cook")
     );
+    assert_eq!(
+        report
+            .publication_proof
+            .git_identity
+            .as_ref()
+            .and_then(|proof| proof.commit_sha.as_deref()),
+        Some("candidate-sha")
+    );
 }
 
 #[test]
@@ -337,6 +386,25 @@ fn finalization_rejects_identity_mismatch_before_any_publication_mutation() {
 
     assert!(error.message.contains("repository-local Git identity"));
     assert!(!backend.committed);
+    assert!(!backend.pushed);
+    assert!(!backend.created);
+}
+
+#[test]
+fn finalization_rejects_committed_identity_mismatch_before_push() {
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        committed_identity_error: true,
+        ..Default::default()
+    };
+
+    let error =
+        finalize_pr_with_backend(options(), &mut backend).expect_err("committed identity mismatch");
+
+    assert!(error
+        .message
+        .contains("differs from the identity validated"));
+    assert!(backend.committed);
     assert!(!backend.pushed);
     assert!(!backend.created);
 }
@@ -648,6 +716,7 @@ fn publishes_clean_committed_candidate_without_committing() {
     assert_eq!(report.changed_files, vec!["deleted.rs", "renamed.rs"]);
     assert!(!backend.committed);
     assert!(backend.pushed);
+    assert_eq!(backend.pushed_commit_sha.as_deref(), Some("candidate-sha"));
     assert!(backend.created);
     assert!(!report.finalization_outcome.committed);
     assert!(report.finalization_outcome.pushed);

--- a/crates/homeboy-agents/src/agent_task_finalization/types.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/types.rs
@@ -316,10 +316,22 @@ pub trait AgentTaskPrFinalizationBackend {
             AgentTaskPrCandidateState::Dirty { changed_files }
         })
     }
-    /// Validates the host-scoped repository-local identity before publication mutates Git state.
+    /// Validates the effective prospective identity before commit mutation.
     fn validate_publication_identity(&mut self, path: &str) -> Result<GitIdentityProof>;
+    /// Validates and reports the immutable identity stored in the candidate commit.
+    fn validate_committed_publication_identity(
+        &mut self,
+        path: &str,
+        expected: Option<&GitIdentityProof>,
+    ) -> Result<GitIdentityProof>;
     fn commit_all(&mut self, path: &str, message: &str) -> Result<()>;
-    fn push_branch(&mut self, path: &str, head: &str) -> Result<AgentTaskPublicationGitTracking>;
+    /// Pushes the verified commit SHA to the candidate branch.
+    fn push_branch(
+        &mut self,
+        path: &str,
+        commit_sha: &str,
+        head: &str,
+    ) -> Result<AgentTaskPublicationGitTracking>;
     fn find_open_pr(
         &mut self,
         path: &str,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3212,14 +3212,42 @@ impl AgentTaskPrFinalizationBackend for CaptureBackend {
             host: "git.example.test".to_string(),
             name: "Homeboy Bot".to_string(),
             email: "bot@example.test".to_string(),
+            committer_name: "Homeboy Bot".to_string(),
+            committer_email: "bot@example.test".to_string(),
+            commit_sha: None,
             scope: "repository_local".to_string(),
         })
+    }
+    fn validate_committed_publication_identity(
+        &mut self,
+        _path: &str,
+        expected: Option<&homeboy_core::git::GitIdentityProof>,
+    ) -> Result<homeboy_core::git::GitIdentityProof> {
+        let mut proof = expected
+            .cloned()
+            .unwrap_or(homeboy_core::git::GitIdentityProof {
+                host: "git.example.test".to_string(),
+                name: "Homeboy Bot".to_string(),
+                email: "bot@example.test".to_string(),
+                committer_name: "Homeboy Bot".to_string(),
+                committer_email: "bot@example.test".to_string(),
+                commit_sha: None,
+                scope: "commit_host_policy".to_string(),
+            });
+        proof.commit_sha = Some("candidate-sha".to_string());
+        proof.scope = "commit_host_policy".to_string();
+        Ok(proof)
     }
     fn commit_all(&mut self, _path: &str, _message: &str) -> Result<()> {
         self.committed = true;
         Ok(())
     }
-    fn push_branch(&mut self, _path: &str, head: &str) -> Result<AgentTaskPublicationGitTracking> {
+    fn push_branch(
+        &mut self,
+        _path: &str,
+        _commit_sha: &str,
+        head: &str,
+    ) -> Result<AgentTaskPublicationGitTracking> {
         self.pushed = true;
         Ok(AgentTaskPublicationGitTracking {
             local_branch: head.to_string(),

--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -116,17 +116,35 @@ pub struct GitIdentity {
     pub email: String,
 }
 
-/// Evidence that the repository-local identity matched its origin-host policy.
+/// Evidence that an effective or committed identity matched its origin-host policy.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GitIdentityProof {
     pub host: String,
     pub name: String,
     pub email: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub committer_name: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub committer_email: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_sha: Option<String>,
     pub scope: String,
 }
 
-/// Validate the repository-local identity selected for the origin host.
+/// Validate the effective author and committer Git would use for a new commit.
 pub fn validate_publication_identity(path: &str) -> crate::error::Result<GitIdentityProof> {
+    let author = effective_identity(path, "GIT_AUTHOR_IDENT")?;
+    let committer = effective_identity(path, "GIT_COMMITTER_IDENT")?;
+    validate_identities(path, author, committer, None, "effective")
+}
+
+fn validate_identities(
+    path: &str,
+    author: GitIdentity,
+    committer: GitIdentity,
+    commit_sha: Option<String>,
+    scope: &str,
+) -> crate::error::Result<GitIdentityProof> {
     let remote = git_config(path, &["config", "--get", "remote.origin.url"])?;
     let host = remote_host(&remote).ok_or_else(|| {
         identity_error(
@@ -138,9 +156,12 @@ pub fn validate_publication_identity(path: &str) -> crate::error::Result<GitIden
     let Some(expected) = config.git_hosts.get(&host) else {
         return Ok(GitIdentityProof {
             host,
-            name: git_config(path, &["config", "--get", "user.name"])?,
-            email: git_config(path, &["config", "--get", "user.email"])?,
-            scope: "effective_unrestricted".to_string(),
+            name: author.name,
+            email: author.email,
+            committer_name: committer.name,
+            committer_email: committer.email,
+            commit_sha,
+            scope: format!("{scope}_unrestricted"),
         });
     };
     if expected.name.trim().is_empty() || expected.email.trim().is_empty() {
@@ -150,15 +171,20 @@ pub fn validate_publication_identity(path: &str) -> crate::error::Result<GitIden
         ));
     }
 
-    let name = git_config(path, &["config", "--local", "--get", "user.name"])?;
-    let email = git_config(path, &["config", "--local", "--get", "user.email"])?;
-    if name != expected.name || email != expected.email {
+    if author.name != expected.name
+        || author.email != expected.email
+        || committer.name != expected.name
+        || committer.email != expected.email
+    {
         return Err(identity_error(
-            "effective repository-local Git identity does not match the origin host policy",
+            "effective Git author or committer does not match the origin host policy",
             json!({
                 "host": host,
                 "expected": { "name": expected.name, "email": expected.email },
-                "actual": { "name": name, "email": email },
+                "actual": {
+                    "author": { "name": author.name, "email": author.email },
+                    "committer": { "name": committer.name, "email": committer.email }
+                },
                 "remediation": [{
                     "kind": "configure_repository_local_identity",
                     "commands": [
@@ -171,10 +197,103 @@ pub fn validate_publication_identity(path: &str) -> crate::error::Result<GitIden
     }
     Ok(GitIdentityProof {
         host,
-        name,
-        email,
-        scope: "repository_local".to_string(),
+        name: author.name,
+        email: author.email,
+        committer_name: committer.name,
+        committer_email: committer.email,
+        commit_sha,
+        scope: if scope == "effective" {
+            "repository_local".to_string()
+        } else {
+            format!("{scope}_host_policy")
+        },
     })
+}
+
+/// Validate the immutable author and committer stored in `HEAD`.
+pub fn validate_committed_publication_identity(
+    path: &str,
+    expected: Option<&GitIdentityProof>,
+) -> crate::error::Result<GitIdentityProof> {
+    let output = git_config(
+        path,
+        &["show", "-s", "--format=%H%n%an%n%ae%n%cn%n%ce", "HEAD"],
+    )?;
+    let mut lines = output.lines();
+    let sha = lines.next().unwrap_or_default().to_string();
+    let author = GitIdentity {
+        name: lines.next().unwrap_or_default().to_string(),
+        email: lines.next().unwrap_or_default().to_string(),
+    };
+    let committer = GitIdentity {
+        name: lines.next().unwrap_or_default().to_string(),
+        email: lines.next().unwrap_or_default().to_string(),
+    };
+    if sha.is_empty()
+        || author.name.is_empty()
+        || author.email.is_empty()
+        || committer.name.is_empty()
+        || committer.email.is_empty()
+    {
+        return Err(identity_error(
+            "HEAD does not contain a complete commit identity",
+            json!({ "remediation": [] }),
+        ));
+    }
+    if let Some(expected) = expected {
+        if author.name != expected.name
+            || author.email != expected.email
+            || committer.name != expected.committer_name
+            || committer.email != expected.committer_email
+        {
+            return Err(identity_error(
+                "committed Git identity differs from the identity validated before commit",
+                json!({
+                    "expected": {
+                        "author": { "name": expected.name, "email": expected.email },
+                        "committer": {
+                            "name": expected.committer_name,
+                            "email": expected.committer_email
+                        }
+                    },
+                    "actual": {
+                        "author": { "name": author.name, "email": author.email },
+                        "committer": { "name": committer.name, "email": committer.email }
+                    },
+                    "commit_sha": sha,
+                    "remediation": []
+                }),
+            ));
+        }
+    }
+    validate_identities(path, author, committer, Some(sha), "commit")
+}
+
+fn effective_identity(path: &str, variable: &str) -> crate::error::Result<GitIdentity> {
+    let value = git_config(path, &["var", variable])?;
+    let Some(email_end) = value.rfind('>') else {
+        return Err(identity_error(
+            "Git could not resolve a complete prospective identity",
+            json!({ "identity": variable, "remediation": [] }),
+        ));
+    };
+    let Some(email_start) = value[..email_end].rfind(" <") else {
+        return Err(identity_error(
+            "Git could not resolve a complete prospective identity",
+            json!({ "identity": variable, "remediation": [] }),
+        ));
+    };
+    let identity = GitIdentity {
+        name: value[..email_start].trim().to_string(),
+        email: value[email_start + 2..email_end].trim().to_string(),
+    };
+    if identity.name.is_empty() || identity.email.is_empty() {
+        return Err(identity_error(
+            "Git could not resolve a complete prospective identity",
+            json!({ "identity": variable, "remediation": [] }),
+        ));
+    }
+    Ok(identity)
 }
 
 fn git_config(path: &str, args: &[&str]) -> crate::error::Result<String> {
@@ -319,6 +438,7 @@ mod identity_tests {
     use crate::test_support::with_isolated_home;
     use std::collections::HashMap;
     use std::process::Command;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
 
     #[test]
     fn bot_shorthand() {
@@ -378,24 +498,24 @@ mod identity_tests {
             assert_eq!(proof.host, "git.example.test");
             assert_eq!(proof.name, "Existing Author");
             assert_eq!(proof.email, "author@example.test");
+            assert_eq!(proof.committer_name, "Existing Author");
+            assert_eq!(proof.committer_email, "author@example.test");
             assert_eq!(proof.scope, "effective_unrestricted");
         });
     }
 
     #[test]
-    fn publication_identity_configured_host_requires_repository_local_identity() {
+    fn publication_identity_configured_host_requires_complete_effective_identity() {
         with_isolated_home(|_| {
             let temp = identity_test_repo();
             save_identity_policy();
 
-            let error = validate_publication_identity(temp.path().to_str().expect("path"))
-                .expect_err("repository-local identity is required");
+            let error = with_identity_environment(("", ""), ("", ""), || {
+                validate_publication_identity(temp.path().to_str().expect("path"))
+                    .expect_err("effective identity is required")
+            });
 
-            assert_eq!(error.details["host"], "git.example.test");
-            assert_eq!(
-                error.details["remediation"][0]["kind"],
-                "configure_repository_local_identity"
-            );
+            assert!(error.message.contains("prospective identity"));
         });
     }
 
@@ -410,7 +530,7 @@ mod identity_tests {
             let error = validate_publication_identity(temp.path().to_str().expect("path"))
                 .expect_err("incorrect identity");
 
-            assert_eq!(error.details["actual"]["name"], "Wrong Author");
+            assert_eq!(error.details["actual"]["author"]["name"], "Wrong Author");
             assert_eq!(error.details["expected"]["name"], "Expected Author");
         });
     }
@@ -431,8 +551,163 @@ mod identity_tests {
 
             assert_eq!(proof.name, "Expected Author");
             assert_eq!(proof.email, "expected@example.test");
+            assert_eq!(proof.committer_name, "Expected Author");
             assert_eq!(proof.scope, "repository_local");
         });
+    }
+
+    #[test]
+    fn publication_identity_accepts_allowed_environment_overrides() {
+        with_isolated_home(|_| {
+            let temp = identity_test_repo();
+            save_identity_policy();
+            run_identity_git(temp.path(), &["config", "user.name", "Wrong Author"]);
+            run_identity_git(temp.path(), &["config", "user.email", "wrong@example.test"]);
+
+            with_identity_environment(
+                ("Expected Author", "expected@example.test"),
+                ("Expected Author", "expected@example.test"),
+                || {
+                    let proof = validate_publication_identity(temp.path().to_str().expect("path"))
+                        .expect("allowed environment identity");
+                    assert_eq!(proof.name, "Expected Author");
+                    assert_eq!(proof.committer_name, "Expected Author");
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn publication_identity_rejects_environment_override() {
+        with_isolated_home(|_| {
+            let temp = identity_test_repo();
+            save_identity_policy();
+            run_identity_git(temp.path(), &["config", "user.name", "Expected Author"]);
+            run_identity_git(
+                temp.path(),
+                &["config", "user.email", "expected@example.test"],
+            );
+
+            with_identity_environment(
+                ("Override Author", "override@example.test"),
+                ("Expected Author", "expected@example.test"),
+                || {
+                    let error = validate_publication_identity(temp.path().to_str().expect("path"))
+                        .expect_err("rejected environment identity");
+                    assert_eq!(
+                        error.details["actual"]["author"]["email"],
+                        "override@example.test"
+                    );
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn publication_identity_rejects_different_author_and_committer() {
+        with_isolated_home(|_| {
+            let temp = identity_test_repo();
+            save_identity_policy();
+
+            with_identity_environment(
+                ("Expected Author", "expected@example.test"),
+                ("Other Committer", "other@example.test"),
+                || {
+                    let error = validate_publication_identity(temp.path().to_str().expect("path"))
+                        .expect_err("different committer");
+                    assert_eq!(
+                        error.details["actual"]["committer"]["name"],
+                        "Other Committer"
+                    );
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn committed_publication_identity_is_bound_to_head_sha() {
+        with_isolated_home(|_| {
+            let temp = identity_test_repo();
+            save_identity_policy();
+            run_identity_git(temp.path(), &["config", "user.name", "Expected Author"]);
+            run_identity_git(
+                temp.path(),
+                &["config", "user.email", "expected@example.test"],
+            );
+            run_identity_git(temp.path(), &["commit", "--allow-empty", "-m", "candidate"]);
+
+            let proof =
+                validate_committed_publication_identity(temp.path().to_str().expect("path"), None)
+                    .expect("committed identity");
+            let head = git_config(temp.path().to_str().expect("path"), &["rev-parse", "HEAD"])
+                .expect("head");
+
+            assert_eq!(proof.commit_sha.as_deref(), Some(head.as_str()));
+            assert_eq!(proof.name, "Expected Author");
+            assert_eq!(proof.committer_name, "Expected Author");
+            assert_eq!(proof.scope, "commit_host_policy");
+        });
+    }
+
+    #[test]
+    fn committed_publication_identity_must_match_validated_intent() {
+        with_isolated_home(|_| {
+            let temp = identity_test_repo();
+            run_identity_git(temp.path(), &["config", "user.name", "Intended Author"]);
+            run_identity_git(
+                temp.path(),
+                &["config", "user.email", "intended@example.test"],
+            );
+            let intended = validate_publication_identity(temp.path().to_str().expect("path"))
+                .expect("prospective identity");
+
+            with_identity_environment(
+                ("Different Author", "different@example.test"),
+                ("Different Committer", "different-committer@example.test"),
+                || run_identity_git(temp.path(), &["commit", "--allow-empty", "-m", "candidate"]),
+            );
+            let error = validate_committed_publication_identity(
+                temp.path().to_str().expect("path"),
+                Some(&intended),
+            )
+            .expect_err("commit identity drift");
+
+            assert!(error
+                .message
+                .contains("differs from the identity validated"));
+            assert_eq!(
+                error.details["actual"]["author"]["name"],
+                "Different Author"
+            );
+            assert!(!error.details["commit_sha"]
+                .as_str()
+                .unwrap_or_default()
+                .is_empty());
+        });
+    }
+
+    #[test]
+    fn git_identity_proof_deserializes_legacy_serialized_evidence() {
+        let proof: GitIdentityProof = serde_json::from_value(serde_json::json!({
+            "host": "git.example.test",
+            "name": "Existing Author",
+            "email": "author@example.test",
+            "scope": "repository_local"
+        }))
+        .expect("legacy identity proof");
+
+        assert!(proof.committer_name.is_empty());
+        assert!(proof.committer_email.is_empty());
+        assert_eq!(proof.commit_sha, None);
+        assert_eq!(
+            serde_json::to_value(proof).expect("serialize legacy identity proof"),
+            serde_json::json!({
+                "host": "git.example.test",
+                "name": "Existing Author",
+                "email": "author@example.test",
+                "scope": "repository_local"
+            })
+        );
     }
 
     fn identity_test_repo() -> tempfile::TempDir {
@@ -471,6 +746,64 @@ mod identity_tests {
             .status()
             .expect("run git");
         assert!(status.success());
+    }
+
+    fn with_identity_environment<R>(
+        author: (&str, &str),
+        committer: (&str, &str),
+        test: impl FnOnce() -> R,
+    ) -> R {
+        let _environment = IdentityEnvironment::new(author, committer);
+        test()
+    }
+
+    static IDENTITY_ENVIRONMENT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    struct IdentityEnvironment {
+        _lock: MutexGuard<'static, ()>,
+        previous: [Option<String>; 4],
+    }
+
+    impl IdentityEnvironment {
+        fn new(author: (&str, &str), committer: (&str, &str)) -> Self {
+            let lock = IDENTITY_ENVIRONMENT_LOCK
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let values = [
+                ("GIT_AUTHOR_NAME", author.0),
+                ("GIT_AUTHOR_EMAIL", author.1),
+                ("GIT_COMMITTER_NAME", committer.0),
+                ("GIT_COMMITTER_EMAIL", committer.1),
+            ];
+            let previous = values.map(|(key, _)| std::env::var(key).ok());
+            for (key, value) in values {
+                std::env::set_var(key, value);
+            }
+            Self {
+                _lock: lock,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for IdentityEnvironment {
+        fn drop(&mut self) {
+            for (key, value) in [
+                "GIT_AUTHOR_NAME",
+                "GIT_AUTHOR_EMAIL",
+                "GIT_COMMITTER_NAME",
+                "GIT_COMMITTER_EMAIL",
+            ]
+            .into_iter()
+            .zip(self.previous.iter())
+            {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Validate effective author and committer identities and bind publication proof to the immutable commit.

## What changed
- Resolve Git author and committer precedence before mutation, including environment overrides.
- Verify the resulting or pre-existing commit identity and SHA before push.

## How to test
1. Run `cargo test -p homeboy-core publication_identity -- --test-threads=1`; expect identity policy tests pass.
2. Run `cargo test -p homeboy-agents identity_mismatch -- --test-threads=1`; expect finalization mismatch tests pass.
3. Run `cargo check -p homeboy-agents -p homeboy-core`; expect passes.

## Compatibility
Existing unrestricted-host behavior remains; configured host policies now validate both prospective and committed identities.

## Evidence
- Base unchanged since verification: main remains at b9ae69677c82c8325f790cafee50e0d702347503.
- CI expected: Homeboy pull request CI
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9751
- Verified finalization base: main at b9ae69677c82c8325f790cafee50e0d702347503
- cargo-check: passed (Passed)
- changed-file-rustfmt: passed (Passed)
- finalization-identity-mismatch: passed (Passed)
- git-diff-check: passed (Passed)
- publication-identity-policy: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Reviewed and rebased the provider patch and verified prospective and committed Git identity policy boundaries.

## Source relationships
- Closes Extra-Chill/homeboy#9751
- Relates to Extra-Chill/homeboy#9774
