### PR TITLE
Resume promotions from durable checkpoint contracts

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -123,7 +123,22 @@ pub fn resume_promoted_patch(
         &normalized_patch.content,
     )?];
     let mut provider = ExternalPromotionWorkspaceProvider::from_options(&options);
-    let verified_base = capture_declared_base(target_path, options.base_ref.as_deref())?;
+    // A resumed checkpoint verifies the already-applied candidate. Its base is
+    // the immutable observation made before apply, not a new moving origin read.
+    let verified_base = previous
+        .get("verified_base")
+        .filter(|base| !base.is_null())
+        .cloned()
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|_| {
+            Error::validation_invalid_argument(
+                "promotion",
+                "promotion resume durable resolved base is invalid",
+                None,
+                None,
+            )
+        })?;
     let gates = run_promotion_gates(&options, &mut provider, target_path)?;
     let target =
         AgentTaskPromotionTarget::from_worktree(options.to_worktree.clone(), Some(target_path));
@@ -158,6 +173,7 @@ pub fn resume_promoted_patch(
             "dependencies_materialized": gates.dependencies_materialized,
             "candidate": candidate,
             "resumed_post_apply_promotion": true,
+            "resume_contract": previous.pointer("/provenance/resume_contract"),
         }),
         operator_notification: promotion_notification(gates.status, &target),
     };
@@ -246,16 +262,28 @@ fn validate_resume_candidate(
         "task_base_sha": options.task_base_sha,
         "candidate_ref": options.candidate_ref,
     });
-    if previous
-        .pointer("/provenance/resume_inputs")
-        .is_some_and(|recorded| recorded != &expected_inputs)
-    {
+    let recorded_inputs = previous
+        .pointer("/provenance/resume_contract/inputs")
+        .or_else(|| previous.pointer("/provenance/resume_inputs"));
+    if recorded_inputs.is_some_and(|recorded| recorded != &expected_inputs) {
         return Err(Error::validation_invalid_argument(
             "promotion",
             "promotion resume base or candidate input does not match the durable post-apply promotion",
             None,
             None,
         ));
+    }
+    if let Some(recorded_gates) = previous.pointer("/provenance/resume_contract/gates") {
+        let actual_gates = serde_json::to_value(&options.gates)
+            .map_err(|error| Error::internal_json(error.to_string(), None))?;
+        if recorded_gates != &actual_gates {
+            return Err(Error::validation_invalid_argument(
+                "promotion",
+                "promotion resume deterministic gate contract does not match the durable post-apply promotion",
+                None,
+                None,
+            ));
+        }
     }
     let status = std::process::Command::new("git")
         .args(["status", "--porcelain"])
@@ -304,15 +332,12 @@ fn validate_resume_candidate(
         }
     }
     if let Some(recorded_base) = previous.get("verified_base") {
-        let current_base = serde_json::to_value(capture_declared_base(
-            target_path,
-            options.base_ref.as_deref(),
-        )?)
-        .map_err(|error| Error::internal_json(error.to_string(), None))?;
-        if &current_base != recorded_base {
+        if recorded_base.is_null()
+            || recorded_base.get("base").and_then(Value::as_str) != options.base_ref.as_deref()
+        {
             return Err(Error::validation_invalid_argument(
                 "base_ref",
-                "promotion resume declared base no longer matches the durable post-apply promotion",
+                "promotion resume declared base does not match the durable post-apply promotion",
                 None,
                 None,
             ));
@@ -649,6 +674,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
             worktree_path,
             &outcome.schema,
             artifact.metadata.clone(),
+            pre_apply_verified_base.clone(),
         )?;
         checkpoint(&report)?;
         Some(report)
@@ -1088,6 +1114,7 @@ fn promote_committed_changes(
             artifact
                 .map(|artifact| artifact.metadata.clone())
                 .unwrap_or(Value::Null),
+            None,
         )?;
         checkpoint(&report)?;
         Some(report)
@@ -1481,6 +1508,7 @@ fn post_apply_report(
     worktree_path: &Path,
     source_schema: &str,
     artifact_metadata: Value,
+    verified_base: Option<AgentTaskPromotionVerifiedBase>,
 ) -> Result<AgentTaskPromotionReport> {
     let status = AgentTaskPromotionStatus::VerificationPending;
     let operator_notification = promotion_notification(status, &target);
@@ -1494,24 +1522,25 @@ fn post_apply_report(
         })),
         _ => None,
     };
