### PR TITLE
test(agents): cover validation-only finalization leaves git_tracking unset

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -326,6 +326,41 @@ fn creates_new_pr_after_green_gates() {
 }
 
 #[test]
+fn preflight_validates_without_publishing_or_git_tracking() {
+    // #9798 / #9802: the validation-only (`!publish`) finalization path performs
+    // no commit/push, so its publication proof must record no git tracking. This
+    // guards the report(...) call that regressed to a missing git_tracking arg
+    // and locks the "validated" projection's contract.
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        ..Default::default()
+    };
+
+    let report = preflight_pr_with_backend(options(), &mut backend).expect("preflight validated");
+
+    assert_eq!(report.status, "validated");
+    assert_eq!(report.pr_action, "none");
+    assert_eq!(report.pr_number, None);
+    assert!(report.pr_url.is_none());
+
+    // No publication mutation happened.
+    assert!(!backend.committed);
+    assert!(!backend.pushed);
+    assert!(!backend.created);
+    assert_eq!(backend.commit_calls, 0);
+    assert_eq!(backend.push_calls, 0);
+    assert!(!report.finalization_outcome.published);
+
+    // Identity is still proven (validation resolves it), but there is no
+    // publication git tracking because nothing was pushed.
+    assert!(report.publication_proof.git_identity.is_some());
+    assert!(
+        report.publication_proof.git_tracking.is_none(),
+        "validation-only publication proof must not carry git tracking"
+    );
+}
+
+#[test]
 fn finalization_rejects_identity_mismatch_before_any_publication_mutation() {
     let mut backend = MockBackend {
         changed_files: vec!["src/lib.rs".to_string()],


### PR DESCRIPTION
## Summary
Both #9798 and #9802 report the same `main` build break — `report(...)` called with 12 args at `agent_task_finalization.rs:205` after `git_tracking` became a required 13th argument. **That break is already fixed on `main`** (commit `e0bdd9a39`, merged via #9803): the validation-only path now passes `git_tracking: None`.

Both issues additionally ask for **coverage that the validation-only path keeps `git_tracking` unset**. This PR adds it.

## Change
New test `preflight_validates_without_publishing_or_git_tracking` exercises the public `preflight_pr_with_backend` (the `!publish` path) and asserts:
- `status == "validated"`, `pr_action == "none"`, no PR number/url.
- No commit/push (`committed`/`pushed`/`created` false; 0 commit/push calls; `published == false`).
- Git identity is still proven, but `publication_proof.git_tracking.is_none()`.

This locks the "validated" projection's contract so the missing-arg regression can't silently return.

## Testing
- `cargo test -p homeboy-agents --lib agent_task_finalization::tests` — 37 passed (1 new).

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Confirming the build break was already resolved and adding the requested validation-only coverage.

Closes #9798
Closes #9802