### PR TITLE
fix(runs): correlate Lab artifacts across nested and flat job-id metadata

### DIFF
--- a/crates/homeboy-core/src/observation/runs_service/artifact_links.rs
+++ b/crates/homeboy-core/src/observation/runs_service/artifact_links.rs
@@ -27,6 +27,19 @@ fn public_url_for_url_artifact(artifact: &ArtifactRecord) -> Option<String> {
         .flatten()
 }
 
+/// Read a run's Lab remote job id from either metadata shape.
+///
+/// Records write the same identity two ways: the nested `lab.remote_job.id`
+/// (runner-exec mirrors) and the flat `lab.remote_job_id` (bench/trace sibling
+/// runs). Correlating a runner-exec run with its downstream siblings requires
+/// tolerating both, otherwise a job-id-only match silently finds nothing (#9783).
+fn lab_remote_job_id(run: &RunRecord) -> Option<&str> {
+    let lab = run.metadata_json.get("lab")?;
+    lab.pointer("/remote_job/id")
+        .or_else(|| lab.get("remote_job_id"))
+        .and_then(Value::as_str)
+}
+
 /// Collect artifacts belonging to remote bench/trace runs that share the
 /// same Lab `remote_job_id` with the supplied runner-exec run. Used so
 /// `runs artifacts <runner-job-run>` surfaces the downstream bench/trace
@@ -38,15 +51,12 @@ pub fn related_lab_artifacts_for_runner_job(
     if run.kind != "runner-exec" {
         return Ok(Vec::new());
     }
+    // Resolve the runner-exec run's Lab job id. Prefer authoritative runner
+    // evidence; fall back to the persisted metadata in either shape.
     let Some(job_id) =
         runner_evidence::with_runner_evidence(|p| p.mirrored_runner_job_identity(run))
             .map(|(_runner_id, job_id)| job_id)
-            .or_else(|| {
-                run.metadata_json
-                    .pointer("/lab/remote_job_id")
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-            })
+            .or_else(|| lab_remote_job_id(run).map(str::to_string))
     else {
         return Ok(Vec::new());
     };
@@ -61,12 +71,8 @@ pub fn related_lab_artifacts_for_runner_job(
         if candidate.id == run.id {
             continue;
         }
-        if candidate
-            .metadata_json
-            .pointer("/lab/remote_job_id")
-            .and_then(Value::as_str)
-            != Some(job_id.as_str())
-        {
+        // Match siblings on the same Lab job id, tolerating both metadata shapes.
+        if lab_remote_job_id(&candidate) != Some(job_id.as_str()) {
             continue;
         }
         artifacts.extend(store.list_artifacts(&candidate.id)?);
@@ -87,4 +93,70 @@ pub fn list_artifacts_for_run(
     crate::artifacts::index_remote_published_artifact_refs_for_run(store, &run.id)?;
     let artifacts = store.list_artifacts(&run.id)?;
     Ok(enrich_artifact_links(artifacts))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lab_remote_job_id;
+    use crate::observation::RunRecord;
+
+    fn run_with_metadata(metadata: serde_json::Value) -> RunRecord {
+        RunRecord {
+            id: "r".to_string(),
+            kind: "runner-exec".to_string(),
+            component_id: None,
+            started_at: "2026-07-23T00:00:00Z".to_string(),
+            finished_at: None,
+            status: "running".to_string(),
+            command: None,
+            cwd: None,
+            homeboy_version: None,
+            git_sha: None,
+            rig_id: None,
+            metadata_json: metadata,
+        }
+    }
+
+    #[test]
+    fn reads_nested_remote_job_id() {
+        // runner-exec mirrors persist the nested shape.
+        let run = run_with_metadata(serde_json::json!({
+            "lab": { "runner": { "id": "lab" }, "remote_job": { "id": "job-123" } }
+        }));
+        assert_eq!(lab_remote_job_id(&run), Some("job-123"));
+    }
+
+    #[test]
+    fn reads_flat_remote_job_id() {
+        // bench/trace sibling runs persist the flat shape.
+        let run = run_with_metadata(serde_json::json!({
+            "lab": { "remote_job_id": "job-123" }
+        }));
+        assert_eq!(lab_remote_job_id(&run), Some("job-123"));
+    }
+
+    #[test]
+    fn nested_and_flat_shapes_correlate_to_the_same_job() {
+        // #9783: a runner-exec run (nested) and its sibling (flat) must resolve
+        // to the same job id so artifact linking finds the sibling.
+        let runner = run_with_metadata(serde_json::json!({
+            "lab": { "runner": { "id": "lab" }, "remote_job": { "id": "job-9783" } }
+        }));
+        let sibling = run_with_metadata(serde_json::json!({
+            "lab": { "remote_job_id": "job-9783" }
+        }));
+        assert_eq!(lab_remote_job_id(&runner), lab_remote_job_id(&sibling));
+    }
+
+    #[test]
+    fn missing_lineage_returns_none() {
+        assert_eq!(
+            lab_remote_job_id(&run_with_metadata(serde_json::json!({}))),
+            None
+        );
+        assert_eq!(
+            lab_remote_job_id(&run_with_metadata(serde_json::json!({ "lab": {} }))),
+            None
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- `related_lab_artifacts_for_runner_job` links a runner-exec run to its downstream bench/trace siblings by matching Lab `remote_job_id`, but read only the **flat** `lab.remote_job_id` shape. runner-exec mirrors persist the **nested** `lab.remote_job.id` shape, so the runner-exec job-id resolution *and* the sibling match missed each other and returned zero related artifacts (#9783).

## Fix
New `lab_remote_job_id(&RunRecord)` reads either shape (nested `lab.remote_job.id` or flat `lab.remote_job_id`), used on both sides of the correlation. A runner-exec run (nested) and its flat-metadata siblings now resolve to the same job.

## Testing
- `cargo test -p homeboy-cli --lib runner_job_artifact_listing_includes_related_sibling_lab_run_artifacts` — passes (was failing on main; the fixture pairs a nested runner-exec run with a flat sibling).
- `cargo test -p homeboy-core --lib artifact_links::tests` — 4 new tests (nested read, flat read, cross-shape correlation, missing-lineage None).

## Note
This closes the test-failure I filed as #9783 while working on #9629. It depends on #9803 (unbreak-main) to build — that PR fixes an unrelated `agent_task_finalization` arity break currently on `main`.

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Root-causing the nested-vs-flat metadata mismatch and adding shape-tolerant correlation + tests.

Closes #9783