-    // A base observation is recorded when the target can reach its remote. The
-    // post-apply checkpoint must still survive a transient remote failure so it
-    // can protect the already-applied candidate for recovery.
-    let verified_base = capture_declared_base(worktree_path, options.base_ref.as_deref())
-        .ok()
-        .flatten();
+    // Managed targets pass their pre-apply snapshot. Provider-owned targets do
+    // not expose a path until apply, so retain the established best-effort read.
+    let verified_base = verified_base.or_else(|| {
+        capture_declared_base(worktree_path, options.base_ref.as_deref())
+            .ok()
+            .flatten()
+    });
     Ok(AgentTaskPromotionReport {
         schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
         status,
         source: promotion_source(source_kind, outcome, options),
         to_worktree: options.to_worktree.clone(),
-        target,
-        patch_artifact,
+        target: target.clone(),
+        patch_artifact: patch_artifact.clone(),
         changed_files,
         command_evidence,
         deterministic_gates: Vec::new(),
         gate_results: Vec::new(),
-        verified_base,
+        verified_base: verified_base.clone(),
         provenance: json!({
             "source_schema": source_schema,
             "artifact_metadata": artifact_metadata,
@@ -1525,6 +1554,18 @@ fn post_apply_report(
                 "base_ref": options.base_ref,
                 "task_base_sha": options.task_base_sha,
                 "candidate_ref": options.candidate_ref,
+            },
+            "resume_contract": {
+                "resolved_base": verified_base,
+                "artifact": patch_artifact,
+                "destination": target,
+                "candidate": candidate,
+                "inputs": {
+                    "base_ref": options.base_ref,
+                    "task_base_sha": options.task_base_sha,
+                    "candidate_ref": options.candidate_ref,
+                },
+                "gates": options.gates,
             },
         }),
         operator_notification,

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -747,7 +747,7 @@ fn resume_promoted_patch_rebuilds_green_proof_from_pending_post_apply_checkpoint
         source_run_id: Some("run-8307".to_string()),
         source_path: Some(source_path),
         source_worktree_path: None,
-        base_ref: None,
+        base_ref: Some("main".to_string()),
         task_base_sha: None,
         candidate_ref: None,
         to_worktree: "repo@fix-8307".to_string(),
@@ -771,6 +771,13 @@ fn resume_promoted_patch_rebuilds_green_proof_from_pending_post_apply_checkpoint
         "to_worktree": "repo@fix-8307",
         "target": { "worktree": "repo@fix-8307", "path": target },
         "patch_artifact": { "id": "patch", "kind": "patch", "sha256": sha256_hex(VALID_PATCH) },
+        "verified_base": { "base": "main", "sha": "checkpointed-base" },
+        "provenance": {
+            "resume_contract": {
+                "inputs": { "base_ref": "main", "task_base_sha": null, "candidate_ref": null },
+                "gates": serde_json::to_value(&options.gates).expect("gate contract")
+            }
+        }
     });
 
     let report = resume_promoted_patch(options, &target, &previous).expect("resume proof");
@@ -786,6 +793,10 @@ fn resume_promoted_patch_rebuilds_green_proof_from_pending_post_apply_checkpoint
         homeboy_core::gate::HomeboyGateStatus::Passed
     );
     assert_eq!(report.provenance["resumed_post_apply_promotion"], true);
+    assert_eq!(
+        report.verified_base.expect("checkpointed base").sha,
+        "checkpointed-base"
+    );
     assert!(report.provenance["candidate"].is_object());
     assert_eq!(report.deterministic_gates.len(), 2);
     assert_eq!(

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -214,6 +214,7 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
                         args.to_worktree.as_deref(),
                         args.provider_command.as_deref(),
                         &args.provider_argv,
+                        record.metadata.get("latest_promotion"),
                         aggregate,
                         review,
                     )
