### PR TITLE
fix(agents): pass git_tracking to validation-only finalization report (unbreak main)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -215,6 +215,9 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
             false,
             false,
             Some(git_identity),
+            // Validation-only finalization performs no push, so there is no
+            // publication git tracking to record.
+            None,
         ));
     }
     if commit_required {


### PR DESCRIPTION
## Summary
`homeboy-agents` fails to compile on `main`:

```
error[E0061]: this function takes 13 arguments but 12 arguments were supplied
  --> crates/homeboy-agents/src/agent_task_finalization.rs:205:19
```

`report()` gained a 13th `git_tracking` parameter, and the `no_changes` (l.182) and `review_ready` (l.269) call sites were updated, but the validation-only `!publish` early return (l.205) was left at 12 args — likely a merge collision between two PRs touching `report()`.

## Fix
Validation-only finalization performs no push, so there is no publication git tracking to record — pass `None`, matching the `no_changes` site.

## Testing
- `cargo check -p homeboy-agents --lib` — clean (was E0061 on main).

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Caught while a downstream fix couldn't build the tree; identified the missing arg against the two correct call sites.