### PR TITLE
Fix validation-only finalization build

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -215,6 +215,7 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
             false,
             false,
             Some(git_identity),
+            None,
         ));
     }
     if commit_required {

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -630,6 +630,7 @@ fn reports_no_changes_without_commit_push_or_pr() {
     assert_eq!(backend.changed_files_calls, 0);
     assert_eq!(backend.commit_calls, 0);
     assert_eq!(backend.push_calls, 0);
+    assert!(report.publication_proof.git_tracking.is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- pass an explicit empty Git tracking proof through validation-only finalization
- assert that no tracking claim is emitted when no push occurs
- restore compilation of current `main` and unblock runner branch builds

Fixes #9802.

## Verification

- `cargo test -p homeboy-agents reports_no_changes_without_commit_push_or_pr`
- `cargo check -p homeboy-agents`
- `cargo fmt --check`
- `git diff --check`

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode identified the missing argument, drafted the minimal fix and regression assertion, and ran the verification commands. Chris Huber reviewed and remains responsible for the change.