@@ -947,6 +948,7 @@ fn promotion_candidates(
     to_worktree: Option<&str>,
     provider_command: Option<&str>,
     provider_argv: &[String],
+    latest_promotion: Option<&Value>,
     aggregate: &AgentTaskAggregate,
     review: &AgentTaskAggregateReport,
 ) -> Vec<Value> {
@@ -1008,9 +1010,25 @@ fn promotion_candidates(
                     "--artifact-id".to_string(),
                     artifact_id.clone(),
                 ];
-                if let Some(to_worktree) = to_worktree {
+                let continuation = latest_promotion.filter(|promotion| {
+                    promotion_is_resumable(promotion, false)
+                        && promotion.pointer("/source/task_id").and_then(Value::as_str)
+                            == Some(candidate.task_id.as_str())
+                        && promotion.pointer("/patch_artifact/id").and_then(Value::as_str)
+                            == Some(artifact_id.as_str())
+                });
+                if let Some(to_worktree) = continuation
+                    .and_then(|promotion| promotion.pointer("/target/worktree"))
+                    .and_then(Value::as_str)
+                    .or(to_worktree)
+                {
                     command.push("--to-worktree".to_string());
                     command.push(to_worktree.to_string());
+                }
+                if let Some(contract) = continuation
+                    .and_then(|promotion| promotion.pointer("/provenance/resume_contract"))
+                {
+                    append_resume_contract(&mut command, contract);
                 }
                 if let Some(provider_command) = provider_command {
                     command.push("--provider-command".to_string());
@@ -1033,6 +1051,70 @@ fn promotion_candidates(
             })
         })
         .collect()
+}
+
+/// Render the durable gate contract rather than relying on evolving CLI defaults.
+fn append_resume_contract(command: &mut Vec<String>, contract: &Value) {
+    if let Some(base) = contract.pointer("/inputs/base_ref").and_then(Value::as_str) {
+        command.extend(["--base".to_string(), base.to_string()]);
+    }
+    let Some(gates) = contract.get("gates") else {
+        return;
+    };
+    for (key, flag) in [
+        ("verify", "--verify"),
+        ("private_verify", "--private-verify"),
+    ] {
+        if let Some(values) = gates.get(key).and_then(Value::as_array) {
+            for value in values.iter().filter_map(Value::as_str) {
+                command.extend([flag.to_string(), value.to_string()]);
+            }
+        }
+    }
+    for (key, flag) in [
+        ("private_gate_reveal", "--private-gate-reveal"),
+        ("gate_timeout_seconds", "--gate-timeout-seconds"),
+        (
+            "gate_heartbeat_interval_seconds",
+            "--gate-heartbeat-interval-seconds",
+        ),
+    ] {
+        if let Some(value) = gates.get(key) {
+            let value = value
+                .as_str()
+                .map(str::to_string)
+                .or_else(|| value.as_u64().map(|value| value.to_string()));
+            if let Some(value) = value {
+                command.extend([flag.to_string(), value.replace('_', "-")]);
+            }
+        }
+    }
+    if gates.get("rerun_completed_gates").and_then(Value::as_bool) == Some(true) {
+        command.push("--rerun-completed-gates".to_string());
+    }
+    if let Some(environment) = gates.get("gate_environment") {
+        if let Some(mode) = environment.get("mode").and_then(Value::as_str) {
+            command.extend([
+                "--gate-environment-mode".to_string(),
+                mode.replace('_', "-"),
+            ]);
+        }
+        if let Some(variables) = environment.get("variables").and_then(Value::as_object) {
+            for (name, value) in variables {
+                if let Some(value) = value.as_str() {
+                    command.extend(["--gate-env".to_string(), format!("{name}={value}")]);
+                }
+            }
+        }
+        for (key, flag) in [
+            ("isolate_home", "--isolate-gate-home"),
+            ("isolate_xdg", "--isolate-gate-xdg"),
+        ] {
+            if let Some(value) = environment.get(key).and_then(Value::as_bool) {
+                command.push(format!("{flag}={value}"));
+            }
+        }
+    }
 }
 
 fn review_next_actions(
@@ -1278,6 +1360,7 @@ mod tests {
                 "promotion-provider".to_string(),
                 "--workspace=/tmp/target".to_string(),
             ],
+            None,
             &aggregate,
             &review,
         );
@@ -1304,6 +1387,57 @@ mod tests {
     }
 
     #[test]
+    fn resume_contract_emits_exact_base_and_gate_arguments() {
+        let mut command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        append_resume_contract(
+            &mut command,
+            &serde_json::json!({
+                "inputs": { "base_ref": "release" },
+                "gates": {
+                    "verify": ["cargo test --lib"],
+                    "private_verify": ["./private-check"],
+                    "private_gate_reveal": "full_evidence",
+                    "gate_timeout_seconds": 42,
+                    "gate_heartbeat_interval_seconds": 7,
+                    "rerun_completed_gates": false,
+                    "gate_environment": {
+                        "mode": "replace",
+                        "variables": { "MODE": "test" },
+                        "isolate_home": true,
+                        "isolate_xdg": false
+                    }
+                }
+            }),
+        );
+
+        assert_eq!(
+            command,
+            vec![
+                "homeboy",
+                "agent-task",
+                "--base",
+                "release",
+                "--verify",
+                "cargo test --lib",
+                "--private-verify",
+                "./private-check",
+                "--private-gate-reveal",
+                "full-evidence",
+                "--gate-timeout-seconds",
+                "42",
+                "--gate-heartbeat-interval-seconds",
+                "7",
+                "--gate-environment-mode",
+                "replace",
+                "--gate-env",
+                "MODE=test",
+                "--isolate-gate-home=true",
+                "--isolate-gate-xdg=false",
+            ]
+        );
+    }
+
+    #[test]
     fn promotion_candidates_canonicalize_aliases_and_preserve_attempt_choices() {
         let temp = tempfile::tempdir().expect("tempdir");
         let equivalent_aggregate = recoverable_review_aggregate(&temp, &[1, 1]);
@@ -1318,6 +1452,7 @@ mod tests {
             Some("fixture@target"),
             None,
             &[],
+            None,
             &equivalent_aggregate,
             &equivalent_review,
         );
@@ -1335,6 +1470,7 @@ mod tests {
             Some("fixture@target"),
             None,
             &[],
+            None,
             &distinct_aggregate,
             &distinct_review,
         );


### PR DESCRIPTION
## Summary
Make interrupted post-apply promotions resumable from their durable immutable base, candidate, artifact, and gate contract.

## What changed
- Records a complete resume contract in the post-apply checkpoint before gates run.
- Validates exact artifact, destination, candidate, inputs, and gates while retaining the checkpointed resolved base.
- Makes agent-task review emit the exact recorded continuation arguments.

## How to test
1. Run `cargo test -p homeboy-agents resume_promoted_patch -- --test-threads=1`; expect all matching resume tests pass.
2. Run `cargo test -p homeboy-agents promotion_checkpoints_applied_target_before_gate_transport_failure -- --test-threads=1`; expect checkpoint transport regression passes.
3. Run `cargo test -p homeboy-cli resume_contract_emits_exact_base_and_gate_arguments -- --test-threads=1`; expect review continuation regression passes.
4. Run `cargo check -p homeboy-agents -p homeboy-cli`; expect both crates compile.
5. Run `cargo fmt --check`; expect formatting is clean.
6. Run `git diff --check`; expect diff has no whitespace errors.

## Compatibility
Legacy resume\_inputs checkpoints remain readable; exact dirty candidates resume, conflicting edits remain fail-closed, and moving origin state no longer invalidates an immutable checkpoint.

## Evidence
- Base advanced after verification: verified main at 06b844a3443fac3d00c072773095a280cf3120f2; publication observed e832f662154e02769120af5bd78d36e21358713f. Candidate ancestry was validated against the verified snapshot.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9400
- Verified finalization base: main at 06b844a3443fac3d00c072773095a280cf3120f2
- agents-cli-check: passed (Passed)
- checkpoint-transport: passed (Passed)
- promotion-resume: passed (Passed)
- review-continuation: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** OpenCode with openai/gpt-5.6-terra drafted the implementation; OpenCode with openai/gpt-5.6-sol reviewed the candidate, integrated current main, verified compatibility, and ran finalization.

## Source relationships
- Closes Extra-Chill/homeboy#9400
